### PR TITLE
[22.x] qt: 22.1rc1 translations update

### DIFF
--- a/src/Makefile.qt_locale.include
+++ b/src/Makefile.qt_locale.include
@@ -4,6 +4,7 @@ QT_TS = \
   qt/locale/bitcoin_az.ts \
   qt/locale/bitcoin_be.ts \
   qt/locale/bitcoin_bg.ts \
+  qt/locale/bitcoin_bn.ts \
   qt/locale/bitcoin_bs.ts \
   qt/locale/bitcoin_ca.ts \
   qt/locale/bitcoin_cs.ts \
@@ -30,7 +31,9 @@ QT_TS = \
   qt/locale/bitcoin_gl.ts \
   qt/locale/bitcoin_gl_ES.ts \
   qt/locale/bitcoin_gu.ts \
+  qt/locale/bitcoin_ha.ts \
   qt/locale/bitcoin_he.ts \
+  qt/locale/bitcoin_hi.ts \
   qt/locale/bitcoin_hr.ts \
   qt/locale/bitcoin_hu.ts \
   qt/locale/bitcoin_id.ts \
@@ -66,15 +69,19 @@ QT_TS = \
   qt/locale/bitcoin_sc.ts \
   qt/locale/bitcoin_si.ts \
   qt/locale/bitcoin_sk.ts \
+  qt/locale/bitcoin_sl.ts \
   qt/locale/bitcoin_sn.ts \
   qt/locale/bitcoin_sq.ts \
   qt/locale/bitcoin_sr.ts \
   qt/locale/bitcoin_sr@latin.ts \
   qt/locale/bitcoin_sv.ts \
+  qt/locale/bitcoin_sw.ts \
   qt/locale/bitcoin_szl.ts \
   qt/locale/bitcoin_ta.ts \
   qt/locale/bitcoin_te.ts \
   qt/locale/bitcoin_th.ts \
+  qt/locale/bitcoin_tk.ts \
+  qt/locale/bitcoin_tl.ts \
   qt/locale/bitcoin_tr.ts \
   qt/locale/bitcoin_ug.ts \
   qt/locale/bitcoin_uk.ts \
@@ -87,4 +94,5 @@ QT_TS = \
   qt/locale/bitcoin_zh.ts \
   qt/locale/bitcoin_zh_CN.ts \
   qt/locale/bitcoin_zh_HK.ts \
-  qt/locale/bitcoin_zh_TW.ts
+  qt/locale/bitcoin_zh_TW.ts \
+  qt/locale/bitcoin_zu.ts

--- a/src/qt/bitcoin_locale.qrc
+++ b/src/qt/bitcoin_locale.qrc
@@ -5,6 +5,7 @@
         <file alias="az">locale/bitcoin_az.qm</file>
         <file alias="be">locale/bitcoin_be.qm</file>
         <file alias="bg">locale/bitcoin_bg.qm</file>
+        <file alias="bn">locale/bitcoin_bn.qm</file>
         <file alias="bs">locale/bitcoin_bs.qm</file>
         <file alias="ca">locale/bitcoin_ca.qm</file>
         <file alias="cs">locale/bitcoin_cs.qm</file>
@@ -31,7 +32,9 @@
         <file alias="gl">locale/bitcoin_gl.qm</file>
         <file alias="gl_ES">locale/bitcoin_gl_ES.qm</file>
         <file alias="gu">locale/bitcoin_gu.qm</file>
+        <file alias="ha">locale/bitcoin_ha.qm</file>
         <file alias="he">locale/bitcoin_he.qm</file>
+        <file alias="hi">locale/bitcoin_hi.qm</file>
         <file alias="hr">locale/bitcoin_hr.qm</file>
         <file alias="hu">locale/bitcoin_hu.qm</file>
         <file alias="id">locale/bitcoin_id.qm</file>
@@ -67,15 +70,19 @@
         <file alias="sc">locale/bitcoin_sc.qm</file>
         <file alias="si">locale/bitcoin_si.qm</file>
         <file alias="sk">locale/bitcoin_sk.qm</file>
+        <file alias="sl">locale/bitcoin_sl.qm</file>
         <file alias="sn">locale/bitcoin_sn.qm</file>
         <file alias="sq">locale/bitcoin_sq.qm</file>
         <file alias="sr">locale/bitcoin_sr.qm</file>
         <file alias="sr@latin">locale/bitcoin_sr@latin.qm</file>
         <file alias="sv">locale/bitcoin_sv.qm</file>
+        <file alias="sw">locale/bitcoin_sw.qm</file>
         <file alias="szl">locale/bitcoin_szl.qm</file>
         <file alias="ta">locale/bitcoin_ta.qm</file>
         <file alias="te">locale/bitcoin_te.qm</file>
         <file alias="th">locale/bitcoin_th.qm</file>
+        <file alias="tk">locale/bitcoin_tk.qm</file>
+        <file alias="tl">locale/bitcoin_tl.qm</file>
         <file alias="tr">locale/bitcoin_tr.qm</file>
         <file alias="ug">locale/bitcoin_ug.qm</file>
         <file alias="uk">locale/bitcoin_uk.qm</file>
@@ -89,5 +96,6 @@
         <file alias="zh_CN">locale/bitcoin_zh_CN.qm</file>
         <file alias="zh_HK">locale/bitcoin_zh_HK.qm</file>
         <file alias="zh_TW">locale/bitcoin_zh_TW.qm</file>
+        <file alias="zu">locale/bitcoin_zu.qm</file>
     </qresource>
 </RCC>

--- a/src/qt/locale/bitcoin_ar.ts
+++ b/src/qt/locale/bitcoin_ar.ts
@@ -23,7 +23,7 @@
     </message>
     <message>
         <source>C&amp;lose</source>
-        <translation type="unfinished">غلق</translation>
+        <translation type="unfinished">أغلق</translation>
     </message>
     <message>
         <source>Delete the currently selected address from the list</source>
@@ -51,7 +51,7 @@
     </message>
     <message>
         <source>Choose the address to receive coins with</source>
-        <translation type="unfinished">إختر العنوان الرقمي اللذي سيحصل على العملات</translation>
+        <translation type="unfinished">اختر العنوان الذي تود إرسال العملات إليه</translation>
     </message>
     <message>
         <source>C&amp;hoose</source>
@@ -280,6 +280,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">ادخل عنوان محفطة البتكوين (مثال %1)</translation>
     </message>
     <message>
+        <source>Unroutable</source>
+        <translation type="unfinished">غير قابل للطرق</translation>
+    </message>
+    <message>
         <source>Internal</source>
         <translation type="unfinished">داخلي</translation>
     </message>
@@ -292,8 +296,24 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">خارجي</translation>
     </message>
     <message>
+        <source>Full Relay</source>
+        <translation type="unfinished">تتابع كامل</translation>
+    </message>
+    <message>
+        <source>Block Relay</source>
+        <translation type="unfinished">بلوك ريلاي</translation>
+    </message>
+    <message>
         <source>Manual</source>
         <translation type="unfinished">يدوي</translation>
+    </message>
+    <message>
+        <source>Feeler</source>
+        <translation type="unfinished">المحسس</translation>
+    </message>
+    <message>
+        <source>Address Fetch</source>
+        <translation type="unfinished">إحضار العنوان</translation>
     </message>
     <message>
         <source>%1 d</source>
@@ -326,56 +346,56 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation>
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n ثواني</numerusform>
+            <numerusform> %nثانيا</numerusform>
+            <numerusform>%n ثواني</numerusform>
+            <numerusform>%n ثواني</numerusform>
+            <numerusform>%n ثواني</numerusform>
+            <numerusform>%n ثواني</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n minute(s)</source>
         <translation>
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n الدقائق</numerusform>
+            <numerusform>%n اللحظة</numerusform>
+            <numerusform>%n الدقائق</numerusform>
+            <numerusform>%n الدقائق</numerusform>
+            <numerusform>%n الدقائق</numerusform>
+            <numerusform>%n الدقائق</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n ساعات</numerusform>
+            <numerusform>%n ساعة</numerusform>
+            <numerusform>%n ساعات</numerusform>
+            <numerusform>%n ساعات</numerusform>
+            <numerusform>%n ساعات</numerusform>
+            <numerusform>%n ساعات</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n أيام</numerusform>
+            <numerusform>%n يوم</numerusform>
+            <numerusform>%n أيام</numerusform>
+            <numerusform>%n أيام</numerusform>
+            <numerusform>%n أيام</numerusform>
+            <numerusform>%n أيام</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n أسابيع</numerusform>
+            <numerusform>%n أسبوع</numerusform>
+            <numerusform>%n أسابيع</numerusform>
+            <numerusform>%n أسابيع</numerusform>
+            <numerusform>%n أسابيع</numerusform>
+            <numerusform>%n أسابيع</numerusform>
         </translation>
     </message>
     <message>
@@ -385,17 +405,21 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n سنين</numerusform>
+            <numerusform>%n عام</numerusform>
+            <numerusform>%n سنين</numerusform>
+            <numerusform>%n سنين</numerusform>
+            <numerusform>%n سنين</numerusform>
+            <numerusform>%n سنين</numerusform>
         </translation>
     </message>
     <message>
         <source>%1 B</source>
         <translation type="unfinished">%1 بايت</translation>
+    </message>
+    <message>
+        <source>%1 kB</source>
+        <translation type="unfinished">%1 كيلو بايت</translation>
     </message>
     <message>
         <source>%1 MB</source>
@@ -574,6 +598,26 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation>شريط أدوات علامات التبويب</translation>
     </message>
     <message>
+        <source>Synchronizing with network…</source>
+        <translation type="unfinished">مزامنة مع الشبكة ...</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation type="unfinished">كتل الفهرسة على القرص ...</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation type="unfinished">كتل المعالجة على القرص ...</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation type="unfinished">جارٍ إعادة فهرسة الكتل الموجودة على القرص ...</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation type="unfinished">الاتصال بالأقران ...</translation>
+    </message>
+    <message>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished">أطلب دفعات (يولد كودات الرمز المربع وبيت كوين: العناوين المعطاة)</translation>
     </message>
@@ -592,17 +636,21 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation>
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>كتل %n معالجة من تاريخ المعاملات.</numerusform>
+            <numerusform>كتل %n معالجة من تاريخ المعاملات.</numerusform>
+            <numerusform>كتل %n معالجة من تاريخ المعاملات.</numerusform>
+            <numerusform>كتل %n معالجة من تاريخ المعاملات.</numerusform>
+            <numerusform>كتل %n معالجة من تاريخ المعاملات.</numerusform>
+            <numerusform>كتل %n معالجة من تاريخ المعاملات.</numerusform>
         </translation>
     </message>
     <message>
         <source>%1 behind</source>
         <translation>خلف %1</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation type="unfinished">يمسك…</translation>
     </message>
     <message>
         <source>Last received block was generated %1 ago.</source>
@@ -716,13 +764,33 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n اتصال (اتصالات) نشط بشبكة Bitcoin.</numerusform>
+            <numerusform>%n اتصال (اتصالات) نشط بشبكة Bitcoin.</numerusform>
+            <numerusform>%n اتصال (اتصالات) نشط بشبكة Bitcoin.</numerusform>
+            <numerusform>%n اتصال (اتصالات) نشط بشبكة Bitcoin.</numerusform>
+            <numerusform>%n اتصال (اتصالات) نشط بشبكة Bitcoin.</numerusform>
+            <numerusform>%n اتصال (اتصالات) نشط بشبكة Bitcoin.</numerusform>
         </translation>
+    </message>
+    <message>
+        <source>Click for more actions.</source>
+        <extracomment>A substring of the tooltip. "More actions" are available via the context menu.</extracomment>
+        <translation type="unfinished">انقر لمزيد من الإجراءات.</translation>
+    </message>
+    <message>
+        <source>Show Peers tab</source>
+        <extracomment>A context menu item. The "Peers tab" is an element of the "Node window".</extracomment>
+        <translation type="unfinished">إظهار علامة التبويب النظراء</translation>
+    </message>
+    <message>
+        <source>Disable network activity</source>
+        <extracomment>A context menu item.</extracomment>
+        <translation type="unfinished">تعطيل نشاط الشبكة</translation>
+    </message>
+    <message>
+        <source>Enable network activity</source>
+        <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
+        <translation type="unfinished">تمكين نشاط الشبكة</translation>
     </message>
     <message>
         <source>Error: %1</source>
@@ -884,6 +952,30 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">نسخ الكمية</translation>
     </message>
     <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">انسخ العنوان</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">نسخ و تصنيف</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">نسخ &amp;مبلغ</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">نسخ المعاملة &amp;المعرف</translation>
+    </message>
+    <message>
+        <source>L&amp;ock unspent</source>
+        <translation type="unfinished">قفل غير منفق</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock unspent</source>
+        <translation type="unfinished">&amp; إفتح غير المنفق</translation>
+    </message>
+    <message>
         <source>Copy quantity</source>
         <translation type="unfinished">نسخ الكمية </translation>
     </message>
@@ -954,7 +1046,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Create wallet warning</source>
         <translation type="unfinished">تحذير إنشاء محفظة</translation>
     </message>
-    </context>
+    <message>
+        <source>Can't list signers</source>
+        <translation type="unfinished">لا يمكن سرد الموقعين</translation>
+    </message>
+</context>
 <context>
     <name>OpenWalletActivity</name>
     <message>
@@ -1044,6 +1140,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">المحفظة الوصفية</translation>
     </message>
     <message>
+        <source>Use an external signing device such as a hardware wallet. Configure the external signer script in wallet preferences first.</source>
+        <translation type="unfinished">استخدم جهاز توقيع خارجي مثل محفظة الأجهزة.  قم بتكوين البرنامج النصي للموقِّع الخارجي في تفضيلات المحفظة أولاً.</translation>
+    </message>
+    <message>
+        <source>External signer</source>
+        <translation type="unfinished">الموقّع الخارجي</translation>
+    </message>
+    <message>
         <source>Create</source>
         <translation type="unfinished">إنشاء</translation>
     </message>
@@ -1051,7 +1155,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Compiled without sqlite support (required for descriptor wallets)</source>
         <translation type="unfinished">تم تجميعه بدون دعم sqlite (مطلوب لمحافظ الواصف)</translation>
     </message>
-    </context>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">مجمعة بدون دعم توقيع خارجي (مطلوب للتوقيع الخارجي)</translation>
+    </message>
+</context>
 <context>
     <name>EditAddressDialog</name>
     <message>
@@ -1137,6 +1246,18 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">بتكوين</translation>
     </message>
     <message>
+        <source>%1 GB of free space available</source>
+        <translation type="unfinished">%1 مساحة خالية غيغابايت متاحة</translation>
+    </message>
+    <message>
+        <source>(of %1 GB needed)</source>
+        <translation type="unfinished">(من %1 الجيجابايت المطلوبة)</translation>
+    </message>
+    <message>
+        <source>(%1 GB needed for full chain)</source>
+        <translation type="unfinished">(%1 مطلوب غيغابايت للسلسلة الكاملة)</translation>
+    </message>
+    <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
         <translation type="unfinished">سيتم تخزين %1 جيجابايت على الأقل من البيانات في هذا الدليل، وستنمو مع الوقت.</translation>
     </message>
@@ -1148,12 +1269,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>(يكفي لاستعادة النسخ الاحتياطية %n القديمة من يوم (أيام))</numerusform>
+            <numerusform>(يكفي لاستعادة النسخ الاحتياطية %n القديمة من يوم (أيام))</numerusform>
+            <numerusform>(يكفي لاستعادة النسخ الاحتياطية %n القديمة من يوم (أيام))</numerusform>
+            <numerusform>(يكفي لاستعادة النسخ الاحتياطية %n القديمة من يوم (أيام))</numerusform>
+            <numerusform>(يكفي لاستعادة النسخ الاحتياطية %n القديمة من يوم (أيام))</numerusform>
+            <numerusform>(يكفي لاستعادة النسخ الاحتياطية %n القديمة من يوم (أيام))</numerusform>
         </translation>
     </message>
     <message>
@@ -1189,8 +1310,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">عند النقر على "موافق" ، سيبدأ %1 في تنزيل ومعالجة سلسلة الكتل %4 الكاملة (%2 جيجابايت) بدءًا من المعاملات الأقدم في %3 عند تشغيل %4 في البداية.</translation>
     </message>
     <message>
+        <source>Limit block chain storage to</source>
+        <translation type="unfinished">تقييد تخزين سلسلة الكتل إلى</translation>
+    </message>
+    <message>
         <source>Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</source>
         <translation type="unfinished">تتطلب العودة إلى هذا الإعداد إعادة تنزيل سلسلة الكتل بالكامل. من الأسرع تنزيل السلسلة الكاملة أولاً وتقليمها لاحقًا. تعطيل بعض الميزات المتقدمة.</translation>
+    </message>
+    <message>
+        <source> GB</source>
+        <translation type="unfinished">غيغابايت</translation>
     </message>
     <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
@@ -1226,6 +1355,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 </context>
 <context>
     <name>ShutdownWindow</name>
+    <message>
+        <source>%1 is shutting down…</source>
+        <translation type="unfinished">%1 يتم الإغلاق ...</translation>
+    </message>
     <message>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished">لا توقف عمل الكمبيوتر حتى تختفي هذه النافذة</translation>
@@ -1281,7 +1414,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Esc</source>
         <translation type="unfinished">خروج</translation>
     </message>
-    </context>
+    <message>
+        <source>Unknown. Syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">مجهول.  مزامنة الرؤوس (%1،%2٪) ...</translation>
+    </message>
+</context>
 <context>
     <name>OpenURIDialog</name>
     <message>
@@ -1394,6 +1531,18 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>&amp;Spend unconfirmed change</source>
         <translation type="unfinished">دفع الفكة غير المؤكدة</translation>
+    </message>
+    <message>
+        <source>External Signer (e.g. hardware wallet)</source>
+        <translation type="unfinished">الموقّع الخارجي (مثل محفظة الأجهزة)</translation>
+    </message>
+    <message>
+        <source>&amp;External signer script path</source>
+        <translation type="unfinished">&amp; مسار البرنامج النصي للموقّع الخارجي</translation>
+    </message>
+    <message>
+        <source>Full path to a Bitcoin Core compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</source>
+        <translation type="unfinished">المسار الكامل إلى برنامج نصي متوافق مع Bitcoin Core (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). احذر: يمكن أن تسرق البرامج الضارة عملاتك!</translation>
     </message>
     <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
@@ -1526,6 +1675,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>&amp;Cancel</source>
         <translation>الغاء</translation>
+    </message>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">مجمعة بدون دعم توقيع خارجي (مطلوب للتوقيع الخارجي)</translation>
     </message>
     <message>
         <source>default</source>
@@ -1718,6 +1872,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">حفظ بيانات المعاملات</translation>
     </message>
     <message>
+        <source>Partially Signed Transaction (Binary)</source>
+        <extracomment>Expanded name of the binary PSBT file format. See: BIP 174.</extracomment>
+        <translation type="unfinished">معاملة موقعة جزئيًا (ثنائي)</translation>
+    </message>
+    <message>
         <source>PSBT saved to disk.</source>
         <translation type="unfinished">تم حفظ PSBT على القرص.</translation>
     </message>
@@ -1785,6 +1944,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">'bitcoin://' هو ليس عنوان URL صالح. استعمل 'bitcoin:' بدلا من ذلك.</translation>
     </message>
     <message>
+        <source>Cannot process payment request because BIP70 is not supported.
+Due to widespread security flaws in BIP70 it's strongly recommended that any merchant instructions to switch wallets be ignored.
+If you are receiving this error you should request the merchant provide a BIP21 compatible URI.</source>
+        <translation type="unfinished">لا يمكن معالجة طلب الدفع لأن BIP70 غير مدعوم. نظرًا لوجود عيوب أمنية واسعة النطاق في BIP70 ، يوصى بشدة بتجاهل أي تعليمات تاجر لتبديل المحافظ. إذا كنت تتلقى هذا الخطأ ، يجب أن تطلب من التاجر تقديم عنوان URI متوافق مع BIP21.</translation>
+    </message>
+    <message>
         <source>URI cannot be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation type="unfinished">لا يمكن تحليل العنوان (URI)! يمكن أن يحدث هذا بسبب عنوان بتكوين غير صالح أو معلمات عنوان (URI) غير صحيحة.</translation>
     </message>
@@ -1804,6 +1969,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Ping</source>
         <extracomment>Title of Peers Table column which indicates the current latency of the connection with the peer.</extracomment>
         <translation type="unfinished">رنين</translation>
+    </message>
+    <message>
+        <source>Peer</source>
+        <extracomment>Title of Peers Table column which contains a unique number used to identify a connection.</extracomment>
+        <translation type="unfinished">الأقران</translation>
     </message>
     <message>
         <source>Sent</source>
@@ -1833,6 +2003,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 </context>
 <context>
     <name>QRImageWidget</name>
+    <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">&amp;احفظ الصورة…</translation>
+    </message>
     <message>
         <source>&amp;Copy Image</source>
         <translation type="unfinished">&amp;نسخ الصورة</translation>
@@ -1998,12 +2172,56 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">اذونات</translation>
     </message>
     <message>
+        <source>The direction and type of peer connection: %1</source>
+        <translation type="unfinished">اتجاه ونوع اتصال الأقران : %1</translation>
+    </message>
+    <message>
+        <source>Direction/Type</source>
+        <translation type="unfinished">الاتجاه / النوع</translation>
+    </message>
+    <message>
+        <source>The network protocol this peer is connected through: IPv4, IPv6, Onion, I2P, or CJDNS.</source>
+        <translation type="unfinished">بروتوكول الشبكة الذي يتصل به هذا النظير من خلال: IPv4 أو IPv6 أو Onion أو I2P أو CJDNS.</translation>
+    </message>
+    <message>
         <source>Services</source>
         <translation type="unfinished">خدمات</translation>
     </message>
     <message>
+        <source>Whether the peer requested us to relay transactions.</source>
+        <translation type="unfinished">ما إذا كان الزميل قد طلب منا ترحيل المعاملات.</translation>
+    </message>
+    <message>
+        <source>Wants Tx Relay</source>
+        <translation type="unfinished">يريد Tx Relay</translation>
+    </message>
+    <message>
+        <source>High bandwidth BIP152 compact block relay: %1</source>
+        <translation type="unfinished">عرض النطاق الترددي العالي BIP152 كتلة التتابع المدمجة: %1</translation>
+    </message>
+    <message>
+        <source>High Bandwidth</source>
+        <translation type="unfinished">عرض النطاق الترددي العالي</translation>
+    </message>
+    <message>
         <source>Connection Time</source>
         <translation type="unfinished">مدة الاتصال</translation>
+    </message>
+    <message>
+        <source>Elapsed time since a novel block passing initial validity checks was received from this peer.</source>
+        <translation type="unfinished">الوقت المنقضي منذ استلام كتلة جديدة اجتياز اختبارات الصلاحية الأولية من هذا النظير.</translation>
+    </message>
+    <message>
+        <source>Last Block</source>
+        <translation type="unfinished">الكتلة الأخيرة </translation>
+    </message>
+    <message>
+        <source>Elapsed time since a novel transaction accepted into our mempool was received from this peer.</source>
+        <translation type="unfinished">الوقت المنقضي منذ استلام معاملة جديدة تم قبولها في مجموعة المذكرات الخاصة بنا من هذا النظير.</translation>
+    </message>
+    <message>
+        <source>Last Tx</source>
+        <translation type="unfinished">آخر Tx</translation>
     </message>
     <message>
         <source>Last Send</source>
@@ -2070,12 +2288,68 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">خارج:</translation>
     </message>
     <message>
+        <source>Inbound: initiated by peer</source>
+        <translation type="unfinished">الواردة: بدأها النظير</translation>
+    </message>
+    <message>
+        <source>Outbound Full Relay: default</source>
+        <translation type="unfinished">ترحيل كامل صادر: افتراضي</translation>
+    </message>
+    <message>
+        <source>Outbound Block Relay: does not relay transactions or addresses</source>
+        <translation type="unfinished">ترحيل الكتلة الصادرة: لا يقوم بترحيل المعاملات أو العناوين</translation>
+    </message>
+    <message>
+        <source>Outbound Manual: added using RPC %1 or %2/%3 configuration options</source>
+        <translation type="unfinished">دليل الصادر: تمت إضافته باستخدام خيارات RPC %1 أو %2/%3 التكوين</translation>
+    </message>
+    <message>
+        <source>Outbound Feeler: short-lived, for testing addresses</source>
+        <translation type="unfinished">أداة التجسس الصادرة: قصيرة الأجل ، لاختبار العناوين</translation>
+    </message>
+    <message>
+        <source>Outbound Address Fetch: short-lived, for soliciting addresses</source>
+        <translation type="unfinished">إحضار العنوان الصادر: قصير الأجل ، لطلب العناوين</translation>
+    </message>
+    <message>
+        <source>we selected the peer for high bandwidth relay</source>
+        <translation type="unfinished">اخترنا النظير لترحيل النطاق الترددي العالي</translation>
+    </message>
+    <message>
+        <source>the peer selected us for high bandwidth relay</source>
+        <translation type="unfinished">اختارنا النظير لترحيل النطاق الترددي العالي</translation>
+    </message>
+    <message>
+        <source>no high bandwidth relay selected</source>
+        <translation type="unfinished">لم يتم تحديد ترحيل النطاق الترددي العالي</translation>
+    </message>
+    <message>
+        <source>Ctrl++</source>
+        <extracomment>Main shortcut to increase the RPC console font size.</extracomment>
+        <translation type="unfinished">Ctrl ++</translation>
+    </message>
+    <message>
+        <source>Ctrl+-</source>
+        <extracomment>Main shortcut to decrease the RPC console font size.</extracomment>
+        <translation type="unfinished">Ctrl + -</translation>
+    </message>
+    <message>
+        <source>Ctrl+_</source>
+        <extracomment>Secondary shortcut to decrease the RPC console font size.</extracomment>
+        <translation type="unfinished">Ctrl+_
+ </translation>
+    </message>
+    <message>
         <source>&amp;Disconnect</source>
         <translation type="unfinished">قطع الاتصال</translation>
     </message>
     <message>
         <source>1 &amp;hour</source>
         <translation type="unfinished">1 &amp;ساعة</translation>
+    </message>
+    <message>
+        <source>1 d&amp;ay</source>
+        <translation type="unfinished">ي&amp;وم 1</translation>
     </message>
     <message>
         <source>1 &amp;week</source>
@@ -2096,6 +2370,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Executing command without any wallet</source>
         <translation type="unfinished">تنفيذ الأوامر بدون محفظة </translation>
+    </message>
+    <message>
+        <source>Executing…</source>
+        <extracomment>A console message indicating an entered command is currently being executed.</extracomment>
+        <translation type="unfinished">جار التنفيذ...</translation>
     </message>
     <message>
         <source>via %1</source>
@@ -2120,6 +2399,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Ban for</source>
         <translation type="unfinished">حظر ل</translation>
+    </message>
+    <message>
+        <source>Never</source>
+        <translation type="unfinished">مطلقا</translation>
     </message>
     <message>
         <source>Unknown</source>
@@ -2209,12 +2492,32 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">نسخ  &amp;URI</translation>
     </message>
     <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">انسخ العنوان</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">نسخ و تصنيف</translation>
+    </message>
+    <message>
+        <source>Copy &amp;message</source>
+        <translation type="unfinished">نسخ و ارسال </translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">نسخ &amp;مبلغ</translation>
+    </message>
+    <message>
         <source>Could not unlock wallet.</source>
         <translation type="unfinished"> يمكن فتح المحفظة.</translation>
     </message>
     </context>
 <context>
     <name>ReceiveRequestDialog</name>
+    <message>
+        <source>Request payment to …</source>
+        <translation type="unfinished"> طلب الدفع لـ....</translation>
+    </message>
     <message>
         <source>Address:</source>
         <translation type="unfinished">العناوين:</translation>
@@ -2242,6 +2545,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Copy &amp;Address</source>
         <translation type="unfinished">نسخ &amp;العنوان</translation>
+    </message>
+    <message>
+        <source>&amp;Verify</source>
+        <translation type="unfinished">تأكيد</translation>
+    </message>
+    <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">&amp;احفظ الصورة…</translation>
     </message>
     <message>
         <source>Payment information</source>
@@ -2374,8 +2685,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">مسح كل حقول النموذج المطلوبة</translation>
     </message>
     <message>
+        <source>Inputs…</source>
+        <translation type="unfinished">المدخلات </translation>
+    </message>
+    <message>
         <source>Dust:</source>
         <translation type="unfinished">غبار:</translation>
+    </message>
+    <message>
+        <source>Choose…</source>
+        <translation type="unfinished">اختيار </translation>
     </message>
     <message>
         <source>Hide transaction fee settings</source>
@@ -2450,6 +2769,15 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">%1 (%2 كثلة)</translation>
     </message>
     <message>
+        <source>Sign on device</source>
+        <extracomment>"device" usually means a hardware wallet</extracomment>
+        <translation type="unfinished">ولوج الى المحفظة </translation>
+    </message>
+    <message>
+        <source>Connect your hardware wallet first.</source>
+        <translation type="unfinished">قم بتوصيل جهاز المحفظة أولا </translation>
+    </message>
+    <message>
         <source>Cr&amp;eate Unsigned</source>
         <translation type="unfinished">إنشاء غير موقع
  </translation>
@@ -2471,12 +2799,39 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">إنشاء غير موقع</translation>
     </message>
     <message>
+        <source>Sign and send</source>
+        <translation type="unfinished">تسجيل و ارسال</translation>
+    </message>
+    <message>
+        <source>Sign failed</source>
+        <translation type="unfinished">فشل التسجيل</translation>
+    </message>
+    <message>
+        <source>External signer not found</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">لم يتم العثور على تسجيل خارجي</translation>
+    </message>
+    <message>
+        <source>External signer failure</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">فشل التسجيل الخارجي</translation>
+    </message>
+    <message>
         <source>Save Transaction Data</source>
         <translation type="unfinished">حفظ بيانات المعاملات</translation>
     </message>
     <message>
+        <source>Partially Signed Transaction (Binary)</source>
+        <extracomment>Expanded name of the binary PSBT file format. See: BIP 174.</extracomment>
+        <translation type="unfinished">معاملة موقعة جزئيًا (ثنائي)</translation>
+    </message>
+    <message>
         <source>PSBT saved</source>
         <translation type="unfinished">تم حفظ PSBT</translation>
+    </message>
+    <message>
+        <source>External balance:</source>
+        <translation type="unfinished">رصيد خارجي </translation>
     </message>
     <message>
         <source>or</source>
@@ -2549,12 +2904,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation>
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>التأكيد مقدر أن يبدآ في غضون %n كتل.</numerusform>
+            <numerusform>التأكيد مقدر أن يبدأ في غضون %n كتل.</numerusform>
+            <numerusform>التأكيد مقدر أن يبدأ في غضون %n كتل.</numerusform>
+            <numerusform>التأكيد مقدر أن يبدأ في غضون %n كتل.</numerusform>
+            <numerusform>التأكيد مقدر أن يبدأ في غضون %n كتل.</numerusform>
+            <numerusform>التأكيد مقدر أن يبدأ في غضون %n كتل.</numerusform>
         </translation>
     </message>
     <message>
@@ -2797,16 +3152,23 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
 </context>
 <context>
+    <name>TrafficGraphWidget</name>
+    <message>
+        <source>kB/s</source>
+        <translation type="unfinished">كيلوبايت/ثانية</translation>
+    </message>
+</context>
+<context>
     <name>TransactionDesc</name>
     <message numerus="yes">
         <source>Open for %n more block(s)</source>
         <translation>
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>مفتوح لـ %n كتل اضافية</numerusform>
+            <numerusform>مفتوح لـ %n كتل اضافية</numerusform>
+            <numerusform>مفتوح لـ %n كتل اضافية</numerusform>
+            <numerusform>مفتوح لـ %n كتل اضافية</numerusform>
+            <numerusform>مفتوح لـ %n كتل اضافية</numerusform>
+            <numerusform>مفتوح لـ %n كتل اضافية</numerusform>
         </translation>
     </message>
     <message>
@@ -2884,12 +3246,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation>
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>ينضج خلال %n كتل إضافية</numerusform>
+            <numerusform>ينضج خلال %n كتل إضافية</numerusform>
+            <numerusform>ينضج خلال %n كتل إضافية</numerusform>
+            <numerusform>ينضج خلال %n كتل إضافية</numerusform>
+            <numerusform>ينضج خلال %n كتل إضافية</numerusform>
+            <numerusform>ينضج خلال %n كتل إضافية</numerusform>
         </translation>
     </message>
     <message>
@@ -3145,6 +3507,46 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">الحد الأدنى</translation>
     </message>
     <message>
+        <source>Range…</source>
+        <translation type="unfinished">نطاق</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">انسخ العنوان</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">نسخ و تصنيف</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">نسخ &amp;مبلغ</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">نسخ المعاملة &amp;المعرف</translation>
+    </message>
+    <message>
+        <source>Copy full transaction &amp;details</source>
+        <translation type="unfinished">نسخ كامل تفاصيل المعاملة</translation>
+    </message>
+    <message>
+        <source>&amp;Show transaction details</source>
+        <translation type="unfinished">و اظهر تفاصيل الصفقة</translation>
+    </message>
+    <message>
+        <source>Increase transaction &amp;fee</source>
+        <translation type="unfinished">زيادة الصفقات و الرسوم</translation>
+    </message>
+    <message>
+        <source>A&amp;bandon transaction</source>
+        <translation type="unfinished">التخلي عن المعاملة</translation>
+    </message>
+    <message>
+        <source>&amp;Edit address label</source>
+        <translation type="unfinished">و تحرير تسمية العنوان </translation>
+    </message>
+    <message>
         <source>Export Transaction History</source>
         <translation type="unfinished">تصدير تفاصيل المعاملات</translation>
     </message>
@@ -3276,6 +3678,10 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished">لا يمكن تنفيذ المعاملة</translation>
     </message>
     <message>
+        <source>Can't display address</source>
+        <translation type="unfinished">لا يمكن عرض العنوان </translation>
+    </message>
+    <message>
         <source>default wallet</source>
         <translation type="unfinished">المحفظة الإفتراضية</translation>
     </message>
@@ -3319,6 +3725,11 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished">نسخ احتياط للمحفظة</translation>
     </message>
     <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">بيانات المحفظة</translation>
+    </message>
+    <message>
         <source>Backup Failed</source>
         <translation type="unfinished">فشل النسخ الاحتياطي</translation>
     </message>
@@ -3360,6 +3771,10 @@ Go to File &gt; Open Wallet to load a wallet.
     <message>
         <source>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.</source>
         <translation type="unfinished">عملية حساب الرسوم فشلت. الرسوم الاحتياطية غير مفعلة. انتظر عدة كتل أو مكن خيار الرسوم الاحتياطية.</translation>
+    </message>
+    <message>
+        <source>File %s already exists. If you are sure this is what you want, move it out of the way first.</source>
+        <translation type="unfinished">الملف %s موجود مسبقا , اذا كنت متأكدا من المتابعة يرجى ارساله بعيدا للاستمرار </translation>
     </message>
     <message>
         <source>Invalid amount for -maxtxfee=&lt;amount&gt;: '%s' (must be at least the minrelay fee of %s to prevent stuck transactions)</source>
@@ -3462,6 +3877,14 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished">إنتهاء التحميل</translation>
     </message>
     <message>
+        <source>Dump file %s does not exist.</source>
+        <translation type="unfinished">ملف مهمل %s غير موجود</translation>
+    </message>
+    <message>
+        <source>Error creating %s</source>
+        <translation type="unfinished">خطأ في إنشاء %s</translation>
+    </message>
+    <message>
         <source>Error loading %s</source>
         <translation type="unfinished">خطأ في تحميل %s</translation>
     </message>
@@ -3490,12 +3913,32 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished">خطأ في القراءة من قاعدة البيانات ، والتوقف.</translation>
     </message>
     <message>
+        <source>Error reading next record from wallet database</source>
+        <translation type="unfinished">خطأ قراءة السجل التالي من قاعدة بيانات المحفظة</translation>
+    </message>
+    <message>
         <source>Error upgrading chainstate database</source>
         <translation type="unfinished">خطأ في ترقية قاعدة بيانات chainstate</translation>
     </message>
     <message>
+        <source>Error: Couldn't create cursor into database</source>
+        <translation type="unfinished">خطأ : لا يمكن انشاء مؤشر ضمن قاعدة البيانات </translation>
+    </message>
+    <message>
         <source>Error: Disk space is low for %s</source>
         <translation type="unfinished">خطأ : مساحة القرص منخفضة ل %s</translation>
+    </message>
+    <message>
+        <source>Error: Missing checksum</source>
+        <translation type="unfinished">خطأ : مجموع اختباري مفقود </translation>
+    </message>
+    <message>
+        <source>Error: No %s addresses available.</source>
+        <translation type="unfinished">خطأ : لا عناوين%s متوفرة </translation>
+    </message>
+    <message>
+        <source>Error: Unable to write record to new wallet</source>
+        <translation type="unfinished">خطأ : لا يمكن كتابة السجل للمحفظة الجديدة</translation>
     </message>
     <message>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
@@ -3512,6 +3955,10 @@ Go to File &gt; Open Wallet to load a wallet.
     <message>
         <source>Ignoring duplicate -wallet %s.</source>
         <translation type="unfinished"> تم تجاهل تعريف مكرر -wallet %s</translation>
+    </message>
+    <message>
+        <source>Importing…</source>
+        <translation type="unfinished">استيراد </translation>
     </message>
     <message>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
@@ -3546,6 +3993,22 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished">مبلغ غير صحيح -fallbackfee=: '%s'</translation>
     </message>
     <message>
+        <source>Loading P2P addresses…</source>
+        <translation type="unfinished">تحميل عناوين P2P....</translation>
+    </message>
+    <message>
+        <source>Loading banlist…</source>
+        <translation type="unfinished">تحميل قائمة الحظر</translation>
+    </message>
+    <message>
+        <source>Loading block index…</source>
+        <translation type="unfinished">تحميل مؤشر الكتلة</translation>
+    </message>
+    <message>
+        <source>Loading wallet…</source>
+        <translation type="unfinished">تحميل المحفظة</translation>
+    </message>
+    <message>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished">لا تتوفر واصفات ملفات كافية.</translation>
     </message>
@@ -3556,6 +4019,14 @@ Go to File &gt; Open Wallet to load a wallet.
     <message>
         <source>Prune mode is incompatible with -txindex.</source>
         <translation type="unfinished">وضع التجريد غير متوافق مع -txindex.</translation>
+    </message>
+    <message>
+        <source>Replaying blocks…</source>
+        <translation type="unfinished">كتل الإعادة</translation>
+    </message>
+    <message>
+        <source>Rescanning…</source>
+        <translation type="unfinished">إعادة المسح </translation>
     </message>
     <message>
         <source>SQLiteDatabase: Failed to execute statement to verify database: %s</source>
@@ -3620,6 +4091,10 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished">يجب أن تحتوي المعاملة على مستلم واحد على الأقل</translation>
     </message>
     <message>
+        <source>Transaction needs a change address, but we can't generate it. %s</source>
+        <translation type="unfinished">تحتاج المعاملة إلى عنوان تغيير ، لكن لا يمكننا إنشاؤها.%s</translation>
+    </message>
+    <message>
         <source>Transaction too large</source>
         <translation type="unfinished">المعاملة كبيرة جدا</translation>
     </message>
@@ -3638,6 +4113,10 @@ Go to File &gt; Open Wallet to load a wallet.
     <message>
         <source>Unable to generate keys</source>
         <translation type="unfinished"> غير قادر على توليد مفاتيح.</translation>
+    </message>
+    <message>
+        <source>Unable to open %s for writing</source>
+        <translation type="unfinished">غير قادر على فتح %s للكتابة </translation>
     </message>
     <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
@@ -3662,6 +4141,14 @@ Go to File &gt; Open Wallet to load a wallet.
     <message>
         <source>Upgrading txindex database</source>
         <translation type="unfinished">تحديث قاعدة بيانات txindex</translation>
+    </message>
+    <message>
+        <source>Verifying blocks…</source>
+        <translation type="unfinished">جار التحقق من الكتل...</translation>
+    </message>
+    <message>
+        <source>Verifying wallet(s)…</source>
+        <translation type="unfinished"> التحقق من المحافظ ....</translation>
     </message>
     <message>
         <source>Wallet needed to be rewritten: restart %s to complete</source>

--- a/src/qt/locale/bitcoin_az.ts
+++ b/src/qt/locale/bitcoin_az.ts
@@ -92,6 +92,11 @@ Daxil olma, yalnız 'qanuni' tipli ünvanlar ilə mümkündür.</translation>
         <translation type="unfinished">Ünvan siyahısını ixrac et</translation>
     </message>
     <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See https://en.wikipedia.org/wiki/Comma-separated_values</extracomment>
+        <translation type="unfinished">Vergüllə ayrılmış fayl</translation>
+    </message>
+    <message>
         <source>There was an error trying to save the address list to %1. Please try again.</source>
         <extracomment>An error message. %1 is a stand-in argument for the name of the file we attempted to save to.</extracomment>
         <translation type="unfinished">Ünvan siyahısını %1 daxilində saxlamağı sınayarkən xəta baş verdi. Zəhmət olmasa yenidən sınayın.</translation>
@@ -159,6 +164,26 @@ Daxil olma, yalnız 'qanuni' tipli ünvanlar ilə mümkündür.</translation>
         <translation type="unfinished">Pulqabı şifrələməsini təsdiqlə</translation>
     </message>
     <message>
+        <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
+        <translation type="unfinished">Xəbərdarlıq: Əgər siz pulqabınızı şifrədən çıxarsanız və şifrəli sözü itirmiş olsanız &lt;b&gt;BÜTÜN BİTCOİNLƏRİNİZİ İTİRƏCƏKSİNİZ&lt;/b&gt;!</translation>
+    </message>
+    <message>
+        <source>Are you sure you wish to encrypt your wallet?</source>
+        <translation type="unfinished">Pulqabınızı şifrədən çıxarmaq istədiyinizə əminsiniz?</translation>
+    </message>
+    <message>
+        <source>Wallet encrypted</source>
+        <translation type="unfinished">Cüzdan şifrələndi.</translation>
+    </message>
+    <message>
+        <source>Enter the new passphrase for the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
+        <translation type="unfinished">Cüzdan üçün yeni şifrəli sözü daxil edin.&lt;br/&gt;Lütfən &lt;b&gt;on və daha çox qarışıq simvollardan&lt;/b&gt; və ya &lt;b&gt;səkkiz və daha çox sayda sözdən&lt;/b&gt; ibarət şifrəli söz istifadə edin.</translation>
+    </message>
+    <message>
+        <source>Enter the old passphrase and new passphrase for the wallet.</source>
+        <translation type="unfinished">Cüzdan üçün köhnə şifrəli sözü və ardınca yeni şifrəli sözü daxil edin</translation>
+    </message>
+    <message>
         <source>Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished">Unutmayın ki, cüzdanınızın şifrələməsi bitcoinlərinizi kompüterinizə zərərli proqram tərəfindən oğurlanmaqdan tamamilə qoruya bilməz.</translation>
     </message>
@@ -174,9 +199,87 @@ Daxil olma, yalnız 'qanuni' tipli ünvanlar ilə mümkündür.</translation>
         <source>Your wallet is now encrypted. </source>
         <translation type="unfinished">Cüzdanınız artıq şifrələnib.</translation>
     </message>
-    </context>
+    <message>
+        <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
+        <translation type="unfinished">VACİBDİR: Cüzdanınızın əvvəlki ehtiyyat nüsxələri yenicə yaradılan şifrələnmiş cüzdan ilə əvəz olunmalıdır. Təhlükəsizlik baxımından yeni şifrələnmiş cüzdanı işə salan kimi əvvəlki şifrəsi açılmış cüzdanın ehtiyyat nüsxələri qeyri-işlək olacaqdır.</translation>
+    </message>
+    <message>
+        <source>Wallet encryption failed</source>
+        <translation type="unfinished">Cüzdanın şifrələnməsi baş tutmadı</translation>
+    </message>
+    <message>
+        <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
+        <translation type="unfinished">Daxili xəta səbəbindən cüzdanın şifrələnməsi baş tutmadı. Cüzdanınız şifrələnmədi.</translation>
+    </message>
+    <message>
+        <source>The supplied passphrases do not match.</source>
+        <translation type="unfinished">Təqdim etdiyiniz şifrəli söz uyğun deyil.</translation>
+    </message>
+    <message>
+        <source>Wallet unlock failed</source>
+        <translation type="unfinished">Cüzdanın şifrədən çıxarılması baş tutmadı</translation>
+    </message>
+    <message>
+        <source>The passphrase entered for the wallet decryption was incorrect.</source>
+        <translation type="unfinished">Cüzdanı şifrədən çıxarmaq üçün daxil etdiyiniz şifrəli söz səhvdir.</translation>
+    </message>
+    <message>
+        <source>Wallet passphrase was successfully changed.</source>
+        <translation type="unfinished">Cüzdanın şifrəli sözü uğurla dəyişdirildi.</translation>
+    </message>
+    <message>
+        <source>Warning: The Caps Lock key is on!</source>
+        <translation type="unfinished">Xəbərdarlıq: Caps Lock düyməsi yanılıdır!</translation>
+    </message>
+</context>
+<context>
+    <name>BanTableModel</name>
+    <message>
+        <source>Banned Until</source>
+        <translation type="unfinished">Qadağan edildi</translation>
+    </message>
+</context>
+<context>
+    <name>BitcoinApplication</name>
+    <message>
+        <source>Runaway exception</source>
+        <translation type="unfinished">İdarə edilə bilməyən istisna</translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
+        <translation type="unfinished">Ciddi xəta baş verdi. %1 təhlükəsiz davam etdirilə bilməz və bağlanacaqdır.</translation>
+    </message>
+    <message>
+        <source>Internal error</source>
+        <translation type="unfinished">Daxili xəta</translation>
+    </message>
+    <message>
+        <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
+        <translation type="unfinished">Daxili xəta baş verdi. %1 təhlükəsiz davam etməyə cəhd edəcək. Bu gözlənilməz bir xətadır və onun haqqında aşağıdakı şəkildə bildirmək olar.</translation>
+    </message>
+</context>
 <context>
     <name>QObject</name>
+    <message>
+        <source>Error: Specified data directory "%1" does not exist.</source>
+        <translation type="unfinished">Xəta: Göstərilmiş verilənlər qovluğu "%1" mövcud deyil</translation>
+    </message>
+    <message>
+        <source>Error: Cannot parse configuration file: %1.</source>
+        <translation type="unfinished">Xəta: Tənzimləmə faylını təhlil etmək mümkün deyil: %1</translation>
+    </message>
+    <message>
+        <source>Error: %1</source>
+        <translation type="unfinished">XƏta: %1</translation>
+    </message>
+    <message>
+        <source>%1 didn't yet exit safely…</source>
+        <translation type="unfinished">%1 hələ də təhlükəsiz bağlanmadı...</translation>
+    </message>
+    <message>
+        <source>Amount</source>
+        <translation type="unfinished">Məbləğ</translation>
+    </message>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation>
@@ -223,8 +326,197 @@ Daxil olma, yalnız 'qanuni' tipli ünvanlar ilə mümkündür.</translation>
 <context>
     <name>BitcoinGUI</name>
     <message>
+        <source>&amp;Overview</source>
+        <translation>&amp;İcmal</translation>
+    </message>
+    <message>
+        <source>Show general overview of wallet</source>
+        <translation>Cüzdanın əsas icmalı göstərilsin</translation>
+    </message>
+    <message>
+        <source>&amp;Transactions</source>
+        <translation>&amp;Tranzaksiyalar</translation>
+    </message>
+    <message>
+        <source>Browse transaction history</source>
+        <translation>Köçürmə tarixçəsinə baxış</translation>
+    </message>
+    <message>
+        <source>E&amp;xit</source>
+        <translation>Çı&amp;xış</translation>
+    </message>
+    <message>
+        <source>Quit application</source>
+        <translation>Tətbiqdən çıxış</translation>
+    </message>
+    <message>
+        <source>&amp;About %1</source>
+        <translation type="unfinished">%1 h&amp;aqqında</translation>
+    </message>
+    <message>
+        <source>Show information about %1</source>
+        <translation type="unfinished">%1 haqqında məlumatlar göstərilsin</translation>
+    </message>
+    <message>
+        <source>About &amp;Qt</source>
+        <translation>&amp;Qt haqqında</translation>
+    </message>
+    <message>
+        <source>Show information about Qt</source>
+        <translation>Qt haqqında məlumatlar göstərilsin</translation>
+    </message>
+    <message>
+        <source>Modify configuration options for %1</source>
+        <translation type="unfinished">%1 üçün tənzimləmə seçimlərini dəyişin</translation>
+    </message>
+    <message>
+        <source>Create a new wallet</source>
+        <translation type="unfinished">Yeni cüzdan yaradın</translation>
+    </message>
+    <message>
+        <source>Wallet:</source>
+        <translation type="unfinished">Cüzdan</translation>
+    </message>
+    <message>
+        <source>Network activity disabled.</source>
+        <extracomment>A substring of the tooltip.</extracomment>
+        <translation type="unfinished">İnternet bağlantısı söndürülüb.</translation>
+    </message>
+    <message>
+        <source>Proxy is &lt;b&gt;enabled&lt;/b&gt;: %1</source>
+        <translation type="unfinished">Proksi &lt;b&gt;işə salınıb&lt;/b&gt;: %1</translation>
+    </message>
+    <message>
+        <source>Send coins to a Bitcoin address</source>
+        <translation>Pulları Bitcoin ünvanına göndərin</translation>
+    </message>
+    <message>
+        <source>Backup wallet to another location</source>
+        <translation>Cüzdanın ehtiyyat nüsxəsini başqa yerdə saxlayın</translation>
+    </message>
+    <message>
+        <source>Change the passphrase used for wallet encryption</source>
+        <translation>Cüzdanın şifrələnməsi üçün istifadə olunan şifrəli sözü dəyişin</translation>
+    </message>
+    <message>
+        <source>&amp;Send</source>
+        <translation>&amp;Göndərin</translation>
+    </message>
+    <message>
+        <source>&amp;Receive</source>
+        <translation>&amp;Qəbul edin</translation>
+    </message>
+    <message>
+        <source>&amp;Options…</source>
+        <translation type="unfinished">&amp;Parametrlər</translation>
+    </message>
+    <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation type="unfinished">&amp;Cüzdanı şifrələyin...</translation>
+    </message>
+    <message>
+        <source>Encrypt the private keys that belong to your wallet</source>
+        <translation>Cüzdanınıza aid məxfi açarları şifrələyin</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation type="unfinished">&amp;Cüzdanın ehtiyyat nüsxəsini saxlayın...</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation type="unfinished">&amp;Şifrəli sözü dəyişin...</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation type="unfinished">İs&amp;marıcı imzalayın...</translation>
+    </message>
+    <message>
+        <source>Sign messages with your Bitcoin addresses to prove you own them</source>
+        <translation>Bitcoin ünvanlarınızın sahibi olduğunuzu sübut etmək üçün ismarıcları imzalayın</translation>
+    </message>
+    <message>
+        <source>&amp;Verify message…</source>
+        <translation type="unfinished">&amp;İsmarıcı doğrulayın...</translation>
+    </message>
+    <message>
+        <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
+        <translation>Göstərilmiş Bitcoin ünvanları ilə imzalandıqlarına əmin olmaq üçün ismarıcları doğrulayın</translation>
+    </message>
+    <message>
+        <source>&amp;Load PSBT from file…</source>
+        <translation type="unfinished">PSBT-i fayldan yük&amp;ləyin...</translation>
+    </message>
+    <message>
+        <source>Open &amp;URI…</source>
+        <translation type="unfinished">&amp;URI-ni açın</translation>
+    </message>
+    <message>
+        <source>Close Wallet…</source>
+        <translation type="unfinished">Cüzdanı bağlayın...</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation type="unfinished">Cüzdan yaradın...</translation>
+    </message>
+    <message>
+        <source>Close All Wallets…</source>
+        <translation type="unfinished">Bütün cüzdanları bağlayın...</translation>
+    </message>
+    <message>
+        <source>&amp;File</source>
+        <translation>&amp;Fayl</translation>
+    </message>
+    <message>
         <source>&amp;Settings</source>
         <translation>&amp;Tənzimləmələr</translation>
+    </message>
+    <message>
+        <source>&amp;Help</source>
+        <translation>&amp;Kömək</translation>
+    </message>
+    <message>
+        <source>Tabs toolbar</source>
+        <translation>Vərəq alətlər zolağı</translation>
+    </message>
+    <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation type="unfinished">Başlıqlar eyniləşdirilir (%1%)...</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation type="unfinished">İnternet şəbəkəsi ilə eyniləşdirmə...</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation type="unfinished">Bloklar diskdə indekslənir...</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation type="unfinished">Bloklar diskdə icra olunur...</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation type="unfinished">Bloklar diskdə təkrar indekslənir...</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation type="unfinished">İştirakçılara qoşulur...</translation>
+    </message>
+    <message>
+        <source>Request payments (generates QR codes and bitcoin: URIs)</source>
+        <translation type="unfinished">Ödəmə tələbi (QR-kodlar və Bitcoin URI-ləri yaradılır)^</translation>
+    </message>
+    <message>
+        <source>Show the list of used sending addresses and labels</source>
+        <translation type="unfinished">İstifadə olunmuş göndərmə ünvanlarının və etiketlərin siyahısını göstərmək </translation>
+    </message>
+    <message>
+        <source>Show the list of used receiving addresses and labels</source>
+        <translation type="unfinished">İstifadə edilmiş </translation>
+    </message>
+    <message>
+        <source>&amp;Command-line options</source>
+        <translation type="unfinished">Əmr &amp;sətri parametrləri</translation>
     </message>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
@@ -232,6 +524,22 @@ Daxil olma, yalnız 'qanuni' tipli ünvanlar ilə mümkündür.</translation>
             <numerusform />
             <numerusform />
         </translation>
+    </message>
+    <message>
+        <source>%1 behind</source>
+        <translation>%1 geridə qaldı</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation type="unfinished">Eyniləşir...</translation>
+    </message>
+    <message>
+        <source>Last received block was generated %1 ago.</source>
+        <translation>Sonuncu qəbul edilmiş blok %1 əvvəl yaradılıb.</translation>
+    </message>
+    <message>
+        <source>Transactions after this will not yet be visible.</source>
+        <translation>Bundan sonrakı köçürmələr hələlik görünməyəcək.</translation>
     </message>
     <message>
         <source>Error</source>
@@ -246,8 +554,88 @@ Daxil olma, yalnız 'qanuni' tipli ünvanlar ilə mümkündür.</translation>
         <translation>Məlumat</translation>
     </message>
     <message>
+        <source>Up to date</source>
+        <translation>Eyniləşdirildi</translation>
+    </message>
+    <message>
+        <source>Load Partially Signed Bitcoin Transaction</source>
+        <translation type="unfinished">Qismən imzalanmış Bitcoin köçürmələrini yükləyin</translation>
+    </message>
+    <message>
+        <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
+        <translation type="unfinished">Qismən İmzalanmış Bitcoin Köçürməsini (PSBT) mübadilə yaddaşından yükləmək</translation>
+    </message>
+    <message>
+        <source>Node window</source>
+        <translation type="unfinished">Qovşaq pəncərəsi</translation>
+    </message>
+    <message>
+        <source>Open node debugging and diagnostic console</source>
+        <translation type="unfinished">Qovşaq sazlaması və diaqnostika konsolunu açın</translation>
+    </message>
+    <message>
+        <source>&amp;Sending addresses</source>
+        <translation type="unfinished">&amp;Göndərmək üçün ünvanlar</translation>
+    </message>
+    <message>
+        <source>&amp;Receiving addresses</source>
+        <translation type="unfinished">&amp;Qəbul etmək üçün ünvanlar</translation>
+    </message>
+    <message>
+        <source>Open a bitcoin: URI</source>
+        <translation type="unfinished">Bitcoin açın: URI</translation>
+    </message>
+    <message>
+        <source>Open Wallet</source>
+        <translation type="unfinished">Cüzdanı açın</translation>
+    </message>
+    <message>
         <source>Open a wallet</source>
         <translation type="unfinished">Bir pulqabı aç</translation>
+    </message>
+    <message>
+        <source>Close wallet</source>
+        <translation type="unfinished">Cüzdanı bağlayın</translation>
+    </message>
+    <message>
+        <source>Close all wallets</source>
+        <translation type="unfinished">Bütün cüzdanları bağlayın</translation>
+    </message>
+    <message>
+        <source>Show the %1 help message to get a list with possible Bitcoin command-line options</source>
+        <translation type="unfinished">Mümkün Bitcoin əmr sətri əməliyyatları siyahısını almaq üçün %1 kömək ismarıcı göstərilsin</translation>
+    </message>
+    <message>
+        <source>&amp;Mask values</source>
+        <translation type="unfinished">&amp;Dəyərləri gizlədin</translation>
+    </message>
+    <message>
+        <source>Mask the values in the Overview tab</source>
+        <translation type="unfinished">İcmal vərəqində dəyərləri gizlədin</translation>
+    </message>
+    <message>
+        <source>default wallet</source>
+        <translation type="unfinished">standart cüzdan</translation>
+    </message>
+    <message>
+        <source>No wallets available</source>
+        <translation type="unfinished">Heç bir cüzdan yoxdur</translation>
+    </message>
+    <message>
+        <source>&amp;Window</source>
+        <translation type="unfinished">&amp;Pəncərə</translation>
+    </message>
+    <message>
+        <source>Zoom</source>
+        <translation type="unfinished">Miqyas</translation>
+    </message>
+    <message>
+        <source>Main Window</source>
+        <translation type="unfinished">Əsas pəncərə</translation>
+    </message>
+    <message>
+        <source>%1 client</source>
+        <translation type="unfinished">%1 müştəri</translation>
     </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
@@ -257,20 +645,371 @@ Daxil olma, yalnız 'qanuni' tipli ünvanlar ilə mümkündür.</translation>
             <numerusform />
         </translation>
     </message>
-    </context>
+    <message>
+        <source>Click for more actions.</source>
+        <extracomment>A substring of the tooltip. "More actions" are available via the context menu.</extracomment>
+        <translation type="unfinished">Daha çıx əməllər üçün vurun.</translation>
+    </message>
+    <message>
+        <source>Show Peers tab</source>
+        <extracomment>A context menu item. The "Peers tab" is an element of the "Node window".</extracomment>
+        <translation type="unfinished">İştirakşılar vərəqini göstərmək</translation>
+    </message>
+    <message>
+        <source>Disable network activity</source>
+        <extracomment>A context menu item.</extracomment>
+        <translation type="unfinished">Şəbəkə bağlantısını söndürün</translation>
+    </message>
+    <message>
+        <source>Enable network activity</source>
+        <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
+        <translation type="unfinished">Şəbəkə bağlantısını açın</translation>
+    </message>
+    <message>
+        <source>Error: %1</source>
+        <translation type="unfinished">XƏta: %1</translation>
+    </message>
+    <message>
+        <source>Warning: %1</source>
+        <translation type="unfinished">Xəbərdarlıq: %1</translation>
+    </message>
+    <message>
+        <source>Date: %1
+</source>
+        <translation type="unfinished">Tarix: %1
+</translation>
+    </message>
+    <message>
+        <source>Amount: %1
+</source>
+        <translation type="unfinished">Məbləğ: %1
+</translation>
+    </message>
+    <message>
+        <source>Wallet: %1
+</source>
+        <translation type="unfinished">Cüzdan: %1
+</translation>
+    </message>
+    <message>
+        <source>Type: %1
+</source>
+        <translation type="unfinished">Növ: %1
+</translation>
+    </message>
+    <message>
+        <source>Label: %1
+</source>
+        <translation type="unfinished">Yarlıq: %1
+</translation>
+    </message>
+    <message>
+        <source>Address: %1
+</source>
+        <translation type="unfinished">Ünvan: %1
+</translation>
+    </message>
+    <message>
+        <source>Sent transaction</source>
+        <translation>Köçürməni göndərin</translation>
+    </message>
+    <message>
+        <source>Incoming transaction</source>
+        <translation>Daxil </translation>
+    </message>
+    <message>
+        <source>HD key generation is &lt;b&gt;enabled&lt;/b&gt;</source>
+        <translation type="unfinished">HD açar yaradılması &lt;b&gt;aktivdir&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>HD key generation is &lt;b&gt;disabled&lt;/b&gt;</source>
+        <translation type="unfinished">HD açar yaradılması &lt;b&gt;söndürülüb</translation>
+    </message>
+    <message>
+        <source>Private key &lt;b&gt;disabled&lt;/b&gt;</source>
+        <translation type="unfinished">Məxfi açar &lt;b&gt;söndürülüb&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
+        <translation>Cüzdan &lt;b&gt;şifrələnib&lt;/b&gt; və hal-hazırda &lt;b&gt;kiliddən çıxarılıb&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
+        <translation>Cüzdan &lt;b&gt;şifrələnib&lt;/b&gt; və hal-hazırda &lt;b&gt;kiliddlənib&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Original message:</source>
+        <translation type="unfinished">Orijinal ismarıc:</translation>
+    </message>
+</context>
+<context>
+    <name>UnitDisplayStatusBarControl</name>
+    <message>
+        <source>Unit to show amounts in. Click to select another unit.</source>
+        <translation type="unfinished">Məbləğin vahidi. Başqa vahidi seçmək üçün vurun.</translation>
+    </message>
+</context>
 <context>
     <name>CoinControlDialog</name>
     <message>
+        <source>Coin Selection</source>
+        <translation type="unfinished">Pul seçimi</translation>
+    </message>
+    <message>
+        <source>Quantity:</source>
+        <translation type="unfinished">Miqdar:</translation>
+    </message>
+    <message>
+        <source>Bytes:</source>
+        <translation type="unfinished">Baytlar:</translation>
+    </message>
+    <message>
+        <source>Amount:</source>
+        <translation type="unfinished">Məbləğ:</translation>
+    </message>
+    <message>
+        <source>Fee:</source>
+        <translation type="unfinished">Komissiya:</translation>
+    </message>
+    <message>
+        <source>Dust:</source>
+        <translation type="unfinished">Toz:</translation>
+    </message>
+    <message>
+        <source>After Fee:</source>
+        <translation type="unfinished">Komissiydan sonra:</translation>
+    </message>
+    <message>
+        <source>Change:</source>
+        <translation type="unfinished">Qalıq:</translation>
+    </message>
+    <message>
+        <source>(un)select all</source>
+        <translation type="unfinished">seçim</translation>
+    </message>
+    <message>
+        <source>Tree mode</source>
+        <translation type="unfinished">Ağac rejimi</translation>
+    </message>
+    <message>
+        <source>List mode</source>
+        <translation type="unfinished">Siyahı rejim</translation>
+    </message>
+    <message>
+        <source>Amount</source>
+        <translation type="unfinished">Məbləğ</translation>
+    </message>
+    <message>
+        <source>Received with label</source>
+        <translation type="unfinished">Yarlıq ilə qəbul olundu</translation>
+    </message>
+    <message>
+        <source>Received with address</source>
+        <translation type="unfinished">Ünvan ilə alındı</translation>
+    </message>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">TArix</translation>
+    </message>
+    <message>
+        <source>Confirmations</source>
+        <translation type="unfinished">Təsdiqləmələr</translation>
+    </message>
+    <message>
+        <source>Confirmed</source>
+        <translation type="unfinished">Təsdiqləndi</translation>
+    </message>
+    <message>
+        <source>Copy amount</source>
+        <translation type="unfinished">Məbləği kopyalayın</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Ünvanı kopyalayın</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">&amp;Etiketi kopyalayın</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">&amp;Məbləği kopyalayın</translation>
+    </message>
+    <message>
+        <source>L&amp;ock unspent</source>
+        <translation type="unfinished">Xərclənməmiş qalığı &amp;kilidləyin</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock unspent</source>
+        <translation type="unfinished">Xərclənməmiş qalığı kilidd'n &amp;çıxarın</translation>
+    </message>
+    <message>
         <source>Copy quantity</source>
         <translation type="unfinished">Miqdarı kopyalayın</translation>
+    </message>
+    <message>
+        <source>Copy fee</source>
+        <translation type="unfinished">Komissiyanı kopyalayın</translation>
+    </message>
+    <message>
+        <source>Copy after fee</source>
+        <translation type="unfinished">Komissyadan sonra kopyalayın</translation>
+    </message>
+    <message>
+        <source>Copy bytes</source>
+        <translation type="unfinished">Baytları koyalayın</translation>
+    </message>
+    <message>
+        <source>Copy dust</source>
+        <translation type="unfinished">Tozu kopyalayın</translation>
     </message>
     <message>
         <source>Copy change</source>
         <translation type="unfinished">Dəyişikliyi kopyalayın</translation>
     </message>
     <message>
+        <source>(%1 locked)</source>
+        <translation type="unfinished">(%1 kilidləndi)</translation>
+    </message>
+    <message>
+        <source>yes</source>
+        <translation type="unfinished">bəli</translation>
+    </message>
+    <message>
+        <source>no</source>
+        <translation type="unfinished">xeyr</translation>
+    </message>
+    <message>
+        <source>This label turns red if any recipient receives an amount smaller than the current dust threshold.</source>
+        <translation type="unfinished">Əgər alıcı məbləği cari toz həddindən az alarsa bu etiket qırmızı olur.</translation>
+    </message>
+    <message>
+        <source>Can vary +/- %1 satoshi(s) per input.</source>
+        <translation type="unfinished">Hər daxilolmada +/- %1 satoşi dəyişə bilər.</translation>
+    </message>
+    <message>
         <source>(no label)</source>
         <translation type="unfinished">(etiket yoxdur)</translation>
+    </message>
+    <message>
+        <source>change from %1 (%2)</source>
+        <translation type="unfinished">bunlardan qalıq: %1 (%2)</translation>
+    </message>
+    <message>
+        <source>(change)</source>
+        <translation type="unfinished">(qalıq)</translation>
+    </message>
+</context>
+<context>
+    <name>CreateWalletActivity</name>
+    <message>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation type="unfinished">&lt;b&gt;%1&lt;/b&gt; cüzdanı yaradılır...</translation>
+    </message>
+    <message>
+        <source>Create wallet failed</source>
+        <translation type="unfinished">Cüzdan yaradıla bilmədi</translation>
+    </message>
+    <message>
+        <source>Create wallet warning</source>
+        <translation type="unfinished">Cüzdan yaradılma xəbərdarlı\ı</translation>
+    </message>
+    <message>
+        <source>Can't list signers</source>
+        <translation type="unfinished">İmzalaynları göstərmək mümkün deyil</translation>
+    </message>
+</context>
+<context>
+    <name>OpenWalletActivity</name>
+    <message>
+        <source>Open wallet failed</source>
+        <translation type="unfinished">Pulqabı açıla bilmədi</translation>
+    </message>
+    <message>
+        <source>Open wallet warning</source>
+        <translation type="unfinished">Pulqabının açılması xəbərdarlığı</translation>
+    </message>
+    <message>
+        <source>default wallet</source>
+        <translation type="unfinished">standart cüzdan</translation>
+    </message>
+    <message>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation type="unfinished">&lt;b&gt;%1&lt;/b&gt; pulqabı açılır...</translation>
+    </message>
+</context>
+<context>
+    <name>WalletController</name>
+    <message>
+        <source>Close wallet</source>
+        <translation type="unfinished">Cüzdanı bağlayın</translation>
+    </message>
+    <message>
+        <source>Are you sure you wish to close the wallet &lt;i&gt;%1&lt;/i&gt;?</source>
+        <translation type="unfinished">&lt;i&gt;%1&lt;/i&gt; pulqabını bağlamaq istədiyinizə əminsiniz?</translation>
+    </message>
+    <message>
+        <source>Closing the wallet for too long can result in having to resync the entire chain if pruning is enabled.</source>
+        <translation type="unfinished">Pulqabının uzun müddət bağlı qaldıqda əgər budama (azalma) aktiv olarsa bu, bütün zəncirin təkrar eyniləşditrilməsi ilə nəticələnə bilər.</translation>
+    </message>
+    <message>
+        <source>Close all wallets</source>
+        <translation type="unfinished">Bütün cüzdanları bağlayın</translation>
+    </message>
+    <message>
+        <source>Are you sure you wish to close all wallets?</source>
+        <translation type="unfinished">Bütün pulqabılarını bağlamaq istədiyinizə əminsiniz?</translation>
+    </message>
+</context>
+<context>
+    <name>CreateWalletDialog</name>
+    <message>
+        <source>Create Wallet</source>
+        <translation type="unfinished">Cüzdan yaradın</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <translation type="unfinished">Pulqabının adı</translation>
+    </message>
+    <message>
+        <source>Wallet</source>
+        <translation type="unfinished">Pulqabı</translation>
+    </message>
+    <message>
+        <source>Encrypt the wallet. The wallet will be encrypted with a passphrase of your choice.</source>
+        <translation type="unfinished">Pulqabının şifrələnməsi. Pulqabı sizin seçdiyiniz şifrəli söz ilə şifrələnəcək.</translation>
+    </message>
+    <message>
+        <source>Encrypt Wallet</source>
+        <translation type="unfinished">Pulqabını şifrələyin</translation>
+    </message>
+    <message>
+        <source>Advanced Options</source>
+        <translation type="unfinished">Əlavə parametrlər</translation>
+    </message>
+    <message>
+        <source>Disable private keys for this wallet. Wallets with private keys disabled will have no private keys and cannot have an HD seed or imported private keys. This is ideal for watch-only wallets.</source>
+        <translation type="unfinished">Bu pulqabının məxfi açarını söndürün. Məxfi açarı söndürülmüş pulqabılarında məxfi açarlar saxlanılmır, onlarda HD məxfi açarlar yaradıla bilıməz və məxfi açarlar idxal edilə bilməz. Bu sadəcə müşahidə edən pulqabıları üçün ideal variantdır.</translation>
+    </message>
+    <message>
+        <source>Disable Private Keys</source>
+        <translation type="unfinished">Məxfi açarları söndürün</translation>
+    </message>
+    <message>
+        <source>Make a blank wallet. Blank wallets do not initially have private keys or scripts. Private keys and addresses can be imported, or an HD seed can be set, at a later time.</source>
+        <translation type="unfinished">Boş pulqabı yaradın. Boş pulqabında ilkin olaraq açarlar və skriptlər yoxdur. Sonra məxfi açarlar və ünvanlar idxal edilə bilər və ya HD məxfi açarlar təyin edilə bilər.</translation>
+    </message>
+    <message>
+        <source>Make Blank Wallet</source>
+        <translation type="unfinished">Boş pulqabı yaradın</translation>
+    </message>
+    <message>
+        <source>Use descriptors for scriptPubKey management</source>
+        <translation type="unfinished">Publik açar skripti (scriptPubKey) idarəetməsi üçün diskreptorlardan itifadə edin</translation>
+    </message>
+    <message>
+        <source>Descriptor Wallet</source>
+        <translation type="unfinished">D</translation>
     </message>
     </context>
 <context>
@@ -303,6 +1042,10 @@ Daxil olma, yalnız 'qanuni' tipli ünvanlar ilə mümkündür.</translation>
         <translation>&amp;UPnP istifadə edən xəritə portu</translation>
     </message>
     <message>
+        <source>&amp;Window</source>
+        <translation>&amp;Pəncərə</translation>
+    </message>
+    <message>
         <source>The user interface language can be set here. This setting will take effect after restarting %1.</source>
         <translation type="unfinished">İstifadəçi interfeys dili burada tənzimlənə bilər. Bu tənzimləmə %1 yenidən başladıldıqdan sonra təsirli olacaq.</translation>
     </message>
@@ -325,9 +1068,43 @@ Daxil olma, yalnız 'qanuni' tipli ünvanlar ilə mümkündür.</translation>
         <source>&amp;Reset</source>
         <translation type="unfinished">&amp;Sıfırla</translation>
     </message>
+    <message>
+        <source>Node window</source>
+        <translation type="unfinished">Qovşaq pəncərəsi</translation>
+    </message>
+    </context>
+<context>
+    <name>ReceiveCoinsDialog</name>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Ünvanı kopyalayın</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">&amp;Etiketi kopyalayın</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">&amp;Məbləği kopyalayın</translation>
+    </message>
+    </context>
+<context>
+    <name>ReceiveRequestDialog</name>
+    <message>
+        <source>Amount:</source>
+        <translation type="unfinished">Məbləğ:</translation>
+    </message>
+    <message>
+        <source>Wallet:</source>
+        <translation type="unfinished">Cüzdan</translation>
+    </message>
     </context>
 <context>
     <name>RecentRequestsTableModel</name>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">TArix</translation>
+    </message>
     <message>
         <source>Label</source>
         <translation type="unfinished">Etiket</translation>
@@ -340,8 +1117,56 @@ Daxil olma, yalnız 'qanuni' tipli ünvanlar ilə mümkündür.</translation>
 <context>
     <name>SendCoinsDialog</name>
     <message>
+        <source>Quantity:</source>
+        <translation type="unfinished">Miqdar:</translation>
+    </message>
+    <message>
+        <source>Bytes:</source>
+        <translation type="unfinished">Baytlar:</translation>
+    </message>
+    <message>
+        <source>Amount:</source>
+        <translation type="unfinished">Məbləğ:</translation>
+    </message>
+    <message>
+        <source>Fee:</source>
+        <translation type="unfinished">Komissiya:</translation>
+    </message>
+    <message>
+        <source>After Fee:</source>
+        <translation type="unfinished">Komissiydan sonra:</translation>
+    </message>
+    <message>
+        <source>Change:</source>
+        <translation type="unfinished">Qalıq:</translation>
+    </message>
+    <message>
+        <source>Dust:</source>
+        <translation type="unfinished">Toz:</translation>
+    </message>
+    <message>
         <source>Copy quantity</source>
         <translation type="unfinished">Miqdarı kopyalayın</translation>
+    </message>
+    <message>
+        <source>Copy amount</source>
+        <translation type="unfinished">Məbləği kopyalayın</translation>
+    </message>
+    <message>
+        <source>Copy fee</source>
+        <translation type="unfinished">Komissiyanı kopyalayın</translation>
+    </message>
+    <message>
+        <source>Copy after fee</source>
+        <translation type="unfinished">Komissyadan sonra kopyalayın</translation>
+    </message>
+    <message>
+        <source>Copy bytes</source>
+        <translation type="unfinished">Baytları koyalayın</translation>
+    </message>
+    <message>
+        <source>Copy dust</source>
+        <translation type="unfinished">Tozu kopyalayın</translation>
     </message>
     <message>
         <source>Copy change</source>
@@ -368,6 +1193,10 @@ Daxil olma, yalnız 'qanuni' tipli ünvanlar ilə mümkündür.</translation>
             <numerusform />
         </translation>
     </message>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">TArix</translation>
+    </message>
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation>
@@ -375,9 +1204,17 @@ Daxil olma, yalnız 'qanuni' tipli ünvanlar ilə mümkündür.</translation>
             <numerusform />
         </translation>
     </message>
+    <message>
+        <source>Amount</source>
+        <translation type="unfinished">Məbləğ</translation>
+    </message>
     </context>
 <context>
     <name>TransactionTableModel</name>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">TArix</translation>
+    </message>
     <message>
         <source>Label</source>
         <translation type="unfinished">Etiket</translation>
@@ -401,6 +1238,31 @@ Daxil olma, yalnız 'qanuni' tipli ünvanlar ilə mümkündür.</translation>
         <translation type="unfinished">Başqa</translation>
     </message>
     <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Ünvanı kopyalayın</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">&amp;Etiketi kopyalayın</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">&amp;Məbləği kopyalayın</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See https://en.wikipedia.org/wiki/Comma-separated_values</extracomment>
+        <translation type="unfinished">Vergüllə ayrılmış fayl</translation>
+    </message>
+    <message>
+        <source>Confirmed</source>
+        <translation type="unfinished">Təsdiqləndi</translation>
+    </message>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">TArix</translation>
+    </message>
+    <message>
         <source>Label</source>
         <translation type="unfinished">Etiket</translation>
     </message>
@@ -413,6 +1275,20 @@ Daxil olma, yalnız 'qanuni' tipli ünvanlar ilə mümkündür.</translation>
         <translation type="unfinished">İxrac edilmədi</translation>
     </message>
     </context>
+<context>
+    <name>WalletFrame</name>
+    <message>
+        <source>Create a new wallet</source>
+        <translation type="unfinished">Yeni cüzdan yaradın</translation>
+    </message>
+</context>
+<context>
+    <name>WalletModel</name>
+    <message>
+        <source>default wallet</source>
+        <translation type="unfinished">standart cüzdan</translation>
+    </message>
+</context>
 <context>
     <name>WalletView</name>
     <message>

--- a/src/qt/locale/bitcoin_bg.ts
+++ b/src/qt/locale/bitcoin_bg.ts
@@ -66,6 +66,11 @@
         <translation type="unfinished">Тези са вашите Биткойн адреси за изпращане на монети. Винаги проверявайте количеството и получаващия адрес преди изпращане. </translation>
     </message>
     <message>
+        <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
+Signing is only possible with addresses of the type 'legacy'.</source>
+        <translation type="unfinished">създавам</translation>
+    </message>
+    <message>
         <source>&amp;Copy Address</source>
         <translation type="unfinished">Копирай адрес</translation>
     </message>
@@ -161,6 +166,10 @@
         <translation type="unfinished">портфейлa е шифрован</translation>
     </message>
     <message>
+        <source>Enter the new passphrase for the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
+        <translation type="unfinished">Въведете нова пасфраза за уолета.&lt;br/&gt;Моля използвайте пасфраза от &lt;b&gt;десет или повече произволни символа &lt;/b&gt;, или &lt;b&gt;осем или повече думи&lt;/b&gt;.</translation>
+    </message>
+    <message>
         <source>Enter the old passphrase and new passphrase for the wallet.</source>
         <translation type="unfinished">Въведете старата и новата паролна фраза за портфейла.</translation>
     </message>
@@ -221,10 +230,29 @@
     </message>
 </context>
 <context>
+    <name>BitcoinApplication</name>
+    <message>
+        <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
+        <translation type="unfinished">Фатална грешка се появи. %1 не може да продължи безопастно и ще се затвори.</translation>
+    </message>
+    <message>
+        <source>Internal error</source>
+        <translation type="unfinished">Вътрешна грешка.</translation>
+    </message>
+    </context>
+<context>
     <name>QObject</name>
     <message>
         <source>Error: Specified data directory "%1" does not exist.</source>
         <translation type="unfinished">Грешка:Избраната "%1" директория не съществува.</translation>
+    </message>
+    <message>
+        <source>Error: %1</source>
+        <translation type="unfinished">Грешка: %1</translation>
+    </message>
+    <message>
+        <source>%1 didn't yet exit safely…</source>
+        <translation type="unfinished">%1 не излезе безопасно…</translation>
     </message>
     <message>
         <source>unknown</source>
@@ -393,6 +421,10 @@
         <translation type="unfinished">Мрежата деактивирана</translation>
     </message>
     <message>
+        <source>Proxy is &lt;b&gt;enabled&lt;/b&gt;: %1</source>
+        <translation type="unfinished">Прокси е &lt;b&gt;разрешено&lt;/b&gt;: %1</translation>
+    </message>
+    <message>
         <source>Send coins to a Bitcoin address</source>
         <translation>Изпращане към Биткоин адрес</translation>
     </message>
@@ -413,6 +445,10 @@
         <translation>&amp;получавам</translation>
     </message>
     <message>
+        <source>&amp;Options…</source>
+        <translation type="unfinished">&amp;Опции</translation>
+    </message>
+    <message>
         <source>&amp;Show / Hide</source>
         <translation>&amp;Показване / Скриване</translation>
     </message>
@@ -421,16 +457,44 @@
         <translation>Показване и скриване на основния прозорец</translation>
     </message>
     <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation type="unfinished">&amp;Крипритай уолет..</translation>
+    </message>
+    <message>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>Шифроване на личните ключове,които принадлежат на портфейла Ви.</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation type="unfinished">&amp;Бекъп уолет.</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation type="unfinished">&amp;Промени пасфрейз.</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation type="unfinished">Подпиши &amp;съобщение…</translation>
     </message>
     <message>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation>Пишете съобщения със своя Биткойн адрес за да докажете,че е ваш.</translation>
     </message>
     <message>
+        <source>&amp;Verify message…</source>
+        <translation type="unfinished">&amp;Потвърди съобщение…</translation>
+    </message>
+    <message>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation>Потвърждаване на съобщения  за да се знае,че са написани с дадените Биткойн адреси.</translation>
+    </message>
+    <message>
+        <source>&amp;Load PSBT from file…</source>
+        <translation type="unfinished">&amp;Зареди PSBT от файл…</translation>
+    </message>
+    <message>
+        <source>Close All Wallets…</source>
+        <translation type="unfinished">Затвори всички уолети</translation>
     </message>
     <message>
         <source>&amp;File</source>
@@ -447,6 +511,10 @@
     <message>
         <source>Tabs toolbar</source>
         <translation>Лентата с инструменти</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation type="unfinished">Синхронизиране с мрежа</translation>
     </message>
     <message>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
@@ -508,6 +576,10 @@
         <translation type="unfinished">Отворете портфейл</translation>
     </message>
     <message>
+        <source>Open a wallet</source>
+        <translation type="unfinished">Отвори портфейл</translation>
+    </message>
+    <message>
         <source>Close wallet</source>
         <translation type="unfinished">Затвори портфейла</translation>
     </message>
@@ -522,6 +594,10 @@
     <message>
         <source>default wallet</source>
         <translation type="unfinished">Портфейл по подразбиране</translation>
+    </message>
+    <message>
+        <source>No wallets available</source>
+        <translation type="unfinished">Няма достъпни портфейли</translation>
     </message>
     <message>
         <source>&amp;Window</source>
@@ -552,6 +628,29 @@
         </translation>
     </message>
     <message>
+        <source>Click for more actions.</source>
+        <extracomment>A substring of the tooltip. "More actions" are available via the context menu.</extracomment>
+        <translation type="unfinished">Клик за повече действия</translation>
+    </message>
+    <message>
+        <source>Disable network activity</source>
+        <extracomment>A context menu item.</extracomment>
+        <translation type="unfinished">Блокирай мрежова активност</translation>
+    </message>
+    <message>
+        <source>Enable network activity</source>
+        <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
+        <translation type="unfinished">Разреши мрежова активност</translation>
+    </message>
+    <message>
+        <source>Error: %1</source>
+        <translation type="unfinished">Грешка: %1</translation>
+    </message>
+    <message>
+        <source>Warning: %1</source>
+        <translation type="unfinished">Внимание: %1</translation>
+    </message>
+    <message>
         <source>Date: %1
 </source>
         <translation type="unfinished">Дата: %1
@@ -562,6 +661,11 @@
 </source>
         <translation type="unfinished">Сума: %1
 </translation>
+    </message>
+    <message>
+        <source>Wallet: %1
+</source>
+        <translation type="unfinished">Портфейл: %1</translation>
     </message>
     <message>
         <source>Type: %1
@@ -590,6 +694,18 @@
         <translation>Входяща транзакция</translation>
     </message>
     <message>
+        <source>HD key generation is &lt;b&gt;enabled&lt;/b&gt;</source>
+        <translation type="unfinished">Генерирането на HD ключ е &lt;b&gt;разрешено&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>HD key generation is &lt;b&gt;disabled&lt;/b&gt;</source>
+        <translation type="unfinished">Генерирането на HD ключ е &lt;b&gt;изключено&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Private key &lt;b&gt;disabled&lt;/b&gt;</source>
+        <translation type="unfinished">Частнен ключ&lt;b&gt;изключен&lt;/b&gt;</translation>
+    </message>
+    <message>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>Портфейлът е &lt;b&gt;криптиран&lt;/b&gt; и &lt;b&gt;отключен&lt;/b&gt;</translation>
     </message>
@@ -597,7 +713,11 @@
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Портфейлът е &lt;b&gt;криптиран&lt;/b&gt; и &lt;b&gt;заключен&lt;/b&gt;</translation>
     </message>
-    </context>
+    <message>
+        <source>Original message:</source>
+        <translation type="unfinished">Оригинално съобщение:</translation>
+    </message>
+</context>
 <context>
     <name>CoinControlDialog</name>
     <message>
@@ -673,6 +793,22 @@
         <translation type="unfinished">Копиране на сумата</translation>
     </message>
     <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Копирай адрес</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Копирай сума</translation>
+    </message>
+    <message>
+        <source>L&amp;ock unspent</source>
+        <translation type="unfinished">Заключи неизхарчено</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock unspent</source>
+        <translation type="unfinished">Отключи неизхарчено</translation>
+    </message>
+    <message>
         <source>Copy quantity</source>
         <translation type="unfinished">Копиране на количеството</translation>
     </message>
@@ -713,6 +849,10 @@
         <translation type="unfinished">Този етикет става червен ако някой получател получи количество, по-малко от текущия праг на прах</translation>
     </message>
     <message>
+        <source>Can vary +/- %1 satoshi(s) per input.</source>
+        <translation type="unfinished">Може да варира с +/- %1 байт(а).</translation>
+    </message>
+    <message>
         <source>(no label)</source>
         <translation type="unfinished">(без етикет)</translation>
     </message>
@@ -728,12 +868,20 @@
 <context>
     <name>CreateWalletActivity</name>
     <message>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation type="unfinished">Създаване на уолет 1 1%1 1</translation>
+    </message>
+    <message>
         <source>Create wallet failed</source>
         <translation type="unfinished">Създаването на портфейл не бе успешен</translation>
     </message>
     </context>
 <context>
     <name>OpenWalletActivity</name>
+    <message>
+        <source>Open wallet failed</source>
+        <translation type="unfinished">Отварянето на уолет неупсешно</translation>
+    </message>
     <message>
         <source>default wallet</source>
         <translation type="unfinished">Портфейл по подразбиране</translation>
@@ -757,8 +905,20 @@
         <translation type="unfinished">Създайте портфейл</translation>
     </message>
     <message>
+        <source>Wallet Name</source>
+        <translation type="unfinished">Име на портфейл</translation>
+    </message>
+    <message>
         <source>Wallet</source>
         <translation type="unfinished">портфейл</translation>
+    </message>
+    <message>
+        <source>Encrypt Wallet</source>
+        <translation type="unfinished">Криптирай портфейла</translation>
+    </message>
+    <message>
+        <source>Create</source>
+        <translation type="unfinished">Създай</translation>
     </message>
     </context>
 <context>
@@ -854,6 +1014,10 @@
         </translation>
     </message>
     <message>
+        <source>%1 will download and store a copy of the Bitcoin block chain.</source>
+        <translation type="unfinished">%1 ще свали и съхрани копие на биткойн блокчейна.</translation>
+    </message>
+    <message>
         <source>Error</source>
         <translation>грешка</translation>
     </message>
@@ -868,6 +1032,10 @@
     <message>
         <source>As this is the first time the program is launched, you can choose where %1 will store its data.</source>
         <translation type="unfinished">Програмата се стартира за първи път вие може да изберете къде %1 ще се запаметят данните.</translation>
+    </message>
+    <message>
+        <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
+        <translation type="unfinished">Първоначалната синхронизация е изключително взискателна, и може да разкрие хардуерни проблеми с вашия компютър, които до сега са били незабелязани. Всеки път, когато включите %1,  свалянето ще започне от където е приключило.</translation>
     </message>
     <message>
         <source>Use the default data directory</source>
@@ -1228,6 +1396,10 @@
         <translation type="unfinished">Грешка при създаването на QR Code от URI.</translation>
     </message>
     <message>
+        <source>QR code support not available.</source>
+        <translation type="unfinished">QR код подръжка не е достъпна.</translation>
+    </message>
+    <message>
         <source>Save QR Code</source>
         <translation type="unfinished">Запази QR Код</translation>
     </message>
@@ -1267,6 +1439,18 @@
         <translation>Брой връзки</translation>
     </message>
     <message>
+        <source>Block chain</source>
+        <translation>Блокчейн</translation>
+    </message>
+    <message>
+        <source>Memory usage</source>
+        <translation type="unfinished">Използвана памет</translation>
+    </message>
+    <message>
+        <source>Wallet: </source>
+        <translation type="unfinished">Портфейл:</translation>
+    </message>
+    <message>
         <source>Received</source>
         <translation type="unfinished">Получени</translation>
     </message>
@@ -1287,12 +1471,24 @@
         <translation type="unfinished">Версия</translation>
     </message>
     <message>
+        <source>Synced Blocks</source>
+        <translation type="unfinished">Синхронизирани блокове</translation>
+    </message>
+    <message>
         <source>User Agent</source>
         <translation type="unfinished">Потребителски агент</translation>
     </message>
     <message>
         <source>Node window</source>
         <translation type="unfinished">Прозорец на възела</translation>
+    </message>
+    <message>
+        <source>Decrease font size</source>
+        <translation type="unfinished">Намали размера на шрифта</translation>
+    </message>
+    <message>
+        <source>Permissions</source>
+        <translation type="unfinished">Разрешения</translation>
     </message>
     <message>
         <source>Services</source>
@@ -1349,6 +1545,10 @@
     <message>
         <source>Out:</source>
         <translation type="unfinished">Изходящи</translation>
+    </message>
+    <message>
+        <source>Executing command without any wallet</source>
+        <translation type="unfinished">Извършване на команда без портфейл</translation>
     </message>
     <message>
         <source>via %1</source>
@@ -1420,6 +1620,14 @@
     <message>
         <source>Copy &amp;URI</source>
         <translation type="unfinished">Копиране на &amp;URI</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Копирай адрес</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Копирай сума</translation>
     </message>
     <message>
         <source>Could not unlock wallet.</source>
@@ -1693,6 +1901,10 @@
         <translation type="unfinished">Премахване на този запис</translation>
     </message>
     <message>
+        <source>Use available balance</source>
+        <translation type="unfinished">Ползвай достъпен баланс</translation>
+    </message>
+    <message>
         <source>Message:</source>
         <translation type="unfinished">Съобщение:</translation>
     </message>
@@ -1824,6 +2036,10 @@
     <message>
         <source>Open until %1</source>
         <translation type="unfinished">Подлежи на промяна до %1</translation>
+    </message>
+    <message>
+        <source>0/unconfirmed, %1</source>
+        <translation type="unfinished">0/непотвърдено, %1</translation>
     </message>
     <message>
         <source>%1/unconfirmed</source>
@@ -2093,6 +2309,14 @@
         <translation type="unfinished">Минимална сума</translation>
     </message>
     <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Копирай адрес</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Копирай сума</translation>
+    </message>
+    <message>
         <source>Export Transaction History</source>
         <translation type="unfinished">Изнасяне историята на транзакциите</translation>
     </message>
@@ -2178,6 +2402,10 @@
         <translation type="unfinished">грешка</translation>
     </message>
     <message>
+        <source>Partially Signed Transaction (*.psbt)</source>
+        <translation type="unfinished">Частично Подписана Транзакция (*.psbt)</translation>
+    </message>
+    <message>
         <source>Backup Wallet</source>
         <translation type="unfinished">Запазване на портфейла</translation>
     </message>
@@ -2200,6 +2428,10 @@
     </context>
 <context>
     <name>bitcoin-core</name>
+    <message>
+        <source>Config setting for %s only applied on %s network when in [%s] section.</source>
+        <translation type="unfinished">Конфигурирай настройки за %s само когато са приложени на %s мрежа, когато са в [%s] секция.</translation>
+    </message>
     <message>
         <source>Do you want to rebuild the block database now?</source>
         <translation type="unfinished">Желаете ли да пресъздадете базата данни с блокове сега?</translation>

--- a/src/qt/locale/bitcoin_bn.ts
+++ b/src/qt/locale/bitcoin_bn.ts
@@ -1,0 +1,331 @@
+<TS version="2.1" language="bn">
+<context>
+    <name>AddressBookPage</name>
+    <message>
+        <source>Right-click to edit address or label</source>
+        <translation type="unfinished">ঠিকানা বা লেবেল পরিবর্তন করতে ডান ক্লিক করুন।</translation>
+    </message>
+    <message>
+        <source>Create a new address</source>
+        <translation>নতুন একটি ঠিকানা তৈরি করুন</translation>
+    </message>
+    <message>
+        <source>&amp;New</source>
+        <translation type="unfinished">নতুন</translation>
+    </message>
+    <message>
+        <source>Copy the currently selected address to the system clipboard</source>
+        <translation>বর্তমানে নির্বাচিত ঠিকানাটি সিস্টেম ক্লিপবোর্ডে কপি করুন</translation>
+    </message>
+    <message>
+        <source>&amp;Copy</source>
+        <translation type="unfinished">&amp;কপি</translation>
+    </message>
+    <message>
+        <source>C&amp;lose</source>
+        <translation type="unfinished">বন্ধ করুন</translation>
+    </message>
+    <message>
+        <source>Delete the currently selected address from the list</source>
+        <translation>বাছাইকৃত ঠিকানাটি লিস্ট থেকে মুছুন</translation>
+    </message>
+    <message>
+        <source>Enter address or label to search</source>
+        <translation type="unfinished">খুঁজতে ঠিকানা বা লেবেল লিখুন</translation>
+    </message>
+    <message>
+        <source>&amp;Delete</source>
+        <translation>&amp;মুছুন</translation>
+    </message>
+    <message>
+        <source>Choose the address to send coins to</source>
+        <translation type="unfinished">কয়েন পাঠানোর ঠিকানা বাছাই করুন</translation>
+    </message>
+    <message>
+        <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
+Signing is only possible with addresses of the type 'legacy'.</source>
+        <translation type="unfinished">পেমেন্ট পাওয়ার জন্য এটি আপনার বিটকয়েন ঠিকানা। নতুন ঠিকানা তৈরী করতে "নতুন গ্রহণের ঠিকানা তৈরী করুন" বোতাম ব্যবহার করুন। সাইন ইন করা শুধুমাত্র "উত্তরাধিকার" ঠিকানার মাধ্যমেই সম্ভব।</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See https://en.wikipedia.org/wiki/Comma-separated_values</extracomment>
+        <translation type="unfinished">কমা দিয়ে আলাদা করা ফাইল</translation>
+    </message>
+    </context>
+<context>
+    <name>BitcoinApplication</name>
+    <message>
+        <source>Runaway exception</source>
+        <translation type="unfinished">পলাতক ব্যতিক্রম</translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
+        <translation type="unfinished">একটি মারাত্মক ত্রুটি ঘটেছে।%1 নিরাপদে চলতে পারবেনা এবং প্রস্থান করবে</translation>
+    </message>
+    <message>
+        <source>Internal error</source>
+        <translation type="unfinished">অভ্যন্তরীণ ত্রুটি</translation>
+    </message>
+    <message>
+        <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
+        <translation type="unfinished">একটি অভ্যন্তরীণ ত্রুটি ঘটেছে। %1 নিরাপদে চালিয়ে যাওয়ার চেষ্টা করবে। এটি একটি অপ্রত্যাশিত বাগ যা নীচের বর্ণনা অনুযায়ী রিপোর্ট করা যেতে পারে৷</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <source>Error initializing settings: %1</source>
+        <translation type="unfinished">সেটিংস শুরু করা যাচ্ছে না: %1</translation>
+    </message>
+    <message>
+        <source>%1 didn't yet exit safely…</source>
+        <translation type="unfinished">%1 এখনো নিরাপদে বের হয়নি</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n second(s)</source>
+        <translation>
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n minute(s)</source>
+        <translation>
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n week(s)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n year(s)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    </context>
+<context>
+    <name>BitcoinGUI</name>
+    <message>
+        <source>&amp;Options…</source>
+        <translation type="unfinished">&amp;বিকল্প...</translation>
+    </message>
+    <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation type="unfinished">&amp;ওয়ালেট এনক্রিপ্ট করুন...</translation>
+    </message>
+    <message>
+        <source>Close Wallet…</source>
+        <translation type="unfinished">ওয়ালেট বন্ধ করুন...</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation type="unfinished">ওয়ালেট তৈরী করুন...</translation>
+    </message>
+    <message>
+        <source>Close All Wallets…</source>
+        <translation type="unfinished">সব ওয়ালেট গুলো বন্ধ করুন...</translation>
+    </message>
+    <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation type="unfinished">শিরোনাম সিঙ্ক করা হচ্ছে (%1%)...</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation type="unfinished">নেটওয়ার্কের সাথে সিঙ্ক্রোনাইজ করা হচ্ছে...</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation type="unfinished">ডিস্ক এ ব্লকস ইনডেক্স করা হচ্ছে...</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation type="unfinished">ডিস্কে ব্লক প্রসেস করা হচ্ছে...</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation type="unfinished">ডিস্ক এ ব্লকস পুনর্বিন্যাস করা হচ্ছে...</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation type="unfinished">সহকর্মীদের সাথে সংযোগ করা হচ্ছে...</translation>
+    </message>
+    <message numerus="yes">
+        <source>Processed %n block(s) of transaction history.</source>
+        <translation>
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message>
+        <source>Load Partially Signed Bitcoin Transaction</source>
+        <translation type="unfinished">আংশিক স্বাক্ষরিত বিটকয়েন লেনদেন লোড করুন</translation>
+    </message>
+    <message>
+        <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
+        <translation type="unfinished">ক্লিপবোর্ড থেকে আংশিক স্বাক্ষরিত বিটকয়েন লেনদেন লোড করুন</translation>
+    </message>
+    <message>
+        <source>Close all wallets</source>
+        <translation type="unfinished">সব ওয়ালেটগুলি  বেছে নিন </translation>
+    </message>
+    <message>
+        <source>&amp;Mask values</source>
+        <translation type="unfinished">অক্ষরগুলি আড়াল করুন </translation>
+    </message>
+    <message>
+        <source>Mask the values in the Overview tab</source>
+        <translation type="unfinished">ওভারভিউ ট্যাবে মানগুলি আড়াল করুন</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n active connection(s) to Bitcoin network.</source>
+        <extracomment>A substring of the tooltip.</extracomment>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    </context>
+<context>
+    <name>WalletController</name>
+    <message>
+        <source>Close all wallets</source>
+        <translation type="unfinished">সব ওয়ালেটগুলি  বেছে নিন </translation>
+    </message>
+    <message>
+        <source>Are you sure you wish to close all wallets?</source>
+        <translation type="unfinished">আপনি কি নিশ্চিত যে আপনি সমস্ত ওয়ালেট বন্ধ করতে চান?</translation>
+    </message>
+</context>
+<context>
+    <name>CreateWalletDialog</name>
+    <message>
+        <source>Advanced Options</source>
+        <translation type="unfinished">উন্নত বিকল্প </translation>
+    </message>
+    <message>
+        <source>Use descriptors for scriptPubKey management</source>
+        <translation type="unfinished">ScriptPub-এর জন্য বর্ণনাকারীর ব্যবস্থা করুন 
+ </translation>
+    </message>
+    <message>
+        <source>Descriptor Wallet</source>
+        <translation type="unfinished">বর্ণনাকারী ওয়ালেট </translation>
+    </message>
+    <message>
+        <source>Compiled without sqlite support (required for descriptor wallets)</source>
+        <translation type="unfinished">sqlite সমর্থন ছাড়াই সংকলিত (বরণাকারী  ওয়ালেটের জন্য প্রয়োজনীয়)</translation>
+    </message>
+    </context>
+<context>
+    <name>Intro</name>
+    <message numerus="yes">
+        <source>(sufficient to restore backups %n day(s) old)</source>
+        <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    </context>
+<context>
+    <name>SendCoinsDialog</name>
+    <message numerus="yes">
+        <source>Estimated to begin confirmation within %n block(s).</source>
+        <translation>
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    </context>
+<context>
+    <name>TransactionDesc</name>
+    <message numerus="yes">
+        <source>Open for %n more block(s)</source>
+        <translation>
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>matures in %n more block(s)</source>
+        <translation>
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    </context>
+<context>
+    <name>TransactionTableModel</name>
+    <message numerus="yes">
+        <source>Open for %n more block(s)</source>
+        <translation>
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    </context>
+<context>
+    <name>TransactionView</name>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See https://en.wikipedia.org/wiki/Comma-separated_values</extracomment>
+        <translation type="unfinished">কমা দিয়ে আলাদা করা ফাইল</translation>
+    </message>
+    </context>
+<context>
+    <name>bitcoin-core</name>
+    <message>
+        <source>SQLiteDatabase: Unexpected application id. Expected %u, got %u</source>
+        <translation type="unfinished">এস. কিয়ু. লাইট ডাটাবেস : অপ্রত্যাশিত এপ্লিকেশন আই.ডি. প্রত্যাশিত %u, পাওয়া গেলো %u </translation>
+    </message>
+    <message>
+        <source>Starting network threads…</source>
+        <translation type="unfinished">নেটওয়ার্ক থ্রেড শুরু হচ্ছে...</translation>
+    </message>
+    <message>
+        <source>The specified config file %s does not exist</source>
+        <translation type="unfinished">নির্দিষ্ট কনফিগ ফাইল %s এর অস্তিত্ব নেই</translation>
+    </message>
+    <message>
+        <source>Transaction needs a change address, but we can't generate it. %s</source>
+        <translation type="unfinished">লেনদেনের জন্যে একটি পরিবর্তন ঠিকানা প্রয়োজন, কিন্তু আমরা সেটি তৈরি করতে পারছি না। %s</translation>
+    </message>
+    <message>
+        <source>Unable to open %s for writing</source>
+        <translation type="unfinished">লেখার জন্যে %s খোলা যাচ্ছে না</translation>
+    </message>
+    <message>
+        <source>Unknown new rules activated (versionbit %i)</source>
+        <translation type="unfinished">অজানা নতুন নিয়ম সক্রিয় হলো (ভার্শনবিট %i)</translation>
+    </message>
+    <message>
+        <source>Verifying blocks…</source>
+        <translation type="unfinished">ব্লকস যাচাই করা হচ্ছে...</translation>
+    </message>
+    <message>
+        <source>Verifying wallet(s)…</source>
+        <translation type="unfinished">ওয়ালেট(স) যাচাই করা হচ্ছে...</translation>
+    </message>
+    </context>
+</TS>

--- a/src/qt/locale/bitcoin_bs.ts
+++ b/src/qt/locale/bitcoin_bs.ts
@@ -241,6 +241,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>BitcoinApplication</name>
     <message>
+        <source>Runaway exception</source>
+        <translation type="unfinished">Odbegli izuzetak</translation>
+    </message>
+    <message>
         <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
         <translation type="unfinished">Dogodila se fatalna greška. %1 više ne može sigurno nastaviti i prestat će raditi.</translation>
     </message>
@@ -270,6 +274,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Error initializing settings: %1</source>
         <translation type="unfinished">Greška prilikom inicijalizacije postavki: %1</translation>
+    </message>
+    <message>
+        <source>%1 didn't yet exit safely…</source>
+        <translation type="unfinished">%1 još nije sigurno izašao...</translation>
     </message>
     <message>
         <source>unknown</source>
@@ -347,6 +355,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation>Pregledajte historiju transakcija</translation>
     </message>
     <message>
+        <source>E&amp;xit</source>
+        <translation>&amp;Izlaz</translation>
+    </message>
+    <message>
         <source>Quit application</source>
         <translation>Zatvori aplikaciju</translation>
     </message>
@@ -408,6 +420,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation>&amp;Primite</translation>
     </message>
     <message>
+        <source>&amp;Options…</source>
+        <translation type="unfinished">&amp;Opcije…</translation>
+    </message>
+    <message>
         <source>&amp;Show / Hide</source>
         <translation>&amp;Prikaži / Sakrij</translation>
     </message>
@@ -428,6 +444,18 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation>Potvrdite poruke kako biste bili sigurni da su potpisane navedenim Bitcoin adresama</translation>
     </message>
     <message>
+        <source>Close Wallet…</source>
+        <translation type="unfinished">Zatvori novčanik...</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation type="unfinished">Napravi novčanik...</translation>
+    </message>
+    <message>
+        <source>Close All Wallets…</source>
+        <translation type="unfinished">Zatvori sve novčanike...</translation>
+    </message>
+    <message>
         <source>&amp;File</source>
         <translation>&amp;Datoteka</translation>
     </message>
@@ -442,6 +470,22 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Tabs toolbar</source>
         <translation>Alatna traka kartica</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation type="unfinished">Sinhronizacija sa mrežom...</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation type="unfinished">Indeksiraju se blokovi na disku...</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation type="unfinished">Procesuiraju se blokovi na disku...</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation type="unfinished">Reindekiraju se blokovi na disku...</translation>
     </message>
     <message>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
@@ -583,6 +627,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
             <numerusform />
             <numerusform />
         </translation>
+    </message>
+    <message>
+        <source>Click for more actions.</source>
+        <extracomment>A substring of the tooltip. "More actions" are available via the context menu.</extracomment>
+        <translation type="unfinished">Klikni za još radnji</translation>
+    </message>
+    <message>
+        <source>Disable network activity</source>
+        <extracomment>A context menu item.</extracomment>
+        <translation type="unfinished">Onemogući rad mreže</translation>
     </message>
     <message>
         <source>Error: %1</source>
@@ -1501,4 +1555,187 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Greška</translation>
     </message>
     </context>
+<context>
+    <name>bitcoin-core</name>
+    <message>
+        <source>Replaying blocks…</source>
+        <translation type="unfinished">Reprodukcija blokova…</translation>
+    </message>
+    <message>
+        <source>Rescanning…</source>
+        <translation type="unfinished">Ponovno skeniranje…</translation>
+    </message>
+    <message>
+        <source>SQLiteDatabase: Failed to execute statement to verify database: %s</source>
+        <translation type="unfinished">SQLiteDatabase: Izvršenje naredbe za provjeru baze podataka nije uspjelo: %s</translation>
+    </message>
+    <message>
+        <source>SQLiteDatabase: Failed to prepare statement to verify database: %s</source>
+        <translation type="unfinished">SQLiteDatabase: Nije uspjela priprema naredbe za provjeru baze podataka: %s</translation>
+    </message>
+    <message>
+        <source>SQLiteDatabase: Failed to read database verification error: %s</source>
+        <translation type="unfinished">SQLiteDatabase: Neuspjelo čitanje greške verifikacije baze podataka: %s</translation>
+    </message>
+    <message>
+        <source>SQLiteDatabase: Unexpected application id. Expected %u, got %u</source>
+        <translation type="unfinished">SQLiteDatabase: Neočekivani ID aplikacije. Ocekivao %u, dobio %u</translation>
+    </message>
+    <message>
+        <source>Section [%s] is not recognized.</source>
+        <translation type="unfinished">Odjeljak [%s] nije prepoznat.</translation>
+    </message>
+    <message>
+        <source>Signing transaction failed</source>
+        <translation type="unfinished">Potpisivanje transakcije nije uspjelo</translation>
+    </message>
+    <message>
+        <source>Specified -walletdir "%s" does not exist</source>
+        <translation type="unfinished">Navedeni -walletdir "%s" ne postoji</translation>
+    </message>
+    <message>
+        <source>Specified -walletdir "%s" is a relative path</source>
+        <translation type="unfinished">Navedeni -walletdir "%s" je relativna putanja</translation>
+    </message>
+    <message>
+        <source>Specified -walletdir "%s" is not a directory</source>
+        <translation type="unfinished">Navedeni -walletdir "%s" nije direktorij</translation>
+    </message>
+    <message>
+        <source>Specified blocks directory "%s" does not exist.</source>
+        <translation type="unfinished">Navedeni direktorij blokova "%s" ne postoji.</translation>
+    </message>
+    <message>
+        <source>Starting network threads…</source>
+        <translation type="unfinished">Pokretanje mrežnih niti…</translation>
+    </message>
+    <message>
+        <source>The source code is available from %s.</source>
+        <translation type="unfinished">Izvorni kod je dostupan od %s.</translation>
+    </message>
+    <message>
+        <source>The specified config file %s does not exist</source>
+        <translation type="unfinished">Navedena konfiguracijska datoteka %s ne postoji</translation>
+    </message>
+    <message>
+        <source>The transaction amount is too small to pay the fee</source>
+        <translation type="unfinished">Iznos transakcije je premali za plaćanje naknade</translation>
+    </message>
+    <message>
+        <source>The wallet will avoid paying less than the minimum relay fee.</source>
+        <translation type="unfinished">Novčanik će izbjeći plaćanje manje od minimalne relejne naknade.</translation>
+    </message>
+    <message>
+        <source>This is experimental software.</source>
+        <translation type="unfinished">Ovo je eksperimentalni softver.</translation>
+    </message>
+    <message>
+        <source>This is the minimum transaction fee you pay on every transaction.</source>
+        <translation type="unfinished">Ovo je minimalna naknada za transakciju koju plaćate za svaku transakciju.</translation>
+    </message>
+    <message>
+        <source>This is the transaction fee you will pay if you send a transaction.</source>
+        <translation type="unfinished">Ovo je naknada za transakciju koju ćete platiti ako pošaljete transakciju.</translation>
+    </message>
+    <message>
+        <source>Transaction amount too small</source>
+        <translation type="unfinished">Iznos transakcije je premali</translation>
+    </message>
+    <message>
+        <source>Transaction amounts must not be negative</source>
+        <translation type="unfinished">Iznosi transakcija ne smiju biti negativni</translation>
+    </message>
+    <message>
+        <source>Transaction has too long of a mempool chain</source>
+        <translation type="unfinished">Transakcija ima predugačak mempool lanac </translation>
+    </message>
+    <message>
+        <source>Transaction must have at least one recipient</source>
+        <translation type="unfinished">Transakcija mora imati najmanje jednog primaoca</translation>
+    </message>
+    <message>
+        <source>Transaction needs a change address, but we can't generate it. %s</source>
+        <translation type="unfinished">Transakciji je potrebna promjena adrese, ali je ne možemo generirati. %s</translation>
+    </message>
+    <message>
+        <source>Transaction too large</source>
+        <translation type="unfinished">Transakcija je prevelika</translation>
+    </message>
+    <message>
+        <source>Unable to bind to %s on this computer (bind returned error %s)</source>
+        <translation type="unfinished">Nije moguće povezati se na %s na ovom računaru (povezivanje je vratilo grešku %s)</translation>
+    </message>
+    <message>
+        <source>Unable to bind to %s on this computer. %s is probably already running.</source>
+        <translation type="unfinished">Nije moguće povezati se na %s na ovom računaru. %s vjerovatno već radi.</translation>
+    </message>
+    <message>
+        <source>Unable to create the PID file '%s': %s</source>
+        <translation type="unfinished">Nije moguće kreirati PID fajl '%s': %s</translation>
+    </message>
+    <message>
+        <source>Unable to generate initial keys</source>
+        <translation type="unfinished">Nije moguće generirati početne ključeve</translation>
+    </message>
+    <message>
+        <source>Unable to generate keys</source>
+        <translation type="unfinished">Nije moguće generirati ključeve</translation>
+    </message>
+    <message>
+        <source>Unable to open %s for writing</source>
+        <translation type="unfinished">Nije moguće otvoriti %s za pisanje</translation>
+    </message>
+    <message>
+        <source>Unable to start HTTP server. See debug log for details.</source>
+        <translation type="unfinished">Nije moguće pokrenuti HTTP server. Pogledajte dnevnik otklanjanja grešaka za detalje.</translation>
+    </message>
+    <message>
+        <source>Unknown -blockfilterindex value %s.</source>
+        <translation type="unfinished">Nepoznata vrijednost -blockfilterindex %s.</translation>
+    </message>
+    <message>
+        <source>Unknown address type '%s'</source>
+        <translation type="unfinished">Nepoznata vrsta adrese '%s'</translation>
+    </message>
+    <message>
+        <source>Unknown change type '%s'</source>
+        <translation type="unfinished">Nepoznata vrsta promjene '%s'</translation>
+    </message>
+    <message>
+        <source>Unknown network specified in -onlynet: '%s'</source>
+        <translation type="unfinished">Nepoznata mreža navedena u -onlynet: '%s'</translation>
+    </message>
+    <message>
+        <source>Unknown new rules activated (versionbit %i)</source>
+        <translation type="unfinished">Nepoznata nova pravila aktivirana (versionbit %i)</translation>
+    </message>
+    <message>
+        <source>Unsupported logging category %s=%s.</source>
+        <translation type="unfinished">Nepodržana kategorija logivanja %s=%s.</translation>
+    </message>
+    <message>
+        <source>Upgrading UTXO database</source>
+        <translation type="unfinished">Nadogradnja UTXO baze podataka</translation>
+    </message>
+    <message>
+        <source>Upgrading txindex database</source>
+        <translation type="unfinished">Nadogradnja txindex baze podataka</translation>
+    </message>
+    <message>
+        <source>User Agent comment (%s) contains unsafe characters.</source>
+        <translation type="unfinished">Komentar korisničkog agenta (%s) sadrži nesigurne znakove.</translation>
+    </message>
+    <message>
+        <source>Verifying blocks…</source>
+        <translation type="unfinished">Provjera blokova…</translation>
+    </message>
+    <message>
+        <source>Verifying wallet(s)…</source>
+        <translation type="unfinished">Provjera novčanika…</translation>
+    </message>
+    <message>
+        <source>Wallet needed to be rewritten: restart %s to complete</source>
+        <translation type="unfinished">Novčanik je trebao biti prepisan: ponovo pokrenite %s da biste završili</translation>
+    </message>
+</context>
 </TS>

--- a/src/qt/locale/bitcoin_ca.ts
+++ b/src/qt/locale/bitcoin_ca.ts
@@ -31,7 +31,7 @@
     </message>
     <message>
         <source>Enter address or label to search</source>
-        <translation type="unfinished">Introduïu una adreça o una etiqueta per cercar</translation>
+        <translation type="unfinished">Introduïu una adreça o una etiqueta per a cercar</translation>
     </message>
     <message>
         <source>Export the data in the current tab to a file</source>
@@ -67,12 +67,12 @@
     </message>
     <message>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
-        <translation type="unfinished">Aquestes són les vostres adreces de Bitcoin per enviar els pagaments. Sempre reviseu l'import i l'adreça del destinatari abans de transferir monedes.</translation>
+        <translation type="unfinished">Aquestes són les vostres adreces de Bitcoin per a enviar els pagaments. Sempre reviseu l'import i l'adreça del destinatari abans de transferir monedes.</translation>
     </message>
     <message>
         <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
 Signing is only possible with addresses of the type 'legacy'.</source>
-        <translation type="unfinished">Aquestes son les teves adreces de Bitcoin per rebre pagaments. Utilitza el botó "Crear nova adreça de recepció" de la pestanya de recepció per crear una nova adreça.
+        <translation type="unfinished">Aquestes son les teves adreces de Bitcoin per a rebre pagaments. Utilitza el botó "Crear nova adreça de recepció" de la pestanya de recepció per a crear una nova adreça.
 Només és possible firmar amb adreces del tipus "legacy".</translation>
     </message>
     <message>
@@ -189,7 +189,7 @@ Només és possible firmar amb adreces del tipus "legacy".</translation>
     </message>
     <message>
         <source>Wallet to be encrypted</source>
-        <translation type="unfinished">Cartera per ser encriptada</translation>
+        <translation type="unfinished">Cartera a encriptar</translation>
     </message>
     <message>
         <source>Your wallet is about to be encrypted. </source>
@@ -257,7 +257,11 @@ Només és possible firmar amb adreces del tipus "legacy".</translation>
         <source>Internal error</source>
         <translation type="unfinished">Error intern</translation>
     </message>
-    </context>
+    <message>
+        <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
+        <translation type="unfinished">S'ha produït un error intern. %1 intentarà continuar amb seguretat. Es pot informar sobre aquest error inesperat com es descriu a continuació.</translation>
+    </message>
+</context>
 <context>
     <name>QObject</name>
     <message>
@@ -277,6 +281,10 @@ Només és possible firmar amb adreces del tipus "legacy".</translation>
         <translation type="unfinished">Error a l'inicialitzar la configuració: %1</translation>
     </message>
     <message>
+        <source>%1 didn't yet exit safely…</source>
+        <translation type="unfinished">%1 no ha sortit de manera segura...</translation>
+    </message>
+    <message>
         <source>unknown</source>
         <translation type="unfinished">desconegut</translation>
     </message>
@@ -287,6 +295,10 @@ Només és possible firmar amb adreces del tipus "legacy".</translation>
     <message>
         <source>Enter a Bitcoin address (e.g. %1)</source>
         <translation type="unfinished">Introduïu una adreça de Bitcoin (p. ex. %1)</translation>
+    </message>
+    <message>
+        <source>Unroutable</source>
+        <translation type="unfinished">No encaminable</translation>
     </message>
     <message>
         <source>Internal</source>
@@ -302,11 +314,15 @@ Només és possible firmar amb adreces del tipus "legacy".</translation>
     </message>
     <message>
         <source>Full Relay</source>
-        <translation type="unfinished">Transmissió completa</translation>
+        <translation type="unfinished">Trànsit completat</translation>
     </message>
     <message>
         <source>Block Relay</source>
-        <translation type="unfinished">Bloc de transmissió</translation>
+        <translation type="unfinished">Bloc de trànsit</translation>
+    </message>
+    <message>
+        <source>Feeler</source>
+        <translation type="unfinished">Sensor</translation>
     </message>
     <message>
         <source>Address Fetch</source>
@@ -319,36 +335,36 @@ Només és possible firmar amb adreces del tipus "legacy".</translation>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation>
-            <numerusform />
-            <numerusform />
+            <numerusform>%n segon</numerusform>
+            <numerusform>%n segons</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n minute(s)</source>
         <translation>
-            <numerusform />
-            <numerusform />
+            <numerusform>%n minut</numerusform>
+            <numerusform>%n minuts</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n hora</numerusform>
+            <numerusform>%n hores</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n dia</numerusform>
+            <numerusform>%n dies</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n setmana</numerusform>
+            <numerusform>%n setmanes</numerusform>
         </translation>
     </message>
     <message>
@@ -358,8 +374,8 @@ Només és possible firmar amb adreces del tipus "legacy".</translation>
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n any</numerusform>
+            <numerusform>%n anys</numerusform>
         </translation>
     </message>
     </context>
@@ -447,6 +463,10 @@ Només és possible firmar amb adreces del tipus "legacy".</translation>
         <translation>&amp;Rep</translation>
     </message>
     <message>
+        <source>&amp;Options…</source>
+        <translation type="unfinished">&amp;Opcions...</translation>
+    </message>
+    <message>
         <source>&amp;Show / Hide</source>
         <translation>&amp;Mostra / Amaga</translation>
     </message>
@@ -455,16 +475,60 @@ Només és possible firmar amb adreces del tipus "legacy".</translation>
         <translation>Mostra o amaga la finestra principal</translation>
     </message>
     <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation type="unfinished">&amp;Encripta la cartera...</translation>
+    </message>
+    <message>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>Encripta les claus privades pertanyents de la cartera</translation>
     </message>
     <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation type="unfinished">&amp;Còpia de seguretat de la cartera...</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation type="unfinished">&amp;Canviar la contrasenya...</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation type="unfinished">Signa el &amp;missatge</translation>
+    </message>
+    <message>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
-        <translation>Signa el missatges amb la seva adreça de Bitcoin per provar que les poseeixes</translation>
+        <translation>Signa els missatges amb la seva adreça de Bitcoin per a provar que les posseeixes</translation>
+    </message>
+    <message>
+        <source>&amp;Verify message…</source>
+        <translation type="unfinished">&amp;Verifica el missatge</translation>
     </message>
     <message>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
-        <translation>Verifiqueu els missatges per assegurar-vos que han estat signats amb una adreça Bitcoin específica.</translation>
+        <translation>Verifiqueu els missatges per a assegurar-vos que han estat signats amb una adreça Bitcoin específica.</translation>
+    </message>
+    <message>
+        <source>&amp;Load PSBT from file…</source>
+        <translation type="unfinished">&amp;Carrega el PSBT des del fitxer ...</translation>
+    </message>
+    <message>
+        <source>Load PSBT from clipboard…</source>
+        <translation type="unfinished">Carrega PSBT des del porta-retalls ...</translation>
+    </message>
+    <message>
+        <source>Open &amp;URI…</source>
+        <translation type="unfinished">Obre l'&amp;URL...</translation>
+    </message>
+    <message>
+        <source>Close Wallet…</source>
+        <translation type="unfinished">Tanca la cartera...</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation type="unfinished">Crea la cartera...</translation>
+    </message>
+    <message>
+        <source>Close All Wallets…</source>
+        <translation type="unfinished">Tanca totes les carteres...</translation>
     </message>
     <message>
         <source>&amp;File</source>
@@ -483,6 +547,30 @@ Només és possible firmar amb adreces del tipus "legacy".</translation>
         <translation>Barra d'eines de les pestanyes</translation>
     </message>
     <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation type="unfinished">Sincronitzant capçaleres (%1%)...</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation type="unfinished">S'està sincronitzant amb la xarxa...</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation type="unfinished">S'estan indexant els blocs al disc...</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation type="unfinished">S'estan processant els blocs al disc...</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation type="unfinished">S'estan reindexant els blocs al disc...</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation type="unfinished">Connectant als iguals...</translation>
+    </message>
+    <message>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished">Sol·licita pagaments (genera codis QR i bitcoin: URI)</translation>
     </message>
@@ -498,16 +586,13 @@ Només és possible firmar amb adreces del tipus "legacy".</translation>
         <source>&amp;Command-line options</source>
         <translation type="unfinished">Opcions de la &amp;línia d'ordres</translation>
     </message>
-    <message numerus="yes">
-        <source>Processed %n block(s) of transaction history.</source>
-        <translation>
-            <numerusform />
-            <numerusform />
-        </translation>
-    </message>
     <message>
         <source>%1 behind</source>
         <translation>%1 darrere</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation type="unfinished">S'està posant al dia ...</translation>
     </message>
     <message>
         <source>Last received block was generated %1 ago.</source>
@@ -575,7 +660,7 @@ Només és possible firmar amb adreces del tipus "legacy".</translation>
     </message>
     <message>
         <source>Show the %1 help message to get a list with possible Bitcoin command-line options</source>
-        <translation type="unfinished">Mostra el missatge d'ajuda del %1 per obtenir una llista amb les possibles opcions de línia d'ordres de Bitcoin</translation>
+        <translation type="unfinished">Mostra el missatge d'ajuda del %1 per a obtenir una llista amb les possibles opcions de línia d'ordres de Bitcoin</translation>
     </message>
     <message>
         <source>&amp;Mask values</source>
@@ -617,9 +702,29 @@ Només és possible firmar amb adreces del tipus "legacy".</translation>
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n connexió activa a la xarxa Bitcoin</numerusform>
+            <numerusform>%n connexions actives a la xarxa Bitcoin</numerusform>
         </translation>
+    </message>
+    <message>
+        <source>Click for more actions.</source>
+        <extracomment>A substring of the tooltip. "More actions" are available via the context menu.</extracomment>
+        <translation type="unfinished">Fes clic per a més accions.</translation>
+    </message>
+    <message>
+        <source>Show Peers tab</source>
+        <extracomment>A context menu item. The "Peers tab" is an element of the "Node window".</extracomment>
+        <translation type="unfinished">Mostrar pestanyes d'iguals</translation>
+    </message>
+    <message>
+        <source>Disable network activity</source>
+        <extracomment>A context menu item.</extracomment>
+        <translation type="unfinished">Inhabilita l'activitat de la xarxa.</translation>
+    </message>
+    <message>
+        <source>Enable network activity</source>
+        <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
+        <translation type="unfinished">Habilita l'activitat de la xarxa</translation>
     </message>
     <message>
         <source>Error: %1</source>
@@ -702,7 +807,7 @@ Només és possible firmar amb adreces del tipus "legacy".</translation>
     <name>UnitDisplayStatusBarControl</name>
     <message>
         <source>Unit to show amounts in. Click to select another unit.</source>
-        <translation type="unfinished">Unitat en què mostrar els imports. Feu clic per seleccionar una altra unitat.</translation>
+        <translation type="unfinished">Unitat en què mostrar els imports. Feu clic per a seleccionar una altra unitat.</translation>
     </message>
 </context>
 <context>
@@ -721,7 +826,7 @@ Només és possible firmar amb adreces del tipus "legacy".</translation>
     </message>
     <message>
         <source>Fee:</source>
-        <translation type="unfinished">Comissió:</translation>
+        <translation type="unfinished">Tarifa:</translation>
     </message>
     <message>
         <source>Dust:</source>
@@ -729,7 +834,7 @@ Només és possible firmar amb adreces del tipus "legacy".</translation>
     </message>
     <message>
         <source>After Fee:</source>
-        <translation type="unfinished">Comissió posterior:</translation>
+        <translation type="unfinished">Tarifa posterior:</translation>
     </message>
     <message>
         <source>Change:</source>
@@ -776,16 +881,40 @@ Només és possible firmar amb adreces del tipus "legacy".</translation>
         <translation type="unfinished">Copia l'import</translation>
     </message>
     <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Copia l'adreça</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Copia l'&amp;etiqueta</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Copia la &amp;quantitat</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">Copiar &amp;ID de transacció</translation>
+    </message>
+    <message>
+        <source>L&amp;ock unspent</source>
+        <translation type="unfinished">Bl&amp;oqueja sense gastar</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock unspent</source>
+        <translation type="unfinished">&amp;Desbloqueja sense gastar</translation>
+    </message>
+    <message>
         <source>Copy quantity</source>
         <translation type="unfinished">Copia la quantitat</translation>
     </message>
     <message>
         <source>Copy fee</source>
-        <translation type="unfinished">Copia la comissió</translation>
+        <translation type="unfinished">Copia la tarifa</translation>
     </message>
     <message>
         <source>Copy after fee</source>
-        <translation type="unfinished">Copia la comissió posterior</translation>
+        <translation type="unfinished">Copia la tarifa posterior</translation>
     </message>
     <message>
         <source>Copy bytes</source>
@@ -831,6 +960,10 @@ Només és possible firmar amb adreces del tipus "legacy".</translation>
 <context>
     <name>CreateWalletActivity</name>
     <message>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation type="unfinished">Creant cartera &lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+    <message>
         <source>Create wallet failed</source>
         <translation type="unfinished">La creació de cartera ha fallat</translation>
     </message>
@@ -838,7 +971,11 @@ Només és possible firmar amb adreces del tipus "legacy".</translation>
         <source>Create wallet warning</source>
         <translation type="unfinished">Avís en la creació de la cartera</translation>
     </message>
-    </context>
+    <message>
+        <source>Can't list signers</source>
+        <translation type="unfinished">No es poden enumerar signants</translation>
+    </message>
+</context>
 <context>
     <name>OpenWalletActivity</name>
     <message>
@@ -853,7 +990,11 @@ Només és possible firmar amb adreces del tipus "legacy".</translation>
         <source>default wallet</source>
         <translation type="unfinished">cartera predeterminada</translation>
     </message>
-    </context>
+    <message>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation type="unfinished">Obrint la Cartera &lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+</context>
 <context>
     <name>WalletController</name>
     <message>
@@ -929,14 +1070,27 @@ Això és ideal per a carteres de mode només lectura.</translation>
         <translation type="unfinished">Cartera del descriptor</translation>
     </message>
     <message>
+        <source>Use an external signing device such as a hardware wallet. Configure the external signer script in wallet preferences first.</source>
+        <translation type="unfinished">Utilitzeu un dispositiu de signatura extern, com ara una cartera de maquinari. Configureu primer l’escriptura de signatura externa a les preferències de cartera.</translation>
+    </message>
+    <message>
+        <source>External signer</source>
+        <translation type="unfinished">Signant extern</translation>
+    </message>
+    <message>
         <source>Create</source>
         <translation type="unfinished">Crear</translation>
     </message>
     <message>
         <source>Compiled without sqlite support (required for descriptor wallets)</source>
-        <translation type="unfinished">Compilat sense el suport sqlite (requerit per carteres descriptor)</translation>
+        <translation type="unfinished">Compilat sense el suport sqlite (requerit per a carteres descriptor)</translation>
     </message>
-    </context>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Compilat sense suport de signatura externa (necessari per a la signatura externa)</translation>
+    </message>
+</context>
 <context>
     <name>EditAddressDialog</name>
     <message>
@@ -977,7 +1131,7 @@ Això és ideal per a carteres de mode només lectura.</translation>
     </message>
     <message>
         <source>Address "%1" already exists as a receiving address with label "%2" and so cannot be added as a sending address.</source>
-        <translation type="unfinished">L'adreça "%1" ja existeix com una adreça per rebre amb l'etiqueta "%2" i per tant no pot ésser afegida com adreça per enviar.</translation>
+        <translation type="unfinished">L'adreça "%1" ja existeix com una adreça per a rebre amb l'etiqueta "%2" i per tant no pot ésser afegida com adreça per a enviar.</translation>
     </message>
     <message>
         <source>The entered address "%1" is already in the address book with label "%2".</source>
@@ -1018,6 +1172,18 @@ Això és ideal per a carteres de mode només lectura.</translation>
 <context>
     <name>Intro</name>
     <message>
+        <source>%1 GB of free space available</source>
+        <translation type="unfinished">%1 GB d’espai lliure disponible</translation>
+    </message>
+    <message>
+        <source>(of %1 GB needed)</source>
+        <translation type="unfinished">(of %1 GB necessaris)</translation>
+    </message>
+    <message>
+        <source>(%1 GB needed for full chain)</source>
+        <translation type="unfinished">(%1 GB necessaris per a la cadena completa)</translation>
+    </message>
+    <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
         <translation type="unfinished">Almenys %1 GB de dades s'emmagatzemaran en aquest directori, i creixerà amb el temps.</translation>
     </message>
@@ -1029,8 +1195,8 @@ Això és ideal per a carteres de mode només lectura.</translation>
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>(suficient per restaurar les còpies de seguretat de%n dia (s))</numerusform>
+            <numerusform>(suficient per a restaurar les còpies de seguretat de %n die(s))</numerusform>
         </translation>
     </message>
     <message>
@@ -1062,6 +1228,10 @@ Això és ideal per a carteres de mode només lectura.</translation>
         <translation type="unfinished">Quan feu clic a D'acord, %1 començarà a descarregar i processar la cadena de blocs %4 completa (%2 GB) començant per les primeres transaccions de %3, any de llençament inicial de %4.</translation>
     </message>
     <message>
+        <source>Limit block chain storage to</source>
+        <translation type="unfinished">Limita l’emmagatzematge de la cadena de blocs a</translation>
+    </message>
+    <message>
         <source>Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</source>
         <translation type="unfinished">Desfer aquest canvi requereix tornar-se a descarregar el blockchain sencer. És més ràpid descarregar la cadena completa primer i després podar. Deshabilita algunes de les característiques avançades.</translation>
     </message>
@@ -1071,7 +1241,7 @@ Això és ideal per a carteres de mode només lectura.</translation>
     </message>
     <message>
         <source>If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</source>
-        <translation type="unfinished">Si heu decidit limitar l'emmagatzematge de la cadena de blocs (podar), les dades històriques encara s'hauran de baixar i processar, però se suprimiran més endavant per mantenir baix l'ús del disc.</translation>
+        <translation type="unfinished">Si heu decidit limitar l'emmagatzematge de la cadena de blocs (podar), les dades històriques encara s'hauran de baixar i processar, però se suprimiran més endavant per a mantenir baix l'ús del disc.</translation>
     </message>
     <message>
         <source>Use the default data directory</source>
@@ -1100,6 +1270,10 @@ Això és ideal per a carteres de mode només lectura.</translation>
 <context>
     <name>ShutdownWindow</name>
     <message>
+        <source>%1 is shutting down…</source>
+        <translation type="unfinished">%1 s'està tancant ...</translation>
+    </message>
+    <message>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished">No apagueu l'ordinador fins que no desaparegui aquesta finestra.</translation>
     </message>
@@ -1123,6 +1297,14 @@ Això és ideal per a carteres de mode només lectura.</translation>
         <translation type="unfinished">Nombre de blocs pendents</translation>
     </message>
     <message>
+        <source>Unknown…</source>
+        <translation type="unfinished">Desconegut...</translation>
+    </message>
+    <message>
+        <source>calculating…</source>
+        <translation type="unfinished">s'està calculant...</translation>
+    </message>
+    <message>
         <source>Last block time</source>
         <translation type="unfinished">Últim temps de bloc</translation>
     </message>
@@ -1144,9 +1326,13 @@ Això és ideal per a carteres de mode només lectura.</translation>
     </message>
     <message>
         <source>%1 is currently syncing.  It will download headers and blocks from peers and validate them until reaching the tip of the block chain.</source>
-        <translation type="unfinished">%1 sincronitzant ara mateix. Es descarregaran capçaleres i blocs d'altres peers i es validaran fins a obtenir la punta de la cadena de blocs. </translation>
+        <translation type="unfinished">%1 sincronitzant ara mateix. Es descarregaran capçaleres i blocs d'altres iguals i es validaran fins a obtenir la punta de la cadena de blocs. </translation>
     </message>
-    </context>
+    <message>
+        <source>Unknown. Syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">Desconegut. Sincronització de les capçaleres (%1, %2%)...</translation>
+    </message>
+</context>
 <context>
     <name>OpenURIDialog</name>
     <message>
@@ -1174,7 +1360,7 @@ Això és ideal per a carteres de mode només lectura.</translation>
     </message>
     <message>
         <source>Enabling pruning significantly reduces the disk space required to store transactions. All blocks are still fully validated. Reverting this setting requires re-downloading the entire blockchain.</source>
-        <translation type="unfinished">Habilitar la poda redueix significativament l’espai en disc necessari per emmagatzemar les transaccions. Tots els blocs encara estan completament validats. Per revertir aquesta configuració, cal tornar a descarregar tota la cadena de blocs.</translation>
+        <translation type="unfinished">Habilitar la poda redueix significativament l’espai en disc necessari per a emmagatzemar les transaccions. Tots els blocs encara estan completament validats. Per a revertir aquesta configuració, cal tornar a descarregar tota la cadena de blocs.</translation>
     </message>
     <message>
         <source>Size of &amp;database cache</source>
@@ -1190,7 +1376,7 @@ Això és ideal per a carteres de mode només lectura.</translation>
     </message>
     <message>
         <source>Shows if the supplied default SOCKS5 proxy is used to reach peers via this network type.</source>
-        <translation type="unfinished">Mostra si el proxy SOCKS5 predeterminat subministrat s'utilitza per arribar a altres nodes a través d'aquest tipus de xarxa.</translation>
+        <translation type="unfinished">Mostra si el proxy SOCKS5 predeterminat subministrat s'utilitza per a arribar a altres iguals a través d'aquest tipus de xarxa.</translation>
     </message>
     <message>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
@@ -1249,6 +1435,18 @@ Això és ideal per a carteres de mode només lectura.</translation>
         <translation type="unfinished">&amp;Gasta el canvi sense confirmar</translation>
     </message>
     <message>
+        <source>External Signer (e.g. hardware wallet)</source>
+        <translation type="unfinished">Signador extern (per exemple, cartera de maquinari)</translation>
+    </message>
+    <message>
+        <source>&amp;External signer script path</source>
+        <translation type="unfinished">&amp;Camí de l'script del signatari extern</translation>
+    </message>
+    <message>
+        <source>Full path to a Bitcoin Core compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</source>
+        <translation type="unfinished">Camí complet a un script compatible amb Bitcoin Core (per exemple, C:\Downloads\hwi.exe o /Users/you/Downloads/hwi.py). Aneu amb compte: el programari maliciós pot robar-vos les monedes!</translation>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation>Obre el port del client de Bitcoin al router de forma automàtica. Això només funciona quan el router implementa UPnP i l'opció està activada.</translation>
     </message>
@@ -1290,7 +1488,7 @@ Això és ideal per a carteres de mode només lectura.</translation>
     </message>
     <message>
         <source>Used for reaching peers via:</source>
-        <translation type="unfinished">Utilitzat per arribar als iguals mitjançant:</translation>
+        <translation type="unfinished">Utilitzat per a arribar als iguals mitjançant:</translation>
     </message>
     <message>
         <source>&amp;Window</source>
@@ -1330,11 +1528,11 @@ Això és ideal per a carteres de mode només lectura.</translation>
     </message>
     <message>
         <source>&amp;Unit to show amounts in:</source>
-        <translation>&amp;Unitats per mostrar els imports en:</translation>
+        <translation>&amp;Unitats per a mostrar els imports en:</translation>
     </message>
     <message>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
-        <translation>Selecciona la unitat de subdivisió per defecte per mostrar en la interfície quan s'envien monedes.</translation>
+        <translation>Selecciona la unitat de subdivisió per defecte per a mostrar en la interfície quan s'envien monedes.</translation>
     </message>
     <message>
         <source>Whether to show coin control features or not.</source>
@@ -1346,7 +1544,7 @@ Això és ideal per a carteres de mode només lectura.</translation>
     </message>
     <message>
         <source>Use separate SOCKS&amp;5 proxy to reach peers via Tor onion services:</source>
-        <translation type="unfinished">Utilitzeu el servidor intermediari SOCKS&amp;5 per arribar als peers mitjançant els serveis d'onion de Tor:</translation>
+        <translation type="unfinished">Utilitzeu el servidor intermediari SOCKS&amp;5 per a arribar als iguals mitjançant els serveis d'onion de Tor:</translation>
     </message>
     <message>
         <source>&amp;Third party transaction URLs</source>
@@ -1377,6 +1575,11 @@ Això és ideal per a carteres de mode només lectura.</translation>
         <translation>&amp;Cancel·la</translation>
     </message>
     <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Compilat sense suport de signatura externa (necessari per a la signatura externa)</translation>
+    </message>
+    <message>
         <source>default</source>
         <translation>Per defecte</translation>
     </message>
@@ -1390,7 +1593,7 @@ Això és ideal per a carteres de mode només lectura.</translation>
     </message>
     <message>
         <source>Client restart required to activate changes.</source>
-        <translation type="unfinished">Cal reiniciar el client per activar els canvis.</translation>
+        <translation type="unfinished">Cal reiniciar el client per a activar els canvis.</translation>
     </message>
     <message>
         <source>Client will be shut down. Do you want to proceed?</source>
@@ -1402,7 +1605,7 @@ Això és ideal per a carteres de mode només lectura.</translation>
     </message>
     <message>
         <source>The configuration file is used to specify advanced user options which override GUI settings. Additionally, any command-line options will override this configuration file.</source>
-        <translation type="unfinished">El fitxer de configuració s'utilitza per especificar les opcions d'usuari avançades que substitueixen la configuració de la interfície gràfica d'usuari. A més, qualsevol opció de la línia d'ordres substituirà aquest fitxer de configuració.</translation>
+        <translation type="unfinished">El fitxer de configuració s'utilitza per a especificar les opcions d'usuari avançades que substitueixen la configuració de la interfície gràfica d'usuari. A més, qualsevol opció de la línia d'ordres substituirà aquest fitxer de configuració.</translation>
     </message>
     <message>
         <source>The configuration file could not be opened.</source>
@@ -1507,6 +1710,10 @@ Això és ideal per a carteres de mode només lectura.</translation>
         <translation type="unfinished">Còpia al Clipboard</translation>
     </message>
     <message>
+        <source>Save…</source>
+        <translation type="unfinished">Desa...</translation>
+    </message>
+    <message>
         <source>Close</source>
         <translation type="unfinished">Tanca</translation>
     </message>
@@ -1528,7 +1735,7 @@ Això és ideal per a carteres de mode només lectura.</translation>
     </message>
     <message>
         <source>Signed transaction successfully. Transaction is ready to broadcast.</source>
-        <translation type="unfinished">La transacció s'ha firmat correctament. La transacció està a punt per emetre's.</translation>
+        <translation type="unfinished">La transacció s'ha firmat correctament. La transacció està a punt per a emetre's.</translation>
     </message>
     <message>
         <source>Unknown error processing transaction.</source>
@@ -1561,11 +1768,11 @@ Això és ideal per a carteres de mode només lectura.</translation>
     </message>
     <message>
         <source>Unable to calculate transaction fee or total transaction amount.</source>
-        <translation type="unfinished">Incapaç de calcular la comissió de transacció o la quantitat total de la transacció</translation>
+        <translation type="unfinished">Incapaç de calcular la tarifa de transacció o la quantitat total de la transacció</translation>
     </message>
     <message>
         <source>Pays transaction fee: </source>
-        <translation type="unfinished">Paga comissió de transacció:</translation>
+        <translation type="unfinished">Paga la tarifa de transacció:</translation>
     </message>
     <message>
         <source>Total Amount</source>
@@ -1597,7 +1804,7 @@ Això és ideal per a carteres de mode només lectura.</translation>
     </message>
     <message>
         <source>Transaction is fully signed and ready for broadcast.</source>
-        <translation type="unfinished">La transacció està completament firmada i a punt per emetre's.</translation>
+        <translation type="unfinished">La transacció està completament firmada i a punt per a emetre's.</translation>
     </message>
     <message>
         <source>Transaction status is unknown.</source>
@@ -1627,7 +1834,7 @@ Això és ideal per a carteres de mode només lectura.</translation>
 Due to widespread security flaws in BIP70 it's strongly recommended that any merchant instructions to switch wallets be ignored.
 If you are receiving this error you should request the merchant provide a BIP21 compatible URI.</source>
         <translation type="unfinished">No es pot processar la sol·licitud de pagament perquè no s'admet BIP70.
-A causa dels defectes generalitzats de seguretat del BIP70, es recomana que s'ignorin totes les instruccions del comerciant per canviar carteres.
+A causa dels defectes generalitzats de seguretat del BIP70, es recomana que s'ignorin totes les instruccions del comerciant per a canviar carteres.
 Si rebeu aquest error, haureu de sol·licitar al comerciant que proporcioni un URI compatible amb BIP21.</translation>
     </message>
     <message>
@@ -1645,6 +1852,11 @@ Si rebeu aquest error, haureu de sol·licitar al comerciant que proporcioni un U
         <source>User Agent</source>
         <extracomment>Title of Peers Table column which contains the peer's User Agent string.</extracomment>
         <translation type="unfinished">Agent d'usuari</translation>
+    </message>
+    <message>
+        <source>Peer</source>
+        <extracomment>Title of Peers Table column which contains a unique number used to identify a connection.</extracomment>
+        <translation type="unfinished">Igual</translation>
     </message>
     <message>
         <source>Sent</source>
@@ -1674,6 +1886,10 @@ Si rebeu aquest error, haureu de sol·licitar al comerciant que proporcioni un U
 </context>
 <context>
     <name>QRImageWidget</name>
+    <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">&amp;Desa l'imatge...</translation>
+    </message>
     <message>
         <source>&amp;Copy Image</source>
         <translation type="unfinished">&amp;Copia la imatge</translation>
@@ -1784,7 +2000,7 @@ Si rebeu aquest error, haureu de sol·licitar al comerciant que proporcioni un U
     </message>
     <message>
         <source>Select a peer to view detailed information.</source>
-        <translation type="unfinished">Seleccioneu un igual per mostrar informació detallada.</translation>
+        <translation type="unfinished">Seleccioneu un igual per a mostrar informació detallada.</translation>
     </message>
     <message>
         <source>Version</source>
@@ -1804,7 +2020,7 @@ Si rebeu aquest error, haureu de sol·licitar al comerciant que proporcioni un U
     </message>
     <message>
         <source>The mapped Autonomous System used for diversifying peer selection.</source>
-        <translation type="unfinished">El sistema autònom de mapat utilitzat per diversificar la selecció entre iguals.</translation>
+        <translation type="unfinished">El sistema autònom de mapat utilitzat per a diversificar la selecció entre iguals.</translation>
     </message>
     <message>
         <source>Mapped AS</source>
@@ -1847,8 +2063,24 @@ Si rebeu aquest error, haureu de sol·licitar al comerciant que proporcioni un U
         <translation type="unfinished">Direcció / Tipus</translation>
     </message>
     <message>
+        <source>The network protocol this peer is connected through: IPv4, IPv6, Onion, I2P, or CJDNS.</source>
+        <translation type="unfinished">El protocol de xarxa mitjançant aquest igual es connecta: IPv4, IPv6, Onion, I2P o CJDNS.</translation>
+    </message>
+    <message>
         <source>Services</source>
         <translation type="unfinished">Serveis</translation>
+    </message>
+    <message>
+        <source>Whether the peer requested us to relay transactions.</source>
+        <translation type="unfinished">Si l'igual ens va sol·licitar que donem trànsit a les transaccions.</translation>
+    </message>
+    <message>
+        <source>Wants Tx Relay</source>
+        <translation type="unfinished">Vol trànsit Tx</translation>
+    </message>
+    <message>
+        <source>High bandwidth BIP152 compact block relay: %1</source>
+        <translation type="unfinished">Trànsit de bloc compacte BIP152 d'ample de banda elevat: %1</translation>
     </message>
     <message>
         <source>High Bandwidth</source>
@@ -1860,11 +2092,19 @@ Si rebeu aquest error, haureu de sol·licitar al comerciant que proporcioni un U
     </message>
     <message>
         <source>Elapsed time since a novel block passing initial validity checks was received from this peer.</source>
-        <translation type="unfinished">Temps transcorregut des que un nou bloc passant les comprovacions inicials ha estat rebut per aquest node</translation>
+        <translation type="unfinished">Temps transcorregut des que un nou bloc passant les comprovacions inicials ha estat rebut per aquest igual.</translation>
     </message>
     <message>
         <source>Last Block</source>
         <translation type="unfinished">Últim bloc</translation>
+    </message>
+    <message>
+        <source>Elapsed time since a novel transaction accepted into our mempool was received from this peer.</source>
+        <translation type="unfinished">El temps transcorregut des que es va rebre d'aquesta transacció una nova transacció acceptada al nostre igual.</translation>
+    </message>
+    <message>
+        <source>Last Tx</source>
+        <translation type="unfinished">Última Tx</translation>
     </message>
     <message>
         <source>Last Send</source>
@@ -1923,16 +2163,40 @@ Si rebeu aquest error, haureu de sol·licitar al comerciant que proporcioni un U
         <translation type="unfinished">Fora:</translation>
     </message>
     <message>
+        <source>Inbound: initiated by peer</source>
+        <translation type="unfinished">Entrant: iniciat per igual</translation>
+    </message>
+    <message>
+        <source>Outbound Full Relay: default</source>
+        <translation type="unfinished">Trànsit complet de sortida: per defecte</translation>
+    </message>
+    <message>
+        <source>Outbound Block Relay: does not relay transactions or addresses</source>
+        <translation type="unfinished">Trànsit de blocs de sortida: no transmet trànsit ni adreces</translation>
+    </message>
+    <message>
+        <source>Outbound Manual: added using RPC %1 or %2/%3 configuration options</source>
+        <translation type="unfinished">Manual de sortida: afegit mitjançant les opcions de configuració RPC %1 o %2/%3 </translation>
+    </message>
+    <message>
+        <source>Outbound Feeler: short-lived, for testing addresses</source>
+        <translation type="unfinished">Sensor de sortida: de curta durada, per a provar adreces</translation>
+    </message>
+    <message>
+        <source>Outbound Address Fetch: short-lived, for soliciting addresses</source>
+        <translation type="unfinished">Obtenció d'adreces de sortida: de curta durada, per a sol·licitar adreces</translation>
+    </message>
+    <message>
         <source>we selected the peer for high bandwidth relay</source>
-        <translation type="unfinished">hem seleccionat el node per a un gran relleu d'amplada de banda</translation>
+        <translation type="unfinished">hem seleccionat l'igual per a un gran trànsit d'amplada de banda</translation>
     </message>
     <message>
         <source>the peer selected us for high bandwidth relay</source>
-        <translation type="unfinished">el node que hem seleccionat per al relleu de gran amplada de banda</translation>
+        <translation type="unfinished">l'igual que hem seleccionat per al trànsit de gran amplada de banda</translation>
     </message>
     <message>
         <source>no high bandwidth relay selected</source>
-        <translation type="unfinished">cap relleu de gran amplada de banda ha estat seleccionat</translation>
+        <translation type="unfinished">cap trànsit de gran amplada de banda ha estat seleccionat</translation>
     </message>
     <message>
         <source>&amp;Disconnect</source>
@@ -1941,6 +2205,10 @@ Si rebeu aquest error, haureu de sol·licitar al comerciant que proporcioni un U
     <message>
         <source>1 &amp;hour</source>
         <translation type="unfinished">1 &amp;hora</translation>
+    </message>
+    <message>
+        <source>1 d&amp;ay</source>
+        <translation type="unfinished">1 d&amp;ia</translation>
     </message>
     <message>
         <source>1 &amp;week</source>
@@ -1967,6 +2235,32 @@ Si rebeu aquest error, haureu de sol·licitar al comerciant que proporcioni un U
         <translation type="unfinished">S'està executant comanda usant la cartera "%1"</translation>
     </message>
     <message>
+        <source>Welcome to the %1 RPC console.
+Use up and down arrows to navigate history, and %2 to clear screen.
+Use %3 and %4 to increase or decrease the font size.
+Type %5 for an overview of available commands.
+For more information on using this console, type %6.
+
+%7WARNING: Scammers have been active, telling users to type commands here, stealing their wallet contents. Do not use this console without fully understanding the ramifications of a command.%8</source>
+        <extracomment>RPC console welcome message. Placeholders %7 and %8 are style tags for the warning content, and they are not space separated from the rest of the text intentionally.</extracomment>
+        <translation type="unfinished">Benvingut a la consola RPC %1.
+Utilitzeu les fletxes amunt i avall per a navegar per l'historial i %2 per a esborrar la pantalla.
+Utilitzeu %3 i %4 per augmentar o reduir la mida de la lletra.
+Escriviu %5 per a obtenir una visió general de les ordres disponibles.
+Per a obtenir més informació sobre com utilitzar aquesta consola, escriviu %6.
+ADVERTIMENT %7: Els estafadors han estat actius, dient als usuaris que escriguin ordres aquí, robant el contingut de la seva cartera.
+No utilitzeu aquesta consola sense entendre completament les ramificacions d'una ordre. %8</translation>
+    </message>
+    <message>
+        <source>Executing…</source>
+        <extracomment>A console message indicating an entered command is currently being executed.</extracomment>
+        <translation type="unfinished">Executant...</translation>
+    </message>
+    <message>
+        <source>(peer: %1)</source>
+        <translation type="unfinished">(igual: %1)</translation>
+    </message>
+    <message>
         <source>via %1</source>
         <translation type="unfinished">a través de %1</translation>
     </message>
@@ -1984,7 +2278,7 @@ Si rebeu aquest error, haureu de sol·licitar al comerciant que proporcioni un U
     </message>
     <message>
         <source>Ban for</source>
-        <translation type="unfinished">Bandeja per</translation>
+        <translation type="unfinished">Bandeja per a</translation>
     </message>
     <message>
         <source>Never</source>
@@ -2019,15 +2313,15 @@ Si rebeu aquest error, haureu de sol·licitar al comerciant que proporcioni un U
     </message>
     <message>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
-        <translation type="unfinished">Utilitzeu aquest formulari per sol·licitar pagaments. Tots els camps són &lt;b&gt;opcionals&lt;/b&gt;.</translation>
+        <translation type="unfinished">Utilitzeu aquest formulari per a sol·licitar pagaments. Tots els camps són &lt;b&gt;opcionals&lt;/b&gt;.</translation>
     </message>
     <message>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
-        <translation type="unfinished">Un import opcional per sol·licitar. Deixeu-ho en blanc o zero per no sol·licitar cap import específic.</translation>
+        <translation type="unfinished">Un import opcional per a sol·licitar. Deixeu-ho en blanc o zero per a no sol·licitar cap import específic.</translation>
     </message>
     <message>
         <source>An optional label to associate with the new receiving address (used by you to identify an invoice).  It is also attached to the payment request.</source>
-        <translation type="unfinished">Una etiqueta opcional per associar-se a la nova adreça de recepció (usada per vostè per identificar una factura). També s’adjunta a la sol·licitud de pagament.</translation>
+        <translation type="unfinished">Una etiqueta opcional per a associar-se a la nova adreça de recepció (usada per vostè per a identificar una factura). També s’adjunta a la sol·licitud de pagament.</translation>
     </message>
     <message>
         <source>An optional message that is attached to the payment request and may be displayed to the sender.</source>
@@ -2078,6 +2372,22 @@ Si rebeu aquest error, haureu de sol·licitar al comerciant que proporcioni un U
         <translation type="unfinished">Copia l'&amp;URI</translation>
     </message>
     <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Copia l'adreça</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Copia l'&amp;etiqueta</translation>
+    </message>
+    <message>
+        <source>Copy &amp;message</source>
+        <translation type="unfinished">Copia el &amp;missatge</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Copia la &amp;quantitat</translation>
+    </message>
+    <message>
         <source>Could not unlock wallet.</source>
         <translation type="unfinished">No s'ha pogut desblocar la cartera.</translation>
     </message>
@@ -2088,6 +2398,10 @@ Si rebeu aquest error, haureu de sol·licitar al comerciant que proporcioni un U
 </context>
 <context>
     <name>ReceiveRequestDialog</name>
+    <message>
+        <source>Request payment to …</source>
+        <translation type="unfinished">Sol·licitar pagament a ...</translation>
+    </message>
     <message>
         <source>Address:</source>
         <translation type="unfinished">Direcció:</translation>
@@ -2115,6 +2429,19 @@ Si rebeu aquest error, haureu de sol·licitar al comerciant que proporcioni un U
     <message>
         <source>Copy &amp;Address</source>
         <translation type="unfinished">Copia l'&amp;adreça</translation>
+    </message>
+    <message>
+        <source>&amp;Verify</source>
+        <translation type="unfinished">&amp;Verifica
+</translation>
+    </message>
+    <message>
+        <source>Verify this address on e.g. a hardware wallet screen</source>
+        <translation type="unfinished">Verifiqueu aquesta adreça en una pantalla de cartera de maquinari per exemple</translation>
+    </message>
+    <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">&amp;Desa l'imatge...</translation>
     </message>
     <message>
         <source>Payment information</source>
@@ -2184,11 +2511,11 @@ Si rebeu aquest error, haureu de sol·licitar al comerciant que proporcioni un U
     </message>
     <message>
         <source>Fee:</source>
-        <translation type="unfinished">Comissió:</translation>
+        <translation type="unfinished">Tarifa:</translation>
     </message>
     <message>
         <source>After Fee:</source>
-        <translation type="unfinished">Comissió posterior:</translation>
+        <translation type="unfinished">Tarifa posterior:</translation>
     </message>
     <message>
         <source>Change:</source>
@@ -2204,7 +2531,7 @@ Si rebeu aquest error, haureu de sol·licitar al comerciant que proporcioni un U
     </message>
     <message>
         <source>Transaction Fee:</source>
-        <translation type="unfinished">Comissió de transacció</translation>
+        <translation type="unfinished">Tarifa de transacció</translation>
     </message>
     <message>
         <source>Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until you have validated the complete chain.</source>
@@ -2239,20 +2566,39 @@ Si rebeu aquest error, haureu de sol·licitar al comerciant que proporcioni un U
         <translation type="unfinished">Neteja tots els camps del formulari.</translation>
     </message>
     <message>
+        <source>Inputs…</source>
+        <translation type="unfinished">Entrades...</translation>
+    </message>
+    <message>
         <source>Dust:</source>
         <translation type="unfinished">Polsim:</translation>
+    </message>
+    <message>
+        <source>Choose…</source>
+        <translation type="unfinished">Tria...</translation>
     </message>
     <message>
         <source>Hide transaction fee settings</source>
         <translation type="unfinished">Amagueu la configuració de les tarifes de transacció</translation>
     </message>
     <message>
+        <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
+
+Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satoshis per kvB" for a transaction size of 500 virtual bytes (half of 1 kvB) would ultimately yield a fee of only 50 satoshis.</source>
+        <translation type="unfinished">Especifiqueu una tarifa personalitzada per kB (1.000 bytes) de la mida virtual de la transacció.
+Nota: atès que la tarifa es calcula per byte, una tarifa de "100 satoshis per kvB" per a una mida de transacció de 500 bytes virtuals (la meitat d'1 kvB) donaria finalment una tarifa de només 50 satoshis.</translation>
+    </message>
+    <message>
         <source>When there is less transaction volume than space in the blocks, miners as well as relaying nodes may enforce a minimum fee. Paying only this minimum fee is just fine, but be aware that this can result in a never confirming transaction once there is more demand for bitcoin transactions than the network can process.</source>
-        <translation type="unfinished">Quan no hi ha prou espai en els blocs per encabir totes les transaccions, els miners i així mateix els nodes repetidors poden exigir una taxa mínima. És acceptable pagar únicament la taxa mínima, però tingueu present que pot resultar que la vostra transacció no sigui mai confirmada mentre hi hagi més demanda de transaccions bitcoin de les que la xarxa pot processar.</translation>
+        <translation type="unfinished">Quan no hi ha prou espai en els blocs per a encabir totes les transaccions, els miners i així mateix els nodes de trànsit poden exigir una taxa mínima. És acceptable pagar únicament la taxa mínima, però tingueu present que pot resultar que la vostra transacció no sigui mai confirmada mentre hi hagi més demanda de transaccions bitcoin de les que la xarxa pot processar.</translation>
     </message>
     <message>
         <source>A too low fee might result in a never confirming transaction (read the tooltip)</source>
         <translation type="unfinished">Una taxa massa baixa pot resultar en una transacció que no es confirmi mai (llegiu el consell)</translation>
+    </message>
+    <message>
+        <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
+        <translation type="unfinished">(La tarifa intel·ligent encara no s'ha inicialitzat. Normalment triga uns quants blocs...)</translation>
     </message>
     <message>
         <source>Confirmation time target:</source>
@@ -2260,11 +2606,11 @@ Si rebeu aquest error, haureu de sol·licitar al comerciant que proporcioni un U
     </message>
     <message>
         <source>Enable Replace-By-Fee</source>
-        <translation type="unfinished">Habilita Replace-By-Fee: substitució per comissió</translation>
+        <translation type="unfinished">Habilita Replace-By-Fee: substitució per tarifa</translation>
     </message>
     <message>
         <source>With Replace-By-Fee (BIP-125) you can increase a transaction's fee after it is sent. Without this, a higher fee may be recommended to compensate for increased transaction delay risk.</source>
-        <translation type="unfinished">Amb la substitució per comissió o Replace-By-Fee (BIP-125) pot incrementar la comissió de la transacció després d'enviar-la. Sense això, seria recomenable una comissió més alta per compensar el risc d'increment del retard de la transacció.</translation>
+        <translation type="unfinished">Amb la substitució per tarifa o Replace-By-Fee (BIP-125) pot incrementar la tarifa de la transacció després d'enviar-la. Sense això, seria recomenable una tarifa més alta per a compensar el risc d'increment del retard de la transacció.</translation>
     </message>
     <message>
         <source>Clear &amp;All</source>
@@ -2292,11 +2638,11 @@ Si rebeu aquest error, haureu de sol·licitar al comerciant que proporcioni un U
     </message>
     <message>
         <source>Copy fee</source>
-        <translation type="unfinished">Copia la comissió</translation>
+        <translation type="unfinished">Copia la tarifa</translation>
     </message>
     <message>
         <source>Copy after fee</source>
-        <translation type="unfinished">Copia la comissió posterior</translation>
+        <translation type="unfinished">Copia la tarifa posterior</translation>
     </message>
     <message>
         <source>Copy bytes</source>
@@ -2313,6 +2659,20 @@ Si rebeu aquest error, haureu de sol·licitar al comerciant que proporcioni un U
     <message>
         <source>%1 (%2 blocks)</source>
         <translation type="unfinished">%1 (%2 blocs)</translation>
+    </message>
+    <message>
+        <source>Sign on device</source>
+        <extracomment>"device" usually means a hardware wallet</extracomment>
+        <translation type="unfinished">Identifica't al dispositiu</translation>
+    </message>
+    <message>
+        <source>Connect your hardware wallet first.</source>
+        <translation type="unfinished">Connecteu primer la vostra cartera de maquinari.</translation>
+    </message>
+    <message>
+        <source>Set external signer script path in Options -&gt; Wallet</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Definiu el camí de l'script del signant extern a Opcions -&gt; Cartera</translation>
     </message>
     <message>
         <source>Cr&amp;eate Unsigned</source>
@@ -2343,8 +2703,30 @@ Si rebeu aquest error, haureu de sol·licitar al comerciant que proporcioni un U
         <translation type="unfinished">Esteu segur que ho voleu enviar?</translation>
     </message>
     <message>
+        <source>To review recipient list click "Show Details…"</source>
+        <translation type="unfinished">Per a revisar la llista de destinataris, feu clic a «Mostra els detalls...»</translation>
+    </message>
+    <message>
         <source>Create Unsigned</source>
         <translation type="unfinished">Creació sense firmar</translation>
+    </message>
+    <message>
+        <source>Sign and send</source>
+        <translation type="unfinished">Signa i envia</translation>
+    </message>
+    <message>
+        <source>Sign failed</source>
+        <translation type="unfinished">Signatura fallida</translation>
+    </message>
+    <message>
+        <source>External signer not found</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">No s'ha trobat el signant extern</translation>
+    </message>
+    <message>
+        <source>External signer failure</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Error del signant extern</translation>
     </message>
     <message>
         <source>Save Transaction Data</source>
@@ -2360,12 +2742,16 @@ Si rebeu aquest error, haureu de sol·licitar al comerciant que proporcioni un U
         <translation type="unfinished">PSBT guardada</translation>
     </message>
     <message>
+        <source>External balance:</source>
+        <translation type="unfinished">Balanç extern:</translation>
+    </message>
+    <message>
         <source>or</source>
         <translation type="unfinished">o</translation>
     </message>
     <message>
         <source>You can increase the fee later (signals Replace-By-Fee, BIP-125).</source>
-        <translation type="unfinished">Pot incrementar la comissió més tard (senyala Replace-By-Fee o substitució per comissió, BIP-125).</translation>
+        <translation type="unfinished">Pot incrementar la tarifa més tard (senyala Replace-By-Fee o substitució per tarifa, BIP-125).</translation>
     </message>
     <message>
         <source>Please, review your transaction proposal. This will produce a Partially Signed Bitcoin Transaction (PSBT) which you can save or copy and then sign with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
@@ -2377,7 +2763,7 @@ Si rebeu aquest error, haureu de sol·licitar al comerciant que proporcioni un U
     </message>
     <message>
         <source>Transaction fee</source>
-        <translation type="unfinished">Comissió de transacció</translation>
+        <translation type="unfinished">Tarifa de transacció</translation>
     </message>
     <message>
         <source>Not signalling Replace-By-Fee, BIP-125.</source>
@@ -2413,7 +2799,7 @@ Si rebeu aquest error, haureu de sol·licitar al comerciant que proporcioni un U
     </message>
     <message>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
-        <translation type="unfinished">El total excedeix el vostre balanç quan s'afegeix la comissió a la transacció %1.</translation>
+        <translation type="unfinished">El total excedeix el vostre balanç quan s'afegeix la tarifa a la transacció %1.</translation>
     </message>
     <message>
         <source>Duplicate address found: addresses should only be used once each.</source>
@@ -2425,7 +2811,7 @@ Si rebeu aquest error, haureu de sol·licitar al comerciant que proporcioni un U
     </message>
     <message>
         <source>A fee higher than %1 is considered an absurdly high fee.</source>
-        <translation type="unfinished">Una comissió superior a %1 es considera una comissió absurdament alta.</translation>
+        <translation type="unfinished">Una tarifa superior a %1 es considera una tarifa absurdament alta.</translation>
     </message>
     <message>
         <source>Payment request expired.</source>
@@ -2434,8 +2820,8 @@ Si rebeu aquest error, haureu de sol·licitar al comerciant que proporcioni un U
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation>
-            <numerusform />
-            <numerusform />
+            <numerusform>S'estima que començarà la confirmació en %n bloc.</numerusform>
+            <numerusform>S'estima que començarà la confirmació en %n blocs.</numerusform>
         </translation>
     </message>
     <message>
@@ -2499,11 +2885,11 @@ Si rebeu aquest error, haureu de sol·licitar al comerciant que proporcioni un U
     </message>
     <message>
         <source>The fee will be deducted from the amount being sent. The recipient will receive less bitcoins than you enter in the amount field. If multiple recipients are selected, the fee is split equally.</source>
-        <translation type="unfinished">La comissió es deduirà de l'import que s'enviarà. El destinatari rebrà menys bitcoins que les que introduïu al camp d'import. Si se seleccionen múltiples destinataris, la comissió es dividirà per igual.</translation>
+        <translation type="unfinished">La tarifa es deduirà de l'import que s'enviarà. El destinatari rebrà menys bitcoins que les que introduïu al camp d'import. Si se seleccionen múltiples destinataris, la tarifa es dividirà per igual.</translation>
     </message>
     <message>
         <source>S&amp;ubtract fee from amount</source>
-        <translation type="unfinished">S&amp;ubstreu la comissió de l'import</translation>
+        <translation type="unfinished">S&amp;ubstreu la tarifa de l'import</translation>
     </message>
     <message>
         <source>Use available balance</source>
@@ -2546,7 +2932,7 @@ Si rebeu aquest error, haureu de sol·licitar al comerciant que proporcioni un U
     </message>
     <message>
         <source>You can sign messages/agreements with your addresses to prove you can receive bitcoins sent to them. Be careful not to sign anything vague or random, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
-        <translation type="unfinished">Podeu signar missatges/acords amb les vostres adreces per provar que rebeu les bitcoins que s'hi envien. Aneu amb compte no signar res que sigui vague o aleatori, perquè en alguns atacs de suplantació es pot provar que hi signeu la vostra identitat. Només signeu aquelles declaracions completament detallades en què hi esteu d'acord. </translation>
+        <translation type="unfinished">Podeu signar missatges/acords amb les vostres adreces per a provar que rebeu les bitcoins que s'hi envien. Aneu amb compte no signar res que sigui vague o aleatori, perquè en alguns atacs de suplantació es pot provar que hi signeu la vostra identitat. Només signeu aquelles declaracions completament detallades en què hi esteu d'acord. </translation>
     </message>
     <message>
         <source>The Bitcoin address to sign the message with</source>
@@ -2578,7 +2964,7 @@ Si rebeu aquest error, haureu de sol·licitar al comerciant que proporcioni un U
     </message>
     <message>
         <source>Sign the message to prove you own this Bitcoin address</source>
-        <translation>Signa el missatge per provar que ets propietari d'aquesta adreça Bitcoin</translation>
+        <translation>Signa el missatge per a provar que ets propietari d'aquesta adreça Bitcoin</translation>
     </message>
     <message>
         <source>Sign &amp;Message</source>
@@ -2598,7 +2984,7 @@ Si rebeu aquest error, haureu de sol·licitar al comerciant que proporcioni un U
     </message>
     <message>
         <source>Enter the receiver's address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack. Note that this only proves the signing party receives with the address, it cannot prove sendership of any transaction!</source>
-        <translation type="unfinished">Introduïu l'adreça del receptor, el missatge (assegureu-vos de copiar els salts de línia, espais, tabuladors, etc. exactament) i signatura de sota per verificar el missatge. Tingueu cura de no llegir més en la signatura del que està al missatge signat, per evitar ser enganyat per un atac d'home-en-el-mig. Tingueu en compte que això només demostra que la part que signa rep amb l'adreça, i no es pot provar l'enviament de qualsevol transacció!</translation>
+        <translation type="unfinished">Introduïu l'adreça del receptor, el missatge (assegureu-vos de copiar els salts de línia, espais, tabuladors, etc. exactament) i signatura de sota per a verificar el missatge. Tingueu cura de no llegir més en la signatura del que està al missatge signat, per a evitar ser enganyat per un atac d'home-en-el-mig. Tingueu en compte que això només demostra que la part que signa rep amb l'adreça, i no es pot provar l'enviament de qualsevol transacció!</translation>
     </message>
     <message>
         <source>The Bitcoin address the message was signed with</source>
@@ -2606,7 +2992,7 @@ Si rebeu aquest error, haureu de sol·licitar al comerciant que proporcioni un U
     </message>
     <message>
         <source>The signed message to verify</source>
-        <translation type="unfinished">El missatge signat per verificar</translation>
+        <translation type="unfinished">El missatge signat per a verificar</translation>
     </message>
     <message>
         <source>The signature given when the message was signed</source>
@@ -2614,7 +3000,7 @@ Si rebeu aquest error, haureu de sol·licitar al comerciant que proporcioni un U
     </message>
     <message>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
-        <translation>Verificar el missatge per assegurar-se que ha estat signat amb una adreça Bitcoin específica</translation>
+        <translation>Verificar el missatge per a assegurar-se que ha estat signat amb una adreça Bitcoin específica</translation>
     </message>
     <message>
         <source>Verify &amp;Message</source>
@@ -2686,8 +3072,8 @@ Si rebeu aquest error, haureu de sol·licitar al comerciant que proporcioni un U
     <message numerus="yes">
         <source>Open for %n more block(s)</source>
         <translation>
-            <numerusform />
-            <numerusform />
+            <numerusform>Obre per a %n bloc més</numerusform>
+            <numerusform>Obre per a %n blocs més</numerusform>
         </translation>
     </message>
     <message>
@@ -2769,8 +3155,8 @@ Si rebeu aquest error, haureu de sol·licitar al comerciant que proporcioni un U
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation>
-            <numerusform />
-            <numerusform />
+            <numerusform>madura en %n bloc més</numerusform>
+            <numerusform>madura en %n blocs més</numerusform>
         </translation>
     </message>
     <message>
@@ -2791,7 +3177,7 @@ Si rebeu aquest error, haureu de sol·licitar al comerciant que proporcioni un U
     </message>
     <message>
         <source>Transaction fee</source>
-        <translation type="unfinished">Comissió de transacció</translation>
+        <translation type="unfinished">Tarifa de transacció</translation>
     </message>
     <message>
         <source>Net amount</source>
@@ -2866,7 +3252,7 @@ Si rebeu aquest error, haureu de sol·licitar al comerciant que proporcioni un U
     </message>
     <message>
         <source>Details for %1</source>
-        <translation type="unfinished">Detalls per %1</translation>
+        <translation type="unfinished">Detalls per a %1</translation>
     </message>
 </context>
 <context>
@@ -2886,8 +3272,8 @@ Si rebeu aquest error, haureu de sol·licitar al comerciant que proporcioni un U
     <message numerus="yes">
         <source>Open for %n more block(s)</source>
         <translation>
-            <numerusform />
-            <numerusform />
+            <numerusform>Obre per a %n bloc més</numerusform>
+            <numerusform>Obre per a %n blocs més</numerusform>
         </translation>
     </message>
     <message>
@@ -2952,7 +3338,7 @@ Si rebeu aquest error, haureu de sol·licitar al comerciant que proporcioni un U
     </message>
     <message>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
-        <translation type="unfinished">Estat de la transacció. Desplaceu-vos sobre aquest camp per mostrar el nombre de confirmacions.</translation>
+        <translation type="unfinished">Estat de la transacció. Desplaceu-vos sobre aquest camp per a mostrar el nombre de confirmacions.</translation>
     </message>
     <message>
         <source>Date and time that the transaction was received.</source>
@@ -3028,6 +3414,50 @@ Si rebeu aquest error, haureu de sol·licitar al comerciant que proporcioni un U
     <message>
         <source>Min amount</source>
         <translation type="unfinished">Import mínim</translation>
+    </message>
+    <message>
+        <source>Range…</source>
+        <translation type="unfinished">Rang...</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Copia l'adreça</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Copia l'&amp;etiqueta</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Copia la &amp;quantitat</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">Copiar &amp;ID de transacció</translation>
+    </message>
+    <message>
+        <source>Copy &amp;raw transaction</source>
+        <translation type="unfinished">Copia la transacció &amp;crua</translation>
+    </message>
+    <message>
+        <source>Copy full transaction &amp;details</source>
+        <translation type="unfinished">Copieu els &amp;detalls complets de la transacció</translation>
+    </message>
+    <message>
+        <source>&amp;Show transaction details</source>
+        <translation type="unfinished">&amp;Mostra els detalls de la transacció</translation>
+    </message>
+    <message>
+        <source>Increase transaction &amp;fee</source>
+        <translation type="unfinished">Augmenta la &amp;tarifa de transacció</translation>
+    </message>
+    <message>
+        <source>A&amp;bandon transaction</source>
+        <translation type="unfinished">Transacció d'a&amp;bandonar</translation>
+    </message>
+    <message>
+        <source>&amp;Edit address label</source>
+        <translation type="unfinished">&amp;Edita l'etiqueta de l'adreça</translation>
     </message>
     <message>
         <source>Export Transaction History</source>
@@ -3137,6 +3567,10 @@ Ves a Arxiu &gt; Obrir Cartera per a carregar cartera.
         <translation type="unfinished">Nova tarifa:</translation>
     </message>
     <message>
+        <source>Warning: This may pay the additional fee by reducing change outputs or adding inputs, when necessary. It may add a new change output if one does not already exist. These changes may potentially leak privacy.</source>
+        <translation type="unfinished">Avís: això pot pagar la tarifa addicional en reduir les sortides de canvi o afegint entrades, quan sigui necessari. Pot afegir una nova sortida de canvi si encara no n'hi ha. Aquests canvis poden filtrar la privadesa.</translation>
+    </message>
+    <message>
         <source>Confirm fee bump</source>
         <translation type="unfinished">Confirmeu el recàrrec de tarifes</translation>
     </message>
@@ -3155,6 +3589,10 @@ Ves a Arxiu &gt; Obrir Cartera per a carregar cartera.
     <message>
         <source>Could not commit transaction</source>
         <translation type="unfinished">No s'ha pogut confirmar la transacció</translation>
+    </message>
+    <message>
+        <source>Can't display address</source>
+        <translation type="unfinished">No es pot mostrar l'adreça</translation>
     </message>
     <message>
         <source>default wallet</source>
@@ -3229,11 +3667,15 @@ Ves a Arxiu &gt; Obrir Cartera per a carregar cartera.
     </message>
     <message>
         <source>%s corrupt. Try using the wallet tool bitcoin-wallet to salvage or restoring a backup.</source>
-        <translation type="unfinished">%s està malmès. Proveu d’utilitzar l’eina bitcoin-wallet per recuperar o restaurar una còpia de seguretat.</translation>
+        <translation type="unfinished">%s està malmès. Proveu d’utilitzar l’eina bitcoin-wallet per a recuperar o restaurar una còpia de seguretat.</translation>
     </message>
     <message>
         <source>-maxtxfee is set very high! Fees this large could be paid on a single transaction.</source>
-        <translation type="unfinished">-maxtxfee especificat molt alt! Comissions tan grans podrien pagar-se en una única transacció.</translation>
+        <translation type="unfinished">-maxtxfee especificat molt alt! Tarifes tan grans podrien pagar-se en una única transacció.</translation>
+    </message>
+    <message>
+        <source>Cannot downgrade wallet from version %i to version %i. Wallet version unchanged.</source>
+        <translation type="unfinished">No es pot degradar la cartera de la versió %i a la versió %i. La versió de la cartera no ha canviat.</translation>
     </message>
     <message>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running.</source>
@@ -3244,12 +3686,32 @@ Ves a Arxiu &gt; Obrir Cartera per a carregar cartera.
         <translation type="unfinished">No es poden proporcionar connexions específiques i no es poden trobar connexions sortint al mateix temps.</translation>
     </message>
     <message>
+        <source>Cannot upgrade a non HD split wallet from version %i to version %i without upgrading to support pre-split keypool. Please use version %i or no version specified.</source>
+        <translation type="unfinished">No es pot actualitzar una cartera dividida no HD de la versió %i a la versió %i sense actualitzar-la per a admetre l'agrupació de claus dividida prèviament. Utilitzeu la versió %i o cap versió especificada.</translation>
+    </message>
+    <message>
         <source>Distributed under the MIT software license, see the accompanying file %s or %s</source>
         <translation type="unfinished">Distribuït sota la llicència del programari MIT, consulteu el fitxer d'acompanyament %s o %s</translation>
     </message>
     <message>
         <source>Error reading %s! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation type="unfinished">S'ha produït un error en llegir %s. Totes les claus es llegeixen correctament, però les dades de la transacció o les entrades de la llibreta d'adreces podrien faltar o ser incorrectes.</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile format record is incorrect. Got "%s", expected "format".</source>
+        <translation type="unfinished">Error: el registre del format del fitxer de bolcat és incorrecte. S'ha obtingut «%s», s'esperava «format».</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile identifier record is incorrect. Got "%s", expected "%s".</source>
+        <translation type="unfinished">Error: el registre de l'identificador del fitxer de bolcat és incorrecte. S'ha obtingut «%s», s'esperava «%s».</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile version is not supported. This version of bitcoin-wallet only supports version 1 dumpfiles. Got dumpfile with version %s</source>
+        <translation type="unfinished">Error: la versió del fitxer de bolcat no és compatible. Aquesta versió de bitcoin-wallet només admet fitxers de bolcat de la versió 1. S'ha obtingut un fitxer de bolcat amb la versió %s</translation>
+    </message>
+    <message>
+        <source>Error: Legacy wallets only support the "legacy", "p2sh-segwit", and "bech32" address types</source>
+        <translation type="unfinished">Error: les carteres heretades només admeten els tipus d'adreces «legacy», «p2sh-segwit» i «bech32»</translation>
     </message>
     <message>
         <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
@@ -3260,12 +3722,28 @@ Ves a Arxiu &gt; Obrir Cartera per a carregar cartera.
         <translation type="unfinished">L'estimació de la quota ha fallat. Fallbackfee està desactivat. Espereu uns quants blocs o activeu -fallbackfee.</translation>
     </message>
     <message>
+        <source>File %s already exists. If you are sure this is what you want, move it out of the way first.</source>
+        <translation type="unfinished">El fitxer %s ja existeix. Si esteu segur que això és el que voleu, primer desplaceu-lo.</translation>
+    </message>
+    <message>
         <source>Invalid amount for -maxtxfee=&lt;amount&gt;: '%s' (must be at least the minrelay fee of %s to prevent stuck transactions)</source>
-        <translation type="unfinished">Import no vàlid per a -maxtxfee=&lt;amount&gt;: '%s' (cal que sigui com a mínim la comissió de minrelay de %s per evitar que les comissions s'encallin)</translation>
+        <translation type="unfinished">Import no vàlid per a -maxtxfee=&lt;amount&gt;: '%s' (cal que sigui com a mínim la tarifa de minrelay de %s per evitar que les tarifes s'encallin)</translation>
     </message>
     <message>
         <source>More than one onion bind address is provided. Using %s for the automatically created Tor onion service.</source>
         <translation type="unfinished"> Es proporciona més d'una adreça de vinculació. Utilitzant %s pel servei Tor onion automàticament creat.</translation>
+    </message>
+    <message>
+        <source>No dump file provided. To use createfromdump, -dumpfile=&lt;filename&gt; must be provided.</source>
+        <translation type="unfinished">No s'ha proporcionat cap fitxer de bolcat. Per a utilitzar createfromdump, s'ha de proporcionar&lt;filename&gt;.</translation>
+    </message>
+    <message>
+        <source>No dump file provided. To use dump, -dumpfile=&lt;filename&gt; must be provided.</source>
+        <translation type="unfinished">No s'ha proporcionat cap fitxer de bolcat. Per a bolcar, cal proporcionar&lt;filename&gt;.</translation>
+    </message>
+    <message>
+        <source>No wallet file format provided. To use createfromdump, -format=&lt;format&gt; must be provided.</source>
+        <translation type="unfinished">No s'ha proporcionat cap format de fitxer de cartera. Per a utilitzar createfromdump, s'ha de proporcionar&lt;format&gt;.</translation>
     </message>
     <message>
         <source>Please check that your computer's date and time are correct! If your clock is wrong, %s will not work properly.</source>
@@ -3273,7 +3751,7 @@ Ves a Arxiu &gt; Obrir Cartera per a carregar cartera.
     </message>
     <message>
         <source>Please contribute if you find %s useful. Visit %s for further information about the software.</source>
-        <translation type="unfinished">Contribueix si trobes %s útil. Visita %s per obtenir més informació sobre el programari.</translation>
+        <translation type="unfinished">Contribueix si trobes %s útil. Visita %s per a obtenir més informació sobre el programari.</translation>
     </message>
     <message>
         <source>Prune configured below the minimum of %d MiB.  Please use a higher number.</source>
@@ -3293,7 +3771,7 @@ Ves a Arxiu &gt; Obrir Cartera per a carregar cartera.
     </message>
     <message>
         <source>The transaction amount is too small to send after the fee has been deducted</source>
-        <translation type="unfinished">L'import de la transacció és massa petit per enviar-la després que se'n dedueixi la comissió</translation>
+        <translation type="unfinished">L'import de la transacció és massa petit per a enviar-la després que se'n dedueixi la tarifa</translation>
     </message>
     <message>
         <source>This error could occur if this wallet was not shutdown cleanly and was last loaded using a build with a newer version of Berkeley DB. If so, please use the software that last loaded this wallet</source>
@@ -3305,7 +3783,7 @@ Ves a Arxiu &gt; Obrir Cartera per a carregar cartera.
     </message>
     <message>
         <source>This is the maximum transaction fee you pay (in addition to the normal fee) to prioritize partial spend avoidance over regular coin selection.</source>
-        <translation type="unfinished">Aquesta és la comissió màxima de transacció que pagueu (a més de la tarifa normal) per prioritzar l'evitació parcial de la despesa per sobre de la selecció regular de monedes.</translation>
+        <translation type="unfinished">Aquesta és la tarifa màxima de transacció que pagueu (a més de la tarifa normal) per a prioritzar l'evitació parcial de la despesa per sobre de la selecció regular de monedes.</translation>
     </message>
     <message>
         <source>This is the transaction fee you may discard if change is smaller than dust at this level</source>
@@ -3324,6 +3802,14 @@ Ves a Arxiu &gt; Obrir Cartera per a carregar cartera.
         <translation type="unfinished">No es poden reproduir els blocs. Haureu de reconstruir la base de dades mitjançant -reindex- chainstate.</translation>
     </message>
     <message>
+        <source>Unknown wallet file format "%s" provided. Please provide one of "bdb" or "sqlite".</source>
+        <translation type="unfinished">S'ha proporcionat un format de fitxer de cartera desconegut «%s». Proporcioneu un de «bdb» o «sqlite».</translation>
+    </message>
+    <message>
+        <source>Warning: Dumpfile wallet format "%s" does not match command line specified format "%s".</source>
+        <translation type="unfinished">Avís: el format de cartera del fitxer de bolcat «%s» no coincideix amb el format «%s» especificat a la línia d'ordres.</translation>
+    </message>
+    <message>
         <source>Warning: Private keys detected in wallet {%s} with disabled private keys</source>
         <translation type="unfinished">Avís: Claus privades detectades en la cartera {%s} amb claus privades deshabilitades</translation>
     </message>
@@ -3332,8 +3818,12 @@ Ves a Arxiu &gt; Obrir Cartera per a carregar cartera.
         <translation type="unfinished">Avís: sembla que no estem plenament d'acord amb els nostres iguals! Podria caler que actualitzar l'aplicació, o potser que ho facin altres nodes.</translation>
     </message>
     <message>
+        <source>Witness data for blocks after height %d requires validation. Please restart with -reindex.</source>
+        <translation type="unfinished">Les dades de testimoni dels blocs després de l'altura %d requereixen validació. Reinicieu amb -reindex.</translation>
+    </message>
+    <message>
         <source>You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain</source>
-        <translation type="unfinished">Cal que torneu a construir la base de dades fent servir -reindex per tornar al mode no podat. Això tornarà a baixar la cadena de blocs sencera</translation>
+        <translation type="unfinished">Cal que torneu a construir la base de dades fent servir -reindex per a tornar al mode no podat. Això tornarà a baixar la cadena de blocs sencera</translation>
     </message>
     <message>
         <source>%s is set very high!</source>
@@ -3392,6 +3882,14 @@ Ves a Arxiu &gt; Obrir Cartera per a carregar cartera.
         <translation type="unfinished">Ha acabat la càrrega</translation>
     </message>
     <message>
+        <source>Dump file %s does not exist.</source>
+        <translation type="unfinished">El fitxer de bolcat %s no existeix.</translation>
+    </message>
+    <message>
+        <source>Error creating %s</source>
+        <translation type="unfinished">Error al crear %s</translation>
+    </message>
+    <message>
         <source>Error initializing block database</source>
         <translation type="unfinished">Error carregant la base de dades de blocs</translation>
     </message>
@@ -3428,16 +3926,53 @@ Ves a Arxiu &gt; Obrir Cartera per a carregar cartera.
         <translation type="unfinished">Error en llegir la base de dades, tancant.</translation>
     </message>
     <message>
+        <source>Error reading next record from wallet database</source>
+        <translation type="unfinished">S'ha produït un error en llegir el següent registre de la base de dades de la cartera</translation>
+    </message>
+    <message>
         <source>Error upgrading chainstate database</source>
         <translation type="unfinished">S'ha produït un error en actualitzar la base de dades de chainstate</translation>
+    </message>
+    <message>
+        <source>Error: Couldn't create cursor into database</source>
+        <translation type="unfinished">Error: No s'ha pogut crear el cursor a la base de dades</translation>
     </message>
     <message>
         <source>Error: Disk space is low for %s</source>
         <translation type="unfinished">Error: l'espai del disc és insuficient per a %s</translation>
     </message>
     <message>
+        <source>Error: Dumpfile checksum does not match. Computed %s, expected %s</source>
+        <translation type="unfinished">Error: la suma de comprovació del fitxer bolcat no coincideix. S'ha calculat %s, s'esperava 
+%s</translation>
+    </message>
+    <message>
+        <source>Error: Got key that was not hex: %s</source>
+        <translation type="unfinished">Error: S'ha obtingut una clau que no era hexadecimal: %s</translation>
+    </message>
+    <message>
+        <source>Error: Got value that was not hex: %s</source>
+        <translation type="unfinished">Error: S'ha obtingut un valor que no era hexadecimal: %s</translation>
+    </message>
+    <message>
         <source>Error: Keypool ran out, please call keypoolrefill first</source>
         <translation type="unfinished">Error: Keypool s’ha esgotat. Visiteu primer keypoolrefill</translation>
+    </message>
+    <message>
+        <source>Error: Missing checksum</source>
+        <translation type="unfinished">Error: falta la suma de comprovació</translation>
+    </message>
+    <message>
+        <source>Error: No %s addresses available.</source>
+        <translation type="unfinished">Error: no hi ha %s adreces disponibles.</translation>
+    </message>
+    <message>
+        <source>Error: Unable to parse version %u as a uint32_t</source>
+        <translation type="unfinished">Error: no es pot analitzar la versió %u com a uint32_t</translation>
+    </message>
+    <message>
+        <source>Error: Unable to write record to new wallet</source>
+        <translation type="unfinished">Error: no es pot escriure el registre a la cartera nova</translation>
     </message>
     <message>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
@@ -3460,6 +3995,10 @@ Ves a Arxiu &gt; Obrir Cartera per a carregar cartera.
         <translation type="unfinished">Ignorant -cartera duplicada %s.</translation>
     </message>
     <message>
+        <source>Importing…</source>
+        <translation type="unfinished">Importació en curs...</translation>
+    </message>
+    <message>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation type="unfinished">No s'ha trobat el bloc de gènesi o és incorrecte. El directori de dades de la xarxa és incorrecte?</translation>
     </message>
@@ -3470,6 +4009,10 @@ Ves a Arxiu &gt; Obrir Cartera per a carregar cartera.
     <message>
         <source>Insufficient funds</source>
         <translation type="unfinished">Balanç insuficient</translation>
+    </message>
+    <message>
+        <source>Invalid -i2psam address or hostname: '%s'</source>
+        <translation type="unfinished">Adreça o nom d'amfitrió -i2psam no vàlids: «%s»</translation>
     </message>
     <message>
         <source>Invalid -onion address or hostname: '%s'</source>
@@ -3485,15 +4028,15 @@ Ves a Arxiu &gt; Obrir Cartera per a carregar cartera.
     </message>
     <message>
         <source>Invalid amount for -%s=&lt;amount&gt;: '%s'</source>
-        <translation type="unfinished">Import invàlid per -%s=&lt;amount&gt;: '%s'</translation>
+        <translation type="unfinished">Import invàlid per a -%s=&lt;amount&gt;: '%s'</translation>
     </message>
     <message>
         <source>Invalid amount for -discardfee=&lt;amount&gt;: '%s'</source>
-        <translation type="unfinished">Import invàlid per -discardfee=&lt;amount&gt;: '%s'</translation>
+        <translation type="unfinished">Import invàlid per a -discardfee=&lt;amount&gt;: '%s'</translation>
     </message>
     <message>
         <source>Invalid amount for -fallbackfee=&lt;amount&gt;: '%s'</source>
-        <translation type="unfinished">Import invàlid per -fallbackfee=&lt;amount&gt;: '%s'</translation>
+        <translation type="unfinished">Import invàlid per a -fallbackfee=&lt;amount&gt;: '%s'</translation>
     </message>
     <message>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: '%s' (must be at least %s)</source>
@@ -3502,6 +4045,22 @@ Ves a Arxiu &gt; Obrir Cartera per a carregar cartera.
     <message>
         <source>Invalid netmask specified in -whitelist: '%s'</source>
         <translation type="unfinished">S'ha especificat una màscara de xarxa no vàlida a -whitelist: «%s»</translation>
+    </message>
+    <message>
+        <source>Loading P2P addresses…</source>
+        <translation type="unfinished">S'estan carregant les adreces P2P...</translation>
+    </message>
+    <message>
+        <source>Loading banlist…</source>
+        <translation type="unfinished">S'està carregant la llista de bans...</translation>
+    </message>
+    <message>
+        <source>Loading block index…</source>
+        <translation type="unfinished">S'està carregant l'índex de blocs...</translation>
+    </message>
+    <message>
+        <source>Loading wallet…</source>
+        <translation type="unfinished">Carregant cartera...</translation>
     </message>
     <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
@@ -3520,20 +4079,36 @@ Ves a Arxiu &gt; Obrir Cartera per a carregar cartera.
         <translation type="unfinished">La poda no es pot configurar amb un valor negatiu.</translation>
     </message>
     <message>
+        <source>Prune mode is incompatible with -coinstatsindex.</source>
+        <translation type="unfinished">El mode de poda és incompatible amb -coinstatsindex.</translation>
+    </message>
+    <message>
         <source>Prune mode is incompatible with -txindex.</source>
         <translation type="unfinished">El mode de poda és incompatible amb -txindex.</translation>
+    </message>
+    <message>
+        <source>Pruning blockstore…</source>
+        <translation type="unfinished">Taller de poda...</translation>
     </message>
     <message>
         <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
         <translation type="unfinished">Reducció de -maxconnections de %d a %d, a causa de les limitacions del sistema.</translation>
     </message>
     <message>
+        <source>Replaying blocks…</source>
+        <translation type="unfinished">Reproduint blocs…</translation>
+    </message>
+    <message>
+        <source>Rescanning…</source>
+        <translation type="unfinished">S'està tornant a escanejar…</translation>
+    </message>
+    <message>
         <source>SQLiteDatabase: Failed to execute statement to verify database: %s</source>
-        <translation type="unfinished">SQLiteDatabase: No s'ha pogut executar la sentència per verificar la base de dades: %s</translation>
+        <translation type="unfinished">SQLiteDatabase: No s'ha pogut executar la sentència per a verificar la base de dades: %s</translation>
     </message>
     <message>
         <source>SQLiteDatabase: Failed to prepare statement to verify database: %s</source>
-        <translation type="unfinished">SQLiteDatabase: No s'ha pogut preparar la sentència per verificar la base de dades: %s</translation>
+        <translation type="unfinished">SQLiteDatabase: No s'ha pogut preparar la sentència per a verificar la base de dades: %s</translation>
     </message>
     <message>
         <source>SQLiteDatabase: Failed to read database verification error: %s</source>
@@ -3568,16 +4143,24 @@ Ves a Arxiu &gt; Obrir Cartera per a carregar cartera.
         <translation type="unfinished">El directori de blocs especificat "%s" no existeix.</translation>
     </message>
     <message>
+        <source>Starting network threads…</source>
+        <translation type="unfinished">S'estan iniciant fils de xarxa...</translation>
+    </message>
+    <message>
         <source>The source code is available from %s.</source>
         <translation type="unfinished">El codi font està disponible a %s.</translation>
     </message>
     <message>
+        <source>The specified config file %s does not exist</source>
+        <translation type="unfinished">El fitxer de configuració especificat %s no existeix</translation>
+    </message>
+    <message>
         <source>The transaction amount is too small to pay the fee</source>
-        <translation type="unfinished">L'import de la transacció és massa petit per pagar-ne una comissió</translation>
+        <translation type="unfinished">L'import de la transacció és massa petit per a pagar-ne una tarifa</translation>
     </message>
     <message>
         <source>The wallet will avoid paying less than the minimum relay fee.</source>
-        <translation type="unfinished">La cartera evitarà pagar menys de la comissió de tramesa mínima</translation>
+        <translation type="unfinished">La cartera evitarà pagar menys de la tarifa de trànsit mínima</translation>
     </message>
     <message>
         <source>This is experimental software.</source>
@@ -3585,11 +4168,11 @@ Ves a Arxiu &gt; Obrir Cartera per a carregar cartera.
     </message>
     <message>
         <source>This is the minimum transaction fee you pay on every transaction.</source>
-        <translation type="unfinished">Aquesta és la comissió mínima de transacció que paga en cada transacció.</translation>
+        <translation type="unfinished">Aquesta és la tarifa mínima de transacció que paga en cada transacció.</translation>
     </message>
     <message>
         <source>This is the transaction fee you will pay if you send a transaction.</source>
-        <translation type="unfinished">Aquesta és la comissió de transacció que pagareu si envieu una transacció.</translation>
+        <translation type="unfinished">Aquesta és la tarifa de transacció que pagareu si envieu una transacció.</translation>
     </message>
     <message>
         <source>Transaction amount too small</source>
@@ -3606,6 +4189,10 @@ Ves a Arxiu &gt; Obrir Cartera per a carregar cartera.
     <message>
         <source>Transaction must have at least one recipient</source>
         <translation type="unfinished">La transacció ha de tenir com a mínim un destinatari</translation>
+    </message>
+    <message>
+        <source>Transaction needs a change address, but we can't generate it. %s</source>
+        <translation type="unfinished">La transacció necessita una adreça de canvi, però no la podem generar. %s</translation>
     </message>
     <message>
         <source>Transaction too large</source>
@@ -3632,6 +4219,10 @@ Ves a Arxiu &gt; Obrir Cartera per a carregar cartera.
         <translation type="unfinished">No s'han pogut generar les claus</translation>
     </message>
     <message>
+        <source>Unable to open %s for writing</source>
+        <translation type="unfinished">No es pot obrir %s per a escriure</translation>
+    </message>
+    <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
         <translation type="unfinished">No s'ha pogut iniciar el servidor HTTP. Vegeu debug.log per a més detalls.</translation>
     </message>
@@ -3652,6 +4243,10 @@ Ves a Arxiu &gt; Obrir Cartera per a carregar cartera.
         <translation type="unfinished">Xarxa desconeguda especificada a -onlynet: '%s'</translation>
     </message>
     <message>
+        <source>Unknown new rules activated (versionbit %i)</source>
+        <translation type="unfinished">S'han activat regles noves desconegudes (bit de versió %i)</translation>
+    </message>
+    <message>
         <source>Unsupported logging category %s=%s.</source>
         <translation type="unfinished">Categoria de registre no admesa %s=%s.</translation>
     </message>
@@ -3666,6 +4261,14 @@ Ves a Arxiu &gt; Obrir Cartera per a carregar cartera.
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
         <translation type="unfinished">El comentari de l'agent d'usuari (%s) conté caràcters insegurs.</translation>
+    </message>
+    <message>
+        <source>Verifying blocks…</source>
+        <translation type="unfinished">S'estan verificant els blocs...</translation>
+    </message>
+    <message>
+        <source>Verifying wallet(s)…</source>
+        <translation type="unfinished">Verifificant carteres...</translation>
     </message>
     <message>
         <source>Wallet needed to be rewritten: restart %s to complete</source>

--- a/src/qt/locale/bitcoin_cs.ts
+++ b/src/qt/locale/bitcoin_cs.ts
@@ -3,7 +3,7 @@
     <name>AddressBookPage</name>
     <message>
         <source>Right-click to edit address or label</source>
-        <translation type="unfinished">Pravým tlačítkem myši můžeš upravit označení adresy</translation>
+        <translation type="unfinished">Pravým tlačítkem myši upravte adresu nebo štítek</translation>
     </message>
     <message>
         <source>Create a new address</source>
@@ -241,6 +241,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>BitcoinApplication</name>
     <message>
+        <source>Runaway exception</source>
+        <translation type="unfinished">Uprchlá výjimka</translation>
+    </message>
+    <message>
         <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
         <translation type="unfinished">Stala se fatální chyba. %1 nemůže bezpečně pokračovat v činnosti, a bude ukončen.</translation>
     </message>
@@ -272,6 +276,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Zjišťování neshod: %1</translation>
     </message>
     <message>
+        <source>%1 didn't yet exit safely…</source>
+        <translation type="unfinished">%1 ještě bezpečně neskončil...</translation>
+    </message>
+    <message>
         <source>unknown</source>
         <translation type="unfinished">neznámo</translation>
     </message>
@@ -284,12 +292,40 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Zadej bitcoinovou adresu (např. %1)</translation>
     </message>
     <message>
+        <source>Unroutable</source>
+        <translation type="unfinished">Nesměrovatelné</translation>
+    </message>
+    <message>
+        <source>Internal</source>
+        <translation type="unfinished">Vnitřní</translation>
+    </message>
+    <message>
         <source>Inbound</source>
         <translation type="unfinished">Sem</translation>
     </message>
     <message>
         <source>Outbound</source>
         <translation type="unfinished">Ven</translation>
+    </message>
+    <message>
+        <source>Full Relay</source>
+        <translation type="unfinished">Plná štafeta</translation>
+    </message>
+    <message>
+        <source>Block Relay</source>
+        <translation type="unfinished">Blokové relé</translation>
+    </message>
+    <message>
+        <source>Manual</source>
+        <translation type="unfinished">Manuální</translation>
+    </message>
+    <message>
+        <source>Feeler</source>
+        <translation type="unfinished">Tykadlo</translation>
+    </message>
+    <message>
+        <source>Address Fetch</source>
+        <translation type="unfinished">Načtení adresy</translation>
     </message>
     <message>
         <source>None</source>
@@ -302,17 +338,17 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation>
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n sekunda</numerusform>
+            <numerusform>%n sekund</numerusform>
+            <numerusform>%n sekund</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n minute(s)</source>
         <translation>
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n minuta</numerusform>
+            <numerusform>%n minut</numerusform>
+            <numerusform>%n minut</numerusform>
         </translation>
     </message>
     <message numerus="yes">
@@ -334,9 +370,9 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n týden</numerusform>
+            <numerusform>%n týdnů</numerusform>
+            <numerusform>%n týdnů</numerusform>
         </translation>
     </message>
     <message>
@@ -346,9 +382,9 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n rok</numerusform>
+            <numerusform>%n roků</numerusform>
+            <numerusform>%n roků</numerusform>
         </translation>
     </message>
     </context>
@@ -448,16 +484,48 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation>Zobraz nebo skryj hlavní okno</translation>
     </message>
     <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation type="unfinished">&amp;Zašifrovat peněženku...</translation>
+    </message>
+    <message>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>Zašifruj soukromé klíče ve své peněžence</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation type="unfinished">&amp;Zazálohovat peněženku</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation type="unfinished">&amp;Změnit heslo...</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation type="unfinished">Podepiš &amp;zprávu...</translation>
     </message>
     <message>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation>Podepiš zprávy svými bitcoinovými adresami, čímž prokážeš, že jsi jejich vlastníkem</translation>
     </message>
     <message>
+        <source>&amp;Verify message…</source>
+        <translation type="unfinished">&amp;Ověř zprávu...</translation>
+    </message>
+    <message>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation>Ověř zprávy, aby ses ujistil, že byly podepsány danými bitcoinovými adresami</translation>
+    </message>
+    <message>
+        <source>&amp;Load PSBT from file…</source>
+        <translation type="unfinished">&amp;Načíst PSBT ze souboru...</translation>
+    </message>
+    <message>
+        <source>Load PSBT from clipboard…</source>
+        <translation type="unfinished">Načíst PSBT ze schránky</translation>
+    </message>
+    <message>
+        <source>Open &amp;URI…</source>
+        <translation type="unfinished">Načíst &amp;URI...</translation>
     </message>
     <message>
         <source>Close Wallet…</source>
@@ -488,8 +556,28 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation>Panel s listy</translation>
     </message>
     <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation type="unfinished">Synchronizuji hlavičky bloků (%1 %)...</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation type="unfinished">Synchronizuji se se sítí...</translation>
+    </message>
+    <message>
         <source>Indexing blocks on disk…</source>
         <translation type="unfinished">Vytvářím index bloků na disku...</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation type="unfinished">Zpracovávám bloky na disku...</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation type="unfinished">Vytvářím nový index bloků na disku...</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation type="unfinished">Připojuji se…</translation>
     </message>
     <message>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
@@ -510,14 +598,18 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation>
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>Zpracován %n blok transakční historie.</numerusform>
+            <numerusform>Zpracováno %n bloků transakční historie.</numerusform>
+            <numerusform>Zpracováno %n bloků transakční historie.</numerusform>
         </translation>
     </message>
     <message>
         <source>%1 behind</source>
         <translation>Stahuji ještě %1 bloků transakcí</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation type="unfinished">Stahuji...</translation>
     </message>
     <message>
         <source>Last received block was generated %1 ago.</source>
@@ -631,10 +723,30 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n aktivní spojení s Bitcoinovou sítí.</numerusform>
+            <numerusform>%n aktivních spojení s Bitcoinovou sítí.</numerusform>
+            <numerusform>%n aktivních spojení s Bitcoinovou sítí.</numerusform>
         </translation>
+    </message>
+    <message>
+        <source>Click for more actions.</source>
+        <extracomment>A substring of the tooltip. "More actions" are available via the context menu.</extracomment>
+        <translation type="unfinished">Klikněte pro více možností.</translation>
+    </message>
+    <message>
+        <source>Show Peers tab</source>
+        <extracomment>A context menu item. The "Peers tab" is an element of the "Node window".</extracomment>
+        <translation type="unfinished">Zobrazit uzly</translation>
+    </message>
+    <message>
+        <source>Disable network activity</source>
+        <extracomment>A context menu item.</extracomment>
+        <translation type="unfinished">Vypnout síťovou aktivitu</translation>
+    </message>
+    <message>
+        <source>Enable network activity</source>
+        <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
+        <translation type="unfinished">Zapnout síťovou aktivitu</translation>
     </message>
     <message>
         <source>Error: %1</source>
@@ -795,6 +907,30 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Kopíruj částku</translation>
     </message>
     <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Zkopírovat adresu</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Zkopírovat &amp;označení</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Zkopírovat &amp;částku</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">Zkopírovat &amp;ID transakce</translation>
+    </message>
+    <message>
+        <source>L&amp;ock unspent</source>
+        <translation type="unfinished">&amp;zamknout neutracené</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock unspent</source>
+        <translation type="unfinished">&amp;Odemknout neutracené</translation>
+    </message>
+    <message>
         <source>Copy quantity</source>
         <translation type="unfinished">Kopíruj počet</translation>
     </message>
@@ -854,6 +990,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>CreateWalletActivity</name>
     <message>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation type="unfinished">Vytvářím peněženku &lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+    <message>
         <source>Create wallet failed</source>
         <translation type="unfinished">Vytvoření peněženky selhalo</translation>
     </message>
@@ -861,7 +1001,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Create wallet warning</source>
         <translation type="unfinished">Vytvořit varování peněženky</translation>
     </message>
-    </context>
+    <message>
+        <source>Can't list signers</source>
+        <translation type="unfinished">Nelze vypsat podepisovatele</translation>
+    </message>
+</context>
 <context>
     <name>OpenWalletActivity</name>
     <message>
@@ -876,7 +1020,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>default wallet</source>
         <translation type="unfinished">výchozí peněženka</translation>
     </message>
-    </context>
+    <message>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation type="unfinished">Otevírám peněženku &lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+</context>
 <context>
     <name>WalletController</name>
     <message>
@@ -951,6 +1099,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Popisovačová peněženka</translation>
     </message>
     <message>
+        <source>Use an external signing device such as a hardware wallet. Configure the external signer script in wallet preferences first.</source>
+        <translation type="unfinished">Použijte externí podepisovací zařízení, například hardwarovou peněženku. V nastavení peněženky nejprve nakonfigurujte skript externího podepisovacího zařízení.</translation>
+    </message>
+    <message>
+        <source>External signer</source>
+        <translation type="unfinished">Externí podepisovatel</translation>
+    </message>
+    <message>
         <source>Create</source>
         <translation type="unfinished">Vytvořit</translation>
     </message>
@@ -958,7 +1114,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Compiled without sqlite support (required for descriptor wallets)</source>
         <translation type="unfinished">Zkompilováno bez podpory sqlite (vyžadováno pro popisovačové peněženky)</translation>
     </message>
-    </context>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Zkompilováno bez externí podpory podepisování (nutné pro externí podepisování)</translation>
+    </message>
+</context>
 <context>
     <name>EditAddressDialog</name>
     <message>
@@ -1059,9 +1220,9 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>(Dostačující k obnovení zálohy %n den staré)</numerusform>
+            <numerusform>(Dostačující k obnovení záloh %n dnů staré)</numerusform>
+            <numerusform>(Dostačující k obnovení záloh %n dnů staré)</numerusform>
         </translation>
     </message>
     <message>
@@ -1095,6 +1256,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
         <translation type="unfinished">Jakmile stiskneš OK, %1 začne stahovat a zpracovávat celý %4ový blockchain (%2 GB), počínaje nejstaršími transakcemi z roku %3, kdy byl %4 spuštěn.</translation>
+    </message>
+    <message>
+        <source>Limit block chain storage to</source>
+        <translation type="unfinished">Omezit uložiště blokového řetězce na</translation>
     </message>
     <message>
         <source>Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</source>
@@ -1138,6 +1303,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 </context>
 <context>
     <name>ShutdownWindow</name>
+    <message>
+        <source>%1 is shutting down…</source>
+        <translation type="unfinished">%1 se ukončuje...</translation>
+    </message>
     <message>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished">Nevypínej počítač, dokud toto okno nezmizí.</translation>
@@ -1197,7 +1366,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>%1 is currently syncing.  It will download headers and blocks from peers and validate them until reaching the tip of the block chain.</source>
         <translation type="unfinished">%1 se právě synchronizuje. Stáhnou se hlavičky a bloky od protějsků. Ty se budou se ověřovat až se kompletně ověří celý řetězec bloků.</translation>
     </message>
-    </context>
+    <message>
+        <source>Unknown. Syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">Neznámé. Synchronizace hlaviček bloků (%1, %2%)...</translation>
+    </message>
+</context>
 <context>
     <name>OpenURIDialog</name>
     <message>
@@ -1302,6 +1475,18 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>&amp;Spend unconfirmed change</source>
         <translation type="unfinished">&amp;Utrácet i ještě nepotvrzené drobné</translation>
+    </message>
+    <message>
+        <source>External Signer (e.g. hardware wallet)</source>
+        <translation type="unfinished">Externí podepisovatel (například hardwarová peněženka)</translation>
+    </message>
+    <message>
+        <source>&amp;External signer script path</source>
+        <translation type="unfinished">Cesta ke skriptu &amp;Externího podepisovatele</translation>
+    </message>
+    <message>
+        <source>Full path to a Bitcoin Core compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</source>
+        <translation type="unfinished">Absolutní cesta ke skriptu kompatibilnímu s Bitcoin Core (např. C:\Downloads\hwi.exe nebo /Users/you/Downloads/hwi.py). Pozor: malware vám může ukrást mince!</translation>
     </message>
     <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
@@ -1434,6 +1619,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>&amp;Cancel</source>
         <translation>&amp;Zrušit</translation>
+    </message>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Zkompilováno bez externí podpory podepisování (nutné pro externí podepisování)</translation>
     </message>
     <message>
         <source>default</source>
@@ -1760,6 +1950,10 @@ Pokud vidíte tuto chybu, měli byste požádat, aby obchodník poskytl adresu k
 <context>
     <name>QRImageWidget</name>
     <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">&amp;Uložit obrázek...</translation>
+    </message>
+    <message>
         <source>&amp;Copy Image</source>
         <translation type="unfinished">&amp;Kopíruj obrázek</translation>
     </message>
@@ -1956,6 +2150,14 @@ Pokud vidíte tuto chybu, měli byste požádat, aby obchodník poskytl adresu k
         <translation type="unfinished">Chce přeposílání transakcí</translation>
     </message>
     <message>
+        <source>High bandwidth BIP152 compact block relay: %1</source>
+        <translation type="unfinished">Kompaktní blokové relé BIP152 s vysokou šířkou pásma: %1</translation>
+    </message>
+    <message>
+        <source>High Bandwidth</source>
+        <translation type="unfinished">Velká šířka pásma</translation>
+    </message>
+    <message>
         <source>Connection Time</source>
         <translation type="unfinished">Doba spojení</translation>
     </message>
@@ -2040,12 +2242,52 @@ Pokud vidíte tuto chybu, měli byste požádat, aby obchodník poskytl adresu k
         <translation type="unfinished">Ven:</translation>
     </message>
     <message>
+        <source>Inbound: initiated by peer</source>
+        <translation type="unfinished">Příchozí: iniciováno uzlem</translation>
+    </message>
+    <message>
+        <source>Outbound Full Relay: default</source>
+        <translation type="unfinished">Outbound Full Relay: výchozí</translation>
+    </message>
+    <message>
+        <source>Outbound Block Relay: does not relay transactions or addresses</source>
+        <translation type="unfinished">Outbound Block Relay: nepřenáší transakce ani adresy</translation>
+    </message>
+    <message>
+        <source>Outbound Manual: added using RPC %1 or %2/%3 configuration options</source>
+        <translation type="unfinished">Outbound Manual: přidáno pomocí RPC %1 nebo %2/%3 konfiguračních možností</translation>
+    </message>
+    <message>
+        <source>Outbound Feeler: short-lived, for testing addresses</source>
+        <translation type="unfinished">Outbound Feeler: krátkodobý, pro testování adres</translation>
+    </message>
+    <message>
+        <source>Outbound Address Fetch: short-lived, for soliciting addresses</source>
+        <translation type="unfinished">Odchozí načítání adresy: krátkodobé, pro získávání adres</translation>
+    </message>
+    <message>
+        <source>we selected the peer for high bandwidth relay</source>
+        <translation type="unfinished">vybrali jsme peer pro přenos s velkou šířkou pásma</translation>
+    </message>
+    <message>
+        <source>the peer selected us for high bandwidth relay</source>
+        <translation type="unfinished">partner nás vybral pro přenos s vysokou šířkou pásma</translation>
+    </message>
+    <message>
+        <source>no high bandwidth relay selected</source>
+        <translation type="unfinished">není vybráno žádné širokopásmové relé</translation>
+    </message>
+    <message>
         <source>&amp;Disconnect</source>
         <translation type="unfinished">&amp;Odpoj</translation>
     </message>
     <message>
         <source>1 &amp;hour</source>
         <translation type="unfinished">1 &amp;hodinu</translation>
+    </message>
+    <message>
+        <source>1 d&amp;ay</source>
+        <translation type="unfinished">1 &amp;den</translation>
     </message>
     <message>
         <source>1 &amp;week</source>
@@ -2070,6 +2312,15 @@ Pokud vidíte tuto chybu, měli byste požádat, aby obchodník poskytl adresu k
     <message>
         <source>Executing command using "%1" wallet</source>
         <translation type="unfinished">Příkaz se vykonává s použitím peněženky "%1"</translation>
+    </message>
+    <message>
+        <source>Executing…</source>
+        <extracomment>A console message indicating an entered command is currently being executed.</extracomment>
+        <translation type="unfinished">Provádím...</translation>
+    </message>
+    <message>
+        <source>(peer: %1)</source>
+        <translation type="unfinished">(uzel: %1)</translation>
     </message>
     <message>
         <source>Yes</source>
@@ -2183,6 +2434,22 @@ Pokud vidíte tuto chybu, měli byste požádat, aby obchodník poskytl adresu k
         <translation type="unfinished">&amp;Kopíruj URI</translation>
     </message>
     <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Zkopírovat adresu</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Zkopírovat &amp;označení</translation>
+    </message>
+    <message>
+        <source>Copy &amp;message</source>
+        <translation type="unfinished">Zkopírovat &amp;zprávu</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Zkopírovat &amp;částku</translation>
+    </message>
+    <message>
         <source>Could not unlock wallet.</source>
         <translation type="unfinished">Nemohu odemknout peněženku.</translation>
     </message>
@@ -2193,6 +2460,10 @@ Pokud vidíte tuto chybu, měli byste požádat, aby obchodník poskytl adresu k
 </context>
 <context>
     <name>ReceiveRequestDialog</name>
+    <message>
+        <source>Request payment to …</source>
+        <translation type="unfinished">Požádat o platbu pro ...</translation>
+    </message>
     <message>
         <source>Address:</source>
         <translation type="unfinished">Adresa:</translation>
@@ -2220,6 +2491,18 @@ Pokud vidíte tuto chybu, měli byste požádat, aby obchodník poskytl adresu k
     <message>
         <source>Copy &amp;Address</source>
         <translation type="unfinished">Kopíruj &amp;adresu</translation>
+    </message>
+    <message>
+        <source>&amp;Verify</source>
+        <translation type="unfinished">&amp;Ověřit</translation>
+    </message>
+    <message>
+        <source>Verify this address on e.g. a hardware wallet screen</source>
+        <translation type="unfinished">Ověřte tuto adresu na obrazovce vaší hardwarové peněženky</translation>
+    </message>
+    <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">&amp;Uložit obrázek...</translation>
     </message>
     <message>
         <source>Payment information</source>
@@ -2352,6 +2635,10 @@ Pokud vidíte tuto chybu, měli byste požádat, aby obchodník poskytl adresu k
         <translation type="unfinished">Promaž obsah ze všech formulářových políček.</translation>
     </message>
     <message>
+        <source>Inputs…</source>
+        <translation type="unfinished">Vstupy...</translation>
+    </message>
+    <message>
         <source>Dust:</source>
         <translation type="unfinished">Prach:</translation>
     </message>
@@ -2364,12 +2651,24 @@ Pokud vidíte tuto chybu, měli byste požádat, aby obchodník poskytl adresu k
         <translation type="unfinished">Schovat nastavení poplatků transakce - transaction fee</translation>
     </message>
     <message>
+        <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
+
+Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satoshis per kvB" for a transaction size of 500 virtual bytes (half of 1 kvB) would ultimately yield a fee of only 50 satoshis.</source>
+        <translation type="unfinished">Zadejte vlastní poplatek za kB (1 000 bajtů) virtuální velikosti transakce.
+
+ Poznámka: Vzhledem k tomu, že poplatek se vypočítává na bázi za bajt, sazba poplatku „100 satoshi za kvB“ za velikost transakce 500 virtuálních bajtů (polovina z 1 kvB) by nakonec přinesla poplatek pouze 50 satoshi.</translation>
+    </message>
+    <message>
         <source>When there is less transaction volume than space in the blocks, miners as well as relaying nodes may enforce a minimum fee. Paying only this minimum fee is just fine, but be aware that this can result in a never confirming transaction once there is more demand for bitcoin transactions than the network can process.</source>
         <translation type="unfinished">Když je zde měně transakcí než místa na bloky, mineři stejně tak relay-e mohou nasadit minimální poplatky. Zaplacením pouze minimálního poplatku je v pohodě, ale mějte na paměti že toto může mít za následek nikdy neověřenou transakci pokud zde bude více bitcoinových transakcí než může síť zvládnout.</translation>
     </message>
     <message>
         <source>A too low fee might result in a never confirming transaction (read the tooltip)</source>
         <translation type="unfinished">Příliš malý poplatek může způsobit, že transakce nebude nikdy potvrzena (přečtěte popis)</translation>
+    </message>
+    <message>
+        <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
+        <translation type="unfinished">(Chytrý poplatek ještě nebyl inicializován. Obvykle to trvá několik bloků...)</translation>
     </message>
     <message>
         <source>Confirmation time target:</source>
@@ -2437,6 +2736,15 @@ Pokud vidíte tuto chybu, měli byste požádat, aby obchodník poskytl adresu k
         <translation type="unfinished">Přihlásit na zařízení</translation>
     </message>
     <message>
+        <source>Connect your hardware wallet first.</source>
+        <translation type="unfinished">Nejdříve připojte vaši hardwarovou peněženku.</translation>
+    </message>
+    <message>
+        <source>Set external signer script path in Options -&gt; Wallet</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Nastavte cestu pro skript pro externí podepisování v Nastavení -&gt; Peněženka</translation>
+    </message>
+    <message>
         <source>Cr&amp;eate Unsigned</source>
         <translation type="unfinished">Vytvořit bez podpisu</translation>
     </message>
@@ -2465,8 +2773,30 @@ Pokud vidíte tuto chybu, měli byste požádat, aby obchodník poskytl adresu k
         <translation type="unfinished">Jsi si jistý, že tuhle transakci chceš poslat?</translation>
     </message>
     <message>
+        <source>To review recipient list click "Show Details…"</source>
+        <translation type="unfinished">Chcete-li zkontrolovat seznam příjemců, klikněte na „Zobrazit podrobnosti ...“</translation>
+    </message>
+    <message>
         <source>Create Unsigned</source>
         <translation type="unfinished">Vytvořit bez podpisu</translation>
+    </message>
+    <message>
+        <source>Sign and send</source>
+        <translation type="unfinished">Podepsat a poslat</translation>
+    </message>
+    <message>
+        <source>Sign failed</source>
+        <translation type="unfinished">Podepsání selhalo</translation>
+    </message>
+    <message>
+        <source>External signer not found</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Externí podepisovatel nebyl nalezen</translation>
+    </message>
+    <message>
+        <source>External signer failure</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Selhání externího podepisovatele</translation>
     </message>
     <message>
         <source>Save Transaction Data</source>
@@ -2480,6 +2810,10 @@ Pokud vidíte tuto chybu, měli byste požádat, aby obchodník poskytl adresu k
     <message>
         <source>PSBT saved</source>
         <translation type="unfinished">PSBT uložena</translation>
+    </message>
+    <message>
+        <source>External balance:</source>
+        <translation type="unfinished">Externí zůstatek:</translation>
     </message>
     <message>
         <source>or</source>
@@ -2556,9 +2890,9 @@ Pokud vidíte tuto chybu, měli byste požádat, aby obchodník poskytl adresu k
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation>
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>Očekávaný počátek potvrzení během %n bloku.</numerusform>
+            <numerusform>Očekávaný počátek potvrzení během %n bloků.</numerusform>
+            <numerusform>Očekávaný počátek potvrzení během %n bloků.</numerusform>
         </translation>
     </message>
     <message>
@@ -2805,9 +3139,9 @@ Pokud vidíte tuto chybu, měli byste požádat, aby obchodník poskytl adresu k
     <message numerus="yes">
         <source>Open for %n more block(s)</source>
         <translation>
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>Otevřeno pro %n další blok</numerusform>
+            <numerusform>Otevřeno pro %n dalších bloků</numerusform>
+            <numerusform>Otevřeno pro %n dalších bloků</numerusform>
         </translation>
     </message>
     <message>
@@ -2889,9 +3223,9 @@ Pokud vidíte tuto chybu, měli byste požádat, aby obchodník poskytl adresu k
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation>
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>dozraje za %n další blok</numerusform>
+            <numerusform>dozraje za %n dalších bloků</numerusform>
+            <numerusform>dozraje za %n dalších bloků</numerusform>
         </translation>
     </message>
     <message>
@@ -2999,9 +3333,9 @@ Pokud vidíte tuto chybu, měli byste požádat, aby obchodník poskytl adresu k
     <message numerus="yes">
         <source>Open for %n more block(s)</source>
         <translation>
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>Otevřeno pro %n další blok</numerusform>
+            <numerusform>Otevřeno pro %n dalších bloků</numerusform>
+            <numerusform>Otevřeno pro %n dalších bloků</numerusform>
         </translation>
     </message>
     <message>
@@ -3144,6 +3478,50 @@ Pokud vidíte tuto chybu, měli byste požádat, aby obchodník poskytl adresu k
         <translation type="unfinished">Minimální částka</translation>
     </message>
     <message>
+        <source>Range…</source>
+        <translation type="unfinished">Rozsah...</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Zkopírovat adresu</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Zkopírovat &amp;označení</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Zkopírovat &amp;částku</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">Zkopírovat &amp;ID transakce</translation>
+    </message>
+    <message>
+        <source>Copy &amp;raw transaction</source>
+        <translation type="unfinished">Zkopírovat &amp;surovou transakci</translation>
+    </message>
+    <message>
+        <source>Copy full transaction &amp;details</source>
+        <translation type="unfinished">Zkopírovat kompletní &amp;podrobnosti transakce</translation>
+    </message>
+    <message>
+        <source>&amp;Show transaction details</source>
+        <translation type="unfinished">&amp;Zobrazit detaily transakce</translation>
+    </message>
+    <message>
+        <source>Increase transaction &amp;fee</source>
+        <translation type="unfinished">Zvýšit transakční &amp;poplatek</translation>
+    </message>
+    <message>
+        <source>A&amp;bandon transaction</source>
+        <translation type="unfinished">&amp;Zahodit transakci</translation>
+    </message>
+    <message>
+        <source>&amp;Edit address label</source>
+        <translation type="unfinished">&amp;Upravit označení adresy</translation>
+    </message>
+    <message>
         <source>Export Transaction History</source>
         <translation type="unfinished">Exportuj transakční historii</translation>
     </message>
@@ -3251,6 +3629,10 @@ Přejděte do Soubor &gt; Otevřít peněženku pro načtení peněženky.
         <translation type="unfinished">Nový poplatek:</translation>
     </message>
     <message>
+        <source>Warning: This may pay the additional fee by reducing change outputs or adding inputs, when necessary. It may add a new change output if one does not already exist. These changes may potentially leak privacy.</source>
+        <translation type="unfinished">Upozornění: To může v případě potřeby zaplatit dodatečný poplatek snížením výstupů změn nebo přidáním vstupů.  Může přidat nový výstup změn, pokud takový ještě neexistuje.  Tyto změny mohou potenciálně uniknout soukromí.</translation>
+    </message>
+    <message>
         <source>Confirm fee bump</source>
         <translation type="unfinished">Potvrď navýšení poplatku</translation>
     </message>
@@ -3269,6 +3651,10 @@ Přejděte do Soubor &gt; Otevřít peněženku pro načtení peněženky.
     <message>
         <source>Could not commit transaction</source>
         <translation type="unfinished">Nemohl jsem uložit transakci do peněženky</translation>
+    </message>
+    <message>
+        <source>Can't display address</source>
+        <translation type="unfinished">Nemohu zobrazit adresu</translation>
     </message>
     <message>
         <source>default wallet</source>
@@ -3386,6 +3772,10 @@ Přejděte do Soubor &gt; Otevřít peněženku pro načtení peněženky.
         <translation type="unfinished">Chyba: verze souboru výpisu není podporována. Tato verze peněženky Bitcoin podporuje pouze soubory výpisu verze 1. Získán soubor výpisu verze %s</translation>
     </message>
     <message>
+        <source>Error: Legacy wallets only support the "legacy", "p2sh-segwit", and "bech32" address types</source>
+        <translation type="unfinished">Chyba: Starší peněženky podporují pouze typy adres "legacy", "p2sh-segwit" a "bech32".</translation>
+    </message>
+    <message>
         <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
         <translation type="unfinished">Chyba: Nelze naslouchat příchozí spojení (listen vrátil chybu %s)</translation>
     </message>
@@ -3488,6 +3878,10 @@ Přejděte do Soubor &gt; Otevřít peněženku pro načtení peněženky.
     <message>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished">Upozornění: Nesouhlasím zcela se svými protějšky! Možná potřebuji aktualizovat nebo ostatní uzly potřebují aktualizovat.</translation>
+    </message>
+    <message>
+        <source>Witness data for blocks after height %d requires validation. Please restart with -reindex.</source>
+        <translation type="unfinished">Svědecká data pro bloky po výšce %d vyžadují ověření.  Restartujte prosím pomocí -reindex.</translation>
     </message>
     <message>
         <source>You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain</source>
@@ -3634,6 +4028,10 @@ Přejděte do Soubor &gt; Otevřít peněženku pro načtení peněženky.
         <translation type="unfinished">Chyba: chybí kontrolní součet</translation>
     </message>
     <message>
+        <source>Error: No %s addresses available.</source>
+        <translation type="unfinished">Chyba: Žádné %s adresy nejsou dostupné.</translation>
+    </message>
+    <message>
         <source>Error: Unable to parse version %u as a uint32_t</source>
         <translation type="unfinished">Chyba: nelze zpracovat verzi %u jako uint32_t</translation>
     </message>
@@ -3660,6 +4058,10 @@ Přejděte do Soubor &gt; Otevřít peněženku pro načtení peněženky.
     <message>
         <source>Ignoring duplicate -wallet %s.</source>
         <translation type="unfinished">Ignoruji duplicitní -wallet %s.</translation>
+    </message>
+    <message>
+        <source>Importing…</source>
+        <translation type="unfinished">Importuji...</translation>
     </message>
     <message>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
@@ -3710,6 +4112,22 @@ Přejděte do Soubor &gt; Otevřít peněženku pro načtení peněženky.
         <translation type="unfinished">Ve -whitelist byla zadána neplatná podsíť: '%s'</translation>
     </message>
     <message>
+        <source>Loading P2P addresses…</source>
+        <translation type="unfinished">Načítám P2P adresy…</translation>
+    </message>
+    <message>
+        <source>Loading banlist…</source>
+        <translation type="unfinished">Načítám banlist...</translation>
+    </message>
+    <message>
+        <source>Loading block index…</source>
+        <translation type="unfinished">Načítám index bloků...</translation>
+    </message>
+    <message>
+        <source>Loading wallet…</source>
+        <translation type="unfinished">Načítám peněženku...</translation>
+    </message>
+    <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
         <translation type="unfinished">V rámci -whitebind je třeba specifikovat i port: '%s'</translation>
     </message>
@@ -3726,12 +4144,28 @@ Přejděte do Soubor &gt; Otevřít peněženku pro načtení peněženky.
         <translation type="unfinished">Prořezávání nemůže být zkonfigurováno s negativní hodnotou.</translation>
     </message>
     <message>
+        <source>Prune mode is incompatible with -coinstatsindex.</source>
+        <translation type="unfinished">Prořezávací režim je nekompatibilní s -coinstatsindex.</translation>
+    </message>
+    <message>
         <source>Prune mode is incompatible with -txindex.</source>
         <translation type="unfinished">Prořezávací režim není kompatibilní s -txindex.</translation>
     </message>
     <message>
+        <source>Pruning blockstore…</source>
+        <translation type="unfinished">Prořezávám úložiště bloků...</translation>
+    </message>
+    <message>
         <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
         <translation type="unfinished">Omezuji -maxconnections z %d na %d kvůli systémovým omezením.</translation>
+    </message>
+    <message>
+        <source>Replaying blocks…</source>
+        <translation type="unfinished">Přehrání bloků...</translation>
+    </message>
+    <message>
+        <source>Rescanning…</source>
+        <translation type="unfinished">Přeskenovávám...</translation>
     </message>
     <message>
         <source>SQLiteDatabase: Failed to execute statement to verify database: %s</source>
@@ -3772,6 +4206,10 @@ Přejděte do Soubor &gt; Otevřít peněženku pro načtení peněženky.
     <message>
         <source>Specified blocks directory "%s" does not exist.</source>
         <translation type="unfinished">Zadaný adresář bloků "%s" neexistuje.</translation>
+    </message>
+    <message>
+        <source>Starting network threads…</source>
+        <translation type="unfinished">Spouštím síťová vlákna…</translation>
     </message>
     <message>
         <source>The source code is available from %s.</source>
@@ -3816,6 +4254,10 @@ Přejděte do Soubor &gt; Otevřít peněženku pro načtení peněženky.
     <message>
         <source>Transaction must have at least one recipient</source>
         <translation type="unfinished">Transakce musí mít alespoň jednoho příjemce</translation>
+    </message>
+    <message>
+        <source>Transaction needs a change address, but we can't generate it. %s</source>
+        <translation type="unfinished">Transakce potřebuje změnu adresy, ale ta se nepodařila vygenerovat. %s</translation>
     </message>
     <message>
         <source>Transaction too large</source>
@@ -3866,6 +4308,10 @@ Přejděte do Soubor &gt; Otevřít peněženku pro načtení peněženky.
         <translation type="unfinished">V -onlynet byla uvedena neznámá síť: '%s'</translation>
     </message>
     <message>
+        <source>Unknown new rules activated (versionbit %i)</source>
+        <translation type="unfinished">Neznámá nová pravidla aktivována (verzový bit %i)</translation>
+    </message>
+    <message>
         <source>Unsupported logging category %s=%s.</source>
         <translation type="unfinished">Nepodporovaná logovací kategorie %s=%s.</translation>
     </message>
@@ -3880,6 +4326,14 @@ Přejděte do Soubor &gt; Otevřít peněženku pro načtení peněženky.
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
         <translation type="unfinished">Komentář u typu klienta (%s) obsahuje riskantní znaky.</translation>
+    </message>
+    <message>
+        <source>Verifying blocks…</source>
+        <translation type="unfinished">Ověřuji bloky…</translation>
+    </message>
+    <message>
+        <source>Verifying wallet(s)…</source>
+        <translation type="unfinished">Kontroluji peněženku/y…</translation>
     </message>
     <message>
         <source>Wallet needed to be rewritten: restart %s to complete</source>

--- a/src/qt/locale/bitcoin_da.ts
+++ b/src/qt/locale/bitcoin_da.ts
@@ -245,6 +245,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>BitcoinApplication</name>
     <message>
+        <source>Runaway exception</source>
+        <translation type="unfinished">Runaway undtagelse</translation>
+    </message>
+    <message>
         <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
         <translation type="unfinished">Der skete en fatal fejl. %1 kan ikke længere fortsætte sikkert og vil afslutte.</translation>
     </message>
@@ -252,7 +256,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Internal error</source>
         <translation type="unfinished">Intern fejl</translation>
     </message>
-    </context>
+    <message>
+        <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
+        <translation type="unfinished">Der skete en intern fejl. %1 vil prøve at forsætte på sikker vis. Dette er en uventet fejl som kan reporteres som beskrevet under. </translation>
+    </message>
+</context>
 <context>
     <name>QObject</name>
     <message>
@@ -272,6 +280,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Fejl ved initialisering af indstillinger: %1</translation>
     </message>
     <message>
+        <source>%1 didn't yet exit safely…</source>
+        <translation type="unfinished">%1 har endnu ikke afsluttet på sikker vis…</translation>
+    </message>
+    <message>
         <source>unknown</source>
         <translation type="unfinished">ukendt</translation>
     </message>
@@ -282,6 +294,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Enter a Bitcoin address (e.g. %1)</source>
         <translation type="unfinished">Indtast en Bitcoin-adresse (fx %1)</translation>
+    </message>
+    <message>
+        <source>Unroutable</source>
+        <translation type="unfinished">Urutebar</translation>
     </message>
     <message>
         <source>Internal</source>
@@ -296,8 +312,20 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Udgående</translation>
     </message>
     <message>
+        <source>Full Relay</source>
+        <translation type="unfinished">Fuld Videresend</translation>
+    </message>
+    <message>
+        <source>Block Relay</source>
+        <translation type="unfinished">Blok Vidersend</translation>
+    </message>
+    <message>
         <source>Manual</source>
         <translation type="unfinished">Brugervejledning</translation>
+    </message>
+    <message>
+        <source>Feeler</source>
+        <translation type="unfinished">Føler</translation>
     </message>
     <message>
         <source>Address Fetch</source>
@@ -314,36 +342,36 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation>
-            <numerusform />
-            <numerusform />
+            <numerusform>%n sekund</numerusform>
+            <numerusform>%n sekunder</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n minute(s)</source>
         <translation>
-            <numerusform />
-            <numerusform />
+            <numerusform>%n minut</numerusform>
+            <numerusform>%n minutter</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n time</numerusform>
+            <numerusform>%n timer</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n dag</numerusform>
+            <numerusform>%n dage</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n uge</numerusform>
+            <numerusform>%n uger</numerusform>
         </translation>
     </message>
     <message>
@@ -353,8 +381,8 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n år</numerusform>
+            <numerusform>%n år</numerusform>
         </translation>
     </message>
     </context>
@@ -462,6 +490,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">&amp;Sikkerhedskopiér Tegnebog</translation>
     </message>
     <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation type="unfinished">&amp;Skift adgangskode</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation type="unfinished">Signér &amp;besked</translation>
+    </message>
+    <message>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation>Signér beskeder med dine Bitcoin-adresser for at bevise, at de tilhører dig</translation>
     </message>
@@ -472,6 +508,18 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation>Verificér beskeder for at sikre, at de er signeret med de angivne Bitcoin-adresser</translation>
+    </message>
+    <message>
+        <source>&amp;Load PSBT from file…</source>
+        <translation type="unfinished">&amp;Indlæs PSBT fra fil...</translation>
+    </message>
+    <message>
+        <source>Load PSBT from clipboard…</source>
+        <translation type="unfinished">Indlæs PSBT fra clipboard...</translation>
+    </message>
+    <message>
+        <source>Open &amp;URI…</source>
+        <translation type="unfinished">Åben &amp;URI...</translation>
     </message>
     <message>
         <source>Close Wallet…</source>
@@ -502,8 +550,24 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation>Faneværktøjslinje</translation>
     </message>
     <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation type="unfinished">Synkroniserer hoveder (%1%)…</translation>
+    </message>
+    <message>
         <source>Synchronizing with network…</source>
         <translation type="unfinished">Synkroniserer med netværk …</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation type="unfinished">Indekserer blokke på disken…</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation type="unfinished">Bearbejder blokke på disken…</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation type="unfinished">Genindekserer blokke på disken…</translation>
     </message>
     <message>
         <source>Connecting to peers…</source>
@@ -528,8 +592,8 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation>
-            <numerusform />
-            <numerusform />
+            <numerusform>Bearbejdede %n blokke af transaktionshistorik.</numerusform>
+            <numerusform>Bearbejdede %n blokke af transaktionshistorik.</numerusform>
         </translation>
     </message>
     <message>
@@ -644,9 +708,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n aktiv(e) forbindelse(r) til Bitcoin-netværket.</numerusform>
+            <numerusform>%n aktiv(e) forbindelse(r) til Bitcoin-netværket.</numerusform>
         </translation>
+    </message>
+    <message>
+        <source>Click for more actions.</source>
+        <extracomment>A substring of the tooltip. "More actions" are available via the context menu.</extracomment>
+        <translation type="unfinished">Click for flere aktioner.</translation>
     </message>
     <message>
         <source>Show Peers tab</source>
@@ -816,6 +885,30 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Kopiér beløb</translation>
     </message>
     <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Kopiér adresse</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Kopiér &amp;mærkat</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Kopiér &amp;beløb</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">Kopiér transaktion &amp;ID</translation>
+    </message>
+    <message>
+        <source>L&amp;ock unspent</source>
+        <translation type="unfinished">&amp;Fastlås ubrugte</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock unspent</source>
+        <translation type="unfinished">&amp;Lås ubrugte op</translation>
+    </message>
+    <message>
         <source>Copy quantity</source>
         <translation type="unfinished">Kopiér mængde</translation>
     </message>
@@ -886,7 +979,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Create wallet warning</source>
         <translation type="unfinished">Advarsel for oprettelse af tegnebog</translation>
     </message>
-    </context>
+    <message>
+        <source>Can't list signers</source>
+        <translation type="unfinished">Kan ikke liste underskrivere</translation>
+    </message>
+</context>
 <context>
     <name>OpenWalletActivity</name>
     <message>
@@ -901,7 +998,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>default wallet</source>
         <translation type="unfinished">Standard tegnebog</translation>
     </message>
-    </context>
+    <message>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation type="unfinished">Åbner Tegnebog &lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+</context>
 <context>
     <name>WalletController</name>
     <message>
@@ -976,6 +1077,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Beskriver-Pung</translation>
     </message>
     <message>
+        <source>Use an external signing device such as a hardware wallet. Configure the external signer script in wallet preferences first.</source>
+        <translation type="unfinished">Brug en ekstern signeringsenhed som en hardwaretegnebog. Konfigurer den eksterne underskriver skript i tegnebogspræferencerne først.</translation>
+    </message>
+    <message>
+        <source>External signer</source>
+        <translation type="unfinished">Ekstern underskriver</translation>
+    </message>
+    <message>
         <source>Create</source>
         <translation type="unfinished">Opret</translation>
     </message>
@@ -983,7 +1092,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Compiled without sqlite support (required for descriptor wallets)</source>
         <translation type="unfinished">Kompileret uden sqlite-understøttelse (krævet til beskriver-punge)</translation>
     </message>
-    </context>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Kompileret uden ekstern underskriver understøttelse (nødvendig for ekstern underskriver)</translation>
+    </message>
+</context>
 <context>
     <name>EditAddressDialog</name>
     <message>
@@ -1065,6 +1179,18 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>Intro</name>
     <message>
+        <source>%1 GB of free space available</source>
+        <translation type="unfinished">%1 GB af fri plads tilgængelig</translation>
+    </message>
+    <message>
+        <source>(of %1 GB needed)</source>
+        <translation type="unfinished">(ud af %1 GB behøvet)</translation>
+    </message>
+    <message>
+        <source>(%1 GB needed for full chain)</source>
+        <translation type="unfinished">(%1 GB nødvendig for komplet kæde)</translation>
+    </message>
+    <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
         <translation type="unfinished">Mindst %1 GB data vil blive gemt i denne mappe, og det vil vokse over tid.</translation>
     </message>
@@ -1076,8 +1202,8 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>(tilstrækkelig for at gendanne backups %n dag(e) gammel)</numerusform>
+            <numerusform>(tilstrækkelig for at gendanne backups %n dag(e) gammel)</numerusform>
         </translation>
     </message>
     <message>
@@ -1113,8 +1239,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Når du klikker OK, vil %1 begynde at downloade og bearbejde den fulde %4-blokkæde (%2 GB), startende med de tidligste transaktioner i %3, da %4 først startede.</translation>
     </message>
     <message>
+        <source>Limit block chain storage to</source>
+        <translation type="unfinished">Begræns blokkæde opbevaring til</translation>
+    </message>
+    <message>
         <source>Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</source>
         <translation type="unfinished">Ændring af denne indstilling senere kræver gendownload af hele blokkæden. Det er hurtigere at downloade den komplette kæde først og beskære den senere. Slår nogle avancerede funktioner fra.</translation>
+    </message>
+    <message>
+        <source> GB</source>
+        <translation type="unfinished">GB</translation>
     </message>
     <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
@@ -1146,6 +1280,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 </context>
 <context>
     <name>ShutdownWindow</name>
+    <message>
+        <source>%1 is shutting down…</source>
+        <translation type="unfinished">%1 lukker ned…</translation>
+    </message>
     <message>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished">Luk ikke computeren ned, før dette vindue forsvinder.</translation>
@@ -1201,7 +1339,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>%1 is currently syncing.  It will download headers and blocks from peers and validate them until reaching the tip of the block chain.</source>
         <translation type="unfinished">%1 synkroniserer lige nu. Hoveder og blokke bliver downloadet og valideret fra andre knuder. Processen fortsætter indtil den seneste blok nås.</translation>
     </message>
-    </context>
+    <message>
+        <source>Unknown. Syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">Ukendt. Synkroniserer Hoveder (%1, %2%)...</translation>
+    </message>
+</context>
 <context>
     <name>OpenURIDialog</name>
     <message>
@@ -1226,6 +1368,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>&amp;Start %1 on system login</source>
         <translation type="unfinished">&amp;Start %1 ved systemlogin</translation>
+    </message>
+    <message>
+        <source>Enabling pruning significantly reduces the disk space required to store transactions. All blocks are still fully validated. Reverting this setting requires re-downloading the entire blockchain.</source>
+        <translation type="unfinished">Aktivering af beskæring reducerer betydeligt den diskplads, der kræves til at gemme transaktioner. Alle blokke er stadig fuldt validerede. Gendannelse af denne indstilling kræver gendownload af hele blokkæden.</translation>
     </message>
     <message>
         <source>Size of &amp;database cache</source>
@@ -1304,12 +1450,32 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">&amp;Brug ubekræftede byttepenge</translation>
     </message>
     <message>
+        <source>External Signer (e.g. hardware wallet)</source>
+        <translation type="unfinished">Ekstern underskriver (f.eks. hardwaretegnebog)</translation>
+    </message>
+    <message>
+        <source>&amp;External signer script path</source>
+        <translation type="unfinished">&amp;Ekstern underskrivers scriptsti</translation>
+    </message>
+    <message>
+        <source>Full path to a Bitcoin Core compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</source>
+        <translation type="unfinished">Fuld sti til et Bitcoin Core-kompatibelt script (f.eks. C:\Downloads\hwi.exe eller /Users/you/Downloads/hwi.py). Pas på: malware kan stjæle dine mønter!</translation>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation>Åbn automatisk Bitcoin-klientens port på routeren. Dette virker kun, når din router understøtter UPnP, og UPnP er aktiveret.</translation>
     </message>
     <message>
         <source>Map port using &amp;UPnP</source>
         <translation>Konfigurér port vha. &amp;UPnP</translation>
+    </message>
+    <message>
+        <source>Automatically open the Bitcoin client port on the router. This only works when your router supports NAT-PMP and it is enabled. The external port could be random.</source>
+        <translation type="unfinished">Åbn automatisk Bitcoin-klientporten på routeren. Dette virker kun, når din router understøtter NAT-PMP, og den er aktiveret. Den eksterne port kan være tilfældig.</translation>
+    </message>
+    <message>
+        <source>Map port using NA&amp;T-PMP</source>
+        <translation type="unfinished">Kortport ved hjælp af NA&amp;T-PMP</translation>
     </message>
     <message>
         <source>Accept connections from outside.</source>
@@ -1342,6 +1508,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>&amp;Window</source>
         <translation>&amp;Vindue</translation>
+    </message>
+    <message>
+        <source>Show the icon in the system tray.</source>
+        <translation type="unfinished">Vis ikonet i proceslinjen.</translation>
+    </message>
+    <message>
+        <source>&amp;Show tray icon</source>
+        <translation type="unfinished">&amp;Vis bakkeikon</translation>
     </message>
     <message>
         <source>Show only a tray icon after minimizing the window.</source>
@@ -1392,6 +1566,18 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">&amp;Tredjeparts-transaktions-URL'er</translation>
     </message>
     <message>
+        <source>Monospaced font in the Overview tab:</source>
+        <translation type="unfinished">Monospaced skrifttype på fanen Oversigt:</translation>
+    </message>
+    <message>
+        <source>embedded "%1"</source>
+        <translation type="unfinished">indlejret "%1"</translation>
+    </message>
+    <message>
+        <source>closest matching "%1"</source>
+        <translation type="unfinished">tættest matchende "%1"</translation>
+    </message>
+    <message>
         <source>Options set in this dialog are overridden by the command line or in the configuration file:</source>
         <translation type="unfinished">Valgmuligheder sat i denne dialog er overskrevet af kommandolinjen eller i konfigurationsfilen:</translation>
     </message>
@@ -1402,6 +1588,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>&amp;Cancel</source>
         <translation>&amp;Annullér</translation>
+    </message>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Kompileret uden ekstern underskriver understøttelse (nødvendig for ekstern underskriver)</translation>
     </message>
     <message>
         <source>default</source>
@@ -1586,6 +1777,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Gem Transaktionsdata</translation>
     </message>
     <message>
+        <source>Partially Signed Transaction (Binary)</source>
+        <extracomment>Expanded name of the binary PSBT file format. See: BIP 174.</extracomment>
+        <translation type="unfinished">Delvist underskrevet transaktion (Binær)</translation>
+    </message>
+    <message>
         <source>PSBT saved to disk.</source>
         <translation type="unfinished">PSBT gemt på disk.</translation>
     </message>
@@ -1655,6 +1851,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>'bitcoin://' is not a valid URI. Use 'bitcoin:' instead.</source>
         <translation type="unfinished">'bitcoin://' er ikke et gyldigt URI. Brug 'bitcoin:' istedet.</translation>
+    </message>
+    <message>
+        <source>Cannot process payment request because BIP70 is not supported.
+Due to widespread security flaws in BIP70 it's strongly recommended that any merchant instructions to switch wallets be ignored.
+If you are receiving this error you should request the merchant provide a BIP21 compatible URI.</source>
+        <translation type="unfinished">Kan ikke behandle betalingsanmodning, fordi BIP70 ikke understøttes.
+På grund af udbredte sikkerhedsfejl i BIP70 anbefales det på det kraftigste, at enhver købmands instruktioner om at skifte tegnebog ignoreres.
+Hvis du modtager denne fejl, skal du anmode forhandleren om en BIP21-kompatibel URI.</translation>
     </message>
     <message>
         <source>URI cannot be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
@@ -1869,16 +2073,56 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Tilladelser</translation>
     </message>
     <message>
+        <source>The direction and type of peer connection: %1</source>
+        <translation type="unfinished">Retningen og typen af peer-forbindelse: %1</translation>
+    </message>
+    <message>
+        <source>Direction/Type</source>
+        <translation type="unfinished">Retning/Type</translation>
+    </message>
+    <message>
+        <source>The network protocol this peer is connected through: IPv4, IPv6, Onion, I2P, or CJDNS.</source>
+        <translation type="unfinished">Netværksprotokollen, som denne peer er forbundet via: IPv4, IPv6, Onion, I2P eller CJDNS.</translation>
+    </message>
+    <message>
         <source>Services</source>
         <translation type="unfinished">Tjenester</translation>
+    </message>
+    <message>
+        <source>Whether the peer requested us to relay transactions.</source>
+        <translation type="unfinished">Om peeren anmodede os om at videresende transaktioner.</translation>
+    </message>
+    <message>
+        <source>Wants Tx Relay</source>
+        <translation type="unfinished">Vil have transaktion videresend</translation>
+    </message>
+    <message>
+        <source>High bandwidth BIP152 compact block relay: %1</source>
+        <translation type="unfinished">BIP152 kompakt blokrelæ med høj bredbånd: %1</translation>
+    </message>
+    <message>
+        <source>High Bandwidth</source>
+        <translation type="unfinished">Højt Bredbånd</translation>
     </message>
     <message>
         <source>Connection Time</source>
         <translation type="unfinished">Forbindelsestid</translation>
     </message>
     <message>
+        <source>Elapsed time since a novel block passing initial validity checks was received from this peer.</source>
+        <translation type="unfinished">Forløbet tid siden en ny blok, der bestod indledende gyldighedstjek, blev modtaget fra denne peer.</translation>
+    </message>
+    <message>
         <source>Last Block</source>
         <translation type="unfinished">Sidste Blok</translation>
+    </message>
+    <message>
+        <source>Elapsed time since a novel transaction accepted into our mempool was received from this peer.</source>
+        <translation type="unfinished">Forløbet tid siden en ny transaktion, der blev accepteret i vores mempool, blev modtaget fra denne peer.</translation>
+    </message>
+    <message>
+        <source>Last Tx</source>
+        <translation type="unfinished">Sidste transaktion</translation>
     </message>
     <message>
         <source>Last Send</source>
@@ -1945,12 +2189,52 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Udgående:</translation>
     </message>
     <message>
+        <source>Inbound: initiated by peer</source>
+        <translation type="unfinished">Indgående: initieret af peer</translation>
+    </message>
+    <message>
+        <source>Outbound Full Relay: default</source>
+        <translation type="unfinished">Udgående fuld relæ: standard</translation>
+    </message>
+    <message>
+        <source>Outbound Block Relay: does not relay transactions or addresses</source>
+        <translation type="unfinished">Udgående blokrelæ: videresender ikke transaktioner eller adresser</translation>
+    </message>
+    <message>
+        <source>Outbound Manual: added using RPC %1 or %2/%3 configuration options</source>
+        <translation type="unfinished">Udgående manual: tilføjet ved hjælp af RPC %1 eller %2/%3 konfigurationsmuligheder</translation>
+    </message>
+    <message>
+        <source>Outbound Feeler: short-lived, for testing addresses</source>
+        <translation type="unfinished">Udgående fejl: kortvarig, til test af adresser</translation>
+    </message>
+    <message>
+        <source>Outbound Address Fetch: short-lived, for soliciting addresses</source>
+        <translation type="unfinished">Udgående adressehentning: kortvarig, til at anmode om adresser</translation>
+    </message>
+    <message>
+        <source>we selected the peer for high bandwidth relay</source>
+        <translation type="unfinished">vi valgte denne peer for høj bredbånd relæ</translation>
+    </message>
+    <message>
+        <source>the peer selected us for high bandwidth relay</source>
+        <translation type="unfinished">peeren valgte os til høj bredbånd relæ</translation>
+    </message>
+    <message>
+        <source>no high bandwidth relay selected</source>
+        <translation type="unfinished">ingen høj bredbånd relæ valgt</translation>
+    </message>
+    <message>
         <source>&amp;Disconnect</source>
         <translation type="unfinished">&amp;Afbryd forbindelse</translation>
     </message>
     <message>
         <source>1 &amp;hour</source>
         <translation type="unfinished">1 &amp;time</translation>
+    </message>
+    <message>
+        <source>1 d&amp;ay</source>
+        <translation type="unfinished">1 &amp;dag</translation>
     </message>
     <message>
         <source>1 &amp;week</source>
@@ -1975,6 +2259,28 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Executing command using "%1" wallet</source>
         <translation type="unfinished">Eksekverer kommando ved brug af "%1" tegnebog</translation>
+    </message>
+    <message>
+        <source>Welcome to the %1 RPC console.
+Use up and down arrows to navigate history, and %2 to clear screen.
+Use %3 and %4 to increase or decrease the font size.
+Type %5 for an overview of available commands.
+For more information on using this console, type %6.
+
+%7WARNING: Scammers have been active, telling users to type commands here, stealing their wallet contents. Do not use this console without fully understanding the ramifications of a command.%8</source>
+        <extracomment>RPC console welcome message. Placeholders %7 and %8 are style tags for the warning content, and they are not space separated from the rest of the text intentionally.</extracomment>
+        <translation type="unfinished">Velkommen til %1 RPC-konsollen.
+Brug op- og nedpilene til at navigere i historikken og %2 til at rydde skærmen.
+Brug %3 og %4 til at øge eller formindske skriftstørrelsen.
+Skriv %5 for at få en oversigt over tilgængelige kommandoer.
+For mere information om brug af denne konsol, skriv %6.
+
+%7 ADVARSEL: Svindlere har været aktive og bedt brugerne om at skrive kommandoer her og stjæle deres tegnebogsindhold. Brug ikke denne konsol uden fuldt ud at forstå konsekvenserne af en kommando.%8</translation>
+    </message>
+    <message>
+        <source>Executing…</source>
+        <extracomment>A console message indicating an entered command is currently being executed.</extracomment>
+        <translation type="unfinished">Udfører...</translation>
     </message>
     <message>
         <source>Yes</source>
@@ -2088,6 +2394,22 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Kopiér &amp;URI</translation>
     </message>
     <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Kopiér adresse</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Kopiér &amp;mærkat</translation>
+    </message>
+    <message>
+        <source>Copy &amp;message</source>
+        <translation type="unfinished">Kopiér &amp;besked</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Kopiér &amp;beløb</translation>
+    </message>
+    <message>
         <source>Could not unlock wallet.</source>
         <translation type="unfinished">Kunne ikke låse tegnebog op.</translation>
     </message>
@@ -2129,6 +2451,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Copy &amp;Address</source>
         <translation type="unfinished">Kopiér &amp;adresse</translation>
+    </message>
+    <message>
+        <source>&amp;Verify</source>
+        <translation type="unfinished">&amp;Bekræft</translation>
+    </message>
+    <message>
+        <source>Verify this address on e.g. a hardware wallet screen</source>
+        <translation type="unfinished">Bekræft denne adresse på f.eks. en hardwaretegnebogs skærm</translation>
     </message>
     <message>
         <source>&amp;Save Image…</source>
@@ -2281,12 +2611,24 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Skjul indstillinger for transaktionsgebyr</translation>
     </message>
     <message>
+        <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
+
+Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satoshis per kvB" for a transaction size of 500 virtual bytes (half of 1 kvB) would ultimately yield a fee of only 50 satoshis.</source>
+        <translation type="unfinished">Angiv et brugerdefineret gebyr pr. kB (1.000 bytes) af transaktionens virtuelle størrelse.
+
+Bemærk: Da gebyret beregnes på per-byte-basis, ville en gebyrsats på "100 satoshis pr. kvB" for en transaktionsstørrelse på 500 virtuelle bytes (halvdelen af 1 kvB) i sidste ende kun give et gebyr på 50 satoshis.</translation>
+    </message>
+    <message>
         <source>When there is less transaction volume than space in the blocks, miners as well as relaying nodes may enforce a minimum fee. Paying only this minimum fee is just fine, but be aware that this can result in a never confirming transaction once there is more demand for bitcoin transactions than the network can process.</source>
         <translation type="unfinished">På tidspunkter, hvor der er færre transaktioner, end der er plads til i nye blokke, kan minere og videresendende knuder gennemtvinge et minimumsgebyr. Du kan vælge kun at betale dette minimumsgebyr, men vær opmærksom på, at det kan resultere i en transaktion, der aldrig bliver bekræftet, hvis mængden af nye bitcoin-transaktioner stiger til mere, end hvad netværket kan behandle ad gangen.</translation>
     </message>
     <message>
         <source>A too low fee might result in a never confirming transaction (read the tooltip)</source>
         <translation type="unfinished">Et for lavt gebyr kan resultere i en transaktion, der aldrig bekræftes (læs værktøjstippet)</translation>
+    </message>
+    <message>
+        <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
+        <translation type="unfinished">(Smart gebyr er ikke initialiseret endnu. Dette tager normalt et par blokke...)</translation>
     </message>
     <message>
         <source>Confirmation time target:</source>
@@ -2349,6 +2691,20 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">%1 (%2 blokke)</translation>
     </message>
     <message>
+        <source>Sign on device</source>
+        <extracomment>"device" usually means a hardware wallet</extracomment>
+        <translation type="unfinished">Underskriv på enhed</translation>
+    </message>
+    <message>
+        <source>Connect your hardware wallet first.</source>
+        <translation type="unfinished">Tilslut din hardwaretegnebog først.</translation>
+    </message>
+    <message>
+        <source>Set external signer script path in Options -&gt; Wallet</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Indstil ekstern underskriver scriptsti i Indstillinger -&gt; Tegnebog</translation>
+    </message>
+    <message>
         <source>Cr&amp;eate Unsigned</source>
         <translation type="unfinished">L&amp;av usigneret</translation>
     </message>
@@ -2373,16 +2729,47 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Er du sikker på, at du vil sende?</translation>
     </message>
     <message>
+        <source>To review recipient list click "Show Details…"</source>
+        <translation type="unfinished">For at vurdere modtager listen tryk "Vis Detaljer..."</translation>
+    </message>
+    <message>
         <source>Create Unsigned</source>
         <translation type="unfinished">Opret Usigneret</translation>
+    </message>
+    <message>
+        <source>Sign and send</source>
+        <translation type="unfinished">Underskriv og send</translation>
+    </message>
+    <message>
+        <source>Sign failed</source>
+        <translation type="unfinished">Underskrivningen fejlede</translation>
+    </message>
+    <message>
+        <source>External signer not found</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Ekstern underskriver ikke fundet</translation>
+    </message>
+    <message>
+        <source>External signer failure</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Ekstern underskriver fejl</translation>
     </message>
     <message>
         <source>Save Transaction Data</source>
         <translation type="unfinished">Gem Transaktionsdata</translation>
     </message>
     <message>
+        <source>Partially Signed Transaction (Binary)</source>
+        <extracomment>Expanded name of the binary PSBT file format. See: BIP 174.</extracomment>
+        <translation type="unfinished">Delvist underskrevet transaktion (Binær)</translation>
+    </message>
+    <message>
         <source>PSBT saved</source>
         <translation type="unfinished">PSBT gemt</translation>
+    </message>
+    <message>
+        <source>External balance:</source>
+        <translation type="unfinished">Ekstern balance:</translation>
     </message>
     <message>
         <source>or</source>
@@ -2459,8 +2846,8 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation>
-            <numerusform />
-            <numerusform />
+            <numerusform>Anslået til at begynde bekræftelse inden for %n blok.</numerusform>
+            <numerusform>Anslået til at begynde bekræftelse inden for %n blokke.</numerusform>
         </translation>
     </message>
     <message>
@@ -2703,8 +3090,8 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>Open for %n more block(s)</source>
         <translation>
-            <numerusform />
-            <numerusform />
+            <numerusform>Åben for yderligere %n blok</numerusform>
+            <numerusform>Åben for yderligere %n blokke</numerusform>
         </translation>
     </message>
     <message>
@@ -2782,8 +3169,8 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation>
-            <numerusform />
-            <numerusform />
+            <numerusform>modnes i yderligere %n blok</numerusform>
+            <numerusform>modnes i yderligere %n blokke</numerusform>
         </translation>
     </message>
     <message>
@@ -2895,8 +3282,8 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>Open for %n more block(s)</source>
         <translation>
-            <numerusform />
-            <numerusform />
+            <numerusform>Åben for yderligere %n blok</numerusform>
+            <numerusform>Åben for yderligere %n blokke</numerusform>
         </translation>
     </message>
     <message>
@@ -3043,6 +3430,46 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Interval...</translation>
     </message>
     <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Kopiér adresse</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Kopiér &amp;mærkat</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Kopiér &amp;beløb</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">Kopiér transaktion &amp;ID</translation>
+    </message>
+    <message>
+        <source>Copy &amp;raw transaction</source>
+        <translation type="unfinished">Kopiér &amp;rå transaktion</translation>
+    </message>
+    <message>
+        <source>Copy full transaction &amp;details</source>
+        <translation type="unfinished">Kopiér alle transaktion &amp;oplysninger </translation>
+    </message>
+    <message>
+        <source>&amp;Show transaction details</source>
+        <translation type="unfinished">&amp;Vis transaktionsoplysninger</translation>
+    </message>
+    <message>
+        <source>Increase transaction &amp;fee</source>
+        <translation type="unfinished">Hæv transaktions &amp;gebyr</translation>
+    </message>
+    <message>
+        <source>A&amp;bandon transaction</source>
+        <translation type="unfinished">&amp;Opgiv transaction</translation>
+    </message>
+    <message>
+        <source>&amp;Edit address label</source>
+        <translation type="unfinished">&amp;Rediger adresseetiket</translation>
+    </message>
+    <message>
         <source>Export Transaction History</source>
         <translation type="unfinished">Eksportér transaktionshistorik</translation>
     </message>
@@ -3146,6 +3573,10 @@ Gå til Fil &gt; Åbn Pung for, at indlæse en pung.
         <translation type="unfinished">Nyt gebyr:</translation>
     </message>
     <message>
+        <source>Warning: This may pay the additional fee by reducing change outputs or adding inputs, when necessary. It may add a new change output if one does not already exist. These changes may potentially leak privacy.</source>
+        <translation type="unfinished">Advarsel: Dette kan betale det ekstra gebyr ved at reducere byttepengesoutputs eller tilføje inputs, når det er nødvendigt. Det kan tilføje et nyt byttepengesoutput, hvis et ikke allerede eksisterer. Disse ændringer kan potentielt lække privatlivets fred.</translation>
+    </message>
+    <message>
         <source>Confirm fee bump</source>
         <translation type="unfinished">Bekræft gebyrforøgelse</translation>
     </message>
@@ -3164,6 +3595,10 @@ Gå til Fil &gt; Åbn Pung for, at indlæse en pung.
     <message>
         <source>Could not commit transaction</source>
         <translation type="unfinished">Kunne ikke gennemføre transaktionen</translation>
+    </message>
+    <message>
+        <source>Can't display address</source>
+        <translation type="unfinished">Adressen kan ikke vises</translation>
     </message>
     <message>
         <source>default wallet</source>
@@ -3249,12 +3684,20 @@ Gå til Fil &gt; Åbn Pung for, at indlæse en pung.
         <translation type="unfinished">-maxtxfee er sat meget højt! Gebyrer så store risikeres betalt på en enkelt transaktion.</translation>
     </message>
     <message>
+        <source>Cannot downgrade wallet from version %i to version %i. Wallet version unchanged.</source>
+        <translation type="unfinished">Kan ikke nedgradere tegnebogen fra version %i til version %i. Wallet-versionen uændret.</translation>
+    </message>
+    <message>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running.</source>
         <translation type="unfinished">Kan ikke opnå en lås på datamappe %s. %s kører sansynligvis allerede.</translation>
     </message>
     <message>
         <source>Cannot provide specific connections and have addrman find outgoing connections at the same.</source>
         <translation type="unfinished">Kan ikke give specifikke forbindelser og få addrman til at finde udgående forbindelser på samme tid.</translation>
+    </message>
+    <message>
+        <source>Cannot upgrade a non HD split wallet from version %i to version %i without upgrading to support pre-split keypool. Please use version %i or no version specified.</source>
+        <translation type="unfinished">Kan ikke opgradere en ikke-HD split wallet fra version %i til version %i uden at opgradere til at understøtte pre-split keypool. Brug venligst version %i eller ingen version angivet.</translation>
     </message>
     <message>
         <source>Distributed under the MIT software license, see the accompanying file %s or %s</source>
@@ -3265,6 +3708,22 @@ Gå til Fil &gt; Åbn Pung for, at indlæse en pung.
         <translation type="unfinished">Fejl under læsning af %s! Alle nøgler blev læst korrekt, men transaktionsdata eller indgange i adressebogen kan mangle eller være ukorrekte.</translation>
     </message>
     <message>
+        <source>Error: Dumpfile format record is incorrect. Got "%s", expected "format".</source>
+        <translation type="unfinished">Fejl: Dumpfilformat dokument er forkert. Fik "%s", forventet "format".</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile identifier record is incorrect. Got "%s", expected "%s".</source>
+        <translation type="unfinished">Fejl: Dumpfilformat dokument er forkert. Fik "%s", forventet "%s".</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile version is not supported. This version of bitcoin-wallet only supports version 1 dumpfiles. Got dumpfile with version %s</source>
+        <translation type="unfinished">Fejl: Dumpfil-versionen understøttes ikke. Denne version af bitcoin-tegnebog understøtter kun version 1 dumpfiler. Fik dumpfil med version %s</translation>
+    </message>
+    <message>
+        <source>Error: Legacy wallets only support the "legacy", "p2sh-segwit", and "bech32" address types</source>
+        <translation type="unfinished">Fejl: Ældre tegnebøger understøtter kun adressetyperne "legacy", "p2sh-segwit" og "bech32"</translation>
+    </message>
+    <message>
         <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
         <translation type="unfinished">Fejl: Lytning efter indkommende forbindelser mislykkedes (lytning resultarede i fejl %s)</translation>
     </message>
@@ -3273,12 +3732,28 @@ Gå til Fil &gt; Åbn Pung for, at indlæse en pung.
         <translation type="unfinished">Estimering af gebyr mislykkedes. Tilbagefaldsgebyr er deaktiveret. Vent et par blokke eller aktiver -fallbackfee.</translation>
     </message>
     <message>
+        <source>File %s already exists. If you are sure this is what you want, move it out of the way first.</source>
+        <translation type="unfinished">Fil %s eksisterer allerede. Hvis du er sikker på, at det er det, du vil have, så flyt det af vejen først.</translation>
+    </message>
+    <message>
         <source>Invalid amount for -maxtxfee=&lt;amount&gt;: '%s' (must be at least the minrelay fee of %s to prevent stuck transactions)</source>
         <translation type="unfinished">Ugyldigt beløb for -maxtxfee=&lt;beløb&gt;: “%s” (skal være på mindst minrelay-gebyret på %s for at undgå hængende transaktioner)</translation>
     </message>
     <message>
         <source>More than one onion bind address is provided. Using %s for the automatically created Tor onion service.</source>
         <translation type="unfinished">Mere end én onion-bindingsadresse er opgivet. Bruger %s til den automatiske oprettelse af Tor-onion-tjeneste.</translation>
+    </message>
+    <message>
+        <source>No dump file provided. To use createfromdump, -dumpfile=&lt;filename&gt; must be provided.</source>
+        <translation type="unfinished">Der er ikke angivet nogen dumpfil. For at bruge createfromdump skal -dumpfile= &lt;filename&gt; angives.</translation>
+    </message>
+    <message>
+        <source>No dump file provided. To use dump, -dumpfile=&lt;filename&gt; must be provided.</source>
+        <translation type="unfinished">Der er ikke angivet nogen dumpfil. For at bruge dump skal -dumpfile=&lt;filename&gt; angives.</translation>
+    </message>
+    <message>
+        <source>No wallet file format provided. To use createfromdump, -format=&lt;format&gt; must be provided.</source>
+        <translation type="unfinished">Der er ikke angivet noget tegnebogsfilformat. For at bruge createfromdump skal -format=&lt;format&gt; angives.</translation>
     </message>
     <message>
         <source>Please check that your computer's date and time are correct! If your clock is wrong, %s will not work properly.</source>
@@ -3337,12 +3812,24 @@ Gå til Fil &gt; Åbn Pung for, at indlæse en pung.
         <translation type="unfinished">Kan ikke genafspille blokke. Du er nødt til at genopbytte databasen ved hjælp af -reindex-chainstate.</translation>
     </message>
     <message>
+        <source>Unknown wallet file format "%s" provided. Please provide one of "bdb" or "sqlite".</source>
+        <translation type="unfinished">Ukendt tegnebogsfilformat "%s" angivet. Angiv en af "bdb" eller "sqlite".</translation>
+    </message>
+    <message>
+        <source>Warning: Dumpfile wallet format "%s" does not match command line specified format "%s".</source>
+        <translation type="unfinished">Advarsel: Dumpfile tegnebogsformatet "%s" matcher ikke kommandolinjens specificerede format "%s".</translation>
+    </message>
+    <message>
         <source>Warning: Private keys detected in wallet {%s} with disabled private keys</source>
         <translation type="unfinished">Advarsel: Private nøgler opdaget i tegnebog {%s} med deaktiverede private nøgler</translation>
     </message>
     <message>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished">Advarsel: Vi ser ikke ud til at være fuldt ud enige med andre knuder! Du kan være nødt til at opgradere, eller andre knuder kan være nødt til at opgradere.</translation>
+    </message>
+    <message>
+        <source>Witness data for blocks after height %d requires validation. Please restart with -reindex.</source>
+        <translation type="unfinished">Vidnedata for blokke efter højde %d kræver validering. Genstart venligst med -reindex.</translation>
     </message>
     <message>
         <source>You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain</source>
@@ -3409,6 +3896,14 @@ Gå til Fil &gt; Åbn Pung for, at indlæse en pung.
         <translation type="unfinished">Indlæsning gennemført</translation>
     </message>
     <message>
+        <source>Dump file %s does not exist.</source>
+        <translation type="unfinished">Dumpfil %s findes ikke.</translation>
+    </message>
+    <message>
+        <source>Error creating %s</source>
+        <translation type="unfinished">Fejl skaber %s</translation>
+    </message>
+    <message>
         <source>Error initializing block database</source>
         <translation type="unfinished">Klargøring af blokdatabase mislykkedes</translation>
     </message>
@@ -3445,16 +3940,52 @@ Gå til Fil &gt; Åbn Pung for, at indlæse en pung.
         <translation type="unfinished">Fejl under læsning fra database; lukker ned.</translation>
     </message>
     <message>
+        <source>Error reading next record from wallet database</source>
+        <translation type="unfinished">Fejl ved læsning af næste post fra tegnebogsdatabase</translation>
+    </message>
+    <message>
         <source>Error upgrading chainstate database</source>
         <translation type="unfinished">Fejl under opgradering af kædetilstandsdatabase</translation>
+    </message>
+    <message>
+        <source>Error: Couldn't create cursor into database</source>
+        <translation type="unfinished">Fejl: Kunne ikke oprette markøren i databasen</translation>
     </message>
     <message>
         <source>Error: Disk space is low for %s</source>
         <translation type="unfinished">Fejl: Disk plads er lavt for %s</translation>
     </message>
     <message>
+        <source>Error: Dumpfile checksum does not match. Computed %s, expected %s</source>
+        <translation type="unfinished">Fejl: Dumpfil kontrolsum stemmer ikke overens. Beregnet %s, forventet %s</translation>
+    </message>
+    <message>
+        <source>Error: Got key that was not hex: %s</source>
+        <translation type="unfinished">Fejl: Fik nøgle, der ikke var hex: %s</translation>
+    </message>
+    <message>
+        <source>Error: Got value that was not hex: %s</source>
+        <translation type="unfinished">Fejl: Fik værdi, der ikke var hex: %s</translation>
+    </message>
+    <message>
         <source>Error: Keypool ran out, please call keypoolrefill first</source>
         <translation type="unfinished">Fejl: Nøglepøl løb tør, tilkald venligst keypoolrefill først</translation>
+    </message>
+    <message>
+        <source>Error: Missing checksum</source>
+        <translation type="unfinished">Fejl: Manglende kontrolsum</translation>
+    </message>
+    <message>
+        <source>Error: No %s addresses available.</source>
+        <translation type="unfinished">Fejl: Ingen tilgængelige %s adresser.</translation>
+    </message>
+    <message>
+        <source>Error: Unable to parse version %u as a uint32_t</source>
+        <translation type="unfinished">Fejl: Kan ikke parse version %u som en uint32_t</translation>
+    </message>
+    <message>
+        <source>Error: Unable to write record to new wallet</source>
+        <translation type="unfinished">Fejl: Kan ikke skrive post til ny tegnebog</translation>
     </message>
     <message>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
@@ -3491,6 +4022,10 @@ Gå til Fil &gt; Åbn Pung for, at indlæse en pung.
     <message>
         <source>Insufficient funds</source>
         <translation type="unfinished">Manglende dækning</translation>
+    </message>
+    <message>
+        <source>Invalid -i2psam address or hostname: '%s'</source>
+        <translation type="unfinished">Ugyldig -i2psam-adresse eller værtsnavn: '%s'</translation>
     </message>
     <message>
         <source>Invalid -onion address or hostname: '%s'</source>
@@ -3557,6 +4092,10 @@ Gå til Fil &gt; Åbn Pung for, at indlæse en pung.
         <translation type="unfinished">Beskæring kan ikke opsættes med en negativ værdi.</translation>
     </message>
     <message>
+        <source>Prune mode is incompatible with -coinstatsindex.</source>
+        <translation type="unfinished">Beskæringstilstand er inkompatibel med -coinstatsindex.</translation>
+    </message>
+    <message>
         <source>Prune mode is incompatible with -txindex.</source>
         <translation type="unfinished">Beskæringstilstand er ikke kompatibel med -txindex.</translation>
     </message>
@@ -3567,6 +4106,10 @@ Gå til Fil &gt; Åbn Pung for, at indlæse en pung.
     <message>
         <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
         <translation type="unfinished">Reducerer -maxconnections fra %d til %d på grund af systembegrænsninger.</translation>
+    </message>
+    <message>
+        <source>Replaying blocks…</source>
+        <translation type="unfinished">Genafspiller blokke...</translation>
     </message>
     <message>
         <source>Rescanning…</source>
@@ -3613,8 +4156,16 @@ Gå til Fil &gt; Åbn Pung for, at indlæse en pung.
         <translation type="unfinished">Angivet blokmappe “%s” eksisterer ikke.</translation>
     </message>
     <message>
+        <source>Starting network threads…</source>
+        <translation type="unfinished">Starter netværkstråde...</translation>
+    </message>
+    <message>
         <source>The source code is available from %s.</source>
         <translation type="unfinished">Kildekoden er tilgængelig fra %s.</translation>
+    </message>
+    <message>
+        <source>The specified config file %s does not exist</source>
+        <translation type="unfinished">Den angivne konfigurationsfil %s findes ikke</translation>
     </message>
     <message>
         <source>The transaction amount is too small to pay the fee</source>
@@ -3653,6 +4204,10 @@ Gå til Fil &gt; Åbn Pung for, at indlæse en pung.
         <translation type="unfinished">Transaktionen skal have mindst én modtager</translation>
     </message>
     <message>
+        <source>Transaction needs a change address, but we can't generate it. %s</source>
+        <translation type="unfinished">Transaktionen behøver en byttepenge adresse, men vi kan ikke generere den. %s</translation>
+    </message>
+    <message>
         <source>Transaction too large</source>
         <translation type="unfinished">Transaktionen er for stor</translation>
     </message>
@@ -3677,6 +4232,10 @@ Gå til Fil &gt; Åbn Pung for, at indlæse en pung.
         <translation type="unfinished">U-istand til at generere nøgler</translation>
     </message>
     <message>
+        <source>Unable to open %s for writing</source>
+        <translation type="unfinished">Kan ikke åbne %s til skrivning</translation>
+    </message>
+    <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
         <translation type="unfinished">Kunne ikke starte HTTP-server. Se fejlretningslog for detaljer.</translation>
     </message>
@@ -3697,6 +4256,10 @@ Gå til Fil &gt; Åbn Pung for, at indlæse en pung.
         <translation type="unfinished">Ukendt netværk anført i -onlynet: “%s”</translation>
     </message>
     <message>
+        <source>Unknown new rules activated (versionbit %i)</source>
+        <translation type="unfinished">Ukendte nye regler aktiveret (versionsbit %i)</translation>
+    </message>
+    <message>
         <source>Unsupported logging category %s=%s.</source>
         <translation type="unfinished">Ikke understøttet logningskategori %s=%s.</translation>
     </message>
@@ -3711,6 +4274,10 @@ Gå til Fil &gt; Åbn Pung for, at indlæse en pung.
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
         <translation type="unfinished">Brugeragent-kommentar (%s) indeholder usikre tegn.</translation>
+    </message>
+    <message>
+        <source>Verifying blocks…</source>
+        <translation type="unfinished">Verificerer blokke…</translation>
     </message>
     <message>
         <source>Verifying wallet(s)…</source>

--- a/src/qt/locale/bitcoin_de.ts
+++ b/src/qt/locale/bitcoin_de.ts
@@ -1268,7 +1268,7 @@ Das Signieren ist nur mit Adressen vom Typ 'Legacy' möglich.</translation>
     </message>
     <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
-        <translation type="unfinished">Diese initiale Synchronisation führt zur hohen Last und kann Harewareprobleme, die bisher nicht aufgetreten sind, mit ihrem Computer verursachen. Jedes Mal, wenn Sie %1 ausführen, wird der Download zum letzten Synchronisationspunkt fortgesetzt.</translation>
+        <translation type="unfinished">Diese initiale Synchronisation führt zur hohen Last und kann Hardwareprobleme, die bisher nicht aufgetreten sind, mit ihrem Computer verursachen. Jedes Mal, wenn Sie %1 ausführen, wird der Download zum letzten Synchronisationspunkt fortgesetzt.</translation>
     </message>
     <message>
         <source>If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</source>
@@ -3774,7 +3774,7 @@ Gehen Sie zu Datei &gt; Öffnen Sie die Brieftasche, um eine Brieftasche zu lade
     </message>
     <message>
         <source>Error: Legacy wallets only support the "legacy", "p2sh-segwit", and "bech32" address types</source>
-        <translation type="unfinished">Fehler: Legacy Brieftaschen unterstützen nur die Adresstypen "legacy", "p2sh-segwit" und "bech32".</translation>
+        <translation type="unfinished">Fehler: Althergebrachte Brieftaschen unterstützen nur die Adresstypen "legacy", "p2sh-segwit" und "bech32".</translation>
     </message>
     <message>
         <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
@@ -4161,7 +4161,7 @@ Berechnet: %s, erwartet: %s</translation>
     </message>
     <message>
         <source>Replaying blocks…</source>
-        <translation type="unfinished">Spiele alle Blocks durch…</translation>
+        <translation type="unfinished">Spiele alle Blocks erneut ein…</translation>
     </message>
     <message>
         <source>Rescanning…</source>
@@ -4214,7 +4214,7 @@ Verifikations-Error: %s</translation>
     </message>
     <message>
         <source>The source code is available from %s.</source>
-        <translation type="unfinished">Der Quellcode ist von %s verfügbar.</translation>
+        <translation type="unfinished">Der Quellcode ist auf %s verfügbar.</translation>
     </message>
     <message>
         <source>The specified config file %s does not exist</source>
@@ -4286,7 +4286,7 @@ Verifikations-Error: %s</translation>
     </message>
     <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
-        <translation type="unfinished">Kann HTTP Server nicht starten. Siehe debug log für Details.</translation>
+        <translation type="unfinished">Kann HTTP-Server nicht starten. Siehe Debug-Log für Details.</translation>
     </message>
     <message>
         <source>Unknown -blockfilterindex value %s.</source>

--- a/src/qt/locale/bitcoin_el.ts
+++ b/src/qt/locale/bitcoin_el.ts
@@ -77,11 +77,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>&amp;Copy Address</source>
-        <translation type="unfinished">&amp;Αντιγραφή Διεύθυνσης</translation>
+        <translation type="unfinished">&amp;Αντιγραφή διεύθυνσης</translation>
     </message>
     <message>
         <source>Copy &amp;Label</source>
-        <translation type="unfinished">Αντιγραφή&amp;Ετικέτα</translation>
+        <translation type="unfinished">Αντιγραφή &amp;ετικέτας</translation>
     </message>
     <message>
         <source>&amp;Edit</source>
@@ -103,7 +103,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Exporting Failed</source>
-        <translation type="unfinished">Αποτυχία Εξαγωγής</translation>
+        <translation type="unfinished">Αποτυχία εξαγωγής</translation>
     </message>
 </context>
 <context>
@@ -137,7 +137,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Repeat new passphrase</source>
-        <translation>Επανέλαβε τον νέο κωδικό πρόσβασης</translation>
+        <translation>Επανάλαβε τον νέο κωδικό πρόσβασης</translation>
     </message>
     <message>
         <source>Show passphrase</source>
@@ -249,7 +249,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Internal error</source>
         <translation type="unfinished">Εσωτερικό σφάλμα</translation>
     </message>
-    </context>
+    <message>
+        <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
+        <translation type="unfinished">Προέκυψε ένα εσωτερικό σφάλμα. Το %1 θα επιχειρήσει να συνεχίσει με ασφάλεια. Αυτό είναι ένα απροσδόκητο σφάλμα· μπορείτε να το αναφέρετε όπως περιγράφεται παρακάτω.</translation>
+    </message>
+</context>
 <context>
     <name>QObject</name>
     <message>
@@ -285,6 +289,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Εισάγετε μια διεύθυνση Bitcoin (π.χ. %1)</translation>
     </message>
     <message>
+        <source>Unroutable</source>
+        <translation type="unfinished">Αδρομολόγητο</translation>
+    </message>
+    <message>
+        <source>Internal</source>
+        <translation type="unfinished">Εσωτερικό</translation>
+    </message>
+    <message>
         <source>Inbound</source>
         <translation type="unfinished">Εισερχόμενα</translation>
     </message>
@@ -303,6 +315,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Manual</source>
         <translation type="unfinished">Χειροκίνητα</translation>
+    </message>
+    <message>
+        <source>Address Fetch</source>
+        <translation type="unfinished">Λήψη Διεύθυνσης</translation>
     </message>
     <message>
         <source>None</source>
@@ -535,6 +551,22 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Συγχρονισμός με το δίκτυο...</translation>
     </message>
     <message>
+        <source>Indexing blocks on disk…</source>
+        <translation type="unfinished">Καταλογισμός μπλοκ στον δίσκο...</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation type="unfinished">Επεξεργασία των μπλοκ στον δίσκο...</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation type="unfinished">Επανακαταλογισμός μπλοκ στον δίσκο...</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation type="unfinished">Σύνδεση στους χρήστες...</translation>
+    </message>
+    <message>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished">Αίτηση πληρωμών (δημιουργεί QR codes και διευθύνσεις bitcoin: )</translation>
     </message>
@@ -553,13 +585,17 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation>
-            <numerusform />
-            <numerusform />
+            <numerusform>Επεξεργάστηκε %n των κομματιών της ιστορίας συναλλαγών.</numerusform>
+            <numerusform>Επεξεργάστηκε %n των κομματιών της ιστορίας συναλλαγών.</numerusform>
         </translation>
     </message>
     <message>
         <source>%1 behind</source>
         <translation>%1 πίσω</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation type="unfinished">Φτάνει...</translation>
     </message>
     <message>
         <source>Last received block was generated %1 ago.</source>
@@ -681,6 +717,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Click for more actions.</source>
         <extracomment>A substring of the tooltip. "More actions" are available via the context menu.</extracomment>
         <translation type="unfinished">Κάντε κλικ για περισσότερες επιλογές.</translation>
+    </message>
+    <message>
+        <source>Show Peers tab</source>
+        <extracomment>A context menu item. The "Peers tab" is an element of the "Node window".</extracomment>
+        <translation type="unfinished">Προβολή καρτέλας Χρηστών</translation>
     </message>
     <message>
         <source>Disable network activity</source>
@@ -863,6 +904,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Αντιγραφή συναλλαγής &amp;ID</translation>
     </message>
     <message>
+        <source>L&amp;ock unspent</source>
+        <translation type="unfinished">L&amp;ock διαθέσιμο</translation>
+    </message>
+    <message>
         <source>Copy quantity</source>
         <translation type="unfinished">Αντιγραφή ποσότητας</translation>
     </message>
@@ -933,7 +978,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Create wallet warning</source>
         <translation type="unfinished">Προειδοποίηση δημιουργίας πορτοφολιού</translation>
     </message>
-    </context>
+    <message>
+        <source>Can't list signers</source>
+        <translation type="unfinished">Αδυναμία απαρίθμησης εγγεγραμμένων </translation>
+    </message>
+</context>
 <context>
     <name>OpenWalletActivity</name>
     <message>
@@ -1025,6 +1074,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Descriptor Wallet</source>
         <translation type="unfinished">Πορτοφόλι Περιγραφέα </translation>
+    </message>
+    <message>
+        <source>Use an external signing device such as a hardware wallet. Configure the external signer script in wallet preferences first.</source>
+        <translation type="unfinished">Χρησιμοποιήστε μια εξωτερική συσκευή υπογραφής, όπως ένα πορτοφόλι υλικού. Ρυθμίστε πρώτα στις προτιμήσεις του πορτοφολιού το εξωτερικό script υπογραφής.</translation>
+    </message>
+    <message>
+        <source>External signer</source>
+        <translation type="unfinished">Εξωτερικός υπογράφων</translation>
     </message>
     <message>
         <source>Create</source>
@@ -1172,6 +1229,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Όταν κάνετε κλικ στο OK, το %1 θα ξεκινήσει τη λήψη και την επεξεργασία της πλήρους αλυσίδας μπλοκ% 4 (%2GB) αρχίζοντας από τις πρώτες συναλλαγές στο %3 όταν αρχικά ξεκίνησε το %4.</translation>
     </message>
     <message>
+        <source>Limit block chain storage to</source>
+        <translation type="unfinished">Περιόρισε την χωρητικότητα της αλυσίδας block σε</translation>
+    </message>
+    <message>
         <source>Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</source>
         <translation type="unfinished">Η επαναφορά αυτής της ρύθμισης απαιτεί εκ νέου λήψη ολόκληρου του μπλοκ αλυσίδας. Είναι πιο γρήγορο να κατεβάσετε πρώτα την πλήρη αλυσίδα και να την κλαδέψετε αργότερα. Απενεργοποιεί ορισμένες προηγμένες λειτουργίες.</translation>
     </message>
@@ -1270,7 +1331,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>%1 is currently syncing.  It will download headers and blocks from peers and validate them until reaching the tip of the block chain.</source>
-        <translation type="unfinished">Το %1 συγχρονίζεται αυτήν τη στιγμή. Θα κατεβάσει κεφαλίδες και μπλοκ από τους συντρόφους και θα τους επικυρώσει μέχρι να φτάσουν στην άκρη της αλυσίδας μπλοκ.</translation>
+        <translation type="unfinished">Το %1 συγχρονίζεται αυτήν τη στιγμή. Θα κατεβάσει κεφαλίδες και μπλοκ από τους χρήστες και θα τους επικυρώσει μέχρι να φτάσουν στην άκρη της αλυσίδας μπλοκ.</translation>
     </message>
     <message>
         <source>Unknown. Syncing Headers (%1, %2%)…</source>
@@ -1312,7 +1373,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
-        <translation type="unfinished">Διεύθυνση IP του διαμεσολαβητή (π.χ. 127.0.0.1  / IPv6: ::1)</translation>
+        <translation type="unfinished">Διεύθυνση IP του διαμεσολαβητή (π.χ. IPv4: 127.0.0.1  / IPv6: ::1)</translation>
     </message>
     <message>
         <source>Shows if the supplied default SOCKS5 proxy is used to reach peers via this network type.</source>
@@ -1383,12 +1444,24 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">&amp;Ξόδεμα μη επικυρωμένων ρέστων</translation>
     </message>
     <message>
+        <source>External Signer (e.g. hardware wallet)</source>
+        <translation type="unfinished">Εξωτερική συσκευή υπογραφής (π.χ. πορτοφόλι υλικού)</translation>
+    </message>
+    <message>
+        <source>Full path to a Bitcoin Core compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</source>
+        <translation type="unfinished">Πλήρης διαδρομή ενός script συμβατού με το Bitcoin Core (π.χ.: C:\Downloads\hwi.exe ή /Users/you/Downloads/hwi.py). Προσοχή: το κακόβουλο λογισμικό μπορεί να κλέψει τα νομίσματά σας!</translation>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation>Αυτόματο άνοιγμα των θυρών Bitcoin στον δρομολογητή. Λειτουργεί μόνο αν ο δρομολογητής σας υποστηρίζει τη λειτουργία UPnP.</translation>
     </message>
     <message>
         <source>Map port using &amp;UPnP</source>
         <translation>Απόδοση θυρών με χρήστη &amp;UPnP</translation>
+    </message>
+    <message>
+        <source>Automatically open the Bitcoin client port on the router. This only works when your router supports NAT-PMP and it is enabled. The external port could be random.</source>
+        <translation type="unfinished">Ανοίξτε αυτόματα τη πόρτα του Bitcoin client στο router. Αυτό λειτουργεί μόνο όταν το router σας υποστηρίζει NAT-PMP και είναι ενεργοποιημένο. Η εξωτερική πόρτα μπορεί να είναι τυχαία.</translation>
     </message>
     <message>
         <source>Map port using NA&amp;T-PMP</source>
@@ -1424,7 +1497,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Used for reaching peers via:</source>
-        <translation type="unfinished">Χρησιμοποιείται για να φτάσεις στους σύντροφους μέσω:</translation>
+        <translation type="unfinished">Χρησιμοποιείται για να φτάσεις στους χρήστες μέσω:</translation>
     </message>
     <message>
         <source>&amp;Window</source>
@@ -1481,6 +1554,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Use separate SOCKS&amp;5 proxy to reach peers via Tor onion services:</source>
         <translation type="unfinished">Χρησιμοποιήστε ξεχωριστό διακομιστή μεσολάβησης SOCKS&amp;5 για σύνδεση με αποδέκτες μέσω των υπηρεσιών onion του Tor:</translation>
+    </message>
+    <message>
+        <source>embedded "%1"</source>
+        <translation type="unfinished">ενσωματωμένο "%1"</translation>
+    </message>
+    <message>
+        <source>closest matching "%1"</source>
+        <translation type="unfinished">πλησιέστερη αντιστοίχιση "%1"</translation>
     </message>
     <message>
         <source>Options set in this dialog are overridden by the command line or in the configuration file:</source>
@@ -1654,6 +1735,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Αποτυχία εκπλήρωσης συναλλαγής: %1</translation>
     </message>
     <message>
+        <source>Could not sign any more inputs.</source>
+        <translation type="unfinished">Δεν είναι δυνατή η υπογραφή περισσότερων καταχωρήσεων.</translation>
+    </message>
+    <message>
+        <source>Signed %1 inputs, but more signatures are still required.</source>
+        <translation type="unfinished">Υπεγράφη %1 καταχώρηση, αλλά περισσότερες υπογραφές χρειάζονται.</translation>
+    </message>
+    <message>
         <source>Signed transaction successfully. Transaction is ready to broadcast.</source>
         <translation type="unfinished">Η συναλλαγή υπογράφηκε με επιτυχία. Η συναλλαγή είναι έτοιμη για μετάδοση.</translation>
     </message>
@@ -1679,6 +1768,11 @@ ID Συναλλαγής: %1</translation>
         <translation type="unfinished">Αποθήκευση Δεδομένων Συναλλαγής</translation>
     </message>
     <message>
+        <source>Partially Signed Transaction (Binary)</source>
+        <extracomment>Expanded name of the binary PSBT file format. See: BIP 174.</extracomment>
+        <translation type="unfinished">Μερικώς Υπογεγραμμένη Συναλλαγή (binary)</translation>
+    </message>
+    <message>
         <source>PSBT saved to disk.</source>
         <translation type="unfinished">PSBT αποθηκεύτηκε στο δίσκο.</translation>
     </message>
@@ -1701,6 +1795,18 @@ ID Συναλλαγής: %1</translation>
     <message>
         <source>or</source>
         <translation type="unfinished">ή</translation>
+    </message>
+    <message>
+        <source>Transaction has %1 unsigned inputs.</source>
+        <translation type="unfinished">Η συναλλαγή έχει %1 μη υπογεγραμμένη καταχώρηση.</translation>
+    </message>
+    <message>
+        <source>Transaction is missing some information about inputs.</source>
+        <translation type="unfinished">Λείπουν μερικές πληροφορίες από την συναλλαγή.</translation>
+    </message>
+    <message>
+        <source>Transaction still needs signature(s).</source>
+        <translation type="unfinished">Η συναλλαγή απαιτεί υπογραφή/ές</translation>
     </message>
     <message>
         <source>(But this wallet cannot sign transactions.)</source>
@@ -1752,6 +1858,11 @@ ID Συναλλαγής: %1</translation>
         <source>User Agent</source>
         <extracomment>Title of Peers Table column which contains the peer's User Agent string.</extracomment>
         <translation type="unfinished">Agent χρήστη</translation>
+    </message>
+    <message>
+        <source>Peer</source>
+        <extracomment>Title of Peers Table column which contains a unique number used to identify a connection.</extracomment>
+        <translation type="unfinished">Χρήστης</translation>
     </message>
     <message>
         <source>Sent</source>
@@ -1899,7 +2010,7 @@ ID Συναλλαγής: %1</translation>
     </message>
     <message>
         <source>Banned peers</source>
-        <translation type="unfinished">Αποκλεισμένοι σύντροφοι</translation>
+        <translation type="unfinished">Αποκλεισμένοι χρήστες</translation>
     </message>
     <message>
         <source>Select a peer to view detailed information.</source>
@@ -1966,8 +2077,24 @@ ID Συναλλαγής: %1</translation>
         <translation type="unfinished">Υπηρεσίες</translation>
     </message>
     <message>
+        <source>Wants Tx Relay</source>
+        <translation type="unfinished">Απαιτεί Αναμετάδοση Tx</translation>
+    </message>
+    <message>
+        <source>High Bandwidth</source>
+        <translation type="unfinished">Υψηλό εύρος ζώνης</translation>
+    </message>
+    <message>
         <source>Connection Time</source>
         <translation type="unfinished">Χρόνος σύνδεσης</translation>
+    </message>
+    <message>
+        <source>Last Block</source>
+        <translation type="unfinished">Τελευταίο Block</translation>
+    </message>
+    <message>
+        <source>Last Tx</source>
+        <translation type="unfinished">Τελευταίο Tx</translation>
     </message>
     <message>
         <source>Last Send</source>
@@ -2034,6 +2161,14 @@ ID Συναλλαγής: %1</translation>
         <translation type="unfinished">Εξερχόμενα:</translation>
     </message>
     <message>
+        <source>Inbound: initiated by peer</source>
+        <translation type="unfinished">Εισερχόμενo: Ξεκίνησε από peer</translation>
+    </message>
+    <message>
+        <source>the peer selected us for high bandwidth relay</source>
+        <translation type="unfinished">ο ομότιμος μας επέλεξε για υψηλής ταχύτητας αναμετάδοση </translation>
+    </message>
+    <message>
         <source>&amp;Disconnect</source>
         <translation type="unfinished">&amp;Αποσύνδεση</translation>
     </message>
@@ -2065,6 +2200,15 @@ ID Συναλλαγής: %1</translation>
         <source>Executing command using "%1" wallet</source>
         <translation type="unfinished"> 
 Εκτελέστε εντολή χρησιμοποιώντας το πορτοφόλι "%1"</translation>
+    </message>
+    <message>
+        <source>Executing…</source>
+        <extracomment>A console message indicating an entered command is currently being executed.</extracomment>
+        <translation type="unfinished">Εκτέλεση...</translation>
+    </message>
+    <message>
+        <source>(peer: %1)</source>
+        <translation type="unfinished">(χρήστης: %1)</translation>
     </message>
     <message>
         <source>via %1</source>
@@ -2396,12 +2540,24 @@ ID Συναλλαγής: %1</translation>
         <translation type="unfinished">Απόκρυψη ρυθμίσεων αμοιβής συναλλαγής</translation>
     </message>
     <message>
+        <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
+
+Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satoshis per kvB" for a transaction size of 500 virtual bytes (half of 1 kvB) would ultimately yield a fee of only 50 satoshis.</source>
+        <translation type="unfinished">Καθορίστε μία εξατομικευμένη χρέωση ανά kB (1.000 bytes) του εικονικού μεγέθους της συναλλαγής.
+
+Σημείωση: Εφόσον η χρέωση υπολογίζεται ανά byte, ένας ρυθμός χρέωσης των «100 satoshis ανά kvB» για μέγεθος συναλλαγής 500 ψηφιακών bytes (το μισό του 1 kvB) θα απέφερε χρέωση μόλις 50 satoshis.</translation>
+    </message>
+    <message>
         <source>When there is less transaction volume than space in the blocks, miners as well as relaying nodes may enforce a minimum fee. Paying only this minimum fee is just fine, but be aware that this can result in a never confirming transaction once there is more demand for bitcoin transactions than the network can process.</source>
         <translation type="unfinished">Όταν υπάρχει λιγότερος όγκος συναλλαγών από το χώρο στα μπλοκ, οι ανθρακωρύχοι καθώς και οι κόμβοι αναμετάδοσης μπορούν να επιβάλουν ένα ελάχιστο τέλος. Η πληρωμή μόνο αυτού του ελάχιστου τέλους είναι μια χαρά, αλλά γνωρίζετε ότι αυτό μπορεί να οδηγήσει σε μια συναλλαγή που δεν επιβεβαιώνει ποτέ τη στιγμή που υπάρχει μεγαλύτερη ζήτηση για συναλλαγές bitcoin από ό, τι μπορεί να επεξεργαστεί το δίκτυο.</translation>
     </message>
     <message>
         <source>A too low fee might result in a never confirming transaction (read the tooltip)</source>
         <translation type="unfinished">Μια πολύ χαμηλή χρέωση μπορεί να οδηγήσει σε μια συναλλαγή που δεν επιβεβαιώνει ποτέ (διαβάστε την επεξήγηση εργαλείου)</translation>
+    </message>
+    <message>
+        <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
+        <translation type="unfinished">(Η έξυπνη χρέωση δεν έχει αρχικοποιηθεί ακόμη. Αυτό συνήθως παίρνει κάποια μπλοκ...)</translation>
     </message>
     <message>
         <source>Confirmation time target:</source>
@@ -2464,6 +2620,11 @@ ID Συναλλαγής: %1</translation>
         <translation type="unfinished">%1 (%2 μπλοκς)</translation>
     </message>
     <message>
+        <source>Sign on device</source>
+        <extracomment>"device" usually means a hardware wallet</extracomment>
+        <translation type="unfinished">Εγγραφή στην συσκευή</translation>
+    </message>
+    <message>
         <source>Connect your hardware wallet first.</source>
         <translation type="unfinished">Συνδέστε πρώτα τη συσκευή πορτοφολιού σας.</translation>
     </message>
@@ -2492,6 +2653,10 @@ ID Συναλλαγής: %1</translation>
         <translation type="unfinished">Είστε βέβαιοι ότι θέλετε να στείλετε;</translation>
     </message>
     <message>
+        <source>To review recipient list click "Show Details…"</source>
+        <translation type="unfinished">Για να αναθεωρήσετε τη λίστα παραληπτών, κάντε κλικ στην επιλογή "Εμφάνιση λεπτομερειών..."</translation>
+    </message>
+    <message>
         <source>Create Unsigned</source>
         <translation type="unfinished">Δημιουργία Ανυπόγραφου</translation>
     </message>
@@ -2500,12 +2665,30 @@ ID Συναλλαγής: %1</translation>
         <translation type="unfinished">Υπογραφή και αποστολή</translation>
     </message>
     <message>
+        <source>Sign failed</source>
+        <translation type="unfinished">H εγγραφή απέτυχε</translation>
+    </message>
+    <message>
+        <source>External signer not found</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Δεν βρέθηκε ο εξωτερικός υπογράφων</translation>
+    </message>
+    <message>
         <source>Save Transaction Data</source>
         <translation type="unfinished">Αποθήκευση Δεδομένων Συναλλαγής</translation>
     </message>
     <message>
+        <source>Partially Signed Transaction (Binary)</source>
+        <extracomment>Expanded name of the binary PSBT file format. See: BIP 174.</extracomment>
+        <translation type="unfinished">Μερικώς Υπογεγραμμένη Συναλλαγή (binary)</translation>
+    </message>
+    <message>
         <source>PSBT saved</source>
         <translation type="unfinished">Το PSBT αποθηκεύτηκε</translation>
+    </message>
+    <message>
+        <source>External balance:</source>
+        <translation type="unfinished">Εξωτερικό υπόλοιπο:</translation>
     </message>
     <message>
         <source>or</source>
@@ -2583,8 +2766,8 @@ ID Συναλλαγής: %1</translation>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation>
-            <numerusform />
-            <numerusform />
+            <numerusform>Αναμένεται η έναρξη επιβεβαίωσης εντός %n μπλοκ.</numerusform>
+            <numerusform>Αναμένεται η έναρξη επιβεβαίωσης εντός %n μπλοκ.</numerusform>
         </translation>
     </message>
     <message>
@@ -3171,6 +3354,10 @@ ID Συναλλαγής: %1</translation>
         <translation type="unfinished">Ελάχιστο ποσό</translation>
     </message>
     <message>
+        <source>Range…</source>
+        <translation type="unfinished">Πεδίο...</translation>
+    </message>
+    <message>
         <source>&amp;Copy address</source>
         <translation type="unfinished">&amp;Αντιγραφή διεύθυνσης</translation>
     </message>
@@ -3185,6 +3372,10 @@ ID Συναλλαγής: %1</translation>
     <message>
         <source>Copy transaction &amp;ID</source>
         <translation type="unfinished">Αντιγραφή συναλλαγής &amp;ID</translation>
+    </message>
+    <message>
+        <source>Copy &amp;raw transaction</source>
+        <translation type="unfinished">Αντιγραφή &amp;ανεπεξέργαστης συναλλαγής</translation>
     </message>
     <message>
         <source>Copy full transaction &amp;details</source>
@@ -3338,6 +3529,10 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished">Δεν ήταν δυνατή η ανάληψη συναλλαγής</translation>
     </message>
     <message>
+        <source>Can't display address</source>
+        <translation type="unfinished">Αδυναμία προβολής διεύθυνσης</translation>
+    </message>
+    <message>
         <source>default wallet</source>
         <translation type="unfinished">Προεπιλεγμένο πορτοφόλι</translation>
     </message>
@@ -3357,8 +3552,24 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished">Σφάλμα</translation>
     </message>
     <message>
+        <source>Unable to decode PSBT from clipboard (invalid base64)</source>
+        <translation type="unfinished">Αδυναμία αποκωδικοποίησης PSBT από το πρόχειρο (μη έγκυρο Base64)</translation>
+    </message>
+    <message>
         <source>Load Transaction Data</source>
         <translation type="unfinished">Φόρτωση δεδομένων συναλλαγής</translation>
+    </message>
+    <message>
+        <source>Partially Signed Transaction (*.psbt)</source>
+        <translation type="unfinished">Μερικώς υπογεγραμμένη συναλλαγή (*.psbt)</translation>
+    </message>
+    <message>
+        <source>PSBT file must be smaller than 100 MiB</source>
+        <translation type="unfinished">Το αρχείο PSBT πρέπει να είναι μικρότερο από 100 MiB</translation>
+    </message>
+    <message>
+        <source>Unable to decode PSBT</source>
+        <translation type="unfinished">Αδυναμία στην αποκωδικοποίηση του PSBT</translation>
     </message>
     <message>
         <source>Backup Wallet</source>
@@ -3397,8 +3608,16 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished">Οι προγραμματιστές %s</translation>
     </message>
     <message>
+        <source>%s corrupt. Try using the wallet tool bitcoin-wallet to salvage or restoring a backup.</source>
+        <translation type="unfinished">%s κατεστραμμένο. Δοκιμάστε να το επισκευάσετε με το εργαλείο πορτοφολιού bitcoin-wallet, ή επαναφέρετε κάποιο αντίγραφο ασφαλείας.</translation>
+    </message>
+    <message>
         <source>-maxtxfee is set very high! Fees this large could be paid on a single transaction.</source>
         <translation type="unfinished"> -maxtxfee είναι καταχωρημένο πολύ υψηλά! Έξοδα τόσο υψηλά μπορούν να πληρωθούν σε μια ενιαία συναλλαγή.</translation>
+    </message>
+    <message>
+        <source>Cannot downgrade wallet from version %i to version %i. Wallet version unchanged.</source>
+        <translation type="unfinished">Αδύνατη η υποβάθμιση του πορτοφολιού από την έκδοση %i στην έκδοση %i. Η έκδοση του πορτοφολιού δεν έχει αλλάξει.</translation>
     </message>
     <message>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running.</source>
@@ -3417,6 +3636,14 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished">Σφάλμα κατά την ανάγνωση %s! Όλα τα κλειδιά διαβάζονται σωστά, αλλά τα δεδομένα των συναλλαγών ή οι καταχωρίσεις του βιβλίου διευθύνσεων ενδέχεται να λείπουν ή να είναι εσφαλμένα.</translation>
     </message>
     <message>
+        <source>Error: Dumpfile format record is incorrect. Got "%s", expected "format".</source>
+        <translation type="unfinished">Σφάλμα: Η καταγραφή του φορμά του αρχείου dump είναι εσφαλμένη. Ελήφθη: «%s», αναμενόταν: «φορμά».</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile version is not supported. This version of bitcoin-wallet only supports version 1 dumpfiles. Got dumpfile with version %s</source>
+        <translation type="unfinished">Σφάλμα: Η έκδοση του αρχείου dump δεν υποστηρίζεται. Αυτή η έκδοση του bitcoin-wallet υποστηρίζει αρχεία dump μόνο της έκδοσης 1. Δόθηκε αρχείο dump έκδοσης %s.</translation>
+    </message>
+    <message>
         <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
         <translation type="unfinished">Σφάλμα: Η ακρόαση για εισερχόμενες συνδέσεις απέτυχε (ακούστε επιστραμμένο σφάλμα %s)</translation>
     </message>
@@ -3425,8 +3652,24 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished">Η αποτίμηση του τέλους απέτυχε. Το Fallbackfee είναι απενεργοποιημένο. Περιμένετε λίγα τετράγωνα ή ενεργοποιήστε το -fallbackfee.</translation>
     </message>
     <message>
+        <source>File %s already exists. If you are sure this is what you want, move it out of the way first.</source>
+        <translation type="unfinished">Το αρχείο %s υπάρχει ήδη. Αν είστε σίγουροι ότι αυτό θέλετε, βγάλτε το πρώτα από τη μέση.</translation>
+    </message>
+    <message>
         <source>Invalid amount for -maxtxfee=&lt;amount&gt;: '%s' (must be at least the minrelay fee of %s to prevent stuck transactions)</source>
         <translation type="unfinished">Μη έγκυρο ποσό για το -maxtxfee =: '%s' (πρέπει να είναι τουλάχιστον το minrelay έξοδο του %s για την αποφυγή κολλημένων συναλλαγών)</translation>
+    </message>
+    <message>
+        <source>No dump file provided. To use createfromdump, -dumpfile=&lt;filename&gt; must be provided.</source>
+        <translation type="unfinished">Δεν δόθηκε αρχείο dump. Για να χρησιμοποιηθεί το createfromdump θα πρέπει να δοθεί το -dumpfile=&lt;filename&gt;.</translation>
+    </message>
+    <message>
+        <source>No dump file provided. To use dump, -dumpfile=&lt;filename&gt; must be provided.</source>
+        <translation type="unfinished">Δεν δόθηκε αρχείο dump. Για να χρησιμοποιηθεί το dump, πρέπει να δοθεί το -dumpfile=&lt;filename&gt;.</translation>
+    </message>
+    <message>
+        <source>No wallet file format provided. To use createfromdump, -format=&lt;format&gt; must be provided.</source>
+        <translation type="unfinished">Δεν δόθηκε φορμά αρχείου πορτοφολιού. Για τη χρήση του createfromdump, πρέπει να δοθεί -format=&lt;format&gt;.</translation>
     </message>
     <message>
         <source>Please check that your computer's date and time are correct! If your clock is wrong, %s will not work properly.</source>
@@ -3443,6 +3686,10 @@ Go to File &gt; Open Wallet to load a wallet.
     <message>
         <source>Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of pruned node)</source>
         <translation type="unfinished">Κλάδεμα: ο τελευταίος συγχρονισμός πορτοφολιού ξεπερνά τα κλαδεμένα δεδομένα. Πρέπει να κάνετε -reindex (κατεβάστε ολόκληρο το blockchain και πάλι σε περίπτωση κλαδέματος κόμβου)</translation>
+    </message>
+    <message>
+        <source>SQLiteDatabase: Unknown sqlite wallet schema version %d. Only version %d is supported</source>
+        <translation type="unfinished">SQLiteDatabase: Άγνωστη sqlite έκδοση %d του schema πορτοφολιού . Υποστηρίζεται μόνο η έκδοση %d.</translation>
     </message>
     <message>
         <source>The block database contains a block which appears to be from the future. This may be due to your computer's date and time being set incorrectly. Only rebuild the block database if you are sure that your computer's date and time are correct</source>
@@ -3470,7 +3717,7 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
-        <translation type="unfinished">Προειδοποίηση: Δεν φαίνεται να συμφωνούμε πλήρως με τους συμμαθητές μας! Ίσως χρειαστεί να κάνετε αναβάθμιση ή ίσως χρειαστεί να αναβαθμίσετε άλλους κόμβους.</translation>
+        <translation type="unfinished">Προειδοποίηση: Δεν φαίνεται να συμφωνείτε πλήρως με τους χρήστες! Ίσως χρειάζεται να κάνετε αναβάθμιση, ή ίσως οι άλλοι κόμβοι χρειάζονται αναβάθμιση.</translation>
     </message>
     <message>
         <source>You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain</source>
@@ -3479,6 +3726,10 @@ Go to File &gt; Open Wallet to load a wallet.
     <message>
         <source>-maxmempool must be at least %d MB</source>
         <translation type="unfinished">-maxmempool πρέπει να είναι τουλάχιστον %d MB</translation>
+    </message>
+    <message>
+        <source>A fatal internal error occurred, see debug.log for details</source>
+        <translation type="unfinished">Προέκυψε ένα κρίσιμο εσωτερικό σφάλμα. Ανατρέξτε στο debug.log για λεπτομέρειες</translation>
     </message>
     <message>
         <source>Cannot resolve -%s address: '%s'</source>
@@ -3525,6 +3776,14 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished">Η φόρτωση ολοκληρώθηκε</translation>
     </message>
     <message>
+        <source>Dump file %s does not exist.</source>
+        <translation type="unfinished">Το αρχείο dump %s δεν υπάρχει.</translation>
+    </message>
+    <message>
+        <source>Error creating %s</source>
+        <translation type="unfinished">Σφάλμα στη δημιουργία %s</translation>
+    </message>
+    <message>
         <source>Error initializing block database</source>
         <translation type="unfinished">Σφάλμα κατά την ενεργοποίηση της βάσης δεδομένων των μπλοκ</translation>
     </message>
@@ -3569,6 +3828,26 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished">Σφάλμα: Ο χώρος στο δίσκο είναι χαμηλός για %s</translation>
     </message>
     <message>
+        <source>Error: Dumpfile checksum does not match. Computed %s, expected %s</source>
+        <translation type="unfinished">Σφάλμα: Το checksum του αρχείου dump δεν αντιστοιχεί. Υπολογίστηκε: %s, αναμενόταν: %s</translation>
+    </message>
+    <message>
+        <source>Error: Got key that was not hex: %s</source>
+        <translation type="unfinished">Σφάλμα: Ελήφθη μη δεκαεξαδικό κλειδί: %s</translation>
+    </message>
+    <message>
+        <source>Error: Got value that was not hex: %s</source>
+        <translation type="unfinished">Σφάλμα: Ελήφθη μη δεκαεξαδική τιμή: %s</translation>
+    </message>
+    <message>
+        <source>Error: Missing checksum</source>
+        <translation type="unfinished">Σφάλμα: Δεν υπάρχει το checksum</translation>
+    </message>
+    <message>
+        <source>Error: No %s addresses available.</source>
+        <translation type="unfinished">Σφάλμα: Δεν υπάρχουν διευθύνσεις %s διαθέσιμες.</translation>
+    </message>
+    <message>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished">Αποτυχία παρακολούθησης σε οποιαδήποτε θύρα. Χρησιμοποιήστε -listen=0 αν θέλετε αυτό.</translation>
     </message>
@@ -3579,6 +3858,14 @@ Go to File &gt; Open Wallet to load a wallet.
     <message>
         <source>Failed to verify database</source>
         <translation type="unfinished">Η επιβεβαίωση της βάσης δεδομένων απέτυχε</translation>
+    </message>
+    <message>
+        <source>Ignoring duplicate -wallet %s.</source>
+        <translation type="unfinished">Αγνόηση διπλότυπου -wallet %s.</translation>
+    </message>
+    <message>
+        <source>Importing…</source>
+        <translation type="unfinished">Εισαγωγή...</translation>
     </message>
     <message>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
@@ -3621,8 +3908,24 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished">Μη έγκυρη μάσκα δικτύου που καθορίζεται στο -whitelist: '%s'</translation>
     </message>
     <message>
+        <source>Loading P2P addresses…</source>
+        <translation type="unfinished">Φόρτωση διευθύνσεων P2P...</translation>
+    </message>
+    <message>
+        <source>Loading banlist…</source>
+        <translation type="unfinished">Φόρτωση λίστας απαγόρευσης...</translation>
+    </message>
+    <message>
+        <source>Loading wallet…</source>
+        <translation type="unfinished">Φόρτωση πορτοφολιού...</translation>
+    </message>
+    <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
         <translation type="unfinished">Πρέπει να καθορίσετε μια θύρα με -whitebind: '%s'</translation>
+    </message>
+    <message>
+        <source>No proxy server specified. Use -proxy=&lt;ip&gt; or -proxy=&lt;ip:port&gt;.</source>
+        <translation type="unfinished">Δεν ορίστηκε διακομιστής μεσολάβησης. Χρησιμοποιήστε -proxy=&lt;ip&gt; ή -proxy=&lt;ip:port&gt;.</translation>
     </message>
     <message>
         <source>Not enough file descriptors available.</source>
@@ -3639,6 +3942,26 @@ Go to File &gt; Open Wallet to load a wallet.
     <message>
         <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
         <translation type="unfinished">Μείωση -maxconnections από %d σε %d, λόγω των περιορισμών του συστήματος.</translation>
+    </message>
+    <message>
+        <source>Rescanning…</source>
+        <translation type="unfinished">Σάρωση εκ νέου...</translation>
+    </message>
+    <message>
+        <source>SQLiteDatabase: Failed to execute statement to verify database: %s</source>
+        <translation type="unfinished">SQLite βάση δεδομένων: Απέτυχε η εκτέλεση της δήλωσης για την επαλήθευση της βάσης δεδομένων: %s</translation>
+    </message>
+    <message>
+        <source>SQLiteDatabase: Failed to prepare statement to verify database: %s</source>
+        <translation type="unfinished">SQLite βάση δεδομένων: Απέτυχε η προετοιμασία της δήλωσης για την επαλήθευση της βάσης δεδομένων: %s</translation>
+    </message>
+    <message>
+        <source>SQLiteDatabase: Failed to read database verification error: %s</source>
+        <translation type="unfinished">SQLite βάση δεδομένων: Απέτυχε η ανάγνωση της επαλήθευσης του σφάλματος της βάσης δεδομένων: %s</translation>
+    </message>
+    <message>
+        <source>SQLiteDatabase: Unexpected application id. Expected %u, got %u</source>
+        <translation type="unfinished">SQLiteDatabase: Μη αναμενόμενο αναγνωριστικό εφαρμογής. Αναμενόταν: %u, ελήφθη: %u</translation>
     </message>
     <message>
         <source>Section [%s] is not recognized.</source>
@@ -3665,8 +3988,16 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished">Δεν υπάρχει κατάλογος καθορισμένων μπλοκ "%s".</translation>
     </message>
     <message>
+        <source>Starting network threads…</source>
+        <translation type="unfinished">Εκκίνηση των threads δικτύου...</translation>
+    </message>
+    <message>
         <source>The source code is available from %s.</source>
         <translation type="unfinished"> Ο πηγαίος κώδικας είναι διαθέσιμος από το %s.</translation>
+    </message>
+    <message>
+        <source>The specified config file %s does not exist</source>
+        <translation type="unfinished">Το δοθέν αρχείο ρυθμίσεων %s δεν υπάρχει </translation>
     </message>
     <message>
         <source>The transaction amount is too small to pay the fee</source>
@@ -3698,11 +4029,15 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <source>Transaction has too long of a mempool chain</source>
-        <translation type="unfinished">Η συναλλαγή έχει μια μακρά αλυσίδα mempool</translation>
+        <translation type="unfinished">Η συναλλαγή έχει υπεβολικά μεγάλη αλυσίδα mempool</translation>
     </message>
     <message>
         <source>Transaction must have at least one recipient</source>
         <translation type="unfinished">Η συναλλαγή πρέπει να έχει τουλάχιστον έναν παραλήπτη</translation>
+    </message>
+    <message>
+        <source>Transaction needs a change address, but we can't generate it. %s</source>
+        <translation type="unfinished">Η συναλλαγή απαιτεί μία διεύθυνση αλλαγής, αλλά δεν μπορούμε να την παράξουμε. %s</translation>
     </message>
     <message>
         <source>Transaction too large</source>
@@ -3729,6 +4064,10 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished">Δεν είναι δυνατή η δημιουργία κλειδιών</translation>
     </message>
     <message>
+        <source>Unable to open %s for writing</source>
+        <translation type="unfinished">Αδυναμία στο άνοιγμα του %s για εγγραφή</translation>
+    </message>
+    <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
         <translation type="unfinished">Δεν είναι δυνατή η εκκίνηση του διακομιστή HTTP. Δείτε το αρχείο εντοπισμού σφαλμάτων για λεπτομέρειες.</translation>
     </message>
@@ -3745,6 +4084,10 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished">Έχει οριστεί άγνωστo δίκτυο στο -onlynet: '%s'</translation>
     </message>
     <message>
+        <source>Unknown new rules activated (versionbit %i)</source>
+        <translation type="unfinished">Ενεργοποιήθηκαν άγνωστοι νέοι κανόνες (bit έκδοσης %i)</translation>
+    </message>
+    <message>
         <source>Unsupported logging category %s=%s.</source>
         <translation type="unfinished">Μη υποστηριζόμενη κατηγορία καταγραφής %s=%s.</translation>
     </message>
@@ -3759,6 +4102,14 @@ Go to File &gt; Open Wallet to load a wallet.
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
         <translation type="unfinished">Το σχόλιο του παράγοντα χρήστη (%s) περιέχει μη ασφαλείς χαρακτήρες.</translation>
+    </message>
+    <message>
+        <source>Verifying blocks…</source>
+        <translation type="unfinished">Επαλήθευση των blocks…</translation>
+    </message>
+    <message>
+        <source>Verifying wallet(s)…</source>
+        <translation type="unfinished">Επαλήθευση πορτοφολιού/ιών...</translation>
     </message>
     <message>
         <source>Wallet needed to be rewritten: restart %s to complete</source>

--- a/src/qt/locale/bitcoin_eo.ts
+++ b/src/qt/locale/bitcoin_eo.ts
@@ -91,6 +91,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Eksporti Adresliston</translation>
     </message>
     <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See https://en.wikipedia.org/wiki/Comma-separated_values</extracomment>
+        <translation type="unfinished">Perkome disigita dosiero</translation>
+    </message>
+    <message>
         <source>There was an error trying to save the address list to %1. Please try again.</source>
         <extracomment>An error message. %1 is a stand-in argument for the name of the file we attempted to save to.</extracomment>
         <translation type="unfinished">Okazis eraron dum konservo de adreslisto al %1. Bonvolu provi denove.</translation>
@@ -2027,6 +2032,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Min amount</source>
         <translation type="unfinished">Minimuma sumo</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See https://en.wikipedia.org/wiki/Comma-separated_values</extracomment>
+        <translation type="unfinished">Perkome disigita dosiero</translation>
     </message>
     <message>
         <source>Confirmed</source>

--- a/src/qt/locale/bitcoin_es.ts
+++ b/src/qt/locale/bitcoin_es.ts
@@ -3,11 +3,11 @@
     <name>AddressBookPage</name>
     <message>
         <source>Right-click to edit address or label</source>
-        <translation type="unfinished">Haz clic derecho para editar la dirección o etiqueta</translation>
+        <translation type="unfinished">Haz clic con el botón derecho del ratón para editar la dirección o la etiqueta</translation>
     </message>
     <message>
         <source>Create a new address</source>
-        <translation>Crear una nueva dirección</translation>
+        <translation>Crea una nueva dirección</translation>
     </message>
     <message>
         <source>&amp;New</source>
@@ -15,7 +15,7 @@
     </message>
     <message>
         <source>Copy the currently selected address to the system clipboard</source>
-        <translation>Copiar la dirección seleccionada al portapapeles del sistema</translation>
+        <translation>Copia la dirección actualmente seleccionada, al portapapeles del sistema</translation>
     </message>
     <message>
         <source>&amp;Copy</source>
@@ -23,11 +23,11 @@
     </message>
     <message>
         <source>C&amp;lose</source>
-        <translation type="unfinished">Cerrar</translation>
+        <translation type="unfinished">&amp;Cerrar</translation>
     </message>
     <message>
         <source>Delete the currently selected address from the list</source>
-        <translation>Borrar de la lista la dirección seleccionada</translation>
+        <translation>Borrar de la lista la dirección actualmente seleccionada</translation>
     </message>
     <message>
         <source>Enter address or label to search</source>
@@ -268,49 +268,69 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
         <translation type="unfinished">1%1 todavía no ha terminado de forma segura...</translation>
     </message>
     <message>
+        <source>Unroutable</source>
+        <translation type="unfinished">No se puede enrutar</translation>
+    </message>
+    <message>
         <source>Internal</source>
         <translation type="unfinished">Interno</translation>
+    </message>
+    <message>
+        <source>Full Relay</source>
+        <translation type="unfinished">Transmisión completa</translation>
+    </message>
+    <message>
+        <source>Block Relay</source>
+        <translation type="unfinished">Transmisión de Bloque</translation>
+    </message>
+    <message>
+        <source>Feeler</source>
+        <translation type="unfinished">Sensor</translation>
+    </message>
+    <message>
+        <source>Address Fetch</source>
+        <translation type="unfinished">Búsqueda de dirección</translation>
     </message>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation>
-            <numerusform />
-            <numerusform />
+            <numerusform>%n segundo</numerusform>
+            <numerusform>%n segundos</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n minute(s)</source>
         <translation>
-            <numerusform />
-            <numerusform />
+            <numerusform>%n minuto</numerusform>
+            <numerusform>%n minutos</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n hora</numerusform>
+            <numerusform>%n horas</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n día</numerusform>
+            <numerusform>%n dias</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n semana</numerusform>
+            <numerusform>%n semanas</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n año</numerusform>
+            <numerusform>%n años</numerusform>
         </translation>
     </message>
     </context>
@@ -516,14 +536,19 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n conexión(es) activas a la red Bitcoin</numerusform>
+            <numerusform>%n conexión(es) activas con la red de Bitcoin</numerusform>
         </translation>
     </message>
     <message>
         <source>Click for more actions.</source>
         <extracomment>A substring of the tooltip. "More actions" are available via the context menu.</extracomment>
         <translation type="unfinished">Haz click para ver más acciones.</translation>
+    </message>
+    <message>
+        <source>Show Peers tab</source>
+        <extracomment>A context menu item. The "Peers tab" is an element of the "Node window".</extracomment>
+        <translation type="unfinished">Mostrar pestaña Pares</translation>
     </message>
     <message>
         <source>Disable network activity</source>
@@ -591,6 +616,22 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
         <translation type="unfinished">copiar y etiquetar </translation>
     </message>
     <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Copiar cantidad</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">Copiar &amp;ID de la transacción</translation>
+    </message>
+    <message>
+        <source>L&amp;ock unspent</source>
+        <translation type="unfinished">Bloquear no gastado</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock unspent</source>
+        <translation type="unfinished">&amp;Desbloquear lo no gastado</translation>
+    </message>
+    <message>
         <source>yes</source>
         <translation type="unfinished">sí</translation>
     </message>
@@ -599,6 +640,17 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
         <translation type="unfinished">(sin etiqueta)</translation>
     </message>
     </context>
+<context>
+    <name>CreateWalletActivity</name>
+    <message>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation type="unfinished">Creando Monedero &lt;b&gt;%1&lt;/b&gt;…</translation>
+    </message>
+    <message>
+        <source>Can't list signers</source>
+        <translation type="unfinished">No se pueden enumerar los firmantes</translation>
+    </message>
+</context>
 <context>
     <name>OpenWalletActivity</name>
     <message>
@@ -636,6 +688,14 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
         <translation type="unfinished">Descriptor del monedero</translation>
     </message>
     <message>
+        <source>Use an external signing device such as a hardware wallet. Configure the external signer script in wallet preferences first.</source>
+        <translation type="unfinished">Utilice un dispositivo de firma externo, como un monedero de hardware. Configure primero el script del firmante externo en las preferencias del monedero.</translation>
+    </message>
+    <message>
+        <source>External signer</source>
+        <translation type="unfinished">firmante externo</translation>
+    </message>
+    <message>
         <source>Create</source>
         <translation type="unfinished">Crear</translation>
     </message>
@@ -643,7 +703,12 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
         <source>Compiled without sqlite support (required for descriptor wallets)</source>
         <translation type="unfinished">Compilado sin soporte de sqlite (requerido para billeteras descriptoras)</translation>
     </message>
-    </context>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Compilado sin soporte de firma externa (necesario para la firma externa)</translation>
+    </message>
+</context>
 <context>
     <name>EditAddressDialog</name>
     <message>
@@ -661,17 +726,32 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
         <source>(of %1 GB needed)</source>
         <translation type="unfinished">(de %1 GB necesarios)</translation>
     </message>
+    <message>
+        <source>(%1 GB needed for full chain)</source>
+        <translation type="unfinished">(%1 GB necesarios para la cadena completa)</translation>
+    </message>
     <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>(sufficient to restore backups %n day(s) old)</numerusform>
+            <numerusform>(suficiente para restaurar copias de seguridad de %n días de antigüedad)</numerusform>
         </translation>
+    </message>
+    <message>
+        <source>Limit block chain storage to</source>
+        <translation type="unfinished">Limitar el almacenamiento de cadena de bloque a</translation>
     </message>
     <message>
         <source> GB</source>
         <translation type="unfinished">GB</translation>
+    </message>
+    </context>
+<context>
+    <name>ShutdownWindow</name>
+    <message>
+        <source>%1 is shutting down…</source>
+        <translation type="unfinished">%1 se está cerrando...</translation>
     </message>
     </context>
 <context>
@@ -684,12 +764,28 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
         <source>calculating…</source>
         <translation type="unfinished">calculando...</translation>
     </message>
-    </context>
+    <message>
+        <source>Unknown. Syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">Desconocido. Sincronizando Cabeceras (%1, %2%)…</translation>
+    </message>
+</context>
 <context>
     <name>OptionsDialog</name>
     <message>
         <source>Enabling pruning significantly reduces the disk space required to store transactions. All blocks are still fully validated. Reverting this setting requires re-downloading the entire blockchain.</source>
         <translation type="unfinished">Activar el pruning reduce significativamente el espacio de disco necesario para guardar las transacciones. Todos los bloques son completamente validados de cualquier manera. Revertir esta opción requiere que descarques de nuevo toda la cadena de bloques.</translation>
+    </message>
+    <message>
+        <source>External Signer (e.g. hardware wallet)</source>
+        <translation type="unfinished">Dispositivo Externo de Firma (ej. billetera de hardware)</translation>
+    </message>
+    <message>
+        <source>&amp;External signer script path</source>
+        <translation type="unfinished">&amp;Ruta de script de firma externo</translation>
+    </message>
+    <message>
+        <source>Full path to a Bitcoin Core compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</source>
+        <translation type="unfinished">Ruta completa al script compatible con Bitcoin Core (ej. C:\Descargas\hwi.exe o /Usuarios/SuUsuario/Descargas/hwi.py). Cuidado: código malicioso podría robarle sus monedas!</translation>
     </message>
     <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports NAT-PMP and it is enabled. The external port could be random.</source>
@@ -714,6 +810,23 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     <message>
         <source>Use separate SOCKS&amp;5 proxy to reach peers via Tor onion services:</source>
         <translation type="unfinished">Usar proxy SOCKS&amp;5 para alcanzar nodos via servicios ocultos Tor:</translation>
+    </message>
+    <message>
+        <source>Monospaced font in the Overview tab:</source>
+        <translation type="unfinished">letra Monospace en la pestaña Resumen: </translation>
+    </message>
+    <message>
+        <source>embedded "%1"</source>
+        <translation type="unfinished">incrustado "%1"</translation>
+    </message>
+    <message>
+        <source>closest matching "%1"</source>
+        <translation type="unfinished">coincidencia más aproximada "%1"</translation>
+    </message>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Compilado sin soporte de firma externa (necesario para la firma externa)</translation>
     </message>
     </context>
 <context>
@@ -848,7 +961,23 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     </message>
 </context>
 <context>
+    <name>PaymentServer</name>
+    <message>
+        <source>Cannot process payment request because BIP70 is not supported.
+Due to widespread security flaws in BIP70 it's strongly recommended that any merchant instructions to switch wallets be ignored.
+If you are receiving this error you should request the merchant provide a BIP21 compatible URI.</source>
+        <translation type="unfinished">No se puede procesar la solicitud de pago debido a que no se soporta BIP70.
+Debido a los fallos de seguridad generalizados en el BIP70, se recomienda encarecidamente ignorar las instrucciones del comerciante para cambiar de monedero.
+Si recibe este error, debe solicitar al comerciante que le proporcione un URI compatible con BIP21.</translation>
+    </message>
+    </context>
+<context>
     <name>PeerTableModel</name>
+    <message>
+        <source>Peer</source>
+        <extracomment>Title of Peers Table column which contains a unique number used to identify a connection.</extracomment>
+        <translation type="unfinished">Pares</translation>
+    </message>
     <message>
         <source>Sent</source>
         <extracomment>Title of Peers Table column which indicates the total amount of network information we have sent to the peer.</extracomment>
@@ -867,6 +996,10 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     </context>
 <context>
     <name>QRImageWidget</name>
+    <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">&amp;Guardar imagen...</translation>
+    </message>
     <message>
         <source>PNG Image</source>
         <extracomment>Expanded name of the PNG file format. See https://en.wikipedia.org/wiki/Portable_Network_Graphics</extracomment>
@@ -916,6 +1049,10 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
         <translation type="unfinished">Permisos</translation>
     </message>
     <message>
+        <source>The direction and type of peer connection: %1</source>
+        <translation type="unfinished">La dirección y tipo de conexión del par: %1</translation>
+    </message>
+    <message>
         <source>Direction/Type</source>
         <translation type="unfinished">Dirección/Tipo</translation>
     </message>
@@ -925,12 +1062,32 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
  IPv4, IPv6, Onion, I2P, o CJDNS.</translation>
     </message>
     <message>
+        <source>Whether the peer requested us to relay transactions.</source>
+        <translation type="unfinished">Si el peer nos solicitó que transmitiéramos las transacciones.</translation>
+    </message>
+    <message>
+        <source>Wants Tx Relay</source>
+        <translation type="unfinished">Desea una transmisión de transacción</translation>
+    </message>
+    <message>
+        <source>High bandwidth BIP152 compact block relay: %1</source>
+        <translation type="unfinished">Transmisión de bloque compacto BIP152 banbda ancha: %1</translation>
+    </message>
+    <message>
         <source>High Bandwidth</source>
         <translation type="unfinished">banda ancha</translation>
     </message>
     <message>
+        <source>Elapsed time since a novel block passing initial validity checks was received from this peer.</source>
+        <translation type="unfinished">Tiempo transcurrido desde que se recibió de este par un nuevo bloque que superó las comprobaciones de validez iniciales.</translation>
+    </message>
+    <message>
         <source>Last Block</source>
         <translation type="unfinished">Último Bloque</translation>
+    </message>
+    <message>
+        <source>Elapsed time since a novel transaction accepted into our mempool was received from this peer.</source>
+        <translation type="unfinished">Tiempo transcurrido desde que se recibió de este par una nueva transacción aceptada en nuestro mempool.</translation>
     </message>
     <message>
         <source>Last Tx</source>
@@ -941,13 +1098,60 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
         <translation type="unfinished">Entrante: iniciado por el par</translation>
     </message>
     <message>
+        <source>Outbound Full Relay: default</source>
+        <translation type="unfinished">Retransmisión completa saliente: predeterminado</translation>
+    </message>
+    <message>
+        <source>Outbound Block Relay: does not relay transactions or addresses</source>
+        <translation type="unfinished">Retransmisión de bloques de salida: no transmite transacciones o direcciones</translation>
+    </message>
+    <message>
+        <source>Outbound Manual: added using RPC %1 or %2/%3 configuration options</source>
+        <translation type="unfinished">Manual de salida: añadido usando las opciones de configuración RPC %1 o %2/%3</translation>
+    </message>
+    <message>
+        <source>Outbound Feeler: short-lived, for testing addresses</source>
+        <translation type="unfinished">Tanteador de salida: de corta duración, para probar las direcciones</translation>
+    </message>
+    <message>
+        <source>Outbound Address Fetch: short-lived, for soliciting addresses</source>
+        <translation type="unfinished">Búsqueda de direcciones de salida: de corta duración, para solicitar direcciones</translation>
+    </message>
+    <message>
         <source>we selected the peer for high bandwidth relay</source>
         <translation type="unfinished">hemos seleccionado el par para la retransmisión de banda ancha</translation>
+    </message>
+    <message>
+        <source>the peer selected us for high bandwidth relay</source>
+        <translation type="unfinished">El par nos ha seleccionado para transmisión de banda ancha</translation>
+    </message>
+    <message>
+        <source>no high bandwidth relay selected</source>
+        <translation type="unfinished">Ninguna transmisión de banda ancha seleccionada</translation>
+    </message>
+    <message>
+        <source>1 d&amp;ay</source>
+        <translation type="unfinished">1 día</translation>
+    </message>
+    <message>
+        <source>Welcome to the %1 RPC console.
+Use up and down arrows to navigate history, and %2 to clear screen.
+Use %3 and %4 to increase or decrease the font size.
+Type %5 for an overview of available commands.
+For more information on using this console, type %6.
+
+%7WARNING: Scammers have been active, telling users to type commands here, stealing their wallet contents. Do not use this console without fully understanding the ramifications of a command.%8</source>
+        <extracomment>RPC console welcome message. Placeholders %7 and %8 are style tags for the warning content, and they are not space separated from the rest of the text intentionally.</extracomment>
+        <translation type="unfinished">Bienvenido a la consola RPC %1.Utiliza las flechas arriba y abajo para navegar por el historial, y %2 para borrar la pantalla.Utiliza %3 y %4 para aumentar o disminuir el tamaño de la fuente.Tipo %5 para ver un resumen de los comandos disponibles.Para más información sobre cómo usar esta consola, escribe %6.%7AVISO: Los estafadores han estado activos, diciendo a los usuarios que escriban comandos aquí, robando el contenido de sus carteras. No use esta consola sin entender completamente las ramificaciones de un comando.%8</translation>
     </message>
     <message>
         <source>Executing…</source>
         <extracomment>A console message indicating an entered command is currently being executed.</extracomment>
         <translation type="unfinished">Ejecutando...</translation>
+    </message>
+    <message>
+        <source>(peer: %1)</source>
+        <translation type="unfinished">(par: %1)</translation>
     </message>
     <message>
         <source>Never</source>
@@ -969,12 +1173,24 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
         <translation type="unfinished">copiar y etiquetar </translation>
     </message>
     <message>
+        <source>Copy &amp;message</source>
+        <translation type="unfinished">Copiar &amp;mensaje</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Copiar cantidad</translation>
+    </message>
+    <message>
         <source>Could not generate new %1 address</source>
         <translation type="unfinished">No se ha podido generar una nueva dirección %1</translation>
     </message>
 </context>
 <context>
     <name>ReceiveRequestDialog</name>
+    <message>
+        <source>Request payment to …</source>
+        <translation type="unfinished">Solicitar pago a...</translation>
+    </message>
     <message>
         <source>Address:</source>
         <translation type="unfinished">Dirección:</translation>
@@ -990,6 +1206,19 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     <message>
         <source>Wallet:</source>
         <translation type="unfinished">Monedero:</translation>
+    </message>
+    <message>
+        <source>&amp;Verify</source>
+        <translation type="unfinished">&amp;Verificar
+</translation>
+    </message>
+    <message>
+        <source>Verify this address on e.g. a hardware wallet screen</source>
+        <translation type="unfinished">Verifique esta dirección en la pantalla de su billetera fría u otro dispositivo</translation>
+    </message>
+    <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">&amp;Guardar imagen...</translation>
     </message>
     </context>
 <context>
@@ -1046,12 +1275,56 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
         <translation type="unfinished">Elegir...</translation>
     </message>
     <message>
+        <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
+
+Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satoshis per kvB" for a transaction size of 500 virtual bytes (half of 1 kvB) would ultimately yield a fee of only 50 satoshis.</source>
+        <translation type="unfinished">Especifique una tarifa personalizada por kB (1.000 bytes) del tamaño virtual de la transacción.
+
+Nota: Dado que la tasa se calcula por cada byte, una tasa de "100 satoshis por kvB" para una transacción de 500 bytes virtuales (la mitad de 1 kvB) supondría finalmente una tasa de sólo 50 satoshis.</translation>
+    </message>
+    <message>
+        <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
+        <translation type="unfinished">(Comisión inteligente no inicializada todavía. Esto, normalmente tarda unos pocos bloques…)</translation>
+    </message>
+    <message>
+        <source>Sign on device</source>
+        <extracomment>"device" usually means a hardware wallet</extracomment>
+        <translation type="unfinished">Iniciar sesión en el dispositivo</translation>
+    </message>
+    <message>
+        <source>Connect your hardware wallet first.</source>
+        <translation type="unfinished">Conecte su wallet externo primero.</translation>
+    </message>
+    <message>
+        <source>Set external signer script path in Options -&gt; Wallet</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Configure una ruta externa al script en Opciones -&gt; Wallet</translation>
+    </message>
+    <message>
+        <source>To review recipient list click "Show Details…"</source>
+        <translation type="unfinished">Para revisar la lista de recipientes clique en "Mostrar Detalles..."</translation>
+    </message>
+    <message>
         <source>Create Unsigned</source>
         <translation type="unfinished">Crear sin firmar</translation>
     </message>
     <message>
+        <source>Sign and send</source>
+        <translation type="unfinished">Firmar y enviar</translation>
+    </message>
+    <message>
         <source>Sign failed</source>
         <translation type="unfinished">Firma falló</translation>
+    </message>
+    <message>
+        <source>External signer not found</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Dispositivo externo de firma no encontrado</translation>
+    </message>
+    <message>
+        <source>External signer failure</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Fallo en cartera hardware externa </translation>
     </message>
     <message>
         <source>Save Transaction Data</source>
@@ -1065,6 +1338,10 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     <message>
         <source>PSBT saved</source>
         <translation type="unfinished">PSBT guardado </translation>
+    </message>
+    <message>
+        <source>External balance:</source>
+        <translation type="unfinished">Saldo externo:</translation>
     </message>
     <message>
         <source>or</source>
@@ -1085,8 +1362,8 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation>
-            <numerusform />
-            <numerusform />
+            <numerusform>Se estima que la confirmación comience en %n bloque(s).</numerusform>
+            <numerusform>Estimado para empezar la confirmación dentro de %n bloques.</numerusform>
         </translation>
     </message>
     <message>
@@ -1121,8 +1398,8 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     <message numerus="yes">
         <source>Open for %n more block(s)</source>
         <translation>
-            <numerusform />
-            <numerusform />
+            <numerusform>Abierto para %n bloques más</numerusform>
+            <numerusform>Abrir para %n bloques más</numerusform>
         </translation>
     </message>
     <message>
@@ -1132,8 +1409,8 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation>
-            <numerusform />
-            <numerusform />
+            <numerusform>madura en %n bloque más</numerusform>
+            <numerusform>madura en %n bloques más</numerusform>
         </translation>
     </message>
     <message>
@@ -1150,8 +1427,8 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     <message numerus="yes">
         <source>Open for %n more block(s)</source>
         <translation>
-            <numerusform />
-            <numerusform />
+            <numerusform>Abrir para 1 %n bloques más</numerusform>
+            <numerusform>Abrir para %n bloques más</numerusform>
         </translation>
     </message>
     <message>
@@ -1166,12 +1443,48 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
 <context>
     <name>TransactionView</name>
     <message>
+        <source>Range…</source>
+        <translation type="unfinished">Rango...</translation>
+    </message>
+    <message>
         <source>&amp;Copy address</source>
         <translation type="unfinished">copiar dirección </translation>
     </message>
     <message>
         <source>Copy &amp;label</source>
         <translation type="unfinished">copiar y etiquetar </translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Copiar cantidad</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">Copiar &amp;ID de la transacción</translation>
+    </message>
+    <message>
+        <source>Copy &amp;raw transaction</source>
+        <translation type="unfinished">Copiar traducción en crudo</translation>
+    </message>
+    <message>
+        <source>Copy full transaction &amp;details</source>
+        <translation type="unfinished">Copiar la transacción entera &amp; detalles</translation>
+    </message>
+    <message>
+        <source>&amp;Show transaction details</source>
+        <translation type="unfinished">Mostrar detalles de la transacción</translation>
+    </message>
+    <message>
+        <source>Increase transaction &amp;fee</source>
+        <translation type="unfinished">Incrementar la comisión de transacción</translation>
+    </message>
+    <message>
+        <source>A&amp;bandon transaction</source>
+        <translation type="unfinished">Abandonar transacción</translation>
+    </message>
+    <message>
+        <source>&amp;Edit address label</source>
+        <translation type="unfinished">Editar etiqueta de dirección</translation>
     </message>
     <message>
         <source>Confirmed</source>
@@ -1208,6 +1521,15 @@ Vaya a Archivo&gt; Abrir monedero para cargar un monedero.
 <context>
     <name>WalletModel</name>
     <message>
+        <source>Warning: This may pay the additional fee by reducing change outputs or adding inputs, when necessary. It may add a new change output if one does not already exist. These changes may potentially leak privacy.</source>
+        <translation type="unfinished">Advertencia: Esto puede pagar la tasa adicional al reducir el cambio de salidas o agregar entradas, cuando sea necesario. Puede agregar una nueva salida de cambio si aún no existe. Estos cambios pueden potencialmente filtrar la privacidad.</translation>
+    </message>
+    <message>
+        <source>Can't display address</source>
+        <translation type="unfinished">No se puede mostrar la dirección
+</translation>
+    </message>
+    <message>
         <source>default wallet</source>
         <translation type="unfinished">Monedero predeterminado</translation>
     </message>
@@ -1242,6 +1564,11 @@ Vaya a Archivo&gt; Abrir monedero para cargar un monedero.
         <source>Unable to decode PSBT</source>
         <translation type="unfinished">Imposible descodificar PSBT</translation>
     </message>
+    <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">Datos de la billetera </translation>
+    </message>
     </context>
 <context>
     <name>bitcoin-core</name>
@@ -1250,8 +1577,40 @@ Vaya a Archivo&gt; Abrir monedero para cargar un monedero.
         <translation type="unfinished">%s corrupto. Intente utilizar la monedero herramienta de bitcoin-monedero para salvar o restaurar una copia de seguridad.</translation>
     </message>
     <message>
+        <source>Cannot downgrade wallet from version %i to version %i. Wallet version unchanged.</source>
+        <translation type="unfinished">No se pudo cambiar la versión %i a la versión anterior %i.  Versión del monedero sin cambios.</translation>
+    </message>
+    <message>
+        <source>Cannot upgrade a non HD split wallet from version %i to version %i without upgrading to support pre-split keypool. Please use version %i or no version specified.</source>
+        <translation type="unfinished">No se puede actualizar un monedero no dividido en HD de la versión  1%i a la versión 1%i sin actualizar para admitir el grupo de claves pre-dividido. Por favor, use la versión  1%i o ninguna versión especificada.</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile format record is incorrect. Got "%s", expected "format".</source>
+        <translation type="unfinished">Error: el registro del formato del archivo de volcado es incorrecto. Se obtuvo "%s", del "formato" esperado.</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile identifier record is incorrect. Got "%s", expected "%s".</source>
+        <translation type="unfinished">Error: el registro del identificador del archivo de volcado es incorrecto. Se obtuvo   "%s" se esperaba "%s".</translation>
+    </message>
+    <message>
+        <source>Error: Legacy wallets only support the "legacy", "p2sh-segwit", and "bech32" address types</source>
+        <translation type="unfinished">Error: los monederos heredados solo admiten los tipos de dirección "legacy", "p2sh-segwit" y "bech32"</translation>
+    </message>
+    <message>
+        <source>File %s already exists. If you are sure this is what you want, move it out of the way first.</source>
+        <translation type="unfinished">El archivo  %s  ya existe. Si está seguro de que esto es lo que quiere, muévalo de lugar primero.</translation>
+    </message>
+    <message>
         <source>More than one onion bind address is provided. Using %s for the automatically created Tor onion service.</source>
         <translation type="unfinished">Se proporciona más de una dirección de ligar de cebolla. Utilizando %s para el servicio Tor cebolla creado automático.</translation>
+    </message>
+    <message>
+        <source>No dump file provided. To use createfromdump, -dumpfile=&lt;filename&gt; must be provided.</source>
+        <translation type="unfinished">No se ha proporcionado ningún archivo de volcado. Para usar createfromdump, se debe proporcionar  -dumpfile=&lt;filename&gt;.</translation>
+    </message>
+    <message>
+        <source>No dump file provided. To use dump, -dumpfile=&lt;filename&gt; must be provided.</source>
+        <translation type="unfinished">No se ha proporcionado ningún archivo de volcado. Para usar el volcado, debe proporcionarse -dumpfile=&lt;filename&gt;.</translation>
     </message>
     <message>
         <source>No wallet file format provided. To use createfromdump, -format=&lt;format&gt; must be provided.</source>
@@ -1270,6 +1629,18 @@ Vaya a Archivo&gt; Abrir monedero para cargar un monedero.
         <translation type="unfinished">Esta es la máxima tarifa de transacción que pagas (en adicional a la tarifa normal de transacción) para primordialmente evitar gastar un sobrecosto.</translation>
     </message>
     <message>
+        <source>Unknown wallet file format "%s" provided. Please provide one of "bdb" or "sqlite".</source>
+        <translation type="unfinished">Formato de monedero desconocido "%s" proporcionado. Por favor, proporcione uno de "bdb" o "sqlite".</translation>
+    </message>
+    <message>
+        <source>Warning: Dumpfile wallet format "%s" does not match command line specified format "%s".</source>
+        <translation type="unfinished">Aviso: el formato del monedero del archivo de volcado "%s" no coincide con el formato especificado en la línea de comandos "%s".</translation>
+    </message>
+    <message>
+        <source>Witness data for blocks after height %d requires validation. Please restart with -reindex.</source>
+        <translation type="unfinished">Hay que validar los datos de los testigos de los bloques después de la altura%d. Por favor, reinicie con -reindex.</translation>
+    </message>
+    <message>
         <source>A fatal internal error occurred, see debug.log for details</source>
         <translation type="unfinished">Ha ocurrido un error interno grave. Consulte debug.log para más detalles.</translation>
     </message>
@@ -1286,12 +1657,45 @@ Vaya a Archivo&gt; Abrir monedero para cargar un monedero.
         <translation type="unfinished">Error creando %s</translation>
     </message>
     <message>
+        <source>Error reading next record from wallet database</source>
+        <translation type="unfinished">Error al leer el seguiente registro de la base de datos de la "wallet"</translation>
+    </message>
+    <message>
+        <source>Error: Couldn't create cursor into database</source>
+        <translation type="unfinished">Error: No se pudo crear el cursor en la base de datos</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile checksum does not match. Computed %s, expected %s</source>
+        <translation type="unfinished">Error: La suma de comprobación del archivo de volcado no coincide. Calculada%s, prevista%s</translation>
+    </message>
+    <message>
+        <source>Error: Got key that was not hex: %s</source>
+        <translation type="unfinished">Error: Se recibió una llave que no es hex: %s</translation>
+    </message>
+    <message>
+        <source>Error: Got value that was not hex: %s</source>
+        <translation type="unfinished">Error: Se recibió un valor que no es hex: %s</translation>
+    </message>
+    <message>
         <source>Error: Keypool ran out, please call keypoolrefill first</source>
         <translation type="unfinished">Keypool se ha agotado, llame a keypoolrefill primero</translation>
     </message>
     <message>
         <source>Error: Missing checksum</source>
         <translation type="unfinished">Error: No se ha encontrado 'checksum'</translation>
+    </message>
+    <message>
+        <source>Error: No %s addresses available.</source>
+        <translation type="unfinished">Error: No hay %sdirecciones disponibles.
+</translation>
+    </message>
+    <message>
+        <source>Error: Unable to parse version %u as a uint32_t</source>
+        <translation type="unfinished">Error: No se ha podido analizar la versión %ucomo uint32_t</translation>
+    </message>
+    <message>
+        <source>Error: Unable to write record to new wallet</source>
+        <translation type="unfinished">Error: No se pudo escribir el registro en la nueva billetera</translation>
     </message>
     <message>
         <source>Failed to verify database</source>
@@ -1314,12 +1718,44 @@ Vaya a Archivo&gt; Abrir monedero para cargar un monedero.
         <translation type="unfinished">Fondos insuficientes</translation>
     </message>
     <message>
+        <source>Invalid -i2psam address or hostname: '%s'</source>
+        <translation type="unfinished">Dirección de -i2psam o dominio ' %s' inválido</translation>
+    </message>
+    <message>
+        <source>Loading P2P addresses…</source>
+        <translation type="unfinished">Cargando direcciones P2P...</translation>
+    </message>
+    <message>
         <source>Loading banlist…</source>
         <translation type="unfinished">Cargando banlist...</translation>
     </message>
     <message>
+        <source>Loading block index…</source>
+        <translation type="unfinished">Cargando el índice de bloques...</translation>
+    </message>
+    <message>
+        <source>Loading wallet…</source>
+        <translation type="unfinished">Cargando monedero...</translation>
+    </message>
+    <message>
         <source>No proxy server specified. Use -proxy=&lt;ip&gt; or -proxy=&lt;ip:port&gt;.</source>
         <translation type="unfinished">No se ha especificado un servidor de proxy. Use -proxy=&lt;ip&gt;o -proxy=&lt;ip:port&gt;.</translation>
+    </message>
+    <message>
+        <source>Prune mode is incompatible with -coinstatsindex.</source>
+        <translation type="unfinished">"Prune mode" es incompatible with -txindex.</translation>
+    </message>
+    <message>
+        <source>Pruning blockstore…</source>
+        <translation type="unfinished">Podando almacén de bloques…</translation>
+    </message>
+    <message>
+        <source>Replaying blocks…</source>
+        <translation type="unfinished">Reproduciendo bloques…</translation>
+    </message>
+    <message>
+        <source>Rescanning…</source>
+        <translation type="unfinished">Volviendo a escanear...</translation>
     </message>
     <message>
         <source>SQLiteDatabase: Failed to execute statement to verify database: %s</source>
@@ -1338,6 +1774,10 @@ Vaya a Archivo&gt; Abrir monedero para cargar un monedero.
         <translation type="unfinished">SQLiteDatabase: id aplicación inesperada. Esperado %u, tiene %u</translation>
     </message>
     <message>
+        <source>Starting network threads…</source>
+        <translation type="unfinished">Iniciando procesos de red...</translation>
+    </message>
+    <message>
         <source>The specified config file %s does not exist</source>
         <translation type="unfinished">El archivo de configuración especificado %s no existe </translation>
     </message>
@@ -1350,8 +1790,17 @@ Vaya a Archivo&gt; Abrir monedero para cargar un monedero.
         <translation type="unfinished">La transacción debe tener al menos un destinatario</translation>
     </message>
     <message>
+        <source>Transaction needs a change address, but we can't generate it. %s</source>
+        <translation type="unfinished">La transacción necesita una dirección de cambio, pero no podemos generarla. %s
+</translation>
+    </message>
+    <message>
         <source>Unable to open %s for writing</source>
         <translation type="unfinished">No se ha podido abrir %s para escribir</translation>
+    </message>
+    <message>
+        <source>Unknown new rules activated (versionbit %i)</source>
+        <translation type="unfinished">Nuevas reglas desconocidas activadas (versionbit %i)</translation>
     </message>
     <message>
         <source>Verifying blocks…</source>

--- a/src/qt/locale/bitcoin_es_CL.ts
+++ b/src/qt/locale/bitcoin_es_CL.ts
@@ -35,8 +35,7 @@
     </message>
     <message>
         <source>Export the data in the current tab to a file</source>
-        <translation>
-Exportar los datos en la pestaña actual a un archivo</translation>
+        <translation>Exportar los datos en la pestaña actual a un archivo</translation>
     </message>
     <message>
         <source>&amp;Export</source>
@@ -242,10 +241,18 @@ Usa el boton "Crear nueva direccion de recibimiento" en la pestaña de recibir p
 <context>
     <name>BitcoinApplication</name>
     <message>
-        <source>Internal error</source>
-        <translation type="unfinished">error interno</translation>
+        <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
+        <translation type="unfinished">Se ha producido un error garrafal. %1Ya no podrá continuar de manera segura y abandonará.</translation>
     </message>
-    </context>
+    <message>
+        <source>Internal error</source>
+        <translation type="unfinished">Error interno</translation>
+    </message>
+    <message>
+        <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
+        <translation type="unfinished">Se ha producido un error interno. 1%1 Se intentará continuar de manera segura. Este es un error inesperado que se puede reportar como se describe a continuación.</translation>
+    </message>
+</context>
 <context>
     <name>QObject</name>
     <message>

--- a/src/qt/locale/bitcoin_es_CO.ts
+++ b/src/qt/locale/bitcoin_es_CO.ts
@@ -809,6 +809,10 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
 <context>
     <name>CreateWalletActivity</name>
     <message>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation type="unfinished">Creación de monedero&lt;b&gt;%1&lt;/b&gt;</translation>
+    </message>
+    <message>
         <source>Create wallet failed</source>
         <translation type="unfinished">Fallo al crear la billetera</translation>
     </message>
@@ -1666,6 +1670,10 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
     <message>
         <source>Network activity disabled</source>
         <translation type="unfinished">Actividad de red desactivada</translation>
+    </message>
+    <message>
+        <source>Executing command without any wallet</source>
+        <translation type="unfinished">Ejecutando comando con cualquier cartera</translation>
     </message>
     <message>
         <source>Yes</source>
@@ -2650,6 +2658,10 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
         <translation type="unfinished">¿Desea incrementar la cuota?</translation>
     </message>
     <message>
+        <source>Do you want to draft a transaction with fee increase?</source>
+        <translation type="unfinished">¿Desea redactar una transacción con aumento de tarifa?</translation>
+    </message>
+    <message>
         <source>Current fee:</source>
         <translation type="unfinished">Comisión actual:</translation>
     </message>
@@ -2758,6 +2770,10 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
     <message>
         <source>Change index out of range</source>
         <translation type="unfinished">Cambio de indice fuera de rango</translation>
+    </message>
+    <message>
+        <source>Config setting for %s only applied on %s network when in [%s] section.</source>
+        <translation type="unfinished">Configurar ajustes para %s solo aplicados en %s en red cuando [%s] sección.</translation>
     </message>
     <message>
         <source>Corrupted block database detected</source>

--- a/src/qt/locale/bitcoin_es_DO.ts
+++ b/src/qt/locale/bitcoin_es_DO.ts
@@ -162,6 +162,14 @@
         <translation type="unfinished">Monedero cifrado</translation>
     </message>
     <message>
+        <source>Your wallet is about to be encrypted. </source>
+        <translation type="unfinished">Tu monedero va a ser cifrado</translation>
+    </message>
+    <message>
+        <source>Your wallet is now encrypted. </source>
+        <translation type="unfinished">Tu monedero está ahora cifrado</translation>
+    </message>
+    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation type="unfinished">IMPORTANTE: Cualquier copia de seguridad que haya realizado previamente de su archivo de monedero debe reemplazarse con el nuevo archivo de monedero cifrado. Por razones de seguridad, las copias de seguridad previas del archivo de monedero no cifradas serán inservibles en cuanto comience a usar el nuevo monedero cifrado.</translation>
     </message>
@@ -194,6 +202,13 @@
         <translation type="unfinished">Aviso: ¡La tecla de bloqueo de mayúsculas está activada!</translation>
     </message>
 </context>
+<context>
+    <name>BitcoinApplication</name>
+    <message>
+        <source>Internal error</source>
+        <translation type="unfinished">Error interno</translation>
+    </message>
+    </context>
 <context>
     <name>QObject</name>
     <message>
@@ -294,6 +309,10 @@
         <translation>Mostrar información acerca de Qt</translation>
     </message>
     <message>
+        <source>Create a new wallet</source>
+        <translation type="unfinished">Crear monedero nuevo</translation>
+    </message>
+    <message>
         <source>Send coins to a Bitcoin address</source>
         <translation>Enviar monedas a una dirección Bitcoin</translation>
     </message>
@@ -320,6 +339,10 @@
     <message>
         <source>Show or hide the main Window</source>
         <translation>Mostar u ocultar la ventana principal</translation>
+    </message>
+    <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation type="unfinished">&amp;Cifrar monedero</translation>
     </message>
     <message>
         <source>Encrypt the private keys that belong to your wallet</source>
@@ -1686,6 +1709,13 @@
     <message>
         <source>to</source>
         <translation type="unfinished">para</translation>
+    </message>
+</context>
+<context>
+    <name>WalletFrame</name>
+    <message>
+        <source>Create a new wallet</source>
+        <translation type="unfinished">Crear monedero nuevo</translation>
     </message>
 </context>
 <context>

--- a/src/qt/locale/bitcoin_es_MX.ts
+++ b/src/qt/locale/bitcoin_es_MX.ts
@@ -66,10 +66,6 @@
         <translation type="unfinished">Direcciones de recibo</translation>
     </message>
     <message>
-        <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
-        <translation type="unfinished">Estas son tus direcciones de Bitcoin para enviar pagos. Siempre revisa el monto y la dirección de envío antes de enviar monedas.</translation>
-    </message>
-    <message>
         <source>&amp;Copy Address</source>
         <translation type="unfinished">&amp;Copiar dirección</translation>
     </message>
@@ -240,6 +236,10 @@
 <context>
     <name>BitcoinApplication</name>
     <message>
+        <source>Runaway exception</source>
+        <translation type="unfinished">Excepción fuera de control</translation>
+    </message>
+    <message>
         <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
         <translation type="unfinished">Ha ocurrido un error grave. %1 no puede continuar de forma segura y se cerrará.</translation>
     </message>
@@ -267,6 +267,14 @@
         <translation type="unfinished">Monto</translation>
     </message>
     <message>
+        <source>Unroutable</source>
+        <translation type="unfinished">No se puede enrutar</translation>
+    </message>
+    <message>
+        <source>Internal</source>
+        <translation type="unfinished">Interno</translation>
+    </message>
+    <message>
         <source>Inbound</source>
         <translation type="unfinished">Entrada</translation>
     </message>
@@ -275,8 +283,20 @@
         <translation type="unfinished">Salida</translation>
     </message>
     <message>
+        <source>Full Relay</source>
+        <translation type="unfinished">Transmisión completa</translation>
+    </message>
+    <message>
         <source>Block Relay</source>
         <translation type="unfinished">Relé de bloque</translation>
+    </message>
+    <message>
+        <source>Feeler</source>
+        <translation type="unfinished">Sensor</translation>
+    </message>
+    <message>
+        <source>Address Fetch</source>
+        <translation type="unfinished">Búsqueda de dirección</translation>
     </message>
     <message numerus="yes">
         <source>%n second(s)</source>
@@ -288,36 +308,36 @@
     <message numerus="yes">
         <source>%n minute(s)</source>
         <translation>
-            <numerusform />
-            <numerusform />
+            <numerusform>%n minuto</numerusform>
+            <numerusform>%n minutos</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n hora</numerusform>
+            <numerusform>%n horas</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n día</numerusform>
+            <numerusform>%n días </numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%nsemana</numerusform>
+            <numerusform>%n semanas</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n año</numerusform>
+            <numerusform>%n años</numerusform>
         </translation>
     </message>
     </context>
@@ -433,6 +453,10 @@
         <translation type="unfinished">&amp;Cambiar contraseña...</translation>
     </message>
     <message>
+        <source>Sign &amp;message…</source>
+        <translation type="unfinished">Firmar &amp;mensaje...</translation>
+    </message>
+    <message>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation>Firme mensajes con sus direcciones de Bitcoin para demostrar que los posee</translation>
     </message>
@@ -447,6 +471,10 @@
     <message>
         <source>&amp;Load PSBT from file…</source>
         <translation type="unfinished">&amp;Cargar PSBT desde el archivo...</translation>
+    </message>
+    <message>
+        <source>Load PSBT from clipboard…</source>
+        <translation type="unfinished">Cargar PSBT desde el portapapeles...</translation>
     </message>
     <message>
         <source>Open &amp;URI…</source>
@@ -497,6 +525,10 @@
         <translation type="unfinished">Procesando bloques en disco...</translation>
     </message>
     <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation type="unfinished">Reindexando bloques en disco...</translation>
+    </message>
+    <message>
         <source>Connecting to peers…</source>
         <translation type="unfinished">Conectando a pares...</translation>
     </message>
@@ -524,6 +556,10 @@ Solicitar pagos (genera códigos QR y bitcoin: URI)
             <numerusform>Se han procesado %n bloques del historial de transacciones.</numerusform>
             <numerusform>Se han procesado %n bloques del historial de transacciones.</numerusform>
         </translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation type="unfinished">Poniéndose al día...</translation>
     </message>
     <message>
         <source>Transactions after this will not yet be visible.</source>
@@ -588,6 +624,11 @@ Solicitar pagos (genera códigos QR y bitcoin: URI)
             <numerusform>%n conexiones activas con la red Bitcoin</numerusform>
             <numerusform>%n conexiones activas con la red Bitcoin </numerusform>
         </translation>
+    </message>
+    <message>
+        <source>Click for more actions.</source>
+        <extracomment>A substring of the tooltip. "More actions" are available via the context menu.</extracomment>
+        <translation type="unfinished">Haz click para ver más acciones.</translation>
     </message>
     <message>
         <source>Show Peers tab</source>
@@ -740,8 +781,24 @@ Solicitar pagos (genera códigos QR y bitcoin: URI)
         <translation type="unfinished">&amp;Copiar dirección</translation>
     </message>
     <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Copiar &amp;label</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Copiar &amp;amount</translation>
+    </message>
+    <message>
         <source>Copy transaction &amp;ID</source>
         <translation type="unfinished">Copiar &amp;ID de la transacción</translation>
+    </message>
+    <message>
+        <source>L&amp;ock unspent</source>
+        <translation type="unfinished">Bloquear no gastado</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock unspent</source>
+        <translation type="unfinished">&amp;Desbloquear lo no gastado</translation>
     </message>
     <message>
         <source>Copy quantity</source>
@@ -798,7 +855,11 @@ Solicitar pagos (genera códigos QR y bitcoin: URI)
         <source>Create wallet warning</source>
         <translation type="unfinished">Crear advertencia de cartera</translation>
     </message>
-    </context>
+    <message>
+        <source>Can't list signers</source>
+        <translation type="unfinished">No se pueden listar los firmantes</translation>
+    </message>
+</context>
 <context>
     <name>OpenWalletActivity</name>
     <message>
@@ -860,10 +921,23 @@ Solicitar pagos (genera códigos QR y bitcoin: URI)
         <translation type="unfinished">Desactivar las claves privadas</translation>
     </message>
     <message>
+        <source>Use an external signing device such as a hardware wallet. Configure the external signer script in wallet preferences first.</source>
+        <translation type="unfinished">Utilice un dispositivo de firma externo, como un monedero de hardware. Configure primero el script del firmante externo en las preferencias del monedero.</translation>
+    </message>
+    <message>
+        <source>External signer</source>
+        <translation type="unfinished">firmante externo</translation>
+    </message>
+    <message>
         <source>Create</source>
         <translation type="unfinished">Crear</translation>
     </message>
-    </context>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Compilado sin soporte de firma externa (necesario para la firma externa)</translation>
+    </message>
+</context>
 <context>
     <name>EditAddressDialog</name>
     <message>
@@ -936,12 +1010,16 @@ Solicitar pagos (genera códigos QR y bitcoin: URI)
         <source>(of %1 GB needed)</source>
         <translation type="unfinished">(de los %1 GB necesarios)</translation>
     </message>
+    <message>
+        <source>(%1 GB needed for full chain)</source>
+        <translation type="unfinished">(%1 GB necesarios para la cadena completa)</translation>
+    </message>
     <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>(suficiente para restaurar copias de seguridad de %n día de antigüedad)</numerusform>
+            <numerusform>(suficiente para restaurar copias de seguridad de %n días de antigüedad)</numerusform>
         </translation>
     </message>
     <message>
@@ -987,6 +1065,10 @@ Solicitar pagos (genera códigos QR y bitcoin: URI)
 <context>
     <name>ShutdownWindow</name>
     <message>
+        <source>%1 is shutting down…</source>
+        <translation type="unfinished">%1 se está cerrando...</translation>
+    </message>
+    <message>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished">No apague su computadora hasta que esta ventana desaparesca.</translation>
     </message>
@@ -1010,6 +1092,14 @@ Solicitar pagos (genera códigos QR y bitcoin: URI)
         <translation type="unfinished">Número de bloques restantes</translation>
     </message>
     <message>
+        <source>Unknown…</source>
+        <translation type="unfinished">Desconocido...</translation>
+    </message>
+    <message>
+        <source>calculating…</source>
+        <translation type="unfinished">calculando...</translation>
+    </message>
+    <message>
         <source>Progress</source>
         <translation type="unfinished">Progreso </translation>
     </message>
@@ -1025,7 +1115,11 @@ Solicitar pagos (genera códigos QR y bitcoin: URI)
         <source>Hide</source>
         <translation type="unfinished">Ocultar </translation>
     </message>
-    </context>
+    <message>
+        <source>Unknown. Syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">Desconocido. Sincronizando Cabeceras (%1, %2%)…</translation>
+    </message>
+</context>
 <context>
     <name>OpenURIDialog</name>
     <message>
@@ -1038,6 +1132,10 @@ Solicitar pagos (genera códigos QR y bitcoin: URI)
     <message>
         <source>Options</source>
         <translation>Opciones</translation>
+    </message>
+    <message>
+        <source>Enabling pruning significantly reduces the disk space required to store transactions. All blocks are still fully validated. Reverting this setting requires re-downloading the entire blockchain.</source>
+        <translation type="unfinished">Activar el pruning reduce significativamente el espacio de disco necesario para guardar las transacciones. Todos los bloques son completamente validados de cualquier manera. Revertir esta opción requiere que descarques de nuevo toda la cadena de bloques.</translation>
     </message>
     <message>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
@@ -1060,6 +1158,22 @@ Solicitar pagos (genera códigos QR y bitcoin: URI)
         <translation type="unfinished">&amp;Gastar el cambio no confirmado</translation>
     </message>
     <message>
+        <source>External Signer (e.g. hardware wallet)</source>
+        <translation type="unfinished">Dispositivo Externo de Firma (ej. billetera de hardware)</translation>
+    </message>
+    <message>
+        <source>Full path to a Bitcoin Core compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</source>
+        <translation type="unfinished">Ruta completa al script compatible con Bitcoin Core (ej. C:\Descargas\hwi.exe o /Usuarios/SuUsuario/Descargas/hwi.py). Cuidado: código malicioso podría robarle sus monedas!</translation>
+    </message>
+    <message>
+        <source>Automatically open the Bitcoin client port on the router. This only works when your router supports NAT-PMP and it is enabled. The external port could be random.</source>
+        <translation type="unfinished">Abre el puerto del cliente de Bitcoin en el router automáticamente. Esto solo funciona cuando el router soporta NAT-PMP y está habilitado. El puerto externo podría ser elegido al azar.</translation>
+    </message>
+    <message>
+        <source>Map port using NA&amp;T-PMP</source>
+        <translation type="unfinished">Mapear el puerto usando NA&amp;T-PMP</translation>
+    </message>
+    <message>
         <source>Accept connections from outside.</source>
         <translation type="unfinished">Aceptar las conexiones del exterior.</translation>
     </message>
@@ -1068,8 +1182,33 @@ Solicitar pagos (genera códigos QR y bitcoin: URI)
         <translation>&amp;Ventana</translation>
     </message>
     <message>
+        <source>Show the icon in the system tray.</source>
+        <translation type="unfinished">Mostrar el ícono en la bandeja del sistema.</translation>
+    </message>
+    <message>
+        <source>&amp;Show tray icon</source>
+        <translation type="unfinished">Mostrar la bandeja del sistema.</translation>
+    </message>
+    <message>
         <source>User Interface &amp;language:</source>
         <translation>Idioma de la interfaz de usuario:</translation>
+    </message>
+    <message>
+        <source>Monospaced font in the Overview tab:</source>
+        <translation type="unfinished">letra Monospace en la pestaña Resumen: </translation>
+    </message>
+    <message>
+        <source>embedded "%1"</source>
+        <translation type="unfinished">incrustado "%1"</translation>
+    </message>
+    <message>
+        <source>closest matching "%1"</source>
+        <translation type="unfinished">coincidencia más aproximada "%1"</translation>
+    </message>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Compilado sin soporte de firma externa (necesario para la firma externa)</translation>
     </message>
     <message>
         <source>none</source>
@@ -1094,6 +1233,15 @@ Solicitar pagos (genera códigos QR y bitcoin: URI)
 <context>
     <name>PSBTOperationsDialog</name>
     <message>
+        <source>Save…</source>
+        <translation type="unfinished">Guardar...</translation>
+    </message>
+    <message>
+        <source>Partially Signed Transaction (Binary)</source>
+        <extracomment>Expanded name of the binary PSBT file format. See: BIP 174.</extracomment>
+        <translation type="unfinished">Transacción parcialmente firmada (binario) </translation>
+    </message>
+    <message>
         <source>Total Amount</source>
         <translation type="unfinished">Cantidad total</translation>
     </message>
@@ -1115,6 +1263,11 @@ Si recibe este error,  debe solicitar al vendedor un URI compatible con BIP21.</
     </context>
 <context>
     <name>PeerTableModel</name>
+    <message>
+        <source>Peer</source>
+        <extracomment>Title of Peers Table column which contains a unique number used to identify a connection.</extracomment>
+        <translation type="unfinished">Par</translation>
+    </message>
     <message>
         <source>Sent</source>
         <extracomment>Title of Peers Table column which indicates the total amount of network information we have sent to the peer.</extracomment>
@@ -1216,6 +1369,10 @@ Si recibe este error,  debe solicitar al vendedor un URI compatible con BIP21.</
         <translation type="unfinished">Dirección y tipo de conexión entre pares: %1</translation>
     </message>
     <message>
+        <source>Direction/Type</source>
+        <translation type="unfinished">Dirección/Tipo</translation>
+    </message>
+    <message>
         <source>The network protocol this peer is connected through: IPv4, IPv6, Onion, I2P, or CJDNS.</source>
         <translation type="unfinished">Este par está conectado mediante alguno de los siguientes protocolos de red : IPv4, IPv6, Onion, I2P, or CJDNS.</translation>
     </message>
@@ -1224,8 +1381,40 @@ Si recibe este error,  debe solicitar al vendedor un URI compatible con BIP21.</
         <translation type="unfinished">Servicios</translation>
     </message>
     <message>
+        <source>Whether the peer requested us to relay transactions.</source>
+        <translation type="unfinished">Si el peer nos solicitó que transmitiéramos las transacciones.</translation>
+    </message>
+    <message>
+        <source>Wants Tx Relay</source>
+        <translation type="unfinished">Desea una transmisión de transacción</translation>
+    </message>
+    <message>
+        <source>High bandwidth BIP152 compact block relay: %1</source>
+        <translation type="unfinished">Transmisión de bloque compacto BIP152 banbda ancha: %1</translation>
+    </message>
+    <message>
+        <source>High Bandwidth</source>
+        <translation type="unfinished">banda ancha</translation>
+    </message>
+    <message>
         <source>Connection Time</source>
         <translation type="unfinished">Tiempo de conexión</translation>
+    </message>
+    <message>
+        <source>Elapsed time since a novel block passing initial validity checks was received from this peer.</source>
+        <translation type="unfinished">Tiempo transcurrido desde que se recibió de este par un nuevo bloque que superó las comprobaciones de validez iniciales.</translation>
+    </message>
+    <message>
+        <source>Last Block</source>
+        <translation type="unfinished">Último Bloque</translation>
+    </message>
+    <message>
+        <source>Elapsed time since a novel transaction accepted into our mempool was received from this peer.</source>
+        <translation type="unfinished">Tiempo transcurrido desde que se recibió de este par una nueva transacción aceptada en nuestro mempool.</translation>
+    </message>
+    <message>
+        <source>Last Tx</source>
+        <translation type="unfinished">Última tx</translation>
     </message>
     <message>
         <source>Last Send</source>
@@ -1234,6 +1423,46 @@ Si recibe este error,  debe solicitar al vendedor un URI compatible con BIP21.</
     <message>
         <source>Last Receive</source>
         <translation type="unfinished">Última recepción</translation>
+    </message>
+    <message>
+        <source>Inbound: initiated by peer</source>
+        <translation type="unfinished">Entrante: iniciado por el par</translation>
+    </message>
+    <message>
+        <source>Outbound Full Relay: default</source>
+        <translation type="unfinished">Relé Completo de Salida: predeterminado</translation>
+    </message>
+    <message>
+        <source>Outbound Block Relay: does not relay transactions or addresses</source>
+        <translation type="unfinished">Retransmisión de bloque saliente: no retransmite transacciones o direcciones</translation>
+    </message>
+    <message>
+        <source>Outbound Manual: added using RPC %1 or %2/%3 configuration options</source>
+        <translation type="unfinished">Manual de Salida: agregado usando las opciones de configuración RPC %1 o %2/%3</translation>
+    </message>
+    <message>
+        <source>Outbound Feeler: short-lived, for testing addresses</source>
+        <translation type="unfinished">Sensor de Salida: de corta duración, para probar direcciones</translation>
+    </message>
+    <message>
+        <source>Outbound Address Fetch: short-lived, for soliciting addresses</source>
+        <translation type="unfinished">Recuperación de Dirección Saliente: de corta duración, para solicitar direcciones</translation>
+    </message>
+    <message>
+        <source>we selected the peer for high bandwidth relay</source>
+        <translation type="unfinished">hemos seleccionado el par para la retransmisión de banda ancha</translation>
+    </message>
+    <message>
+        <source>the peer selected us for high bandwidth relay</source>
+        <translation type="unfinished">El par nos ha seleccionado para transmisión de banda ancha</translation>
+    </message>
+    <message>
+        <source>no high bandwidth relay selected</source>
+        <translation type="unfinished">Ninguna transmisión de banda ancha seleccionada</translation>
+    </message>
+    <message>
+        <source>1 d&amp;ay</source>
+        <translation type="unfinished">1 día</translation>
     </message>
     <message>
         <source>Network activity disabled</source>
@@ -1261,6 +1490,15 @@ Para obtener más información, escriba %6.
 %7ADVERTENCIA: Los estafadores, de forma activa, han estado indicando a los usuarios que escriban comandos aquí y de esta manera  roban el contenido de sus monederos. No utilice esta consola si no comprende perfectamente las ramificaciones de un comando.%8</translation>
     </message>
     <message>
+        <source>Executing…</source>
+        <extracomment>A console message indicating an entered command is currently being executed.</extracomment>
+        <translation type="unfinished">Ejecutando...</translation>
+    </message>
+    <message>
+        <source>(peer: %1)</source>
+        <translation type="unfinished">(par: %1)</translation>
+    </message>
+    <message>
         <source>Yes</source>
         <translation type="unfinished">Sí</translation>
     </message>
@@ -1271,6 +1509,10 @@ Para obtener más información, escriba %6.
     <message>
         <source>From</source>
         <translation type="unfinished">De</translation>
+    </message>
+    <message>
+        <source>Never</source>
+        <translation type="unfinished">Nunca</translation>
     </message>
     <message>
         <source>Unknown</source>
@@ -1352,12 +1594,28 @@ Para obtener más información, escriba %6.
         <translation type="unfinished">&amp;Copiar dirección</translation>
     </message>
     <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Copiar &amp;label</translation>
+    </message>
+    <message>
+        <source>Copy &amp;message</source>
+        <translation type="unfinished">Copiar &amp;mensaje</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Copiar &amp;amount</translation>
+    </message>
+    <message>
         <source>Could not unlock wallet.</source>
         <translation type="unfinished">No se puede desbloquear la cartera</translation>
     </message>
     </context>
 <context>
     <name>ReceiveRequestDialog</name>
+    <message>
+        <source>Request payment to …</source>
+        <translation type="unfinished">Solicitar pago a...</translation>
+    </message>
     <message>
         <source>Amount:</source>
         <translation type="unfinished">Monto:</translation>
@@ -1373,6 +1631,14 @@ Para obtener más información, escriba %6.
     <message>
         <source>Copy &amp;Address</source>
         <translation type="unfinished">&amp;Copiar dirección</translation>
+    </message>
+    <message>
+        <source>&amp;Verify</source>
+        <translation type="unfinished">&amp;Verificar</translation>
+    </message>
+    <message>
+        <source>Verify this address on e.g. a hardware wallet screen</source>
+        <translation type="unfinished">Verifique esta dirección en la pantalla de su billetera fría u otro dispositivo</translation>
     </message>
     <message>
         <source>&amp;Save Image…</source>
@@ -1437,8 +1703,28 @@ Para obtener más información, escriba %6.
         <translation type="unfinished">Borrar todos los campos del formulario.</translation>
     </message>
     <message>
+        <source>Inputs…</source>
+        <translation type="unfinished">Entradas...</translation>
+    </message>
+    <message>
         <source>Dust:</source>
         <translation type="unfinished">Remanente monetario:</translation>
+    </message>
+    <message>
+        <source>Choose…</source>
+        <translation type="unfinished">Elegir...</translation>
+    </message>
+    <message>
+        <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
+
+Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satoshis per kvB" for a transaction size of 500 virtual bytes (half of 1 kvB) would ultimately yield a fee of only 50 satoshis.</source>
+        <translation type="unfinished">Especifique una tarifa personalizada por kB (1.000 bytes) del tamaño virtual de la transacción.
+
+Nota: Dado que la tasa se calcula por cada byte, una tasa de "100 satoshis por kvB" para una transacción de 500 bytes virtuales (la mitad de 1 kvB) supondría finalmente una tasa de sólo 50 satoshis.</translation>
+    </message>
+    <message>
+        <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
+        <translation type="unfinished">(Comisión inteligente no inicializada todavía. Usualmente esto tarda algunos bloques…)</translation>
     </message>
     <message>
         <source>Balance:</source>
@@ -1473,12 +1759,57 @@ Para obtener más información, escriba %6.
         <translation type="unfinished">Copiar cambio</translation>
     </message>
     <message>
+        <source>Sign on device</source>
+        <extracomment>"device" usually means a hardware wallet</extracomment>
+        <translation type="unfinished">Iniciar sesión en el dispositivo</translation>
+    </message>
+    <message>
+        <source>Connect your hardware wallet first.</source>
+        <translation type="unfinished">Conecte su wallet externo primero.</translation>
+    </message>
+    <message>
+        <source>Set external signer script path in Options -&gt; Wallet</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Configure una ruta externa al script en Opciones -&gt; Wallet</translation>
+    </message>
+    <message>
         <source>Do you want to draft this transaction?</source>
         <translation type="unfinished">¿Quiere redactar esta transacción?</translation>
     </message>
     <message>
         <source>Are you sure you want to send?</source>
         <translation type="unfinished">¿Está seguro de que quiere enviar?</translation>
+    </message>
+    <message>
+        <source>To review recipient list click "Show Details…"</source>
+        <translation type="unfinished">Para revisar la lista de recipientes clique en "Mostrar Detalles..."</translation>
+    </message>
+    <message>
+        <source>Sign and send</source>
+        <translation type="unfinished">Firmar y enviar</translation>
+    </message>
+    <message>
+        <source>Sign failed</source>
+        <translation type="unfinished">Falló Firma</translation>
+    </message>
+    <message>
+        <source>External signer not found</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Dispositivo externo de firma no encontrado</translation>
+    </message>
+    <message>
+        <source>External signer failure</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Fallo en cartera hardware externa </translation>
+    </message>
+    <message>
+        <source>Partially Signed Transaction (Binary)</source>
+        <extracomment>Expanded name of the binary PSBT file format. See: BIP 174.</extracomment>
+        <translation type="unfinished">Transacción parcialmente firmada (binario) </translation>
+    </message>
+    <message>
+        <source>External balance:</source>
+        <translation type="unfinished">Saldo externo:</translation>
     </message>
     <message>
         <source>or</source>
@@ -1531,8 +1862,8 @@ Para obtener más información, escriba %6.
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation>
-            <numerusform />
-            <numerusform />
+            <numerusform>Estimado para empezar la confirmación dentro de %n bloque.</numerusform>
+            <numerusform>Estimado para empezar la confirmación dentro de %n bloques.</numerusform>
         </translation>
     </message>
     <message>
@@ -1631,8 +1962,8 @@ Para obtener más información, escriba %6.
     <message numerus="yes">
         <source>Open for %n more block(s)</source>
         <translation>
-            <numerusform />
-            <numerusform />
+            <numerusform>Abrir para %n bloque más</numerusform>
+            <numerusform>Abrir para %n bloques más</numerusform>
         </translation>
     </message>
     <message>
@@ -1674,8 +2005,8 @@ Para obtener más información, escriba %6.
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation>
-            <numerusform />
-            <numerusform />
+            <numerusform>madura en %n bloque más</numerusform>
+            <numerusform>madura en %n bloques más</numerusform>
         </translation>
     </message>
     <message>
@@ -1727,8 +2058,8 @@ Para obtener más información, escriba %6.
     <message numerus="yes">
         <source>Open for %n more block(s)</source>
         <translation>
-            <numerusform />
-            <numerusform />
+            <numerusform>Abrir para %n bloque más</numerusform>
+            <numerusform>Abrir para %n bloques más</numerusform>
         </translation>
     </message>
     <message>
@@ -1827,12 +2158,48 @@ Para obtener más información, escriba %6.
         <translation type="unfinished">Monto minimo </translation>
     </message>
     <message>
+        <source>Range…</source>
+        <translation type="unfinished">Rango...</translation>
+    </message>
+    <message>
         <source>&amp;Copy address</source>
         <translation type="unfinished">&amp;Copiar dirección</translation>
     </message>
     <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Copiar &amp;label</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Copiar &amp;amount</translation>
+    </message>
+    <message>
         <source>Copy transaction &amp;ID</source>
         <translation type="unfinished">Copiar &amp;ID de la transacción</translation>
+    </message>
+    <message>
+        <source>Copy &amp;raw transaction</source>
+        <translation type="unfinished">Copiar transacción bruta</translation>
+    </message>
+    <message>
+        <source>Copy full transaction &amp;details</source>
+        <translation type="unfinished">Copiar la transacción entera &amp;detalles</translation>
+    </message>
+    <message>
+        <source>&amp;Show transaction details</source>
+        <translation type="unfinished">Mostrar detalles de la transacción</translation>
+    </message>
+    <message>
+        <source>Increase transaction &amp;fee</source>
+        <translation type="unfinished">Incrementar cuota de transacción</translation>
+    </message>
+    <message>
+        <source>A&amp;bandon transaction</source>
+        <translation type="unfinished">Abandonar transacción</translation>
+    </message>
+    <message>
+        <source>&amp;Edit address label</source>
+        <translation type="unfinished">Editar etiqueta de dirección</translation>
     </message>
     <message>
         <source>Export Transaction History</source>
@@ -1898,6 +2265,14 @@ Para obtener más información, escriba %6.
         <translation type="unfinished">Enviar monedas</translation>
     </message>
     <message>
+        <source>Warning: This may pay the additional fee by reducing change outputs or adding inputs, when necessary. It may add a new change output if one does not already exist. These changes may potentially leak privacy.</source>
+        <translation type="unfinished">Advertencia:  Puede pagar la tasa adicional reduciendo las salidas de cambio o añadiendo entradas, cuando sea necesario. Puede añadir una nueva salida de cambio si no existe ya una. Estos cambios pueden filtrar potencialmente la privacidad.</translation>
+    </message>
+    <message>
+        <source>Can't display address</source>
+        <translation type="unfinished">No se puede mostrar la dirección</translation>
+    </message>
+    <message>
         <source>default wallet</source>
         <translation type="unfinished">cartera predeterminada</translation>
     </message>
@@ -1911,6 +2286,11 @@ Para obtener más información, escriba %6.
     <message>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished">Exportar la información en la pestaña actual a un archivo</translation>
+    </message>
+    <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">Datos de la billetera </translation>
     </message>
     <message>
         <source>There was an error trying to save the wallet data to %1.</source>
@@ -1928,6 +2308,18 @@ Para obtener más información, escriba %6.
         <translation type="unfinished">No se pudo cambiar la versión %i a la versión anterior %i.  Versión del monedero sin cambios.</translation>
     </message>
     <message>
+        <source>Cannot upgrade a non HD split wallet from version %i to version %i without upgrading to support pre-split keypool. Please use version %i or no version specified.</source>
+        <translation type="unfinished">No es posible actualizar un monedero no HD de la versión%i a la versión %isin actualizar para admitir el keypool pre divido. Por favor use la versión %i o no una versión no especificada.</translation>
+    </message>
+    <message>
+        <source>File %s already exists. If you are sure this is what you want, move it out of the way first.</source>
+        <translation type="unfinished">El archivo %s ya existe. Si estás seguro de que esto es lo que quieres, muévelo primero.</translation>
+    </message>
+    <message>
+        <source>No wallet file format provided. To use createfromdump, -format=&lt;format&gt; must be provided.</source>
+        <translation type="unfinished">Ningún archivo de billetera proveído. Para usar createfromdump, -format=&lt;format&gt;debe ser proveído.</translation>
+    </message>
+    <message>
         <source>The transaction amount is too small to send after the fee has been deducted</source>
         <translation type="unfinished">La cantidad de la transacción es demasiado pequeña para enviarla después de que se haya deducido la tarifa</translation>
     </message>
@@ -1940,8 +2332,40 @@ Para obtener más información, escriba %6.
         <translation type="unfinished">Carga completa</translation>
     </message>
     <message>
+        <source>Error creating %s</source>
+        <translation type="unfinished">Error creando %s</translation>
+    </message>
+    <message>
         <source>Error reading from database, shutting down.</source>
         <translation type="unfinished">Error de lectura de la base de datos, apagando.</translation>
+    </message>
+    <message>
+        <source>Error reading next record from wallet database</source>
+        <translation type="unfinished">Error leyendo el siguiente registro de la base de datos de la billetera</translation>
+    </message>
+    <message>
+        <source>Error: Couldn't create cursor into database</source>
+        <translation type="unfinished">Error: No se pudo crear el cursor en la base de datos</translation>
+    </message>
+    <message>
+        <source>Error: Got key that was not hex: %s</source>
+        <translation type="unfinished">Error: Se recibió una llave que no es hex: %s</translation>
+    </message>
+    <message>
+        <source>Error: Got value that was not hex: %s</source>
+        <translation type="unfinished">Error: Se recibió un valor que no es hex: %s</translation>
+    </message>
+    <message>
+        <source>Error: Missing checksum</source>
+        <translation type="unfinished">Error: No se ha encontrado 'checksum'</translation>
+    </message>
+    <message>
+        <source>Error: No %s addresses available.</source>
+        <translation type="unfinished">Error: No hay %sdirecciones disponibles,</translation>
+    </message>
+    <message>
+        <source>Error: Unable to write record to new wallet</source>
+        <translation type="unfinished">Error: No se pudo escribir el registro en la nueva billetera</translation>
     </message>
     <message>
         <source>Failed to rescan the wallet during initialization</source>
@@ -1952,16 +2376,64 @@ Para obtener más información, escriba %6.
         <translation type="unfinished">No se pudo verificar la base de datos</translation>
     </message>
     <message>
+        <source>Importing…</source>
+        <translation type="unfinished">Importando...</translation>
+    </message>
+    <message>
         <source>Insufficient funds</source>
         <translation type="unfinished">Fondos insuficientes</translation>
+    </message>
+    <message>
+        <source>Invalid -i2psam address or hostname: '%s'</source>
+        <translation type="unfinished">Dirección de -i2psam o dominio ' %s' inválido</translation>
+    </message>
+    <message>
+        <source>Loading P2P addresses…</source>
+        <translation type="unfinished">Cargando direcciones P2P...</translation>
+    </message>
+    <message>
+        <source>Loading banlist…</source>
+        <translation type="unfinished">Cargando banlist...</translation>
+    </message>
+    <message>
+        <source>Loading block index…</source>
+        <translation type="unfinished">Cargando el índice de bloques...</translation>
+    </message>
+    <message>
+        <source>Loading wallet…</source>
+        <translation type="unfinished">Cargando monedero...</translation>
     </message>
     <message>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished">No hay suficientes descriptores de archivos disponibles.</translation>
     </message>
     <message>
+        <source>Prune mode is incompatible with -coinstatsindex.</source>
+        <translation type="unfinished">El modo recorte es incompatible con -coinstatsindex.</translation>
+    </message>
+    <message>
+        <source>Pruning blockstore…</source>
+        <translation type="unfinished">Podando blockstore...</translation>
+    </message>
+    <message>
+        <source>Replaying blocks…</source>
+        <translation type="unfinished">Reproduciendo bloques...</translation>
+    </message>
+    <message>
+        <source>Rescanning…</source>
+        <translation type="unfinished">Volviendo a escanear...</translation>
+    </message>
+    <message>
         <source>Signing transaction failed</source>
         <translation type="unfinished">La transacción de firma falló</translation>
+    </message>
+    <message>
+        <source>Starting network threads…</source>
+        <translation type="unfinished">Iniciando procesos de red...</translation>
+    </message>
+    <message>
+        <source>The specified config file %s does not exist</source>
+        <translation type="unfinished">El archivo de configuración especificado %s no existe </translation>
     </message>
     <message>
         <source>The transaction amount is too small to pay the fee</source>
@@ -1992,6 +2464,11 @@ Para obtener más información, escriba %6.
         <translation type="unfinished">La transacción debe tener al menos un destinatario</translation>
     </message>
     <message>
+        <source>Transaction needs a change address, but we can't generate it. %s</source>
+        <translation type="unfinished">La transacción necesita una dirección de cambio, pero no podemos generarla. %s
+</translation>
+    </message>
+    <message>
         <source>Transaction too large</source>
         <translation type="unfinished">La transacción es demasiado grande</translation>
     </message>
@@ -2002,6 +2479,22 @@ Para obtener más información, escriba %6.
     <message>
         <source>Unable to generate keys</source>
         <translation type="unfinished">Incapaz de generar claves</translation>
+    </message>
+    <message>
+        <source>Unable to open %s for writing</source>
+        <translation type="unfinished">No se ha podido abrir %s para escribir</translation>
+    </message>
+    <message>
+        <source>Unknown new rules activated (versionbit %i)</source>
+        <translation type="unfinished">Nuevas reglas desconocidas activadas (versionbit %i)</translation>
+    </message>
+    <message>
+        <source>Verifying blocks…</source>
+        <translation type="unfinished">Verificando bloques...</translation>
+    </message>
+    <message>
+        <source>Verifying wallet(s)…</source>
+        <translation type="unfinished">Verificando wallet(s)...</translation>
     </message>
     </context>
 </TS>

--- a/src/qt/locale/bitcoin_eu.ts
+++ b/src/qt/locale/bitcoin_eu.ts
@@ -70,6 +70,12 @@
         <translation type="unfinished">Hauek dira zuk dirua jaso dezaketen Bitcoin helbideak. Egiaztatu beti diru-kopurua eta dirua jasoko duen helbidea zuzen egon daitezen, txanponak bidali baino lehen.</translation>
     </message>
     <message>
+        <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
+Signing is only possible with addresses of the type 'legacy'.</source>
+        <translation type="unfinished">Hauek dira ordainketak jasotzeko zure Bitcoin helbideak. Jaso taulako 'Jasotzeko helbide berri bat sortu' botoia erabili helbide berri bat sortzeko.
+Sinatzea 'legacy' motako helbideekin soilik da posible</translation>
+    </message>
+    <message>
         <source>&amp;Copy Address</source>
         <translation type="unfinished">&amp;Helbidea kopiatu</translation>
     </message>
@@ -84,6 +90,11 @@
     <message>
         <source>Export Address List</source>
         <translation type="unfinished">Helbide lista esportatu</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See https://en.wikipedia.org/wiki/Comma-separated_values</extracomment>
+        <translation type="unfinished">Komaz bereizitako fitxategia</translation>
     </message>
     <message>
         <source>There was an error trying to save the address list to %1. Please try again.</source>
@@ -233,10 +244,25 @@
     </message>
 </context>
 <context>
+    <name>BitcoinApplication</name>
+    <message>
+        <source>Runaway exception</source>
+        <translation type="unfinished">Ranaway exception</translation>
+    </message>
+    <message>
+        <source>Internal error</source>
+        <translation type="unfinished">Barne errorea</translation>
+    </message>
+    </context>
+<context>
     <name>QObject</name>
     <message>
         <source>Error: %1</source>
         <translation type="unfinished">Akatsa: %1</translation>
+    </message>
+    <message>
+        <source>Error initializing settings: %1</source>
+        <translation type="unfinished">Errorea konfigurazioa hasiaraztean: %1</translation>
     </message>
     <message>
         <source>unknown</source>
@@ -245,6 +271,18 @@
     <message>
         <source>Amount</source>
         <translation type="unfinished">Kopurua</translation>
+    </message>
+    <message>
+        <source>Internal</source>
+        <translation type="unfinished">Barnekoa</translation>
+    </message>
+    <message>
+        <source>%1 d</source>
+        <translation type="unfinished">%1 e</translation>
+    </message>
+    <message>
+        <source>%1 h</source>
+        <translation type="unfinished">%1 o</translation>
     </message>
     <message numerus="yes">
         <source>%n second(s)</source>
@@ -373,6 +411,10 @@
         <translation>&amp;Jaso</translation>
     </message>
     <message>
+        <source>&amp;Options…</source>
+        <translation type="unfinished">&amp;Aukerak...</translation>
+    </message>
+    <message>
         <source>&amp;Show / Hide</source>
         <translation>&amp;Erakutsi / Izkutatu</translation>
     </message>
@@ -381,16 +423,60 @@
         <translation>Lehio nagusia erakutsi edo izkutatu</translation>
     </message>
     <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation type="unfinished">&amp;Diruzorroa enkriptatu...</translation>
+    </message>
+    <message>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>Zure diru-zorroari dagozkion giltza pribatuak enkriptatu.</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation type="unfinished">Diruzorroaren &amp;segurtasun kopia egin...</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation type="unfinished">&amp;aldatu pasahitza</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation type="unfinished">sinatu &amp;mezua</translation>
     </message>
     <message>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation>Sinatu mezuak Bitcoinen helbideekin, jabetza frogatzeko.</translation>
     </message>
     <message>
+        <source>&amp;Verify message…</source>
+        <translation type="unfinished">Mezua &amp;balioztatu</translation>
+    </message>
+    <message>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation>Egiaztatu mesua Bitcoin helbide espezifikoarekin erregistratu direla ziurtatzeko</translation>
+    </message>
+    <message>
+        <source>&amp;Load PSBT from file…</source>
+        <translation type="unfinished">&amp;kargatu PSBT fitxategitik...</translation>
+    </message>
+    <message>
+        <source>Load PSBT from clipboard…</source>
+        <translation type="unfinished">Arbeletik PSBT kargatu...</translation>
+    </message>
+    <message>
+        <source>Open &amp;URI…</source>
+        <translation type="unfinished">Ireki&amp;URI...</translation>
+    </message>
+    <message>
+        <source>Close Wallet…</source>
+        <translation type="unfinished">Diruzorroa itxi...</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation type="unfinished">Diruzorroa sortu...</translation>
+    </message>
+    <message>
+        <source>Close All Wallets…</source>
+        <translation type="unfinished">Diru-zorro guztiak itxi...</translation>
     </message>
     <message>
         <source>&amp;File</source>
@@ -407,6 +493,26 @@
     <message>
         <source>Tabs toolbar</source>
         <translation>Fitxen tresna-barra</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation type="unfinished">Sarearekin sinkronizatzen...</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation type="unfinished">Diskoko blokeak indexatzen...</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation type="unfinished">Diskoko blokeak prozesatzen...</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation type="unfinished">Diskoko blokeak berzerrendatzen</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation type="unfinished">Pareekin konektatzen...</translation>
     </message>
     <message>
         <source>Show the list of used sending addresses and labels</source>
@@ -432,6 +538,10 @@
         <translation>%1 atzetik</translation>
     </message>
     <message>
+        <source>Catching up…</source>
+        <translation type="unfinished">Harrapatzen...</translation>
+    </message>
+    <message>
         <source>Last received block was generated %1 ago.</source>
         <translation>Jasotako azken blokea duela %1 sortu zen.</translation>
     </message>
@@ -454,6 +564,14 @@
     <message>
         <source>Up to date</source>
         <translation>Eguneratua</translation>
+    </message>
+    <message>
+        <source>Load Partially Signed Bitcoin Transaction</source>
+        <translation type="unfinished">Partzialki sinatutako Bitcoin transakzioa kargatu</translation>
+    </message>
+    <message>
+        <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
+        <translation type="unfinished">Partzialki sinatutako Bitcoin transakzioa kargatu arbeletik</translation>
     </message>
     <message>
         <source>Node window</source>
@@ -522,6 +640,11 @@
             <numerusform />
             <numerusform />
         </translation>
+    </message>
+    <message>
+        <source>Show Peers tab</source>
+        <extracomment>A context menu item. The "Peers tab" is an element of the "Node window".</extracomment>
+        <translation type="unfinished">Erakutxi kideen fitxa</translation>
     </message>
     <message>
         <source>Error: %1</source>
@@ -671,8 +794,20 @@
         <translation type="unfinished">zenbatekoaren kopia</translation>
     </message>
     <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Kopiatu &amp;Etiketa</translation>
+    </message>
+    <message>
         <source>Copy quantity</source>
         <translation type="unfinished">Kopia kopurua</translation>
+    </message>
+    <message>
+        <source>Copy fee</source>
+        <translation type="unfinished">Kopiatu kuota</translation>
+    </message>
+    <message>
+        <source>Copy after fee</source>
+        <translation type="unfinished">Kopia kuotaren ondoren</translation>
     </message>
     <message>
         <source>Copy bytes</source>
@@ -710,6 +845,10 @@
 <context>
     <name>CreateWalletActivity</name>
     <message>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation type="unfinished">Diru-zorroa sortzen&lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+    <message>
         <source>Create wallet failed</source>
         <translation type="unfinished">Diruzorroa sortzen hutsegitea</translation>
     </message>
@@ -717,7 +856,11 @@
         <source>Create wallet warning</source>
         <translation type="unfinished">Diru-zorroa sortzearen buruzko oharra</translation>
     </message>
-    </context>
+    <message>
+        <source>Can't list signers</source>
+        <translation type="unfinished">Ezin dira sinatzaileak zerrendatu</translation>
+    </message>
+</context>
 <context>
     <name>OpenWalletActivity</name>
     <message>
@@ -732,7 +875,11 @@
         <source>default wallet</source>
         <translation type="unfinished">Diruzorro lehenetsia</translation>
     </message>
-    </context>
+    <message>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation type="unfinished">&lt;b&gt;%1&lt;/b&gt; diruzorroa irekitzen ...</translation>
+    </message>
+</context>
 <context>
     <name>WalletController</name>
     <message>
@@ -743,7 +890,11 @@
         <source>Close all wallets</source>
         <translation type="unfinished">Diruzorro guztiak itxi</translation>
     </message>
-    </context>
+    <message>
+        <source>Are you sure you wish to close all wallets?</source>
+        <translation type="unfinished">Ziur diruzorro guztiak itxi nahi dituzula?</translation>
+    </message>
+</context>
 <context>
     <name>CreateWalletDialog</name>
     <message>
@@ -771,8 +922,16 @@
         <translation type="unfinished">Desgaitu gako pribatuak</translation>
     </message>
     <message>
+        <source>Make Blank Wallet</source>
+        <translation type="unfinished">Egin diruzorro hutsa...</translation>
+    </message>
+    <message>
         <source>Descriptor Wallet</source>
         <translation type="unfinished">Deskriptorearen zorroa</translation>
+    </message>
+    <message>
+        <source>External signer</source>
+        <translation type="unfinished">Kanpo sinatzailea</translation>
     </message>
     <message>
         <source>Create</source>
@@ -817,10 +976,22 @@
 <context>
     <name>FreespaceChecker</name>
     <message>
+        <source>A new data directory will be created.</source>
+        <translation>Datu direktorio berria sortuko da.</translation>
+    </message>
+    <message>
         <source>name</source>
         <translation>izena</translation>
     </message>
-    </context>
+    <message>
+        <source>Path already exists, and is not a directory.</source>
+        <translation>Bidea existitzen da, eta ez da direktorioa.</translation>
+    </message>
+    <message>
+        <source>Cannot create data directory here.</source>
+        <translation>Ezin da datu direktoria hemen sortu.</translation>
+    </message>
+</context>
 <context>
     <name>Intro</name>
     <message numerus="yes">
@@ -843,7 +1014,19 @@
         <source>Welcome to %1.</source>
         <translation type="unfinished">Ongietorri %1-ra</translation>
     </message>
-    </context>
+    <message>
+        <source> GB</source>
+        <translation type="unfinished">GB</translation>
+    </message>
+    <message>
+        <source>Use the default data directory</source>
+        <translation>Erabili datu direktorio lehenetsia</translation>
+    </message>
+    <message>
+        <source>Use a custom data directory:</source>
+        <translation>Erabili datu direktorio pertsonalizatu bat:</translation>
+    </message>
+</context>
 <context>
     <name>HelpMessageDialog</name>
     <message>
@@ -860,6 +1043,13 @@
     </message>
 </context>
 <context>
+    <name>ShutdownWindow</name>
+    <message>
+        <source>%1 is shutting down…</source>
+        <translation type="unfinished">%1Itzaltzen ari da...</translation>
+    </message>
+    </context>
+<context>
     <name>ModalOverlay</name>
     <message>
         <source>Form</source>
@@ -870,12 +1060,24 @@
         <translation type="unfinished">Gainerako blokeen kopurua.</translation>
     </message>
     <message>
+        <source>Unknown…</source>
+        <translation type="unfinished">Ezezaguna...</translation>
+    </message>
+    <message>
+        <source>calculating…</source>
+        <translation type="unfinished">kalkulatzen...</translation>
+    </message>
+    <message>
         <source>Last block time</source>
         <translation type="unfinished">Azken blokearen unea</translation>
     </message>
     <message>
         <source>Progress</source>
         <translation type="unfinished">Aurrerapena</translation>
+    </message>
+    <message>
+        <source>Progress increase per hour</source>
+        <translation type="unfinished">Aurrerapenaren igoera orduko</translation>
     </message>
     <message>
         <source>Hide</source>
@@ -1035,21 +1237,69 @@
         <translation>Ez dago eskuragarri:</translation>
     </message>
     <message>
+        <source>Balances</source>
+        <translation type="unfinished">Saldoa</translation>
+    </message>
+    <message>
         <source>Total:</source>
         <translation>Guztira:</translation>
+    </message>
+    <message>
+        <source>Your current total balance</source>
+        <translation>Zure oraingo erabateko saldoa</translation>
+    </message>
+    <message>
+        <source>Spendable:</source>
+        <translation type="unfinished">Gastagarria:</translation>
+    </message>
+    <message>
+        <source>Recent transactions</source>
+        <translation type="unfinished">Transakzio berriak</translation>
     </message>
     </context>
 <context>
     <name>PSBTOperationsDialog</name>
     <message>
+        <source>Dialog</source>
+        <translation type="unfinished">Elkarrizketa</translation>
+    </message>
+    <message>
+        <source>Sign Tx</source>
+        <translation type="unfinished">Sinatu Tx</translation>
+    </message>
+    <message>
         <source>Copy to Clipboard</source>
         <translation type="unfinished">Kopiatu arbelera</translation>
+    </message>
+    <message>
+        <source>Save…</source>
+        <translation type="unfinished">Gorde...</translation>
     </message>
     <message>
         <source>Close</source>
         <translation type="unfinished">Itxi</translation>
     </message>
-    </context>
+    <message>
+        <source>Save Transaction Data</source>
+        <translation type="unfinished">Gorde transakzioko data</translation>
+    </message>
+    <message>
+        <source>PSBT saved to disk.</source>
+        <translation type="unfinished">PSBT diskoan gorde da.</translation>
+    </message>
+    <message>
+        <source>Total Amount</source>
+        <translation type="unfinished">Kopuru osoa</translation>
+    </message>
+    <message>
+        <source>or</source>
+        <translation type="unfinished">edo</translation>
+    </message>
+    <message>
+        <source>Transaction status is unknown.</source>
+        <translation type="unfinished">Transakzioaren egoera ezezaguna da.</translation>
+    </message>
+</context>
 <context>
     <name>PaymentServer</name>
     <message>
@@ -1065,6 +1315,21 @@
         <translation type="unfinished">Erabiltzaile agentea</translation>
     </message>
     <message>
+        <source>Peer</source>
+        <extracomment>Title of Peers Table column which contains a unique number used to identify a connection.</extracomment>
+        <translation type="unfinished">Kidea</translation>
+    </message>
+    <message>
+        <source>Sent</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have sent to the peer.</extracomment>
+        <translation type="unfinished">Bidalia</translation>
+    </message>
+    <message>
+        <source>Received</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have received from the peer.</extracomment>
+        <translation type="unfinished">Jasoa</translation>
+    </message>
+    <message>
         <source>Address</source>
         <extracomment>Title of Peers Table column which contains the IP/Onion/I2P address of the connected peer.</extracomment>
         <translation type="unfinished">Helbidea</translation>
@@ -1074,9 +1339,102 @@
         <extracomment>Title of Peers Table column which describes the type of peer connection. The "type" describes why the connection exists.</extracomment>
         <translation type="unfinished">Mota</translation>
     </message>
-    </context>
+    <message>
+        <source>Network</source>
+        <extracomment>Title of Peers Table column which states the network the peer connected through.</extracomment>
+        <translation type="unfinished">Sarea</translation>
+    </message>
+</context>
+<context>
+    <name>QRImageWidget</name>
+    <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">&amp;Gorde irudia...</translation>
+    </message>
+    <message>
+        <source>&amp;Copy Image</source>
+        <translation type="unfinished">&amp;kopiatu irudia</translation>
+    </message>
+    <message>
+        <source>Save QR Code</source>
+        <translation type="unfinished">Gorde QR kodea</translation>
+    </message>
+    <message>
+        <source>PNG Image</source>
+        <extracomment>Expanded name of the PNG file format. See https://en.wikipedia.org/wiki/Portable_Network_Graphics</extracomment>
+        <translation type="unfinished">PNG irudia</translation>
+    </message>
+</context>
 <context>
     <name>RPCConsole</name>
+    <message>
+        <source>Client version</source>
+        <translation>Bezeroaren bertsioa</translation>
+    </message>
+    <message>
+        <source>&amp;Information</source>
+        <translation>&amp;Informazioa</translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation type="unfinished">Orokorra</translation>
+    </message>
+    <message>
+        <source>Datadir</source>
+        <translation type="unfinished">Datu direktorioa</translation>
+    </message>
+    <message>
+        <source>Blocksdir</source>
+        <translation type="unfinished">Blokeen direktorioa</translation>
+    </message>
+    <message>
+        <source>Startup time</source>
+        <translation>Abiatzeko ordua</translation>
+    </message>
+    <message>
+        <source>Network</source>
+        <translation>Sarea</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished">Izena</translation>
+    </message>
+    <message>
+        <source>Number of connections</source>
+        <translation>Konexio kopurua</translation>
+    </message>
+    <message>
+        <source>Wallet: </source>
+        <translation type="unfinished">Diruzorroa:</translation>
+    </message>
+    <message>
+        <source>(none)</source>
+        <translation type="unfinished">(bat ere ez)</translation>
+    </message>
+    <message>
+        <source>&amp;Reset</source>
+        <translation type="unfinished">&amp;Berrezarri</translation>
+    </message>
+    <message>
+        <source>Received</source>
+        <translation type="unfinished">Jasoa</translation>
+    </message>
+    <message>
+        <source>Sent</source>
+        <translation type="unfinished">Bidalia</translation>
+    </message>
+    <message>
+        <source>&amp;Peers</source>
+        <translation type="unfinished">&amp;Kideak</translation>
+    </message>
+    <message>
+        <source>Banned peers</source>
+        <translation type="unfinished">Debekatutako kideak</translation>
+    </message>
+    <message>
+        <source>Version</source>
+        <translation type="unfinished">Bertsioa</translation>
+    </message>
     <message>
         <source>User Agent</source>
         <translation type="unfinished">Erabiltzaile agentea</translation>
@@ -1086,8 +1444,37 @@
         <translation type="unfinished">Adabegiaren leihoa</translation>
     </message>
     <message>
+        <source>Permissions</source>
+        <translation type="unfinished">Baimenak</translation>
+    </message>
+    <message>
+        <source>Services</source>
+        <translation type="unfinished">Zerbitzuak</translation>
+    </message>
+    <message>
         <source>Last block time</source>
         <translation>Azken blokearen unea</translation>
+    </message>
+    <message>
+        <source>Clear console</source>
+        <translation>Garbitu kontsola</translation>
+    </message>
+    <message>
+        <source>&amp;Disconnect</source>
+        <translation type="unfinished">&amp;Deskonektatu</translation>
+    </message>
+    <message>
+        <source>Executing…</source>
+        <extracomment>A console message indicating an entered command is currently being executed.</extracomment>
+        <translation type="unfinished">Exekutatzen...</translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished">Bai</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished">Ez</translation>
     </message>
     <message>
         <source>To</source>
@@ -1097,7 +1484,15 @@
         <source>From</source>
         <translation type="unfinished">Tik</translation>
     </message>
-    </context>
+    <message>
+        <source>Never</source>
+        <translation type="unfinished">Inoiz ez</translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">Ezezaguna</translation>
+    </message>
+</context>
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
@@ -1113,6 +1508,30 @@
         <translation type="unfinished">&amp;Mezua:</translation>
     </message>
     <message>
+        <source>Clear all fields of the form.</source>
+        <translation type="unfinished">Garbitu formularioko eremu guztiak.</translation>
+    </message>
+    <message>
+        <source>Clear</source>
+        <translation type="unfinished">Garbitu</translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished">Erakutsi</translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation type="unfinished">Ezabatu</translation>
+    </message>
+    <message>
+        <source>Copy &amp;URI</source>
+        <translation type="unfinished">Kopiatu &amp;URI</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Kopiatu &amp;Etiketa</translation>
+    </message>
+    <message>
         <source>Could not unlock wallet.</source>
         <translation type="unfinished">Ezin da diruzorroa desblokeatu.</translation>
     </message>
@@ -1120,8 +1539,16 @@
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
+        <source>Address:</source>
+        <translation type="unfinished">Helbidea:</translation>
+    </message>
+    <message>
         <source>Amount:</source>
         <translation type="unfinished">Kopurua:</translation>
+    </message>
+    <message>
+        <source>Label:</source>
+        <translation type="unfinished">Etiketa:</translation>
     </message>
     <message>
         <source>Message:</source>
@@ -1132,8 +1559,24 @@
         <translation type="unfinished">Diruzorroa:</translation>
     </message>
     <message>
+        <source>Copy &amp;URI</source>
+        <translation type="unfinished">Kopiatu &amp;URI</translation>
+    </message>
+    <message>
         <source>Copy &amp;Address</source>
         <translation type="unfinished">&amp;Helbidea kopiatu</translation>
+    </message>
+    <message>
+        <source>&amp;Verify</source>
+        <translation type="unfinished">&amp;Egiaztatu</translation>
+    </message>
+    <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">&amp;Gorde irudia...</translation>
+    </message>
+    <message>
+        <source>Payment information</source>
+        <translation type="unfinished">Ordainketaren informazioa</translation>
     </message>
     </context>
 <context>
@@ -1154,12 +1597,24 @@
         <source>(no label)</source>
         <translation type="unfinished">(izendapenik ez)</translation>
     </message>
-    </context>
+    <message>
+        <source>(no message)</source>
+        <translation type="unfinished">(mezurik ez)</translation>
+    </message>
+    <message>
+        <source>Requested</source>
+        <translation type="unfinished">Eskatua</translation>
+    </message>
+</context>
 <context>
     <name>SendCoinsDialog</name>
     <message>
         <source>Send Coins</source>
         <translation>Txanponak bidali</translation>
+    </message>
+    <message>
+        <source>automatically selected</source>
+        <translation type="unfinished">automatikoki aukeratua</translation>
     </message>
     <message>
         <source>Quantity:</source>
@@ -1186,16 +1641,40 @@
         <translation type="unfinished">Bueltak:</translation>
     </message>
     <message>
+        <source>Transaction Fee:</source>
+        <translation type="unfinished">Transakzio kuota:</translation>
+    </message>
+    <message>
+        <source>per kilobyte</source>
+        <translation type="unfinished">Kilobyteko</translation>
+    </message>
+    <message>
         <source>Hide</source>
         <translation type="unfinished">Izkutatu</translation>
+    </message>
+    <message>
+        <source>Recommended:</source>
+        <translation type="unfinished">Gomendatutakoa:</translation>
+    </message>
+    <message>
+        <source>Custom:</source>
+        <translation type="unfinished">Neurrira:</translation>
     </message>
     <message>
         <source>Send to multiple recipients at once</source>
         <translation>Hainbat jasotzaileri batera bidali</translation>
     </message>
     <message>
+        <source>Clear all fields of the form.</source>
+        <translation type="unfinished">Garbitu formularioko eremu guztiak.</translation>
+    </message>
+    <message>
         <source>Dust:</source>
         <translation type="unfinished">Hautsa:</translation>
+    </message>
+    <message>
+        <source>Choose…</source>
+        <translation type="unfinished">Aukeratu...</translation>
     </message>
     <message>
         <source>Balance:</source>
@@ -1206,12 +1685,24 @@
         <translation>Bidalketa berretsi</translation>
     </message>
     <message>
+        <source>S&amp;end</source>
+        <translation>Bidali</translation>
+    </message>
+    <message>
         <source>Copy quantity</source>
         <translation type="unfinished">Kopia kopurua</translation>
     </message>
     <message>
         <source>Copy amount</source>
         <translation type="unfinished">zenbatekoaren kopia</translation>
+    </message>
+    <message>
+        <source>Copy fee</source>
+        <translation type="unfinished">Kopiatu kuota</translation>
+    </message>
+    <message>
+        <source>Copy after fee</source>
+        <translation type="unfinished">Kopia kuotaren ondoren</translation>
     </message>
     <message>
         <source>Copy bytes</source>
@@ -1224,6 +1715,57 @@
     <message>
         <source>Copy change</source>
         <translation type="unfinished">Kopiatu aldaketa</translation>
+    </message>
+    <message>
+        <source>Sign on device</source>
+        <extracomment>"device" usually means a hardware wallet</extracomment>
+        <translation type="unfinished">Sinatu gailuan</translation>
+    </message>
+    <message>
+        <source>Connect your hardware wallet first.</source>
+        <translation type="unfinished">Konektatu zure hardware diruzorroa lehenago.</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to send?</source>
+        <translation type="unfinished">Ziur zaude bidali nahi duzula?</translation>
+    </message>
+    <message>
+        <source>Sign and send</source>
+        <translation type="unfinished">Sinatu eta bidali</translation>
+    </message>
+    <message>
+        <source>Sign failed</source>
+        <translation type="unfinished">Sinadurak hutsegitea</translation>
+    </message>
+    <message>
+        <source>External signer not found</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Kanpo sinatzailea ez da aurkitu</translation>
+    </message>
+    <message>
+        <source>External signer failure</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Kanpo sinatzailearen hutsegitea</translation>
+    </message>
+    <message>
+        <source>Save Transaction Data</source>
+        <translation type="unfinished">Gorde transakzioko data</translation>
+    </message>
+    <message>
+        <source>PSBT saved</source>
+        <translation type="unfinished">PSBT gordeta</translation>
+    </message>
+    <message>
+        <source>External balance:</source>
+        <translation type="unfinished">Kanpo saldoa:</translation>
+    </message>
+    <message>
+        <source>or</source>
+        <translation type="unfinished">edo</translation>
+    </message>
+    <message>
+        <source>Total Amount</source>
+        <translation type="unfinished">Kopuru osoa</translation>
     </message>
     <message>
         <source>Confirm send coins</source>
@@ -1260,6 +1802,10 @@
         <translation>&amp;Etiketa:</translation>
     </message>
     <message>
+        <source>Choose previously used address</source>
+        <translation type="unfinished">Aukeratu lehenago aukeraturiko helbidea</translation>
+    </message>
+    <message>
         <source>Paste address from clipboard</source>
         <translation>Arbeletik helbidea itsatsi</translation>
     </message>
@@ -1275,8 +1821,32 @@
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
+        <source>Choose previously used address</source>
+        <translation type="unfinished">Aukeratu lehenago aukeraturiko helbidea</translation>
+    </message>
+    <message>
         <source>Paste address from clipboard</source>
         <translation>Arbeletik helbidea itsatsi</translation>
+    </message>
+    <message>
+        <source>Enter the message you want to sign here</source>
+        <translation>Sartu sinatu nahi duzun mezua hemen</translation>
+    </message>
+    <message>
+        <source>Signature</source>
+        <translation>Sinadura</translation>
+    </message>
+    <message>
+        <source>Copy the current signature to the system clipboard</source>
+        <translation>Kopiatu oraingo sinadura sistemaren arbelera</translation>
+    </message>
+    <message>
+        <source>Sign &amp;Message</source>
+        <translation>Sinatu &amp;Mezua</translation>
+    </message>
+    <message>
+        <source>&amp;Verify Message</source>
+        <translation>&amp;Egiaztatu mezua</translation>
     </message>
     <message>
         <source>No error</source>
@@ -1294,7 +1864,15 @@
         <source>Please check the signature and try again.</source>
         <translation type="unfinished">Mesedez, begiratu sinadura eta saiatu berriro.</translation>
     </message>
-    </context>
+    <message>
+        <source>Message verification failed.</source>
+        <translation type="unfinished">Mezuen egiaztatzeak huts egin du</translation>
+    </message>
+    <message>
+        <source>Message verified.</source>
+        <translation type="unfinished">Mezua egiaztatua.</translation>
+    </message>
+</context>
 <context>
     <name>TransactionDesc</name>
     <message numerus="yes">
@@ -1399,7 +1977,15 @@
         <source>Amount</source>
         <translation type="unfinished">Kopurua</translation>
     </message>
-    </context>
+    <message>
+        <source>true</source>
+        <translation type="unfinished">egia</translation>
+    </message>
+    <message>
+        <source>false</source>
+        <translation type="unfinished">faltsua</translation>
+    </message>
+</context>
 <context>
     <name>TransactionDescDialog</name>
     <message>
@@ -1431,6 +2017,10 @@
     <message>
         <source>Open until %1</source>
         <translation type="unfinished">Zabalik %1 arte</translation>
+    </message>
+    <message>
+        <source>Unconfirmed</source>
+        <translation type="unfinished">Baieztatu gabea</translation>
     </message>
     <message>
         <source>Confirmed (%1 confirmations)</source>
@@ -1532,6 +2122,15 @@
         <translation type="unfinished">Kopuru minimoa</translation>
     </message>
     <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Kopiatu &amp;Etiketa</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See https://en.wikipedia.org/wiki/Comma-separated_values</extracomment>
+        <translation type="unfinished">Komaz bereizitako fitxategia</translation>
+    </message>
+    <message>
         <source>Confirmed</source>
         <translation type="unfinished">Berretsia</translation>
     </message>
@@ -1570,6 +2169,18 @@
         <translation type="unfinished">Txanponak bidali</translation>
     </message>
     <message>
+        <source>Current fee:</source>
+        <translation type="unfinished">Oraingo kuota:</translation>
+    </message>
+    <message>
+        <source>New fee:</source>
+        <translation type="unfinished">Kuota berria:</translation>
+    </message>
+    <message>
+        <source>PSBT copied</source>
+        <translation type="unfinished">PSBT kopiatua</translation>
+    </message>
+    <message>
         <source>default wallet</source>
         <translation type="unfinished">Diruzorro lehenetsia</translation>
     </message>
@@ -1594,6 +2205,70 @@
     <message>
         <source>Done loading</source>
         <translation type="unfinished">Zamaketa amaitua</translation>
+    </message>
+    <message>
+        <source>Importing…</source>
+        <translation type="unfinished">Inportatzen...</translation>
+    </message>
+    <message>
+        <source>Loading wallet…</source>
+        <translation type="unfinished">Diruzorroa kargatzen...</translation>
+    </message>
+    <message>
+        <source>Replaying blocks…</source>
+        <translation type="unfinished">Blokeak errepikatzen...</translation>
+    </message>
+    <message>
+        <source>Rescanning…</source>
+        <translation type="unfinished">Bereskaneatzen...</translation>
+    </message>
+    <message>
+        <source>Starting network threads…</source>
+        <translation type="unfinished">Sareko hariak abiarazten...</translation>
+    </message>
+    <message>
+        <source>The source code is available from %s.</source>
+        <translation type="unfinished">Iturri kodea %s-tik dago eskuragarri.</translation>
+    </message>
+    <message>
+        <source>The transaction amount is too small to pay the fee</source>
+        <translation type="unfinished">Transakzio kantitatea txikiegia da kuota ordaintzeko.</translation>
+    </message>
+    <message>
+        <source>This is experimental software.</source>
+        <translation type="unfinished">Hau software esperimentala da</translation>
+    </message>
+    <message>
+        <source>Transaction amount too small</source>
+        <translation type="unfinished">transakzio kopurua txikiegia</translation>
+    </message>
+    <message>
+        <source>Transaction too large</source>
+        <translation type="unfinished">Transakzio luzeegia</translation>
+    </message>
+    <message>
+        <source>Unable to generate initial keys</source>
+        <translation type="unfinished">hasierako giltzak sortzeko ezgai</translation>
+    </message>
+    <message>
+        <source>Unable to generate keys</source>
+        <translation type="unfinished">Giltzak sortzeko ezgai</translation>
+    </message>
+    <message>
+        <source>Upgrading UTXO database</source>
+        <translation type="unfinished">UTXO datubasea hobetzen</translation>
+    </message>
+    <message>
+        <source>Upgrading txindex database</source>
+        <translation type="unfinished">txindex datubasea hobetzen</translation>
+    </message>
+    <message>
+        <source>Verifying blocks…</source>
+        <translation type="unfinished">Blokeak egiaztatzen...</translation>
+    </message>
+    <message>
+        <source>Verifying wallet(s)…</source>
+        <translation type="unfinished">Diruzorroa(k) egiaztatzen...</translation>
     </message>
     </context>
 </TS>

--- a/src/qt/locale/bitcoin_fa.ts
+++ b/src/qt/locale/bitcoin_fa.ts
@@ -3,23 +3,23 @@
     <name>AddressBookPage</name>
     <message>
         <source>Right-click to edit address or label</source>
-        <translation type="unfinished">برای ویرایش نشانی یا برچسب کلیک‌راست کنید</translation>
+        <translation type="unfinished">برای ویرایش آدرس یا برچسب  کلیک ‌راست کنی</translation>
     </message>
     <message>
         <source>Create a new address</source>
-        <translation>نشانی جدید ایجاد کنید</translation>
+        <translation>آدرس جدید ایجاد کنید</translation>
     </message>
     <message>
         <source>&amp;New</source>
-        <translation type="unfinished">&amp;تازه</translation>
+        <translation type="unfinished">و جدید</translation>
     </message>
     <message>
         <source>Copy the currently selected address to the system clipboard</source>
-        <translation>کپی کردن آدرس انتخاب شده به کلیپ برد سیستم</translation>
+        <translation>کپی کردن آدرس انتخاب شده در کلیپ برد سیستم</translation>
     </message>
     <message>
         <source>&amp;Copy</source>
-        <translation type="unfinished">&amp;کپی</translation>
+        <translation type="unfinished">و کپی</translation>
     </message>
     <message>
         <source>C&amp;lose</source>
@@ -27,15 +27,15 @@
     </message>
     <message>
         <source>Delete the currently selected address from the list</source>
-        <translation>حذف نشانی‌های انتخابی از فهرست</translation>
+        <translation>حذف آدرس ‌انتخاب شده ی جاری از فهرست</translation>
     </message>
     <message>
         <source>Enter address or label to search</source>
-        <translation type="unfinished">نشانی یا برچسب را برای جستجو وارد کنید</translation>
+        <translation type="unfinished">آدرس یا برچسب را برای جستجو وارد کنید</translation>
     </message>
     <message>
         <source>Export the data in the current tab to a file</source>
-        <translation>خروجی گرفتن داده‌های برگه‌ی فعلی،به یک فایل</translation>
+        <translation>خروجی گرفتن داده‌ها از برگه ی کنونی در یک پوشه</translation>
     </message>
     <message>
         <source>&amp;Export</source>
@@ -44,14 +44,6 @@
     <message>
         <source>&amp;Delete</source>
         <translation>حذف</translation>
-    </message>
-    <message>
-        <source>Choose the address to send coins to</source>
-        <translation type="unfinished">آدرس برای ارسال کوین‌ها را انتخاب کنید</translation>
-    </message>
-    <message>
-        <source>Choose the address to receive coins with</source>
-        <translation type="unfinished">انتخاب آدرس جهت دریافت سکه‌ها با آن</translation>
     </message>
     <message>
         <source>C&amp;hoose</source>
@@ -259,10 +251,22 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>BitcoinApplication</name>
     <message>
+        <source>Runaway exception</source>
+        <translation type="unfinished">استثناء فراری (این استثناء نشان دهنده این است که هسته بیتکوین نتوانست چیزی را در کیف(والت) بنویسد.)</translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
+        <translation type="unfinished"> خطای تخریب کننده ای روی داده است.%1 نمیتواند بصورت ایمن ادامه پیدا کند و پایان می یابد.</translation>
+    </message>
+    <message>
         <source>Internal error</source>
         <translation type="unfinished">مشکل داخلی</translation>
     </message>
-    </context>
+    <message>
+        <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
+        <translation type="unfinished">یک ارور داخلی رخ داده است. %1 تلاش خواهد کرد تا با امنیت ادامه دهد. این یک باگ غیر منتظره است که میتواند به صورت شرح شده در زیر این متن گزارش شود.</translation>
+    </message>
+</context>
 <context>
     <name>QObject</name>
     <message>
@@ -272,6 +276,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Error: %1</source>
         <translation type="unfinished">خطا: %1</translation>
+    </message>
+    <message>
+        <source>%1 didn't yet exit safely…</source>
+        <translation type="unfinished">%1 هنوز به صورت ایمن بیرون نرفته است...</translation>
     </message>
     <message>
         <source>unknown</source>
@@ -284,6 +292,34 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Enter a Bitcoin address (e.g. %1)</source>
         <translation type="unfinished">آدرس بیت کوین را وارد کنید (به طور مثال %1)</translation>
+    </message>
+    <message>
+        <source>Unroutable</source>
+        <translation type="unfinished">غیرقابل برنامه ریزی</translation>
+    </message>
+    <message>
+        <source>Internal</source>
+        <translation type="unfinished">داخلی </translation>
+    </message>
+    <message>
+        <source>Full Relay</source>
+        <translation type="unfinished">رله کامل</translation>
+    </message>
+    <message>
+        <source>Block Relay</source>
+        <translation type="unfinished">رله بلوک</translation>
+    </message>
+    <message>
+        <source>Manual</source>
+        <translation type="unfinished">دستی </translation>
+    </message>
+    <message>
+        <source>Feeler</source>
+        <translation type="unfinished">دیده بان</translation>
+    </message>
+    <message>
+        <source>Address Fetch</source>
+        <translation type="unfinished">فهرست نشانی‌ها</translation>
     </message>
     <message>
         <source>%1 d</source>
@@ -316,31 +352,31 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation>
-            <numerusform />
+            <numerusform>%nثانیه</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n minute(s)</source>
         <translation>
-            <numerusform />
+            <numerusform>%nدقیقه</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n ساعت</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n روز</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n هفته</numerusform>
         </translation>
     </message>
     <message>
@@ -350,12 +386,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n سال</numerusform>
         </translation>
     </message>
     <message>
         <source>%1 B</source>
         <translation type="unfinished">%1 بایت</translation>
+    </message>
+    <message>
+        <source>%1 kB</source>
+        <translation type="unfinished">%1کیلوبایت</translation>
     </message>
     <message>
         <source>%1 MB</source>
@@ -419,10 +459,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
  </translation>
     </message>
     <message>
-        <source>Wallet:</source>
-        <translation type="unfinished">کیف پول:</translation>
-    </message>
-    <message>
         <source>Network activity disabled.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">فعالیت شبکه غیرفعال شد.</translation>
@@ -482,17 +518,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">تغییر عبارت عبور</translation>
     </message>
     <message>
+        <source>Sign &amp;message…</source>
+        <translation type="unfinished">ثبت &amp;پیام</translation>
+    </message>
+    <message>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation>پیام‌ها را با آدرس بیت‌کوین خود امضا کنید تا مالکیت آن‌ها را اثبات کنید</translation>
     </message>
     <message>
         <source>&amp;Verify message…</source>
         <translation type="unfinished">پیام تایید</translation>
-    </message>
-    <message>
-        <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
-        <translation>پیام ها را تأیید کنید تا مطمئن شوید با آدرس های مشخص شده بیت کوین امضا شده اند
- </translation>
     </message>
     <message>
         <source>&amp;Load PSBT from file…</source>
@@ -535,8 +570,28 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation>نوار ابزار</translation>
     </message>
     <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation type="unfinished">درحال همگام‌سازی هدرها (%1%)…</translation>
+    </message>
+    <message>
         <source>Synchronizing with network…</source>
         <translation type="unfinished">هماهنگ‌سازی با شبکه</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation type="unfinished">در حال شماره‌گذاری بلوکها روی دیسک...</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation type="unfinished">در حال پردازش بلوکها روی دیسک..</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation type="unfinished">در حال شماره‌گذاری دوباره بلوکها روی دیسک...</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation type="unfinished">در حال اتصال به همتاهای شبکه(پیِر ها)...</translation>
     </message>
     <message>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
@@ -557,12 +612,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation>
-            <numerusform />
+            <numerusform>%n بلاک از تاریخچه تراکنش، پردازش شد.</numerusform>
         </translation>
     </message>
     <message>
         <source>%1 behind</source>
         <translation>%1 قبل</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation type="unfinished">در حال گرفتن..</translation>
     </message>
     <message>
         <source>Last received block was generated %1 ago.</source>
@@ -659,13 +718,18 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n اتصال فعال به شبکه بیت کوین</numerusform>
         </translation>
     </message>
     <message>
         <source>Click for more actions.</source>
         <extracomment>A substring of the tooltip. "More actions" are available via the context menu.</extracomment>
         <translation type="unfinished">برای عملیات‌های بیشتر کلیک کنید.</translation>
+    </message>
+    <message>
+        <source>Show Peers tab</source>
+        <extracomment>A context menu item. The "Peers tab" is an element of the "Node window".</extracomment>
+        <translation type="unfinished">نمایش برگه همتایان </translation>
     </message>
     <message>
         <source>Disable network activity</source>
@@ -840,6 +904,22 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">تکثیر برچسب</translation>
     </message>
     <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">روگرفت م&amp;قدار</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">کپی شناسه تراکنش </translation>
+    </message>
+    <message>
+        <source>L&amp;ock unspent</source>
+        <translation type="unfinished">قفل کردن خرج نشده ها</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock unspent</source>
+        <translation type="unfinished">بازکردن قفل خرج نشده ها</translation>
+    </message>
+    <message>
         <source>Copy quantity</source>
         <translation type="unfinished">کپی مقدار</translation>
     </message>
@@ -1003,7 +1083,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Create</source>
         <translation type="unfinished">ایجاد</translation>
     </message>
-    </context>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">تدوین شده بدون حمایت از امضای خارجی (نیازمند امضای خارجی)</translation>
+    </message>
+</context>
 <context>
     <name>EditAddressDialog</name>
     <message>
@@ -1105,7 +1190,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>(برای بازیابی نسخه‌های پشتیبان %n روز نیاز است)</numerusform>
         </translation>
     </message>
     <message>
@@ -1131,6 +1216,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>As this is the first time the program is launched, you can choose where %1 will store its data.</source>
         <translation type="unfinished">از آنجا که اولین مرتبه این برنامه اجرا می‌شود، شما می‌توانید محل ذخیره داده‌های %1 را انتخاب نمایید.</translation>
+    </message>
+    <message>
+        <source>Limit block chain storage to</source>
+        <translation type="unfinished">محدود کن حافظه زنجیره بلوک را به</translation>
     </message>
     <message>
         <source> GB</source>
@@ -1251,6 +1340,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">اجرای خودکار %1 بعد زمان ورود به سیستم.</translation>
     </message>
     <message>
+        <source>Enabling pruning significantly reduces the disk space required to store transactions. All blocks are still fully validated. Reverting this setting requires re-downloading the entire blockchain.</source>
+        <translation type="unfinished">فعال کردن هرس به طور قابل توجهی فضای دیسک مورد نیاز برای ذخیره تراکنش ها را کاهش می دهد.  همه بلوک ها هنوز به طور کامل تأیید شده اند.  برای برگرداندن این تنظیم نیاز به بارگیری مجدد کل بلاک چین است.</translation>
+    </message>
+    <message>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished">اندازه کش پایگاه داده.</translation>
     </message>
@@ -1296,12 +1389,21 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">مسیر اسکریپت امضاکنندهٔ جانبی</translation>
     </message>
     <message>
+        <source>Full path to a Bitcoin Core compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</source>
+        <translation type="unfinished">نشانی کامل اسکریپ تطابق پذیر هسته بیتکوین
+ (مثال: C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). آگاه باش: بدافزار میتواند سکه های شما را بدزد!</translation>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation>باز کردن خودکار درگاه شبکهٔ بیت‌کوین روی روترها. تنها زمانی کار می‌کند که روتر از پروتکل UPnP پشتیبانی کند و این پروتکل فعال باشد.</translation>
     </message>
     <message>
         <source>Map port using &amp;UPnP</source>
         <translation>نگاشت درگاه شبکه با استفاده از پروتکل &amp;UPnP</translation>
+    </message>
+    <message>
+        <source>Automatically open the Bitcoin client port on the router. This only works when your router supports NAT-PMP and it is enabled. The external port could be random.</source>
+        <translation type="unfinished">باز کردن خودکار درگاه شبکهٔ بیت‌کوین روی روتر. این پروسه تنها زمانی کار می‌کند که روتر از پروتکل NAT-PMP  پشتیبانی کند و این پروتکل فعال باشد. پورت خارجی میتواند تصادفی باشد </translation>
     </message>
     <message>
         <source>Map port using NA&amp;T-PMP</source>
@@ -1388,12 +1490,29 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">URLهای تراکنش شخص ثالث</translation>
     </message>
     <message>
+        <source>Monospaced font in the Overview tab:</source>
+        <translation type="unfinished">فونت تک فضا(منو اسپیس) در برگه مرور کلی </translation>
+    </message>
+    <message>
+        <source>embedded "%1"</source>
+        <translation type="unfinished">تعبیه شده%1</translation>
+    </message>
+    <message>
+        <source>closest matching "%1"</source>
+        <translation type="unfinished">%1نزدیک ترین تطابق</translation>
+    </message>
+    <message>
         <source>&amp;OK</source>
         <translation>تایید</translation>
     </message>
     <message>
         <source>&amp;Cancel</source>
         <translation>لغو</translation>
+    </message>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">تدوین شده بدون حمایت از امضای خارجی (نیازمند امضای خارجی)</translation>
     </message>
     <message>
         <source>default</source>
@@ -1526,6 +1645,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">کپی کردن</translation>
     </message>
     <message>
+        <source>Save…</source>
+        <translation type="unfinished">ذخیره ...</translation>
+    </message>
+    <message>
         <source>Close</source>
         <translation type="unfinished">بستن</translation>
     </message>
@@ -1538,12 +1661,21 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">ذخیره اطلاعات عملیات</translation>
     </message>
     <message>
+        <source>Partially Signed Transaction (Binary)</source>
+        <extracomment>Expanded name of the binary PSBT file format. See: BIP 174.</extracomment>
+        <translation type="unfinished">تراکنش نسبتا امضا شده (باینری)</translation>
+    </message>
+    <message>
         <source>Total Amount</source>
         <translation type="unfinished">میزان کل</translation>
     </message>
     <message>
         <source>or</source>
         <translation type="unfinished">یا</translation>
+    </message>
+    <message>
+        <source>Transaction has %1 unsigned inputs.</source>
+        <translation type="unfinished">%1Transaction has  unsigned inputs.</translation>
     </message>
     <message>
         <source>Transaction still needs signature(s).</source>
@@ -1575,6 +1707,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">مدیریت URI</translation>
     </message>
     <message>
+        <source>Cannot process payment request because BIP70 is not supported.
+Due to widespread security flaws in BIP70 it's strongly recommended that any merchant instructions to switch wallets be ignored.
+If you are receiving this error you should request the merchant provide a BIP21 compatible URI.</source>
+        <translation type="unfinished">نمی توان درخواست پرداخت را پردازش کرد زیرا BIP70 پشتیبانی نمی شود. به دلیل نقص های امنیتی گسترده در BIP70، اکیداً توصیه می شود که هر دستورالعمل فروشنده برای تغییر کیف پول نادیده گرفته شود. اگر این خطا را دریافت می کنید، باید از فروشنده درخواست کنید که یک URI سازگار با BIP21 ارائه دهد.</translation>
+    </message>
+    <message>
         <source>Payment request file handling</source>
         <translation type="unfinished">درحال پردازش درخواست پرداخت</translation>
     </message>
@@ -1590,6 +1728,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Ping</source>
         <extracomment>Title of Peers Table column which indicates the current latency of the connection with the peer.</extracomment>
         <translation type="unfinished">پینگ</translation>
+    </message>
+    <message>
+        <source>Peer</source>
+        <extracomment>Title of Peers Table column which contains a unique number used to identify a connection.</extracomment>
+        <translation type="unfinished">همتا </translation>
     </message>
     <message>
         <source>Sent</source>
@@ -1620,6 +1763,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>QRImageWidget</name>
     <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">&amp;ذخیره کردن تصویر...</translation>
+    </message>
+    <message>
         <source>&amp;Copy Image</source>
         <translation type="unfinished">&amp;کپی کردن image</translation>
     </message>
@@ -1639,7 +1786,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Save QR Code</source>
         <translation type="unfinished">ذحیره کردن Qr Code</translation>
     </message>
-    </context>
+    <message>
+        <source>PNG Image</source>
+        <extracomment>Expanded name of the PNG file format. See https://en.wikipedia.org/wiki/Portable_Network_Graphics</extracomment>
+        <translation type="unfinished">عکس PNG</translation>
+    </message>
+</context>
 <context>
     <name>RPCConsole</name>
     <message>
@@ -1769,12 +1921,52 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">افزایش دادن اندازه فونت</translation>
     </message>
     <message>
+        <source>Direction/Type</source>
+        <translation type="unfinished">مسیر/نوع </translation>
+    </message>
+    <message>
+        <source>The network protocol this peer is connected through: IPv4, IPv6, Onion, I2P, or CJDNS.</source>
+        <translation type="unfinished">پروتکل شبکه در این همتا از طریق:IPv4, IPv6, Onion, I2P, or CJDNS متصل است.</translation>
+    </message>
+    <message>
         <source>Services</source>
         <translation type="unfinished">خدمات</translation>
     </message>
     <message>
+        <source>Whether the peer requested us to relay transactions.</source>
+        <translation type="unfinished">اینکه آیا همتا از ما درخواست کرده است که تراکنش‌ها را رله کنیم.</translation>
+    </message>
+    <message>
+        <source>Wants Tx Relay</source>
+        <translation type="unfinished">رله Tx می خواهد</translation>
+    </message>
+    <message>
+        <source>High bandwidth BIP152 compact block relay: %1</source>
+        <translation type="unfinished">رله بلوک فشرده BIP152 با پهنای باند بالا: %1</translation>
+    </message>
+    <message>
+        <source>High Bandwidth</source>
+        <translation type="unfinished">پهنای باند بالا</translation>
+    </message>
+    <message>
         <source>Connection Time</source>
         <translation type="unfinished">زمان اتصال</translation>
+    </message>
+    <message>
+        <source>Elapsed time since a novel block passing initial validity checks was received from this peer.</source>
+        <translation type="unfinished">زمان سپری شده از زمان دریافت یک بلوک جدید که بررسی‌های اعتبار اولیه را از این همتا دریافت کرده است.</translation>
+    </message>
+    <message>
+        <source>Last Block</source>
+        <translation type="unfinished">بلوک قبلی</translation>
+    </message>
+    <message>
+        <source>Elapsed time since a novel transaction accepted into our mempool was received from this peer.</source>
+        <translation type="unfinished">زمان سپری شده از زمانی که یک تراکنش جدید در مجموعه ما از این همتا دریافت شده است.</translation>
+    </message>
+    <message>
+        <source>Last Tx</source>
+        <translation type="unfinished">آخرین Tx</translation>
     </message>
     <message>
         <source>Last Send</source>
@@ -1833,12 +2025,72 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">خارج شده:</translation>
     </message>
     <message>
+        <source>Inbound: initiated by peer</source>
+        <translation type="unfinished">ورودی: توسط همتا آغاز شد</translation>
+    </message>
+    <message>
+        <source>Outbound Full Relay: default</source>
+        <translation type="unfinished">خروجی کامل رله : پیش فرض</translation>
+    </message>
+    <message>
+        <source>Outbound Block Relay: does not relay transactions or addresses</source>
+        <translation type="unfinished">رله بلوک خروجی: تراکنش ها یا آدرس ها را انتقال نمی دهد</translation>
+    </message>
+    <message>
+        <source>Outbound Manual: added using RPC %1 or %2/%3 configuration options</source>
+        <translation type="unfinished">راهنمای خروجی: با استفاده از گزینه های پیکربندی RPC %1 یا %2/%3 اضافه شده است</translation>
+    </message>
+    <message>
+        <source>Outbound Feeler: short-lived, for testing addresses</source>
+        <translation type="unfinished">حسگر خروجی: کوتاه مدت، برای آزمایش آدرس ها</translation>
+    </message>
+    <message>
+        <source>Outbound Address Fetch: short-lived, for soliciting addresses</source>
+        <translation type="unfinished">واکشی آدرس خروجی: کوتاه مدت، برای درخواست آدرس</translation>
+    </message>
+    <message>
+        <source>we selected the peer for high bandwidth relay</source>
+        <translation type="unfinished">ما همتا را برای رله با پهنای باند بالا انتخاب کردیم</translation>
+    </message>
+    <message>
+        <source>the peer selected us for high bandwidth relay</source>
+        <translation type="unfinished">همتا ما را برای رله با پهنای باند بالا انتخاب کرد</translation>
+    </message>
+    <message>
+        <source>no high bandwidth relay selected</source>
+        <translation type="unfinished">رله با پهنای باند بالا انتخاب نشده است</translation>
+    </message>
+    <message>
+        <source>Ctrl++</source>
+        <extracomment>Main shortcut to increase the RPC console font size.</extracomment>
+        <translation type="unfinished">Ctrl + +</translation>
+    </message>
+    <message>
+        <source>Ctrl+=</source>
+        <extracomment>Secondary shortcut to increase the RPC console font size.</extracomment>
+        <translation type="unfinished">Ctrl + =</translation>
+    </message>
+    <message>
+        <source>Ctrl+-</source>
+        <extracomment>Main shortcut to decrease the RPC console font size.</extracomment>
+        <translation type="unfinished">Ctrl + -</translation>
+    </message>
+    <message>
+        <source>Ctrl+_</source>
+        <extracomment>Secondary shortcut to decrease the RPC console font size.</extracomment>
+        <translation type="unfinished">Ctrl + _</translation>
+    </message>
+    <message>
         <source>&amp;Disconnect</source>
         <translation type="unfinished">&amp;قطع شدن</translation>
     </message>
     <message>
         <source>1 &amp;hour</source>
         <translation type="unfinished">1 &amp;ساعت</translation>
+    </message>
+    <message>
+        <source>1 d&amp;ay</source>
+        <translation type="unfinished">1 روز</translation>
     </message>
     <message>
         <source>1 &amp;week</source>
@@ -1855,6 +2107,15 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Network activity disabled</source>
         <translation type="unfinished">فعالیت شبکه غیر فعال شد</translation>
+    </message>
+    <message>
+        <source>Executing…</source>
+        <extracomment>A console message indicating an entered command is currently being executed.</extracomment>
+        <translation type="unfinished">در حال اجرا...</translation>
+    </message>
+    <message>
+        <source>(peer: %1)</source>
+        <translation type="unfinished">(همتا: %1)</translation>
     </message>
     <message>
         <source>Yes</source>
@@ -1875,6 +2136,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Ban for</source>
         <translation type="unfinished">بن یا بن شده برای</translation>
+    </message>
+    <message>
+        <source>Never</source>
+        <translation type="unfinished">هرگز</translation>
     </message>
     <message>
         <source>Unknown</source>
@@ -1972,12 +2237,24 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">تکثیر برچسب</translation>
     </message>
     <message>
+        <source>Copy &amp;message</source>
+        <translation type="unfinished">کپی &amp;پیام </translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">روگرفت مقدار</translation>
+    </message>
+    <message>
         <source>Could not unlock wallet.</source>
         <translation type="unfinished">نمیتوان کیف پول را باز کرد.</translation>
     </message>
     </context>
 <context>
     <name>ReceiveRequestDialog</name>
+    <message>
+        <source>Request payment to …</source>
+        <translation type="unfinished">درخواست پرداخت به </translation>
+    </message>
     <message>
         <source>Address:</source>
         <translation type="unfinished">آدرس‌ها:</translation>
@@ -2005,6 +2282,18 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Copy &amp;Address</source>
         <translation type="unfinished">کپی آدرس</translation>
+    </message>
+    <message>
+        <source>&amp;Verify</source>
+        <translation type="unfinished">&amp;تایید کردن</translation>
+    </message>
+    <message>
+        <source>Verify this address on e.g. a hardware wallet screen</source>
+        <translation type="unfinished">این آدرس را در صفحه کیف پول سخت افزاری تأیید کنید</translation>
+    </message>
+    <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">&amp;ذخیره کردن تصویر...</translation>
     </message>
     <message>
         <source>Payment information</source>
@@ -2130,12 +2419,32 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">پاک کردن تمامی گزینه های این فرم</translation>
     </message>
     <message>
+        <source>Inputs…</source>
+        <translation type="unfinished">ورودی ها</translation>
+    </message>
+    <message>
         <source>Dust:</source>
         <translation type="unfinished">گرد و غبار یا داست:</translation>
     </message>
     <message>
+        <source>Choose…</source>
+        <translation type="unfinished">انتخاب کنید...</translation>
+    </message>
+    <message>
         <source>Hide transaction fee settings</source>
         <translation type="unfinished">تنظیمات مخفی کردن کارمزد عملیات</translation>
+    </message>
+    <message>
+        <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
+
+Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satoshis per kvB" for a transaction size of 500 virtual bytes (half of 1 kvB) would ultimately yield a fee of only 50 satoshis.</source>
+        <translation type="unfinished">مشخص کردن هزینه کارمزد مخصوص به ازای کیلوبایت(1,000 بایت) حجم مجازی تراکنش
+
+توجه: از آن جایی که کارمزد بر اساس هر بایت محاسبه می شود,هزینه کارمزد"100 ساتوشی بر کیلو بایت"برای تراکنش با حجم 500 بایت مجازی (نصف 1 کیلوبایت) کارمزد فقط اندازه 50 ساتوشی خواهد بود.</translation>
+    </message>
+    <message>
+        <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
+        <translation type="unfinished">(مقداردهی کارمزد هوشمند هنوز شروع نشده است.این کارمزد معمولا به اندازه چند بلاک طول میکشد...)</translation>
     </message>
     <message>
         <source>Confirmation time target:</source>
@@ -2199,6 +2508,20 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">%1(%2 بلاک ها)</translation>
     </message>
     <message>
+        <source>Sign on device</source>
+        <extracomment>"device" usually means a hardware wallet</extracomment>
+        <translation type="unfinished">امضا کردن در دستگاه</translation>
+    </message>
+    <message>
+        <source>Connect your hardware wallet first.</source>
+        <translation type="unfinished">اول کیف سخت افزاری خود را متصل کنید.</translation>
+    </message>
+    <message>
+        <source>Set external signer script path in Options -&gt; Wallet</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">مسیر اسکریپت امضاکننده خارجی را در Options -&gt; Wallet تنظیم کنید</translation>
+    </message>
+    <message>
         <source>%1 to %2</source>
         <translation type="unfinished">%1 به %2</translation>
     </message>
@@ -2207,12 +2530,39 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">آیا برای ارسال کردن یا فرستادن مطمئن هستید؟</translation>
     </message>
     <message>
+        <source>To review recipient list click "Show Details…"</source>
+        <translation type="unfinished">برای بررسی لیست گیرندگان، روی «نمایش جزئیات…» کلیک کنید.</translation>
+    </message>
+    <message>
+        <source>Sign and send</source>
+        <translation type="unfinished">امضا و ارسال</translation>
+    </message>
+    <message>
         <source>Sign failed</source>
         <translation type="unfinished">امضا موفق نبود</translation>
     </message>
     <message>
+        <source>External signer not found</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">امضا کننده خارجی یافت نشد</translation>
+    </message>
+    <message>
+        <source>External signer failure</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">امضا کننده خارجی شکست خورد.</translation>
+    </message>
+    <message>
         <source>Save Transaction Data</source>
         <translation type="unfinished">ذخیره اطلاعات عملیات</translation>
+    </message>
+    <message>
+        <source>Partially Signed Transaction (Binary)</source>
+        <extracomment>Expanded name of the binary PSBT file format. See: BIP 174.</extracomment>
+        <translation type="unfinished">تراکنش نسبتا امضا شده (باینری)</translation>
+    </message>
+    <message>
+        <source>External balance:</source>
+        <translation type="unfinished">تعادل خارجی </translation>
     </message>
     <message>
         <source>or</source>
@@ -2279,7 +2629,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation>
-            <numerusform />
+            <numerusform>تخمین زده می شود که تأیید در بلوک ها %n آغاز شود.</numerusform>
         </translation>
     </message>
     <message>
@@ -2499,11 +2849,18 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
 </context>
 <context>
+    <name>TrafficGraphWidget</name>
+    <message>
+        <source>kB/s</source>
+        <translation type="unfinished">کیلوبایت بر ثانیه</translation>
+    </message>
+</context>
+<context>
     <name>TransactionDesc</name>
     <message numerus="yes">
         <source>Open for %n more block(s)</source>
         <translation>
-            <numerusform />
+            <numerusform>برای %n بلوک های بیشتر باز کنید</numerusform>
         </translation>
     </message>
     <message>
@@ -2569,7 +2926,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation>
-            <numerusform />
+            <numerusform>در %n بلوک بیشتری بالغ می شود</numerusform>
         </translation>
     </message>
     <message>
@@ -2666,7 +3023,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>Open for %n more block(s)</source>
         <translation>
-            <numerusform />
+            <numerusform>برای %n بلوک بیشتر باز کنید</numerusform>
         </translation>
     </message>
     <message>
@@ -2793,12 +3150,48 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">حداقل میزان وجه</translation>
     </message>
     <message>
+        <source>Range…</source>
+        <translation type="unfinished">بازه:</translation>
+    </message>
+    <message>
         <source>&amp;Copy address</source>
         <translation type="unfinished">تکثیر نشانی</translation>
     </message>
     <message>
         <source>Copy &amp;label</source>
         <translation type="unfinished">تکثیر برچسب</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">روگرفت مقدار</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">کپی شناسه تراکنش </translation>
+    </message>
+    <message>
+        <source>Copy &amp;raw transaction</source>
+        <translation type="unfinished">معامله اولیه را کپی نمائید.</translation>
+    </message>
+    <message>
+        <source>Copy full transaction &amp;details</source>
+        <translation type="unfinished">کپی کردن تمامی اطلاعات تراکنش</translation>
+    </message>
+    <message>
+        <source>&amp;Show transaction details</source>
+        <translation type="unfinished">نمایش جزئیات تراکنش</translation>
+    </message>
+    <message>
+        <source>Increase transaction &amp;fee</source>
+        <translation type="unfinished">افزایش کارمزد تراکنش</translation>
+    </message>
+    <message>
+        <source>A&amp;bandon transaction</source>
+        <translation type="unfinished">ترک معامله</translation>
+    </message>
+    <message>
+        <source>&amp;Edit address label</source>
+        <translation type="unfinished">&amp;ویرایش برچسب آدرس</translation>
     </message>
     <message>
         <source>Export Transaction History</source>
@@ -2889,12 +3282,20 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">کارمزد جدید:</translation>
     </message>
     <message>
+        <source>Warning: This may pay the additional fee by reducing change outputs or adding inputs, when necessary. It may add a new change output if one does not already exist. These changes may potentially leak privacy.</source>
+        <translation type="unfinished">هشدار: ممکن است در صورت لزوم، با کاهش خروجی تغییر یا افزودن ورودی‌ها، هزینه اضافی را پرداخت کنید.  اگر از قبل وجود نداشته باشد، ممکن است یک خروجی تغییر جدید اضافه کند.  این تغییرات ممکن است به طور بالقوه حریم خصوصی را درز کند.</translation>
+    </message>
+    <message>
         <source>PSBT copied</source>
         <translation type="unfinished">PSBT کپی شد</translation>
     </message>
     <message>
         <source>Can't sign transaction.</source>
         <translation type="unfinished">نمیتوان تراکنش را ثبت کرد</translation>
+    </message>
+    <message>
+        <source>Can't display address</source>
+        <translation type="unfinished">نمی توان آدرس را نشان داد</translation>
     </message>
     <message>
         <source>default wallet</source>
@@ -2922,6 +3323,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
  </translation>
     </message>
     <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">داده های کیف پول</translation>
+    </message>
+    <message>
         <source>Backup Failed</source>
         <translation type="unfinished">پشتیبان گیری انجام نشد
  </translation>
@@ -2943,6 +3349,46 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">%s توسعه دهندگان</translation>
     </message>
     <message>
+        <source>Cannot downgrade wallet from version %i to version %i. Wallet version unchanged.</source>
+        <translation type="unfinished">نمی توان کیف پول را از نسخه %i به نسخه %i کاهش داد.  نسخه کیف پول بدون تغییر</translation>
+    </message>
+    <message>
+        <source>Cannot upgrade a non HD split wallet from version %i to version %i without upgrading to support pre-split keypool. Please use version %i or no version specified.</source>
+        <translation type="unfinished">نمی توان یک کیف پول تقسیم غیر HD را از نسخه %i به نسخه %i بدون ارتقا برای پشتیبانی از دسته کلید از پیش تقسیم ارتقا داد.  لطفا از نسخه %i یا بدون نسخه مشخص شده استفاده کنید.</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile format record is incorrect. Got "%s", expected "format".</source>
+        <translation type="unfinished">خطا: رکورد قالب Dumpfile نادرست است.  دریافت شده، "%s" "مورد انتظار".</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile identifier record is incorrect. Got "%s", expected "%s".</source>
+        <translation type="unfinished">خطا: رکورد شناسه Dumpfile نادرست است. دریافت "%s"، انتظار می رود "%s".</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile version is not supported. This version of bitcoin-wallet only supports version 1 dumpfiles. Got dumpfile with version %s</source>
+        <translation type="unfinished">خطا: نسخه Dumpfile پشتیبانی نمی شود.  این نسخه کیف پول بیت کوین فقط از فایل های dumpfiles نسخه 1 پشتیبانی می کند.  Dumpfile با نسخه %s دریافت شد</translation>
+    </message>
+    <message>
+        <source>Error: Legacy wallets only support the "legacy", "p2sh-segwit", and "bech32" address types</source>
+        <translation type="unfinished">خطا: کیف پول های قدیمی فقط از انواع آدرس "legacy"، "p2sh-segwit" و "bech32" پشتیبانی می کنند.</translation>
+    </message>
+    <message>
+        <source>File %s already exists. If you are sure this is what you want, move it out of the way first.</source>
+        <translation type="unfinished">فایل %s از قبل موجود میباشد.  اگر مطمئن هستید که این همان چیزی است که می خواهید، ابتدا آن را از مسیر خارج کنید.</translation>
+    </message>
+    <message>
+        <source>No dump file provided. To use createfromdump, -dumpfile=&lt;filename&gt; must be provided.</source>
+        <translation type="unfinished">هیچ فایل دامپی ارائه نشده است.  برای استفاده از createfromdump، باید -dumpfile=&lt;filename&gt; ارائه شود.</translation>
+    </message>
+    <message>
+        <source>No dump file provided. To use dump, -dumpfile=&lt;filename&gt; must be provided.</source>
+        <translation type="unfinished">هیچ فایل دامپی ارائه نشده است.  برای استفاده از dump، -dumpfile=&lt;filename&gt; باید ارائه شود.</translation>
+    </message>
+    <message>
+        <source>No wallet file format provided. To use createfromdump, -format=&lt;format&gt; must be provided.</source>
+        <translation type="unfinished">هیچ فرمت فایل کیف پول ارائه نشده است. برای استفاده از createfromdump باید -format=&lt;format&gt; ارائه شود.</translation>
+    </message>
+    <message>
         <source>Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of pruned node)</source>
         <translation type="unfinished">هرس: آخرین هماهنگی کیف پول فراتر از داده های هرس شده است. شما باید دوباره -exe کنید (در صورت گره هرس شده دوباره کل بلاکچین را بارگیری کنید)
  </translation>
@@ -2961,6 +3407,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">این است هزینه معامله ممکن است پرداخت چه زمانی هزینه تخمین در دسترس نیست</translation>
     </message>
     <message>
+        <source>Unknown wallet file format "%s" provided. Please provide one of "bdb" or "sqlite".</source>
+        <translation type="unfinished">فرمت فایل کیف پول ناشناخته "%s" ارائه شده است.  لطفا یکی از "bdb" یا "sqlite" را ارائه دهید.</translation>
+    </message>
+    <message>
+        <source>Warning: Dumpfile wallet format "%s" does not match command line specified format "%s".</source>
+        <translation type="unfinished">هشدار: قالب کیف پول Dumpfile "%s" با فرمت مشخص شده خط فرمان %s مطابقت ندارد.</translation>
+    </message>
+    <message>
         <source>Warning: Private keys detected in wallet {%s} with disabled private keys</source>
         <translation type="unfinished">هشدار: کلید های خصوصی در کیف پول شما شناسایی شده است { %s} به همراه کلید های خصوصی غیر فعال</translation>
     </message>
@@ -2968,6 +3422,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished">هشدار: به نظر نمی رسد ما کاملاً با همسالان خود موافق هستیم! ممکن است به ارتقا نیاز داشته باشید یا گره های دیگر به ارتقا نیاز دارند.
  </translation>
+    </message>
+    <message>
+        <source>Witness data for blocks after height %d requires validation. Please restart with -reindex.</source>
+        <translation type="unfinished">داده‌های شاهد برای بلوک‌ها پس از ارتفاع %d نیاز به اعتبارسنجی دارند.  لطفا با -reindex دوباره راه اندازی کنید.</translation>
     </message>
     <message>
         <source>%s is set very high!</source>
@@ -3002,6 +3460,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">فایل زبالهٔ %s وجود ندارد.</translation>
     </message>
     <message>
+        <source>Error creating %s</source>
+        <translation type="unfinished">خطا در ایجاد %s</translation>
+    </message>
+    <message>
         <source>Error initializing block database</source>
         <translation type="unfinished">خطا در آماده سازی پایگاه داده ی بلوک</translation>
     </message>
@@ -3022,8 +3484,44 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">خواندن از پایگاه داده با خطا مواجه شد,در حال خاموش شدن.</translation>
     </message>
     <message>
+        <source>Error reading next record from wallet database</source>
+        <translation type="unfinished">خطا در خواندن رکورد بعدی از پایگاه داده کیف پول</translation>
+    </message>
+    <message>
         <source>Error upgrading chainstate database</source>
         <translation type="unfinished">خطا در بارگذاری پایگاه داده ها</translation>
+    </message>
+    <message>
+        <source>Error: Couldn't create cursor into database</source>
+        <translation type="unfinished">خطا: مکان نما در پایگاه داده ایجاد نشد</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile checksum does not match. Computed %s, expected %s</source>
+        <translation type="unfinished">خطا: جمع چکی Dumpfile مطابقت ندارد.  محاسبه شده %s، مورد انتظار %s.</translation>
+    </message>
+    <message>
+        <source>Error: Got key that was not hex: %s</source>
+        <translation type="unfinished">خطا: کلیدی دریافت کردم که هگز نبود: %s</translation>
+    </message>
+    <message>
+        <source>Error: Got value that was not hex: %s</source>
+        <translation type="unfinished">خطا: مقداری دریافت کردم که هگز نبود: %s</translation>
+    </message>
+    <message>
+        <source>Error: Missing checksum</source>
+        <translation type="unfinished">خطا: جمع چک وجود ندارد</translation>
+    </message>
+    <message>
+        <source>Error: No %s addresses available.</source>
+        <translation type="unfinished">خطا : هیچ آدرس %s وجود ندارد.</translation>
+    </message>
+    <message>
+        <source>Error: Unable to parse version %u as a uint32_t</source>
+        <translation type="unfinished">خطا: تجزیه نسخه %u به عنوان uint32_t ممکن نیست</translation>
+    </message>
+    <message>
+        <source>Error: Unable to write record to new wallet</source>
+        <translation type="unfinished">خطا: نوشتن رکورد در کیف پول جدید امکان پذیر نیست</translation>
     </message>
     <message>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
@@ -3035,8 +3533,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
  </translation>
     </message>
     <message>
+        <source>Importing…</source>
+        <translation type="unfinished">در حال واردات…</translation>
+    </message>
+    <message>
         <source>Insufficient funds</source>
         <translation type="unfinished">وجوه ناکافی</translation>
+    </message>
+    <message>
+        <source>Invalid -i2psam address or hostname: '%s'</source>
+        <translation type="unfinished">آدرس -i2psam یا نام میزبان نامعتبر است: '%s'</translation>
     </message>
     <message>
         <source>Invalid -proxy address or hostname: '%s'</source>
@@ -3047,16 +3553,56 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">میزان نامعتبر برای  -%s=&lt;amount&gt;: '%s'</translation>
     </message>
     <message>
+        <source>Loading P2P addresses…</source>
+        <translation type="unfinished">در حال بارگیری آدرس‌های P2P…</translation>
+    </message>
+    <message>
+        <source>Loading banlist…</source>
+        <translation type="unfinished">در حال بارگیری فهرست ممنوعه…</translation>
+    </message>
+    <message>
+        <source>Loading block index…</source>
+        <translation type="unfinished">در حال بارگیری فهرست بلوک…</translation>
+    </message>
+    <message>
+        <source>Loading wallet…</source>
+        <translation type="unfinished">در حال بارگیری کیف پول…</translation>
+    </message>
+    <message>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished">توصیفگرهای فایل به اندازه کافی در دسترس نیست</translation>
+    </message>
+    <message>
+        <source>Prune mode is incompatible with -coinstatsindex.</source>
+        <translation type="unfinished">حالت Prune با -coinstatsindex ناسازگار است.</translation>
+    </message>
+    <message>
+        <source>Pruning blockstore…</source>
+        <translation type="unfinished">هرس بلوک فروشی…</translation>
+    </message>
+    <message>
+        <source>Replaying blocks…</source>
+        <translation type="unfinished">در حال پخش مجدد بلوک ها…</translation>
+    </message>
+    <message>
+        <source>Rescanning…</source>
+        <translation type="unfinished">در حال اسکن مجدد…</translation>
     </message>
     <message>
         <source>Signing transaction failed</source>
         <translation type="unfinished">ثبت تراکنش با خطا مواجه شد</translation>
     </message>
     <message>
+        <source>Starting network threads…</source>
+        <translation type="unfinished">شروع رشته های شبکه…</translation>
+    </message>
+    <message>
         <source>The source code is available from %s.</source>
         <translation type="unfinished">سورس کد موجود است از %s.</translation>
+    </message>
+    <message>
+        <source>The specified config file %s does not exist</source>
+        <translation type="unfinished">فایل پیکربندی مشخص شده %s وجود ندارد</translation>
     </message>
     <message>
         <source>The transaction amount is too small to pay the fee</source>
@@ -3100,6 +3646,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">تراکنش باید حداقل یک دریافت کننده داشته باشد</translation>
     </message>
     <message>
+        <source>Transaction needs a change address, but we can't generate it. %s</source>
+        <translation type="unfinished">تراکنش به آدرس تغییر نیاز دارد، اما ما نمی‌توانیم آن را ایجاد کنیم. %s</translation>
+    </message>
+    <message>
         <source>Transaction too large</source>
         <translation type="unfinished">حجم تراکنش خیلی زیاد است</translation>
     </message>
@@ -3112,6 +3662,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">نمیتوان کلید ها را تولید کرد</translation>
     </message>
     <message>
+        <source>Unable to open %s for writing</source>
+        <translation type="unfinished">برای نوشتن %s باز نمی شود</translation>
+    </message>
+    <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
         <translation type="unfinished">سرور HTTP راه اندازی نمی شود. برای جزئیات به گزارش اشکال زدایی مراجعه کنید.
  </translation>
@@ -3121,12 +3675,24 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">شبکه مشخص شده غیرقابل شناسایی در onlynet: '%s'</translation>
     </message>
     <message>
+        <source>Unknown new rules activated (versionbit %i)</source>
+        <translation type="unfinished">قوانین جدید ناشناخته فعال شد (‌%iversionbit)</translation>
+    </message>
+    <message>
         <source>Upgrading UTXO database</source>
         <translation type="unfinished">ارتقا دادن پایگاه داده UTXO</translation>
     </message>
     <message>
         <source>Upgrading txindex database</source>
         <translation type="unfinished">ارتقا دادن پایگاه داده اندیس تراکنش ها یا txindex</translation>
+    </message>
+    <message>
+        <source>Verifying blocks…</source>
+        <translation type="unfinished">در حال تأیید بلوک‌ها…</translation>
+    </message>
+    <message>
+        <source>Verifying wallet(s)…</source>
+        <translation type="unfinished">در حال تأیید کیف ها…</translation>
     </message>
     </context>
 </TS>

--- a/src/qt/locale/bitcoin_fi.ts
+++ b/src/qt/locale/bitcoin_fi.ts
@@ -327,36 +327,36 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation>
-            <numerusform />
-            <numerusform />
+            <numerusform>%n sekunti</numerusform>
+            <numerusform>%n sekuntia</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n minute(s)</source>
         <translation>
-            <numerusform />
-            <numerusform />
+            <numerusform>%n minuutti</numerusform>
+            <numerusform>%n minuuttia</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n tunti</numerusform>
+            <numerusform>%n tuntia</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n päivä</numerusform>
+            <numerusform>%n päivää</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n viikko</numerusform>
+            <numerusform>%n viikkoa</numerusform>
         </translation>
     </message>
     <message>
@@ -366,8 +366,8 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%nvuosi</numerusform>
+            <numerusform>%n vuotta</numerusform>
         </translation>
     </message>
     </context>
@@ -705,8 +705,8 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n aktiivinen yhteys Bitcoin-verkkoon.</numerusform>
+            <numerusform>%n aktiivista yhteyttä Bitcoin-verkkoon.</numerusform>
         </translation>
     </message>
     <message>
@@ -1075,7 +1075,12 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
         <source>Compiled without sqlite support (required for descriptor wallets)</source>
         <translation type="unfinished">Koostettu ilman sqlite-tukea (vaaditaan descriptor-lompakoille)</translation>
     </message>
-    </context>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Käännetään ilman ulkoista allekirjoitustukea (tarvitaan ulkoista allekirjoitusta varten)</translation>
+    </message>
+</context>
 <context>
     <name>EditAddressDialog</name>
     <message>
@@ -1444,6 +1449,10 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
         <translation type="unfinished">Ulkopuolinen allekirjoittaja (esim. laitelompakko)</translation>
     </message>
     <message>
+        <source>Full path to a Bitcoin Core compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</source>
+        <translation type="unfinished">Koko polku Bitcoin Core -yhteensopivaan skriptiin (esim. C:\Downloads\hwi.exe tai /Users/you/Downloads/hwi.py). Varo: haittaohjelma voi varastaa kolikkosi!</translation>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation>Avaa Bitcoin-asiakasohjelman portti reitittimellä automaattisesti. Tämä toimii vain, jos reitittimesi tukee UPnP:tä ja se on käytössä.</translation>
     </message>
@@ -1570,6 +1579,11 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
     <message>
         <source>&amp;Cancel</source>
         <translation>&amp;Peruuta</translation>
+    </message>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Käännetään ilman ulkoista allekirjoitustukea (tarvitaan ulkoista allekirjoitusta varten)</translation>
     </message>
     <message>
         <source>default</source>
@@ -2634,6 +2648,11 @@ Jos saat tämän virheen, pyydä kauppiasta antamaan BIP21-yhteensopiva URI.</tr
         <translation type="unfinished">Yhdistä lompakkolaitteesi ensin.</translation>
     </message>
     <message>
+        <source>Set external signer script path in Options -&gt; Wallet</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Aseta ulkoisen allekirjoittajan skriptipolku kohdassa Asetukset -&gt; Lompakko</translation>
+    </message>
+    <message>
         <source>Cr&amp;eate Unsigned</source>
         <translation type="unfinished">L&amp;uo allekirjoittamaton</translation>
     </message>
@@ -3010,8 +3029,8 @@ Jos saat tämän virheen, pyydä kauppiasta antamaan BIP21-yhteensopiva URI.</tr
     <message numerus="yes">
         <source>Open for %n more block(s)</source>
         <translation>
-            <numerusform />
-            <numerusform />
+            <numerusform>Avoinna vielä %n lohkon ajan</numerusform>
+            <numerusform>Avoinna vielä %n lohkon ajan</numerusform>
         </translation>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_fil.ts
+++ b/src/qt/locale/bitcoin_fil.ts
@@ -70,6 +70,12 @@
         <translation type="unfinished">Ito ang iyong mga Bitcoin address para sa pagpapadala ng bayad. Laging suriin ang halaga at ang address na tatanggap bago magpadala ng coins.</translation>
     </message>
     <message>
+        <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
+Signing is only possible with addresses of the type 'legacy'.</source>
+        <translation type="unfinished">Ito ang iyong Bitcoin addresses upang makatanggap ng salapi. Gamitin ang 'Create new receiving address' button sa receive tab upang lumikha ng bagong address. Ang signing ay posible lamang sa mga addresses na nasa anyong 'legacy'.
+</translation>
+    </message>
+    <message>
         <source>&amp;Copy Address</source>
         <translation type="unfinished">Kopyahin ang address</translation>
     </message>
@@ -492,6 +498,10 @@
         <translation type="unfinished">Isara ang walet</translation>
     </message>
     <message>
+        <source>Close all wallets</source>
+        <translation type="unfinished">Isarado ang lahat ng wallets</translation>
+    </message>
+    <message>
         <source>Show the %1 help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished">Ipakita sa %1 ang tulong na mensahe upang makuha ang talaan ng mga posibleng opsyon ng Bitcoin command-line</translation>
     </message>
@@ -750,7 +760,15 @@
         <source>Closing the wallet for too long can result in having to resync the entire chain if pruning is enabled.</source>
         <translation type="unfinished">Ang pagsasara ng walet nang masyadong matagal ay maaaring magresulta sa pangangailangan ng pag-resync sa buong chain kung pinagana ang pruning.</translation>
     </message>
-    </context>
+    <message>
+        <source>Close all wallets</source>
+        <translation type="unfinished">Isarado ang lahat ng wallets</translation>
+    </message>
+    <message>
+        <source>Are you sure you wish to close all wallets?</source>
+        <translation type="unfinished">Sigurado ka bang nais mong isara ang lahat ng mga wallets?</translation>
+    </message>
+</context>
 <context>
     <name>CreateWalletDialog</name>
     <message>
@@ -1327,6 +1345,10 @@
     <message>
         <source>Transaction broadcast successfully! Transaction ID: %1</source>
         <translation type="unfinished">%1</translation>
+    </message>
+    <message>
+        <source>Pays transaction fee: </source>
+        <translation type="unfinished">babayaran ang transaction fee:</translation>
     </message>
     <message>
         <source>Total Amount</source>
@@ -2782,6 +2804,10 @@
     <message>
         <source>The transaction amount is too small to send after the fee has been deducted</source>
         <translation type="unfinished">Ang halaga ng transaksyon ay masyadong maliit na maipadala matapos na maibawas ang bayad</translation>
+    </message>
+    <message>
+        <source>This error could occur if this wallet was not shutdown cleanly and was last loaded using a build with a newer version of Berkeley DB. If so, please use the software that last loaded this wallet</source>
+        <translation type="unfinished">Ang error na ito ay maaaring lumabas kung ang wallet na ito ay hindi na i-shutdown na mabuti at last loaded gamit ang  build na may mas pinabagong bersyon ng Berkeley DB. Kung magkagayon, pakiusap ay gamitin ang software na ginamit na huli ng wallet na ito.</translation>
     </message>
     <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>

--- a/src/qt/locale/bitcoin_fr.ts
+++ b/src/qt/locale/bitcoin_fr.ts
@@ -3,7 +3,7 @@
     <name>AddressBookPage</name>
     <message>
         <source>Right-click to edit address or label</source>
-        <translation type="unfinished">Clic droit pour modifier l’adresse ou l’étiquette</translation>
+        <translation type="unfinished">‎Cliquez avec le bouton droit de la souris pour modifier l’adresse ou l’étiquette‎</translation>
     </message>
     <message>
         <source>Create a new address</source>
@@ -31,7 +31,7 @@
     </message>
     <message>
         <source>Enter address or label to search</source>
-        <translation type="unfinished">Saisir une adresse ou une étiquette à rechercher</translation>
+        <translation type="unfinished">Saisissez une adresse ou une étiquette à rechercher</translation>
     </message>
     <message>
         <source>Export the data in the current tab to a file</source>
@@ -51,7 +51,7 @@
     </message>
     <message>
         <source>Choose the address to receive coins with</source>
-        <translation type="unfinished">Choisir l’adresse avec laquelle recevoir des pîèces</translation>
+        <translation type="unfinished">Choisir l’adresse avec laquelle recevoir des pièces</translation>
     </message>
     <message>
         <source>C&amp;hoose</source>
@@ -59,7 +59,7 @@
     </message>
     <message>
         <source>Sending addresses</source>
-        <translation type="unfinished">Adresses d’envoi</translation>
+        <translation type="unfinished">Adresses d’envoi </translation>
     </message>
     <message>
         <source>Receiving addresses</source>
@@ -68,6 +68,12 @@
     <message>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation type="unfinished">Ce sont vos adresses Bitcoin pour envoyer des paiements. Vérifiez toujours le montant et l’adresse du destinataire avant d’envoyer des pièces.</translation>
+    </message>
+    <message>
+        <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
+Signing is only possible with addresses of the type 'legacy'.</source>
+        <translation type="unfinished">Il s'agit de vos adresses Bitcoin pour la réception des paiements. Utilisez le bouton "Créer une nouvelle adresse de réception" dans l'onglet "Recevoir" pour créer de nouvelles adresses.
+La signature n'est possible qu'avec les adresses de type "patrimoine".</translation>
     </message>
     <message>
         <source>&amp;Copy Address</source>
@@ -240,6 +246,10 @@
 <context>
     <name>BitcoinApplication</name>
     <message>
+        <source>Runaway exception</source>
+        <translation type="unfinished">Exception fugitive</translation>
+    </message>
+    <message>
         <source>Internal error</source>
         <translation type="unfinished">erreur interne</translation>
     </message>
@@ -279,12 +289,36 @@
         <translation type="unfinished">Saisir une adresse Bitcoin (p. ex. %1)</translation>
     </message>
     <message>
+        <source>Unroutable</source>
+        <translation type="unfinished">Non routable</translation>
+    </message>
+    <message>
+        <source>Internal</source>
+        <translation type="unfinished">Interne</translation>
+    </message>
+    <message>
         <source>Inbound</source>
         <translation type="unfinished">Entrant</translation>
     </message>
     <message>
         <source>Outbound</source>
         <translation type="unfinished">Sortant</translation>
+    </message>
+    <message>
+        <source>Full Relay</source>
+        <translation type="unfinished">Relai entier</translation>
+    </message>
+    <message>
+        <source>Block Relay</source>
+        <translation type="unfinished">Relai bloc</translation>
+    </message>
+    <message>
+        <source>Manual</source>
+        <translation type="unfinished">Manuel</translation>
+    </message>
+    <message>
+        <source>Feeler</source>
+        <translation type="unfinished">Senseur</translation>
     </message>
     <message>
         <source>%1 d</source>
@@ -305,36 +339,36 @@
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation>
-            <numerusform />
-            <numerusform />
+            <numerusform>%n seconde</numerusform>
+            <numerusform>%n secondes</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n minute(s)</source>
         <translation>
-            <numerusform />
-            <numerusform />
+            <numerusform>%n minute</numerusform>
+            <numerusform>%n minutes</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n heure</numerusform>
+            <numerusform>%n heures</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n jour</numerusform>
+            <numerusform>%n jours</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n semaine</numerusform>
+            <numerusform>%n semaines</numerusform>
         </translation>
     </message>
     <message>
@@ -344,8 +378,8 @@
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n année</numerusform>
+            <numerusform>%n années</numerusform>
         </translation>
     </message>
     <message>
@@ -449,20 +483,48 @@
         <translation>Afficher ou cacher la fenêtre principale</translation>
     </message>
     <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation type="unfinished">&amp;Crypter le Portefeuille</translation>
+    </message>
+    <message>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>Chiffrer les clés privées qui appartiennent à votre porte-monnaie</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation type="unfinished">&amp;Sauvegarder le Portefeuille</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation type="unfinished">&amp;Changer la phrase de passe…</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation type="unfinished">Signer un &amp;message</translation>
     </message>
     <message>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation>Signer les messages avec vos adresses Bitcoin pour prouver que vous les détenez</translation>
     </message>
     <message>
+        <source>&amp;Verify message…</source>
+        <translation type="unfinished">&amp;Vérifier un message…</translation>
+    </message>
+    <message>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation>Vérifier les messages pour s’assurer qu’ils ont été signés avec les adresses Bitcoin indiquées</translation>
     </message>
     <message>
+        <source>&amp;Load PSBT from file…</source>
+        <translation type="unfinished">&amp;Charger un fichier PSBT...</translation>
+    </message>
+    <message>
         <source>Load PSBT from clipboard…</source>
         <translation type="unfinished">Charger la TBSP à partir du presse-papiers...</translation>
+    </message>
+    <message>
+        <source>Open &amp;URI…</source>
+        <translation type="unfinished">Ouvrir une &amp;URL</translation>
     </message>
     <message>
         <source>Close Wallet…</source>
@@ -493,6 +555,30 @@
         <translation>Barre d’outils des onglets</translation>
     </message>
     <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation type="unfinished">Synchronisation des en-têtes (%1)…</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation type="unfinished">Synchronisation avec le réseau…</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation type="unfinished">Indexation des blocs sur le disque…</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation type="unfinished">Traitement des blocs sur le disque…</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation type="unfinished">Réindexation des blocs sur le disque…</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation type="unfinished">Connexion aux pairs…</translation>
+    </message>
+    <message>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished">Demander des paiements (génère des codes QR et des URI bitcoin:)</translation>
     </message>
@@ -511,13 +597,17 @@
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation>
-            <numerusform />
-            <numerusform />
+            <numerusform>%n blocs d’historique transactionnel ont été traités.</numerusform>
+            <numerusform>%n blocs d’historique transactionnel ont été traités.</numerusform>
         </translation>
     </message>
     <message>
         <source>%1 behind</source>
         <translation>en retard de %1</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation type="unfinished">Rattrapage en cours…</translation>
     </message>
     <message>
         <source>Last received block was generated %1 ago.</source>
@@ -611,9 +701,29 @@
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n connexion(s) actives sur le réseau Bitcoin.</numerusform>
+            <numerusform>%n connexion(s) actives sur le réseau Bitcoin.</numerusform>
         </translation>
+    </message>
+    <message>
+        <source>Click for more actions.</source>
+        <extracomment>A substring of the tooltip. "More actions" are available via the context menu.</extracomment>
+        <translation type="unfinished">Cliquer pour afficher plus d'actions.</translation>
+    </message>
+    <message>
+        <source>Show Peers tab</source>
+        <extracomment>A context menu item. The "Peers tab" is an element of the "Node window".</extracomment>
+        <translation type="unfinished">Afficher l'onglet Pairs</translation>
+    </message>
+    <message>
+        <source>Disable network activity</source>
+        <extracomment>A context menu item.</extracomment>
+        <translation type="unfinished">Désactiver l'activité réseau</translation>
+    </message>
+    <message>
+        <source>Enable network activity</source>
+        <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
+        <translation type="unfinished">Activer l'activité réseau</translation>
     </message>
     <message>
         <source>Error: %1</source>
@@ -778,6 +888,14 @@
         <translation type="unfinished">Copier l’&amp;ID de la transaction</translation>
     </message>
     <message>
+        <source>L&amp;ock unspent</source>
+        <translation type="unfinished">Barrer dépenser</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock unspent</source>
+        <translation type="unfinished">Débarrer non-dépenser</translation>
+    </message>
+    <message>
         <source>Copy quantity</source>
         <translation type="unfinished">Copier la quantité</translation>
     </message>
@@ -837,6 +955,10 @@
 <context>
     <name>CreateWalletActivity</name>
     <message>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation type="unfinished">Création d'un portefeuille&lt;b&gt;%1&lt;/b&gt;</translation>
+    </message>
+    <message>
         <source>Create wallet failed</source>
         <translation type="unfinished">Échec de création du porte-monnaie</translation>
     </message>
@@ -844,7 +966,11 @@
         <source>Create wallet warning</source>
         <translation type="unfinished">Avertissement de création du porte-monnaie</translation>
     </message>
-    </context>
+    <message>
+        <source>Can't list signers</source>
+        <translation type="unfinished">Impossible de lister les signataires</translation>
+    </message>
+</context>
 <context>
     <name>OpenWalletActivity</name>
     <message>
@@ -859,7 +985,11 @@
         <source>default wallet</source>
         <translation type="unfinished">porte-monnaie par défaut</translation>
     </message>
-    </context>
+    <message>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation type="unfinished">Ouverture d'un portefeuille &lt;b&gt;%1&lt;/b&gt;</translation>
+    </message>
+</context>
 <context>
     <name>WalletController</name>
     <message>
@@ -922,10 +1052,23 @@
         <translation type="unfinished">Créer un porte-monnaie vide</translation>
     </message>
     <message>
+        <source>Use an external signing device such as a hardware wallet. Configure the external signer script in wallet preferences first.</source>
+        <translation type="unfinished">Utilisez un périphérique de signature externe tel qu'un portefeuille physique. Configurez d'abord le script de signataire externe dans les préférences du portefeuille.</translation>
+    </message>
+    <message>
+        <source>External signer</source>
+        <translation type="unfinished">Signataire externe</translation>
+    </message>
+    <message>
         <source>Create</source>
         <translation type="unfinished">Créer</translation>
     </message>
-    </context>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Compilé sans support de signature externe (requis pour la signature externe)</translation>
+    </message>
+</context>
 <context>
     <name>EditAddressDialog</name>
     <message>
@@ -1007,6 +1150,18 @@
 <context>
     <name>Intro</name>
     <message>
+        <source>%1 GB of free space available</source>
+        <translation type="unfinished">%1 GB d'espace libre disponible</translation>
+    </message>
+    <message>
+        <source>(of %1 GB needed)</source>
+        <translation type="unfinished">(besoin de %1 GO) </translation>
+    </message>
+    <message>
+        <source>(%1 GB needed for full chain)</source>
+        <translation type="unfinished">(besoin de 1%1 GO pour la chaîne entière)</translation>
+    </message>
+    <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
         <translation type="unfinished">Au moins %1 Go de données seront stockés dans ce répertoire et sa taille augmentera avec le temps.</translation>
     </message>
@@ -1018,8 +1173,8 @@
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>(sufficient to restore backups %n day(s) old)</numerusform>
+            <numerusform>(sufficient to restore backups %n day(s) old)</numerusform>
         </translation>
     </message>
     <message>
@@ -1055,8 +1210,16 @@
         <translation type="unfinished">Quand vous cliquerez sur Valider, %1 commencera à télécharger et à traiter l’intégralité de la chaîne de blocs %4 (%2 Go) en débutant avec les transactions les plus anciennes de %3, quand %4 a été lancé initialement.</translation>
     </message>
     <message>
+        <source>Limit block chain storage to</source>
+        <translation type="unfinished">Limiter l'entreposage de chaîne de blocs à</translation>
+    </message>
+    <message>
         <source>Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</source>
         <translation type="unfinished">Rétablir ce paramètre à sa valeur antérieure exige de retélécharger la chaîne de blocs dans son intégralité. Il est plus rapide de télécharger la chaîne complète dans un premier temps et de l’élaguer ultérieurement. Désactive certaines fonctions avancées.</translation>
+    </message>
+    <message>
+        <source> GB</source>
+        <translation type="unfinished">Go</translation>
     </message>
     <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
@@ -1089,6 +1252,10 @@
 <context>
     <name>ShutdownWindow</name>
     <message>
+        <source>%1 is shutting down…</source>
+        <translation type="unfinished">%1 s'éteint</translation>
+    </message>
+    <message>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished">Ne pas éteindre l’ordinateur jusqu’à la disparition de cette fenêtre.</translation>
     </message>
@@ -1112,6 +1279,14 @@
         <translation type="unfinished">Nombre de blocs restants</translation>
     </message>
     <message>
+        <source>Unknown…</source>
+        <translation type="unfinished">Inconnu…</translation>
+    </message>
+    <message>
+        <source>calculating…</source>
+        <translation type="unfinished">calcul en cours…</translation>
+    </message>
+    <message>
         <source>Last block time</source>
         <translation type="unfinished">Estampille temporelle du dernier bloc</translation>
     </message>
@@ -1128,10 +1303,6 @@
         <translation type="unfinished">Temps estimé avant la fin de la synchronisation</translation>
     </message>
     <message>
-        <source>Hide</source>
-        <translation type="unfinished">Cacher</translation>
-    </message>
-    <message>
         <source>Esc</source>
         <translation type="unfinished">Échap</translation>
     </message>
@@ -1139,7 +1310,12 @@
         <source>%1 is currently syncing.  It will download headers and blocks from peers and validate them until reaching the tip of the block chain.</source>
         <translation type="unfinished">%1 est en cours de synchronisation. Il téléchargera les en-têtes et les blocs des pairs et les validera jusqu’à ce qu’il atteigne la fin de la chaîne de blocs.</translation>
     </message>
-    </context>
+    <message>
+        <source>Unknown. Syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">Inconnu. Titre de synchronisation (%1, %2
+%)...</translation>
+    </message>
+</context>
 <context>
     <name>OpenURIDialog</name>
     <message>
@@ -1164,6 +1340,10 @@
     <message>
         <source>&amp;Start %1 on system login</source>
         <translation type="unfinished">&amp;Démarrer %1 lors de l’ouverture d’une session</translation>
+    </message>
+    <message>
+        <source>Enabling pruning significantly reduces the disk space required to store transactions. All blocks are still fully validated. Reverting this setting requires re-downloading the entire blockchain.</source>
+        <translation type="unfinished">Rendre l'émondage possible, réduit considérablement l'espace requise pour entreposer les transactions. Tous les blocs sont complètement validés. Faire marche arrière avec ce paramètre requiert de télécharger à nouveau l'entière chaîne de blocs.</translation>
     </message>
     <message>
         <source>Size of &amp;database cache</source>
@@ -1246,12 +1426,32 @@
         <translation type="unfinished">&amp;Dépenser la monnaie non confirmée</translation>
     </message>
     <message>
+        <source>External Signer (e.g. hardware wallet)</source>
+        <translation type="unfinished">Signataire Externe (ex. portefeuille de matériel)</translation>
+    </message>
+    <message>
+        <source>&amp;External signer script path</source>
+        <translation type="unfinished">&amp;Accès externe du script du signataire</translation>
+    </message>
+    <message>
+        <source>Full path to a Bitcoin Core compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</source>
+        <translation type="unfinished">Chemin complet vers un script compatible Bitcoin Core (par exemple C:\Downloads\hwi.exe ou /Users/you/Downloads/hwi.py). Attention : des malwares peuvent voler vos coins!</translation>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation>Ouvrir automatiquement le port du client Bitcoin sur le routeur. Cela ne fonctionne que si votre routeur prend en charge l’UPnP et si la fonction est activée.</translation>
     </message>
     <message>
         <source>Map port using &amp;UPnP</source>
         <translation>Mapper le port avec l’&amp;UPnP</translation>
+    </message>
+    <message>
+        <source>Automatically open the Bitcoin client port on the router. This only works when your router supports NAT-PMP and it is enabled. The external port could be random.</source>
+        <translation type="unfinished">Ouvrir automatiquement le port de client sur le routeur. Cela fonctionne seulement lorsque votre routeur supporte NAT-PMP et qu'il soit activé. Le port externe peut-être aléatoire.</translation>
+    </message>
+    <message>
+        <source>Map port using NA&amp;T-PMP</source>
+        <translation type="unfinished">Port de mappe utilise NA&amp;T-PMP</translation>
     </message>
     <message>
         <source>Accept connections from outside.</source>
@@ -1288,6 +1488,14 @@
     <message>
         <source>&amp;Window</source>
         <translation>&amp;Fenêtre</translation>
+    </message>
+    <message>
+        <source>Show the icon in the system tray.</source>
+        <translation type="unfinished">Affichez l'icône dans la barre d'état système.</translation>
+    </message>
+    <message>
+        <source>&amp;Show tray icon</source>
+        <translation type="unfinished">&amp;Montrer l'icône barre</translation>
     </message>
     <message>
         <source>Show only a tray icon after minimizing the window.</source>
@@ -1340,6 +1548,11 @@
     <message>
         <source>&amp;Cancel</source>
         <translation>A&amp;nnuler</translation>
+    </message>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Compilé sans support de signature externe (requis pour la signature externe)</translation>
     </message>
     <message>
         <source>default</source>
@@ -1464,12 +1677,25 @@
 <context>
     <name>PSBTOperationsDialog</name>
     <message>
+        <source>Save…</source>
+        <translation type="unfinished">Sauvegarder...</translation>
+    </message>
+    <message>
+        <source>Partially Signed Transaction (Binary)</source>
+        <extracomment>Expanded name of the binary PSBT file format. See: BIP 174.</extracomment>
+        <translation type="unfinished">Transaction Partiellement Signé (Binaire)</translation>
+    </message>
+    <message>
         <source>Total Amount</source>
         <translation type="unfinished">Montant total</translation>
     </message>
     <message>
         <source>or</source>
         <translation type="unfinished">ou</translation>
+    </message>
+    <message>
+        <source>Transaction has %1 unsigned inputs.</source>
+        <translation type="unfinished">L'opération a %1 entrées non saisie </translation>
     </message>
     </context>
 <context>
@@ -1505,6 +1731,11 @@
         <source>User Agent</source>
         <extracomment>Title of Peers Table column which contains the peer's User Agent string.</extracomment>
         <translation type="unfinished">Agent utilisateur</translation>
+    </message>
+    <message>
+        <source>Peer</source>
+        <extracomment>Title of Peers Table column which contains a unique number used to identify a connection.</extracomment>
+        <translation type="unfinished">Pair</translation>
     </message>
     <message>
         <source>Sent</source>
@@ -1553,7 +1784,12 @@
         <source>Save QR Code</source>
         <translation type="unfinished">Enregistrer le code QR</translation>
     </message>
-    </context>
+    <message>
+        <source>PNG Image</source>
+        <extracomment>Expanded name of the PNG file format. See https://en.wikipedia.org/wiki/Portable_Network_Graphics</extracomment>
+        <translation type="unfinished">Image PNG</translation>
+    </message>
+</context>
 <context>
     <name>RPCConsole</name>
     <message>
@@ -1693,8 +1929,28 @@
         <translation type="unfinished">Augmenter la taille de police</translation>
     </message>
     <message>
+        <source>Wants Tx Relay</source>
+        <translation type="unfinished">Veut Tx relai</translation>
+    </message>
+    <message>
+        <source>High Bandwidth</source>
+        <translation type="unfinished">Bande passante élevée</translation>
+    </message>
+    <message>
         <source>Connection Time</source>
         <translation type="unfinished">Temps de connexion</translation>
+    </message>
+    <message>
+        <source>Elapsed time since a novel block passing initial validity checks was received from this peer.</source>
+        <translation type="unfinished">Temps écoulé depuis qu'un nouveau bloc passant le contrôle de validité a été reçu par ce pair.</translation>
+    </message>
+    <message>
+        <source>Last Block</source>
+        <translation type="unfinished">Dernier bloc</translation>
+    </message>
+    <message>
+        <source>Elapsed time since a novel transaction accepted into our mempool was received from this peer.</source>
+        <translation type="unfinished">Temps écoulé depuis qu'une nouvelle transaction accepté dans notre mempool soit reçu par ce pair.</translation>
     </message>
     <message>
         <source>Last Tx</source>
@@ -1761,6 +2017,18 @@
         <translation type="unfinished">Sortant :</translation>
     </message>
     <message>
+        <source>Inbound: initiated by peer</source>
+        <translation type="unfinished">Entrant: initié par pair</translation>
+    </message>
+    <message>
+        <source>Outbound Full Relay: default</source>
+        <translation type="unfinished">Relai Entier Sortant: défaut</translation>
+    </message>
+    <message>
+        <source>Outbound Block Relay: does not relay transactions or addresses</source>
+        <translation type="unfinished">Relai Bloc Sortant: ne relie pas les transactions ou les adresses</translation>
+    </message>
+    <message>
         <source>&amp;Disconnect</source>
         <translation type="unfinished">&amp;Déconnecter</translation>
     </message>
@@ -1815,6 +2083,10 @@
     <message>
         <source>Ban for</source>
         <translation type="unfinished">Bannir pendant</translation>
+    </message>
+    <message>
+        <source>Never</source>
+        <translation type="unfinished">Jamais</translation>
     </message>
     <message>
         <source>Unknown</source>
@@ -1923,6 +2195,10 @@
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
+        <source>Request payment to …</source>
+        <translation type="unfinished">Demander le paiement à …</translation>
+    </message>
+    <message>
         <source>Amount:</source>
         <translation type="unfinished">Montant :</translation>
     </message>
@@ -1941,6 +2217,14 @@
     <message>
         <source>Copy &amp;Address</source>
         <translation type="unfinished">Copier l’&amp;adresse</translation>
+    </message>
+    <message>
+        <source>&amp;Verify</source>
+        <translation type="unfinished">&amp;Vérifier</translation>
+    </message>
+    <message>
+        <source>Verify this address on e.g. a hardware wallet screen</source>
+        <translation type="unfinished">Vérifiez cette adresse avec  par ex. un écran de portefeuille physique</translation>
     </message>
     <message>
         <source>&amp;Save Image…</source>
@@ -2093,6 +2377,10 @@
         <translation type="unfinished">Si les frais sont trop bas, cette transaction pourrait n’être jamais confirmée (lire l’infobulle)</translation>
     </message>
     <message>
+        <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
+        <translation type="unfinished">(Frais intelligents pas encore initialisés. Cela prend généralement quelques blocs…)</translation>
+    </message>
+    <message>
         <source>Confirmation time target:</source>
         <translation type="unfinished">Estimation du délai de confirmation :</translation>
     </message>
@@ -2162,6 +2450,12 @@
         <translation type="unfinished">Connecter le porte-monnaie hardware en premier lieu.</translation>
     </message>
     <message>
+        <source>Set external signer script path in Options -&gt; Wallet</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Régler chemin du script externe dans Options -»
+Porte-monnaie</translation>
+    </message>
+    <message>
         <source>Cr&amp;eate Unsigned</source>
         <translation type="unfinished">Cr&amp;éer une transaction non signée</translation>
     </message>
@@ -2190,12 +2484,35 @@
         <translation type="unfinished">Voulez-vous vraiment envoyer ?</translation>
     </message>
     <message>
+        <source>To review recipient list click "Show Details…"</source>
+        <translation type="unfinished">Pour réviser la liste du receveur cliquer ''Montrer détails...''</translation>
+    </message>
+    <message>
         <source>Sign and send</source>
         <translation type="unfinished">Signer et envoyer</translation>
     </message>
     <message>
         <source>Sign failed</source>
         <translation type="unfinished">Échec de la signature</translation>
+    </message>
+    <message>
+        <source>External signer not found</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Signataire externe introuvable</translation>
+    </message>
+    <message>
+        <source>External signer failure</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Échec du signataire externe</translation>
+    </message>
+    <message>
+        <source>Partially Signed Transaction (Binary)</source>
+        <extracomment>Expanded name of the binary PSBT file format. See: BIP 174.</extracomment>
+        <translation type="unfinished">Transaction Partiellement Signé (Binaire)</translation>
+    </message>
+    <message>
+        <source>External balance:</source>
+        <translation type="unfinished">Solde extérieur</translation>
     </message>
     <message>
         <source>or</source>
@@ -2268,8 +2585,8 @@
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation>
-            <numerusform />
-            <numerusform />
+            <numerusform>Estimated to begin confirmation within %n block.</numerusform>
+            <numerusform>Estimated to begin confirmation within %n blocks.</numerusform>
         </translation>
     </message>
     <message>
@@ -2512,8 +2829,8 @@
     <message numerus="yes">
         <source>Open for %n more block(s)</source>
         <translation>
-            <numerusform />
-            <numerusform />
+            <numerusform>Open for %n more block</numerusform>
+            <numerusform>Open for %n more blocks</numerusform>
         </translation>
     </message>
     <message>
@@ -2583,8 +2900,8 @@
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation>
-            <numerusform />
-            <numerusform />
+            <numerusform>matures in %n more block</numerusform>
+            <numerusform>matures in %n more blocks</numerusform>
         </translation>
     </message>
     <message>
@@ -2684,8 +3001,8 @@
     <message numerus="yes">
         <source>Open for %n more block(s)</source>
         <translation>
-            <numerusform />
-            <numerusform />
+            <numerusform>Open for %n more block</numerusform>
+            <numerusform>Open for %n more blocks</numerusform>
         </translation>
     </message>
     <message>
@@ -2832,6 +3149,10 @@
         <translation type="unfinished">Montant min.</translation>
     </message>
     <message>
+        <source>Range…</source>
+        <translation type="unfinished">plage</translation>
+    </message>
+    <message>
         <source>&amp;Copy address</source>
         <translation type="unfinished">&amp;Copier l’adresse</translation>
     </message>
@@ -2850,6 +3171,10 @@
     <message>
         <source>A&amp;bandon transaction</source>
         <translation type="unfinished">A&amp;bandonner la transaction</translation>
+    </message>
+    <message>
+        <source>&amp;Edit address label</source>
+        <translation type="unfinished">Modifier l'adresse de l'étiquette. </translation>
     </message>
     <message>
         <source>Export Transaction History</source>
@@ -3316,6 +3641,10 @@
     <message>
         <source>Prune cannot be configured with a negative value.</source>
         <translation type="unfinished">L’élagage ne peut pas être configuré avec une valeur négative.</translation>
+    </message>
+    <message>
+        <source>Prune mode is incompatible with -coinstatsindex.</source>
+        <translation type="unfinished">Le mode élagué est incompatible avec -coinstatsindex.</translation>
     </message>
     <message>
         <source>Prune mode is incompatible with -txindex.</source>

--- a/src/qt/locale/bitcoin_ga.ts
+++ b/src/qt/locale/bitcoin_ga.ts
@@ -830,6 +830,10 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
 <context>
     <name>CreateWalletActivity</name>
     <message>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation type="unfinished">Sparán a Chruthú &lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+    <message>
         <source>Create wallet failed</source>
         <translation type="unfinished">Theip ar chruthú sparán</translation>
     </message>

--- a/src/qt/locale/bitcoin_gl.ts
+++ b/src/qt/locale/bitcoin_gl.ts
@@ -2,6 +2,10 @@
 <context>
     <name>AddressBookPage</name>
     <message>
+        <source>Right-click to edit address or label</source>
+        <translation type="unfinished">Fai Click co botón dereito para editar o enderezo ou etiquetac</translation>
+    </message>
+    <message>
         <source>Create a new address</source>
         <translation>Crear un novo enderezo</translation>
     </message>
@@ -64,6 +68,12 @@
     <message>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation type="unfinished">Estas son as túas direccións Bitcoin para enviar pagos. Revisa sempre a cantidade e a dirección receptora antes de enviar moedas.</translation>
+    </message>
+    <message>
+        <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
+Signing is only possible with addresses of the type 'legacy'.</source>
+        <translation type="unfinished">Estes son os teus enderezos de Bitcoin para recibir pagamentos. Emprega o botón 'Crear novo enderezo para recibir pagamentos' na solapa de recibir para crear novos enderezos.
+Firmar é posible unicamente con enderezos de tipo 'legacy'.</translation>
     </message>
     <message>
         <source>&amp;Copy Address</source>
@@ -964,6 +974,10 @@
     <message>
         <source>&amp;Message:</source>
         <translation type="unfinished">&amp;Mensaxe:</translation>
+    </message>
+    <message>
+        <source>&amp;Create new receiving address</source>
+        <translation type="unfinished">&amp;Crear novo enderezo para recibir pagamentos</translation>
     </message>
     <message>
         <source>Clear all fields of the form.</source>

--- a/src/qt/locale/bitcoin_ha.ts
+++ b/src/qt/locale/bitcoin_ha.ts
@@ -1,63 +1,59 @@
-<TS version="2.1" language="zh">
+<TS version="2.1" language="ha">
 <context>
     <name>AddressBookPage</name>
     <message>
         <source>Right-click to edit address or label</source>
-        <translation type="unfinished">右键单击来编辑地址或者标签</translation>
+        <translation type="unfinished">Danna dama don gyara adireshi ko labil</translation>
     </message>
     <message>
         <source>Create a new address</source>
-        <translation>创建新地址</translation>
+        <translation>Ƙirƙiri sabon adireshi</translation>
     </message>
     <message>
         <source>&amp;New</source>
-        <translation type="unfinished">&amp;新建</translation>
+        <translation type="unfinished">Sabontawa</translation>
+    </message>
+    <message>
+        <source>Copy the currently selected address to the system clipboard</source>
+        <translation>Kwafi adireshin da aka zaɓa a halin yanzu domin yin amfani dashi</translation>
     </message>
     <message>
         <source>Delete the currently selected address from the list</source>
-        <translation>从列表中删除当前已选地址</translation>
+        <translation>Share adireshin da aka zaɓa a halin yanzu daga jerin </translation>
     </message>
     <message>
         <source>Enter address or label to search</source>
-        <translation type="unfinished">输入要搜索的地址或标签</translation>
+        <translation type="unfinished">Shigar da adireshi ko lakabi don bincika</translation>
     </message>
     <message>
         <source>Export the data in the current tab to a file</source>
-        <translation>将当前选项卡中的数据导出到文件</translation>
+        <translation>Fitar da bayanan da ke cikin shafin na yanzu zuwa fayil</translation>
     </message>
     <message>
         <source>&amp;Export</source>
-        <translation>&amp;导出</translation>
+        <translation>&amp; Fitarwa</translation>
     </message>
     <message>
         <source>&amp;Delete</source>
-        <translation>&amp;删除</translation>
-    </message>
-    <message>
-        <source>Choose the address to send coins to</source>
-        <translation type="unfinished">选择收款人地址</translation>
+        <translation>&amp;Sharewa</translation>
     </message>
     <message>
         <source>Choose the address to receive coins with</source>
-        <translation type="unfinished">选择接收比特币地址</translation>
-    </message>
-    <message>
-        <source>Sending addresses</source>
-        <translation type="unfinished">发送地址</translation>
+        <translation type="unfinished">Zaɓi adireshin don karɓar kuɗi internet da shi</translation>
     </message>
     <message>
         <source>Receiving addresses</source>
-        <translation type="unfinished">接收地址</translation>
+        <translation type="unfinished">Adireshi da za a karba dashi</translation>
     </message>
     <message>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
-        <translation type="unfinished">这些是你的比特币支付地址。在发送之前，一定要核对金额和接收地址。</translation>
+        <translation type="unfinished">Waɗannan adiresoshin Bitcoin ne don tura kuɗi bitcoin . ka tabbatar da cewa adreshin daidai ne kamin ka tura abua a ciki</translation>
     </message>
     <message>
         <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
 Signing is only possible with addresses of the type 'legacy'.</source>
-        <translation type="unfinished">你将使用下列比特币地址接受付款。选取收款选项卡中 “产生新收款地址” 按钮来生成新地址。
-签名只能使用“传统”类型的地址。</translation>
+        <translation type="unfinished">Waɗannan adiresoshin Bitcoin ne don karɓar kuɗi. Yi amfani da maɓallin 'Ƙirƙiri sabon adireshin karɓa' a cikin shafin karɓa don ƙirƙirar sababbin adireshi.
+zaka iya shiga ne kawai da adiresoshin 'na musamman' kawai.</translation>
     </message>
     </context>
 <context>
@@ -65,37 +61,43 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation>
-            <numerusform>%n seconds</numerusform>
+            <numerusform />
+            <numerusform />
         </translation>
     </message>
     <message numerus="yes">
         <source>%n minute(s)</source>
         <translation>
-            <numerusform>%n minutes</numerusform>
+            <numerusform />
+            <numerusform />
         </translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
         <translation type="unfinished">
-            <numerusform>%n hours</numerusform>
+            <numerusform />
+            <numerusform />
         </translation>
     </message>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
-            <numerusform>%n days</numerusform>
+            <numerusform />
+            <numerusform />
         </translation>
     </message>
     <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
-            <numerusform>%n weeks</numerusform>
+            <numerusform />
+            <numerusform />
         </translation>
     </message>
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
-            <numerusform>%n years</numerusform>
+            <numerusform />
+            <numerusform />
         </translation>
     </message>
     </context>
@@ -104,44 +106,17 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation>
-            <numerusform>Processed %n blocks of transaction history.</numerusform>
+            <numerusform />
+            <numerusform />
         </translation>
     </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform>%n active connection(s) to Bitcoin network.</numerusform>
+            <numerusform />
+            <numerusform />
         </translation>
-    </message>
-    </context>
-<context>
-    <name>CoinControlDialog</name>
-    <message>
-        <source>Copy fee</source>
-        <translation type="unfinished">复制手续费</translation>
-    </message>
-    <message>
-        <source>yes</source>
-        <translation type="unfinished">是</translation>
-    </message>
-    <message>
-        <source>This label turns red if any recipient receives an amount smaller than the current dust threshold.</source>
-        <translation type="unfinished">当任何一个收款金额小于目前的粉尘金额阈值时，文字会变红色。</translation>
-    </message>
-    </context>
-<context>
-    <name>CreateWalletActivity</name>
-    <message>
-        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
-        <translation type="unfinished">正在创建钱包&lt;b&gt;%1&lt;/b&gt;...</translation>
-    </message>
-    </context>
-<context>
-    <name>EditAddressDialog</name>
-    <message>
-        <source>Edit sending address</source>
-        <translation type="unfinished">编辑付款地址</translation>
     </message>
     </context>
 <context>
@@ -150,7 +125,8 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform>(sufficient to restore backups %n day(s) old)</numerusform>
+            <numerusform />
+            <numerusform />
         </translation>
     </message>
     </context>
@@ -159,7 +135,8 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation>
-            <numerusform>Estimated to begin confirmation within %n blocks.</numerusform>
+            <numerusform />
+            <numerusform />
         </translation>
     </message>
     </context>
@@ -168,13 +145,15 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>Open for %n more block(s)</source>
         <translation>
-            <numerusform>Open for %n more blocks</numerusform>
+            <numerusform />
+            <numerusform />
         </translation>
     </message>
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation>
-            <numerusform>matures in %n more blocks</numerusform>
+            <numerusform />
+            <numerusform />
         </translation>
     </message>
     </context>
@@ -183,8 +162,20 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>Open for %n more block(s)</source>
         <translation>
-            <numerusform>Open for %n more blocks</numerusform>
+            <numerusform />
+            <numerusform />
         </translation>
+    </message>
+    </context>
+<context>
+    <name>WalletView</name>
+    <message>
+        <source>&amp;Export</source>
+        <translation type="unfinished">&amp; Fitarwa</translation>
+    </message>
+    <message>
+        <source>Export the data in the current tab to a file</source>
+        <translation type="unfinished">Fitar da bayanan da ke cikin shafin na yanzu zuwa fayil</translation>
     </message>
     </context>
 </TS>

--- a/src/qt/locale/bitcoin_he.ts
+++ b/src/qt/locale/bitcoin_he.ts
@@ -3,7 +3,7 @@
     <name>AddressBookPage</name>
     <message>
         <source>Right-click to edit address or label</source>
-        <translation type="unfinished">לחיצה על הלחצן הימני בעכבר לעריכת הכתובת או התווית</translation>
+        <translation type="unfinished">לחץ על הלחצן הימני בעכבר לעריכת הכתובת או התווית</translation>
     </message>
     <message>
         <source>Create a new address</source>
@@ -15,7 +15,7 @@
     </message>
     <message>
         <source>Copy the currently selected address to the system clipboard</source>
-        <translation>העתקת את הכתובת המסומנת ללוח</translation>
+        <translation>העתק את הכתובת המסומנת ללוח</translation>
     </message>
     <message>
         <source>&amp;Copy</source>
@@ -90,6 +90,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Export Address List</source>
         <translation type="unfinished">יצוא רשימת הכתובות</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See https://en.wikipedia.org/wiki/Comma-separated_values</extracomment>
+        <translation type="unfinished">קובץ מופרד בפסיקים</translation>
     </message>
     <message>
         <source>There was an error trying to save the address list to %1. Please try again.</source>
@@ -237,10 +242,22 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>BitcoinApplication</name>
     <message>
+        <source>Runaway exception</source>
+        <translation type="unfinished">חריגת בריחה</translation>
+    </message>
+    <message>
         <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
         <translation type="unfinished">אירעה שגיאה חמורה, %1 לא יכול להמשיך בבטחון ולכן יופסק.</translation>
     </message>
-    </context>
+    <message>
+        <source>Internal error</source>
+        <translation type="unfinished">שגיאה פנימית</translation>
+    </message>
+    <message>
+        <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
+        <translation type="unfinished">אירעה שגיאה פנימית. יתבצע ניסיון נוסף על ידי %1 להמשיך בבטחה. זאת תקלה בלתי צפויה וניתן לדווח עליה כמפורט להלן.</translation>
+    </message>
+</context>
 <context>
     <name>QObject</name>
     <message>
@@ -258,6 +275,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Error initializing settings: %1</source>
         <translation type="unfinished">שגיאה בהגדרות הראשוניות: %1</translation>
+    </message>
+    <message>
+        <source>%1 didn't yet exit safely…</source>
+        <translation type="unfinished">לא התבצעה יציאה בטוחה מ־%1 עדיין…</translation>
     </message>
     <message>
         <source>unknown</source>
@@ -358,6 +379,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">%1 ב׳</translation>
     </message>
     <message>
+        <source>%1 kB</source>
+        <translation type="unfinished">%1 ק״ב</translation>
+    </message>
+    <message>
         <source>%1 MB</source>
         <translation type="unfinished">%1 מ״ב</translation>
     </message>
@@ -450,6 +475,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation>&amp;קבלה</translation>
     </message>
     <message>
+        <source>&amp;Options…</source>
+        <translation type="unfinished">&amp;אפשרויות…</translation>
+    </message>
+    <message>
         <source>&amp;Show / Hide</source>
         <translation>ה&amp;צגה / הסתרה</translation>
     </message>
@@ -458,8 +487,20 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation>הצגה או הסתרה של החלון הראשי</translation>
     </message>
     <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation type="unfinished">&amp;הצפנת ארנק</translation>
+    </message>
+    <message>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>הצפנת המפתחות הפרטיים ששייכים לארנק שלך</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation type="unfinished">גיבוי הארנק</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation type="unfinished">ה&amp;חלפת מילת צופן…</translation>
     </message>
     <message>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
@@ -865,7 +906,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>default wallet</source>
         <translation type="unfinished">ארנק בררת מחדל</translation>
     </message>
-    </context>
+    <message>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation type="unfinished">פותח ארנק&lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+</context>
 <context>
     <name>WalletController</name>
     <message>
@@ -1081,8 +1126,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">בעת לחיצה על אישור, %1 יחל בהורדה ועיבוד מלאים של שרשרת המקטעים %4 (%2 ג״ב) החל מההעברות הראשונות ב־%3 עם ההשקה הראשונית של %4.</translation>
     </message>
     <message>
+        <source>Limit block chain storage to</source>
+        <translation type="unfinished">הגבלת אחסון בלוקצ'יין ל</translation>
+    </message>
+    <message>
         <source>Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</source>
         <translation type="unfinished">חזרה לאחור מהגדרות אלו מחייב הורדה מחדש של כל שרשרת הבלוקים. מהיר יותר להוריד את השרשרת המלאה ולקטום אותה מאוחר יותר. הדבר מנטרל כמה תכונות מתקדמות.</translation>
+    </message>
+    <message>
+        <source> GB</source>
+        <translation type="unfinished">ג״ב</translation>
     </message>
     <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
@@ -1140,6 +1193,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Number of blocks left</source>
         <translation type="unfinished">מספר מקטעים שנותרו</translation>
+    </message>
+    <message>
+        <source>calculating…</source>
+        <translation type="unfinished">בתהליך חישוב...</translation>
     </message>
     <message>
         <source>Last block time</source>
@@ -1520,6 +1577,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Copy to Clipboard</source>
         <translation type="unfinished">העתקה ללוח הגזירים</translation>
+    </message>
+    <message>
+        <source>Save…</source>
+        <translation type="unfinished">שמירה…</translation>
     </message>
     <message>
         <source>Close</source>
@@ -3025,6 +3086,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Export Transaction History</source>
         <translation type="unfinished">יצוא היסטוריית העברה</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See https://en.wikipedia.org/wiki/Comma-separated_values</extracomment>
+        <translation type="unfinished">קובץ מופרד בפסיקים</translation>
     </message>
     <message>
         <source>Confirmed</source>

--- a/src/qt/locale/bitcoin_hi.ts
+++ b/src/qt/locale/bitcoin_hi.ts
@@ -1,63 +1,50 @@
-<TS version="2.1" language="zh">
+<TS version="2.1" language="hi">
 <context>
     <name>AddressBookPage</name>
     <message>
         <source>Right-click to edit address or label</source>
-        <translation type="unfinished">右键单击来编辑地址或者标签</translation>
+        <translation type="unfinished">पता या लेबल संपादित करने के लिए राइट-क्लिक करें
+ </translation>
     </message>
     <message>
         <source>Create a new address</source>
-        <translation>创建新地址</translation>
+        <translation>नया पता बनाएं</translation>
     </message>
     <message>
         <source>&amp;New</source>
-        <translation type="unfinished">&amp;新建</translation>
+        <translation type="unfinished">और नया</translation>
+    </message>
+    <message>
+        <source>Copy the currently selected address to the system clipboard</source>
+        <translation>अभी चुने गए पते को सिस्टम क्लिपबोर्ड पर कॉपी करें</translation>
+    </message>
+    <message>
+        <source>&amp;Copy</source>
+        <translation type="unfinished">और संचय </translation>
+    </message>
+    <message>
+        <source>C&amp;lose</source>
+        <translation type="unfinished">बंद</translation>
     </message>
     <message>
         <source>Delete the currently selected address from the list</source>
-        <translation>从列表中删除当前已选地址</translation>
+        <translation>अभी चुने गए पते को सूची से हटाएं</translation>
     </message>
     <message>
         <source>Enter address or label to search</source>
-        <translation type="unfinished">输入要搜索的地址或标签</translation>
+        <translation type="unfinished">खोजने के लिए पते या लेबल को दर्ज करें</translation>
     </message>
     <message>
         <source>Export the data in the current tab to a file</source>
-        <translation>将当前选项卡中的数据导出到文件</translation>
+        <translation>वर्तमान टैब में डेटा को फ़ाइल में निर्यात करें</translation>
     </message>
     <message>
         <source>&amp;Export</source>
-        <translation>&amp;导出</translation>
+        <translation>और निर्यात</translation>
     </message>
     <message>
         <source>&amp;Delete</source>
-        <translation>&amp;删除</translation>
-    </message>
-    <message>
-        <source>Choose the address to send coins to</source>
-        <translation type="unfinished">选择收款人地址</translation>
-    </message>
-    <message>
-        <source>Choose the address to receive coins with</source>
-        <translation type="unfinished">选择接收比特币地址</translation>
-    </message>
-    <message>
-        <source>Sending addresses</source>
-        <translation type="unfinished">发送地址</translation>
-    </message>
-    <message>
-        <source>Receiving addresses</source>
-        <translation type="unfinished">接收地址</translation>
-    </message>
-    <message>
-        <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
-        <translation type="unfinished">这些是你的比特币支付地址。在发送之前，一定要核对金额和接收地址。</translation>
-    </message>
-    <message>
-        <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
-Signing is only possible with addresses of the type 'legacy'.</source>
-        <translation type="unfinished">你将使用下列比特币地址接受付款。选取收款选项卡中 “产生新收款地址” 按钮来生成新地址。
-签名只能使用“传统”类型的地址。</translation>
+        <translation>और हटाएं</translation>
     </message>
     </context>
 <context>
@@ -65,45 +52,64 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation>
+            <numerusform>%n second</numerusform>
             <numerusform>%n seconds</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n minute(s)</source>
         <translation>
+            <numerusform>%n minute</numerusform>
             <numerusform>%n minutes</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
         <translation type="unfinished">
+            <numerusform>%n hour</numerusform>
             <numerusform>%n hours</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
+            <numerusform>%n day</numerusform>
             <numerusform>%n days</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
+            <numerusform>%n week</numerusform>
             <numerusform>%n weeks</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
+            <numerusform>%n year</numerusform>
             <numerusform>%n years</numerusform>
         </translation>
     </message>
     </context>
 <context>
     <name>BitcoinGUI</name>
+    <message>
+        <source>Close Wallet…</source>
+        <translation type="unfinished">बटुआ बंद करें...</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation type="unfinished">वॉलेट बनाएं...</translation>
+    </message>
+    <message>
+        <source>Close All Wallets…</source>
+        <translation type="unfinished">सारे बटुएँ बंद करें...</translation>
+    </message>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation>
+            <numerusform>Processed %n block of transaction history.</numerusform>
             <numerusform>Processed %n blocks of transaction history.</numerusform>
         </translation>
     </message>
@@ -112,36 +118,8 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
             <numerusform>%n active connection(s) to Bitcoin network.</numerusform>
+            <numerusform>%n active connection(s) to Bitcoin network.</numerusform>
         </translation>
-    </message>
-    </context>
-<context>
-    <name>CoinControlDialog</name>
-    <message>
-        <source>Copy fee</source>
-        <translation type="unfinished">复制手续费</translation>
-    </message>
-    <message>
-        <source>yes</source>
-        <translation type="unfinished">是</translation>
-    </message>
-    <message>
-        <source>This label turns red if any recipient receives an amount smaller than the current dust threshold.</source>
-        <translation type="unfinished">当任何一个收款金额小于目前的粉尘金额阈值时，文字会变红色。</translation>
-    </message>
-    </context>
-<context>
-    <name>CreateWalletActivity</name>
-    <message>
-        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
-        <translation type="unfinished">正在创建钱包&lt;b&gt;%1&lt;/b&gt;...</translation>
-    </message>
-    </context>
-<context>
-    <name>EditAddressDialog</name>
-    <message>
-        <source>Edit sending address</source>
-        <translation type="unfinished">编辑付款地址</translation>
     </message>
     </context>
 <context>
@@ -151,6 +129,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
             <numerusform>(sufficient to restore backups %n day(s) old)</numerusform>
+            <numerusform>(sufficient to restore backups %n day(s) old)</numerusform>
         </translation>
     </message>
     </context>
@@ -159,6 +138,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation>
+            <numerusform>Estimated to begin confirmation within %n block.</numerusform>
             <numerusform>Estimated to begin confirmation within %n blocks.</numerusform>
         </translation>
     </message>
@@ -168,12 +148,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>Open for %n more block(s)</source>
         <translation>
+            <numerusform>Open for %n more block</numerusform>
             <numerusform>Open for %n more blocks</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation>
+            <numerusform>matures in %n more block</numerusform>
             <numerusform>matures in %n more blocks</numerusform>
         </translation>
     </message>
@@ -183,6 +165,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>Open for %n more block(s)</source>
         <translation>
+            <numerusform>Open for %n more block</numerusform>
             <numerusform>Open for %n more blocks</numerusform>
         </translation>
     </message>

--- a/src/qt/locale/bitcoin_hr.ts
+++ b/src/qt/locale/bitcoin_hr.ts
@@ -70,6 +70,12 @@
         <translation type="unfinished">Ovo su vaše Bitcoin adrese za slanje novca. Uvijek provjerite iznos i adresu primatelja prije slanja novca.</translation>
     </message>
     <message>
+        <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
+Signing is only possible with addresses of the type 'legacy'.</source>
+        <translation type="unfinished">Ovo su vaše Bitcoin adrese za primanje sredstava. Koristite 'Kreiraj novu adresu za primanje' u tabu Primite kako biste kreirali nove adrese.
+Potpisivanje je moguće samo sa 'legacy' adresama. </translation>
+    </message>
+    <message>
         <source>&amp;Copy Address</source>
         <translation type="unfinished">&amp;Kopirajte adresu</translation>
     </message>
@@ -84,6 +90,11 @@
     <message>
         <source>Export Address List</source>
         <translation type="unfinished">Izvezite listu adresa</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See https://en.wikipedia.org/wiki/Comma-separated_values</extracomment>
+        <translation type="unfinished">Datoteka podataka odvojenih zarezima (*.csv)</translation>
     </message>
     <message>
         <source>There was an error trying to save the address list to %1. Please try again.</source>
@@ -233,6 +244,25 @@
     </message>
 </context>
 <context>
+    <name>BitcoinApplication</name>
+    <message>
+        <source>Runaway exception</source>
+        <translation type="unfinished">Runaway iznimka</translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
+        <translation type="unfinished">Dogodila se greška. %1 ne može sigurno nastaviti te će se zatvoriti.</translation>
+    </message>
+    <message>
+        <source>Internal error</source>
+        <translation type="unfinished">Interna greška</translation>
+    </message>
+    <message>
+        <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
+        <translation type="unfinished">Dogodila se interna greška. %1 će pokušati sigurno nastaviti. Ovo je neočekivani bug koji se može prijaviti kao što je objašnjeno ispod.</translation>
+    </message>
+</context>
+<context>
     <name>QObject</name>
     <message>
         <source>Error: Specified data directory "%1" does not exist.</source>
@@ -247,6 +277,14 @@
         <translation type="unfinished">Greška: %1</translation>
     </message>
     <message>
+        <source>Error initializing settings: %1</source>
+        <translation type="unfinished">Greška pri inicijalizaciji postavki: %1</translation>
+    </message>
+    <message>
+        <source>%1 didn't yet exit safely…</source>
+        <translation type="unfinished">%1 se nije još zatvorio na siguran način.</translation>
+    </message>
+    <message>
         <source>unknown</source>
         <translation type="unfinished">nepoznato</translation>
     </message>
@@ -259,6 +297,14 @@
         <translation type="unfinished">Unesite Bitcoin adresu (npr. %1)</translation>
     </message>
     <message>
+        <source>Unroutable</source>
+        <translation type="unfinished">Neusmjeriv</translation>
+    </message>
+    <message>
+        <source>Internal</source>
+        <translation type="unfinished">Interni</translation>
+    </message>
+    <message>
         <source>Inbound</source>
         <translation type="unfinished">Dolazni</translation>
     </message>
@@ -267,47 +313,67 @@
         <translation type="unfinished">Izlazni</translation>
     </message>
     <message>
+        <source>Full Relay</source>
+        <translation type="unfinished">Potpuni prijenos</translation>
+    </message>
+    <message>
+        <source>Block Relay</source>
+        <translation type="unfinished">Blok prijenos</translation>
+    </message>
+    <message>
+        <source>Manual</source>
+        <translation type="unfinished">Priručnik</translation>
+    </message>
+    <message>
+        <source>Feeler</source>
+        <translation type="unfinished">Ispipavač</translation>
+    </message>
+    <message>
+        <source>Address Fetch</source>
+        <translation type="unfinished">Dohvaćanje adrese</translation>
+    </message>
+    <message>
         <source>None</source>
         <translation type="unfinished">Ništa</translation>
     </message>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation>
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n second</numerusform>
+            <numerusform>%n seconds</numerusform>
+            <numerusform>%n sekundi</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n minute(s)</source>
         <translation>
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n minute</numerusform>
+            <numerusform>%n minutes</numerusform>
+            <numerusform>%n minuta</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n hour</numerusform>
+            <numerusform>%n hours</numerusform>
+            <numerusform>%n sati</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n day</numerusform>
+            <numerusform>%n days</numerusform>
+            <numerusform>%n dana</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n week</numerusform>
+            <numerusform>%n weeks</numerusform>
+            <numerusform>%n tjedana</numerusform>
         </translation>
     </message>
     <message>
@@ -317,9 +383,9 @@
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n year</numerusform>
+            <numerusform>%n years</numerusform>
+            <numerusform>%n godina</numerusform>
         </translation>
     </message>
     </context>
@@ -367,7 +433,7 @@
     </message>
     <message>
         <source>Modify configuration options for %1</source>
-        <translation type="unfinished">Promijenite postavke za %1</translation>
+        <translation type="unfinished">Promijeni konfiguraciju opcija za %1</translation>
     </message>
     <message>
         <source>Create a new wallet</source>
@@ -388,7 +454,7 @@
     </message>
     <message>
         <source>Send coins to a Bitcoin address</source>
-        <translation>Pošaljite novac na Bitcoin adresu</translation>
+        <translation>Pošaljite sredstva na Bitcoin adresu</translation>
     </message>
     <message>
         <source>Backup wallet to another location</source>
@@ -404,27 +470,75 @@
     </message>
     <message>
         <source>&amp;Receive</source>
-        <translation>Pri&amp;mite</translation>
+        <translation>&amp;Primite</translation>
+    </message>
+    <message>
+        <source>&amp;Options…</source>
+        <translation type="unfinished">&amp;Opcije</translation>
     </message>
     <message>
         <source>&amp;Show / Hide</source>
-        <translation>Po&amp;kažite / Sakrijte</translation>
+        <translation>&amp;Prikaži / Sakrij</translation>
     </message>
     <message>
         <source>Show or hide the main Window</source>
-        <translation>Prikažite ili sakrijte glavni prozor</translation>
+        <translation>Prikaži ili sakrij glavni prozor</translation>
+    </message>
+    <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation type="unfinished">&amp;Šifriraj novčanik</translation>
     </message>
     <message>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>Šifrirajte privatne ključeve u novčaniku</translation>
     </message>
     <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation type="unfinished">&amp;Kreiraj sigurnosnu kopiju novčanika</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation type="unfinished">&amp;Promijeni lozinku</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation type="unfinished">Potpiši &amp;poruku</translation>
+    </message>
+    <message>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation>Poruku potpišemo s Bitcoin adresom, kako bi dokazali vlasništvo nad tom adresom</translation>
     </message>
     <message>
+        <source>&amp;Verify message…</source>
+        <translation type="unfinished">&amp;Potvrdi poruku</translation>
+    </message>
+    <message>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation>Provjerite poruku da je potpisana s navedenom Bitcoin adresom</translation>
+    </message>
+    <message>
+        <source>&amp;Load PSBT from file…</source>
+        <translation type="unfinished">&amp;Učitaj PSBT iz datoteke...</translation>
+    </message>
+    <message>
+        <source>Load PSBT from clipboard…</source>
+        <translation type="unfinished">Učitaj PSBT iz međuspremnika...</translation>
+    </message>
+    <message>
+        <source>Open &amp;URI…</source>
+        <translation type="unfinished">Otvori &amp;URI adresu...</translation>
+    </message>
+    <message>
+        <source>Close Wallet…</source>
+        <translation type="unfinished">Zatvori novčanik...</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation type="unfinished">Kreiraj novčanik...</translation>
+    </message>
+    <message>
+        <source>Close All Wallets…</source>
+        <translation type="unfinished">Zatvori sve novčanike...</translation>
     </message>
     <message>
         <source>&amp;File</source>
@@ -441,6 +555,30 @@
     <message>
         <source>Tabs toolbar</source>
         <translation>Traka kartica</translation>
+    </message>
+    <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation type="unfinished">Sinkronizacija zaglavlja bloka (%1%)...</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation type="unfinished">Sinkronizacija s mrežom...</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation type="unfinished">Indeksiranje blokova na disku...</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation type="unfinished">Obrađivanje blokova na disku...</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation type="unfinished">Reindeksiranje blokova na disku...</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation type="unfinished">Povezivanje sa peer-ovima...</translation>
     </message>
     <message>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
@@ -461,14 +599,18 @@
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation>
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>Processed %n block of transaction history.</numerusform>
+            <numerusform>Processed %n blocks of transaction history.</numerusform>
+            <numerusform>Obrađeno %n blokova povijesti transakcije.</numerusform>
         </translation>
     </message>
     <message>
         <source>%1 behind</source>
         <translation>%1 iza</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation type="unfinished">Ažuriranje...</translation>
     </message>
     <message>
         <source>Last received block was generated %1 ago.</source>
@@ -543,6 +685,14 @@
         <translation type="unfinished">Prikažite pomoć programa %1 kako biste ispisali moguće opcije preko terminala</translation>
     </message>
     <message>
+        <source>&amp;Mask values</source>
+        <translation type="unfinished">&amp;Sakrij vrijednosti</translation>
+    </message>
+    <message>
+        <source>Mask the values in the Overview tab</source>
+        <translation type="unfinished">Sakrij vrijednost u tabu Pregled </translation>
+    </message>
+    <message>
         <source>default wallet</source>
         <translation type="unfinished">uobičajeni novčanik</translation>
     </message>
@@ -574,10 +724,30 @@
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n active connection(s) to Bitcoin network.</numerusform>
+            <numerusform>%n active connection(s) to Bitcoin network.</numerusform>
+            <numerusform>%n aktivnih veza s Bitcoin mrežom.</numerusform>
         </translation>
+    </message>
+    <message>
+        <source>Click for more actions.</source>
+        <extracomment>A substring of the tooltip. "More actions" are available via the context menu.</extracomment>
+        <translation type="unfinished">Klikni za više radnji.</translation>
+    </message>
+    <message>
+        <source>Show Peers tab</source>
+        <extracomment>A context menu item. The "Peers tab" is an element of the "Node window".</extracomment>
+        <translation type="unfinished">Pokaži Peers tab </translation>
+    </message>
+    <message>
+        <source>Disable network activity</source>
+        <extracomment>A context menu item.</extracomment>
+        <translation type="unfinished">Onemogući mrežnu aktivnost</translation>
+    </message>
+    <message>
+        <source>Enable network activity</source>
+        <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
+        <translation type="unfinished">Omogući mrežnu aktivnost</translation>
     </message>
     <message>
         <source>Error: %1</source>
@@ -602,7 +772,8 @@
     <message>
         <source>Wallet: %1
 </source>
-        <translation type="unfinished">Novčanik: %1</translation>
+        <translation type="unfinished">Novčanik: %1
+</translation>
     </message>
     <message>
         <source>Type: %1
@@ -650,7 +821,11 @@
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Novčanik je &lt;b&gt;šifriran&lt;/b&gt; i trenutno &lt;b&gt;zaključan&lt;/b&gt;</translation>
     </message>
-    </context>
+    <message>
+        <source>Original message:</source>
+        <translation type="unfinished">Originalna poruka:</translation>
+    </message>
+</context>
 <context>
     <name>UnitDisplayStatusBarControl</name>
     <message>
@@ -733,6 +908,30 @@
         <translation type="unfinished">Kopirajte iznos</translation>
     </message>
     <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Kopiraj adresu</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Kopiraj &amp;oznaku</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Kopiraj &amp;iznos</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">Kopiraj &amp;ID transakcije</translation>
+    </message>
+    <message>
+        <source>L&amp;ock unspent</source>
+        <translation type="unfinished">&amp;Zaključaj nepotrošen input</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock unspent</source>
+        <translation type="unfinished">&amp;Otključaj nepotrošen input</translation>
+    </message>
+    <message>
         <source>Copy quantity</source>
         <translation type="unfinished">Kopirajte iznos</translation>
     </message>
@@ -792,6 +991,10 @@
 <context>
     <name>CreateWalletActivity</name>
     <message>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation type="unfinished">Kreiranje novčanika &lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+    <message>
         <source>Create wallet failed</source>
         <translation type="unfinished">Neuspješno stvaranje novčanika</translation>
     </message>
@@ -799,7 +1002,11 @@
         <source>Create wallet warning</source>
         <translation type="unfinished">Upozorenje kod stvaranja novčanika</translation>
     </message>
-    </context>
+    <message>
+        <source>Can't list signers</source>
+        <translation type="unfinished">Nije moguće izlistati potpisnike</translation>
+    </message>
+</context>
 <context>
     <name>OpenWalletActivity</name>
     <message>
@@ -814,7 +1021,11 @@
         <source>default wallet</source>
         <translation type="unfinished">uobičajeni novčanik</translation>
     </message>
-    </context>
+    <message>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation type="unfinished">Otvaranje novčanika &lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+</context>
 <context>
     <name>WalletController</name>
     <message>
@@ -827,13 +1038,17 @@
     </message>
     <message>
         <source>Closing the wallet for too long can result in having to resync the entire chain if pruning is enabled.</source>
-        <translation type="unfinished">Držanje novčanik zatvorenim predugo može rezultirati ponovnom sinkronizacijom cijelog lanca ako je obrezivanje uključeno.</translation>
+        <translation type="unfinished">Držanje novčanik zatvorenim predugo može rezultirati ponovnom sinkronizacijom cijelog lanca ako je uključen pruning (odbacivanje dijela podataka).</translation>
     </message>
     <message>
         <source>Close all wallets</source>
         <translation type="unfinished">Zatvori sve novčanike</translation>
     </message>
-    </context>
+    <message>
+        <source>Are you sure you wish to close all wallets?</source>
+        <translation type="unfinished">Jeste li sigurni da želite zatvoriti sve novčanike?</translation>
+    </message>
+</context>
 <context>
     <name>CreateWalletDialog</name>
     <message>
@@ -857,6 +1072,10 @@
         <translation type="unfinished">Šifrirajte novčanik</translation>
     </message>
     <message>
+        <source>Advanced Options</source>
+        <translation type="unfinished">Napredne opcije</translation>
+    </message>
+    <message>
         <source>Disable private keys for this wallet. Wallets with private keys disabled will have no private keys and cannot have an HD seed or imported private keys. This is ideal for watch-only wallets.</source>
         <translation type="unfinished">Isključite privatne ključeve za ovaj novčanik. Novčanici gdje su privatni ključevi isključeni neće sadržati privatne ključeve te ne mogu imati HD sjeme ili uvezene privatne ključeve. Ova postavka je idealna za novčanike koje su isključivo za promatranje.</translation>
     </message>
@@ -873,10 +1092,35 @@
         <translation type="unfinished">Stvorite prazni novčanik</translation>
     </message>
     <message>
+        <source>Use descriptors for scriptPubKey management</source>
+        <translation type="unfinished">Koristi deskriptore za upravljanje scriptPubKey-a</translation>
+    </message>
+    <message>
+        <source>Descriptor Wallet</source>
+        <translation type="unfinished">Deskriptor novčanik</translation>
+    </message>
+    <message>
+        <source>Use an external signing device such as a hardware wallet. Configure the external signer script in wallet preferences first.</source>
+        <translation type="unfinished">Koristi vanjski potpisni uređaj kao što je hardverski novčanik.  Prije korištenja konfiguriraj vanjski potpisni skript u postavkama novčanika.</translation>
+    </message>
+    <message>
+        <source>External signer</source>
+        <translation type="unfinished">Vanjski potpisnik</translation>
+    </message>
+    <message>
         <source>Create</source>
         <translation type="unfinished">Stvorite</translation>
     </message>
-    </context>
+    <message>
+        <source>Compiled without sqlite support (required for descriptor wallets)</source>
+        <translation type="unfinished">Kompajlirano bez sqlite mogućnosti (potrebno za deskriptor novčanike)</translation>
+    </message>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Kompajlirano bez mogućnosti vanjskog potpisivanje (potrebno za vanjsko potpisivanje)</translation>
+    </message>
+</context>
 <context>
     <name>EditAddressDialog</name>
     <message>
@@ -936,7 +1180,7 @@
     <name>FreespaceChecker</name>
     <message>
         <source>A new data directory will be created.</source>
-        <translation>Bit će stvorena nova podatkovna mapa.</translation>
+        <translation>Biti će stvorena nova podatkovna mapa.</translation>
     </message>
     <message>
         <source>name</source>
@@ -958,6 +1202,18 @@
 <context>
     <name>Intro</name>
     <message>
+        <source>%1 GB of free space available</source>
+        <translation type="unfinished">Dostupno je %1 GB slobodnog prostora</translation>
+    </message>
+    <message>
+        <source>(of %1 GB needed)</source>
+        <translation type="unfinished">(od potrebnih %1 GB)</translation>
+    </message>
+    <message>
+        <source>(%1 GB needed for full chain)</source>
+        <translation type="unfinished">(potrebno je %1 GB-a za cijeli lanac)</translation>
+    </message>
+    <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
         <translation type="unfinished">Bit će spremljeno barem %1 GB podataka u ovoj mapi te će se povećati tijekom vremena.</translation>
     </message>
@@ -969,9 +1225,9 @@
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>(sufficient to restore backups %n day(s) old)</numerusform>
+            <numerusform>(sufficient to restore backups %n day(s) old)</numerusform>
+            <numerusform>(dovoljno za vraćanje sigurnosne kopije stare %n dan(a))</numerusform>
         </translation>
     </message>
     <message>
@@ -1007,6 +1263,10 @@
         <translation type="unfinished">Kada kliknete OK, %1 počet će preuzimati i procesirati cijeli lanac blokova (%2GB) počevši s najranijim transakcijama u %3 kad je %4 prvi put pokrenut.</translation>
     </message>
     <message>
+        <source>Limit block chain storage to</source>
+        <translation type="unfinished">Ograniči pohranu u blockchain na:</translation>
+    </message>
+    <message>
         <source>Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</source>
         <translation type="unfinished">Vraćanje na ovu postavku zahtijeva ponovno preuzimanje cijelog lanca blokova. Brže je najprije preuzeti cijeli lanac pa ga kasnije obrezati. Isključuje napredne mogućnosti.</translation>
     </message>
@@ -1016,7 +1276,7 @@
     </message>
     <message>
         <source>If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</source>
-        <translation type="unfinished">Ako odlučite ograničiti spremanje lanca blokova pomoću pruninga (obrezivanja), treba preuzeti i procesirati povijesne podatke. Bit će obrisani naknadno kako bi se smanjila količina zauzetog prostora na disku.</translation>
+        <translation type="unfinished">Ako odlučite ograničiti spremanje lanca blokova pomoću pruninga, treba preuzeti i procesirati povijesne podatke. Bit će obrisani naknadno kako bi se smanjila količina zauzetog prostora na disku.</translation>
     </message>
     <message>
         <source>Use the default data directory</source>
@@ -1045,6 +1305,10 @@
 <context>
     <name>ShutdownWindow</name>
     <message>
+        <source>%1 is shutting down…</source>
+        <translation type="unfinished">%1 do zatvaranja...</translation>
+    </message>
+    <message>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished">Ne ugasite računalo dok ovaj prozor ne nestane.</translation>
     </message>
@@ -1068,6 +1332,14 @@
         <translation type="unfinished">Broj preostalih blokova</translation>
     </message>
     <message>
+        <source>Unknown…</source>
+        <translation type="unfinished">Nepoznato...</translation>
+    </message>
+    <message>
+        <source>calculating…</source>
+        <translation type="unfinished">računam...</translation>
+    </message>
+    <message>
         <source>Last block time</source>
         <translation type="unfinished">Posljednje vrijeme bloka</translation>
     </message>
@@ -1087,7 +1359,11 @@
         <source>Hide</source>
         <translation type="unfinished">Sakrijte</translation>
     </message>
-    </context>
+    <message>
+        <source>Unknown. Syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">Nepoznato. Sinkroniziranje zaglavlja blokova (%1, %2%)...</translation>
+    </message>
+</context>
 <context>
     <name>OpenURIDialog</name>
     <message>
@@ -1099,7 +1375,7 @@
     <name>OptionsDialog</name>
     <message>
         <source>Options</source>
-        <translation>Postavke</translation>
+        <translation>Opcije</translation>
     </message>
     <message>
         <source>&amp;Main</source>
@@ -1112,6 +1388,10 @@
     <message>
         <source>&amp;Start %1 on system login</source>
         <translation type="unfinished">&amp;Pokrenite %1 kod prijave u sustav</translation>
+    </message>
+    <message>
+        <source>Enabling pruning significantly reduces the disk space required to store transactions. All blocks are still fully validated. Reverting this setting requires re-downloading the entire blockchain.</source>
+        <translation type="unfinished">Omogućavanje pruninga smanjuje prostor na disku potreban za pohranu transakcija. Svi blokovi su još uvijek potpuno potvrđeni. Poništavanje ove postavke uzrokuje ponovno skidanje cijelog blockchaina.</translation>
     </message>
     <message>
         <source>Size of &amp;database cache</source>
@@ -1147,11 +1427,11 @@
     </message>
     <message>
         <source>Reset all client options to default.</source>
-        <translation>Nastavi sve postavke programa na početne vrijednosti.</translation>
+        <translation>Resetiraj sve opcije programa na početne vrijednosti.</translation>
     </message>
     <message>
         <source>&amp;Reset Options</source>
-        <translation>Po&amp;nastavi postavke</translation>
+        <translation>&amp;Resetiraj opcije</translation>
     </message>
     <message>
         <source>&amp;Network</source>
@@ -1190,12 +1470,32 @@
         <translation type="unfinished">&amp;Trošenje nepotvrđenih vraćenih iznosa</translation>
     </message>
     <message>
+        <source>External Signer (e.g. hardware wallet)</source>
+        <translation type="unfinished">Vanjski potpisnik (npr. hardverski novčanik)</translation>
+    </message>
+    <message>
+        <source>&amp;External signer script path</source>
+        <translation type="unfinished">&amp;Put za vanjsku skriptu potpisnika</translation>
+    </message>
+    <message>
+        <source>Full path to a Bitcoin Core compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</source>
+        <translation type="unfinished">Cijeli put do Bitcoin Core kompatibilnog skripta (npr. C:\Downloads\hwi.exe ili /Users/you/Downloads/hwi.py). Upozerenje: malware može ukrasti vaša sredstva!</translation>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation>Automatski otvori port Bitcoin klijenta na ruteru. To radi samo ako ruter podržava UPnP i ako je omogućen.</translation>
     </message>
     <message>
         <source>Map port using &amp;UPnP</source>
         <translation>Mapiraj port koristeći &amp;UPnP</translation>
+    </message>
+    <message>
+        <source>Automatically open the Bitcoin client port on the router. This only works when your router supports NAT-PMP and it is enabled. The external port could be random.</source>
+        <translation type="unfinished">Automatski otvori port Bitcoin klijenta na ruteru. Ovo radi samo ako ruter podržava UPnP i ako je omogućen. Vanjski port može biti nasumičan.</translation>
+    </message>
+    <message>
+        <source>Map port using NA&amp;T-PMP</source>
+        <translation type="unfinished">Mapiraj port koristeći &amp;UPnP</translation>
     </message>
     <message>
         <source>Accept connections from outside.</source>
@@ -1242,6 +1542,14 @@
         <translation>&amp;Prozor</translation>
     </message>
     <message>
+        <source>Show the icon in the system tray.</source>
+        <translation type="unfinished">Pokaži ikonu sa sustavne trake.</translation>
+    </message>
+    <message>
+        <source>&amp;Show tray icon</source>
+        <translation type="unfinished">&amp;Pokaži ikonu</translation>
+    </message>
+    <message>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation>Prikaži samo ikonu u sistemskoj traci nakon minimiziranja prozora</translation>
     </message>
@@ -1278,8 +1586,28 @@
         <translation type="unfinished">Ovisi želite li prikazati mogućnosti kontroliranja inputa ili ne.</translation>
     </message>
     <message>
+        <source>Connect to the Bitcoin network through a separate SOCKS5 proxy for Tor onion services.</source>
+        <translation type="unfinished">Spojite se na Bitcoin mrežu kroz zaseban SOCKS5 proxy za povezivanje na Tor onion usluge.</translation>
+    </message>
+    <message>
+        <source>Use separate SOCKS&amp;5 proxy to reach peers via Tor onion services:</source>
+        <translation type="unfinished">Koristite zaseban SOCKS&amp;5 proxy kako biste dohvatili klijente preko Tora:</translation>
+    </message>
+    <message>
         <source>&amp;Third party transaction URLs</source>
         <translation type="unfinished">&amp;URL-ovi treće stranke o transakciji</translation>
+    </message>
+    <message>
+        <source>Monospaced font in the Overview tab:</source>
+        <translation type="unfinished">Font fiksne širine u tabu Pregled:</translation>
+    </message>
+    <message>
+        <source>embedded "%1"</source>
+        <translation type="unfinished">ugrađen "%1"</translation>
+    </message>
+    <message>
+        <source>closest matching "%1"</source>
+        <translation type="unfinished">najbliže poklapanje "%1"</translation>
     </message>
     <message>
         <source>Options set in this dialog are overridden by the command line or in the configuration file:</source>
@@ -1292,6 +1620,11 @@
     <message>
         <source>&amp;Cancel</source>
         <translation>&amp;Odustani</translation>
+    </message>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Kompajlirano bez mogućnosti vanjskog potpisivanje (potrebno za vanjsko potpisivanje)</translation>
     </message>
     <message>
         <source>default</source>
@@ -1315,7 +1648,7 @@
     </message>
     <message>
         <source>Configuration options</source>
-        <translation type="unfinished">Konfiguracijske postavke</translation>
+        <translation type="unfinished">Konfiguracijske opcije</translation>
     </message>
     <message>
         <source>The configuration file is used to specify advanced user options which override GUI settings. Additionally, any command-line options will override this configuration file.</source>
@@ -1412,12 +1745,97 @@
         <source>Current total balance in watch-only addresses</source>
         <translation type="unfinished">Trenutno ukupno stanje na isključivo promatranim adresama</translation>
     </message>
-    </context>
+    <message>
+        <source>Privacy mode activated for the Overview tab. To unmask the values, uncheck Settings-&gt;Mask values.</source>
+        <translation type="unfinished">Privatni način aktiviran za tab Pregled. Za prikaz vrijednosti, odznači Postavke -&gt; Sakrij vrijednosti.</translation>
+    </message>
+</context>
 <context>
     <name>PSBTOperationsDialog</name>
     <message>
         <source>Dialog</source>
         <translation type="unfinished">Dijalog</translation>
+    </message>
+    <message>
+        <source>Sign Tx</source>
+        <translation type="unfinished">Potpiši Tx</translation>
+    </message>
+    <message>
+        <source>Broadcast Tx</source>
+        <translation type="unfinished">Objavi Tx</translation>
+    </message>
+    <message>
+        <source>Copy to Clipboard</source>
+        <translation type="unfinished">Kopiraj u međuspremnik</translation>
+    </message>
+    <message>
+        <source>Save…</source>
+        <translation type="unfinished">Spremi...</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation type="unfinished">Zatvori</translation>
+    </message>
+    <message>
+        <source>Failed to load transaction: %1</source>
+        <translation type="unfinished">Neuspješno dohvaćanje transakcije: %1</translation>
+    </message>
+    <message>
+        <source>Failed to sign transaction: %1</source>
+        <translation type="unfinished">Neuspješno potpisivanje transakcije: %1</translation>
+    </message>
+    <message>
+        <source>Could not sign any more inputs.</source>
+        <translation type="unfinished">Nije bilo moguće potpisati više inputa. </translation>
+    </message>
+    <message>
+        <source>Signed %1 inputs, but more signatures are still required.</source>
+        <translation type="unfinished">Potpisano %1 inputa, ali potrebno je još potpisa. </translation>
+    </message>
+    <message>
+        <source>Signed transaction successfully. Transaction is ready to broadcast.</source>
+        <translation type="unfinished">Transakcija uspješno potpisana. Transakcija je spremna za objavu.</translation>
+    </message>
+    <message>
+        <source>Unknown error processing transaction.</source>
+        <translation type="unfinished">Nepoznata greška pri obradi transakcije.</translation>
+    </message>
+    <message>
+        <source>Transaction broadcast successfully! Transaction ID: %1</source>
+        <translation type="unfinished">Uspješna objava transakcije! ID transakcije: %1</translation>
+    </message>
+    <message>
+        <source>Transaction broadcast failed: %1</source>
+        <translation type="unfinished">Neuspješna objava transakcije: %1</translation>
+    </message>
+    <message>
+        <source>PSBT copied to clipboard.</source>
+        <translation type="unfinished">PBST kopiran u meduspremnik.</translation>
+    </message>
+    <message>
+        <source>Save Transaction Data</source>
+        <translation type="unfinished">Spremi podatke transakcije</translation>
+    </message>
+    <message>
+        <source>Partially Signed Transaction (Binary)</source>
+        <extracomment>Expanded name of the binary PSBT file format. See: BIP 174.</extracomment>
+        <translation type="unfinished">Djelomično potpisana transakcija (binarno)</translation>
+    </message>
+    <message>
+        <source>PSBT saved to disk.</source>
+        <translation type="unfinished">PBST spremljen na disk.</translation>
+    </message>
+    <message>
+        <source> * Sends %1 to %2</source>
+        <translation type="unfinished">* Šalje %1 %2</translation>
+    </message>
+    <message>
+        <source>Unable to calculate transaction fee or total transaction amount.</source>
+        <translation type="unfinished">Ne mogu izračunati naknadu za transakciju niti totalni iznos transakcije.</translation>
+    </message>
+    <message>
+        <source>Pays transaction fee: </source>
+        <translation type="unfinished">Plaća naknadu za transakciju:</translation>
     </message>
     <message>
         <source>Total Amount</source>
@@ -1427,7 +1845,35 @@
         <source>or</source>
         <translation type="unfinished">ili</translation>
     </message>
-    </context>
+    <message>
+        <source>Transaction has %1 unsigned inputs.</source>
+        <translation type="unfinished">Transakcija ima %1 nepotpisanih inputa.</translation>
+    </message>
+    <message>
+        <source>Transaction is missing some information about inputs.</source>
+        <translation type="unfinished">Transakciji nedostaje informacija o inputima.</translation>
+    </message>
+    <message>
+        <source>Transaction still needs signature(s).</source>
+        <translation type="unfinished">Transakcija još uvijek treba potpis(e).</translation>
+    </message>
+    <message>
+        <source>(But this wallet cannot sign transactions.)</source>
+        <translation type="unfinished">(Ali ovaj novčanik ne može potpisati transakcije.)</translation>
+    </message>
+    <message>
+        <source>(But this wallet does not have the right keys.)</source>
+        <translation type="unfinished">(Ali ovaj novčanik nema odgovarajuće ključeve.)</translation>
+    </message>
+    <message>
+        <source>Transaction is fully signed and ready for broadcast.</source>
+        <translation type="unfinished">Transakcija je cjelovito potpisana i spremna za objavu.</translation>
+    </message>
+    <message>
+        <source>Transaction status is unknown.</source>
+        <translation type="unfinished">Status transakcije je nepoznat.</translation>
+    </message>
+</context>
 <context>
     <name>PaymentServer</name>
     <message>
@@ -1445,6 +1891,14 @@
     <message>
         <source>'bitcoin://' is not a valid URI. Use 'bitcoin:' instead.</source>
         <translation type="unfinished">'bitcoin://' nije ispravan URI. Koristite 'bitcoin:' umjesto toga.</translation>
+    </message>
+    <message>
+        <source>Cannot process payment request because BIP70 is not supported.
+Due to widespread security flaws in BIP70 it's strongly recommended that any merchant instructions to switch wallets be ignored.
+If you are receiving this error you should request the merchant provide a BIP21 compatible URI.</source>
+        <translation type="unfinished">Nemoguće obraditi zahtjev za plaćanje zato što BIP70 nije podržan.
+S obzirom na široko rasprostranjene sigurnosne nedostatke u BIP70, preporučljivo je da zanemarite preporuke trgovca u  vezi promjene novčanika.
+Ako imate ovu grešku, od trgovca zatražite URI koji je kompatibilan sa BIP21.</translation>
     </message>
     <message>
         <source>URI cannot be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
@@ -1491,6 +1945,10 @@
 <context>
     <name>QRImageWidget</name>
     <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">&amp;Spremi sliku...</translation>
+    </message>
+    <message>
         <source>&amp;Copy Image</source>
         <translation type="unfinished">&amp;Kopirajte sliku</translation>
     </message>
@@ -1510,7 +1968,12 @@
         <source>Save QR Code</source>
         <translation type="unfinished">Spremi QR kod</translation>
     </message>
-    </context>
+    <message>
+        <source>PNG Image</source>
+        <extracomment>Expanded name of the PNG file format. See https://en.wikipedia.org/wiki/Portable_Network_Graphics</extracomment>
+        <translation type="unfinished">PNG slika</translation>
+    </message>
+</context>
 <context>
     <name>RPCConsole</name>
     <message>
@@ -1618,6 +2081,10 @@
         <translation type="unfinished">Broj sinkronizranih blokova</translation>
     </message>
     <message>
+        <source>The mapped Autonomous System used for diversifying peer selection.</source>
+        <translation type="unfinished">Mapirani Autonomni sustav koji se koristi za diverzifikaciju odabira peer-ova.</translation>
+    </message>
+    <message>
         <source>Mapped AS</source>
         <translation type="unfinished">Mapirano kao</translation>
     </message>
@@ -1628,6 +2095,10 @@
     <message>
         <source>Node window</source>
         <translation type="unfinished">Konzola za čvor</translation>
+    </message>
+    <message>
+        <source>Current block height</source>
+        <translation type="unfinished">Trenutna visina bloka</translation>
     </message>
     <message>
         <source>Open the %1 debug log file from the current data directory. This can take a few seconds for large log files.</source>
@@ -1642,12 +2113,60 @@
         <translation type="unfinished">Povećajte veličinu fonta</translation>
     </message>
     <message>
+        <source>Permissions</source>
+        <translation type="unfinished">Dopuštenja</translation>
+    </message>
+    <message>
+        <source>The direction and type of peer connection: %1</source>
+        <translation type="unfinished">Smjer i tip peer konekcije: %1</translation>
+    </message>
+    <message>
+        <source>Direction/Type</source>
+        <translation type="unfinished">Smjer/tip</translation>
+    </message>
+    <message>
+        <source>The network protocol this peer is connected through: IPv4, IPv6, Onion, I2P, or CJDNS.</source>
+        <translation type="unfinished">Mrežni protokoli kroz koje je spojen ovaj peer: IPv4, IPv6, Onion, I2P, ili CJDNS.</translation>
+    </message>
+    <message>
         <source>Services</source>
         <translation type="unfinished">Usluge</translation>
     </message>
     <message>
+        <source>Whether the peer requested us to relay transactions.</source>
+        <translation type="unfinished">Je li peer od nas zatražio prijenos transakcija.</translation>
+    </message>
+    <message>
+        <source>Wants Tx Relay</source>
+        <translation type="unfinished">Želi Tx prijenos</translation>
+    </message>
+    <message>
+        <source>High bandwidth BIP152 compact block relay: %1</source>
+        <translation type="unfinished">Visoka razina BIP152 kompaktnog blok prijenosa: %1</translation>
+    </message>
+    <message>
+        <source>High Bandwidth</source>
+        <translation type="unfinished">Visoka razina prijenosa podataka</translation>
+    </message>
+    <message>
         <source>Connection Time</source>
         <translation type="unfinished">Trajanje veze</translation>
+    </message>
+    <message>
+        <source>Elapsed time since a novel block passing initial validity checks was received from this peer.</source>
+        <translation type="unfinished">Vrijeme prošlo od kada je ovaj peer primio novi bloka koji je prošao osnovne provjere validnosti.</translation>
+    </message>
+    <message>
+        <source>Last Block</source>
+        <translation type="unfinished">Zadnji blok</translation>
+    </message>
+    <message>
+        <source>Elapsed time since a novel transaction accepted into our mempool was received from this peer.</source>
+        <translation type="unfinished">Vrijeme prošlo od kada je ovaj peer primio novu transakciju koja je prihvaćena u naš mempool.</translation>
+    </message>
+    <message>
+        <source>Last Tx</source>
+        <translation type="unfinished">Zadnja Tx</translation>
     </message>
     <message>
         <source>Last Send</source>
@@ -1714,12 +2233,52 @@
         <translation type="unfinished">Izlazne:</translation>
     </message>
     <message>
+        <source>Inbound: initiated by peer</source>
+        <translation type="unfinished">Ulazna: pokrenuo peer</translation>
+    </message>
+    <message>
+        <source>Outbound Full Relay: default</source>
+        <translation type="unfinished">Izlazni potpuni prijenos: zadano</translation>
+    </message>
+    <message>
+        <source>Outbound Block Relay: does not relay transactions or addresses</source>
+        <translation type="unfinished">Izlazni blok prijenos: ne prenosi transakcije ili adrese</translation>
+    </message>
+    <message>
+        <source>Outbound Manual: added using RPC %1 or %2/%3 configuration options</source>
+        <translation type="unfinished">Priručnik za izlazeće (?): dodano koristeći RPC %1 ili %2/%3 konfiguracijske opcije</translation>
+    </message>
+    <message>
+        <source>Outbound Feeler: short-lived, for testing addresses</source>
+        <translation type="unfinished">Izlazni ispipavač: kratkotrajan, za testiranje adresa</translation>
+    </message>
+    <message>
+        <source>Outbound Address Fetch: short-lived, for soliciting addresses</source>
+        <translation type="unfinished">Dohvaćanje izlaznih adresa: kratkotrajno, za traženje adresa</translation>
+    </message>
+    <message>
+        <source>we selected the peer for high bandwidth relay</source>
+        <translation type="unfinished">odabrali smo peera za brzopodatkovni prijenos</translation>
+    </message>
+    <message>
+        <source>the peer selected us for high bandwidth relay</source>
+        <translation type="unfinished">peer odabran za brzopodatkovni prijenos</translation>
+    </message>
+    <message>
+        <source>no high bandwidth relay selected</source>
+        <translation type="unfinished">brzopodatkovni prijenos nije odabran</translation>
+    </message>
+    <message>
         <source>&amp;Disconnect</source>
         <translation type="unfinished">&amp;Odspojite</translation>
     </message>
     <message>
         <source>1 &amp;hour</source>
         <translation type="unfinished">1 &amp;sat</translation>
+    </message>
+    <message>
+        <source>1 d&amp;ay</source>
+        <translation type="unfinished">1 d&amp;an</translation>
     </message>
     <message>
         <source>1 &amp;week</source>
@@ -1746,6 +2305,28 @@
         <translation type="unfinished">Izvršava se naredba koristeći novčanik "%1"</translation>
     </message>
     <message>
+        <source>Welcome to the %1 RPC console.
+Use up and down arrows to navigate history, and %2 to clear screen.
+Use %3 and %4 to increase or decrease the font size.
+Type %5 for an overview of available commands.
+For more information on using this console, type %6.
+
+%7WARNING: Scammers have been active, telling users to type commands here, stealing their wallet contents. Do not use this console without fully understanding the ramifications of a command.%8</source>
+        <extracomment>RPC console welcome message. Placeholders %7 and %8 are style tags for the warning content, and they are not space separated from the rest of the text intentionally.</extracomment>
+        <translation type="unfinished">Dobrodošli u %1 RPC konzolu.
+Koristite strelice za gore i dolje kako biste navigirali kroz povijest, i %2 za micanje svega sa zaslona.
+Koristite %3 i %4 za smanjivanje i povećavanje veličine fonta.
+Utipkajte %5 za pregled svih dosrupnih komandi.
+Za više informacija o korištenju ove konzile, utipkajte %6.
+
+%7UPOZORENJE: Prevaranti su uvijek aktivni te kradu sadržaj novčanika korisnika tako što im daju upute koje komande upisati. Nemojte koristiti ovu konzolu bez potpunog razumijevanja posljedica upisivanja komande.%8</translation>
+    </message>
+    <message>
+        <source>Executing…</source>
+        <extracomment>A console message indicating an entered command is currently being executed.</extracomment>
+        <translation type="unfinished">Izvršavam...</translation>
+    </message>
+    <message>
         <source>via %1</source>
         <translation type="unfinished">preko %1</translation>
     </message>
@@ -1768,6 +2349,10 @@
     <message>
         <source>Ban for</source>
         <translation type="unfinished">Zabranite za</translation>
+    </message>
+    <message>
+        <source>Never</source>
+        <translation type="unfinished">Nikada</translation>
     </message>
     <message>
         <source>Unknown</source>
@@ -1803,6 +2388,10 @@
     <message>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished">Opcionalan iznos koji možete zahtijevati. Ostavite ovo prazno ili unesite nulu ako ne želite zahtijevati specifičan iznos.</translation>
+    </message>
+    <message>
+        <source>An optional label to associate with the new receiving address (used by you to identify an invoice).  It is also attached to the payment request.</source>
+        <translation type="unfinished">Neobvezna oznaka za označavanje nove primateljske adrese (koristi se za identifikaciju računa). Također je pridružena zahtjevu za plaćanje.</translation>
     </message>
     <message>
         <source>An optional message that is attached to the payment request and may be displayed to the sender.</source>
@@ -1853,12 +2442,40 @@
         <translation type="unfinished">Kopiraj &amp;URI</translation>
     </message>
     <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Kopiraj adresu</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Kopiraj &amp;oznaku</translation>
+    </message>
+    <message>
+        <source>Copy &amp;message</source>
+        <translation type="unfinished">Kopiraj &amp;poruku</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Kopiraj &amp;iznos</translation>
+    </message>
+    <message>
         <source>Could not unlock wallet.</source>
         <translation type="unfinished">Ne može se otključati novčanik.</translation>
     </message>
-    </context>
+    <message>
+        <source>Could not generate new %1 address</source>
+        <translation type="unfinished">Ne mogu generirati novu %1 adresu</translation>
+    </message>
+</context>
 <context>
     <name>ReceiveRequestDialog</name>
+    <message>
+        <source>Request payment to …</source>
+        <translation type="unfinished">Zatraži plaćanje na...</translation>
+    </message>
+    <message>
+        <source>Address:</source>
+        <translation type="unfinished">Adresa:</translation>
+    </message>
     <message>
         <source>Amount:</source>
         <translation type="unfinished">Iznos:</translation>
@@ -1882,6 +2499,18 @@
     <message>
         <source>Copy &amp;Address</source>
         <translation type="unfinished">Kopiraj &amp;adresu</translation>
+    </message>
+    <message>
+        <source>&amp;Verify</source>
+        <translation type="unfinished">&amp;Verificiraj</translation>
+    </message>
+    <message>
+        <source>Verify this address on e.g. a hardware wallet screen</source>
+        <translation type="unfinished">Verificiraj ovu adresu na npr. zaslonu hardverskog novčanika</translation>
+    </message>
+    <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">&amp;Spremi sliku...</translation>
     </message>
     <message>
         <source>Payment information</source>
@@ -2014,13 +2643,29 @@
         <translation type="unfinished">Obriši sva polja</translation>
     </message>
     <message>
+        <source>Inputs…</source>
+        <translation type="unfinished">Inputi...</translation>
+    </message>
+    <message>
         <source>Dust:</source>
         <translation type="unfinished">Prah:</translation>
+    </message>
+    <message>
+        <source>Choose…</source>
+        <translation type="unfinished">Odaberi...</translation>
     </message>
     <message>
         <source>Hide transaction fee settings</source>
         <translation type="unfinished">Sakrijte postavke za transakcijske provizije
 </translation>
+    </message>
+    <message>
+        <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
+
+Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satoshis per kvB" for a transaction size of 500 virtual bytes (half of 1 kvB) would ultimately yield a fee of only 50 satoshis.</source>
+        <translation type="unfinished">Zadajte prilagodenu naknadu po kB (1000 bajtova) virtualne veličine transakcije.
+
+Napomena: Budući da se naknada računa po bajtu, naknada od "100 satošija po kB" za transakciju veličine 500 bajtova (polovica od 1 kB) rezultirala bi ultimativno naknadom od samo 50 satošija.</translation>
     </message>
     <message>
         <source>When there is less transaction volume than space in the blocks, miners as well as relaying nodes may enforce a minimum fee. Paying only this minimum fee is just fine, but be aware that this can result in a never confirming transaction once there is more demand for bitcoin transactions than the network can process.</source>
@@ -2029,6 +2674,10 @@
     <message>
         <source>A too low fee might result in a never confirming transaction (read the tooltip)</source>
         <translation type="unfinished">Preniska naknada može rezultirati transakcijom koja se nikad ne potvrđuje (vidite oblačić)</translation>
+    </message>
+    <message>
+        <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
+        <translation type="unfinished">(Pametna procjena naknada još nije inicijalizirana. Inače traje nekoliko blokova...)</translation>
     </message>
     <message>
         <source>Confirmation time target:</source>
@@ -2091,8 +2740,26 @@
         <translation type="unfinished">%1 (%2 blokova)</translation>
     </message>
     <message>
+        <source>Sign on device</source>
+        <extracomment>"device" usually means a hardware wallet</extracomment>
+        <translation type="unfinished">Potpiši na uređaju</translation>
+    </message>
+    <message>
+        <source>Connect your hardware wallet first.</source>
+        <translation type="unfinished">Prvo poveži svoj hardverski novčanik.</translation>
+    </message>
+    <message>
+        <source>Set external signer script path in Options -&gt; Wallet</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Postavi put za vanjsku skriptu potpisnika u Opcije -&gt; Novčanik</translation>
+    </message>
+    <message>
         <source>Cr&amp;eate Unsigned</source>
         <translation type="unfinished">Cr&amp;eate nije potpisan</translation>
+    </message>
+    <message>
+        <source>Creates a Partially Signed Bitcoin Transaction (PSBT) for use with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
+        <translation type="unfinished">Stvara djelomično potpisanu Bitcoin transakciju (Partially Signed Bitcoin Transaction - PSBT) za upotrebu sa npr. novčanikom %1 koji nije povezan s mrežom ili sa PSBT kompatibilnim hardverskim novčanikom.</translation>
     </message>
     <message>
         <source> from wallet '%1'</source>
@@ -2115,8 +2782,47 @@
         <translation type="unfinished">Jeste li sigurni da želite poslati transakciju?</translation>
     </message>
     <message>
+        <source>To review recipient list click "Show Details…"</source>
+        <translation type="unfinished">Kliknite "Prikažite detalje..." kako biste pregledali popis primatelja</translation>
+    </message>
+    <message>
+        <source>Create Unsigned</source>
+        <translation type="unfinished">Kreiraj nepotpisano</translation>
+    </message>
+    <message>
+        <source>Sign and send</source>
+        <translation type="unfinished">Potpiši i pošalji</translation>
+    </message>
+    <message>
         <source>Sign failed</source>
         <translation type="unfinished">Potpis nije uspio</translation>
+    </message>
+    <message>
+        <source>External signer not found</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Vanjski potpisnik nije pronađen</translation>
+    </message>
+    <message>
+        <source>External signer failure</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Neuspješno vanjsko potpisivanje</translation>
+    </message>
+    <message>
+        <source>Save Transaction Data</source>
+        <translation type="unfinished">Spremi podatke transakcije</translation>
+    </message>
+    <message>
+        <source>Partially Signed Transaction (Binary)</source>
+        <extracomment>Expanded name of the binary PSBT file format. See: BIP 174.</extracomment>
+        <translation type="unfinished">Djelomično potpisana transakcija (binarno)</translation>
+    </message>
+    <message>
+        <source>PSBT saved</source>
+        <translation type="unfinished">PSBT spremljen</translation>
+    </message>
+    <message>
+        <source>External balance:</source>
+        <translation type="unfinished">Vanjski balans:</translation>
     </message>
     <message>
         <source>or</source>
@@ -2125,6 +2831,10 @@
     <message>
         <source>You can increase the fee later (signals Replace-By-Fee, BIP-125).</source>
         <translation type="unfinished">Možete kasnije povećati naknadu (javlja Replace-By-Fee, BIP-125).</translation>
+    </message>
+    <message>
+        <source>Please, review your transaction proposal. This will produce a Partially Signed Bitcoin Transaction (PSBT) which you can save or copy and then sign with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
+        <translation type="unfinished">Molimo pregledajte svoj prijedlog transakcije. Ovo će stvoriti djelomično potpisanu Bitcoin transakciju (PBST) koju možete spremiti ili kopirati i zatim potpisati sa npr. novčanikom %1 koji nije povezan s mrežom ili sa PSBT kompatibilnim hardverskim novčanikom.</translation>
     </message>
     <message>
         <source>Please, review your transaction.</source>
@@ -2189,9 +2899,9 @@
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation>
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>Estimated to begin confirmation within %n block.</numerusform>
+            <numerusform>Estimated to begin confirmation within %n blocks.</numerusform>
+            <numerusform>Procijenjeno je da će potvrđivanje početi unutar %n blokova.</numerusform>
         </translation>
     </message>
     <message>
@@ -2438,9 +3148,9 @@
     <message numerus="yes">
         <source>Open for %n more block(s)</source>
         <translation>
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>Open for %n more block</numerusform>
+            <numerusform>Open for %n more blocks</numerusform>
+            <numerusform>Otvori za još %n blokova</numerusform>
         </translation>
     </message>
     <message>
@@ -2518,9 +3228,9 @@
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation>
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>matures in %n more block</numerusform>
+            <numerusform>matures in %n more blocks</numerusform>
+            <numerusform>dozrijeva za još %n blokova</numerusform>
         </translation>
     </message>
     <message>
@@ -2636,9 +3346,9 @@
     <message numerus="yes">
         <source>Open for %n more block(s)</source>
         <translation>
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>Open for %n more block</numerusform>
+            <numerusform>Open for %n more blocks</numerusform>
+            <numerusform>Otvori za još %n blokova</numerusform>
         </translation>
     </message>
     <message>
@@ -2785,8 +3495,57 @@
         <translation type="unfinished">Min iznos</translation>
     </message>
     <message>
+        <source>Range…</source>
+        <translation type="unfinished">Raspon...</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Kopiraj adresu</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Kopiraj &amp;oznaku</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Kopiraj &amp;iznos</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">Kopiraj &amp;ID transakcije</translation>
+    </message>
+    <message>
+        <source>Copy &amp;raw transaction</source>
+        <translation type="unfinished">Kopiraj &amp;sirovu transakciju</translation>
+    </message>
+    <message>
+        <source>Copy full transaction &amp;details</source>
+        <translation type="unfinished">Kopiraj sve transakcijske &amp;detalje</translation>
+    </message>
+    <message>
+        <source>&amp;Show transaction details</source>
+        <translation type="unfinished">&amp;Prikaži detalje transakcije</translation>
+    </message>
+    <message>
+        <source>Increase transaction &amp;fee</source>
+        <translation type="unfinished">Povećaj transakcijsku &amp;naknadu</translation>
+    </message>
+    <message>
+        <source>A&amp;bandon transaction</source>
+        <translation type="unfinished">&amp;Napusti transakciju</translation>
+    </message>
+    <message>
+        <source>&amp;Edit address label</source>
+        <translation type="unfinished">&amp;Izmjeni oznaku adrese</translation>
+    </message>
+    <message>
         <source>Export Transaction History</source>
         <translation type="unfinished">Izvozite povijest transakcija</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See https://en.wikipedia.org/wiki/Comma-separated_values</extracomment>
+        <translation type="unfinished">Datoteka podataka odvojenih zarezima (*.csv)</translation>
     </message>
     <message>
         <source>Confirmed</source>
@@ -2840,6 +3599,14 @@
 <context>
     <name>WalletFrame</name>
     <message>
+        <source>No wallet has been loaded.
+Go to File &gt; Open Wallet to load a wallet.
+- OR -</source>
+        <translation type="unfinished">Nijedan novčanik nije učitan.
+Idi na Datoteka &gt;  Otvori novčanik za učitanje novčanika.
+- ILI -</translation>
+    </message>
+    <message>
         <source>Create a new wallet</source>
         <translation type="unfinished">Stvorite novi novčanik</translation>
     </message>
@@ -2863,6 +3630,10 @@
         <translation type="unfinished">Želite li povećati naknadu?</translation>
     </message>
     <message>
+        <source>Do you want to draft a transaction with fee increase?</source>
+        <translation type="unfinished">Želite li pripremiti nacrt transakcije s povećanom naknadom?</translation>
+    </message>
+    <message>
         <source>Current fee:</source>
         <translation type="unfinished">Trenutna naknada:</translation>
     </message>
@@ -2873,6 +3644,10 @@
     <message>
         <source>New fee:</source>
         <translation type="unfinished">Nova naknada:</translation>
+    </message>
+    <message>
+        <source>Warning: This may pay the additional fee by reducing change outputs or adding inputs, when necessary. It may add a new change output if one does not already exist. These changes may potentially leak privacy.</source>
+        <translation type="unfinished">Upozorenje: Ovo može platiti dodatnu naknadu smanjenjem change outputa ili dodavanjem inputa, po potrebi. Može dodati novi change output ako jedan već ne postoji. Ove promjene bi mogle smanjiti privatnost.</translation>
     </message>
     <message>
         <source>Confirm fee bump</source>
@@ -2895,6 +3670,10 @@
         <translation type="unfinished">Transakcija ne može biti izvršena.</translation>
     </message>
     <message>
+        <source>Can't display address</source>
+        <translation type="unfinished">Ne mogu prikazati adresu</translation>
+    </message>
+    <message>
         <source>default wallet</source>
         <translation type="unfinished">uobičajeni novčanik</translation>
     </message>
@@ -2914,8 +3693,33 @@
         <translation type="unfinished">Greška</translation>
     </message>
     <message>
+        <source>Unable to decode PSBT from clipboard (invalid base64)</source>
+        <translation type="unfinished">Nije moguće dekodirati PSBT iz međuspremnika (nevažeći base64)</translation>
+    </message>
+    <message>
+        <source>Load Transaction Data</source>
+        <translation type="unfinished">Učitaj podatke transakcije</translation>
+    </message>
+    <message>
+        <source>Partially Signed Transaction (*.psbt)</source>
+        <translation type="unfinished">Djelomično potpisana transakcija (*.psbt)</translation>
+    </message>
+    <message>
+        <source>PSBT file must be smaller than 100 MiB</source>
+        <translation type="unfinished">PSBT datoteka mora biti manja od 100 MB</translation>
+    </message>
+    <message>
+        <source>Unable to decode PSBT</source>
+        <translation type="unfinished">Nije moguće dekodirati PSBT</translation>
+    </message>
+    <message>
         <source>Backup Wallet</source>
         <translation type="unfinished">Arhiviranje novčanika</translation>
+    </message>
+    <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">Podaci novčanika</translation>
     </message>
     <message>
         <source>Backup Failed</source>
@@ -2945,8 +3749,16 @@
         <translation type="unfinished">Ekipa %s</translation>
     </message>
     <message>
+        <source>%s corrupt. Try using the wallet tool bitcoin-wallet to salvage or restoring a backup.</source>
+        <translation type="unfinished">%s korumpirano. Pokušajte koristiti bitcoin-wallet alat za novčanike kako biste ga spasili ili pokrenuti sigurnosnu kopiju.</translation>
+    </message>
+    <message>
         <source>-maxtxfee is set very high! Fees this large could be paid on a single transaction.</source>
         <translation type="unfinished">-maxtxfee je postavljen preveliko. Naknade ove veličine će biti plaćene na individualnoj transakciji.</translation>
+    </message>
+    <message>
+        <source>Cannot downgrade wallet from version %i to version %i. Wallet version unchanged.</source>
+        <translation type="unfinished">Nije moguće unazaditi novčanik s verzije %i na verziju %i. Verzija novčanika nepromijenjena.</translation>
     </message>
     <message>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running.</source>
@@ -2957,12 +3769,32 @@
         <translation type="unfinished">Ne može ponuditi specifične veze i dati addrman da traži izlazne veze istovremeno.</translation>
     </message>
     <message>
+        <source>Cannot upgrade a non HD split wallet from version %i to version %i without upgrading to support pre-split keypool. Please use version %i or no version specified.</source>
+        <translation type="unfinished">Nije moguće unaprijediti podijeljeni novčanik bez HD-a s verzije %i na verziju %i bez unaprijeđenja na potporu pred-podjelnog bazena ključeva. Molimo koristite verziju %i ili neku drugu.</translation>
+    </message>
+    <message>
         <source>Distributed under the MIT software license, see the accompanying file %s or %s</source>
         <translation type="unfinished">Distribuirano pod MIT licencom softvera. Vidite pripadajuću datoteku %s ili %s.</translation>
     </message>
     <message>
         <source>Error reading %s! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation type="unfinished">Greška kod iščitanja %s! Svi ključevi su ispravno učitani, ali transakcijski podaci ili zapisi u adresaru mogu biti nepotpuni ili netočni.</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile format record is incorrect. Got "%s", expected "format".</source>
+        <translation type="unfinished">Greška: Format dumpfile zapisa je netočan. Dobiven "%s" očekivani "format".</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile identifier record is incorrect. Got "%s", expected "%s".</source>
+        <translation type="unfinished">Greška: Identifikator dumpfile zapisa je netočan. Dobiven "%s", očekivan "%s".</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile version is not supported. This version of bitcoin-wallet only supports version 1 dumpfiles. Got dumpfile with version %s</source>
+        <translation type="unfinished">Greška: Dumpfile verzija nije podržana. Ova bitcoin-wallet  verzija podržava  samo dumpfile verziju 1. Dobiven dumpfile s verzijom %s</translation>
+    </message>
+    <message>
+        <source>Error: Legacy wallets only support the "legacy", "p2sh-segwit", and "bech32" address types</source>
+        <translation type="unfinished">Greška: Legacy novčanici podržavaju samo "legacy", "p2sh-segwit", i "bech32" tipove adresa</translation>
     </message>
     <message>
         <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
@@ -2973,8 +3805,28 @@
         <translation type="unfinished">Neuspješno procjenjivanje naknada. Fallbackfee je isključena. Pričekajte nekoliko blokova ili uključite -fallbackfee.</translation>
     </message>
     <message>
+        <source>File %s already exists. If you are sure this is what you want, move it out of the way first.</source>
+        <translation type="unfinished">Datoteka %s već postoji. Ako ste sigurni da ovo želite, prvo ju maknite, </translation>
+    </message>
+    <message>
         <source>Invalid amount for -maxtxfee=&lt;amount&gt;: '%s' (must be at least the minrelay fee of %s to prevent stuck transactions)</source>
         <translation type="unfinished">Neispravan iznos za -maxtxfee=&lt;amount&gt;: '%s' (mora biti barem minimalnu naknadu za proslijeđivanje od %s kako se ne bi zapela transakcija)</translation>
+    </message>
+    <message>
+        <source>More than one onion bind address is provided. Using %s for the automatically created Tor onion service.</source>
+        <translation type="unfinished">Pruženo je više od jedne onion bind adrese. Koristim %s za automatski stvorenu Tor onion uslugu.</translation>
+    </message>
+    <message>
+        <source>No dump file provided. To use createfromdump, -dumpfile=&lt;filename&gt; must be provided.</source>
+        <translation type="unfinished">Dump datoteka nije automatski dostupna. Kako biste koristili createfromdump, -dumpfile=&lt;filename&gt; mora biti osiguran. </translation>
+    </message>
+    <message>
+        <source>No dump file provided. To use dump, -dumpfile=&lt;filename&gt; must be provided.</source>
+        <translation type="unfinished">Dump datoteka nije automatski dostupna. Kako biste koristili dump, -dumpfile=&lt;filename&gt; mora biti osiguran. </translation>
+    </message>
+    <message>
+        <source>No wallet file format provided. To use createfromdump, -format=&lt;format&gt; must be provided.</source>
+        <translation type="unfinished">Format datoteke novčanika nije dostupan. Kako biste koristili reatefromdump, -format=&lt;format&gt; mora biti osiguran.</translation>
     </message>
     <message>
         <source>Please check that your computer's date and time are correct! If your clock is wrong, %s will not work properly.</source>
@@ -2993,6 +3845,10 @@
         <translation type="unfinished">Obrezivanje: zadnja sinkronizacija novčanika ide dalje od obrezivanih podataka. Morate koristiti -reindex (ponovo preuzeti cijeli lanac blokova u slučaju obrezivanog čvora)</translation>
     </message>
     <message>
+        <source>SQLiteDatabase: Unknown sqlite wallet schema version %d. Only version %d is supported</source>
+        <translation type="unfinished">SQLiteDatabase: Nepoznata sqlite shema novčanika verzija %d. Podržana je samo verzija %d.</translation>
+    </message>
+    <message>
         <source>The block database contains a block which appears to be from the future. This may be due to your computer's date and time being set incorrectly. Only rebuild the block database if you are sure that your computer's date and time are correct</source>
         <translation type="unfinished">Baza blokova sadrži blok koji je naizgled iz budućnosti. Može to biti posljedica krivo namještenog datuma i vremena na vašem računalu. Obnovite bazu blokova samo ako ste sigurni da su točni datum i vrijeme na vašem računalu.</translation>
     </message>
@@ -3001,8 +3857,16 @@
         <translation type="unfinished">Iznos transakcije je premalen za poslati nakon naknade</translation>
     </message>
     <message>
+        <source>This error could occur if this wallet was not shutdown cleanly and was last loaded using a build with a newer version of Berkeley DB. If so, please use the software that last loaded this wallet</source>
+        <translation type="unfinished">Ova greška bi se mogla dogoditi kada se ovaj novčanik ne ugasi pravilno i ako je posljednji put bio podignut koristeći noviju verziju Berkeley DB. Ako je tako, molimo koristite softver kojim je novčanik podignut zadnji put.</translation>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation type="unfinished">Ovo je eksperimentalna verzija za testiranje - koristite je na vlastitu odgovornost - ne koristite je za rudarenje ili trgovačke primjene</translation>
+    </message>
+    <message>
+        <source>This is the maximum transaction fee you pay (in addition to the normal fee) to prioritize partial spend avoidance over regular coin selection.</source>
+        <translation type="unfinished">Ovo je najveća transakcijska naknada koju plaćate (uz normalnu naknadu) kako biste prioritizirali izbjegavanje djelomične potrošnje nad uobičajenom selekcijom sredstava.</translation>
     </message>
     <message>
         <source>This is the transaction fee you may discard if change is smaller than dust at this level</source>
@@ -3021,12 +3885,24 @@
         <translation type="unfinished">Ne mogu se ponovo odigrati blokovi. Morat ćete ponovo složiti bazu koristeći -reindex-chainstate.</translation>
     </message>
     <message>
+        <source>Unknown wallet file format "%s" provided. Please provide one of "bdb" or "sqlite".</source>
+        <translation type="unfinished">Nepoznati formant novčanika "%s" pružen. Molimo dostavite "bdb" ili "sqlite".</translation>
+    </message>
+    <message>
+        <source>Warning: Dumpfile wallet format "%s" does not match command line specified format "%s".</source>
+        <translation type="unfinished">Upozorenje: Dumpfile format novčanika "%s" se ne poklapa sa formatom komandne linije "%s".</translation>
+    </message>
+    <message>
         <source>Warning: Private keys detected in wallet {%s} with disabled private keys</source>
         <translation type="unfinished">Upozorenje: Privatni ključevi pronađeni u novčaniku {%s} s isključenim privatnim ključevima</translation>
     </message>
     <message>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished">Upozorenje: Izgleda da se ne slažemo u potpunosti s našim klijentima! Možda ćete se vi ili ostali čvorovi morati ažurirati.</translation>
+    </message>
+    <message>
+        <source>Witness data for blocks after height %d requires validation. Please restart with -reindex.</source>
+        <translation type="unfinished">Podaci svjedoka za blokove poslije visine %d zahtijevaju validaciju. Molimo restartirajte sa -reindex.</translation>
     </message>
     <message>
         <source>You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain</source>
@@ -3041,8 +3917,16 @@
         <translation type="unfinished">-maxmempool mora biti barem %d MB</translation>
     </message>
     <message>
+        <source>A fatal internal error occurred, see debug.log for details</source>
+        <translation type="unfinished">Dogodila se kobna greška, vidi detalje u debug.log.</translation>
+    </message>
+    <message>
         <source>Cannot resolve -%s address: '%s'</source>
         <translation type="unfinished">Ne može se razriješiti adresa -%s: '%s'</translation>
+    </message>
+    <message>
+        <source>Cannot set -peerblockfilters without -blockfilterindex.</source>
+        <translation type="unfinished">Nije moguće postaviti -peerblockfilters bez -blockfilterindex.</translation>
     </message>
     <message>
         <source>Cannot write to data directory '%s'; check permissions.</source>
@@ -3069,12 +3953,24 @@
         <translation type="unfinished">Nije moguće pročitati asmap datoteku %s</translation>
     </message>
     <message>
+        <source>Disk space is too low!</source>
+        <translation type="unfinished">Nema dovoljno prostora na disku!</translation>
+    </message>
+    <message>
         <source>Do you want to rebuild the block database now?</source>
         <translation type="unfinished">Želite li sada obnoviti bazu blokova?</translation>
     </message>
     <message>
         <source>Done loading</source>
         <translation type="unfinished">Učitavanje gotovo</translation>
+    </message>
+    <message>
+        <source>Dump file %s does not exist.</source>
+        <translation type="unfinished">Dump datoteka %s ne postoji.</translation>
+    </message>
+    <message>
+        <source>Error creating %s</source>
+        <translation type="unfinished">Greška pri stvaranju %s</translation>
     </message>
     <message>
         <source>Error initializing block database</source>
@@ -3113,12 +4009,52 @@
         <translation type="unfinished">Greška kod iščitanja baze. Zatvara se klijent.</translation>
     </message>
     <message>
+        <source>Error reading next record from wallet database</source>
+        <translation type="unfinished">Greška pri očitavanju idućeg zapisa iz baza podataka novčanika</translation>
+    </message>
+    <message>
         <source>Error upgrading chainstate database</source>
         <translation type="unfinished">Greška kod ažuriranja baze stanja lanca</translation>
     </message>
     <message>
+        <source>Error: Couldn't create cursor into database</source>
+        <translation type="unfinished">Greška: Nije moguće kreirati cursor u batu podataka</translation>
+    </message>
+    <message>
         <source>Error: Disk space is low for %s</source>
         <translation type="unfinished">Pogreška: Malo diskovnog prostora za %s</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile checksum does not match. Computed %s, expected %s</source>
+        <translation type="unfinished">Greška: Dumpfile checksum se ne poklapa. Izračunao %s, očekivano %s</translation>
+    </message>
+    <message>
+        <source>Error: Got key that was not hex: %s</source>
+        <translation type="unfinished">Greška: Dobiven ključ koji nije hex: %s</translation>
+    </message>
+    <message>
+        <source>Error: Got value that was not hex: %s</source>
+        <translation type="unfinished">Greška: Dobivena vrijednost koja nije hex: %s</translation>
+    </message>
+    <message>
+        <source>Error: Keypool ran out, please call keypoolrefill first</source>
+        <translation type="unfinished">Greška: Ispraznio se bazen ključeva, molimo prvo pozovite keypoolrefill</translation>
+    </message>
+    <message>
+        <source>Error: Missing checksum</source>
+        <translation type="unfinished">Greška: Nedostaje checksum</translation>
+    </message>
+    <message>
+        <source>Error: No %s addresses available.</source>
+        <translation type="unfinished">Greška: Nema %s adresa raspoloživo.</translation>
+    </message>
+    <message>
+        <source>Error: Unable to parse version %u as a uint32_t</source>
+        <translation type="unfinished">Greška: Nije moguće parsirati verziju %u kao uint32_t</translation>
+    </message>
+    <message>
+        <source>Error: Unable to write record to new wallet</source>
+        <translation type="unfinished">Greška: Nije moguće unijeti zapis u novi novčanik</translation>
     </message>
     <message>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
@@ -3127,6 +4063,22 @@
     <message>
         <source>Failed to rescan the wallet during initialization</source>
         <translation type="unfinished">Neuspješno ponovo skeniranje novčanika tijekom inicijalizacije</translation>
+    </message>
+    <message>
+        <source>Failed to verify database</source>
+        <translation type="unfinished">Verifikacija baze podataka neuspješna</translation>
+    </message>
+    <message>
+        <source>Fee rate (%s) is lower than the minimum fee rate setting (%s)</source>
+        <translation type="unfinished">Naknada (%s) je niža od postavke minimalne visine naknade (%s)</translation>
+    </message>
+    <message>
+        <source>Ignoring duplicate -wallet %s.</source>
+        <translation type="unfinished">Zanemarujem duplicirani -wallet %s.</translation>
+    </message>
+    <message>
+        <source>Importing…</source>
+        <translation type="unfinished">Uvozim...</translation>
     </message>
     <message>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
@@ -3139,6 +4091,10 @@
     <message>
         <source>Insufficient funds</source>
         <translation type="unfinished">Nedovoljna sredstva</translation>
+    </message>
+    <message>
+        <source>Invalid -i2psam address or hostname: '%s'</source>
+        <translation type="unfinished">Neispravna -i2psam adresa ili ime računala: '%s'</translation>
     </message>
     <message>
         <source>Invalid -onion address or hostname: '%s'</source>
@@ -3173,8 +4129,28 @@
         <translation type="unfinished">Neispravna mrežna maska zadana u -whitelist: '%s'</translation>
     </message>
     <message>
+        <source>Loading P2P addresses…</source>
+        <translation type="unfinished">Pokreće se popis P2P adresa...</translation>
+    </message>
+    <message>
+        <source>Loading banlist…</source>
+        <translation type="unfinished">Pokreće se popis zabrana...</translation>
+    </message>
+    <message>
+        <source>Loading block index…</source>
+        <translation type="unfinished">Učitavanje indeksa blokova...</translation>
+    </message>
+    <message>
+        <source>Loading wallet…</source>
+        <translation type="unfinished">Učitavanje novčanika...</translation>
+    </message>
+    <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
         <translation type="unfinished">Treba zadati port pomoću -whitebind: '%s'</translation>
+    </message>
+    <message>
+        <source>No proxy server specified. Use -proxy=&lt;ip&gt; or -proxy=&lt;ip:port&gt;.</source>
+        <translation type="unfinished">Proxy server nije određen. Koristi -proxy=&lt;ip&gt; ili -proxy=&lt;ip:port&gt;.</translation>
     </message>
     <message>
         <source>Not enough file descriptors available.</source>
@@ -3185,12 +4161,44 @@
         <translation type="unfinished">Obrezivanje (prune) ne može biti postavljeno na negativnu vrijednost.</translation>
     </message>
     <message>
+        <source>Prune mode is incompatible with -coinstatsindex.</source>
+        <translation type="unfinished">Pruning način nije kompatibilan s parametrom coinstatsindex.</translation>
+    </message>
+    <message>
         <source>Prune mode is incompatible with -txindex.</source>
         <translation type="unfinished">Način obreživanja (pruning) nekompatibilan je s parametrom -txindex.</translation>
     </message>
     <message>
+        <source>Pruning blockstore…</source>
+        <translation type="unfinished">Pruning blockstore-a...</translation>
+    </message>
+    <message>
         <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
         <translation type="unfinished">Smanjuje se -maxconnections sa %d na %d zbog sustavnih ograničenja.</translation>
+    </message>
+    <message>
+        <source>Replaying blocks…</source>
+        <translation type="unfinished">Premotavam blokove...</translation>
+    </message>
+    <message>
+        <source>Rescanning…</source>
+        <translation type="unfinished">Ponovno pretraživanje...</translation>
+    </message>
+    <message>
+        <source>SQLiteDatabase: Failed to execute statement to verify database: %s</source>
+        <translation type="unfinished">SQLiteDatabase: Neuspješno izvršenje izjave za verifikaciju baze podataka: %s</translation>
+    </message>
+    <message>
+        <source>SQLiteDatabase: Failed to prepare statement to verify database: %s</source>
+        <translation type="unfinished">SQLiteDatabase: Neuspješno pripremanje izjave za verifikaciju baze: %s</translation>
+    </message>
+    <message>
+        <source>SQLiteDatabase: Failed to read database verification error: %s</source>
+        <translation type="unfinished">SQLiteDatabase: Neuspješno čitanje greške verifikacije baze podataka %s</translation>
+    </message>
+    <message>
+        <source>SQLiteDatabase: Unexpected application id. Expected %u, got %u</source>
+        <translation type="unfinished">SQLiteDatabase: Neočekivani id aplikacije. Očekvano %u, pronađeno %u</translation>
     </message>
     <message>
         <source>Section [%s] is not recognized.</source>
@@ -3217,8 +4225,16 @@
         <translation type="unfinished">Zadana mapa blokova "%s" ne postoji.</translation>
     </message>
     <message>
+        <source>Starting network threads…</source>
+        <translation type="unfinished">Pokreću se mrežne niti...</translation>
+    </message>
+    <message>
         <source>The source code is available from %s.</source>
         <translation type="unfinished">Izvorni kod je dostupan na %s.</translation>
+    </message>
+    <message>
+        <source>The specified config file %s does not exist</source>
+        <translation type="unfinished">Navedena konfiguracijska datoteka %s ne postoji</translation>
     </message>
     <message>
         <source>The transaction amount is too small to pay the fee</source>
@@ -3257,6 +4273,10 @@
         <translation type="unfinished">Transakcija mora imati barem jednog primatelja</translation>
     </message>
     <message>
+        <source>Transaction needs a change address, but we can't generate it. %s</source>
+        <translation type="unfinished">Transakciji je potrebna change adresa, ali ju ne možemo generirati. %s</translation>
+    </message>
+    <message>
         <source>Transaction too large</source>
         <translation type="unfinished">Transakcija prevelika</translation>
     </message>
@@ -3281,6 +4301,10 @@
         <translation type="unfinished">Ne mogu se generirati ključevi</translation>
     </message>
     <message>
+        <source>Unable to open %s for writing</source>
+        <translation type="unfinished">Ne mogu otvoriti %s za upisivanje</translation>
+    </message>
+    <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
         <translation type="unfinished">Ne može se pokrenuti HTTP server. Vidite debug.log za više detalja.</translation>
     </message>
@@ -3301,6 +4325,10 @@
         <translation type="unfinished">Nepoznata mreža zadana kod -onlynet: '%s'</translation>
     </message>
     <message>
+        <source>Unknown new rules activated (versionbit %i)</source>
+        <translation type="unfinished"> Nepoznata nova pravila aktivirana (versionbit %i)</translation>
+    </message>
+    <message>
         <source>Unsupported logging category %s=%s.</source>
         <translation type="unfinished">Nepodržana kategorija zapisa %s=%s.</translation>
     </message>
@@ -3315,6 +4343,14 @@
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
         <translation type="unfinished">Komentar pod "Korisnički agent" (%s) sadrži nesigurne znakove.</translation>
+    </message>
+    <message>
+        <source>Verifying blocks…</source>
+        <translation type="unfinished">Provjervanje blokova...</translation>
+    </message>
+    <message>
+        <source>Verifying wallet(s)…</source>
+        <translation type="unfinished">Provjeravanje novčanika...</translation>
     </message>
     <message>
         <source>Wallet needed to be rewritten: restart %s to complete</source>

--- a/src/qt/locale/bitcoin_hu.ts
+++ b/src/qt/locale/bitcoin_hu.ts
@@ -3,7 +3,7 @@
     <name>AddressBookPage</name>
     <message>
         <source>Right-click to edit address or label</source>
-        <translation type="unfinished">Jobb gombbal ide kattintva szerkeszthető a cím vagy a címke</translation>
+        <translation type="unfinished">A cím vagy címke szerkeszteséhez kattintson a jobb gombbal</translation>
     </message>
     <message>
         <source>Create a new address</source>
@@ -67,12 +67,12 @@
     </message>
     <message>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
-        <translation type="unfinished">Ezek a te  Bitcoin címeid kifizetések küldéséhez. Mindíg ellenőrizd az összeget és a fogadó címet mielőtt coinokat küldenél.</translation>
+        <translation type="unfinished">Ezek az Ön Bitcoin címei kifizetések küldéséhez. Mindig ellenőrizze az összeget és a fogadó címet mielőtt érméket küldene.</translation>
     </message>
     <message>
         <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
 Signing is only possible with addresses of the type 'legacy'.</source>
-        <translation type="unfinished">Ezek a Bitcoin címeid amelyeken fogadni tudsz Bitcoin utalásokat. Az "Új cím létrehozása" gombbal tudsz új címet létrehozni. Aláírni csak korábbi egyessel kezdődő címekkel lehet.</translation>
+        <translation type="unfinished">Ezek a Bitcoin címek amelyeken fogadni tud Bitcoin utalásokat. Az "Új cím létrehozása" gombbal tud új címet létrehozni. Aláírni csak korábbi, egyessel kezdődő címekkel lehet.</translation>
     </message>
     <message>
         <source>&amp;Copy Address</source>
@@ -93,7 +93,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Comma separated file</source>
         <extracomment>Expanded name of the CSV file format. See https://en.wikipedia.org/wiki/Comma-separated_values</extracomment>
-        <translation type="unfinished">CSV fájl</translation>
+        <translation type="unfinished">Vesszővel tagolt fájl</translation>
     </message>
     <message>
         <source>There was an error trying to save the address list to %1. Please try again.</source>
@@ -102,7 +102,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Exporting Failed</source>
-        <translation type="unfinished">Hiba az exportálás során</translation>
+        <translation type="unfinished">Sikertelen Exportálás</translation>
     </message>
 </context>
 <context>
@@ -124,7 +124,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <name>AskPassphraseDialog</name>
     <message>
         <source>Passphrase Dialog</source>
-        <translation>Jelszó párbeszédablak</translation>
+        <translation>Jelszó Párbeszédablak</translation>
     </message>
     <message>
         <source>Enter passphrase</source>
@@ -152,7 +152,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Unlock wallet</source>
-        <translation type="unfinished">Tárca kinyitása</translation>
+        <translation type="unfinished">Tárca feloldása</translation>
     </message>
     <message>
         <source>Change passphrase</source>
@@ -164,7 +164,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
-        <translation type="unfinished">Figyelem: Ha titkosítja a tárcáját és elveszíti a jelszavát, akkor &lt;b&gt;AZ ÖSSZES BITCOINJA ELVESZIK&lt;/b&gt;!</translation>
+        <translation type="unfinished">Figyelem: Ha titkosítja a tárcáját és elveszíti a jelszavát, akkor &lt;b&gt;AZ ÖSSZES BITCOINJA ELVÉSZ&lt;/b&gt;!</translation>
     </message>
     <message>
         <source>Are you sure you wish to encrypt your wallet?</source>
@@ -184,7 +184,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
-        <translation type="unfinished">Ne feledd, hogy a tárca titkosítása nem nyújt teljes védelmet az adathalász programok fertőzésével szemben.</translation>
+        <translation type="unfinished">Ne feledje, hogy a tárca titkosítása nem nyújt teljes védelmet az adathalász programok fertőzésével szemben.</translation>
     </message>
     <message>
         <source>Wallet to be encrypted</source>
@@ -196,7 +196,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Your wallet is now encrypted. </source>
-        <translation type="unfinished">Tárcáját titkosítottuk.</translation>
+        <translation type="unfinished">A tárcája mostmár titkosított.</translation>
     </message>
     <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
@@ -204,11 +204,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Wallet encryption failed</source>
-        <translation type="unfinished">Nem sikerült a tárca titkosítása</translation>
+        <translation type="unfinished">Tárca titkosítása sikertelen</translation>
     </message>
     <message>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
-        <translation type="unfinished">A tárca titkosítása belső hiba miatt nem sikerült. A tárcád nem lett titkosítva.</translation>
+        <translation type="unfinished">A tárca titkosítása belső hiba miatt nem sikerült. A tárcája nem lett titkosítva.</translation>
     </message>
     <message>
         <source>The supplied passphrases do not match.</source>
@@ -216,7 +216,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Wallet unlock failed</source>
-        <translation type="unfinished">A tárca felnyitása nem sikerült</translation>
+        <translation type="unfinished">A tárca feloldása sikertelen</translation>
     </message>
     <message>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
@@ -244,10 +244,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 </context>
 <context>
     <name>BitcoinApplication</name>
-    <message>
-        <source>Runaway exception</source>
-        <translation type="unfinished">Ajajj, nagy baj van: Runaway exception!</translation>
-    </message>
     <message>
         <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
         <translation type="unfinished">Végzetes hiba történt %1 nem tud biztonságban továbblépni így most kilép.</translation>
@@ -293,7 +289,15 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Enter a Bitcoin address (e.g. %1)</source>
-        <translation type="unfinished">Ad meg egy Bitcoin címet (pl: %1)</translation>
+        <translation type="unfinished">Adjon meg egy Bitcoin címet (pl: %1)</translation>
+    </message>
+    <message>
+        <source>Unroutable</source>
+        <translation type="unfinished">Nem átirányítható</translation>
+    </message>
+    <message>
+        <source>Internal</source>
+        <translation type="unfinished">Belső</translation>
     </message>
     <message>
         <source>Inbound</source>
@@ -304,8 +308,24 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Kimenő</translation>
     </message>
     <message>
+        <source>Full Relay</source>
+        <translation type="unfinished">Teljes Elosztó</translation>
+    </message>
+    <message>
         <source>Block Relay</source>
-        <translation type="unfinished">Blokkok továbbküldése</translation>
+        <translation type="unfinished">Blokk Elosztó</translation>
+    </message>
+    <message>
+        <source>Manual</source>
+        <translation type="unfinished">Kézi</translation>
+    </message>
+    <message>
+        <source>Feeler</source>
+        <translation type="unfinished">Felderítő</translation>
+    </message>
+    <message>
+        <source>Address Fetch</source>
+        <translation type="unfinished">Címek Lekérdezése</translation>
     </message>
     <message>
         <source>%1 d</source>
@@ -334,31 +354,31 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation>
-            <numerusform />
+            <numerusform>%n másodperc</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n minute(s)</source>
         <translation>
-            <numerusform />
+            <numerusform>%n perc</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n óra</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n nap</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n hét</numerusform>
         </translation>
     </message>
     <message>
@@ -368,7 +388,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n év</numerusform>
         </translation>
     </message>
     </context>
@@ -473,7 +493,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Encrypt the private keys that belong to your wallet</source>
-        <translation>A tárcádhoz tartozó privát kulcsok titkosítása</translation>
+        <translation>A tárcájához tartozó privát kulcsok titkosítása</translation>
     </message>
     <message>
         <source>&amp;Backup Wallet…</source>
@@ -561,7 +581,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Connecting to peers…</source>
-        <translation type="unfinished">Csatlakozás az ügyfelekhez…</translation>
+        <translation type="unfinished">Csatlakozás partnerekhez…</translation>
     </message>
     <message>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
@@ -970,14 +990,22 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>CreateWalletActivity</name>
     <message>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation type="unfinished">&lt;b&gt;%1&lt;/b&gt; tárca készítése folyamatban…</translation>
+    </message>
+    <message>
         <source>Create wallet failed</source>
-        <translation type="unfinished">A tárcakészítés nem sikerült</translation>
+        <translation type="unfinished">A tárcakészítés meghiúsult</translation>
     </message>
     <message>
         <source>Create wallet warning</source>
         <translation type="unfinished">Tárcakészítési figyelmeztetés</translation>
     </message>
-    </context>
+    <message>
+        <source>Can't list signers</source>
+        <translation type="unfinished">Nem lehet az aláírókat listázni</translation>
+    </message>
+</context>
 <context>
     <name>OpenWalletActivity</name>
     <message>
@@ -992,7 +1020,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>default wallet</source>
         <translation type="unfinished">Alapértelmezett tárca</translation>
     </message>
-    </context>
+    <message>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation type="unfinished">&lt;b&gt;%1&lt;/b&gt; tárca megnyitása…</translation>
+    </message>
+</context>
 <context>
     <name>WalletController</name>
     <message>
@@ -1013,7 +1045,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Are you sure you wish to close all wallets?</source>
-        <translation type="unfinished">Biztos, hogy be akarod zárni az összes tárcát?</translation>
+        <translation type="unfinished">Biztos, hogy be akarja zárni az összes tárcát?</translation>
     </message>
 </context>
 <context>
@@ -1048,7 +1080,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Disable Private Keys</source>
-        <translation type="unfinished">Kapcsold ki a Privát Kódot</translation>
+        <translation type="unfinished">Privát Kulcsok Letiltása</translation>
     </message>
     <message>
         <source>Make a blank wallet. Blank wallets do not initially have private keys or scripts. Private keys and addresses can be imported, or an HD seed can be set, at a later time.</source>
@@ -1067,14 +1099,27 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Descriptor Tárca</translation>
     </message>
     <message>
+        <source>Use an external signing device such as a hardware wallet. Configure the external signer script in wallet preferences first.</source>
+        <translation type="unfinished">Külső aláíró eszköz például hardver tárca használata. Előtte konfigurálja az aláíró szkriptet a tárca beállításaiban.</translation>
+    </message>
+    <message>
+        <source>External signer</source>
+        <translation type="unfinished">Külső aláíró</translation>
+    </message>
+    <message>
         <source>Create</source>
         <translation type="unfinished">Létrehozás</translation>
     </message>
     <message>
         <source>Compiled without sqlite support (required for descriptor wallets)</source>
-        <translation type="unfinished">SQLLite támogatás nélkül fordítva (követelmény a descriptor wallet használatához)</translation>
+        <translation type="unfinished">SQLite támogatás nélkül fordítva (követelmény a descriptor wallet használatához)</translation>
     </message>
-    </context>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">A program külső aláíró támogatás nélkül lett fordítva (követelmény külső aláírók használatához)</translation>
+    </message>
+</context>
 <context>
     <name>EditAddressDialog</name>
     <message>
@@ -1156,6 +1201,18 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>Intro</name>
     <message>
+        <source>%1 GB of free space available</source>
+        <translation type="unfinished">%1 GB szabad hely áll rendelkezésre</translation>
+    </message>
+    <message>
+        <source>(of %1 GB needed)</source>
+        <translation type="unfinished">(a szükséges %1 GB-ból)</translation>
+    </message>
+    <message>
+        <source>(%1 GB needed for full chain)</source>
+        <translation type="unfinished">(%1 GB szükséges a teljes lánchoz)</translation>
+    </message>
+    <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
         <translation type="unfinished">Legalább %1 GB adatot fogunk ebben a könyvtárban tárolni és idővel ez egyre több lesz.</translation>
     </message>
@@ -1167,7 +1224,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>(elegendő %n nappal ezelőtti biztonsági mentések visszaállításához)</numerusform>
         </translation>
     </message>
     <message>
@@ -1188,11 +1245,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Welcome</source>
-        <translation>Üdvözlünk</translation>
+        <translation>Üdvözöljük</translation>
     </message>
     <message>
         <source>Welcome to %1.</source>
-        <translation type="unfinished">Üdvözlünk a %1 -ban.</translation>
+        <translation type="unfinished">Üdvözöljük a %1 -ban.</translation>
     </message>
     <message>
         <source>As this is the first time the program is launched, you can choose where %1 will store its data.</source>
@@ -1203,8 +1260,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Ha az OK-ra kattint, %1 megkezdi a teljes %4 blokk lánc letöltését és feldolgozását (%2GB) a legkorábbi tranzakciókkal kezdve %3 -ben, amikor a %4 bevezetésre került.</translation>
     </message>
     <message>
+        <source>Limit block chain storage to</source>
+        <translation type="unfinished">A blokklánc tárhelyének korlátozása erre:</translation>
+    </message>
+    <message>
         <source>Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</source>
         <translation type="unfinished">A beállítás visszaállításához le kell tölteni a teljes blokkláncot. A teljes lánc letöltése és későbbi nyesése ennél gyorsabb. Bizonyos haladó funkciókat letilt.</translation>
+    </message>
+    <message>
+        <source> GB</source>
+        <translation type="unfinished">GB</translation>
     </message>
     <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
@@ -1235,14 +1300,18 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Command-line options</source>
-        <translation type="unfinished">Parancssoros opciók</translation>
+        <translation type="unfinished">Parancssori opciók</translation>
     </message>
 </context>
 <context>
     <name>ShutdownWindow</name>
     <message>
+        <source>%1 is shutting down…</source>
+        <translation type="unfinished">%1 leáll…</translation>
+    </message>
+    <message>
         <source>Do not shut down the computer until this window disappears.</source>
-        <translation type="unfinished">Ne állítsd le a számítógépet amíg ez az ablak el nem tűnik.</translation>
+        <translation type="unfinished">Ne állítsa le a számítógépet amíg ez az ablak el nem tűnik.</translation>
     </message>
 </context>
 <context>
@@ -1262,6 +1331,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Number of blocks left</source>
         <translation type="unfinished">Hátralévő blokkok száma</translation>
+    </message>
+    <message>
+        <source>Unknown…</source>
+        <translation type="unfinished">Ismeretlen…</translation>
+    </message>
+    <message>
+        <source>calculating…</source>
+        <translation type="unfinished">számolás…</translation>
     </message>
     <message>
         <source>Last block time</source>
@@ -1291,12 +1368,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>%1 is currently syncing.  It will download headers and blocks from peers and validate them until reaching the tip of the block chain.</source>
         <translation type="unfinished">%1 szinkronizálás alatt. Fejléceket és blokkokat tölt le a felektől, majd érvényesíti, amíg el nem éri a blokklánc tetejét.</translation>
     </message>
-    </context>
+    <message>
+        <source>Unknown. Syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">Ismeretlen. Fejlécek szinkronizálása (%1, %2%)…</translation>
+    </message>
+</context>
 <context>
     <name>OpenURIDialog</name>
     <message>
         <source>Open bitcoin URI</source>
-        <translation type="unfinished">Nyisd meg a bitcoin címedet</translation>
+        <translation type="unfinished">Bitcoin URI megnyitása</translation>
     </message>
     </context>
 <context>
@@ -1311,7 +1392,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Automatically start %1 after logging in to the system.</source>
-        <translation type="unfinished">%1 automatikus indítása  a rendszerbe való belépés után.</translation>
+        <translation type="unfinished">%1 automatikus indítása a rendszerbe való belépés után.</translation>
     </message>
     <message>
         <source>&amp;Start %1 on system login</source>
@@ -1319,7 +1400,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Enabling pruning significantly reduces the disk space required to store transactions. All blocks are still fully validated. Reverting this setting requires re-downloading the entire blockchain.</source>
-        <translation type="unfinished">A tárolt blokkok számának visszavágásval jelentősen csökken a tranzakció történet tárolásához szükséges tárhely. Minden blokk továbbra is ellenőrizve lesz. Ha ezt a beállítást késpbb törölni szeretné  újra le kell majd tölteni a teljes blokkláncot.</translation>
+        <translation type="unfinished">A tárolt blokkok számának visszavágásával jelentősen csökken a tranzakció történet tárolásához szükséges tárhely. Minden blokk továbbra is ellenőrizve lesz. Ha ezt a beállítást később törölni szeretné újra le kell majd tölteni a teljes blokkláncot.</translation>
     </message>
     <message>
         <source>Size of &amp;database cache</source>
@@ -1367,7 +1448,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Prune &amp;block storage to</source>
-        <translation type="unfinished">Nyesi a &amp;block tárolását ide:</translation>
+        <translation type="unfinished">Nyesi a &amp;blokkok tárolását erre:</translation>
     </message>
     <message>
         <source>Reverting this setting requires re-downloading the entire blockchain.</source>
@@ -1391,7 +1472,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Enable coin &amp;control features</source>
-        <translation type="unfinished">Pénzküldés beállításainak engedélyezése</translation>
+        <translation type="unfinished">Pénzküldés b&amp;eállításainak engedélyezése</translation>
     </message>
     <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
@@ -1399,11 +1480,23 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>&amp;Spend unconfirmed change</source>
-        <translation type="unfinished">&amp;Költése a a jóváhagyatlan visszajárónak</translation>
+        <translation type="unfinished">&amp;Költése a jóváhagyatlan visszajárónak</translation>
+    </message>
+    <message>
+        <source>External Signer (e.g. hardware wallet)</source>
+        <translation type="unfinished">Külső Aláíró (pl. hardver tárca)</translation>
+    </message>
+    <message>
+        <source>&amp;External signer script path</source>
+        <translation type="unfinished">&amp;Külső aláíró szkript elérési útvonala</translation>
+    </message>
+    <message>
+        <source>Full path to a Bitcoin Core compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</source>
+        <translation type="unfinished">Bitcoin Core kompatibilis szkript teljes elérésí útvonala (pl. C:\Letöltések\hwi.exe vagy /Users/felhasznalo/Letöltések/hwi.py). Vigyázat: rosszindulatú programok ellophatják az érméit!</translation>
     </message>
     <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
-        <translation>A Bitcoin-kliens portjának automatikus megnyitása a routeren. Ez csak akkor működik, ha a routered támogatja az UPnP-t és az engedélyezve is van rajta.</translation>
+        <translation>A Bitcoin-kliens portjának automatikus megnyitása a routeren. Ez csak akkor működik, ha a router támogatja az UPnP-t és az engedélyezve is van rajta.</translation>
     </message>
     <message>
         <source>Map port using &amp;UPnP</source>
@@ -1415,7 +1508,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Map port using NA&amp;T-PMP</source>
-        <translation type="unfinished">Külső port megnyitása NA&amp;T-PMP -vel</translation>
+        <translation type="unfinished">Külső port megnyitása NA&amp;T-PMP-vel</translation>
     </message>
     <message>
         <source>Accept connections from outside.</source>
@@ -1439,7 +1532,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Used for reaching peers via:</source>
-        <translation type="unfinished">Párok elérésére használjuk ezen keresztül:</translation>
+        <translation type="unfinished">Partnerek elérése ezen keresztül:</translation>
     </message>
     <message>
         <source>&amp;Window</source>
@@ -1499,15 +1592,28 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Monospaced font in the Overview tab:</source>
-        <translation type="unfinished">Fix szélességű betütípus használata az áttekintés fülön:</translation>
+        <translation type="unfinished">Fix szélességű betűtípus használata az áttekintés fülön:</translation>
+    </message>
+    <message>
+        <source>embedded "%1"</source>
+        <translation type="unfinished">beágyazott "%1"</translation>
+    </message>
+    <message>
+        <source>closest matching "%1"</source>
+        <translation type="unfinished">legjobb találat "%1"</translation>
     </message>
     <message>
         <source>Options set in this dialog are overridden by the command line or in the configuration file:</source>
-        <translation type="unfinished">Az ebben a párbeszédablakban beállított opciók felülírásra kerültek a parancssor által vagy a konfigurációs fájlban:</translation>
+        <translation type="unfinished">Az itt beállított opciók felülbírálásra kerültek a parancssor vagy a konfigurációs fájl által:</translation>
     </message>
     <message>
         <source>&amp;Cancel</source>
         <translation>&amp;Mégse</translation>
+    </message>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">A program külső aláíró támogatás nélkül lett fordítva (követelmény külső aláírók használatához)</translation>
     </message>
     <message>
         <source>default</source>
@@ -1574,7 +1680,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Your current spendable balance</source>
-        <translation>Jelenlegi egyenleg</translation>
+        <translation>Jelenlegi felhasználható egyenleg</translation>
     </message>
     <message>
         <source>Pending:</source>
@@ -1630,7 +1736,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Privacy mode activated for the Overview tab. To unmask the values, uncheck Settings-&gt;Mask values.</source>
-        <translation type="unfinished">Diszkrét mód aktiváva az áttekintés fülün. Az értékek újbóli megjelenítéséhez kapcsold ki a Beállítások-&gt;Értékek maszkolását</translation>
+        <translation type="unfinished">Diszkrét mód aktiválva az áttekintés fülön. Az értékek megjelenítéséhez kapcsolja ki a Beállítások-&gt;Értékek maszkolását.</translation>
     </message>
 </context>
 <context>
@@ -1652,6 +1758,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Másolás vágólapra</translation>
     </message>
     <message>
+        <source>Save…</source>
+        <translation type="unfinished">Mentés…</translation>
+    </message>
+    <message>
         <source>Close</source>
         <translation type="unfinished">Bezárás</translation>
     </message>
@@ -1665,11 +1775,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Could not sign any more inputs.</source>
-        <translation type="unfinished">Több input-ot nem tudok aláírni.</translation>
+        <translation type="unfinished">Több bejövőt nem lehet aláírni.</translation>
     </message>
     <message>
         <source>Signed %1 inputs, but more signatures are still required.</source>
-        <translation type="unfinished">%1 input aláírva, de több alárásra van szükség.</translation>
+        <translation type="unfinished">%1 bejövő aláírva, de több aláírásra van szükség.</translation>
     </message>
     <message>
         <source>Signed transaction successfully. Transaction is ready to broadcast.</source>
@@ -1677,11 +1787,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Unknown error processing transaction.</source>
-        <translation type="unfinished">Imseretlen hiba a tranzakció feldolázásakor.</translation>
+        <translation type="unfinished">Ismeretlen hiba a tranzakció feldolgozásakor.</translation>
     </message>
     <message>
         <source>Transaction broadcast successfully! Transaction ID: %1</source>
-        <translation type="unfinished">Tranzakció sikeresen szétküldve. Transaction ID: %1</translation>
+        <translation type="unfinished">Tranzakció sikeresen szétküldve. Tranzakció azonosító: %1</translation>
     </message>
     <message>
         <source>Transaction broadcast failed: %1</source>
@@ -1710,7 +1820,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Unable to calculate transaction fee or total transaction amount.</source>
-        <translation type="unfinished">Nem tudok tranzakciós díjat vagy teljes tranzakció értéket kalkulálni.</translation>
+        <translation type="unfinished">Nem sikerült tranzakciós díjat vagy teljes tranzakció értéket számolni.</translation>
     </message>
     <message>
         <source>Pays transaction fee: </source>
@@ -1726,7 +1836,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Transaction has %1 unsigned inputs.</source>
-        <translation type="unfinished">A tranzakciónak %1 aláíratlan bejövő érteke van.</translation>
+        <translation type="unfinished">A tranzakciónak %1 aláíratlan bejövő értéke van.</translation>
     </message>
     <message>
         <source>Transaction is missing some information about inputs.</source>
@@ -1734,7 +1844,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Transaction still needs signature(s).</source>
-        <translation type="unfinished">Még aláírások szükségesen a tranzakcióhoz.</translation>
+        <translation type="unfinished">További aláírások szükségesek a tranzakcióhoz.</translation>
     </message>
     <message>
         <source>(But this wallet cannot sign transactions.)</source>
@@ -1769,17 +1879,17 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>'bitcoin://' is not a valid URI. Use 'bitcoin:' instead.</source>
-        <translation type="unfinished">'bitcoin://' nem érvényes egységes erőforrás azonosító (URI). Használd helyette a 'bitcoin'-t.</translation>
+        <translation type="unfinished">'bitcoin://' nem érvényes egységes erőforrás azonosító (URI). Használja helyette a 'bitcoin:'-t.</translation>
     </message>
     <message>
         <source>Cannot process payment request because BIP70 is not supported.
 Due to widespread security flaws in BIP70 it's strongly recommended that any merchant instructions to switch wallets be ignored.
 If you are receiving this error you should request the merchant provide a BIP21 compatible URI.</source>
-        <translation type="unfinished">Ezt a tranzakciót nem tudom feldolgozni, mert a BIP70 nem támogatott. A jól ismert biztonsági hiányosságok miatt a BIP70-re való váltásra buzdító utasításokat hagyja figyelmen kívül. Amennyiben ezt az ünetet látja kérje meg azt akitől kapta a kérést, hogy adjon Önnek BIP21 kompatibilis URL-t.</translation>
+        <translation type="unfinished">Ezt a tranzakciót nem lehet feldolgozni, mert a BIP70 nem támogatott. A jól ismert biztonsági hiányosságok miatt a BIP70-re való váltásra történő felhívásokat hagyja figyelmen kívül. Amennyiben ezt az üzenetet látja kérjen egy új, BIP21 kompatibilis URI-t.</translation>
     </message>
     <message>
         <source>URI cannot be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
-        <translation type="unfinished">Nem sikerült az URI elemzése! Ezt okozhatja érvénytelen Bitcoin cím, vagy rossz URI paraméterezés.</translation>
+        <translation type="unfinished">Nem sikerült az URI értelmezése! Ezt okozhatja érvénytelen Bitcoin cím, vagy rossz URI paraméterezés.</translation>
     </message>
     <message>
         <source>Payment request file handling</source>
@@ -1788,6 +1898,16 @@ If you are receiving this error you should request the merchant provide a BIP21 
 </context>
 <context>
     <name>PeerTableModel</name>
+    <message>
+        <source>User Agent</source>
+        <extracomment>Title of Peers Table column which contains the peer's User Agent string.</extracomment>
+        <translation type="unfinished">Felhasználói ügynök</translation>
+    </message>
+    <message>
+        <source>Peer</source>
+        <extracomment>Title of Peers Table column which contains a unique number used to identify a connection.</extracomment>
+        <translation type="unfinished">Partner</translation>
+    </message>
     <message>
         <source>Sent</source>
         <extracomment>Title of Peers Table column which indicates the total amount of network information we have sent to the peer.</extracomment>
@@ -1817,12 +1937,16 @@ If you are receiving this error you should request the merchant provide a BIP21 
 <context>
     <name>QRImageWidget</name>
     <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">&amp;Kép Mentése…</translation>
+    </message>
+    <message>
         <source>&amp;Copy Image</source>
         <translation type="unfinished">&amp;Kép Másolása</translation>
     </message>
     <message>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
-        <translation type="unfinished">A keletkezett URI túl hosszú, próbálja meg csökkenteni a cimke / üzenet szövegének méretét.</translation>
+        <translation type="unfinished">A keletkezett URI túl hosszú, próbálja meg csökkenteni a címke / üzenet szövegének méretét.</translation>
     </message>
     <message>
         <source>Error encoding URI into QR Code.</source>
@@ -1874,11 +1998,11 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>To specify a non-default location of the blocks directory use the '%1' option.</source>
-        <translation type="unfinished">Az blokkk könyvárhoz kívánt nem alapértelmezett elérési úthoz használd a '%1' opciót</translation>
+        <translation type="unfinished">A blokk könyvár egyedi elérési útjának beállításához használja a '%1' opciót.</translation>
     </message>
     <message>
         <source>Startup time</source>
-        <translation>Bekapcsolás ideje</translation>
+        <translation>Indítás időpontja</translation>
     </message>
     <message>
         <source>Network</source>
@@ -1930,15 +2054,15 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>&amp;Peers</source>
-        <translation type="unfinished">&amp;Peerek</translation>
+        <translation type="unfinished">&amp;Partnerek</translation>
     </message>
     <message>
         <source>Banned peers</source>
-        <translation type="unfinished">Kitiltott felek</translation>
+        <translation type="unfinished">Tiltott partnerek</translation>
     </message>
     <message>
         <source>Select a peer to view detailed information.</source>
-        <translation type="unfinished">Peer kijelölése a részletes információkért</translation>
+        <translation type="unfinished">Válasszon ki egy partnert a részletes információk megtekintéséhez.</translation>
     </message>
     <message>
         <source>Version</source>
@@ -1958,11 +2082,11 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>The mapped Autonomous System used for diversifying peer selection.</source>
-        <translation type="unfinished">A megadott "Önálló rendszer" használom a peer választás diverzifikálásához.</translation>
+        <translation type="unfinished">A megadott "Autonóm Rendszer" használata a partnerválasztás diverzifikálásához.</translation>
     </message>
     <message>
         <source>Mapped AS</source>
-        <translation type="unfinished">Felvett AS (önálló rendszer)</translation>
+        <translation type="unfinished">Leképezett AR</translation>
     </message>
     <message>
         <source>Node window</source>
@@ -1978,7 +2102,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Decrease font size</source>
-        <translation type="unfinished">Betűméret kicsinyítése</translation>
+        <translation type="unfinished">Betűméret csökkentése</translation>
     </message>
     <message>
         <source>Increase font size</source>
@@ -1989,8 +2113,32 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <translation type="unfinished">Jogosultságok</translation>
     </message>
     <message>
+        <source>The direction and type of peer connection: %1</source>
+        <translation type="unfinished">A csomóponti kapcsolat iránya és típusa: %1</translation>
+    </message>
+    <message>
+        <source>Direction/Type</source>
+        <translation type="unfinished">Irány/Típus</translation>
+    </message>
+    <message>
+        <source>The network protocol this peer is connected through: IPv4, IPv6, Onion, I2P, or CJDNS.</source>
+        <translation type="unfinished">A hálózati protokoll amin keresztül ez a csomópont kapcsolódik: IPv4, IPv6, Onion, I2P vagy CJDNS.</translation>
+    </message>
+    <message>
         <source>Services</source>
         <translation type="unfinished">Szolgáltatások</translation>
+    </message>
+    <message>
+        <source>Whether the peer requested us to relay transactions.</source>
+        <translation type="unfinished">Kérte-e tőlünk a partner a tranzakciók közvetítését.</translation>
+    </message>
+    <message>
+        <source>Wants Tx Relay</source>
+        <translation type="unfinished">Tx Közlést Kér</translation>
+    </message>
+    <message>
+        <source>High bandwidth BIP152 compact block relay: %1</source>
+        <translation type="unfinished">Nagy sávszélességű BIP152 kompakt blokk közvetítő: %1</translation>
     </message>
     <message>
         <source>High Bandwidth</source>
@@ -2001,8 +2149,16 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <translation type="unfinished">Csatlakozás ideje</translation>
     </message>
     <message>
+        <source>Elapsed time since a novel block passing initial validity checks was received from this peer.</source>
+        <translation type="unfinished">A csomóponttól érkező új blokkokra vonatkozó érvényességet igazoló ellenőrzések óta eltelt idő.</translation>
+    </message>
+    <message>
         <source>Last Block</source>
         <translation type="unfinished">Utolsó blokk</translation>
+    </message>
+    <message>
+        <source>Elapsed time since a novel transaction accepted into our mempool was received from this peer.</source>
+        <translation type="unfinished">Az eltelt idő, amióta egy új, a mempoolunkba elfogadott tranzakció érkezett ettől a társtulajdonostól.</translation>
     </message>
     <message>
         <source>Last Tx</source>
@@ -2073,12 +2229,52 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <translation type="unfinished">Ki:</translation>
     </message>
     <message>
+        <source>Inbound: initiated by peer</source>
+        <translation type="unfinished">Bejövő: partner által indított</translation>
+    </message>
+    <message>
+        <source>Outbound Full Relay: default</source>
+        <translation type="unfinished">Kimenő Teljes Elosztó: alapértelmezett</translation>
+    </message>
+    <message>
+        <source>Outbound Block Relay: does not relay transactions or addresses</source>
+        <translation type="unfinished">Kimenő Blokk Elosztó: nem továbbít tranzakciókat vagy címeket</translation>
+    </message>
+    <message>
+        <source>Outbound Manual: added using RPC %1 or %2/%3 configuration options</source>
+        <translation type="unfinished">Kézi Kilépő Kapcsolat: hozzáadva RPC használatával %1 vagy %2/%3 beállításokkal</translation>
+    </message>
+    <message>
+        <source>Outbound Feeler: short-lived, for testing addresses</source>
+        <translation type="unfinished">Outbound Feeler: rövid életű, címek teszteléséhez</translation>
+    </message>
+    <message>
+        <source>Outbound Address Fetch: short-lived, for soliciting addresses</source>
+        <translation type="unfinished">Outbound Address Fetch: rövid életű, címek lekérdezéséhez.</translation>
+    </message>
+    <message>
+        <source>we selected the peer for high bandwidth relay</source>
+        <translation type="unfinished">a partnert nagy sávszélességű elosztónak választottuk</translation>
+    </message>
+    <message>
+        <source>the peer selected us for high bandwidth relay</source>
+        <translation type="unfinished">a partner minket választott nagy sávszélességű elosztójául</translation>
+    </message>
+    <message>
+        <source>no high bandwidth relay selected</source>
+        <translation type="unfinished">nincs nagy sávszélességű elosztó kiválasztva</translation>
+    </message>
+    <message>
         <source>&amp;Disconnect</source>
         <translation type="unfinished">&amp;Szétkapcsol</translation>
     </message>
     <message>
         <source>1 &amp;hour</source>
         <translation type="unfinished">1 &amp;óra</translation>
+    </message>
+    <message>
+        <source>1 d&amp;ay</source>
+        <translation type="unfinished">1 &amp;nap</translation>
     </message>
     <message>
         <source>1 &amp;week</source>
@@ -2103,6 +2299,15 @@ If you are receiving this error you should request the merchant provide a BIP21 
     <message>
         <source>Executing command using "%1" wallet</source>
         <translation type="unfinished">Parancs végrehajtása a "%1" tárca használatával</translation>
+    </message>
+    <message>
+        <source>Executing…</source>
+        <extracomment>A console message indicating an entered command is currently being executed.</extracomment>
+        <translation type="unfinished">Végrehajtás...</translation>
+    </message>
+    <message>
+        <source>(peer: %1)</source>
+        <translation type="unfinished">(ügyfél: %1)</translation>
     </message>
     <message>
         <source>via %1</source>
@@ -2169,11 +2374,11 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>An optional label to associate with the new receiving address (used by you to identify an invoice).  It is also attached to the payment request.</source>
-        <translation type="unfinished">Egy opcionális címke, amit hozzá lehet rendelni az új fogadó címhez (amit használhatsz a számla azonosításához). E mellett hozzá lesz csatolva a fizetési kérelemhez is.</translation>
+        <translation type="unfinished">Egy opcionális címke, ami hozzárendelhető az új fogadó címhez (pl. használható a számla azonosításához). Továbbá hozzá lesz csatolva a fizetési kérelemhez is.</translation>
     </message>
     <message>
         <source>An optional message that is attached to the payment request and may be displayed to the sender.</source>
-        <translation type="unfinished">Egy opcionális üzenet ami a fizetési kérelemhez van fűzve és valószínűleg meg lesz jelenítve a fizető oldalán.</translation>
+        <translation type="unfinished">Egy opcionális üzenet ami a fizetési kérelemhez van fűzve és megjelenhet a fizető félnek.</translation>
     </message>
     <message>
         <source>&amp;Create new receiving address</source>
@@ -2201,7 +2406,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Show the selected request (does the same as double clicking an entry)</source>
-        <translation type="unfinished">Mutassa meg a kiválasztott kérelmet (ugyanaz, mint a duplaklikk)</translation>
+        <translation type="unfinished">Mutassa meg a kiválasztott kérelmet (ugyanaz, mint a duplakattintás)</translation>
     </message>
     <message>
         <source>Show</source>
@@ -2228,6 +2433,10 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <translation type="unfinished">Címke &amp;másolása</translation>
     </message>
     <message>
+        <source>Copy &amp;message</source>
+        <translation type="unfinished">Üzenet &amp;másolása</translation>
+    </message>
+    <message>
         <source>Copy &amp;amount</source>
         <translation type="unfinished">Ö&amp;sszeg másolása</translation>
     </message>
@@ -2242,6 +2451,10 @@ If you are receiving this error you should request the merchant provide a BIP21 
 </context>
 <context>
     <name>ReceiveRequestDialog</name>
+    <message>
+        <source>Request payment to …</source>
+        <translation type="unfinished">Fizetési kérelem küldése…</translation>
+    </message>
     <message>
         <source>Address:</source>
         <translation type="unfinished">Cím:</translation>
@@ -2269,6 +2482,18 @@ If you are receiving this error you should request the merchant provide a BIP21 
     <message>
         <source>Copy &amp;Address</source>
         <translation type="unfinished">&amp;Cím másolása</translation>
+    </message>
+    <message>
+        <source>&amp;Verify</source>
+        <translation type="unfinished">&amp;Ellenőrzés</translation>
+    </message>
+    <message>
+        <source>Verify this address on e.g. a hardware wallet screen</source>
+        <translation type="unfinished">Ellenőrizze ezt a címet például egy hardver tárca képernyőjén</translation>
+    </message>
+    <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">&amp;Kép Mentése…</translation>
     </message>
     <message>
         <source>Payment information</source>
@@ -2401,20 +2626,40 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <translation type="unfinished">Minden mező törlése</translation>
     </message>
     <message>
+        <source>Inputs…</source>
+        <translation type="unfinished">Bemenetek...</translation>
+    </message>
+    <message>
         <source>Dust:</source>
         <translation type="unfinished">Porszem:</translation>
     </message>
     <message>
+        <source>Choose…</source>
+        <translation type="unfinished">Válasszon...</translation>
+    </message>
+    <message>
         <source>Hide transaction fee settings</source>
-        <translation type="unfinished">Rejtsd el a tranzakciós költségek beállításait</translation>
+        <translation type="unfinished">Ne mutassa a tranzakciós költségek beállításait</translation>
+    </message>
+    <message>
+        <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
+
+Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satoshis per kvB" for a transaction size of 500 virtual bytes (half of 1 kvB) would ultimately yield a fee of only 50 satoshis.</source>
+        <translation type="unfinished">Adjon meg egy egyéni díjat a tranzakció virtuális méretének 1 kilobájtjához (1000 bájt).
+
+Megjegyzés: Mivel a díj bájtonként van kiszámítva, egy "100 satoshi kvB-nként"-ként megadott díj egy 500 virtuális bájt (1kvB fele) méretű tranzakció végül csak 50 satoshi-s díjat jelentene.</translation>
     </message>
     <message>
         <source>When there is less transaction volume than space in the blocks, miners as well as relaying nodes may enforce a minimum fee. Paying only this minimum fee is just fine, but be aware that this can result in a never confirming transaction once there is more demand for bitcoin transactions than the network can process.</source>
-        <translation type="unfinished">Ha kevesebb a tranzakció mint amennyi hely lenne egy blokkban, akkor a bányászok és a többi node megkövetelheti a minimum díjat. E minimum díjat fizetni elegendő lehet, de tudnod kell, hogy ez esetleg soha nem konfirmálódó tranzakciót eredményezhet ahogy a tranzakciók száma magasabb lesz mint a network által megengedett.</translation>
+        <translation type="unfinished">Ha kevesebb a tranzakció, mint amennyi hely lenne egy blokkban, akkor a bányászok és a többi csomópont megkövetelheti a minimum díjat. Ezt a minimum díjat fizetni elegendő lehet de elképzelhető, hogy ez esetleg egy soha sem jóváhagyott tranzakciót eredményez ahogy a tranzakciók száma magasabb lesz, mint a hálózat által megengedett.</translation>
     </message>
     <message>
         <source>A too low fee might result in a never confirming transaction (read the tooltip)</source>
-        <translation type="unfinished">A túl alacsony illeték a tranzakció soha be nem teljesülését eredményezheti (olvassa el az elemleírást)</translation>
+        <translation type="unfinished">Túl alacsony díj a tranzakció soha be nem teljesülését eredményezheti (olvassa el az elemleírást)</translation>
+    </message>
+    <message>
+        <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
+        <translation type="unfinished">(Az intelligens díj még nem lett előkészítve. Ez általában eltart néhány blokkig…)</translation>
     </message>
     <message>
         <source>Confirmation time target:</source>
@@ -2426,7 +2671,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>With Replace-By-Fee (BIP-125) you can increase a transaction's fee after it is sent. Without this, a higher fee may be recommended to compensate for increased transaction delay risk.</source>
-        <translation type="unfinished">A With Replace-By-Fee (BIP-125) funkciót használva küldés után is megemelheted a tranzakciós díjat. Ha ezt nem használod akkor magasabb díjat érdemes használni, hogy kisebb legyen a késedelem.</translation>
+        <translation type="unfinished">A Replace-By-Fee (BIP-125) funkciót használva küldés után is megemelheti a tranzakciós díjat. Ha ezt nem szeretné akkor magasabb díjat érdemes használni, hogy kisebb legyen a késedelem.</translation>
     </message>
     <message>
         <source>Clear &amp;All</source>
@@ -2477,6 +2722,20 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <translation type="unfinished">%1 (%2 blokov)</translation>
     </message>
     <message>
+        <source>Sign on device</source>
+        <extracomment>"device" usually means a hardware wallet</extracomment>
+        <translation type="unfinished">Aláírás eszközön</translation>
+    </message>
+    <message>
+        <source>Connect your hardware wallet first.</source>
+        <translation type="unfinished">Először csatlakoztassa a hardvertárcát.</translation>
+    </message>
+    <message>
+        <source>Set external signer script path in Options -&gt; Wallet</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Állítsa be a külső aláíró szkript útvonalát itt: Opciók -&gt; Tárca</translation>
+    </message>
+    <message>
         <source>Cr&amp;eate Unsigned</source>
         <translation type="unfinished">&amp;Aláírás nélkül létrehozása Unsigned</translation>
     </message>
@@ -2486,7 +2745,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source> from wallet '%1'</source>
-        <translation type="unfinished">A "%1" tárcától</translation>
+        <translation type="unfinished"> '%1' tárcából</translation>
     </message>
     <message>
         <source>%1 to '%2'</source>
@@ -2498,15 +2757,37 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Do you want to draft this transaction?</source>
-        <translation type="unfinished">Piszkozatba teszed ezt a tranzakciót?</translation>
+        <translation type="unfinished">Piszkozatba teszi ezt a tranzakciót?</translation>
     </message>
     <message>
         <source>Are you sure you want to send?</source>
         <translation type="unfinished">Biztosan el akarja küldeni?</translation>
     </message>
     <message>
+        <source>To review recipient list click "Show Details…"</source>
+        <translation type="unfinished">A címzettek listájának ellenőrzéséhez kattintson ide: "Részletek..."</translation>
+    </message>
+    <message>
         <source>Create Unsigned</source>
         <translation type="unfinished">Aláíratlan létrehozása</translation>
+    </message>
+    <message>
+        <source>Sign and send</source>
+        <translation type="unfinished">Aláírás és küldés</translation>
+    </message>
+    <message>
+        <source>Sign failed</source>
+        <translation type="unfinished">Aláírás sikertelen</translation>
+    </message>
+    <message>
+        <source>External signer not found</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Külső aláíró nem található</translation>
+    </message>
+    <message>
+        <source>External signer failure</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Külső aláíró hibája</translation>
     </message>
     <message>
         <source>Save Transaction Data</source>
@@ -2522,6 +2803,10 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <translation type="unfinished">PBST elmentve</translation>
     </message>
     <message>
+        <source>External balance:</source>
+        <translation type="unfinished">Külső egyenleg:</translation>
+    </message>
+    <message>
         <source>or</source>
         <translation type="unfinished">vagy</translation>
     </message>
@@ -2531,7 +2816,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Please, review your transaction proposal. This will produce a Partially Signed Bitcoin Transaction (PSBT) which you can save or copy and then sign with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
-        <translation type="unfinished">Kérlek nézd át a tranzakciós javaslatot. Ez létrehoz egy Részlegesen Aláírt Bitcoin Tranzakciót (PSBT) amit elmenthetsz vagy kimásolhatsz. Aztán aláírhatod: offline %1 tárcával vagy egy PSBT kompatibilis hardver tárcával.</translation>
+        <translation type="unfinished">Kérjük nézze át a tranzakciós javaslatot. Ez létrehoz egy Részlegesen Aláírt Bitcoin Tranzakciót (PSBT) amit elmenthet vagy kimásolhat amit később aláírhatja offline %1 tárcával vagy egy PSBT kompatibilis hardvertárcával.</translation>
     </message>
     <message>
         <source>Please, review your transaction.</source>
@@ -2543,7 +2828,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Not signalling Replace-By-Fee, BIP-125.</source>
-        <translation type="unfinished">Nem jelzek Replace-By-Fee, BIP-125-t</translation>
+        <translation type="unfinished">Nincs Replace-By-Fee, BIP-125 jelezve.</translation>
     </message>
     <message>
         <source>Total Amount</source>
@@ -2563,7 +2848,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>The recipient address is not valid. Please recheck.</source>
-        <translation type="unfinished">A fogadó címe érvénytelen. Kérem ellenőrizze.</translation>
+        <translation type="unfinished">A fogadó címe érvénytelen. Kérjük ellenőrizze.</translation>
     </message>
     <message>
         <source>The amount to pay must be larger than 0.</source>
@@ -2587,7 +2872,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>A fee higher than %1 is considered an absurdly high fee.</source>
-        <translation type="unfinished">Magasabb díj mint %1 abszurd magas díjnak számít.</translation>
+        <translation type="unfinished">A díj magasabb, mint %1 ami abszurd magas díjnak számít.</translation>
     </message>
     <message>
         <source>Payment request expired.</source>
@@ -2596,7 +2881,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation>
-            <numerusform />
+            <numerusform>A tranzakció megerősítése %n blokk múlva várható.</numerusform>
         </translation>
     </message>
     <message>
@@ -2636,7 +2921,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Choose previously used address</source>
-        <translation type="unfinished">Válassz egy korábban már használt címet</translation>
+        <translation type="unfinished">Válasszon egy korábban már használt címet</translation>
     </message>
     <message>
         <source>The Bitcoin address to send the payment to</source>
@@ -2656,7 +2941,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>The fee will be deducted from the amount being sent. The recipient will receive less bitcoins than you enter in the amount field. If multiple recipients are selected, the fee is split equally.</source>
-        <translation type="unfinished">Znesek plačila bo zmanjšan za znesek provizije. Prejemnik bo prejel manjše število kovancev, kot je bil vnešeni znesek. Če je prejemnikov več, bo provizija med njih enakomerno porazdeljena.</translation>
+        <translation type="unfinished">A díj le lesz vonva a küldött teljes összegből. A címzett kevesebb bitcoint fog megkapni, mint amennyit az összeg mezőben megadott. Amennyiben több címzett van kiválasztva, az illeték egyenlő mértékben lesz elosztva.</translation>
     </message>
     <message>
         <source>S&amp;ubtract fee from amount</source>
@@ -2684,7 +2969,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
-        <translation type="unfinished">Sporočilo, ki ste ga pripeli na URI tipa bitcoin:. Shranjeno bo skupaj s podatki o transakciji. Opomba: Sporočilo ne bo poslano preko omrežja Bitcoin.</translation>
+        <translation type="unfinished">Egy üzenet a bitcoin: URI-hoz csatolva, amely a tranzakciócal együtt lesz eltárolva az Ön számára. Megjegyzés: Ez az üzenet nem kerül elküldésre a Bitcoin hálózaton keresztül.</translation>
     </message>
     <message>
         <source>Pay To:</source>
@@ -2707,7 +2992,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>You can sign messages/agreements with your addresses to prove you can receive bitcoins sent to them. Be careful not to sign anything vague or random, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
-        <translation type="unfinished">S svojimi naslovi lahko podpisujete sporočila ali pogodbe in s tem dokazujete, da na teh naslovih lahko prejemate kovance. Bodite previdni in ne podpisujte ničesar nejasnega ali naključnega, ker vas zlikovci preko ribarjenja (phishing) lahko prelisičijo, da na njih prepišete svojo identiteto. Podpisujte samo podrobno opisane izjave, s katerimi se strinjate.</translation>
+        <translation type="unfinished">Címeivel aláírhatja az üzeneteket/egyezményeket, amivel bizonyíthatja, hogy át tudja venni az ezekre a címekre küldött bitcoin-t. Vigyázzon, hogy ne írjon alá semmi félreérthetőt, mivel adathalász támadásokkal megpróbálhatják becsapni, hogy az azonosságát átírja másokra. Csak olyan részletes állításokat írjon alá, amivel egyetért.</translation>
     </message>
     <message>
         <source>The Bitcoin address to sign the message with</source>
@@ -2715,7 +3000,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Choose previously used address</source>
-        <translation type="unfinished">Válassz egy korábban már használt címet</translation>
+        <translation type="unfinished">Válasszon egy korábban már használt címet</translation>
     </message>
     <message>
         <source>Paste address from clipboard</source>
@@ -2743,7 +3028,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Reset all sign message fields</source>
-        <translation>Počisti vsa polja za vnos v oknu za podpisovanje</translation>
+        <translation>Az összes aláírási üzenetmező törlése</translation>
     </message>
     <message>
         <source>Clear &amp;All</source>
@@ -2755,7 +3040,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Enter the receiver's address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack. Note that this only proves the signing party receives with the address, it cannot prove sendership of any transaction!</source>
-        <translation type="unfinished">Da preverite verodostojnost sporočila, spodaj vnesite: prejemnikov naslov, prejeto sporočilo (pazljivo skopirajte vse prelome vrstic, presledke, tabulatorje ipd.,) in prejeti podpis. Da se izognete napadom tipa man-in-the-middle, vedite, da iz veljavnega podpisa ne sledi nič drugega, kot tisto, kar je navedeno v sporočilu. Podpis samo potrjuje dejstvo, da ima podpisnik v lasti prejemni naslov, ne more pa dokazati vira nobene transakcije!</translation>
+        <translation type="unfinished">Adja meg a fogadó címét, az üzenetet (megbizonyosodva arról, hogy az új-sor, szóköz, tab, stb. karaktereket is pontosan adta meg) és az aláírást az üzenet ellenőrzéséhez. Ügyeljen arra, ne gondoljon bele többet az aláírásba, mint amennyi az aláírt szövegben ténylegesen áll, hogy elkerülje a köztes-ember (man-in-the-middle) támadást. Megjegyzendő, hogy ez csak azt bizonyítja hogy az aláíró fél az adott címen tud fogadni, de azt nem tudja igazolni hogy képes-e akár egyetlen tranzakció feladására is!</translation>
     </message>
     <message>
         <source>The Bitcoin address the message was signed with</source>
@@ -2779,7 +3064,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Reset all verify message fields</source>
-        <translation>Počisti vsa polja za vnos v oknu za preverjanje</translation>
+        <translation>Az összes ellenőrzési üzenetmező törlése</translation>
     </message>
     <message>
         <source>Click "Sign Message" to generate signature</source>
@@ -2795,7 +3080,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>The entered address does not refer to a key.</source>
-        <translation type="unfinished">Vnešeni naslov se ne nanaša na ključ.</translation>
+        <translation type="unfinished">A megadott cím nem hivatkozik egy kulcshoz sem.</translation>
     </message>
     <message>
         <source>Wallet unlock was cancelled.</source>
@@ -2827,7 +3112,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>The signature did not match the message digest.</source>
-        <translation type="unfinished">Podpis ne ustreza rezultatu (digest) preverjanja.</translation>
+        <translation type="unfinished">Az aláírás nem egyezett az üzenet kivonatával.</translation>
     </message>
     <message>
         <source>Message verification failed.</source>
@@ -2843,7 +3128,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     <message numerus="yes">
         <source>Open for %n more block(s)</source>
         <translation>
-            <numerusform />
+            <numerusform>Még %n blokkig nyitva</numerusform>
         </translation>
     </message>
     <message>
@@ -2852,7 +3137,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>conflicted with a transaction with %1 confirmations</source>
-        <translation type="unfinished">v sporu s transakcijo z %1 potrditvami</translation>
+        <translation type="unfinished">ütközés egy %1 megerősítéssel rendelkező tranzakcióval</translation>
     </message>
     <message>
         <source>0/unconfirmed, %1</source>
@@ -2925,7 +3210,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation>
-            <numerusform />
+            <numerusform>beérik %n blokk múlva</numerusform>
         </translation>
     </message>
     <message>
@@ -2938,11 +3223,11 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Total debit</source>
-        <translation type="unfinished">Teljes terhelés</translation>
+        <translation type="unfinished">Összes terhelés</translation>
     </message>
     <message>
         <source>Total credit</source>
-        <translation type="unfinished">Skupni kredit</translation>
+        <translation type="unfinished">Összes jóváírás</translation>
     </message>
     <message>
         <source>Transaction fee</source>
@@ -2974,7 +3259,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Output index</source>
-        <translation type="unfinished">Indeks izhoda</translation>
+        <translation type="unfinished">Kimeneti index</translation>
     </message>
     <message>
         <source> (Certificate was not verified)</source>
@@ -2986,7 +3271,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to "not accepted" and it won't be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
-        <translation type="unfinished">Ustvarjeni kovanci morajo zoreti %1 blokov, preden jih lahko porabite. Ko ste ta blok ustvarili, je bil posredovan v omrežje, da bo dodan v verigo blokov. Če se bloku ni uspelo uvrstiti v verigo, se bo njegovo stanje spremenilo v "ni bilo sprejeto" in kovancev ne bo mogoče porabiti. To se včasih zgodi, če kak drug rudar v roku nekaj sekund hkrati z vami odkrije drug blok.</translation>
+        <translation type="unfinished">A frissen generált érméket csak %1 blokkal később tudja elkölteni. Ez a blokk nyomban szétküldésre került a hálózatba, amint legenerálásra került, hogy hozzáadható legyen a blokklánchoz. Ha nem kerül be a láncba, akkor az állapota "elutasított"-ra módosul, és az érmék nem költhetők el. Ez akkor következhet be időnként, ha egy másik csomópont mindössze néhány másodperc különbséggel generált le egy blokkot a miénkhez képest.</translation>
     </message>
     <message>
         <source>Debug information</source>
@@ -3041,7 +3326,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     <message numerus="yes">
         <source>Open for %n more block(s)</source>
         <translation>
-            <numerusform />
+            <numerusform>Még %n blokkig nyitva</numerusform>
         </translation>
     </message>
     <message>
@@ -3090,7 +3375,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Payment to yourself</source>
-        <translation type="unfinished">Magadnak kifizetve</translation>
+        <translation type="unfinished">Saját részre kifizetve</translation>
     </message>
     <message>
         <source>Mined</source>
@@ -3126,11 +3411,11 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>User-defined intent/purpose of the transaction.</source>
-        <translation type="unfinished">Uporabniško določen namen transakcije.</translation>
+        <translation type="unfinished">A tranzakció felhasználó által meghatározott szándéka/célja.</translation>
     </message>
     <message>
         <source>Amount removed from or added to balance.</source>
-        <translation type="unfinished">Znesek spremembe stanja sredstev.</translation>
+        <translation type="unfinished">Az egyenleghez jóváírt vagy ráterhelt összeg.</translation>
     </message>
 </context>
 <context>
@@ -3169,7 +3454,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>To yourself</source>
-        <translation type="unfinished">Magának</translation>
+        <translation type="unfinished">Saját részre</translation>
     </message>
     <message>
         <source>Mined</source>
@@ -3181,11 +3466,15 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Enter address, transaction id, or label to search</source>
-        <translation type="unfinished">Vnesi naslov, ID transakcije, ali oznako za iskanje</translation>
+        <translation type="unfinished">Írja be a keresendő címet, tranzakció azonosítót vagy címkét</translation>
     </message>
     <message>
         <source>Min amount</source>
         <translation type="unfinished">Minimális összeg</translation>
+    </message>
+    <message>
+        <source>Range…</source>
+        <translation type="unfinished">Tartomány...</translation>
     </message>
     <message>
         <source>&amp;Copy address</source>
@@ -3204,13 +3493,37 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <translation type="unfinished">&amp;Tranzakcióazonosító másolása</translation>
     </message>
     <message>
+        <source>Copy &amp;raw transaction</source>
+        <translation type="unfinished">Nye&amp;rs tranzakció másolása</translation>
+    </message>
+    <message>
+        <source>Copy full transaction &amp;details</source>
+        <translation type="unfinished">Tr&amp;anzakció teljes részleteinek másolása</translation>
+    </message>
+    <message>
+        <source>&amp;Show transaction details</source>
+        <translation type="unfinished">Tranzakció részleteinek &amp;megjelenítése</translation>
+    </message>
+    <message>
+        <source>Increase transaction &amp;fee</source>
+        <translation type="unfinished">Tranzakciós díj &amp;növelése</translation>
+    </message>
+    <message>
+        <source>A&amp;bandon transaction</source>
+        <translation type="unfinished">Tranzakció me&amp;gszakítása</translation>
+    </message>
+    <message>
+        <source>&amp;Edit address label</source>
+        <translation type="unfinished">Cím címkéjének sz&amp;erkesztése</translation>
+    </message>
+    <message>
         <source>Export Transaction History</source>
         <translation type="unfinished">Tranzakciós előzmények exportálása</translation>
     </message>
     <message>
         <source>Comma separated file</source>
         <extracomment>Expanded name of the CSV file format. See https://en.wikipedia.org/wiki/Comma-separated_values</extracomment>
-        <translation type="unfinished">CSV fájl</translation>
+        <translation type="unfinished">Vesszővel tagolt fájl</translation>
     </message>
     <message>
         <source>Confirmed</source>
@@ -3254,7 +3567,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>The transaction history was successfully saved to %1.</source>
-        <translation type="unfinished">Zgodovina poteklih transakcij je bila uspešno shranjena v datoteko %1.</translation>
+        <translation type="unfinished">A tranzakciós előzmények sikeresen el lettek mentve ide: %1.</translation>
     </message>
     <message>
         <source>Range:</source>
@@ -3262,7 +3575,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>to</source>
-        <translation type="unfinished">za</translation>
+        <translation type="unfinished">meddig</translation>
     </message>
 </context>
 <context>
@@ -3300,7 +3613,7 @@ A Fájl &gt; Megnyitás menüben lehet megnyitni.
     </message>
     <message>
         <source>Do you want to draft a transaction with fee increase?</source>
-        <translation type="unfinished">Akarsz egy piszkozat tranzakciót díj emeléssel?</translation>
+        <translation type="unfinished">Készít egy piszkozat tranzakciót díj emeléssel?</translation>
     </message>
     <message>
         <source>Current fee:</source>
@@ -3315,8 +3628,12 @@ A Fájl &gt; Megnyitás menüben lehet megnyitni.
         <translation type="unfinished">Új díj:</translation>
     </message>
     <message>
+        <source>Warning: This may pay the additional fee by reducing change outputs or adding inputs, when necessary. It may add a new change output if one does not already exist. These changes may potentially leak privacy.</source>
+        <translation type="unfinished">Figyelem: Többletdíjakhoz vezethet ha a bemenetek és visszajáró kimenetek szükség szerint kerülnek hozzáadásra illetve összevonásra. Ezzel létrejöhet új kimenet a visszajárónak, ha még nem létezik ilyen. Ilyen beállításokkal jelentősen sérülhet az adatvédelem hatékonysága.</translation>
+    </message>
+    <message>
         <source>Confirm fee bump</source>
-        <translation type="unfinished">Erősitsd meg a díj emelését</translation>
+        <translation type="unfinished">Erősítse meg a díj emelését</translation>
     </message>
     <message>
         <source>Can't draft transaction.</source>
@@ -3333,6 +3650,10 @@ A Fájl &gt; Megnyitás menüben lehet megnyitni.
     <message>
         <source>Could not commit transaction</source>
         <translation type="unfinished">A tranzakciót nem lehet elküldeni</translation>
+    </message>
+    <message>
+        <source>Can't display address</source>
+        <translation type="unfinished">Nem lehet a címet megjeleníteni</translation>
     </message>
     <message>
         <source>default wallet</source>
@@ -3355,7 +3676,7 @@ A Fájl &gt; Megnyitás menüben lehet megnyitni.
     </message>
     <message>
         <source>Unable to decode PSBT from clipboard (invalid base64)</source>
-        <translation type="unfinished">PSBT sikertelen dekódolása a vágólapról (base64 érvénytelen)</translation>
+        <translation type="unfinished">PSBT sikertelen dekódolása a vágólapról (érvénytelen base64)</translation>
     </message>
     <message>
         <source>Load Transaction Data</source>
@@ -3411,7 +3732,7 @@ A Fájl &gt; Megnyitás menüben lehet megnyitni.
     </message>
     <message>
         <source>%s corrupt. Try using the wallet tool bitcoin-wallet to salvage or restoring a backup.</source>
-        <translation type="unfinished">%s sérült. Megpróbálhatod a bitcoint-wallet tárcaj mentő eszközt, vagy mentésből helyreállítani a tárcát.</translation>
+        <translation type="unfinished">%s sérült. Próbálja meg a bitcoint-wallet tárca mentő eszközt használni, vagy állítsa helyre egy biztonsági mentésből.</translation>
     </message>
     <message>
         <source>-maxtxfee is set very high! Fees this large could be paid on a single transaction.</source>
@@ -3419,15 +3740,19 @@ A Fájl &gt; Megnyitás menüben lehet megnyitni.
     </message>
     <message>
         <source>Cannot downgrade wallet from version %i to version %i. Wallet version unchanged.</source>
-        <translation type="unfinished">Nem sikerült a tárcát %iverzióról %iverzióra vissza módosítani. A tárca verzió változatlan maradt.</translation>
+        <translation type="unfinished">Nem sikerült a tárcát %i verzióról %i verzióra módosítani. A tárca verziója változatlan maradt.</translation>
     </message>
     <message>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running.</source>
-        <translation type="unfinished">Az %s adatkönyvtár nem zárható.  A %s valószínűleg fut már.</translation>
+        <translation type="unfinished">Az %s adatkönyvtár nem zárolható. A %s valószínűleg fut már.</translation>
     </message>
     <message>
         <source>Cannot provide specific connections and have addrman find outgoing connections at the same.</source>
         <translation type="unfinished">Nem lehetséges a megadott kapcsolatok és az addrman által felderített kapcsolatok egyidejű használata.</translation>
+    </message>
+    <message>
+        <source>Cannot upgrade a non HD split wallet from version %i to version %i without upgrading to support pre-split keypool. Please use version %i or no version specified.</source>
+        <translation type="unfinished">Nem lehet frissíteni a nem HD szétválasztott tárcát %i verzióról %i verzióra az ezt támogató kulcstár frissítése nélkül. Kérjuk használja a %i verziót vagy ne adjon meg verziót.</translation>
     </message>
     <message>
         <source>Distributed under the MIT software license, see the accompanying file %s or %s</source>
@@ -3438,12 +3763,32 @@ A Fájl &gt; Megnyitás menüben lehet megnyitni.
         <translation type="unfinished">Hiba %s beolvasása közben. Az összes kulcs sikeresen beolvasva, de a tranzakciós adatok és a címtár rekordok hiányoznak vagy sérültek.</translation>
     </message>
     <message>
+        <source>Error: Dumpfile format record is incorrect. Got "%s", expected "format".</source>
+        <translation type="unfinished">Hiba: A dump fájl formátum rekordja helytelen. Talált "%s", várt "format".</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile identifier record is incorrect. Got "%s", expected "%s".</source>
+        <translation type="unfinished">Hiba: A dump fájl azonosító rekordja helytelen. Talált "%s", várt "%s".</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile version is not supported. This version of bitcoin-wallet only supports version 1 dumpfiles. Got dumpfile with version %s</source>
+        <translation type="unfinished">Hiba: A dump fájl verziója nem támogatott. A bitcoin-wallet ez a kiadása csak 1-es verziójú dump fájlokat támogat. A talált dump fájl verziója %s.</translation>
+    </message>
+    <message>
+        <source>Error: Legacy wallets only support the "legacy", "p2sh-segwit", and "bech32" address types</source>
+        <translation type="unfinished">Hiba: Régi típusú tárcák csak "legacy", "p2sh-segwit" és "bech32" címformátumokat támogatják</translation>
+    </message>
+    <message>
         <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
-        <translation type="unfinished">Napaka: Ni mogoče sprejemati dohodnih povezav (vrnjena napaka: %s)</translation>
+        <translation type="unfinished">Hiba: Figyelés a bejövő kapcsolatokra sikertelen (a listen hibaüzenete: %s)</translation>
     </message>
     <message>
         <source>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.</source>
         <translation type="unfinished">Díjbecslés sikertelen. Alapértelmezett díj le van tiltva. Fárj néhány blokkot vagy engedélyezd a -fallbackfee -t.</translation>
+    </message>
+    <message>
+        <source>File %s already exists. If you are sure this is what you want, move it out of the way first.</source>
+        <translation type="unfinished">A %s fájl már létezik. Ha tényleg ezt szeretné használni akkor előtte mozgassa el onnan.</translation>
     </message>
     <message>
         <source>Invalid amount for -maxtxfee=&lt;amount&gt;: '%s' (must be at least the minrelay fee of %s to prevent stuck transactions)</source>
@@ -3451,15 +3796,27 @@ A Fájl &gt; Megnyitás menüben lehet megnyitni.
     </message>
     <message>
         <source>More than one onion bind address is provided. Using %s for the automatically created Tor onion service.</source>
-        <translation type="unfinished">Egynél több hagymakötési cím van megadva. %s használata az automatikusan létrehozott Tor hagyma szolgáltatáshoz.</translation>
+        <translation type="unfinished">Egynél több társított onion cím lett megadva. %s használata az automatikusan létrehozott Tor szolgáltatáshoz.</translation>
+    </message>
+    <message>
+        <source>No dump file provided. To use createfromdump, -dumpfile=&lt;filename&gt; must be provided.</source>
+        <translation type="unfinished">Nincs dump fájl megadva. A createfromdump használatához -dumpfile=&lt;filename&gt; megadása kötelező.</translation>
+    </message>
+    <message>
+        <source>No dump file provided. To use dump, -dumpfile=&lt;filename&gt; must be provided.</source>
+        <translation type="unfinished">Nincs dump fájl megadva. A dump használatához -dumpfile=&lt;filename&gt; megadása kötelező.</translation>
+    </message>
+    <message>
+        <source>No wallet file format provided. To use createfromdump, -format=&lt;format&gt; must be provided.</source>
+        <translation type="unfinished">Nincs tárca fájlformátum megadva. A createfromdump használatához -format=&lt;format&gt; megadása kötelező.</translation>
     </message>
     <message>
         <source>Please check that your computer's date and time are correct! If your clock is wrong, %s will not work properly.</source>
-        <translation type="unfinished">Opozorilo: Preverite, če sta datum in ura na vašem računalniku točna! %s ne bo deloval pravilno, če je nastavljeni čas nepravilen.</translation>
+        <translation type="unfinished">Ellenőrizze, hogy helyesen van-e beállítva a gépén a dátum és az idő! A %s nem fog megfelelően működni, ha rosszul van beállítva az óra.</translation>
     </message>
     <message>
         <source>Please contribute if you find %s useful. Visit %s for further information about the software.</source>
-        <translation type="unfinished">Kérlek támogasd ha hasznásnak találtad a  %s-t. Az alábbi linken találsz bővebb információt a szoftverről %s.</translation>
+        <translation type="unfinished">Kérjük támogasson ha hasznosnak találta a %s-t. Az alábbi linken további információt találhat a szoftverről: %s.</translation>
     </message>
     <message>
         <source>Prune configured below the minimum of %d MiB.  Please use a higher number.</source>
@@ -3475,7 +3832,7 @@ A Fájl &gt; Megnyitás menüben lehet megnyitni.
     </message>
     <message>
         <source>The block database contains a block which appears to be from the future. This may be due to your computer's date and time being set incorrectly. Only rebuild the block database if you are sure that your computer's date and time are correct</source>
-        <translation type="unfinished">A blokk adatbázis tartalmaz egy blokkot ami a jövőből érkezettnek látszik. Ennek oka lehet, hogy a számítógéped dátum és idő beállítása helytelen. Csak akkor építsd újra a block adatbázist ha biztos vagy benne, hogy az időbeállítás helyes.</translation>
+        <translation type="unfinished">A blokk adatbázis tartalmaz egy blokkot ami a jövőből érkezettnek látszik. Ennek oka lehet, hogy a számítógép dátum és idő beállítása helytelen. Csak akkor építse újra a blokk adatbázist ha biztos vagy benne, hogy az időbeállítás helyes.</translation>
     </message>
     <message>
         <source>The transaction amount is too small to send after the fee has been deducted</source>
@@ -3483,7 +3840,7 @@ A Fájl &gt; Megnyitás menüben lehet megnyitni.
     </message>
     <message>
         <source>This error could occur if this wallet was not shutdown cleanly and was last loaded using a build with a newer version of Berkeley DB. If so, please use the software that last loaded this wallet</source>
-        <translation type="unfinished">Ez a hiba akkor jelentkezhet ha a tárca nem volt rendesen lezárva és egy újabb verziójában volt megnyitva a Berkeley DB-nek. Ha így van akkor használd azt a verziót amivel legutóbb megnyitottad.</translation>
+        <translation type="unfinished">Ez a hiba akkor jelentkezhet, ha a tárca nem volt rendesen lezárva és egy újabb verziójában volt megnyitva a Berkeley DB-nek. Ha így van, akkor használja azt a verziót amivel legutóbb megnyitotta.</translation>
     </message>
     <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
@@ -3499,7 +3856,7 @@ A Fájl &gt; Megnyitás menüben lehet megnyitni.
     </message>
     <message>
         <source>This is the transaction fee you may pay when fee estimates are not available.</source>
-        <translation type="unfinished">Ezt a tranzakciós díjat fogod fizetni ha a díjbecslés nem lehetséges.</translation>
+        <translation type="unfinished">Ezt a tranzakciós díjat fogja fizetni ha a díjbecslés nem lehetséges.</translation>
     </message>
     <message>
         <source>Total length of network version string (%i) exceeds maximum length (%i). Reduce the number or size of uacomments.</source>
@@ -3507,7 +3864,15 @@ A Fájl &gt; Megnyitás menüben lehet megnyitni.
     </message>
     <message>
         <source>Unable to replay blocks. You will need to rebuild the database using -reindex-chainstate.</source>
-        <translation type="unfinished">Ne morem ponoviti blokov. Podatkovno bazo bo potrebno ponovno zgraditi z uporabo ukaza -reindex-chainstate.</translation>
+        <translation type="unfinished">Blokkok visszajátszása nem lehetséges. Újra kell építenie az adatbázist a -reindex-chainstate opció használatával.</translation>
+    </message>
+    <message>
+        <source>Unknown wallet file format "%s" provided. Please provide one of "bdb" or "sqlite".</source>
+        <translation type="unfinished">A megadott tárca fájl formátuma "%s" ismeretlen. Kérjuk adja meg "bdb" vagy "sqlite" egyikét.</translation>
+    </message>
+    <message>
+        <source>Warning: Dumpfile wallet format "%s" does not match command line specified format "%s".</source>
+        <translation type="unfinished">Figyelem: A dumpfájl tárca formátum (%s) nem egyezik a parancssor által megadott formátummal (%s).</translation>
     </message>
     <message>
         <source>Warning: Private keys detected in wallet {%s} with disabled private keys</source>
@@ -3515,7 +3880,11 @@ A Fájl &gt; Megnyitás menüben lehet megnyitni.
     </message>
     <message>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
-        <translation type="unfinished">Opozorilo: Trenutno se s soležniki ne strinjamo v popolnosti! Mogoče bi morali vi ali drugi udeleženci posodobiti odjemalce.</translation>
+        <translation type="unfinished">Figyelem: Úgy tűnik nem értünk egyet teljesen a partnereinkel! Lehet, hogy frissítenie kell, vagy a többi partnernek kell frissítenie.</translation>
+    </message>
+    <message>
+        <source>Witness data for blocks after height %d requires validation. Please restart with -reindex.</source>
+        <translation type="unfinished">Ellenőrzés szükséges a %d feletti blokkok tanúsító adatának. Kérjük indítsa újra -reindex paraméterrel.</translation>
     </message>
     <message>
         <source>You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain</source>
@@ -3535,7 +3904,7 @@ A Fájl &gt; Megnyitás menüben lehet megnyitni.
     </message>
     <message>
         <source>Cannot resolve -%s address: '%s'</source>
-        <translation type="unfinished">Naslova -%s ni mogoče razrešiti: '%s'</translation>
+        <translation type="unfinished">-%s cím feloldása nem sikerült: '%s'</translation>
     </message>
     <message>
         <source>Cannot set -peerblockfilters without -blockfilterindex.</source>
@@ -3547,7 +3916,7 @@ A Fájl &gt; Megnyitás menüben lehet megnyitni.
     </message>
     <message>
         <source>Change index out of range</source>
-        <translation type="unfinished">Indeks drobiža izven dovoljenega območja</translation>
+        <translation type="unfinished">Visszajáró index a határértéken kívül van</translation>
     </message>
     <message>
         <source>Config setting for %s only applied on %s network when in [%s] section.</source>
@@ -3575,7 +3944,7 @@ A Fájl &gt; Megnyitás menüben lehet megnyitni.
     </message>
     <message>
         <source>Do you want to rebuild the block database now?</source>
-        <translation type="unfinished">Újra akarod építeni a blokk adatbázist most?</translation>
+        <translation type="unfinished">Újra akarja építeni a blokk adatbázist most?</translation>
     </message>
     <message>
         <source>Done loading</source>
@@ -3587,7 +3956,7 @@ A Fájl &gt; Megnyitás menüben lehet megnyitni.
     </message>
     <message>
         <source>Error creating %s</source>
-        <translation type="unfinished">Nem tudtam létrehozni %s -t.</translation>
+        <translation type="unfinished">Hiba %s létrehozása közben</translation>
     </message>
     <message>
         <source>Error initializing block database</source>
@@ -3634,20 +4003,48 @@ A Fájl &gt; Megnyitás menüben lehet megnyitni.
         <translation type="unfinished">Hiba a blokk adatbázis betöltése közben</translation>
     </message>
     <message>
+        <source>Error: Couldn't create cursor into database</source>
+        <translation type="unfinished">Hiba: Nem tudott kurzort az adatbázisba készíteni</translation>
+    </message>
+    <message>
         <source>Error: Disk space is low for %s</source>
         <translation type="unfinished">Hiba: kevés a hely a lemezen %s -nek!</translation>
     </message>
     <message>
+        <source>Error: Dumpfile checksum does not match. Computed %s, expected %s</source>
+        <translation type="unfinished">Hiba: A dumpfájl ellenőrző összege nem egyezik. %s-t kapott, %s-re számított</translation>
+    </message>
+    <message>
+        <source>Error: Got key that was not hex: %s</source>
+        <translation type="unfinished">Hiba: Nem hexadecimális kulcsot kapott: %s</translation>
+    </message>
+    <message>
+        <source>Error: Got value that was not hex: %s</source>
+        <translation type="unfinished">Hiba: Nem hexadecimális értéket kapott: %s</translation>
+    </message>
+    <message>
         <source>Error: Keypool ran out, please call keypoolrefill first</source>
-        <translation type="unfinished">A címraktár kiürült, tötsd újra a keyppolrefill paranccsal.</translation>
+        <translation type="unfinished">A címraktár kiürült, kérjük előbb adja ki a keypoolrefill parancsot.</translation>
     </message>
     <message>
         <source>Error: Missing checksum</source>
         <translation type="unfinished">Hiba: Hiányzó ellenőrző összeg</translation>
     </message>
     <message>
+        <source>Error: No %s addresses available.</source>
+        <translation type="unfinished">Hiba: Nem áll rendelkezésre %s cím.</translation>
+    </message>
+    <message>
+        <source>Error: Unable to parse version %u as a uint32_t</source>
+        <translation type="unfinished">Hiba: Nem lehet a %u verziót uint32_t-ként értelmezni</translation>
+    </message>
+    <message>
+        <source>Error: Unable to write record to new wallet</source>
+        <translation type="unfinished">Hiba: Nem sikerült rekordot írni az új pénztárcába</translation>
+    </message>
+    <message>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
-        <translation type="unfinished">Egyik hálózati porton sem sikerül hallgatni. Használja a -listen=0 kapcsolót, ha ezt szeretné.</translation>
+        <translation type="unfinished">Egyik hálózati portot sem sikerül figyelni. Használja a -listen=0 kapcsolót, ha ezt szeretné.</translation>
     </message>
     <message>
         <source>Failed to rescan the wallet during initialization</source>
@@ -3666,8 +4063,12 @@ A Fájl &gt; Megnyitás menüben lehet megnyitni.
         <translation type="unfinished">A duplikált -tárca %s figyelmen kívül hagyása.</translation>
     </message>
     <message>
+        <source>Importing…</source>
+        <translation type="unfinished">Importálás…</translation>
+    </message>
+    <message>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
-        <translation type="unfinished">Helytelen vagy nemlétező genézis blokk. Helytelen hálózati adatkönyvtár?</translation>
+        <translation type="unfinished">Helytelen vagy nemlétező ősblokk. Helytelen hálózati adatkönyvtár?</translation>
     </message>
     <message>
         <source>Initialization sanity check failed. %s is shutting down.</source>
@@ -3676,6 +4077,10 @@ A Fájl &gt; Megnyitás menüben lehet megnyitni.
     <message>
         <source>Insufficient funds</source>
         <translation type="unfinished">Fedezethiány</translation>
+    </message>
+    <message>
+        <source>Invalid -i2psam address or hostname: '%s'</source>
+        <translation type="unfinished">Érvénytelen -i2psam cím vagy hostname: '%s'</translation>
     </message>
     <message>
         <source>Invalid -onion address or hostname: '%s'</source>
@@ -3691,15 +4096,15 @@ A Fájl &gt; Megnyitás menüben lehet megnyitni.
     </message>
     <message>
         <source>Invalid amount for -%s=&lt;amount&gt;: '%s'</source>
-        <translation type="unfinished">Neveljavna količina za -%s=&lt;amount&gt;: '%s'</translation>
+        <translation type="unfinished">Érvénytelen összeg, -%s=&lt;amount&gt;: '%s'</translation>
     </message>
     <message>
         <source>Invalid amount for -discardfee=&lt;amount&gt;: '%s'</source>
-        <translation type="unfinished">Neveljavna količina za -discardfee=&lt;amount&gt;: '%s'</translation>
+        <translation type="unfinished">Érvénytelen összeg, -discardfee=&lt;amount&gt;: '%s'</translation>
     </message>
     <message>
         <source>Invalid amount for -fallbackfee=&lt;amount&gt;: '%s'</source>
-        <translation type="unfinished">Neveljavna količina za -fallbackfee=&lt;amount&gt;: '%s'</translation>
+        <translation type="unfinished">Érvénytelen összeg, -fallbackfee=&lt;amount&gt;: '%s'</translation>
     </message>
     <message>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: '%s' (must be at least %s)</source>
@@ -3710,8 +4115,24 @@ A Fájl &gt; Megnyitás menüben lehet megnyitni.
         <translation type="unfinished">Érvénytelen hálózati maszk van megadva itt:  -whitelist: '%s'</translation>
     </message>
     <message>
+        <source>Loading P2P addresses…</source>
+        <translation type="unfinished">P2P címek betöltése…</translation>
+    </message>
+    <message>
+        <source>Loading banlist…</source>
+        <translation type="unfinished">Tiltólista betöltése…</translation>
+    </message>
+    <message>
+        <source>Loading block index…</source>
+        <translation type="unfinished">Blokkindex betöltése…</translation>
+    </message>
+    <message>
+        <source>Loading wallet…</source>
+        <translation type="unfinished">Tárca betöltése…</translation>
+    </message>
+    <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
-        <translation type="unfinished">Pri opciji -whitebind morate navesti vrata: %s</translation>
+        <translation type="unfinished">A -whitebind opcióhoz meg kell adni egy portot is: '%s'</translation>
     </message>
     <message>
         <source>No proxy server specified. Use -proxy=&lt;ip&gt; or -proxy=&lt;ip:port&gt;.</source>
@@ -3723,15 +4144,31 @@ A Fájl &gt; Megnyitás menüben lehet megnyitni.
     </message>
     <message>
         <source>Prune cannot be configured with a negative value.</source>
-        <translation type="unfinished">Nyesett üzemmódot nem lehet negatív értékkel kialakítani.</translation>
+        <translation type="unfinished">Nyesett üzemmódot nem lehet negatív értékkel konfigurálni.</translation>
+    </message>
+    <message>
+        <source>Prune mode is incompatible with -coinstatsindex.</source>
+        <translation type="unfinished">A Prune mód nem kompatibilis a -coinstatsindex funkcióval.</translation>
     </message>
     <message>
         <source>Prune mode is incompatible with -txindex.</source>
         <translation type="unfinished">A -txindex nem használható nyesett üzemmódban.</translation>
     </message>
     <message>
+        <source>Pruning blockstore…</source>
+        <translation type="unfinished">Blokktároló nyesése…</translation>
+    </message>
+    <message>
         <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
-        <translation type="unfinished">Zmanjšujem maksimalno število povezav (-maxconnections) iz %d na %d, zaradi sistemskih omejitev.</translation>
+        <translation type="unfinished">A -maxconnections csökkentése %d értékről %d értékre, a rendszer korlátai miatt.</translation>
+    </message>
+    <message>
+        <source>Replaying blocks…</source>
+        <translation type="unfinished">Blokkok visszajátszása…</translation>
+    </message>
+    <message>
+        <source>Rescanning…</source>
+        <translation type="unfinished">Újraszkennelés…</translation>
     </message>
     <message>
         <source>SQLiteDatabase: Failed to execute statement to verify database: %s</source>
@@ -3774,8 +4211,16 @@ A Fájl &gt; Megnyitás menüben lehet megnyitni.
         <translation type="unfinished">A megadott blokk "%s" nem létezik.</translation>
     </message>
     <message>
+        <source>Starting network threads…</source>
+        <translation type="unfinished">Hálózati szálak indítása…</translation>
+    </message>
+    <message>
         <source>The source code is available from %s.</source>
         <translation type="unfinished">A forráskód elérhető: %s.</translation>
+    </message>
+    <message>
+        <source>The specified config file %s does not exist</source>
+        <translation type="unfinished">A megadott konfigurációs fájl %s nem létezik</translation>
     </message>
     <message>
         <source>The transaction amount is too small to pay the fee</source>
@@ -3814,16 +4259,20 @@ A Fájl &gt; Megnyitás menüben lehet megnyitni.
         <translation type="unfinished">Legalább egy címzett kell a tranzakcióhoz</translation>
     </message>
     <message>
+        <source>Transaction needs a change address, but we can't generate it. %s</source>
+        <translation type="unfinished">A tranzakcióhoz szükség van visszajáró címekre, de nem lehet generálni egyet. %s</translation>
+    </message>
+    <message>
         <source>Transaction too large</source>
         <translation type="unfinished">Túl nagy tranzakció</translation>
     </message>
     <message>
         <source>Unable to bind to %s on this computer (bind returned error %s)</source>
-        <translation type="unfinished">Na tem računalniku ni bilo mogoče vezati naslova %s (vrnjena napaka: %s)</translation>
+        <translation type="unfinished">Ezen a számítógépen nem lehet ehhez társítani: %s (a bind ezzel a hibával tért vissza: %s)</translation>
     </message>
     <message>
         <source>Unable to bind to %s on this computer. %s is probably already running.</source>
-        <translation type="unfinished">Na tem računalniku ni bilo mogoče vezati naslova %s. %s je verjetno že zagnan.</translation>
+        <translation type="unfinished">Ezen a gépen nem lehet ehhez társítani: %s. %s már valószínűleg fut.</translation>
     </message>
     <message>
         <source>Unable to create the PID file '%s': %s</source>
@@ -3831,7 +4280,7 @@ A Fájl &gt; Megnyitás menüben lehet megnyitni.
     </message>
     <message>
         <source>Unable to generate initial keys</source>
-        <translation type="unfinished">Ne zmorem ustvariti začetnih ključev</translation>
+        <translation type="unfinished">Kezdő kulcsok létrehozása sikertelen</translation>
     </message>
     <message>
         <source>Unable to generate keys</source>
@@ -3862,6 +4311,10 @@ A Fájl &gt; Megnyitás menüben lehet megnyitni.
         <translation type="unfinished">Ismeretlen hálózat lett megadva -onlynet: '%s'</translation>
     </message>
     <message>
+        <source>Unknown new rules activated (versionbit %i)</source>
+        <translation type="unfinished">Ismeretlen új szabályok aktiválva (verzióbit %i)</translation>
+    </message>
+    <message>
         <source>Unsupported logging category %s=%s.</source>
         <translation type="unfinished">Nem támogatott logolási kategória %s=%s</translation>
     </message>
@@ -3883,11 +4336,11 @@ A Fájl &gt; Megnyitás menüben lehet megnyitni.
     </message>
     <message>
         <source>Verifying wallet(s)…</source>
-        <translation type="unfinished">Tárca(k) ellenőrzés(e)</translation>
+        <translation type="unfinished">Elérhető tárcák ellenőrzése...</translation>
     </message>
     <message>
         <source>Wallet needed to be rewritten: restart %s to complete</source>
-        <translation type="unfinished">A Tárca újraírása szükséges: Indítsa újra a %s-t.</translation>
+        <translation type="unfinished">A tárca újraírása szükséges: Indítsa újra a %s-t.</translation>
     </message>
 </context>
 </TS>

--- a/src/qt/locale/bitcoin_id.ts
+++ b/src/qt/locale/bitcoin_id.ts
@@ -50,10 +50,6 @@
         <translation type="unfinished">Pilih alamat untuk mengirim koin</translation>
     </message>
     <message>
-        <source>Choose the address to receive coins with</source>
-        <translation type="unfinished">Piih alamat untuk menerima koin</translation>
-    </message>
-    <message>
         <source>C&amp;hoose</source>
         <translation type="unfinished">&amp;Pilih</translation>
     </message>

--- a/src/qt/locale/bitcoin_is.ts
+++ b/src/qt/locale/bitcoin_is.ts
@@ -3,11 +3,11 @@
     <name>AddressBookPage</name>
     <message>
         <source>Right-click to edit address or label</source>
-        <translation type="unfinished">Smelltu á hægri músatakka til að breyta færslugildi eða merkingu</translation>
+        <translation type="unfinished">Smelltu á hægri músatakka til að velja veski eða merkingu</translation>
     </message>
     <message>
         <source>Create a new address</source>
-        <translation>Búa til nýtt færslugildi</translation>
+        <translation>Búa til nýtt veski</translation>
     </message>
     <message>
         <source>&amp;New</source>
@@ -15,7 +15,7 @@
     </message>
     <message>
         <source>Copy the currently selected address to the system clipboard</source>
-        <translation>Afrita valið færslugildi í klemmuspjald</translation>
+        <translation>Afrita valið veski í klemmuspjald</translation>
     </message>
     <message>
         <source>&amp;Copy</source>
@@ -27,7 +27,11 @@
     </message>
     <message>
         <source>Delete the currently selected address from the list</source>
-        <translation>Eyða völdu færslugildi úr listanum</translation>
+        <translation>Eyða völdu veski úr listanum</translation>
+    </message>
+    <message>
+        <source>Enter address or label to search</source>
+        <translation type="unfinished">Veldu veski eða merkingu fyrir leit</translation>
     </message>
     <message>
         <source>Export the data in the current tab to a file</source>
@@ -43,11 +47,11 @@
     </message>
     <message>
         <source>Choose the address to send coins to</source>
-        <translation type="unfinished">Veldu færslugildi sem greiða skal til</translation>
+        <translation type="unfinished">Veldu veski sem greiða skal til</translation>
     </message>
     <message>
         <source>Choose the address to receive coins with</source>
-        <translation type="unfinished">Veldu færslugildi sem á að taka við mynt</translation>
+        <translation type="unfinished">Veldu veski til að taka við rafmynt</translation>
     </message>
     <message>
         <source>C&amp;hoose</source>
@@ -55,15 +59,15 @@
     </message>
     <message>
         <source>Sending addresses</source>
-        <translation type="unfinished">Færslugildi sem senda frá sér</translation>
+        <translation type="unfinished">Veski sem senda frá sér</translation>
     </message>
     <message>
         <source>Receiving addresses</source>
-        <translation type="unfinished">Færslugildi sem þiggja til sín</translation>
+        <translation type="unfinished">Veski sem þiggja til sín</translation>
     </message>
     <message>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
-        <translation type="unfinished">Þetta eru Bitcoin færslugildin sem senda greiðslur. Skoðið ævinlega vel upphæðina og færslugildin sem þiggja greiðslur áður en mynt er send.</translation>
+        <translation type="unfinished">Þetta eru Bitcoin veskin sem senda greiðslur. Skoðið ævinlega vel upphæðina og veskin sem þiggja greiðslur áður en rafmynt er send.</translation>
     </message>
     <message>
         <source>&amp;Copy Address</source>

--- a/src/qt/locale/bitcoin_it.ts
+++ b/src/qt/locale/bitcoin_it.ts
@@ -23,7 +23,7 @@
     </message>
     <message>
         <source>C&amp;lose</source>
-        <translation type="unfinished">Chiudi</translation>
+        <translation type="unfinished">Chiudere</translation>
     </message>
     <message>
         <source>Delete the currently selected address from the list</source>
@@ -313,8 +313,16 @@ E' possibile firmare solo con indirizzi di tipo "legacy".</translation>
         <translation type="unfinished">Relè completo</translation>
     </message>
     <message>
+        <source>Block Relay</source>
+        <translation type="unfinished">Relay del blocco</translation>
+    </message>
+    <message>
         <source>Manual</source>
         <translation type="unfinished">Manuale</translation>
+    </message>
+    <message>
+        <source>Address Fetch</source>
+        <translation type="unfinished">Trova l’indirizzo </translation>
     </message>
     <message>
         <source>None</source>
@@ -327,8 +335,8 @@ E' possibile firmare solo con indirizzi di tipo "legacy".</translation>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation>
-            <numerusform />
-            <numerusform />
+            <numerusform>%n secondo</numerusform>
+            <numerusform>%n secondi</numerusform>
         </translation>
     </message>
     <message numerus="yes">
@@ -341,22 +349,22 @@ E' possibile firmare solo con indirizzi di tipo "legacy".</translation>
     <message numerus="yes">
         <source>%n hour(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n ora</numerusform>
+            <numerusform>%n ore</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n giorno</numerusform>
+            <numerusform>%n giorni</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n settimana</numerusform>
+            <numerusform>%n settimane</numerusform>
         </translation>
     </message>
     <message>
@@ -366,8 +374,8 @@ E' possibile firmare solo con indirizzi di tipo "legacy".</translation>
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n anno</numerusform>
+            <numerusform>%n anni</numerusform>
         </translation>
     </message>
     </context>
@@ -577,8 +585,8 @@ E' possibile firmare solo con indirizzi di tipo "legacy".</translation>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation>
-            <numerusform />
-            <numerusform />
+            <numerusform>%n blocchi dello storico delle transazioni sono stati elaborati</numerusform>
+            <numerusform>%n blocchi dello storico delle transazioni sono stati elaborati</numerusform>
         </translation>
     </message>
     <message>
@@ -693,8 +701,8 @@ E' possibile firmare solo con indirizzi di tipo "legacy".</translation>
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n connessioni(e) attive(a) al network Bitcoin.</numerusform>
+            <numerusform>%n connessioni(e) attive(a) al network Bitcoin.</numerusform>
         </translation>
     </message>
     <message>
@@ -880,6 +888,26 @@ E' possibile firmare solo con indirizzi di tipo "legacy".</translation>
         <translation type="unfinished">&amp;Copia indirizzo</translation>
     </message>
     <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Copia &amp;etichetta</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Copia &amp;amount</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">Copia la transazione &amp;ID</translation>
+    </message>
+    <message>
+        <source>L&amp;ock unspent</source>
+        <translation type="unfinished">L&amp;ock non spesi</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock unspent</source>
+        <translation type="unfinished">&amp;Unlock non spesi</translation>
+    </message>
+    <message>
         <source>Copy quantity</source>
         <translation type="unfinished">Copia quantità</translation>
     </message>
@@ -946,7 +974,11 @@ E' possibile firmare solo con indirizzi di tipo "legacy".</translation>
         <source>Create wallet warning</source>
         <translation type="unfinished">Creazione portafoglio attenzione</translation>
     </message>
-    </context>
+    <message>
+        <source>Can't list signers</source>
+        <translation type="unfinished">impossibile elencare firmatori</translation>
+    </message>
+</context>
 <context>
     <name>OpenWalletActivity</name>
     <message>
@@ -1165,8 +1197,8 @@ E' possibile firmare solo con indirizzi di tipo "legacy".</translation>
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>(sufficiente per ripristinare i backup vecchi di %n giorno)</numerusform>
+            <numerusform>(sufficiente per ripristinare i backup di %n giorni fa)</numerusform>
         </translation>
     </message>
     <message>
@@ -1383,7 +1415,7 @@ Per specificare più URL separarli con una barra verticale "|".</translation>
     </message>
     <message>
         <source>Prune &amp;block storage to</source>
-        <translation type="unfinished">Eliminare e bloccare l'archiviazione su</translation>
+        <translation type="unfinished">Modalità "prune": elimina i blocchi dal disco dopo</translation>
     </message>
     <message>
         <source>Reverting this setting requires re-downloading the entire blockchain.</source>
@@ -1416,6 +1448,14 @@ Per specificare più URL separarli con una barra verticale "|".</translation>
     <message>
         <source>External Signer (e.g. hardware wallet)</source>
         <translation type="unfinished">Firmatario esterno (es. Hardware Wallet)</translation>
+    </message>
+    <message>
+        <source>&amp;External signer script path</source>
+        <translation type="unfinished">percorso per lo script &amp;External signer</translation>
+    </message>
+    <message>
+        <source>Full path to a Bitcoin Core compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</source>
+        <translation type="unfinished">Percorso completo per uno script compatibile con Bitcoin Core (per esempio C:\Downloads\hwi.exe o /Users/you/Downloads/hwi.py). Attenzione: programmi maligni possono rubare i tuoi soldi!</translation>
     </message>
     <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
@@ -2025,12 +2065,32 @@ Se ricevi questo errore, dovresti richiedere al commerciante di fornire un URI c
         <translation type="unfinished">Permessi</translation>
     </message>
     <message>
+        <source>The direction and type of peer connection: %1</source>
+        <translation type="unfinished">Direzione e tipo di connessione peer: %1</translation>
+    </message>
+    <message>
         <source>Direction/Type</source>
         <translation type="unfinished">Direzione/Tipo</translation>
     </message>
     <message>
+        <source>The network protocol this peer is connected through: IPv4, IPv6, Onion, I2P, or CJDNS.</source>
+        <translation type="unfinished">Il protocollo di rete tramite cui si connette il peer: IPv4, IPv6, Onion, I2P o CJDNS.</translation>
+    </message>
+    <message>
         <source>Services</source>
         <translation type="unfinished">Servizi</translation>
+    </message>
+    <message>
+        <source>Whether the peer requested us to relay transactions.</source>
+        <translation type="unfinished">Se il peer ha chiesto di ritrasmettere le transazioni.</translation>
+    </message>
+    <message>
+        <source>Wants Tx Relay</source>
+        <translation type="unfinished">Vuole il relay della transazione</translation>
+    </message>
+    <message>
+        <source>High bandwidth BIP152 compact block relay: %1</source>
+        <translation type="unfinished">Relay del blocco compatto a banda larga BIP152 : %1</translation>
     </message>
     <message>
         <source>High Bandwidth</source>
@@ -2041,8 +2101,16 @@ Se ricevi questo errore, dovresti richiedere al commerciante di fornire un URI c
         <translation type="unfinished">Tempo di Connessione</translation>
     </message>
     <message>
+        <source>Elapsed time since a novel block passing initial validity checks was received from this peer.</source>
+        <translation type="unfinished">Tempo trascorso da che un blocco nuovo in passaggio dei controlli di validità iniziali è stato ricevuto da questo peer.</translation>
+    </message>
+    <message>
         <source>Last Block</source>
         <translation type="unfinished">Ultimo blocco</translation>
+    </message>
+    <message>
+        <source>Elapsed time since a novel transaction accepted into our mempool was received from this peer.</source>
+        <translation type="unfinished">Tempo trascorso da che una transazione nuova accettata nel nostro mempool è stata ricevuta da questo peer.</translation>
     </message>
     <message>
         <source>Last Tx</source>
@@ -2109,6 +2177,42 @@ Se ricevi questo errore, dovresti richiedere al commerciante di fornire un URI c
         <translation type="unfinished">Uscita:</translation>
     </message>
     <message>
+        <source>Inbound: initiated by peer</source>
+        <translation type="unfinished">In arrivo: a richiesta del peer</translation>
+    </message>
+    <message>
+        <source>Outbound Full Relay: default</source>
+        <translation type="unfinished">Relay completo in uscita: default</translation>
+    </message>
+    <message>
+        <source>Outbound Block Relay: does not relay transactions or addresses</source>
+        <translation type="unfinished">Relay del blocco in uscita: non trasmette transazioni o indirizzi</translation>
+    </message>
+    <message>
+        <source>Outbound Manual: added using RPC %1 or %2/%3 configuration options</source>
+        <translation type="unfinished">In uscita manuale: aggiunto usando RPC %1 o le opzioni di configurazione %2/%3 </translation>
+    </message>
+    <message>
+        <source>Outbound Feeler: short-lived, for testing addresses</source>
+        <translation type="unfinished">Feeler in uscita: a vita breve, per testare indirizzi</translation>
+    </message>
+    <message>
+        <source>Outbound Address Fetch: short-lived, for soliciting addresses</source>
+        <translation type="unfinished">Trova l’indirizzo in uscita: a vita breve, per richiedere indirizzi</translation>
+    </message>
+    <message>
+        <source>we selected the peer for high bandwidth relay</source>
+        <translation type="unfinished">Abbiamo selezionato il peer per il relay a banda larga </translation>
+    </message>
+    <message>
+        <source>the peer selected us for high bandwidth relay</source>
+        <translation type="unfinished">il peer ha scelto noi per il relay a banda larga</translation>
+    </message>
+    <message>
+        <source>no high bandwidth relay selected</source>
+        <translation type="unfinished">nessun relay a banda larga selezionato</translation>
+    </message>
+    <message>
         <source>&amp;Disconnect</source>
         <translation type="unfinished">&amp;Disconnetti</translation>
     </message>
@@ -2139,6 +2243,23 @@ Se ricevi questo errore, dovresti richiedere al commerciante di fornire un URI c
     <message>
         <source>Executing command using "%1" wallet</source>
         <translation type="unfinished">Esecuzione del comando usando il wallet "%1"</translation>
+    </message>
+    <message>
+        <source>Welcome to the %1 RPC console.
+Use up and down arrows to navigate history, and %2 to clear screen.
+Use %3 and %4 to increase or decrease the font size.
+Type %5 for an overview of available commands.
+For more information on using this console, type %6.
+
+%7WARNING: Scammers have been active, telling users to type commands here, stealing their wallet contents. Do not use this console without fully understanding the ramifications of a command.%8</source>
+        <extracomment>RPC console welcome message. Placeholders %7 and %8 are style tags for the warning content, and they are not space separated from the rest of the text intentionally.</extracomment>
+        <translation type="unfinished">Ti diamo il benvenuto nella %1 console RPC.
+Premi i tasti su e giù per navigare nella cronologia e il tasto %2 per liberare lo schermo.
+Premi %3 e %4 per ingrandire o rimpicciolire la dimensione dei caratteri.
+Premi %5 per una panoramica dei comandi disponibili.
+Per ulteriori informazioni su come usare la console, premi %6.
+
+%7ATTENZIONE: Dei truffatori hanno detto agli utenti di inserire qui i loro comandi e hanno rubato il contenuto dei loro portafogli. Non usare questa console senza essere a completa conoscenza delle diramazioni di un comando.%8</translation>
     </message>
     <message>
         <source>Executing…</source>
@@ -2257,6 +2378,18 @@ Se ricevi questo errore, dovresti richiedere al commerciante di fornire un URI c
         <translation type="unfinished">&amp;Copia indirizzo</translation>
     </message>
     <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Copia ed etichetta</translation>
+    </message>
+    <message>
+        <source>Copy &amp;message</source>
+        <translation type="unfinished">Copia &amp;message</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Copia &amp;amount</translation>
+    </message>
+    <message>
         <source>Could not unlock wallet.</source>
         <translation type="unfinished">Impossibile sbloccare il portafoglio.</translation>
     </message>
@@ -2298,6 +2431,10 @@ Se ricevi questo errore, dovresti richiedere al commerciante di fornire un URI c
     <message>
         <source>Copy &amp;Address</source>
         <translation type="unfinished">Copia &amp;Indirizzo</translation>
+    </message>
+    <message>
+        <source>&amp;Verify</source>
+        <translation type="unfinished">&amp;Verifica</translation>
     </message>
     <message>
         <source>Verify this address on e.g. a hardware wallet screen</source>
@@ -2585,6 +2722,11 @@ Nota: poiché la commissione è calcolata su base per byte, una commissione di "
         <translation type="unfinished">Firmatario esterno non trovato</translation>
     </message>
     <message>
+        <source>External signer failure</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Il firmatario esterno non ha funzionato</translation>
+    </message>
+    <message>
         <source>Save Transaction Data</source>
         <translation type="unfinished">Salva Dati Transazione</translation>
     </message>
@@ -2596,6 +2738,10 @@ Nota: poiché la commissione è calcolata su base per byte, una commissione di "
     <message>
         <source>PSBT saved</source>
         <translation type="unfinished">PSBT salvata</translation>
+    </message>
+    <message>
+        <source>External balance:</source>
+        <translation type="unfinished">Saldo esterno:</translation>
     </message>
     <message>
         <source>or</source>
@@ -2672,8 +2818,8 @@ Nota: poiché la commissione è calcolata su base per byte, una commissione di "
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation>
-            <numerusform />
-            <numerusform />
+            <numerusform>Inizio della conferma stimato tra %n blocco.</numerusform>
+            <numerusform>Inizio della conferma stimato tra %n blocchi.</numerusform>
         </translation>
     </message>
     <message>
@@ -2916,8 +3062,8 @@ Nota: poiché la commissione è calcolata su base per byte, una commissione di "
     <message numerus="yes">
         <source>Open for %n more block(s)</source>
         <translation>
-            <numerusform />
-            <numerusform />
+            <numerusform>Aperto per  %n blocco ancora</numerusform>
+            <numerusform>Aperto per altri %n blocchi</numerusform>
         </translation>
     </message>
     <message>
@@ -2999,8 +3145,8 @@ Nota: poiché la commissione è calcolata su base per byte, una commissione di "
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation>
-            <numerusform />
-            <numerusform />
+            <numerusform>matura tra %n blocco</numerusform>
+            <numerusform>matura tra %n blocchi</numerusform>
         </translation>
     </message>
     <message>
@@ -3116,8 +3262,8 @@ Nota: poiché la commissione è calcolata su base per byte, una commissione di "
     <message numerus="yes">
         <source>Open for %n more block(s)</source>
         <translation>
-            <numerusform />
-            <numerusform />
+            <numerusform>Aperto per %n blocco ancora </numerusform>
+            <numerusform>Aperto per altri %n blocchi</numerusform>
         </translation>
     </message>
     <message>
@@ -3272,6 +3418,42 @@ Nota: poiché la commissione è calcolata su base per byte, una commissione di "
         <translation type="unfinished">&amp;Copia indirizzo</translation>
     </message>
     <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Copia ed etichetta</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Copia &amp;amount</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">Copia la transazione &amp;ID</translation>
+    </message>
+    <message>
+        <source>Copy &amp;raw transaction</source>
+        <translation type="unfinished">Copia la transazione &amp;raw</translation>
+    </message>
+    <message>
+        <source>Copy full transaction &amp;details</source>
+        <translation type="unfinished">Copia tutti i dettagli &amp;della transazione </translation>
+    </message>
+    <message>
+        <source>&amp;Show transaction details</source>
+        <translation type="unfinished">&amp;Mostra i dettagli della transazione</translation>
+    </message>
+    <message>
+        <source>Increase transaction &amp;fee</source>
+        <translation type="unfinished">Aumenta la commissione &amp;della transazione</translation>
+    </message>
+    <message>
+        <source>A&amp;bandon transaction</source>
+        <translation type="unfinished">A&amp;bbandona transazione</translation>
+    </message>
+    <message>
+        <source>&amp;Edit address label</source>
+        <translation type="unfinished">&amp;Modifica l'etichetta dell'indirizzo</translation>
+    </message>
+    <message>
         <source>Export Transaction History</source>
         <translation type="unfinished">Esporta lo storico delle transazioni</translation>
     </message>
@@ -3403,6 +3585,10 @@ Vai su File &gt; Apri Portafoglio per caricare un portafoglio.
         <translation type="unfinished">Non è stato possibile completare la transazione</translation>
     </message>
     <message>
+        <source>Can't display address</source>
+        <translation type="unfinished">Non è possibile mostrare l'indirizzo</translation>
+    </message>
+    <message>
         <source>default wallet</source>
         <translation type="unfinished">Portafoglio predefinito:</translation>
     </message>
@@ -3498,12 +3684,32 @@ Vai su File &gt; Apri Portafoglio per caricare un portafoglio.
         <translation type="unfinished">Non è possibile fornire connessioni specifiche e contemporaneamente usare addrman per trovare connessioni uscenti.</translation>
     </message>
     <message>
+        <source>Cannot upgrade a non HD split wallet from version %i to version %i without upgrading to support pre-split keypool. Please use version %i or no version specified.</source>
+        <translation type="unfinished">impossibile aggiornare un portafoglio non diviso e non HD dalla versione %i alla versione %i senza fare l'aggiornamento per supportare il pre-split keypool. Prego usare la versione %i senza specificare la versione</translation>
+    </message>
+    <message>
         <source>Distributed under the MIT software license, see the accompanying file %s or %s</source>
         <translation type="unfinished">Distribuito sotto la licenza software del MIT, si veda il file %s o %s incluso</translation>
     </message>
     <message>
         <source>Error reading %s! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation type="unfinished">Errore lettura %s! Tutte le chiavi sono state lette correttamente, ma i dati delle transazioni o della rubrica potrebbero essere mancanti o non corretti.</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile format record is incorrect. Got "%s", expected "format".</source>
+        <translation type="unfinished">Errore: il formato della registrazione del dumpfile non è corretto. Ricevuto "%s", sarebbe dovuto essere "format"</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile identifier record is incorrect. Got "%s", expected "%s".</source>
+        <translation type="unfinished">Errore: l'identificativo rispetto la registrazione del dumpfile è incorretta.  ricevuto "%s", sarebbe dovuto essere "%s".</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile version is not supported. This version of bitcoin-wallet only supports version 1 dumpfiles. Got dumpfile with version %s</source>
+        <translation type="unfinished">Errore: la versione di questo dumpfile non è supportata. Questa versione del bitcoin-wallet supporta solo la versione 1 dei dumpfile. ricevuto un dumpfile di versione%s</translation>
+    </message>
+    <message>
+        <source>Error: Legacy wallets only support the "legacy", "p2sh-segwit", and "bech32" address types</source>
+        <translation type="unfinished">Errore: i portafogli elettronici obsoleti supportano solo i seguenti tipi di indirizzi: "legacy", "p2sh-segwit", e "bech32"</translation>
     </message>
     <message>
         <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
@@ -3514,12 +3720,28 @@ Vai su File &gt; Apri Portafoglio per caricare un portafoglio.
         <translation type="unfinished">Stima della commissione non riuscita. Fallbackfee è disabilitato. Attendi qualche blocco o abilita -fallbackfee.</translation>
     </message>
     <message>
+        <source>File %s already exists. If you are sure this is what you want, move it out of the way first.</source>
+        <translation type="unfinished">file %s esistono già. Se desideri continuare comunque, prima rimuovilo.</translation>
+    </message>
+    <message>
         <source>Invalid amount for -maxtxfee=&lt;amount&gt;: '%s' (must be at least the minrelay fee of %s to prevent stuck transactions)</source>
         <translation type="unfinished">Importo non valido per -maxtxfee=&lt;amount&gt;: '%s' (deve essere almeno pari alla commissione 'minrelay fee' di %s per prevenire transazioni bloccate)</translation>
     </message>
     <message>
         <source>More than one onion bind address is provided. Using %s for the automatically created Tor onion service.</source>
         <translation type="unfinished">Viene fornito più di un indirizzo di associazione onion. L'utilizzo di %s per il servizio Tor onion viene creato automaticamente.</translation>
+    </message>
+    <message>
+        <source>No dump file provided. To use createfromdump, -dumpfile=&lt;filename&gt; must be provided.</source>
+        <translation type="unfinished">Nessun dump file fornito. Per usare creadumpfile, -dumpfile=&lt;filename&gt; deve essere fornito.</translation>
+    </message>
+    <message>
+        <source>No dump file provided. To use dump, -dumpfile=&lt;filename&gt; must be provided.</source>
+        <translation type="unfinished">Nessun dump file fornito. Per usare dump, -dumpfile=&lt;filename&gt; deve essere fornito.</translation>
+    </message>
+    <message>
+        <source>No wallet file format provided. To use createfromdump, -format=&lt;format&gt; must be provided.</source>
+        <translation type="unfinished">Nessun formato assegnato al fil wallet. Per usare createfromdump, -format=&lt;format&gt; deve essere fornito.</translation>
     </message>
     <message>
         <source>Please check that your computer's date and time are correct! If your clock is wrong, %s will not work properly.</source>
@@ -3578,12 +3800,24 @@ Vai su File &gt; Apri Portafoglio per caricare un portafoglio.
         <translation type="unfinished">Impossibile ripetere i blocchi. È necessario ricostruire il database usando -reindex-chainstate.</translation>
     </message>
     <message>
+        <source>Unknown wallet file format "%s" provided. Please provide one of "bdb" or "sqlite".</source>
+        <translation type="unfinished">Il formato “%s” del file portafoglio fornito non è riconosciuto. si prega di fornire uno che sia “bdb” o “sqlite”. </translation>
+    </message>
+    <message>
+        <source>Warning: Dumpfile wallet format "%s" does not match command line specified format "%s".</source>
+        <translation type="unfinished">Attenzione: il formato “%s” del file dump di portafoglio non combacia con il formato “%s” specificato nella riga di comando.</translation>
+    </message>
+    <message>
         <source>Warning: Private keys detected in wallet {%s} with disabled private keys</source>
         <translation type="unfinished">Avviso: chiavi private rilevate nel portafoglio { %s} con chiavi private disabilitate</translation>
     </message>
     <message>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished">Attenzione: Sembra che non vi sia pieno consenso con i nostri peer! Un aggiornamento da parte tua o degli altri nodi potrebbe essere necessario.</translation>
+    </message>
+    <message>
+        <source>Witness data for blocks after height %d requires validation. Please restart with -reindex.</source>
+        <translation type="unfinished">I dati di testimonianza per blocchi più alti di %d richiedono verifica. Si prega di riavviare con -reindex.</translation>
     </message>
     <message>
         <source>You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain</source>
@@ -3646,6 +3880,10 @@ Vai su File &gt; Apri Portafoglio per caricare un portafoglio.
         <translation type="unfinished">Caricamento completato</translation>
     </message>
     <message>
+        <source>Dump file %s does not exist.</source>
+        <translation type="unfinished">Il dumpfile %s non esiste.</translation>
+    </message>
+    <message>
         <source>Error creating %s</source>
         <translation type="unfinished">Errore di creazione %s</translation>
     </message>
@@ -3686,12 +3924,32 @@ Vai su File &gt; Apri Portafoglio per caricare un portafoglio.
         <translation type="unfinished">Errore durante la lettura del database. Arresto in corso.</translation>
     </message>
     <message>
+        <source>Error reading next record from wallet database</source>
+        <translation type="unfinished">Si è verificato un errore leggendo la voce successiva dal database del portafogli elettronico</translation>
+    </message>
+    <message>
         <source>Error upgrading chainstate database</source>
         <translation type="unfinished">Errore durante l'aggiornamento del database chainstate</translation>
     </message>
     <message>
+        <source>Error: Couldn't create cursor into database</source>
+        <translation type="unfinished">Errore: Impossibile creare cursor nel database.</translation>
+    </message>
+    <message>
         <source>Error: Disk space is low for %s</source>
         <translation type="unfinished">Errore: lo spazio sul disco è troppo poco per %s</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile checksum does not match. Computed %s, expected %s</source>
+        <translation type="unfinished">Errore: Il Cheksum del dumpfile non corrisponde. Rilevato: %s, sarebbe dovuto essere: %s</translation>
+    </message>
+    <message>
+        <source>Error: Got key that was not hex: %s</source>
+        <translation type="unfinished">Errore: Ricevuta una key che non ha hex:%s</translation>
+    </message>
+    <message>
+        <source>Error: Got value that was not hex: %s</source>
+        <translation type="unfinished">Errore: Ricevuta un valore che non ha hex:%s</translation>
     </message>
     <message>
         <source>Error: Keypool ran out, please call keypoolrefill first</source>
@@ -3700,6 +3958,18 @@ Vai su File &gt; Apri Portafoglio per caricare un portafoglio.
     <message>
         <source>Error: Missing checksum</source>
         <translation type="unfinished">Errore: Checksum non presente</translation>
+    </message>
+    <message>
+        <source>Error: No %s addresses available.</source>
+        <translation type="unfinished">Errore:  Nessun %s indirizzo disponibile</translation>
+    </message>
+    <message>
+        <source>Error: Unable to parse version %u as a uint32_t</source>
+        <translation type="unfinished">Errore: impossibile analizzare la versione %u come uint32_t</translation>
+    </message>
+    <message>
+        <source>Error: Unable to write record to new wallet</source>
+        <translation type="unfinished">Errore: non è possibile scrivere la voce nel nuovo portafogli elettronico</translation>
     </message>
     <message>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
@@ -3728,6 +3998,10 @@ Vai su File &gt; Apri Portafoglio per caricare un portafoglio.
     <message>
         <source>Insufficient funds</source>
         <translation type="unfinished">Fondi insufficienti</translation>
+    </message>
+    <message>
+        <source>Invalid -i2psam address or hostname: '%s'</source>
+        <translation type="unfinished">Indirizzo --i2psam o hostname non valido: '%s'</translation>
     </message>
     <message>
         <source>Invalid -onion address or hostname: '%s'</source>
@@ -3794,12 +4068,28 @@ Vai su File &gt; Apri Portafoglio per caricare un portafoglio.
         <translation type="unfinished">La modalità prune non può essere configurata con un valore negativo.</translation>
     </message>
     <message>
+        <source>Prune mode is incompatible with -coinstatsindex.</source>
+        <translation type="unfinished">La modalità prune è incompatibile con l'opzione -coinstatsindex.</translation>
+    </message>
+    <message>
         <source>Prune mode is incompatible with -txindex.</source>
         <translation type="unfinished">La modalità prune è incompatibile con l'opzione -txindex.</translation>
     </message>
     <message>
+        <source>Pruning blockstore…</source>
+        <translation type="unfinished">Pruning del blockstore...</translation>
+    </message>
+    <message>
         <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
         <translation type="unfinished">Riduzione -maxconnections da %d a %d a causa di limitazioni di sistema.</translation>
+    </message>
+    <message>
+        <source>Replaying blocks…</source>
+        <translation type="unfinished">Verificando i blocchi...</translation>
+    </message>
+    <message>
+        <source>Rescanning…</source>
+        <translation type="unfinished">Riscansionando...</translation>
     </message>
     <message>
         <source>SQLiteDatabase: Failed to execute statement to verify database: %s</source>
@@ -3842,8 +4132,16 @@ Vai su File &gt; Apri Portafoglio per caricare un portafoglio.
         <translation type="unfinished">La cartella specificata "%s" non esiste.</translation>
     </message>
     <message>
+        <source>Starting network threads…</source>
+        <translation type="unfinished">L'esecuzione delle threads della rete sta iniziando...</translation>
+    </message>
+    <message>
         <source>The source code is available from %s.</source>
         <translation type="unfinished">Il codice sorgente è disponibile in %s</translation>
+    </message>
+    <message>
+        <source>The specified config file %s does not exist</source>
+        <translation type="unfinished">Il file di configurazione %s specificato non esiste</translation>
     </message>
     <message>
         <source>The transaction amount is too small to pay the fee</source>
@@ -3882,6 +4180,10 @@ Vai su File &gt; Apri Portafoglio per caricare un portafoglio.
         <translation type="unfinished">La transazione deve avere almeno un destinatario</translation>
     </message>
     <message>
+        <source>Transaction needs a change address, but we can't generate it. %s</source>
+        <translation type="unfinished">La transazione richiede un indirizzo di resto, ma non possiamo generarlo. %s</translation>
+    </message>
+    <message>
         <source>Transaction too large</source>
         <translation type="unfinished">Transazione troppo grande</translation>
     </message>
@@ -3906,6 +4208,10 @@ Vai su File &gt; Apri Portafoglio per caricare un portafoglio.
         <translation type="unfinished">Impossibile generare le chiavi</translation>
     </message>
     <message>
+        <source>Unable to open %s for writing</source>
+        <translation type="unfinished">Impossibile aprire %s per scrivere</translation>
+    </message>
+    <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
         <translation type="unfinished">Impossibile avviare il server HTTP. Dettagli nel log di debug.</translation>
     </message>
@@ -3924,6 +4230,10 @@ Vai su File &gt; Apri Portafoglio per caricare un portafoglio.
     <message>
         <source>Unknown network specified in -onlynet: '%s'</source>
         <translation type="unfinished">Rete sconosciuta specificata in -onlynet: '%s'</translation>
+    </message>
+    <message>
+        <source>Unknown new rules activated (versionbit %i)</source>
+        <translation type="unfinished">Nuove regole non riconosciute sono state attivate (versionbit %i)</translation>
     </message>
     <message>
         <source>Unsupported logging category %s=%s.</source>

--- a/src/qt/locale/bitcoin_ja.ts
+++ b/src/qt/locale/bitcoin_ja.ts
@@ -2352,11 +2352,11 @@ For more information on using this console, type %6.
     </message>
     <message>
         <source>To</source>
-        <translation type="unfinished">送金先</translation>
+        <translation type="unfinished">外向き</translation>
     </message>
     <message>
         <source>From</source>
-        <translation type="unfinished">送金元</translation>
+        <translation type="unfinished">内向き</translation>
     </message>
     <message>
         <source>Ban for</source>

--- a/src/qt/locale/bitcoin_kk.ts
+++ b/src/qt/locale/bitcoin_kk.ts
@@ -2,47 +2,266 @@
 <context>
     <name>AddressBookPage</name>
     <message>
+        <source>Right-click to edit address or label</source>
+        <translation type="unfinished">Мекенжай немесе белгі өңдеу үшін оң клик</translation>
+    </message>
+    <message>
         <source>Create a new address</source>
-        <translation>Жаңа адрес енгізу</translation>
+        <translation>Жаңа мекенжай құру</translation>
     </message>
     <message>
         <source>&amp;New</source>
-        <translation type="unfinished">Жаңа</translation>
+        <translation type="unfinished">&amp;Жаңа</translation>
     </message>
     <message>
         <source>Copy the currently selected address to the system clipboard</source>
-        <translation>Таңдаған адресті тізімнен жою</translation>
+        <translation>Таңдалған мекенжайды жүйенің айырбастау буферіне көшіру</translation>
+    </message>
+    <message>
+        <source>&amp;Copy</source>
+        <translation type="unfinished">&amp;Көшіру</translation>
     </message>
     <message>
         <source>C&amp;lose</source>
-        <translation type="unfinished">Жабу</translation>
+        <translation type="unfinished">Ж&amp;абу</translation>
+    </message>
+    <message>
+        <source>Delete the currently selected address from the list</source>
+        <translation>Таңдалған мекенжайды тізімнен жою</translation>
+    </message>
+    <message>
+        <source>Enter address or label to search</source>
+        <translation type="unfinished">Іздеу үшін мекенжай немесе белгі енгізіңіз</translation>
+    </message>
+    <message>
+        <source>Export the data in the current tab to a file</source>
+        <translation>Қазіргі қойыншадағы деректерді файлға экспорттау</translation>
     </message>
     <message>
         <source>&amp;Export</source>
-        <translation>Экспорт</translation>
+        <translation>&amp;Экспорттау</translation>
     </message>
     <message>
         <source>&amp;Delete</source>
-        <translation>Жою</translation>
+        <translation>&amp;Жою</translation>
     </message>
-    </context>
+    <message>
+        <source>Choose the address to send coins to</source>
+        <translation type="unfinished">Тиын жіберуге мекенжай таңдаңыз</translation>
+    </message>
+    <message>
+        <source>Choose the address to receive coins with</source>
+        <translation type="unfinished">Тиын қабылдайтын мекенжай таңдаңыз</translation>
+    </message>
+    <message>
+        <source>C&amp;hoose</source>
+        <translation type="unfinished">Т&amp;аңдау</translation>
+    </message>
+    <message>
+        <source>Sending addresses</source>
+        <translation type="unfinished">Жіберуші мекенжайлар</translation>
+    </message>
+    <message>
+        <source>Receiving addresses</source>
+        <translation type="unfinished">Қабылдаушы мекенжайлар</translation>
+    </message>
+    <message>
+        <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
+        <translation type="unfinished">Бұл сіздің төлем жіберетін Bitcoin мекенжайларыңыз. Тиын жібермес бұрын, әрқашан сома мен алушы мекенжайды тексеріңіз.</translation>
+    </message>
+    <message>
+        <source>&amp;Copy Address</source>
+        <translation type="unfinished">&amp;Мекенжайды көшіру</translation>
+    </message>
+    <message>
+        <source>Copy &amp;Label</source>
+        <translation type="unfinished">Белгіні &amp;көшіру</translation>
+    </message>
+    <message>
+        <source>&amp;Edit</source>
+        <translation type="unfinished">&amp;Өңдеу</translation>
+    </message>
+    <message>
+        <source>Export Address List</source>
+        <translation type="unfinished">Мекенжай тізімін экспорттау</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See https://en.wikipedia.org/wiki/Comma-separated_values</extracomment>
+        <translation type="unfinished">Үтірмен бөлінген файл</translation>
+    </message>
+    <message>
+        <source>There was an error trying to save the address list to %1. Please try again.</source>
+        <extracomment>An error message. %1 is a stand-in argument for the name of the file we attempted to save to.</extracomment>
+        <translation type="unfinished">Мекенжай тізімін %1 дегенге сақтағанда, қате пайда болды. Қайталап көріңіз. </translation>
+    </message>
+    <message>
+        <source>Exporting Failed</source>
+        <translation type="unfinished">Экспортталмады</translation>
+    </message>
+</context>
+<context>
+    <name>AddressTableModel</name>
+    <message>
+        <source>Label</source>
+        <translation type="unfinished">Белгі</translation>
+    </message>
+    <message>
+        <source>Address</source>
+        <translation type="unfinished">Мекенжай</translation>
+    </message>
+    <message>
+        <source>(no label)</source>
+        <translation type="unfinished">(белгі жоқ)</translation>
+    </message>
+</context>
 <context>
     <name>AskPassphraseDialog</name>
     <message>
+        <source>Passphrase Dialog</source>
+        <translation>Құпиясөйлем диалогі</translation>
+    </message>
+    <message>
         <source>Enter passphrase</source>
-        <translation>Құпия сөзді енгізу</translation>
+        <translation>Құпиясөйлем енгізу</translation>
     </message>
     <message>
         <source>New passphrase</source>
-        <translation>Жаңа құпия сөзі</translation>
+        <translation>Жаңа құпиясөйлем</translation>
     </message>
     <message>
         <source>Repeat new passphrase</source>
-        <translation>Жаңа құпия сөзді қайта енгізу</translation>
+        <translation>Жаңа құпиясөйлемді қайталаңыз</translation>
+    </message>
+    <message>
+        <source>Show passphrase</source>
+        <translation type="unfinished">Құпиясөйлемді көрсету</translation>
+    </message>
+    <message>
+        <source>Encrypt wallet</source>
+        <translation type="unfinished">Әмиянды шифрлау</translation>
+    </message>
+    <message>
+        <source>This operation needs your wallet passphrase to unlock the wallet.</source>
+        <translation type="unfinished">Бұл операцияға әмиянды ашу үшін әмияныңыздың құпиясөйлемі керек.</translation>
+    </message>
+    <message>
+        <source>Unlock wallet</source>
+        <translation type="unfinished">Әмиянды бұғатсыздау</translation>
+    </message>
+    <message>
+        <source>Change passphrase</source>
+        <translation type="unfinished">Құпиясөйлемді өзгерту</translation>
+    </message>
+    <message>
+        <source>Confirm wallet encryption</source>
+        <translation type="unfinished">Әмиян шифрлауды растау</translation>
+    </message>
+    <message>
+        <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
+        <translation type="unfinished">Ескерту: әмияныңызды шифрлап, құпиясөйлеміңізден айырылып қалсаңыз, &lt;b&gt;БАРЛЫҚ BITCOIN-ІҢІЗДЕН ДЕ АЙЫРЫЛАСЫЗ&lt;/b&gt;!</translation>
+    </message>
+    <message>
+        <source>Are you sure you wish to encrypt your wallet?</source>
+        <translation type="unfinished">Әмияныңызды шифрлағыңыз келе ме?</translation>
+    </message>
+    <message>
+        <source>Wallet encrypted</source>
+        <translation type="unfinished">Әмиян шифрланды</translation>
+    </message>
+    <message>
+        <source>Enter the new passphrase for the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
+        <translation type="unfinished">Әмиянның жаңа құпиясөйлемін енгізіңіз.&lt;br/&gt;Құпиясөйлеміңіз &lt;b&gt;10+ кездейсоқ таңбадан&lt;/b&gt; немесе &lt;b&gt;8+ сөзден&lt;/b&gt; тұрсын.</translation>
+    </message>
+    <message>
+        <source>Enter the old passphrase and new passphrase for the wallet.</source>
+        <translation type="unfinished">Әмияныңыздың ескі құпиясөйлемі мен жаңа құпиясөйлемін енгізіңіз.</translation>
+    </message>
+    <message>
+        <source>Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
+        <translation type="unfinished">Шифрлау биткоиніңізді компьютер жұқтырған зиянды БЖ-дан толығымен қорғай алмайтынын есіңізде сақтаңыз.</translation>
+    </message>
+    <message>
+        <source>Wallet to be encrypted</source>
+        <translation type="unfinished">Шифланатын әмиян</translation>
+    </message>
+    <message>
+        <source>Your wallet is about to be encrypted. </source>
+        <translation type="unfinished">Әмияныңыз шифрланады.</translation>
+    </message>
+    <message>
+        <source>Your wallet is now encrypted. </source>
+        <translation type="unfinished">Әмияныңыз шифрланды.</translation>
+    </message>
+    <message>
+        <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
+        <translation type="unfinished">МАҢЫЗДЫ: әмиян файлының бұрынғы резервтік көшірмелерінің бәрі жаңа құрылған шифрлы әмиян файлымен ауыстырылуы керек. Қауіпсіздік мақсатында жаңа шифрланған әмиянды қолданып бастағаныңыздан кейін, бұрынғы шифрланбаған әмиян файлының резервтік көшірмелері жарамсыз болып кетеді.</translation>
+    </message>
+    <message>
+        <source>Wallet encryption failed</source>
+        <translation type="unfinished">Әмиян шифланбады</translation>
+    </message>
+    <message>
+        <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
+        <translation type="unfinished">Әмиян ішкі қате кесірінен шифланбады.</translation>
+    </message>
+    <message>
+        <source>The supplied passphrases do not match.</source>
+        <translation type="unfinished">Енгізілген құпиясөйлемдер сай келмейді.</translation>
+    </message>
+    <message>
+        <source>Wallet unlock failed</source>
+        <translation type="unfinished">Әмиян бұғатсызданбады</translation>
+    </message>
+    <message>
+        <source>The passphrase entered for the wallet decryption was incorrect.</source>
+        <translation type="unfinished">Әмиянды шифрсыздау үшін енгізілген құпиясөйлем бұрыс болды.</translation>
+    </message>
+    <message>
+        <source>Wallet passphrase was successfully changed.</source>
+        <translation type="unfinished">Әмиян құпиясөйлемі сәтті өзгертілді.</translation>
+    </message>
+    <message>
+        <source>Warning: The Caps Lock key is on!</source>
+        <translation type="unfinished">Ескерту: Caps Lock пернесі қосулы!</translation>
+    </message>
+</context>
+<context>
+    <name>BanTableModel</name>
+    <message>
+        <source>IP/Netmask</source>
+        <translation type="unfinished">IP/Субжелі бетпердесі</translation>
+    </message>
+    </context>
+<context>
+    <name>BitcoinApplication</name>
+    <message>
+        <source>Internal error</source>
+        <translation type="unfinished">Ішкі қате</translation>
     </message>
     </context>
 <context>
     <name>QObject</name>
+    <message>
+        <source>Error: Specified data directory "%1" does not exist.</source>
+        <translation type="unfinished">Қате: берілген "%1" дерек директориясы жоқ.</translation>
+    </message>
+    <message>
+        <source>Error: Cannot parse configuration file: %1.</source>
+        <translation type="unfinished">Қате: конфигурация файлы талданбайды: %1.</translation>
+    </message>
+    <message>
+        <source>Error: %1</source>
+        <translation type="unfinished">Қате: %1</translation>
+    </message>
+    <message>
+        <source>Error initializing settings: %1</source>
+        <translation type="unfinished">Баптау қосу қатесі: %1</translation>
+    </message>
+    <message>
+        <source>%1 didn't yet exit safely…</source>
+        <translation type="unfinished">%1 қауіпсіз түрде шығып бітпеді...</translation>
+    </message>
     <message>
         <source>Amount</source>
         <translation type="unfinished">Саны</translation>
@@ -97,28 +316,197 @@
 <context>
     <name>BitcoinGUI</name>
     <message>
+        <source>&amp;Overview</source>
+        <translation>&amp;Шолу</translation>
+    </message>
+    <message>
+        <source>Show general overview of wallet</source>
+        <translation>Негізгі әмиян шолуды көрсету</translation>
+    </message>
+    <message>
         <source>&amp;Transactions</source>
         <translation>&amp;Транзакциялар</translation>
     </message>
     <message>
+        <source>Browse transaction history</source>
+        <translation>Транзакция тарихын шолу</translation>
+    </message>
+    <message>
         <source>E&amp;xit</source>
-        <translation>Шығу</translation>
+        <translation>Ш&amp;ығу</translation>
+    </message>
+    <message>
+        <source>Quit application</source>
+        <translation>Қосымшадан шығу</translation>
+    </message>
+    <message>
+        <source>&amp;About %1</source>
+        <translation type="unfinished">&amp;%1 туралы</translation>
+    </message>
+    <message>
+        <source>Show information about %1</source>
+        <translation type="unfinished">%1 туралы ақпаратты көрсету</translation>
+    </message>
+    <message>
+        <source>About &amp;Qt</source>
+        <translation>Qt &amp;туралы</translation>
+    </message>
+    <message>
+        <source>Show information about Qt</source>
+        <translation>Qt туралы ақпаратты көрсету</translation>
+    </message>
+    <message>
+        <source>Modify configuration options for %1</source>
+        <translation type="unfinished">%1 конфигурация баптауларын өзгерту</translation>
+    </message>
+    <message>
+        <source>Create a new wallet</source>
+        <translation type="unfinished">Жаңа әмиян құру</translation>
+    </message>
+    <message>
+        <source>Wallet:</source>
+        <translation type="unfinished">Әмиян:</translation>
+    </message>
+    <message>
+        <source>Network activity disabled.</source>
+        <extracomment>A substring of the tooltip.</extracomment>
+        <translation type="unfinished">Желі белсенділігі өшірулі.</translation>
+    </message>
+    <message>
+        <source>Proxy is &lt;b&gt;enabled&lt;/b&gt;: %1</source>
+        <translation type="unfinished">Прокси &lt;b&gt;қосулы&lt;/b&gt;: %1</translation>
+    </message>
+    <message>
+        <source>Send coins to a Bitcoin address</source>
+        <translation>Bitcoin мекенжайына тиын жіберу</translation>
+    </message>
+    <message>
+        <source>Backup wallet to another location</source>
+        <translation>Басқа локацияға әмиянның резервтік көшірмесін жасау</translation>
+    </message>
+    <message>
+        <source>Change the passphrase used for wallet encryption</source>
+        <translation>Әмиян шифрлауға қолданылған құпиясөйлемді өзгерту</translation>
     </message>
     <message>
         <source>&amp;Send</source>
-        <translation>Жіберу</translation>
+        <translation>&amp;Жіберу</translation>
     </message>
     <message>
         <source>&amp;Receive</source>
-        <translation>Алу</translation>
+        <translation>&amp;Қабылдау</translation>
+    </message>
+    <message>
+        <source>&amp;Options…</source>
+        <translation type="unfinished">&amp;Баптау…</translation>
+    </message>
+    <message>
+        <source>&amp;Show / Hide</source>
+        <translation>&amp;Көрсету / Жасыру</translation>
+    </message>
+    <message>
+        <source>Show or hide the main Window</source>
+        <translation>Бас Терезені көрсету немесе жасыру</translation>
+    </message>
+    <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation type="unfinished">&amp;Әмиянды шифрлау…</translation>
+    </message>
+    <message>
+        <source>Encrypt the private keys that belong to your wallet</source>
+        <translation>Әмияныңызға тиесілі жеке кілттерді шифрлау</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation type="unfinished">&amp;Әмиянның резервтік көшірмесін жасау…</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation type="unfinished">&amp;Құпиясөйлемді өзгерту…</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation type="unfinished">Хатқа &amp;қол қою…</translation>
+    </message>
+    <message>
+        <source>Sign messages with your Bitcoin addresses to prove you own them</source>
+        <translation>Хатқа Bitcoin мекенжайларын қосып, олар сізге тиесілі екенін дәлелдеу</translation>
+    </message>
+    <message>
+        <source>&amp;Verify message…</source>
+        <translation type="unfinished">&amp;Хат тексеру…</translation>
+    </message>
+    <message>
+        <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
+        <translation>Хат тексеріп, берілген Bitcoin мекенжайлары қосылғанына көз жеткізу</translation>
+    </message>
+    <message>
+        <source>&amp;Load PSBT from file…</source>
+        <translation type="unfinished">&amp;Файлдан PSBT жүктеу…</translation>
+    </message>
+    <message>
+        <source>Load PSBT from clipboard…</source>
+        <translation type="unfinished">Айырбастау буферінен PSBT жүктеу...</translation>
+    </message>
+    <message>
+        <source>Open &amp;URI…</source>
+        <translation type="unfinished">URI &amp;ашу…</translation>
+    </message>
+    <message>
+        <source>Close Wallet…</source>
+        <translation type="unfinished">Әмиянды жабу…</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation type="unfinished">Әмиян құру…</translation>
+    </message>
+    <message>
+        <source>Close All Wallets…</source>
+        <translation type="unfinished">Барлық әмиянды жабу…</translation>
     </message>
     <message>
         <source>&amp;File</source>
-        <translation>Файл</translation>
+        <translation>&amp;Файл</translation>
+    </message>
+    <message>
+        <source>&amp;Settings</source>
+        <translation>&amp;Баптау</translation>
     </message>
     <message>
         <source>&amp;Help</source>
-        <translation>Көмек</translation>
+        <translation>&amp;Көмек</translation>
+    </message>
+    <message>
+        <source>Tabs toolbar</source>
+        <translation>Қойынша құралдар тақтасы</translation>
+    </message>
+    <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation type="unfinished">Тақырыптар синхрондалуда (%1%)…</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation type="unfinished">Желімен синхрондасуда…</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation type="unfinished">Дискідегі блоктар инедекстелуде...</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation type="unfinished">Дискідегі блоктар қайта индекстелуде…</translation>
+    </message>
+    <message>
+        <source>Request payments (generates QR codes and bitcoin: URIs)</source>
+        <translation type="unfinished">Төлем талап ету (QR кодтары мен биткоин құрады: URI)</translation>
+    </message>
+    <message>
+        <source>Show the list of used sending addresses and labels</source>
+        <translation type="unfinished">Қолданылған жіберу мекенжайлары мен белгілер тізімін көрсету</translation>
+    </message>
+    <message>
+        <source>Show the list of used receiving addresses and labels</source>
+        <translation type="unfinished">Қолданылған қабылдау мекенжайлары мен белгілер тізімін көрсету</translation>
     </message>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
@@ -129,11 +517,15 @@
     </message>
     <message>
         <source>%1 behind</source>
-        <translation>%1 қалмады</translation>
+        <translation>%1 артта</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation type="unfinished">Синхрондауда...</translation>
     </message>
     <message>
         <source>Error</source>
-        <translation>қате</translation>
+        <translation>Қате</translation>
     </message>
     <message>
         <source>Warning</source>
@@ -141,11 +533,27 @@
     </message>
     <message>
         <source>Information</source>
-        <translation>Информация</translation>
+        <translation>Ақпарат</translation>
     </message>
     <message>
         <source>Up to date</source>
         <translation>Жаңартылған</translation>
+    </message>
+    <message>
+        <source>Open a wallet</source>
+        <translation type="unfinished">Әмиян ашу</translation>
+    </message>
+    <message>
+        <source>Close wallet</source>
+        <translation type="unfinished">Әмиянды жабу</translation>
+    </message>
+    <message>
+        <source>Close all wallets</source>
+        <translation type="unfinished">Барлық әмиянды жабу</translation>
+    </message>
+    <message>
+        <source>&amp;Window</source>
+        <translation type="unfinished">&amp;Терезе</translation>
     </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
@@ -154,6 +562,10 @@
             <numerusform />
             <numerusform />
         </translation>
+    </message>
+    <message>
+        <source>Error: %1</source>
+        <translation type="unfinished">Қате: %1</translation>
     </message>
     </context>
 <context>
@@ -190,6 +602,25 @@
         <source>Confirmed</source>
         <translation type="unfinished">Растық</translation>
     </message>
+    <message>
+        <source>yes</source>
+        <translation type="unfinished">Иа</translation>
+    </message>
+    <message>
+        <source>(no label)</source>
+        <translation type="unfinished">(белгі жоқ)</translation>
+    </message>
+    </context>
+<context>
+    <name>WalletController</name>
+    <message>
+        <source>Close wallet</source>
+        <translation type="unfinished">Әмиянды жабу</translation>
+    </message>
+    <message>
+        <source>Close all wallets</source>
+        <translation type="unfinished">Барлық әмиянды жабу</translation>
+    </message>
     </context>
 <context>
     <name>CreateWalletDialog</name>
@@ -224,19 +655,58 @@
         </translation>
     </message>
     <message>
+        <source>%1 will download and store a copy of the Bitcoin block chain.</source>
+        <translation type="unfinished">%1 Bitcoin блокчейнінің көшірмесін жүктеп сақтайды.</translation>
+    </message>
+    <message>
         <source>Error</source>
         <translation>қате</translation>
+    </message>
+    <message>
+        <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
+        <translation type="unfinished">Бастапқы синхронизация өте қымбат және компьютеріңіздің байқалмаған жабдық мәселелерін ашуы мүмкін. %1 қосылған сайын, жүктеу тоқтатылған жерден бастап жалғасады.</translation>
     </message>
     </context>
 <context>
     <name>OptionsDialog</name>
     <message>
+        <source>Options</source>
+        <translation>Баптау</translation>
+    </message>
+    <message>
+        <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
+        <translation type="unfinished">Проксидің IP мекенжайы (мысалы, IPv4: 127.0.0.1 / IPv6: ::1)</translation>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished">Әмиян</translation>
     </message>
     <message>
+        <source>Map port using &amp;UPnP</source>
+        <translation>UPnP арқылы порт &amp;сәйкестендіру</translation>
+    </message>
+    <message>
+        <source>&amp;Window</source>
+        <translation>&amp;Терезе</translation>
+    </message>
+    <message>
         <source>Error</source>
         <translation type="unfinished">қате</translation>
+    </message>
+    </context>
+<context>
+    <name>PeerTableModel</name>
+    <message>
+        <source>Address</source>
+        <extracomment>Title of Peers Table column which contains the IP/Onion/I2P address of the connected peer.</extracomment>
+        <translation type="unfinished">Мекенжай</translation>
+    </message>
+    </context>
+<context>
+    <name>QRImageWidget</name>
+    <message>
+        <source>Error encoding URI into QR Code.</source>
+        <translation type="unfinished">URI-дің QR кодына кодталу қатесі.</translation>
     </message>
     </context>
 <context>
@@ -245,12 +715,28 @@
         <source>&amp;Information</source>
         <translation>Информация</translation>
     </message>
+    <message>
+        <source>Number of connections</source>
+        <translation>Қосылымдар саны</translation>
+    </message>
+    <message>
+        <source>Decrease font size</source>
+        <translation type="unfinished">Қаріп өлшемін төмендету</translation>
+    </message>
+    <message>
+        <source>Executing command without any wallet</source>
+        <translation type="unfinished">Пәрмен әмиянсыз орындалуда</translation>
+    </message>
     </context>
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
         <source>&amp;Amount:</source>
         <translation type="unfinished">Саны</translation>
+    </message>
+    <message>
+        <source>Requested payments history</source>
+        <translation type="unfinished">Төлемдер тарихы сұралды</translation>
     </message>
     </context>
 <context>
@@ -259,12 +745,24 @@
         <source>Amount:</source>
         <translation type="unfinished">Саны</translation>
     </message>
+    <message>
+        <source>Wallet:</source>
+        <translation type="unfinished">Әмиян:</translation>
+    </message>
     </context>
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
         <source>Date</source>
         <translation type="unfinished">Күні</translation>
+    </message>
+    <message>
+        <source>Label</source>
+        <translation type="unfinished">Белгі</translation>
+    </message>
+    <message>
+        <source>(no label)</source>
+        <translation type="unfinished">(белгі жоқ)</translation>
     </message>
     </context>
 <context>
@@ -292,12 +790,27 @@
             <numerusform />
         </translation>
     </message>
-    </context>
+    <message>
+        <source>(no label)</source>
+        <translation type="unfinished">(белгі жоқ)</translation>
+    </message>
+</context>
 <context>
     <name>SendCoinsEntry</name>
     <message>
         <source>A&amp;mount:</source>
         <translation>Саны</translation>
+    </message>
+    </context>
+<context>
+    <name>SignVerifyMessageDialog</name>
+    <message>
+        <source>Verify &amp;Message</source>
+        <translation>Хат &amp;тексеру</translation>
+    </message>
+    <message>
+        <source>Message verification failed.</source>
+        <translation type="unfinished">Хат тексерілмеді</translation>
     </message>
     </context>
 <context>
@@ -308,6 +821,10 @@
             <numerusform />
             <numerusform />
         </translation>
+    </message>
+    <message>
+        <source>0/unconfirmed, %1</source>
+        <translation type="unfinished">0/расталмаған, %1</translation>
     </message>
     <message>
         <source>Date</source>
@@ -331,6 +848,10 @@
         <source>Date</source>
         <translation type="unfinished">Күні</translation>
     </message>
+    <message>
+        <source>Label</source>
+        <translation type="unfinished">Белгі</translation>
+    </message>
     <message numerus="yes">
         <source>Open for %n more block(s)</source>
         <translation>
@@ -338,9 +859,22 @@
             <numerusform />
         </translation>
     </message>
+    <message>
+        <source>(no label)</source>
+        <translation type="unfinished">(белгі жоқ)</translation>
+    </message>
     </context>
 <context>
     <name>TransactionView</name>
+    <message>
+        <source>Other</source>
+        <translation type="unfinished">Басқа</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See https://en.wikipedia.org/wiki/Comma-separated_values</extracomment>
+        <translation type="unfinished">Үтірмен бөлінген файл</translation>
+    </message>
     <message>
         <source>Confirmed</source>
         <translation type="unfinished">Растық</translation>
@@ -349,12 +883,35 @@
         <source>Date</source>
         <translation type="unfinished">Күні</translation>
     </message>
+    <message>
+        <source>Label</source>
+        <translation type="unfinished">Белгі</translation>
+    </message>
+    <message>
+        <source>Address</source>
+        <translation type="unfinished">Мекенжай</translation>
+    </message>
+    <message>
+        <source>Exporting Failed</source>
+        <translation type="unfinished">Экспортталмады</translation>
+    </message>
     </context>
+<context>
+    <name>WalletFrame</name>
+    <message>
+        <source>Create a new wallet</source>
+        <translation type="unfinished">Жаңа әмиян құру</translation>
+    </message>
+</context>
 <context>
     <name>WalletView</name>
     <message>
         <source>&amp;Export</source>
         <translation type="unfinished">Экспорт</translation>
+    </message>
+    <message>
+        <source>Export the data in the current tab to a file</source>
+        <translation type="unfinished">Қазіргі қойыншадағы деректерді файлға экспорттау</translation>
     </message>
     <message>
         <source>Error</source>
@@ -364,12 +921,20 @@
 <context>
     <name>bitcoin-core</name>
     <message>
+        <source>Invalid amount for -fallbackfee=&lt;amount&gt;: '%s'</source>
+        <translation type="unfinished">-fallbackfee=&lt;amount&gt; үшін қате сан: "%s"</translation>
+    </message>
+    <message>
         <source>Transaction amount too small</source>
         <translation type="unfinished">Транзакция өте кішкентай</translation>
     </message>
     <message>
         <source>Transaction too large</source>
         <translation type="unfinished">Транзакция өте үлкен</translation>
+    </message>
+    <message>
+        <source>Verifying wallet(s)…</source>
+        <translation type="unfinished">Әмиян(дар) тексерілуде…</translation>
     </message>
     </context>
 </TS>

--- a/src/qt/locale/bitcoin_ko.ts
+++ b/src/qt/locale/bitcoin_ko.ts
@@ -3,15 +3,15 @@
     <name>AddressBookPage</name>
     <message>
         <source>Right-click to edit address or label</source>
-        <translation type="unfinished">지갑 주소나 라벨을 수정하려면 우클릭을 하십시오.</translation>
+        <translation type="unfinished">우클릭하여 주소나 상표 수정하기</translation>
     </message>
     <message>
         <source>Create a new address</source>
-        <translation>새로운 지갑 주소 생성</translation>
+        <translation>새로운 주소 생성 </translation>
     </message>
     <message>
         <source>&amp;New</source>
-        <translation type="unfinished">새 항목(&amp;N)</translation>
+        <translation type="unfinished">&amp;새 항목</translation>
     </message>
     <message>
         <source>Copy the currently selected address to the system clipboard</source>
@@ -19,15 +19,15 @@
     </message>
     <message>
         <source>&amp;Copy</source>
-        <translation type="unfinished">복사(&amp;C)</translation>
+        <translation type="unfinished">&amp;복사</translation>
     </message>
     <message>
         <source>C&amp;lose</source>
-        <translation type="unfinished">닫기(&amp;L)</translation>
+        <translation type="unfinished">C&amp;닫기</translation>
     </message>
     <message>
         <source>Delete the currently selected address from the list</source>
-        <translation>목록에 현재 선택한 주소를 삭제</translation>
+        <translation>목록에 현재 선택한 주소 삭제</translation>
     </message>
     <message>
         <source>Enter address or label to search</source>
@@ -39,11 +39,11 @@
     </message>
     <message>
         <source>&amp;Export</source>
-        <translation>내보내기 (&amp;E)</translation>
+        <translation>&amp;내보내기</translation>
     </message>
     <message>
         <source>&amp;Delete</source>
-        <translation>삭제(&amp;D)</translation>
+        <translation>&amp;삭제</translation>
     </message>
     <message>
         <source>Choose the address to send coins to</source>
@@ -51,11 +51,11 @@
     </message>
     <message>
         <source>Choose the address to receive coins with</source>
-        <translation type="unfinished">코인을 받을 주소를 선택하십시오.</translation>
+        <translation type="unfinished">코인을 받을 주소를 선택하십시오</translation>
     </message>
     <message>
         <source>C&amp;hoose</source>
-        <translation type="unfinished">선택(&amp;H)</translation>
+        <translation type="unfinished">&amp;선택</translation>
     </message>
     <message>
         <source>Sending addresses</source>
@@ -297,12 +297,40 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">비트코인 주소를 입력하세요 (예: %1)</translation>
     </message>
     <message>
+        <source>Unroutable</source>
+        <translation type="unfinished">라우팅할 수 없습니다.</translation>
+    </message>
+    <message>
+        <source>Internal</source>
+        <translation type="unfinished">내부</translation>
+    </message>
+    <message>
         <source>Inbound</source>
         <translation type="unfinished">인바운드</translation>
     </message>
     <message>
         <source>Outbound</source>
         <translation type="unfinished">아웃바운드</translation>
+    </message>
+    <message>
+        <source>Full Relay</source>
+        <translation type="unfinished">전체 릴레이</translation>
+    </message>
+    <message>
+        <source>Block Relay</source>
+        <translation type="unfinished">블록 릴레이</translation>
+    </message>
+    <message>
+        <source>Manual</source>
+        <translation type="unfinished">매뉴얼</translation>
+    </message>
+    <message>
+        <source>Feeler</source>
+        <translation type="unfinished">필러</translation>
+    </message>
+    <message>
+        <source>Address Fetch</source>
+        <translation type="unfinished">주소 가져오기</translation>
     </message>
     <message>
         <source>%1 d</source>
@@ -339,19 +367,19 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>%n hour(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n시간</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n일</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n주</numerusform>
         </translation>
     </message>
     <message>
@@ -361,7 +389,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n년</numerusform>
         </translation>
     </message>
     <message>
@@ -587,7 +615,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation>
-            <numerusform />
+            <numerusform>트랜잭션 기록 블록 %n개를 처리했습니다.</numerusform>
         </translation>
     </message>
     <message>
@@ -710,7 +738,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n은/는 비트코인 네트워크에 대한 활성 연결입니다.</numerusform>
         </translation>
     </message>
     <message>
@@ -892,6 +920,30 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">거래액 복사</translation>
     </message>
     <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp; 주소 복사</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">복사 &amp; 라벨</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">복사 &amp; 금액</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">복사 트랜잭션 &amp; 아이디</translation>
+    </message>
+    <message>
+        <source>L&amp;ock unspent</source>
+        <translation type="unfinished">L&amp;ock 미사용</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock unspent</source>
+        <translation type="unfinished">&amp; 사용 안 함 잠금 해제</translation>
+    </message>
+    <message>
         <source>Copy quantity</source>
         <translation type="unfinished">수량 복사</translation>
     </message>
@@ -962,7 +1014,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Create wallet warning</source>
         <translation type="unfinished">지갑 생성 경고</translation>
     </message>
-    </context>
+    <message>
+        <source>Can't list signers</source>
+        <translation type="unfinished">서명자를 나열할 수 없습니다.</translation>
+    </message>
+</context>
 <context>
     <name>OpenWalletActivity</name>
     <message>
@@ -1056,6 +1112,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">디스크립터 지갑</translation>
     </message>
     <message>
+        <source>Use an external signing device such as a hardware wallet. Configure the external signer script in wallet preferences first.</source>
+        <translation type="unfinished">Hardware wallet과 같은 외부 서명 장치를 사용합니다. 지갑 기본 설정에서 외부 서명자 스크립트를 먼저 구성하십시오.</translation>
+    </message>
+    <message>
+        <source>External signer</source>
+        <translation type="unfinished">외부 서명자</translation>
+    </message>
+    <message>
         <source>Create</source>
         <translation type="unfinished">생성</translation>
     </message>
@@ -1063,7 +1127,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Compiled without sqlite support (required for descriptor wallets)</source>
         <translation type="unfinished">에스큐엘라이트 지원 없이 컴파일 되었습니다. (디스크립터 지갑에 요구됩니다.)</translation>
     </message>
-    </context>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">외부 서명 지원 없이 컴파일됨 (외부 서명에 필요) 개발자 참고 사항 [from:developer] "외부 서명"은 하드웨어 지갑과 같은 장치를 사용하는 것을 의미합니다.</translation>
+    </message>
+</context>
 <context>
     <name>EditAddressDialog</name>
     <message>
@@ -1172,7 +1241,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>(%n일 전의 백업을 복원하기에 충분함)</numerusform>
         </translation>
     </message>
     <message>
@@ -1343,6 +1412,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">시스템 로그인시 %1 시작(&amp;S)</translation>
     </message>
     <message>
+        <source>Enabling pruning significantly reduces the disk space required to store transactions. All blocks are still fully validated. Reverting this setting requires re-downloading the entire blockchain.</source>
+        <translation type="unfinished">정리를 활성화하면 트랜잭션을 저장하는 데 필요한 디스크 공간이 크게 줄어듭니다. 모든 블록의 유효성이 여전히 완전히 확인되었습니다. 이 설정을 되돌리려면 전체 블록체인을 다시 다운로드해야 합니다.</translation>
+    </message>
+    <message>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished">데이터베이스 캐시 크기(&amp;D)</translation>
     </message>
@@ -1417,6 +1490,19 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>&amp;Spend unconfirmed change</source>
         <translation type="unfinished">검증되지 않은 잔돈 쓰기 (&amp;S)</translation>
+    </message>
+    <message>
+        <source>External Signer (e.g. hardware wallet)</source>
+        <translation type="unfinished">외부 서명자 (예: 하드웨어 지갑)</translation>
+    </message>
+    <message>
+        <source>&amp;External signer script path</source>
+        <translation type="unfinished">외부 서명자 스크립트 경로
+ </translation>
+    </message>
+    <message>
+        <source>Full path to a Bitcoin Core compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</source>
+        <translation type="unfinished">비트코인 코어 호환 스크립트의 전체 경로 (예: C:\Downloads\whi.exe 또는 /Users/you/Downloads/hwi.py). 주의: 악성 프로그램이 코인을 훔칠 수 있습니다!</translation>
     </message>
     <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
@@ -1527,6 +1613,18 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">제 3자 거래 URL들(&amp;T)</translation>
     </message>
     <message>
+        <source>Monospaced font in the Overview tab:</source>
+        <translation type="unfinished">개요 탭의 고정 폭 글꼴:</translation>
+    </message>
+    <message>
+        <source>embedded "%1"</source>
+        <translation type="unfinished">%1 포함됨</translation>
+    </message>
+    <message>
+        <source>closest matching "%1"</source>
+        <translation type="unfinished">가장 가까운 의미 "1%1"</translation>
+    </message>
+    <message>
         <source>Options set in this dialog are overridden by the command line or in the configuration file:</source>
         <translation type="unfinished">이 다이얼로그에서 설정한 옵션은 커맨드라인이나 설정파일에 의해 바뀔 수 있습니다:</translation>
     </message>
@@ -1537,6 +1635,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>&amp;Cancel</source>
         <translation>취소(&amp;C)</translation>
+    </message>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">외부 서명 지원 없이 컴파일됨 (외부 서명에 필요) 개발자 참고 사항 [from:developer] "외부 서명"은 하드웨어 지갑과 같은 장치를 사용하는 것을 의미합니다.</translation>
     </message>
     <message>
         <source>default</source>
@@ -1681,6 +1784,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">클립보드로 복사</translation>
     </message>
     <message>
+        <source>Save…</source>
+        <translation type="unfinished">저장...</translation>
+    </message>
+    <message>
         <source>Close</source>
         <translation type="unfinished">닫기</translation>
     </message>
@@ -1719,6 +1826,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Save Transaction Data</source>
         <translation type="unfinished">트랜잭션 데이터 저장</translation>
+    </message>
+    <message>
+        <source>Partially Signed Transaction (Binary)</source>
+        <extracomment>Expanded name of the binary PSBT file format. See: BIP 174.</extracomment>
+        <translation type="unfinished">부분 서명 트랜잭션 (이진수)</translation>
     </message>
     <message>
         <source>PSBT saved to disk.</source>
@@ -1792,6 +1904,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">'bitcoin://"은 잘못된 URI입니다. 'bitcoin:'을 사용하십시오.</translation>
     </message>
     <message>
+        <source>Cannot process payment request because BIP70 is not supported.
+Due to widespread security flaws in BIP70 it's strongly recommended that any merchant instructions to switch wallets be ignored.
+If you are receiving this error you should request the merchant provide a BIP21 compatible URI.</source>
+        <translation type="unfinished">BIP70이 지원되지 않으므로 결제 요청을 처리할 수 없습니다.
+BIP70의 광범위한 보안 결함으로 인해 모든 가맹점에서는 지갑을 전환하라는 지침을 무시하는 것이 좋습니다.
+이 오류가 발생하면 판매자에게 BIP21 호환 URI를 제공하도록 요청해야 합니다.</translation>
+    </message>
+    <message>
         <source>URI cannot be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation type="unfinished">URI의 파싱에 문제가 발생했습니다. 잘못된 비트코인 주소나 URI 파라미터 구성에 오류가 존재할 수 있습니다.</translation>
     </message>
@@ -1845,6 +1965,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 </context>
 <context>
     <name>QRImageWidget</name>
+    <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">이미지 저장...(&amp;S)</translation>
+    </message>
     <message>
         <source>&amp;Copy Image</source>
         <translation type="unfinished">이미지 복사(&amp;C)</translation>
@@ -2014,12 +2138,52 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">권한</translation>
     </message>
     <message>
+        <source>The direction and type of peer connection: %1</source>
+        <translation type="unfinished">피어 연결의 방향 및 유형: %1</translation>
+    </message>
+    <message>
+        <source>The network protocol this peer is connected through: IPv4, IPv6, Onion, I2P, or CJDNS.</source>
+        <translation type="unfinished">이 피어가 연결된 네트워크 프로토콜: IPv4, IPv6, Onion, I2P 또는 CJDNS.</translation>
+    </message>
+    <message>
         <source>Services</source>
         <translation type="unfinished">서비스</translation>
     </message>
     <message>
+        <source>Whether the peer requested us to relay transactions.</source>
+        <translation type="unfinished">피어가 트랜잭션 중계를 요청했는지 여부.</translation>
+    </message>
+    <message>
+        <source>Wants Tx Relay</source>
+        <translation type="unfinished">Tx 릴레이를 원합니다</translation>
+    </message>
+    <message>
+        <source>High bandwidth BIP152 compact block relay: %1</source>
+        <translation type="unfinished">고대역폭 BIP152 소형 블록 릴레이: %1</translation>
+    </message>
+    <message>
+        <source>High Bandwidth</source>
+        <translation type="unfinished">고대역폭</translation>
+    </message>
+    <message>
         <source>Connection Time</source>
         <translation type="unfinished">접속 시간</translation>
+    </message>
+    <message>
+        <source>Elapsed time since a novel block passing initial validity checks was received from this peer.</source>
+        <translation type="unfinished">초기 유효성 검사를 통과하는 새로운 블록이 이 피어로부터 수신된 이후 경과된 시간입니다.</translation>
+    </message>
+    <message>
+        <source>Last Block</source>
+        <translation type="unfinished">마지막 블록</translation>
+    </message>
+    <message>
+        <source>Elapsed time since a novel transaction accepted into our mempool was received from this peer.</source>
+        <translation type="unfinished">이 피어에서 새 트랜잭션이 수신된 이후 경과된 시간입니다.</translation>
+    </message>
+    <message>
+        <source>Last Tx</source>
+        <translation type="unfinished">마지막 Tx</translation>
     </message>
     <message>
         <source>Last Send</source>
@@ -2086,12 +2250,53 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">출력:</translation>
     </message>
     <message>
+        <source>Inbound: initiated by peer</source>
+        <translation type="unfinished">시작점 : 동기에 의해 시작됨</translation>
+    </message>
+    <message>
+        <source>Outbound Full Relay: default</source>
+        <translation type="unfinished">아웃바운드 전체 릴레이: 기본값</translation>
+    </message>
+    <message>
+        <source>Outbound Block Relay: does not relay transactions or addresses</source>
+        <translation type="unfinished">아웃바운드 블록 릴레이: 트랜잭션 또는 주소를 릴레이하지 않음</translation>
+    </message>
+    <message>
+        <source>Outbound Manual: added using RPC %1 or %2/%3 configuration options</source>
+        <translation type="unfinished">아웃바운드 매뉴얼 : RPC 1%1 이나 2%2/3%3 을 사용해서 환경설정 옵션을 추가</translation>
+    </message>
+    <message>
+        <source>Outbound Feeler: short-lived, for testing addresses</source>
+        <translation type="unfinished">Outbound Feeler: 짧은 용도, 주소 테스트용</translation>
+    </message>
+    <message>
+        <source>Outbound Address Fetch: short-lived, for soliciting addresses</source>
+        <translation type="unfinished">아웃바운드 주소 가져오기: 단기, 주소 요청용
+ </translation>
+    </message>
+    <message>
+        <source>we selected the peer for high bandwidth relay</source>
+        <translation type="unfinished">저희는 가장 빠른 대역폭을 가지고 있는 피어를 선택합니다.</translation>
+    </message>
+    <message>
+        <source>the peer selected us for high bandwidth relay</source>
+        <translation type="unfinished">피어는 높은 대역폭을 위해 우리를 선택합니다</translation>
+    </message>
+    <message>
+        <source>no high bandwidth relay selected</source>
+        <translation type="unfinished">고대역폭 릴레이가 선택되지 않음</translation>
+    </message>
+    <message>
         <source>&amp;Disconnect</source>
         <translation type="unfinished">접속 끊기(&amp;D)</translation>
     </message>
     <message>
         <source>1 &amp;hour</source>
         <translation type="unfinished">1시간(&amp;H)</translation>
+    </message>
+    <message>
+        <source>1 d&amp;ay</source>
+        <translation type="unfinished">1일(&amp;a)</translation>
     </message>
     <message>
         <source>1 &amp;week</source>
@@ -2116,6 +2321,23 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Executing command using "%1" wallet</source>
         <translation type="unfinished">"%1" 지갑을 사용하여 명령 실행</translation>
+    </message>
+    <message>
+        <source>Welcome to the %1 RPC console.
+Use up and down arrows to navigate history, and %2 to clear screen.
+Use %3 and %4 to increase or decrease the font size.
+Type %5 for an overview of available commands.
+For more information on using this console, type %6.
+
+%7WARNING: Scammers have been active, telling users to type commands here, stealing their wallet contents. Do not use this console without fully understanding the ramifications of a command.%8</source>
+        <extracomment>RPC console welcome message. Placeholders %7 and %8 are style tags for the warning content, and they are not space separated from the rest of the text intentionally.</extracomment>
+        <translation type="unfinished">1%1 RPC 콘솔에 오신 것을 환영합니다.
+위쪽 및 아래쪽 화살표를 사용하여 기록 탐색을하고 2%2를 사용하여 화면을 지우세요. 
+3%3과 4%4을 사용하여 글꼴 크기 증가 또는 감소하세요
+사용 가능한 명령의 개요를 보려면 5%5를 입력하십시오.
+이 콘솔 사용에 대한 자세한 내용을 보려면 6%6을 입력하십시오.
+7%7 경고: 사기꾼들은 사용자들에게 여기에 명령을 입력하라고 말하고 활발히 금품을 훔칩니다. 완전히 이해하지 않고 이 콘솔을 사용하지 마십시오. 8%8
+</translation>
     </message>
     <message>
         <source>Executing…</source>
@@ -2149,6 +2371,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Ban for</source>
         <translation type="unfinished">차단사유:</translation>
+    </message>
+    <message>
+        <source>Never</source>
+        <translation type="unfinished">절대</translation>
     </message>
     <message>
         <source>Unknown</source>
@@ -2238,6 +2464,22 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">URI 복사(&amp;U)</translation>
     </message>
     <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp; 주소 복사</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">복사 &amp; 라벨</translation>
+    </message>
+    <message>
+        <source>Copy &amp;message</source>
+        <translation type="unfinished">메세지 복사(&amp;m)</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">복사 &amp; 금액</translation>
+    </message>
+    <message>
         <source>Could not unlock wallet.</source>
         <translation type="unfinished">지갑을 잠금해제 할 수 없습니다.</translation>
     </message>
@@ -2248,6 +2490,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 </context>
 <context>
     <name>ReceiveRequestDialog</name>
+    <message>
+        <source>Request payment to …</source>
+        <translation type="unfinished">에게 지불을 요청</translation>
+    </message>
     <message>
         <source>Address:</source>
         <translation type="unfinished">주소:</translation>
@@ -2275,6 +2521,18 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Copy &amp;Address</source>
         <translation type="unfinished">주소 복사(&amp;A)</translation>
+    </message>
+    <message>
+        <source>&amp;Verify</source>
+        <translation type="unfinished">&amp;승인</translation>
+    </message>
+    <message>
+        <source>Verify this address on e.g. a hardware wallet screen</source>
+        <translation type="unfinished">하드웨어 지갑 화면 등에서 이 주소를 확인하십시오</translation>
+    </message>
+    <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">이미지 저장...(&amp;S)</translation>
     </message>
     <message>
         <source>Payment information</source>
@@ -2423,12 +2681,24 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">거래 수수료 설정 숨기기</translation>
     </message>
     <message>
+        <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
+
+Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satoshis per kvB" for a transaction size of 500 virtual bytes (half of 1 kvB) would ultimately yield a fee of only 50 satoshis.</source>
+        <translation type="unfinished">트랜잭션 가상 크기의 kB (1,000바이트)당 사용자 지정 수수료를 지정합니다.
+
+참고: 수수료는 바이트 단위로 계산되므로 500 가상 바이트(1kvB의 절반)의 트랜잭션 크기에 대해 "kvB당 100 사토시"의 수수료율은 궁극적으로 50사토시만 수수료를 산출합니다.</translation>
+    </message>
+    <message>
         <source>When there is less transaction volume than space in the blocks, miners as well as relaying nodes may enforce a minimum fee. Paying only this minimum fee is just fine, but be aware that this can result in a never confirming transaction once there is more demand for bitcoin transactions than the network can process.</source>
         <translation type="unfinished">거래량이 블록에 남은 공간보다 적은 경우, 채굴자나 중계 노드들이 최소 수수료를 허용할 수 있습니다. 최소 수수료만 지불하는건 괜찮지만, 네트워크가 처리할 수 있는 용량을 넘는 비트코인 거래가 있을 경우에는 이 거래가 승인이 안될 수 있다는 점을 유의하세요.</translation>
     </message>
     <message>
         <source>A too low fee might result in a never confirming transaction (read the tooltip)</source>
         <translation type="unfinished">너무 적은 수수료로는 거래 승인이 안될 수도 있습니다 (툴팁을 참고하세요)</translation>
+    </message>
+    <message>
+        <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
+        <translation type="unfinished">(Smart fee가 아직 초기화 되지 않았습니다. 블록 분석이 완전하게 끝날 때 까지 기다려주십시오...)</translation>
     </message>
     <message>
         <source>Confirmation time target:</source>
@@ -2491,6 +2761,20 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">%1 (%2 블록)</translation>
     </message>
     <message>
+        <source>Sign on device</source>
+        <extracomment>"device" usually means a hardware wallet</extracomment>
+        <translation type="unfinished">장치에 로그인</translation>
+    </message>
+    <message>
+        <source>Connect your hardware wallet first.</source>
+        <translation type="unfinished">먼저 하드웨어 지갑을 연결하십시오.</translation>
+    </message>
+    <message>
+        <source>Set external signer script path in Options -&gt; Wallet</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">옵션 -&gt; 지갑에서 외부 서명자 스크립트 경로 설정</translation>
+    </message>
+    <message>
         <source>Cr&amp;eate Unsigned</source>
         <translation type="unfinished">사인되지 않은 것을 생성(&amp;e)</translation>
     </message>
@@ -2523,8 +2807,31 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">서명되지 않은 것을 생성</translation>
     </message>
     <message>
+        <source>Sign and send</source>
+        <translation type="unfinished">서명하고 보내기</translation>
+    </message>
+    <message>
+        <source>Sign failed</source>
+        <translation type="unfinished">서명 실패</translation>
+    </message>
+    <message>
+        <source>External signer not found</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">외부 서명자를 찾을 수 없음</translation>
+    </message>
+    <message>
+        <source>External signer failure</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">외부 서명자 실패</translation>
+    </message>
+    <message>
         <source>Save Transaction Data</source>
         <translation type="unfinished">트랜잭션 데이터 저장</translation>
+    </message>
+    <message>
+        <source>Partially Signed Transaction (Binary)</source>
+        <extracomment>Expanded name of the binary PSBT file format. See: BIP 174.</extracomment>
+        <translation type="unfinished">부분 서명 트랜잭션 (이진수)</translation>
     </message>
     <message>
         <source>PSBT saved</source>
@@ -3197,6 +3504,30 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">최소 거래액</translation>
     </message>
     <message>
+        <source>Range…</source>
+        <translation type="unfinished">범위...</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp; 주소 복사</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">복사 &amp; 라벨</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">복사 &amp; 금액</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">복사 트랜잭션 &amp; 아이디</translation>
+    </message>
+    <message>
+        <source>&amp;Edit address label</source>
+        <translation type="unfinished">&amp;주소 라벨 수정하기</translation>
+    </message>
+    <message>
         <source>Export Transaction History</source>
         <translation type="unfinished">거래 기록 내보내기</translation>
     </message>
@@ -3308,6 +3639,10 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished">새로운 수수료:</translation>
     </message>
     <message>
+        <source>Warning: This may pay the additional fee by reducing change outputs or adding inputs, when necessary. It may add a new change output if one does not already exist. These changes may potentially leak privacy.</source>
+        <translation type="unfinished">경고: 이것은 필요할 때 변경 결과를 줄이거나 입력을 추가함으로써 추가 수수료를 지불할 수 있습니다. 아직 새 변경 출력이 없는 경우 새 변경 출력을 추가할 수 있습니다. 이러한 변경으로 인해 개인 정보가 유출될 수 있습니다.</translation>
+    </message>
+    <message>
         <source>Confirm fee bump</source>
         <translation type="unfinished">수수료 범프 승인</translation>
     </message>
@@ -3326,6 +3661,10 @@ Go to File &gt; Open Wallet to load a wallet.
     <message>
         <source>Could not commit transaction</source>
         <translation type="unfinished">거래를 커밋 할 수 없습니다.</translation>
+    </message>
+    <message>
+        <source>Can't display address</source>
+        <translation type="unfinished">주소를 표시할 수 없습니다.</translation>
     </message>
     <message>
         <source>default wallet</source>
@@ -3433,6 +3772,10 @@ Go to File &gt; Open Wallet to load a wallet.
     <message>
         <source>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.</source>
         <translation type="unfinished">수수료 추정이 실패했습니다. 고장 대체 수수료가 비활성화 상태입니다. 몇 블록을 기다리거나 -fallbackfee를 활성화 하십시오.</translation>
+    </message>
+    <message>
+        <source>File %s already exists. If you are sure this is what you want, move it out of the way first.</source>
+        <translation type="unfinished">%s 파일이 이미 존재합니다. 무엇을 하고자 하는지 확실하시다면, 파일을 먼저 다른 곳으로 옮기십시오.</translation>
     </message>
     <message>
         <source>Invalid amount for -maxtxfee=&lt;amount&gt;: '%s' (must be at least the minrelay fee of %s to prevent stuck transactions)</source>
@@ -3567,6 +3910,16 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished">로딩 완료</translation>
     </message>
     <message>
+        <source>Dump file %s does not exist.</source>
+        <translation type="unfinished">파일 버리기 1%s 존재 안함
+</translation>
+    </message>
+    <message>
+        <source>Error creating %s</source>
+        <translation type="unfinished">만들기 오류 1%s
+</translation>
+    </message>
+    <message>
         <source>Error initializing block database</source>
         <translation type="unfinished">블록 데이터베이스 초기화 오류 발생</translation>
     </message>
@@ -3603,6 +3956,10 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished">블록 데이터베이스를 불러오는데 오류가 발생하였습니다, 곧 종료됩니다.</translation>
     </message>
     <message>
+        <source>Error reading next record from wallet database</source>
+        <translation type="unfinished">지갑 데이터베이스에서 다음 기록을 불러오는데 오류가 발생하였습니다.</translation>
+    </message>
+    <message>
         <source>Error upgrading chainstate database</source>
         <translation type="unfinished">체인 상태 데이터베이스 업그레이드 중 오류가 발생했습니다.</translation>
     </message>
@@ -3613,6 +3970,14 @@ Go to File &gt; Open Wallet to load a wallet.
     <message>
         <source>Error: Keypool ran out, please call keypoolrefill first</source>
         <translation type="unfinished">오류: 키풀이 바닥남, 키풀 리필을 먼저 호출할 하십시오</translation>
+    </message>
+    <message>
+        <source>Error: Missing checksum</source>
+        <translation type="unfinished">오류: 체크섬 누락</translation>
+    </message>
+    <message>
+        <source>Error: Unable to write record to new wallet</source>
+        <translation type="unfinished">오류: 새로운 지갑에 기록하지 못했습니다.</translation>
     </message>
     <message>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
@@ -3627,6 +3992,10 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished">데이터베이스를 검증 실패</translation>
     </message>
     <message>
+        <source>Importing…</source>
+        <translation type="unfinished">불러오는 중...</translation>
+    </message>
+    <message>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation type="unfinished">제네시스 블록이 없거나 잘 못 되었습니다. 네트워크의 datadir을 확인해 주십시오.</translation>
     </message>
@@ -3637,6 +4006,10 @@ Go to File &gt; Open Wallet to load a wallet.
     <message>
         <source>Insufficient funds</source>
         <translation type="unfinished">잔액이 부족합니다</translation>
+    </message>
+    <message>
+        <source>Invalid -i2psam address or hostname: '%s'</source>
+        <translation type="unfinished">올바르지 않은 -i2psam 주소 또는 호스트 이름: '%s'</translation>
     </message>
     <message>
         <source>Invalid -onion address or hostname: '%s'</source>
@@ -3671,6 +4044,22 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished">유효하지 않은 넷마스크가 -whitelist: '%s" 를 통해 지정됨</translation>
     </message>
     <message>
+        <source>Loading P2P addresses…</source>
+        <translation type="unfinished">P2P 주소를 불러오는 중...</translation>
+    </message>
+    <message>
+        <source>Loading banlist…</source>
+        <translation type="unfinished">추방리스트를 불러오는 중...</translation>
+    </message>
+    <message>
+        <source>Loading block index…</source>
+        <translation type="unfinished">블록 인덱스를 불러오는 중...</translation>
+    </message>
+    <message>
+        <source>Loading wallet…</source>
+        <translation type="unfinished">지갑을 불러오는 중...</translation>
+    </message>
+    <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
         <translation type="unfinished">-whitebind: '%s' 를 이용하여 포트를 지정해야 합니다</translation>
     </message>
@@ -3687,12 +4076,28 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished">블록 축소는 음수로 설정할 수 없습니다.</translation>
     </message>
     <message>
+        <source>Prune mode is incompatible with -coinstatsindex.</source>
+        <translation type="unfinished">블록 축소 모드는 -coinstatsindex와 호환되지 않습니다.</translation>
+    </message>
+    <message>
         <source>Prune mode is incompatible with -txindex.</source>
         <translation type="unfinished">블록 축소 모드는 -txindex와 호환되지 않습니다.</translation>
     </message>
     <message>
+        <source>Pruning blockstore…</source>
+        <translation type="unfinished">블록 데이터를 축소 중입니다...</translation>
+    </message>
+    <message>
         <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
         <translation type="unfinished">시스템 한계로 인하여 -maxconnections를 %d 에서 %d로 줄였습니다.</translation>
+    </message>
+    <message>
+        <source>Replaying blocks…</source>
+        <translation type="unfinished">블록 재생 중...</translation>
+    </message>
+    <message>
+        <source>Rescanning…</source>
+        <translation type="unfinished">재스캔 중...</translation>
     </message>
     <message>
         <source>SQLiteDatabase: Failed to execute statement to verify database: %s</source>
@@ -3729,6 +4134,10 @@ Go to File &gt; Open Wallet to load a wallet.
     <message>
         <source>Specified blocks directory "%s" does not exist.</source>
         <translation type="unfinished">지정한 블록 디렉토리 "%s" 가 존재하지 않습니다.</translation>
+    </message>
+    <message>
+        <source>Starting network threads…</source>
+        <translation type="unfinished">네트워크 스레드 시작중...</translation>
     </message>
     <message>
         <source>The source code is available from %s.</source>
@@ -3795,6 +4204,10 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished">키 생성 불가</translation>
     </message>
     <message>
+        <source>Unable to open %s for writing</source>
+        <translation type="unfinished">%s을 쓰기 위하여 열 수 없습니다.</translation>
+    </message>
+    <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
         <translation type="unfinished">HTTP 서버를 시작할 수 없습니다. 자세한 사항은 디버그 로그를 확인 하세요.</translation>
     </message>
@@ -3809,6 +4222,10 @@ Go to File &gt; Open Wallet to load a wallet.
     <message>
         <source>Unknown network specified in -onlynet: '%s'</source>
         <translation type="unfinished">-onlynet: '%s' 에 알수없는 네트워크가 지정되었습니다</translation>
+    </message>
+    <message>
+        <source>Unknown new rules activated (versionbit %i)</source>
+        <translation type="unfinished">알 수 없는 새로운 규칙이 활성화 되었습니다. (versionbit %i)</translation>
     </message>
     <message>
         <source>Unsupported logging category %s=%s.</source>

--- a/src/qt/locale/bitcoin_ku_IQ.ts
+++ b/src/qt/locale/bitcoin_ku_IQ.ts
@@ -137,6 +137,18 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation>دووبارەکردنەوەی دەستەواژەی تێپەڕی نوێ</translation>
     </message>
     <message>
+        <source>Encrypt wallet</source>
+        <translation type="unfinished">کیف خو یه پاره رمزه دانینه بر</translation>
+    </message>
+    <message>
+        <source>This operation needs your wallet passphrase to unlock the wallet.</source>
+        <translation type="unfinished">او شوله بو ور کرنا کیف پاره گرکه رمزا کیفه وؤ یه پاره بزانی</translation>
+    </message>
+    <message>
+        <source>Are you sure you wish to encrypt your wallet?</source>
+        <translation type="unfinished">به راستی اون هشیارن کا دخازن بو کیف خو یه پاره رمزه دانین</translation>
+    </message>
+    <message>
         <source>Enter the new passphrase for the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished">دەستەواژەی تێپەڕەوی نوێ تێبنووسە بۆ جزدان.1 تکایە دەستەواژەی تێپەڕێک بەکاربێنە لە 2ten یان زیاتر لە هێما هەڕەمەکیەکان2، یان 38 یان زیاتر ووشەکان3.</translation>
     </message>

--- a/src/qt/locale/bitcoin_lt.ts
+++ b/src/qt/locale/bitcoin_lt.ts
@@ -70,6 +70,11 @@
         <translation type="unfinished">Tai yra jūsų Bitcoin adresai išeinantiems mokėjimams. Visada pasitikrinkite sumą ir gavėjo adresą prieš siunčiant lėšas.</translation>
     </message>
     <message>
+        <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
+Signing is only possible with addresses of the type 'legacy'.</source>
+        <translation type="unfinished">Tai jūsų Bitcoin mokėjimų gavimo adresai. Naudokite 'Sukurti naują gavimo adresą' mygtuką gavimų skirtuke kad sukurtumėte naują adresą.</translation>
+    </message>
+    <message>
         <source>&amp;Copy Address</source>
         <translation type="unfinished">&amp;Kopijuoti adresą</translation>
     </message>
@@ -167,6 +172,18 @@
     <message>
         <source>Enter the old passphrase and new passphrase for the wallet.</source>
         <translation type="unfinished">Įveskite seną ir naują slaptažodį.</translation>
+    </message>
+    <message>
+        <source>Wallet to be encrypted</source>
+        <translation type="unfinished">Piniginė kurią užšifruosite</translation>
+    </message>
+    <message>
+        <source>Your wallet is about to be encrypted. </source>
+        <translation type="unfinished">Jūsų piniginė netrukus bus užšifruota</translation>
+    </message>
+    <message>
+        <source>Your wallet is now encrypted. </source>
+        <translation type="unfinished">Jūsų piniginė užšifruota.</translation>
     </message>
     <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
@@ -492,6 +509,18 @@
     <message>
         <source>Up to date</source>
         <translation>Atnaujinta</translation>
+    </message>
+    <message>
+        <source>Load Partially Signed Bitcoin Transaction</source>
+        <translation type="unfinished">Užkraukite dalinai pasirašytą Bitcoin transakciją</translation>
+    </message>
+    <message>
+        <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
+        <translation type="unfinished">Užkraukite dalinai pasirašytas Bitcoin transakcijas iš iškarpinės...</translation>
+    </message>
+    <message>
+        <source>Node window</source>
+        <translation type="unfinished">Mazgo langas</translation>
     </message>
     <message>
         <source>&amp;Sending addresses</source>
@@ -1614,6 +1643,10 @@
         <translation type="unfinished">Vartotojo atstovas</translation>
     </message>
     <message>
+        <source>Node window</source>
+        <translation type="unfinished">Mazgo langas</translation>
+    </message>
+    <message>
         <source>Open the %1 debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation type="unfinished">Atidarykite %1 derinimo žurnalo failą iš dabartinio duomenų katalogo. Tai gali užtrukti kelias sekundes dideliems žurnalo failams.</translation>
     </message>
@@ -2507,6 +2540,10 @@
         <translation type="unfinished">Sandorio ID</translation>
     </message>
     <message>
+        <source>Transaction total size</source>
+        <translation type="unfinished">Bendras transakcijos dydis</translation>
+    </message>
+    <message>
         <source>Merchant</source>
         <translation type="unfinished">Prekybininkas</translation>
     </message>
@@ -2934,6 +2971,10 @@
     <message>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished">Nėra pakankamai failų aprašų.</translation>
+    </message>
+    <message>
+        <source>Signing transaction failed</source>
+        <translation type="unfinished">Transakcijos pasirašymas nepavyko</translation>
     </message>
     <message>
         <source>The source code is available from %s.</source>

--- a/src/qt/locale/bitcoin_lv.ts
+++ b/src/qt/locale/bitcoin_lv.ts
@@ -88,7 +88,7 @@
     <message>
         <source>There was an error trying to save the address list to %1. Please try again.</source>
         <extracomment>An error message. %1 is a stand-in argument for the name of the file we attempted to save to.</extracomment>
-        <translation type="unfinished">Mēģinot saglabāt adrešu sarakstu %1 radās kļūda. Mēģiniet vēlreiz.</translation>
+        <translation type="unfinished">Mēģinot saglabāt adrešu sarakstu %1 radās kļūda. Lūdzu mēģiniet vēlreiz.</translation>
     </message>
     <message>
         <source>Exporting Failed</source>
@@ -126,7 +126,7 @@
     </message>
     <message>
         <source>Repeat new passphrase</source>
-        <translation>Jaunā parole vēlreiz</translation>
+        <translation>Ievadiet jauno paroli vēlreiz</translation>
     </message>
     <message>
         <source>Show passphrase</source>
@@ -185,10 +185,18 @@
         <translation type="unfinished">Maciņa šifrēšana neizdevās</translation>
     </message>
     <message>
+        <source>The supplied passphrases do not match.</source>
+        <translation type="unfinished">Ievadītās paroles nav vienādas.</translation>
+    </message>
+    <message>
         <source>Wallet unlock failed</source>
         <translation type="unfinished">Maciņa atslēgšana neizdevās</translation>
     </message>
-    </context>
+    <message>
+        <source>Warning: The Caps Lock key is on!</source>
+        <translation type="unfinished">Uzmanību! Caps Lock uz klavietūras ir ieslēgts!</translation>
+    </message>
+</context>
 <context>
     <name>QObject</name>
     <message>
@@ -287,12 +295,20 @@
         <translation type="unfinished">&amp;Par %1</translation>
     </message>
     <message>
+        <source>Show information about %1</source>
+        <translation type="unfinished">Rādīt informāciju par %1</translation>
+    </message>
+    <message>
         <source>About &amp;Qt</source>
         <translation>Par &amp;Qt</translation>
     </message>
     <message>
         <source>Show information about Qt</source>
         <translation>Parādīt informāciju par Qt</translation>
+    </message>
+    <message>
+        <source>Create a new wallet</source>
+        <translation type="unfinished">Izveidot jaunu maciņu</translation>
     </message>
     <message>
         <source>Wallet:</source>
@@ -317,6 +333,10 @@
     <message>
         <source>&amp;Receive</source>
         <translation>&amp;Saņemt</translation>
+    </message>
+    <message>
+        <source>&amp;Options…</source>
+        <translation type="unfinished">&amp;Opcijas...</translation>
     </message>
     <message>
         <source>&amp;Show / Hide</source>
@@ -353,6 +373,10 @@
     <message>
         <source>Tabs toolbar</source>
         <translation>Ciļņu rīkjosla</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation type="unfinished">Sinhronizē ar tīklu</translation>
     </message>
     <message>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
@@ -712,6 +736,10 @@
         <translation>Apstiprināt iestatījumu atiestatīšanu</translation>
     </message>
     <message>
+        <source>Configuration options</source>
+        <translation type="unfinished">Konfigurāciju Opcijas</translation>
+    </message>
+    <message>
         <source>Error</source>
         <translation type="unfinished">Kļūda</translation>
     </message>
@@ -757,6 +785,33 @@
     <message>
         <source>Your current total balance</source>
         <translation>Jūsu kopējā tekošā bilance</translation>
+    </message>
+    <message>
+        <source>Spendable:</source>
+        <translation type="unfinished">Iztērējams:</translation>
+    </message>
+    <message>
+        <source>Recent transactions</source>
+        <translation type="unfinished">Nesenās transakcijas</translation>
+    </message>
+    </context>
+<context>
+    <name>PSBTOperationsDialog</name>
+    <message>
+        <source>Dialog</source>
+        <translation type="unfinished">Dialogs</translation>
+    </message>
+    <message>
+        <source>Copy to Clipboard</source>
+        <translation type="unfinished">Nokopēt</translation>
+    </message>
+    <message>
+        <source>Save…</source>
+        <translation type="unfinished">Saglabāt...</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation type="unfinished">Aiztaisīt</translation>
     </message>
     </context>
 <context>
@@ -1205,6 +1260,13 @@
         <translation type="unfinished">Eksportēšana Neizdevās</translation>
     </message>
     </context>
+<context>
+    <name>WalletFrame</name>
+    <message>
+        <source>Create a new wallet</source>
+        <translation type="unfinished">Izveidot jaunu maciņu</translation>
+    </message>
+</context>
 <context>
     <name>WalletModel</name>
     <message>

--- a/src/qt/locale/bitcoin_ml.ts
+++ b/src/qt/locale/bitcoin_ml.ts
@@ -966,6 +966,13 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     </context>
 <context>
+    <name>PSBTOperationsDialog</name>
+    <message>
+        <source>Signed transaction successfully. Transaction is ready to broadcast.</source>
+        <translation type="unfinished">ഇടപാട് വിജയകരമായി ഒപ്പിട്ടു.  ഇടപാട് പ്രക്ഷേപണത്തിന് തയ്യാറാണ്</translation>
+    </message>
+    </context>
+<context>
     <name>PaymentServer</name>
     <message>
         <source>URI handling</source>
@@ -1029,6 +1036,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Node window</source>
         <translation type="unfinished">നോഡ് വിൻഡോ</translation>
+    </message>
+    <message>
+        <source>Permissions</source>
+        <translation type="unfinished">അനുവാത്തംനൽകൾ</translation>
     </message>
     <message>
         <source>Last block time</source>
@@ -1168,6 +1179,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
             <numerusform />
             <numerusform />
         </translation>
+    </message>
+    <message>
+        <source>%1 confirmations</source>
+        <translation type="unfinished">%1 സ്ഥിരീകരണങ്ങൾ</translation>
     </message>
     <message>
         <source>Date</source>

--- a/src/qt/locale/bitcoin_mn.ts
+++ b/src/qt/locale/bitcoin_mn.ts
@@ -35,7 +35,7 @@
     </message>
     <message>
         <source>&amp;Export</source>
-        <translation>&amp;Экспортдлох</translation>
+        <translation>&amp;Экспорт</translation>
     </message>
     <message>
         <source>&amp;Delete</source>
@@ -163,6 +163,10 @@
 <context>
     <name>QObject</name>
     <message>
+        <source>Error: %1</source>
+        <translation type="unfinished">Алдаа: %1</translation>
+    </message>
+    <message>
         <source>unknown</source>
         <translation type="unfinished">үл мэдэгдэх</translation>
     </message>
@@ -244,12 +248,37 @@
         <translation>Клиентийн тухай мэдээллийг харуул</translation>
     </message>
     <message>
+        <source>Wallet:</source>
+        <translation type="unfinished">Хэтэвч:</translation>
+    </message>
+    <message>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Түрүйвчийг цоожлох нууц үгийг солих</translation>
     </message>
     <message>
+        <source>&amp;Send</source>
+        <translation>&amp;Илгээх
+ </translation>
+    </message>
+    <message>
+        <source>&amp;Receive</source>
+        <translation>&amp;Хүлээж авах</translation>
+    </message>
+    <message>
         <source>&amp;Show / Hide</source>
         <translation>&amp;Харуул / Нуу</translation>
+    </message>
+    <message>
+        <source>&amp;Verify message…</source>
+        <translation type="unfinished">&amp;Баталгаажуулах мэссэж</translation>
+    </message>
+    <message>
+        <source>Close Wallet…</source>
+        <translation type="unfinished">Хэтэвч хаах…</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation type="unfinished">Хэтэвч үүсгэх…</translation>
     </message>
     <message>
         <source>&amp;File</source>
@@ -275,6 +304,10 @@
         <translation>Алдаа</translation>
     </message>
     <message>
+        <source>Warning</source>
+        <translation>Анхааруулга</translation>
+    </message>
+    <message>
         <source>Information</source>
         <translation>Мэдээллэл</translation>
     </message>
@@ -289,6 +322,10 @@
             <numerusform />
             <numerusform />
         </translation>
+    </message>
+    <message>
+        <source>Error: %1</source>
+        <translation type="unfinished">Алдаа: %1</translation>
     </message>
     <message>
         <source>Sent transaction</source>
@@ -582,6 +619,10 @@
     <message>
         <source>Message:</source>
         <translation type="unfinished">Зурвас:</translation>
+    </message>
+    <message>
+        <source>Wallet:</source>
+        <translation type="unfinished">Хэтэвч:</translation>
     </message>
     <message>
         <source>Copy &amp;Address</source>

--- a/src/qt/locale/bitcoin_ms.ts
+++ b/src/qt/locale/bitcoin_ms.ts
@@ -358,7 +358,7 @@ Alihkan fail data ke dalam tab semasa</translation>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation>
-            <numerusform />
+            <numerusform>Processed %n blocks of transaction history.</numerusform>
         </translation>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_my.ts
+++ b/src/qt/locale/bitcoin_my.ts
@@ -22,6 +22,10 @@
         <translation type="unfinished">&amp;ကူးမယ်</translation>
     </message>
     <message>
+        <source>C&amp;lose</source>
+        <translation type="unfinished">ပိတ်မည်</translation>
+    </message>
+    <message>
         <source>Delete the currently selected address from the list</source>
         <translation>လက်ရှိရွေးထားတဲ့ လိပ်စာကို ဖျက်မယ်။</translation>
     </message>
@@ -44,6 +48,14 @@
     <message>
         <source>Choose the address to send coins to</source>
         <translation type="unfinished">လိပ်စာကိုပေးပို့ဖို့လိပ်စာရွေးချယ်ပါ</translation>
+    </message>
+    <message>
+        <source>Choose the address to receive coins with</source>
+        <translation type="unfinished">ဒင်္ဂါးများလက်ခံရယူမည့်လိပ်စာကို​​ရွေးပါ</translation>
+    </message>
+    <message>
+        <source>C&amp;hoose</source>
+        <translation type="unfinished">​ရွေးပါ</translation>
     </message>
     <message>
         <source>Sending addresses</source>
@@ -246,6 +258,10 @@
     </context>
 <context>
     <name>TransactionView</name>
+    <message>
+        <source>Other</source>
+        <translation type="unfinished">အခြား</translation>
+    </message>
     <message>
         <source>Date</source>
         <translation type="unfinished">နေ့စွဲ</translation>

--- a/src/qt/locale/bitcoin_nb.ts
+++ b/src/qt/locale/bitcoin_nb.ts
@@ -84,7 +84,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>&amp;Edit</source>
-        <translation type="unfinished">R&amp;ediger</translation>
+        <translation type="unfinished">&amp;Rediger</translation>
     </message>
     <message>
         <source>Export Address List</source>
@@ -98,11 +98,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>There was an error trying to save the address list to %1. Please try again.</source>
         <extracomment>An error message. %1 is a stand-in argument for the name of the file we attempted to save to.</extracomment>
-        <translation type="unfinished">Fet oppstod en feil ved lagring av adresselisten til %1. Vennligst prøv igjen.</translation>
+        <translation type="unfinished">Det oppstod en feil ved lagring av adresselisten til %1. Vennligst prøv igjen.</translation>
     </message>
     <message>
         <source>Exporting Failed</source>
-        <translation type="unfinished">Eksporten feilet</translation>
+        <translation type="unfinished">Eksportering feilet</translation>
     </message>
 </context>
 <context>
@@ -176,7 +176,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Enter the new passphrase for the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
-        <translation type="unfinished">Angi den nye passordfrasen for lommeboken.&lt;br/&gt; Vennglist du bruker en passordfrase &lt;b&gt; ti eller tilfeldige tegn &lt;/b&gt;, eller &lt;b&gt; åtte eller flere ord.</translation>
+        <translation type="unfinished">Angi den nye passordfrasen for lommeboken.&lt;br/&gt; Vennglist bruk en passordfrase med &lt;b&gt; ti eller flere tilfeldige tegn &lt;/b&gt;, eller &lt;b&gt; åtte eller flere ord.</translation>
     </message>
     <message>
         <source>Enter the old passphrase and new passphrase for the wallet.</source>
@@ -245,6 +245,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>BitcoinApplication</name>
     <message>
+        <source>Runaway exception</source>
+        <translation type="unfinished">Løpsk unntak</translation>
+    </message>
+    <message>
         <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
         <translation type="unfinished">En fatal feil har skjedd. %1 kan ikke lenger trygt fortsette og kommer til å avslutte.</translation>
     </message>
@@ -252,7 +256,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Internal error</source>
         <translation type="unfinished">Intern feil</translation>
     </message>
-    </context>
+    <message>
+        <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
+        <translation type="unfinished">En intern feil har oppstått. %1 vil forsøke å fortsette trygt. Dette er en uventet feil som kan bli rapportert som forklart nedenfor.</translation>
+    </message>
+</context>
 <context>
     <name>QObject</name>
     <message>
@@ -284,6 +292,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Oppgi en Bitcoin-adresse (f.eks. %1)</translation>
     </message>
     <message>
+        <source>Unroutable</source>
+        <translation type="unfinished">Ikke-rutbar</translation>
+    </message>
+    <message>
         <source>Internal</source>
         <translation type="unfinished">Intern</translation>
     </message>
@@ -294,6 +306,26 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Outbound</source>
         <translation type="unfinished">Utgående</translation>
+    </message>
+    <message>
+        <source>Full Relay</source>
+        <translation type="unfinished">Fullrelé</translation>
+    </message>
+    <message>
+        <source>Block Relay</source>
+        <translation type="unfinished">Blokkrelé</translation>
+    </message>
+    <message>
+        <source>Manual</source>
+        <translation type="unfinished">Håndbok</translation>
+    </message>
+    <message>
+        <source>Feeler</source>
+        <translation type="unfinished">Føler</translation>
+    </message>
+    <message>
+        <source>Address Fetch</source>
+        <translation type="unfinished">Adressehenting</translation>
     </message>
     <message>
         <source>%1 h</source>
@@ -869,6 +901,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Kopier &amp;beløp</translation>
     </message>
     <message>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">Kopier transaksjons&amp;ID</translation>
+    </message>
+    <message>
         <source>L&amp;ock unspent</source>
         <translation type="unfinished">Lås ubrukte</translation>
     </message>
@@ -947,7 +983,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Create wallet warning</source>
         <translation type="unfinished">Lag lommebokvarsel</translation>
     </message>
-    </context>
+    <message>
+        <source>Can't list signers</source>
+        <translation type="unfinished">Kan ikke vise liste over undertegnere</translation>
+    </message>
+</context>
 <context>
     <name>OpenWalletActivity</name>
     <message>
@@ -1037,6 +1077,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Deskriptor lommebok</translation>
     </message>
     <message>
+        <source>Use an external signing device such as a hardware wallet. Configure the external signer script in wallet preferences first.</source>
+        <translation type="unfinished">Bruk en ekstern undertegningsenhet, som en fysisk lommebok. Konfigurer det eksterne undertegningskriptet i lommebokinnstillingene først.</translation>
+    </message>
+    <message>
+        <source>External signer</source>
+        <translation type="unfinished">Ekstern undertegner</translation>
+    </message>
+    <message>
         <source>Create</source>
         <translation type="unfinished">Opprett</translation>
     </message>
@@ -1044,7 +1092,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Compiled without sqlite support (required for descriptor wallets)</source>
         <translation type="unfinished">Kompilert uten sqlite støtte (kreves for deskriptor lommebok)</translation>
     </message>
-    </context>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Kompilert uten støtte for ekstern undertegning (kreves for ekstern undertegning)</translation>
+    </message>
+</context>
 <context>
     <name>EditAddressDialog</name>
     <message>
@@ -1393,6 +1446,18 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">&amp;Bruk ubekreftet veksel</translation>
     </message>
     <message>
+        <source>External Signer (e.g. hardware wallet)</source>
+        <translation type="unfinished">Ekstern undertegner (f.eks. fysisk lommebok)</translation>
+    </message>
+    <message>
+        <source>&amp;External signer script path</source>
+        <translation type="unfinished">&amp;Ekstern undertegner skriptsti</translation>
+    </message>
+    <message>
+        <source>Full path to a Bitcoin Core compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</source>
+        <translation type="unfinished">Fullstendig sti til et Bitcoin Core-kompatibelt skript (f.eks. C:\Downloads\hwi.exe eller /Users/you/Downloads/hwi.py). Advarsel: skadevare kan stjele myntene dine!</translation>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation>Åpne automatisk Bitcoin klientporten på ruteren. Dette virker kun om din ruter støtter UPnP og dette er påslått.</translation>
     </message>
@@ -1489,12 +1554,21 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Innebygd "%1"</translation>
     </message>
     <message>
+        <source>closest matching "%1"</source>
+        <translation type="unfinished">nærmeste treff "%1"</translation>
+    </message>
+    <message>
         <source>Options set in this dialog are overridden by the command line or in the configuration file:</source>
         <translation type="unfinished">Alternativer som er satt i denne dialogboksen overstyres av kommandolinjen eller i konfigurasjonsfilen:</translation>
     </message>
     <message>
         <source>&amp;Cancel</source>
         <translation>&amp;Avbryt</translation>
+    </message>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Kompilert uten støtte for ekstern undertegning (kreves for ekstern undertegning)</translation>
     </message>
     <message>
         <source>default</source>
@@ -2004,12 +2078,20 @@ Hvis du får denne feilen burde du be forretningsdrivende om å tilby en BIP21 k
         <translation type="unfinished">Hvorvidt likemannen ba oss om å videresende transaksjoner.</translation>
     </message>
     <message>
+        <source>Wants Tx Relay</source>
+        <translation type="unfinished">Ønsker Tx Relé</translation>
+    </message>
+    <message>
         <source>High Bandwidth</source>
         <translation type="unfinished">Høy Båndbredde</translation>
     </message>
     <message>
         <source>Connection Time</source>
         <translation type="unfinished">Tilkoblingstid</translation>
+    </message>
+    <message>
+        <source>Elapsed time since a novel block passing initial validity checks was received from this peer.</source>
+        <translation type="unfinished">Forløpt tid siden en ny blokk som passerte de initielle validitetskontrollene ble mottatt fra denne likemannen.</translation>
     </message>
     <message>
         <source>Last Block</source>
@@ -2092,6 +2174,34 @@ Hvis du får denne feilen burde du be forretningsdrivende om å tilby en BIP21 k
         <translation type="unfinished">Innkommende: initiert av likemann</translation>
     </message>
     <message>
+        <source>Outbound Full Relay: default</source>
+        <translation type="unfinished">Utgående Fullrelé: standard</translation>
+    </message>
+    <message>
+        <source>Outbound Block Relay: does not relay transactions or addresses</source>
+        <translation type="unfinished">Utgående Blokkrelé: videresender ikke transaksjoner eller adresser</translation>
+    </message>
+    <message>
+        <source>Outbound Feeler: short-lived, for testing addresses</source>
+        <translation type="unfinished">Utgående Føler: kortlevd, til testing av adresser</translation>
+    </message>
+    <message>
+        <source>Outbound Address Fetch: short-lived, for soliciting addresses</source>
+        <translation type="unfinished">Utgående Adressehenting: kortlevd, for å hente adresser</translation>
+    </message>
+    <message>
+        <source>we selected the peer for high bandwidth relay</source>
+        <translation type="unfinished">vi valgte likemannen for høy båndbredderelé</translation>
+    </message>
+    <message>
+        <source>the peer selected us for high bandwidth relay</source>
+        <translation type="unfinished">likemannen valgte oss for høy båndbredderelé</translation>
+    </message>
+    <message>
+        <source>no high bandwidth relay selected</source>
+        <translation type="unfinished">intet høy båndbredderelé valgt</translation>
+    </message>
+    <message>
         <source>Ctrl+=</source>
         <extracomment>Secondary shortcut to increase the RPC console font size.</extracomment>
         <translation type="unfinished">Cltr+=</translation>
@@ -2103,6 +2213,10 @@ Hvis du får denne feilen burde du be forretningsdrivende om å tilby en BIP21 k
     <message>
         <source>1 &amp;hour</source>
         <translation type="unfinished">1 &amp;time</translation>
+    </message>
+    <message>
+        <source>1 d&amp;ay</source>
+        <translation type="unfinished">1 &amp;dag</translation>
     </message>
     <message>
         <source>1 &amp;week</source>
@@ -2127,6 +2241,11 @@ Hvis du får denne feilen burde du be forretningsdrivende om å tilby en BIP21 k
     <message>
         <source>Executing command using "%1" wallet</source>
         <translation type="unfinished">Utfør kommando med lommebok "%1"</translation>
+    </message>
+    <message>
+        <source>Executing…</source>
+        <extracomment>A console message indicating an entered command is currently being executed.</extracomment>
+        <translation type="unfinished">Utfører...</translation>
     </message>
     <message>
         <source>(peer: %1)</source>
@@ -2307,6 +2426,10 @@ Hvis du får denne feilen burde du be forretningsdrivende om å tilby en BIP21 k
         <translation type="unfinished">&amp;Verifiser</translation>
     </message>
     <message>
+        <source>Verify this address on e.g. a hardware wallet screen</source>
+        <translation type="unfinished">Verifiser denne adressen på f.eks. en fysisk lommebokskjerm</translation>
+    </message>
+    <message>
         <source>&amp;Save Image…</source>
         <translation type="unfinished">&amp;Lagre Bilde...</translation>
     </message>
@@ -2433,6 +2556,10 @@ Hvis du får denne feilen burde du be forretningsdrivende om å tilby en BIP21 k
         <translation type="unfinished">Fjern alle felter fra skjemaet.</translation>
     </message>
     <message>
+        <source>Inputs…</source>
+        <translation type="unfinished">Inputs...</translation>
+    </message>
+    <message>
         <source>Dust:</source>
         <translation type="unfinished">Støv:</translation>
     </message>
@@ -2451,6 +2578,10 @@ Hvis du får denne feilen burde du be forretningsdrivende om å tilby en BIP21 k
     <message>
         <source>A too low fee might result in a never confirming transaction (read the tooltip)</source>
         <translation type="unfinished">For lavt gebyr kan føre til en transaksjon som aldri bekreftes (les verktøytips)</translation>
+    </message>
+    <message>
+        <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
+        <translation type="unfinished">(Smartgebyr er ikke initialisert ennå. Dette tar vanligvis noen få blokker...)</translation>
     </message>
     <message>
         <source>Confirmation time target:</source>
@@ -2546,6 +2677,16 @@ Hvis du får denne feilen burde du be forretningsdrivende om å tilby en BIP21 k
         <translation type="unfinished">Signering feilet</translation>
     </message>
     <message>
+        <source>External signer not found</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Ekstern undertegner ikke funnet</translation>
+    </message>
+    <message>
+        <source>External signer failure</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Ekstern undertegnerfeil</translation>
+    </message>
+    <message>
         <source>Save Transaction Data</source>
         <translation type="unfinished">Lagre Transaksjonsdata</translation>
     </message>
@@ -2557,6 +2698,10 @@ Hvis du får denne feilen burde du be forretningsdrivende om å tilby en BIP21 k
     <message>
         <source>PSBT saved</source>
         <translation type="unfinished">PSBT lagret</translation>
+    </message>
+    <message>
+        <source>External balance:</source>
+        <translation type="unfinished">Ekstern saldo:</translation>
     </message>
     <message>
         <source>or</source>
@@ -2633,8 +2778,8 @@ Hvis du får denne feilen burde du be forretningsdrivende om å tilby en BIP21 k
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation>
-            <numerusform />
-            <numerusform />
+            <numerusform>Estimert å begynne bekreftelse innen %n blokk.</numerusform>
+            <numerusform>Estimert å begynne bekreftelse innen %n blokker.</numerusform>
         </translation>
     </message>
     <message>
@@ -3006,7 +3151,7 @@ Hvis du får denne feilen burde du be forretningsdrivende om å tilby en BIP21 k
     </message>
     <message>
         <source>Output index</source>
-        <translation type="unfinished">Utdatainndeks</translation>
+        <translation type="unfinished">Outputindeks</translation>
     </message>
     <message>
         <source> (Certificate was not verified)</source>
@@ -3027,10 +3172,6 @@ Hvis du får denne feilen burde du be forretningsdrivende om å tilby en BIP21 k
     <message>
         <source>Transaction</source>
         <translation type="unfinished">Transaksjon</translation>
-    </message>
-    <message>
-        <source>Inputs</source>
-        <translation type="unfinished">Inndata</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -3130,10 +3271,6 @@ Hvis du får denne feilen burde du be forretningsdrivende om å tilby en BIP21 k
         <translation type="unfinished">kun oppsyn</translation>
     </message>
     <message>
-        <source>(n/a)</source>
-        <translation type="unfinished">(i/t)</translation>
-    </message>
-    <message>
         <source>(no label)</source>
         <translation type="unfinished">(ingen beskrivelse)</translation>
     </message>
@@ -3217,6 +3354,10 @@ Hvis du får denne feilen burde du be forretningsdrivende om å tilby en BIP21 k
         <translation type="unfinished">Minimumsbeløp</translation>
     </message>
     <message>
+        <source>Range…</source>
+        <translation type="unfinished">Intervall...</translation>
+    </message>
+    <message>
         <source>&amp;Copy address</source>
         <translation type="unfinished">&amp;Kopier adresse</translation>
     </message>
@@ -3229,8 +3370,24 @@ Hvis du får denne feilen burde du be forretningsdrivende om å tilby en BIP21 k
         <translation type="unfinished">Kopier &amp;beløp</translation>
     </message>
     <message>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">Kopier transaksjons&amp;ID</translation>
+    </message>
+    <message>
         <source>Copy full transaction &amp;details</source>
         <translation type="unfinished">Kopier komplette transaksjons&amp;detaljer</translation>
+    </message>
+    <message>
+        <source>&amp;Show transaction details</source>
+        <translation type="unfinished">&amp;Vis transaksjonsdetaljer</translation>
+    </message>
+    <message>
+        <source>Increase transaction &amp;fee</source>
+        <translation type="unfinished">Øk transaksjons&amp;gebyr</translation>
+    </message>
+    <message>
+        <source>&amp;Edit address label</source>
+        <translation type="unfinished">&amp;Rediger merkelapp</translation>
     </message>
     <message>
         <source>Export Transaction History</source>
@@ -3334,6 +3491,10 @@ Gå til Fil &gt; Åpne lommebok for å laste en lommebok.
     <message>
         <source>New fee:</source>
         <translation type="unfinished">Nytt gebyr:</translation>
+    </message>
+    <message>
+        <source>Warning: This may pay the additional fee by reducing change outputs or adding inputs, when necessary. It may add a new change output if one does not already exist. These changes may potentially leak privacy.</source>
+        <translation type="unfinished">Advarsel: Dette kan betale tilleggsgebyret ved å redusere endringsoutput eller legge til input, ved behov. Det kan legge til en ny endringsoutput hvis en ikke allerede eksisterer. Disse endringene kan potensielt lekke privatinformasjon.</translation>
     </message>
     <message>
         <source>Confirm fee bump</source>
@@ -3467,12 +3628,28 @@ Gå til Fil &gt; Åpne lommebok for å laste en lommebok.
         <translation type="unfinished">Feil under lesing av %s! Alle nøkler har blitt lest rett, men transaksjonsdata eller adressebokoppføringer kan mangle eller være uriktige.</translation>
     </message>
     <message>
+        <source>Error: Dumpfile format record is incorrect. Got "%s", expected "format".</source>
+        <translation type="unfinished">Feil: Dumpfil formatoppføring stemmer ikke. Fikk "%s", forventet "format".</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile identifier record is incorrect. Got "%s", expected "%s".</source>
+        <translation type="unfinished">Feil: Dumpfil identifiseringsoppføring stemmer ikke. Fikk "%s", forventet "%s".</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile version is not supported. This version of bitcoin-wallet only supports version 1 dumpfiles. Got dumpfile with version %s</source>
+        <translation type="unfinished">Feil: Dumpfil versjon er ikke støttet. Denne versjonen av bitcoin-lommebok støtter kun versjon 1 dumpfiler. Fikk dumpfil med versjon %s</translation>
+    </message>
+    <message>
         <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
         <translation type="unfinished">Feil: Lytting etter innkommende tilkoblinger feilet (lytting returnerte feil %s)</translation>
     </message>
     <message>
         <source>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.</source>
         <translation type="unfinished">Avgiftsberegning mislyktes. Fallbackfee er deaktivert. Vent et par blokker eller aktiver -fallbackfee.</translation>
+    </message>
+    <message>
+        <source>File %s already exists. If you are sure this is what you want, move it out of the way first.</source>
+        <translation type="unfinished">Filen %s eksisterer allerede. Hvis du er sikker på at det er dette du vil, flytt den vekk først.</translation>
     </message>
     <message>
         <source>Invalid amount for -maxtxfee=&lt;amount&gt;: '%s' (must be at least the minrelay fee of %s to prevent stuck transactions)</source>
@@ -3497,6 +3674,10 @@ Gå til Fil &gt; Åpne lommebok for å laste en lommebok.
     <message>
         <source>Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of pruned node)</source>
         <translation type="unfinished">Beskjæring: siste lommeboksynkronisering går utenfor beskjærte data. Du må bruke -reindex (laster ned hele blokkjeden igjen for beskjærte noder)</translation>
+    </message>
+    <message>
+        <source>SQLiteDatabase: Unknown sqlite wallet schema version %d. Only version %d is supported</source>
+        <translation type="unfinished">SQLiteDatabase: Ukjent sqlite lommebok skjema versjon %d. Kun versjon %d er støttet</translation>
     </message>
     <message>
         <source>The block database contains a block which appears to be from the future. This may be due to your computer's date and time being set incorrectly. Only rebuild the block database if you are sure that your computer's date and time are correct</source>
@@ -3533,6 +3714,10 @@ Gå til Fil &gt; Åpne lommebok for å laste en lommebok.
     <message>
         <source>Unable to replay blocks. You will need to rebuild the database using -reindex-chainstate.</source>
         <translation type="unfinished">Kan ikke spille av blokker igjen. Du må bygge opp igjen databasen ved bruk av -reindex-chainstate.</translation>
+    </message>
+    <message>
+        <source>Warning: Dumpfile wallet format "%s" does not match command line specified format "%s".</source>
+        <translation type="unfinished">Advarsel: Dumpfil lommebokformat "%s" stemmer ikke med format "%s" spesifisert i kommandolinje.</translation>
     </message>
     <message>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
@@ -3595,6 +3780,10 @@ Gå til Fil &gt; Åpne lommebok for å laste en lommebok.
         <translation type="unfinished">Ferdig med lasting</translation>
     </message>
     <message>
+        <source>Dump file %s does not exist.</source>
+        <translation type="unfinished">Dump fil %s eksisterer ikke.</translation>
+    </message>
+    <message>
         <source>Error creating %s</source>
         <translation type="unfinished">Feil under opprettelse av %s</translation>
     </message>
@@ -3631,6 +3820,10 @@ Gå til Fil &gt; Åpne lommebok for å laste en lommebok.
         <translation type="unfinished">Feil ved lesing fra database, stenger ned.</translation>
     </message>
     <message>
+        <source>Error reading next record from wallet database</source>
+        <translation type="unfinished">Feil ved lesing av neste oppføring fra lommebokdatabase</translation>
+    </message>
+    <message>
         <source>Error upgrading chainstate database</source>
         <translation type="unfinished">Feil ved oppgradering av kjedetilstandsdatabase</translation>
     </message>
@@ -3643,12 +3836,28 @@ Gå til Fil &gt; Åpne lommebok for å laste en lommebok.
         <translation type="unfinished">Feil: Dumpfil sjekksum samsvarer ikke. Beregnet %s, forventet %s</translation>
     </message>
     <message>
+        <source>Error: Got key that was not hex: %s</source>
+        <translation type="unfinished">Feil: Fikk nøkkel som ikke var hex: %s</translation>
+    </message>
+    <message>
+        <source>Error: Got value that was not hex: %s</source>
+        <translation type="unfinished">Feil: Fikk verdi som ikke var hex: %s</translation>
+    </message>
+    <message>
         <source>Error: Keypool ran out, please call keypoolrefill first</source>
         <translation type="unfinished">Feil: Keypool gikk tom, kall keypoolrefill først.</translation>
     </message>
     <message>
         <source>Error: Missing checksum</source>
         <translation type="unfinished">Feil: Manglende sjekksum</translation>
+    </message>
+    <message>
+        <source>Error: No %s addresses available.</source>
+        <translation type="unfinished">Feil: Ingen %s adresser tilgjengelige.</translation>
+    </message>
+    <message>
+        <source>Error: Unable to write record to new wallet</source>
+        <translation type="unfinished">Feil: Kan ikke skrive rekord til ny lommebok</translation>
     </message>
     <message>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
@@ -3715,6 +3924,18 @@ Gå til Fil &gt; Åpne lommebok for å laste en lommebok.
         <translation type="unfinished">Ugyldig nettmaske spesifisert i -whitelist: '%s'</translation>
     </message>
     <message>
+        <source>Loading P2P addresses…</source>
+        <translation type="unfinished">Laster P2P-adresser...</translation>
+    </message>
+    <message>
+        <source>Loading banlist…</source>
+        <translation type="unfinished">Laster inn bannlysningsliste…</translation>
+    </message>
+    <message>
+        <source>Loading block index…</source>
+        <translation type="unfinished">Laster blokkindeks...</translation>
+    </message>
+    <message>
         <source>Loading wallet…</source>
         <translation type="unfinished">Laster lommebok...</translation>
     </message>
@@ -3735,8 +3956,12 @@ Gå til Fil &gt; Åpne lommebok for å laste en lommebok.
         <translation type="unfinished">Beskjæringsmodus kan ikke konfigureres med en negativ verdi.</translation>
     </message>
     <message>
+        <source>Prune mode is incompatible with -coinstatsindex.</source>
+        <translation type="unfinished">Beskjæringsmodus er inkompatibel med -coinstatsindex.</translation>
+    </message>
+    <message>
         <source>Prune mode is incompatible with -txindex.</source>
-        <translation type="unfinished">Beskjæringsmodus er ikke kompatibel med -txindex.</translation>
+        <translation type="unfinished">Beskjæringsmodus er inkompatibel med -txindex.</translation>
     </message>
     <message>
         <source>Pruning blockstore…</source>
@@ -3747,8 +3972,28 @@ Gå til Fil &gt; Åpne lommebok for å laste en lommebok.
         <translation type="unfinished">Reduserer -maxconnections fra %d til %d, pga. systembegrensninger.</translation>
     </message>
     <message>
+        <source>Replaying blocks…</source>
+        <translation type="unfinished">Spiller av blokker på nytt …</translation>
+    </message>
+    <message>
         <source>Rescanning…</source>
         <translation type="unfinished">Leser gjennom igjen...</translation>
+    </message>
+    <message>
+        <source>SQLiteDatabase: Failed to execute statement to verify database: %s</source>
+        <translation type="unfinished">SQLiteDatabase: Kunne ikke utføre uttrykk for å verifisere database: %s</translation>
+    </message>
+    <message>
+        <source>SQLiteDatabase: Failed to prepare statement to verify database: %s</source>
+        <translation type="unfinished">SQLiteDataBase: Kunne ikke forberede uttrykk for å verifisere database: %s</translation>
+    </message>
+    <message>
+        <source>SQLiteDatabase: Failed to read database verification error: %s</source>
+        <translation type="unfinished">SQLiteDatabase: Kunne ikke lese databaseverifikasjonsfeil: %s</translation>
+    </message>
+    <message>
+        <source>SQLiteDatabase: Unexpected application id. Expected %u, got %u</source>
+        <translation type="unfinished">SQLiteDatabase: Uventet applikasjonsid. Forventet %u, fikk %u</translation>
     </message>
     <message>
         <source>Signing transaction failed</source>
@@ -3815,6 +4060,10 @@ Gå til Fil &gt; Åpne lommebok for å laste en lommebok.
         <translation type="unfinished">Transaksjonen må ha minst én mottaker</translation>
     </message>
     <message>
+        <source>Transaction needs a change address, but we can't generate it. %s</source>
+        <translation type="unfinished">Transaksjonen trenger en vekseladresse, men vi kan ikke generere den. %s</translation>
+    </message>
+    <message>
         <source>Transaction too large</source>
         <translation type="unfinished">Transaksjonen er for stor</translation>
     </message>
@@ -3835,12 +4084,20 @@ Gå til Fil &gt; Åpne lommebok for å laste en lommebok.
         <translation type="unfinished">Klarte ikke å lage nøkkel</translation>
     </message>
     <message>
+        <source>Unable to open %s for writing</source>
+        <translation type="unfinished">Kan ikke åpne %s for skriving</translation>
+    </message>
+    <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
         <translation type="unfinished">Kunne ikke starte HTTP-tjener. Se feilrettingslogg for detaljer.</translation>
     </message>
     <message>
         <source>Unknown network specified in -onlynet: '%s'</source>
         <translation type="unfinished">Ukjent nettverk angitt i -onlynet '%s'</translation>
+    </message>
+    <message>
+        <source>Unknown new rules activated (versionbit %i)</source>
+        <translation type="unfinished">Ukjente nye regler aktivert (versionbit %i)</translation>
     </message>
     <message>
         <source>Unsupported logging category %s=%s.</source>

--- a/src/qt/locale/bitcoin_nl.ts
+++ b/src/qt/locale/bitcoin_nl.ts
@@ -67,12 +67,12 @@
     </message>
     <message>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
-        <translation type="unfinished">Dit zijn uw Bitcoinadressen om betalingen mee te verzenden. Controleer altijd het bedrag en het ontvangstadres voordat u uw bitcoins verzendt.</translation>
+        <translation type="unfinished">Dit zijn uw Bitcoin adressen om betalingen mee te verzenden. Controleer altijd het bedrag en het ontvangstadres voordat u uw bitcoins verzendt.</translation>
     </message>
     <message>
         <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
 Signing is only possible with addresses of the type 'legacy'.</source>
-        <translation type="unfinished">Dit zijn uw Bitcoinadressen voor het ontvangen van betalingen. Gebruik de 'Nieuw ontvangstadres maken' knop in de ontvangst tab om nieuwe adressen te maken.
+        <translation type="unfinished">Dit zijn uw Bitcoin adressen voor het ontvangen van betalingen. Gebruik de 'Nieuw ontvangstadres maken' knop in de ontvangst tab om nieuwe adressen te maken.
 Ondertekenen is alleen mogelijk met adressen van het type 'legacy'.</translation>
     </message>
     <message>
@@ -145,7 +145,7 @@ Ondertekenen is alleen mogelijk met adressen van het type 'legacy'.</translation
     </message>
     <message>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
-        <translation type="unfinished">Deze bewerking heeft uw portemonnee-wachtwoordzin nodig om de portemonnee te ontgrendelen.</translation>
+        <translation type="unfinished">Deze bewerking heeft uw portemonnee wachtwoordzin nodig om de portemonnee te ontgrendelen.</translation>
     </message>
     <message>
         <source>Unlock wallet</source>
@@ -173,7 +173,7 @@ Ondertekenen is alleen mogelijk met adressen van het type 'legacy'.</translation
     </message>
     <message>
         <source>Enter the new passphrase for the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
-        <translation type="unfinished">Voer de neuwe wachtwoordzin in voor de portemonnee.&lt;br/&gt;Gebruik a.u.b. een wachtwoordzin van &lt;b&gt;tien of meer willekeurige karakters&lt;/b&gt;, of &lt;b&gt;acht of meer woorden&lt;/b&gt;.</translation>
+        <translation type="unfinished">Voer de nieuwe wachtwoordzin in voor de portemonnee.&lt;br/&gt;Gebruik a.u.b. een wachtwoordzin van &lt;b&gt;tien of meer willekeurige karakters&lt;/b&gt;, of &lt;b&gt;acht of meer woorden&lt;/b&gt;.</translation>
     </message>
     <message>
         <source>Enter the old passphrase and new passphrase for the wallet.</source>
@@ -197,7 +197,7 @@ Ondertekenen is alleen mogelijk met adressen van het type 'legacy'.</translation
     </message>
     <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <translation type="unfinished">BELANGRIJK: Elke eerder gemaakte backup van uw portemonneebestand dient u te vervangen door het nieuw gegenereerde, versleutelde portemonneebestand. Om veiligheidsredenen zullen eerdere backups van het niet-versleutelde portemonneebestand onbruikbaar worden zodra u uw nieuwe, versleutelde, portemonnee begint te gebruiken.</translation>
+        <translation type="unfinished">BELANGRIJK: Elke eerder gemaakte backup van uw portemonneebestand dient u te vervangen door het nieuw gegenereerde, versleutelde portemonneebestand. Om veiligheidsredenen zullen eerdere backups van het niet versleutelde portemonneebestand onbruikbaar worden zodra u uw nieuwe, versleutelde, portemonnee begint te gebruiken.</translation>
     </message>
     <message>
         <source>Wallet encryption failed</source>
@@ -217,7 +217,7 @@ Ondertekenen is alleen mogelijk met adressen van het type 'legacy'.</translation
     </message>
     <message>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
-        <translation type="unfinished">Het opgegeven wachtwoord voor de portemonnee-ontsleuteling is niet correct.</translation>
+        <translation type="unfinished">Het opgegeven wachtwoord voor de portemonnee ontsleuteling is niet correct.</translation>
     </message>
     <message>
         <source>Wallet passphrase was successfully changed.</source>
@@ -225,7 +225,7 @@ Ondertekenen is alleen mogelijk met adressen van het type 'legacy'.</translation
     </message>
     <message>
         <source>Warning: The Caps Lock key is on!</source>
-        <translation type="unfinished">Waarschuwing: De Caps-Lock-toets staat aan!</translation>
+        <translation type="unfinished">Waarschuwing: De Caps-Lock toets staat aan!</translation>
     </message>
 </context>
 <context>
@@ -286,7 +286,7 @@ Ondertekenen is alleen mogelijk met adressen van het type 'legacy'.</translation
     </message>
     <message>
         <source>Enter a Bitcoin address (e.g. %1)</source>
-        <translation type="unfinished">Voer een Bitcoinadres in (bijv. %1)</translation>
+        <translation type="unfinished">Voer een Bitcoin adres in (bijv. %1)</translation>
     </message>
     <message>
         <source>Unroutable</source>
@@ -452,7 +452,7 @@ Ondertekenen is alleen mogelijk met adressen van het type 'legacy'.</translation
     </message>
     <message>
         <source>Send coins to a Bitcoin address</source>
-        <translation>Verstuur munten naar een Bitcoinadres</translation>
+        <translation>Verstuur munten naar een Bitcoin adres</translation>
     </message>
     <message>
         <source>Backup wallet to another location</source>
@@ -504,7 +504,7 @@ Ondertekenen is alleen mogelijk met adressen van het type 'legacy'.</translation
     </message>
     <message>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
-        <translation>Onderteken berichten met uw Bitcoinadressen om te bewijzen dat u deze adressen bezit</translation>
+        <translation>Onderteken berichten met uw Bitcoin adressen om te bewijzen dat u deze adressen bezit</translation>
     </message>
     <message>
         <source>&amp;Verify message…</source>
@@ -512,7 +512,7 @@ Ondertekenen is alleen mogelijk met adressen van het type 'legacy'.</translation
     </message>
     <message>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
-        <translation>Verifiëer handtekeningen om zeker te zijn dat de berichten zijn ondertekend met de gespecificeerde Bitcoinadressen</translation>
+        <translation>Verifiëer handtekeningen om zeker te zijn dat de berichten zijn ondertekend met de gespecificeerde Bitcoin adressen</translation>
     </message>
     <message>
         <source>&amp;Load PSBT from file…</source>
@@ -635,11 +635,11 @@ Ondertekenen is alleen mogelijk met adressen van het type 'legacy'.</translation
     </message>
     <message>
         <source>Load Partially Signed Bitcoin Transaction</source>
-        <translation type="unfinished">Laad gedeeltelijk ondertekende Bitcoin-transactie</translation>
+        <translation type="unfinished">Laad gedeeltelijk ondertekende Bitcoin transactie</translation>
     </message>
     <message>
         <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
-        <translation type="unfinished">Laad gedeeltelijk ondertekende Bitcoin-transactie vanaf het klembord</translation>
+        <translation type="unfinished">Laad gedeeltelijk ondertekende Bitcoin transactie vanaf het klembord</translation>
     </message>
     <message>
         <source>Node window</source>
@@ -714,7 +714,7 @@ Ondertekenen is alleen mogelijk met adressen van het type 'legacy'.</translation
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
             <numerusform>%n actieve verbinding(en) met Bitcoinnetwerk.</numerusform>
-            <numerusform>%n actieve verbinding(en) met Bitcoinnetwerk.</numerusform>
+            <numerusform>%n actieve verbinding(en) met Bitcoin netwerk.</numerusform>
         </translation>
     </message>
     <message>
@@ -941,7 +941,7 @@ Ondertekenen is alleen mogelijk met adressen van het type 'legacy'.</translation
     </message>
     <message>
         <source>This label turns red if any recipient receives an amount smaller than the current dust threshold.</source>
-        <translation type="unfinished">Dit label wordt rood, als een ontvanger een bedrag van minder dan de huidige dust-drempel gekregen heeft.</translation>
+        <translation type="unfinished">Dit label wordt rood, als een ontvanger een bedrag van minder dan de huidige dust drempel gekregen heeft.</translation>
     </message>
     <message>
         <source>Can vary +/- %1 satoshi(s) per input.</source>
@@ -1126,7 +1126,7 @@ Dit is ideaal voor alleen-lezen portommonees.</translation>
     </message>
     <message>
         <source>The entered address "%1" is not a valid Bitcoin address.</source>
-        <translation type="unfinished">Het opgegeven adres "%1" is een ongeldig Bitcoinadres.</translation>
+        <translation type="unfinished">Het opgegeven adres "%1" is een ongeldig Bitcoin adres.</translation>
     </message>
     <message>
         <source>Address "%1" already exists as a receiving address with label "%2" and so cannot be added as a sending address.</source>
@@ -1293,7 +1293,7 @@ Dit is ideaal voor alleen-lezen portommonees.</translation>
     </message>
     <message>
         <source>Recent transactions may not yet be visible, and therefore your wallet's balance might be incorrect. This information will be correct once your wallet has finished synchronizing with the bitcoin network, as detailed below.</source>
-        <translation type="unfinished">Recente transacties zijn mogelijk nog niet zichtbaar. De balans van de portemonnee is daarom mogelijk niet correct. Deze informatie is correct zodra de synchronisatie met het Bitcoin-netwerk is voltooid, zoals onderaan beschreven.</translation>
+        <translation type="unfinished">Recente transacties zijn mogelijk nog niet zichtbaar. De balans van de portemonnee is daarom mogelijk niet correct. Deze informatie is correct zodra de portemonnee gelijk loopt met het Bitcoin netwerk, zoals onderaan beschreven.</translation>
     </message>
     <message>
         <source>Attempting to spend bitcoins that are affected by not-yet-displayed transactions will not be accepted by the network.</source>
@@ -1325,7 +1325,7 @@ Dit is ideaal voor alleen-lezen portommonees.</translation>
     </message>
     <message>
         <source>Estimated time left until synced</source>
-        <translation type="unfinished">Geschatte tijd tot synchronisatie voltooid</translation>
+        <translation type="unfinished">Geschatte tijd totdat uw portemonnee gelijk loopt met het bitcoin netwerk.</translation>
     </message>
     <message>
         <source>Hide</source>
@@ -1340,13 +1340,6 @@ Dit is ideaal voor alleen-lezen portommonees.</translation>
         <translation type="unfinished">Onbekend. Blockheaders synchroniseren (%1, %2%)...</translation>
     </message>
 </context>
-<context>
-    <name>OpenURIDialog</name>
-    <message>
-        <source>Open bitcoin URI</source>
-        <translation type="unfinished">Open bitcoin-URI</translation>
-    </message>
-    </context>
 <context>
     <name>OptionsDialog</name>
     <message>
@@ -1451,7 +1444,7 @@ Dit is ideaal voor alleen-lezen portommonees.</translation>
     </message>
     <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
-        <translation>Open de Bitcoinpoort automatisch op de router. Dit werkt alleen als de router UPnP ondersteunt en het aanstaat.</translation>
+        <translation>Open de Bitcoin poort automatisch op de router. Dit werkt alleen als de router UPnP ondersteunt en het aanstaat.</translation>
     </message>
     <message>
         <source>Map port using &amp;UPnP</source>
@@ -1543,7 +1536,7 @@ Dit is ideaal voor alleen-lezen portommonees.</translation>
     </message>
     <message>
         <source>Connect to the Bitcoin network through a separate SOCKS5 proxy for Tor onion services.</source>
-        <translation type="unfinished">Maak verbinding met het Bitcoin-netwerk via een aparte SOCKS5-proxy voor Tor Onion-services.</translation>
+        <translation type="unfinished">Maak verbinding met het Bitcoin netwerk via een aparte SOCKS5-proxy voor Tor Onion-services.</translation>
     </message>
     <message>
         <source>Use separate SOCKS&amp;5 proxy to reach peers via Tor onion services:</source>
@@ -1635,7 +1628,7 @@ Dit is ideaal voor alleen-lezen portommonees.</translation>
     </message>
     <message>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
-        <translation>De weergegeven informatie kan verouderd zijn. Uw portemonnee synchroniseert automatisch met het Bitcoinnetwerk nadat een verbinding is gelegd, maar dit proces is nog niet voltooid.</translation>
+        <translation>De weergegeven informatie kan verouderd zijn. Uw portemonnee synchroniseert automatisch met het Bitcoin netwerk nadat een verbinding is gelegd, maar dit proces is nog niet voltooid.</translation>
     </message>
     <message>
         <source>Watch-only:</source>
@@ -2281,7 +2274,7 @@ Voor meer informatie over het gebruik van deze console, type %6.
     </message>
     <message>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
-        <translation type="unfinished">Een optioneel bericht om bij te voegen aan het betalingsverzoek, welke zal getoond worden wanneer het verzoek is geopend. Opmerking: Het bericht zal niet worden verzonden met de betaling over het Bitcoinnetwerk.</translation>
+        <translation type="unfinished">Een optioneel bericht om bij te voegen aan het betalingsverzoek, welke zal getoond worden wanneer het verzoek is geopend. Opmerking: Het bericht zal niet worden verzonden met de betaling over het Bitcoin netwerk.</translation>
     </message>
     <message>
         <source>An optional label to associate with the new receiving address.</source>
@@ -2644,7 +2637,7 @@ Notitie: Omdat de vergoeding per byte wordt gerekend, zal een vergoeding van "10
     </message>
     <message>
         <source>Creates a Partially Signed Bitcoin Transaction (PSBT) for use with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
-        <translation type="unfinished">Creëert een Partially Signed Bitcoin Transaction (PSBT) om te gebruiken met b.v. een offline %1 wallet, of een PSBT-compatibele hardware wallet.</translation>
+        <translation type="unfinished">Creëert een Gedeeltelijk Getekende Bitcoin Transactie (PSBT) om te gebruiken met b.v. een offline %1 wallet, of een PSBT-compatibele hardware wallet.</translation>
     </message>
     <message>
         <source> from wallet '%1'</source>
@@ -2791,7 +2784,7 @@ Vb. een offline %1 portemonee, of een PSBT-combatiebele hardware portemonee.</tr
     </message>
     <message>
         <source>Warning: Invalid Bitcoin address</source>
-        <translation type="unfinished">Waarschuwing: Ongeldig Bitcoinadres</translation>
+        <translation type="unfinished">Waarschuwing: Ongeldig Bitcoin adres</translation>
     </message>
     <message>
         <source>Warning: Unknown change address</source>
@@ -2870,7 +2863,7 @@ Vb. een offline %1 portemonee, of een PSBT-combatiebele hardware portemonee.</tr
     </message>
     <message>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
-        <translation type="unfinished">Een bericht dat werd toegevoegd aan de bitcoin: URI welke wordt opgeslagen met de transactie ter referentie. Opmerking: Dit bericht zal niet worden verzonden over het Bitcoinnetwerk.</translation>
+        <translation type="unfinished">Een bericht dat werd toegevoegd aan de bitcoin: URI welke wordt opgeslagen met de transactie ter referentie. Opmerking: Dit bericht zal niet worden verzonden over het Bitcoin netwerk.</translation>
     </message>
     <message>
         <source>Pay To:</source>
@@ -2893,7 +2886,7 @@ Vb. een offline %1 portemonee, of een PSBT-combatiebele hardware portemonee.</tr
     </message>
     <message>
         <source>The Bitcoin address to sign the message with</source>
-        <translation type="unfinished">Het Bitcoinadres om bericht mee te ondertekenen</translation>
+        <translation type="unfinished">Het Bitcoin adres om bericht mee te ondertekenen</translation>
     </message>
     <message>
         <source>Choose previously used address</source>
@@ -2917,7 +2910,7 @@ Vb. een offline %1 portemonee, of een PSBT-combatiebele hardware portemonee.</tr
     </message>
     <message>
         <source>Sign the message to prove you own this Bitcoin address</source>
-        <translation>Onderteken een bericht om te bewijzen dat u een bepaald Bitcoinadres bezit</translation>
+        <translation>Onderteken een bericht om te bewijzen dat u een bepaald Bitcoin adres bezit</translation>
     </message>
     <message>
         <source>Sign &amp;Message</source>
@@ -2941,7 +2934,7 @@ Vb. een offline %1 portemonee, of een PSBT-combatiebele hardware portemonee.</tr
     </message>
     <message>
         <source>The Bitcoin address the message was signed with</source>
-        <translation type="unfinished">Het Bitcoinadres waarmee het bericht ondertekend is</translation>
+        <translation type="unfinished">Het Bitcoin adres waarmee het bericht ondertekend is</translation>
     </message>
     <message>
         <source>The signed message to verify</source>
@@ -2953,7 +2946,7 @@ Vb. een offline %1 portemonee, of een PSBT-combatiebele hardware portemonee.</tr
     </message>
     <message>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
-        <translation>Controleer een bericht om te verifiëren dat het gespecificeerde Bitcoinadres het bericht heeft ondertekend.</translation>
+        <translation>Controleer een bericht om te verifiëren dat het gespecificeerde Bitcoin adres het bericht heeft ondertekend.</translation>
     </message>
     <message>
         <source>Verify &amp;Message</source>
@@ -2981,7 +2974,7 @@ Vb. een offline %1 portemonee, of een PSBT-combatiebele hardware portemonee.</tr
     </message>
     <message>
         <source>Wallet unlock was cancelled.</source>
-        <translation type="unfinished">Portemonnee-ontsleuteling is geannuleerd.</translation>
+        <translation type="unfinished">Portemonnee ontsleuteling is geannuleerd.</translation>
     </message>
     <message>
         <source>No error</source>
@@ -3592,7 +3585,7 @@ Ga naar Bestand &gt; Open portemonee om er één te openen.
     </message>
     <message>
         <source>%s corrupt. Try using the wallet tool bitcoin-wallet to salvage or restoring a backup.</source>
-        <translation type="unfinished">%s is corrupt. Probeer de portemonnee tool bitcoin-portemonnee om het probleem op te lossen of een backup terug te zetten.</translation>
+        <translation type="unfinished">%s is corrupt. Probeer de portemonnee tool bitcoin-wallet om het probleem op te lossen of een backup terug te zetten.</translation>
     </message>
     <message>
         <source>-maxtxfee is set very high! Fees this large could be paid on a single transaction.</source>
@@ -3684,7 +3677,7 @@ Ga naar Bestand &gt; Open portemonee om er één te openen.
     </message>
     <message>
         <source>Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of pruned node)</source>
-        <translation type="unfinished">Prune: laatste wallet synchronisatie gaat verder terug dan de middels -prune beperkte data. U moet -reindex gebruiken (downloadt opnieuw de gehele blokketen voor een pruned node)</translation>
+        <translation type="unfinished">Prune: laatste wallet synchronisatie gaat verder terug dan de middels beperkte data. U moet -reindex gebruiken (downloadt opnieuw de gehele blokketen voor een pruned node)</translation>
     </message>
     <message>
         <source>SQLiteDatabase: Unknown sqlite wallet schema version %d. Only version %d is supported</source>

--- a/src/qt/locale/bitcoin_pl.ts
+++ b/src/qt/locale/bitcoin_pl.ts
@@ -7,7 +7,7 @@
     </message>
     <message>
         <source>Create a new address</source>
-        <translation>Stwórz nowy portfel</translation>
+        <translation>Utwórz nowy adres</translation>
     </message>
     <message>
         <source>&amp;New</source>
@@ -15,7 +15,7 @@
     </message>
     <message>
         <source>Copy the currently selected address to the system clipboard</source>
-        <translation>Skopiuj wybrany adres do schowka</translation>
+        <translation>Skopiuj wybrany adres do schowka systemowego</translation>
     </message>
     <message>
         <source>&amp;Copy</source>
@@ -27,11 +27,11 @@
     </message>
     <message>
         <source>Delete the currently selected address from the list</source>
-        <translation>Usuń zaznaczony adres z listy</translation>
+        <translation>Usuń aktualnie wybrany adres z listy</translation>
     </message>
     <message>
         <source>Enter address or label to search</source>
-        <translation type="unfinished">Wprowadź adres albo etykietę aby wyszukać</translation>
+        <translation type="unfinished">Wprowadź adres lub etykietę aby wyszukać</translation>
     </message>
     <message>
         <source>Export the data in the current tab to a file</source>
@@ -47,41 +47,41 @@
     </message>
     <message>
         <source>Choose the address to send coins to</source>
-        <translation type="unfinished">Wybierz adres, na który chcesz wysłać monety</translation>
+        <translation type="unfinished">Wybierz adres, na który chcesz wysyłać monety</translation>
     </message>
     <message>
         <source>Choose the address to receive coins with</source>
-        <translation type="unfinished">Wybierz adres, na który chcesz otrzymać monety</translation>
+        <translation type="unfinished">Wybierz adres, na który chcesz otrzymywać monety</translation>
     </message>
     <message>
         <source>C&amp;hoose</source>
-        <translation type="unfinished">W&amp;ybierz</translation>
+        <translation type="unfinished">Wybierz</translation>
     </message>
     <message>
         <source>Sending addresses</source>
-        <translation type="unfinished">Adresy wysyłania</translation>
+        <translation type="unfinished">&amp;Adresy wysyłania8f0451c0-ec7d-4357-a370-eff72fb0685f</translation>
     </message>
     <message>
         <source>Receiving addresses</source>
-        <translation type="unfinished">Adresy odbioru</translation>
+        <translation type="unfinished">Odbierające adresy</translation>
     </message>
     <message>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
-        <translation type="unfinished">To są twoje adresy Bitcoin do wysyłania płatności. Zawsze sprawdź kwotę i adres odbiorcy przed wysłaniem monet.</translation>
+        <translation type="unfinished">Tutaj znajdują się adresy Bitcoin na które wysyłasz płatności. Zawsze sprawdzaj ilość i adres odbiorcy przed wysyłką monet. </translation>
     </message>
     <message>
         <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
 Signing is only possible with addresses of the type 'legacy'.</source>
-        <translation type="unfinished">To są twoje adresy Bitcoin do otrzymywania płatności. Użyj przycisku „Utwórz nowy adres odbiorcy” na karcie odbioru, aby utworzyć nowe adresy.
-Podpisywanie jest możliwe tylko z adresami typu „legacy”.</translation>
+        <translation type="unfinished">To są twoje adresy Bitcoin do otrzymywania płatności. Użyj przycisku 'Utwórz nowy adres odbioru' na karcie odbioru, aby utworzyć nowe adresy.
+Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
     </message>
     <message>
         <source>&amp;Copy Address</source>
-        <translation type="unfinished">&amp;Kopiuj adres</translation>
+        <translation type="unfinished">Kopiuj adres</translation>
     </message>
     <message>
         <source>Copy &amp;Label</source>
-        <translation type="unfinished">Kopiuj &amp;Etykietę</translation>
+        <translation type="unfinished">Kopiuj etykietę</translation>
     </message>
     <message>
         <source>&amp;Edit</source>
@@ -89,12 +89,12 @@ Podpisywanie jest możliwe tylko z adresami typu „legacy”.</translation>
     </message>
     <message>
         <source>Export Address List</source>
-        <translation type="unfinished">Eksportuj listę adresów</translation>
+        <translation type="unfinished">Eksportuj listę adresów </translation>
     </message>
     <message>
         <source>Comma separated file</source>
         <extracomment>Expanded name of the CSV file format. See https://en.wikipedia.org/wiki/Comma-separated_values</extracomment>
-        <translation type="unfinished">Plik rozdzielany przecinkami</translation>
+        <translation type="unfinished">Plik *.CSV rozdzielany pzrecinkami</translation>
     </message>
     <message>
         <source>There was an error trying to save the address list to %1. Please try again.</source>
@@ -103,7 +103,7 @@ Podpisywanie jest możliwe tylko z adresami typu „legacy”.</translation>
     </message>
     <message>
         <source>Exporting Failed</source>
-        <translation type="unfinished">Eksportowanie nie powiodło się</translation>
+        <translation type="unfinished"> Eksportowanie nie powiodło się </translation>
     </message>
 </context>
 <context>
@@ -125,11 +125,11 @@ Podpisywanie jest możliwe tylko z adresami typu „legacy”.</translation>
     <name>AskPassphraseDialog</name>
     <message>
         <source>Passphrase Dialog</source>
-        <translation>Okienko Hasła</translation>
+        <translation> Okienko Hasła </translation>
     </message>
     <message>
         <source>Enter passphrase</source>
-        <translation>Wpisz hasło</translation>
+        <translation> Wpisz hasło </translation>
     </message>
     <message>
         <source>New passphrase</source>
@@ -137,19 +137,19 @@ Podpisywanie jest możliwe tylko z adresami typu „legacy”.</translation>
     </message>
     <message>
         <source>Repeat new passphrase</source>
-        <translation>Powtórz nowe hasło</translation>
+        <translation> Powtórz nowe hasło </translation>
     </message>
     <message>
         <source>Show passphrase</source>
-        <translation type="unfinished">Pokaż hasło</translation>
+        <translation type="unfinished">Pokaż hasło </translation>
     </message>
     <message>
         <source>Encrypt wallet</source>
-        <translation type="unfinished">Zaszyfruj portfel</translation>
+        <translation type="unfinished">Zaszyfruj portfel </translation>
     </message>
     <message>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
-        <translation type="unfinished">Ta operacja wymaga hasła do portfela aby odblokować portfel.</translation>
+        <translation type="unfinished">Ta operacja wymaga hasła do portfela aby odblokować portfel. </translation>
     </message>
     <message>
         <source>Unlock wallet</source>
@@ -157,39 +157,39 @@ Podpisywanie jest możliwe tylko z adresami typu „legacy”.</translation>
     </message>
     <message>
         <source>Change passphrase</source>
-        <translation type="unfinished">Zmień hasło</translation>
+        <translation type="unfinished"> Zmień hasło </translation>
     </message>
     <message>
         <source>Confirm wallet encryption</source>
-        <translation type="unfinished">Potwierdź szyfrowanie portfela</translation>
+        <translation type="unfinished">Potwierdź szyfrowanie portfela </translation>
     </message>
     <message>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
-        <translation type="unfinished">Uwaga: jeśli zaszyfrujesz swój portfel i zgubisz hasło &lt;b&gt;STRACISZ WSZYSTKIE SWOJE BITCOINY&lt;/b&gt;!</translation>
+        <translation type="unfinished">Ostrzeżenie: Jeśli zaszyfrujesz swój portfel i zgubisz hasło - &lt;b&gt;STRACISZ WSZYSTKIE SWOJE BITCONY&lt;/b&gt;!</translation>
     </message>
     <message>
         <source>Are you sure you wish to encrypt your wallet?</source>
-        <translation type="unfinished">Jesteś pewien, że chcesz zaszyfrować swój portfel?</translation>
+        <translation type="unfinished">Jesteś pewien, że chcesz zaszyfrować swój portfel? </translation>
     </message>
     <message>
         <source>Wallet encrypted</source>
-        <translation type="unfinished">Portfel zaszyfrowany</translation>
+        <translation type="unfinished">Portfel zaszyfrowany </translation>
     </message>
     <message>
         <source>Enter the new passphrase for the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
-        <translation type="unfinished">Wprowadź nowe hasło do portfela.&lt;br/&gt;Hasło powinno zawierać  &lt;b&gt;co najmniej 10 losowych znaków&lt;/b&gt; lub &lt;b&gt;co najmniej osiem słów&lt;/b&gt;.</translation>
+        <translation type="unfinished">Wprowadź nowe hasło do portfela.&lt;br/&gt; Hasło powinno zawierać co najmniej &lt;b&gt;10 losowych znaków&lt;/b&gt; lub&lt;b&gt; co najmniej 8 słów&lt;/b&gt;.</translation>
     </message>
     <message>
         <source>Enter the old passphrase and new passphrase for the wallet.</source>
-        <translation type="unfinished">Wprowadź stare i nowe hasło dla portfela.</translation>
+        <translation type="unfinished">Wprowadź stare i nowe hasło portfela. </translation>
     </message>
     <message>
         <source>Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
-        <translation type="unfinished">Zwróć uwagę, że zaszyfrowanie portfela nie zabezpieczy się w pełni przed kradzieżą przez malware jakie może zainfekować twój komputer.</translation>
+        <translation type="unfinished">Zwróć uwagę, że zaszyfrowanie portfela nie zabezpieczy się w pełni przed kradzieżą przez malware jakie może zainfekować twój komputer. </translation>
     </message>
     <message>
         <source>Wallet to be encrypted</source>
-        <translation type="unfinished">Portfel do zaszyfrowania</translation>
+        <translation type="unfinished"> Portfel do zaszyfrowania </translation>
     </message>
     <message>
         <source>Your wallet is about to be encrypted. </source>
@@ -229,7 +229,7 @@ Podpisywanie jest możliwe tylko z adresami typu „legacy”.</translation>
     </message>
     <message>
         <source>Warning: The Caps Lock key is on!</source>
-        <translation type="unfinished">Ostrzeżenie: Caps Lock jest włączony!</translation>
+        <translation type="unfinished">Uwaga: klawisz Caps Lock jest włączony!</translation>
     </message>
 </context>
 <context>
@@ -246,14 +246,22 @@ Podpisywanie jest możliwe tylko z adresami typu „legacy”.</translation>
 <context>
     <name>BitcoinApplication</name>
     <message>
+        <source>Runaway exception</source>
+        <translation type="unfinished">Błąd zapisu do portfela</translation>
+    </message>
+    <message>
         <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
-        <translation type="unfinished">Wystąpił fatalny błąd. %1 nie może być kontynuowany i zostanie zakończony.</translation>
+        <translation type="unfinished">Wystąpił krytyczny błąd. %1 nie może dalej bezpiecznie pracować i zostanie zakończony.</translation>
     </message>
     <message>
         <source>Internal error</source>
         <translation type="unfinished">Błąd wewnętrzny</translation>
     </message>
-    </context>
+    <message>
+        <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
+        <translation type="unfinished">Wystąpił krytyczny błąd. %1 będzie próbować bezpiecznie pracować. Jest to niespodziewany błąd, który może zostać zgłoszony w sposób opisany poniżej.</translation>
+    </message>
+</context>
 <context>
     <name>QObject</name>
     <message>
@@ -277,40 +285,16 @@ Podpisywanie jest możliwe tylko z adresami typu „legacy”.</translation>
         <translation type="unfinished">%1 jeszcze się bezpiecznie nie zamknął...</translation>
     </message>
     <message>
-        <source>unknown</source>
-        <translation type="unfinished">nieznane</translation>
-    </message>
-    <message>
         <source>Amount</source>
         <translation type="unfinished">Kwota</translation>
     </message>
     <message>
-        <source>Enter a Bitcoin address (e.g. %1)</source>
-        <translation type="unfinished">Wprowadź adres bitcoinowy (np. %1)</translation>
+        <source>Full Relay</source>
+        <translation type="unfinished">Pełny Przekaźnik</translation>
     </message>
     <message>
-        <source>Internal</source>
-        <translation type="unfinished">Wewnętrzny</translation>
-    </message>
-    <message>
-        <source>Inbound</source>
-        <translation type="unfinished">Wejściowy</translation>
-    </message>
-    <message>
-        <source>Outbound</source>
-        <translation type="unfinished">Wyjściowy</translation>
-    </message>
-    <message>
-        <source>Manual</source>
-        <translation type="unfinished">Ręczny</translation>
-    </message>
-    <message>
-        <source>None</source>
-        <translation type="unfinished">Żaden</translation>
-    </message>
-    <message>
-        <source>N/A</source>
-        <translation type="unfinished">NIEDOSTĘPNE</translation>
+        <source>Block Relay</source>
+        <translation type="unfinished">Przekaźnik Blokowy</translation>
     </message>
     <message numerus="yes">
         <source>%n second(s)</source>
@@ -351,10 +335,6 @@ Podpisywanie jest możliwe tylko z adresami typu „legacy”.</translation>
             <numerusform />
             <numerusform />
         </translation>
-    </message>
-    <message>
-        <source>%1 and %2</source>
-        <translation type="unfinished">%1 i %2</translation>
     </message>
     <message numerus="yes">
         <source>%n year(s)</source>
@@ -430,7 +410,7 @@ Podpisywanie jest możliwe tylko z adresami typu „legacy”.</translation>
     </message>
     <message>
         <source>Send coins to a Bitcoin address</source>
-        <translation>Wyślij monety na adres bitcoinowy</translation>
+        <translation>Wyślij monety na adres Bitcoin</translation>
     </message>
     <message>
         <source>Backup wallet to another location</source>
@@ -462,19 +442,55 @@ Podpisywanie jest możliwe tylko z adresami typu „legacy”.</translation>
     </message>
     <message>
         <source>&amp;Encrypt Wallet…</source>
-        <translation type="unfinished">&amp;Zaszyfruj portfel</translation>
+        <translation type="unfinished">Zaszyfruj portf&amp;el...</translation>
     </message>
     <message>
         <source>Encrypt the private keys that belong to your wallet</source>
-        <translation>Szyfruj klucze prywatne, które są w twoim portfelu</translation>
+        <translation>Zaszyfruj klucz prywatny należący do twojego portfela</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation type="unfinished">Utwórz kopię zapasową portfela...</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation type="unfinished">&amp;Zmień hasło...</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation type="unfinished">Podpisz &amp;wiadomość...</translation>
     </message>
     <message>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
-        <translation>Podpisz wiadomości swoim adresem aby udowodnić jego posiadanie</translation>
+        <translation>Podpisz wiadomości swoim adresem, aby udowodnić jego posiadanie</translation>
+    </message>
+    <message>
+        <source>&amp;Verify message…</source>
+        <translation type="unfinished">&amp;Zweryfikuj wiadomość...</translation>
     </message>
     <message>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
-        <translation>Zweryfikuj wiadomość,  aby upewnić się, że została podpisana podanym adresem bitcoinowym.</translation>
+        <translation>Zweryfikuj wiadomości, aby upewnić się, że zostały podpisane przy użyciu określonych adresów Bitcoin</translation>
+    </message>
+    <message>
+        <source>&amp;Load PSBT from file…</source>
+        <translation type="unfinished">Wczytaj PSBT z pliku...</translation>
+    </message>
+    <message>
+        <source>Open &amp;URI…</source>
+        <translation type="unfinished">Otwórz &amp;URI...</translation>
+    </message>
+    <message>
+        <source>Close Wallet…</source>
+        <translation type="unfinished">Zamknij portfel...</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation type="unfinished">Utwórz portfel...</translation>
+    </message>
+    <message>
+        <source>Close All Wallets…</source>
+        <translation type="unfinished">Zamknij wszystkie portfele ...</translation>
     </message>
     <message>
         <source>&amp;File</source>
@@ -482,31 +498,43 @@ Podpisywanie jest możliwe tylko z adresami typu „legacy”.</translation>
     </message>
     <message>
         <source>&amp;Settings</source>
-        <translation>P&amp;referencje</translation>
+        <translation>U&amp;stawienia</translation>
     </message>
     <message>
         <source>&amp;Help</source>
-        <translation>Pomo&amp;c</translation>
+        <translation>Pomoc</translation>
     </message>
     <message>
         <source>Tabs toolbar</source>
         <translation>Pasek zakładek</translation>
     </message>
     <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation type="unfinished">Synchronizuję nagłówki (%1%)…</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation type="unfinished">Synchronizacja z siecią...</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation type="unfinished">Indeksowanie bloków...</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation type="unfinished">Przetwarzanie bloków...</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation type="unfinished">Ponowne indeksowanie bloków...</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation type="unfinished">Łączenie z uczestnikami sieci...</translation>
+    </message>
+    <message>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
-        <translation type="unfinished">Żądaj płatności (generuje kod QR oraz bitcoinowe URI)</translation>
-    </message>
-    <message>
-        <source>Show the list of used sending addresses and labels</source>
-        <translation type="unfinished">Pokaż listę adresów i etykiet użytych do wysyłania</translation>
-    </message>
-    <message>
-        <source>Show the list of used receiving addresses and labels</source>
-        <translation type="unfinished">Pokaż listę adresów i etykiet użytych do odbierania</translation>
-    </message>
-    <message>
-        <source>&amp;Command-line options</source>
-        <translation type="unfinished">&amp;Opcje linii komend</translation>
+        <translation type="unfinished">Zażądaj płatności (wygeneruj QE code i bitcoin: URI)</translation>
     </message>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
@@ -517,16 +545,8 @@ Podpisywanie jest możliwe tylko z adresami typu „legacy”.</translation>
         </translation>
     </message>
     <message>
-        <source>%1 behind</source>
-        <translation>%1 za</translation>
-    </message>
-    <message>
-        <source>Last received block was generated %1 ago.</source>
-        <translation>Ostatni otrzymany blok został wygenerowany %1 temu.</translation>
-    </message>
-    <message>
-        <source>Transactions after this will not yet be visible.</source>
-        <translation>Transakcje po tym momencie nie będą jeszcze widoczne.</translation>
+        <source>Catching up…</source>
+        <translation type="unfinished">Synchronizuję...</translation>
     </message>
     <message>
         <source>Error</source>
@@ -545,32 +565,8 @@ Podpisywanie jest możliwe tylko z adresami typu „legacy”.</translation>
         <translation>Aktualny</translation>
     </message>
     <message>
-        <source>Load Partially Signed Bitcoin Transaction</source>
-        <translation type="unfinished">Załaduj częściowo podpisaną transakcję Bitcoin</translation>
-    </message>
-    <message>
-        <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
-        <translation type="unfinished">Załaduj częściowo podpisaną transakcję Bitcoin ze schowka</translation>
-    </message>
-    <message>
-        <source>Node window</source>
-        <translation type="unfinished">Okno węzła</translation>
-    </message>
-    <message>
-        <source>Open node debugging and diagnostic console</source>
-        <translation type="unfinished">Otwórz konsolę diagnostyczną i debugowanie węzłów</translation>
-    </message>
-    <message>
-        <source>&amp;Sending addresses</source>
-        <translation type="unfinished">&amp;Adresy wysyłania</translation>
-    </message>
-    <message>
-        <source>&amp;Receiving addresses</source>
-        <translation type="unfinished">&amp;Adresy odbioru</translation>
-    </message>
-    <message>
         <source>Open a bitcoin: URI</source>
-        <translation type="unfinished">Otwórz URI</translation>
+        <translation type="unfinished">Otwórz bitcoin: URI</translation>
     </message>
     <message>
         <source>Open Wallet</source>
@@ -589,18 +585,6 @@ Podpisywanie jest możliwe tylko z adresami typu „legacy”.</translation>
         <translation type="unfinished">Zamknij wszystkie portfele</translation>
     </message>
     <message>
-        <source>Show the %1 help message to get a list with possible Bitcoin command-line options</source>
-        <translation type="unfinished">Pokaż pomoc %1 aby zobaczyć listę wszystkich opcji lnii poleceń.</translation>
-    </message>
-    <message>
-        <source>&amp;Mask values</source>
-        <translation type="unfinished">&amp;Schowaj wartości</translation>
-    </message>
-    <message>
-        <source>Mask the values in the Overview tab</source>
-        <translation type="unfinished">Schowaj wartości w zakładce Podsumowanie</translation>
-    </message>
-    <message>
         <source>default wallet</source>
         <translation type="unfinished">domyślny portfel</translation>
     </message>
@@ -609,20 +593,12 @@ Podpisywanie jest możliwe tylko z adresami typu „legacy”.</translation>
         <translation type="unfinished">Brak dostępnych portfeli</translation>
     </message>
     <message>
-        <source>&amp;Window</source>
-        <translation type="unfinished">&amp;Okno</translation>
-    </message>
-    <message>
         <source>Minimize</source>
         <translation type="unfinished">Minimalizuj</translation>
     </message>
     <message>
         <source>Zoom</source>
         <translation type="unfinished">Powiększ</translation>
-    </message>
-    <message>
-        <source>Main Window</source>
-        <translation type="unfinished">Okno główne</translation>
     </message>
     <message>
         <source>%1 client</source>
@@ -636,6 +612,26 @@ Podpisywanie jest możliwe tylko z adresami typu „legacy”.</translation>
             <numerusform />
             <numerusform />
         </translation>
+    </message>
+    <message>
+        <source>Click for more actions.</source>
+        <extracomment>A substring of the tooltip. "More actions" are available via the context menu.</extracomment>
+        <translation type="unfinished">Kliknij po więcej funkcji.</translation>
+    </message>
+    <message>
+        <source>Show Peers tab</source>
+        <extracomment>A context menu item. The "Peers tab" is an element of the "Node window".</extracomment>
+        <translation type="unfinished">Wyświetl połączenia</translation>
+    </message>
+    <message>
+        <source>Disable network activity</source>
+        <extracomment>A context menu item.</extracomment>
+        <translation type="unfinished">Wyłącz aktywność sieciową</translation>
+    </message>
+    <message>
+        <source>Enable network activity</source>
+        <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
+        <translation type="unfinished">Włącz aktywność sieciową</translation>
     </message>
     <message>
         <source>Error: %1</source>
@@ -690,51 +686,12 @@ Podpisywanie jest możliwe tylko z adresami typu „legacy”.</translation>
         <translation>Transakcja przychodząca</translation>
     </message>
     <message>
-        <source>HD key generation is &lt;b&gt;enabled&lt;/b&gt;</source>
-        <translation type="unfinished">Generowanie kluczy HD jest &lt;b&gt;włączone&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>HD key generation is &lt;b&gt;disabled&lt;/b&gt;</source>
-        <translation type="unfinished">Generowanie kluczy HD jest &lt;b&gt;wyłączone&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>Private key &lt;b&gt;disabled&lt;/b&gt;</source>
-        <translation type="unfinished">Klucz prywatny&lt;b&gt;dezaktywowany&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
-        <translation>Portfel jest &lt;b&gt;zaszyfrowany&lt;/b&gt; i obecnie &lt;b&gt;odblokowany&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
-        <translation>Portfel jest &lt;b&gt;zaszyfrowany&lt;/b&gt; i obecnie &lt;b&gt;zablokowany&lt;/b&gt;</translation>
-    </message>
-    <message>
         <source>Original message:</source>
-        <translation type="unfinished">Wiadomość oryginalna:</translation>
-    </message>
-</context>
-<context>
-    <name>UnitDisplayStatusBarControl</name>
-    <message>
-        <source>Unit to show amounts in. Click to select another unit.</source>
-        <translation type="unfinished">Jednostka w jakiej pokazywane są kwoty. Kliknij aby wybrać inną.</translation>
+        <translation type="unfinished">Orginalna wiadomość:</translation>
     </message>
 </context>
 <context>
     <name>CoinControlDialog</name>
-    <message>
-        <source>Coin Selection</source>
-        <translation type="unfinished">Wybór monet</translation>
-    </message>
-    <message>
-        <source>Quantity:</source>
-        <translation type="unfinished">Ilość:</translation>
-    </message>
-    <message>
-        <source>Bytes:</source>
-        <translation type="unfinished">Bajtów:</translation>
-    </message>
     <message>
         <source>Amount:</source>
         <translation type="unfinished">Kwota:</translation>
@@ -744,40 +701,20 @@ Podpisywanie jest możliwe tylko z adresami typu „legacy”.</translation>
         <translation type="unfinished">Opłata:</translation>
     </message>
     <message>
-        <source>Dust:</source>
-        <translation type="unfinished">Pył:</translation>
-    </message>
-    <message>
         <source>After Fee:</source>
         <translation type="unfinished">Po opłacie:</translation>
     </message>
     <message>
         <source>Change:</source>
-        <translation type="unfinished">Reszta:</translation>
+        <translation type="unfinished">Zmiana:</translation>
     </message>
     <message>
         <source>(un)select all</source>
-        <translation type="unfinished">Zaznacz/Odznacz wszystko</translation>
-    </message>
-    <message>
-        <source>Tree mode</source>
-        <translation type="unfinished">Widok drzewa</translation>
-    </message>
-    <message>
-        <source>List mode</source>
-        <translation type="unfinished">Widok listy</translation>
+        <translation type="unfinished">zaznacz/odznacz wszytsko</translation>
     </message>
     <message>
         <source>Amount</source>
         <translation type="unfinished">Kwota</translation>
-    </message>
-    <message>
-        <source>Received with label</source>
-        <translation type="unfinished">Otrzymano z opisem</translation>
-    </message>
-    <message>
-        <source>Received with address</source>
-        <translation type="unfinished">Otrzymano z adresem</translation>
     </message>
     <message>
         <source>Date</source>
@@ -785,43 +722,43 @@ Podpisywanie jest możliwe tylko z adresami typu „legacy”.</translation>
     </message>
     <message>
         <source>Confirmations</source>
-        <translation type="unfinished">Potwierdzenia</translation>
+        <translation type="unfinished">Potwierdzenie</translation>
     </message>
     <message>
         <source>Confirmed</source>
-        <translation type="unfinished">Potwierdzony</translation>
+        <translation type="unfinished">Potwerdzone</translation>
     </message>
     <message>
-        <source>Copy amount</source>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">Kopiuj adres</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Kopiuj etykietę</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
         <translation type="unfinished">Kopiuj kwotę</translation>
     </message>
     <message>
-        <source>Copy quantity</source>
-        <translation type="unfinished">Skopiuj ilość</translation>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">Skopiuj &amp;ID transakcji</translation>
+    </message>
+    <message>
+        <source>L&amp;ock unspent</source>
+        <translation type="unfinished">Z&amp;ablokuj niewydane</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock unspent</source>
+        <translation type="unfinished">&amp;Odblokuj niewydane</translation>
     </message>
     <message>
         <source>Copy fee</source>
         <translation type="unfinished">Skopiuj prowizję</translation>
     </message>
     <message>
-        <source>Copy after fee</source>
-        <translation type="unfinished">Skopiuj ilość po opłacie</translation>
-    </message>
-    <message>
-        <source>Copy bytes</source>
-        <translation type="unfinished">Skopiuj ilość bajtów</translation>
-    </message>
-    <message>
-        <source>Copy dust</source>
-        <translation type="unfinished">Kopiuj pył</translation>
-    </message>
-    <message>
         <source>Copy change</source>
         <translation type="unfinished">Skopiuj resztę</translation>
-    </message>
-    <message>
-        <source>(%1 locked)</source>
-        <translation type="unfinished">(%1 zablokowane)</translation>
     </message>
     <message>
         <source>yes</source>
@@ -832,52 +769,48 @@ Podpisywanie jest możliwe tylko z adresami typu „legacy”.</translation>
         <translation type="unfinished">nie</translation>
     </message>
     <message>
-        <source>This label turns red if any recipient receives an amount smaller than the current dust threshold.</source>
-        <translation type="unfinished">Ta etykieta staje się czerwona jeżeli którykolwiek odbiorca otrzymuje kwotę mniejszą niż obecny próg pyłu.</translation>
-    </message>
-    <message>
-        <source>Can vary +/- %1 satoshi(s) per input.</source>
-        <translation type="unfinished">Waha się +/- %1 satoshi na wejście.</translation>
-    </message>
-    <message>
         <source>(no label)</source>
         <translation type="unfinished">(brak etykiety)</translation>
     </message>
-    <message>
-        <source>change from %1 (%2)</source>
-        <translation type="unfinished">reszta z %1 (%2)</translation>
-    </message>
-    <message>
-        <source>(change)</source>
-        <translation type="unfinished">(reszta)</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>CreateWalletActivity</name>
     <message>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation type="unfinished">Tworzenie portfela &lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+    <message>
         <source>Create wallet failed</source>
-        <translation type="unfinished">Tworzenie portfela nieudane</translation>
+        <translation type="unfinished">Nieudane tworzenie potrfela</translation>
     </message>
     <message>
         <source>Create wallet warning</source>
         <translation type="unfinished">Ostrzeżenie przy tworzeniu portfela</translation>
     </message>
-    </context>
+    <message>
+        <source>Can't list signers</source>
+        <translation type="unfinished">Nie można wyświetlić sygnatariuszy</translation>
+    </message>
+</context>
 <context>
     <name>OpenWalletActivity</name>
     <message>
         <source>Open wallet failed</source>
-        <translation type="unfinished">Otwarcie portfela nie powiodło się</translation>
+        <translation type="unfinished">Otworzenie portfela nie powiodło się</translation>
     </message>
     <message>
         <source>Open wallet warning</source>
-        <translation type="unfinished">Ostrzeżenie przy otwieraniu portfela</translation>
+        <translation type="unfinished">Ostrzeżenie przy otworzeniu potrfela</translation>
     </message>
     <message>
         <source>default wallet</source>
         <translation type="unfinished">domyślny portfel</translation>
     </message>
-    </context>
+    <message>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation type="unfinished">Otwieranie portfela &lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+</context>
 <context>
     <name>WalletController</name>
     <message>
@@ -885,168 +818,39 @@ Podpisywanie jest możliwe tylko z adresami typu „legacy”.</translation>
         <translation type="unfinished">Zamknij portfel</translation>
     </message>
     <message>
-        <source>Are you sure you wish to close the wallet &lt;i&gt;%1&lt;/i&gt;?</source>
-        <translation type="unfinished">Na pewno chcesz zamknąć portfel &lt;i&gt;%1&lt;/i&gt;?</translation>
-    </message>
-    <message>
-        <source>Closing the wallet for too long can result in having to resync the entire chain if pruning is enabled.</source>
-        <translation type="unfinished">Zamknięcie portfela na zbyt długo może skutkować koniecznością ponownego załadowania całego łańcucha, jeżeli jest włączony pruning.</translation>
-    </message>
-    <message>
         <source>Close all wallets</source>
         <translation type="unfinished">Zamknij wszystkie portfele</translation>
     </message>
-    <message>
-        <source>Are you sure you wish to close all wallets?</source>
-        <translation type="unfinished">Na pewno zamknąć wszystkie portfe?</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>CreateWalletDialog</name>
     <message>
         <source>Create Wallet</source>
-        <translation type="unfinished">Stwórz portfel</translation>
+        <translation type="unfinished">Stwórz potrfel</translation>
     </message>
     <message>
-        <source>Wallet Name</source>
-        <translation type="unfinished">Nazwa portfela</translation>
+        <source>Use an external signing device such as a hardware wallet. Configure the external signer script in wallet preferences first.</source>
+        <translation type="unfinished">Użyj zewnętrznego urządzenia podpisującego, takiego jak portfel sprzętowy. Najpierw skonfiguruj zewnętrzny skrypt podpisujący w preferencjach portfela.</translation>
     </message>
     <message>
-        <source>Wallet</source>
-        <translation type="unfinished">Portfel</translation>
+        <source>External signer</source>
+        <translation type="unfinished">Zewnętrzny sygnatariusz</translation>
     </message>
     <message>
-        <source>Encrypt the wallet. The wallet will be encrypted with a passphrase of your choice.</source>
-        <translation type="unfinished">Zaszyfruj portfel. Portfel zostanie zaszyfrowany wprowadzonym hasłem.</translation>
-    </message>
-    <message>
-        <source>Encrypt Wallet</source>
-        <translation type="unfinished">Zaszyfruj portfel</translation>
-    </message>
-    <message>
-        <source>Advanced Options</source>
-        <translation type="unfinished">Opcje Zaawansowane</translation>
-    </message>
-    <message>
-        <source>Disable private keys for this wallet. Wallets with private keys disabled will have no private keys and cannot have an HD seed or imported private keys. This is ideal for watch-only wallets.</source>
-        <translation type="unfinished">Wyłącz klucze prywatne dla tego portfela. Portfel z wyłączonymi kluczami prywatnymi nie może zawierać zaimportowanych kluczy prywatnych ani ustawionego seeda HD. Jest to idealne rozwiązanie dla portfeli śledzących (watch-only).</translation>
-    </message>
-    <message>
-        <source>Disable Private Keys</source>
-        <translation type="unfinished">Wyłącz klucze prywatne</translation>
-    </message>
-    <message>
-        <source>Make a blank wallet. Blank wallets do not initially have private keys or scripts. Private keys and addresses can be imported, or an HD seed can be set, at a later time.</source>
-        <translation type="unfinished">Stwórz czysty portfel. Portfel taki początkowo nie zawiera żadnych kluczy prywatnych ani skryptów. Później mogą zostać zaimportowane klucze prywatne, adresy lub będzie można ustawić seed HD.</translation>
-    </message>
-    <message>
-        <source>Make Blank Wallet</source>
-        <translation type="unfinished">Stwórz czysty portfel</translation>
-    </message>
-    <message>
-        <source>Use descriptors for scriptPubKey management</source>
-        <translation type="unfinished">Użyj deskryptorów do zarządzania scriptPubKey</translation>
-    </message>
-    <message>
-        <source>Descriptor Wallet</source>
-        <translation type="unfinished">Portfel deskryptora</translation>
-    </message>
-    <message>
-        <source>Create</source>
-        <translation type="unfinished">Stwórz</translation>
-    </message>
-    <message>
-        <source>Compiled without sqlite support (required for descriptor wallets)</source>
-        <translation type="unfinished">Skompilowano bez wsparcia sqlite (wymaganego dla deskryptorów potfeli)</translation>
-    </message>
-    </context>
-<context>
-    <name>EditAddressDialog</name>
-    <message>
-        <source>Edit Address</source>
-        <translation>Zmień adres</translation>
-    </message>
-    <message>
-        <source>&amp;Label</source>
-        <translation>&amp;Etykieta</translation>
-    </message>
-    <message>
-        <source>The label associated with this address list entry</source>
-        <translation type="unfinished">Etykieta skojarzona z tym wpisem na liście adresów</translation>
-    </message>
-    <message>
-        <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
-        <translation type="unfinished">Ten adres jest skojarzony z wpisem na liście adresów. Może być zmodyfikowany jedynie dla adresów wysyłających.</translation>
-    </message>
-    <message>
-        <source>&amp;Address</source>
-        <translation>&amp;Adres</translation>
-    </message>
-    <message>
-        <source>New sending address</source>
-        <translation type="unfinished">Nowy adres wysyłania</translation>
-    </message>
-    <message>
-        <source>Edit receiving address</source>
-        <translation type="unfinished">Zmień adres odbioru</translation>
-    </message>
-    <message>
-        <source>Edit sending address</source>
-        <translation type="unfinished">Zmień adres wysyłania</translation>
-    </message>
-    <message>
-        <source>The entered address "%1" is not a valid Bitcoin address.</source>
-        <translation type="unfinished">Wprowadzony adres "%1" nie jest prawidłowym adresem Bitcoin.</translation>
-    </message>
-    <message>
-        <source>Address "%1" already exists as a receiving address with label "%2" and so cannot be added as a sending address.</source>
-        <translation type="unfinished">Adres "%1" już istnieje jako adres odbiorczy z etykietą "%2" i dlatego nie można go dodać jako adresu nadawcy.</translation>
-    </message>
-    <message>
-        <source>The entered address "%1" is already in the address book with label "%2".</source>
-        <translation type="unfinished">Wprowadzony adres "%1" już istnieje w książce adresowej z opisem "%2".</translation>
-    </message>
-    <message>
-        <source>Could not unlock wallet.</source>
-        <translation type="unfinished">Nie można było odblokować portfela.</translation>
-    </message>
-    <message>
-        <source>New key generation failed.</source>
-        <translation type="unfinished">Generowanie nowego klucza nie powiodło się.</translation>
-    </message>
-</context>
-<context>
-    <name>FreespaceChecker</name>
-    <message>
-        <source>A new data directory will be created.</source>
-        <translation>Będzie utworzony nowy folder danych.</translation>
-    </message>
-    <message>
-        <source>name</source>
-        <translation>nazwa</translation>
-    </message>
-    <message>
-        <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
-        <translation>Katalog już istnieje. Dodaj %1 jeśli masz zamiar utworzyć tutaj nowy katalog.</translation>
-    </message>
-    <message>
-        <source>Path already exists, and is not a directory.</source>
-        <translation>Ścieżka już istnieje i nie jest katalogiem.</translation>
-    </message>
-    <message>
-        <source>Cannot create data directory here.</source>
-        <translation>Nie można było tutaj utworzyć folderu.</translation>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Skompilowany bez obsługi podpisywania zewnętrznego (wymagany do podpisywania zewnętrzengo)</translation>
     </message>
 </context>
 <context>
     <name>Intro</name>
     <message>
-        <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
-        <translation type="unfinished">Co najmniej %1 GB danych, zostanie zapisane w tym katalogu, dane te będą przyrastały w czasie.</translation>
+        <source>(of %1 GB needed)</source>
+        <translation type="unfinished">(z %1 GB potrzebnych)</translation>
     </message>
     <message>
-        <source>Approximately %1 GB of data will be stored in this directory.</source>
-        <translation type="unfinished">Około %1 GB danych zostanie zapisane w tym katalogu.</translation>
+        <source>(%1 GB needed for full chain)</source>
+        <translation type="unfinished">(%1 GB potrzebnych na pełny łańcuch)</translation>
     </message>
     <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
@@ -1058,1080 +862,178 @@ Podpisywanie jest możliwe tylko z adresami typu „legacy”.</translation>
         </translation>
     </message>
     <message>
-        <source>%1 will download and store a copy of the Bitcoin block chain.</source>
-        <translation type="unfinished">%1 pobierze i zapisze lokalnie kopię łańcucha bloków Bitcoin.</translation>
-    </message>
-    <message>
-        <source>The wallet will also be stored in this directory.</source>
-        <translation type="unfinished">Portfel również zostanie zapisany w tym katalogu.</translation>
-    </message>
-    <message>
-        <source>Error: Specified data directory "%1" cannot be created.</source>
-        <translation type="unfinished">Błąd: podany folder danych «%1» nie mógł zostać utworzony.</translation>
-    </message>
-    <message>
         <source>Error</source>
         <translation>Błąd</translation>
     </message>
     <message>
-        <source>Welcome</source>
-        <translation>Witaj</translation>
+        <source>Limit block chain storage to</source>
+        <translation type="unfinished">Ogranicz przechowywanie łańcucha bloków do</translation>
     </message>
     <message>
-        <source>Welcome to %1.</source>
-        <translation type="unfinished">Witaj w %1.</translation>
-    </message>
-    <message>
-        <source>As this is the first time the program is launched, you can choose where %1 will store its data.</source>
-        <translation type="unfinished">Ponieważ jest to pierwsze uruchomienie programu, możesz wybrać gdzie %1 będzie przechowywał swoje dane.</translation>
-    </message>
-    <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation type="unfinished">Gdy naciśniesz OK, %1 zacznie się pobieranie i przetwarzanie całego %4 łańcucha bloków (%2GB) zaczynając od najwcześniejszych transakcji w %3 gdy %4 został uruchomiony.</translation>
-    </message>
-    <message>
-        <source>Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</source>
-        <translation type="unfinished">Wyłączenie tej opcji spowoduje konieczność pobrania całego łańcucha bloków. Szybciej jest najpierw pobrać cały łańcuch a następnie go przyciąć (prune). Wyłącza niektóre zaawansowane funkcje.</translation>
-    </message>
-    <message>
-        <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
-        <translation type="unfinished">Wstępna synchronizacja jest bardzo wymagająca i może ujawnić wcześniej niezauważone problemy sprzętowe. Za każdym uruchomieniem %1 pobieranie będzie kontynuowane od miejsca w którym zostało zatrzymane.</translation>
-    </message>
-    <message>
-        <source>If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</source>
-        <translation type="unfinished">Jeśli wybrałeś opcję ograniczenia przechowywania łańcucha bloków (przycinanie) dane historyczne cały czas będą musiały być pobrane i przetworzone, jednak po tym zostaną usunięte aby ograniczyć użycie dysku.</translation>
-    </message>
-    <message>
-        <source>Use the default data directory</source>
-        <translation>Użyj domyślnego folderu danych</translation>
-    </message>
-    <message>
-        <source>Use a custom data directory:</source>
-        <translation>Użyj wybranego folderu dla danych</translation>
-    </message>
-</context>
-<context>
-    <name>HelpMessageDialog</name>
-    <message>
-        <source>version</source>
-        <translation type="unfinished">wersja</translation>
-    </message>
-    <message>
-        <source>About %1</source>
-        <translation type="unfinished">Informacje o %1</translation>
-    </message>
-    <message>
-        <source>Command-line options</source>
-        <translation type="unfinished">Opcje konsoli</translation>
-    </message>
-</context>
-<context>
-    <name>ShutdownWindow</name>
-    <message>
-        <source>Do not shut down the computer until this window disappears.</source>
-        <translation type="unfinished">Nie wyłączaj komputera dopóki to okno nie zniknie.</translation>
-    </message>
-</context>
-<context>
-    <name>ModalOverlay</name>
-    <message>
-        <source>Form</source>
-        <translation type="unfinished">Formularz</translation>
-    </message>
-    <message>
-        <source>Recent transactions may not yet be visible, and therefore your wallet's balance might be incorrect. This information will be correct once your wallet has finished synchronizing with the bitcoin network, as detailed below.</source>
-        <translation type="unfinished">Świeże transakcje mogą nie być jeszcze widoczne, a zatem saldo portfela może być nieprawidłowe. Te detale będą poprawne, gdy portfel zakończy synchronizację z siecią bitcoin, zgodnie z poniższym opisem.</translation>
-    </message>
-    <message>
-        <source>Attempting to spend bitcoins that are affected by not-yet-displayed transactions will not be accepted by the network.</source>
-        <translation type="unfinished">Próba wydania bitcoinów które nie są jeszcze wyświetlone jako transakcja zostanie odrzucona przez sieć.</translation>
-    </message>
-    <message>
-        <source>Number of blocks left</source>
-        <translation type="unfinished">Pozostało bloków</translation>
-    </message>
-    <message>
-        <source>Last block time</source>
-        <translation type="unfinished">Czas ostatniego bloku</translation>
-    </message>
-    <message>
-        <source>Progress</source>
-        <translation type="unfinished">Postęp</translation>
-    </message>
-    <message>
-        <source>Progress increase per hour</source>
-        <translation type="unfinished">Przyrost postępu na godzinę</translation>
-    </message>
-    <message>
-        <source>Estimated time left until synced</source>
-        <translation type="unfinished">Przewidywany czas zakończenia synchronizacji</translation>
-    </message>
-    <message>
-        <source>Hide</source>
-        <translation type="unfinished">Ukryj</translation>
-    </message>
-    <message>
-        <source>Esc</source>
-        <translation type="unfinished">Wyjdź</translation>
-    </message>
-    <message>
-        <source>%1 is currently syncing.  It will download headers and blocks from peers and validate them until reaching the tip of the block chain.</source>
-        <translation type="unfinished">%1 jest w trakcie synchronizacji. Trwa pobieranie i weryfikacja nagłówków oraz bloków z sieci w celu uzyskania aktualnego stanu łańcucha.</translation>
+        <source> GB</source>
+        <translation type="unfinished">GB</translation>
     </message>
     </context>
 <context>
-    <name>OpenURIDialog</name>
+    <name>ShutdownWindow</name>
     <message>
-        <source>Open bitcoin URI</source>
-        <translation type="unfinished">Otwórz URI</translation>
+        <source>%1 is shutting down…</source>
+        <translation type="unfinished">%1 się zamyka...</translation>
+    </message>
+    </context>
+<context>
+    <name>ModalOverlay</name>
+    <message>
+        <source>Unknown…</source>
+        <translation type="unfinished">Nieznany...</translation>
+    </message>
+    <message>
+        <source>calculating…</source>
+        <translation type="unfinished">obliczanie...</translation>
     </message>
     </context>
 <context>
     <name>OptionsDialog</name>
     <message>
-        <source>Options</source>
-        <translation>Opcje</translation>
+        <source>External Signer (e.g. hardware wallet)</source>
+        <translation type="unfinished">Zewnętrzny sygnatariusz (n.p. portfel sprzętowy) </translation>
     </message>
     <message>
-        <source>&amp;Main</source>
-        <translation>Główne</translation>
-    </message>
-    <message>
-        <source>Automatically start %1 after logging in to the system.</source>
-        <translation type="unfinished">Automatycznie uruchom %1 po zalogowaniu do systemu.</translation>
-    </message>
-    <message>
-        <source>&amp;Start %1 on system login</source>
-        <translation type="unfinished">Uruchamiaj %1 wraz z zalogowaniem do &amp;systemu</translation>
-    </message>
-    <message>
-        <source>Size of &amp;database cache</source>
-        <translation type="unfinished">Wielkość bufora bazy &amp;danych</translation>
-    </message>
-    <message>
-        <source>Number of script &amp;verification threads</source>
-        <translation type="unfinished">Liczba wątków &amp;weryfikacji skryptu</translation>
-    </message>
-    <message>
-        <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
-        <translation type="unfinished">Adres IP serwera proxy (np. IPv4: 127.0.0.1 / IPv6: ::1)</translation>
-    </message>
-    <message>
-        <source>Shows if the supplied default SOCKS5 proxy is used to reach peers via this network type.</source>
-        <translation type="unfinished">Pakazuje czy dostarczone domyślne SOCKS5 proxy jest użyte do połączenia z węzłami przez sieć tego typu.</translation>
-    </message>
-    <message>
-        <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
-        <translation type="unfinished">Minimalizuje zamiast zakończyć działanie programu przy zamykaniu okna. Kiedy ta opcja jest włączona, program zakończy działanie po wybieraniu Zamknij w menu.</translation>
-    </message>
-    <message>
-        <source>Third party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</source>
-        <translation type="unfinished">Zewnętrzne URL podglądu transakcji (np. eksplorator bloków), które będą wyświetlały się w menu kontekstowym, w zakładce transakcji. %s będzie zamieniany w adresie na hash transakcji. Oddziel wiele adresów pionową kreską |.</translation>
-    </message>
-    <message>
-        <source>Open the %1 configuration file from the working directory.</source>
-        <translation type="unfinished">Otwiera %1 plik konfiguracyjny z czynnego katalogu.</translation>
-    </message>
-    <message>
-        <source>Open Configuration File</source>
-        <translation type="unfinished">Otwórz plik konfiguracyjny</translation>
-    </message>
-    <message>
-        <source>Reset all client options to default.</source>
-        <translation>Przywróć wszystkie domyślne ustawienia klienta.</translation>
-    </message>
-    <message>
-        <source>&amp;Reset Options</source>
-        <translation>Z&amp;resetuj ustawienia</translation>
-    </message>
-    <message>
-        <source>&amp;Network</source>
-        <translation>&amp;Sieć</translation>
-    </message>
-    <message>
-        <source>Prune &amp;block storage to</source>
-        <translation type="unfinished">Przytnij magazyn &amp;bloków do</translation>
-    </message>
-    <message>
-        <source>Reverting this setting requires re-downloading the entire blockchain.</source>
-        <translation type="unfinished">Cofnięcie tego ustawienia wymaga ponownego załadowania całego łańcucha bloków.</translation>
-    </message>
-    <message>
-        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
-        <translation type="unfinished">(0 = automatycznie, &lt;0 = zostaw tyle wolnych rdzeni)</translation>
-    </message>
-    <message>
-        <source>W&amp;allet</source>
-        <translation type="unfinished">Portfel</translation>
-    </message>
-    <message>
-        <source>Expert</source>
-        <translation type="unfinished">Ekspert</translation>
-    </message>
-    <message>
-        <source>Enable coin &amp;control features</source>
-        <translation type="unfinished">Włącz funk&amp;cje kontoli monet</translation>
-    </message>
-    <message>
-        <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
-        <translation type="unfinished">Jeżeli wyłączysz możliwość wydania niezatwierdzonej wydanej reszty, reszta z transakcji nie będzie mogła zostać wykorzystana, dopóki ta transakcja nie będzie miała przynajmniej jednego potwierdzenia. To także ma wpływ na obliczanie Twojego salda.</translation>
-    </message>
-    <message>
-        <source>&amp;Spend unconfirmed change</source>
-        <translation type="unfinished">Wydaj niepotwierdzoną re&amp;sztę</translation>
-    </message>
-    <message>
-        <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
-        <translation>Automatycznie otwiera port klienta Bitcoin na routerze. Ta opcja dzieła tylko jeśli twój router wspiera UPnP i jest ono włączone.</translation>
-    </message>
-    <message>
-        <source>Map port using &amp;UPnP</source>
-        <translation>Mapuj port używając &amp;UPnP</translation>
-    </message>
-    <message>
-        <source>Map port using NA&amp;T-PMP</source>
-        <translation type="unfinished">Mapuj port przy użyciu NA&amp;T-PMP</translation>
-    </message>
-    <message>
-        <source>Accept connections from outside.</source>
-        <translation type="unfinished">Akceptuj połączenia z zewnątrz.</translation>
-    </message>
-    <message>
-        <source>Allow incomin&amp;g connections</source>
-        <translation type="unfinished">Zezwól na &amp;połączenia przychodzące</translation>
-    </message>
-    <message>
-        <source>Connect to the Bitcoin network through a SOCKS5 proxy.</source>
-        <translation type="unfinished">Połącz się z siecią Bitcoin poprzez proxy SOCKS5.</translation>
-    </message>
-    <message>
-        <source>&amp;Connect through SOCKS5 proxy (default proxy):</source>
-        <translation type="unfinished">Połącz przez proxy SO&amp;CKS5 (domyślne proxy):</translation>
-    </message>
-    <message>
-        <source>Proxy &amp;IP:</source>
-        <translation>&amp;IP proxy:</translation>
-    </message>
-    <message>
-        <source>Port of the proxy (e.g. 9050)</source>
-        <translation>Port proxy (np. 9050)</translation>
-    </message>
-    <message>
-        <source>Used for reaching peers via:</source>
-        <translation type="unfinished">Użyto do połączenia z peerami przy pomocy:</translation>
-    </message>
-    <message>
-        <source>&amp;Window</source>
-        <translation>&amp;Okno</translation>
-    </message>
-    <message>
-        <source>Show the icon in the system tray.</source>
-        <translation type="unfinished">Pokaż ikonę w zasobniku systemowym.</translation>
-    </message>
-    <message>
-        <source>&amp;Show tray icon</source>
-        <translation type="unfinished">&amp;Pokaż ikonę zasobnika</translation>
-    </message>
-    <message>
-        <source>Show only a tray icon after minimizing the window.</source>
-        <translation>Pokazuj tylko ikonę przy zegarku po zminimalizowaniu okna.</translation>
+        <source>Automatically open the Bitcoin client port on the router. This only works when your router supports NAT-PMP and it is enabled. The external port could be random.</source>
+        <translation type="unfinished">Automatycznie otwiera port klienta Bitcoin w routerze. Działa jedynie wtedy, gdy router wspiera NAT-PMP i usługa ta jest włączona. Zewnętrzny port może być losowy.</translation>
     </message>
     <message>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation>&amp;Minimalizuj do zasobnika systemowego zamiast do paska zadań</translation>
     </message>
     <message>
-        <source>M&amp;inimize on close</source>
-        <translation>M&amp;inimalizuj przy zamknięciu</translation>
+        <source>Monospaced font in the Overview tab:</source>
+        <translation type="unfinished">Czcionka o stałej szerokości w zakładce Przegląd</translation>
     </message>
     <message>
-        <source>&amp;Display</source>
-        <translation>&amp;Wyświetlanie</translation>
+        <source>closest matching "%1"</source>
+        <translation type="unfinished">najbliższy pasujący "%1"</translation>
     </message>
     <message>
-        <source>User Interface &amp;language:</source>
-        <translation>Język &amp;użytkownika:</translation>
-    </message>
-    <message>
-        <source>The user interface language can be set here. This setting will take effect after restarting %1.</source>
-        <translation type="unfinished">Można tu ustawić język interfejsu uzytkownika. Ustawienie przyniesie skutek po ponownym uruchomieniu %1.</translation>
-    </message>
-    <message>
-        <source>&amp;Unit to show amounts in:</source>
-        <translation>&amp;Jednostka pokazywana przy kwocie:</translation>
-    </message>
-    <message>
-        <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
-        <translation>Wybierz podział jednostki pokazywany w interfejsie  oraz podczas wysyłania monet</translation>
-    </message>
-    <message>
-        <source>Whether to show coin control features or not.</source>
-        <translation type="unfinished">Wybierz pokazywanie lub nie funkcji kontroli monet.</translation>
-    </message>
-    <message>
-        <source>Connect to the Bitcoin network through a separate SOCKS5 proxy for Tor onion services.</source>
-        <translation type="unfinished">Połącz się z siecią Bitcoin przy pomocy oddzielnego SOCKS5 proxy dla sieci TOR.</translation>
-    </message>
-    <message>
-        <source>Use separate SOCKS&amp;5 proxy to reach peers via Tor onion services:</source>
-        <translation type="unfinished">Użyj oddzielnego proxy SOCKS&amp;5 aby osiągnąć węzły w ukrytych usługach Tor:</translation>
-    </message>
-    <message>
-        <source>&amp;Third party transaction URLs</source>
-        <translation type="unfinished">&amp;Zewnętrzny URL podglądu transakcji</translation>
-    </message>
-    <message>
-        <source>Options set in this dialog are overridden by the command line or in the configuration file:</source>
-        <translation type="unfinished">Opcje ustawione w tym oknie są nadpisane przez linię komend lub plik konfiguracyjny:</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Anuluj</translation>
-    </message>
-    <message>
-        <source>default</source>
-        <translation>domyślny</translation>
-    </message>
-    <message>
-        <source>none</source>
-        <translation type="unfinished">żaden</translation>
-    </message>
-    <message>
-        <source>Confirm options reset</source>
-        <translation>Potwierdź reset ustawień</translation>
-    </message>
-    <message>
-        <source>Client restart required to activate changes.</source>
-        <translation type="unfinished">Wymagany restart programu, aby uaktywnić zmiany.</translation>
-    </message>
-    <message>
-        <source>Client will be shut down. Do you want to proceed?</source>
-        <translation type="unfinished">Program zostanie wyłączony. Czy chcesz kontynuować?</translation>
-    </message>
-    <message>
-        <source>Configuration options</source>
-        <translation type="unfinished">Opcje konfiguracji</translation>
-    </message>
-    <message>
-        <source>The configuration file is used to specify advanced user options which override GUI settings. Additionally, any command-line options will override this configuration file.</source>
-        <translation type="unfinished">Plik konfiguracyjny jest używany celem zdefiniowania zaawansowanych opcji nadpisujących ustawienia aplikacji okienkowej (GUI). Parametry zdefiniowane z poziomu linii poleceń nadpisują parametry określone w tym pliku.</translation>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Skompilowany bez obsługi podpisywania zewnętrznego (wymagany do podpisywania zewnętrzengo)</translation>
     </message>
     <message>
         <source>Error</source>
         <translation type="unfinished">Błąd</translation>
     </message>
-    <message>
-        <source>The configuration file could not be opened.</source>
-        <translation type="unfinished">Plik z konfiguracją nie mógł być otworzony.</translation>
-    </message>
-    <message>
-        <source>This change would require a client restart.</source>
-        <translation type="unfinished">Ta zmiana może wymagać ponownego uruchomienia klienta.</translation>
-    </message>
-    <message>
-        <source>The supplied proxy address is invalid.</source>
-        <translation>Adres podanego proxy jest nieprawidłowy</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>OverviewPage</name>
     <message>
-        <source>Form</source>
-        <translation>Formularz</translation>
-    </message>
-    <message>
-        <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
-        <translation>Wyświetlana informacja może być nieaktualna. Twój portfel synchronizuje się automatycznie z siecią bitcoin, zaraz po tym jak uzyskano połączenie, ale proces ten nie został jeszcze ukończony.</translation>
-    </message>
-    <message>
-        <source>Watch-only:</source>
-        <translation type="unfinished">Tylko podglądaj:</translation>
-    </message>
-    <message>
-        <source>Available:</source>
-        <translation type="unfinished">Dostępne:</translation>
-    </message>
-    <message>
-        <source>Your current spendable balance</source>
-        <translation>Twoje obecne saldo</translation>
-    </message>
-    <message>
-        <source>Pending:</source>
-        <translation type="unfinished">W toku:</translation>
-    </message>
-    <message>
-        <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
-        <translation>Suma transakcji, które nie zostały jeszcze potwierdzone, a które nie zostały wliczone do twojego obecnego salda</translation>
-    </message>
-    <message>
-        <source>Immature:</source>
-        <translation>Niedojrzały:</translation>
-    </message>
-    <message>
-        <source>Mined balance that has not yet matured</source>
-        <translation>Balans wydobytych monet, które jeszcze nie dojrzały</translation>
-    </message>
-    <message>
-        <source>Balances</source>
-        <translation type="unfinished">Salda</translation>
-    </message>
-    <message>
-        <source>Total:</source>
-        <translation>Ogółem:</translation>
-    </message>
-    <message>
-        <source>Your current total balance</source>
-        <translation>Twoje obecne saldo</translation>
-    </message>
-    <message>
-        <source>Your current balance in watch-only addresses</source>
-        <translation type="unfinished">Twoje obecne saldo na podglądanym adresie</translation>
-    </message>
-    <message>
-        <source>Spendable:</source>
-        <translation type="unfinished">Możliwe do wydania:</translation>
-    </message>
-    <message>
-        <source>Recent transactions</source>
-        <translation type="unfinished">Ostatnie transakcje</translation>
-    </message>
-    <message>
-        <source>Unconfirmed transactions to watch-only addresses</source>
-        <translation type="unfinished">Niepotwierdzone transakcje na podglądanych adresach</translation>
-    </message>
-    <message>
-        <source>Mined balance in watch-only addresses that has not yet matured</source>
-        <translation type="unfinished">Wykopane monety na podglądanych adresach które jeszcze nie dojrzały</translation>
-    </message>
-    <message>
-        <source>Current total balance in watch-only addresses</source>
-        <translation type="unfinished">Łączna kwota na podglądanych adresach</translation>
-    </message>
-    <message>
         <source>Privacy mode activated for the Overview tab. To unmask the values, uncheck Settings-&gt;Mask values.</source>
-        <translation type="unfinished">Tryb Prywatny został włączony dla zakłądki Podgląd. By odkryć wartości, odznacz Ustawienia-&gt;Ukrywaj wartości.</translation>
+        <translation type="unfinished">Tryb Prywatny został włączony dla zakładki Podgląd. By odkryć wartości, odznacz Ustawienia-&gt;Ukrywaj wartości.</translation>
     </message>
 </context>
 <context>
     <name>PSBTOperationsDialog</name>
     <message>
-        <source>Sign Tx</source>
-        <translation type="unfinished">Podpisz transakcję (Tx)</translation>
-    </message>
-    <message>
-        <source>Broadcast Tx</source>
-        <translation type="unfinished">Rozgłoś transakcję (Tx)</translation>
-    </message>
-    <message>
-        <source>Copy to Clipboard</source>
-        <translation type="unfinished">Kopiuj do schowka</translation>
-    </message>
-    <message>
-        <source>Close</source>
-        <translation type="unfinished">Zamknij</translation>
-    </message>
-    <message>
-        <source>Failed to load transaction: %1</source>
-        <translation type="unfinished">Nie udało się wczytać transakcji: %1</translation>
-    </message>
-    <message>
-        <source>Failed to sign transaction: %1</source>
-        <translation type="unfinished">Nie udało się podpisać transakcji: %1</translation>
-    </message>
-    <message>
-        <source>Could not sign any more inputs.</source>
-        <translation type="unfinished">Nie udało się podpisać więcej wejść.</translation>
-    </message>
-    <message>
-        <source>Signed %1 inputs, but more signatures are still required.</source>
-        <translation type="unfinished">Podpisano %1 wejść, ale potrzebnych jest więcej podpisów.</translation>
-    </message>
-    <message>
-        <source>Signed transaction successfully. Transaction is ready to broadcast.</source>
-        <translation type="unfinished">transakcja</translation>
-    </message>
-    <message>
-        <source>Unknown error processing transaction.</source>
-        <translation type="unfinished">Nieznany błąd podczas przetwarzania transakcji.</translation>
-    </message>
-    <message>
-        <source>Transaction broadcast failed: %1</source>
-        <translation type="unfinished">Nie udało się rozgłosić transakscji: %1</translation>
-    </message>
-    <message>
-        <source>PSBT copied to clipboard.</source>
-        <translation type="unfinished">PSBT skopiowane do schowka</translation>
-    </message>
-    <message>
-        <source>Save Transaction Data</source>
-        <translation type="unfinished">Zapisz dane transakcji</translation>
-    </message>
-    <message>
-        <source>PSBT saved to disk.</source>
-        <translation type="unfinished">PSBT zapisane na dysk.</translation>
-    </message>
-    <message>
-        <source> * Sends %1 to %2</source>
-        <translation type="unfinished">Wysyłanie %1 do %2</translation>
-    </message>
-    <message>
-        <source>Unable to calculate transaction fee or total transaction amount.</source>
-        <translation type="unfinished">Nie można obliczyć opłaty za transakcję lub łącznej kwoty transakcji.</translation>
-    </message>
-    <message>
-        <source>Pays transaction fee: </source>
-        <translation type="unfinished">Opłata transakcyjna:</translation>
-    </message>
-    <message>
-        <source>Total Amount</source>
-        <translation type="unfinished">Łączna wartość</translation>
-    </message>
-    <message>
-        <source>or</source>
-        <translation type="unfinished">lub</translation>
+        <source>Save…</source>
+        <translation type="unfinished">Zapisz...</translation>
     </message>
     <message>
         <source>Transaction has %1 unsigned inputs.</source>
         <translation type="unfinished">Transakcja ma %1 niepodpisane wejścia.</translation>
     </message>
-    <message>
-        <source>Transaction is missing some information about inputs.</source>
-        <translation type="unfinished">Transakcja ma niekompletne informacje o niektórych wejściach.</translation>
-    </message>
-    <message>
-        <source>Transaction still needs signature(s).</source>
-        <translation type="unfinished">Transakcja ciągle oczekuje na podpis(y).</translation>
-    </message>
-    <message>
-        <source>(But this wallet cannot sign transactions.)</source>
-        <translation type="unfinished">(Ale ten portfel nie może podipisać transakcji.)</translation>
-    </message>
-    <message>
-        <source>(But this wallet does not have the right keys.)</source>
-        <translation type="unfinished">(Ale ten portfel nie posiada wlaściwych kluczy.)</translation>
-    </message>
-    <message>
-        <source>Transaction is fully signed and ready for broadcast.</source>
-        <translation type="unfinished">Transakcja jest w pełni podpisana i gotowa do rozgłoszenia.</translation>
-    </message>
-    <message>
-        <source>Transaction status is unknown.</source>
-        <translation type="unfinished">Status transakcji nie jest znany.</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>PaymentServer</name>
     <message>
-        <source>Payment request error</source>
-        <translation type="unfinished">Błąd żądania płatności</translation>
+        <source>Cannot process payment request because BIP70 is not supported.
+Due to widespread security flaws in BIP70 it's strongly recommended that any merchant instructions to switch wallets be ignored.
+If you are receiving this error you should request the merchant provide a BIP21 compatible URI.</source>
+        <translation type="unfinished">Nie można przetworzyć żądanie zapłaty poniewasz BIP70 nie jest obsługiwany.
+Ze względu na wady bezpieczeństwa w BIP70 jest zalecane ignorować wszelkich instrukcji od sprzedawcę dotyczących zmiany portfela.
+Jeśli pojawia się ten błąd, poproś sprzedawcę o podanie URI zgodnego z BIP21. </translation>
     </message>
-    <message>
-        <source>Cannot start bitcoin: click-to-pay handler</source>
-        <translation type="unfinished">Nie można uruchomić protokołu bitcoin: kliknij-by-zapłacić</translation>
-    </message>
-    <message>
-        <source>URI handling</source>
-        <translation type="unfinished">Obsługa URI</translation>
-    </message>
-    <message>
-        <source>'bitcoin://' is not a valid URI. Use 'bitcoin:' instead.</source>
-        <translation type="unfinished">'bitcoin://' nie jest poprawnym URI. Użyj 'bitcoin:'.</translation>
-    </message>
-    <message>
-        <source>URI cannot be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
-        <translation type="unfinished">Nie można przeanalizować identyfikatora URI! Może to być spowodowane nieważnym adresem Bitcoin lub nieprawidłowymi parametrami URI.</translation>
-    </message>
-    <message>
-        <source>Payment request file handling</source>
-        <translation type="unfinished">Przechwytywanie plików żądania płatności</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>PeerTableModel</name>
-    <message>
-        <source>User Agent</source>
-        <extracomment>Title of Peers Table column which contains the peer's User Agent string.</extracomment>
-        <translation type="unfinished">Aplikacja kliencka</translation>
-    </message>
-    <message>
-        <source>Sent</source>
-        <extracomment>Title of Peers Table column which indicates the total amount of network information we have sent to the peer.</extracomment>
-        <translation type="unfinished">Wysłane</translation>
-    </message>
-    <message>
-        <source>Received</source>
-        <extracomment>Title of Peers Table column which indicates the total amount of network information we have received from the peer.</extracomment>
-        <translation type="unfinished">Otrzymane</translation>
-    </message>
     <message>
         <source>Address</source>
         <extracomment>Title of Peers Table column which contains the IP/Onion/I2P address of the connected peer.</extracomment>
         <translation type="unfinished">Adres</translation>
     </message>
-    <message>
-        <source>Type</source>
-        <extracomment>Title of Peers Table column which describes the type of peer connection. The "type" describes why the connection exists.</extracomment>
-        <translation type="unfinished">Typ</translation>
-    </message>
-    <message>
-        <source>Network</source>
-        <extracomment>Title of Peers Table column which states the network the peer connected through.</extracomment>
-        <translation type="unfinished">Sieć</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>QRImageWidget</name>
     <message>
-        <source>&amp;Copy Image</source>
-        <translation type="unfinished">&amp;Kopiuj obraz</translation>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">&amp;Zapisz Obraz...</translation>
     </message>
-    <message>
-        <source>Resulting URI too long, try to reduce the text for label / message.</source>
-        <translation type="unfinished">Wynikowy URI jest zbyt długi, spróbuj zmniejszyć tekst etykiety / wiadomości</translation>
-    </message>
-    <message>
-        <source>Error encoding URI into QR Code.</source>
-        <translation type="unfinished">Błąd kodowania URI w kod QR</translation>
-    </message>
-    <message>
-        <source>QR code support not available.</source>
-        <translation type="unfinished">Wsparcie dla kodów QR jest niedostępne.</translation>
-    </message>
-    <message>
-        <source>Save QR Code</source>
-        <translation type="unfinished">Zapisz Kod QR</translation>
-    </message>
-    <message>
-        <source>PNG Image</source>
-        <extracomment>Expanded name of the PNG file format. See https://en.wikipedia.org/wiki/Portable_Network_Graphics</extracomment>
-        <translation type="unfinished">Obraz PNG</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>RPCConsole</name>
     <message>
-        <source>N/A</source>
-        <translation>NIEDOSTĘPNE</translation>
+        <source>Direction/Type</source>
+        <translation type="unfinished">Kierunek/Rodzaj</translation>
     </message>
     <message>
-        <source>Client version</source>
-        <translation>Wersja klienta</translation>
+        <source>High Bandwidth</source>
+        <translation type="unfinished">Wysoka Przepustowość</translation>
     </message>
     <message>
-        <source>&amp;Information</source>
-        <translation>&amp;Informacje</translation>
+        <source>no high bandwidth relay selected</source>
+        <translation type="unfinished">nie wybrano przekaźnika o dużej przepustowości</translation>
     </message>
     <message>
-        <source>General</source>
-        <translation type="unfinished">Ogólne</translation>
+        <source>1 d&amp;ay</source>
+        <translation type="unfinished">1 d&amp;zień</translation>
     </message>
     <message>
-        <source>Datadir</source>
-        <translation type="unfinished">Katalog danych</translation>
+        <source>Executing…</source>
+        <extracomment>A console message indicating an entered command is currently being executed.</extracomment>
+        <translation type="unfinished">Wykonuję...</translation>
     </message>
-    <message>
-        <source>To specify a non-default location of the data directory use the '%1' option.</source>
-        <translation type="unfinished">Użyj opcji '%1' aby wskazać niestandardową lokalizację katalogu danych.</translation>
-    </message>
-    <message>
-        <source>To specify a non-default location of the blocks directory use the '%1' option.</source>
-        <translation type="unfinished">Użyj opcji '%1' aby wskazać niestandardową lokalizację katalogu bloków.</translation>
-    </message>
-    <message>
-        <source>Startup time</source>
-        <translation>Czas uruchomienia</translation>
-    </message>
-    <message>
-        <source>Network</source>
-        <translation>Sieć</translation>
-    </message>
-    <message>
-        <source>Name</source>
-        <translation type="unfinished">Nazwa</translation>
-    </message>
-    <message>
-        <source>Number of connections</source>
-        <translation>Liczba połączeń</translation>
-    </message>
-    <message>
-        <source>Block chain</source>
-        <translation>Łańcuch bloków</translation>
-    </message>
-    <message>
-        <source>Memory Pool</source>
-        <translation type="unfinished">Memory Pool (obszar pamięci)</translation>
-    </message>
-    <message>
-        <source>Current number of transactions</source>
-        <translation type="unfinished">Obecna liczba transakcji</translation>
-    </message>
-    <message>
-        <source>Memory usage</source>
-        <translation type="unfinished">Zużycie pamięci</translation>
-    </message>
-    <message>
-        <source>Wallet: </source>
-        <translation type="unfinished">Portfel:</translation>
-    </message>
-    <message>
-        <source>(none)</source>
-        <translation type="unfinished">(brak)</translation>
-    </message>
-    <message>
-        <source>Received</source>
-        <translation type="unfinished">Otrzymane</translation>
-    </message>
-    <message>
-        <source>Sent</source>
-        <translation type="unfinished">Wysłane</translation>
-    </message>
-    <message>
-        <source>&amp;Peers</source>
-        <translation type="unfinished">&amp;Węzły</translation>
-    </message>
-    <message>
-        <source>Banned peers</source>
-        <translation type="unfinished">Blokowane węzły</translation>
-    </message>
-    <message>
-        <source>Select a peer to view detailed information.</source>
-        <translation type="unfinished">Wybierz węzeł żeby zobaczyć szczegóły.</translation>
-    </message>
-    <message>
-        <source>Version</source>
-        <translation type="unfinished">Wersja</translation>
-    </message>
-    <message>
-        <source>Starting Block</source>
-        <translation type="unfinished">Blok startowy</translation>
-    </message>
-    <message>
-        <source>Synced Headers</source>
-        <translation type="unfinished">Zsynchronizowane nagłówki</translation>
-    </message>
-    <message>
-        <source>Synced Blocks</source>
-        <translation type="unfinished">Zsynchronizowane bloki</translation>
-    </message>
-    <message>
-        <source>The mapped Autonomous System used for diversifying peer selection.</source>
-        <translation type="unfinished">Zmapowany autonomiczny system (ang. asmap) używany do dywersyfikacji wyboru węzłów.</translation>
-    </message>
-    <message>
-        <source>Mapped AS</source>
-        <translation type="unfinished">Zmapowany autonomiczny system (ang. asmap)</translation>
-    </message>
-    <message>
-        <source>User Agent</source>
-        <translation type="unfinished">Aplikacja kliencka</translation>
-    </message>
-    <message>
-        <source>Node window</source>
-        <translation type="unfinished">Okno węzła</translation>
-    </message>
-    <message>
-        <source>Current block height</source>
-        <translation type="unfinished">Obecna ilość bloków</translation>
-    </message>
-    <message>
-        <source>Open the %1 debug log file from the current data directory. This can take a few seconds for large log files.</source>
-        <translation type="unfinished">Otwórz plik dziennika debugowania %1 z obecnego katalogu z danymi. Może to potrwać kilka sekund przy większych plikach.</translation>
-    </message>
-    <message>
-        <source>Decrease font size</source>
-        <translation type="unfinished">Zmniejsz rozmiar czcionki</translation>
-    </message>
-    <message>
-        <source>Increase font size</source>
-        <translation type="unfinished">Zwiększ rozmiar czcionki</translation>
-    </message>
-    <message>
-        <source>Permissions</source>
-        <translation type="unfinished">Uprawnienia</translation>
-    </message>
-    <message>
-        <source>The network protocol this peer is connected through: IPv4, IPv6, Onion, I2P, or CJDNS.</source>
-        <translation type="unfinished">Protokół sieciowy używany przez ten węzeł: IPv4, IPv6, Onion, I2P, lub CJDNS.</translation>
-    </message>
-    <message>
-        <source>Services</source>
-        <translation type="unfinished">Usługi</translation>
-    </message>
-    <message>
-        <source>Connection Time</source>
-        <translation type="unfinished">Czas połączenia</translation>
-    </message>
-    <message>
-        <source>Last Block</source>
-        <translation type="unfinished">Ostatni Blok</translation>
-    </message>
-    <message>
-        <source>Last Tx</source>
-        <translation type="unfinished">Ostatnia transakcja</translation>
-    </message>
-    <message>
-        <source>Last Send</source>
-        <translation type="unfinished">Ostatnio wysłano</translation>
-    </message>
-    <message>
-        <source>Last Receive</source>
-        <translation type="unfinished">Ostatnio odebrano</translation>
-    </message>
-    <message>
-        <source>Ping Time</source>
-        <translation type="unfinished">Czas odpowiedzi</translation>
-    </message>
-    <message>
-        <source>The duration of a currently outstanding ping.</source>
-        <translation type="unfinished">Czas trwania nadmiarowego pingu</translation>
-    </message>
-    <message>
-        <source>Ping Wait</source>
-        <translation type="unfinished">Czas odpowiedzi</translation>
-    </message>
-    <message>
-        <source>Min Ping</source>
-        <translation type="unfinished">Minimalny czas odpowiedzi</translation>
-    </message>
-    <message>
-        <source>Time Offset</source>
-        <translation type="unfinished">Przesunięcie czasu</translation>
-    </message>
-    <message>
-        <source>Last block time</source>
-        <translation>Czas ostatniego bloku</translation>
-    </message>
-    <message>
-        <source>&amp;Open</source>
-        <translation>&amp;Otwórz</translation>
-    </message>
-    <message>
-        <source>&amp;Console</source>
-        <translation>&amp;Konsola</translation>
-    </message>
-    <message>
-        <source>&amp;Network Traffic</source>
-        <translation type="unfinished">$Ruch sieci</translation>
-    </message>
-    <message>
-        <source>Totals</source>
-        <translation type="unfinished">Kwota ogólna</translation>
-    </message>
-    <message>
-        <source>Debug log file</source>
-        <translation>Plik logowania debugowania</translation>
-    </message>
-    <message>
-        <source>Clear console</source>
-        <translation>Wyczyść konsolę</translation>
-    </message>
-    <message>
-        <source>In:</source>
-        <translation type="unfinished">Wejście:</translation>
-    </message>
-    <message>
-        <source>Out:</source>
-        <translation type="unfinished">Wyjście:</translation>
-    </message>
-    <message>
-        <source>Inbound: initiated by peer</source>
-        <translation type="unfinished">Przychodzące: zainicjowane przez węzeł</translation>
-    </message>
-    <message>
-        <source>&amp;Disconnect</source>
-        <translation type="unfinished">&amp;Rozłącz</translation>
-    </message>
-    <message>
-        <source>1 &amp;hour</source>
-        <translation type="unfinished">1 &amp;godzina</translation>
-    </message>
-    <message>
-        <source>1 &amp;week</source>
-        <translation type="unfinished">1 &amp;tydzień</translation>
-    </message>
-    <message>
-        <source>1 &amp;year</source>
-        <translation type="unfinished">1 &amp;rok</translation>
-    </message>
-    <message>
-        <source>&amp;Unban</source>
-        <translation type="unfinished">&amp;Odblokuj</translation>
-    </message>
-    <message>
-        <source>Network activity disabled</source>
-        <translation type="unfinished">Aktywność sieciowa wyłączona</translation>
-    </message>
-    <message>
-        <source>Executing command without any wallet</source>
-        <translation type="unfinished">Wykonuję komendę bez portfela</translation>
-    </message>
-    <message>
-        <source>Executing command using "%1" wallet</source>
-        <translation type="unfinished">Wykonuję komendę używając portfela "%1"</translation>
-    </message>
-    <message>
-        <source>via %1</source>
-        <translation type="unfinished">przez %1</translation>
-    </message>
-    <message>
-        <source>Yes</source>
-        <translation type="unfinished">Tak</translation>
-    </message>
-    <message>
-        <source>No</source>
-        <translation type="unfinished">Nie</translation>
-    </message>
-    <message>
-        <source>To</source>
-        <translation type="unfinished">Do</translation>
-    </message>
-    <message>
-        <source>From</source>
-        <translation type="unfinished">Od</translation>
-    </message>
-    <message>
-        <source>Ban for</source>
-        <translation type="unfinished">Zbanuj na</translation>
-    </message>
-    <message>
-        <source>Never</source>
-        <translation type="unfinished">Nigdy</translation>
-    </message>
-    <message>
-        <source>Unknown</source>
-        <translation type="unfinished">Nieznany</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <source>&amp;Amount:</source>
-        <translation type="unfinished">&amp;Ilość:</translation>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">Kopiuj adres</translation>
     </message>
     <message>
-        <source>&amp;Label:</source>
-        <translation type="unfinished">&amp;Etykieta:</translation>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Kopiuj etykietę</translation>
     </message>
     <message>
-        <source>&amp;Message:</source>
-        <translation type="unfinished">&amp;Wiadomość:</translation>
+        <source>Copy &amp;message</source>
+        <translation type="unfinished">Skopiuj wiado&amp;mość</translation>
     </message>
     <message>
-        <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
-        <translation type="unfinished">Opcjonalna wiadomość do dołączenia do żądania płatności, która będzie wyświetlana, gdy żądanie zostanie otwarte. Uwaga: wiadomość ta nie zostanie wysłana wraz z płatnością w sieci Bitcoin.</translation>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Kopiuj kwotę</translation>
     </message>
-    <message>
-        <source>An optional label to associate with the new receiving address.</source>
-        <translation type="unfinished">Opcjonalna etykieta do skojarzenia z nowym adresem odbiorczym.</translation>
-    </message>
-    <message>
-        <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
-        <translation type="unfinished">Użyj tego formularza do zażądania płatności. Wszystkie pola są &lt;b&gt;opcjonalne&lt;/b&gt;.</translation>
-    </message>
-    <message>
-        <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
-        <translation type="unfinished">Opcjonalna kwota by zażądać. Zostaw puste lub zero by nie zażądać konkretnej kwoty.</translation>
-    </message>
-    <message>
-        <source>An optional label to associate with the new receiving address (used by you to identify an invoice).  It is also attached to the payment request.</source>
-        <translation type="unfinished">Dodatkowa etykieta powiązana z nowym adresem do odbierania płatności (używanym w celu odnalezienia faktury). Jest również powiązana z żądaniem płatności.</translation>
-    </message>
-    <message>
-        <source>An optional message that is attached to the payment request and may be displayed to the sender.</source>
-        <translation type="unfinished">Dodatkowa wiadomość dołączana do żądania zapłaty, która może być odczytana przez płacącego.</translation>
-    </message>
-    <message>
-        <source>&amp;Create new receiving address</source>
-        <translation type="unfinished">&amp;Stwórz nowy adres odbiorczy</translation>
-    </message>
-    <message>
-        <source>Clear all fields of the form.</source>
-        <translation type="unfinished">Wyczyść wszystkie pola formularza.</translation>
-    </message>
-    <message>
-        <source>Clear</source>
-        <translation type="unfinished">Wyczyść</translation>
-    </message>
-    <message>
-        <source>Native segwit addresses (aka Bech32 or BIP-173) reduce your transaction fees later on and offer better protection against typos, but old wallets don't support them. When unchecked, an address compatible with older wallets will be created instead.</source>
-        <translation type="unfinished">Natywne adresy segwit (aka Bech32 lub BIP-173) zmniejszają później twoje opłaty transakcyjne i dają lepsze zabezpieczenie przed literówkami, ale stare portfele ich nie obsługują. Jeżeli odznaczone, stworzony zostanie adres kompatybilny ze starszymi portfelami.</translation>
-    </message>
-    <message>
-        <source>Generate native segwit (Bech32) address</source>
-        <translation type="unfinished">Wygeneruj natywny adres segwit (Bech32)</translation>
-    </message>
-    <message>
-        <source>Requested payments history</source>
-        <translation type="unfinished">Żądanie historii płatności</translation>
-    </message>
-    <message>
-        <source>Show the selected request (does the same as double clicking an entry)</source>
-        <translation type="unfinished">Pokaż wybrane żądanie (robi to samo co dwukrotne kliknięcie pozycji)</translation>
-    </message>
-    <message>
-        <source>Show</source>
-        <translation type="unfinished">Pokaż</translation>
-    </message>
-    <message>
-        <source>Remove the selected entries from the list</source>
-        <translation type="unfinished">Usuń zaznaczone z listy</translation>
-    </message>
-    <message>
-        <source>Remove</source>
-        <translation type="unfinished">Usuń</translation>
-    </message>
-    <message>
-        <source>Copy &amp;URI</source>
-        <translation type="unfinished">Kopiuj &amp;URI</translation>
-    </message>
-    <message>
-        <source>Could not unlock wallet.</source>
-        <translation type="unfinished">Nie można było odblokować portfela.</translation>
-    </message>
-    <message>
-        <source>Could not generate new %1 address</source>
-        <translation type="unfinished">Nie udało się wygenerować nowego adresu %1</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <source>Address:</source>
-        <translation type="unfinished">Adres:</translation>
+        <source>Request payment to …</source>
+        <translation type="unfinished">Żądaj płatności do ...</translation>
     </message>
     <message>
         <source>Amount:</source>
         <translation type="unfinished">Kwota:</translation>
     </message>
     <message>
-        <source>Label:</source>
-        <translation type="unfinished">Etykieta:</translation>
-    </message>
-    <message>
-        <source>Message:</source>
-        <translation type="unfinished">Wiadomość:</translation>
-    </message>
-    <message>
         <source>Wallet:</source>
         <translation type="unfinished">Portfel:</translation>
     </message>
     <message>
-        <source>Copy &amp;URI</source>
-        <translation type="unfinished">Kopiuj &amp;URI</translation>
+        <source>&amp;Verify</source>
+        <translation type="unfinished">&amp;Zweryfikuj</translation>
     </message>
     <message>
-        <source>Copy &amp;Address</source>
-        <translation type="unfinished">Kopiuj &amp;adres</translation>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">&amp;Zapisz Obraz...</translation>
     </message>
-    <message>
-        <source>Payment information</source>
-        <translation type="unfinished">Informacje o płatności</translation>
-    </message>
-    <message>
-        <source>Request payment to %1</source>
-        <translation type="unfinished">Zażądaj płatności do %1</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
@@ -2143,52 +1045,12 @@ Podpisywanie jest możliwe tylko z adresami typu „legacy”.</translation>
         <translation type="unfinished">Etykieta</translation>
     </message>
     <message>
-        <source>Message</source>
-        <translation type="unfinished">Wiadomość</translation>
-    </message>
-    <message>
         <source>(no label)</source>
         <translation type="unfinished">(brak etykiety)</translation>
     </message>
-    <message>
-        <source>(no message)</source>
-        <translation type="unfinished">(brak wiadomości)</translation>
-    </message>
-    <message>
-        <source>(no amount requested)</source>
-        <translation type="unfinished">(brak kwoty)</translation>
-    </message>
-    <message>
-        <source>Requested</source>
-        <translation type="unfinished">Zażądano</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>SendCoinsDialog</name>
-    <message>
-        <source>Send Coins</source>
-        <translation>Wyślij monety</translation>
-    </message>
-    <message>
-        <source>Coin Control Features</source>
-        <translation type="unfinished">Funkcje kontroli monet</translation>
-    </message>
-    <message>
-        <source>automatically selected</source>
-        <translation type="unfinished">zaznaczone automatycznie</translation>
-    </message>
-    <message>
-        <source>Insufficient funds!</source>
-        <translation type="unfinished">Niewystarczające środki!</translation>
-    </message>
-    <message>
-        <source>Quantity:</source>
-        <translation type="unfinished">Ilość:</translation>
-    </message>
-    <message>
-        <source>Bytes:</source>
-        <translation type="unfinished">Bajtów:</translation>
-    </message>
     <message>
         <source>Amount:</source>
         <translation type="unfinished">Kwota:</translation>
@@ -2203,124 +1065,19 @@ Podpisywanie jest możliwe tylko z adresami typu „legacy”.</translation>
     </message>
     <message>
         <source>Change:</source>
-        <translation type="unfinished">Reszta:</translation>
+        <translation type="unfinished">Zmiana:</translation>
     </message>
     <message>
-        <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
-        <translation type="unfinished">Kiedy ta opcja jest wybrana, to jeżeli adres reszty jest pusty lub nieprawidłowy, to reszta będzie wysyłana na nowo wygenerowany adres,</translation>
-    </message>
-    <message>
-        <source>Custom change address</source>
-        <translation type="unfinished">Niestandardowe zmiany adresu</translation>
-    </message>
-    <message>
-        <source>Transaction Fee:</source>
-        <translation type="unfinished">Opłata transakcyjna:</translation>
-    </message>
-    <message>
-        <source>Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until you have validated the complete chain.</source>
-        <translation type="unfinished">206/5000
-Korzystanie z opłaty domyślnej może skutkować wysłaniem transakcji, która potwierdzi się w kilka godzin lub dni (lub nigdy). Rozważ wybranie opłaty ręcznie lub poczekaj, aż sprawdzisz poprawność całego łańcucha.</translation>
-    </message>
-    <message>
-        <source>Warning: Fee estimation is currently not possible.</source>
-        <translation type="unfinished">Uwaga: Oszacowanie opłaty za transakcje jest aktualnie niemożliwe.</translation>
-    </message>
-    <message>
-        <source>per kilobyte</source>
-        <translation type="unfinished">za kilobajt</translation>
-    </message>
-    <message>
-        <source>Hide</source>
-        <translation type="unfinished">Ukryj</translation>
-    </message>
-    <message>
-        <source>Recommended:</source>
-        <translation type="unfinished">Zalecane:</translation>
-    </message>
-    <message>
-        <source>Custom:</source>
-        <translation type="unfinished">Własna:</translation>
-    </message>
-    <message>
-        <source>Send to multiple recipients at once</source>
-        <translation>Wyślij do wielu odbiorców na raz</translation>
-    </message>
-    <message>
-        <source>Add &amp;Recipient</source>
-        <translation>Dodaj Odbio&amp;rcę</translation>
-    </message>
-    <message>
-        <source>Clear all fields of the form.</source>
-        <translation type="unfinished">Wyczyść wszystkie pola formularza.</translation>
-    </message>
-    <message>
-        <source>Dust:</source>
-        <translation type="unfinished">Pył:</translation>
-    </message>
-    <message>
-        <source>Hide transaction fee settings</source>
-        <translation type="unfinished">Ukryj ustawienia opłat transakcyjnych</translation>
-    </message>
-    <message>
-        <source>When there is less transaction volume than space in the blocks, miners as well as relaying nodes may enforce a minimum fee. Paying only this minimum fee is just fine, but be aware that this can result in a never confirming transaction once there is more demand for bitcoin transactions than the network can process.</source>
-        <translation type="unfinished">Gdy ilość transakcji jest mniejsza niż ilość miejsca w bloku, górnicy i węzły przekazujące wymagają minimalnej opłaty. Zapłata tylko tej wartości jest dopuszczalna, lecz może skutkować transakcją która nigdy nie zostanie potwierdzona w sytuacji, gdy ilość transakcji przekroczy przepustowość sieci.</translation>
-    </message>
-    <message>
-        <source>A too low fee might result in a never confirming transaction (read the tooltip)</source>
-        <translation type="unfinished">Zbyt niska opłata może spowodować, że transakcja nigdy nie zostanie zatwierdzona (przeczytaj podpowiedź)</translation>
-    </message>
-    <message>
-        <source>Confirmation time target:</source>
-        <translation type="unfinished">Docelowy czas potwierdzenia:</translation>
-    </message>
-    <message>
-        <source>Enable Replace-By-Fee</source>
-        <translation type="unfinished">Włącz RBF (podmiana transakcji przez podniesienie opłaty)</translation>
-    </message>
-    <message>
-        <source>With Replace-By-Fee (BIP-125) you can increase a transaction's fee after it is sent. Without this, a higher fee may be recommended to compensate for increased transaction delay risk.</source>
-        <translation type="unfinished">Dzięki podmień-przez-opłatę (RBF, BIP-125) możesz podnieść opłatę transakcyjną już wysłanej transakcji. Bez tego, może być rekomendowana większa opłata aby zmniejszyć ryzyko opóźnienia zatwierdzenia transakcji.</translation>
-    </message>
-    <message>
-        <source>Clear &amp;All</source>
-        <translation>Wyczyść &amp;wszystko</translation>
-    </message>
-    <message>
-        <source>Balance:</source>
-        <translation>Saldo:</translation>
-    </message>
-    <message>
-        <source>Confirm the send action</source>
-        <translation>Potwierdź akcję wysyłania</translation>
-    </message>
-    <message>
-        <source>S&amp;end</source>
-        <translation>Wy&amp;syłka</translation>
-    </message>
-    <message>
-        <source>Copy quantity</source>
-        <translation type="unfinished">Skopiuj ilość</translation>
+        <source>Choose…</source>
+        <translation type="unfinished">Wybierz...</translation>
     </message>
     <message>
         <source>Copy amount</source>
-        <translation type="unfinished">Kopiuj kwotę</translation>
+        <translation type="unfinished">Kopiuj kwote</translation>
     </message>
     <message>
         <source>Copy fee</source>
         <translation type="unfinished">Skopiuj prowizję</translation>
-    </message>
-    <message>
-        <source>Copy after fee</source>
-        <translation type="unfinished">Skopiuj ilość po opłacie</translation>
-    </message>
-    <message>
-        <source>Copy bytes</source>
-        <translation type="unfinished">Skopiuj ilość bajtów</translation>
-    </message>
-    <message>
-        <source>Copy dust</source>
-        <translation type="unfinished">Kopiuj pył</translation>
     </message>
     <message>
         <source>Copy change</source>
@@ -2328,123 +1085,38 @@ Korzystanie z opłaty domyślnej może skutkować wysłaniem transakcji, która 
     </message>
     <message>
         <source>%1 (%2 blocks)</source>
-        <translation type="unfinished">%1 (%2 bloków)</translation>
+        <translation type="unfinished">%1 (%2 bloków)github.com </translation>
     </message>
     <message>
-        <source>Cr&amp;eate Unsigned</source>
-        <translation type="unfinished">&amp;Utwórz niepodpisaną transakcję</translation>
+        <source>Sign on device</source>
+        <extracomment>"device" usually means a hardware wallet</extracomment>
+        <translation type="unfinished">Podpisz na urządzeniu</translation>
     </message>
     <message>
-        <source>Creates a Partially Signed Bitcoin Transaction (PSBT) for use with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
-        <translation type="unfinished">Tworzy częściowo podpisaną transakcję (ang. PSBT) używaną np. offline z portfelem %1 lub z innym portfelem zgodnym z PSBT.</translation>
-    </message>
-    <message>
-        <source> from wallet '%1'</source>
-        <translation type="unfinished">z portfela '%1'</translation>
+        <source>Connect your hardware wallet first.</source>
+        <translation type="unfinished">Najpierw podłącz swój sprzętowy portfel.</translation>
     </message>
     <message>
         <source>%1 to '%2'</source>
-        <translation type="unfinished">%1 do '%2'</translation>
+        <translation type="unfinished">%1 do '%2'8f0451c0-ec7d-4357-a370-eff72fb0685f</translation>
     </message>
     <message>
-        <source>%1 to %2</source>
-        <translation type="unfinished">%1 do %2</translation>
+        <source>To review recipient list click "Show Details…"</source>
+        <translation type="unfinished">Aby przejrzeć listę odbiorców kliknij "Pokaż szczegóły..."</translation>
     </message>
     <message>
-        <source>Do you want to draft this transaction?</source>
-        <translation type="unfinished">Czy chcesz zapisać szkic tej transakcji?</translation>
+        <source>External signer not found</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Nie znaleziono zewnętrznego sygnatariusza </translation>
     </message>
     <message>
-        <source>Are you sure you want to send?</source>
-        <translation type="unfinished">Czy na pewno chcesz wysłać?</translation>
+        <source>External signer failure</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Błąd zewnętrznego sygnatariusza </translation>
     </message>
     <message>
-        <source>Create Unsigned</source>
-        <translation type="unfinished">Utwórz niepodpisaną transakcję</translation>
-    </message>
-    <message>
-        <source>Sign failed</source>
-        <translation type="unfinished">Podpisywanie nie powiodło się.</translation>
-    </message>
-    <message>
-        <source>Save Transaction Data</source>
-        <translation type="unfinished">Zapisz dane transakcji</translation>
-    </message>
-    <message>
-        <source>PSBT saved</source>
-        <translation type="unfinished">Zapisano PSBT</translation>
-    </message>
-    <message>
-        <source>or</source>
-        <translation type="unfinished">lub</translation>
-    </message>
-    <message>
-        <source>You can increase the fee later (signals Replace-By-Fee, BIP-125).</source>
-        <translation type="unfinished">Możesz później zwiększyć opłatę (sygnalizuje podmień-przez-opłatę (RBF), BIP 125).</translation>
-    </message>
-    <message>
-        <source>Please, review your transaction proposal. This will produce a Partially Signed Bitcoin Transaction (PSBT) which you can save or copy and then sign with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
-        <translation type="unfinished">Proszę przejrzeć propozycję transakcji. Zostanie utworzona częściowo podpisana transakcja (ang. PSBT), którą można skopiować, a następnie podpisać np. offline z portfelem %1 lub z innym portfelem zgodnym z PSBT.</translation>
-    </message>
-    <message>
-        <source>Please, review your transaction.</source>
-        <translation type="unfinished">Proszę, zweryfikuj swoją transakcję.</translation>
-    </message>
-    <message>
-        <source>Transaction fee</source>
-        <translation type="unfinished">Opłata transakcyjna</translation>
-    </message>
-    <message>
-        <source>Not signalling Replace-By-Fee, BIP-125.</source>
-        <translation type="unfinished">Nie sygnalizuje podmień-przez-opłatę (RBF), BIP-125</translation>
-    </message>
-    <message>
-        <source>Total Amount</source>
-        <translation type="unfinished">Łączna wartość</translation>
-    </message>
-    <message>
-        <source>Confirm send coins</source>
-        <translation type="unfinished">Potwierdź wysyłanie monet</translation>
-    </message>
-    <message>
-        <source>Confirm transaction proposal</source>
-        <translation type="unfinished">Potwierdź propozycję transakcji</translation>
-    </message>
-    <message>
-        <source>Watch-only balance:</source>
-        <translation type="unfinished">Kwota na obserwowanych kontach:</translation>
-    </message>
-    <message>
-        <source>The recipient address is not valid. Please recheck.</source>
-        <translation type="unfinished">Adres odbiorcy jest nieprawidłowy, proszę sprawić ponownie.</translation>
-    </message>
-    <message>
-        <source>The amount to pay must be larger than 0.</source>
-        <translation type="unfinished">Kwota do zapłacenia musi być większa od 0.</translation>
-    </message>
-    <message>
-        <source>The amount exceeds your balance.</source>
-        <translation type="unfinished">Kwota przekracza twoje saldo.</translation>
-    </message>
-    <message>
-        <source>The total exceeds your balance when the %1 transaction fee is included.</source>
-        <translation type="unfinished">Suma przekracza twoje saldo, gdy doliczymy %1 prowizji transakcyjnej.</translation>
-    </message>
-    <message>
-        <source>Duplicate address found: addresses should only be used once each.</source>
-        <translation type="unfinished">Duplikat adres-u znaleziony: adresy powinny zostać użyte tylko raz.</translation>
-    </message>
-    <message>
-        <source>Transaction creation failed!</source>
-        <translation type="unfinished">Utworzenie transakcji nie powiodło się!</translation>
-    </message>
-    <message>
-        <source>A fee higher than %1 is considered an absurdly high fee.</source>
-        <translation type="unfinished">Opłata wyższa niż %1 jest uznawana za absurdalnie dużą.</translation>
-    </message>
-    <message>
-        <source>Payment request expired.</source>
-        <translation type="unfinished">Żądanie płatności upłynęło.</translation>
+        <source>External balance:</source>
+        <translation type="unfinished">Zewnętrzny balans:</translation>
     </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
@@ -2455,243 +1127,8 @@ Korzystanie z opłaty domyślnej może skutkować wysłaniem transakcji, która 
         </translation>
     </message>
     <message>
-        <source>Warning: Invalid Bitcoin address</source>
-        <translation type="unfinished">Ostrzeżenie: nieprawidłowy adres Bitcoin</translation>
-    </message>
-    <message>
-        <source>Warning: Unknown change address</source>
-        <translation type="unfinished">Ostrzeżenie: Nieznany adres reszty</translation>
-    </message>
-    <message>
-        <source>Confirm custom change address</source>
-        <translation type="unfinished">Potwierdź zmianę adresu własnego</translation>
-    </message>
-    <message>
-        <source>The address you selected for change is not part of this wallet. Any or all funds in your wallet may be sent to this address. Are you sure?</source>
-        <translation type="unfinished">Wybrany adres reszty nie jest częścią tego portfela. Dowolne lub wszystkie środki w twoim portfelu mogą być wysyłane na ten adres. Jesteś pewny?</translation>
-    </message>
-    <message>
         <source>(no label)</source>
         <translation type="unfinished">(brak etykiety)</translation>
-    </message>
-</context>
-<context>
-    <name>SendCoinsEntry</name>
-    <message>
-        <source>A&amp;mount:</source>
-        <translation>Su&amp;ma:</translation>
-    </message>
-    <message>
-        <source>Pay &amp;To:</source>
-        <translation>Zapłać &amp;dla:</translation>
-    </message>
-    <message>
-        <source>&amp;Label:</source>
-        <translation>&amp;Etykieta:</translation>
-    </message>
-    <message>
-        <source>Choose previously used address</source>
-        <translation type="unfinished">Wybierz wcześniej użyty adres</translation>
-    </message>
-    <message>
-        <source>The Bitcoin address to send the payment to</source>
-        <translation type="unfinished">Adres Bitcoin gdzie wysłać płatność</translation>
-    </message>
-    <message>
-        <source>Paste address from clipboard</source>
-        <translation>Wklej adres ze schowka</translation>
-    </message>
-    <message>
-        <source>Remove this entry</source>
-        <translation type="unfinished">Usuń ten wpis</translation>
-    </message>
-    <message>
-        <source>The amount to send in the selected unit</source>
-        <translation type="unfinished">Kwota do wysłania w wybranej jednostce</translation>
-    </message>
-    <message>
-        <source>The fee will be deducted from the amount being sent. The recipient will receive less bitcoins than you enter in the amount field. If multiple recipients are selected, the fee is split equally.</source>
-        <translation type="unfinished">Opłata zostanie odjęta od kwoty wysyłane.Odbiorca otrzyma mniej niż bitcoins wpisz w polu kwoty. Jeśli wybrano kilku odbiorców, opłata jest podzielona równo.</translation>
-    </message>
-    <message>
-        <source>S&amp;ubtract fee from amount</source>
-        <translation type="unfinished">Odejmij od wysokości opłaty</translation>
-    </message>
-    <message>
-        <source>Use available balance</source>
-        <translation type="unfinished">Użyj dostępnego salda</translation>
-    </message>
-    <message>
-        <source>Message:</source>
-        <translation type="unfinished">Wiadomość:</translation>
-    </message>
-    <message>
-        <source>This is an unauthenticated payment request.</source>
-        <translation type="unfinished">To żądanie zapłaty nie zostało zweryfikowane.</translation>
-    </message>
-    <message>
-        <source>This is an authenticated payment request.</source>
-        <translation type="unfinished">To żądanie zapłaty jest zweryfikowane.</translation>
-    </message>
-    <message>
-        <source>Enter a label for this address to add it to the list of used addresses</source>
-        <translation type="unfinished">Wprowadź etykietę dla tego adresu by dodać go do listy użytych adresów</translation>
-    </message>
-    <message>
-        <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
-        <translation type="unfinished">Wiadomość, która została dołączona do URI bitcoin:, która będzie przechowywana wraz z transakcją w celach informacyjnych. Uwaga: Ta wiadomość nie będzie rozsyłana w sieci Bitcoin.</translation>
-    </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">Wpłać do:</translation>
-    </message>
-    <message>
-        <source>Memo:</source>
-        <translation type="unfinished">Notatka:</translation>
-    </message>
-</context>
-<context>
-    <name>SignVerifyMessageDialog</name>
-    <message>
-        <source>Signatures - Sign / Verify a Message</source>
-        <translation>Podpisy - Podpisz / zweryfikuj wiadomość</translation>
-    </message>
-    <message>
-        <source>&amp;Sign Message</source>
-        <translation>Podpi&amp;sz Wiadomość</translation>
-    </message>
-    <message>
-        <source>You can sign messages/agreements with your addresses to prove you can receive bitcoins sent to them. Be careful not to sign anything vague or random, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
-        <translation type="unfinished">Możesz podpisywać wiadomości swoimi adresami aby udowodnić, że jesteś ich właścicielem. Uważaj, aby nie podpisywać niczego co wzbudza Twoje podejrzenia, ponieważ ktoś może stosować phishing próbując nakłonić Cię do ich podpisania. Akceptuj i podpisuj tylko w pełni zrozumiałe komunikaty i wiadomości.</translation>
-    </message>
-    <message>
-        <source>The Bitcoin address to sign the message with</source>
-        <translation type="unfinished">Adres Bitcoin, za pomocą którego podpisać wiadomość</translation>
-    </message>
-    <message>
-        <source>Choose previously used address</source>
-        <translation type="unfinished">Wybierz wcześniej użyty adres</translation>
-    </message>
-    <message>
-        <source>Paste address from clipboard</source>
-        <translation>Wklej adres ze schowka</translation>
-    </message>
-    <message>
-        <source>Enter the message you want to sign here</source>
-        <translation>Tutaj wprowadź wiadomość, którą chcesz podpisać</translation>
-    </message>
-    <message>
-        <source>Signature</source>
-        <translation>Podpis</translation>
-    </message>
-    <message>
-        <source>Copy the current signature to the system clipboard</source>
-        <translation>Kopiuje aktualny podpis do schowka systemowego</translation>
-    </message>
-    <message>
-        <source>Sign the message to prove you own this Bitcoin address</source>
-        <translation>Podpisz wiadomość aby dowieść, że ten adres jest twój</translation>
-    </message>
-    <message>
-        <source>Sign &amp;Message</source>
-        <translation>Podpisz Wiado&amp;mość</translation>
-    </message>
-    <message>
-        <source>Reset all sign message fields</source>
-        <translation>Zresetuj wszystkie pola podpisanej wiadomości</translation>
-    </message>
-    <message>
-        <source>Clear &amp;All</source>
-        <translation>Wyczyść &amp;wszystko</translation>
-    </message>
-    <message>
-        <source>&amp;Verify Message</source>
-        <translation>&amp;Zweryfikuj wiadomość</translation>
-    </message>
-    <message>
-        <source>Enter the receiver's address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack. Note that this only proves the signing party receives with the address, it cannot prove sendership of any transaction!</source>
-        <translation type="unfinished">Wpisz adres, wiadomość oraz sygnaturę (podpis) odbiorcy (upewnij się, że dokładnie skopiujesz wszystkie zakończenia linii, spacje, tabulacje itp.).  Uważaj by nie dodać więcej do podpisu niż do samej podpisywanej wiadomości by uniknąć ataku man-in-the-middle. 
-Zwróć uwagę, że poprawnie zweryfikowana wiadomość potwierdza to, że nadawca posiada klucz do adresu, natomiast nie potwierdza to, że poprawne wysłanie jakiejkolwiek transakcji!</translation>
-    </message>
-    <message>
-        <source>The Bitcoin address the message was signed with</source>
-        <translation type="unfinished">Adres Bitcoin, którym została podpisana wiadomość</translation>
-    </message>
-    <message>
-        <source>The signed message to verify</source>
-        <translation type="unfinished">Podpisana wiadomość do weryfikacji</translation>
-    </message>
-    <message>
-        <source>The signature given when the message was signed</source>
-        <translation type="unfinished">Sygnatura podawana przy podpisywaniu wiadomości</translation>
-    </message>
-    <message>
-        <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
-        <translation>Zweryfikuj wiadomość,  aby upewnić się, że została podpisana odpowiednim adresem Bitcoin.</translation>
-    </message>
-    <message>
-        <source>Verify &amp;Message</source>
-        <translation>Zweryfikuj Wiado&amp;mość</translation>
-    </message>
-    <message>
-        <source>Reset all verify message fields</source>
-        <translation>Resetuje wszystkie pola weryfikacji wiadomości</translation>
-    </message>
-    <message>
-        <source>Click "Sign Message" to generate signature</source>
-        <translation type="unfinished">Kliknij "Podpisz Wiadomość" żeby uzyskać podpis</translation>
-    </message>
-    <message>
-        <source>The entered address is invalid.</source>
-        <translation type="unfinished">Podany adres jest nieprawidłowy.</translation>
-    </message>
-    <message>
-        <source>Please check the address and try again.</source>
-        <translation type="unfinished">Proszę sprawdzić adres i spróbować ponownie.</translation>
-    </message>
-    <message>
-        <source>The entered address does not refer to a key.</source>
-        <translation type="unfinished">Wprowadzony adres nie odnosi się do klucza.</translation>
-    </message>
-    <message>
-        <source>Wallet unlock was cancelled.</source>
-        <translation type="unfinished">Odblokowanie portfela zostało anulowane.</translation>
-    </message>
-    <message>
-        <source>No error</source>
-        <translation type="unfinished">Brak błędów</translation>
-    </message>
-    <message>
-        <source>Private key for the entered address is not available.</source>
-        <translation type="unfinished">Klucz prywatny dla podanego adresu nie jest dostępny.</translation>
-    </message>
-    <message>
-        <source>Message signing failed.</source>
-        <translation type="unfinished">Podpisanie wiadomości nie powiodło się.</translation>
-    </message>
-    <message>
-        <source>Message signed.</source>
-        <translation type="unfinished">Wiadomość podpisana.</translation>
-    </message>
-    <message>
-        <source>The signature could not be decoded.</source>
-        <translation type="unfinished">Podpis nie może zostać zdekodowany.</translation>
-    </message>
-    <message>
-        <source>Please check the signature and try again.</source>
-        <translation type="unfinished">Sprawdź podpis i spróbuj ponownie.</translation>
-    </message>
-    <message>
-        <source>The signature did not match the message digest.</source>
-        <translation type="unfinished">Podpis nie odpowiada skrótowi wiadomości.</translation>
-    </message>
-    <message>
-        <source>Message verification failed.</source>
-        <translation type="unfinished">Weryfikacja wiadomości nie powiodła się.</translation>
-    </message>
-    <message>
-        <source>Message verified.</source>
-        <translation type="unfinished">Wiadomość zweryfikowana.</translation>
     </message>
 </context>
 <context>
@@ -2705,76 +1142,12 @@ Zwróć uwagę, że poprawnie zweryfikowana wiadomość potwierdza to, że nadaw
         </translation>
     </message>
     <message>
-        <source>Open until %1</source>
-        <translation type="unfinished">Otwórz do %1</translation>
-    </message>
-    <message>
         <source>conflicted with a transaction with %1 confirmations</source>
         <translation type="unfinished">sprzeczny z transakcją posiadającą %1 potwierdzeń</translation>
     </message>
     <message>
-        <source>0/unconfirmed, %1</source>
-        <translation type="unfinished">0/niezatwierdzone, %1</translation>
-    </message>
-    <message>
-        <source>in memory pool</source>
-        <translation type="unfinished">w obszarze pamięci</translation>
-    </message>
-    <message>
-        <source>not in memory pool</source>
-        <translation type="unfinished">nie w obszarze pamięci</translation>
-    </message>
-    <message>
-        <source>abandoned</source>
-        <translation type="unfinished">porzucone</translation>
-    </message>
-    <message>
-        <source>%1/unconfirmed</source>
-        <translation type="unfinished">%1/niezatwierdzone</translation>
-    </message>
-    <message>
-        <source>%1 confirmations</source>
-        <translation type="unfinished">%1 potwierdzeń</translation>
-    </message>
-    <message>
         <source>Date</source>
         <translation type="unfinished">Data</translation>
-    </message>
-    <message>
-        <source>Source</source>
-        <translation type="unfinished">Źródło</translation>
-    </message>
-    <message>
-        <source>Generated</source>
-        <translation type="unfinished">Wygenerowano</translation>
-    </message>
-    <message>
-        <source>From</source>
-        <translation type="unfinished">Od</translation>
-    </message>
-    <message>
-        <source>unknown</source>
-        <translation type="unfinished">nieznane</translation>
-    </message>
-    <message>
-        <source>To</source>
-        <translation type="unfinished">Do</translation>
-    </message>
-    <message>
-        <source>own address</source>
-        <translation type="unfinished">własny adres</translation>
-    </message>
-    <message>
-        <source>watch-only</source>
-        <translation type="unfinished">tylko-obserwowany</translation>
-    </message>
-    <message>
-        <source>label</source>
-        <translation type="unfinished">etykieta</translation>
-    </message>
-    <message>
-        <source>Credit</source>
-        <translation type="unfinished">Uznanie</translation>
     </message>
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
@@ -2785,110 +1158,15 @@ Zwróć uwagę, że poprawnie zweryfikowana wiadomość potwierdza to, że nadaw
         </translation>
     </message>
     <message>
-        <source>not accepted</source>
-        <translation type="unfinished">niezaakceptowane</translation>
-    </message>
-    <message>
-        <source>Debit</source>
-        <translation type="unfinished">Debet</translation>
-    </message>
-    <message>
-        <source>Total debit</source>
-        <translation type="unfinished">Łączne obciążenie</translation>
-    </message>
-    <message>
-        <source>Total credit</source>
-        <translation type="unfinished">Łączne uznanie</translation>
-    </message>
-    <message>
-        <source>Transaction fee</source>
-        <translation type="unfinished">Opłata transakcyjna</translation>
-    </message>
-    <message>
-        <source>Net amount</source>
-        <translation type="unfinished">Kwota netto</translation>
-    </message>
-    <message>
-        <source>Message</source>
-        <translation type="unfinished">Wiadomość</translation>
-    </message>
-    <message>
-        <source>Comment</source>
-        <translation type="unfinished">Komentarz</translation>
-    </message>
-    <message>
-        <source>Transaction ID</source>
-        <translation type="unfinished">ID transakcji</translation>
-    </message>
-    <message>
-        <source>Transaction total size</source>
-        <translation type="unfinished">Rozmiar transakcji</translation>
-    </message>
-    <message>
-        <source>Transaction virtual size</source>
-        <translation type="unfinished">Wirtualny rozmiar transakcji</translation>
-    </message>
-    <message>
-        <source>Output index</source>
-        <translation type="unfinished">Indeks wyjściowy</translation>
-    </message>
-    <message>
-        <source> (Certificate was not verified)</source>
-        <translation type="unfinished">(Certyfikat nie został zweryfikowany)</translation>
-    </message>
-    <message>
-        <source>Merchant</source>
-        <translation type="unfinished">Kupiec</translation>
-    </message>
-    <message>
-        <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to "not accepted" and it won't be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
-        <translation type="unfinished">Wygenerowane monety muszą dojrzeć przez %1 bloków zanim będzie można je wydać. Gdy wygenerowałeś blok, został on rozgłoszony w sieci w celu dodania do łańcucha bloków. Jeżeli nie uda mu się wejść do łańcucha jego status zostanie zmieniony na "nie zaakceptowano" i nie będzie można go wydać. To czasem zdarza się gdy inny węzeł wygeneruje blok w kilka sekund od twojego.</translation>
-    </message>
-    <message>
-        <source>Debug information</source>
-        <translation type="unfinished">Informacje debugowania</translation>
-    </message>
-    <message>
-        <source>Transaction</source>
-        <translation type="unfinished">Transakcja</translation>
-    </message>
-    <message>
-        <source>Inputs</source>
-        <translation type="unfinished">Wejścia</translation>
-    </message>
-    <message>
         <source>Amount</source>
         <translation type="unfinished">Kwota</translation>
     </message>
-    <message>
-        <source>true</source>
-        <translation type="unfinished">prawda</translation>
-    </message>
-    <message>
-        <source>false</source>
-        <translation type="unfinished">fałsz</translation>
-    </message>
-</context>
-<context>
-    <name>TransactionDescDialog</name>
-    <message>
-        <source>This pane shows a detailed description of the transaction</source>
-        <translation>Ten panel pokazuje szczegółowy opis transakcji</translation>
-    </message>
-    <message>
-        <source>Details for %1</source>
-        <translation type="unfinished">Szczegóły %1</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
         <source>Date</source>
         <translation type="unfinished">Data</translation>
-    </message>
-    <message>
-        <source>Type</source>
-        <translation type="unfinished">Typ</translation>
     </message>
     <message>
         <source>Label</source>
@@ -2903,172 +1181,68 @@ Zwróć uwagę, że poprawnie zweryfikowana wiadomość potwierdza to, że nadaw
         </translation>
     </message>
     <message>
-        <source>Open until %1</source>
-        <translation type="unfinished">Otwórz do %1</translation>
-    </message>
-    <message>
-        <source>Unconfirmed</source>
-        <translation type="unfinished">Niepotwierdzone</translation>
-    </message>
-    <message>
-        <source>Abandoned</source>
-        <translation type="unfinished">Porzucone</translation>
-    </message>
-    <message>
-        <source>Confirming (%1 of %2 recommended confirmations)</source>
-        <translation type="unfinished">Potwierdzanie (%1 z %2 rekomendowanych potwierdzeń)</translation>
-    </message>
-    <message>
-        <source>Confirmed (%1 confirmations)</source>
-        <translation type="unfinished">Potwierdzono (%1 potwierdzeń)</translation>
-    </message>
-    <message>
-        <source>Conflicted</source>
-        <translation type="unfinished">Skonfliktowane</translation>
-    </message>
-    <message>
-        <source>Immature (%1 confirmations, will be available after %2)</source>
-        <translation type="unfinished">Niedojrzała (%1 potwierdzeń, będzie dostępna po %2)</translation>
-    </message>
-    <message>
-        <source>Generated but not accepted</source>
-        <translation type="unfinished">Wygenerowane ale nie zaakceptowane</translation>
-    </message>
-    <message>
-        <source>Received with</source>
-        <translation type="unfinished">Otrzymane przez</translation>
-    </message>
-    <message>
-        <source>Received from</source>
-        <translation type="unfinished">Odebrano od</translation>
-    </message>
-    <message>
-        <source>Sent to</source>
-        <translation type="unfinished">Wysłane do</translation>
-    </message>
-    <message>
-        <source>Payment to yourself</source>
-        <translation type="unfinished">Płatność do siebie</translation>
-    </message>
-    <message>
-        <source>Mined</source>
-        <translation type="unfinished">Wydobyto</translation>
-    </message>
-    <message>
-        <source>watch-only</source>
-        <translation type="unfinished">tylko-obserwowany</translation>
-    </message>
-    <message>
-        <source>(n/a)</source>
-        <translation type="unfinished">(brak)</translation>
-    </message>
-    <message>
         <source>(no label)</source>
         <translation type="unfinished">(brak etykiety)</translation>
     </message>
-    <message>
-        <source>Transaction status. Hover over this field to show number of confirmations.</source>
-        <translation type="unfinished">Status transakcji. Najedź na pole, aby zobaczyć liczbę potwierdzeń.</translation>
-    </message>
-    <message>
-        <source>Date and time that the transaction was received.</source>
-        <translation type="unfinished">Data i czas odebrania transakcji.</translation>
-    </message>
-    <message>
-        <source>Type of transaction.</source>
-        <translation type="unfinished">Rodzaj transakcji.</translation>
-    </message>
-    <message>
-        <source>Whether or not a watch-only address is involved in this transaction.</source>
-        <translation type="unfinished">Czy adres tylko-obserwowany jest lub nie użyty w tej transakcji.</translation>
-    </message>
-    <message>
-        <source>User-defined intent/purpose of the transaction.</source>
-        <translation type="unfinished">Zdefiniowana przez użytkownika intencja/cel transakcji.</translation>
-    </message>
-    <message>
-        <source>Amount removed from or added to balance.</source>
-        <translation type="unfinished">Kwota odjęta z lub dodana do konta.</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>TransactionView</name>
     <message>
-        <source>All</source>
-        <translation type="unfinished">Wszystko</translation>
+        <source>Range…</source>
+        <translation type="unfinished">Zakres...</translation>
     </message>
     <message>
-        <source>Today</source>
-        <translation type="unfinished">Dzisiaj</translation>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">Kopiuj adres</translation>
     </message>
     <message>
-        <source>This week</source>
-        <translation type="unfinished">W tym tygodniu</translation>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Kopiuj etykietę</translation>
     </message>
     <message>
-        <source>This month</source>
-        <translation type="unfinished">W tym miesiącu</translation>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Kopiuj kwotę</translation>
     </message>
     <message>
-        <source>Last month</source>
-        <translation type="unfinished">W zeszłym miesiącu</translation>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">Skopiuj &amp;ID transakcji</translation>
     </message>
     <message>
-        <source>This year</source>
-        <translation type="unfinished">W tym roku</translation>
+        <source>Copy &amp;raw transaction</source>
+        <translation type="unfinished">Kopiuj &amp;raw transakcje</translation>
     </message>
     <message>
-        <source>Received with</source>
-        <translation type="unfinished">Otrzymane przez</translation>
+        <source>Copy full transaction &amp;details</source>
+        <translation type="unfinished">Skopiuj pełne &amp;detale transakcji</translation>
     </message>
     <message>
-        <source>Sent to</source>
-        <translation type="unfinished">Wysłane do</translation>
+        <source>&amp;Show transaction details</source>
+        <translation type="unfinished">Wyświetl &amp;szczegóły transakcji</translation>
     </message>
     <message>
-        <source>To yourself</source>
-        <translation type="unfinished">Do siebie</translation>
+        <source>Increase transaction &amp;fee</source>
+        <translation type="unfinished">Zwiększ opłatę transakcji</translation>
     </message>
     <message>
-        <source>Mined</source>
-        <translation type="unfinished">Wydobyto</translation>
+        <source>A&amp;bandon transaction</source>
+        <translation type="unfinished">Porzuć transakcję</translation>
     </message>
     <message>
-        <source>Other</source>
-        <translation type="unfinished">Inne</translation>
-    </message>
-    <message>
-        <source>Enter address, transaction id, or label to search</source>
-        <translation type="unfinished">Wprowadź adres, identyfikator transakcji lub etykietę żeby wyszukać</translation>
-    </message>
-    <message>
-        <source>Min amount</source>
-        <translation type="unfinished">Minimalna kwota</translation>
-    </message>
-    <message>
-        <source>Export Transaction History</source>
-        <translation type="unfinished">Eksport historii transakcji</translation>
+        <source>&amp;Edit address label</source>
+        <translation type="unfinished">Wy&amp;edytuj adres etykiety</translation>
     </message>
     <message>
         <source>Comma separated file</source>
         <extracomment>Expanded name of the CSV file format. See https://en.wikipedia.org/wiki/Comma-separated_values</extracomment>
-        <translation type="unfinished">Plik rozdzielany przecinkami</translation>
+        <translation type="unfinished">Plik *.CSV (rozdzielany przecinkami)</translation>
     </message>
     <message>
         <source>Confirmed</source>
-        <translation type="unfinished">Potwierdzony</translation>
-    </message>
-    <message>
-        <source>Watch-only</source>
-        <translation type="unfinished">Tylko-obserwowany</translation>
+        <translation type="unfinished">Potwerdzone</translation>
     </message>
     <message>
         <source>Date</source>
         <translation type="unfinished">Data</translation>
-    </message>
-    <message>
-        <source>Type</source>
-        <translation type="unfinished">Typ</translation>
     </message>
     <message>
         <source>Label</source>
@@ -3080,39 +1254,11 @@ Zwróć uwagę, że poprawnie zweryfikowana wiadomość potwierdza to, że nadaw
     </message>
     <message>
         <source>Exporting Failed</source>
-        <translation type="unfinished">Eksportowanie nie powiodło się</translation>
+        <translation type="unfinished"> Eksportowanie nie powiodło się </translation>
     </message>
-    <message>
-        <source>There was an error trying to save the transaction history to %1.</source>
-        <translation type="unfinished">Wystąpił błąd przy próbie zapisu historii transakcji do %1.</translation>
-    </message>
-    <message>
-        <source>Exporting Successful</source>
-        <translation type="unfinished">Eksport powiódł się</translation>
-    </message>
-    <message>
-        <source>The transaction history was successfully saved to %1.</source>
-        <translation type="unfinished">Historia transakcji została zapisana do %1.</translation>
-    </message>
-    <message>
-        <source>Range:</source>
-        <translation type="unfinished">Zakres:</translation>
-    </message>
-    <message>
-        <source>to</source>
-        <translation type="unfinished">do</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>WalletFrame</name>
-    <message>
-        <source>No wallet has been loaded.
-Go to File &gt; Open Wallet to load a wallet.
-- OR -</source>
-        <translation type="unfinished">Portfel nie został wybrany.
-Przejdź do Plik &gt; Otwórz Portfel aby wgrać portfel.
-</translation>
-    </message>
     <message>
         <source>Create a new wallet</source>
         <translation type="unfinished">Stwórz nowy portfel</translation>
@@ -3121,56 +1267,8 @@ Przejdź do Plik &gt; Otwórz Portfel aby wgrać portfel.
 <context>
     <name>WalletModel</name>
     <message>
-        <source>Send Coins</source>
-        <translation type="unfinished">Wyślij monety</translation>
-    </message>
-    <message>
-        <source>Fee bump error</source>
-        <translation type="unfinished">Błąd zwiększenia prowizji</translation>
-    </message>
-    <message>
-        <source>Increasing transaction fee failed</source>
-        <translation type="unfinished">Nieudane zwiększenie prowizji</translation>
-    </message>
-    <message>
-        <source>Do you want to increase the fee?</source>
-        <translation type="unfinished">Czy chcesz zwiększyć prowizję?</translation>
-    </message>
-    <message>
-        <source>Do you want to draft a transaction with fee increase?</source>
-        <translation type="unfinished">Czy chcesz zapisać szkic transakcji ze zwiększoną opłatą transakcyjną?</translation>
-    </message>
-    <message>
-        <source>Current fee:</source>
-        <translation type="unfinished">Aktualna opłata:</translation>
-    </message>
-    <message>
-        <source>Increase:</source>
-        <translation type="unfinished">Zwiększ:</translation>
-    </message>
-    <message>
-        <source>New fee:</source>
-        <translation type="unfinished">Nowa opłata:</translation>
-    </message>
-    <message>
-        <source>Confirm fee bump</source>
-        <translation type="unfinished">Potwierdź zwiększenie opłaty</translation>
-    </message>
-    <message>
-        <source>Can't draft transaction.</source>
-        <translation type="unfinished">Nie można zapisać szkicu transakcji.</translation>
-    </message>
-    <message>
-        <source>PSBT copied</source>
-        <translation type="unfinished">Skopiowano PSBT</translation>
-    </message>
-    <message>
-        <source>Can't sign transaction.</source>
-        <translation type="unfinished">Nie można podpisać transakcji.</translation>
-    </message>
-    <message>
-        <source>Could not commit transaction</source>
-        <translation type="unfinished">Nie można zatwierdzić transakcji</translation>
+        <source>Can't display address</source>
+        <translation type="unfinished">Nie można wyświetlić adresu</translation>
     </message>
     <message>
         <source>default wallet</source>
@@ -3192,500 +1290,84 @@ Przejdź do Plik &gt; Otwórz Portfel aby wgrać portfel.
         <translation type="unfinished">Błąd</translation>
     </message>
     <message>
-        <source>Unable to decode PSBT from clipboard (invalid base64)</source>
-        <translation type="unfinished">Nie udało się załadować częściowo podpisanej transakcji (nieważny base64)</translation>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">Informacje portfela</translation>
     </message>
-    <message>
-        <source>Load Transaction Data</source>
-        <translation type="unfinished">Wczytaj dane transakcji</translation>
-    </message>
-    <message>
-        <source>Partially Signed Transaction (*.psbt)</source>
-        <translation type="unfinished">Częściowo Podpisana Transakcja (*.psbt)</translation>
-    </message>
-    <message>
-        <source>PSBT file must be smaller than 100 MiB</source>
-        <translation type="unfinished">PSBT musi być mniejsze niż 100MB</translation>
-    </message>
-    <message>
-        <source>Unable to decode PSBT</source>
-        <translation type="unfinished">Nie można odczytać PSBT</translation>
-    </message>
-    <message>
-        <source>Backup Wallet</source>
-        <translation type="unfinished">Kopia zapasowa portfela</translation>
-    </message>
-    <message>
-        <source>Backup Failed</source>
-        <translation type="unfinished">Nie udało się wykonać kopii zapasowej</translation>
-    </message>
-    <message>
-        <source>There was an error trying to save the wallet data to %1.</source>
-        <translation type="unfinished">Wystąpił błąd przy próbie zapisu pliku portfela do %1.</translation>
-    </message>
-    <message>
-        <source>Backup Successful</source>
-        <translation type="unfinished">Wykonano kopię zapasową</translation>
-    </message>
-    <message>
-        <source>The wallet data was successfully saved to %1.</source>
-        <translation type="unfinished">Dane portfela zostały poprawnie zapisane w %1.</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="unfinished">Anuluj</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>bitcoin-core</name>
     <message>
-        <source>The %s developers</source>
-        <translation type="unfinished">Deweloperzy %s</translation>
+        <source>Cannot downgrade wallet from version %i to version %i. Wallet version unchanged.</source>
+        <translation type="unfinished">Nie można zmienić wersji portfela z wersji %ina wersje %i. Wersja portfela pozostaje niezmieniona.</translation>
     </message>
     <message>
-        <source>%s corrupt. Try using the wallet tool bitcoin-wallet to salvage or restoring a backup.</source>
-        <translation type="unfinished">%s jest uszkodzony. Spróbuj użyć narzędzia bitcoin-portfel, aby uratować portfel lub przywrócić kopię zapasową.</translation>
+        <source>Unknown wallet file format "%s" provided. Please provide one of "bdb" or "sqlite".</source>
+        <translation type="unfinished">Podano nieznany typ pliku portfela "%s". Proszę podać jeden z "bdb" lub "sqlite".</translation>
     </message>
     <message>
-        <source>-maxtxfee is set very high! Fees this large could be paid on a single transaction.</source>
-        <translation type="unfinished">-maxtxfee ma ustawioną badzo dużą wartość! Tak wysokie opłaty mogą być zapłacone w jednej transakcji.</translation>
+        <source>Error creating %s</source>
+        <translation type="unfinished">Błąd podczas tworzenia %s</translation>
     </message>
     <message>
-        <source>Cannot obtain a lock on data directory %s. %s is probably already running.</source>
-        <translation type="unfinished">Nie można uzyskać blokady na katalogu z danymi %s. %s najprawdopodobniej jest już uruchomiony.</translation>
+        <source>Error reading next record from wallet database</source>
+        <translation type="unfinished">Błąd odczytu kolejnego rekordu z bazy danych portfela</translation>
     </message>
     <message>
-        <source>Cannot provide specific connections and have addrman find outgoing connections at the same.</source>
-        <translation type="unfinished">Nie można podać określonych połączeń i jednocześnie mieć addrman szukającego połączeń wychodzących.</translation>
+        <source>Error: Dumpfile checksum does not match. Computed %s, expected %s</source>
+        <translation type="unfinished">Błąd: Plik zrzutu suma kontrolna nie pasuje. Obliczone %s,  spodziewane %s</translation>
     </message>
     <message>
-        <source>Distributed under the MIT software license, see the accompanying file %s or %s</source>
-        <translation type="unfinished">Rozprowadzane na licencji MIT, zobacz dołączony plik %s lub %s</translation>
+        <source>Error: Missing checksum</source>
+        <translation type="unfinished">Bład: Brak suma kontroly</translation>
     </message>
     <message>
-        <source>Error reading %s! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
-        <translation type="unfinished">Błąd odczytu %s! Wszystkie klucze zostały odczytane poprawnie, ale może brakować  danych transakcji lub wpisów w książce adresowej, lub mogą one być nieprawidłowe.</translation>
+        <source>Error: No %s addresses available.</source>
+        <translation type="unfinished">Błąd: %s adres nie dostępny</translation>
     </message>
     <message>
-        <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
-        <translation type="unfinished">Błąd: Nasłuchiwanie połączeń przychodzących nie powiodło się (nasłuch zwrócił błąd %s)</translation>
+        <source>Error: Unable to write record to new wallet</source>
+        <translation type="unfinished">Błąd: Wpisanie rekordu do nowego portfela jest niemożliwe</translation>
     </message>
     <message>
-        <source>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.</source>
-        <translation type="unfinished">Estymacja opłat nieudana. Domyślna opłata jest wyłączona. Poczekaj kilka bloków lub włącz  -fallbackfee.</translation>
+        <source>Importing…</source>
+        <translation type="unfinished">Importowanie...</translation>
     </message>
     <message>
-        <source>Invalid amount for -maxtxfee=&lt;amount&gt;: '%s' (must be at least the minrelay fee of %s to prevent stuck transactions)</source>
-        <translation type="unfinished">Niewłaściwa ilość dla -maxtxfee=&lt;ilość&gt;: '%s' (musi wynosić przynajmniej minimalną wielkość %s aby zapobiec utknięciu transakcji)</translation>
+        <source>Loading P2P addresses…</source>
+        <translation type="unfinished">Ładowanie adresów P2P...</translation>
     </message>
     <message>
-        <source>Please check that your computer's date and time are correct! If your clock is wrong, %s will not work properly.</source>
-        <translation type="unfinished">Proszę sprawdzić czy data i czas na Twoim komputerze są poprawne! Jeżeli ustawienia zegara będą złe, %s nie będzie działał prawidłowo.</translation>
+        <source>Loading banlist…</source>
+        <translation type="unfinished">Ładowanie listy zablokowanych...</translation>
     </message>
     <message>
-        <source>Please contribute if you find %s useful. Visit %s for further information about the software.</source>
-        <translation type="unfinished">Wspomóż proszę, jeśli uznasz %s za użyteczne. Odwiedź  %s, aby uzyskać więcej informacji o tym oprogramowaniu.</translation>
+        <source>Loading block index…</source>
+        <translation type="unfinished">Ładowanie indeksu bloku...</translation>
     </message>
     <message>
-        <source>Prune configured below the minimum of %d MiB.  Please use a higher number.</source>
-        <translation type="unfinished">Przycinanie skonfigurowano poniżej minimalnych %d MiB. Proszę użyć wyższej liczby.</translation>
+        <source>Loading wallet…</source>
+        <translation type="unfinished">Ładowanie portfela...</translation>
     </message>
     <message>
-        <source>Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of pruned node)</source>
-        <translation type="unfinished">Prune: ostatnia synchronizacja portfela jest za danymi. Muszisz -reindexować (pobrać cały ciąg bloków ponownie w przypadku przyciętego węzła)</translation>
+        <source>Rescanning…</source>
+        <translation type="unfinished">Ponowne skanowanie...</translation>
     </message>
     <message>
-        <source>SQLiteDatabase: Unknown sqlite wallet schema version %d. Only version %d is supported</source>
-        <translation type="unfinished">SQLiteDatabase: Nieznany schemat portfela sqlite wersji %d. Obsługiwana jest tylko wersja %d</translation>
+        <source>Starting network threads…</source>
+        <translation type="unfinished">Startowanie wątków sieciowych...</translation>
     </message>
     <message>
-        <source>The block database contains a block which appears to be from the future. This may be due to your computer's date and time being set incorrectly. Only rebuild the block database if you are sure that your computer's date and time are correct</source>
-        <translation type="unfinished">Baza bloków zawiera blok, który wydaje się pochodzić z przyszłości. Może to wynikać z nieprawidłowego ustawienia daty i godziny Twojego komputera. Bazę danych bloków dobuduj tylko, jeśli masz pewność, że data i godzina twojego komputera są poprawne</translation>
+        <source>Unable to open %s for writing</source>
+        <translation type="unfinished">Nie można otworzyć %s w celu zapisu</translation>
     </message>
     <message>
-        <source>The transaction amount is too small to send after the fee has been deducted</source>
-        <translation type="unfinished">Zbyt niska kwota transakcji do wysłania po odjęciu opłaty</translation>
+        <source>Verifying blocks…</source>
+        <translation type="unfinished">Weryfikowanie bloków...</translation>
     </message>
     <message>
-        <source>This error could occur if this wallet was not shutdown cleanly and was last loaded using a build with a newer version of Berkeley DB. If so, please use the software that last loaded this wallet</source>
-        <translation type="unfinished">Ten błąd mógł wystąpić jeżeli portfel nie został poprawnie zamknięty oraz był ostatnio załadowany przy użyciu buildu z nowszą wersją Berkley DB. Jeżeli tak, proszę użyć oprogramowania które ostatnio załadowało ten portfel</translation>
+        <source>Verifying wallet(s)…</source>
+        <translation type="unfinished">Weryfikowanie porfela(li)...</translation>
     </message>
-    <message>
-        <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
-        <translation type="unfinished">To jest wersja testowa - używać na własne ryzyko - nie używać do kopania albo zastosowań komercyjnych.</translation>
-    </message>
-    <message>
-        <source>This is the maximum transaction fee you pay (in addition to the normal fee) to prioritize partial spend avoidance over regular coin selection.</source>
-        <translation type="unfinished">Jest to maksymalna opłata transakcyjna, którą płacisz (oprócz normalnej opłaty) za priorytetowe traktowanie unikania częściowych wydatków w stosunku do regularnego wyboru monet.</translation>
-    </message>
-    <message>
-        <source>This is the transaction fee you may discard if change is smaller than dust at this level</source>
-        <translation type="unfinished">To jest opłata transakcyjna jaką odrzucisz, jeżeli reszta jest mniejsza niż "dust" na tym poziomie</translation>
-    </message>
-    <message>
-        <source>This is the transaction fee you may pay when fee estimates are not available.</source>
-        <translation type="unfinished">To jest opłata transakcyjna którą zapłacisz, gdy mechanizmy estymacji opłaty nie są dostępne.</translation>
-    </message>
-    <message>
-        <source>Total length of network version string (%i) exceeds maximum length (%i). Reduce the number or size of uacomments.</source>
-        <translation type="unfinished">Całkowita długość łańcucha wersji (%i) przekracza maksymalną dopuszczalną długość (%i). Zmniejsz ilość lub rozmiar parametru uacomment.</translation>
-    </message>
-    <message>
-        <source>Unable to replay blocks. You will need to rebuild the database using -reindex-chainstate.</source>
-        <translation type="unfinished">Nie można przetworzyć bloków. Konieczne będzie przebudowanie bazy danych za pomocą -reindex-chainstate.</translation>
-    </message>
-    <message>
-        <source>Warning: Private keys detected in wallet {%s} with disabled private keys</source>
-        <translation type="unfinished">Uwaga: Wykryto klucze prywatne w portfelu [%s] który ma wyłączone klucze prywatne</translation>
-    </message>
-    <message>
-        <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
-        <translation type="unfinished">Uwaga: Wygląda na to, że nie ma pełnej zgodności z naszymi węzłami! Możliwe, że potrzebujesz aktualizacji bądź inne węzły jej potrzebują</translation>
-    </message>
-    <message>
-        <source>You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain</source>
-        <translation type="unfinished">Musisz przebudować bazę używając parametru -reindex aby wrócić do trybu pełnego. To spowoduje ponowne pobranie całego łańcucha bloków</translation>
-    </message>
-    <message>
-        <source>%s is set very high!</source>
-        <translation type="unfinished">%s jest ustawione bardzo wysoko!</translation>
-    </message>
-    <message>
-        <source>-maxmempool must be at least %d MB</source>
-        <translation type="unfinished">-maxmempool musi być przynajmniej %d MB</translation>
-    </message>
-    <message>
-        <source>A fatal internal error occurred, see debug.log for details</source>
-        <translation type="unfinished">Błąd: Wystąpił fatalny błąd wewnętrzny, sprawdź szczegóły w debug.log</translation>
-    </message>
-    <message>
-        <source>Cannot resolve -%s address: '%s'</source>
-        <translation type="unfinished">Nie można rozpoznać -%s adresu: '%s'</translation>
-    </message>
-    <message>
-        <source>Cannot set -peerblockfilters without -blockfilterindex.</source>
-        <translation type="unfinished">Nie można ustawić -peerblockfilters bez -blockfilterindex.</translation>
-    </message>
-    <message>
-        <source>Cannot write to data directory '%s'; check permissions.</source>
-        <translation type="unfinished">Nie mogę zapisać do katalogu danych '%s'; sprawdź uprawnienia.</translation>
-    </message>
-    <message>
-        <source>Change index out of range</source>
-        <translation type="unfinished">Index zmian poza zasięgiem.</translation>
-    </message>
-    <message>
-        <source>Config setting for %s only applied on %s network when in [%s] section.</source>
-        <translation type="unfinished">Ustawienie konfiguracyjne %s działa na sieć %s tylko, jeżeli jest w sekcji [%s].</translation>
-    </message>
-    <message>
-        <source>Copyright (C) %i-%i</source>
-        <translation type="unfinished">Prawa autorskie (C) %i-%i</translation>
-    </message>
-    <message>
-        <source>Corrupted block database detected</source>
-        <translation type="unfinished">Wykryto uszkodzoną bazę bloków</translation>
-    </message>
-    <message>
-        <source>Could not find asmap file %s</source>
-        <translation type="unfinished">Nie można odnaleźć pliku asmap %s</translation>
-    </message>
-    <message>
-        <source>Could not parse asmap file %s</source>
-        <translation type="unfinished">Nie można przetworzyć pliku asmap %s</translation>
-    </message>
-    <message>
-        <source>Disk space is too low!</source>
-        <translation type="unfinished">Zbyt mało miejsca na dysku!</translation>
-    </message>
-    <message>
-        <source>Do you want to rebuild the block database now?</source>
-        <translation type="unfinished">Czy chcesz teraz przebudować bazę bloków?</translation>
-    </message>
-    <message>
-        <source>Done loading</source>
-        <translation type="unfinished">Wczytywanie zakończone</translation>
-    </message>
-    <message>
-        <source>Error initializing block database</source>
-        <translation type="unfinished">Błąd inicjowania bazy danych bloków</translation>
-    </message>
-    <message>
-        <source>Error initializing wallet database environment %s!</source>
-        <translation type="unfinished">Błąd inicjowania środowiska bazy portfela %s!</translation>
-    </message>
-    <message>
-        <source>Error loading %s</source>
-        <translation type="unfinished">Błąd ładowania %s</translation>
-    </message>
-    <message>
-        <source>Error loading %s: Private keys can only be disabled during creation</source>
-        <translation type="unfinished">Błąd ładowania %s: Klucze prywatne mogą być wyłączone tylko podczas tworzenia</translation>
-    </message>
-    <message>
-        <source>Error loading %s: Wallet corrupted</source>
-        <translation type="unfinished">Błąd ładowania %s: Uszkodzony portfel</translation>
-    </message>
-    <message>
-        <source>Error loading %s: Wallet requires newer version of %s</source>
-        <translation type="unfinished">Błąd ładowania %s: Portfel wymaga nowszej wersji %s</translation>
-    </message>
-    <message>
-        <source>Error loading block database</source>
-        <translation type="unfinished">Błąd ładowania bazy bloków</translation>
-    </message>
-    <message>
-        <source>Error opening block database</source>
-        <translation type="unfinished">Błąd otwierania bazy bloków</translation>
-    </message>
-    <message>
-        <source>Error reading from database, shutting down.</source>
-        <translation type="unfinished">Błąd odczytu z bazy danych, wyłączam się.</translation>
-    </message>
-    <message>
-        <source>Error upgrading chainstate database</source>
-        <translation type="unfinished">Błąd ładowania bazy bloków</translation>
-    </message>
-    <message>
-        <source>Error: Disk space is low for %s</source>
-        <translation type="unfinished">Błąd: zbyt mało miejsca na dysku dla %s</translation>
-    </message>
-    <message>
-        <source>Error: Keypool ran out, please call keypoolrefill first</source>
-        <translation type="unfinished">Błąd: Pula kluczy jest pusta, odwołaj się do puli kluczy.</translation>
-    </message>
-    <message>
-        <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
-        <translation type="unfinished">Próba nasłuchiwania na jakimkolwiek porcie nie powiodła się. Użyj -listen=0 jeśli tego chcesz.</translation>
-    </message>
-    <message>
-        <source>Failed to rescan the wallet during initialization</source>
-        <translation type="unfinished">Nie udało się ponownie przeskanować portfela podczas inicjalizacji.</translation>
-    </message>
-    <message>
-        <source>Failed to verify database</source>
-        <translation type="unfinished">Nie udało się zweryfikować bazy danych</translation>
-    </message>
-    <message>
-        <source>Fee rate (%s) is lower than the minimum fee rate setting (%s)</source>
-        <translation type="unfinished">Wartość opłaty (%s) jest mniejsza niż wartość minimalna w ustawieniach (%s)</translation>
-    </message>
-    <message>
-        <source>Ignoring duplicate -wallet %s.</source>
-        <translation type="unfinished">Ignorowanie duplikatu -wallet %s</translation>
-    </message>
-    <message>
-        <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
-        <translation type="unfinished">Nieprawidłowy lub brak bloku genezy. Błędny folder_danych dla sieci?</translation>
-    </message>
-    <message>
-        <source>Initialization sanity check failed. %s is shutting down.</source>
-        <translation type="unfinished">Wstępna kontrola poprawności nie powiodła się. %s wyłącza się.</translation>
-    </message>
-    <message>
-        <source>Insufficient funds</source>
-        <translation type="unfinished">Niewystarczające środki</translation>
-    </message>
-    <message>
-        <source>Invalid -onion address or hostname: '%s'</source>
-        <translation type="unfinished">Niewłaściwy adres -onion lub nazwa hosta: '%s'</translation>
-    </message>
-    <message>
-        <source>Invalid -proxy address or hostname: '%s'</source>
-        <translation type="unfinished">Nieprawidłowy adres -proxy lub nazwa hosta: '%s'</translation>
-    </message>
-    <message>
-        <source>Invalid P2P permission: '%s'</source>
-        <translation type="unfinished">Nieprawidłowe uprawnienia P2P: '%s'</translation>
-    </message>
-    <message>
-        <source>Invalid amount for -%s=&lt;amount&gt;: '%s'</source>
-        <translation type="unfinished">Nieprawidłowa kwota dla -%s=&lt;amount&gt;: '%s'</translation>
-    </message>
-    <message>
-        <source>Invalid amount for -discardfee=&lt;amount&gt;: '%s'</source>
-        <translation type="unfinished">Nieprawidłowa kwota dla -discardfee=&lt;amount&gt;: '%s'</translation>
-    </message>
-    <message>
-        <source>Invalid amount for -fallbackfee=&lt;amount&gt;: '%s'</source>
-        <translation type="unfinished">Nieprawidłowa kwota dla -fallbackfee=&lt;amount&gt;: '%s'</translation>
-    </message>
-    <message>
-        <source>Invalid amount for -paytxfee=&lt;amount&gt;: '%s' (must be at least %s)</source>
-        <translation type="unfinished">Nieprawidłowa kwota dla -paytxfee=&lt;amount&gt;: '%s' (musi być co najmniej %s)</translation>
-    </message>
-    <message>
-        <source>Invalid netmask specified in -whitelist: '%s'</source>
-        <translation type="unfinished">Nieprawidłowa maska sieci określona w -whitelist: '%s'</translation>
-    </message>
-    <message>
-        <source>Need to specify a port with -whitebind: '%s'</source>
-        <translation type="unfinished">Musisz określić port z -whitebind: '%s'</translation>
-    </message>
-    <message>
-        <source>No proxy server specified. Use -proxy=&lt;ip&gt; or -proxy=&lt;ip:port&gt;.</source>
-        <translation type="unfinished">Żaden serwer proxy nie jest ustawiony. Użyj -proxy=&lt;ip&gt; lub -proxy=&lt;ip:port&gt;.</translation>
-    </message>
-    <message>
-        <source>Not enough file descriptors available.</source>
-        <translation type="unfinished">Brak wystarczającej liczby deskryptorów plików.</translation>
-    </message>
-    <message>
-        <source>Prune cannot be configured with a negative value.</source>
-        <translation type="unfinished">Przycinanie nie może być skonfigurowane z negatywną wartością.</translation>
-    </message>
-    <message>
-        <source>Prune mode is incompatible with -txindex.</source>
-        <translation type="unfinished">Tryb ograniczony jest niekompatybilny z -txindex.</translation>
-    </message>
-    <message>
-        <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
-        <translation type="unfinished">Zmniejszanie -maxconnections z %d do %d z powodu ograniczeń systemu.</translation>
-    </message>
-    <message>
-        <source>SQLiteDatabase: Failed to execute statement to verify database: %s</source>
-        <translation type="unfinished">SQLiteDatabase: nie powiodło się wykonanie instrukcji weryfikującej bazę danych: %s</translation>
-    </message>
-    <message>
-        <source>SQLiteDatabase: Failed to prepare statement to verify database: %s</source>
-        <translation type="unfinished">SQLiteDatabase: nie udało się przygotować instrukcji do weryfikacji bazy danych: %s</translation>
-    </message>
-    <message>
-        <source>SQLiteDatabase: Failed to read database verification error: %s</source>
-        <translation type="unfinished">SQLiteDatabase: nie udało się odczytać błędu weryfikacji bazy danych: %s</translation>
-    </message>
-    <message>
-        <source>SQLiteDatabase: Unexpected application id. Expected %u, got %u</source>
-        <translation type="unfinished">SQLiteDatabase: nieoczekiwany identyfikator aplikacji. Oczekiwano %u, otrzymano %u</translation>
-    </message>
-    <message>
-        <source>Section [%s] is not recognized.</source>
-        <translation type="unfinished">Sekcja [%s] jest nieznana.</translation>
-    </message>
-    <message>
-        <source>Signing transaction failed</source>
-        <translation type="unfinished">Podpisywanie transakcji nie powiodło się</translation>
-    </message>
-    <message>
-        <source>Specified -walletdir "%s" does not exist</source>
-        <translation type="unfinished">Podany -walletdir "%s" nie istnieje</translation>
-    </message>
-    <message>
-        <source>Specified -walletdir "%s" is a relative path</source>
-        <translation type="unfinished">Podany -walletdir "%s" jest ścieżką względną</translation>
-    </message>
-    <message>
-        <source>Specified -walletdir "%s" is not a directory</source>
-        <translation type="unfinished">Podany -walletdir "%s" nie jest katalogiem</translation>
-    </message>
-    <message>
-        <source>Specified blocks directory "%s" does not exist.</source>
-        <translation type="unfinished">Podany folder bloków "%s" nie istnieje.
-</translation>
-    </message>
-    <message>
-        <source>The source code is available from %s.</source>
-        <translation type="unfinished">Kod źródłowy dostępny jest z %s.</translation>
-    </message>
-    <message>
-        <source>The transaction amount is too small to pay the fee</source>
-        <translation type="unfinished">Zbyt niska kwota transakcji by zapłacić opłatę</translation>
-    </message>
-    <message>
-        <source>The wallet will avoid paying less than the minimum relay fee.</source>
-        <translation type="unfinished">Portfel będzie unikał płacenia mniejszej niż przekazana opłaty.</translation>
-    </message>
-    <message>
-        <source>This is experimental software.</source>
-        <translation type="unfinished">To oprogramowanie eksperymentalne.</translation>
-    </message>
-    <message>
-        <source>This is the minimum transaction fee you pay on every transaction.</source>
-        <translation type="unfinished">Minimalna opłata transakcyjna którą płacisz przy każdej transakcji.</translation>
-    </message>
-    <message>
-        <source>This is the transaction fee you will pay if you send a transaction.</source>
-        <translation type="unfinished">To jest opłata transakcyjna którą zapłacisz jeśli wyślesz transakcję.</translation>
-    </message>
-    <message>
-        <source>Transaction amount too small</source>
-        <translation type="unfinished">Zbyt niska kwota transakcji</translation>
-    </message>
-    <message>
-        <source>Transaction amounts must not be negative</source>
-        <translation type="unfinished">Kwota transakcji musi być dodatnia</translation>
-    </message>
-    <message>
-        <source>Transaction has too long of a mempool chain</source>
-        <translation type="unfinished">Transakcja posiada zbyt długi łańcuch pamięci</translation>
-    </message>
-    <message>
-        <source>Transaction must have at least one recipient</source>
-        <translation type="unfinished">Transakcja wymaga co najmniej jednego odbiorcy</translation>
-    </message>
-    <message>
-        <source>Transaction too large</source>
-        <translation type="unfinished">Transakcja zbyt duża</translation>
-    </message>
-    <message>
-        <source>Unable to bind to %s on this computer (bind returned error %s)</source>
-        <translation type="unfinished">Nie można przywiązać do %s na tym komputerze (bind zwrócił błąd %s)</translation>
-    </message>
-    <message>
-        <source>Unable to bind to %s on this computer. %s is probably already running.</source>
-        <translation type="unfinished">Nie można przywiązać do %s na tym komputerze. %s prawdopodobnie jest już uruchomiony.</translation>
-    </message>
-    <message>
-        <source>Unable to create the PID file '%s': %s</source>
-        <translation type="unfinished">Nie można stworzyć pliku PID '%s': %s</translation>
-    </message>
-    <message>
-        <source>Unable to generate initial keys</source>
-        <translation type="unfinished">Nie można wygenerować kluczy początkowych</translation>
-    </message>
-    <message>
-        <source>Unable to generate keys</source>
-        <translation type="unfinished">Nie można wygenerować kluczy</translation>
-    </message>
-    <message>
-        <source>Unable to start HTTP server. See debug log for details.</source>
-        <translation type="unfinished">Uruchomienie serwera HTTP nie powiodło się. Zobacz dziennik debugowania, aby uzyskać więcej szczegółów.</translation>
-    </message>
-    <message>
-        <source>Unknown -blockfilterindex value %s.</source>
-        <translation type="unfinished">Nieznana wartość -blockfilterindex %s.</translation>
-    </message>
-    <message>
-        <source>Unknown address type '%s'</source>
-        <translation type="unfinished">Nieznany typ adresu '%s'</translation>
-    </message>
-    <message>
-        <source>Unknown change type '%s'</source>
-        <translation type="unfinished">Nieznany typ reszty '%s'</translation>
-    </message>
-    <message>
-        <source>Unknown network specified in -onlynet: '%s'</source>
-        <translation type="unfinished">Nieznana sieć w -onlynet: '%s'</translation>
-    </message>
-    <message>
-        <source>Unsupported logging category %s=%s.</source>
-        <translation type="unfinished">Nieobsługiwana kategoria rejestrowania %s=%s.</translation>
-    </message>
-    <message>
-        <source>Upgrading UTXO database</source>
-        <translation type="unfinished">Aktualizowanie bazy danych UTXO</translation>
-    </message>
-    <message>
-        <source>Upgrading txindex database</source>
-        <translation type="unfinished">Aktualizowanie bazy txindex</translation>
-    </message>
-    <message>
-        <source>User Agent comment (%s) contains unsafe characters.</source>
-        <translation type="unfinished">Komentarz User Agent (%s) zawiera niebezpieczne znaki.</translation>
-    </message>
-    <message>
-        <source>Wallet needed to be rewritten: restart %s to complete</source>
-        <translation type="unfinished">Portfel wymaga przepisania: zrestartuj %s aby ukończyć</translation>
-    </message>
-</context>
+    </context>
 </TS>

--- a/src/qt/locale/bitcoin_pt.ts
+++ b/src/qt/locale/bitcoin_pt.ts
@@ -7,7 +7,7 @@
     </message>
     <message>
         <source>Create a new address</source>
-        <translation>Criar um novo endereço</translation>
+        <translation>Crie um endereço novo</translation>
     </message>
     <message>
         <source>&amp;New</source>
@@ -246,6 +246,10 @@ Assinar só é possível com endereços do tipo "legado".</translation>
 <context>
     <name>BitcoinApplication</name>
     <message>
+        <source>Runaway exception</source>
+        <translation type="unfinished">Exceção de Runaway</translation>
+    </message>
+    <message>
         <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
         <translation type="unfinished">Um erro fatal ocorreu. %1 não pode mais continuar de maneira segura e será terminada.</translation>
     </message>
@@ -253,7 +257,11 @@ Assinar só é possível com endereços do tipo "legado".</translation>
         <source>Internal error</source>
         <translation type="unfinished">Erro interno</translation>
     </message>
-    </context>
+    <message>
+        <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
+        <translation type="unfinished">Ocorreu um erro interno. %1 irá tentar continuar com segurança. Isto é um erro inesperado que pode ser reportado como descrito abaixo.</translation>
+    </message>
+</context>
 <context>
     <name>QObject</name>
     <message>
@@ -271,6 +279,10 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     <message>
         <source>Error initializing settings: %1</source>
         <translation type="unfinished">Erro ao inicializar configurações: %1</translation>
+    </message>
+    <message>
+        <source>%1 didn't yet exit safely…</source>
+        <translation type="unfinished">%1 ainda não terminou com segurança...</translation>
     </message>
     <message>
         <source>unknown</source>
@@ -299,6 +311,22 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     <message>
         <source>Outbound</source>
         <translation type="unfinished">Saída</translation>
+    </message>
+    <message>
+        <source>Full Relay</source>
+        <translation type="unfinished">Retransmissão total</translation>
+    </message>
+    <message>
+        <source>Block Relay</source>
+        <translation type="unfinished">Retransmissão de Blocos</translation>
+    </message>
+    <message>
+        <source>Feeler</source>
+        <translation type="unfinished">Antena</translation>
+    </message>
+    <message>
+        <source>Address Fetch</source>
+        <translation type="unfinished">Procura de endreços</translation>
     </message>
     <message>
         <source>None</source>
@@ -483,6 +511,14 @@ Assinar só é possível com endereços do tipo "legado".</translation>
         <translation>Verifique mensagens para assegurar que foram assinadas com o endereço Bitcoin especificado</translation>
     </message>
     <message>
+        <source>&amp;Load PSBT from file…</source>
+        <translation type="unfinished">&amp;Carregar PSBT do arquivo...</translation>
+    </message>
+    <message>
+        <source>Load PSBT from clipboard…</source>
+        <translation type="unfinished">Carregar PSBT da área de transferência...</translation>
+    </message>
+    <message>
         <source>Open &amp;URI…</source>
         <translation type="unfinished">Abrir &amp;URI…</translation>
     </message>
@@ -557,13 +593,17 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation>
-            <numerusform />
-            <numerusform />
+            <numerusform>Processado %n bloco do histórico de transações.</numerusform>
+            <numerusform>Processados %n blocos do histórico de transações.</numerusform>
         </translation>
     </message>
     <message>
         <source>%1 behind</source>
         <translation>%1 em atraso</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation type="unfinished">Recuperando o atraso...</translation>
     </message>
     <message>
         <source>Last received block was generated %1 ago.</source>
@@ -677,9 +717,29 @@ Assinar só é possível com endereços do tipo "legado".</translation>
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n ligação ativa à rede Bitcoin.</numerusform>
+            <numerusform>%n ligações ativas à rede Bitcoin</numerusform>
         </translation>
+    </message>
+    <message>
+        <source>Click for more actions.</source>
+        <extracomment>A substring of the tooltip. "More actions" are available via the context menu.</extracomment>
+        <translation type="unfinished">Clique para mais acções.</translation>
+    </message>
+    <message>
+        <source>Show Peers tab</source>
+        <extracomment>A context menu item. The "Peers tab" is an element of the "Node window".</extracomment>
+        <translation type="unfinished">Mostra aba de Pares</translation>
+    </message>
+    <message>
+        <source>Disable network activity</source>
+        <extracomment>A context menu item.</extracomment>
+        <translation type="unfinished">Desativar atividade da rede</translation>
+    </message>
+    <message>
+        <source>Enable network activity</source>
+        <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
+        <translation type="unfinished">Activar atividade da rede</translation>
     </message>
     <message>
         <source>Error: %1</source>
@@ -848,6 +908,18 @@ Assinar só é possível com endereços do tipo "legado".</translation>
         <translation type="unfinished">Copiar &amp;quantia</translation>
     </message>
     <message>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">Copiar Id. da transação</translation>
+    </message>
+    <message>
+        <source>L&amp;ock unspent</source>
+        <translation type="unfinished">&amp;Bloquear não gasto</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock unspent</source>
+        <translation type="unfinished">&amp;Desbloquear não gasto</translation>
+    </message>
+    <message>
         <source>Copy quantity</source>
         <translation type="unfinished">Copiar quantidade</translation>
     </message>
@@ -918,7 +990,11 @@ Assinar só é possível com endereços do tipo "legado".</translation>
         <source>Create wallet warning</source>
         <translation type="unfinished">Aviso ao criar carteira</translation>
     </message>
-    </context>
+    <message>
+        <source>Can't list signers</source>
+        <translation type="unfinished">Não é possível listar signatários</translation>
+    </message>
+</context>
 <context>
     <name>OpenWalletActivity</name>
     <message>
@@ -1012,6 +1088,14 @@ Assinar só é possível com endereços do tipo "legado".</translation>
         <translation type="unfinished">Carteira de descritor</translation>
     </message>
     <message>
+        <source>Use an external signing device such as a hardware wallet. Configure the external signer script in wallet preferences first.</source>
+        <translation type="unfinished">Utilize um dispositivo de assinatura externo tal com uma carteira de hardware. Configure primeiro o script de assinatura nas preferências da carteira.</translation>
+    </message>
+    <message>
+        <source>External signer</source>
+        <translation type="unfinished">Signatário externo</translation>
+    </message>
+    <message>
         <source>Create</source>
         <translation type="unfinished">Criar</translation>
     </message>
@@ -1019,7 +1103,12 @@ Assinar só é possível com endereços do tipo "legado".</translation>
         <source>Compiled without sqlite support (required for descriptor wallets)</source>
         <translation type="unfinished">Compilado sem suporte para sqlite (requerido para carteiras de descritor)</translation>
     </message>
-    </context>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Compilado sem suporte de assinatura externa. (necessário para assinatura externa)</translation>
+    </message>
+</context>
 <context>
     <name>EditAddressDialog</name>
     <message>
@@ -1109,6 +1198,10 @@ Assinar só é possível com endereços do tipo "legado".</translation>
         <translation type="unfinished">(de %1 GB necessários)</translation>
     </message>
     <message>
+        <source>(%1 GB needed for full chain)</source>
+        <translation type="unfinished">(1%1 GB necessários para a blockchain  completa)</translation>
+    </message>
+    <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
         <translation type="unfinished">No mínimo %1 GB de dados irão ser armazenados nesta pasta.</translation>
     </message>
@@ -1120,8 +1213,8 @@ Assinar só é possível com endereços do tipo "legado".</translation>
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>(suficiente para restaurar backups com %n dia(s) de antiguidade)</numerusform>
+            <numerusform>(suficiente para restaurar backups com %n dia(s) de antiguidade)</numerusform>
         </translation>
     </message>
     <message>
@@ -1155,6 +1248,10 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     <message>
         <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
         <translation type="unfinished">Quando clicar OK, %1 vai começar a descarregar e processar a cadeia de blocos %4 completa (%2GB) começando com as transações mais antigas em %3 quando a %4 foi inicialmente lançada.</translation>
+    </message>
+    <message>
+        <source>Limit block chain storage to</source>
+        <translation type="unfinished">Limitar o tamanho da blockchain para</translation>
     </message>
     <message>
         <source>Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</source>
@@ -1257,7 +1354,11 @@ Assinar só é possível com endereços do tipo "legado".</translation>
         <source>%1 is currently syncing.  It will download headers and blocks from peers and validate them until reaching the tip of the block chain.</source>
         <translation type="unfinished">%1 está neste momento a sincronizar. Irá descarregar os cabeçalhos e blocos dos pares e validá-los até atingir a ponta da cadeia de blocos.</translation>
     </message>
-    </context>
+    <message>
+        <source>Unknown. Syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">Desconhecido. A sincronizar cabeçalhos (%1, %2%)...</translation>
+    </message>
+</context>
 <context>
     <name>OpenURIDialog</name>
     <message>
@@ -1282,6 +1383,10 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     <message>
         <source>&amp;Start %1 on system login</source>
         <translation type="unfinished">&amp;Iniciar o %1 no início de sessão do sistema</translation>
+    </message>
+    <message>
+        <source>Enabling pruning significantly reduces the disk space required to store transactions. All blocks are still fully validated. Reverting this setting requires re-downloading the entire blockchain.</source>
+        <translation type="unfinished">A ativação do pruning reduz significativamente o espaço em disco necessário para armazenar transações. Todos os blocos ainda estão totalmente validados. Reverter esta configuração requer que faça novamente o download de toda a blockchain.</translation>
     </message>
     <message>
         <source>Size of &amp;database cache</source>
@@ -1365,12 +1470,32 @@ Assinar só é possível com endereços do tipo "legado".</translation>
         <translation type="unfinished">&amp;Gastar troco não confirmado</translation>
     </message>
     <message>
+        <source>External Signer (e.g. hardware wallet)</source>
+        <translation type="unfinished">Signatário externo (ex: carteira física)</translation>
+    </message>
+    <message>
+        <source>&amp;External signer script path</source>
+        <translation type="unfinished">&amp;Caminho do script para signatário externo </translation>
+    </message>
+    <message>
+        <source>Full path to a Bitcoin Core compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</source>
+        <translation type="unfinished">Caminho completo para um script compatível com Bitcoin Core (por exemplo, C: \ Downloads \ hwi.exe ou /Users/you/Downloads/hwi.py). Cuidado: o malware pode roubar suas moedas!</translation>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation>Abrir a porta do cliente bitcoin automaticamente no seu router. Isto apenas funciona se o seu router suportar UPnP e este se encontrar ligado.</translation>
     </message>
     <message>
         <source>Map port using &amp;UPnP</source>
         <translation>Mapear porta, utilizando &amp;UPnP</translation>
+    </message>
+    <message>
+        <source>Automatically open the Bitcoin client port on the router. This only works when your router supports NAT-PMP and it is enabled. The external port could be random.</source>
+        <translation type="unfinished">Abrir a porta do cliente bitcoin automaticamente no seu router. Isto só funciona se o seu router suportar NAT-PMP e este se encontrar ligado. A porta externa poderá ser aleatória.</translation>
+    </message>
+    <message>
+        <source>Map port using NA&amp;T-PMP</source>
+        <translation type="unfinished">Mapear porta usando &amp;NAT-PMP</translation>
     </message>
     <message>
         <source>Accept connections from outside.</source>
@@ -1407,6 +1532,14 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     <message>
         <source>&amp;Window</source>
         <translation>&amp;Janela</translation>
+    </message>
+    <message>
+        <source>Show the icon in the system tray.</source>
+        <translation type="unfinished">Mostrar o ícone na barra de ferramentas.</translation>
+    </message>
+    <message>
+        <source>&amp;Show tray icon</source>
+        <translation type="unfinished">&amp;Mostrar ícone de bandeja</translation>
     </message>
     <message>
         <source>Show only a tray icon after minimizing the window.</source>
@@ -1457,12 +1590,25 @@ Assinar só é possível com endereços do tipo "legado".</translation>
         <translation type="unfinished">URLs de transação de &amp;terceiros</translation>
     </message>
     <message>
+        <source>Monospaced font in the Overview tab:</source>
+        <translation type="unfinished">Fonte no painel de visualização:</translation>
+    </message>
+    <message>
+        <source>embedded "%1"</source>
+        <translation type="unfinished">embutido "%1"</translation>
+    </message>
+    <message>
         <source>Options set in this dialog are overridden by the command line or in the configuration file:</source>
         <translation type="unfinished">As opções nesta janela são substituídas pela linha de comandos ou no ficheiro de configuração:</translation>
     </message>
     <message>
         <source>&amp;Cancel</source>
         <translation>&amp;Cancelar</translation>
+    </message>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Compilado sem suporte de assinatura externa. (necessário para assinatura externa)</translation>
     </message>
     <message>
         <source>default</source>
@@ -1652,6 +1798,11 @@ ID transação: %1</translation>
         <translation type="unfinished">Salvar informação de transação</translation>
     </message>
     <message>
+        <source>Partially Signed Transaction (Binary)</source>
+        <extracomment>Expanded name of the binary PSBT file format. See: BIP 174.</extracomment>
+        <translation type="unfinished">Transação parcialmente assinada (Binário)</translation>
+    </message>
+    <message>
         <source>PSBT saved to disk.</source>
         <translation type="unfinished">PSBT salva no disco.</translation>
     </message>
@@ -1723,6 +1874,14 @@ ID transação: %1</translation>
         <translation type="unfinished">'bitcoin://' não é um URI válido. Utilize 'bitcoin:'.</translation>
     </message>
     <message>
+        <source>Cannot process payment request because BIP70 is not supported.
+Due to widespread security flaws in BIP70 it's strongly recommended that any merchant instructions to switch wallets be ignored.
+If you are receiving this error you should request the merchant provide a BIP21 compatible URI.</source>
+        <translation type="unfinished">Não é possível processar o pagamento pedido porque o BIP70 não é suportado.
+Devido a falhas de segurança no BIP70, é recomendado que todas as instruçōes ao comerciante para mudar de carteiras sejam ignorada.
+Se está a receber este erro, deverá pedir ao comerciante para fornecer um URI compatível com BIP21.</translation>
+    </message>
+    <message>
         <source>URI cannot be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation type="unfinished">URI não foi lido corretamente! Isto pode ser causado por um endereço Bitcoin inválido ou por parâmetros URI malformados.</translation>
     </message>
@@ -1737,6 +1896,11 @@ ID transação: %1</translation>
         <source>Ping</source>
         <extracomment>Title of Peers Table column which indicates the current latency of the connection with the peer.</extracomment>
         <translation type="unfinished">Latência</translation>
+    </message>
+    <message>
+        <source>Peer</source>
+        <extracomment>Title of Peers Table column which contains a unique number used to identify a connection.</extracomment>
+        <translation type="unfinished">Par</translation>
     </message>
     <message>
         <source>Sent</source>
@@ -1955,12 +2119,28 @@ ID transação: %1</translation>
         <translation type="unfinished">Se este par pediu ou não para retransmitirmos transações.</translation>
     </message>
     <message>
+        <source>High Bandwidth</source>
+        <translation type="unfinished">Alta largura de banda</translation>
+    </message>
+    <message>
         <source>Connection Time</source>
         <translation type="unfinished">Tempo de Ligação</translation>
     </message>
     <message>
+        <source>Elapsed time since a novel block passing initial validity checks was received from this peer.</source>
+        <translation type="unfinished">Tempo decorrido desde que um novo bloco que passou as verificações de validade iniciais foi recebido deste par.</translation>
+    </message>
+    <message>
         <source>Last Block</source>
         <translation type="unfinished">Último bloco</translation>
+    </message>
+    <message>
+        <source>Elapsed time since a novel transaction accepted into our mempool was received from this peer.</source>
+        <translation type="unfinished">Tempo decorrido desde que uma nova transação aceite para a nossa mempool foi recebida deste par.</translation>
+    </message>
+    <message>
+        <source>Last Tx</source>
+        <translation type="unfinished">Última Tx</translation>
     </message>
     <message>
         <source>Last Send</source>
@@ -2027,6 +2207,22 @@ ID transação: %1</translation>
         <translation type="unfinished">Saída:</translation>
     </message>
     <message>
+        <source>Inbound: initiated by peer</source>
+        <translation type="unfinished">Entrando: iniciado por par</translation>
+    </message>
+    <message>
+        <source>we selected the peer for high bandwidth relay</source>
+        <translation type="unfinished">selecionámos o par para uma retransmissão de alta banda larga</translation>
+    </message>
+    <message>
+        <source>the peer selected us for high bandwidth relay</source>
+        <translation type="unfinished">o par selecionou-nos para uma retransmissão de alta banda larga</translation>
+    </message>
+    <message>
+        <source>no high bandwidth relay selected</source>
+        <translation type="unfinished">nenhum retransmissor de alta banda larga selecionado</translation>
+    </message>
+    <message>
         <source>&amp;Disconnect</source>
         <translation type="unfinished">&amp;Desconectar</translation>
     </message>
@@ -2063,9 +2259,30 @@ ID transação: %1</translation>
         <translation type="unfinished">A executar o comando utilizando a carteira "%1"</translation>
     </message>
     <message>
+        <source>Welcome to the %1 RPC console.
+Use up and down arrows to navigate history, and %2 to clear screen.
+Use %3 and %4 to increase or decrease the font size.
+Type %5 for an overview of available commands.
+For more information on using this console, type %6.
+
+%7WARNING: Scammers have been active, telling users to type commands here, stealing their wallet contents. Do not use this console without fully understanding the ramifications of a command.%8</source>
+        <extracomment>RPC console welcome message. Placeholders %7 and %8 are style tags for the warning content, and they are not space separated from the rest of the text intentionally.</extracomment>
+        <translation type="unfinished">Bem vindo à %1 consola RPC.
+Utilize as setas para cima e para baixo para navegar no histórico, e %2 para limpar o ecrã.
+Utilize o %3 e %4 para aumentar ou diminuir o tamanho da letra.
+Escreva %5 para uma visão geral dos comandos disponíveis.
+Para mais informação acerca da utilização desta consola, escreva %6.
+
+%7ATENÇÃO: Foram notadas burlas, dizendo aos utilizadores para escreverem comandos aqui, roubando os conteúdos da sua carteira. Não utilize esta consola sem perceber as ramificações de um comando.%8</translation>
+    </message>
+    <message>
         <source>Executing…</source>
         <extracomment>A console message indicating an entered command is currently being executed.</extracomment>
         <translation type="unfinished">A executar...</translation>
+    </message>
+    <message>
+        <source>(peer: %1)</source>
+        <translation type="unfinished">(par: %1)</translation>
     </message>
     <message>
         <source>Yes</source>
@@ -2242,6 +2459,10 @@ ID transação: %1</translation>
         <translation type="unfinished">&amp;Verificar</translation>
     </message>
     <message>
+        <source>Verify this address on e.g. a hardware wallet screen</source>
+        <translation type="unfinished">Verifique este endreço, por exemplo, no ecrã de uma wallet física</translation>
+    </message>
+    <message>
         <source>&amp;Save Image…</source>
         <translation type="unfinished">&amp;Guardar imagem…</translation>
     </message>
@@ -2372,6 +2593,10 @@ ID transação: %1</translation>
         <translation type="unfinished">Limpar todos os campos do formulário.</translation>
     </message>
     <message>
+        <source>Inputs…</source>
+        <translation type="unfinished">Entradas...</translation>
+    </message>
+    <message>
         <source>Dust:</source>
         <translation type="unfinished">Lixo:</translation>
     </message>
@@ -2390,6 +2615,10 @@ ID transação: %1</translation>
     <message>
         <source>A too low fee might result in a never confirming transaction (read the tooltip)</source>
         <translation type="unfinished">Uma taxa muito baixa pode resultar numa transação nunca confirmada (leia a dica)</translation>
+    </message>
+    <message>
+        <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
+        <translation type="unfinished">(A taxa inteligente ainda não foi inicializada. Isto demora normalmente alguns blocos...)</translation>
     </message>
     <message>
         <source>Confirmation time target:</source>
@@ -2452,6 +2681,15 @@ ID transação: %1</translation>
         <translation type="unfinished">%1 (%2 blocos)</translation>
     </message>
     <message>
+        <source>Sign on device</source>
+        <extracomment>"device" usually means a hardware wallet</extracomment>
+        <translation type="unfinished">entrar no dispositivo</translation>
+    </message>
+    <message>
+        <source>Connect your hardware wallet first.</source>
+        <translation type="unfinished">Por favor conecte a sua wallet física primeiro.</translation>
+    </message>
+    <message>
         <source>Cr&amp;eate Unsigned</source>
         <translation type="unfinished">Criar não assinado</translation>
     </message>
@@ -2480,16 +2718,47 @@ ID transação: %1</translation>
         <translation type="unfinished">Tem a certeza que deseja enviar?</translation>
     </message>
     <message>
+        <source>To review recipient list click "Show Details…"</source>
+        <translation type="unfinished">Para rever a lista de destinatários clique "Mostrar detalhes..."</translation>
+    </message>
+    <message>
         <source>Create Unsigned</source>
         <translation type="unfinished">Criar sem assinatura</translation>
+    </message>
+    <message>
+        <source>Sign and send</source>
+        <translation type="unfinished">Assinar e enviar</translation>
+    </message>
+    <message>
+        <source>Sign failed</source>
+        <translation type="unfinished">Assinatura falhou</translation>
+    </message>
+    <message>
+        <source>External signer not found</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Signatário externo não encontrado</translation>
+    </message>
+    <message>
+        <source>External signer failure</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Falha do signatário externo</translation>
     </message>
     <message>
         <source>Save Transaction Data</source>
         <translation type="unfinished">Salvar informação de transação</translation>
     </message>
     <message>
+        <source>Partially Signed Transaction (Binary)</source>
+        <extracomment>Expanded name of the binary PSBT file format. See: BIP 174.</extracomment>
+        <translation type="unfinished">Transação parcialmente assinada (Binário)</translation>
+    </message>
+    <message>
         <source>PSBT saved</source>
         <translation type="unfinished">PSBT salva</translation>
+    </message>
+    <message>
+        <source>External balance:</source>
+        <translation type="unfinished">Balanço externo:</translation>
     </message>
     <message>
         <source>or</source>
@@ -2566,8 +2835,8 @@ ID transação: %1</translation>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation>
-            <numerusform />
-            <numerusform />
+            <numerusform>Estimado para iniciar a confirmação dentro de %n blocos.</numerusform>
+            <numerusform>Estimado para iniciar a confirmação dentro de %n blocos.</numerusform>
         </translation>
     </message>
     <message>
@@ -3178,6 +3447,14 @@ ID transação: %1</translation>
         <translation type="unfinished">Copiar &amp;quantia</translation>
     </message>
     <message>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">Copiar Id. da transação</translation>
+    </message>
+    <message>
+        <source>&amp;Show transaction details</source>
+        <translation type="unfinished">Mo&amp;strar detalhes da transação</translation>
+    </message>
+    <message>
         <source>&amp;Edit address label</source>
         <translation type="unfinished">&amp;Editar etiqueta do endereço</translation>
     </message>
@@ -3313,6 +3590,10 @@ Ir para o arquivo &gt; Abrir carteira para carregar a carteira
         <translation type="unfinished">Não foi possível cometer a transação</translation>
     </message>
     <message>
+        <source>Can't display address</source>
+        <translation type="unfinished">Não é possível exibir o endereço</translation>
+    </message>
+    <message>
         <source>default wallet</source>
         <translation type="unfinished">carteira predefinida</translation>
     </message>
@@ -3396,6 +3677,10 @@ Ir para o arquivo &gt; Abrir carteira para carregar a carteira
         <translation type="unfinished">-maxtxfee está definido com um valor muito alto! Taxas desta magnitude podem ser pagas numa única transação.</translation>
     </message>
     <message>
+        <source>Cannot downgrade wallet from version %i to version %i. Wallet version unchanged.</source>
+        <translation type="unfinished">Não é possível fazer o downgrade da carteira da versão %i para %i. Versão da carteira inalterada.</translation>
+    </message>
+    <message>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running.</source>
         <translation type="unfinished">Não foi possível obter o bloqueio de escrita no da pasta de dados %s. %s provavelmente já está a ser executado.</translation>
     </message>
@@ -3412,6 +3697,10 @@ Ir para o arquivo &gt; Abrir carteira para carregar a carteira
         <translation type="unfinished">Erro ao ler %s! Todas as chaves foram lidas corretamente, mas os dados de transação ou as entradas no livro de endereços podem não existir ou estarem incorretos.</translation>
     </message>
     <message>
+        <source>Error: Dumpfile version is not supported. This version of bitcoin-wallet only supports version 1 dumpfiles. Got dumpfile with version %s</source>
+        <translation type="unfinished">Erro: Esta versão do bitcoin-wallet apenas suporta arquivos de despejo na versão 1. (Versão atual: %s)</translation>
+    </message>
+    <message>
         <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
         <translation type="unfinished">Erro: a escuta de ligações de entrada falhou (escuta devolveu o erro %s)</translation>
     </message>
@@ -3420,12 +3709,21 @@ Ir para o arquivo &gt; Abrir carteira para carregar a carteira
         <translation type="unfinished">Falha na estimativa de taxa. A taxa alternativa de recurso está desativada. Espere alguns blocos ou ative -fallbackfee.</translation>
     </message>
     <message>
+        <source>File %s already exists. If you are sure this is what you want, move it out of the way first.</source>
+        <translation type="unfinished">Arquivo%sjá existe. Se você tem certeza de que é isso que quer, tire-o do caminho primeiro.</translation>
+    </message>
+    <message>
         <source>Invalid amount for -maxtxfee=&lt;amount&gt;: '%s' (must be at least the minrelay fee of %s to prevent stuck transactions)</source>
         <translation type="unfinished">Montante inválido para -maxtxfee=&lt;amount&gt;: '%s' (deverá ser, no mínimo, a taxa mínima de propagação de %s, de modo a evitar transações bloqueadas)</translation>
     </message>
     <message>
         <source>More than one onion bind address is provided. Using %s for the automatically created Tor onion service.</source>
         <translation type="unfinished">Mais de um endereço de ligação onion é fornecido. Usando %s para o serviço Tor onion criado automaticamente.</translation>
+    </message>
+    <message>
+        <source>No wallet file format provided. To use createfromdump, -format=&lt;format&gt; must be provided.</source>
+        <translation type="unfinished">Nenhum formato de arquivo de carteira fornecido. Para usar createfromdump, -format = &lt;format&gt;
+deve ser fornecido.</translation>
     </message>
     <message>
         <source>Please check that your computer's date and time are correct! If your clock is wrong, %s will not work properly.</source>
@@ -3556,6 +3854,10 @@ Ir para o arquivo &gt; Abrir carteira para carregar a carteira
         <translation type="unfinished">Carregamento concluído</translation>
     </message>
     <message>
+        <source>Dump file %s does not exist.</source>
+        <translation type="unfinished">Arquivo de despejo %s não existe</translation>
+    </message>
+    <message>
         <source>Error creating %s</source>
         <translation type="unfinished">Erro a criar %s</translation>
     </message>
@@ -3596,6 +3898,10 @@ Ir para o arquivo &gt; Abrir carteira para carregar a carteira
         <translation type="unfinished">Erro ao ler da base de dados. A encerrar.</translation>
     </message>
     <message>
+        <source>Error reading next record from wallet database</source>
+        <translation type="unfinished">Erro ao ler o registo seguinte da base de dados da carteira</translation>
+    </message>
+    <message>
         <source>Error upgrading chainstate database</source>
         <translation type="unfinished">Erro ao atualizar a base de dados do estado da cadeia (chainstate)</translation>
     </message>
@@ -3604,8 +3910,32 @@ Ir para o arquivo &gt; Abrir carteira para carregar a carteira
         <translation type="unfinished">Erro: espaço em disco demasiado baixo para %s</translation>
     </message>
     <message>
+        <source>Error: Got key that was not hex: %s</source>
+        <translation type="unfinished">Erro: Chave obtida sem ser no formato hex: %s</translation>
+    </message>
+    <message>
+        <source>Error: Got value that was not hex: %s</source>
+        <translation type="unfinished">Erro: Valor obtido sem ser no formato hex: %s</translation>
+    </message>
+    <message>
         <source>Error: Keypool ran out, please call keypoolrefill first</source>
         <translation type="unfinished">A keypool esgotou-se, por favor execute primeiro keypoolrefill1</translation>
+    </message>
+    <message>
+        <source>Error: Missing checksum</source>
+        <translation type="unfinished">Erro: soma de verificação ausente</translation>
+    </message>
+    <message>
+        <source>Error: No %s addresses available.</source>
+        <translation type="unfinished">Erro: Não existem %s endereços disponíveis.</translation>
+    </message>
+    <message>
+        <source>Error: Unable to parse version %u as a uint32_t</source>
+        <translation type="unfinished">Erro: Não foi possível converter versão %u como uint32_t</translation>
+    </message>
+    <message>
+        <source>Error: Unable to write record to new wallet</source>
+        <translation type="unfinished">Erro: Não foi possível escrever registro para a nova carteira</translation>
     </message>
     <message>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
@@ -3644,6 +3974,10 @@ Ir para o arquivo &gt; Abrir carteira para carregar a carteira
         <translation type="unfinished">Fundos insuficientes</translation>
     </message>
     <message>
+        <source>Invalid -i2psam address or hostname: '%s'</source>
+        <translation type="unfinished">Endereço ou nome de servidor -i2psam inválido: '%s'</translation>
+    </message>
+    <message>
         <source>Invalid -onion address or hostname: '%s'</source>
         <translation type="unfinished">Endereço -onion ou hostname inválido: '%s'</translation>
     </message>
@@ -3676,6 +4010,18 @@ Ir para o arquivo &gt; Abrir carteira para carregar a carteira
         <translation type="unfinished">Máscara de rede inválida especificada em -whitelist: '%s'</translation>
     </message>
     <message>
+        <source>Loading P2P addresses…</source>
+        <translation type="unfinished">Carregando endereços P2P...</translation>
+    </message>
+    <message>
+        <source>Loading banlist…</source>
+        <translation type="unfinished">A carregar a lista de banidos...</translation>
+    </message>
+    <message>
+        <source>Loading block index…</source>
+        <translation type="unfinished">Carregando índice do bloco...</translation>
+    </message>
+    <message>
         <source>Loading wallet…</source>
         <translation type="unfinished">A carregar a carteira…</translation>
     </message>
@@ -3696,12 +4042,28 @@ Ir para o arquivo &gt; Abrir carteira para carregar a carteira
         <translation type="unfinished">A redução não pode ser configurada com um valor negativo.</translation>
     </message>
     <message>
+        <source>Prune mode is incompatible with -coinstatsindex.</source>
+        <translation type="unfinished">Modo de poda é incompatível com -coinstatsindex.</translation>
+    </message>
+    <message>
         <source>Prune mode is incompatible with -txindex.</source>
         <translation type="unfinished">O modo de redução é incompatível com -txindex.</translation>
     </message>
     <message>
+        <source>Pruning blockstore…</source>
+        <translation type="unfinished">Prunando os blocos existentes...</translation>
+    </message>
+    <message>
         <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
         <translation type="unfinished">Reduzindo -maxconnections de %d para %d, devido a limitações no sistema.</translation>
+    </message>
+    <message>
+        <source>Replaying blocks…</source>
+        <translation type="unfinished">Repetindo blocos...</translation>
+    </message>
+    <message>
+        <source>Rescanning…</source>
+        <translation type="unfinished">.Reexaminando...</translation>
     </message>
     <message>
         <source>SQLiteDatabase: Failed to execute statement to verify database: %s</source>
@@ -3745,8 +4107,17 @@ Ir para o arquivo &gt; Abrir carteira para carregar a carteira
 A pasta de blocos especificados "%s" não existe.</translation>
     </message>
     <message>
+        <source>Starting network threads…</source>
+        <translation type="unfinished">A iniciar threads de rede...</translation>
+    </message>
+    <message>
         <source>The source code is available from %s.</source>
         <translation type="unfinished">O código fonte está disponível pelo %s.</translation>
+    </message>
+    <message>
+        <source>The specified config file %s does not exist</source>
+        <translation type="unfinished">O ficheiro de configuração especificado %s não existe
+</translation>
     </message>
     <message>
         <source>The transaction amount is too small to pay the fee</source>
@@ -3785,6 +4156,10 @@ A pasta de blocos especificados "%s" não existe.</translation>
         <translation type="unfinished">A transação dever pelo menos um destinatário</translation>
     </message>
     <message>
+        <source>Transaction needs a change address, but we can't generate it. %s</source>
+        <translation type="unfinished">Transação precisa alteração de endereço, mas não podemos gerar o mesmo. %s</translation>
+    </message>
+    <message>
         <source>Transaction too large</source>
         <translation type="unfinished">Transação grande demais</translation>
     </message>
@@ -3809,6 +4184,10 @@ A pasta de blocos especificados "%s" não existe.</translation>
         <translation type="unfinished">Não foi possível gerar chaves</translation>
     </message>
     <message>
+        <source>Unable to open %s for writing</source>
+        <translation type="unfinished">Não foi possível abrir %s para escrita</translation>
+    </message>
+    <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
         <translation type="unfinished">Não é possível iniciar o servidor HTTP. Verifique o debug.log para detalhes.</translation>
     </message>
@@ -3827,6 +4206,10 @@ A pasta de blocos especificados "%s" não existe.</translation>
     <message>
         <source>Unknown network specified in -onlynet: '%s'</source>
         <translation type="unfinished">Rede desconhecida especificada em -onlynet: '%s'</translation>
+    </message>
+    <message>
+        <source>Unknown new rules activated (versionbit %i)</source>
+        <translation type="unfinished">Ativadas novas regras desconhecidas (versionbit %i)</translation>
     </message>
     <message>
         <source>Unsupported logging category %s=%s.</source>

--- a/src/qt/locale/bitcoin_pt_BR.ts
+++ b/src/qt/locale/bitcoin_pt_BR.ts
@@ -3,7 +3,7 @@
     <name>AddressBookPage</name>
     <message>
         <source>Right-click to edit address or label</source>
-        <translation type="unfinished">Clique com o botão direito para editar endereço ou rótulo</translation>
+        <translation type="unfinished">Clique com o botão direito para editar endereço ou etiqueta</translation>
     </message>
     <message>
         <source>Create a new address</source>
@@ -35,7 +35,7 @@
     </message>
     <message>
         <source>Export the data in the current tab to a file</source>
-        <translation>Exportar os dados na aba atual para um arquivo</translation>
+        <translation>Exportar os dados do separador atual para um ficheiro</translation>
     </message>
     <message>
         <source>&amp;Export</source>
@@ -73,7 +73,7 @@
         <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
 Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Estes são seus endereços Bitcoin para receber pagamentos. Use o botão 'Criar novos endereços de recebimento' na barra receber para criar novos endereços.
-Somente é possível acessar com endereços do tipo 'legado'.</translation>
+Somente é possível assinar com endereços do tipo 'legado'.</translation>
     </message>
     <message>
         <source>&amp;Copy Address</source>
@@ -110,7 +110,7 @@ Somente é possível acessar com endereços do tipo 'legado'.</translation>
     <name>AddressTableModel</name>
     <message>
         <source>Label</source>
-        <translation type="unfinished">Rótulo</translation>
+        <translation type="unfinished">Etiqueta</translation>
     </message>
     <message>
         <source>Address</source>
@@ -332,7 +332,7 @@ Somente é possível acessar com endereços do tipo 'legado'.</translation>
         <source>%n week(s)</source>
         <translation type="unfinished">
             <numerusform>%n week</numerusform>
-            <numerusform>%n weeks</numerusform>
+            <numerusform>%n semanas</numerusform>
         </translation>
     </message>
     <message>
@@ -343,7 +343,7 @@ Somente é possível acessar com endereços do tipo 'legado'.</translation>
         <source>%n year(s)</source>
         <translation type="unfinished">
             <numerusform>%n year</numerusform>
-            <numerusform>%n years</numerusform>
+            <numerusform>%n anos</numerusform>
         </translation>
     </message>
     </context>
@@ -607,7 +607,7 @@ Somente é possível acessar com endereços do tipo 'legado'.</translation>
     </message>
     <message>
         <source>Open node debugging and diagnostic console</source>
-        <translation type="unfinished">Abrir console de diagnóstico e depuração de Nó</translation>
+        <translation type="unfinished">Abrir console de diagnóstico e depuração de nó</translation>
     </message>
     <message>
         <source>&amp;Sending addresses</source>
@@ -693,7 +693,7 @@ Somente é possível acessar com endereços do tipo 'legado'.</translation>
     <message>
         <source>Show Peers tab</source>
         <extracomment>A context menu item. The "Peers tab" is an element of the "Node window".</extracomment>
-        <translation type="unfinished">Mostrar abas De pares.</translation>
+        <translation type="unfinished">Mostra aba de Pares</translation>
     </message>
     <message>
         <source>Disable network activity</source>
@@ -1476,6 +1476,10 @@ Somente é possível acessar com endereços do tipo 'legado'.</translation>
         <translation type="unfinished">&amp;URLs de transação de terceiros</translation>
     </message>
     <message>
+        <source>Monospaced font in the Overview tab:</source>
+        <translation type="unfinished">Fonte no painel de visualização:</translation>
+    </message>
+    <message>
         <source>Options set in this dialog are overridden by the command line or in the configuration file:</source>
         <translation type="unfinished">Opções nesta tela foram sobreescritas por comandos ou no arquivo de configuração:</translation>
     </message>
@@ -1489,7 +1493,7 @@ Somente é possível acessar com endereços do tipo 'legado'.</translation>
     </message>
     <message>
         <source>none</source>
-        <translation type="unfinished">nenhum</translation>
+        <translation type="unfinished">Nenhum</translation>
     </message>
     <message>
         <source>Confirm options reset</source>
@@ -1754,7 +1758,7 @@ Somente é possível acessar com endereços do tipo 'legado'.</translation>
     <message>
         <source>Peer</source>
         <extracomment>Title of Peers Table column which contains a unique number used to identify a connection.</extracomment>
-        <translation type="unfinished">&amp;Nós</translation>
+        <translation type="unfinished">Nós</translation>
     </message>
     <message>
         <source>Sent</source>
@@ -2945,7 +2949,7 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     </message>
     <message>
         <source>Transaction total size</source>
-        <translation type="unfinished">Tamanho tota da transação</translation>
+        <translation type="unfinished">Tamanho total da transação</translation>
     </message>
     <message>
         <source>Transaction virtual size</source>
@@ -3170,6 +3174,11 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     <message>
         <source>Export Transaction History</source>
         <translation type="unfinished">Exportar histórico de transações</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See https://en.wikipedia.org/wiki/Comma-separated_values</extracomment>
+        <translation type="unfinished">Arquivo separado por vírgula</translation>
     </message>
     <message>
         <source>Confirmed</source>

--- a/src/qt/locale/bitcoin_ro.ts
+++ b/src/qt/locale/bitcoin_ro.ts
@@ -946,10 +946,18 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
         <translation type="unfinished">Inchide portofel</translation>
     </message>
     <message>
+        <source>Are you sure you wish to close the wallet &lt;i&gt;%1&lt;/i&gt;?</source>
+        <translation type="unfinished">Esti sigur ca doresti sa inchizi portofelul&lt;b&gt;%1&lt;b&gt;?</translation>
+    </message>
+    <message>
         <source>Close all wallets</source>
         <translation type="unfinished">Închideți toate portofelele</translation>
     </message>
-    </context>
+    <message>
+        <source>Are you sure you wish to close all wallets?</source>
+        <translation type="unfinished">Esti sigur ca doresti sa inchizi toate portofelele?</translation>
+    </message>
+</context>
 <context>
     <name>CreateWalletDialog</name>
     <message>
@@ -1139,6 +1147,10 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
         <translation type="unfinished">Revenirea la această setare necesită re-descărcarea întregului blockchain. Este mai rapid să descărcați mai întâi rețeaua complet și să o fragmentați  mai târziu. Dezactivează unele funcții avansate.</translation>
     </message>
     <message>
+        <source> GB</source>
+        <translation type="unfinished">GB</translation>
+    </message>
+    <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
         <translation type="unfinished">Sincronizarea initiala necesita foarte multe resurse, si poate releva probleme de hardware ale computerului care anterior au trecut neobservate. De fiecare data cand rulati %1, descarcarea va continua de unde a fost intrerupta.</translation>
     </message>
@@ -1210,6 +1222,13 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
     <message>
         <source>Hide</source>
         <translation type="unfinished">Ascunde</translation>
+    </message>
+    </context>
+<context>
+    <name>OpenURIDialog</name>
+    <message>
+        <source>Open bitcoin URI</source>
+        <translation type="unfinished">DeschidețI Bitcoin URI</translation>
     </message>
     </context>
 <context>
@@ -1375,6 +1394,10 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
         <translation type="unfinished">Arată controlul caracteristicilor monedei sau nu.</translation>
     </message>
     <message>
+        <source>Connect to the Bitcoin network through a separate SOCKS5 proxy for Tor onion services.</source>
+        <translation type="unfinished">Conectați-vă la rețeaua Bitcoin printr-un proxy SOCKS5 separat pentru serviciile Tor (onion).</translation>
+    </message>
+    <message>
         <source>&amp;Third party transaction URLs</source>
         <translation type="unfinished">URL-uri tranzacţii &amp;terţe părţi</translation>
     </message>
@@ -1497,8 +1520,16 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
 <context>
     <name>PSBTOperationsDialog</name>
     <message>
+        <source>Copy to Clipboard</source>
+        <translation type="unfinished">Copiați în clipboard</translation>
+    </message>
+    <message>
         <source>Close</source>
         <translation type="unfinished">Inchide</translation>
+    </message>
+    <message>
+        <source>Save Transaction Data</source>
+        <translation type="unfinished">Salvați datele tranzacției</translation>
     </message>
     <message>
         <source>Total Amount</source>
@@ -1508,7 +1539,11 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
         <source>or</source>
         <translation type="unfinished">sau</translation>
     </message>
-    </context>
+    <message>
+        <source>Transaction status is unknown.</source>
+        <translation type="unfinished">Starea tranzacției este necunoscută.</translation>
+    </message>
+</context>
 <context>
     <name>PaymentServer</name>
     <message>
@@ -1582,6 +1617,10 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
     <message>
         <source>Error encoding URI into QR Code.</source>
         <translation type="unfinished">Eroare la codarea URl-ului în cod QR.</translation>
+    </message>
+    <message>
+        <source>QR code support not available.</source>
+        <translation type="unfinished">Suportul pentru codurile QR nu este disponibil.</translation>
     </message>
     <message>
         <source>Save QR Code</source>
@@ -1905,6 +1944,10 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
+        <source>Address:</source>
+        <translation type="unfinished">Adresa:</translation>
+    </message>
+    <message>
         <source>Amount:</source>
         <translation type="unfinished">Sumă:</translation>
     </message>
@@ -2129,6 +2172,10 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
     <message>
         <source>Are you sure you want to send?</source>
         <translation type="unfinished">Sigur doriţi să trimiteţi?</translation>
+    </message>
+    <message>
+        <source>Save Transaction Data</source>
+        <translation type="unfinished">Salvați datele tranzacției</translation>
     </message>
     <message>
         <source>or</source>
@@ -2383,6 +2430,10 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
     <message>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished">Deblocarea portofelului a fost anulata.</translation>
+    </message>
+    <message>
+        <source>No error</source>
+        <translation type="unfinished">Fara Eroare</translation>
     </message>
     <message>
         <source>Private key for the entered address is not available.</source>
@@ -3016,6 +3067,10 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
     <message>
         <source>Corrupted block database detected</source>
         <translation type="unfinished">Bloc defect din baza de date detectat</translation>
+    </message>
+    <message>
+        <source>Disk space is too low!</source>
+        <translation type="unfinished">Spatiul de stocare insuficient!</translation>
     </message>
     <message>
         <source>Do you want to rebuild the block database now?</source>

--- a/src/qt/locale/bitcoin_ru.ts
+++ b/src/qt/locale/bitcoin_ru.ts
@@ -3,7 +3,7 @@
     <name>AddressBookPage</name>
     <message>
         <source>Right-click to edit address or label</source>
-        <translation type="unfinished">Нажмите правой кнопкой мыши для изменения адреса или метки</translation>
+        <translation type="unfinished">Нажмите правой кнопкой мыши, чтобы изменить адрес или метку</translation>
     </message>
     <message>
         <source>Create a new address</source>
@@ -15,7 +15,7 @@
     </message>
     <message>
         <source>Copy the currently selected address to the system clipboard</source>
-        <translation>Копировать выделенный сейчас адрес в буфер обмена</translation>
+        <translation>Скопировать выбранный адрес в буфер обмена</translation>
     </message>
     <message>
         <source>&amp;Copy</source>
@@ -27,7 +27,7 @@
     </message>
     <message>
         <source>Delete the currently selected address from the list</source>
-        <translation>Удалить выделенный сейчас адрес из списка</translation>
+        <translation>Удалить текущий выбранный адрес из списка</translation>
     </message>
     <message>
         <source>Enter address or label to search</source>
@@ -35,7 +35,7 @@
     </message>
     <message>
         <source>Export the data in the current tab to a file</source>
-        <translation>Экспортировать данные текущей вкладки в файл</translation>
+        <translation>Экспортировать данные из текущей вкладки в файл</translation>
     </message>
     <message>
         <source>&amp;Export</source>
@@ -47,11 +47,11 @@
     </message>
     <message>
         <source>Choose the address to send coins to</source>
-        <translation type="unfinished">Выберите адрес для отправки перевода</translation>
+        <translation type="unfinished">Выберите адрес для отправки монет</translation>
     </message>
     <message>
         <source>Choose the address to receive coins with</source>
-        <translation type="unfinished">Выберите адрес для получения перевода</translation>
+        <translation type="unfinished">Выберите адрес для получения монет</translation>
     </message>
     <message>
         <source>C&amp;hoose</source>
@@ -59,21 +59,17 @@
     </message>
     <message>
         <source>Sending addresses</source>
-        <translation type="unfinished">Адреса для отправки</translation>
+        <translation type="unfinished">Адреса отправки</translation>
     </message>
     <message>
         <source>Receiving addresses</source>
-        <translation type="unfinished">Адреса для получения</translation>
-    </message>
-    <message>
-        <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
-        <translation type="unfinished">Это ваши биткоин-адреса для отправки платежей. Всегда проверяйте сумму и адрес получателя перед отправкой перевода.</translation>
+        <translation type="unfinished">Адреса получения</translation>
     </message>
     <message>
         <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
 Signing is only possible with addresses of the type 'legacy'.</source>
-        <translation type="unfinished">Это ваши биткоин-адреса для получения платежей. Используйте кнопку «Создать новый адрес для получения» на вкладке Получить, чтобы создать новые адреса.
-Подписание возможно только с адресами типа "legacy".</translation>
+        <translation type="unfinished">Это ваши биткойн-адреса для приема платежей. Используйте кнопку 'Создать новый адрес получения' на вкладке получения, чтобы создать новые адреса.
+Подпись возможна только с адресами типа 'устаревший'.</translation>
     </message>
     <message>
         <source>&amp;Copy Address</source>
@@ -85,7 +81,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>&amp;Edit</source>
-        <translation type="unfinished">&amp;Редактировать.</translation>
+        <translation type="unfinished">&amp;Редактировать</translation>
     </message>
     <message>
         <source>Export Address List</source>
@@ -99,11 +95,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>There was an error trying to save the address list to %1. Please try again.</source>
         <extracomment>An error message. %1 is a stand-in argument for the name of the file we attempted to save to.</extracomment>
-        <translation type="unfinished">Произошла ошибка при сохранении списка адресов в %1. Пожалуйста, попробуйте еще раз.</translation>
+        <translation type="unfinished">Произошла ошибка при попытке сохранить список адресов в %1. Пожалуйста, попробуйте еще раз.</translation>
     </message>
     <message>
         <source>Exporting Failed</source>
-        <translation type="unfinished">Экспорт не удался</translation>
+        <translation type="unfinished">Ошибка экспорта</translation>
     </message>
 </context>
 <context>
@@ -149,7 +145,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
-        <translation type="unfinished">Для выполнения операции нужно расшифровать ваш кошелёк при помощи парольной фразы.</translation>
+        <translation type="unfinished">Данная операция требует введения пароля для разблокировки вашего кошелька.</translation>
     </message>
     <message>
         <source>Unlock wallet</source>
@@ -181,19 +177,19 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Enter the old passphrase and new passphrase for the wallet.</source>
-        <translation type="unfinished">Введите старую и новую парольные фразы для кошелька.</translation>
+        <translation type="unfinished">Введите старый и новый пароли для кошелька</translation>
     </message>
     <message>
         <source>Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
-        <translation type="unfinished">Помните, что шифрование кошелька не может полностью защитить ваши биткоины от кражи вредоносными программами, заражающими ваш компьютер.</translation>
+        <translation type="unfinished">Помните, что шифрование кошелька не может полностью защитить ваши биткойны от кражи вредоносными программами, заразившими ваш компьютер.</translation>
     </message>
     <message>
         <source>Wallet to be encrypted</source>
-        <translation type="unfinished">Кошелёк зашифрован</translation>
+        <translation type="unfinished">Кошелек должен быть зашифрован</translation>
     </message>
     <message>
         <source>Your wallet is about to be encrypted. </source>
-        <translation type="unfinished">Ваш кошелёк будет зашифрован.</translation>
+        <translation type="unfinished">Ваш кошелек будет зашифрован.</translation>
     </message>
     <message>
         <source>Your wallet is now encrypted. </source>
@@ -201,7 +197,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <translation type="unfinished">ВАЖНО: любые резервные копии вашего кошелька, которые вы делали ранее, необходимо заменить файлом с зашифрованным кошельком, который только что был сгенерирован. В целях безопасности предыдущие резервные копии незашифрованного кошелька станут непригодными для использования после того, как вы начнёте использовать новый, зашифрованный кошелёк.</translation>
+        <translation type="unfinished">ВАЖНО: Все предыдущие резервные копии вашего кошелька, которые вы сделали, необходимо заменить недавно сгенерированным, зашифрованным файлом кошелька. Из соображений безопасности, предыдущие резервные копии незашифрованного файла кошелька станут бесполезными как только вы начнёте использовать новый, зашифрованный кошелёк.</translation>
     </message>
     <message>
         <source>Wallet encryption failed</source>
@@ -251,8 +247,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
-        <translation type="unfinished">Произошла критическая ошибка. %1 больше не может продолжать безопасную работу и будет закрыт.
- </translation>
+        <translation type="unfinished">Произошла фатальная ошибка. %1 больше не может безопасно продолжить и будет закрыт.</translation>
     </message>
     <message>
         <source>Internal error</source>
@@ -260,18 +255,18 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
-        <translation type="unfinished">Произошла внутренняя ошибка. %1 попытается безопасно продолжить работу. Вы можете сообщить об этой неожиданной ошибке, как описано ниже.</translation>
+        <translation type="unfinished">Возникла внутренняя ошибка. %1 попытается продолжить работу безопасно. Это неожиданная ошибка, о которой можно сообщить, как описано ниже.</translation>
     </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
         <source>Error: Specified data directory "%1" does not exist.</source>
-        <translation type="unfinished">Ошибка: указанная директория данных "%1" не существует.</translation>
+        <translation type="unfinished">Ошибка: указанный каталог данных "%1" не существует.</translation>
     </message>
     <message>
         <source>Error: Cannot parse configuration file: %1.</source>
-        <translation type="unfinished">Ошибка: невозможно разобрать файл конфигурации: %1.</translation>
+        <translation type="unfinished">Ошибка: не удается проанализировать файл конфигурации: %1.</translation>
     </message>
     <message>
         <source>Error: %1</source>
@@ -283,153 +278,69 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>%1 didn't yet exit safely…</source>
-        <translation type="unfinished">%1 ещё не завершился безопасно...</translation>
+        <translation type="unfinished">%1 ещё безопасно не закрылся...</translation>
     </message>
     <message>
         <source>unknown</source>
-        <translation type="unfinished">неизвестно</translation>
+        <translation type="unfinished">Неизвестно</translation>
     </message>
     <message>
         <source>Amount</source>
         <translation type="unfinished">Сумма</translation>
     </message>
     <message>
-        <source>Enter a Bitcoin address (e.g. %1)</source>
-        <translation type="unfinished">Введите биткоин-адрес (напр. %1)</translation>
-    </message>
-    <message>
         <source>Unroutable</source>
         <translation type="unfinished">Немаршрутизируемый</translation>
-    </message>
-    <message>
-        <source>Internal</source>
-        <translation type="unfinished">Внутренний</translation>
-    </message>
-    <message>
-        <source>Inbound</source>
-        <translation type="unfinished">Входящий</translation>
-    </message>
-    <message>
-        <source>Outbound</source>
-        <translation type="unfinished">Исходящий</translation>
-    </message>
-    <message>
-        <source>Full Relay</source>
-        <translation type="unfinished">Полный ретранслятор</translation>
-    </message>
-    <message>
-        <source>Block Relay</source>
-        <translation type="unfinished">Ретранслятор блоков</translation>
-    </message>
-    <message>
-        <source>Manual</source>
-        <translation type="unfinished">Вручную</translation>
-    </message>
-    <message>
-        <source>Feeler</source>
-        <translation type="unfinished">Пробный</translation>
-    </message>
-    <message>
-        <source>Address Fetch</source>
-        <translation type="unfinished">Получение адресов</translation>
-    </message>
-    <message>
-        <source>%1 d</source>
-        <translation type="unfinished">%1 д</translation>
-    </message>
-    <message>
-        <source>%1 h</source>
-        <translation type="unfinished">%1 ч</translation>
-    </message>
-    <message>
-        <source>%1 m</source>
-        <translation type="unfinished">%1 м</translation>
-    </message>
-    <message>
-        <source>%1 s</source>
-        <translation type="unfinished">%1 с</translation>
-    </message>
-    <message>
-        <source>None</source>
-        <translation type="unfinished">Нет</translation>
-    </message>
-    <message>
-        <source>N/A</source>
-        <translation type="unfinished">Н/д</translation>
-    </message>
-    <message>
-        <source>%1 ms</source>
-        <translation type="unfinished">%1 мс</translation>
     </message>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation>
-            <numerusform>%n секунда</numerusform>
-            <numerusform>%n секунд</numerusform>
-            <numerusform>%n секунд</numerusform>
+            <numerusform />
+            <numerusform />
+            <numerusform />
         </translation>
     </message>
     <message numerus="yes">
         <source>%n minute(s)</source>
         <translation>
-            <numerusform>%n минута</numerusform>
-            <numerusform>%n минут</numerusform>
-            <numerusform>%n минут</numerusform>
+            <numerusform />
+            <numerusform />
+            <numerusform />
         </translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
         <translation type="unfinished">
-            <numerusform>%n час</numerusform>
-            <numerusform>%n часов</numerusform>
-            <numerusform>%n часов</numerusform>
+            <numerusform />
+            <numerusform />
+            <numerusform />
         </translation>
     </message>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
-            <numerusform>%n день</numerusform>
-            <numerusform>%n дней</numerusform>
-            <numerusform>%n дней</numerusform>
+            <numerusform />
+            <numerusform />
+            <numerusform />
         </translation>
     </message>
     <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
-            <numerusform>%n неделя</numerusform>
-            <numerusform>%n недель</numerusform>
-            <numerusform>%n недель</numerusform>
+            <numerusform />
+            <numerusform />
+            <numerusform />
         </translation>
-    </message>
-    <message>
-        <source>%1 and %2</source>
-        <translation type="unfinished">%1 и %2</translation>
     </message>
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
-            <numerusform>%n год</numerusform>
-            <numerusform>%n лет</numerusform>
-            <numerusform>%n лет</numerusform>
+            <numerusform />
+            <numerusform />
+            <numerusform />
         </translation>
     </message>
-    <message>
-        <source>%1 B</source>
-        <translation type="unfinished">%1 Б</translation>
-    </message>
-    <message>
-        <source>%1 kB</source>
-        <translation type="unfinished">%1 КБ</translation>
-    </message>
-    <message>
-        <source>%1 MB</source>
-        <translation type="unfinished">%1 МБ</translation>
-    </message>
-    <message>
-        <source>%1 GB</source>
-        <translation type="unfinished">%1 ГБ</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>BitcoinGUI</name>
     <message>
@@ -438,7 +349,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Show general overview of wallet</source>
-        <translation>Отобразить главное окно кошелька</translation>
+        <translation>Отобразить основное окно кошелька</translation>
     </message>
     <message>
         <source>&amp;Transactions</source>
@@ -450,11 +361,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>E&amp;xit</source>
-        <translation>В&amp;ыход</translation>
+        <translation>&amp;Выйти</translation>
     </message>
     <message>
         <source>Quit application</source>
-        <translation>Закрыть приложение</translation>
+        <translation>Выйти из приложения</translation>
     </message>
     <message>
         <source>&amp;About %1</source>
@@ -466,7 +377,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>About &amp;Qt</source>
-        <translation>O &amp;Qt</translation>
+        <translation>О &amp;Qt</translation>
     </message>
     <message>
         <source>Show information about Qt</source>
@@ -487,7 +398,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Network activity disabled.</source>
         <extracomment>A substring of the tooltip.</extracomment>
-        <translation type="unfinished">Взаимодействие с сетью отключено.</translation>
+        <translation type="unfinished">Сетевая активность отключена.</translation>
     </message>
     <message>
         <source>Proxy is &lt;b&gt;enabled&lt;/b&gt;: %1</source>
@@ -495,15 +406,15 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Send coins to a Bitcoin address</source>
-        <translation>Отправить средства на биткоин-адрес</translation>
+        <translation>Отправить средства на Биткоин адрес</translation>
     </message>
     <message>
         <source>Backup wallet to another location</source>
-        <translation>Создать резервную копию кошелька в другом расположении</translation>
+        <translation>Создать резервную копию кошелька в другом месте</translation>
     </message>
     <message>
         <source>Change the passphrase used for wallet encryption</source>
-        <translation>Изменить парольную фразу, используемую для шифрования кошелька</translation>
+        <translation>Изменить пароль используемый для шифрования кошелька</translation>
     </message>
     <message>
         <source>&amp;Send</source>
@@ -519,7 +430,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>&amp;Show / Hide</source>
-        <translation>&amp;Показать / Спрятать</translation>
+        <translation>&amp;Показать/Скрыть</translation>
     </message>
     <message>
         <source>Show or hide the main Window</source>
@@ -527,7 +438,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>&amp;Encrypt Wallet…</source>
-        <translation type="unfinished">&amp;Зашифровать кошелёк...</translation>
+        <translation type="unfinished">&amp;Зашифровать Кошелёк...</translation>
     </message>
     <message>
         <source>Encrypt the private keys that belong to your wallet</source>
@@ -535,11 +446,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>&amp;Backup Wallet…</source>
-        <translation type="unfinished">Создать &amp;резервную копию кошелька...</translation>
+        <translation type="unfinished">&amp;Создать резервную копию кошелька...</translation>
     </message>
     <message>
         <source>&amp;Change Passphrase…</source>
-        <translation type="unfinished">&amp;Изменить парольную фразу...</translation>
+        <translation type="unfinished">&amp;Изменить пароль...</translation>
     </message>
     <message>
         <source>Sign &amp;message…</source>
@@ -547,11 +458,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
-        <translation>Подписывайте сообщения вашими биткоин-адресами, чтобы доказать, что вы ими владеете</translation>
+        <translation>Подписать сообщения своими Биткоин кошельками, что-бы доказать, что вы ими владеете</translation>
     </message>
     <message>
         <source>&amp;Verify message…</source>
-        <translation type="unfinished">&amp;Проверить сообщение</translation>
+        <translation type="unfinished">&amp;Проверить сообщение...</translation>
     </message>
     <message>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
@@ -567,7 +478,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Open &amp;URI…</source>
-        <translation type="unfinished">О&amp;ткрыть URI...</translation>
+        <translation type="unfinished">Открыть &amp;URI...</translation>
     </message>
     <message>
         <source>Close Wallet…</source>
@@ -595,7 +506,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Tabs toolbar</source>
-        <translation>Панель вкладок</translation>
+        <translation>Панель инструментов</translation>
     </message>
     <message>
         <source>Syncing Headers (%1%)…</source>
@@ -627,27 +538,27 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Show the list of used sending addresses and labels</source>
-        <translation type="unfinished">Показать список адресов, на которые были отправлены средства, и их метки</translation>
+        <translation type="unfinished">Показать список использованных адресов и меток отправки</translation>
     </message>
     <message>
         <source>Show the list of used receiving addresses and labels</source>
-        <translation type="unfinished">Показать список адресов, на которые были получены средства, и их метки</translation>
+        <translation type="unfinished">Показать список использованных адресов и меток получателей</translation>
     </message>
     <message>
         <source>&amp;Command-line options</source>
-        <translation type="unfinished">Параметры &amp;командной строки</translation>
+        <translation type="unfinished">Параметры командной строки</translation>
     </message>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation>
-            <numerusform>Обработан %n блок в истории транзакций.</numerusform>
-            <numerusform>Обработано %n блоков в истории транзакций.</numerusform>
-            <numerusform>Обработано %n блоков в истории транзакций.</numerusform>
+            <numerusform>Обработан %n блок истории транзакций.</numerusform>
+            <numerusform>Обработано %n блока истории транзакций.</numerusform>
+            <numerusform>Обработано %n блоков истории транзакций.</numerusform>
         </translation>
     </message>
     <message>
         <source>%1 behind</source>
-        <translation>Отстаём на %1</translation>
+        <translation>%1 позади</translation>
     </message>
     <message>
         <source>Catching up…</source>
@@ -675,11 +586,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Up to date</source>
-        <translation>Синхронизировано</translation>
+        <translation>До настоящего времени </translation>
     </message>
     <message>
         <source>Load Partially Signed Bitcoin Transaction</source>
-        <translation type="unfinished">Загрузить частично подписанную биткоин-транзакцию (PSBT)</translation>
+        <translation type="unfinished">Загрузить частично подписанную биткойн-транзакцию</translation>
     </message>
     <message>
         <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
@@ -687,7 +598,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Node window</source>
-        <translation type="unfinished">Окно ноды</translation>
+        <translation type="unfinished">Окно узла</translation>
     </message>
     <message>
         <source>Open node debugging and diagnostic console</source>
@@ -695,15 +606,15 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>&amp;Sending addresses</source>
-        <translation type="unfinished">Адреса для &amp;отправки</translation>
+        <translation type="unfinished">&amp;Адреса для отправки</translation>
     </message>
     <message>
         <source>&amp;Receiving addresses</source>
-        <translation type="unfinished">Адреса для &amp;получения</translation>
+        <translation type="unfinished">&amp;Адреса для получения</translation>
     </message>
     <message>
         <source>Open a bitcoin: URI</source>
-        <translation type="unfinished">Открыть URI протокола bitcoin:</translation>
+        <translation type="unfinished">Открыть биткойн: URI</translation>
     </message>
     <message>
         <source>Open Wallet</source>
@@ -720,18 +631,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Close all wallets</source>
         <translation type="unfinished">Закрыть все кошельки</translation>
-    </message>
-    <message>
-        <source>Show the %1 help message to get a list with possible Bitcoin command-line options</source>
-        <translation type="unfinished">Показать помощь по %1, чтобы просмотреть список доступных параметров командной строки</translation>
-    </message>
-    <message>
-        <source>&amp;Mask values</source>
-        <translation type="unfinished">&amp;Скрыть значения</translation>
-    </message>
-    <message>
-        <source>Mask the values in the Overview tab</source>
-        <translation type="unfinished">Скрыть значения на вкладке Обзор</translation>
     </message>
     <message>
         <source>default wallet</source>
@@ -751,7 +650,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Zoom</source>
-        <translation type="unfinished">Масштаб</translation>
+        <translation type="unfinished">Увеличить</translation>
     </message>
     <message>
         <source>Main Window</source>
@@ -759,7 +658,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>%1 client</source>
-        <translation type="unfinished">%1 клиент</translation>
+        <translation type="unfinished">%1 клиент </translation>
     </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
@@ -966,11 +865,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>L&amp;ock unspent</source>
-        <translation type="unfinished">О&amp;статок неизрасходованных</translation>
+        <translation type="unfinished">З&amp;аблокировать неизрасходованный остаток</translation>
     </message>
     <message>
         <source>&amp;Unlock unspent</source>
-        <translation type="unfinished">&amp;Разблокировать неизрасходованные</translation>
+        <translation type="unfinished">&amp;Разблокировать неизрасходованный остаток</translation>
     </message>
     <message>
         <source>Copy quantity</source>
@@ -1014,7 +913,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Can vary +/- %1 satoshi(s) per input.</source>
-        <translation type="unfinished">Может меняться +/- %1 сатоши за каждый вход.</translation>
+        <translation type="unfinished">Может меняться на +/- %1 сатоши за каждый вход.</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -1037,7 +936,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Create wallet failed</source>
-        <translation type="unfinished">Не удалось создать кошелёк</translation>
+        <translation type="unfinished">Не удалось создать кошелек</translation>
     </message>
     <message>
         <source>Create wallet warning</source>
@@ -1177,36 +1076,32 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Метка, связанная с этой записью в адресной книге</translation>
     </message>
     <message>
-        <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
-        <translation type="unfinished">Адрес, связанный с этой записью адресной книги. Он может быть изменён только если это адрес для отправки.</translation>
-    </message>
-    <message>
         <source>&amp;Address</source>
         <translation>&amp;Адрес</translation>
     </message>
     <message>
         <source>New sending address</source>
-        <translation type="unfinished">Новый адрес для отправки</translation>
+        <translation type="unfinished">Новый адрес отправки</translation>
     </message>
     <message>
         <source>Edit receiving address</source>
-        <translation type="unfinished">Изменить адрес для получения</translation>
+        <translation type="unfinished">Изменить адрес получения</translation>
     </message>
     <message>
         <source>Edit sending address</source>
-        <translation type="unfinished">Изменить адрес для отправки</translation>
+        <translation type="unfinished">Изменить адрес отправки</translation>
     </message>
     <message>
         <source>The entered address "%1" is not a valid Bitcoin address.</source>
-        <translation type="unfinished">Введенный адрес "%1" не является действительным биткоин-адресом.</translation>
+        <translation type="unfinished">Введенный адрес "%1" недействителен в сети Биткоин.</translation>
     </message>
     <message>
         <source>Address "%1" already exists as a receiving address with label "%2" and so cannot be added as a sending address.</source>
-        <translation type="unfinished">Адрес "%1" уже существует в качестве адреса для получения с меткой "%2" и поэтому не может быть добавлен в качестве адреса для отправки.</translation>
+        <translation type="unfinished">Адрес "%1" уже существует как адрес получателя с  именем "%2", и поэтому не может быть добавлен как адрес отправителя.</translation>
     </message>
     <message>
         <source>The entered address "%1" is already in the address book with label "%2".</source>
-        <translation type="unfinished">Введённый адрес "%1" уже существует в адресной книге с меткой "%2".</translation>
+        <translation type="unfinished">Введенный адрес "%1" уже существует в адресной книге под именем "%2".</translation>
     </message>
     <message>
         <source>Could not unlock wallet.</source>
@@ -1214,38 +1109,34 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>New key generation failed.</source>
-        <translation type="unfinished">Произошла ошибка при генерации нового ключа.</translation>
+        <translation type="unfinished">Генерация нового ключа не удалась.</translation>
     </message>
 </context>
 <context>
     <name>FreespaceChecker</name>
     <message>
         <source>A new data directory will be created.</source>
-        <translation>Будет создана новая директория данных.</translation>
+        <translation>Будет создан новый каталог данных.</translation>
     </message>
     <message>
         <source>name</source>
-        <translation>имя</translation>
+        <translation>название</translation>
     </message>
     <message>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
-        <translation>Директория уже существует. Добавьте %1, если хотите создать здесь новую директорию.</translation>
+        <translation>Каталог уже существует. Добавьте %1, если хотите создать здесь новый каталог.</translation>
     </message>
     <message>
         <source>Path already exists, and is not a directory.</source>
-        <translation>Данный путь уже существует, и это не директория.</translation>
+        <translation>Данный путь уже существует, и это не каталог.</translation>
     </message>
     <message>
         <source>Cannot create data directory here.</source>
-        <translation>Невозможно создать директорию данных здесь.</translation>
+        <translation>Невозможно создать здесь каталог данных.</translation>
     </message>
 </context>
 <context>
     <name>Intro</name>
-    <message>
-        <source>Bitcoin</source>
-        <translation type="unfinished">биткоин</translation>
-    </message>
     <message>
         <source>%1 GB of free space available</source>
         <translation type="unfinished">Доступно %1 ГБ свободного места</translation>
@@ -1256,36 +1147,36 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>(%1 GB needed for full chain)</source>
-        <translation type="unfinished">(необходимо %1 ГБ для полной цепочки блоков)</translation>
+        <translation type="unfinished">(для полной цепи необходимо %1 ГБ)</translation>
     </message>
     <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
-        <translation type="unfinished">В эту директорию будет сохранено не менее %1 ГБ данных, и со временем их объём будет увеличиваться.</translation>
+        <translation type="unfinished">В этот каталог будет сохранено не менее %1 ГБ данных, и со временем их объём будет увеличиваться.</translation>
     </message>
     <message>
         <source>Approximately %1 GB of data will be stored in this directory.</source>
-        <translation type="unfinished">В эту директорию будет сохранено приблизительно %1 ГБ данных.</translation>
+        <translation type="unfinished">В этот каталог будет сохранено приблизительно %1 ГБ данных.</translation>
     </message>
     <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform>(достаточно для восстановления резервных копий %n-дневной давности)</numerusform>
-            <numerusform>(достаточно для восстановления резервных копий %n-дневной давности)</numerusform>
-            <numerusform>(достаточно для восстановления резервных копий %n-дневной давности)</numerusform>
+            <numerusform />
+            <numerusform />
+            <numerusform />
         </translation>
     </message>
     <message>
         <source>%1 will download and store a copy of the Bitcoin block chain.</source>
-        <translation type="unfinished">%1 скачает и сохранит копию цепочки блоков биткоина.</translation>
+        <translation type="unfinished">%1будет скачано и сохранит копию цепи блоков Bitcoin</translation>
     </message>
     <message>
         <source>The wallet will also be stored in this directory.</source>
-        <translation type="unfinished">Кошелёк также будет сохранен в эту директорию.</translation>
+        <translation type="unfinished">Кошелёк также будет сохранен в этот каталог.</translation>
     </message>
     <message>
         <source>Error: Specified data directory "%1" cannot be created.</source>
-        <translation type="unfinished">Ошибка: невозможно создать указанную директорию данных "%1".</translation>
+        <translation type="unfinished">Ошибка: невозможно создать указанный каталог данных "%1".</translation>
     </message>
     <message>
         <source>Error</source>
@@ -1301,11 +1192,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>As this is the first time the program is launched, you can choose where %1 will store its data.</source>
-        <translation type="unfinished">Поскольку программа запущена впервые, вы можете выбрать, где %1 будет хранить свои данные.</translation>
+        <translation type="unfinished">Так как это первый запуск программы, Вы можете выбрать, где %1будет хранить данные.</translation>
     </message>
     <message>
         <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation type="unfinished">Когда вы нажмёте ОК, %1 начнет скачивать и обрабатывать полную цепочку блоков %4а (%2 ГБ), начиная с самых первых транзакций в %3, когда %4 был изначально запущен.</translation>
+        <translation type="unfinished">Когда вы нажмете ОК, %1 начнет загружать и обрабатывать полную цепочку блоков %4 (%2GB)  начиная с самых ранних транзакций в %3, когда %4 был первоначально запущен.</translation>
     </message>
     <message>
         <source>Limit block chain storage to</source>
@@ -1321,19 +1212,19 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
-        <translation type="unfinished">Эта первичная синхронизация очень требовательна к ресурсам и может выявить проблемы с аппаратным обеспечением вашего компьютера, которые ранее оставались незамеченными. Каждый раз, когда вы запускаете %1, скачивание будет продолжено с места остановки.</translation>
+        <translation type="unfinished">Эта первичная синхронизация очень требовательна к ресурсам и может выявить проблемы с аппаратным обеспечением вашего компьютера, которые ранее оставались незамеченными. Каждый раз, когда Вы запускаете %1, скачивание будет продолжено с места остановки.</translation>
     </message>
     <message>
         <source>If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</source>
-        <translation type="unfinished">Если вы решили ограничить объём хранимого блокчейна (обрезка), все исторические данные всё равно необходимо скачать и обработать, но после этого они будут удалены для экономии места на диске.</translation>
+        <translation type="unfinished">Если Вы выбрали ограничить объём хранимой цепи блоков (обрезка), все прежние данные должны быть скачаны и обработаны, но после этого они будут удалены с целью экономии места на диске.</translation>
     </message>
     <message>
         <source>Use the default data directory</source>
-        <translation>Использовать стандартную директорию данных</translation>
+        <translation>Использовать стандартный каталог данных</translation>
     </message>
     <message>
         <source>Use a custom data directory:</source>
-        <translation>Использовать пользовательскую директорию данных</translation>
+        <translation>Использовать пользовательский каталог данных</translation>
     </message>
 </context>
 <context>
@@ -1344,22 +1235,22 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>About %1</source>
-        <translation type="unfinished">О%1</translation>
+        <translation type="unfinished">О %1</translation>
     </message>
     <message>
         <source>Command-line options</source>
-        <translation type="unfinished">Параметры командной строки</translation>
+        <translation type="unfinished">Опции командной строки</translation>
     </message>
 </context>
 <context>
     <name>ShutdownWindow</name>
     <message>
         <source>%1 is shutting down…</source>
-        <translation type="unfinished">%1 завершает работу...</translation>
+        <translation type="unfinished">%1завершает процесс...</translation>
     </message>
     <message>
         <source>Do not shut down the computer until this window disappears.</source>
-        <translation type="unfinished">Не выключайте компьютер, пока это окно не исчезнет.</translation>
+        <translation type="unfinished">Не выключайте компьютер, пока это окно не пропадёт.</translation>
     </message>
 </context>
 <context>
@@ -1367,14 +1258,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Form</source>
         <translation type="unfinished">Форма</translation>
-    </message>
-    <message>
-        <source>Recent transactions may not yet be visible, and therefore your wallet's balance might be incorrect. This information will be correct once your wallet has finished synchronizing with the bitcoin network, as detailed below.</source>
-        <translation type="unfinished">Недавние транзакции могут быть пока не видны, и поэтому отображаемый баланс вашего кошелька может быть неверным. Информация станет верной после завершения синхронизации с сетью биткоина, прогресс которой вы можете видеть ниже.</translation>
-    </message>
-    <message>
-        <source>Attempting to spend bitcoins that are affected by not-yet-displayed transactions will not be accepted by the network.</source>
-        <translation type="unfinished">Попытка потратить средства, затронутые не видными пока транзакциями, будет отклонена сетью.</translation>
     </message>
     <message>
         <source>Number of blocks left</source>
@@ -1385,24 +1268,8 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Неизвестно...</translation>
     </message>
     <message>
-        <source>calculating…</source>
-        <translation type="unfinished">вычисляется...</translation>
-    </message>
-    <message>
-        <source>Last block time</source>
-        <translation type="unfinished">Время последнего блока</translation>
-    </message>
-    <message>
-        <source>Progress</source>
-        <translation type="unfinished">Прогресс</translation>
-    </message>
-    <message>
-        <source>Progress increase per hour</source>
-        <translation type="unfinished">Прирост прогресса в час</translation>
-    </message>
-    <message>
         <source>Estimated time left until synced</source>
-        <translation type="unfinished">Расчётное время до завершения синхронизации</translation>
+        <translation type="unfinished">Расчетное время до завершения синхронизации</translation>
     </message>
     <message>
         <source>Hide</source>
@@ -1410,17 +1277,9 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Esc</source>
-        <translation type="unfinished">Выйти</translation>
+        <translation type="unfinished">Выход</translation>
     </message>
-    <message>
-        <source>%1 is currently syncing.  It will download headers and blocks from peers and validate them until reaching the tip of the block chain.</source>
-        <translation type="unfinished">%1 в настоящий момент синхронизируется. Заголовки и блоки будут скачиваться с других узлов сети и проверяться до тех пор, пока не будет достигнут конец цепочки блоков.</translation>
-    </message>
-    <message>
-        <source>Unknown. Syncing Headers (%1, %2%)…</source>
-        <translation type="unfinished">Неизвестно. Синхронизируются заголовки (%1, %2%)...</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>OpenURIDialog</name>
     <message>
@@ -1436,247 +1295,31 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>&amp;Main</source>
-        <translation>&amp;Главные</translation>
+        <translation>&amp;Основное</translation>
     </message>
     <message>
         <source>Automatically start %1 after logging in to the system.</source>
-        <translation type="unfinished">Автоматически запускать %1 после входа в систему.</translation>
-    </message>
-    <message>
-        <source>&amp;Start %1 on system login</source>
-        <translation type="unfinished">&amp;Запускать %1 при входе в систему</translation>
-    </message>
-    <message>
-        <source>Enabling pruning significantly reduces the disk space required to store transactions. All blocks are still fully validated. Reverting this setting requires re-downloading the entire blockchain.</source>
-        <translation type="unfinished">Включение обрезки значительно снизит требования к месту на диске для хранения транзакций. Блоки будут по-прежнему полностью проверяться. Возврат этого параметра в прежнее значение приведёт к повторному скачиванию всей цепочки блоков.</translation>
-    </message>
-    <message>
-        <source>Size of &amp;database cache</source>
-        <translation type="unfinished">Размер кеша &amp;базы данных</translation>
-    </message>
-    <message>
-        <source>Number of script &amp;verification threads</source>
-        <translation type="unfinished">Количество потоков для &amp;проверки скриптов</translation>
-    </message>
-    <message>
-        <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
-        <translation type="unfinished">IP-адрес прокси (к примеру, IPv4: 127.0.0.1 / IPv6: ::1)</translation>
-    </message>
-    <message>
-        <source>Shows if the supplied default SOCKS5 proxy is used to reach peers via this network type.</source>
-        <translation type="unfinished">Показывает, используется ли прокси SOCKS5 по умолчанию для доступа к узлам через этот тип сети.</translation>
-    </message>
-    <message>
-        <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
-        <translation type="unfinished">Сворачивать вместо выхода из приложения при закрытии окна. Если данный параметр включён, приложение закроется только после нажатия "Выход" в меню.</translation>
-    </message>
-    <message>
-        <source>Third party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</source>
-        <translation type="unfinished">Сторонние URL-адреса (например, обозреватель блоков), которые будут показаны на вкладке транзакций как элементы контекстного меню. %s в URL будет заменён на хэш транзакции. Несколько URL-адресов разделяются вертикальной чертой |.</translation>
+        <translation type="unfinished">Автоматически запускать %1после входа в систему.</translation>
     </message>
     <message>
         <source>Open the %1 configuration file from the working directory.</source>
-        <translation type="unfinished">Открывает файл конфигурации %1 из рабочей директории.</translation>
-    </message>
-    <message>
-        <source>Open Configuration File</source>
-        <translation type="unfinished">Открыть файл конфигурации</translation>
-    </message>
-    <message>
-        <source>Reset all client options to default.</source>
-        <translation>Сбросить все параметры клиента к значениям по умолчанию.</translation>
-    </message>
-    <message>
-        <source>&amp;Reset Options</source>
-        <translation>&amp;Сбросить параметры</translation>
-    </message>
-    <message>
-        <source>&amp;Network</source>
-        <translation>&amp;Сеть</translation>
-    </message>
-    <message>
-        <source>Prune &amp;block storage to</source>
-        <translation type="unfinished">Обрезать объём хранимых блоков до</translation>
-    </message>
-    <message>
-        <source>GB</source>
-        <translation type="unfinished">ГБ</translation>
-    </message>
-    <message>
-        <source>Reverting this setting requires re-downloading the entire blockchain.</source>
-        <translation type="unfinished">Возврат этой настройки в прежнее значение потребует повторного скачивания всей цепочки блоков.</translation>
-    </message>
-    <message>
-        <source>MiB</source>
-        <translation type="unfinished">МиБ</translation>
-    </message>
-    <message>
-        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
-        <translation type="unfinished">(0 = автоматически, &lt;0 = оставить столько ядер свободными)</translation>
-    </message>
-    <message>
-        <source>W&amp;allet</source>
-        <translation type="unfinished">&amp;Кошелёк</translation>
-    </message>
-    <message>
-        <source>Expert</source>
-        <translation type="unfinished">Экспертные настройки</translation>
-    </message>
-    <message>
-        <source>Enable coin &amp;control features</source>
-        <translation type="unfinished">Включить возможность &amp;управления монетами</translation>
-    </message>
-    <message>
-        <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
-        <translation type="unfinished">Если вы отключите трату неподтверждённой сдачи, сдачу от транзакции нельзя будет использвать до тех пор, пока у этой транзакции не будет хотя бы одного подтверждения. Это также влияет на расчёт вашего баланса.</translation>
-    </message>
-    <message>
-        <source>&amp;Spend unconfirmed change</source>
-        <translation type="unfinished">&amp;Тратить неподтверждённую сдачу</translation>
+        <translation type="unfinished">Открывает файл конфигурации %1 из рабочего каталога.</translation>
     </message>
     <message>
         <source>External Signer (e.g. hardware wallet)</source>
-        <translation type="unfinished">Внешняя подпись (например, аппаратный кошелек)</translation>
+        <translation type="unfinished">Внешний подписант(например, аппаратный кошелёк)</translation>
     </message>
     <message>
         <source>&amp;External signer script path</source>
-        <translation type="unfinished">&amp;Путь к скрипту внешней подписи</translation>
+        <translation type="unfinished">&amp;Внешний скрипт подписи</translation>
     </message>
     <message>
         <source>Full path to a Bitcoin Core compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</source>
-        <translation type="unfinished">Полный путь к сценарию, совместимому с Bitcoin Core (например, C:\Downloads\hwi.exe или /Users/you/Downloads/hwi.py). Осторожно: вредоносные программы могут украсть ваши монеты!</translation>
-    </message>
-    <message>
-        <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
-        <translation>Автоматически открыть порт биткоин-клиента на маршрутизаторе. Работает, если ваш маршрутизатор поддерживает UPnP, и данная функция на нём включена.</translation>
-    </message>
-    <message>
-        <source>Map port using &amp;UPnP</source>
-        <translation>Пробросить порт через &amp;UPnP</translation>
-    </message>
-    <message>
-        <source>Automatically open the Bitcoin client port on the router. This only works when your router supports NAT-PMP and it is enabled. The external port could be random.</source>
-        <translation type="unfinished">Автоматически открыть порт биткоин-клиента на роутере. Работает? если ваш роутер поддерживает NAT-PMP, и данная функция на нём включена. Внешний порт может быть случайным.</translation>
-    </message>
-    <message>
-        <source>Map port using NA&amp;T-PMP</source>
-        <translation type="unfinished">Пробросить порт с помощью NA&amp;T-PMP</translation>
-    </message>
-    <message>
-        <source>Accept connections from outside.</source>
-        <translation type="unfinished">Принимать входящие соединения.</translation>
-    </message>
-    <message>
-        <source>Allow incomin&amp;g connections</source>
-        <translation type="unfinished">Разрешить входящие соединения</translation>
-    </message>
-    <message>
-        <source>Connect to the Bitcoin network through a SOCKS5 proxy.</source>
-        <translation type="unfinished">Подключиться к сети биткоина через прокси SOCKS5.</translation>
-    </message>
-    <message>
-        <source>&amp;Connect through SOCKS5 proxy (default proxy):</source>
-        <translation type="unfinished">&amp;Подключаться через прокси SOCKS5 (прокси по умолчанию):</translation>
-    </message>
-    <message>
-        <source>Proxy &amp;IP:</source>
-        <translation>IP прокси:</translation>
-    </message>
-    <message>
-        <source>&amp;Port:</source>
-        <translation>&amp;Порт:</translation>
-    </message>
-    <message>
-        <source>Port of the proxy (e.g. 9050)</source>
-        <translation>Порт прокси: (напр. 9050)</translation>
-    </message>
-    <message>
-        <source>Used for reaching peers via:</source>
-        <translation type="unfinished">Используется для подключения к узлам по:</translation>
+        <translation type="unfinished">Путь к скрипту, совместимому с Bitcoin Core (напр. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Внимание: остерегайтесь вредоносных скриптов!</translation>
     </message>
     <message>
         <source>&amp;Window</source>
-        <translation>&amp;Окно</translation>
-    </message>
-    <message>
-        <source>Show the icon in the system tray.</source>
-        <translation type="unfinished">Показывать значок в области уведомлений</translation>
-    </message>
-    <message>
-        <source>&amp;Show tray icon</source>
-        <translation type="unfinished">&amp;Показывать значок в области ведомлений</translation>
-    </message>
-    <message>
-        <source>Show only a tray icon after minimizing the window.</source>
-        <translation>Отобразить только значок в области уведомлений после сворачивания окна.</translation>
-    </message>
-    <message>
-        <source>&amp;Minimize to the tray instead of the taskbar</source>
-        <translation>&amp;Сворачивать в область уведомлений вместо панели задач</translation>
-    </message>
-    <message>
-        <source>M&amp;inimize on close</source>
-        <translation>С&amp;ворачивать при закрытии</translation>
-    </message>
-    <message>
-        <source>&amp;Display</source>
-        <translation>&amp;Внешний вид</translation>
-    </message>
-    <message>
-        <source>User Interface &amp;language:</source>
-        <translation>Язык пользовательского интерфейса:</translation>
-    </message>
-    <message>
-        <source>The user interface language can be set here. This setting will take effect after restarting %1.</source>
-        <translation type="unfinished">Здесь можно выбрать язык пользовательского интерфейса. Параметры будут применены после перезапуска %1</translation>
-    </message>
-    <message>
-        <source>&amp;Unit to show amounts in:</source>
-        <translation>&amp;Отображать суммы в единицах:</translation>
-    </message>
-    <message>
-        <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
-        <translation>Выберите единицу измерения, которая будет показана по умолчанию в интерфейсе и при отправке монет.</translation>
-    </message>
-    <message>
-        <source>Whether to show coin control features or not.</source>
-        <translation type="unfinished">Показывать ли параметры управления монетами.</translation>
-    </message>
-    <message>
-        <source>Connect to the Bitcoin network through a separate SOCKS5 proxy for Tor onion services.</source>
-        <translation type="unfinished">Подключаться к сети биткоина через отдельный прокси SOCKS5 для скрытых сервисов Tor.</translation>
-    </message>
-    <message>
-        <source>Use separate SOCKS&amp;5 proxy to reach peers via Tor onion services:</source>
-        <translation type="unfinished">Использовать отдельный прокси SOCKS&amp;5 для соединения с узлами через скрытые сервисы Tor:</translation>
-    </message>
-    <message>
-        <source>&amp;Third party transaction URLs</source>
-        <translation type="unfinished">&amp;URL транзакций на сторонних сервисах</translation>
-    </message>
-    <message>
-        <source>Monospaced font in the Overview tab:</source>
-        <translation type="unfinished">Моноширинный шрифт на вкладке Обзор:</translation>
-    </message>
-    <message>
-        <source>embedded "%1"</source>
-        <translation type="unfinished">встроенный "%1"</translation>
-    </message>
-    <message>
-        <source>closest matching "%1"</source>
-        <translation type="unfinished">ближайшее совпадение "%1"</translation>
-    </message>
-    <message>
-        <source>Options set in this dialog are overridden by the command line or in the configuration file:</source>
-        <translation type="unfinished">Параметры, установленные в этом диалоговом окне, были переопределены командной строкой или в файле конфигурации:</translation>
-    </message>
-    <message>
-        <source>&amp;OK</source>
-        <translation>&amp;ОК</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>О&amp;тмена</translation>
+        <translation>окно</translation>
     </message>
     <message>
         <source>Compiled without external signing support (required for external signing)</source>
@@ -1684,288 +1327,17 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Скомпилировано без поддержки внешней подписи (требуется для внешней подписи)</translation>
     </message>
     <message>
-        <source>default</source>
-        <translation>по умолчанию</translation>
-    </message>
-    <message>
-        <source>none</source>
-        <translation type="unfinished">ни один</translation>
-    </message>
-    <message>
-        <source>Confirm options reset</source>
-        <translation>Подтвердить сброс опций</translation>
-    </message>
-    <message>
-        <source>Client restart required to activate changes.</source>
-        <translation type="unfinished">Для активации изменений необходим перезапуск клиента.</translation>
-    </message>
-    <message>
-        <source>Client will be shut down. Do you want to proceed?</source>
-        <translation type="unfinished">Клиент будет закрыт. Продолжить?</translation>
-    </message>
-    <message>
-        <source>Configuration options</source>
-        <translation type="unfinished">Параметры конфигурации</translation>
-    </message>
-    <message>
-        <source>The configuration file is used to specify advanced user options which override GUI settings. Additionally, any command-line options will override this configuration file.</source>
-        <translation type="unfinished">Файл конфигурации используется для указания расширенных пользовательских параметров, которые будут иметь приоритет над настройками в графическом интерфейсе. Параметры командной строки имеют приоритет над файлом конфигурации.</translation>
-    </message>
-    <message>
         <source>Error</source>
         <translation type="unfinished">Ошибка</translation>
     </message>
-    <message>
-        <source>The configuration file could not be opened.</source>
-        <translation type="unfinished">Невозможно открыть файл конфигурации.</translation>
-    </message>
-    <message>
-        <source>This change would require a client restart.</source>
-        <translation type="unfinished">Это изменение потребует перезапуска клиента.</translation>
-    </message>
-    <message>
-        <source>The supplied proxy address is invalid.</source>
-        <translation>Указанный прокси-адрес недействителен.</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>OverviewPage</name>
     <message>
         <source>Form</source>
         <translation>Форма</translation>
     </message>
-    <message>
-        <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
-        <translation>Показанная информация может быть устаревшей. Ваш кошелёк автоматически синхронизируется с сетью биткоина после подключения, но этот процесс пока не завершён.</translation>
-    </message>
-    <message>
-        <source>Watch-only:</source>
-        <translation type="unfinished">Только наблюдение:</translation>
-    </message>
-    <message>
-        <source>Available:</source>
-        <translation type="unfinished">Доступно:</translation>
-    </message>
-    <message>
-        <source>Your current spendable balance</source>
-        <translation>Ваш баланс, который можно расходовать</translation>
-    </message>
-    <message>
-        <source>Pending:</source>
-        <translation type="unfinished">В ожидании:</translation>
-    </message>
-    <message>
-        <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
-        <translation>Общая сумма всех транзакций, которые ещё не подтверждены и не учитываются в балансе, который можно расходовать</translation>
-    </message>
-    <message>
-        <source>Immature:</source>
-        <translation>Незрелые:</translation>
-    </message>
-    <message>
-        <source>Mined balance that has not yet matured</source>
-        <translation>Баланс добытых монет, который ещё не созрел</translation>
-    </message>
-    <message>
-        <source>Balances</source>
-        <translation type="unfinished">Балансы</translation>
-    </message>
-    <message>
-        <source>Total:</source>
-        <translation>Всего:</translation>
-    </message>
-    <message>
-        <source>Your current total balance</source>
-        <translation>Ваш текущий итоговый баланс</translation>
-    </message>
-    <message>
-        <source>Your current balance in watch-only addresses</source>
-        <translation type="unfinished">Ваш текущий баланс в наблюдаемых адресах</translation>
-    </message>
-    <message>
-        <source>Spendable:</source>
-        <translation type="unfinished">Доступно:</translation>
-    </message>
-    <message>
-        <source>Recent transactions</source>
-        <translation type="unfinished">Последние транзакции</translation>
-    </message>
-    <message>
-        <source>Unconfirmed transactions to watch-only addresses</source>
-        <translation type="unfinished">Неподтвержденные транзакции на наблюдаемые адреса</translation>
-    </message>
-    <message>
-        <source>Mined balance in watch-only addresses that has not yet matured</source>
-        <translation type="unfinished">Баланс добытых монет на наблюдаемых адресах, который ещё не созрел</translation>
-    </message>
-    <message>
-        <source>Current total balance in watch-only addresses</source>
-        <translation type="unfinished">Текущий итоговый баланс на наблюдаемых адресах</translation>
-    </message>
-    <message>
-        <source>Privacy mode activated for the Overview tab. To unmask the values, uncheck Settings-&gt;Mask values.</source>
-        <translation type="unfinished">Включён режим приватности для вкладки обзора. Чтобы показать данные, отключите пункт Настройки -&gt; Скрыть значения.</translation>
-    </message>
-</context>
-<context>
-    <name>PSBTOperationsDialog</name>
-    <message>
-        <source>Dialog</source>
-        <translation type="unfinished">Диалог</translation>
-    </message>
-    <message>
-        <source>Sign Tx</source>
-        <translation type="unfinished">Подписать транзакцию</translation>
-    </message>
-    <message>
-        <source>Broadcast Tx</source>
-        <translation type="unfinished">Отправить транзакцию</translation>
-    </message>
-    <message>
-        <source>Copy to Clipboard</source>
-        <translation type="unfinished">Скопировать в буфер обмена</translation>
-    </message>
-    <message>
-        <source>Save…</source>
-        <translation type="unfinished">Сохранить...</translation>
-    </message>
-    <message>
-        <source>Close</source>
-        <translation type="unfinished">Закрыть</translation>
-    </message>
-    <message>
-        <source>Failed to load transaction: %1</source>
-        <translation type="unfinished">Не удалось загрузить транзакцию: %1</translation>
-    </message>
-    <message>
-        <source>Failed to sign transaction: %1</source>
-        <translation type="unfinished">Не удалось подписать транзакцию: %1</translation>
-    </message>
-    <message>
-        <source>Could not sign any more inputs.</source>
-        <translation type="unfinished">Не удалось подписать оставшиеся входы.</translation>
-    </message>
-    <message>
-        <source>Signed %1 inputs, but more signatures are still required.</source>
-        <translation type="unfinished">Подписано %1 входов, но требуется больше подписей.</translation>
-    </message>
-    <message>
-        <source>Signed transaction successfully. Transaction is ready to broadcast.</source>
-        <translation type="unfinished">Транзакция успешно подписана. Транзакция готова к отправке.</translation>
-    </message>
-    <message>
-        <source>Unknown error processing transaction.</source>
-        <translation type="unfinished">Неизвестная ошибка во время обработки транзакции.</translation>
-    </message>
-    <message>
-        <source>Transaction broadcast successfully! Transaction ID: %1</source>
-        <translation type="unfinished">Транзакция успешно отправлена! Идентификатор транзакции: %1</translation>
-    </message>
-    <message>
-        <source>Transaction broadcast failed: %1</source>
-        <translation type="unfinished">Отправка транзакции не удалась: %1</translation>
-    </message>
-    <message>
-        <source>PSBT copied to clipboard.</source>
-        <translation type="unfinished">PSBT скопирована в буфер обмена</translation>
-    </message>
-    <message>
-        <source>Save Transaction Data</source>
-        <translation type="unfinished">Сохранить данные о транзакции</translation>
-    </message>
-    <message>
-        <source>Partially Signed Transaction (Binary)</source>
-        <extracomment>Expanded name of the binary PSBT file format. See: BIP 174.</extracomment>
-        <translation type="unfinished">Частично подписанная транзакция (двоичный файл)</translation>
-    </message>
-    <message>
-        <source>PSBT saved to disk.</source>
-        <translation type="unfinished">PSBT сохранена на диск.</translation>
-    </message>
-    <message>
-        <source> * Sends %1 to %2</source>
-        <translation type="unfinished">* Отправляет %1 на %2</translation>
-    </message>
-    <message>
-        <source>Unable to calculate transaction fee or total transaction amount.</source>
-        <translation type="unfinished">Не удалось вычислить сумму комиссии или общую сумму транзакции.</translation>
-    </message>
-    <message>
-        <source>Pays transaction fee: </source>
-        <translation type="unfinished">Платит комиссию:</translation>
-    </message>
-    <message>
-        <source>Total Amount</source>
-        <translation type="unfinished">Итоговая сумма</translation>
-    </message>
-    <message>
-        <source>or</source>
-        <translation type="unfinished">или</translation>
-    </message>
-    <message>
-        <source>Transaction has %1 unsigned inputs.</source>
-        <translation type="unfinished">Транзакция имеет %1 неподписанных входов.</translation>
-    </message>
-    <message>
-        <source>Transaction is missing some information about inputs.</source>
-        <translation type="unfinished">Транзакция имеет недостаточно информации о некоторых входах.</translation>
-    </message>
-    <message>
-        <source>Transaction still needs signature(s).</source>
-        <translation type="unfinished">Транзакции требуется по крайней мере ещё одна подпись.</translation>
-    </message>
-    <message>
-        <source>(But this wallet cannot sign transactions.)</source>
-        <translation type="unfinished">(Но этот кошелёк не может подписывать транзакции.)</translation>
-    </message>
-    <message>
-        <source>(But this wallet does not have the right keys.)</source>
-        <translation type="unfinished">(Но этот кошелёк не имеет необходимых ключей.)</translation>
-    </message>
-    <message>
-        <source>Transaction is fully signed and ready for broadcast.</source>
-        <translation type="unfinished">Транзакция полностью подписана, и готова к отправке.</translation>
-    </message>
-    <message>
-        <source>Transaction status is unknown.</source>
-        <translation type="unfinished">Статус транзакции неизвестен.</translation>
-    </message>
-</context>
-<context>
-    <name>PaymentServer</name>
-    <message>
-        <source>Payment request error</source>
-        <translation type="unfinished">Ошибка запроса платежа</translation>
-    </message>
-    <message>
-        <source>Cannot start bitcoin: click-to-pay handler</source>
-        <translation type="unfinished">Не удаётся запустить обработчик click-to-pay для протокола bitcoin:</translation>
-    </message>
-    <message>
-        <source>URI handling</source>
-        <translation type="unfinished">Обработка URI</translation>
-    </message>
-    <message>
-        <source>'bitcoin://' is not a valid URI. Use 'bitcoin:' instead.</source>
-        <translation type="unfinished">«bitcoin://» — это неверный URI. Используйте вместо него «bitcoin:».</translation>
-    </message>
-    <message>
-        <source>Cannot process payment request because BIP70 is not supported.
-Due to widespread security flaws in BIP70 it's strongly recommended that any merchant instructions to switch wallets be ignored.
-If you are receiving this error you should request the merchant provide a BIP21 compatible URI.</source>
-        <translation type="unfinished">Не удалось обработать транзакцию, потому что BIP70 не поддерживается.
-Из-за широко распространённых уязвимостей в BIP70 настоятельно рекомендуется игнорировать любые инструкции продавцов сменить кошелёк.
-Если вы получили эту ошибку, вам следует попросить у продавца URI, совместимый с BIP21.</translation>
-    </message>
-    <message>
-        <source>URI cannot be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
-        <translation type="unfinished">Не удалось обработать URI! Это может быть вызвано тем, что биткоин-адрес неверен или параметры URI неправильно сформированы.</translation>
-    </message>
-    <message>
-        <source>Payment request file handling</source>
-        <translation type="unfinished">Обработка файла с запросом платежа</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>PeerTableModel</name>
     <message>
@@ -1974,194 +1346,24 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <translation type="unfinished">Пользовательский агент</translation>
     </message>
     <message>
-        <source>Ping</source>
-        <extracomment>Title of Peers Table column which indicates the current latency of the connection with the peer.</extracomment>
-        <translation type="unfinished">Отклик</translation>
-    </message>
-    <message>
         <source>Peer</source>
         <extracomment>Title of Peers Table column which contains a unique number used to identify a connection.</extracomment>
         <translation type="unfinished">Узел</translation>
     </message>
-    <message>
-        <source>Sent</source>
-        <extracomment>Title of Peers Table column which indicates the total amount of network information we have sent to the peer.</extracomment>
-        <translation type="unfinished">Отправлено</translation>
-    </message>
-    <message>
-        <source>Received</source>
-        <extracomment>Title of Peers Table column which indicates the total amount of network information we have received from the peer.</extracomment>
-        <translation type="unfinished">Получено</translation>
-    </message>
-    <message>
-        <source>Address</source>
-        <extracomment>Title of Peers Table column which contains the IP/Onion/I2P address of the connected peer.</extracomment>
-        <translation type="unfinished">Адрес</translation>
-    </message>
-    <message>
-        <source>Type</source>
-        <extracomment>Title of Peers Table column which describes the type of peer connection. The "type" describes why the connection exists.</extracomment>
-        <translation type="unfinished">Тип</translation>
-    </message>
-    <message>
-        <source>Network</source>
-        <extracomment>Title of Peers Table column which states the network the peer connected through.</extracomment>
-        <translation type="unfinished">Сеть</translation>
-    </message>
-</context>
-<context>
-    <name>QRImageWidget</name>
-    <message>
-        <source>&amp;Save Image…</source>
-        <translation type="unfinished">&amp;Сохранить изображение...</translation>
-    </message>
-    <message>
-        <source>&amp;Copy Image</source>
-        <translation type="unfinished">&amp;Копировать изображение</translation>
-    </message>
-    <message>
-        <source>Resulting URI too long, try to reduce the text for label / message.</source>
-        <translation type="unfinished">Получившийся URI слишком длинный, попробуйте сократить текст метки / сообщения.</translation>
-    </message>
-    <message>
-        <source>Error encoding URI into QR Code.</source>
-        <translation type="unfinished">Ошибка преобразования URI в QR-код.</translation>
-    </message>
-    <message>
-        <source>QR code support not available.</source>
-        <translation type="unfinished">Поддержка QR кодов недоступна.</translation>
-    </message>
-    <message>
-        <source>Save QR Code</source>
-        <translation type="unfinished">Сохранить QR-код</translation>
-    </message>
-    <message>
-        <source>PNG Image</source>
-        <extracomment>Expanded name of the PNG file format. See https://en.wikipedia.org/wiki/Portable_Network_Graphics</extracomment>
-        <translation type="unfinished">Изображение PNG</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>RPCConsole</name>
     <message>
-        <source>N/A</source>
-        <translation>Н/д</translation>
-    </message>
-    <message>
-        <source>Client version</source>
-        <translation>Версия клиента</translation>
-    </message>
-    <message>
-        <source>&amp;Information</source>
-        <translation>&amp;Информация</translation>
-    </message>
-    <message>
-        <source>General</source>
-        <translation type="unfinished">Общий</translation>
-    </message>
-    <message>
-        <source>Datadir</source>
-        <translation type="unfinished">Директория данных</translation>
-    </message>
-    <message>
         <source>To specify a non-default location of the data directory use the '%1' option.</source>
-        <translation type="unfinished">Чтобы указать нестандартное расположение директории для данных, используйте параметр '%1'.</translation>
-    </message>
-    <message>
-        <source>Blocksdir</source>
-        <translation type="unfinished">Директория блоков</translation>
+        <translation type="unfinished">Чтобы указать нестандартное расположение каталога данных, используйте параметр '%1'.</translation>
     </message>
     <message>
         <source>To specify a non-default location of the blocks directory use the '%1' option.</source>
-        <translation type="unfinished">Чтобы указать нестандартное расположение директории для блоков, используйте параметр '%1'.</translation>
-    </message>
-    <message>
-        <source>Startup time</source>
-        <translation>Время запуска</translation>
-    </message>
-    <message>
-        <source>Network</source>
-        <translation>Сеть</translation>
-    </message>
-    <message>
-        <source>Name</source>
-        <translation type="unfinished">Название</translation>
-    </message>
-    <message>
-        <source>Number of connections</source>
-        <translation>Количество соединений</translation>
-    </message>
-    <message>
-        <source>Block chain</source>
-        <translation>Цепочка блоков</translation>
-    </message>
-    <message>
-        <source>Memory Pool</source>
-        <translation type="unfinished">Пул памяти</translation>
-    </message>
-    <message>
-        <source>Current number of transactions</source>
-        <translation type="unfinished">Текущее количество транзакций</translation>
-    </message>
-    <message>
-        <source>Memory usage</source>
-        <translation type="unfinished">Использование памяти</translation>
-    </message>
-    <message>
-        <source>Wallet: </source>
-        <translation type="unfinished">Кошелёк:</translation>
-    </message>
-    <message>
-        <source>(none)</source>
-        <translation type="unfinished">(нет)</translation>
+        <translation type="unfinished">Чтобы указать нестандартное расположение каталога блоков, используйте параметр '%1'.</translation>
     </message>
     <message>
         <source>&amp;Reset</source>
-        <translation type="unfinished">&amp;Сбросить</translation>
-    </message>
-    <message>
-        <source>Received</source>
-        <translation type="unfinished">Получено</translation>
-    </message>
-    <message>
-        <source>Sent</source>
-        <translation type="unfinished">Отправлено</translation>
-    </message>
-    <message>
-        <source>&amp;Peers</source>
-        <translation type="unfinished">&amp;Узлы</translation>
-    </message>
-    <message>
-        <source>Banned peers</source>
-        <translation type="unfinished">Заблокированные узлы</translation>
-    </message>
-    <message>
-        <source>Select a peer to view detailed information.</source>
-        <translation type="unfinished">Выберите узел для просмотра детальной информации.</translation>
-    </message>
-    <message>
-        <source>Version</source>
-        <translation type="unfinished">Версия</translation>
-    </message>
-    <message>
-        <source>Starting Block</source>
-        <translation type="unfinished">Начальный блок</translation>
-    </message>
-    <message>
-        <source>Synced Headers</source>
-        <translation type="unfinished">Синхронизировано заголовков</translation>
-    </message>
-    <message>
-        <source>Synced Blocks</source>
-        <translation type="unfinished">Синхронизировано блоков</translation>
-    </message>
-    <message>
-        <source>The mapped Autonomous System used for diversifying peer selection.</source>
-        <translation type="unfinished">Подключённая автономная система, используемая для диверсификации узлов, к которым производится подключение.</translation>
-    </message>
-    <message>
-        <source>Mapped AS</source>
-        <translation type="unfinished">Подключённая АС</translation>
+        <translation type="unfinished">&amp;Сброс</translation>
     </message>
     <message>
         <source>User Agent</source>
@@ -2169,357 +1371,19 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Node window</source>
-        <translation type="unfinished">Окно ноды</translation>
-    </message>
-    <message>
-        <source>Current block height</source>
-        <translation type="unfinished">Текущая высота блока</translation>
+        <translation type="unfinished">Окно узла</translation>
     </message>
     <message>
         <source>Open the %1 debug log file from the current data directory. This can take a few seconds for large log files.</source>
-        <translation type="unfinished">Открыть файл журнала отладки %1 из текущей директории данных. Для больших файлов журнала это может занять несколько секунд.</translation>
-    </message>
-    <message>
-        <source>Decrease font size</source>
-        <translation type="unfinished">Уменьшить размер шрифта</translation>
-    </message>
-    <message>
-        <source>Increase font size</source>
-        <translation type="unfinished">Увеличить размер шрифта</translation>
-    </message>
-    <message>
-        <source>Permissions</source>
-        <translation type="unfinished">Разрешения</translation>
-    </message>
-    <message>
-        <source>The direction and type of peer connection: %1</source>
-        <translation type="unfinished">Направление и тип подключения узла: %1</translation>
-    </message>
-    <message>
-        <source>Direction/Type</source>
-        <translation type="unfinished">Направление/тип</translation>
-    </message>
-    <message>
-        <source>The network protocol this peer is connected through: IPv4, IPv6, Onion, I2P, or CJDNS.</source>
-        <translation type="unfinished">Сетевой протокол, через который подключён этот узел: IPv4, IPv6, Onion, I2P или CJDNS.</translation>
-    </message>
-    <message>
-        <source>Services</source>
-        <translation type="unfinished">Сервисы</translation>
-    </message>
-    <message>
-        <source>Whether the peer requested us to relay transactions.</source>
-        <translation type="unfinished">Попросил ли нас узел передавать транзакции дальше.</translation>
-    </message>
-    <message>
-        <source>Wants Tx Relay</source>
-        <translation type="unfinished">Желает передавать транзакции</translation>
-    </message>
-    <message>
-        <source>High bandwidth BIP152 compact block relay: %1</source>
-        <translation type="unfinished">Широкополосный ретранслятор компактных блоков BIP152: %1</translation>
-    </message>
-    <message>
-        <source>High Bandwidth</source>
-        <translation type="unfinished">Широкая полоса</translation>
-    </message>
-    <message>
-        <source>Connection Time</source>
-        <translation type="unfinished">Время соединения</translation>
-    </message>
-    <message>
-        <source>Elapsed time since a novel block passing initial validity checks was received from this peer.</source>
-        <translation type="unfinished">Время с момента получения нового блока, прошедшего базовую проверку, от этого узла</translation>
-    </message>
-    <message>
-        <source>Last Block</source>
-        <translation type="unfinished">Последний блок</translation>
-    </message>
-    <message>
-        <source>Elapsed time since a novel transaction accepted into our mempool was received from this peer.</source>
-        <translation type="unfinished">Время с момента принятия новой транзакции в наш мемпул от этого узла.</translation>
-    </message>
-    <message>
-        <source>Last Tx</source>
-        <translation type="unfinished">Последняя транзакция</translation>
-    </message>
-    <message>
-        <source>Last Send</source>
-        <translation type="unfinished">Посл. время отправки</translation>
-    </message>
-    <message>
-        <source>Last Receive</source>
-        <translation type="unfinished">Посл. время получения</translation>
-    </message>
-    <message>
-        <source>Ping Time</source>
-        <translation type="unfinished">Время отклика</translation>
-    </message>
-    <message>
-        <source>The duration of a currently outstanding ping.</source>
-        <translation type="unfinished">Продолжительность текущего времени отклика.</translation>
-    </message>
-    <message>
-        <source>Ping Wait</source>
-        <translation type="unfinished">Ожидание отклика</translation>
-    </message>
-    <message>
-        <source>Min Ping</source>
-        <translation type="unfinished">Мин. время отклика</translation>
-    </message>
-    <message>
-        <source>Time Offset</source>
-        <translation type="unfinished">Временной сдвиг</translation>
-    </message>
-    <message>
-        <source>Last block time</source>
-        <translation>Время последнего блока</translation>
-    </message>
-    <message>
-        <source>&amp;Open</source>
-        <translation>&amp;Открыть</translation>
-    </message>
-    <message>
-        <source>&amp;Console</source>
-        <translation>&amp;Консоль</translation>
-    </message>
-    <message>
-        <source>&amp;Network Traffic</source>
-        <translation type="unfinished">&amp;Сетевой трафик</translation>
-    </message>
-    <message>
-        <source>Totals</source>
-        <translation type="unfinished">Всего</translation>
-    </message>
-    <message>
-        <source>Debug log file</source>
-        <translation>Файл журнала отладки</translation>
-    </message>
-    <message>
-        <source>Clear console</source>
-        <translation>Очистить консоль</translation>
-    </message>
-    <message>
-        <source>In:</source>
-        <translation type="unfinished">Вход:</translation>
-    </message>
-    <message>
-        <source>Out:</source>
-        <translation type="unfinished">Выход:</translation>
-    </message>
-    <message>
-        <source>Inbound: initiated by peer</source>
-        <translation type="unfinished">Входящее: инициировано узлом</translation>
-    </message>
-    <message>
-        <source>Outbound Full Relay: default</source>
-        <translation type="unfinished">Исходящий полный ретранслятор: по умолчанию</translation>
-    </message>
-    <message>
-        <source>Outbound Block Relay: does not relay transactions or addresses</source>
-        <translation type="unfinished">Исходящий ретранслятор блоков: не ретранслирует транзакции или адреса</translation>
-    </message>
-    <message>
-        <source>Outbound Manual: added using RPC %1 or %2/%3 configuration options</source>
-        <translation type="unfinished">Исходящий ручной: добавлен через RPC %1 или опции конфигурации %2/%3</translation>
-    </message>
-    <message>
-        <source>Outbound Feeler: short-lived, for testing addresses</source>
-        <translation type="unfinished">Исходящий пробный: короткое время жизни, для тестирования адресов</translation>
-    </message>
-    <message>
-        <source>Outbound Address Fetch: short-lived, for soliciting addresses</source>
-        <translation type="unfinished">Исходящий для получения адресов: короткое время жизни, для запроса адресов</translation>
-    </message>
-    <message>
-        <source>we selected the peer for high bandwidth relay</source>
-        <translation type="unfinished">мы выбрали этот узел для широкополосной передачи</translation>
-    </message>
-    <message>
-        <source>the peer selected us for high bandwidth relay</source>
-        <translation type="unfinished">этот узел выбрал нас для широкополосной передачи</translation>
-    </message>
-    <message>
-        <source>no high bandwidth relay selected</source>
-        <translation type="unfinished">широкополосный передатчик не выбран</translation>
-    </message>
-    <message>
-        <source>&amp;Disconnect</source>
-        <translation type="unfinished">О&amp;тключиться</translation>
-    </message>
-    <message>
-        <source>1 &amp;hour</source>
-        <translation type="unfinished">1 &amp;час</translation>
+        <translation type="unfinished">Открыть файл журнала отладки %1 из текущего каталога данных. Для больших файлов журнала это может занять несколько секунд.</translation>
     </message>
     <message>
         <source>1 d&amp;ay</source>
-        <translation type="unfinished">1 д&amp;ень</translation>
+        <translation type="unfinished">1 &amp;день</translation>
     </message>
-    <message>
-        <source>1 &amp;week</source>
-        <translation type="unfinished">1 &amp;неделя</translation>
-    </message>
-    <message>
-        <source>1 &amp;year</source>
-        <translation type="unfinished">1 &amp;год</translation>
-    </message>
-    <message>
-        <source>&amp;Unban</source>
-        <translation type="unfinished">&amp;Разбанить</translation>
-    </message>
-    <message>
-        <source>Network activity disabled</source>
-        <translation type="unfinished">Сетевая активность отключена</translation>
-    </message>
-    <message>
-        <source>Executing command without any wallet</source>
-        <translation type="unfinished">Выполнение команды без кошелька</translation>
-    </message>
-    <message>
-        <source>Executing command using "%1" wallet</source>
-        <translation type="unfinished">Выполнение команды с помощью кошелька "%1"</translation>
-    </message>
-    <message>
-        <source>Welcome to the %1 RPC console.
-Use up and down arrows to navigate history, and %2 to clear screen.
-Use %3 and %4 to increase or decrease the font size.
-Type %5 for an overview of available commands.
-For more information on using this console, type %6.
-
-%7WARNING: Scammers have been active, telling users to type commands here, stealing their wallet contents. Do not use this console without fully understanding the ramifications of a command.%8</source>
-        <extracomment>RPC console welcome message. Placeholders %7 and %8 are style tags for the warning content, and they are not space separated from the rest of the text intentionally.</extracomment>
-        <translation type="unfinished">Добро пожаловать в RPC-консоль %1.
-Используйте стрелки вверх и вниз, чтобы перемещаться по истории и %2, чтобы очистить экране.
-Чтобы увеличить или уменьшить размер шрифта, нажмите %3 или %4.
-Наберите %5, чтобы получить список доступных команд.
-Чтобы получить больше информации об этой консоли, наберите %6.
-
-%7ВНИМАНИЕ: мошенники очень часто просят пользователей вводить здесь различные команды и таким образом крадут содержимое кошельков. Не используйте эту консоль, если не полностью понимаете последствия каждой команды.%8</translation>
-    </message>
-    <message>
-        <source>Executing…</source>
-        <extracomment>A console message indicating an entered command is currently being executed.</extracomment>
-        <translation type="unfinished">Выполняется...</translation>
-    </message>
-    <message>
-        <source>(peer: %1)</source>
-        <translation type="unfinished">(узел: %1)</translation>
-    </message>
-    <message>
-        <source>via %1</source>
-        <translation type="unfinished">с помощью %1</translation>
-    </message>
-    <message>
-        <source>Yes</source>
-        <translation type="unfinished">Да</translation>
-    </message>
-    <message>
-        <source>No</source>
-        <translation type="unfinished">Нет</translation>
-    </message>
-    <message>
-        <source>To</source>
-        <translation type="unfinished">Кому</translation>
-    </message>
-    <message>
-        <source>From</source>
-        <translation type="unfinished">От</translation>
-    </message>
-    <message>
-        <source>Ban for</source>
-        <translation type="unfinished">Заблокировать на</translation>
-    </message>
-    <message>
-        <source>Never</source>
-        <translation type="unfinished">Никогда</translation>
-    </message>
-    <message>
-        <source>Unknown</source>
-        <translation type="unfinished">Неизвестно</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>ReceiveCoinsDialog</name>
-    <message>
-        <source>&amp;Amount:</source>
-        <translation type="unfinished">&amp;Сумма:</translation>
-    </message>
-    <message>
-        <source>&amp;Label:</source>
-        <translation type="unfinished">&amp;Метка:</translation>
-    </message>
-    <message>
-        <source>&amp;Message:</source>
-        <translation type="unfinished">&amp;Сообщение:</translation>
-    </message>
-    <message>
-        <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
-        <translation type="unfinished">Необязательное сообщение для запроса платежа, которое будет показано при открытии запроса. Внимание: это сообщение не будет отправлено вместе с платежом через сеть биткоина.</translation>
-    </message>
-    <message>
-        <source>An optional label to associate with the new receiving address.</source>
-        <translation type="unfinished">Для нового адреса получения можно добавить метку.</translation>
-    </message>
-    <message>
-        <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
-        <translation type="unfinished">Используйте эту форму, чтобы запросить платёж. Все поля &lt;b&gt;необязательны&lt;/b&gt;.</translation>
-    </message>
-    <message>
-        <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
-        <translation type="unfinished">Можно указать сумму, платёж на которую вы запрашиваете. Оставьте пустой или введите ноль, чтобы не запрашивать определённую сумму.</translation>
-    </message>
-    <message>
-        <source>An optional label to associate with the new receiving address (used by you to identify an invoice).  It is also attached to the payment request.</source>
-        <translation type="unfinished">Можно указать метку, которая будет присвоена новому адресу получения (чтобы вы могли идентифицировать выставленный счёт). Также она присоединяется к запросу платежа.</translation>
-    </message>
-    <message>
-        <source>An optional message that is attached to the payment request and may be displayed to the sender.</source>
-        <translation type="unfinished">Можно ввести сообщение, которое присоединяется к запросу платежа и может быть показано отправителю.</translation>
-    </message>
-    <message>
-        <source>&amp;Create new receiving address</source>
-        <translation type="unfinished">&amp;Создать новый адрес для получения</translation>
-    </message>
-    <message>
-        <source>Clear all fields of the form.</source>
-        <translation type="unfinished">Очищает все поля формы.</translation>
-    </message>
-    <message>
-        <source>Clear</source>
-        <translation type="unfinished">Очистить</translation>
-    </message>
-    <message>
-        <source>Native segwit addresses (aka Bech32 or BIP-173) reduce your transaction fees later on and offer better protection against typos, but old wallets don't support them. When unchecked, an address compatible with older wallets will be created instead.</source>
-        <translation type="unfinished">Нативные segwit-адреса (Bech32 или BIP-173) уменьшают комиссии ваших транзакций в будущем и лучше защищают от опечаток, но не поддерживаются старыми кошельками. Если галочка не установлена, будет создан адрес, совместимый со старыми кошельками.</translation>
-    </message>
-    <message>
-        <source>Generate native segwit (Bech32) address</source>
-        <translation type="unfinished">Генерировать нативный segwit-адрес (Bech32)</translation>
-    </message>
-    <message>
-        <source>Requested payments history</source>
-        <translation type="unfinished">История запросов платежей</translation>
-    </message>
-    <message>
-        <source>Show the selected request (does the same as double clicking an entry)</source>
-        <translation type="unfinished">Показывает выбранный запрос (двойное нажатие на записи делает то же самое)</translation>
-    </message>
-    <message>
-        <source>Show</source>
-        <translation type="unfinished">Показать</translation>
-    </message>
-    <message>
-        <source>Remove the selected entries from the list</source>
-        <translation type="unfinished">Удаляет выбранные записи из списка</translation>
-    </message>
-    <message>
-        <source>Remove</source>
-        <translation type="unfinished">Удалить</translation>
-    </message>
-    <message>
-        <source>Copy &amp;URI</source>
-        <translation type="unfinished">Копировать &amp;URI</translation>
-    </message>
     <message>
         <source>&amp;Copy address</source>
         <translation type="unfinished">&amp;Копировать адрес</translation>
@@ -2530,7 +1394,7 @@ For more information on using this console, type %6.
     </message>
     <message>
         <source>Copy &amp;message</source>
-        <translation type="unfinished">Копирование &amp;сообщение</translation>
+        <translation type="unfinished">Копировать &amp;сообщение</translation>
     </message>
     <message>
         <source>Copy &amp;amount</source>
@@ -2540,44 +1404,16 @@ For more information on using this console, type %6.
         <source>Could not unlock wallet.</source>
         <translation type="unfinished">Невозможно разблокировать кошелёк.</translation>
     </message>
-    <message>
-        <source>Could not generate new %1 address</source>
-        <translation type="unfinished">Не удалось сгенерировать новый %1 адрес</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>ReceiveRequestDialog</name>
-    <message>
-        <source>Request payment to …</source>
-        <translation type="unfinished">Запросить платёж на ...</translation>
-    </message>
-    <message>
-        <source>Address:</source>
-        <translation type="unfinished">Адрес:</translation>
-    </message>
     <message>
         <source>Amount:</source>
         <translation type="unfinished">Сумма:</translation>
     </message>
     <message>
-        <source>Label:</source>
-        <translation type="unfinished">Метка:</translation>
-    </message>
-    <message>
-        <source>Message:</source>
-        <translation type="unfinished">Сообщение:</translation>
-    </message>
-    <message>
         <source>Wallet:</source>
         <translation type="unfinished">Кошелёк:</translation>
-    </message>
-    <message>
-        <source>Copy &amp;URI</source>
-        <translation type="unfinished">Копировать &amp;URI</translation>
-    </message>
-    <message>
-        <source>Copy &amp;Address</source>
-        <translation type="unfinished">Копировать &amp;адрес</translation>
     </message>
     <message>
         <source>&amp;Verify</source>
@@ -2585,21 +1421,9 @@ For more information on using this console, type %6.
     </message>
     <message>
         <source>Verify this address on e.g. a hardware wallet screen</source>
-        <translation type="unfinished">Проверьте этот адрес, например, на экране аппаратного кошелька</translation>
+        <translation type="unfinished">Проверьте адрес, например на экране аппаратного кошелька</translation>
     </message>
-    <message>
-        <source>&amp;Save Image…</source>
-        <translation type="unfinished">&amp;Сохранить изображение...</translation>
-    </message>
-    <message>
-        <source>Payment information</source>
-        <translation type="unfinished">Информация о платеже</translation>
-    </message>
-    <message>
-        <source>Request payment to %1</source>
-        <translation type="unfinished">Запросить платёж на %1</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
@@ -2618,36 +1442,12 @@ For more information on using this console, type %6.
         <source>(no label)</source>
         <translation type="unfinished">(нет метки)</translation>
     </message>
-    <message>
-        <source>(no message)</source>
-        <translation type="unfinished">(нет сообщения)</translation>
-    </message>
-    <message>
-        <source>(no amount requested)</source>
-        <translation type="unfinished">(сумма не указана)</translation>
-    </message>
-    <message>
-        <source>Requested</source>
-        <translation type="unfinished">Запрошено</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>SendCoinsDialog</name>
     <message>
         <source>Send Coins</source>
         <translation>Отправить монеты</translation>
-    </message>
-    <message>
-        <source>Coin Control Features</source>
-        <translation type="unfinished">Функции управления монетами</translation>
-    </message>
-    <message>
-        <source>automatically selected</source>
-        <translation type="unfinished">выбираются автоматически</translation>
-    </message>
-    <message>
-        <source>Insufficient funds!</source>
-        <translation type="unfinished">Недостаточно средств!</translation>
     </message>
     <message>
         <source>Quantity:</source>
@@ -2674,116 +1474,12 @@ For more information on using this console, type %6.
         <translation type="unfinished">Сдача:</translation>
     </message>
     <message>
-        <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
-        <translation type="unfinished">Если адрес для сдачи пустой или неверный, сдача будет отправлена на вновь сгенерированный адрес.</translation>
-    </message>
-    <message>
-        <source>Custom change address</source>
-        <translation type="unfinished">Указать адрес для сдачи</translation>
-    </message>
-    <message>
-        <source>Transaction Fee:</source>
-        <translation type="unfinished">Комиссия за транзакцию:</translation>
-    </message>
-    <message>
-        <source>Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until you have validated the complete chain.</source>
-        <translation type="unfinished">Использование комиссии по умолчанию может привести к отправке транзакции, для подтверждения которой потребуется несколько часов или дней (или которая никогда не подтвердится). Рекомендуется указать комиссию вручную или подождать, пока не закончится проверка всей цепочки блоков.</translation>
-    </message>
-    <message>
-        <source>Warning: Fee estimation is currently not possible.</source>
-        <translation type="unfinished">Предупреждение: расчёт комиссии в данный момент невозможен.</translation>
-    </message>
-    <message>
-        <source>per kilobyte</source>
-        <translation type="unfinished">за килобайт</translation>
-    </message>
-    <message>
         <source>Hide</source>
         <translation type="unfinished">Скрыть</translation>
     </message>
     <message>
-        <source>Recommended:</source>
-        <translation type="unfinished">Рекомендованное значение:</translation>
-    </message>
-    <message>
-        <source>Custom:</source>
-        <translation type="unfinished">Пользовательское значение:</translation>
-    </message>
-    <message>
-        <source>Send to multiple recipients at once</source>
-        <translation>Отправить нескольким получателям сразу</translation>
-    </message>
-    <message>
-        <source>Add &amp;Recipient</source>
-        <translation>Добавить &amp;получателя</translation>
-    </message>
-    <message>
-        <source>Clear all fields of the form.</source>
-        <translation type="unfinished">Очищает все поля формы.</translation>
-    </message>
-    <message>
-        <source>Inputs…</source>
-        <translation type="unfinished">Входы...</translation>
-    </message>
-    <message>
         <source>Dust:</source>
         <translation type="unfinished">Пыль:</translation>
-    </message>
-    <message>
-        <source>Choose…</source>
-        <translation type="unfinished">Выбрать...</translation>
-    </message>
-    <message>
-        <source>Hide transaction fee settings</source>
-        <translation type="unfinished">Скрыть настройки комиссий</translation>
-    </message>
-    <message>
-        <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
-
-Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satoshis per kvB" for a transaction size of 500 virtual bytes (half of 1 kvB) would ultimately yield a fee of only 50 satoshis.</source>
-        <translation type="unfinished">Укажите пользовательскую комиссию за КБ (1000 байт) виртуального размера транзакции.
-
-Примечание: так как комиссия рассчитывается пропорционально размеру в байтах, комиссия «100 сатоши за ВКБ» для транзакции размером 500 виртуальных байт (половина 1 ВКБ) приведет к сбору в размере всего 50 сатоши.</translation>
-    </message>
-    <message>
-        <source>When there is less transaction volume than space in the blocks, miners as well as relaying nodes may enforce a minimum fee. Paying only this minimum fee is just fine, but be aware that this can result in a never confirming transaction once there is more demand for bitcoin transactions than the network can process.</source>
-        <translation type="unfinished">Когда объём транзакций меньше, чем пространство в блоках, майнеры и ретранслирующие узлы могут устанавливать минимальную комиссию. Платить только эту минимальную комиссию вполне допустимо, но примите во внимание,  что ваша транзакция может никогда не подтвердиться, если впоследствии транзакций окажется больше, чем может обработать сеть.</translation>
-    </message>
-    <message>
-        <source>A too low fee might result in a never confirming transaction (read the tooltip)</source>
-        <translation type="unfinished">Слишком низкая комиссия может привести к невозможности подтверждения транзакции (см. подсказку)</translation>
-    </message>
-    <message>
-        <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
-        <translation type="unfinished">(Умная комиссия пока не инициализирована. Обычно для этого требуется несколько блоков...)</translation>
-    </message>
-    <message>
-        <source>Confirmation time target:</source>
-        <translation type="unfinished">Целевое время подтверждения</translation>
-    </message>
-    <message>
-        <source>Enable Replace-By-Fee</source>
-        <translation type="unfinished">Включить Replace-By-Fee</translation>
-    </message>
-    <message>
-        <source>With Replace-By-Fee (BIP-125) you can increase a transaction's fee after it is sent. Without this, a higher fee may be recommended to compensate for increased transaction delay risk.</source>
-        <translation type="unfinished">С помощью Replace-By-Fee (BIP-125) вы можете увеличить комиссию после отправки транзакции. Если эта опция выключена, рекомендуемая комиссия может увеличиться, чтобы компенсировать риск задержки транзакции.</translation>
-    </message>
-    <message>
-        <source>Clear &amp;All</source>
-        <translation>Очистить &amp;всё</translation>
-    </message>
-    <message>
-        <source>Balance:</source>
-        <translation>Баланс:</translation>
-    </message>
-    <message>
-        <source>Confirm the send action</source>
-        <translation>Подтвердите отправку</translation>
-    </message>
-    <message>
-        <source>S&amp;end</source>
-        <translation>&amp;Отправить</translation>
     </message>
     <message>
         <source>Copy quantity</source>
@@ -2814,189 +1510,40 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
         <translation type="unfinished">Копировать сдачу</translation>
     </message>
     <message>
-        <source>%1 (%2 blocks)</source>
-        <translation type="unfinished">%1 (%2 блоков)</translation>
-    </message>
-    <message>
         <source>Sign on device</source>
         <extracomment>"device" usually means a hardware wallet</extracomment>
-        <translation type="unfinished">Войти на устройство</translation>
+        <translation type="unfinished">Подтвердите на устройстве</translation>
     </message>
     <message>
         <source>Connect your hardware wallet first.</source>
-        <translation type="unfinished">Сначала подключите аппаратный кошелек.</translation>
+        <translation type="unfinished">Сначала подключите ваш аппаратный кошелёк.</translation>
     </message>
     <message>
         <source>Set external signer script path in Options -&gt; Wallet</source>
         <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
-        <translation type="unfinished">Задайте путь к скрипту внешней подписи в Параметры -&gt; Кошелек</translation>
-    </message>
-    <message>
-        <source>Cr&amp;eate Unsigned</source>
-        <translation type="unfinished">Создать &amp;без подписи</translation>
-    </message>
-    <message>
-        <source>Creates a Partially Signed Bitcoin Transaction (PSBT) for use with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
-        <translation type="unfinished">Создает частично подписанную биткоин-транзакцию (PSBT), чтобы использовать её, например, с офлайновым кошельком %1, или PSBT-совместимым аппаратным кошельком.</translation>
-    </message>
-    <message>
-        <source> from wallet '%1'</source>
-        <translation type="unfinished">с кошелька '%1'</translation>
-    </message>
-    <message>
-        <source>%1 to '%2'</source>
-        <translation type="unfinished">%1 на '%2'</translation>
-    </message>
-    <message>
-        <source>%1 to %2</source>
-        <translation type="unfinished">С %1 на %2</translation>
-    </message>
-    <message>
-        <source>Do you want to draft this transaction?</source>
-        <translation type="unfinished">Вы хотите создать черновик этой транзакции?</translation>
-    </message>
-    <message>
-        <source>Are you sure you want to send?</source>
-        <translation type="unfinished">Вы действительно хотите отправить средства?</translation>
-    </message>
-    <message>
-        <source>To review recipient list click "Show Details…"</source>
-        <translation type="unfinished">Чтобы просмотреть список получателей, нажмите «Показать подробности...»</translation>
-    </message>
-    <message>
-        <source>Create Unsigned</source>
-        <translation type="unfinished">Создать без подписи</translation>
-    </message>
-    <message>
-        <source>Sign and send</source>
-        <translation type="unfinished">Подписать и отправить</translation>
-    </message>
-    <message>
-        <source>Sign failed</source>
-        <translation type="unfinished">Подписание не удалось.</translation>
+        <translation type="unfinished">Укажите внешний скрипт подписи в Настройки -&gt; Кошелек</translation>
     </message>
     <message>
         <source>External signer not found</source>
         <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
-        <translation type="unfinished">Внешняя подпись не найдена</translation>
+        <translation type="unfinished">Внешний скрипт подписи не найден</translation>
     </message>
     <message>
         <source>External signer failure</source>
         <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
-        <translation type="unfinished">Ошибка внешней подписи</translation>
-    </message>
-    <message>
-        <source>Save Transaction Data</source>
-        <translation type="unfinished">Сохранить данные о транзакции</translation>
-    </message>
-    <message>
-        <source>Partially Signed Transaction (Binary)</source>
-        <extracomment>Expanded name of the binary PSBT file format. See: BIP 174.</extracomment>
-        <translation type="unfinished">Частично подписанная транзакция (двоичный файл)</translation>
-    </message>
-    <message>
-        <source>PSBT saved</source>
-        <translation type="unfinished">PSBT сохранена</translation>
+        <translation type="unfinished">Ошибка внешнего скрипта подписи</translation>
     </message>
     <message>
         <source>External balance:</source>
         <translation type="unfinished">Внешний баланс:</translation>
     </message>
-    <message>
-        <source>or</source>
-        <translation type="unfinished">или</translation>
-    </message>
-    <message>
-        <source>You can increase the fee later (signals Replace-By-Fee, BIP-125).</source>
-        <translation type="unfinished">Вы можете увеличить комиссию позже (указан Replace-By-Fee, BIP-125).</translation>
-    </message>
-    <message>
-        <source>Please, review your transaction proposal. This will produce a Partially Signed Bitcoin Transaction (PSBT) which you can save or copy and then sign with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
-        <translation type="unfinished">Пожалуйста, ещё раз просмотрите черновик вашей транзакции. Будет создана частично подписанная биткоин-транзакция (PSBT), которую можно сохранить или скопировать, после чего подписать, например, офлайновым кошельком %1 или PSBT-совместимым аппаратным кошельком.</translation>
-    </message>
-    <message>
-        <source>Please, review your transaction.</source>
-        <translation type="unfinished">Пожалуйста, ещё раз просмотрите вашу транзакцию.</translation>
-    </message>
-    <message>
-        <source>Transaction fee</source>
-        <translation type="unfinished">Комиссия за транзакцию</translation>
-    </message>
-    <message>
-        <source>Not signalling Replace-By-Fee, BIP-125.</source>
-        <translation type="unfinished">Не указан Replace-By-Fee, BIP-125.</translation>
-    </message>
-    <message>
-        <source>Total Amount</source>
-        <translation type="unfinished">Итоговая сумма</translation>
-    </message>
-    <message>
-        <source>Confirm send coins</source>
-        <translation type="unfinished">Подтвердите отправку монет</translation>
-    </message>
-    <message>
-        <source>Confirm transaction proposal</source>
-        <translation type="unfinished">Подтвердите черновик транзакции</translation>
-    </message>
-    <message>
-        <source>Watch-only balance:</source>
-        <translation type="unfinished">Наблюдаемый баланс:</translation>
-    </message>
-    <message>
-        <source>The recipient address is not valid. Please recheck.</source>
-        <translation type="unfinished">Адрес получателя неверный. Пожалуйста, перепроверьте.</translation>
-    </message>
-    <message>
-        <source>The amount to pay must be larger than 0.</source>
-        <translation type="unfinished">Сумма оплаты должна быть больше 0.</translation>
-    </message>
-    <message>
-        <source>The amount exceeds your balance.</source>
-        <translation type="unfinished">Сумма превышает ваш баланс.</translation>
-    </message>
-    <message>
-        <source>The total exceeds your balance when the %1 transaction fee is included.</source>
-        <translation type="unfinished">Итоговая сумма с учётом комиссии %1 превышает ваш баланс.</translation>
-    </message>
-    <message>
-        <source>Duplicate address found: addresses should only be used once each.</source>
-        <translation type="unfinished">Обнаружен дублирующийся адрес: используйте каждый адрес только один раз.</translation>
-    </message>
-    <message>
-        <source>Transaction creation failed!</source>
-        <translation type="unfinished">Не удалось создать транзакцию!</translation>
-    </message>
-    <message>
-        <source>A fee higher than %1 is considered an absurdly high fee.</source>
-        <translation type="unfinished">Комиссия более чем в %1 считается абсурдно высокой.</translation>
-    </message>
-    <message>
-        <source>Payment request expired.</source>
-        <translation type="unfinished">Истекло время ожидания запроса платежа</translation>
-    </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation>
-            <numerusform>Предполагается, что подтверждение начнется после %n блока.</numerusform>
-            <numerusform>Предполагается, что подтверждение начнется после %n блоков.</numerusform>
-            <numerusform>Предполагается, что подтверждение начнется после %n блоков.</numerusform>
+            <numerusform />
+            <numerusform />
+            <numerusform />
         </translation>
-    </message>
-    <message>
-        <source>Warning: Invalid Bitcoin address</source>
-        <translation type="unfinished">Предупреждение: неверный биткоин-адрес</translation>
-    </message>
-    <message>
-        <source>Warning: Unknown change address</source>
-        <translation type="unfinished">Предупреждение: неизвестный адрес сдачи</translation>
-    </message>
-    <message>
-        <source>Confirm custom change address</source>
-        <translation type="unfinished">Подтвердите указанный адрес для сдачи</translation>
-    </message>
-    <message>
-        <source>The address you selected for change is not part of this wallet. Any or all funds in your wallet may be sent to this address. Are you sure?</source>
-        <translation type="unfinished">Выбранный вами адрес для сдачи не принадлежит этому кошельку. Часть или все средства в вашем кошельке могут быть отправлены на этот адрес. Вы уверены?</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -3004,429 +1551,45 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     </message>
 </context>
 <context>
-    <name>SendCoinsEntry</name>
-    <message>
-        <source>A&amp;mount:</source>
-        <translation>&amp;Сумма:</translation>
-    </message>
-    <message>
-        <source>Pay &amp;To:</source>
-        <translation>&amp;Отправить на:</translation>
-    </message>
-    <message>
-        <source>&amp;Label:</source>
-        <translation>&amp;Метка:</translation>
-    </message>
-    <message>
-        <source>Choose previously used address</source>
-        <translation type="unfinished">Выбрать ранее использованный адрес</translation>
-    </message>
-    <message>
-        <source>The Bitcoin address to send the payment to</source>
-        <translation type="unfinished">Биткоин-адрес, на который нужно отправить платёж</translation>
-    </message>
-    <message>
-        <source>Paste address from clipboard</source>
-        <translation>Вставить адрес из буфера обмена</translation>
-    </message>
-    <message>
-        <source>Remove this entry</source>
-        <translation type="unfinished">Удалить эту запись</translation>
-    </message>
-    <message>
-        <source>The amount to send in the selected unit</source>
-        <translation type="unfinished">Сумма к отправке в выбранных единицах</translation>
-    </message>
-    <message>
-        <source>The fee will be deducted from the amount being sent. The recipient will receive less bitcoins than you enter in the amount field. If multiple recipients are selected, the fee is split equally.</source>
-        <translation type="unfinished">Комиссия будет вычтена из отправляемой суммы. Получателю придёт меньше биткоинов, чем вы ввели в поле «Сумма». Если выбрано несколько получателей, комиссия распределяется поровну.</translation>
-    </message>
-    <message>
-        <source>S&amp;ubtract fee from amount</source>
-        <translation type="unfinished">В&amp;ычесть комиссию из суммы</translation>
-    </message>
-    <message>
-        <source>Use available balance</source>
-        <translation type="unfinished">Весь доступный баланс</translation>
-    </message>
-    <message>
-        <source>Message:</source>
-        <translation type="unfinished">Сообщение:</translation>
-    </message>
-    <message>
-        <source>This is an unauthenticated payment request.</source>
-        <translation type="unfinished">Это непроверенный запрос на оплату.</translation>
-    </message>
-    <message>
-        <source>This is an authenticated payment request.</source>
-        <translation type="unfinished">Это проверенный запрос на оплату.</translation>
-    </message>
-    <message>
-        <source>Enter a label for this address to add it to the list of used addresses</source>
-        <translation type="unfinished">Введите метку для этого адреса, чтобы добавить его в список использованных адресов</translation>
-    </message>
-    <message>
-        <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
-        <translation type="unfinished">Сообщение, которое было прикреплено к URI и которое будет сохранено вместе с транзакцией для вашего сведения. Обратите внимание: сообщение не будет отправлено через сеть биткоина.</translation>
-    </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">Отправить на:</translation>
-    </message>
-    <message>
-        <source>Memo:</source>
-        <translation type="unfinished">Примечание:</translation>
-    </message>
-</context>
-<context>
-    <name>SignVerifyMessageDialog</name>
-    <message>
-        <source>Signatures - Sign / Verify a Message</source>
-        <translation>Подписи - подписать / проверить сообщение</translation>
-    </message>
-    <message>
-        <source>&amp;Sign Message</source>
-        <translation>&amp;Подписать сообщение</translation>
-    </message>
-    <message>
-        <source>You can sign messages/agreements with your addresses to prove you can receive bitcoins sent to them. Be careful not to sign anything vague or random, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
-        <translation type="unfinished">Вы можете подписывать сообщения/соглашения своими адресами, чтобы доказать, что вы можете получать биткоины на них. Будьте осторожны и не подписывайте непонятные или случайные сообщения, так как мошенники могут таким образом пытаться присвоить вашу личность. Подписывайте только такие сообщения, с которыми вы согласны вплоть до мелочей.</translation>
-    </message>
-    <message>
-        <source>The Bitcoin address to sign the message with</source>
-        <translation type="unfinished">Биткоин-адрес, которым подписать сообщение</translation>
-    </message>
-    <message>
-        <source>Choose previously used address</source>
-        <translation type="unfinished">Выбрать ранее использованный адрес</translation>
-    </message>
-    <message>
-        <source>Paste address from clipboard</source>
-        <translation>Вставить адрес из буфера обмена</translation>
-    </message>
-    <message>
-        <source>Enter the message you want to sign here</source>
-        <translation>Введите здесь сообщение, которое вы хотите подписать</translation>
-    </message>
-    <message>
-        <source>Signature</source>
-        <translation>Подпись</translation>
-    </message>
-    <message>
-        <source>Copy the current signature to the system clipboard</source>
-        <translation>Скопировать текущую подпись в буфер обмена</translation>
-    </message>
-    <message>
-        <source>Sign the message to prove you own this Bitcoin address</source>
-        <translation>Подписать сообщение, чтобы доказать владение биткоин-адресом</translation>
-    </message>
-    <message>
-        <source>Sign &amp;Message</source>
-        <translation>Подписать &amp;сообщение</translation>
-    </message>
-    <message>
-        <source>Reset all sign message fields</source>
-        <translation>Сбросить значения всех полей</translation>
-    </message>
-    <message>
-        <source>Clear &amp;All</source>
-        <translation>Очистить &amp;всё</translation>
-    </message>
-    <message>
-        <source>&amp;Verify Message</source>
-        <translation>П&amp;роверить сообщение</translation>
-    </message>
-    <message>
-        <source>Enter the receiver's address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack. Note that this only proves the signing party receives with the address, it cannot prove sendership of any transaction!</source>
-        <translation type="unfinished">Введите ниже адрес получателя, сообщение (убедитесь, что переводы строк, пробелы, знаки табуляции и т. п. скопированы в точности) и подпись, чтобы проверить сообщение. Убедитесь, что вы не придаёте сообщению большего смысла, чем оно на самом деле несёт, чтобы не стать жертвой атаки "человек посередине". Обратите внимание, что подпись доказывает лишь то, что подписавший может получать биткоины на этот адрес, но никак не то, что он отправил какую-либо транзакцию!</translation>
-    </message>
-    <message>
-        <source>The Bitcoin address the message was signed with</source>
-        <translation type="unfinished">Биткоин-адрес, которым было подписано сообщение</translation>
-    </message>
-    <message>
-        <source>The signed message to verify</source>
-        <translation type="unfinished">Подписанное сообщение для проверки</translation>
-    </message>
-    <message>
-        <source>The signature given when the message was signed</source>
-        <translation type="unfinished">Подпись, созданная при подписании сообщения</translation>
-    </message>
-    <message>
-        <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
-        <translation>Проверить сообщение, чтобы убедиться, что оно действительно подписано указанным биткоин-адресом</translation>
-    </message>
-    <message>
-        <source>Verify &amp;Message</source>
-        <translation>Проверить &amp;сообщение</translation>
-    </message>
-    <message>
-        <source>Reset all verify message fields</source>
-        <translation>Сбросить все поля проверки сообщения</translation>
-    </message>
-    <message>
-        <source>Click "Sign Message" to generate signature</source>
-        <translation type="unfinished">Нажмите "Подписать сообщение" для создания подписи</translation>
-    </message>
-    <message>
-        <source>The entered address is invalid.</source>
-        <translation type="unfinished">Введенный адрес недействителен.</translation>
-    </message>
-    <message>
-        <source>Please check the address and try again.</source>
-        <translation type="unfinished">Проверьте адрес и попробуйте ещё раз.</translation>
-    </message>
-    <message>
-        <source>The entered address does not refer to a key.</source>
-        <translation type="unfinished">Введённый адрес не связан с ключом.</translation>
-    </message>
-    <message>
-        <source>Wallet unlock was cancelled.</source>
-        <translation type="unfinished">Разблокирование кошелька было отменено.</translation>
-    </message>
-    <message>
-        <source>No error</source>
-        <translation type="unfinished">Нет ошибок</translation>
-    </message>
-    <message>
-        <source>Private key for the entered address is not available.</source>
-        <translation type="unfinished">Недоступен секретный ключ для введённого адреса.</translation>
-    </message>
-    <message>
-        <source>Message signing failed.</source>
-        <translation type="unfinished">Не удалось подписать сообщение.</translation>
-    </message>
-    <message>
-        <source>Message signed.</source>
-        <translation type="unfinished">Сообщение подписано.</translation>
-    </message>
-    <message>
-        <source>The signature could not be decoded.</source>
-        <translation type="unfinished">Невозможно декодировать подпись.</translation>
-    </message>
-    <message>
-        <source>Please check the signature and try again.</source>
-        <translation type="unfinished">Пожалуйста, проверьте подпись и попробуйте ещё раз.</translation>
-    </message>
-    <message>
-        <source>The signature did not match the message digest.</source>
-        <translation type="unfinished">Подпись не соответствует отпечатку сообщения.</translation>
-    </message>
-    <message>
-        <source>Message verification failed.</source>
-        <translation type="unfinished">Сообщение не прошло проверку.</translation>
-    </message>
-    <message>
-        <source>Message verified.</source>
-        <translation type="unfinished">Сообщение проверено.</translation>
-    </message>
-</context>
-<context>
-    <name>TrafficGraphWidget</name>
-    <message>
-        <source>kB/s</source>
-        <translation type="unfinished">КБ/с</translation>
-    </message>
-</context>
-<context>
     <name>TransactionDesc</name>
     <message numerus="yes">
         <source>Open for %n more block(s)</source>
         <translation>
-            <numerusform>Открыть еще  %n блок</numerusform>
-            <numerusform>Открыть еще  %n блоков</numerusform>
-            <numerusform>Открыть еще  %n блоков</numerusform>
+            <numerusform />
+            <numerusform />
+            <numerusform />
         </translation>
-    </message>
-    <message>
-        <source>Open until %1</source>
-        <translation type="unfinished">Открыта до %1</translation>
-    </message>
-    <message>
-        <source>conflicted with a transaction with %1 confirmations</source>
-        <translation type="unfinished">конфликтует с транзакцией с %1 подтверждениями</translation>
-    </message>
-    <message>
-        <source>0/unconfirmed, %1</source>
-        <translation type="unfinished">0 / не подтверждено, %1</translation>
-    </message>
-    <message>
-        <source>in memory pool</source>
-        <translation type="unfinished">в пуле памяти</translation>
-    </message>
-    <message>
-        <source>not in memory pool</source>
-        <translation type="unfinished">не в пуле памяти</translation>
-    </message>
-    <message>
-        <source>abandoned</source>
-        <translation type="unfinished">отброшена</translation>
-    </message>
-    <message>
-        <source>%1/unconfirmed</source>
-        <translation type="unfinished">%1 / не подтверждено</translation>
-    </message>
-    <message>
-        <source>%1 confirmations</source>
-        <translation type="unfinished">%1 подтверждений</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation type="unfinished">Статус</translation>
     </message>
     <message>
         <source>Date</source>
         <translation type="unfinished">Дата</translation>
     </message>
     <message>
-        <source>Source</source>
-        <translation type="unfinished">Источник</translation>
-    </message>
-    <message>
-        <source>Generated</source>
-        <translation type="unfinished">Сгенерировано</translation>
-    </message>
-    <message>
-        <source>From</source>
-        <translation type="unfinished">От</translation>
-    </message>
-    <message>
         <source>unknown</source>
-        <translation type="unfinished">неизвестно</translation>
-    </message>
-    <message>
-        <source>To</source>
-        <translation type="unfinished">Кому</translation>
-    </message>
-    <message>
-        <source>own address</source>
-        <translation type="unfinished">свой адрес</translation>
-    </message>
-    <message>
-        <source>watch-only</source>
-        <translation type="unfinished">наблюдаемый</translation>
-    </message>
-    <message>
-        <source>label</source>
-        <translation type="unfinished">метка</translation>
-    </message>
-    <message>
-        <source>Credit</source>
-        <translation type="unfinished">Кредит</translation>
+        <translation type="unfinished">Неизвестно</translation>
     </message>
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation>
-            <numerusform>станет доступно через %n блок</numerusform>
-            <numerusform>станет доступно через %n блоков</numerusform>
-            <numerusform>станет доступно через %n блоков</numerusform>
+            <numerusform />
+            <numerusform />
+            <numerusform />
         </translation>
-    </message>
-    <message>
-        <source>not accepted</source>
-        <translation type="unfinished">не принят</translation>
-    </message>
-    <message>
-        <source>Debit</source>
-        <translation type="unfinished">Дебет</translation>
-    </message>
-    <message>
-        <source>Total debit</source>
-        <translation type="unfinished">Итого дебет</translation>
-    </message>
-    <message>
-        <source>Total credit</source>
-        <translation type="unfinished">Итого кредит</translation>
-    </message>
-    <message>
-        <source>Transaction fee</source>
-        <translation type="unfinished">Комиссия за транзакцию</translation>
-    </message>
-    <message>
-        <source>Net amount</source>
-        <translation type="unfinished">Сумма нетто</translation>
     </message>
     <message>
         <source>Message</source>
         <translation type="unfinished">Сообщение</translation>
     </message>
     <message>
-        <source>Comment</source>
-        <translation type="unfinished">Комментарий</translation>
-    </message>
-    <message>
-        <source>Transaction ID</source>
-        <translation type="unfinished">Идентификатор транзакции</translation>
-    </message>
-    <message>
-        <source>Transaction total size</source>
-        <translation type="unfinished">Общий размер транзакции</translation>
-    </message>
-    <message>
-        <source>Transaction virtual size</source>
-        <translation type="unfinished">Виртуальный размер транзакции</translation>
-    </message>
-    <message>
-        <source>Output index</source>
-        <translation type="unfinished">Индекс выхода</translation>
-    </message>
-    <message>
-        <source> (Certificate was not verified)</source>
-        <translation type="unfinished">(Сертификат не был проверен)</translation>
-    </message>
-    <message>
-        <source>Merchant</source>
-        <translation type="unfinished">Продавец</translation>
-    </message>
-    <message>
-        <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to "not accepted" and it won't be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
-        <translation type="unfinished">Сгенерированные монеты должны созреть в течение %1 блоков, прежде чем смогут быть потрачены. Когда вы сгенерировали этот блок, он был отправлен в сеть для добавления в цепочку блоков. Если он не попадёт в цепочку, его статус изменится на "не принят", и монеты будут недействительны. Это иногда происходит в случае, если другой узел сгенерирует блок на несколько секунд раньше вас.</translation>
-    </message>
-    <message>
-        <source>Debug information</source>
-        <translation type="unfinished">Отладочная информация</translation>
-    </message>
-    <message>
-        <source>Transaction</source>
-        <translation type="unfinished">Транзакция</translation>
-    </message>
-    <message>
-        <source>Inputs</source>
-        <translation type="unfinished">Входы</translation>
-    </message>
-    <message>
         <source>Amount</source>
         <translation type="unfinished">Сумма</translation>
     </message>
-    <message>
-        <source>true</source>
-        <translation type="unfinished">истина</translation>
-    </message>
-    <message>
-        <source>false</source>
-        <translation type="unfinished">ложь</translation>
-    </message>
-</context>
-<context>
-    <name>TransactionDescDialog</name>
-    <message>
-        <source>This pane shows a detailed description of the transaction</source>
-        <translation>На этой панели показано подробное описание транзакции</translation>
-    </message>
-    <message>
-        <source>Details for %1</source>
-        <translation type="unfinished">Подробности по %1</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
         <source>Date</source>
         <translation type="unfinished">Дата</translation>
-    </message>
-    <message>
-        <source>Type</source>
-        <translation type="unfinished">Тип</translation>
     </message>
     <message>
         <source>Label</source>
@@ -3435,158 +1598,18 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     <message numerus="yes">
         <source>Open for %n more block(s)</source>
         <translation>
-            <numerusform>Открыть еще %n блок</numerusform>
-            <numerusform>Открыть еще %n блоков</numerusform>
-            <numerusform>Открыть еще %n блоков</numerusform>
+            <numerusform />
+            <numerusform />
+            <numerusform />
         </translation>
-    </message>
-    <message>
-        <source>Open until %1</source>
-        <translation type="unfinished">Открыта до %1</translation>
-    </message>
-    <message>
-        <source>Unconfirmed</source>
-        <translation type="unfinished">Не подтверждена</translation>
-    </message>
-    <message>
-        <source>Abandoned</source>
-        <translation type="unfinished">Отброшена</translation>
-    </message>
-    <message>
-        <source>Confirming (%1 of %2 recommended confirmations)</source>
-        <translation type="unfinished">Подтверждается (%1 из %2 рекомендуемых подтверждений)</translation>
-    </message>
-    <message>
-        <source>Confirmed (%1 confirmations)</source>
-        <translation type="unfinished">Подтверждена (%1 подтверждений)</translation>
-    </message>
-    <message>
-        <source>Conflicted</source>
-        <translation type="unfinished">Конфликтует</translation>
-    </message>
-    <message>
-        <source>Immature (%1 confirmations, will be available after %2)</source>
-        <translation type="unfinished">Незрелая (%1 подтверждений, будет доступно после %2)</translation>
-    </message>
-    <message>
-        <source>Generated but not accepted</source>
-        <translation type="unfinished">Сгенерирована, но не принята</translation>
-    </message>
-    <message>
-        <source>Received with</source>
-        <translation type="unfinished">Получено на</translation>
-    </message>
-    <message>
-        <source>Received from</source>
-        <translation type="unfinished">Получено от</translation>
-    </message>
-    <message>
-        <source>Sent to</source>
-        <translation type="unfinished">Отправлено на</translation>
-    </message>
-    <message>
-        <source>Payment to yourself</source>
-        <translation type="unfinished">Платёж себе</translation>
-    </message>
-    <message>
-        <source>Mined</source>
-        <translation type="unfinished">Добыта</translation>
-    </message>
-    <message>
-        <source>watch-only</source>
-        <translation type="unfinished">наблюдаемый</translation>
-    </message>
-    <message>
-        <source>(n/a)</source>
-        <translation type="unfinished">(н/д)</translation>
     </message>
     <message>
         <source>(no label)</source>
         <translation type="unfinished">(нет метки)</translation>
     </message>
-    <message>
-        <source>Transaction status. Hover over this field to show number of confirmations.</source>
-        <translation type="unfinished">Статус транзакции. Наведите курсор на это поле для отображения количества подтверждений.</translation>
-    </message>
-    <message>
-        <source>Date and time that the transaction was received.</source>
-        <translation type="unfinished">Дата и время получения транзакции.</translation>
-    </message>
-    <message>
-        <source>Type of transaction.</source>
-        <translation type="unfinished">Тип транзакции.</translation>
-    </message>
-    <message>
-        <source>Whether or not a watch-only address is involved in this transaction.</source>
-        <translation type="unfinished">Использовался ли в транзакции наблюдаемый адрес.</translation>
-    </message>
-    <message>
-        <source>User-defined intent/purpose of the transaction.</source>
-        <translation type="unfinished">Определяемое пользователем назначение/цель транзакции.</translation>
-    </message>
-    <message>
-        <source>Amount removed from or added to balance.</source>
-        <translation type="unfinished">Сумма, вычтенная из баланса или добавленная к нему.</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>TransactionView</name>
-    <message>
-        <source>All</source>
-        <translation type="unfinished">Все</translation>
-    </message>
-    <message>
-        <source>Today</source>
-        <translation type="unfinished">Сегодня</translation>
-    </message>
-    <message>
-        <source>This week</source>
-        <translation type="unfinished">Эта неделя</translation>
-    </message>
-    <message>
-        <source>This month</source>
-        <translation type="unfinished">Этот месяц</translation>
-    </message>
-    <message>
-        <source>Last month</source>
-        <translation type="unfinished">Последний месяц</translation>
-    </message>
-    <message>
-        <source>This year</source>
-        <translation type="unfinished">Этот год</translation>
-    </message>
-    <message>
-        <source>Received with</source>
-        <translation type="unfinished">Получено на</translation>
-    </message>
-    <message>
-        <source>Sent to</source>
-        <translation type="unfinished">Отправлено на</translation>
-    </message>
-    <message>
-        <source>To yourself</source>
-        <translation type="unfinished">Себе</translation>
-    </message>
-    <message>
-        <source>Mined</source>
-        <translation type="unfinished">Добыта</translation>
-    </message>
-    <message>
-        <source>Other</source>
-        <translation type="unfinished">Другое</translation>
-    </message>
-    <message>
-        <source>Enter address, transaction id, or label to search</source>
-        <translation type="unfinished">Введите адрес, идентификатор транзакции или метку для поиска</translation>
-    </message>
-    <message>
-        <source>Min amount</source>
-        <translation type="unfinished">Мин. сумма</translation>
-    </message>
-    <message>
-        <source>Range…</source>
-        <translation type="unfinished">Диапазон...</translation>
-    </message>
     <message>
         <source>&amp;Copy address</source>
         <translation type="unfinished">&amp;Копировать адрес</translation>
@@ -3597,7 +1620,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     </message>
     <message>
         <source>Copy &amp;amount</source>
-        <translation type="unfinished">Копировать &amp;amount</translation>
+        <translation type="unfinished">Копировать &amp;сумму</translation>
     </message>
     <message>
         <source>Copy transaction &amp;ID</source>
@@ -3605,27 +1628,27 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     </message>
     <message>
         <source>Copy &amp;raw transaction</source>
-        <translation type="unfinished">Копировать &amp;raw транзакции</translation>
+        <translation type="unfinished">Копировать &amp;исходный код транзакции</translation>
     </message>
     <message>
         <source>Copy full transaction &amp;details</source>
-        <translation type="unfinished">Копировать полную транзакцию &amp;детали</translation>
+        <translation type="unfinished">Копировать все подробности транзакции</translation>
     </message>
     <message>
         <source>&amp;Show transaction details</source>
-        <translation type="unfinished">&amp;Показать детали транзакции</translation>
+        <translation type="unfinished">&amp;Показать подробности транзакции</translation>
     </message>
     <message>
         <source>Increase transaction &amp;fee</source>
-        <translation type="unfinished">Увеличьте &amp;комиссию за транзакцию</translation>
+        <translation type="unfinished">Увеличить комиссию</translation>
+    </message>
+    <message>
+        <source>A&amp;bandon transaction</source>
+        <translation type="unfinished">Отказ от транзакции</translation>
     </message>
     <message>
         <source>&amp;Edit address label</source>
-        <translation type="unfinished">&amp;Изменить адресную метку</translation>
-    </message>
-    <message>
-        <source>Export Transaction History</source>
-        <translation type="unfinished">Экспортировать историю транзакций</translation>
+        <translation type="unfinished">Изменить адресную метку</translation>
     </message>
     <message>
         <source>Comma separated file</source>
@@ -3637,64 +1660,20 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
         <translation type="unfinished">Подтверждена</translation>
     </message>
     <message>
-        <source>Watch-only</source>
-        <translation type="unfinished">Наблюдаемая</translation>
-    </message>
-    <message>
         <source>Date</source>
         <translation type="unfinished">Дата</translation>
-    </message>
-    <message>
-        <source>Type</source>
-        <translation type="unfinished">Тип</translation>
     </message>
     <message>
         <source>Label</source>
         <translation type="unfinished">Метка</translation>
     </message>
     <message>
-        <source>Address</source>
-        <translation type="unfinished">Адрес</translation>
-    </message>
-    <message>
-        <source>ID</source>
-        <translation type="unfinished">Идентификатр</translation>
-    </message>
-    <message>
         <source>Exporting Failed</source>
-        <translation type="unfinished">Экспорт не удался</translation>
+        <translation type="unfinished">Ошибка экспорта</translation>
     </message>
-    <message>
-        <source>There was an error trying to save the transaction history to %1.</source>
-        <translation type="unfinished">При попытке сохранения истории транзакций в %1 произошла ошибка.</translation>
-    </message>
-    <message>
-        <source>Exporting Successful</source>
-        <translation type="unfinished">Экспорт выполнен успешно</translation>
-    </message>
-    <message>
-        <source>The transaction history was successfully saved to %1.</source>
-        <translation type="unfinished">История транзакций была успешно сохранена в %1.</translation>
-    </message>
-    <message>
-        <source>Range:</source>
-        <translation type="unfinished">Диапазон:</translation>
-    </message>
-    <message>
-        <source>to</source>
-        <translation type="unfinished">для</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>WalletFrame</name>
-    <message>
-        <source>No wallet has been loaded.
-Go to File &gt; Open Wallet to load a wallet.
-- OR -</source>
-        <translation type="unfinished">Нет загруженных кошельков.
-Выберите в меню Файл -&gt; Открыть кошелёк, чтобы загрузить кошелёк.
-- ИЛИ -</translation>
-    </message>
     <message>
         <source>Create a new wallet</source>
         <translation type="unfinished">Создать новый кошелёк</translation>
@@ -3707,60 +1686,16 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished">Отправить монеты</translation>
     </message>
     <message>
-        <source>Fee bump error</source>
-        <translation type="unfinished">Ошибка повышения комиссии</translation>
-    </message>
-    <message>
-        <source>Increasing transaction fee failed</source>
-        <translation type="unfinished">Не удалось увеличить комиссию</translation>
-    </message>
-    <message>
-        <source>Do you want to increase the fee?</source>
-        <translation type="unfinished">Вы хотите увеличить комиссию?</translation>
-    </message>
-    <message>
         <source>Do you want to draft a transaction with fee increase?</source>
-        <translation type="unfinished">Вы хотите создать черновик транзакции с увеличением комиссии?</translation>
-    </message>
-    <message>
-        <source>Current fee:</source>
-        <translation type="unfinished">Текущая комиссия:</translation>
-    </message>
-    <message>
-        <source>Increase:</source>
-        <translation type="unfinished">Увеличение:</translation>
-    </message>
-    <message>
-        <source>New fee:</source>
-        <translation type="unfinished">Новая комиссия:</translation>
-    </message>
-    <message>
-        <source>Warning: This may pay the additional fee by reducing change outputs or adding inputs, when necessary. It may add a new change output if one does not already exist. These changes may potentially leak privacy.</source>
-        <translation type="unfinished">Внимание: комиссия может быть увеличена путём уменьшения выводов для сдачи или добавления входов (по необходимости). Может быть добавлен новый вывод для сдачи, если он не существует. Эти изменения могут привести к ухудшению вашей конфиденциальности.</translation>
+        <translation type="unfinished">Хотите оформить транзакцию с увеличением комиссии?</translation>
     </message>
     <message>
         <source>Confirm fee bump</source>
-        <translation type="unfinished">Подтвердите увеличение комиссии</translation>
-    </message>
-    <message>
-        <source>Can't draft transaction.</source>
-        <translation type="unfinished">Невозможно подготовить черновик транзакции.</translation>
-    </message>
-    <message>
-        <source>PSBT copied</source>
-        <translation type="unfinished">PSBT скопирована</translation>
-    </message>
-    <message>
-        <source>Can't sign transaction.</source>
-        <translation type="unfinished">Невозможно подписать транзакцию</translation>
-    </message>
-    <message>
-        <source>Could not commit transaction</source>
-        <translation type="unfinished">Не удалось отправить транзакцию</translation>
+        <translation type="unfinished">Подтвердить увеличение комиссии</translation>
     </message>
     <message>
         <source>Can't display address</source>
-        <translation type="unfinished">Невозможно отобразить адрес</translation>
+        <translation type="unfinished">Не могу отобразить адрес</translation>
     </message>
     <message>
         <source>default wallet</source>
@@ -3775,675 +1710,50 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <source>Export the data in the current tab to a file</source>
-        <translation type="unfinished">Экспортировать данные текущей вкладки в файл</translation>
+        <translation type="unfinished">Экспортировать данные из текущей вкладки в файл</translation>
     </message>
     <message>
         <source>Error</source>
         <translation type="unfinished">Ошибка</translation>
     </message>
-    <message>
-        <source>Unable to decode PSBT from clipboard (invalid base64)</source>
-        <translation type="unfinished">Не удалось декодировать PSBT из буфера обмена (неверный base64)</translation>
-    </message>
-    <message>
-        <source>Load Transaction Data</source>
-        <translation type="unfinished">Загрузить данные о транзакции</translation>
-    </message>
-    <message>
-        <source>Partially Signed Transaction (*.psbt)</source>
-        <translation type="unfinished">Частично подписанная транзакция (*.psbt)</translation>
-    </message>
-    <message>
-        <source>PSBT file must be smaller than 100 MiB</source>
-        <translation type="unfinished">Файл PSBT должен быть меньше 100 МиБ</translation>
-    </message>
-    <message>
-        <source>Unable to decode PSBT</source>
-        <translation type="unfinished">Не удалось декодировать PSBT</translation>
-    </message>
-    <message>
-        <source>Backup Wallet</source>
-        <translation type="unfinished">Создать резервную копию кошелька</translation>
-    </message>
-    <message>
-        <source>Wallet Data</source>
-        <extracomment>Name of the wallet data file format.</extracomment>
-        <translation type="unfinished">Данные кошелька</translation>
-    </message>
-    <message>
-        <source>Backup Failed</source>
-        <translation type="unfinished">Резервное копирование не удалось</translation>
-    </message>
-    <message>
-        <source>There was an error trying to save the wallet data to %1.</source>
-        <translation type="unfinished">При попытке сохранения данных кошелька в %1 произошла ошибка.</translation>
-    </message>
-    <message>
-        <source>Backup Successful</source>
-        <translation type="unfinished">Резервное копирование выполнено успешно</translation>
-    </message>
-    <message>
-        <source>The wallet data was successfully saved to %1.</source>
-        <translation type="unfinished">Данные кошелька были успешно сохранены в %1.</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="unfinished">Отмена</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>bitcoin-core</name>
     <message>
-        <source>The %s developers</source>
-        <translation type="unfinished">Разработчики %s</translation>
-    </message>
-    <message>
-        <source>%s corrupt. Try using the wallet tool bitcoin-wallet to salvage or restoring a backup.</source>
-        <translation type="unfinished">%s испорчен. Попробуйте восстановить с помощью инструмента bitcoin-wallet или восстановите из резервной копии.</translation>
-    </message>
-    <message>
-        <source>-maxtxfee is set very high! Fees this large could be paid on a single transaction.</source>
-        <translation type="unfinished">Установлено очень большое значение -maxtxfee! Такие большие комиссии могут быть уплачены в отдельной транзакции.</translation>
-    </message>
-    <message>
-        <source>Cannot downgrade wallet from version %i to version %i. Wallet version unchanged.</source>
-        <translation type="unfinished">Невозможно понизить версию кошелька с %i до %i. Версия кошелька не была изменена.</translation>
-    </message>
-    <message>
-        <source>Cannot obtain a lock on data directory %s. %s is probably already running.</source>
-        <translation type="unfinished">Невозможно заблокировать каталог данных %s. Вероятно, %s уже запущен.</translation>
-    </message>
-    <message>
-        <source>Cannot provide specific connections and have addrman find outgoing connections at the same.</source>
-        <translation type="unfinished">Не удаётся предоставить определённые соединения, чтобы при этом addrman нашёл в них исходящие соединения.</translation>
-    </message>
-    <message>
-        <source>Cannot upgrade a non HD split wallet from version %i to version %i without upgrading to support pre-split keypool. Please use version %i or no version specified.</source>
-        <translation type="unfinished">Невозможно обновить разделённый кошелёк без HD с версии %i до версии %i, не обновившись для поддержки предварительно разделённого пула ключей. Пожалуйста, используйте версию %iили повторите без указания версии.</translation>
-    </message>
-    <message>
-        <source>Distributed under the MIT software license, see the accompanying file %s or %s</source>
-        <translation type="unfinished">Распространяется под лицензией MIT, см. приложенный файл %s или %s</translation>
-    </message>
-    <message>
-        <source>Error reading %s! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
-        <translation type="unfinished">Ошибка чтения %s! Все ключи прочитаны верно, но данные транзакций или записи адресной книги могут отсутствовать или быть неправильными.</translation>
-    </message>
-    <message>
-        <source>Error: Dumpfile format record is incorrect. Got "%s", expected "format".</source>
-        <translation type="unfinished">Ошибка: запись формата дамп-файла неверна. Обнаружено "%s", ожидалось "format".</translation>
-    </message>
-    <message>
-        <source>Error: Dumpfile identifier record is incorrect. Got "%s", expected "%s".</source>
-        <translation type="unfinished">Ошибка: запись идентификатора дамп-файла неверна. Обнаружено "%s", ожидалось "%s".</translation>
-    </message>
-    <message>
         <source>Error: Dumpfile version is not supported. This version of bitcoin-wallet only supports version 1 dumpfiles. Got dumpfile with version %s</source>
-        <translation type="unfinished">Ошибка: версия дамп-файла не поддерживается. Эта версия bitcoin-wallet поддерживает только дамп-файлы версии 1. Обнаружено дамп-файл версии %s</translation>
+        <translation type="unfinished">Ошибка: версия дамп-файла не поддерживается. Эта версия биткойн-кошелека поддерживает только дамп-файлы версии 1. Обнаружен дамп-файл версии %s</translation>
     </message>
     <message>
         <source>Error: Legacy wallets only support the "legacy", "p2sh-segwit", and "bech32" address types</source>
-        <translation type="unfinished">Ошибка: устаревшие кошельки поддерживают только адреса типа "legacy", "p2sh-segwit" и "bech32".</translation>
-    </message>
-    <message>
-        <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
-        <translation type="unfinished">Ошибка: Не удалось начать прослушивание входящих подключений (прослушивание вернуло ошибку %s)</translation>
-    </message>
-    <message>
-        <source>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.</source>
-        <translation type="unfinished">Не удалось оценить комиссию. Резервная комиссия отключена. Подождите несколько блоков или включите -fallbackfee.</translation>
-    </message>
-    <message>
-        <source>File %s already exists. If you are sure this is what you want, move it out of the way first.</source>
-        <translation type="unfinished">Файл %s уже существует. Если вы уверены, что так и должно быть, сначала уберите оттуда этот файл.</translation>
-    </message>
-    <message>
-        <source>Invalid amount for -maxtxfee=&lt;amount&gt;: '%s' (must be at least the minrelay fee of %s to prevent stuck transactions)</source>
-        <translation type="unfinished">Неверное значение для -maxtxfee=&lt;amount&gt;: '%s' (должна быть не ниже минимально ретранслируемой комиссии %s для предотвращения зависания транзакций)</translation>
-    </message>
-    <message>
-        <source>More than one onion bind address is provided. Using %s for the automatically created Tor onion service.</source>
-        <translation type="unfinished">Предоставлен более чем один onion-адрес для привязки. Для автоматически созданного onion-сервиса Tor будет использован %s.</translation>
-    </message>
-    <message>
-        <source>No dump file provided. To use createfromdump, -dumpfile=&lt;filename&gt; must be provided.</source>
-        <translation type="unfinished">Не указан дамп-файл. Чтобы использовать createfromdump, необходимо указать -dumpfile=&lt;filename&gt;</translation>
-    </message>
-    <message>
-        <source>No dump file provided. To use dump, -dumpfile=&lt;filename&gt; must be provided.</source>
-        <translation type="unfinished">Не указан дамп-файл. Чтобы использовать dump, необходимо указать -dumpfile=&lt;filename&gt;</translation>
-    </message>
-    <message>
-        <source>No wallet file format provided. To use createfromdump, -format=&lt;format&gt; must be provided.</source>
-        <translation type="unfinished">Не указан формат файла кошелька. Чтобы использовать createfromdump, необходимо указать -format=&lt;format&gt;</translation>
-    </message>
-    <message>
-        <source>Please check that your computer's date and time are correct! If your clock is wrong, %s will not work properly.</source>
-        <translation type="unfinished">Пожалуйста, убедитесь, что на вашем компьютере верно установлены дата и время. Если ваши часы неверны, %s не будет работать правильно.</translation>
-    </message>
-    <message>
-        <source>Please contribute if you find %s useful. Visit %s for further information about the software.</source>
-        <translation type="unfinished">Пожалуйста, внесите свой вклад, если вы считаете %s полезным. Посетите %s для получения дополнительной информации о программном обеспечении.</translation>
-    </message>
-    <message>
-        <source>Prune configured below the minimum of %d MiB.  Please use a higher number.</source>
-        <translation type="unfinished">Обрезка блоков выставлена меньше, чем минимум в %d МиБ. Пожалуйста, используйте большее значение.</translation>
-    </message>
-    <message>
-        <source>Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of pruned node)</source>
-        <translation type="unfinished">Обрезка: последняя синхронизация кошелька вышла за рамки обрезанных данных. Необходимо сделать -reindex (снова скачать всю цепочку блоков, если у вас узел с обрезкой)</translation>
-    </message>
-    <message>
-        <source>SQLiteDatabase: Unknown sqlite wallet schema version %d. Only version %d is supported</source>
-        <translation type="unfinished">SQLiteDatabase: Неизвестная версия схемы sqlite кошелька: %d. Поддерживается только версия %d</translation>
-    </message>
-    <message>
-        <source>The block database contains a block which appears to be from the future. This may be due to your computer's date and time being set incorrectly. Only rebuild the block database if you are sure that your computer's date and time are correct</source>
-        <translation type="unfinished">В базе данных блоков найден блок из будущего. Это может произойти из-за неверно установленных даты и времени на вашем компьютере. Перестраивайте базу данных блоков только если вы уверены, что дата и время установлены верно.</translation>
-    </message>
-    <message>
-        <source>The transaction amount is too small to send after the fee has been deducted</source>
-        <translation type="unfinished">Сумма транзакции за вычетом комиссии слишком мала</translation>
-    </message>
-    <message>
-        <source>This error could occur if this wallet was not shutdown cleanly and was last loaded using a build with a newer version of Berkeley DB. If so, please use the software that last loaded this wallet</source>
-        <translation type="unfinished">Данная ошибка может произойти в том случае, если этот кошелёк не был правильно закрыт и в последний раз был загружен используя версию с более новой версией Berkley DB. Если это так, воспользуйтесь той программой, в которой этот кошелёк открывался в последний раз.</translation>
-    </message>
-    <message>
-        <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
-        <translation type="unfinished">Это тестовая сборка - используйте на свой страх и риск - не используйте для добычи или торговых приложений</translation>
-    </message>
-    <message>
-        <source>This is the maximum transaction fee you pay (in addition to the normal fee) to prioritize partial spend avoidance over regular coin selection.</source>
-        <translation type="unfinished">Это максимальная транзакция, которую вы заплатите (в добавок к обычной плате), чтобы отдать приоритет избежанию частичной траты перед обычным управлением монетами.</translation>
-    </message>
-    <message>
-        <source>This is the transaction fee you may discard if change is smaller than dust at this level</source>
-        <translation type="unfinished">Это комиссия за транзакцию, которую вы можете отбросить, если сдача меньше, чем пыль на этом уровне</translation>
-    </message>
-    <message>
-        <source>This is the transaction fee you may pay when fee estimates are not available.</source>
-        <translation type="unfinished">Это комиссия за транзакцию, которую вы можете заплатить, когда расчёт комиссии недоступен.</translation>
-    </message>
-    <message>
-        <source>Total length of network version string (%i) exceeds maximum length (%i). Reduce the number or size of uacomments.</source>
-        <translation type="unfinished">Текущая длина строки версии сети (%i) превышает максимальную длину (%i). Уменьшите количество или размер uacomments.</translation>
-    </message>
-    <message>
-        <source>Unable to replay blocks. You will need to rebuild the database using -reindex-chainstate.</source>
-        <translation type="unfinished">Невозможно воспроизвести блоки. Вам необходимо перестроить базу данных, используя -reindex-chaintate.</translation>
-    </message>
-    <message>
-        <source>Unknown wallet file format "%s" provided. Please provide one of "bdb" or "sqlite".</source>
-        <translation type="unfinished">Указан неизвестный формат файла кошелька "%s". Укажите "bdb" либо "sqlite".</translation>
-    </message>
-    <message>
-        <source>Warning: Dumpfile wallet format "%s" does not match command line specified format "%s".</source>
-        <translation type="unfinished">Внимание: формат кошелька дамп-файла "%s" не соответствует указанному в командной строке формату "%s".</translation>
-    </message>
-    <message>
-        <source>Warning: Private keys detected in wallet {%s} with disabled private keys</source>
-        <translation type="unfinished">Предупреждение: приватные ключи обнаружены в кошельке {%s} с отключенными приватными ключами</translation>
-    </message>
-    <message>
-        <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
-        <translation type="unfinished">Внимание: мы не полностью согласны с другими узлами! Вам или другим участникам, возможно, следует обновить клиент.</translation>
-    </message>
-    <message>
-        <source>Witness data for blocks after height %d requires validation. Please restart with -reindex.</source>
-        <translation type="unfinished">Для свидетельских данных в блоках после %d необходима проверка. Пожалуйста, перезапустите клиент с параметром -reindex.</translation>
-    </message>
-    <message>
-        <source>You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain</source>
-        <translation type="unfinished">Вам необходимо пересобрать базу данных с помощью -reindex, чтобы вернуться к полному режиму. Это приведёт к повторному скачиванию всей цепочки блоков</translation>
-    </message>
-    <message>
-        <source>%s is set very high!</source>
-        <translation type="unfinished">%s задан слишком высоким!</translation>
-    </message>
-    <message>
-        <source>-maxmempool must be at least %d MB</source>
-        <translation type="unfinished">-maxmempool должен быть как минимум %d МБ</translation>
-    </message>
-    <message>
-        <source>A fatal internal error occurred, see debug.log for details</source>
-        <translation type="unfinished">Ошибка: произошла критическая внутренняя ошибка, для получения деталей см. debug.log</translation>
-    </message>
-    <message>
-        <source>Cannot resolve -%s address: '%s'</source>
-        <translation type="unfinished">Не удается разрешить -%s адрес: '%s'</translation>
-    </message>
-    <message>
-        <source>Cannot set -peerblockfilters without -blockfilterindex.</source>
-        <translation type="unfinished">Нельзя указывать -peerblockfilters без -blockfilterindex.</translation>
-    </message>
-    <message>
-        <source>Cannot write to data directory '%s'; check permissions.</source>
-        <translation type="unfinished">Не удается выполнить запись в каталог данных '%s'; проверьте разрешения.</translation>
-    </message>
-    <message>
-        <source>Change index out of range</source>
-        <translation type="unfinished">Индекс сдачи вне диапазона</translation>
-    </message>
-    <message>
-        <source>Config setting for %s only applied on %s network when in [%s] section.</source>
-        <translation type="unfinished">Настройка конфигурации %s применяется в сети %s только если находится в разделе [%s].</translation>
-    </message>
-    <message>
-        <source>Corrupted block database detected</source>
-        <translation type="unfinished">Обнаружена повреждённая база данных блоков</translation>
-    </message>
-    <message>
-        <source>Could not find asmap file %s</source>
-        <translation type="unfinished">Невозможно найти файл asmap %s</translation>
-    </message>
-    <message>
-        <source>Could not parse asmap file %s</source>
-        <translation type="unfinished">Не могу разобрать файл asmap %s</translation>
-    </message>
-    <message>
-        <source>Disk space is too low!</source>
-        <translation type="unfinished">Мало места на диске!</translation>
-    </message>
-    <message>
-        <source>Do you want to rebuild the block database now?</source>
-        <translation type="unfinished">Пересобрать базу данных блоков прямо сейчас?</translation>
-    </message>
-    <message>
-        <source>Done loading</source>
-        <translation type="unfinished">Загрузка завершена</translation>
-    </message>
-    <message>
-        <source>Dump file %s does not exist.</source>
-        <translation type="unfinished">Дамп файл %s не существует.</translation>
-    </message>
-    <message>
-        <source>Error creating %s</source>
-        <translation type="unfinished">Ошибка загрузки %s</translation>
-    </message>
-    <message>
-        <source>Error initializing block database</source>
-        <translation type="unfinished">Ошибка инициализации базы данных блоков</translation>
-    </message>
-    <message>
-        <source>Error initializing wallet database environment %s!</source>
-        <translation type="unfinished">Ошибка инициализации окружения базы данных кошелька %s!</translation>
-    </message>
-    <message>
-        <source>Error loading %s</source>
-        <translation type="unfinished">Ошибка загрузки %s</translation>
-    </message>
-    <message>
-        <source>Error loading %s: Private keys can only be disabled during creation</source>
-        <translation type="unfinished">Ошибка загрузки %s: приватные ключи можно отключить только при создании</translation>
-    </message>
-    <message>
-        <source>Error loading %s: Wallet corrupted</source>
-        <translation type="unfinished">Ошибка загрузки %s: кошелёк поврежден</translation>
-    </message>
-    <message>
-        <source>Error loading %s: Wallet requires newer version of %s</source>
-        <translation type="unfinished">Ошибка загрузки %s: кошелёк требует более новой версии %s</translation>
-    </message>
-    <message>
-        <source>Error loading block database</source>
-        <translation type="unfinished">Ошибка чтения базы данных блоков</translation>
-    </message>
-    <message>
-        <source>Error opening block database</source>
-        <translation type="unfinished">Не удалось открыть базу данных блоков</translation>
-    </message>
-    <message>
-        <source>Error reading from database, shutting down.</source>
-        <translation type="unfinished">Ошибка чтения из базы данных, программа закрывается.</translation>
-    </message>
-    <message>
-        <source>Error reading next record from wallet database</source>
-        <translation type="unfinished">Ошибка чтения следующей записи из базы данных кошелька</translation>
-    </message>
-    <message>
-        <source>Error upgrading chainstate database</source>
-        <translation type="unfinished">Ошибка обновления базы данных chainstate</translation>
-    </message>
-    <message>
-        <source>Error: Couldn't create cursor into database</source>
-        <translation type="unfinished">Ошибка: не удалось создать курсор в базе данных</translation>
-    </message>
-    <message>
-        <source>Error: Disk space is low for %s</source>
-        <translation type="unfinished">Ошибка: на диске недостаточно места для %s</translation>
-    </message>
-    <message>
-        <source>Error: Dumpfile checksum does not match. Computed %s, expected %s</source>
-        <translation type="unfinished">Ошибка: контрольная сумма дамп-файла не совпадает. Вычислено %s, ожидалось %s.</translation>
-    </message>
-    <message>
-        <source>Error: Got key that was not hex: %s</source>
-        <translation type="unfinished">Ошибка: получен ключ, оказавшийся не шестнадцатеричным: %s</translation>
-    </message>
-    <message>
-        <source>Error: Got value that was not hex: %s</source>
-        <translation type="unfinished">Ошибка: получено значение, оказавшееся не шестнадцатеричным: %s</translation>
-    </message>
-    <message>
-        <source>Error: Keypool ran out, please call keypoolrefill first</source>
-        <translation type="unfinished">Ошибка: пул ключей опустел, пожалуйста сначала выполните keypoolrefill</translation>
-    </message>
-    <message>
-        <source>Error: Missing checksum</source>
-        <translation type="unfinished">Ошибка: отсутствует контрольная сумма</translation>
+        <translation type="unfinished">Ошибка: Устаревшие кошельки поддерживают только "legacy", "p2sh-segwit", и "bech32" типы адресов.</translation>
     </message>
     <message>
         <source>Error: No %s addresses available.</source>
-        <translation type="unfinished">Ошибка: Адреса %s недоступны.</translation>
-    </message>
-    <message>
-        <source>Error: Unable to parse version %u as a uint32_t</source>
-        <translation type="unfinished">Ошибка: невозможно разобрать версию %u как uint32_t</translation>
-    </message>
-    <message>
-        <source>Error: Unable to write record to new wallet</source>
-        <translation type="unfinished">Ошибка: невозможно произвести запись в новый кошелек</translation>
-    </message>
-    <message>
-        <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
-        <translation type="unfinished">Не удалось начать прослушивание на порту. Используйте -listen=0, если вас это устраивает.</translation>
-    </message>
-    <message>
-        <source>Failed to rescan the wallet during initialization</source>
-        <translation type="unfinished">Не удалось пересканировать кошелёк во время инициализации</translation>
-    </message>
-    <message>
-        <source>Failed to verify database</source>
-        <translation type="unfinished">Не удалось проверить базу данных</translation>
-    </message>
-    <message>
-        <source>Fee rate (%s) is lower than the minimum fee rate setting (%s)</source>
-        <translation type="unfinished">Уровень комиссии (%s) меньше, чем значение настройки минимального уровня комиссии (%s).</translation>
-    </message>
-    <message>
-        <source>Ignoring duplicate -wallet %s.</source>
-        <translation type="unfinished">Игнорируются повторные параметры -wallet %s.</translation>
-    </message>
-    <message>
-        <source>Importing…</source>
-        <translation type="unfinished">Импорт...</translation>
-    </message>
-    <message>
-        <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
-        <translation type="unfinished">Неверный или отсутствующий начальный блок. Неверно указана директория данных для этой сети?</translation>
-    </message>
-    <message>
-        <source>Initialization sanity check failed. %s is shutting down.</source>
-        <translation type="unfinished">Начальная проверка исправности не удалась. %s завершает работу.</translation>
-    </message>
-    <message>
-        <source>Insufficient funds</source>
-        <translation type="unfinished">Недостаточно средств</translation>
-    </message>
-    <message>
-        <source>Invalid -i2psam address or hostname: '%s'</source>
-        <translation type="unfinished">Неверный адрес или имя хоста в -i2psam: '%s'</translation>
-    </message>
-    <message>
-        <source>Invalid -onion address or hostname: '%s'</source>
-        <translation type="unfinished">Неверный -onion адрес или имя хоста: '%s'</translation>
-    </message>
-    <message>
-        <source>Invalid -proxy address or hostname: '%s'</source>
-        <translation type="unfinished">Неверный адрес -proxy или имя хоста: '%s'</translation>
-    </message>
-    <message>
-        <source>Invalid P2P permission: '%s'</source>
-        <translation type="unfinished">Неверные разрешение для P2P: '%s'</translation>
-    </message>
-    <message>
-        <source>Invalid amount for -%s=&lt;amount&gt;: '%s'</source>
-        <translation type="unfinished">Неверная сумма для -%s=&lt;amount&gt;: '%s'</translation>
-    </message>
-    <message>
-        <source>Invalid amount for -discardfee=&lt;amount&gt;: '%s'</source>
-        <translation type="unfinished">Неверная сумма для -discardfee=&lt;amount&gt;: '%s'</translation>
-    </message>
-    <message>
-        <source>Invalid amount for -fallbackfee=&lt;amount&gt;: '%s'</source>
-        <translation type="unfinished">Неверная сумма для -fallbackfee=&lt;amount&gt;: '%s'</translation>
-    </message>
-    <message>
-        <source>Invalid amount for -paytxfee=&lt;amount&gt;: '%s' (must be at least %s)</source>
-        <translation type="unfinished">Неверная сумма для -paytxfee=&lt;amount&gt;: '%s' (должно быть как минимум %s)</translation>
-    </message>
-    <message>
-        <source>Invalid netmask specified in -whitelist: '%s'</source>
-        <translation type="unfinished">Указана неверная сетевая маска в -whitelist: '%s'</translation>
-    </message>
-    <message>
-        <source>Loading P2P addresses…</source>
-        <translation type="unfinished">Загрузка P2P адресов...</translation>
-    </message>
-    <message>
-        <source>Loading banlist…</source>
-        <translation type="unfinished">Загрузка черного списка...</translation>
-    </message>
-    <message>
-        <source>Loading block index…</source>
-        <translation type="unfinished">Загрузка индекса блоков...</translation>
-    </message>
-    <message>
-        <source>Loading wallet…</source>
-        <translation type="unfinished">Загрузка кошелька...</translation>
-    </message>
-    <message>
-        <source>Need to specify a port with -whitebind: '%s'</source>
-        <translation type="unfinished">Необходимо указать порт с -whitebind: '%s'</translation>
-    </message>
-    <message>
-        <source>No proxy server specified. Use -proxy=&lt;ip&gt; or -proxy=&lt;ip:port&gt;.</source>
-        <translation type="unfinished">Не указан прокси-сервер. Используйте -proxy=&lt;ip&gt; или -proxy=&lt;ip:port&gt;</translation>
-    </message>
-    <message>
-        <source>Not enough file descriptors available.</source>
-        <translation type="unfinished">Недостаточно доступных файловых дескрипторов.</translation>
-    </message>
-    <message>
-        <source>Prune cannot be configured with a negative value.</source>
-        <translation type="unfinished">Обрезка блоков не может использовать отрицательное значение.</translation>
-    </message>
-    <message>
-        <source>Prune mode is incompatible with -coinstatsindex.</source>
-        <translation type="unfinished">Режим удаления блоков несовместим с -coinstatsindex.</translation>
-    </message>
-    <message>
-        <source>Prune mode is incompatible with -txindex.</source>
-        <translation type="unfinished">Режим обрезки несовместим с -txindex.</translation>
+        <translation type="unfinished">Ошибка: Нет %s доступных адресов</translation>
     </message>
     <message>
         <source>Pruning blockstore…</source>
-        <translation type="unfinished">Сокращение объема хранилища блоков...</translation>
-    </message>
-    <message>
-        <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
-        <translation type="unfinished">Уменьшите -maxconnections с %d до %d из-за ограничений системы.</translation>
+        <translation type="unfinished">Сокращение хранилища блоков...</translation>
     </message>
     <message>
         <source>Replaying blocks…</source>
         <translation type="unfinished">Пересборка блоков...</translation>
     </message>
     <message>
-        <source>Rescanning…</source>
-        <translation type="unfinished">Пересканирование...</translation>
-    </message>
-    <message>
-        <source>SQLiteDatabase: Failed to execute statement to verify database: %s</source>
-        <translation type="unfinished">SQLiteDatabase: Не удалось выполнить запрос для проверки базы данных: %s</translation>
-    </message>
-    <message>
-        <source>SQLiteDatabase: Failed to prepare statement to verify database: %s</source>
-        <translation type="unfinished">SQLiteDatabase: Не удалось подготовить запрос для проверки базы данных: %s</translation>
-    </message>
-    <message>
-        <source>SQLiteDatabase: Failed to read database verification error: %s</source>
-        <translation type="unfinished">SQLiteDatabase: Ошибка при проверке базы данных: %s</translation>
-    </message>
-    <message>
-        <source>SQLiteDatabase: Unexpected application id. Expected %u, got %u</source>
-        <translation type="unfinished">SQLiteDatabase: Неожиданный id приложения. Ожидалось %u, но получено %u</translation>
-    </message>
-    <message>
-        <source>Section [%s] is not recognized.</source>
-        <translation type="unfinished">Раздел [%s] не распознан.</translation>
-    </message>
-    <message>
-        <source>Signing transaction failed</source>
-        <translation type="unfinished">Подписание транзакции не удалось</translation>
-    </message>
-    <message>
-        <source>Specified -walletdir "%s" does not exist</source>
-        <translation type="unfinished">Указанный -walletdir "%s" не существует</translation>
-    </message>
-    <message>
-        <source>Specified -walletdir "%s" is a relative path</source>
-        <translation type="unfinished">Указанный -walletdir "%s" является относительным путем</translation>
-    </message>
-    <message>
         <source>Specified -walletdir "%s" is not a directory</source>
-        <translation type="unfinished">Указанный -walletdir "%s" не является директорией</translation>
+        <translation type="unfinished">Указанный -walletdir "%s" не является каталогом</translation>
     </message>
     <message>
         <source>Specified blocks directory "%s" does not exist.</source>
-        <translation type="unfinished">Указанная директория для блоков "%s" не существует.</translation>
-    </message>
-    <message>
-        <source>Starting network threads…</source>
-        <translation type="unfinished">Запуск сетевых потоков...</translation>
-    </message>
-    <message>
-        <source>The source code is available from %s.</source>
-        <translation type="unfinished">Исходный код доступен в %s.</translation>
-    </message>
-    <message>
-        <source>The specified config file %s does not exist</source>
-        <translation type="unfinished">Указанный конфигурационный файл %s не существует</translation>
-    </message>
-    <message>
-        <source>The transaction amount is too small to pay the fee</source>
-        <translation type="unfinished">Сумма транзакции слишком мала для уплаты комиссии</translation>
-    </message>
-    <message>
-        <source>The wallet will avoid paying less than the minimum relay fee.</source>
-        <translation type="unfinished">Кошелёк будет стараться не платить меньше, чем минимальная комиссии ретрансляции.</translation>
-    </message>
-    <message>
-        <source>This is experimental software.</source>
-        <translation type="unfinished">Это экспериментальная программа.</translation>
-    </message>
-    <message>
-        <source>This is the minimum transaction fee you pay on every transaction.</source>
-        <translation type="unfinished">Это минимальная комиссия, которую вы платите для любой транзакции</translation>
-    </message>
-    <message>
-        <source>This is the transaction fee you will pay if you send a transaction.</source>
-        <translation type="unfinished">Это размер комиссии, которую вы заплатите при отправке транзакции</translation>
-    </message>
-    <message>
-        <source>Transaction amount too small</source>
-        <translation type="unfinished">Размер транзакции слишком мал</translation>
-    </message>
-    <message>
-        <source>Transaction amounts must not be negative</source>
-        <translation type="unfinished">Сумма транзакции не должна быть отрицательной</translation>
-    </message>
-    <message>
-        <source>Transaction has too long of a mempool chain</source>
-        <translation type="unfinished">В транзакции слишком длинная цепочка пула памяти</translation>
-    </message>
-    <message>
-        <source>Transaction must have at least one recipient</source>
-        <translation type="unfinished">Транзакция должна иметь хотя бы одного получателя</translation>
-    </message>
-    <message>
-        <source>Transaction needs a change address, but we can't generate it. %s</source>
-        <translation type="unfinished">Для транзакции требуется адрес сдачи, но сгенерировать его не удалось. %s</translation>
-    </message>
-    <message>
-        <source>Transaction too large</source>
-        <translation type="unfinished">Транзакция слишком большая</translation>
-    </message>
-    <message>
-        <source>Unable to bind to %s on this computer (bind returned error %s)</source>
-        <translation type="unfinished">Невозможно привязаться к %s на этом компьютере (bind вернул ошибку %s)</translation>
-    </message>
-    <message>
-        <source>Unable to bind to %s on this computer. %s is probably already running.</source>
-        <translation type="unfinished">Невозможно привязаться к %s на этом компьютере. Возможно, %s уже запущен.</translation>
-    </message>
-    <message>
-        <source>Unable to create the PID file '%s': %s</source>
-        <translation type="unfinished">Невозможно создать файл PID '%s': %s</translation>
-    </message>
-    <message>
-        <source>Unable to generate initial keys</source>
-        <translation type="unfinished">Невозможно сгенерировать начальные ключи</translation>
-    </message>
-    <message>
-        <source>Unable to generate keys</source>
-        <translation type="unfinished">Невозможно сгенерировать ключи</translation>
-    </message>
-    <message>
-        <source>Unable to open %s for writing</source>
-        <translation type="unfinished">Не удается открыть %s для записи</translation>
+        <translation type="unfinished">Указанный каталог блоков "%s" не существует.</translation>
     </message>
     <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
-        <translation type="unfinished">Невозможно запустить HTTP-сервер. См. журнал отладки.</translation>
-    </message>
-    <message>
-        <source>Unknown -blockfilterindex value %s.</source>
-        <translation type="unfinished">Неизвестное значение -blockfilterindex %s.</translation>
-    </message>
-    <message>
-        <source>Unknown address type '%s'</source>
-        <translation type="unfinished">Неизвестный тип адреса '%s'</translation>
-    </message>
-    <message>
-        <source>Unknown change type '%s'</source>
-        <translation type="unfinished">Неизвестный тип сдачи '%s'</translation>
-    </message>
-    <message>
-        <source>Unknown network specified in -onlynet: '%s'</source>
-        <translation type="unfinished">Неизвестная сеть указана в -onlynet: '%s'</translation>
+        <translation type="unfinished">Невозможно запустить HTTP-сервер. См. подробности в журнале отладки.</translation>
     </message>
     <message>
         <source>Unknown new rules activated (versionbit %i)</source>
-        <translation type="unfinished">Неизвестные новые правила активированы (versionbit %i)</translation>
+        <translation type="unfinished">Внимание: неизвестные правила вступили в силу (versionbit %i)</translation>
     </message>
-    <message>
-        <source>Unsupported logging category %s=%s.</source>
-        <translation type="unfinished">Неподдерживаемая категория ведения журнала %s=%s.</translation>
-    </message>
-    <message>
-        <source>Upgrading UTXO database</source>
-        <translation type="unfinished">Обновление базы данных UTXO</translation>
-    </message>
-    <message>
-        <source>Upgrading txindex database</source>
-        <translation type="unfinished">Обновление базы данных txindex</translation>
-    </message>
-    <message>
-        <source>User Agent comment (%s) contains unsafe characters.</source>
-        <translation type="unfinished">Комментарий User Agent (%s) содержит небезопасные символы.</translation>
-    </message>
-    <message>
-        <source>Verifying blocks…</source>
-        <translation type="unfinished">Проверка блоков...</translation>
-    </message>
-    <message>
-        <source>Verifying wallet(s)…</source>
-        <translation type="unfinished">Проверка кошелька(ов)...</translation>
-    </message>
-    <message>
-        <source>Wallet needed to be rewritten: restart %s to complete</source>
-        <translation type="unfinished">Необходимо перезаписать кошелёк, перезапустите %s для завершения операции</translation>
-    </message>
-</context>
+    </context>
 </TS>

--- a/src/qt/locale/bitcoin_si.ts
+++ b/src/qt/locale/bitcoin_si.ts
@@ -11,7 +11,7 @@
     </message>
     <message>
         <source>&amp;New</source>
-        <translation type="unfinished">නව</translation>
+        <translation type="unfinished">&amp;නව</translation>
     </message>
     <message>
         <source>Copy the currently selected address to the system clipboard</source>
@@ -19,11 +19,11 @@
     </message>
     <message>
         <source>&amp;Copy</source>
-        <translation type="unfinished">පිටපත් කරන්න</translation>
+        <translation type="unfinished">&amp;පිටපත් කරන්න</translation>
     </message>
     <message>
         <source>C&amp;lose</source>
-        <translation type="unfinished">වසා දමන්න</translation>
+        <translation type="unfinished">වස&amp;න්න</translation>
     </message>
     <message>
         <source>Delete the currently selected address from the list</source>
@@ -32,6 +32,10 @@
     <message>
         <source>Enter address or label to search</source>
         <translation type="unfinished">සෙවීමට ලිපිනය හෝ ලේබලය ඇතුළත් කරන්න</translation>
+    </message>
+    <message>
+        <source>&amp;Export</source>
+        <translation>&amp;නිර්යාත කරන්න</translation>
     </message>
     <message>
         <source>Choose the address to send coins to</source>
@@ -51,18 +55,35 @@
     </message>
     <message>
         <source>Receiving addresses</source>
-        <translation type="unfinished">ලබන ලිපින</translation>
+        <translation type="unfinished">ලැබෙන ලිපින</translation>
     </message>
     <message>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation type="unfinished">මේවා ඔබගේ ගෙවීම් යැවීම සඳහා වන බිට්කොයින් ලිපින වේ. කාසි යැවීමට පෙර සෑම විටම මුදල සහ ලැබීමේ ලිපිනය පරීක්ෂා කරන්න.</translation>
     </message>
     <message>
+        <source>&amp;Copy Address</source>
+        <translation type="unfinished">&amp;ලිපිනය පිටපත්</translation>
+    </message>
+    <message>
+        <source>&amp;Edit</source>
+        <translation type="unfinished">&amp;සංස්කරණය</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See https://en.wikipedia.org/wiki/Comma-separated_values</extracomment>
+        <translation type="unfinished">අල්පවිරාම වලින් වෙන්වූ ගොනුව</translation>
+    </message>
+    <message>
         <source>There was an error trying to save the address list to %1. Please try again.</source>
         <extracomment>An error message. %1 is a stand-in argument for the name of the file we attempted to save to.</extracomment>
         <translation type="unfinished">ලිපින ලැයිස්තුව %1 ට සුරැකීමට උත්සාහ කිරීමේදී දෝෂයක් ඇතිවිය. කරුණාකර නැවත උත්සාහ කරන්න.</translation>
     </message>
-    </context>
+    <message>
+        <source>Exporting Failed</source>
+        <translation type="unfinished">නිර්යාත වීමට අසමත් විය</translation>
+    </message>
+</context>
 <context>
     <name>AddressTableModel</name>
     <message>
@@ -174,7 +195,7 @@
     </message>
     <message>
         <source>Wallet unlock failed</source>
-        <translation type="unfinished">පසුම්බි අගුළු ඇරීම අසාර්ථක විය</translation>
+        <translation type="unfinished">පසුම්බියේ අගුල හැරීමට අසමත් විය</translation>
     </message>
     <message>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
@@ -190,7 +211,22 @@
     </message>
 </context>
 <context>
+    <name>BitcoinApplication</name>
+    <message>
+        <source>Internal error</source>
+        <translation type="unfinished">අභ්‍යන්තර දෝෂයකි</translation>
+    </message>
+    </context>
+<context>
     <name>QObject</name>
+    <message>
+        <source>Error: %1</source>
+        <translation type="unfinished">දෝෂය: %1</translation>
+    </message>
+    <message>
+        <source>unknown</source>
+        <translation type="unfinished">නොදනී</translation>
+    </message>
     <message>
         <source>Amount</source>
         <translation type="unfinished">අගය</translation>
@@ -241,8 +277,113 @@
 <context>
     <name>BitcoinGUI</name>
     <message>
+        <source>&amp;Overview</source>
+        <translation>&amp;දළ විශ්ලේෂණය</translation>
+    </message>
+    <message>
         <source>Browse transaction history</source>
         <translation>ගනුදෙනු ඉතිහාසය පිරික්සන්න</translation>
+    </message>
+    <message>
+        <source>E&amp;xit</source>
+        <translation>පි&amp;ටවන්න</translation>
+    </message>
+    <message>
+        <source>Quit application</source>
+        <translation>යෙදුමෙන් පිටවන්න</translation>
+    </message>
+    <message>
+        <source>&amp;About %1</source>
+        <translation type="unfinished">%1 &amp;පිළිබඳව</translation>
+    </message>
+    <message>
+        <source>Show information about %1</source>
+        <translation type="unfinished">%1 පිළිබඳව තොරතුරු පෙන්වන්න</translation>
+    </message>
+    <message>
+        <source>About &amp;Qt</source>
+        <translation>කියුටී &amp;පිළිබඳව</translation>
+    </message>
+    <message>
+        <source>Show information about Qt</source>
+        <translation>කියුටී පිළිබඳව තොරතුරු පෙන්වන්න</translation>
+    </message>
+    <message>
+        <source>Create a new wallet</source>
+        <translation type="unfinished">නව පසුම්බියක් සාදන්න</translation>
+    </message>
+    <message>
+        <source>Wallet:</source>
+        <translation type="unfinished">පසුම්බිය:</translation>
+    </message>
+    <message>
+        <source>Network activity disabled.</source>
+        <extracomment>A substring of the tooltip.</extracomment>
+        <translation type="unfinished">ජාලයේ ක්‍රියාකාරකම අබල කර ඇත.</translation>
+    </message>
+    <message>
+        <source>Send coins to a Bitcoin address</source>
+        <translation>බිට්කොයින් ලිපිනයට කාසි යවන්න</translation>
+    </message>
+    <message>
+        <source>Backup wallet to another location</source>
+        <translation>වෙනත් ස්ථානයකට පසුම්බිය උපස්ථ කරන්න</translation>
+    </message>
+    <message>
+        <source>&amp;Send</source>
+        <translation>&amp;යවන්න</translation>
+    </message>
+    <message>
+        <source>&amp;Receive</source>
+        <translation>&amp;ලබන්න</translation>
+    </message>
+    <message>
+        <source>&amp;Options…</source>
+        <translation type="unfinished">&amp;විකල්ප…</translation>
+    </message>
+    <message>
+        <source>&amp;Show / Hide</source>
+        <translation>&amp;පෙන්වන්න / සඟවන්න</translation>
+    </message>
+    <message>
+        <source>Show or hide the main Window</source>
+        <translation>ප්‍රධාන කවුළුව සඟවන්න හෝ පෙන්වන්න</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation type="unfinished">&amp;පසුම්බිය උපස්ථකරන්න…</translation>
+    </message>
+    <message>
+        <source>Close Wallet…</source>
+        <translation type="unfinished">පසුම්බිය වසන්න…</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation type="unfinished">පසුම්බිය වසන්න…</translation>
+    </message>
+    <message>
+        <source>Close All Wallets…</source>
+        <translation type="unfinished">සියළු පසුම්බි වසන්න…</translation>
+    </message>
+    <message>
+        <source>&amp;File</source>
+        <translation>&amp;ගොනුව</translation>
+    </message>
+    <message>
+        <source>&amp;Settings</source>
+        <translation>&amp;සැකසුම්</translation>
+    </message>
+    <message>
+        <source>&amp;Help</source>
+        <translation>&amp;උදව්</translation>
+    </message>
+    <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation type="unfinished">(%1%) ශීර්ෂ සමමුහූර්ත වෙමින්…</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation type="unfinished">ජාලය සමඟ සමමුහූර්ත වෙමින්…</translation>
     </message>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
@@ -252,12 +393,60 @@
         </translation>
     </message>
     <message>
+        <source>Error</source>
+        <translation>දෝෂයකි</translation>
+    </message>
+    <message>
         <source>Warning</source>
         <translation>අවවාදය</translation>
     </message>
     <message>
         <source>Information</source>
         <translation>තොරතුර</translation>
+    </message>
+    <message>
+        <source>&amp;Sending addresses</source>
+        <translation type="unfinished">&amp;යවන ලිපින</translation>
+    </message>
+    <message>
+        <source>&amp;Receiving addresses</source>
+        <translation type="unfinished">&amp;ලැබෙන ලිපින</translation>
+    </message>
+    <message>
+        <source>Open Wallet</source>
+        <translation type="unfinished">පසුම්බිය විවෘත කරන්න</translation>
+    </message>
+    <message>
+        <source>Open a wallet</source>
+        <translation type="unfinished">පසුම්බියක් විවෘත කරන්න</translation>
+    </message>
+    <message>
+        <source>Close wallet</source>
+        <translation type="unfinished">පසුම්බිය වසන්න</translation>
+    </message>
+    <message>
+        <source>Close all wallets</source>
+        <translation type="unfinished">සියළු පසුම්බි වසන්න</translation>
+    </message>
+    <message>
+        <source>default wallet</source>
+        <translation type="unfinished">පෙරනිමි පසුම්බිය</translation>
+    </message>
+    <message>
+        <source>&amp;Window</source>
+        <translation type="unfinished">&amp;කවුළුව</translation>
+    </message>
+    <message>
+        <source>Zoom</source>
+        <translation type="unfinished">විශාල කරන්න</translation>
+    </message>
+    <message>
+        <source>Main Window</source>
+        <translation type="unfinished">ප්‍රධාන කවුළුව</translation>
+    </message>
+    <message>
+        <source>%1 client</source>
+        <translation type="unfinished">%1 අනුග්‍රාහකය</translation>
     </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
@@ -267,7 +456,66 @@
             <numerusform />
         </translation>
     </message>
-    </context>
+    <message>
+        <source>Click for more actions.</source>
+        <extracomment>A substring of the tooltip. "More actions" are available via the context menu.</extracomment>
+        <translation type="unfinished">තව ක්‍රියාමාර්ග සඳහා ඔබන්න.</translation>
+    </message>
+    <message>
+        <source>Disable network activity</source>
+        <extracomment>A context menu item.</extracomment>
+        <translation type="unfinished">ජාලයේ ක්‍රියාකාරකම අබල කරන්න</translation>
+    </message>
+    <message>
+        <source>Enable network activity</source>
+        <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
+        <translation type="unfinished">ජාලයේ ක්‍රියාකාරකම සබල කරන්න</translation>
+    </message>
+    <message>
+        <source>Error: %1</source>
+        <translation type="unfinished">දෝෂය: %1</translation>
+    </message>
+    <message>
+        <source>Warning: %1</source>
+        <translation type="unfinished">අවවාදය: %1</translation>
+    </message>
+    <message>
+        <source>Date: %1
+</source>
+        <translation type="unfinished">දිනය: %1
+</translation>
+    </message>
+    <message>
+        <source>Wallet: %1
+</source>
+        <translation type="unfinished">පසුම්බිය: %1
+</translation>
+    </message>
+    <message>
+        <source>Type: %1
+</source>
+        <translation type="unfinished">වර්ගය: %1
+</translation>
+    </message>
+    <message>
+        <source>Address: %1
+</source>
+        <translation type="unfinished">ලිපිනය: %1
+</translation>
+    </message>
+    <message>
+        <source>Sent transaction</source>
+        <translation>යැවූ ගනුදෙනුව</translation>
+    </message>
+    <message>
+        <source>Private key &lt;b&gt;disabled&lt;/b&gt;</source>
+        <translation type="unfinished">පෞද්ගලික යතුර &lt;b&gt;අබලයි&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Original message:</source>
+        <translation type="unfinished">මුල් පණිවිඩය:</translation>
+    </message>
+</context>
 <context>
     <name>CoinControlDialog</name>
     <message>
@@ -276,7 +524,7 @@
     </message>
     <message>
         <source>Bytes:</source>
-        <translation type="unfinished">බයිට්ස්:</translation>
+        <translation type="unfinished">බයිට:</translation>
     </message>
     <message>
         <source>Amount:</source>
@@ -291,8 +539,24 @@
         <translation type="unfinished">අගය</translation>
     </message>
     <message>
+        <source>Received with address</source>
+        <translation type="unfinished">ලිපිනය සමඟ ලැබුණි</translation>
+    </message>
+    <message>
         <source>Date</source>
         <translation type="unfinished">දිනය</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;ලිපිනය පිටපත්</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">ගනුදෙනු &amp;හැඳු. පිටපත්</translation>
+    </message>
+    <message>
+        <source>Copy bytes</source>
+        <translation type="unfinished">බයිට පිටපත් කරන්න</translation>
     </message>
     <message>
         <source>yes</source>
@@ -312,14 +576,90 @@
     </message>
 </context>
 <context>
+    <name>OpenWalletActivity</name>
+    <message>
+        <source>default wallet</source>
+        <translation type="unfinished">පෙරනිමි පසුම්බිය</translation>
+    </message>
+    </context>
+<context>
+    <name>WalletController</name>
+    <message>
+        <source>Close wallet</source>
+        <translation type="unfinished">පසුම්බිය වසන්න</translation>
+    </message>
+    <message>
+        <source>Close all wallets</source>
+        <translation type="unfinished">සියළු පසුම්බි වසන්න</translation>
+    </message>
+    </context>
+<context>
+    <name>CreateWalletDialog</name>
+    <message>
+        <source>Create Wallet</source>
+        <translation type="unfinished">පසුම්බිය සාදන්න</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <translation type="unfinished">පසුම්බියේ නම</translation>
+    </message>
+    <message>
+        <source>Wallet</source>
+        <translation type="unfinished">පසුම්බිය</translation>
+    </message>
+    <message>
+        <source>Advanced Options</source>
+        <translation type="unfinished">වැඩිදුර විකල්ප</translation>
+    </message>
+    <message>
+        <source>Disable Private Keys</source>
+        <translation type="unfinished">පෞද්ගලික යතුරු අබලකරන්න</translation>
+    </message>
+    <message>
+        <source>Create</source>
+        <translation type="unfinished">සාදන්න</translation>
+    </message>
+    </context>
+<context>
+    <name>EditAddressDialog</name>
+    <message>
+        <source>Edit Address</source>
+        <translation>ලිපිනය සංස්කරණය</translation>
+    </message>
+    <message>
+        <source>&amp;Address</source>
+        <translation>&amp;ලිපිනය</translation>
+    </message>
+    <message>
+        <source>New sending address</source>
+        <translation type="unfinished">නව යවන ලිපිනය</translation>
+    </message>
+    <message>
+        <source>Edit receiving address</source>
+        <translation type="unfinished">ලැබෙන ලිපිනය සංස්කරණය</translation>
+    </message>
+    <message>
+        <source>Edit sending address</source>
+        <translation type="unfinished">යවන ලිපිනය සංස්කරණය</translation>
+    </message>
+    </context>
+<context>
     <name>FreespaceChecker</name>
     <message>
         <source>name</source>
         <translation>නම</translation>
     </message>
-    </context>
+    <message>
+        <source>Cannot create data directory here.</source>
+        <translation>මෙතැන දත්ත නාමාවලිය සෑදිය නොහැකිය.</translation>
+    </message>
+</context>
 <context>
     <name>Intro</name>
+    <message>
+        <source>Bitcoin</source>
+        <translation type="unfinished">බිට්කොයින්</translation>
+    </message>
     <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
@@ -329,8 +669,147 @@
         </translation>
     </message>
     <message>
+        <source>Error</source>
+        <translation>දෝෂයකි</translation>
+    </message>
+    <message>
         <source>Welcome</source>
-        <translation>ආයුබෝවන්</translation>
+        <translation>සාදරයෙන් පිළිගනිමු</translation>
+    </message>
+    <message>
+        <source>Welcome to %1.</source>
+        <translation type="unfinished">%1 වෙත සාදරයෙන් පිළිගනිමු.</translation>
+    </message>
+    <message>
+        <source> GB</source>
+        <translation type="unfinished">ගි.බ.</translation>
+    </message>
+    <message>
+        <source>Use the default data directory</source>
+        <translation>පෙරනිමි දත්ත නාමාවලිය භාවිතා කරන්න</translation>
+    </message>
+    </context>
+<context>
+    <name>HelpMessageDialog</name>
+    <message>
+        <source>version</source>
+        <translation type="unfinished">අනුවාදය</translation>
+    </message>
+    <message>
+        <source>About %1</source>
+        <translation type="unfinished">%1 පිළිබඳව</translation>
+    </message>
+    </context>
+<context>
+    <name>ModalOverlay</name>
+    <message>
+        <source>Form</source>
+        <translation type="unfinished">වෙතින්</translation>
+    </message>
+    <message>
+        <source>Unknown…</source>
+        <translation type="unfinished">නොදනී…</translation>
+    </message>
+    <message>
+        <source>calculating…</source>
+        <translation type="unfinished">ගණනය වෙමින්…</translation>
+    </message>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished">සඟවන්න</translation>
+    </message>
+    </context>
+<context>
+    <name>OptionsDialog</name>
+    <message>
+        <source>Options</source>
+        <translation>විකල්ප</translation>
+    </message>
+    <message>
+        <source>&amp;Main</source>
+        <translation>&amp;ප්‍රධාන</translation>
+    </message>
+    <message>
+        <source>Size of &amp;database cache</source>
+        <translation type="unfinished">දත්තසමුදා නිහිතයේ ප්‍රමාණය</translation>
+    </message>
+    <message>
+        <source>Open Configuration File</source>
+        <translation type="unfinished">වින්‍යාස ගොනුව විවෘතකරන්න</translation>
+    </message>
+    <message>
+        <source>&amp;Reset Options</source>
+        <translation>&amp;නැවත සැකසීමේ විකල්ප</translation>
+    </message>
+    <message>
+        <source>&amp;Network</source>
+        <translation>&amp;ජාලය</translation>
+    </message>
+    <message>
+        <source>GB</source>
+        <translation type="unfinished">ගි.බ.</translation>
+    </message>
+    <message>
+        <source>MiB</source>
+        <translation type="unfinished">මෙ.බ.</translation>
+    </message>
+    <message>
+        <source>W&amp;allet</source>
+        <translation type="unfinished">ප&amp;සුම්බිය</translation>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation type="unfinished">කාසි පාලන විශේෂාංග සබලකරන්න</translation>
+    </message>
+    <message>
+        <source>Accept connections from outside.</source>
+        <translation type="unfinished">පිටතින් සම්බන්ධතා පිළිගන්න.</translation>
+    </message>
+    <message>
+        <source>Tor</source>
+        <translation type="unfinished">ටෝර්</translation>
+    </message>
+    <message>
+        <source>&amp;Window</source>
+        <translation>&amp;කවුළුව</translation>
+    </message>
+    <message>
+        <source>User Interface &amp;language:</source>
+        <translation>අතරු මුහුණතේ &amp;භාෂාව:</translation>
+    </message>
+    <message>
+        <source>embedded "%1"</source>
+        <translation type="unfinished">එබ්බවූ "%1"</translation>
+    </message>
+    <message>
+        <source>&amp;OK</source>
+        <translation>&amp;හරි</translation>
+    </message>
+    <message>
+        <source>&amp;Cancel</source>
+        <translation>&amp;අවලංගු</translation>
+    </message>
+    <message>
+        <source>default</source>
+        <translation>පෙරනිමි</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">දෝෂයකි</translation>
+    </message>
+    </context>
+<context>
+    <name>OverviewPage</name>
+    <message>
+        <source>Form</source>
+        <translation>වෙතින්</translation>
+    </message>
+    </context>
+<context>
+    <name>PSBTOperationsDialog</name>
+    <message>
+        <source>or</source>
+        <translation type="unfinished">හෝ</translation>
     </message>
     </context>
 <context>
@@ -340,12 +819,39 @@
         <extracomment>Title of Peers Table column which contains the IP/Onion/I2P address of the connected peer.</extracomment>
         <translation type="unfinished">ලිපිනය</translation>
     </message>
+    <message>
+        <source>Type</source>
+        <extracomment>Title of Peers Table column which describes the type of peer connection. The "type" describes why the connection exists.</extracomment>
+        <translation type="unfinished">වර්ගය</translation>
+    </message>
+    </context>
+<context>
+    <name>RPCConsole</name>
+    <message>
+        <source>To</source>
+        <translation type="unfinished">වෙත</translation>
+    </message>
+    <message>
+        <source>From</source>
+        <translation type="unfinished">වෙතින්</translation>
+    </message>
+    </context>
+<context>
+    <name>ReceiveCoinsDialog</name>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;ලිපිනය පිටපත්</translation>
+    </message>
     </context>
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
         <source>Amount:</source>
         <translation type="unfinished">අගය:</translation>
+    </message>
+    <message>
+        <source>Wallet:</source>
+        <translation type="unfinished">පසුම්බිය:</translation>
     </message>
     </context>
 <context>
@@ -359,6 +865,10 @@
         <translation type="unfinished">ලේබලය</translation>
     </message>
     <message>
+        <source>Message</source>
+        <translation type="unfinished">පණිවිඩය</translation>
+    </message>
+    <message>
         <source>(no label)</source>
         <translation type="unfinished">(ලේබලයක් නැත)</translation>
     </message>
@@ -366,12 +876,16 @@
 <context>
     <name>SendCoinsDialog</name>
     <message>
+        <source>Send Coins</source>
+        <translation>කාසි යවන්න</translation>
+    </message>
+    <message>
         <source>Quantity:</source>
         <translation type="unfinished">ප්‍රමාණය:</translation>
     </message>
     <message>
         <source>Bytes:</source>
-        <translation type="unfinished">බයිට්ස්:</translation>
+        <translation type="unfinished">බයිට:</translation>
     </message>
     <message>
         <source>Amount:</source>
@@ -380,6 +894,38 @@
     <message>
         <source>Fee:</source>
         <translation type="unfinished">ගාස්තුව:</translation>
+    </message>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished">සඟවන්න</translation>
+    </message>
+    <message>
+        <source>S&amp;end</source>
+        <translation>ය&amp;වන්න</translation>
+    </message>
+    <message>
+        <source>Copy bytes</source>
+        <translation type="unfinished">බයිට පිටපත් කරන්න</translation>
+    </message>
+    <message>
+        <source>%1 to '%2'</source>
+        <translation type="unfinished">%1 සිට '%2'</translation>
+    </message>
+    <message>
+        <source>%1 to %2</source>
+        <translation type="unfinished">%1 සිට %2</translation>
+    </message>
+    <message>
+        <source>Sign and send</source>
+        <translation type="unfinished">ඇතුල් වී යවන්න</translation>
+    </message>
+    <message>
+        <source>Sign failed</source>
+        <translation type="unfinished">ඇතුල් වීමට අසමත්</translation>
+    </message>
+    <message>
+        <source>or</source>
+        <translation type="unfinished">හෝ</translation>
     </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
@@ -394,6 +940,20 @@
     </message>
 </context>
 <context>
+    <name>SignVerifyMessageDialog</name>
+    <message>
+        <source>Signature</source>
+        <translation>අත්සන</translation>
+    </message>
+    </context>
+<context>
+    <name>TrafficGraphWidget</name>
+    <message>
+        <source>kB/s</source>
+        <translation type="unfinished">කි.බ./තත්.</translation>
+    </message>
+</context>
+<context>
     <name>TransactionDesc</name>
     <message numerus="yes">
         <source>Open for %n more block(s)</source>
@@ -403,8 +963,28 @@
         </translation>
     </message>
     <message>
+        <source>Status</source>
+        <translation type="unfinished">තත්වය</translation>
+    </message>
+    <message>
         <source>Date</source>
         <translation type="unfinished">දිනය</translation>
+    </message>
+    <message>
+        <source>Source</source>
+        <translation type="unfinished">මූලාශ්‍රය</translation>
+    </message>
+    <message>
+        <source>From</source>
+        <translation type="unfinished">වෙතින්</translation>
+    </message>
+    <message>
+        <source>unknown</source>
+        <translation type="unfinished">නොදනී</translation>
+    </message>
+    <message>
+        <source>To</source>
+        <translation type="unfinished">වෙත</translation>
     </message>
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
@@ -412,6 +992,22 @@
             <numerusform />
             <numerusform />
         </translation>
+    </message>
+    <message>
+        <source>Message</source>
+        <translation type="unfinished">පණිවිඩය</translation>
+    </message>
+    <message>
+        <source>Comment</source>
+        <translation type="unfinished">අදහස</translation>
+    </message>
+    <message>
+        <source>Transaction ID</source>
+        <translation type="unfinished">ගනුදෙනු හැඳු.</translation>
+    </message>
+    <message>
+        <source>Inputs</source>
+        <translation type="unfinished">ආදාන</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -425,6 +1021,10 @@
         <translation type="unfinished">දිනය</translation>
     </message>
     <message>
+        <source>Type</source>
+        <translation type="unfinished">වර්ගය</translation>
+    </message>
+    <message>
         <source>Label</source>
         <translation type="unfinished">ලේබලය</translation>
     </message>
@@ -436,15 +1036,64 @@
         </translation>
     </message>
     <message>
+        <source>(n/a)</source>
+        <translation type="unfinished">(අ/නොවේ)</translation>
+    </message>
+    <message>
         <source>(no label)</source>
         <translation type="unfinished">(ලේබලයක් නැත)</translation>
+    </message>
+    <message>
+        <source>Type of transaction.</source>
+        <translation type="unfinished">ගනුදෙනු වර්ග.</translation>
     </message>
     </context>
 <context>
     <name>TransactionView</name>
     <message>
+        <source>All</source>
+        <translation type="unfinished">සියල්ල</translation>
+    </message>
+    <message>
+        <source>Today</source>
+        <translation type="unfinished">අද</translation>
+    </message>
+    <message>
+        <source>This week</source>
+        <translation type="unfinished">මෙම සතිය</translation>
+    </message>
+    <message>
+        <source>This month</source>
+        <translation type="unfinished">මෙම මාසය</translation>
+    </message>
+    <message>
+        <source>Last month</source>
+        <translation type="unfinished">පසුගිය මාසය</translation>
+    </message>
+    <message>
+        <source>This year</source>
+        <translation type="unfinished">මෙම අවුරුද්ද</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;ලිපිනය පිටපත්</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">ගනුදෙනු &amp;හැඳු. පිටපත්</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See https://en.wikipedia.org/wiki/Comma-separated_values</extracomment>
+        <translation type="unfinished">අල්පවිරාම වලින් වෙන්වූ ගොනුව</translation>
+    </message>
+    <message>
         <source>Date</source>
         <translation type="unfinished">දිනය</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished">වර්ගය</translation>
     </message>
     <message>
         <source>Label</source>
@@ -453,6 +1102,107 @@
     <message>
         <source>Address</source>
         <translation type="unfinished">ලිපිනය</translation>
+    </message>
+    <message>
+        <source>ID</source>
+        <translation type="unfinished">හැඳු.</translation>
+    </message>
+    <message>
+        <source>Exporting Failed</source>
+        <translation type="unfinished">නිර්යාත වීමට අසමත් විය</translation>
+    </message>
+    <message>
+        <source>Exporting Successful</source>
+        <translation type="unfinished">නිර්යාත වීම සාර්ථකයි</translation>
+    </message>
+    <message>
+        <source>to</source>
+        <translation type="unfinished">වෙත</translation>
+    </message>
+</context>
+<context>
+    <name>WalletFrame</name>
+    <message>
+        <source>Create a new wallet</source>
+        <translation type="unfinished">නව පසුම්බියක් සාදන්න</translation>
+    </message>
+</context>
+<context>
+    <name>WalletModel</name>
+    <message>
+        <source>Send Coins</source>
+        <translation type="unfinished">කාසි යවන්න</translation>
+    </message>
+    <message>
+        <source>default wallet</source>
+        <translation type="unfinished">පෙරනිමි පසුම්බිය</translation>
+    </message>
+</context>
+<context>
+    <name>WalletView</name>
+    <message>
+        <source>&amp;Export</source>
+        <translation type="unfinished">&amp;නිර්යාත</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">දෝෂයකි</translation>
+    </message>
+    <message>
+        <source>Backup Wallet</source>
+        <translation type="unfinished">පසුම්බිය උපස්ථකරන්න</translation>
+    </message>
+    <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">පසුම්බියේ දත්ත</translation>
+    </message>
+    <message>
+        <source>Backup Failed</source>
+        <translation type="unfinished">උපස්ථ වීමට අසමත් විය</translation>
+    </message>
+    <message>
+        <source>Backup Successful</source>
+        <translation type="unfinished">උපස්ථ වීම සාර්ථකයි</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">අවලංගු</translation>
+    </message>
+</context>
+<context>
+    <name>bitcoin-core</name>
+    <message>
+        <source>The %s developers</source>
+        <translation type="unfinished">%s සංවර්ධකයින්</translation>
+    </message>
+    <message>
+        <source>Error creating %s</source>
+        <translation type="unfinished">%s සෑදීමේ දෝෂයකි</translation>
+    </message>
+    <message>
+        <source>Error loading %s</source>
+        <translation type="unfinished">%s පූරණය වීමේ දෝෂයකි</translation>
+    </message>
+    <message>
+        <source>Importing…</source>
+        <translation type="unfinished">ආයාත වෙමින්…</translation>
+    </message>
+    <message>
+        <source>Loading wallet…</source>
+        <translation type="unfinished">පසුම්බිය පූරණය වෙමින්…</translation>
+    </message>
+    <message>
+        <source>Rescanning…</source>
+        <translation type="unfinished">යළි සුපිරික්සමින්…</translation>
+    </message>
+    <message>
+        <source>This is experimental software.</source>
+        <translation type="unfinished">මෙය පර්යේෂණාත්මක මෘදුකාංගයකි.</translation>
+    </message>
+    <message>
+        <source>Unknown address type '%s'</source>
+        <translation type="unfinished">'%s' නොදන්නා ලිපින වර්ගයකි</translation>
     </message>
     </context>
 </TS>

--- a/src/qt/locale/bitcoin_sl.ts
+++ b/src/qt/locale/bitcoin_sl.ts
@@ -1,390 +1,393 @@
-<TS version="2.1" language="sk">
+<TS version="2.1" language="sl">
 <context>
     <name>AddressBookPage</name>
     <message>
         <source>Right-click to edit address or label</source>
-        <translation type="unfinished">Kliknutím pravého tlačidla upraviť adresu alebo popis</translation>
+        <translation type="unfinished">Desni klik za urejanje naslova ali oznake</translation>
     </message>
     <message>
         <source>Create a new address</source>
-        <translation>Vytvoriť novú adresu</translation>
+        <translation>Ustvari nov naslov</translation>
     </message>
     <message>
         <source>&amp;New</source>
-        <translation type="unfinished">&amp;Nový</translation>
+        <translation type="unfinished">&amp;Novo</translation>
     </message>
     <message>
         <source>Copy the currently selected address to the system clipboard</source>
-        <translation>Zkopírovať práve zvolenú adresu</translation>
+        <translation>Kopiraj trenutno izbrani naslov v odložišče</translation>
     </message>
     <message>
         <source>&amp;Copy</source>
-        <translation type="unfinished">&amp;Kopírovať</translation>
+        <translation type="unfinished">&amp;Kopiraj</translation>
     </message>
     <message>
         <source>C&amp;lose</source>
-        <translation type="unfinished">Z&amp;atvoriť</translation>
+        <translation type="unfinished">&amp;Zapri</translation>
     </message>
     <message>
         <source>Delete the currently selected address from the list</source>
-        <translation>Vymazať vybranú adresu zo zoznamu</translation>
+        <translation>Izbriši trenutno označeni naslov s seznama</translation>
     </message>
     <message>
         <source>Enter address or label to search</source>
-        <translation type="unfinished">Zadajte adresu alebo popis pre hľadanie</translation>
+        <translation type="unfinished">Iščite po naslovu ali oznaki</translation>
     </message>
     <message>
         <source>Export the data in the current tab to a file</source>
-        <translation>Exportovať dáta v aktuálnej karte do súboru</translation>
+        <translation>Izvozi podatke iz trenutnega zavihka v datoteko</translation>
     </message>
     <message>
         <source>&amp;Export</source>
-        <translation>&amp;Exportovať...</translation>
+        <translation>&amp;Izvozi</translation>
     </message>
     <message>
         <source>&amp;Delete</source>
-        <translation>&amp;Zmazať</translation>
+        <translation>I&amp;zbriši</translation>
     </message>
     <message>
         <source>Choose the address to send coins to</source>
-        <translation type="unfinished">Zvoľte adresu kam poslať mince</translation>
+        <translation type="unfinished">Izberi naslov prejemnika</translation>
     </message>
     <message>
         <source>Choose the address to receive coins with</source>
-        <translation type="unfinished">Zvoľte adresu na ktorú chcete prijať mince</translation>
+        <translation type="unfinished">Izberite naslov, na katerega želite prejeti sredstva</translation>
     </message>
     <message>
         <source>C&amp;hoose</source>
-        <translation type="unfinished">Vy&amp;brať</translation>
+        <translation type="unfinished">&amp;Izberi</translation>
     </message>
     <message>
         <source>Sending addresses</source>
-        <translation type="unfinished">Odosielajúce adresy</translation>
+        <translation type="unfinished">Imenik naslovov za pošiljanje</translation>
     </message>
     <message>
         <source>Receiving addresses</source>
-        <translation type="unfinished">Prijímajúce adresy</translation>
+        <translation type="unfinished">Imenik prejemnih naslovov</translation>
     </message>
     <message>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
-        <translation type="unfinished">Toto sú Vaše Bitcoin adresy pre posielanie platieb. Vždy skontrolujte sumu a prijímaciu adresu pred poslaním mincí.</translation>
+        <translation type="unfinished">To so vaši bitcoin-naslovi za pošiljanje. Pred pošiljanjem vedno preverite količino in prejemnikov naslov.</translation>
     </message>
     <message>
         <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
 Signing is only possible with addresses of the type 'legacy'.</source>
-        <translation type="unfinished">Toto sú vaše Bitcoin adresy pre prijímanie platieb. Pre vytvorenie nových adries kliknite na "Vytvoriť novú prijímaciu adresu" na karte "Prijať". Podpisovanie je možné iba s adresami typu "legacy".</translation>
+        <translation type="unfinished">To so vaši bitcoin-naslovi, ki jih uporabljate za prejemanje plačil. Za tvorbo novega naslova uporabite gumb "Ustvari nov prejemni naslov" v zavihku Prejmi.
+Podpisovanje je možno le s podedovanimi ("legacy") naslovi.</translation>
     </message>
     <message>
         <source>&amp;Copy Address</source>
-        <translation type="unfinished">&amp;Kopírovať adresu</translation>
+        <translation type="unfinished">&amp;Kopiraj naslov</translation>
     </message>
     <message>
         <source>Copy &amp;Label</source>
-        <translation type="unfinished">Kopírovať &amp;popis</translation>
+        <translation type="unfinished">Kopiraj &amp;oznako</translation>
     </message>
     <message>
         <source>&amp;Edit</source>
-        <translation type="unfinished">&amp;Upraviť</translation>
+        <translation type="unfinished">&amp;Uredi</translation>
     </message>
     <message>
         <source>Export Address List</source>
-        <translation type="unfinished">Exportovať zoznam adries</translation>
+        <translation type="unfinished">Izvozi seznam naslovov</translation>
     </message>
     <message>
         <source>Comma separated file</source>
         <extracomment>Expanded name of the CSV file format. See https://en.wikipedia.org/wiki/Comma-separated_values</extracomment>
-        <translation type="unfinished">Čiarkou oddelený súbor</translation>
+        <translation type="unfinished">Vrednosti ločene z vejicami</translation>
     </message>
     <message>
         <source>There was an error trying to save the address list to %1. Please try again.</source>
         <extracomment>An error message. %1 is a stand-in argument for the name of the file we attempted to save to.</extracomment>
-        <translation type="unfinished">Nastala chyba pri pokuse uložiť zoznam adries do %1. Skúste znovu.</translation>
+        <translation type="unfinished">Poskus shranjevanja seznama naslovov v %1 je spodletel. Prosimo, poskusite znova.</translation>
     </message>
     <message>
         <source>Exporting Failed</source>
-        <translation type="unfinished">Export zlyhal</translation>
+        <translation type="unfinished">Izvoz je spodletel.</translation>
     </message>
 </context>
 <context>
     <name>AddressTableModel</name>
     <message>
         <source>Label</source>
-        <translation type="unfinished">Popis</translation>
+        <translation type="unfinished">Oznaka</translation>
     </message>
     <message>
         <source>Address</source>
-        <translation type="unfinished">Adresa</translation>
+        <translation type="unfinished">Naslov</translation>
     </message>
     <message>
         <source>(no label)</source>
-        <translation type="unfinished">(bez popisu)</translation>
+        <translation type="unfinished">(brez oznake)</translation>
     </message>
 </context>
 <context>
     <name>AskPassphraseDialog</name>
     <message>
         <source>Passphrase Dialog</source>
-        <translation>Dialóg hesla</translation>
+        <translation>Pogovorno okno za geslo</translation>
     </message>
     <message>
         <source>Enter passphrase</source>
-        <translation>Zadajte heslo</translation>
+        <translation>Vnesite geslo</translation>
     </message>
     <message>
         <source>New passphrase</source>
-        <translation>Nové heslo</translation>
+        <translation>Novo geslo</translation>
     </message>
     <message>
         <source>Repeat new passphrase</source>
-        <translation>Zopakujte nové heslo</translation>
+        <translation>Ponovite geslo</translation>
     </message>
     <message>
         <source>Show passphrase</source>
-        <translation type="unfinished">Zobraziť frázu</translation>
+        <translation type="unfinished">Pokaži geslo</translation>
     </message>
     <message>
         <source>Encrypt wallet</source>
-        <translation type="unfinished">Zašifrovať peňaženku</translation>
+        <translation type="unfinished">Šifriraj denarnico</translation>
     </message>
     <message>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
-        <translation type="unfinished">Táto operácia potrebuje heslo k vašej peňaženke aby ju mohla odomknúť.</translation>
+        <translation type="unfinished">To dejanje zahteva geslo za odklepanje vaše denarnice.</translation>
     </message>
     <message>
         <source>Unlock wallet</source>
-        <translation type="unfinished">Odomknúť peňaženku</translation>
+        <translation type="unfinished">Odkleni denarnico</translation>
     </message>
     <message>
         <source>Change passphrase</source>
-        <translation type="unfinished">Zmena hesla</translation>
+        <translation type="unfinished">Spremeni &amp;geslo...</translation>
     </message>
     <message>
         <source>Confirm wallet encryption</source>
-        <translation type="unfinished">Potvrďte zašifrovanie peňaženky</translation>
+        <translation type="unfinished">Potrdi šifriranje denarnice</translation>
     </message>
     <message>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
-        <translation type="unfinished">Varovanie: Ak zašifrujete peňaženku a stratíte heslo, &lt;b&gt;STRATÍTE VŠETKY VAŠE BITCOINY&lt;/b&gt;!</translation>
+        <translation type="unfinished">Opozorilo: V primeru izgube gesla šifrirane denarnice, boste &lt;b&gt;IZGUBILI VSE SVOJE BITCOINE&lt;/b&gt;!</translation>
     </message>
     <message>
         <source>Are you sure you wish to encrypt your wallet?</source>
-        <translation type="unfinished">Ste si istí, že si želáte zašifrovať peňaženku?</translation>
+        <translation type="unfinished">Ali ste prepričani, da želite šifrirati svojo denarnico?</translation>
     </message>
     <message>
         <source>Wallet encrypted</source>
-        <translation type="unfinished">Peňaženka zašifrovaná</translation>
+        <translation type="unfinished">Denarnica šifrirana</translation>
     </message>
     <message>
         <source>Enter the new passphrase for the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
-        <translation type="unfinished">Zadajte novú prístupovú frázu pre peňaženku.&lt;br/&gt;Prosím použite frázu dlhú &lt;b&gt;desať či viac náhodných znakov&lt;/b&gt;, alebo &lt;b&gt;osem či viac slov&lt;/b&gt;.</translation>
+        <translation type="unfinished">Vnesite novo geslo za denarnico. &lt;br/&gt;Prosimo, uporabite geslo z vsaj &lt;b&gt;10 ali več naključnimi simboli&lt;/b&gt; ali vsaj osmimi besedami.&lt;b&gt;</translation>
     </message>
     <message>
         <source>Enter the old passphrase and new passphrase for the wallet.</source>
-        <translation type="unfinished">Zadajte starú a novú frázu pre túto peňaženku.</translation>
+        <translation type="unfinished">Vnesite staro geslo in novo geslo za denarnico.</translation>
     </message>
     <message>
         <source>Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
-        <translation type="unfinished">Pamätajte, že zašifrovanie peňaženky neochráni úplne vaše bitcoiny pred ukradnutím škodlivými programami vo vašom počítači.</translation>
+        <translation type="unfinished">Pomnite, da šifriranje denarnice ne more preprečiti morebitnim virusom na vašem računalniku, da bi ukradli vaše bitcoine.</translation>
     </message>
     <message>
         <source>Wallet to be encrypted</source>
-        <translation type="unfinished">Peňaženka na zašifrovanie</translation>
+        <translation type="unfinished">Denarnica, ki naj bo šifrirana</translation>
     </message>
     <message>
         <source>Your wallet is about to be encrypted. </source>
-        <translation type="unfinished">Vaša peňaženka bude zašifrovaná.</translation>
+        <translation type="unfinished">Vaša denarnica bo zašifrirana.</translation>
     </message>
     <message>
         <source>Your wallet is now encrypted. </source>
-        <translation type="unfinished">Vaša peňaženka je zašifrovaná.</translation>
+        <translation type="unfinished">Vaša denarnica je sedaj šifrirana.</translation>
     </message>
     <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <translation type="unfinished">DÔLEŽITÉ: Všetky predchádzajúce zálohy vašej peňaženky, ktoré ste vykonali by mali byť nahradené novo vytvorenou, zašifrovanou peňaženkou. Z bezpečnostných dôvodov bude predchádzajúca záloha nezašifrovanej peňaženky k ničomu, akonáhle začnete používať novú, zašifrovanú peňaženku.</translation>
+        <translation type="unfinished">POMEMBNO: Vse starejše varnostne kopije denarnice je potrebno zamenjati z novo, šifrirano datoteko denarnice. Zaradi varnosti bodo stare varnostne kopije postale neuporabne takoj, ko začnete uporabljati novo, šifrirano denarnico.</translation>
     </message>
     <message>
         <source>Wallet encryption failed</source>
-        <translation type="unfinished">Šifrovanie peňaženky zlyhalo</translation>
+        <translation type="unfinished">Šifriranje denarnice je spodletelo</translation>
     </message>
     <message>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
-        <translation type="unfinished">Šifrovanie peňaženky zlyhalo kôli internej chybe. Vaša peňaženka nebola zašifrovaná.</translation>
+        <translation type="unfinished">Šifriranje denarnice je spodletelo zaradi notranje napake. Vaša denarnica ni bila šifrirana.</translation>
     </message>
     <message>
         <source>The supplied passphrases do not match.</source>
-        <translation type="unfinished">Zadané heslá nesúhlasia.</translation>
+        <translation type="unfinished">Navedeni gesli se ne ujemata.</translation>
     </message>
     <message>
         <source>Wallet unlock failed</source>
-        <translation type="unfinished">Odomykanie peňaženky zlyhalo</translation>
+        <translation type="unfinished">Denarnice ni bilo mogoče odkleniti</translation>
     </message>
     <message>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
-        <translation type="unfinished">Zadané heslo pre dešifrovanie peňaženky bolo nesprávne.</translation>
+        <translation type="unfinished">Geslo za dešifriranje denarnice, ki ste ga vnesli, ni pravilno.</translation>
     </message>
     <message>
         <source>Wallet passphrase was successfully changed.</source>
-        <translation type="unfinished">Heslo k peňaženke bolo úspešne zmenené.</translation>
+        <translation type="unfinished">Geslo za dostop do denarnice je bilo uspešno spremenjeno.</translation>
     </message>
     <message>
         <source>Warning: The Caps Lock key is on!</source>
-        <translation type="unfinished">Upozornenie: Máte zapnutý Caps Lock!</translation>
+        <translation type="unfinished">Opozorilo: Vključena je tipka Caps Lock!</translation>
     </message>
 </context>
 <context>
     <name>BanTableModel</name>
     <message>
-        <source>IP/Netmask</source>
-        <translation type="unfinished">IP/Maska stiete</translation>
-    </message>
-    <message>
         <source>Banned Until</source>
-        <translation type="unfinished">Blokovaný do</translation>
+        <translation type="unfinished">Blokiran do</translation>
     </message>
 </context>
 <context>
     <name>BitcoinApplication</name>
     <message>
         <source>Runaway exception</source>
-        <translation type="unfinished">Nezachytená výnimka</translation>
+        <translation type="unfinished">Pobegla izjema</translation>
     </message>
     <message>
         <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
-        <translation type="unfinished">Kritická chyba. %1  nemôže ďalej bezpečne pokračovať a ukončí sa.</translation>
+        <translation type="unfinished">Prišlo je do usodne napake. %1 ne more več varno nadaljevati s tekom in se bo ustavil.</translation>
     </message>
     <message>
         <source>Internal error</source>
-        <translation type="unfinished">Interná chyba</translation>
+        <translation type="unfinished">Interna napaka</translation>
     </message>
     <message>
         <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
-        <translation type="unfinished">Nastala interná chyba. %1 sa pokúsi bezpečne pokračovať. Toto je neočakávaná chyba, ktorú môžete nahlásiť podľa postupu nižšie.</translation>
+        <translation type="unfinished">Prišlo je do interne napake. %1 bo skušal varno nadaljevati. To je nepričakovana napaka, ki jo lahko prijavite, kot je opisano spodaj.</translation>
     </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
         <source>Error: Specified data directory "%1" does not exist.</source>
-        <translation type="unfinished">Chyba: Zadaný adresár pre dáta „%1“ neexistuje.</translation>
+        <translation type="unfinished">Napaka: Vnešena podatkovna mapa "%1" ne obstaja.</translation>
     </message>
     <message>
         <source>Error: Cannot parse configuration file: %1.</source>
-        <translation type="unfinished">Chyba: Konfiguračný súbor sa nedá spracovať: %1.</translation>
+        <translation type="unfinished">Napaka: Ne morem razčleniti konfiguracijske datoteke: %1.</translation>
     </message>
     <message>
         <source>Error: %1</source>
-        <translation type="unfinished">Chyba: %1</translation>
+        <translation type="unfinished">Napaka: %1</translation>
     </message>
     <message>
         <source>Error initializing settings: %1</source>
-        <translation type="unfinished">Chyba pri inicializácii nastavení: %1</translation>
+        <translation type="unfinished">Napaka pri inicializaciji nastavitev: %1</translation>
     </message>
     <message>
         <source>%1 didn't yet exit safely…</source>
-        <translation type="unfinished">%1 ešte nebol bezpečne ukončený…</translation>
+        <translation type="unfinished">%1 se še ni varno zaključil...</translation>
     </message>
     <message>
         <source>unknown</source>
-        <translation type="unfinished">neznámy</translation>
+        <translation type="unfinished">neznano</translation>
     </message>
     <message>
         <source>Amount</source>
-        <translation type="unfinished">Suma</translation>
+        <translation type="unfinished">Znesek</translation>
     </message>
     <message>
         <source>Enter a Bitcoin address (e.g. %1)</source>
-        <translation type="unfinished">Zadajte bitcoin adresu (napr. %1)</translation>
-    </message>
-    <message>
-        <source>Unroutable</source>
-        <translation type="unfinished">Nesmerovateľné</translation>
+        <translation type="unfinished">Vnesite bitcoin-naslov (npr. %1)</translation>
     </message>
     <message>
         <source>Internal</source>
-        <translation type="unfinished">Interné</translation>
+        <translation type="unfinished">Notranji</translation>
     </message>
     <message>
         <source>Inbound</source>
-        <translation type="unfinished">Prichádzajúce</translation>
+        <translation type="unfinished">Dohodna</translation>
     </message>
     <message>
         <source>Outbound</source>
-        <translation type="unfinished">Odchádzajúce</translation>
+        <translation type="unfinished">Odhodna</translation>
     </message>
     <message>
         <source>Full Relay</source>
-        <translation type="unfinished">Plné preposielanie</translation>
+        <translation type="unfinished">Polno posredovanje</translation>
     </message>
     <message>
         <source>Block Relay</source>
-        <translation type="unfinished">Preposielanie blokov</translation>
+        <translation type="unfinished">Posredovanje blokov</translation>
     </message>
     <message>
         <source>Manual</source>
-        <translation type="unfinished">Manuálne</translation>
+        <translation type="unfinished">Ročno</translation>
+    </message>
+    <message>
+        <source>Feeler</source>
+        <translation type="unfinished">Tipalka</translation>
     </message>
     <message>
         <source>Address Fetch</source>
-        <translation type="unfinished">Získanie adries</translation>
+        <translation type="unfinished">Pridobitev naslovov</translation>
     </message>
     <message>
         <source>None</source>
-        <translation type="unfinished">Žiadne</translation>
+        <translation type="unfinished">Jih ni</translation>
     </message>
     <message>
         <source>N/A</source>
-        <translation type="unfinished">nie je k dispozícii</translation>
+        <translation type="unfinished">Neznano</translation>
     </message>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation>
             <numerusform>%n sekunda</numerusform>
-            <numerusform>%n sekundy</numerusform>
-            <numerusform>%n sekúnd</numerusform>
+            <numerusform>%n sekundi</numerusform>
+            <numerusform>%n sekunde</numerusform>
+            <numerusform>%n sekund</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n minute(s)</source>
         <translation>
-            <numerusform>%n minúta</numerusform>
-            <numerusform>%n minúty</numerusform>
-            <numerusform>%n minút</numerusform>
+            <numerusform>%n minuta</numerusform>
+            <numerusform>%n minuti</numerusform>
+            <numerusform>%n minute</numerusform>
+            <numerusform>%n minut</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
         <translation type="unfinished">
-            <numerusform>%n hodina</numerusform>
-            <numerusform>%n hodiny</numerusform>
-            <numerusform>%n hodín</numerusform>
+            <numerusform>%n ura</numerusform>
+            <numerusform>%n uri</numerusform>
+            <numerusform>%n ure</numerusform>
+            <numerusform>%n ur</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
-            <numerusform>%n deň</numerusform>
+            <numerusform>%n dan</numerusform>
             <numerusform>%n dni</numerusform>
-            <numerusform>%n dní</numerusform>
+            <numerusform>%n dni</numerusform>
+            <numerusform>%n dni</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
-            <numerusform>%n týždeň</numerusform>
-            <numerusform>%n týždne</numerusform>
-            <numerusform>%n týždňov</numerusform>
+            <numerusform>%n teden</numerusform>
+            <numerusform>%n tedna</numerusform>
+            <numerusform>%n tedni</numerusform>
+            <numerusform>%n tedov</numerusform>
         </translation>
     </message>
     <message>
         <source>%1 and %2</source>
-        <translation type="unfinished">%1 a  %2</translation>
+        <translation type="unfinished">%1 in %2</translation>
     </message>
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
-            <numerusform>%n rok</numerusform>
-            <numerusform>%n roky</numerusform>
-            <numerusform>%n rokov</numerusform>
+            <numerusform>%n leto</numerusform>
+            <numerusform>%n leti</numerusform>
+            <numerusform>%n leta</numerusform>
+            <numerusform>%n let</numerusform>
         </translation>
     </message>
     </context>
@@ -392,35 +395,35 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <name>BitcoinGUI</name>
     <message>
         <source>&amp;Overview</source>
-        <translation>&amp;Prehľad</translation>
+        <translation>Pre&amp;gled</translation>
     </message>
     <message>
         <source>Show general overview of wallet</source>
-        <translation>Zobraziť celkový prehľad o peňaženke</translation>
+        <translation>Oglejte si splošne informacije o svoji denarnici</translation>
     </message>
     <message>
         <source>&amp;Transactions</source>
-        <translation>&amp;Transakcie</translation>
+        <translation>&amp;Transakcije</translation>
     </message>
     <message>
         <source>Browse transaction history</source>
-        <translation>Prechádzať históriu transakcií</translation>
+        <translation>Brskajte po zgodovini transakcij</translation>
     </message>
     <message>
         <source>E&amp;xit</source>
-        <translation>U&amp;končiť</translation>
+        <translation>I&amp;zhod</translation>
     </message>
     <message>
         <source>Quit application</source>
-        <translation>Ukončiť program</translation>
+        <translation>Izhod iz programa</translation>
     </message>
     <message>
         <source>&amp;About %1</source>
-        <translation type="unfinished">&amp;O %1</translation>
+        <translation type="unfinished">&amp;O nas%1</translation>
     </message>
     <message>
         <source>Show information about %1</source>
-        <translation type="unfinished">Ukázať informácie o %1</translation>
+        <translation type="unfinished">Prikaži informacije o %1</translation>
     </message>
     <message>
         <source>About &amp;Qt</source>
@@ -428,869 +431,864 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Show information about Qt</source>
-        <translation>Zobrazit informácie o Qt</translation>
+        <translation>Oglejte si informacije o Qt</translation>
     </message>
     <message>
         <source>Modify configuration options for %1</source>
-        <translation type="unfinished">Upraviť nastavenia pre %1</translation>
+        <translation type="unfinished">Spremeni možnosti konfiguracije za %1</translation>
     </message>
     <message>
         <source>Create a new wallet</source>
-        <translation type="unfinished">Vytvoriť novú peňaženku</translation>
+        <translation type="unfinished">Ustvari novo denarnico</translation>
     </message>
     <message>
         <source>Wallet:</source>
-        <translation type="unfinished">Peňaženka:</translation>
+        <translation type="unfinished">Denarnica:</translation>
     </message>
     <message>
         <source>Network activity disabled.</source>
         <extracomment>A substring of the tooltip.</extracomment>
-        <translation type="unfinished">Sieťová aktivita zakázaná.</translation>
+        <translation type="unfinished">Omrežna aktivnost onemogočena.</translation>
     </message>
     <message>
         <source>Proxy is &lt;b&gt;enabled&lt;/b&gt;: %1</source>
-        <translation type="unfinished">Proxy sú &lt;b&gt;zapnuté&lt;/b&gt;: %1</translation>
+        <translation type="unfinished">Posredniški strežnik je &lt;b&gt;omogočen&lt;/b&gt;: %1</translation>
     </message>
     <message>
         <source>Send coins to a Bitcoin address</source>
-        <translation>Poslať bitcoins na adresu</translation>
+        <translation>Pošljite novce na bitcoin-naslov</translation>
     </message>
     <message>
         <source>Backup wallet to another location</source>
-        <translation>Zálohovať peňaženku na iné miesto</translation>
+        <translation>Shranite varnostno kopijo svoje denarnice na drugo mesto</translation>
     </message>
     <message>
         <source>Change the passphrase used for wallet encryption</source>
-        <translation>Zmeniť heslo použité na šifrovanie peňaženky</translation>
+        <translation>Spremenite geslo za šifriranje denarnice</translation>
     </message>
     <message>
         <source>&amp;Send</source>
-        <translation>&amp;Odoslať</translation>
+        <translation>&amp;Pošlji</translation>
     </message>
     <message>
         <source>&amp;Receive</source>
-        <translation>&amp;Prijať</translation>
+        <translation>P&amp;rejmi</translation>
     </message>
     <message>
         <source>&amp;Options…</source>
-        <translation type="unfinished">M&amp;ožnosti…</translation>
+        <translation type="unfinished">&amp;Možnosti ...</translation>
     </message>
     <message>
         <source>&amp;Show / Hide</source>
-        <translation>&amp;Zobraziť / Skryť</translation>
+        <translation>&amp;Prikaži / Skrij</translation>
     </message>
     <message>
         <source>Show or hide the main Window</source>
-        <translation>Zobraziť alebo skryť hlavné okno</translation>
+        <translation>Prikaži ali skrij glavno okno</translation>
     </message>
     <message>
         <source>&amp;Encrypt Wallet…</source>
-        <translation type="unfinished">Zašifrovať p&amp;eňaženku…</translation>
+        <translation type="unfinished">Ši&amp;friraj denarnico...</translation>
     </message>
     <message>
         <source>Encrypt the private keys that belong to your wallet</source>
-        <translation>Zašifruj súkromné kľúče ktoré patria do vašej peňaženky</translation>
+        <translation>Šifrirajte zasebne ključe, ki se nahajajo v denarnici</translation>
     </message>
     <message>
         <source>&amp;Backup Wallet…</source>
-        <translation type="unfinished">&amp;Zálohovať peňaženku…</translation>
+        <translation type="unfinished">Naredi &amp;varnostno kopijo denarnice...</translation>
     </message>
     <message>
         <source>&amp;Change Passphrase…</source>
-        <translation type="unfinished">&amp;Zmeniť heslo…</translation>
+        <translation type="unfinished">Spremeni &amp;geslo...</translation>
     </message>
     <message>
         <source>Sign &amp;message…</source>
-        <translation type="unfinished">Podpísať &amp;správu…</translation>
+        <translation type="unfinished">&amp;Podpiši sporočilo...</translation>
     </message>
     <message>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
-        <translation>Podpísať správu s vašou Bitcoin adresou, aby ste preukázali, že ju vlastníte</translation>
+        <translation>Podpišite poljubno sporočilo z enim svojih bitcoin-naslovov, da prejemniku sporočila dokažete, da je ta naslov v vaši lasti.</translation>
     </message>
     <message>
         <source>&amp;Verify message…</source>
-        <translation type="unfinished">O&amp;veriť správu…</translation>
+        <translation type="unfinished">P&amp;reveri podpis...</translation>
     </message>
     <message>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
-        <translation>Overiť, či boli správy podpísané uvedenou Bitcoin adresou</translation>
+        <translation>Preverite, če je bilo prejeto sporočilo podpisano z določenim bitcoin-naslovom.</translation>
     </message>
     <message>
         <source>&amp;Load PSBT from file…</source>
-        <translation type="unfinished">&amp;Načítať PSBT zo súboru…</translation>
+        <translation type="unfinished">&amp;Naloži DPBT iz datoteke...</translation>
     </message>
     <message>
         <source>Load PSBT from clipboard…</source>
-        <translation type="unfinished">Načítať PSBT zo schránky…</translation>
+        <translation type="unfinished">Naloži DPBT z odložišča...</translation>
     </message>
     <message>
         <source>Open &amp;URI…</source>
-        <translation type="unfinished">Otvoriť &amp;URI…</translation>
+        <translation type="unfinished">Odpri &amp;URI...</translation>
     </message>
     <message>
         <source>Close Wallet…</source>
-        <translation type="unfinished">Zatvoriť Peňaženku...</translation>
+        <translation type="unfinished">Zapri denarnico...</translation>
     </message>
     <message>
         <source>Create Wallet…</source>
-        <translation type="unfinished">Vytvoriť Peňaženku...</translation>
+        <translation type="unfinished">Ustvari denarnico...</translation>
     </message>
     <message>
         <source>Close All Wallets…</source>
-        <translation type="unfinished">Zatvoriť všetky Peňaženky...</translation>
+        <translation type="unfinished">Zapri vse denarnice...</translation>
     </message>
     <message>
         <source>&amp;File</source>
-        <translation>&amp;Súbor</translation>
+        <translation>&amp;Datoteka</translation>
     </message>
     <message>
         <source>&amp;Settings</source>
-        <translation>&amp;Nastavenia</translation>
+        <translation>&amp;Nastavitve</translation>
     </message>
     <message>
         <source>&amp;Help</source>
-        <translation>&amp;Pomoc</translation>
+        <translation>&amp;Pomoč</translation>
     </message>
     <message>
         <source>Tabs toolbar</source>
-        <translation>Lišta nástrojov</translation>
+        <translation>Orodna vrstica zavihkov</translation>
     </message>
     <message>
         <source>Syncing Headers (%1%)…</source>
-        <translation type="unfinished">Synchronizujú sa hlavičky (%1%)…</translation>
+        <translation type="unfinished">Sinhroniziram zaglavja (%1%)...</translation>
     </message>
     <message>
         <source>Synchronizing with network…</source>
-        <translation type="unfinished">Synchronizácia so sieťou…</translation>
+        <translation type="unfinished">Dohitevam omrežje ...</translation>
     </message>
     <message>
         <source>Indexing blocks on disk…</source>
-        <translation type="unfinished">Indexujem bloky na disku…</translation>
+        <translation type="unfinished">Izdelujem kazalo blokov na disku...</translation>
     </message>
     <message>
         <source>Processing blocks on disk…</source>
-        <translation type="unfinished">Spracovávam bloky na disku…</translation>
+        <translation type="unfinished">Procesiram bloke na disku...</translation>
     </message>
     <message>
         <source>Reindexing blocks on disk…</source>
-        <translation type="unfinished">Pre-indexujem bloky na disku…</translation>
+        <translation type="unfinished">Ponovno izdelujem kazala blokov na disku...</translation>
     </message>
     <message>
         <source>Connecting to peers…</source>
-        <translation type="unfinished">Pripája sa k partnerom…</translation>
+        <translation type="unfinished">Povezujem se s soležniki...</translation>
     </message>
     <message>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
-        <translation type="unfinished">Vyžiadať platby (vygeneruje QR kódy a bitcoin: URI)</translation>
+        <translation type="unfinished">Zahtevajte plačilo (ustvarite zahtevek s QR-kodo in URI tipa bitcoin:)</translation>
     </message>
     <message>
         <source>Show the list of used sending addresses and labels</source>
-        <translation type="unfinished">Zobraziť zoznam použitých adries odosielateľa a ich popisy</translation>
+        <translation type="unfinished">Prikaži seznam naslovov in oznak, na katere ste kdaj poslali plačila</translation>
     </message>
     <message>
         <source>Show the list of used receiving addresses and labels</source>
-        <translation type="unfinished">Zobraziť zoznam použitých prijímacích adries a ich popisov</translation>
+        <translation type="unfinished">Prikaži seznam naslovov in oznak, na katere ste kdaj prejeli plačila</translation>
     </message>
     <message>
         <source>&amp;Command-line options</source>
-        <translation type="unfinished">&amp;Možnosti príkazového riadku</translation>
+        <translation type="unfinished">Možnosti &amp;ukazne vrstice</translation>
     </message>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation>
-            <numerusform>Spracovaný %n blok transakčnej histórie.</numerusform>
-            <numerusform>Spracované %n bloky transakčnej histórie.</numerusform>
-            <numerusform>Spracovaných %n blokov transakčnej histórie.</numerusform>
+            <numerusform>Obdelan je %n blok zgodovine transakcij.</numerusform>
+            <numerusform>Obdelana sta %n bloka zgodovine transakcij.</numerusform>
+            <numerusform>Obdelani so %n bloki zgodovine transakcij.</numerusform>
+            <numerusform>Obdelanih je %n blokov zgodovine transakcij.</numerusform>
         </translation>
     </message>
     <message>
         <source>%1 behind</source>
-        <translation>%1 pozadu</translation>
+        <translation>%1 zaostanka</translation>
     </message>
     <message>
         <source>Catching up…</source>
-        <translation type="unfinished">Sťahujem…</translation>
+        <translation type="unfinished">Dohitevam...</translation>
     </message>
     <message>
         <source>Last received block was generated %1 ago.</source>
-        <translation>Posledný prijatý blok bol vygenerovaný pred: %1.</translation>
+        <translation>Zadnji prejeti blok je star %1.</translation>
     </message>
     <message>
         <source>Transactions after this will not yet be visible.</source>
-        <translation>Transakcie po tomto čase ešte nebudú viditeľné.</translation>
+        <translation>Novejše transakcije še ne bodo vidne.</translation>
     </message>
     <message>
         <source>Error</source>
-        <translation>Chyba</translation>
+        <translation>Napaka</translation>
     </message>
     <message>
         <source>Warning</source>
-        <translation>Upozornenie</translation>
+        <translation>Opozorilo</translation>
     </message>
     <message>
         <source>Information</source>
-        <translation>Informácie</translation>
+        <translation>Informacije</translation>
     </message>
     <message>
         <source>Up to date</source>
-        <translation>Aktualizovaný</translation>
+        <translation>Ažurno</translation>
     </message>
     <message>
         <source>Load Partially Signed Bitcoin Transaction</source>
-        <translation type="unfinished">Načítať sčasti podpísanú Bitcoin transakciu</translation>
+        <translation type="unfinished">Naloži delno podpisano bitcoin-transakcijo</translation>
     </message>
     <message>
         <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
-        <translation type="unfinished">Načítať čiastočne podpísanú Bitcoin transakciu, ktorú ste skopírovali</translation>
+        <translation type="unfinished">Naloži delno podpisano bitcoin-transakcijo z odložišča</translation>
     </message>
     <message>
         <source>Node window</source>
-        <translation type="unfinished">Okno uzlov</translation>
+        <translation type="unfinished">Okno vozlišča</translation>
     </message>
     <message>
         <source>Open node debugging and diagnostic console</source>
-        <translation type="unfinished">Otvor konzolu pre ladenie a diagnostiku uzlu</translation>
+        <translation type="unfinished">Odpri konzolo za razhroščevanje in diagnostiko</translation>
     </message>
     <message>
         <source>&amp;Sending addresses</source>
-        <translation type="unfinished">&amp;Odosielajúce adresy</translation>
+        <translation type="unfinished">Naslovi za &amp;pošiljanje ...</translation>
     </message>
     <message>
         <source>&amp;Receiving addresses</source>
-        <translation type="unfinished">&amp;Prijímajúce adresy</translation>
+        <translation type="unfinished">&amp;Naslovi za prejemanje</translation>
     </message>
     <message>
         <source>Open a bitcoin: URI</source>
-        <translation type="unfinished">Otvoriť bitcoin: URI</translation>
+        <translation type="unfinished">Odpri URI tipa bitcoin:</translation>
     </message>
     <message>
         <source>Open Wallet</source>
-        <translation type="unfinished">Otvoriť peňaženku</translation>
+        <translation type="unfinished">Odpri denarnico</translation>
     </message>
     <message>
         <source>Open a wallet</source>
-        <translation type="unfinished">Otvoriť peňaženku</translation>
+        <translation type="unfinished">Odpri denarnico</translation>
     </message>
     <message>
         <source>Close wallet</source>
-        <translation type="unfinished">Zatvoriť peňaženku</translation>
+        <translation type="unfinished">Zapri denarnico</translation>
     </message>
     <message>
         <source>Close all wallets</source>
-        <translation type="unfinished">Zatvoriť všetky peňaženky</translation>
+        <translation type="unfinished">Zapri vse denarnice</translation>
     </message>
     <message>
         <source>Show the %1 help message to get a list with possible Bitcoin command-line options</source>
-        <translation type="unfinished">Ukáž %1 zoznam možných nastavení Bitcoinu pomocou príkazového riadku</translation>
+        <translation type="unfinished">Pokaži sporočilo %1 za pomoč s seznamom vseh možnosti v ukazni vrstici</translation>
     </message>
     <message>
         <source>&amp;Mask values</source>
-        <translation type="unfinished">&amp;Skryť hodnoty</translation>
+        <translation type="unfinished">Za&amp;maskiraj vrednosti</translation>
     </message>
     <message>
         <source>Mask the values in the Overview tab</source>
-        <translation type="unfinished">Skryť hodnoty v karte "Prehľad"</translation>
+        <translation type="unfinished">Zamaskiraj vrednosti v zavihku Pregled</translation>
     </message>
     <message>
         <source>default wallet</source>
-        <translation type="unfinished">predvolená peňaženka</translation>
+        <translation type="unfinished">privzeta denarnica</translation>
     </message>
     <message>
         <source>No wallets available</source>
-        <translation type="unfinished">Nie je dostupná žiadna peňaženka</translation>
+        <translation type="unfinished">Ni denarnic na voljo</translation>
     </message>
     <message>
         <source>&amp;Window</source>
-        <translation type="unfinished">&amp;Okno</translation>
+        <translation type="unfinished">O&amp;kno</translation>
     </message>
     <message>
         <source>Minimize</source>
-        <translation type="unfinished">Minimalizovať</translation>
+        <translation type="unfinished">Pomanjšaj</translation>
     </message>
     <message>
         <source>Zoom</source>
-        <translation type="unfinished">Priblížiť</translation>
+        <translation type="unfinished">Povečaj</translation>
     </message>
     <message>
         <source>Main Window</source>
-        <translation type="unfinished">Hlavné okno</translation>
+        <translation type="unfinished">Glavno okno</translation>
     </message>
     <message>
         <source>%1 client</source>
-        <translation type="unfinished">%1 klient</translation>
+        <translation type="unfinished">Odjemalec %1</translation>
     </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform>%n aktívne pripojenie do siete Bitcoin</numerusform>
-            <numerusform>%n aktívne pripojenia do siete Bitcoin</numerusform>
-            <numerusform>%n aktívnych pripojení do siete Bitcoin</numerusform>
+            <numerusform>%n aktivna povezava v omrežje bitcoin</numerusform>
+            <numerusform>%n aktivni povezavi v omrežje bitcoin</numerusform>
+            <numerusform>%n aktivne povezave v omrežje bitcoin</numerusform>
+            <numerusform>%n aktivnih povezav v omrežje bitcoin</numerusform>
         </translation>
     </message>
     <message>
         <source>Click for more actions.</source>
         <extracomment>A substring of the tooltip. "More actions" are available via the context menu.</extracomment>
-        <translation type="unfinished">Kliknite pre viac akcií.</translation>
+        <translation type="unfinished">Kliknite za več dejanj.</translation>
     </message>
     <message>
         <source>Show Peers tab</source>
         <extracomment>A context menu item. The "Peers tab" is an element of the "Node window".</extracomment>
-        <translation type="unfinished">Zobraziť kartu Partneri</translation>
+        <translation type="unfinished">Prikaži zavihek Soležniki</translation>
     </message>
     <message>
         <source>Disable network activity</source>
         <extracomment>A context menu item.</extracomment>
-        <translation type="unfinished">Zakázať sieťovú aktivitu</translation>
+        <translation type="unfinished">Onemogoči omrežno aktivnost</translation>
     </message>
     <message>
         <source>Enable network activity</source>
         <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
-        <translation type="unfinished">Povoliť sieťovú aktivitu</translation>
+        <translation type="unfinished">Omogoči omrežno aktivnost</translation>
     </message>
     <message>
         <source>Error: %1</source>
-        <translation type="unfinished">Chyba: %1</translation>
+        <translation type="unfinished">Napaka: %1</translation>
     </message>
     <message>
         <source>Warning: %1</source>
-        <translation type="unfinished">Upozornenie: %1</translation>
+        <translation type="unfinished">Opozorilo: %1</translation>
     </message>
     <message>
         <source>Date: %1
 </source>
-        <translation type="unfinished">Dátum: %1
+        <translation type="unfinished">Datum: %1
 </translation>
     </message>
     <message>
         <source>Amount: %1
 </source>
-        <translation type="unfinished">Suma: %1
+        <translation type="unfinished">Znesek: %1
 </translation>
     </message>
     <message>
         <source>Wallet: %1
 </source>
-        <translation type="unfinished">Peňaženka: %1
+        <translation type="unfinished">Denarnica: %1
 </translation>
     </message>
     <message>
         <source>Type: %1
 </source>
-        <translation type="unfinished">Typ: %1
+        <translation type="unfinished">Vrsta: %1
 </translation>
     </message>
     <message>
         <source>Label: %1
 </source>
-        <translation type="unfinished">Popis: %1
+        <translation type="unfinished">Oznaka: %1
 </translation>
     </message>
     <message>
         <source>Address: %1
 </source>
-        <translation type="unfinished">Adresa: %1
+        <translation type="unfinished">Naslov: %1
 </translation>
     </message>
     <message>
         <source>Sent transaction</source>
-        <translation>Odoslané transakcie</translation>
+        <translation>Odliv</translation>
     </message>
     <message>
         <source>Incoming transaction</source>
-        <translation>Prijatá transakcia</translation>
+        <translation>Priliv</translation>
     </message>
     <message>
         <source>HD key generation is &lt;b&gt;enabled&lt;/b&gt;</source>
-        <translation type="unfinished">Generovanie HD kľúčov je &lt;b&gt;zapnuté&lt;/b&gt;</translation>
+        <translation type="unfinished">HD-tvorba ključev je &lt;b&gt;omogočena&lt;/b&gt;</translation>
     </message>
     <message>
         <source>HD key generation is &lt;b&gt;disabled&lt;/b&gt;</source>
-        <translation type="unfinished">Generovanie HD kľúčov je &lt;b&gt;vypnuté&lt;/b&gt;</translation>
+        <translation type="unfinished">HD-tvorba ključev je &lt;b&gt;onemogočena&lt;/b&gt;</translation>
     </message>
     <message>
         <source>Private key &lt;b&gt;disabled&lt;/b&gt;</source>
-        <translation type="unfinished">Súkromný kľúč &lt;b&gt;vypnutý&lt;/b&gt;</translation>
+        <translation type="unfinished">Zasebni ključ &lt;b&gt;onemogočen&lt;/b&gt;</translation>
     </message>
     <message>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
-        <translation>Peňaženka je &lt;b&gt;zašifrovaná&lt;/b&gt; a momentálne &lt;b&gt;odomknutá&lt;/b&gt;</translation>
+        <translation>Denarnica je &lt;b&gt;šifrirana&lt;/b&gt; in trenutno &lt;b&gt;odklenjena&lt;/b&gt;</translation>
     </message>
     <message>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
-        <translation>Peňaženka je &lt;b&gt;zašifrovaná&lt;/b&gt; a momentálne &lt;b&gt;zamknutá&lt;/b&gt;</translation>
+        <translation>Denarnica je &lt;b&gt;šifrirana&lt;/b&gt; in trenutno &lt;b&gt;zaklenjena&lt;/b&gt;</translation>
     </message>
     <message>
         <source>Original message:</source>
-        <translation type="unfinished">Pôvodná správa:</translation>
+        <translation type="unfinished">Izvorno sporočilo:</translation>
     </message>
 </context>
 <context>
     <name>UnitDisplayStatusBarControl</name>
     <message>
         <source>Unit to show amounts in. Click to select another unit.</source>
-        <translation type="unfinished">Jednotka pre zobrazovanie súm. Kliknite pre zvolenie inej jednotky.</translation>
+        <translation type="unfinished">Merska enota za prikaz zneskov. Kliknite za izbiro druge enote.</translation>
     </message>
 </context>
 <context>
     <name>CoinControlDialog</name>
     <message>
         <source>Coin Selection</source>
-        <translation type="unfinished">Výber mince</translation>
+        <translation type="unfinished">Izbira vhodnih kovancev</translation>
     </message>
     <message>
         <source>Quantity:</source>
-        <translation type="unfinished">Množstvo:</translation>
+        <translation type="unfinished">Št. vhodov:</translation>
     </message>
     <message>
         <source>Bytes:</source>
-        <translation type="unfinished">Bajtov:</translation>
+        <translation type="unfinished">Število bajtov:</translation>
     </message>
     <message>
         <source>Amount:</source>
-        <translation type="unfinished">Suma:</translation>
+        <translation type="unfinished">Znesek:</translation>
     </message>
     <message>
         <source>Fee:</source>
-        <translation type="unfinished">Poplatok:</translation>
+        <translation type="unfinished">Provizija:</translation>
     </message>
     <message>
         <source>Dust:</source>
-        <translation type="unfinished">Prach:</translation>
+        <translation type="unfinished">Prah:</translation>
     </message>
     <message>
         <source>After Fee:</source>
-        <translation type="unfinished">Po poplatku:</translation>
+        <translation type="unfinished">Po proviziji:</translation>
     </message>
     <message>
         <source>Change:</source>
-        <translation type="unfinished">Zmena:</translation>
+        <translation type="unfinished">Vračilo:</translation>
     </message>
     <message>
         <source>(un)select all</source>
-        <translation type="unfinished">(ne)vybrať všetko</translation>
+        <translation type="unfinished">izberi vse/nič</translation>
     </message>
     <message>
         <source>Tree mode</source>
-        <translation type="unfinished">Stromový režim</translation>
+        <translation type="unfinished">Drevesni prikaz</translation>
     </message>
     <message>
         <source>List mode</source>
-        <translation type="unfinished">Zoznamový režim</translation>
+        <translation type="unfinished">Seznam</translation>
     </message>
     <message>
         <source>Amount</source>
-        <translation type="unfinished">Suma</translation>
+        <translation type="unfinished">Znesek</translation>
     </message>
     <message>
         <source>Received with label</source>
-        <translation type="unfinished">Prijaté s označením</translation>
+        <translation type="unfinished">Oznaka priliva</translation>
     </message>
     <message>
         <source>Received with address</source>
-        <translation type="unfinished">Prijaté s adresou</translation>
+        <translation type="unfinished">Naslov priliva</translation>
     </message>
     <message>
         <source>Date</source>
-        <translation type="unfinished">Dátum</translation>
+        <translation type="unfinished">Datum</translation>
     </message>
     <message>
         <source>Confirmations</source>
-        <translation type="unfinished">Potvrdenia</translation>
+        <translation type="unfinished">Potrditve</translation>
     </message>
     <message>
         <source>Confirmed</source>
-        <translation type="unfinished">Potvrdené</translation>
+        <translation type="unfinished">Potrjeno</translation>
     </message>
     <message>
         <source>Copy amount</source>
-        <translation type="unfinished">Kopírovať sumu</translation>
+        <translation type="unfinished">Kopiraj znesek</translation>
     </message>
     <message>
         <source>&amp;Copy address</source>
-        <translation type="unfinished">&amp;Kopírovať adresu</translation>
+        <translation type="unfinished">&amp;Kopiraj naslov</translation>
     </message>
     <message>
         <source>Copy &amp;label</source>
-        <translation type="unfinished">Kopírovať &amp;popis</translation>
+        <translation type="unfinished">Kopiraj &amp;oznako</translation>
     </message>
     <message>
         <source>Copy &amp;amount</source>
-        <translation type="unfinished">Kopírovať &amp;sumu</translation>
+        <translation type="unfinished">Kopiraj &amp;znesek</translation>
     </message>
     <message>
         <source>Copy transaction &amp;ID</source>
-        <translation type="unfinished">Kopírovať &amp;ID transakcie</translation>
+        <translation type="unfinished">Kopiraj &amp;ID transakcije</translation>
     </message>
     <message>
         <source>L&amp;ock unspent</source>
-        <translation type="unfinished">U&amp;zamknúť neminuté</translation>
+        <translation type="unfinished">&amp;Zakleni nepotrošene</translation>
     </message>
     <message>
         <source>&amp;Unlock unspent</source>
-        <translation type="unfinished">&amp;Odomknúť neminuté</translation>
+        <translation type="unfinished">&amp;Odkleni nepotrošene</translation>
     </message>
     <message>
         <source>Copy quantity</source>
-        <translation type="unfinished">Kopírovať množstvo</translation>
+        <translation type="unfinished">Kopiraj količino</translation>
     </message>
     <message>
         <source>Copy fee</source>
-        <translation type="unfinished">Kopírovať poplatok</translation>
+        <translation type="unfinished">Kopiraj provizijo</translation>
     </message>
     <message>
         <source>Copy after fee</source>
-        <translation type="unfinished">Kopírovať po poplatkoch</translation>
+        <translation type="unfinished">Kopiraj znesek po proviziji</translation>
     </message>
     <message>
         <source>Copy bytes</source>
-        <translation type="unfinished">Kopírovať bajty</translation>
+        <translation type="unfinished">Kopiraj bajte</translation>
     </message>
     <message>
         <source>Copy dust</source>
-        <translation type="unfinished">Kopírovať prach</translation>
+        <translation type="unfinished">Kopiraj prah</translation>
     </message>
     <message>
         <source>Copy change</source>
-        <translation type="unfinished">Kopírovať zmenu</translation>
-    </message>
-    <message>
-        <source>(%1 locked)</source>
-        <translation type="unfinished">(%1 zamknutých)</translation>
+        <translation type="unfinished">Kopiraj vračilo</translation>
     </message>
     <message>
         <source>yes</source>
-        <translation type="unfinished">áno</translation>
+        <translation type="unfinished">da</translation>
     </message>
     <message>
         <source>no</source>
-        <translation type="unfinished">nie</translation>
+        <translation type="unfinished">ne</translation>
     </message>
     <message>
         <source>This label turns red if any recipient receives an amount smaller than the current dust threshold.</source>
-        <translation type="unfinished">Tento popis sčervenie ak ktorýkoľvek príjemca dostane sumu menšiu ako súčasný limit pre "prach".</translation>
+        <translation type="unfinished">Ta oznaka postane rdeča, če kateri od prejemnikov prejme znesek, nižji od trenutne meje prahu.</translation>
     </message>
     <message>
         <source>Can vary +/- %1 satoshi(s) per input.</source>
-        <translation type="unfinished">Môže sa líšiť o +/- %1 satoshi(s) pre každý vstup.</translation>
+        <translation type="unfinished">Lahko se razlikuje za +/- %1 sat na vhod.</translation>
     </message>
     <message>
         <source>(no label)</source>
-        <translation type="unfinished">(bez popisu)</translation>
+        <translation type="unfinished">(brez oznake)</translation>
     </message>
     <message>
         <source>change from %1 (%2)</source>
-        <translation type="unfinished">zmeniť z %1 (%2)</translation>
+        <translation type="unfinished">vračilo od %1 (%2)</translation>
     </message>
     <message>
         <source>(change)</source>
-        <translation type="unfinished">(zmena)</translation>
+        <translation type="unfinished">(vračilo)</translation>
     </message>
 </context>
 <context>
     <name>CreateWalletActivity</name>
     <message>
         <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
-        <translation type="unfinished">Vytvára sa peňaženka &lt;b&gt;%1&lt;/b&gt;…</translation>
+        <translation type="unfinished">Ustvarjam denarnico &lt;b&gt;%1&lt;/b&gt;...</translation>
     </message>
     <message>
         <source>Create wallet failed</source>
-        <translation type="unfinished">Vytvorenie peňaženky zlyhalo</translation>
+        <translation type="unfinished">Ustvarjanje denarnice je spodletelo</translation>
     </message>
     <message>
         <source>Create wallet warning</source>
-        <translation type="unfinished">Varovanie vytvárania peňaženky</translation>
+        <translation type="unfinished">Opozorilo pri ustvarjanju denarnice</translation>
     </message>
     <message>
         <source>Can't list signers</source>
-        <translation type="unfinished">Nemôžem zobraziť podpisovateľov</translation>
+        <translation type="unfinished">Ne morem našteti podpisnikov</translation>
     </message>
 </context>
 <context>
     <name>OpenWalletActivity</name>
     <message>
         <source>Open wallet failed</source>
-        <translation type="unfinished">Otvorenie peňaženky zlyhalo</translation>
+        <translation type="unfinished">Odpiranje denarnice je spodletelo</translation>
     </message>
     <message>
         <source>Open wallet warning</source>
-        <translation type="unfinished">Varovanie otvárania peňaženky</translation>
+        <translation type="unfinished">Opozorilo pri odpiranju denarnice</translation>
     </message>
     <message>
         <source>default wallet</source>
-        <translation type="unfinished">predvolená peňaženka</translation>
+        <translation type="unfinished">privzeta denarnica</translation>
     </message>
     <message>
         <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
-        <translation type="unfinished">Otvára sa peňaženka &lt;b&gt;%1&lt;/b&gt;…</translation>
+        <translation type="unfinished">Odpiram denarnico &lt;b&gt;%1&lt;/b&gt;...</translation>
     </message>
 </context>
 <context>
     <name>WalletController</name>
     <message>
         <source>Close wallet</source>
-        <translation type="unfinished">Zatvoriť peňaženku</translation>
+        <translation type="unfinished">Zapri denarnico</translation>
     </message>
     <message>
         <source>Are you sure you wish to close the wallet &lt;i&gt;%1&lt;/i&gt;?</source>
-        <translation type="unfinished">Naozaj chcete zavrieť peňaženku &lt;i&gt;%1&lt;/i&gt;?</translation>
+        <translation type="unfinished">Ste prepričani, da želite zapreti denarnico &lt;i&gt;%1&lt;/i&gt;?</translation>
     </message>
     <message>
         <source>Closing the wallet for too long can result in having to resync the entire chain if pruning is enabled.</source>
-        <translation type="unfinished">Zatvorenie peňaženky na príliš dlhú dobu môže mať za následok potrebu znova synchronizovať celý reťazec blokov (blockchain) v prípade, že je aktivované redukovanie blokov.</translation>
+        <translation type="unfinished">Če denarnica ostane zaprta predolgo in je obrezovanje vklopljeno, boste morda morali ponovno prenesti celotno verigo blokov.</translation>
     </message>
     <message>
         <source>Close all wallets</source>
-        <translation type="unfinished">Zatvoriť všetky peňaženky</translation>
+        <translation type="unfinished">Zapri vse denarnice</translation>
     </message>
     <message>
         <source>Are you sure you wish to close all wallets?</source>
-        <translation type="unfinished">Naozaj si želáte zatvoriť všetky peňaženky?</translation>
+        <translation type="unfinished">Ste prepričani, da želite zapreti vse denarnice?</translation>
     </message>
 </context>
 <context>
     <name>CreateWalletDialog</name>
     <message>
         <source>Create Wallet</source>
-        <translation type="unfinished">Vytvoriť peňaženku</translation>
+        <translation type="unfinished">Ustvari denarnico</translation>
     </message>
     <message>
         <source>Wallet Name</source>
-        <translation type="unfinished">Názov peňaženky</translation>
+        <translation type="unfinished">Ime denarnice</translation>
     </message>
     <message>
         <source>Wallet</source>
-        <translation type="unfinished">Peňaženka</translation>
+        <translation type="unfinished">Denarnica</translation>
     </message>
     <message>
         <source>Encrypt the wallet. The wallet will be encrypted with a passphrase of your choice.</source>
-        <translation type="unfinished">Zašifrovať peňaženku. Peňaženka bude zašifrovaná frázou, ktoré si zvolíte.</translation>
+        <translation type="unfinished">Šifriraj denarnico. Denarnica bo šifrirana z geslom, ki ga izberete.</translation>
     </message>
     <message>
         <source>Encrypt Wallet</source>
-        <translation type="unfinished">Zašifrovať peňaženku</translation>
+        <translation type="unfinished">Šifriraj denarnico</translation>
     </message>
     <message>
         <source>Advanced Options</source>
-        <translation type="unfinished">Rozšírené nastavenia</translation>
+        <translation type="unfinished">Napredne možnosti</translation>
     </message>
     <message>
         <source>Disable private keys for this wallet. Wallets with private keys disabled will have no private keys and cannot have an HD seed or imported private keys. This is ideal for watch-only wallets.</source>
-        <translation type="unfinished">Vypnúť súkromné kľúče pre túto peňaženku. Peňaženky s vypnutými súkromnými kľúčmi nebudú mať súkromné kľúče a nemôžu mať HD inicializáciu ani importované súkromné kľúče. Toto je ideálne pre peňaženky iba na sledovanie.</translation>
+        <translation type="unfinished">Onemogoči zasebne ključe za to denarnico. Denarnice z onemogočenimi zasebnimi ključi ne bodo imele zasebnih ključev in ne morejo imeti HD-semena ali uvoženih zasebnih ključev. To je primerno za opazovane denarnice.</translation>
     </message>
     <message>
         <source>Disable Private Keys</source>
-        <translation type="unfinished">Vypnúť súkromné kľúče</translation>
+        <translation type="unfinished">Onemogoči zasebne ključe</translation>
     </message>
     <message>
         <source>Make a blank wallet. Blank wallets do not initially have private keys or scripts. Private keys and addresses can be imported, or an HD seed can be set, at a later time.</source>
-        <translation type="unfinished">Vytvoriť prázdnu peňaženku. Prázdne peňaženky na začiatku nemajú žiadne súkromné kľúče ani skripty. Neskôr môžu byť importované súkromné kľúče a adresy alebo nastavená HD inicializácia.</translation>
+        <translation type="unfinished">Ustvari prazno denarnico. Prazne denarnice ne vključujejo zasebnih ključev ali skript. Pozneje lahko uvozite zasebne ključe ali vnesete HD-seme.</translation>
     </message>
     <message>
         <source>Make Blank Wallet</source>
-        <translation type="unfinished">Vytvoriť prázdnu peňaženku</translation>
+        <translation type="unfinished">Ustvari prazno denarnico</translation>
     </message>
     <message>
         <source>Use descriptors for scriptPubKey management</source>
-        <translation type="unfinished">Na správu scriptPubKey používajte deskriptory</translation>
+        <translation type="unfinished">Uporabi deskriptorje za upravljanje s scriptPubKey</translation>
     </message>
     <message>
         <source>Descriptor Wallet</source>
-        <translation type="unfinished">Peňaženka deskriptora</translation>
+        <translation type="unfinished">Denarnica z deskriptorji</translation>
     </message>
     <message>
         <source>Use an external signing device such as a hardware wallet. Configure the external signer script in wallet preferences first.</source>
-        <translation type="unfinished">Použiť externé podpisovacie zariadenie ako napr. hardvérová peňaženka. Nastavte najprv externý skript podpisovateľa v nastaveniach peňaženky.</translation>
+        <translation type="unfinished">Za podpisovanje uporabite zunanjo napravo, kot je n.pr. hardverska denarnica. Najprej nastavite zunanjega podpisnika v nastavitvah denarnice.</translation>
     </message>
     <message>
         <source>External signer</source>
-        <translation type="unfinished">Externý podpisovateľ</translation>
+        <translation type="unfinished">Zunanji podpisni</translation>
     </message>
     <message>
         <source>Create</source>
-        <translation type="unfinished">Vytvoriť</translation>
+        <translation type="unfinished">Ustvari</translation>
     </message>
     <message>
         <source>Compiled without sqlite support (required for descriptor wallets)</source>
-        <translation type="unfinished">Zostavené bez podpory sqlite (povinné pre peňaženky deskriptorov)</translation>
+        <translation type="unfinished">Prevedeno brez podpore za SQLite (potrebna za deskriptorske denarnice)</translation>
     </message>
     <message>
         <source>Compiled without external signing support (required for external signing)</source>
         <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
-        <translation type="unfinished">Skompilované bez podpory externého podpisovania (potrebné pre externé podpisovanie)</translation>
+        <translation type="unfinished">Prevedeno brez podpore za zunanje podpisovanje</translation>
     </message>
 </context>
 <context>
     <name>EditAddressDialog</name>
     <message>
         <source>Edit Address</source>
-        <translation>Upraviť adresu</translation>
+        <translation>Uredi naslov</translation>
     </message>
     <message>
         <source>&amp;Label</source>
-        <translation>&amp;Popis</translation>
+        <translation>&amp;Oznaka</translation>
     </message>
     <message>
         <source>The label associated with this address list entry</source>
-        <translation type="unfinished">Popis spojený s týmto záznamom v adresári</translation>
+        <translation type="unfinished">Oznaka tega naslova</translation>
     </message>
     <message>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
-        <translation type="unfinished">Adresa spojená s týmto záznamom v adresári. Možno upravovať len pre odosielajúce adresy.</translation>
+        <translation type="unfinished">Oznaka tega naslova. Urejate jo lahko le pri naslovih za pošiljanje.</translation>
     </message>
     <message>
         <source>&amp;Address</source>
-        <translation>&amp;Adresa</translation>
+        <translation>&amp;Naslov</translation>
     </message>
     <message>
         <source>New sending address</source>
-        <translation type="unfinished">Nová adresa pre odoslanie</translation>
+        <translation type="unfinished">Nov naslov za pošiljanje</translation>
     </message>
     <message>
         <source>Edit receiving address</source>
-        <translation type="unfinished">Upraviť prijímajúcu adresu</translation>
+        <translation type="unfinished">Uredi prejemni naslov</translation>
     </message>
     <message>
         <source>Edit sending address</source>
-        <translation type="unfinished">Upraviť odosielaciu adresu</translation>
+        <translation type="unfinished">Uredi naslov za pošiljanje</translation>
     </message>
     <message>
         <source>The entered address "%1" is not a valid Bitcoin address.</source>
-        <translation type="unfinished">Vložená adresa "%1" nieje platnou adresou Bitcoin.</translation>
+        <translation type="unfinished">Vnešeni naslov "%1" ni veljaven bitcoin-naslov.</translation>
     </message>
     <message>
         <source>Address "%1" already exists as a receiving address with label "%2" and so cannot be added as a sending address.</source>
-        <translation type="unfinished">Adresa "%1" už existuje ako prijímacia adresa s označením "%2" .Nemôže tak byť pridaná ako odosielacia adresa.</translation>
+        <translation type="unfinished">Naslov "%1" že obstaja kot naslov za prejemanje z oznako "%2", zato ga ne morete dodati kot naslov za pošiljanje.</translation>
     </message>
     <message>
         <source>The entered address "%1" is already in the address book with label "%2".</source>
-        <translation type="unfinished">Zadaná adresa "%1" sa už nachádza v zozname adries s označením "%2".</translation>
+        <translation type="unfinished">Vnešeni naslov "%1" je že v imeniku, in sicer z oznako "%2".</translation>
     </message>
     <message>
         <source>Could not unlock wallet.</source>
-        <translation type="unfinished">Nepodarilo sa odomknúť peňaženku.</translation>
+        <translation type="unfinished">Denarnice ni bilo mogoče odkleniti.</translation>
     </message>
     <message>
         <source>New key generation failed.</source>
-        <translation type="unfinished">Generovanie nového kľúča zlyhalo.</translation>
+        <translation type="unfinished">Generiranje novega ključa je spodletelo.</translation>
     </message>
 </context>
 <context>
     <name>FreespaceChecker</name>
     <message>
         <source>A new data directory will be created.</source>
-        <translation>Bude vytvorený nový dátový adresár.</translation>
+        <translation>Ustvarjena bo nova podatkovna mapa.</translation>
     </message>
     <message>
         <source>name</source>
-        <translation>názov</translation>
+        <translation>ime</translation>
     </message>
     <message>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
-        <translation>Priečinok už existuje. Pridajte "%1", ak tu chcete vytvoriť nový priečinok.</translation>
+        <translation>Mapa že obstaja. Dodajte %1, če želite tu ustvariti novo mapo.</translation>
     </message>
     <message>
         <source>Path already exists, and is not a directory.</source>
-        <translation>Cesta už existuje a nie je to adresár.</translation>
+        <translation>Pot že obstaja, vendar ni mapa.</translation>
     </message>
     <message>
         <source>Cannot create data directory here.</source>
-        <translation>Tu nemôžem vytvoriť dátový adresár.</translation>
+        <translation>Na tem mestu ni mogoče ustvariti nove mape.</translation>
     </message>
 </context>
 <context>
     <name>Intro</name>
     <message>
         <source>%1 GB of free space available</source>
-        <translation type="unfinished">%1 GB voľného miesta</translation>
+        <translation type="unfinished">Na voljo je %1 GB prostora.</translation>
     </message>
     <message>
         <source>(of %1 GB needed)</source>
-        <translation type="unfinished">(z %1 GB potrebných)</translation>
-    </message>
-    <message>
-        <source>(%1 GB needed for full chain)</source>
-        <translation type="unfinished">(%1 GB potrebných pre plný reťazec)</translation>
+        <translation type="unfinished">(od potrebnih %1 GB)</translation>
     </message>
     <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
-        <translation type="unfinished">V tejto zložke bude uložených aspoň %1 GB dát a postupom času sa bude zväčšovať.</translation>
+        <translation type="unfinished">V  tem direktoriju bo shranjenih vsaj %1 GB podatkov, količina podatkov pa bo s časom naraščala.</translation>
     </message>
     <message>
         <source>Approximately %1 GB of data will be stored in this directory.</source>
-        <translation type="unfinished">Približne %1 GB dát bude uložených v tejto zložke.</translation>
+        <translation type="unfinished">V tem direktoriju bo shranjenih približno %1 GB podatkov.</translation>
     </message>
     <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform>(dostatočné pre obnovenie záloh %n deň starých)</numerusform>
-            <numerusform>(dostatočné pre obnovenie záloh %n dni staré)</numerusform>
-            <numerusform>(dostatočné pre obnovenie záloh %n dní starých)</numerusform>
+            <numerusform>(dovolj za obnovitev varnostnih kopij, starih %n dan)</numerusform>
+            <numerusform>(dovolj za obnovitev varnostnih kopij, starih %n dni)</numerusform>
+            <numerusform>(dovolj za obnovitev varnostnih kopij, starih %n dni)</numerusform>
+            <numerusform>(dovolj za obnovitev varnostnih kopij, starih %n dni)</numerusform>
         </translation>
     </message>
     <message>
         <source>%1 will download and store a copy of the Bitcoin block chain.</source>
-        <translation type="unfinished">%1 bude sťahovať kopiu reťazca blokov.</translation>
+        <translation type="unfinished">%1 bo prenesel in shranil kopijo verige blokov.</translation>
     </message>
     <message>
         <source>The wallet will also be stored in this directory.</source>
-        <translation type="unfinished">Tvoja peňaženka bude uložena tiež v tomto adresári.</translation>
+        <translation type="unfinished">Tudi denarnica bo shranjena v tem direktoriju.</translation>
     </message>
     <message>
         <source>Error: Specified data directory "%1" cannot be created.</source>
-        <translation type="unfinished">Chyba: Zadaný priečinok pre dáta "%1" nemôže byť vytvorený.</translation>
+        <translation type="unfinished">Napaka: Ni mogoče ustvariti mape "%1".</translation>
     </message>
     <message>
         <source>Error</source>
-        <translation>Chyba</translation>
+        <translation>Napaka</translation>
     </message>
     <message>
         <source>Welcome</source>
-        <translation>Vitajte</translation>
+        <translation>Dobrodošli</translation>
     </message>
     <message>
         <source>Welcome to %1.</source>
-        <translation type="unfinished">Vitajte v %1</translation>
+        <translation type="unfinished">Dobrodošli v %1</translation>
     </message>
     <message>
         <source>As this is the first time the program is launched, you can choose where %1 will store its data.</source>
-        <translation type="unfinished">Keďže toto je prvé spustenie programu, môžete si vybrať, kam %1 bude ukladať vaše údaje.</translation>
+        <translation type="unfinished">Ker ste program zagnali prvič, lahko izberete, kje bo %1 shranil podatke.</translation>
     </message>
     <message>
         <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation type="unfinished">Hneď po stlačení OK, začne %1 sťahovať a spracovávať celý %4 blockchain (%2G B), začínajúc najaktuálnejšími transakciami z roku %3, kedy bol %4 spustený.</translation>
+        <translation type="unfinished">Ko kliknete OK, bo %1 začel prenašati podatke in procesirati celotno verigo blokov %4 (%2 GB), začenši z najstarejšo transakcijo iz %3 ob prvotnem začetku %4.</translation>
     </message>
     <message>
         <source>Limit block chain storage to</source>
-        <translation type="unfinished">Obmedziť veľkosť reťazca blokov na</translation>
+        <translation type="unfinished">Omeji velikost shrambe verige blokov na </translation>
     </message>
     <message>
         <source>Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</source>
-        <translation type="unfinished">Zvrátenie tohto nastavenia vyžaduje opätovné stiahnutie celého reťazca blokov. Je rýchlejšie najprv stiahnuť celý reťazec blokov a potom ho redukovať neskôr. Vypne niektoré pokročilé funkcie.</translation>
+        <translation type="unfinished">Če spremenite to nastavitev, boste morali ponovno naložiti celotno verigo blokov. Hitreje je najprej prenesti celotno verigo in jo obrezati pozneje. Ta nastavitev onemogoči nekatere napredne funkcije.</translation>
     </message>
     <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
-        <translation type="unfinished">Prvá synchronizácia je veľmi náročná a môžu sa tak vďaka nej začat na Vašom počítači prejavovať doteraz skryté hardwarové problémy. Vždy, keď spustíte %1, bude sťahovanie pokračovať tam, kde naposledy skončilo.</translation>
+        <translation type="unfinished">Začetna sinhronizacija je zelo zahtevna in lahko odkrije probleme s strojno opremo v vašem računalniku, ki so prej bili neopaženi. Vsakič, ko zaženete %1, bo le-ta nadaljeval s prenosom, kjer je prejšnjič ostal.</translation>
     </message>
     <message>
         <source>If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</source>
-        <translation type="unfinished">Ak ste obmedzili úložný priestor pre reťazec blokov (t.j. redukovanie), tak sa historické dáta síce stiahnu a spracujú, ale následne sa zasa zmažú, aby nezaberali na disku miesto.</translation>
+        <translation type="unfinished">Če ste se odločili omejiti shranjevanje blokovnih verig (obrezovanje), je treba zgodovinske podatke še vedno prenesti in obdelati, vendar bodo kasneje izbrisani, da bo poraba prostora nizka.</translation>
     </message>
     <message>
         <source>Use the default data directory</source>
-        <translation>Použiť predvolený dátový adresár</translation>
+        <translation>Uporabi privzeto podatkovno mapo</translation>
     </message>
     <message>
         <source>Use a custom data directory:</source>
-        <translation>Použiť vlastný dátový adresár:</translation>
+        <translation>Uporabi to podatkovno mapo:</translation>
     </message>
 </context>
 <context>
     <name>HelpMessageDialog</name>
     <message>
         <source>version</source>
-        <translation type="unfinished">verzia</translation>
+        <translation type="unfinished">različica</translation>
     </message>
     <message>
         <source>About %1</source>
@@ -1298,84 +1296,80 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Command-line options</source>
-        <translation type="unfinished">Voľby príkazového riadku</translation>
+        <translation type="unfinished">Možnosti ukazne vrstice</translation>
     </message>
 </context>
 <context>
     <name>ShutdownWindow</name>
     <message>
         <source>%1 is shutting down…</source>
-        <translation type="unfinished">%1 sa vypína…</translation>
+        <translation type="unfinished">%1 se zaustavlja...</translation>
     </message>
     <message>
         <source>Do not shut down the computer until this window disappears.</source>
-        <translation type="unfinished">Nevypínajte počítač kým toto okno nezmizne.</translation>
+        <translation type="unfinished">Ne zaustavljajte računalnika, dokler to okno ne izgine.</translation>
     </message>
 </context>
 <context>
     <name>ModalOverlay</name>
     <message>
         <source>Form</source>
-        <translation type="unfinished">Formulár</translation>
+        <translation type="unfinished">Obrazec</translation>
     </message>
     <message>
         <source>Recent transactions may not yet be visible, and therefore your wallet's balance might be incorrect. This information will be correct once your wallet has finished synchronizing with the bitcoin network, as detailed below.</source>
-        <translation type="unfinished">Nedávne transakcie nemusia byť ešte viditeľné preto môže byť zostatok vo vašej peňaženke nesprávny. Táto informácia bude správna keď sa dokončí synchronizovanie peňaženky so sieťou bitcoin, ako je rozpísané nižšie.</translation>
+        <translation type="unfinished">Zadnje transakcije morda še niso vidne, zato je prikazano dobroimetje v denarnici lahko napačno. Pravilni podatki bodo prikazani, ko bo vaša denarnica končala s sinhronizacijo z omrežjem bitcoin; glejte podrobnosti spodaj.</translation>
     </message>
     <message>
         <source>Attempting to spend bitcoins that are affected by not-yet-displayed transactions will not be accepted by the network.</source>
-        <translation type="unfinished">Pokus o minutie bitcoinov, ktoré sú ovplyvnené ešte nezobrazenými transakciami, nebude sieťou akceptovaný.</translation>
+        <translation type="unfinished">Poskusa pošiljanja bitcoinov, na katere vplivajo še ne prikazane transakcije, omrežje ne bo sprejelo.</translation>
     </message>
     <message>
         <source>Number of blocks left</source>
-        <translation type="unfinished">Počet zostávajúcich blokov</translation>
+        <translation type="unfinished">Preostalo število blokov</translation>
     </message>
     <message>
         <source>Unknown…</source>
-        <translation type="unfinished">Neznámy…</translation>
+        <translation type="unfinished">Neznano...</translation>
     </message>
     <message>
         <source>calculating…</source>
-        <translation type="unfinished">počíta sa…</translation>
+        <translation type="unfinished">računam...</translation>
     </message>
     <message>
         <source>Last block time</source>
-        <translation type="unfinished">Čas posledného bloku</translation>
+        <translation type="unfinished">Čas zadnjega bloka</translation>
     </message>
     <message>
         <source>Progress</source>
-        <translation type="unfinished">Postup synchronizácie</translation>
+        <translation type="unfinished">Napredek</translation>
     </message>
     <message>
         <source>Progress increase per hour</source>
-        <translation type="unfinished">Prírastok postupu za hodinu</translation>
+        <translation type="unfinished">Napredek na uro</translation>
     </message>
     <message>
         <source>Estimated time left until synced</source>
-        <translation type="unfinished">Odhadovaný čas do ukončenia synchronizácie</translation>
+        <translation type="unfinished">Ocenjeni čas do sinhronizacije</translation>
     </message>
     <message>
         <source>Hide</source>
-        <translation type="unfinished">Skryť</translation>
-    </message>
-    <message>
-        <source>Esc</source>
-        <translation type="unfinished">Esc - úniková klávesa</translation>
+        <translation type="unfinished">Skrij</translation>
     </message>
     <message>
         <source>%1 is currently syncing.  It will download headers and blocks from peers and validate them until reaching the tip of the block chain.</source>
-        <translation type="unfinished">%1 sa práve synchronizuje. Sťahujú sa hlavičky a bloky od partnerov. Tie sa budú sa overovať až sa kompletne overí celý reťazec blokov (blockchain).</translation>
+        <translation type="unfinished">%1 trenutno dohiteva omrežje. Od soležnikov bodo preneseni in preverjeni zaglavja in bloki do vrha verige.</translation>
     </message>
     <message>
         <source>Unknown. Syncing Headers (%1, %2%)…</source>
-        <translation type="unfinished">Neznámy. Synchronizujú sa hlavičky (%1, %2%)…</translation>
+        <translation type="unfinished">Neznano. Sinhroniziram zaglavja (%1, %2%)...</translation>
     </message>
 </context>
 <context>
     <name>OpenURIDialog</name>
     <message>
         <source>Open bitcoin URI</source>
-        <translation type="unfinished">Otvoriť bitcoin URI</translation>
+        <translation type="unfinished">Odpri URI tipa bitcoin:</translation>
     </message>
     </context>
 <context>
@@ -1386,510 +1380,526 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>&amp;Main</source>
-        <translation>&amp;Hlavné</translation>
+        <translation>&amp;Glavno</translation>
     </message>
     <message>
         <source>Automatically start %1 after logging in to the system.</source>
-        <translation type="unfinished">Automaticky spustiť %1 pri spustení systému.</translation>
+        <translation type="unfinished">Avtomatsko zaženi %1 po prijavi v sistem.</translation>
     </message>
     <message>
         <source>&amp;Start %1 on system login</source>
-        <translation type="unfinished">&amp;Spustiť %1 pri prihlásení</translation>
+        <translation type="unfinished">&amp;Zaženi %1 ob prijavi v sistem</translation>
     </message>
     <message>
         <source>Enabling pruning significantly reduces the disk space required to store transactions. All blocks are still fully validated. Reverting this setting requires re-downloading the entire blockchain.</source>
-        <translation type="unfinished">Zapnutie redukovania rapídne zníži priestor potrebný pre uloženie transakcií. Všetky bloky sú plne overované. Zvrátenie tohto nastavenia vyžaduje následné stiahnutie celého reťazca blokov.</translation>
+        <translation type="unfinished">Obrezovanje močno zniža potrebo po prostoru za shranjevanje transakcij. Še vedno pa se bodo v celoti preverjali vsi bloki. Če to nastavitev odstranite, bo potrebno ponovno prenesti celotno verigo blokov.</translation>
     </message>
     <message>
         <source>Size of &amp;database cache</source>
-        <translation type="unfinished">Veľkosť vyrovnávacej pamäti &amp;databázy</translation>
+        <translation type="unfinished">Velikost &amp;predpomnilnika podatkovne baze:</translation>
     </message>
     <message>
         <source>Number of script &amp;verification threads</source>
-        <translation type="unfinished">Počet &amp;vlákien overujúcich skript</translation>
+        <translation type="unfinished">Število programskih &amp;niti za preverjanje:</translation>
     </message>
     <message>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
-        <translation type="unfinished">IP adresy proxy (napr. IPv4: 127.0.0.1 / IPv6: ::1)</translation>
+        <translation type="unfinished">IP naslov posredniškega strežnika (npr. IPv4: 127.0.0.1 ali IPv6: ::1)</translation>
     </message>
     <message>
         <source>Shows if the supplied default SOCKS5 proxy is used to reach peers via this network type.</source>
-        <translation type="unfinished">Ukazuje, či sa zadaná východzia SOCKS5 proxy používa k pripojovaniu k peerom v rámci tohto typu siete.</translation>
+        <translation type="unfinished">Prikaže, če je nastavljeni privzeti proxy SOCKS5 uporabljen za doseganje soležnikov prek te vrste omrežja.</translation>
     </message>
     <message>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
-        <translation type="unfinished">Minimalizovať namiesto ukončenia aplikácie keď sa okno zavrie. Keď je zvolená táto možnosť, aplikácia sa zavrie len po zvolení Ukončiť v menu.</translation>
+        <translation type="unfinished">Ko zaprete glavno okno programa, bo program tekel še naprej, okno pa bo zgolj minimirano. Program v tem primeru ustavite tako, da v meniju izberete ukaz Izhod.</translation>
     </message>
     <message>
         <source>Third party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</source>
-        <translation type="unfinished">URL tretích strán (napr. prehliadač blockchain) ktoré sa zobrazujú v záložke transakcií ako položky kontextového menu. %s v URL je nahradené hash-om transakcie. Viaceré URL sú oddelené zvislou čiarou |.</translation>
+        <translation type="unfinished">Naslovi URL-jev tretjih oseb (npr. raziskovalec blokov), ki bodo navedeni v kontekstnem meniju seznama transakcij. Niz %s v nastavljenem URL-naslovu bo zamenjan z identifikatorjem transakcije. Več zaporednih naslovov URL lahko med seboj ločite z navpičnico |.</translation>
     </message>
     <message>
         <source>Open the %1 configuration file from the working directory.</source>
-        <translation type="unfinished">Otvorte konfiguračný súbor %1 s pracovného adresára.</translation>
+        <translation type="unfinished">Odpri %1 konfiguracijsko datoteko iz delovne podatkovne mape.</translation>
     </message>
     <message>
         <source>Open Configuration File</source>
-        <translation type="unfinished">Otvoriť konfiguračný súbor</translation>
+        <translation type="unfinished">Odpri konfiguracijsko datoteko</translation>
     </message>
     <message>
         <source>Reset all client options to default.</source>
-        <translation>Vynulovať všetky voľby klienta na predvolené.</translation>
+        <translation>Ponastavi vse nastavitve programa na privzete vrednosti.</translation>
     </message>
     <message>
         <source>&amp;Reset Options</source>
-        <translation>&amp;Vynulovať voľby</translation>
+        <translation>&amp;Ponastavi nastavitve</translation>
     </message>
     <message>
         <source>&amp;Network</source>
-        <translation>&amp;Sieť</translation>
+        <translation>&amp;Omrežje</translation>
     </message>
     <message>
         <source>Prune &amp;block storage to</source>
-        <translation type="unfinished">Redukovať priestor pre &amp;bloky na</translation>
+        <translation type="unfinished">Obreži velikost podatkovne &amp;baze na</translation>
     </message>
     <message>
         <source>Reverting this setting requires re-downloading the entire blockchain.</source>
-        <translation type="unfinished">Obnovenie tohto nastavenia vyžaduje opätovné stiahnutie celého blockchainu.</translation>
+        <translation type="unfinished">Če spremenite to nastavitev, boste morali ponovno naložiti celotno verigo blokov.</translation>
     </message>
     <message>
         <source>(0 = auto, &lt;0 = leave that many cores free)</source>
-        <translation type="unfinished">(0 = auto, &lt;0 = toľko jadier nechať  voľných)</translation>
+        <translation type="unfinished">(0 = samodejno, &lt;0 = toliko procesorskih jeder naj ostane prostih)</translation>
     </message>
     <message>
         <source>W&amp;allet</source>
-        <translation type="unfinished">&amp;Peňaženka</translation>
+        <translation type="unfinished">&amp;Denarnica</translation>
+    </message>
+    <message>
+        <source>Expert</source>
+        <translation type="unfinished">Za strokovnjake</translation>
     </message>
     <message>
         <source>Enable coin &amp;control features</source>
-        <translation type="unfinished">Povoliť možnosti &amp;kontroly mincí</translation>
+        <translation type="unfinished">Omogoči &amp;upravljanje s kovanci</translation>
     </message>
     <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
-        <translation type="unfinished">Ak vypnete míňanie nepotvrdeného výdavku, tak výdavok z transakcie bude možné použiť, až keď daná transakcia bude mať aspoň jedno potvrdenie. Toto má vplyv aj na výpočet vášho zostatku.</translation>
+        <translation type="unfinished">Če onemogočite trošenje vračila iz še nepotrjenih transakcij, potem vračila ne morete uporabiti, dokler plačilo ni vsaj enkrat potrjeno. Ta opcija vpliva tudi na izračun dobroimetja.</translation>
     </message>
     <message>
         <source>&amp;Spend unconfirmed change</source>
-        <translation type="unfinished">&amp;Minúť nepotvrdený výdavok</translation>
+        <translation type="unfinished">Omogoči &amp;trošenje vračila iz še nepotrjenih plačil</translation>
     </message>
     <message>
         <source>External Signer (e.g. hardware wallet)</source>
-        <translation type="unfinished">Externý podpisovateľ (napr. hardvérová peňaženka)</translation>
+        <translation type="unfinished">Zunanji podpisnik (n.pr. hardverska denarnica)</translation>
     </message>
     <message>
         <source>&amp;External signer script path</source>
-        <translation type="unfinished">Cesta k &amp;externému skriptu podpisovateľa</translation>
+        <translation type="unfinished">&amp;Pot do zunanjega podpisnika</translation>
     </message>
     <message>
         <source>Full path to a Bitcoin Core compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</source>
-        <translation type="unfinished">Plná cesta k skriptu kompatibilnému s Bitcoin Core (napr. C:\Downloads\hwi.exe alebo /Users/Vy/Stahovania/hwi.py). Pozor: škodlivé programy môžu ukradnúť vaše mince!</translation>
+        <translation type="unfinished">Polna pot do datoteke s skripto, združljivo z Bitcoin Core (n.pr. C:\Downloads\hwi.exe ali /Users/jaz/Downloads/hwi.py). Previdno: zlonamerna programska oprema vam lahko ukrade novce!</translation>
     </message>
     <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
-        <translation>Automaticky otvoriť port pre Bitcoin na routeri. Toto funguje len ak router podporuje UPnP a je táto podpora aktivovaná.</translation>
+        <translation>Samodejno odpiranje vrat za bitcoin-odjemalec na usmerjevalniku (routerju). To deluje le, če usmerjevalnik podpira UPnP in je ta funkcija na usmerjevalniku omogočena.</translation>
     </message>
     <message>
         <source>Map port using &amp;UPnP</source>
-        <translation>Mapovať port pomocou &amp;UPnP</translation>
+        <translation>Preslikaj vrata z uporabo &amp;UPnP</translation>
     </message>
     <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports NAT-PMP and it is enabled. The external port could be random.</source>
-        <translation type="unfinished">Automaticky otvoriť port pre Bitcoin na routeri. Toto funguje len ak router podporuje NAT-PMP a je táto podpora aktivovaná. Externý port môže byť náhodný.</translation>
+        <translation type="unfinished">Samodejno odpiranje vrat za bitcoin-odjemalec na usmerjevalniku. To deluje le, če usmerjevalnik podpira NAT-PMP in je ta funkcija na usmerjevalniku omogočena. Zunanja številka vrat je lahko naključna.</translation>
     </message>
     <message>
         <source>Map port using NA&amp;T-PMP</source>
-        <translation type="unfinished">Mapovať port pomocou NA&amp;T-PMP</translation>
+        <translation type="unfinished">Preslikaj vrata z uporabo NA&amp;T-PMP</translation>
     </message>
     <message>
         <source>Accept connections from outside.</source>
-        <translation type="unfinished">Prijať spojenia zvonku.</translation>
+        <translation type="unfinished">Sprejmi povezave od zunaj.</translation>
     </message>
     <message>
         <source>Allow incomin&amp;g connections</source>
-        <translation type="unfinished">Povoliť prichá&amp;dzajúce spojenia</translation>
+        <translation type="unfinished">Dovoli &amp;dohodne povezave</translation>
     </message>
     <message>
         <source>Connect to the Bitcoin network through a SOCKS5 proxy.</source>
-        <translation type="unfinished">Pripojiť do siete Bitcoin cez proxy server SOCKS5.</translation>
+        <translation type="unfinished">Poveži se v omrežje Bitcoin preko posredniškega strežnika SOCKS5.</translation>
     </message>
     <message>
         <source>&amp;Connect through SOCKS5 proxy (default proxy):</source>
-        <translation type="unfinished">&amp;Pripojiť cez proxy server SOCKS5 (predvolený proxy):</translation>
+        <translation type="unfinished">&amp;Poveži se preko posredniškega strežnika SOCKS5 (privzeti strežnik):</translation>
+    </message>
+    <message>
+        <source>Proxy &amp;IP:</source>
+        <translation>&amp;IP-naslov posredniškega strežnika:</translation>
+    </message>
+    <message>
+        <source>&amp;Port:</source>
+        <translation>&amp;Vrata:</translation>
     </message>
     <message>
         <source>Port of the proxy (e.g. 9050)</source>
-        <translation>Port proxy (napr. 9050)</translation>
+        <translation>Vrata posredniškega strežnika (npr. 9050)</translation>
     </message>
     <message>
         <source>Used for reaching peers via:</source>
-        <translation type="unfinished">Použité pre získavanie peerov cez:</translation>
+        <translation type="unfinished">Uporabljano za povezovanje s soležniki preko:</translation>
     </message>
     <message>
         <source>&amp;Window</source>
-        <translation>&amp;Okno</translation>
+        <translation>O&amp;kno</translation>
     </message>
     <message>
         <source>Show the icon in the system tray.</source>
-        <translation type="unfinished">Zobraziť ikonu v systémovej lište.</translation>
+        <translation type="unfinished">Prikaži ikono na sistemskem pladnju.</translation>
     </message>
     <message>
         <source>&amp;Show tray icon</source>
-        <translation type="unfinished">Zobraziť ikonu v obla&amp;sti oznámení</translation>
+        <translation type="unfinished">&amp;Prikaži ikono na pladnju</translation>
     </message>
     <message>
         <source>Show only a tray icon after minimizing the window.</source>
-        <translation>Zobraziť len ikonu na lište po minimalizovaní okna.</translation>
+        <translation>Po minimiranju okna le prikaži ikono programa na pladnju.</translation>
     </message>
     <message>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
-        <translation>&amp;Zobraziť len ikonu na lište po minimalizovaní okna.</translation>
+        <translation>&amp;Minimiraj na pladenj namesto na opravilno vrstico</translation>
     </message>
     <message>
         <source>M&amp;inimize on close</source>
-        <translation>M&amp;inimalizovať pri zatvorení</translation>
+        <translation>Ob zapiranju okno zgolj m&amp;inimiraj</translation>
     </message>
     <message>
         <source>&amp;Display</source>
-        <translation>&amp;Zobrazenie</translation>
+        <translation>&amp;Prikaz</translation>
     </message>
     <message>
         <source>User Interface &amp;language:</source>
-        <translation>&amp;Jazyk užívateľského rozhrania:</translation>
+        <translation>&amp;Jezik uporabniškega vmesnika:</translation>
     </message>
     <message>
         <source>The user interface language can be set here. This setting will take effect after restarting %1.</source>
-        <translation type="unfinished">Jazyk uživateľského rozhrania sa dá nastaviť tu. Toto nastavenie sa uplatní až po reštarte %1.</translation>
+        <translation type="unfinished">Tukaj je mogoče nastaviti jezik uporabniškega vmesnika. Ta nastavitev bo udejanjena šele, ko boste znova zagnali %1.</translation>
     </message>
     <message>
         <source>&amp;Unit to show amounts in:</source>
-        <translation>&amp;Zobrazovať hodnoty v jednotkách:</translation>
+        <translation>&amp;Enota za prikaz zneskov:</translation>
     </message>
     <message>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
-        <translation>Zvoľte ako deliť bitcoin pri zobrazovaní pri platbách a užívateľskom rozhraní.</translation>
+        <translation>Izberite privzeto mersko enoto za prikaz v uporabniškem vmesniku in pri pošiljanju.</translation>
     </message>
     <message>
         <source>Whether to show coin control features or not.</source>
-        <translation type="unfinished">Či zobrazovať možnosti kontroly mincí alebo nie.</translation>
+        <translation type="unfinished">Omogoči dodatne možnosti podrobnega nadzora nad  kovanci v transakcijah.</translation>
     </message>
     <message>
         <source>Connect to the Bitcoin network through a separate SOCKS5 proxy for Tor onion services.</source>
-        <translation type="unfinished">Pripojiť k Bitcoin sieti skrz samostatnú SOCKS5 proxy pre službu Tor.</translation>
+        <translation type="unfinished">Poveži se v omrežje Bitcoin prek ločenega posredniškega strežnika SOCKS5 za storitve onion (Tor).</translation>
     </message>
     <message>
         <source>Use separate SOCKS&amp;5 proxy to reach peers via Tor onion services:</source>
-        <translation type="unfinished">Použiť samostatný SOCKS&amp;5 proxy server na nadviazanie spojenia s peer-mi cez službu Tor:</translation>
+        <translation type="unfinished">Uporabi ločen posredniški strežik SOCKS5 za povezavo s soležniki prek storitev onion (Tor):</translation>
     </message>
     <message>
         <source>&amp;Third party transaction URLs</source>
-        <translation type="unfinished">URL transakcií tretích strán</translation>
+        <translation type="unfinished">URL za nakazila &amp;tretjih oseb:</translation>
     </message>
     <message>
         <source>Monospaced font in the Overview tab:</source>
-        <translation type="unfinished">Písmo s pevnou šírkou na karte Prehľad:</translation>
+        <translation type="unfinished">Pisava enakomerne širine v zavihku Pregled:</translation>
     </message>
     <message>
         <source>embedded "%1"</source>
-        <translation type="unfinished">zabudovaný "%1"</translation>
+        <translation type="unfinished">vdelan "%1"</translation>
     </message>
     <message>
         <source>closest matching "%1"</source>
-        <translation type="unfinished">najbližší zodpovedajúci "%1"</translation>
+        <translation type="unfinished">najboljše ujemanje "%1"</translation>
     </message>
     <message>
         <source>Options set in this dialog are overridden by the command line or in the configuration file:</source>
-        <translation type="unfinished">Voľby nastavené v tomto dialógovom okne sú prepísané príkazovým riadkom alebo konfiguračným súborom:</translation>
+        <translation type="unfinished">Možnosti, nastavljene v tem pogovornem oknu, ki so bile preglašene v ukazni vrstici ali konfiguracijski datoteki:</translation>
+    </message>
+    <message>
+        <source>&amp;OK</source>
+        <translation>&amp;V redu</translation>
     </message>
     <message>
         <source>&amp;Cancel</source>
-        <translation>&amp;Zrušiť</translation>
+        <translation>&amp;Prekliči</translation>
     </message>
     <message>
         <source>Compiled without external signing support (required for external signing)</source>
         <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
-        <translation type="unfinished">Skompilované bez podpory externého podpisovania (potrebné pre externé podpisovanie)</translation>
+        <translation type="unfinished">Prevedeno brez podpore za zunanje podpisovanje</translation>
     </message>
     <message>
         <source>default</source>
-        <translation>predvolené</translation>
+        <translation>privzeto</translation>
     </message>
     <message>
         <source>none</source>
-        <translation type="unfinished">žiadne</translation>
+        <translation type="unfinished">jih ni</translation>
     </message>
     <message>
         <source>Confirm options reset</source>
-        <translation>Potvrdiť obnovenie možností</translation>
+        <translation>Potrdi ponastavitev</translation>
     </message>
     <message>
         <source>Client restart required to activate changes.</source>
-        <translation type="unfinished">Reštart klienta potrebný pre aktivovanie zmien.</translation>
+        <translation type="unfinished">Za udejanjenje sprememb je potreben ponoven zagon programa.</translation>
     </message>
     <message>
         <source>Client will be shut down. Do you want to proceed?</source>
-        <translation type="unfinished">Klient bude vypnutý, chcete pokračovať?</translation>
+        <translation type="unfinished">Program bo zaustavljen. Želite nadaljevati z izhodom?</translation>
     </message>
     <message>
         <source>Configuration options</source>
-        <translation type="unfinished">Možnosti nastavenia</translation>
+        <translation type="unfinished">Možnosti konfiguracije</translation>
     </message>
     <message>
         <source>The configuration file is used to specify advanced user options which override GUI settings. Additionally, any command-line options will override this configuration file.</source>
-        <translation type="unfinished">Konfiguračný súbor slúži k nastavovaniu užívateľsky pokročilých možností, ktoré majú prednosť pred konfiguráciou z grafického rozhrania. Parametre z príkazového riadka však majú pred konfiguračným súborom prednosť.</translation>
+        <translation type="unfinished">Konfiguracijska datoteka se uporablja za določanje naprednih uporabniških možnosti, ki preglasijo nastavitve v uporabniškem vmesniku. Poleg tega bodo vse možnosti ukazne vrstice preglasile to konfiguracijsko datoteko.</translation>
     </message>
     <message>
         <source>Error</source>
-        <translation type="unfinished">Chyba</translation>
+        <translation type="unfinished">Napaka</translation>
     </message>
     <message>
         <source>The configuration file could not be opened.</source>
-        <translation type="unfinished">Konfiguračný súbor nejde otvoriť.</translation>
+        <translation type="unfinished">Konfiguracijske datoteke ni bilo moč odpreti.</translation>
     </message>
     <message>
         <source>This change would require a client restart.</source>
-        <translation type="unfinished">Táto zmena by vyžadovala reštart klienta.</translation>
+        <translation type="unfinished">Ta sprememba bi zahtevala ponoven zagon programa.</translation>
     </message>
     <message>
         <source>The supplied proxy address is invalid.</source>
-        <translation>Zadaná proxy adresa je neplatná.</translation>
+        <translation>Vnešeni naslov posredniškega strežnika ni veljaven.</translation>
     </message>
 </context>
 <context>
     <name>OverviewPage</name>
     <message>
         <source>Form</source>
-        <translation>Formulár</translation>
+        <translation>Obrazec</translation>
     </message>
     <message>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
-        <translation>Zobrazené informácie môžu byť neaktuálne. Vaša peňaženka sa automaticky synchronizuje so sieťou Bitcoin po nadviazaní spojenia, ale tento proces ešte nie je ukončený.</translation>
+        <translation>Prikazani podatki so morda zastareli. Program ob vzpostavitvi povezave samodejno sinhronizira denarnico z omrežjem Bitcoin, a trenutno ta proces še ni zaključen.</translation>
     </message>
     <message>
         <source>Watch-only:</source>
-        <translation type="unfinished">Iba sledované:</translation>
+        <translation type="unfinished">Opazovano:</translation>
     </message>
     <message>
         <source>Available:</source>
-        <translation type="unfinished">Dostupné:</translation>
+        <translation type="unfinished">Na voljo:</translation>
     </message>
     <message>
         <source>Your current spendable balance</source>
-        <translation>Váš aktuálny disponibilný zostatok</translation>
+        <translation>Skupno dobroimetje na razpolago</translation>
     </message>
     <message>
         <source>Pending:</source>
-        <translation type="unfinished">Čakajúce potvrdenie:</translation>
+        <translation type="unfinished">Nepotrjeno:</translation>
     </message>
     <message>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
-        <translation>Suma transakcií ktoré ešte neboli potvrdené a ešte sa nepočítajú do disponibilného zostatku</translation>
+        <translation>Skupni znesek sredstev, s katerimi še ne razpolagate prosto, ker so del še nepotrjenih transakcij.</translation>
     </message>
     <message>
         <source>Immature:</source>
-        <translation>Nezrelé:</translation>
+        <translation>Nedozorelo:</translation>
     </message>
     <message>
         <source>Mined balance that has not yet matured</source>
-        <translation>Vytvorený zostatok ktorý ešte nedosiahol zrelosť</translation>
+        <translation>Nedozorelo narudarjeno dobroimetje</translation>
     </message>
     <message>
         <source>Balances</source>
-        <translation type="unfinished">Stav účtu</translation>
+        <translation type="unfinished">Stanje sredstev</translation>
     </message>
     <message>
         <source>Total:</source>
-        <translation>Celkovo:</translation>
+        <translation>Skupaj:</translation>
     </message>
     <message>
         <source>Your current total balance</source>
-        <translation>Váš súčasný celkový zostatok</translation>
+        <translation>Trenutno skupno dobroimetje</translation>
     </message>
     <message>
         <source>Your current balance in watch-only addresses</source>
-        <translation type="unfinished">Váš celkový zostatok pre adresy ktoré sa iba sledujú</translation>
+        <translation type="unfinished">Trenutno dobroimetje sredstev na opazovanih naslovih</translation>
     </message>
     <message>
         <source>Spendable:</source>
-        <translation type="unfinished">Použiteľné:</translation>
+        <translation type="unfinished">Na voljo za pošiljanje:</translation>
     </message>
     <message>
         <source>Recent transactions</source>
-        <translation type="unfinished">Nedávne transakcie</translation>
+        <translation type="unfinished">Zadnje transakcije</translation>
     </message>
     <message>
         <source>Unconfirmed transactions to watch-only addresses</source>
-        <translation type="unfinished">Nepotvrdené transakcie pre adresy ktoré sa iba sledujú</translation>
+        <translation type="unfinished">Nepotrjene transakcije na opazovanih naslovih</translation>
     </message>
     <message>
         <source>Mined balance in watch-only addresses that has not yet matured</source>
-        <translation type="unfinished">Vyťažená suma pre adresy ktoré sa iba sledujú ale ešte nie je dozretá</translation>
+        <translation type="unfinished">Nedozorelo narudarjeno dobroimetje na opazovanih naslovih</translation>
     </message>
     <message>
         <source>Current total balance in watch-only addresses</source>
-        <translation type="unfinished">Aktuálny celkový zostatok pre adries ktoré sa iba sledujú</translation>
+        <translation type="unfinished">Trenutno skupno dobroimetje na opazovanih naslovih</translation>
     </message>
     <message>
         <source>Privacy mode activated for the Overview tab. To unmask the values, uncheck Settings-&gt;Mask values.</source>
-        <translation type="unfinished">Na karte "Prehľad" je aktivovaný súkromný mód, pre odkrytie hodnôt odškrtnite v nastaveniach "Skryť hodnoty"</translation>
+        <translation type="unfinished">V zavihku Pregled je vklopljen zasebni način. Za prikaz vrednosti odstranite kljukico na mestu Nastavitve &gt; Zamaskiraj vrednosti.</translation>
     </message>
 </context>
 <context>
     <name>PSBTOperationsDialog</name>
     <message>
         <source>Dialog</source>
-        <translation type="unfinished">Dialóg</translation>
+        <translation type="unfinished">Pogovorno okno</translation>
     </message>
     <message>
         <source>Sign Tx</source>
-        <translation type="unfinished">Podpísať transakciu</translation>
+        <translation type="unfinished">Podpiši transakcijo</translation>
     </message>
     <message>
         <source>Broadcast Tx</source>
-        <translation type="unfinished">Odoslať transakciu</translation>
+        <translation type="unfinished">Oddaj transakcijo v omrežje</translation>
     </message>
     <message>
         <source>Copy to Clipboard</source>
-        <translation type="unfinished">Skopírovať</translation>
+        <translation type="unfinished">Kopiraj v odložišče</translation>
     </message>
     <message>
         <source>Save…</source>
-        <translation type="unfinished">Uložiť…</translation>
+        <translation type="unfinished">Shrani...</translation>
     </message>
     <message>
         <source>Close</source>
-        <translation type="unfinished">Zatvoriť</translation>
+        <translation type="unfinished">Zapri</translation>
     </message>
     <message>
         <source>Failed to load transaction: %1</source>
-        <translation type="unfinished">Nepodarilo sa načítať transakciu: %1</translation>
+        <translation type="unfinished">Nalaganje transakcije je spodletelo: %1</translation>
     </message>
     <message>
         <source>Failed to sign transaction: %1</source>
-        <translation type="unfinished">Nepodarilo sa podpísať transakciu: %1</translation>
+        <translation type="unfinished">Podpisovanje transakcije je spodletelo: %1</translation>
     </message>
     <message>
         <source>Could not sign any more inputs.</source>
-        <translation type="unfinished">Nie je možné podpísať žiadne ďalšie vstupy.</translation>
+        <translation type="unfinished">Ne morem podpisati več kot toliko vhodov.</translation>
     </message>
     <message>
         <source>Signed %1 inputs, but more signatures are still required.</source>
-        <translation type="unfinished">Podpísaných %1 vstupov, no ešte sú požadované ďalšie podpisy.</translation>
+        <translation type="unfinished">%1 vhodov podpisanih, a potrebnih je več podpisov.</translation>
     </message>
     <message>
         <source>Signed transaction successfully. Transaction is ready to broadcast.</source>
-        <translation type="unfinished">Transakcia bola úspešne podpísaná a je pripravená na odoslanie.</translation>
+        <translation type="unfinished">Transakcija je uspešno podpisana in pripravljena na oddajo v omrežje.</translation>
     </message>
     <message>
         <source>Unknown error processing transaction.</source>
-        <translation type="unfinished">Neznáma chyba pri spracovávaní transakcie</translation>
+        <translation type="unfinished">Neznana napaka pri obdelavi transakcije.</translation>
     </message>
     <message>
         <source>Transaction broadcast successfully! Transaction ID: %1</source>
-        <translation type="unfinished">Transakcia bola úspešne odoslaná! ID transakcie: %1</translation>
+        <translation type="unfinished">Transakcija uspešno oddana v omrežje. ID transakcije: %1</translation>
     </message>
     <message>
         <source>Transaction broadcast failed: %1</source>
-        <translation type="unfinished">Odosielanie transakcie zlyhalo: %1</translation>
+        <translation type="unfinished">Oddaja transakcije v omrežje je spodletela: %1</translation>
     </message>
     <message>
         <source>PSBT copied to clipboard.</source>
-        <translation type="unfinished">PSBT bola skopírovaná.</translation>
+        <translation type="unfinished">DPBT kopirana v odložišče.</translation>
     </message>
     <message>
         <source>Save Transaction Data</source>
-        <translation type="unfinished">Uložiť údaje z transakcie</translation>
+        <translation type="unfinished">Shrani podatke transakcije</translation>
     </message>
     <message>
         <source>Partially Signed Transaction (Binary)</source>
         <extracomment>Expanded name of the binary PSBT file format. See: BIP 174.</extracomment>
-        <translation type="unfinished">Čiastočne podpísaná transakcia (binárna)</translation>
+        <translation type="unfinished">Delno podpisana transakcija (binarno)</translation>
     </message>
     <message>
         <source>PSBT saved to disk.</source>
-        <translation type="unfinished">PSBT bola uložená na disk.</translation>
+        <translation type="unfinished">DPBT shranjena na disk.</translation>
     </message>
     <message>
         <source> * Sends %1 to %2</source>
-        <translation type="unfinished">* Pošle %1 do %2</translation>
+        <translation type="unfinished">* Pošlje %1 na %2</translation>
     </message>
     <message>
         <source>Unable to calculate transaction fee or total transaction amount.</source>
-        <translation type="unfinished">Nepodarilo sa vypočítať poplatok za transakciu alebo celkovú sumu transakcie.</translation>
+        <translation type="unfinished">Ne morem izračunati transakcijske provizije ali skupnega zneska transakcije.</translation>
     </message>
     <message>
         <source>Pays transaction fee: </source>
-        <translation type="unfinished">Zaplatí poplatok za transakciu:</translation>
+        <translation type="unfinished">Vsebuje transakcijsko provizijo:</translation>
     </message>
     <message>
         <source>Total Amount</source>
-        <translation type="unfinished">Celková suma</translation>
+        <translation type="unfinished">Skupni znesek</translation>
     </message>
     <message>
         <source>or</source>
-        <translation type="unfinished">alebo</translation>
+        <translation type="unfinished">ali</translation>
     </message>
     <message>
         <source>Transaction has %1 unsigned inputs.</source>
-        <translation type="unfinished">Transakcia má %1 nepodpísaných vstupov.</translation>
+        <translation type="unfinished">Transakcija ima toliko nepodpisanih vhodov: %1.</translation>
     </message>
     <message>
         <source>Transaction is missing some information about inputs.</source>
-        <translation type="unfinished">Transakcii chýbajú niektoré informácie o vstupoch.</translation>
+        <translation type="unfinished">Transakciji manjkajo nekateri podatki o vhodih.</translation>
     </message>
     <message>
         <source>Transaction still needs signature(s).</source>
-        <translation type="unfinished">Transakcii stále chýbajú podpis(y).</translation>
+        <translation type="unfinished">Transakcija potrebuje nadaljnje podpise.</translation>
     </message>
     <message>
         <source>(But this wallet cannot sign transactions.)</source>
-        <translation type="unfinished">(Ale táto peňaženka nemôže podpisovať transakcie)</translation>
+        <translation type="unfinished">(Ta denarnica pa ne more podpisovati transakcij.)</translation>
     </message>
     <message>
         <source>(But this wallet does not have the right keys.)</source>
-        <translation type="unfinished">(Ale táto peňaženka nemá správne kľúče)</translation>
+        <translation type="unfinished">(Ta denarnica pa nima pravih ključev.)</translation>
     </message>
     <message>
         <source>Transaction is fully signed and ready for broadcast.</source>
-        <translation type="unfinished">Transakcia je plne podpísaná a je pripravená na odoslanie.</translation>
+        <translation type="unfinished">Transakcija je v celoti podpisana in pripravljena za oddajo v omrežje.</translation>
     </message>
     <message>
         <source>Transaction status is unknown.</source>
-        <translation type="unfinished">Status transakcie je neznámy.</translation>
+        <translation type="unfinished">Status transakcije ni znan.</translation>
     </message>
 </context>
 <context>
     <name>PaymentServer</name>
     <message>
         <source>Payment request error</source>
-        <translation type="unfinished">Chyba pri vyžiadaní platby</translation>
+        <translation type="unfinished">Napaka pri zahtevku za plačilo</translation>
     </message>
     <message>
         <source>Cannot start bitcoin: click-to-pay handler</source>
-        <translation type="unfinished">Nemôžeme spustiť Bitcoin: obsluha click-to-pay</translation>
+        <translation type="unfinished">Ni mogoče zagnati rokovalca plačilnih povezav tipa bitcoin:.</translation>
     </message>
     <message>
         <source>URI handling</source>
-        <translation type="unfinished">URI manipulácia</translation>
+        <translation type="unfinished">Rokovanje z URI</translation>
     </message>
     <message>
         <source>'bitcoin://' is not a valid URI. Use 'bitcoin:' instead.</source>
-        <translation type="unfinished">'bitcoin://' je neplatná URI. Použite 'bitcoin:'</translation>
+        <translation type="unfinished">'bitcoin://' ni veljaven URI. Namesto tega uporabite 'bitcoin:' .</translation>
     </message>
     <message>
         <source>Cannot process payment request because BIP70 is not supported.
 Due to widespread security flaws in BIP70 it's strongly recommended that any merchant instructions to switch wallets be ignored.
 If you are receiving this error you should request the merchant provide a BIP21 compatible URI.</source>
-        <translation type="unfinished">Nemôžem spracovať platbu pretože BIP70 nie je podporovaný.
-Kvôli bezpečnostným chybám v BIP70 sa odporúča ignorovať pokyny obchodníka na prepnutie peňaženky.
-Ak ste dostali túto chybu mali by ste požiadať obchodníka o URI kompatibilné s BIP21.</translation>
+        <translation type="unfinished">Zahtevka za plačilo ne morem obdelati, ker BIP70 ni podprt.
+Zaradi široko razširjenih varnostih hib v BIP70 vam toplo priporočamo, da morebitnih navodil prodajalcev po zamenjavi denarnice ne upoštevate.
+Svetujemo, da prodajalca prosite, naj vam priskrbi URI na podlagi BIP21.</translation>
     </message>
     <message>
         <source>URI cannot be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
-        <translation type="unfinished">URI sa nedá analyzovať! To môže byť spôsobené neplatnou Bitcoin adresou alebo zle nastavenými vlastnosťami URI.</translation>
+        <translation type="unfinished">URI je nerazumljiv. Možno je, da je bitcoin-naslov neveljaven ali pa so parametri URI-ja napačno oblikovani.</translation>
     </message>
     <message>
         <source>Payment request file handling</source>
-        <translation type="unfinished">Obsluha súboru s požiadavkou na platbu</translation>
+        <translation type="unfinished">Rokovanje z datoteko z zahtevkom za plačilo</translation>
     </message>
 </context>
 <context>
@@ -1897,313 +1907,313 @@ Ak ste dostali túto chybu mali by ste požiadať obchodníka o URI kompatibiln�
     <message>
         <source>User Agent</source>
         <extracomment>Title of Peers Table column which contains the peer's User Agent string.</extracomment>
-        <translation type="unfinished">Aplikácia</translation>
+        <translation type="unfinished">Ime agenta</translation>
     </message>
     <message>
         <source>Ping</source>
         <extracomment>Title of Peers Table column which indicates the current latency of the connection with the peer.</extracomment>
-        <translation type="unfinished">Odozva</translation>
+        <translation type="unfinished">Odzivni čas (Ping)</translation>
     </message>
     <message>
         <source>Peer</source>
         <extracomment>Title of Peers Table column which contains a unique number used to identify a connection.</extracomment>
-        <translation type="unfinished">Partneri</translation>
+        <translation type="unfinished">Soležnik</translation>
     </message>
     <message>
         <source>Sent</source>
         <extracomment>Title of Peers Table column which indicates the total amount of network information we have sent to the peer.</extracomment>
-        <translation type="unfinished">Odoslané</translation>
+        <translation type="unfinished">Poslano</translation>
     </message>
     <message>
         <source>Received</source>
         <extracomment>Title of Peers Table column which indicates the total amount of network information we have received from the peer.</extracomment>
-        <translation type="unfinished">Prijaté</translation>
+        <translation type="unfinished">Prejeto</translation>
     </message>
     <message>
         <source>Address</source>
         <extracomment>Title of Peers Table column which contains the IP/Onion/I2P address of the connected peer.</extracomment>
-        <translation type="unfinished">Adresa</translation>
+        <translation type="unfinished">Naslov</translation>
     </message>
     <message>
         <source>Type</source>
         <extracomment>Title of Peers Table column which describes the type of peer connection. The "type" describes why the connection exists.</extracomment>
-        <translation type="unfinished">Typ</translation>
+        <translation type="unfinished">Vrsta</translation>
     </message>
     <message>
         <source>Network</source>
         <extracomment>Title of Peers Table column which states the network the peer connected through.</extracomment>
-        <translation type="unfinished">Sieť</translation>
+        <translation type="unfinished">Omrežje</translation>
     </message>
 </context>
 <context>
     <name>QRImageWidget</name>
     <message>
         <source>&amp;Save Image…</source>
-        <translation type="unfinished">&amp;Uložiť obrázok…</translation>
+        <translation type="unfinished">&amp;Shrani sliko ...</translation>
     </message>
     <message>
         <source>&amp;Copy Image</source>
-        <translation type="unfinished">&amp;Kopírovať obrázok</translation>
+        <translation type="unfinished">&amp;Kopiraj sliko</translation>
     </message>
     <message>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
-        <translation type="unfinished">Výsledné URI je príliš dlhé, skúste skrátiť text pre popis alebo správu.</translation>
+        <translation type="unfinished">Nastali URI je predolg. Skušajte skrajšati besedilo v oznaki/sporočilu.</translation>
     </message>
     <message>
         <source>Error encoding URI into QR Code.</source>
-        <translation type="unfinished">Chyba kódovania URI do QR Code.</translation>
+        <translation type="unfinished">Napaka pri kodiranju URI naslova v QR kodo.</translation>
     </message>
     <message>
         <source>QR code support not available.</source>
-        <translation type="unfinished">Nie je dostupná podpora QR kódov.</translation>
+        <translation type="unfinished">Podpora za QR kode ni na voljo.</translation>
     </message>
     <message>
         <source>Save QR Code</source>
-        <translation type="unfinished">Uložiť QR Code</translation>
+        <translation type="unfinished">Shrani QR kodo</translation>
     </message>
     <message>
         <source>PNG Image</source>
         <extracomment>Expanded name of the PNG file format. See https://en.wikipedia.org/wiki/Portable_Network_Graphics</extracomment>
-        <translation type="unfinished">PNG obrázok</translation>
+        <translation type="unfinished">Slika PNG</translation>
     </message>
 </context>
 <context>
     <name>RPCConsole</name>
     <message>
         <source>N/A</source>
-        <translation>nie je k dispozícii</translation>
+        <translation>Neznano</translation>
     </message>
     <message>
         <source>Client version</source>
-        <translation>Verzia klienta</translation>
+        <translation>Različica odjemalca</translation>
     </message>
     <message>
         <source>&amp;Information</source>
-        <translation>&amp;Informácie</translation>
+        <translation>&amp;Informacije</translation>
     </message>
     <message>
         <source>General</source>
-        <translation type="unfinished">Všeobecné</translation>
+        <translation type="unfinished">Splošno</translation>
     </message>
     <message>
         <source>Datadir</source>
-        <translation type="unfinished">Priečinok s dátami</translation>
+        <translation type="unfinished">Podatkovna mapa</translation>
     </message>
     <message>
         <source>To specify a non-default location of the data directory use the '%1' option.</source>
-        <translation type="unfinished">Ak chcete zadať miesto dátového adresára, ktoré nie je predvolené, použite voľbu '%1'.</translation>
+        <translation type="unfinished">Za izbiranje ne-privzete lokacije podatkovne mape uporabite možnost '%1'.</translation>
     </message>
     <message>
         <source>Blocksdir</source>
-        <translation type="unfinished">Priečinok s blokmi</translation>
+        <translation type="unfinished">Podatkovna mapa blokov</translation>
     </message>
     <message>
         <source>To specify a non-default location of the blocks directory use the '%1' option.</source>
-        <translation type="unfinished">Ak chcete zadať miesto adresára pre bloky, ktoré nie je predvolené, použite voľbu '%1'.</translation>
+        <translation type="unfinished">Če želite določiti neprivzeto lokacijo podatkovne mape blokov, uporabite možnost '%1'.</translation>
     </message>
     <message>
         <source>Startup time</source>
-        <translation>Čas spustenia</translation>
+        <translation>Čas zagona</translation>
     </message>
     <message>
         <source>Network</source>
-        <translation>Sieť</translation>
+        <translation>Omrežje</translation>
     </message>
     <message>
         <source>Name</source>
-        <translation type="unfinished">Názov</translation>
+        <translation type="unfinished">Ime</translation>
     </message>
     <message>
         <source>Number of connections</source>
-        <translation>Počet pripojení</translation>
+        <translation>Število povezav</translation>
     </message>
     <message>
         <source>Block chain</source>
-        <translation>Reťazec blokov</translation>
+        <translation>Veriga blokov</translation>
     </message>
     <message>
         <source>Memory Pool</source>
-        <translation type="unfinished">Pamäť Poolu</translation>
+        <translation type="unfinished">Čakalna vrsta transakcij</translation>
     </message>
     <message>
         <source>Current number of transactions</source>
-        <translation type="unfinished">Aktuálny počet transakcií</translation>
+        <translation type="unfinished">Trenutno število transakcij</translation>
     </message>
     <message>
         <source>Memory usage</source>
-        <translation type="unfinished">Využitie pamäte</translation>
+        <translation type="unfinished">Raba pomnilnika</translation>
     </message>
     <message>
         <source>Wallet: </source>
-        <translation type="unfinished">Peňaženka:</translation>
+        <translation type="unfinished">Denarnica:</translation>
     </message>
     <message>
         <source>(none)</source>
-        <translation type="unfinished">(žiadne)</translation>
+        <translation type="unfinished">(jih ni)</translation>
     </message>
     <message>
         <source>&amp;Reset</source>
-        <translation type="unfinished">&amp;Vynulovať</translation>
+        <translation type="unfinished">&amp;Ponastavi</translation>
     </message>
     <message>
         <source>Received</source>
-        <translation type="unfinished">Prijaté</translation>
+        <translation type="unfinished">Prejeto</translation>
     </message>
     <message>
         <source>Sent</source>
-        <translation type="unfinished">Odoslané</translation>
+        <translation type="unfinished">Poslano</translation>
     </message>
     <message>
         <source>&amp;Peers</source>
-        <translation type="unfinished">&amp;Partneri</translation>
+        <translation type="unfinished">&amp;Soležniki</translation>
     </message>
     <message>
         <source>Banned peers</source>
-        <translation type="unfinished">Zablokovaní partneri</translation>
+        <translation type="unfinished">Blokirani soležniki</translation>
     </message>
     <message>
         <source>Select a peer to view detailed information.</source>
-        <translation type="unfinished">Vyberte počítač partnera pre zobrazenie podrobností.</translation>
+        <translation type="unfinished">Izberite soležnika, o katerem si želite ogledati podrobnejše informacije.</translation>
     </message>
     <message>
         <source>Version</source>
-        <translation type="unfinished">Verzia</translation>
+        <translation type="unfinished">Različica</translation>
     </message>
     <message>
         <source>Starting Block</source>
-        <translation type="unfinished">Počiatočný blok</translation>
+        <translation type="unfinished">Začetni blok</translation>
     </message>
     <message>
         <source>Synced Headers</source>
-        <translation type="unfinished">Zosynchronizované hlavičky</translation>
+        <translation type="unfinished">Sinhronizirana zaglavja</translation>
     </message>
     <message>
         <source>Synced Blocks</source>
-        <translation type="unfinished">Zosynchronizované bloky</translation>
+        <translation type="unfinished">Sinhronizirani bloki</translation>
     </message>
     <message>
         <source>The mapped Autonomous System used for diversifying peer selection.</source>
-        <translation type="unfinished">Mapovaný nezávislý - Autonómny Systém používaný na rozšírenie vzájomného výberu peerov.</translation>
+        <translation type="unfinished">Preslikani avtonomni sistem, uporabljan za raznoliko izbiro soležnikov.</translation>
     </message>
     <message>
         <source>Mapped AS</source>
-        <translation type="unfinished">Mapovaný AS</translation>
+        <translation type="unfinished">Preslikani AS</translation>
     </message>
     <message>
         <source>User Agent</source>
-        <translation type="unfinished">Aplikácia</translation>
+        <translation type="unfinished">Ime agenta</translation>
     </message>
     <message>
         <source>Node window</source>
-        <translation type="unfinished">Okno uzlov</translation>
+        <translation type="unfinished">Okno vozlišča</translation>
     </message>
     <message>
         <source>Current block height</source>
-        <translation type="unfinished">Aktuálne číslo bloku</translation>
+        <translation type="unfinished">Višina trenutnega bloka</translation>
     </message>
     <message>
         <source>Open the %1 debug log file from the current data directory. This can take a few seconds for large log files.</source>
-        <translation type="unfinished">Otvoriť %1 ladiaci výpis z aktuálnej zložky. Pre veľké súbory to môže chvíľu trvať.</translation>
+        <translation type="unfinished">Odpre %1 razhroščevalni dnevnik debug.log, ki se nahaja v trenutni podatkovni mapi. Če je datoteka velika, lahko postopek traja nekaj sekund.</translation>
     </message>
     <message>
         <source>Decrease font size</source>
-        <translation type="unfinished">Zmenšiť písmo</translation>
+        <translation type="unfinished">Zmanjšaj velikost pisave</translation>
     </message>
     <message>
         <source>Increase font size</source>
-        <translation type="unfinished">Zväčšiť písmo</translation>
+        <translation type="unfinished">Povečaj velikost pisave</translation>
     </message>
     <message>
         <source>Permissions</source>
-        <translation type="unfinished">Povolenia</translation>
+        <translation type="unfinished">Pooblastila</translation>
     </message>
     <message>
         <source>The direction and type of peer connection: %1</source>
-        <translation type="unfinished">Smer a typ spojenia s partnerom: %1</translation>
+        <translation type="unfinished">Smer in vrsta povezave s soležnikom: %1</translation>
     </message>
     <message>
         <source>Direction/Type</source>
-        <translation type="unfinished">Smer/Typ</translation>
+        <translation type="unfinished">Smer/vrsta</translation>
     </message>
     <message>
         <source>The network protocol this peer is connected through: IPv4, IPv6, Onion, I2P, or CJDNS.</source>
-        <translation type="unfinished">Sieťový protokol, ktorým je pripojený tento partner: IPv4, IPv6, Onion, I2P, alebo CJDNS.</translation>
+        <translation type="unfinished">Protokol, po katerem je soležnik povezan: IPv4, IPv6, Onion, I2p ali CJDNS.</translation>
     </message>
     <message>
         <source>Services</source>
-        <translation type="unfinished">Služby</translation>
+        <translation type="unfinished">Storitve</translation>
     </message>
     <message>
         <source>Whether the peer requested us to relay transactions.</source>
-        <translation type="unfinished">Či nás partner požiadal o preposielanie transakcií.</translation>
+        <translation type="unfinished">Ali nas je soležnik zaprosil za posredovanje transakcij.</translation>
     </message>
     <message>
         <source>Wants Tx Relay</source>
-        <translation type="unfinished">Požaduje preposielanie transakcií</translation>
+        <translation type="unfinished">Želi posredovanje</translation>
     </message>
     <message>
         <source>High bandwidth BIP152 compact block relay: %1</source>
-        <translation type="unfinished">Preposielanie kompaktných blokov vysokou rýchlosťou podľa BIP152: %1</translation>
+        <translation type="unfinished">Posredovanje zgoščenih blokov po BIP152 prek visoke pasovne širine: %1</translation>
     </message>
     <message>
         <source>High Bandwidth</source>
-        <translation type="unfinished">Vysoká rýchlosť</translation>
+        <translation type="unfinished">Visoka pasovna širina</translation>
     </message>
     <message>
         <source>Connection Time</source>
-        <translation type="unfinished">Dĺžka spojenia</translation>
+        <translation type="unfinished">Trajanje povezave</translation>
     </message>
     <message>
         <source>Elapsed time since a novel block passing initial validity checks was received from this peer.</source>
-        <translation type="unfinished">Uplynutý čas odkedy bol od tohto partnera prijatý nový blok s overenou platnosťou.</translation>
+        <translation type="unfinished">Čas, ki je pretekel, odkar smo od tega soležnika prejeli nov blok, ki je prestal začetno preverjanje veljavnosti.</translation>
     </message>
     <message>
         <source>Last Block</source>
-        <translation type="unfinished">Posledný blok</translation>
+        <translation type="unfinished">Zadnji blok</translation>
     </message>
     <message>
         <source>Elapsed time since a novel transaction accepted into our mempool was received from this peer.</source>
-        <translation type="unfinished">Uplynutý čas odkedy bola od tohto partnera prijatá nová transakcia do pamäte.</translation>
+        <translation type="unfinished">Čas, ki je pretekel, odkar smo od tega soležnika prejeli novo nepotrjeno transakcijo.</translation>
     </message>
     <message>
         <source>Last Tx</source>
-        <translation type="unfinished">Posledná transakcia</translation>
+        <translation type="unfinished">Zadnja tx</translation>
     </message>
     <message>
         <source>Last Send</source>
-        <translation type="unfinished">Posledné odoslanie</translation>
+        <translation type="unfinished">Nazadje oddano</translation>
     </message>
     <message>
         <source>Last Receive</source>
-        <translation type="unfinished">Posledné prijatie</translation>
+        <translation type="unfinished">Nazadnje prejeto</translation>
     </message>
     <message>
         <source>Ping Time</source>
-        <translation type="unfinished">Čas odozvy</translation>
+        <translation type="unfinished">Odzivni čas</translation>
     </message>
     <message>
         <source>The duration of a currently outstanding ping.</source>
-        <translation type="unfinished">Trvanie aktuálnej požiadavky na odozvu.</translation>
+        <translation type="unfinished">Trajanje trenutnega pinga.</translation>
     </message>
     <message>
         <source>Ping Wait</source>
-        <translation type="unfinished">Čakanie na odozvu</translation>
+        <translation type="unfinished">Čakanje pinga</translation>
     </message>
     <message>
         <source>Min Ping</source>
-        <translation type="unfinished">Minimálna odozva</translation>
+        <translation type="unfinished">Min ping</translation>
     </message>
     <message>
         <source>Time Offset</source>
-        <translation type="unfinished">Časový posun</translation>
+        <translation type="unfinished">Časovni odklon</translation>
     </message>
     <message>
         <source>Last block time</source>
-        <translation>Čas posledného bloku</translation>
+        <translation>Čas zadnjega bloka</translation>
     </message>
     <message>
         <source>&amp;Open</source>
-        <translation>&amp;Otvoriť</translation>
+        <translation>&amp;Odpri</translation>
     </message>
     <message>
         <source>&amp;Console</source>
@@ -2211,828 +2221,808 @@ Ak ste dostali túto chybu mali by ste požiadať obchodníka o URI kompatibiln�
     </message>
     <message>
         <source>&amp;Network Traffic</source>
-        <translation type="unfinished">&amp;Sieťová prevádzka</translation>
+        <translation type="unfinished">&amp;Omrežni promet</translation>
     </message>
     <message>
         <source>Totals</source>
-        <translation type="unfinished">Celkovo:</translation>
+        <translation type="unfinished">Skupaj</translation>
     </message>
     <message>
         <source>Debug log file</source>
-        <translation>Súbor záznamu ladenia</translation>
+        <translation>Razhroščevalni dnevnik</translation>
     </message>
     <message>
         <source>Clear console</source>
-        <translation>Vymazať konzolu</translation>
+        <translation>Počisti konzolo</translation>
     </message>
     <message>
         <source>In:</source>
-        <translation type="unfinished">Dnu:</translation>
+        <translation type="unfinished">Dohodnih:</translation>
     </message>
     <message>
         <source>Out:</source>
-        <translation type="unfinished">Von:</translation>
+        <translation type="unfinished">Odhodnih:</translation>
     </message>
     <message>
         <source>Inbound: initiated by peer</source>
-        <translation type="unfinished">Prichádzajúce: iniciované partnerom</translation>
+        <translation type="unfinished">Dohodna: sprožil jo je soležnik</translation>
     </message>
     <message>
         <source>Outbound Full Relay: default</source>
-        <translation type="unfinished">Odchádzajúce plné preposielanie: predvolené</translation>
+        <translation type="unfinished">Odhodno polno posredovanje: privzeto</translation>
     </message>
     <message>
         <source>Outbound Block Relay: does not relay transactions or addresses</source>
-        <translation type="unfinished">Odchádzajúce preposielanie blokov: nepreposiela transakcie alebo adresy</translation>
+        <translation type="unfinished">Odhodno posredovanje blokov: ne posreduje transakcij in naslovov</translation>
     </message>
     <message>
         <source>Outbound Manual: added using RPC %1 or %2/%3 configuration options</source>
-        <translation type="unfinished">Odchádzajúce manuálne: pridané pomocou RPC %1 alebo konfiguračnými voľbami %2/%3</translation>
+        <translation type="unfinished">Odhodna ročna: dodana po RPC s konfiguracijskimi možnostmi %1 ali %2/%3</translation>
     </message>
     <message>
         <source>Outbound Feeler: short-lived, for testing addresses</source>
-        <translation type="unfinished">Odchádzajúci Feeler: krátkodobé, pre testovanie adries</translation>
+        <translation type="unfinished">Odhodna tipalka: kratkoživa, za testiranje naslovov</translation>
     </message>
     <message>
         <source>Outbound Address Fetch: short-lived, for soliciting addresses</source>
-        <translation type="unfinished">Odchádzajúce získavanie adries: krátkodobé, pre dohodnutie adries</translation>
+        <translation type="unfinished">Odhodna dostavljalka naslovov: krakoživa, zaproša za naslove</translation>
     </message>
     <message>
         <source>we selected the peer for high bandwidth relay</source>
-        <translation type="unfinished">zvolili sme partnera pre rýchle preposielanie</translation>
+        <translation type="unfinished">soležnika smo izbrali za posredovanje na visoki pasovni širini</translation>
     </message>
     <message>
         <source>the peer selected us for high bandwidth relay</source>
-        <translation type="unfinished">partner nás zvolil pre rýchle preposielanie</translation>
+        <translation type="unfinished">soležnik nas je izbral za posredovanje na visoki pasovni širini</translation>
     </message>
     <message>
         <source>no high bandwidth relay selected</source>
-        <translation type="unfinished">nebolo zvolené rýchle preposielanie</translation>
+        <translation type="unfinished">ni posredovanja na visoki pasovni širini</translation>
     </message>
     <message>
         <source>&amp;Disconnect</source>
-        <translation type="unfinished">&amp;Odpojiť</translation>
+        <translation type="unfinished">&amp;Prekini povezavo</translation>
     </message>
     <message>
         <source>1 &amp;hour</source>
-        <translation type="unfinished">1 &amp;hodinu</translation>
+        <translation type="unfinished">1 &amp;ura</translation>
     </message>
     <message>
         <source>1 d&amp;ay</source>
-        <translation type="unfinished">1 &amp;deň</translation>
+        <translation type="unfinished">1 d&amp;an</translation>
     </message>
     <message>
         <source>1 &amp;week</source>
-        <translation type="unfinished">1 &amp;týždeň</translation>
+        <translation type="unfinished">1 &amp;teden</translation>
     </message>
     <message>
         <source>1 &amp;year</source>
-        <translation type="unfinished">1 &amp;rok</translation>
+        <translation type="unfinished">1 &amp;leto</translation>
     </message>
     <message>
         <source>&amp;Unban</source>
-        <translation type="unfinished">&amp;Zrušiť zákaz</translation>
+        <translation type="unfinished">&amp;Odblokiraj</translation>
     </message>
     <message>
         <source>Network activity disabled</source>
-        <translation type="unfinished">Sieťová aktivita zakázaná</translation>
+        <translation type="unfinished">Omrežna aktivnost onemogočena.</translation>
     </message>
     <message>
         <source>Executing command without any wallet</source>
-        <translation type="unfinished">Príkaz sa vykonáva bez peňaženky</translation>
+        <translation type="unfinished">Izvajam ukaz brez denarnice</translation>
     </message>
     <message>
         <source>Executing command using "%1" wallet</source>
-        <translation type="unfinished">Príkaz sa vykonáva s použitím peňaženky "%1"</translation>
-    </message>
-    <message>
-        <source>Welcome to the %1 RPC console.
-Use up and down arrows to navigate history, and %2 to clear screen.
-Use %3 and %4 to increase or decrease the font size.
-Type %5 for an overview of available commands.
-For more information on using this console, type %6.
-
-%7WARNING: Scammers have been active, telling users to type commands here, stealing their wallet contents. Do not use this console without fully understanding the ramifications of a command.%8</source>
-        <extracomment>RPC console welcome message. Placeholders %7 and %8 are style tags for the warning content, and they are not space separated from the rest of the text intentionally.</extracomment>
-        <translation type="unfinished">Vitajte v RPC konzole %1.
-Použite šípky hore a dolu pre posun v histórii, a %2 pre výmaz obrazovky.
-Použite %3 a %4 pre zväčenie alebo zmenšenie veľkosti písma.
-Napíšte %5 pre prehľad dostupných príkazov.
-Pre viac informácií o používaní tejto konzoly napíšte %6.
-
-%7Varovanie: Podvodníci sú aktívni, nabádajú používateľov písať sem príkazy, čím ukradnú obsah ich peňaženky. Nepoužívajte túto konzolu ak plne nerozumiete dôsledkom príslušného príkazu.%8</translation>
+        <translation type="unfinished">Izvajam ukaz v denarnici "%1"</translation>
     </message>
     <message>
         <source>Executing…</source>
         <extracomment>A console message indicating an entered command is currently being executed.</extracomment>
-        <translation type="unfinished">Vykonáva sa…</translation>
+        <translation type="unfinished">Izvajam...</translation>
     </message>
     <message>
         <source>(peer: %1)</source>
-        <translation type="unfinished">(partner: %1)</translation>
+        <translation type="unfinished">(soležnik: %1)</translation>
     </message>
     <message>
         <source>via %1</source>
-        <translation type="unfinished">cez %1</translation>
+        <translation type="unfinished">preko %1</translation>
     </message>
     <message>
         <source>Yes</source>
-        <translation type="unfinished">Áno</translation>
+        <translation type="unfinished">Da</translation>
     </message>
     <message>
         <source>No</source>
-        <translation type="unfinished">Nie</translation>
+        <translation type="unfinished">Ne</translation>
     </message>
     <message>
         <source>To</source>
-        <translation type="unfinished">Do</translation>
+        <translation type="unfinished">Prejemnik</translation>
     </message>
     <message>
         <source>From</source>
-        <translation type="unfinished">Od</translation>
+        <translation type="unfinished">Pošiljatelj</translation>
     </message>
     <message>
         <source>Ban for</source>
-        <translation type="unfinished">Zákaz pre</translation>
+        <translation type="unfinished">Blokiraj za</translation>
     </message>
     <message>
         <source>Never</source>
-        <translation type="unfinished">Nikdy</translation>
+        <translation type="unfinished">Nikoli</translation>
     </message>
     <message>
         <source>Unknown</source>
-        <translation type="unfinished">neznámy</translation>
+        <translation type="unfinished">Neznano</translation>
     </message>
 </context>
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
         <source>&amp;Amount:</source>
-        <translation type="unfinished">&amp;Suma:</translation>
+        <translation type="unfinished">&amp;Znesek:</translation>
     </message>
     <message>
         <source>&amp;Label:</source>
-        <translation type="unfinished">&amp;Popis:</translation>
+        <translation type="unfinished">&amp;Oznaka:</translation>
     </message>
     <message>
         <source>&amp;Message:</source>
-        <translation type="unfinished">&amp;Správa:</translation>
+        <translation type="unfinished">&amp;Sporočilo:</translation>
     </message>
     <message>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
-        <translation type="unfinished">Pridať voliteľnú správu k výzve na zaplatenie, ktorá sa zobrazí keď bude výzva otvorená. Poznámka: Správa nebude poslaná s platbou cez sieť Bitcoin.</translation>
+        <translation type="unfinished">Neobvezno sporočilo kot priponka zahtevku za plačilo, ki bo prikazano, ko bo zahtevek odprt. Opomba: Opravljeno plačilo v omrežju bitcoin tega sporočila ne bo vsebovalo.</translation>
     </message>
     <message>
         <source>An optional label to associate with the new receiving address.</source>
-        <translation type="unfinished">Voliteľný popis ktorý sa pridá k tejto novej prijímajúcej adrese.</translation>
+        <translation type="unfinished">Neobvezna oznaka novega sprejemnega naslova.</translation>
     </message>
     <message>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
-        <translation type="unfinished">Použite tento formulár pre vyžiadanie platby. Všetky polia sú &lt;b&gt;voliteľné&lt;/b&gt;.</translation>
-    </message>
-    <message>
-        <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
-        <translation type="unfinished">Voliteľná požadovaná suma. Nechajte prázdne alebo nulu ak nepožadujete určitú sumu.</translation>
+        <translation type="unfinished">S tem obrazcem ustvarite nov zahtevek za plačilo. Vsa polja so &lt;b&gt;neobvezna&lt;/b&gt;.</translation>
     </message>
     <message>
         <source>An optional label to associate with the new receiving address (used by you to identify an invoice).  It is also attached to the payment request.</source>
-        <translation type="unfinished">Voliteľný popis ktorý sa pridá k tejto novej prijímajúcej adrese (pre jednoduchšiu identifikáciu). Tento popis je taktiež pridaný do výzvy k platbe.</translation>
+        <translation type="unfinished">Neobvezna oznaka, povezana z novim prejemnim naslovom. Uporabite jo lahko za prepoznavo plačila. Zapisana bo tudi v zahtevek za plačilo.</translation>
     </message>
     <message>
         <source>An optional message that is attached to the payment request and may be displayed to the sender.</source>
-        <translation type="unfinished">Voliteľná správa ktorá bude pridaná k tejto platobnej výzve a môže byť zobrazená odosielateľovi.</translation>
+        <translation type="unfinished">Neobvezna oznaka, ki se shrani v zahtevek za plačilo in se lahko prikaže plačniku.</translation>
     </message>
     <message>
         <source>&amp;Create new receiving address</source>
-        <translation type="unfinished">&amp;Vytvoriť novú prijímaciu adresu</translation>
+        <translation type="unfinished">&amp;Ustvari nov prejemni naslov</translation>
     </message>
     <message>
         <source>Clear all fields of the form.</source>
-        <translation type="unfinished">Vyčistiť všetky polia formulára.</translation>
+        <translation type="unfinished">Počisti vsa polja v obrazcu.</translation>
     </message>
     <message>
         <source>Clear</source>
-        <translation type="unfinished">Vyčistiť</translation>
+        <translation type="unfinished">Počisti</translation>
     </message>
     <message>
         <source>Native segwit addresses (aka Bech32 or BIP-173) reduce your transaction fees later on and offer better protection against typos, but old wallets don't support them. When unchecked, an address compatible with older wallets will be created instead.</source>
-        <translation type="unfinished">Natívne segwit adresy (Bech32 or BIP-173) znižujú Vaše budúce transakčné poplatky a ponúkajú lepšiu ochranu pred preklepmi, avšak staré peňaženky ich nepodporujú. Ak je toto pole nezaškrtnuté, bude vytvorená adresa kompatibilná so staršími peňaženkami.</translation>
+        <translation type="unfinished">Lastni naslovi segwit (Bech32 ali BIP-173) znižajo vaše prihodnje transakcijske stroške in nudijo boljšo zaščito pred tipkarskimi škrati, vendar jih stare denarnice ne podpirajo. Če polja ne označite, bo namesto tega ustvarjen naslov, združljiv s starejšimi denarnicami.</translation>
     </message>
     <message>
         <source>Generate native segwit (Bech32) address</source>
-        <translation type="unfinished">Generovať natívnu segwit adresu (Bech32)</translation>
+        <translation type="unfinished">Ustvari lastni segwit (Bech32) naslov</translation>
     </message>
     <message>
         <source>Requested payments history</source>
-        <translation type="unfinished">História vyžiadaných platieb</translation>
+        <translation type="unfinished">Zgodovina zahtevkov za plačilo</translation>
     </message>
     <message>
         <source>Show the selected request (does the same as double clicking an entry)</source>
-        <translation type="unfinished">Zobraz zvolenú požiadavku (urobí to isté ako dvoj-klik na záznam)</translation>
+        <translation type="unfinished">Prikaz izbranega zahtevka. (Isto funkcijo opravi dvojni klik na zapis.)</translation>
     </message>
     <message>
         <source>Show</source>
-        <translation type="unfinished">Zobraziť</translation>
+        <translation type="unfinished">Prikaži</translation>
     </message>
     <message>
         <source>Remove the selected entries from the list</source>
-        <translation type="unfinished">Odstrániť zvolené záznamy zo zoznamu</translation>
+        <translation type="unfinished">Odstrani označene vnose iz seznama</translation>
     </message>
     <message>
         <source>Remove</source>
-        <translation type="unfinished">Odstrániť</translation>
+        <translation type="unfinished">Odstrani</translation>
     </message>
     <message>
         <source>Copy &amp;URI</source>
-        <translation type="unfinished">Kopírovať &amp;URI</translation>
+        <translation type="unfinished">Kopiraj &amp;URl</translation>
     </message>
     <message>
         <source>&amp;Copy address</source>
-        <translation type="unfinished">&amp;Kopírovať adresu</translation>
+        <translation type="unfinished">&amp;Kopiraj naslov</translation>
     </message>
     <message>
         <source>Copy &amp;label</source>
-        <translation type="unfinished">Kopírovať &amp;popis</translation>
+        <translation type="unfinished">Kopiraj &amp;oznako</translation>
     </message>
     <message>
         <source>Copy &amp;message</source>
-        <translation type="unfinished">Kopírovať &amp;správu</translation>
+        <translation type="unfinished">Kopiraj &amp;sporočilo</translation>
     </message>
     <message>
         <source>Copy &amp;amount</source>
-        <translation type="unfinished">Kopírovať &amp;sumu</translation>
+        <translation type="unfinished">Kopiraj &amp;znesek</translation>
     </message>
     <message>
         <source>Could not unlock wallet.</source>
-        <translation type="unfinished">Nepodarilo sa odomknúť peňaženku.</translation>
+        <translation type="unfinished">Denarnice ni bilo mogoče odkleniti.</translation>
     </message>
     <message>
         <source>Could not generate new %1 address</source>
-        <translation type="unfinished">Nepodarilo sa vygenerovať novú %1 adresu</translation>
+        <translation type="unfinished">Ne morem ustvariti novega %1 naslova</translation>
     </message>
 </context>
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
         <source>Request payment to …</source>
-        <translation type="unfinished">Požiadať o platbu pre …</translation>
+        <translation type="unfinished">Zahtevaj plačilo prejmeniku ...</translation>
     </message>
     <message>
         <source>Address:</source>
-        <translation type="unfinished">Adresa:</translation>
+        <translation type="unfinished">Naslov:</translation>
     </message>
     <message>
         <source>Amount:</source>
-        <translation type="unfinished">Suma:</translation>
+        <translation type="unfinished">Znesek:</translation>
     </message>
     <message>
         <source>Label:</source>
-        <translation type="unfinished">Popis:</translation>
+        <translation type="unfinished">Oznaka:</translation>
     </message>
     <message>
         <source>Message:</source>
-        <translation type="unfinished">Správa:</translation>
+        <translation type="unfinished">Sporočilo:</translation>
     </message>
     <message>
         <source>Wallet:</source>
-        <translation type="unfinished">Peňaženka:</translation>
+        <translation type="unfinished">Denarnica:</translation>
     </message>
     <message>
         <source>Copy &amp;URI</source>
-        <translation type="unfinished">Kopírovať &amp;URI</translation>
+        <translation type="unfinished">Kopiraj &amp;URl</translation>
     </message>
     <message>
         <source>Copy &amp;Address</source>
-        <translation type="unfinished">Kopírovať &amp;adresu</translation>
+        <translation type="unfinished">Kopiraj &amp;naslov</translation>
     </message>
     <message>
         <source>&amp;Verify</source>
-        <translation type="unfinished">O&amp;veriť</translation>
+        <translation type="unfinished">Pre&amp;veri</translation>
     </message>
     <message>
         <source>Verify this address on e.g. a hardware wallet screen</source>
-        <translation type="unfinished">Overiť túto adresu napr. na obrazovke hardvérovej peňaženky</translation>
+        <translation type="unfinished">Preveri ta naslov, n.pr. na zaslonu hardverske naprave</translation>
     </message>
     <message>
         <source>&amp;Save Image…</source>
-        <translation type="unfinished">&amp;Uložiť obrázok…</translation>
+        <translation type="unfinished">&amp;Shrani sliko ...</translation>
     </message>
     <message>
         <source>Payment information</source>
-        <translation type="unfinished">Informácia o platbe</translation>
+        <translation type="unfinished">Informacije o plačilu</translation>
     </message>
     <message>
         <source>Request payment to %1</source>
-        <translation type="unfinished">Vyžiadať platbu pre %1</translation>
+        <translation type="unfinished">Zaprosi za plačilo na naslov %1</translation>
     </message>
 </context>
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
         <source>Date</source>
-        <translation type="unfinished">Dátum</translation>
+        <translation type="unfinished">Datum</translation>
     </message>
     <message>
         <source>Label</source>
-        <translation type="unfinished">Popis</translation>
+        <translation type="unfinished">Oznaka</translation>
     </message>
     <message>
         <source>Message</source>
-        <translation type="unfinished">Správa</translation>
+        <translation type="unfinished">Sporočilo</translation>
     </message>
     <message>
         <source>(no label)</source>
-        <translation type="unfinished">(bez popisu)</translation>
+        <translation type="unfinished">(brez oznake)</translation>
     </message>
     <message>
         <source>(no message)</source>
-        <translation type="unfinished">(žiadna správa)</translation>
+        <translation type="unfinished">(brez sporočila)</translation>
     </message>
     <message>
         <source>(no amount requested)</source>
-        <translation type="unfinished">(nepožadovaná žiadna suma)</translation>
+        <translation type="unfinished">(brez zneska)</translation>
     </message>
     <message>
         <source>Requested</source>
-        <translation type="unfinished">Požadované</translation>
+        <translation type="unfinished">Zahtevan znesek</translation>
     </message>
 </context>
 <context>
     <name>SendCoinsDialog</name>
     <message>
         <source>Send Coins</source>
-        <translation>Poslať mince</translation>
+        <translation>Pošlji kovance</translation>
     </message>
     <message>
         <source>Coin Control Features</source>
-        <translation type="unfinished">Možnosti kontroly mincí</translation>
+        <translation type="unfinished">Upravljanje s kovanci</translation>
     </message>
     <message>
         <source>automatically selected</source>
-        <translation type="unfinished">automaticky vybrané</translation>
+        <translation type="unfinished">samodejno izbrani</translation>
     </message>
     <message>
         <source>Insufficient funds!</source>
-        <translation type="unfinished">Nedostatok prostriedkov!</translation>
+        <translation type="unfinished">Premalo sredstev!</translation>
     </message>
     <message>
         <source>Quantity:</source>
-        <translation type="unfinished">Množstvo:</translation>
+        <translation type="unfinished">Št. vhodov:</translation>
     </message>
     <message>
         <source>Bytes:</source>
-        <translation type="unfinished">Bajtov:</translation>
+        <translation type="unfinished">Število bajtov:</translation>
     </message>
     <message>
         <source>Amount:</source>
-        <translation type="unfinished">Suma:</translation>
+        <translation type="unfinished">Znesek:</translation>
     </message>
     <message>
         <source>Fee:</source>
-        <translation type="unfinished">Poplatok:</translation>
+        <translation type="unfinished">Provizija:</translation>
     </message>
     <message>
         <source>After Fee:</source>
-        <translation type="unfinished">Po poplatku:</translation>
+        <translation type="unfinished">Po proviziji:</translation>
     </message>
     <message>
         <source>Change:</source>
-        <translation type="unfinished">Zmena:</translation>
+        <translation type="unfinished">Vračilo:</translation>
     </message>
     <message>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
-        <translation type="unfinished">Ak aktivované ale adresa pre výdavok je prázdna alebo neplatná, výdavok bude poslaný na novovytvorenú adresu.</translation>
+        <translation type="unfinished">Če to vključite, nato pa vnesete neveljaven naslov za vračilo ali pa pustite polje prazno, bo vračilo poslano na novoustvarjen naslov.</translation>
     </message>
     <message>
         <source>Custom change address</source>
-        <translation type="unfinished">Vlastná adresa zmeny</translation>
+        <translation type="unfinished">Naslov za vračilo drobiža po meri</translation>
     </message>
     <message>
         <source>Transaction Fee:</source>
-        <translation type="unfinished">Poplatok za transakciu:</translation>
+        <translation type="unfinished">Provizija:</translation>
     </message>
     <message>
         <source>Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until you have validated the complete chain.</source>
-        <translation type="unfinished">Použitie núdzového poplatku („fallbackfee“) môže vyústiť v transakciu, ktoré bude trvat hodiny nebo dny (prípadne večnosť), kým bude potvrdená. Zvážte preto ručné nastaveníe poplatku, prípadne počkajte, až sa Vám kompletne zvaliduje reťazec blokov.</translation>
+        <translation type="unfinished">Uporaba nadomestne provizije lahko povzroči, da bo transakcija potrjena šele po več urah ali dneh (ali morda sploh nikoli). Razmislite o ročni nastavitvi provizije ali počakajte, da se preveri celotna veriga.</translation>
     </message>
     <message>
         <source>Warning: Fee estimation is currently not possible.</source>
-        <translation type="unfinished">Upozornenie: teraz nie je možné poplatok odhadnúť.</translation>
+        <translation type="unfinished">Opozorilo: ocena provizije trenutno ni mogoča.</translation>
     </message>
     <message>
         <source>per kilobyte</source>
-        <translation type="unfinished">za kilobajt</translation>
+        <translation type="unfinished">na kilobajt</translation>
     </message>
     <message>
         <source>Hide</source>
-        <translation type="unfinished">Skryť</translation>
+        <translation type="unfinished">Skrij</translation>
     </message>
     <message>
         <source>Recommended:</source>
-        <translation type="unfinished">Odporúčaný:</translation>
+        <translation type="unfinished">Priporočena:</translation>
     </message>
     <message>
         <source>Custom:</source>
-        <translation type="unfinished">Vlastný:</translation>
+        <translation type="unfinished">Po meri:</translation>
     </message>
     <message>
         <source>Send to multiple recipients at once</source>
-        <translation>Poslať viacerým príjemcom naraz</translation>
+        <translation>Pošlji več prejemnikom hkrati</translation>
     </message>
     <message>
         <source>Add &amp;Recipient</source>
-        <translation>&amp;Pridať príjemcu</translation>
+        <translation>Dodaj &amp;prejemnika</translation>
     </message>
     <message>
         <source>Clear all fields of the form.</source>
-        <translation type="unfinished">Vyčistiť všetky polia formulára.</translation>
+        <translation type="unfinished">Počisti vsa polja v obrazcu.</translation>
     </message>
     <message>
         <source>Inputs…</source>
-        <translation type="unfinished">Vstupy…</translation>
+        <translation type="unfinished">Vhodi ...</translation>
     </message>
     <message>
         <source>Dust:</source>
-        <translation type="unfinished">Prach:</translation>
+        <translation type="unfinished">Prah:</translation>
     </message>
     <message>
         <source>Choose…</source>
-        <translation type="unfinished">Zvoliť…</translation>
+        <translation type="unfinished">Izberi ...</translation>
     </message>
     <message>
         <source>Hide transaction fee settings</source>
-        <translation type="unfinished">Skryť nastavenie poplatkov transakcie</translation>
+        <translation type="unfinished">Skrij nastavitve transakcijske provizije</translation>
     </message>
     <message>
         <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
 
 Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satoshis per kvB" for a transaction size of 500 virtual bytes (half of 1 kvB) would ultimately yield a fee of only 50 satoshis.</source>
-        <translation type="unfinished">Špecifikujte vlastný poplatok za kB (1000 bajtov) virtuálnej veľkosti transakcie.
+        <translation type="unfinished">Določite poljubno provizijo na kB (1000 bajtov) navidezne velikosti transakcije.
 
-Poznámka: Keďže poplatok je počítaný za bajt, poplatok pri sadzbe "100 satoshi za kB" pri veľkosti transakcie 500 bajtov (polovica z 1 kB) by stál len 50 satoshi.</translation>
+Opomba: Ker se provizija izračuna na bajt, bi provizija "100 satoshijev na kvB" za transakcijo velikosti 500 navideznih bajtov (polovica enega kvB) znašala le 50 satošijev.</translation>
     </message>
     <message>
         <source>When there is less transaction volume than space in the blocks, miners as well as relaying nodes may enforce a minimum fee. Paying only this minimum fee is just fine, but be aware that this can result in a never confirming transaction once there is more demand for bitcoin transactions than the network can process.</source>
-        <translation type="unfinished">Ak je v blokoch menej objemu transakcií ako priestoru, ťažiari ako aj vysielacie uzly, môžu uplatniť minimálny poplatok. Platiť iba minimálny poplatok je v poriadku, ale uvedomte si, že to môže mať za následok transakciu, ktorá sa nikdy nepotvrdí, akonáhle je väčší dopyt po bitcoinových transakciách, než dokáže sieť spracovať.</translation>
+        <translation type="unfinished">Kadar je v blokih manj prostora, kot je zahtev po transakcijah, lahko rudarji in posredovalna vozlišča zahtevajo minimalno provizijo. V redu, če plačate samo to minimalno provizijo, vendar se zavedajte, da se potem transakcija lahko nikoli ne potrdi, če bo povpraševanje po transakcijah večje, kot ga omrežje lahko obdela.</translation>
     </message>
     <message>
         <source>A too low fee might result in a never confirming transaction (read the tooltip)</source>
-        <translation type="unfinished">Príliš nízky poplatok môže mať za následok nikdy nepotvrdenú transakciu (prečítajte si popis)</translation>
+        <translation type="unfinished">Transakcija s prenizko provizijo se lahko nikoli ne potrdi (preberite namig)</translation>
     </message>
     <message>
         <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
-        <translation type="unfinished">(Smart poplatok ešte nie je inicializovaný. Toto zvyčajne vyžaduje niekoľko blokov…)</translation>
+        <translation type="unfinished">(Samodejni obračun provizije še ni pripravljen. Izračun običajno traja nekaj blokov ...)</translation>
     </message>
     <message>
         <source>Confirmation time target:</source>
-        <translation type="unfinished">Cieľový čas potvrdenia:</translation>
+        <translation type="unfinished">Ciljni čas do potrditve:</translation>
     </message>
     <message>
         <source>Enable Replace-By-Fee</source>
-        <translation type="unfinished">Povoliť dodatočné navýšenie poplatku (tzv. „Replace-By-Fee“)</translation>
+        <translation type="unfinished">Omogoči Replace-By-Fee</translation>
     </message>
     <message>
         <source>With Replace-By-Fee (BIP-125) you can increase a transaction's fee after it is sent. Without this, a higher fee may be recommended to compensate for increased transaction delay risk.</source>
-        <translation type="unfinished">S dodatočným navýšením poplatku (BIP-125, tzv. „Replace-By-Fee“), môžete zvýšiť poplatok aj po odoslaní. Bez toho, by mohol byť navrhnutý väčší transakčný poplatok, aby kompenzoval zvýšené riziko omeškania transakcie.</translation>
+        <translation type="unfinished">"Replace-By-Fee" (RBF, BIP-125, "Povozi s provizijo") omogoča, da povečate provizijo za transakcijo po tem, ko je bila transakcija že poslana. Če tega ne izberete, se lahko priporoči višja provizija, ker je potem tveganje zamude pri potrjevanju večje.</translation>
     </message>
     <message>
         <source>Clear &amp;All</source>
-        <translation>&amp;Zmazať všetko</translation>
+        <translation>Počisti &amp;vse</translation>
     </message>
     <message>
         <source>Balance:</source>
-        <translation>Zostatok:</translation>
+        <translation>Dobroimetje:</translation>
     </message>
     <message>
         <source>Confirm the send action</source>
-        <translation>Potvrďte odoslanie</translation>
+        <translation>Potrdi pošiljanje</translation>
     </message>
     <message>
         <source>S&amp;end</source>
-        <translation>&amp;Odoslať</translation>
+        <translation>&amp;Pošlji</translation>
     </message>
     <message>
         <source>Copy quantity</source>
-        <translation type="unfinished">Kopírovať množstvo</translation>
+        <translation type="unfinished">Kopiraj količino</translation>
     </message>
     <message>
         <source>Copy amount</source>
-        <translation type="unfinished">Kopírovať sumu</translation>
+        <translation type="unfinished">Kopiraj znesek</translation>
     </message>
     <message>
         <source>Copy fee</source>
-        <translation type="unfinished">Kopírovať poplatok</translation>
+        <translation type="unfinished">Kopiraj provizijo</translation>
     </message>
     <message>
         <source>Copy after fee</source>
-        <translation type="unfinished">Kopírovať po poplatkoch</translation>
+        <translation type="unfinished">Kopiraj znesek po proviziji</translation>
     </message>
     <message>
         <source>Copy bytes</source>
-        <translation type="unfinished">Kopírovať bajty</translation>
+        <translation type="unfinished">Kopiraj bajte</translation>
     </message>
     <message>
         <source>Copy dust</source>
-        <translation type="unfinished">Kopírovať prach</translation>
+        <translation type="unfinished">Kopiraj prah</translation>
     </message>
     <message>
         <source>Copy change</source>
-        <translation type="unfinished">Kopírovať zmenu</translation>
+        <translation type="unfinished">Kopiraj vračilo</translation>
     </message>
     <message>
         <source>%1 (%2 blocks)</source>
-        <translation type="unfinished">%1 (%2 bloky(ov))</translation>
+        <translation type="unfinished">%1 (%2 blokov)</translation>
     </message>
     <message>
         <source>Sign on device</source>
         <extracomment>"device" usually means a hardware wallet</extracomment>
-        <translation type="unfinished">Podpísať na zariadení</translation>
+        <translation type="unfinished">Podpiši na napravi</translation>
     </message>
     <message>
         <source>Connect your hardware wallet first.</source>
-        <translation type="unfinished">Najprv pripojte hardvérovú peňaženku.</translation>
+        <translation type="unfinished">Najprej povežite svojo hardversko denarnico.</translation>
     </message>
     <message>
         <source>Set external signer script path in Options -&gt; Wallet</source>
         <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
-        <translation type="unfinished">Nastavte cestu ku skriptu externého podpisovateľa v Možnosti -&gt; Peňaženka</translation>
+        <translation type="unfinished">Mesto skripte zunanjega podpisnika nastavite v Možnosti &gt; Denarnica.</translation>
     </message>
     <message>
         <source>Cr&amp;eate Unsigned</source>
-        <translation type="unfinished">Vy&amp;tvoriť bez podpisu</translation>
+        <translation type="unfinished">Ustvari n&amp;epodpisano</translation>
     </message>
     <message>
         <source>Creates a Partially Signed Bitcoin Transaction (PSBT) for use with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
-        <translation type="unfinished">Vytvorí čiastočne podpísanú Bitcoin transakciu (Partially Signed Bitcoin Transaction - PSBT) na použitie napríklad s offline %1 peňaženkou alebo v hardvérovej peňaženke kompatibilnej s PSBT.</translation>
+        <translation type="unfinished">Ustvari delno podpisano bitcoin-transakcijo (DPBT, angl. PSBT), ki jo lahko kopirate in potem podpišete n.pr. z nepovezano (offline) %1 denarnico ali pa s hardversko denarnico, ki podpira DPBT.</translation>
     </message>
     <message>
         <source> from wallet '%1'</source>
-        <translation type="unfinished"> z peňaženky '%1'</translation>
+        <translation type="unfinished"> iz denarnice '%1'</translation>
     </message>
     <message>
         <source>%1 to '%2'</source>
-        <translation type="unfinished">%1 do '%2'</translation>
+        <translation type="unfinished">%1 v '%2'</translation>
     </message>
     <message>
         <source>%1 to %2</source>
-        <translation type="unfinished">%1 do %2</translation>
+        <translation type="unfinished">%1 v %2</translation>
     </message>
     <message>
         <source>Do you want to draft this transaction?</source>
-        <translation type="unfinished">Chcete naplánovať túto transakciu?</translation>
+        <translation type="unfinished">Želite shraniti to transakcijo kot osnutek?</translation>
     </message>
     <message>
         <source>Are you sure you want to send?</source>
-        <translation type="unfinished">Určite chcete odoslať transakciu?</translation>
+        <translation type="unfinished">Ali ste prepričani, da želite poslati sredstva?</translation>
     </message>
     <message>
         <source>To review recipient list click "Show Details…"</source>
-        <translation type="unfinished">Pre kontrolu zoznamu príjemcov kliknite "Zobraziť detaily…"</translation>
+        <translation type="unfinished">Za pregled sezama prejemnikov kliknite na "Pokaži podrobnosti..."</translation>
     </message>
     <message>
         <source>Create Unsigned</source>
-        <translation type="unfinished">Vytvoriť bez podpisu</translation>
+        <translation type="unfinished">Ustvari nepodpisano</translation>
     </message>
     <message>
         <source>Sign and send</source>
-        <translation type="unfinished">Podpísať a odoslať</translation>
+        <translation type="unfinished">Podpiši in pošlji</translation>
     </message>
     <message>
         <source>Sign failed</source>
-        <translation type="unfinished">Podpisovanie neúspešné</translation>
+        <translation type="unfinished">Podpisovanje spodletelo</translation>
     </message>
     <message>
         <source>External signer not found</source>
         <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
-        <translation type="unfinished">Externý podpisovateľ sa nenašiel</translation>
+        <translation type="unfinished">Ne najdem zunanjega podpisnika</translation>
     </message>
     <message>
         <source>External signer failure</source>
         <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
-        <translation type="unfinished">Externý podpisovateľ zlyhal</translation>
+        <translation type="unfinished">Težava pri zunanjem podpisniku</translation>
     </message>
     <message>
         <source>Save Transaction Data</source>
-        <translation type="unfinished">Uložiť údaje z transakcie</translation>
+        <translation type="unfinished">Shrani podatke transakcije</translation>
     </message>
     <message>
         <source>Partially Signed Transaction (Binary)</source>
         <extracomment>Expanded name of the binary PSBT file format. See: BIP 174.</extracomment>
-        <translation type="unfinished">Čiastočne podpísaná transakcia (binárna)</translation>
+        <translation type="unfinished">Delno podpisana transakcija (binarno)</translation>
     </message>
     <message>
         <source>PSBT saved</source>
-        <translation type="unfinished">PSBT uložená</translation>
+        <translation type="unfinished">DPBT shranjena</translation>
     </message>
     <message>
         <source>External balance:</source>
-        <translation type="unfinished">Externý zostatok:</translation>
+        <translation type="unfinished">Zunanje dobroimetje:</translation>
     </message>
     <message>
         <source>or</source>
-        <translation type="unfinished">alebo</translation>
+        <translation type="unfinished">ali</translation>
     </message>
     <message>
         <source>You can increase the fee later (signals Replace-By-Fee, BIP-125).</source>
-        <translation type="unfinished">Poplatok môžete navýšiť neskôr (vysiela sa "Replace-By-Fee" - nahradenie poplatkom, BIP-125).</translation>
+        <translation type="unfinished">Provizijo lahko zvišate kasneje (vsebuje Replace-By-Fee, BIP-125).</translation>
     </message>
     <message>
         <source>Please, review your transaction proposal. This will produce a Partially Signed Bitcoin Transaction (PSBT) which you can save or copy and then sign with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
-        <translation type="unfinished">Prečítajte si prosím svoj návrh transakcie. Výsledkom bude čiastočne podpísaná bitcoinová transakcia (PSBT), ktorú môžete uložiť alebo skopírovať a potom podpísať napr. cez offline peňaženku %1 alebo hardvérovú peňaženku kompatibilnú s PSBT.</translation>
+        <translation type="unfinished">Prosimo, preglejte predlog za transakcijo. Ustvarjena bo delno podpisana bitcoin-transakcija (DPBT), ki jo lahko shranite ali kopirate in potem podpišete n.pr. z nepovezano (offline) %1 denarnico ali pa s hardversko denarnico, ki podpira DPBT.</translation>
     </message>
     <message>
         <source>Please, review your transaction.</source>
-        <translation type="unfinished">Prosím, skontrolujte Vašu transakciu.</translation>
+        <translation type="unfinished">Prosimo, preglejte svojo transakcijo.</translation>
     </message>
     <message>
         <source>Transaction fee</source>
-        <translation type="unfinished">Transakčný poplatok</translation>
+        <translation type="unfinished">Provizija transakcije</translation>
     </message>
     <message>
         <source>Not signalling Replace-By-Fee, BIP-125.</source>
-        <translation type="unfinished">Nevysiela sa "Replace-By-Fee" - nahradenie poplatkom, BIP-125.</translation>
+        <translation type="unfinished">Ne vsebuje Replace-By-Fee, BIP-125</translation>
     </message>
     <message>
         <source>Total Amount</source>
-        <translation type="unfinished">Celková suma</translation>
+        <translation type="unfinished">Skupni znesek</translation>
     </message>
     <message>
         <source>Confirm send coins</source>
-        <translation type="unfinished">Potvrďte odoslanie mincí</translation>
+        <translation type="unfinished">Potrdi pošiljanje</translation>
     </message>
     <message>
         <source>Confirm transaction proposal</source>
-        <translation type="unfinished">Potvrdiť návrh transakcie</translation>
+        <translation type="unfinished">Potrdi predlog transakcije</translation>
     </message>
     <message>
         <source>Watch-only balance:</source>
-        <translation type="unfinished">Iba sledovaný zostatok:</translation>
+        <translation type="unfinished">Opazovano dobroimetje:</translation>
     </message>
     <message>
         <source>The recipient address is not valid. Please recheck.</source>
-        <translation type="unfinished">Adresa príjemcu je neplatná. Prosím, overte ju.</translation>
+        <translation type="unfinished">Naslov prejemnika je neveljaven. Prosimo, preverite.</translation>
     </message>
     <message>
         <source>The amount to pay must be larger than 0.</source>
-        <translation type="unfinished">Suma na úhradu musí byť väčšia ako 0.</translation>
+        <translation type="unfinished">Znesek plačila mora biti večji od 0.</translation>
     </message>
     <message>
         <source>The amount exceeds your balance.</source>
-        <translation type="unfinished">Suma je vyššia ako Váš zostatok.</translation>
+        <translation type="unfinished">Znesek presega vaše dobroimetje.</translation>
     </message>
     <message>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
-        <translation type="unfinished">Celková suma prevyšuje Váš zostatok ak sú započítané aj transakčné poplatky %1.</translation>
+        <translation type="unfinished">Celotni znesek z vključeno provizijo %1 je višji od vašega dobroimetja.</translation>
     </message>
     <message>
         <source>Duplicate address found: addresses should only be used once each.</source>
-        <translation type="unfinished">Našla sa duplicitná adresa: každá adresa by sa mala použiť len raz.</translation>
+        <translation type="unfinished">Naslov je že bil uporabljen. Vsak naslov naj bi se uporabil samo enkrat.</translation>
     </message>
     <message>
         <source>Transaction creation failed!</source>
-        <translation type="unfinished">Vytvorenie transakcie zlyhalo!</translation>
+        <translation type="unfinished">Transakcije ni bilo mogoče ustvariti!</translation>
     </message>
     <message>
         <source>A fee higher than %1 is considered an absurdly high fee.</source>
-        <translation type="unfinished">Poplatok vyšší ako %1 sa považuje za neprimerane vysoký.</translation>
+        <translation type="unfinished">Provizija, ki je večja od %1, velja za nesmiselno veliko.</translation>
     </message>
     <message>
         <source>Payment request expired.</source>
-        <translation type="unfinished">Vypršala platnosť požiadavky na platbu.</translation>
+        <translation type="unfinished">Zahtevek za plačilo je potekel.</translation>
     </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation>
-            <numerusform>Odhadované potvrdenie za %n blok.</numerusform>
-            <numerusform>Odhadované potvrdenie za %n bloky.</numerusform>
-            <numerusform>Odhadované potvrdenie za %n blokov.</numerusform>
+            <numerusform>Ocenjen pričetek potrjevanja v naslednjem bloku.</numerusform>
+            <numerusform>Ocenjen pričetek potrjevanja v naslednjih dveh blokih.</numerusform>
+            <numerusform>Ocenjen pričetek potrjevanja v naslednjih %n blokih.</numerusform>
+            <numerusform>Ocenjen pričetek potrjevanja v naslednjih %n blokih.</numerusform>
         </translation>
     </message>
     <message>
         <source>Warning: Invalid Bitcoin address</source>
-        <translation type="unfinished">Varovanie: Neplatná Bitcoin adresa</translation>
+        <translation type="unfinished">Opozorilo: Neveljaven bitcoin-naslov</translation>
     </message>
     <message>
         <source>Warning: Unknown change address</source>
-        <translation type="unfinished">UPOZORNENIE: Neznáma výdavková adresa</translation>
+        <translation type="unfinished">Opozorilo: Neznan naslov za vračilo drobiža</translation>
     </message>
     <message>
         <source>Confirm custom change address</source>
-        <translation type="unfinished">Potvrďte vlastnú výdavkovú adresu</translation>
+        <translation type="unfinished">Potrdi naslov za vračilo drobiža po meri</translation>
     </message>
     <message>
         <source>The address you selected for change is not part of this wallet. Any or all funds in your wallet may be sent to this address. Are you sure?</source>
-        <translation type="unfinished">Zadaná adresa pre výdavok nie je súčasťou tejto peňaženky. Časť alebo všetky peniaze z peňaženky môžu byť odoslané na túto adresu. Ste si istý?</translation>
+        <translation type="unfinished">Naslov, ki ste ga izbrali za vračilo, ne pripada tej denarnici. Na ta naslov bodo lahko poslana katerakoli ali vsa sredstva v vaši denarnici. Ali ste prepričani?</translation>
     </message>
     <message>
         <source>(no label)</source>
-        <translation type="unfinished">(bez popisu)</translation>
+        <translation type="unfinished">(brez oznake)</translation>
     </message>
 </context>
 <context>
     <name>SendCoinsEntry</name>
     <message>
         <source>A&amp;mount:</source>
-        <translation>Su&amp;ma:</translation>
+        <translation>&amp;Znesek:</translation>
     </message>
     <message>
         <source>Pay &amp;To:</source>
-        <translation>Zapla&amp;tiť:</translation>
+        <translation>&amp;Prejemnik plačila:</translation>
     </message>
     <message>
         <source>&amp;Label:</source>
-        <translation>&amp;Popis:</translation>
+        <translation>&amp;Oznaka:</translation>
     </message>
     <message>
         <source>Choose previously used address</source>
-        <translation type="unfinished">Vybrať predtým použitú adresu</translation>
+        <translation type="unfinished">Izberite enega od že uporabljenih naslovov</translation>
     </message>
     <message>
         <source>The Bitcoin address to send the payment to</source>
-        <translation type="unfinished">Zvoľte adresu kam poslať platbu</translation>
+        <translation type="unfinished">Bitcoin-naslov, na katerega bo plačilo poslano</translation>
     </message>
     <message>
         <source>Paste address from clipboard</source>
-        <translation>Vložiť adresu zo schránky</translation>
+        <translation>Prilepite naslov iz odložišča</translation>
     </message>
     <message>
         <source>Remove this entry</source>
-        <translation type="unfinished">Odstrániť túto položku</translation>
+        <translation type="unfinished">Odstrani ta vnos</translation>
     </message>
     <message>
         <source>The amount to send in the selected unit</source>
-        <translation type="unfinished">Suma na odoslanie vo vybranej mene</translation>
+        <translation type="unfinished">Znesek za pošiljanje v izbrani enoti</translation>
     </message>
     <message>
         <source>The fee will be deducted from the amount being sent. The recipient will receive less bitcoins than you enter in the amount field. If multiple recipients are selected, the fee is split equally.</source>
-        <translation type="unfinished">Poplatok sa odpočíta od čiastky, ktorú odosielate. Príjemca dostane menej bitcoinov ako zadáte. Ak je vybraných viacero príjemcov, poplatok je rozdelený rovným dielom.</translation>
+        <translation type="unfinished">Znesek plačila bo zmanjšan za znesek provizije. Prejemnik bo prejel manjši znesek, kot je bil vnešen. Če je prejemnikov več, bo provizija med njih enakomerno porazdeljena.</translation>
     </message>
     <message>
         <source>S&amp;ubtract fee from amount</source>
-        <translation type="unfinished">Odpočítať poplatok od s&amp;umy</translation>
+        <translation type="unfinished">O&amp;dštej provizijo od zneska</translation>
     </message>
     <message>
         <source>Use available balance</source>
-        <translation type="unfinished">Použiť dostupné zdroje</translation>
+        <translation type="unfinished">Uporabi celotno razpoložljivo dobroimetje</translation>
     </message>
     <message>
         <source>Message:</source>
-        <translation type="unfinished">Správa:</translation>
+        <translation type="unfinished">Sporočilo:</translation>
     </message>
     <message>
         <source>This is an unauthenticated payment request.</source>
-        <translation type="unfinished">Toto je neoverená výzva k platbe.</translation>
+        <translation type="unfinished">Ta zahtevek za plačilo je neoverjen.</translation>
     </message>
     <message>
         <source>This is an authenticated payment request.</source>
-        <translation type="unfinished">Toto je overená výzva k platbe.</translation>
+        <translation type="unfinished">Ta zahtevek za plačilo je overjen.</translation>
     </message>
     <message>
         <source>Enter a label for this address to add it to the list of used addresses</source>
-        <translation type="unfinished">Vložte popis pre túto adresu aby sa uložila do zoznamu použitých adries</translation>
+        <translation type="unfinished">Če vnesete oznako za zgornji naslov, se bo skupaj z naslovom shranila v imenik že uporabljenih naslovov</translation>
     </message>
     <message>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
-        <translation type="unfinished">Správa ktorá bola pripojená k bitcoin: URI a ktorá bude uložená s transakcou pre Vaše potreby. Poznámka: Táto správa nebude poslaná cez sieť Bitcoin.</translation>
+        <translation type="unfinished">Sporočilo, ki je bilo pripeto na URI tipa bitcoin: in bo shranjeno skupaj s podatki o transakciji. Opomba: Sporočilo ne bo poslano preko omrežja Bitcoin.</translation>
     </message>
     <message>
         <source>Pay To:</source>
-        <translation type="unfinished">Platba pre:</translation>
+        <translation type="unfinished">Prejemnik:</translation>
     </message>
     <message>
         <source>Memo:</source>
-        <translation type="unfinished">Poznámka:</translation>
+        <translation type="unfinished">Opomba:</translation>
     </message>
 </context>
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
         <source>Signatures - Sign / Verify a Message</source>
-        <translation>Podpisy - Podpísať / Overiť správu</translation>
+        <translation>Podpiši / preveri sporočilo</translation>
     </message>
     <message>
         <source>&amp;Sign Message</source>
-        <translation>&amp;Podpísať Správu</translation>
+        <translation>&amp;Podpiši sporočilo</translation>
     </message>
     <message>
         <source>You can sign messages/agreements with your addresses to prove you can receive bitcoins sent to them. Be careful not to sign anything vague or random, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
-        <translation type="unfinished">Môžete podpísať správy svojou adresou a dokázať, že viete prijímať mince zaslané na túto adresu. Buďte však opatrní a podpíšte len podrobné prehlásenia, s ktorými plne súhlasíte, nakoľko útoky typu "phishing" Vás môžu lákať k podpísaniu nejasných alebo príliš všeobecných tvrdení čím prevezmú vašu identitu.</translation>
+        <translation type="unfinished">S svojimi naslovi lahko podpisujete sporočila ali dogovore in s tem dokazujete, da na teh naslovih lahko prejemate kovance. Bodite previdni in ne podpisujte ničesar nejasnega ali naključnega, ker vas zlikovci preko ribarjenja (phishing) lahko prelisičijo, da na njih prepišete svojo identiteto. Podpisujte samo podrobno opisane izjave, s katerimi se strinjate.</translation>
     </message>
     <message>
         <source>The Bitcoin address to sign the message with</source>
-        <translation type="unfinished">Bitcoin adresa pre podpísanie správy s</translation>
+        <translation type="unfinished">Bitcoin-naslov, s katerim podpisujete sporočilo</translation>
     </message>
     <message>
         <source>Choose previously used address</source>
-        <translation type="unfinished">Vybrať predtým použitú adresu</translation>
+        <translation type="unfinished">Izberite enega od že uporabljenih naslovov</translation>
     </message>
     <message>
         <source>Paste address from clipboard</source>
-        <translation>Vložiť adresu zo schránky</translation>
+        <translation>Prilepite naslov iz odložišča</translation>
     </message>
     <message>
         <source>Enter the message you want to sign here</source>
-        <translation>Sem vložte správu ktorú chcete podpísať</translation>
+        <translation>Vnesite sporočilo, ki ga želite podpisati</translation>
     </message>
     <message>
         <source>Signature</source>
@@ -3040,111 +3030,111 @@ Poznámka: Keďže poplatok je počítaný za bajt, poplatok pri sadzbe "100 sat
     </message>
     <message>
         <source>Copy the current signature to the system clipboard</source>
-        <translation>Kopírovať tento podpis do systémovej schránky</translation>
+        <translation>Kopirj trenutni podpis v sistemsko odložišče.</translation>
     </message>
     <message>
         <source>Sign the message to prove you own this Bitcoin address</source>
-        <translation>Podpíšte správu aby ste dokázali že vlastníte túto adresu</translation>
+        <translation>Podpišite sporočilo, da dokažete lastništvo zgornjega naslova.</translation>
     </message>
     <message>
         <source>Sign &amp;Message</source>
-        <translation>Podpísať &amp;správu</translation>
+        <translation>Podpiši &amp;sporočilo</translation>
     </message>
     <message>
         <source>Reset all sign message fields</source>
-        <translation>Vynulovať všetky polia podpisu správy</translation>
+        <translation>Počisti vsa vnosna polja v obrazcu za podpisovanje</translation>
     </message>
     <message>
         <source>Clear &amp;All</source>
-        <translation>&amp;Zmazať všetko</translation>
+        <translation>Počisti &amp;vse</translation>
     </message>
     <message>
         <source>&amp;Verify Message</source>
-        <translation>O&amp;veriť správu...</translation>
+        <translation>&amp;Preveri sporočilo</translation>
     </message>
     <message>
         <source>Enter the receiver's address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack. Note that this only proves the signing party receives with the address, it cannot prove sendership of any transaction!</source>
-        <translation type="unfinished">Vložte adresu príjemcu, správu (uistite sa, že presne kopírujete ukončenia riadkov, medzery, odrážky, atď.) a podpis pre potvrdenie správy. Buďte opatrní a nedomýšľajte si viac než je uvedené v samotnej podpísanej správe a môžete sa tak vyhnúť podvodu MITM útokom. Toto len potvrdzuje, že podpisujúca strana môže prijímať na tejto adrese, nepotvrdzuje to vlastníctvo žiadnej transakcie!</translation>
+        <translation type="unfinished">Da preverite verodostojnost sporočila, spodaj vnesite: prejemnikov naslov, prejeto sporočilo (pazljivo skopirajte vse prelome vrstic, presledke, tabulatorje itd.) ter prejeti podpis. Da se izognete napadom tipa man-in-the-middle, vedite, da iz veljavnega podpisa ne sledi nič drugega, kot tisto, kar je navedeno v sporočilu. Podpis samo potrjuje dejstvo, da ima podpisnik v lasti prejemni naslov, ne more pa dokazati pošiljanja nobene transakcije!</translation>
     </message>
     <message>
         <source>The Bitcoin address the message was signed with</source>
-        <translation type="unfinished">Adresa Bitcoin, ktorou bola podpísaná správa</translation>
+        <translation type="unfinished">Bitcoin-naslov, s katerim je bilo sporočilo podpisano</translation>
     </message>
     <message>
         <source>The signed message to verify</source>
-        <translation type="unfinished">Podpísaná správa na overenie</translation>
+        <translation type="unfinished">Podpisano sporočilo, ki ga želite preveriti</translation>
     </message>
     <message>
         <source>The signature given when the message was signed</source>
-        <translation type="unfinished">Poskytnutý podpis pri podpísaní správy</translation>
+        <translation type="unfinished">Podpis, ustvarjen ob podpisovanju sporočila</translation>
     </message>
     <message>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
-        <translation>Overím správy sa uistiť že bola podpísaná označenou Bitcoin adresou</translation>
+        <translation>Preverite, ali je bilo sporočilo v resnici podpisano z navedenim bitcoin-naslovom.</translation>
     </message>
     <message>
         <source>Verify &amp;Message</source>
-        <translation>&amp;Overiť správu</translation>
+        <translation>Preveri &amp;sporočilo</translation>
     </message>
     <message>
         <source>Reset all verify message fields</source>
-        <translation>Obnoviť všetky polia v overiť správu</translation>
+        <translation>Počisti vsa polja za vnos v obrazcu za preverjanje</translation>
     </message>
     <message>
         <source>Click "Sign Message" to generate signature</source>
-        <translation type="unfinished">Kliknite "Podpísať správu" pre vytvorenie podpisu</translation>
+        <translation type="unfinished">Kliknite "Podpiši sporočilo", da se ustvari podpis</translation>
     </message>
     <message>
         <source>The entered address is invalid.</source>
-        <translation type="unfinished">Zadaná adresa je neplatná.</translation>
+        <translation type="unfinished">Vnešen naslov je neveljaven.</translation>
     </message>
     <message>
         <source>Please check the address and try again.</source>
-        <translation type="unfinished">Prosím skontrolujte adresu a skúste znova.</translation>
+        <translation type="unfinished">Prosimo, preverite naslov in poskusite znova.</translation>
     </message>
     <message>
         <source>The entered address does not refer to a key.</source>
-        <translation type="unfinished">Vložená adresa nezodpovedá žiadnemu kľúču.</translation>
+        <translation type="unfinished">Vnešeni naslov se ne nanaša na ključ.</translation>
     </message>
     <message>
         <source>Wallet unlock was cancelled.</source>
-        <translation type="unfinished">Odomknutie peňaženky bolo zrušené.</translation>
+        <translation type="unfinished">Odklepanje denarnice je bilo preklicano.</translation>
     </message>
     <message>
         <source>No error</source>
-        <translation type="unfinished">Bez chyby</translation>
+        <translation type="unfinished">Ni napak</translation>
     </message>
     <message>
         <source>Private key for the entered address is not available.</source>
-        <translation type="unfinished">Súkromný kľúč pre zadanú adresu nieje k dispozícii.</translation>
+        <translation type="unfinished">Zasebni ključ vnešenega naslova ni na voljo.</translation>
     </message>
     <message>
         <source>Message signing failed.</source>
-        <translation type="unfinished">Podpísanie správy zlyhalo.</translation>
+        <translation type="unfinished">Podpisovanje sporočila je spodletelo.</translation>
     </message>
     <message>
         <source>Message signed.</source>
-        <translation type="unfinished">Správa podpísaná.</translation>
+        <translation type="unfinished">Sporočilo podpisano.</translation>
     </message>
     <message>
         <source>The signature could not be decoded.</source>
-        <translation type="unfinished">Podpis nie je možné dekódovať.</translation>
+        <translation type="unfinished">Podpisa ni bilo mogoče dešifrirati.</translation>
     </message>
     <message>
         <source>Please check the signature and try again.</source>
-        <translation type="unfinished">Prosím skontrolujte podpis a skúste znova.</translation>
+        <translation type="unfinished">Prosimo, preverite podpis in poskusite znova.</translation>
     </message>
     <message>
         <source>The signature did not match the message digest.</source>
-        <translation type="unfinished">Podpis sa nezhoduje so zhrnutím správy.</translation>
+        <translation type="unfinished">Podpis ne ustreza zgoščeni vrednosti sporočila.</translation>
     </message>
     <message>
         <source>Message verification failed.</source>
-        <translation type="unfinished">Overenie správy zlyhalo.</translation>
+        <translation type="unfinished">Preverjanje sporočila je spodletelo.</translation>
     </message>
     <message>
         <source>Message verified.</source>
-        <translation type="unfinished">Správa overená.</translation>
+        <translation type="unfinished">Sporočilo je preverjeno.</translation>
     </message>
 </context>
 <context>
@@ -3152,448 +3142,455 @@ Poznámka: Keďže poplatok je počítaný za bajt, poplatok pri sadzbe "100 sat
     <message numerus="yes">
         <source>Open for %n more block(s)</source>
         <translation>
-            <numerusform>Otvorená pre ďalší %n blok</numerusform>
-            <numerusform>Otvorená pre ďalšie %n bloky</numerusform>
-            <numerusform>Otvorená pre ďalších %n blokov</numerusform>
+            <numerusform>Odprto še za naslednji blok</numerusform>
+            <numerusform>Odprto še za naslednja %n bloka</numerusform>
+            <numerusform>Odprto še za naslednje %n bloke</numerusform>
+            <numerusform>Odprto še za naslednjih %n blokov</numerusform>
         </translation>
     </message>
     <message>
         <source>Open until %1</source>
-        <translation type="unfinished">Otvorené do %1</translation>
+        <translation type="unfinished">Odprto do %1</translation>
     </message>
     <message>
         <source>conflicted with a transaction with %1 confirmations</source>
-        <translation type="unfinished">koliduje s transakciou s %1 potvrdeniami</translation>
+        <translation type="unfinished">v sporu s transakcijo z %1 potrditvami</translation>
     </message>
     <message>
         <source>0/unconfirmed, %1</source>
-        <translation type="unfinished">0/nepotvrdené, %1</translation>
+        <translation type="unfinished">0/nepotrjeno, %1</translation>
     </message>
     <message>
         <source>in memory pool</source>
-        <translation type="unfinished">v transakčnom zásobníku</translation>
+        <translation type="unfinished">v čakalni vrsti</translation>
     </message>
     <message>
         <source>not in memory pool</source>
-        <translation type="unfinished">nie je v transakčnom zásobníku</translation>
+        <translation type="unfinished">ni v čakalni vrsti</translation>
     </message>
     <message>
         <source>abandoned</source>
-        <translation type="unfinished">zanechaná</translation>
+        <translation type="unfinished">opuščena</translation>
     </message>
     <message>
         <source>%1/unconfirmed</source>
-        <translation type="unfinished">%1/nepotvrdené</translation>
+        <translation type="unfinished">%1/nepotrjena</translation>
     </message>
     <message>
         <source>%1 confirmations</source>
-        <translation type="unfinished">%1 potvrdení</translation>
+        <translation type="unfinished">%1 potrditev</translation>
     </message>
     <message>
         <source>Status</source>
-        <translation type="unfinished">Stav</translation>
+        <translation type="unfinished">Stanje</translation>
     </message>
     <message>
         <source>Date</source>
-        <translation type="unfinished">Dátum</translation>
+        <translation type="unfinished">Datum</translation>
     </message>
     <message>
         <source>Source</source>
-        <translation type="unfinished">Zdroj</translation>
+        <translation type="unfinished">Vir</translation>
     </message>
     <message>
         <source>Generated</source>
-        <translation type="unfinished">Vygenerované</translation>
+        <translation type="unfinished">Ustvarjeno</translation>
     </message>
     <message>
         <source>From</source>
-        <translation type="unfinished">Od</translation>
+        <translation type="unfinished">Pošiljatelj</translation>
     </message>
     <message>
         <source>unknown</source>
-        <translation type="unfinished">neznámy</translation>
+        <translation type="unfinished">neznano</translation>
     </message>
     <message>
         <source>To</source>
-        <translation type="unfinished">Do</translation>
+        <translation type="unfinished">Prejemnik</translation>
     </message>
     <message>
         <source>own address</source>
-        <translation type="unfinished">vlastná adresa</translation>
+        <translation type="unfinished">lasten naslov</translation>
     </message>
     <message>
         <source>watch-only</source>
-        <translation type="unfinished">Iba sledovanie</translation>
+        <translation type="unfinished">opazovano</translation>
     </message>
     <message>
         <source>label</source>
-        <translation type="unfinished">popis</translation>
+        <translation type="unfinished">oznaka</translation>
     </message>
     <message>
         <source>Credit</source>
-        <translation type="unfinished">Kredit</translation>
+        <translation type="unfinished">V dobro</translation>
     </message>
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation>
-            <numerusform>dozrie o ďalší %n blok</numerusform>
-            <numerusform>dozrie o ďalšie %n bloky</numerusform>
-            <numerusform>dozrie o ďalších %n blokov</numerusform>
+            <numerusform>dozori v naslednjem bloku</numerusform>
+            <numerusform>dozori v naslednjih %n blokih</numerusform>
+            <numerusform>dozori v naslednjih %nblokih</numerusform>
+            <numerusform>dozori v naslednjih %n blokih</numerusform>
         </translation>
     </message>
     <message>
         <source>not accepted</source>
-        <translation type="unfinished">neprijaté</translation>
+        <translation type="unfinished">ni sprejeto</translation>
     </message>
     <message>
         <source>Debit</source>
-        <translation type="unfinished">Debet</translation>
+        <translation type="unfinished">V breme</translation>
     </message>
     <message>
         <source>Total debit</source>
-        <translation type="unfinished">Celkový debet</translation>
+        <translation type="unfinished">Skupaj v breme</translation>
     </message>
     <message>
         <source>Total credit</source>
-        <translation type="unfinished">Celkový kredit</translation>
+        <translation type="unfinished">Skupaj v dobro</translation>
     </message>
     <message>
         <source>Transaction fee</source>
-        <translation type="unfinished">Transakčný poplatok</translation>
+        <translation type="unfinished">Provizija transakcije</translation>
     </message>
     <message>
         <source>Net amount</source>
-        <translation type="unfinished">Suma netto</translation>
+        <translation type="unfinished">Neto znesek</translation>
     </message>
     <message>
         <source>Message</source>
-        <translation type="unfinished">Správa</translation>
+        <translation type="unfinished">Sporočilo</translation>
     </message>
     <message>
         <source>Comment</source>
-        <translation type="unfinished">Komentár</translation>
+        <translation type="unfinished">Opomba</translation>
     </message>
     <message>
         <source>Transaction ID</source>
-        <translation type="unfinished">ID transakcie</translation>
+        <translation type="unfinished">ID transakcije</translation>
     </message>
     <message>
         <source>Transaction total size</source>
-        <translation type="unfinished">Celková veľkosť transakcie</translation>
+        <translation type="unfinished">Skupna velikost transakcije</translation>
     </message>
     <message>
         <source>Transaction virtual size</source>
-        <translation type="unfinished">Virtuálna veľkosť transakcie</translation>
+        <translation type="unfinished">Navidezna velikost transakcije</translation>
     </message>
     <message>
         <source>Output index</source>
-        <translation type="unfinished">Index výstupu</translation>
+        <translation type="unfinished">Indeks izhoda</translation>
     </message>
     <message>
         <source> (Certificate was not verified)</source>
-        <translation type="unfinished">(Certifikát nebol overený)</translation>
+        <translation type="unfinished">(Certifikat ni bil preverjen)</translation>
     </message>
     <message>
         <source>Merchant</source>
-        <translation type="unfinished">Kupec</translation>
+        <translation type="unfinished">Trgovec</translation>
     </message>
     <message>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to "not accepted" and it won't be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
-        <translation type="unfinished">Vytvorené coins musia dospieť %1 blokov kým môžu byť minuté. Keď vytvoríte tento blok, bude rozoslaný do siete aby bol akceptovaný do reťaze blokov. Ak sa nedostane reťaze, jeho stav sa zmení na "zamietnutý" a nebude sa dať minúť. Toto sa môže občas stať ak iná nóda vytvorí blok približne v tom istom čase.</translation>
+        <translation type="unfinished">Ustvarjeni kovanci morajo zoreti %1 blokov, preden jih lahko porabite. Ko ste ta blok ustvarili, je bil posredovan v omrežje, bi se vključil v verigo blokov. Če se bloku ne bo uspelo uvrstiti v verigo, se bo njegovo stanje spremenilo v "ni sprejeto" in kovancev ne bo mogoče porabiti. To se občasno zgodi, kadar kak drug rudar ustvari drug blok znotraj roka nekaj sekund od vašega.</translation>
     </message>
     <message>
         <source>Debug information</source>
-        <translation type="unfinished">Ladiace informácie</translation>
+        <translation type="unfinished">Informacije za razhroščanje</translation>
     </message>
     <message>
         <source>Transaction</source>
-        <translation type="unfinished">Transakcie</translation>
+        <translation type="unfinished">Transakcija</translation>
     </message>
     <message>
         <source>Inputs</source>
-        <translation type="unfinished">Vstupy</translation>
+        <translation type="unfinished">Vhodi</translation>
     </message>
     <message>
         <source>Amount</source>
-        <translation type="unfinished">Suma</translation>
+        <translation type="unfinished">Znesek</translation>
     </message>
     <message>
         <source>true</source>
-        <translation type="unfinished">pravda</translation>
+        <translation type="unfinished">je</translation>
     </message>
     <message>
         <source>false</source>
-        <translation type="unfinished">nepravda</translation>
+        <translation type="unfinished">ni</translation>
     </message>
 </context>
 <context>
     <name>TransactionDescDialog</name>
     <message>
         <source>This pane shows a detailed description of the transaction</source>
-        <translation>Táto časť obrazovky zobrazuje detailný popis transakcie</translation>
+        <translation>V tem podoknu so prikazane podrobnosti o transakciji</translation>
     </message>
     <message>
         <source>Details for %1</source>
-        <translation type="unfinished">Podrobnosti pre %1</translation>
+        <translation type="unfinished">Podrobnosti za %1</translation>
     </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
         <source>Date</source>
-        <translation type="unfinished">Dátum</translation>
+        <translation type="unfinished">Datum</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="unfinished">Typ</translation>
+        <translation type="unfinished">Vrsta</translation>
     </message>
     <message>
         <source>Label</source>
-        <translation type="unfinished">Popis</translation>
+        <translation type="unfinished">Oznaka</translation>
     </message>
     <message numerus="yes">
         <source>Open for %n more block(s)</source>
         <translation>
-            <numerusform>Otvorená pre ďalší %n blok</numerusform>
-            <numerusform>Otvorená pre ďalšie %n bloky</numerusform>
-            <numerusform>Otvorená pre ďalších %n blokov</numerusform>
+            <numerusform>Odprto še za naslednji blok</numerusform>
+            <numerusform>Odprto še naslednja %n bloka</numerusform>
+            <numerusform>Odprto še naslednje %n bloke</numerusform>
+            <numerusform>Odprto še naslednjih %n blokov</numerusform>
         </translation>
     </message>
     <message>
         <source>Open until %1</source>
-        <translation type="unfinished">Otvorené do %1</translation>
+        <translation type="unfinished">Odprto do %1</translation>
     </message>
     <message>
         <source>Unconfirmed</source>
-        <translation type="unfinished">Nepotvrdené</translation>
+        <translation type="unfinished">Nepotrjena</translation>
     </message>
     <message>
         <source>Abandoned</source>
-        <translation type="unfinished">Zanechaná</translation>
+        <translation type="unfinished">Opuščena</translation>
     </message>
     <message>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
-        <translation type="unfinished">Potvrdzujem (%1 z %2 odporúčaných potvrdení)</translation>
+        <translation type="unfinished">Se potrjuje (%1 od %2 priporočenih potrditev)</translation>
     </message>
     <message>
         <source>Confirmed (%1 confirmations)</source>
-        <translation type="unfinished">Potvrdené (%1 potvrdení)</translation>
+        <translation type="unfinished">Potrjena (%1 potrditev)</translation>
     </message>
     <message>
         <source>Conflicted</source>
-        <translation type="unfinished">V rozpore</translation>
+        <translation type="unfinished">Sporna</translation>
     </message>
     <message>
         <source>Immature (%1 confirmations, will be available after %2)</source>
-        <translation type="unfinished">Nezrelé (%1 potvrdení, bude dostupné po %2)</translation>
+        <translation type="unfinished">Nedozorelo (št. potrditev: %1, na voljo šele po %2)</translation>
     </message>
     <message>
         <source>Generated but not accepted</source>
-        <translation type="unfinished">Vypočítané ale neakceptované</translation>
+        <translation type="unfinished">Generirano, toda ne sprejeto</translation>
     </message>
     <message>
         <source>Received with</source>
-        <translation type="unfinished">Prijaté s</translation>
+        <translation type="unfinished">Prejeto z</translation>
     </message>
     <message>
         <source>Received from</source>
-        <translation type="unfinished">Prijaté od</translation>
+        <translation type="unfinished">Prejeto od</translation>
     </message>
     <message>
         <source>Sent to</source>
-        <translation type="unfinished">Odoslané na</translation>
+        <translation type="unfinished">Poslano na </translation>
     </message>
     <message>
         <source>Payment to yourself</source>
-        <translation type="unfinished">Platba sebe samému</translation>
+        <translation type="unfinished">Plačilo sebi</translation>
     </message>
     <message>
         <source>Mined</source>
-        <translation type="unfinished">Vyťažené</translation>
+        <translation type="unfinished">Narudarjeno</translation>
     </message>
     <message>
         <source>watch-only</source>
-        <translation type="unfinished">Iba sledovanie</translation>
+        <translation type="unfinished">opazovan</translation>
+    </message>
+    <message>
+        <source>(n/a)</source>
+        <translation type="unfinished">(ni na voljo)</translation>
     </message>
     <message>
         <source>(no label)</source>
-        <translation type="unfinished">(bez popisu)</translation>
+        <translation type="unfinished">(brez oznake)</translation>
     </message>
     <message>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
-        <translation type="unfinished">Stav transakcie. Prejdite ponad toto pole pre zobrazenie počtu potvrdení.</translation>
+        <translation type="unfinished">Stanje transakcije. Podržite miško nad tem poljem za prikaz števila potrditev.</translation>
     </message>
     <message>
         <source>Date and time that the transaction was received.</source>
-        <translation type="unfinished">Dátum a čas prijatia transakcie.</translation>
+        <translation type="unfinished">Datum in čas prejema transakcije.</translation>
     </message>
     <message>
         <source>Type of transaction.</source>
-        <translation type="unfinished">Typ transakcie.</translation>
+        <translation type="unfinished">Vrsta transakcije</translation>
     </message>
     <message>
         <source>Whether or not a watch-only address is involved in this transaction.</source>
-        <translation type="unfinished">Či je v tejto transakcii adresy iba na sledovanie.</translation>
+        <translation type="unfinished">Ali je v transakciji udeležen opazovan naslov.</translation>
     </message>
     <message>
         <source>User-defined intent/purpose of the transaction.</source>
-        <translation type="unfinished">Užívateľsky určený účel transakcie.</translation>
+        <translation type="unfinished">Uporabniško določen namen transakcije.</translation>
     </message>
     <message>
         <source>Amount removed from or added to balance.</source>
-        <translation type="unfinished">Suma pridaná alebo odobraná k zostatku.</translation>
+        <translation type="unfinished">Višina spremembe dobroimetja.</translation>
     </message>
 </context>
 <context>
     <name>TransactionView</name>
     <message>
         <source>All</source>
-        <translation type="unfinished">Všetky</translation>
+        <translation type="unfinished">Vse</translation>
     </message>
     <message>
         <source>Today</source>
-        <translation type="unfinished">Dnes</translation>
+        <translation type="unfinished">Danes</translation>
     </message>
     <message>
         <source>This week</source>
-        <translation type="unfinished">Tento týždeň</translation>
+        <translation type="unfinished">Ta teden</translation>
     </message>
     <message>
         <source>This month</source>
-        <translation type="unfinished">Tento mesiac</translation>
+        <translation type="unfinished">Ta mesec</translation>
     </message>
     <message>
         <source>Last month</source>
-        <translation type="unfinished">Minulý mesiac</translation>
+        <translation type="unfinished">Prejšnji mesec</translation>
     </message>
     <message>
         <source>This year</source>
-        <translation type="unfinished">Tento rok</translation>
+        <translation type="unfinished">Letos</translation>
     </message>
     <message>
         <source>Received with</source>
-        <translation type="unfinished">Prijaté s</translation>
+        <translation type="unfinished">Prejeto z</translation>
     </message>
     <message>
         <source>Sent to</source>
-        <translation type="unfinished">Odoslané na</translation>
+        <translation type="unfinished">Poslano na </translation>
     </message>
     <message>
         <source>To yourself</source>
-        <translation type="unfinished">Ku mne</translation>
+        <translation type="unfinished">Sebi</translation>
     </message>
     <message>
         <source>Mined</source>
-        <translation type="unfinished">Vyťažené</translation>
+        <translation type="unfinished">Narudarjeno</translation>
     </message>
     <message>
         <source>Other</source>
-        <translation type="unfinished">Iné</translation>
+        <translation type="unfinished">Drugo</translation>
     </message>
     <message>
         <source>Enter address, transaction id, or label to search</source>
-        <translation type="unfinished">Pre vyhľadávanie vložte adresu, id transakcie, alebo popis.</translation>
+        <translation type="unfinished">Vnesi naslov, ID transakcije ali oznako za iskanje</translation>
     </message>
     <message>
         <source>Min amount</source>
-        <translation type="unfinished">Minimálna suma</translation>
+        <translation type="unfinished">Najmanjši znesek</translation>
     </message>
     <message>
         <source>Range…</source>
-        <translation type="unfinished">Rozsah…</translation>
+        <translation type="unfinished">Razpon…</translation>
     </message>
     <message>
         <source>&amp;Copy address</source>
-        <translation type="unfinished">&amp;Kopírovať adresu</translation>
+        <translation type="unfinished">&amp;Kopiraj naslov</translation>
     </message>
     <message>
         <source>Copy &amp;label</source>
-        <translation type="unfinished">Kopírovať &amp;popis</translation>
+        <translation type="unfinished">Kopiraj &amp;oznako</translation>
     </message>
     <message>
         <source>Copy &amp;amount</source>
-        <translation type="unfinished">Kopírovať &amp;sumu</translation>
+        <translation type="unfinished">Kopiraj &amp;znesek</translation>
     </message>
     <message>
         <source>Copy transaction &amp;ID</source>
-        <translation type="unfinished">Kopírovať &amp;ID transakcie</translation>
+        <translation type="unfinished">Kopiraj &amp;ID transakcije</translation>
     </message>
     <message>
         <source>Copy &amp;raw transaction</source>
-        <translation type="unfinished">Skopírovať neup&amp;ravenú transakciu</translation>
+        <translation type="unfinished">Kopiraj su&amp;rovo transkacijo</translation>
     </message>
     <message>
         <source>Copy full transaction &amp;details</source>
-        <translation type="unfinished">Skopírovať plné &amp;detaily transakcie</translation>
+        <translation type="unfinished">Kopiraj vse po&amp;drobnosti o transakciji</translation>
     </message>
     <message>
         <source>&amp;Show transaction details</source>
-        <translation type="unfinished">&amp;Zobraziť podrobnosti transakcie</translation>
+        <translation type="unfinished">Prikaži podrobno&amp;sti o transakciji</translation>
     </message>
     <message>
         <source>Increase transaction &amp;fee</source>
-        <translation type="unfinished">Zvýšiť transakčný &amp;poplatok</translation>
+        <translation type="unfinished">Povečaj transakcijsko provi&amp;zijo</translation>
     </message>
     <message>
         <source>A&amp;bandon transaction</source>
-        <translation type="unfinished">Z&amp;amietnuť transakciu</translation>
+        <translation type="unfinished">O&amp;pusti transakcijo</translation>
     </message>
     <message>
         <source>&amp;Edit address label</source>
-        <translation type="unfinished">&amp;Upraviť popis transakcie</translation>
+        <translation type="unfinished">&amp;Uredi oznako naslova</translation>
     </message>
     <message>
         <source>Export Transaction History</source>
-        <translation type="unfinished">Exportovať históriu transakcií</translation>
+        <translation type="unfinished">Izvozi zgodovino transakcij</translation>
     </message>
     <message>
         <source>Comma separated file</source>
         <extracomment>Expanded name of the CSV file format. See https://en.wikipedia.org/wiki/Comma-separated_values</extracomment>
-        <translation type="unfinished">Čiarkou oddelený súbor</translation>
+        <translation type="unfinished">Datoteka CSV (podatki ločeni z vejicami)</translation>
     </message>
     <message>
         <source>Confirmed</source>
-        <translation type="unfinished">Potvrdené</translation>
+        <translation type="unfinished">Potrjeno</translation>
     </message>
     <message>
         <source>Watch-only</source>
-        <translation type="unfinished">Iba sledovanie</translation>
+        <translation type="unfinished">Opazovano</translation>
     </message>
     <message>
         <source>Date</source>
-        <translation type="unfinished">Dátum</translation>
+        <translation type="unfinished">Datum</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="unfinished">Typ</translation>
+        <translation type="unfinished">Vrsta</translation>
     </message>
     <message>
         <source>Label</source>
-        <translation type="unfinished">Popis</translation>
+        <translation type="unfinished">Oznaka</translation>
     </message>
     <message>
         <source>Address</source>
-        <translation type="unfinished">Adresa</translation>
+        <translation type="unfinished">Naslov</translation>
     </message>
     <message>
         <source>Exporting Failed</source>
-        <translation type="unfinished">Export zlyhal</translation>
+        <translation type="unfinished">Izvoz je spodletel.</translation>
     </message>
     <message>
         <source>There was an error trying to save the transaction history to %1.</source>
-        <translation type="unfinished">Vyskytla sa chyba pri pokuse o uloženie histórie transakcií do %1.</translation>
+        <translation type="unfinished">Prišlo je do napake med shranjevanjem zgodovine transakcij v datoteko %1.</translation>
     </message>
     <message>
         <source>Exporting Successful</source>
-        <translation type="unfinished">Export úspešný</translation>
+        <translation type="unfinished">Izvoz uspešen</translation>
     </message>
     <message>
         <source>The transaction history was successfully saved to %1.</source>
-        <translation type="unfinished">História transakciá bola úspešne uložená do %1.</translation>
+        <translation type="unfinished">Zgodovina transakcij je bila uspešno shranjena v datoteko %1.</translation>
     </message>
     <message>
         <source>Range:</source>
-        <translation type="unfinished">Rozsah:</translation>
+        <translation type="unfinished">Razpon:</translation>
     </message>
     <message>
         <source>to</source>
@@ -3606,759 +3603,755 @@ Poznámka: Keďže poplatok je počítaný za bajt, poplatok pri sadzbe "100 sat
         <source>No wallet has been loaded.
 Go to File &gt; Open Wallet to load a wallet.
 - OR -</source>
-        <translation type="unfinished">Nie je načítaná žiadna peňaženka.
-Choďte do Súbor &gt; Otvoriť Peňaženku, pre načítanie peňaženky.
-- ALEBO -</translation>
+        <translation type="unfinished">Odprta ni nobena denarnica.
+Za odpiranje denarnice kliknite Datoteka &gt; Odpri denarnico
+- ali -</translation>
     </message>
     <message>
         <source>Create a new wallet</source>
-        <translation type="unfinished">Vytvoriť novú peňaženku</translation>
+        <translation type="unfinished">Ustvari novo denarnico</translation>
     </message>
 </context>
 <context>
     <name>WalletModel</name>
     <message>
         <source>Send Coins</source>
-        <translation type="unfinished">Poslať mince</translation>
+        <translation type="unfinished">Pošlji kovance</translation>
     </message>
     <message>
         <source>Fee bump error</source>
-        <translation type="unfinished">Chyba pri navyšovaní poplatku</translation>
+        <translation type="unfinished">Napaka pri poviševanju provizije</translation>
     </message>
     <message>
         <source>Increasing transaction fee failed</source>
-        <translation type="unfinished">Nepodarilo sa navýšiť poplatok</translation>
+        <translation type="unfinished">Povečanje provizije transakcije je spodletelo</translation>
     </message>
     <message>
         <source>Do you want to increase the fee?</source>
-        <translation type="unfinished">Chcete navýšiť poplatok?</translation>
+        <translation type="unfinished">Ali želite povišati provizijo?</translation>
     </message>
     <message>
         <source>Do you want to draft a transaction with fee increase?</source>
-        <translation type="unfinished">Chcete naplánovať túto transakciu s navýšením poplatkov.</translation>
+        <translation type="unfinished">Želite shraniti osnutek transakcije s povečano provizijo?</translation>
     </message>
     <message>
         <source>Current fee:</source>
-        <translation type="unfinished">Momentálny poplatok:</translation>
+        <translation type="unfinished">Trenutna provizija:</translation>
     </message>
     <message>
         <source>Increase:</source>
-        <translation type="unfinished">Navýšenie:</translation>
+        <translation type="unfinished">Povečanje:</translation>
     </message>
     <message>
         <source>New fee:</source>
-        <translation type="unfinished">Nový poplatok:</translation>
+        <translation type="unfinished">Nova provizija:</translation>
     </message>
     <message>
         <source>Warning: This may pay the additional fee by reducing change outputs or adding inputs, when necessary. It may add a new change output if one does not already exist. These changes may potentially leak privacy.</source>
-        <translation type="unfinished">Varovanie: Toto môže zaplatiť ďalší poplatok znížením výstupov alebo pridaním vstupov, ak to bude potrebné. Môže pridať nový výstup ak ešte žiadny neexistuje. Tieto zmeny by mohli ohroziť súkromie.</translation>
+        <translation type="unfinished">Opozorilo: za dodatno provizijo je včasih potrebno odstraniti izhode za vračilo ali dodati vhode. Lahko se tudi doda izhod za vračilo, če ga še ni. Te spremembe lahko okrnijo zasebnost.</translation>
     </message>
     <message>
         <source>Confirm fee bump</source>
-        <translation type="unfinished">Potvrď navýšenie poplatku</translation>
+        <translation type="unfinished">Potrdi povečanje provizije</translation>
     </message>
     <message>
         <source>Can't draft transaction.</source>
-        <translation type="unfinished">Nemožno naplánovať túto transakciu.</translation>
+        <translation type="unfinished">Ne morem shraniti osnutka transakcije</translation>
     </message>
     <message>
         <source>PSBT copied</source>
-        <translation type="unfinished">PSBT skopírovaná</translation>
+        <translation type="unfinished">DPBT kopirana</translation>
     </message>
     <message>
         <source>Can't sign transaction.</source>
-        <translation type="unfinished">Nemôzeme podpíaať transakciu.</translation>
+        <translation type="unfinished">Ne morem podpisati transakcije.</translation>
     </message>
     <message>
         <source>Could not commit transaction</source>
-        <translation type="unfinished">Nemôzeme uložiť transakciu do peňaženky</translation>
+        <translation type="unfinished">Transakcije ni bilo mogoče zaključiti</translation>
     </message>
     <message>
         <source>Can't display address</source>
-        <translation type="unfinished">Nemôžem zobraziť adresu</translation>
+        <translation type="unfinished">Ne morem prikazati naslova</translation>
     </message>
     <message>
         <source>default wallet</source>
-        <translation type="unfinished">predvolená peňaženka</translation>
+        <translation type="unfinished">privzeta denarnica</translation>
     </message>
 </context>
 <context>
     <name>WalletView</name>
     <message>
         <source>&amp;Export</source>
-        <translation type="unfinished">&amp;Exportovať...</translation>
+        <translation type="unfinished">&amp;Izvozi</translation>
     </message>
     <message>
         <source>Export the data in the current tab to a file</source>
-        <translation type="unfinished">Exportovať dáta v aktuálnej karte do súboru</translation>
+        <translation type="unfinished">Izvozi podatke iz trenutnega zavihka v datoteko</translation>
     </message>
     <message>
         <source>Error</source>
-        <translation type="unfinished">Chyba</translation>
+        <translation type="unfinished">Napaka</translation>
     </message>
     <message>
         <source>Unable to decode PSBT from clipboard (invalid base64)</source>
-        <translation type="unfinished">Nepodarilo sa dekódovať skopírovanú PSBT (invalid base64)</translation>
+        <translation type="unfinished">Ne morem dekodirati DPBT z odložišča (neveljaven format base64)</translation>
     </message>
     <message>
         <source>Load Transaction Data</source>
-        <translation type="unfinished">Načítať údaje o transakcii</translation>
+        <translation type="unfinished">Naloži podatke transakcije</translation>
     </message>
     <message>
         <source>Partially Signed Transaction (*.psbt)</source>
-        <translation type="unfinished">Čiastočne podpísaná transakcia (*.psbt)</translation>
+        <translation type="unfinished">Delno podpisana transakcija (*.psbt)</translation>
     </message>
     <message>
         <source>PSBT file must be smaller than 100 MiB</source>
-        <translation type="unfinished">Súbor PSBT musí byť menší než 100 MiB</translation>
+        <translation type="unfinished">Velikost DPBT ne sme presegati 100 MiB.</translation>
     </message>
     <message>
         <source>Unable to decode PSBT</source>
-        <translation type="unfinished">Nepodarilo sa dekódovať PSBT</translation>
+        <translation type="unfinished">Ne morem dekodirati DPBT</translation>
     </message>
     <message>
         <source>Backup Wallet</source>
-        <translation type="unfinished">Zálohovanie peňaženky</translation>
+        <translation type="unfinished">Izdelava varnostne kopije denarnice</translation>
     </message>
     <message>
         <source>Wallet Data</source>
         <extracomment>Name of the wallet data file format.</extracomment>
-        <translation type="unfinished">Dáta peňaženky</translation>
+        <translation type="unfinished">Podatki o denarnici</translation>
     </message>
     <message>
         <source>Backup Failed</source>
-        <translation type="unfinished">Zálohovanie zlyhalo</translation>
+        <translation type="unfinished">Varnostno kopiranje je spodeltelo</translation>
     </message>
     <message>
         <source>There was an error trying to save the wallet data to %1.</source>
-        <translation type="unfinished">Vyskytla sa chyba pri pokuse o uloženie dát peňaženky do %1.</translation>
+        <translation type="unfinished">Prišlo je do napake pri shranjevanju podatkov denarnice v datoteko %1.</translation>
     </message>
     <message>
         <source>Backup Successful</source>
-        <translation type="unfinished">Záloha úspešná</translation>
+        <translation type="unfinished">Varnostno kopiranje je uspelo</translation>
     </message>
     <message>
         <source>The wallet data was successfully saved to %1.</source>
-        <translation type="unfinished">Dáta peňaženky boli úspešne uložené do %1.</translation>
+        <translation type="unfinished">Podatki denarnice so bili uspešno shranjeni v %1.</translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished">Zrušiť</translation>
+        <translation type="unfinished">Prekliči</translation>
     </message>
 </context>
 <context>
     <name>bitcoin-core</name>
     <message>
         <source>The %s developers</source>
-        <translation type="unfinished">Vývojári %s</translation>
+        <translation type="unfinished">Razvijalci %s</translation>
     </message>
     <message>
         <source>%s corrupt. Try using the wallet tool bitcoin-wallet to salvage or restoring a backup.</source>
-        <translation type="unfinished">%s je poškodený. Skúste použiť nástroj peňaženky bitcoin-wallet na záchranu alebo obnovu zálohy.</translation>
+        <translation type="unfinished">%s je okvarjena. Lahko jo poskusite popraviti z orodjem bitcoin-wallet ali pa jo obnovite iz varnostne kopije.</translation>
     </message>
     <message>
         <source>-maxtxfee is set very high! Fees this large could be paid on a single transaction.</source>
-        <translation type="unfinished">-maxtxfee je nastavené veľmi vysoko! Takto vysoký poplatok môže byť zaplatebý v jednej transakcii.</translation>
+        <translation type="unfinished">-maxtxfee je nastavljen zelo visoko! Tako visoka provizija bi se lahko plačala na posamezni transakciji.</translation>
     </message>
     <message>
         <source>Cannot downgrade wallet from version %i to version %i. Wallet version unchanged.</source>
-        <translation type="unfinished">Nie je možné degradovať peňaženku z verzie %i na verziu %i. Verzia peňaženky nebola zmenená.</translation>
+        <translation type="unfinished">Različice denarnice ne morem znižati z %i na %i. Različica denarnice ostaja nespremenjena.</translation>
     </message>
     <message>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running.</source>
-        <translation type="unfinished">Nemožné uzamknúť zložku %s. %s pravdepodobne už beží.</translation>
+        <translation type="unfinished">Ne morem zakleniti podatkovne mape %s. %s je verjetno že zagnan.</translation>
     </message>
     <message>
         <source>Cannot provide specific connections and have addrman find outgoing connections at the same.</source>
-        <translation type="unfinished">Nemôžete zadať konkrétne spojenia a zároveň mať nastavený addrman pre hľadanie odchádzajúcich spojení.</translation>
+        <translation type="unfinished">Izrecne povezave ne morejo biti nastavljene hkrati z iskanjem izhodnih povezav z addrman.</translation>
     </message>
     <message>
         <source>Cannot upgrade a non HD split wallet from version %i to version %i without upgrading to support pre-split keypool. Please use version %i or no version specified.</source>
-        <translation type="unfinished">Nie je možné vylepšiť peňaženku bez rozdelenia HD z verzie %i na verziu %i bez upgradovania na podporu kľúčov pred rozdelením. Prosím použite verziu %i alebo nezadávajte verziu.</translation>
+        <translation type="unfinished">Ne morem nadgraditi nerazcepljene ne-HD denarnice z verzije %i na verzijo %i brez nadgradnje za podporo za ključe pred razcepitvijo. Prosim, uporabite verzijo %i ali pa ne izberite nobene verzije.</translation>
     </message>
     <message>
         <source>Distributed under the MIT software license, see the accompanying file %s or %s</source>
-        <translation type="unfinished">Distribuované pod softvérovou licenciou MIT, pozri sprievodný súbor %s alebo %s</translation>
+        <translation type="unfinished">Distribuirano v okviru programske licence MIT. Podrobnosti so navedene v  priloženi datoteki %s ali %s</translation>
     </message>
     <message>
         <source>Error reading %s! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
-        <translation type="unfinished">Nastala chyba pri čítaní súboru %s! Všetkz kľúče sa prečítali správne, ale dáta o transakcíách alebo záznamy v adresári môžu chýbať alebo byť nesprávne.</translation>
+        <translation type="unfinished">Napaka pri branju %s! Vsi ključi so bili prebrani pravilno, vendar so lahko vnosi o transakcijah ali vnosi naslovov nepravilni ali manjkajo.</translation>
     </message>
     <message>
         <source>Error: Dumpfile format record is incorrect. Got "%s", expected "format".</source>
-        <translation type="unfinished">Chyba: Formát záznamu v súbore dumpu je nesprávny. Obdržaný "%s", očakávaný "format".</translation>
+        <translation type="unfinished">Napaka: oblika izvožene (dump) datoteke je napačna. Vsebuje "%s", pričakovano "format".</translation>
     </message>
     <message>
         <source>Error: Dumpfile identifier record is incorrect. Got "%s", expected "%s".</source>
-        <translation type="unfinished">Chyba: Záznam identifikátora v súbore dumpu je nesprávny. Obdržaný "%s", očakávaný "%s".</translation>
+        <translation type="unfinished">Napaka: identifikator zapisa v izvozni (dump) datoteki je napačen. Vsebuje "%s", pričakovano "%s".</translation>
     </message>
     <message>
         <source>Error: Dumpfile version is not supported. This version of bitcoin-wallet only supports version 1 dumpfiles. Got dumpfile with version %s</source>
-        <translation type="unfinished">Chyba: Verzia súboru dumpu nie je podporovaná. Táto verzia peňaženky bitcoin podporuje iba súbory dumpu verzie 1. Obdržal som súbor s verziou %s</translation>
+        <translation type="unfinished">Napaka: verzija izvozne (dump) datoteke ni podprta. Ta verzija ukaza bitcoin-wallet podpira le izvozne datoteke verzije 1, ta datoteka pa ima verzijo %s.</translation>
     </message>
     <message>
         <source>Error: Legacy wallets only support the "legacy", "p2sh-segwit", and "bech32" address types</source>
-        <translation type="unfinished">Chyba: Staršie peňaženky podporujú len adresy typu "legacy", "p2sh-segwit", a "bech32"</translation>
+        <translation type="unfinished">Napaka: podedovane denarnice podpirajo le naslove vrst "legacy", "p2sh-segwit" in "bech32".</translation>
     </message>
     <message>
         <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
-        <translation type="unfinished">Chyba: Počúvanie prichádzajúcich spojení zlyhalo (vrátená chyba je %s)</translation>
+        <translation type="unfinished">Napaka: ni mogoče biti odprt za dohodne povezave (vrnjena napaka: %s)</translation>
     </message>
     <message>
         <source>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.</source>
-        <translation type="unfinished">Odhad poplatku sa nepodaril. Fallbackfee je zakázaný. Počkajte niekoľko blokov alebo povoľte -fallbackfee.</translation>
+        <translation type="unfinished">Ocena provizije ni uspela. Uporaba nadomestne provizije (fallback fee) je onemogočena. Počakajte nekaj blokov ali omogočite -fallbackfee.</translation>
     </message>
     <message>
         <source>File %s already exists. If you are sure this is what you want, move it out of the way first.</source>
-        <translation type="unfinished">Súbor %s už existuje. Ak si nie ste istý, že toto chcete, presuňte ho najprv preč.</translation>
+        <translation type="unfinished">Datoteka %s že obstaja. Če stre prepričani, da to želite, obstoječo datoteko najprej odstranite oz. premaknite.</translation>
     </message>
     <message>
         <source>Invalid amount for -maxtxfee=&lt;amount&gt;: '%s' (must be at least the minrelay fee of %s to prevent stuck transactions)</source>
-        <translation type="unfinished">Neplatná suma pre -maxtxfee=&lt;amount&gt;: '%s' (aby sa transakcia nezasekla, minimálny prenosový poplatok musí byť aspoň %s)</translation>
+        <translation type="unfinished">Neveljaven znesek za -maxtxfee=&lt;amount&gt;: '%s' (biti mora najmanj %s, da transakcije ne obtičijo)</translation>
     </message>
     <message>
         <source>More than one onion bind address is provided. Using %s for the automatically created Tor onion service.</source>
-        <translation type="unfinished">K dispozícii je viac ako jedna adresa onion. Použitie %s pre automaticky vytvorenú službu Tor.</translation>
+        <translation type="unfinished">Nastavljen je več kot en onion-naslov. Za samodejno ustvarjeno storitev na Toru uporabljam %s.</translation>
     </message>
     <message>
         <source>No dump file provided. To use createfromdump, -dumpfile=&lt;filename&gt; must be provided.</source>
-        <translation type="unfinished">Nezadaný žiadny súbor dumpu. Pre použitie createfromdump musíte zadať -dumpfile=&lt;filename&gt;.</translation>
+        <translation type="unfinished">Potrebno je določiti izvozno (dump) datoteko. Z ukazom createfromdump morate uporabiti možnost -dumpfile=&lt;filename&gt;.</translation>
     </message>
     <message>
         <source>No dump file provided. To use dump, -dumpfile=&lt;filename&gt; must be provided.</source>
-        <translation type="unfinished">Nezadaný žiadny súbor dumpu. Pre použitie dump musíte zadať -dumpfile=&lt;filename&gt;.</translation>
+        <translation type="unfinished">Potrebno je določiti izvozno (dump) datoteko. Z ukazom dump morate uporabiti možnost -dumpfile=&lt;filename&gt;.</translation>
     </message>
     <message>
         <source>No wallet file format provided. To use createfromdump, -format=&lt;format&gt; must be provided.</source>
-        <translation type="unfinished">Nezadaný formát súboru peňaženky. Pre použitie createfromdump musíte zadať -format=&lt;format&gt;.</translation>
+        <translation type="unfinished">Potrebno je določiti obliko izvozne (dump) datoteke. Z ukazom createfromdump morate uporabiti možnost -format=&lt;format&gt;.</translation>
     </message>
     <message>
         <source>Please check that your computer's date and time are correct! If your clock is wrong, %s will not work properly.</source>
-        <translation type="unfinished">Prosím skontrolujte systémový čas a dátum. Keď je váš čas nesprávny, %s nebude fungovať správne.</translation>
+        <translation type="unfinished">Opozorilo: Preverite, če sta datum in ura na vašem računalniku točna! %s ne bo deloval pravilno, če je nastavljeni čas nepravilen.</translation>
     </message>
     <message>
         <source>Please contribute if you find %s useful. Visit %s for further information about the software.</source>
-        <translation type="unfinished">Keď si myslíte, že %s je užitočný, podporte nás. Pre viac informácií o software navštívte %s.</translation>
+        <translation type="unfinished">Prosimo, prispevajte, če se vam zdi %s uporaben. Za dodatne informacije o programski opremi obiščite %s.</translation>
     </message>
     <message>
         <source>Prune configured below the minimum of %d MiB.  Please use a higher number.</source>
-        <translation type="unfinished">Redukcia nastavená pod minimálnu hodnotu %d MiB. Prosím použite vyššiu hodnotu.</translation>
+        <translation type="unfinished">Obrezovanje ne sme biti nastavljeno pod %d miB. Prosimo, uporabite večjo številko.</translation>
     </message>
     <message>
         <source>Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of pruned node)</source>
-        <translation type="unfinished">Redukovanie: posledná synchronizácia peňaženky prebehla pred časmi blokov v redukovaných dátach. Je potrebné vykonať -reindex (v prípade redukovaného režimu stiahne znovu celý reťazec blokov)</translation>
+        <translation type="unfinished">Obrezovanje: zadnja sinhronizacija denarnice je izven obrezanih podatkov. Izvesti morate -reindex (v primeru obrezanega načina delovanja bo potrebno znova prenesti celotno verigo blokov).</translation>
     </message>
     <message>
         <source>SQLiteDatabase: Unknown sqlite wallet schema version %d. Only version %d is supported</source>
-        <translation type="unfinished">SQLiteDatabase: Neznáma verzia schémy peňaženky sqlite %d. Podporovaná je iba verzia %d</translation>
+        <translation type="unfinished">Baza SQLite: Neznana verzija sheme SQLite denarnice %d. Podprta je le verzija %d.</translation>
     </message>
     <message>
         <source>The block database contains a block which appears to be from the future. This may be due to your computer's date and time being set incorrectly. Only rebuild the block database if you are sure that your computer's date and time are correct</source>
-        <translation type="unfinished">Databáza blokov obsahuje blok, ktorý vyzerá byť z budúcnosti. Toto môže byť spôsobené nesprávnym systémovým časom vášho počítača. Obnovujte databázu blokov len keď ste si istý, že systémový čas je nastavený správne.</translation>
+        <translation type="unfinished">Baza podatkov blokov vsebuje blok, ki naj bi bil iz prihodnosti. To je lahko posledica napačne nastavitve datuma in časa vašega računalnika. Znova zgradite bazo podatkov samo, če ste prepričani, da sta datum in čas računalnika pravilna.</translation>
     </message>
     <message>
         <source>The transaction amount is too small to send after the fee has been deducted</source>
-        <translation type="unfinished">Suma je príliš malá pre odoslanie transakcie</translation>
+        <translation type="unfinished">Znesek transakcije po odbitku provizije je premajhen za pošiljanje.</translation>
     </message>
     <message>
         <source>This error could occur if this wallet was not shutdown cleanly and was last loaded using a build with a newer version of Berkeley DB. If so, please use the software that last loaded this wallet</source>
-        <translation type="unfinished">K tejto chybe môže dôjsť, ak nebola táto peňaženka správne vypnutá a bola naposledy načítaná pomocou zostavy s novšou verziou Berkeley DB. Ak je to tak, použite softvér, ktorý naposledy načítal túto peňaženku</translation>
+        <translation type="unfinished">Ta napaka se lahko pojavi, če denarnica ni bila pravilno zaprta in je bila nazadnje naložena s programsko opremo z novejšo verzijo Berkely DB. Če je temu tako, prosimo uporabite programsko opremo, s katero je bila ta denarnica nazadnje naložena.</translation>
     </message>
     <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
-        <translation type="unfinished">Toto je predbežná testovacia zostava - používate na vlastné riziko - nepoužívajte na ťaženie alebo obchodné aplikácie</translation>
+        <translation type="unfinished">To je preizkusna različica še neizdanega programa. Uporabljate jo na lastno odgovornost. Programa ne uporabljajte za rudarjenje ali trgovske aplikacije.</translation>
     </message>
     <message>
         <source>This is the maximum transaction fee you pay (in addition to the normal fee) to prioritize partial spend avoidance over regular coin selection.</source>
-        <translation type="unfinished">Toto je maximálny transakčný poplatok, ktorý zaplatíte (okrem bežného poplatku), aby ste uprednostnili čiastočné vyhýbanie sa výdavkom pred pravidelným výberom mincí.</translation>
+        <translation type="unfinished">To je najvišja transakcijska provizija, ki jo plačate (poleg običajne provizije), da dobi izogibanje delni porabi prednost pred običajno izbiro kovancev.</translation>
     </message>
     <message>
         <source>This is the transaction fee you may discard if change is smaller than dust at this level</source>
-        <translation type="unfinished">Toto je transakčný poplatok, ktorý môžete škrtnúť, ak je zmena na tejto úrovni menšia ako prach</translation>
+        <translation type="unfinished">To je transakcijska provizija, ki jo lahko zavržete, če je znesek vračila manjši od prahu na tej ravni</translation>
     </message>
     <message>
         <source>This is the transaction fee you may pay when fee estimates are not available.</source>
-        <translation type="unfinished">Toto je poplatok za transakciu keď odhad poplatkov ešte nie je k dispozícii.</translation>
+        <translation type="unfinished">To je transakcijska provizija, ki jo lahko plačate, kadar ocene provizij niso na voljo.</translation>
     </message>
     <message>
         <source>Total length of network version string (%i) exceeds maximum length (%i). Reduce the number or size of uacomments.</source>
-        <translation type="unfinished">Celková dĺžka verzie sieťového reťazca (%i) prekračuje maximálnu dĺžku (%i). Znížte počet a veľkosť komentárov.</translation>
+        <translation type="unfinished">Skupna dolžina niza različice omrežja (%i) presega največjo dovoljeno dolžino (%i). Zmanjšajte število ali velikost nastavitev uacomments.</translation>
     </message>
     <message>
         <source>Unable to replay blocks. You will need to rebuild the database using -reindex-chainstate.</source>
-        <translation type="unfinished">Nedarí sa znovu aplikovať bloky. Budete musieť prestavať databázu použitím -reindex-chainstate.</translation>
+        <translation type="unfinished">Ne morem ponovno obdelati blokov. Podatkovno bazo boste morali ponovno zgraditi z uporabo ukaza -reindex-chainstate.</translation>
     </message>
     <message>
         <source>Unknown wallet file format "%s" provided. Please provide one of "bdb" or "sqlite".</source>
-        <translation type="unfinished">Poskytnutý neznámy formát peňaženky "%s". Prosím použite "bdb" alebo "sqlite".</translation>
+        <translation type="unfinished">Nastavljena je neznana oblika datoteke denarnice "%s". Prosimo, uporabite "bdb" ali "sqlite".</translation>
     </message>
     <message>
         <source>Warning: Dumpfile wallet format "%s" does not match command line specified format "%s".</source>
-        <translation type="unfinished">Varovanie: Formát peňaženky súboru dumpu "%s" nesúhlasí s formátom zadaným na príkazovom riadku "%s".</translation>
+        <translation type="unfinished">Opozorilo: oblika izvozne (dump) datoteke "%s" ne ustreza obliki "%s", izbrani v ukazni vrstici.</translation>
     </message>
     <message>
         <source>Warning: Private keys detected in wallet {%s} with disabled private keys</source>
-        <translation type="unfinished">Upozornenie: Boli zistené súkromné kľúče v peňaženke {%s} so zakázanými súkromnými kľúčmi.</translation>
+        <translation type="unfinished">Opozorilo: v denarnici {%s} z onemogočenimi zasebnimi ključi so prisotni zasebni ključi.</translation>
     </message>
     <message>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
-        <translation type="unfinished">Varovanie: Zjavne sa úplne nezhodujeme s našimi peer-mi! Možno potrebujete prejsť na novšiu verziu alebo ostatné uzly potrebujú vyššiu verziu.</translation>
+        <translation type="unfinished">Opozorilo: Trenutno se s soležniki ne strinjamo v popolnosti! Morda morate posodobiti programsko opremo ali pa morajo to storiti vaši soležniki.</translation>
     </message>
     <message>
         <source>Witness data for blocks after height %d requires validation. Please restart with -reindex.</source>
-        <translation type="unfinished">Svedecké údaje pre bloky za výškou %d vyžadujú overenie. Prosím reštartujte s parametrom -reindex.</translation>
+        <translation type="unfinished">Podatke o priči (witness) za bloke nad višino %d je potrebno preveriti. Ponovno zaženite program z možnostjo -reindex.</translation>
     </message>
     <message>
         <source>You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain</source>
-        <translation type="unfinished">K návratu k neredukovanému režimu je potrebné prestavať databázu použitím -reindex. Tiež sa znova stiahne celý reťazec blokov</translation>
+        <translation type="unfinished">Za vrnitev v neobrezan način morate obnoviti bazo z uporabo -reindex. Potreben bo prenos celotne verige blokov.</translation>
     </message>
     <message>
         <source>%s is set very high!</source>
-        <translation type="unfinished">Hodnota %s je nastavená veľmi vysoko!</translation>
+        <translation type="unfinished">%s je postavljen zelo visoko!</translation>
     </message>
     <message>
         <source>-maxmempool must be at least %d MB</source>
-        <translation type="unfinished">-maxmempool musí byť najmenej %d MB</translation>
+        <translation type="unfinished">-maxmempool mora biti vsaj %d MB</translation>
     </message>
     <message>
         <source>A fatal internal error occurred, see debug.log for details</source>
-        <translation type="unfinished">Nastala fatálna interná chyba, pre viac informácií pozrite debug.log</translation>
+        <translation type="unfinished">Prišlo je do usodne notranje napake. Za podrobnosti glejte datoteko debug.log.</translation>
     </message>
     <message>
         <source>Cannot resolve -%s address: '%s'</source>
-        <translation type="unfinished">Nedá preložiť -%s adresu: '%s'</translation>
+        <translation type="unfinished">Naslova -%s ni mogoče razrešiti: '%s'</translation>
     </message>
     <message>
         <source>Cannot set -peerblockfilters without -blockfilterindex.</source>
-        <translation type="unfinished">Nepodarilo sa určiť -peerblockfilters bez -blockfilterindex.</translation>
-    </message>
-    <message>
-        <source>Cannot write to data directory '%s'; check permissions.</source>
-        <translation type="unfinished">Nie je možné zapísať do adresára ' %s'. Skontrolujte povolenia.</translation>
+        <translation type="unfinished">Nastavitev -peerblockfilters ni veljavna brez nastavitve -blockfilterindex.</translation>
     </message>
     <message>
         <source>Change index out of range</source>
-        <translation type="unfinished">Menný index mimo rozsah</translation>
+        <translation type="unfinished">Indeks vračila izven dovoljenega območja</translation>
     </message>
     <message>
         <source>Config setting for %s only applied on %s network when in [%s] section.</source>
-        <translation type="unfinished">Nastavenie konfigurácie pre %s platí iba v sieti %s a v sekcii [%s].</translation>
+        <translation type="unfinished">Konfiguracijske nastavitve za %s se na omrežju %s upoštevajo le, če so zapisane v odseku [%s].</translation>
     </message>
     <message>
         <source>Corrupted block database detected</source>
-        <translation type="unfinished">Zistená poškodená databáza blokov</translation>
+        <translation type="unfinished">Podatkovna baza blokov je okvarjena</translation>
     </message>
     <message>
         <source>Could not find asmap file %s</source>
-        <translation type="unfinished">Nepodarilo sa nájsť asmap súbor %s</translation>
+        <translation type="unfinished">Ne najdem asmap-datoteke %s</translation>
     </message>
     <message>
         <source>Could not parse asmap file %s</source>
-        <translation type="unfinished">Nepodarilo sa analyzovať asmap súbor %s</translation>
+        <translation type="unfinished">Razčlenjevanje asmap-datoteke %s je spodletelo</translation>
     </message>
     <message>
         <source>Disk space is too low!</source>
-        <translation type="unfinished">Nedostatok miesta na disku!</translation>
+        <translation type="unfinished">Prostora na disku je premalo!</translation>
     </message>
     <message>
         <source>Do you want to rebuild the block database now?</source>
-        <translation type="unfinished">Chcete znovu zostaviť databázu blokov?</translation>
+        <translation type="unfinished">Želite zdaj obnoviti podatkovno bazo blokov?</translation>
     </message>
     <message>
         <source>Done loading</source>
-        <translation type="unfinished">Dokončené načítavanie</translation>
+        <translation type="unfinished">Nalaganje končano</translation>
     </message>
     <message>
         <source>Dump file %s does not exist.</source>
-        <translation type="unfinished">Súbor dumpu %s neexistuje.</translation>
+        <translation type="unfinished">Izvozna (dump) datoteka %s ne obstaja.</translation>
     </message>
     <message>
         <source>Error creating %s</source>
-        <translation type="unfinished">Chyba pri vytváraní %s</translation>
+        <translation type="unfinished">Napaka pri tvorbi %s</translation>
     </message>
     <message>
         <source>Error initializing block database</source>
-        <translation type="unfinished">Chyba inicializácie databázy blokov</translation>
+        <translation type="unfinished">Napaka pri inicializaciji podatkovne baze blokov</translation>
     </message>
     <message>
         <source>Error initializing wallet database environment %s!</source>
-        <translation type="unfinished">Chyba spustenia databázového prostredia peňaženky %s!</translation>
+        <translation type="unfinished">Napaka pri inicializaciji okolja podatkovne baze denarnice %s!</translation>
     </message>
     <message>
         <source>Error loading %s</source>
-        <translation type="unfinished">Chyba načítania %s</translation>
+        <translation type="unfinished">Napaka pri nalaganju %s</translation>
     </message>
     <message>
         <source>Error loading %s: Private keys can only be disabled during creation</source>
-        <translation type="unfinished">Chyba pri načítaní %s: Súkromné kľúče môžu byť zakázané len počas vytvárania</translation>
+        <translation type="unfinished">Napaka pri nalaganju %s: Zasebni ključi se lahko onemogočijo samo ob tvorbi.</translation>
     </message>
     <message>
         <source>Error loading %s: Wallet corrupted</source>
-        <translation type="unfinished">Chyba načítania %s: Peňaženka je poškodená</translation>
+        <translation type="unfinished">Napaka pri nalaganju %s: Denarnica ovkarjena</translation>
     </message>
     <message>
         <source>Error loading %s: Wallet requires newer version of %s</source>
-        <translation type="unfinished">Chyba načítania %s: Peňaženka vyžaduje novšiu verziu %s</translation>
+        <translation type="unfinished">Napaka pri nalaganju %s: denarnica zahteva novejšo različico %s</translation>
     </message>
     <message>
         <source>Error loading block database</source>
-        <translation type="unfinished">Chyba načítania databázy blokov</translation>
+        <translation type="unfinished">Napaka pri nalaganju podatkovne baze blokov</translation>
     </message>
     <message>
         <source>Error opening block database</source>
-        <translation type="unfinished">Chyba otvárania databázy blokov</translation>
+        <translation type="unfinished">Napaka pri odpiranju podatkovne baze blokov</translation>
     </message>
     <message>
         <source>Error reading from database, shutting down.</source>
-        <translation type="unfinished">Chyba pri načítaní z databázy, ukončuje sa.</translation>
+        <translation type="unfinished">Napaka pri branju iz podarkovne baze, zapiram.</translation>
     </message>
     <message>
         <source>Error reading next record from wallet database</source>
-        <translation type="unfinished">Chyba pri čítaní ďalšieho záznamu z databázy peňaženky</translation>
+        <translation type="unfinished">Napaka pri branju naslednjega zapisa v podatkovni bazi denarnice.</translation>
     </message>
     <message>
         <source>Error upgrading chainstate database</source>
-        <translation type="unfinished">Chyba pri vylepšení databáze reťzcov blokov</translation>
+        <translation type="unfinished">Napaka pri nadgradnji baze podatkov stanja verige.</translation>
     </message>
     <message>
         <source>Error: Couldn't create cursor into database</source>
-        <translation type="unfinished">Chyba: Nepodarilo sa vytvoriť kurzor do databázy</translation>
+        <translation type="unfinished">Napaka: ne morem ustvariti kurzorja v bazo</translation>
     </message>
     <message>
         <source>Error: Disk space is low for %s</source>
-        <translation type="unfinished">Chyba: Málo miesta na disku pre %s</translation>
+        <translation type="unfinished">Opozorilo: premalo prostora na disku za %s</translation>
     </message>
     <message>
         <source>Error: Dumpfile checksum does not match. Computed %s, expected %s</source>
-        <translation type="unfinished">Chyba: Kontrolný súčet súboru dumpu nesúhlasí. Vypočítaný %s, očakávaný %s</translation>
+        <translation type="unfinished">Napaka: kontrolna vsota izvozne (dump) datoteke se ne ujema. Izračunano %s, pričakovano %s</translation>
     </message>
     <message>
         <source>Error: Got key that was not hex: %s</source>
-        <translation type="unfinished">Chyba: Obdržaný kľúč nebol v hex tvare: %s</translation>
+        <translation type="unfinished">Napaka: ključ ni heksadecimalen: %s</translation>
     </message>
     <message>
         <source>Error: Got value that was not hex: %s</source>
-        <translation type="unfinished">Chyba: Obdržaná hodnota nebola v hex tvare: : %s</translation>
+        <translation type="unfinished">Napaka: vrednost ni heksadecimalna: %s</translation>
     </message>
     <message>
         <source>Error: Keypool ran out, please call keypoolrefill first</source>
-        <translation type="unfinished">Chyba: Keypool došiel, zavolajte najskôr keypoolrefill</translation>
+        <translation type="unfinished">Napaka: zaloga ključev je prazna -- najprej uporabite keypoolrefill</translation>
     </message>
     <message>
         <source>Error: Missing checksum</source>
-        <translation type="unfinished">Chyba: Chýba kontrolný súčet</translation>
+        <translation type="unfinished">Napaka: kontrolna vsota manjka</translation>
     </message>
     <message>
         <source>Error: No %s addresses available.</source>
-        <translation type="unfinished">Chyba: Žiadne adresy %s.</translation>
+        <translation type="unfinished">Napaka: na voljo ni nobenega naslova '%s'</translation>
     </message>
     <message>
         <source>Error: Unable to parse version %u as a uint32_t</source>
-        <translation type="unfinished">Chyba: Nepodarilo sa prečítať verziu %u ako uint32_t</translation>
+        <translation type="unfinished">Napaka: verzije %u ne morem prebrati kot uint32_t</translation>
     </message>
     <message>
         <source>Error: Unable to write record to new wallet</source>
-        <translation type="unfinished">Chyba: Nepodarilo sa zapísať záznam do novej peňaženky</translation>
+        <translation type="unfinished">Napaka: zapisa ni mogoče zapisati v novo denarnico</translation>
     </message>
     <message>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
-        <translation type="unfinished">Chyba počúvania na ktoromkoľvek porte. Použi -listen=0 ak toto chcete.</translation>
+        <translation type="unfinished">Poslušanje ni uspelo na nobenih vratih. Če to želite, uporabite -listen=0</translation>
     </message>
     <message>
         <source>Failed to rescan the wallet during initialization</source>
-        <translation type="unfinished">Počas inicializácie sa nepodarila pre-skenovať peňaženka</translation>
+        <translation type="unfinished">Med inicializacijo denarnice ni bilo mogoče preveriti zgodovine (rescan failed).</translation>
     </message>
     <message>
         <source>Failed to verify database</source>
-        <translation type="unfinished">Nepodarilo sa overiť databázu</translation>
+        <translation type="unfinished">Preverba podatkovne baze je spodletela.</translation>
     </message>
     <message>
         <source>Fee rate (%s) is lower than the minimum fee rate setting (%s)</source>
-        <translation type="unfinished">Zvolený poplatok (%s)  je nižší ako nastavený minimálny poplatok (%s)</translation>
+        <translation type="unfinished">Stopnja provizije (%s) je nižja od nastavljenega minimuma (%s)</translation>
     </message>
     <message>
         <source>Ignoring duplicate -wallet %s.</source>
-        <translation type="unfinished">Ignorujú sa duplikátne -wallet %s.</translation>
+        <translation type="unfinished">Podvojen -wallet %s -- ne upoštevam.</translation>
     </message>
     <message>
         <source>Importing…</source>
-        <translation type="unfinished">Prebieha import…</translation>
+        <translation type="unfinished">Uvažam ...</translation>
     </message>
     <message>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
-        <translation type="unfinished">Nesprávny alebo žiadny genesis blok nájdený. Nesprávny dátový priečinok alebo sieť?</translation>
+        <translation type="unfinished">Izvornega bloka ni mogoče najti ali pa je neveljaven. Preverite, če ste izbrali pravo podatkovno mapo za izbrano omrežje.</translation>
     </message>
     <message>
         <source>Initialization sanity check failed. %s is shutting down.</source>
-        <translation type="unfinished">Kontrola čistoty pri inicializácií zlyhala. %s sa vypína.</translation>
+        <translation type="unfinished">Začetno preverjanje smiselnosti je spodletelo. %s se zaustavlja.</translation>
     </message>
     <message>
         <source>Insufficient funds</source>
-        <translation type="unfinished">Nedostatok prostriedkov</translation>
+        <translation type="unfinished">Premalo sredstev</translation>
     </message>
     <message>
         <source>Invalid -i2psam address or hostname: '%s'</source>
-        <translation type="unfinished">Neplatná adresa alebo názov počítača pre -i2psam: '%s'</translation>
+        <translation type="unfinished">Neveljaven naslov ali ime gostitelja -i2psam: '%s'</translation>
     </message>
     <message>
         <source>Invalid -onion address or hostname: '%s'</source>
-        <translation type="unfinished">Neplatná -onion adresa alebo hostiteľ: '%s'</translation>
+        <translation type="unfinished">Neveljaven naslov ali ime gostitelja -onion: '%s'</translation>
     </message>
     <message>
         <source>Invalid -proxy address or hostname: '%s'</source>
-        <translation type="unfinished">Neplatná -proxy adresa alebo hostiteľ: '%s'</translation>
+        <translation type="unfinished">Neveljaven naslov ali ime gostitelja -proxy: '%s'</translation>
     </message>
     <message>
         <source>Invalid P2P permission: '%s'</source>
-        <translation type="unfinished">Neplatné oprávnenie P2P: '%s'</translation>
+        <translation type="unfinished">Neveljavna pooblastila P2P: '%s'</translation>
     </message>
     <message>
         <source>Invalid amount for -%s=&lt;amount&gt;: '%s'</source>
-        <translation type="unfinished">Neplatná suma pre -%s=&lt;amount&gt;: '%s'</translation>
+        <translation type="unfinished">Neveljavna vrednost za -%s=&lt;amount&gt;: '%s'</translation>
     </message>
     <message>
         <source>Invalid amount for -discardfee=&lt;amount&gt;: '%s'</source>
-        <translation type="unfinished">Neplatná čiastka pre -discardfee=&lt;čiastka&gt;: '%s'</translation>
+        <translation type="unfinished">Neveljavna vrednost za -discardfee=&lt;amount&gt;: '%s'</translation>
     </message>
     <message>
         <source>Invalid amount for -fallbackfee=&lt;amount&gt;: '%s'</source>
-        <translation type="unfinished">Neplatná suma pre -fallbackfee=&lt;amount&gt;: '%s'</translation>
+        <translation type="unfinished">Neveljavna vrednost za -fallbackfee=&lt;amount&gt;: '%s'</translation>
     </message>
     <message>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: '%s' (must be at least %s)</source>
-        <translation type="unfinished">Neplatná suma pre -paytxfee=&lt;amount&gt;: '%s' (musí byť aspoň %s)</translation>
+        <translation type="unfinished">Neveljavna vrednost za -paytxfee=&lt;amount&gt;: '%s' (biti mora vsaj %s)</translation>
     </message>
     <message>
         <source>Invalid netmask specified in -whitelist: '%s'</source>
-        <translation type="unfinished">Nadaná neplatná netmask vo -whitelist: '%s'</translation>
+        <translation type="unfinished">V -whitelist je navedena neveljavna omrežna maska '%s'</translation>
     </message>
     <message>
         <source>Loading P2P addresses…</source>
-        <translation type="unfinished">Načítavam P2P adresy…</translation>
+        <translation type="unfinished">Nalagam P2P naslove ...</translation>
     </message>
     <message>
         <source>Loading banlist…</source>
-        <translation type="unfinished">Načítavam zoznam zákazov…</translation>
+        <translation type="unfinished">Nalaganje seznam blokiranih ...</translation>
     </message>
     <message>
         <source>Loading block index…</source>
-        <translation type="unfinished">Načítavam zoznam blokov…</translation>
+        <translation type="unfinished">Nalagam kazalo blokov ...</translation>
     </message>
     <message>
         <source>Loading wallet…</source>
-        <translation type="unfinished">Načítavam peňaženku…</translation>
+        <translation type="unfinished">Nalagam denarnico ...</translation>
     </message>
     <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
-        <translation type="unfinished">Je potrebné zadať port s -whitebind: '%s'</translation>
+        <translation type="unfinished">Pri opciji -whitebind morate navesti vrata: %s</translation>
     </message>
     <message>
         <source>No proxy server specified. Use -proxy=&lt;ip&gt; or -proxy=&lt;ip:port&gt;.</source>
-        <translation type="unfinished">Nie je špecifikovaný proxy server. Použite -proxy=&lt;ip&gt; alebo -proxy=&lt;ip:port&gt;.</translation>
+        <translation type="unfinished">Posredniški strežnik (proxy) ni nastavljen. Uporabite -proxy=&lt;ip&gt; ali -proxy=&lt;ip:port&gt;.</translation>
     </message>
     <message>
         <source>Not enough file descriptors available.</source>
-        <translation type="unfinished">Nedostatok kľúčových slov súboru.</translation>
+        <translation type="unfinished">Na voljo ni dovolj deskriptorjev datotek.</translation>
     </message>
     <message>
         <source>Prune cannot be configured with a negative value.</source>
-        <translation type="unfinished">Redukovanie nemôže byť nastavené na zápornú hodnotu.</translation>
+        <translation type="unfinished">Negativne vrednosti parametra funkcije obrezovanja niso sprejemljive.</translation>
     </message>
     <message>
         <source>Prune mode is incompatible with -coinstatsindex.</source>
-        <translation type="unfinished">Režim redukovania je nekompatibilný s -coinstatsindex.</translation>
+        <translation type="unfinished">Funkcija obrezovanja ni združljiva z opcijo -coinstatsindex.</translation>
     </message>
     <message>
         <source>Prune mode is incompatible with -txindex.</source>
-        <translation type="unfinished">Režim redukovania je nekompatibilný s -txindex.</translation>
+        <translation type="unfinished">Funkcija obrezovanja ni združljiva z opcijo -txindex.</translation>
     </message>
     <message>
         <source>Pruning blockstore…</source>
-        <translation type="unfinished">Redukuje sa úložisko blokov…</translation>
+        <translation type="unfinished">Obrezujem ...</translation>
     </message>
     <message>
         <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
-        <translation type="unfinished">Obmedzuje sa -maxconnections z %d na %d kvôli systémovým obmedzeniam.</translation>
+        <translation type="unfinished">Zmanjšujem maksimalno število povezav (-maxconnections) iz %d na %d zaradi sistemskih omejitev.</translation>
     </message>
     <message>
         <source>Replaying blocks…</source>
-        <translation type="unfinished">Preposielam bloky…</translation>
+        <translation type="unfinished">Ponovno obdelujem bloke ...</translation>
     </message>
     <message>
         <source>Rescanning…</source>
-        <translation type="unfinished">Nové prehľadávanie…</translation>
+        <translation type="unfinished">Ponovno obdelujem ...</translation>
     </message>
     <message>
         <source>SQLiteDatabase: Failed to execute statement to verify database: %s</source>
-        <translation type="unfinished">SQLiteDatabase: Nepodarilo sa vykonať príkaz na overenie databázy: %s</translation>
+        <translation type="unfinished">Baza SQLite: Izvršitev stavka za preverbo baze je spodletela: %s</translation>
     </message>
     <message>
         <source>SQLiteDatabase: Failed to prepare statement to verify database: %s</source>
-        <translation type="unfinished">SQLiteDatabase: Nepodarilo sa pripraviť príkaz na overenie databázy: %s</translation>
+        <translation type="unfinished">Baza SQLite: priprava stavka za preverbo baze je spodletela: %s</translation>
     </message>
     <message>
         <source>SQLiteDatabase: Failed to read database verification error: %s</source>
-        <translation type="unfinished">SQLiteDatabase: Nepodarilo sa prečítať chybu overenia databázy: %s</translation>
+        <translation type="unfinished">Baza SQLite: branje napake pri preverjanju baze je spodletelo: %s</translation>
     </message>
     <message>
         <source>SQLiteDatabase: Unexpected application id. Expected %u, got %u</source>
-        <translation type="unfinished">SQLiteDatabase: Neočakávané ID aplikácie: %u. Očakávané:  %u</translation>
+        <translation type="unfinished">Baza SQLite: nepričakovan identifikator aplikacije. Pričakovana vrednost je %u, dobljena vrednost je %u.</translation>
     </message>
     <message>
         <source>Section [%s] is not recognized.</source>
-        <translation type="unfinished">Sekcia [%s] nie je rozpoznaná.</translation>
+        <translation type="unfinished">Neznan odsek [%s].</translation>
     </message>
     <message>
         <source>Signing transaction failed</source>
-        <translation type="unfinished">Podpísanie správy zlyhalo</translation>
+        <translation type="unfinished">Podpisovanje transakcije je spodletelo.</translation>
     </message>
     <message>
         <source>Specified -walletdir "%s" does not exist</source>
-        <translation type="unfinished">Uvedená -walletdir "%s" neexistuje</translation>
+        <translation type="unfinished">Navedeni direktorij -walletdir "%s" ne obstaja</translation>
     </message>
     <message>
         <source>Specified -walletdir "%s" is a relative path</source>
-        <translation type="unfinished">Uvedená -walletdir "%s" je relatívna cesta</translation>
+        <translation type="unfinished">Navedeni -walletdir "%s" je relativna pot</translation>
     </message>
     <message>
         <source>Specified -walletdir "%s" is not a directory</source>
-        <translation type="unfinished">Uvedený -walletdir "%s" nie je priečinok</translation>
+        <translation type="unfinished">Navedena pot -walletdir "%s" ni direktorij</translation>
     </message>
     <message>
         <source>Specified blocks directory "%s" does not exist.</source>
-        <translation type="unfinished">Zadaný adresár blokov "%s" neexistuje.</translation>
+        <translation type="unfinished">Navedeni podatkovni direktorij za bloke "%s" ne obstaja.</translation>
     </message>
     <message>
         <source>Starting network threads…</source>
-        <translation type="unfinished">Spúšťajú sa sieťové vlákna…</translation>
+        <translation type="unfinished">Zaganjam omrežne niti ...</translation>
     </message>
     <message>
         <source>The source code is available from %s.</source>
-        <translation type="unfinished">Zdrojový kód je dostupný z %s</translation>
+        <translation type="unfinished">Izvorna koda je dosegljiva na %s.</translation>
     </message>
     <message>
         <source>The specified config file %s does not exist</source>
-        <translation type="unfinished">Zadaný konfiguračný súbor %s neexistuje</translation>
+        <translation type="unfinished">Navedena konfiguracijska datoteka %s ne obstaja</translation>
     </message>
     <message>
         <source>The transaction amount is too small to pay the fee</source>
-        <translation type="unfinished">Suma transakcie je príliš malá na zaplatenie poplatku</translation>
+        <translation type="unfinished">Znesek transakcije je prenizek za plačilo provizije</translation>
     </message>
     <message>
         <source>The wallet will avoid paying less than the minimum relay fee.</source>
-        <translation type="unfinished">Peňaženka zabráni zaplateniu menšej sumy ako je minimálny poplatok.</translation>
+        <translation type="unfinished">Denarnica se bo izognila plačilu proviziji, manjši od minimalne provizije za posredovanje (relay fee).</translation>
     </message>
     <message>
         <source>This is experimental software.</source>
-        <translation type="unfinished">Toto je experimentálny softvér.</translation>
+        <translation type="unfinished">Program je eksperimentalne narave.</translation>
     </message>
     <message>
         <source>This is the minimum transaction fee you pay on every transaction.</source>
-        <translation type="unfinished">Toto je minimálny poplatok za transakciu pri každej transakcii.</translation>
+        <translation type="unfinished">To je minimalna transakcijska provizija, ki jo plačate za vsako transakcijo.</translation>
     </message>
     <message>
         <source>This is the transaction fee you will pay if you send a transaction.</source>
-        <translation type="unfinished">Toto je poplatok za transakciu pri odoslaní transakcie.</translation>
+        <translation type="unfinished">To je provizija, ki jo boste plačali, ko pošljete transakcijo.</translation>
     </message>
     <message>
         <source>Transaction amount too small</source>
-        <translation type="unfinished">Suma transakcie príliš malá</translation>
+        <translation type="unfinished">Znesek transakcije je prenizek</translation>
     </message>
     <message>
         <source>Transaction amounts must not be negative</source>
-        <translation type="unfinished">Sumy transakcií nesmú byť záporné</translation>
+        <translation type="unfinished">Znesek transakcije ne sme biti negativen</translation>
     </message>
     <message>
         <source>Transaction has too long of a mempool chain</source>
-        <translation type="unfinished">Transakcia má v transakčnom zásobníku príliš dlhý reťazec</translation>
+        <translation type="unfinished">Transakcija je del predolge verige nepotrjenih transakcij</translation>
     </message>
     <message>
         <source>Transaction must have at least one recipient</source>
-        <translation type="unfinished">Transakcia musí mať aspoň jedného príjemcu</translation>
+        <translation type="unfinished">Transakcija mora imeti vsaj enega prejemnika.</translation>
     </message>
     <message>
         <source>Transaction needs a change address, but we can't generate it. %s</source>
-        <translation type="unfinished">Transakcia potrebuje adresu na zmenu, ale nemôžeme ju vygenerovať. %s</translation>
+        <translation type="unfinished">Transakcija potrebuje naslov za vračilo, ki pa ga ne moremo ustvariti. %s</translation>
     </message>
     <message>
         <source>Transaction too large</source>
-        <translation type="unfinished">Transakcia príliš veľká</translation>
+        <translation type="unfinished">Transkacija je prevelika</translation>
     </message>
     <message>
         <source>Unable to bind to %s on this computer (bind returned error %s)</source>
-        <translation type="unfinished">Na tomto počítači sa nedá vytvoriť väzba %s (vytvorenie väzby vrátilo chybu %s)</translation>
+        <translation type="unfinished">Na tem računalniku ni bilo mogoče vezati naslova %s (vrnjena napaka: %s)</translation>
     </message>
     <message>
         <source>Unable to bind to %s on this computer. %s is probably already running.</source>
-        <translation type="unfinished">Nemožné pripojiť k %s na tomto počíťači. %s už pravdepodobne beží.</translation>
+        <translation type="unfinished">Na tem računalniku ni bilo mogoče vezati naslova %s. %s je verjetno že zagnan.</translation>
     </message>
     <message>
         <source>Unable to create the PID file '%s': %s</source>
-        <translation type="unfinished">Nepodarilo sa vytvoriť súbor PID '%s': %s</translation>
+        <translation type="unfinished">Ne morem ustvariti PID-datoteke '%s': %s</translation>
     </message>
     <message>
         <source>Unable to generate initial keys</source>
-        <translation type="unfinished">Nepodarilo sa vygenerovať úvodné kľúče</translation>
+        <translation type="unfinished">Ne morem ustvariti začetnih ključev</translation>
     </message>
     <message>
         <source>Unable to generate keys</source>
-        <translation type="unfinished">Nepodarilo sa vygenerovať kľúče</translation>
+        <translation type="unfinished">Ne morem ustvariti ključev</translation>
     </message>
     <message>
         <source>Unable to open %s for writing</source>
-        <translation type="unfinished">Nepodarilo sa otvoriť %s pre zapisovanie</translation>
+        <translation type="unfinished">Ne morem odpreti %s za pisanje</translation>
     </message>
     <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
-        <translation type="unfinished">Nepodarilo sa spustiť HTTP server. Pre viac detailov zobrazte debug log.</translation>
+        <translation type="unfinished">Zagon HTTP strežnika neuspešen. Poglejte razhroščevalni dnevnik za podrobnosti (debug.log).</translation>
     </message>
     <message>
         <source>Unknown -blockfilterindex value %s.</source>
-        <translation type="unfinished">Neznáma -blockfilterindex hodnota %s.</translation>
+        <translation type="unfinished">Neznana vrednost -blockfilterindex %s.</translation>
     </message>
     <message>
         <source>Unknown address type '%s'</source>
-        <translation type="unfinished">Neznámy typ adresy '%s'</translation>
+        <translation type="unfinished">Neznana vrsta naslova '%s'</translation>
     </message>
     <message>
         <source>Unknown change type '%s'</source>
-        <translation type="unfinished">Neznámy typ zmeny '%s'</translation>
+        <translation type="unfinished">Neznana vrsta vračila '%s'</translation>
     </message>
     <message>
         <source>Unknown network specified in -onlynet: '%s'</source>
-        <translation type="unfinished">Neznáma sieť upresnená v -onlynet: '%s'</translation>
+        <translation type="unfinished">V nastavitvi -onlynet je podano neznano omrežje '%s'.</translation>
     </message>
     <message>
         <source>Unknown new rules activated (versionbit %i)</source>
-        <translation type="unfinished">Aktivované neznáme nové pravidlá (bit verzie %i)</translation>
+        <translation type="unfinished">Aktivirana so neznana nova pravila (versionbit %i)</translation>
     </message>
     <message>
         <source>Unsupported logging category %s=%s.</source>
-        <translation type="unfinished">Nepodporovaná logovacia kategória %s=%s.</translation>
+        <translation type="unfinished">Nepodprta kategorija beleženja %s=%s.</translation>
     </message>
     <message>
         <source>Upgrading UTXO database</source>
-        <translation type="unfinished">Vylepšuje sa databáza neminutých výstupov (UTXO)</translation>
+        <translation type="unfinished">Nadgrajujem podatkovno bazo UTXO (nepotrošenih kovancev)</translation>
     </message>
     <message>
         <source>Upgrading txindex database</source>
-        <translation type="unfinished">Inovuje sa txindex databáza</translation>
+        <translation type="unfinished">Nadgrajujem podatkovno bazo txindex</translation>
     </message>
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
-        <translation type="unfinished">Komentár u typu klienta (%s) obsahuje riskantné znaky.</translation>
+        <translation type="unfinished">Komentar uporabniškega agenta (%s) vsebuje nevarne znake.</translation>
     </message>
     <message>
         <source>Verifying blocks…</source>
-        <translation type="unfinished">Overujem bloky…</translation>
+        <translation type="unfinished">Preverjam celovitost blokov ...</translation>
     </message>
     <message>
         <source>Verifying wallet(s)…</source>
-        <translation type="unfinished">Kontrolujem peňaženku(y)…</translation>
+        <translation type="unfinished">Preverjam denarnice ...</translation>
     </message>
     <message>
         <source>Wallet needed to be rewritten: restart %s to complete</source>
-        <translation type="unfinished">Peňaženka musí byť prepísaná: pre dokončenie reštartujte %s</translation>
+        <translation type="unfinished">Denarnica mora biti prepisana. Za zaključek ponovno zaženite %s.</translation>
     </message>
 </context>
 </TS>

--- a/src/qt/locale/bitcoin_sr.ts
+++ b/src/qt/locale/bitcoin_sr.ts
@@ -92,6 +92,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Извези Листу Адреса</translation>
     </message>
     <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See https://en.wikipedia.org/wiki/Comma-separated_values</extracomment>
+        <translation type="unfinished">CSV фајл</translation>
+    </message>
+    <message>
         <source>There was an error trying to save the address list to %1. Please try again.</source>
         <extracomment>An error message. %1 is a stand-in argument for the name of the file we attempted to save to.</extracomment>
         <translation type="unfinished">Десила се грешка приликом покушаја да се листа адреса упамти на  %1. Молимо покушајте поново.</translation>
@@ -241,10 +246,22 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>BitcoinApplication</name>
     <message>
+        <source>Runaway exception</source>
+        <translation type="unfinished">Изузетак покретања</translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
+        <translation type="unfinished">Дошло је до фаталне грешке. 1%1 даље не може безбедно да настави, те ће се угасити.</translation>
+    </message>
+    <message>
         <source>Internal error</source>
         <translation type="unfinished">Интерна грешка</translation>
     </message>
-    </context>
+    <message>
+        <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
+        <translation type="unfinished">Догодила се интерна грешка. %1 ће покушати да настави безбедно. Ово је неочекивана грешка која може да се пријави као што је објашњено испод.</translation>
+    </message>
+</context>
 <context>
     <name>QObject</name>
     <message>
@@ -254,6 +271,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Error: %1</source>
         <translation type="unfinished">Грешка: %1</translation>
+    </message>
+    <message>
+        <source>Error initializing settings: %1</source>
+        <translation type="unfinished">Грешка приликом иницијализације подешавања. 1%1</translation>
+    </message>
+    <message>
+        <source>%1 didn't yet exit safely…</source>
+        <translation type="unfinished">1%1 још увек није изашао безбедно…</translation>
     </message>
     <message>
         <source>unknown</source>
@@ -268,12 +293,40 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Унеси Биткоин адресу, (нпр %1)</translation>
     </message>
     <message>
+        <source>Unroutable</source>
+        <translation type="unfinished">Немогуће преусмерити</translation>
+    </message>
+    <message>
+        <source>Internal</source>
+        <translation type="unfinished">Унутрашње</translation>
+    </message>
+    <message>
         <source>Inbound</source>
         <translation type="unfinished">Долазеће</translation>
     </message>
     <message>
         <source>Outbound</source>
         <translation type="unfinished">Одлазеће</translation>
+    </message>
+    <message>
+        <source>Full Relay</source>
+        <translation type="unfinished">Потпуна предаја</translation>
+    </message>
+    <message>
+        <source>Block Relay</source>
+        <translation type="unfinished">Блокирана предаја</translation>
+    </message>
+    <message>
+        <source>Manual</source>
+        <translation type="unfinished">Упутство</translation>
+    </message>
+    <message>
+        <source>Feeler</source>
+        <translation type="unfinished">Сензор</translation>
+    </message>
+    <message>
+        <source>Address Fetch</source>
+        <translation type="unfinished">Преузимање адресе</translation>
     </message>
     <message>
         <source>None</source>
@@ -286,41 +339,41 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation>
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n секунди</numerusform>
+            <numerusform>%n секунди</numerusform>
+            <numerusform>%n секунда</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n minute(s)</source>
         <translation>
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n минут</numerusform>
+            <numerusform>%n минут</numerusform>
+            <numerusform>%n минута</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n сат</numerusform>
+            <numerusform>%n сат</numerusform>
+            <numerusform>%n сат</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n дана</numerusform>
+            <numerusform>%n дана</numerusform>
+            <numerusform>%n дана</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n недеља</numerusform>
+            <numerusform>%n недеља</numerusform>
+            <numerusform>%n недеља</numerusform>
         </translation>
     </message>
     <message>
@@ -330,10 +383,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n година</numerusform>
+            <numerusform>%n година</numerusform>
+            <numerusform>%n година</numerusform>
         </translation>
+    </message>
+    <message>
+        <source>%1 kB</source>
+        <translation type="unfinished">%1 килобајта</translation>
     </message>
     </context>
 <context>
@@ -464,6 +521,18 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation>Верификуј поруке и утврди да ли су потписане од стране спецификованих Биткоин адреса</translation>
     </message>
     <message>
+        <source>&amp;Load PSBT from file…</source>
+        <translation type="unfinished">&amp;Учитава ”PSBT” из датотеке…</translation>
+    </message>
+    <message>
+        <source>Load PSBT from clipboard…</source>
+        <translation type="unfinished">Учитај ”PSBT” из привремене меморије</translation>
+    </message>
+    <message>
+        <source>Open &amp;URI…</source>
+        <translation type="unfinished">Отвори &amp;URI</translation>
+    </message>
+    <message>
         <source>Close Wallet…</source>
         <translation type="unfinished">Затвори новчаник...</translation>
     </message>
@@ -496,6 +565,22 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Синхронизација са мрежом...</translation>
     </message>
     <message>
+        <source>Indexing blocks on disk…</source>
+        <translation type="unfinished">Индексирање блокова на диску…</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation type="unfinished">Процесуирање блокова на диску</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation type="unfinished">Реиндексирање блокова на диску…</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation type="unfinished">Повезивање са клијентима...</translation>
+    </message>
+    <message>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished">Затражи плаћање (генерише QR кодове и биткоин: URI-е)</translation>
     </message>
@@ -514,14 +599,18 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation>
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>Обрађенo је %n блокова историјата трансакција.</numerusform>
+            <numerusform>Обрађенo је %n блокова историјата трансакција.</numerusform>
+            <numerusform>Обрађенo је %n блокова историјата трансакција.</numerusform>
         </translation>
     </message>
     <message>
         <source>%1 behind</source>
         <translation>%1 уназад</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation type="unfinished">Ажурирање у току...</translation>
     </message>
     <message>
         <source>Last received block was generated %1 ago.</source>
@@ -546,6 +635,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Up to date</source>
         <translation>Ажурирано</translation>
+    </message>
+    <message>
+        <source>Load Partially Signed Bitcoin Transaction</source>
+        <translation type="unfinished">Учитај делимично потписану Bitcoin трансакцију</translation>
+    </message>
+    <message>
+        <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
+        <translation type="unfinished">Учитај делимично потписану Bitcoin трансакцију из clipboard-a</translation>
     </message>
     <message>
         <source>Node window</source>
@@ -588,6 +685,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Прикажи  поруку помоћи %1 за листу са могућим опцијама Биткоин командне линије</translation>
     </message>
     <message>
+        <source>&amp;Mask values</source>
+        <translation type="unfinished">&amp;Маскирај вредности</translation>
+    </message>
+    <message>
+        <source>Mask the values in the Overview tab</source>
+        <translation type="unfinished">Филтрирај вредности у картици за преглед</translation>
+    </message>
+    <message>
         <source>default wallet</source>
         <translation type="unfinished">подразумевани новчаник</translation>
     </message>
@@ -615,10 +720,30 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n активних конекција са Биткоин мрежом</numerusform>
+            <numerusform>%n активних конекција са Биткоин мрежом</numerusform>
+            <numerusform>%n активних конекција са Биткоин мрежом</numerusform>
         </translation>
+    </message>
+    <message>
+        <source>Click for more actions.</source>
+        <extracomment>A substring of the tooltip. "More actions" are available via the context menu.</extracomment>
+        <translation type="unfinished">Клик за више акција</translation>
+    </message>
+    <message>
+        <source>Show Peers tab</source>
+        <extracomment>A context menu item. The "Peers tab" is an element of the "Node window".</extracomment>
+        <translation type="unfinished">Прикажи картицу са ”Клијентима”</translation>
+    </message>
+    <message>
+        <source>Disable network activity</source>
+        <extracomment>A context menu item.</extracomment>
+        <translation type="unfinished">Онемогући мрежне активности</translation>
+    </message>
+    <message>
+        <source>Enable network activity</source>
+        <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
+        <translation type="unfinished">Омогући мрежне активности</translation>
     </message>
     <message>
         <source>Error: %1</source>
@@ -779,6 +904,30 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Копирај износ</translation>
     </message>
     <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Копирај адресу</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Копирај &amp;означи</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Копирај &amp;износ</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">Копирај трансакцију &amp;ID</translation>
+    </message>
+    <message>
+        <source>L&amp;ock unspent</source>
+        <translation type="unfinished">Закључај непотрошено</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock unspent</source>
+        <translation type="unfinished">Откључај непотрошено</translation>
+    </message>
+    <message>
         <source>Copy quantity</source>
         <translation type="unfinished">Копирај количину</translation>
     </message>
@@ -845,7 +994,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Create wallet warning</source>
         <translation type="unfinished">Направи упозорење за новчаник</translation>
     </message>
-    </context>
+    <message>
+        <source>Can't list signers</source>
+        <translation type="unfinished">Не могу да излистам потписнике</translation>
+    </message>
+</context>
 <context>
     <name>OpenWalletActivity</name>
     <message>
@@ -860,7 +1013,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>default wallet</source>
         <translation type="unfinished">подразумевани новчаник</translation>
     </message>
-    </context>
+    <message>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation type="unfinished">Отвањаре новчаника &lt;b&gt;%1&lt;/b&gt;</translation>
+    </message>
+</context>
 <context>
     <name>WalletController</name>
     <message>
@@ -907,6 +1064,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Шифрирај новчаник</translation>
     </message>
     <message>
+        <source>Advanced Options</source>
+        <translation type="unfinished">Напредне опције</translation>
+    </message>
+    <message>
         <source>Disable private keys for this wallet. Wallets with private keys disabled will have no private keys and cannot have an HD seed or imported private keys. This is ideal for watch-only wallets.</source>
         <translation type="unfinished">Онемогући приватни кључ за овај новчаник. Новчаници са онемогућеним приватним кључем неће  имати приватни кључ и не могу имати HD семе или увезени приватни кључ. Ова опција идеална је за новчанике који су искључиво за посматрање.</translation>
     </message>
@@ -923,10 +1084,36 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Направи Празан Новчаник</translation>
     </message>
     <message>
+        <source>Use descriptors for scriptPubKey management</source>
+        <translation type="unfinished">Користите дескрипторе за управљање сцриптПубКеи-ом</translation>
+    </message>
+    <message>
+        <source>Descriptor Wallet</source>
+        <translation type="unfinished">Дескриптор Новчаник</translation>
+    </message>
+    <message>
+        <source>Use an external signing device such as a hardware wallet. Configure the external signer script in wallet preferences first.</source>
+        <translation type="unfinished">Користите спољни уређај за потписивање као што је хардверски новчаник. Прво конфигуришите скрипту спољног потписника у подешавањима новчаника.
+</translation>
+    </message>
+    <message>
+        <source>External signer</source>
+        <translation type="unfinished">Екстерни потписник</translation>
+    </message>
+    <message>
         <source>Create</source>
         <translation type="unfinished">Направи</translation>
     </message>
-    </context>
+    <message>
+        <source>Compiled without sqlite support (required for descriptor wallets)</source>
+        <translation type="unfinished">Састављено без склите подршке (потребно за новчанике дескриптора)</translation>
+    </message>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Састављено без подршке за спољно потписивање (потребно за спољно потписивање)</translation>
+    </message>
+</context>
 <context>
     <name>EditAddressDialog</name>
     <message>
@@ -1012,6 +1199,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Биткоин</translation>
     </message>
     <message>
+        <source>(of %1 GB needed)</source>
+        <translation type="unfinished">(од  потребних %1 GB)</translation>
+    </message>
+    <message>
+        <source>(%1 GB needed for full chain)</source>
+        <translation type="unfinished">(%1 гигабајта је потребно за цео ланац)</translation>
+    </message>
+    <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
         <translation type="unfinished">Најмање %1 GB подататака биће складиштен у овај директорјиум који ће временом порасти.</translation>
     </message>
@@ -1023,9 +1218,9 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>(довољно за враћање резервних копија старих %n дана)</numerusform>
+            <numerusform>(довољно за враћање резервних копија старих %n дана)</numerusform>
+            <numerusform>(довољно за враћање резервних копија старих %n дана)</numerusform>
         </translation>
     </message>
     <message>
@@ -1061,8 +1256,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Када кликнете на ОК, %1 ће почети с преузимањем и процесуирањем целокупног ланца блокова %4 (%2GB), почевши од најранијих трансакција у %3 када је %4 покренут.</translation>
     </message>
     <message>
+        <source>Limit block chain storage to</source>
+        <translation type="unfinished">Ограничите складиштење блок ланца на</translation>
+    </message>
+    <message>
         <source>Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</source>
         <translation type="unfinished">Враћање ове опције захтева поновно преузимање целокупног блокчејна - ланца блокова. Брже је преузети цели ланац и касније га скратити. Онемогућава неке напредне опције.</translation>
+    </message>
+    <message>
+        <source> GB</source>
+        <translation type="unfinished">Гигабајт</translation>
     </message>
     <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
@@ -1161,7 +1364,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>%1 is currently syncing.  It will download headers and blocks from peers and validate them until reaching the tip of the block chain.</source>
         <translation type="unfinished">%1 се синхронузује. Преузеће заглавља и блокове од клијената и потврдити их док не стигне на крај ланца блокова.</translation>
     </message>
-    </context>
+    <message>
+        <source>Unknown. Syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">Непознато. Синхронизација заглавља (%1, %2%)...</translation>
+    </message>
+</context>
 <context>
     <name>OpenURIDialog</name>
     <message>
@@ -1186,6 +1393,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>&amp;Start %1 on system login</source>
         <translation type="unfinished">&amp;Покрени %1 приликом пријаве на систем</translation>
+    </message>
+    <message>
+        <source>Enabling pruning significantly reduces the disk space required to store transactions. All blocks are still fully validated. Reverting this setting requires re-downloading the entire blockchain.</source>
+        <translation type="unfinished">Омогућавање смањења значајно смањује простор на диску потребан за складиштење трансакција. Сви блокови су још увек у потпуности валидирани. Враћање ове поставке захтева поновно преузимање целог блоцкцхаина.</translation>
     </message>
     <message>
         <source>Size of &amp;database cache</source>
@@ -1264,12 +1475,32 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">&amp;Троши непотврђени кусур</translation>
     </message>
     <message>
+        <source>External Signer (e.g. hardware wallet)</source>
+        <translation type="unfinished">Екстерни потписник (нпр. хардверски новчаник)</translation>
+    </message>
+    <message>
+        <source>&amp;External signer script path</source>
+        <translation type="unfinished">&amp;Путања скрипте спољног потписника</translation>
+    </message>
+    <message>
+        <source>Full path to a Bitcoin Core compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</source>
+        <translation type="unfinished">Пуна путања до скрипте компатибилне са Битцоин Цоре (нпр. Ц:\Довнлоадс\хви.еке или /Усерс/иоу/Довнлоадс/хви.пи). Пазите: злонамерни софтвер може украсти ваше новчиће</translation>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation>Аутоматски отвори Биткоин клијент порт на рутеру. Ова опција ради само уколико твој рутер подржава и има омогућен UPnP.</translation>
     </message>
     <message>
         <source>Map port using &amp;UPnP</source>
         <translation>Мапирај порт користећи &amp;UPnP</translation>
+    </message>
+    <message>
+        <source>Automatically open the Bitcoin client port on the router. This only works when your router supports NAT-PMP and it is enabled. The external port could be random.</source>
+        <translation type="unfinished">Аутоматски отворите порт за Битцоин клијент на рутеру. Ово функционише само када ваш рутер подржава НАТ-ПМП и када је омогућен. Спољни порт би могао бити насумичан.</translation>
+    </message>
+    <message>
+        <source>Map port using NA&amp;T-PMP</source>
+        <translation type="unfinished">Мапирајте порт користећи НА&amp;Т-ПМП</translation>
     </message>
     <message>
         <source>Accept connections from outside.</source>
@@ -1308,6 +1539,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Тор</translation>
     </message>
     <message>
+        <source>Show the icon in the system tray.</source>
+        <translation type="unfinished">Прикажите икону у системској палети.</translation>
+    </message>
+    <message>
+        <source>&amp;Show tray icon</source>
+        <translation type="unfinished">&amp;Прикажи икону у траци</translation>
+    </message>
+    <message>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation>Покажи само иконицу у панелу након минимизирања прозора</translation>
     </message>
@@ -1344,8 +1583,28 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Да ли да се прикажу опције контроле новчића или не.</translation>
     </message>
     <message>
+        <source>Connect to the Bitcoin network through a separate SOCKS5 proxy for Tor onion services.</source>
+        <translation type="unfinished">Повежите се на Битцоин мрежу преко засебног СОЦКС5 проксија за Тор онион услуге.</translation>
+    </message>
+    <message>
+        <source>Use separate SOCKS&amp;5 proxy to reach peers via Tor onion services:</source>
+        <translation type="unfinished">Користите посебан СОЦКС&amp;5 прокси да бисте дошли до вршњака преко услуга Тор онион:</translation>
+    </message>
+    <message>
         <source>&amp;Third party transaction URLs</source>
         <translation type="unfinished">&amp;URL-ови трансакција трећих страна</translation>
+    </message>
+    <message>
+        <source>Monospaced font in the Overview tab:</source>
+        <translation type="unfinished">Једноразредни фонт на картици Преглед:</translation>
+    </message>
+    <message>
+        <source>embedded "%1"</source>
+        <translation type="unfinished">уграђено ”%1”</translation>
+    </message>
+    <message>
+        <source>closest matching "%1"</source>
+        <translation type="unfinished">Најближа сличност ”%1”</translation>
     </message>
     <message>
         <source>Options set in this dialog are overridden by the command line or in the configuration file:</source>
@@ -1358,6 +1617,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>&amp;Cancel</source>
         <translation>&amp;Откажи</translation>
+    </message>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Састављено без подршке за спољно потписивање (потребно за спољно потписивање)</translation>
     </message>
     <message>
         <source>default</source>
@@ -1478,7 +1742,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Current total balance in watch-only addresses</source>
         <translation type="unfinished">Тренутни укупни салдо у адресама у опцији само-гледај</translation>
     </message>
-    </context>
+    <message>
+        <source>Privacy mode activated for the Overview tab. To unmask the values, uncheck Settings-&gt;Mask values.</source>
+        <translation type="unfinished">Режим приватности је активиран за картицу Преглед. Да бисте демаскирали вредности, поништите избор Подешавања-&gt;Маск вредности.</translation>
+    </message>
+</context>
 <context>
     <name>PSBTOperationsDialog</name>
     <message>
@@ -1506,8 +1774,65 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Затвори</translation>
     </message>
     <message>
+        <source>Failed to load transaction: %1</source>
+        <translation type="unfinished">Неуспело учитавање трансакције: %1</translation>
+    </message>
+    <message>
+        <source>Failed to sign transaction: %1</source>
+        <translation type="unfinished">Неуспело потписивање трансакције: %1</translation>
+    </message>
+    <message>
+        <source>Could not sign any more inputs.</source>
+        <translation type="unfinished">Није могуће потписати више уноса.</translation>
+    </message>
+    <message>
+        <source>Signed %1 inputs, but more signatures are still required.</source>
+        <translation type="unfinished">Потписано %1 поље, али је потребно још потписа.</translation>
+    </message>
+    <message>
+        <source>Signed transaction successfully. Transaction is ready to broadcast.</source>
+        <translation type="unfinished">Потписана трансакција је успешно. Трансакција је спремна за емитовање.</translation>
+    </message>
+    <message>
+        <source>Unknown error processing transaction.</source>
+        <translation type="unfinished">Непозната грешка у обради трансакције.</translation>
+    </message>
+    <message>
+        <source>Transaction broadcast successfully! Transaction ID: %1</source>
+        <translation type="unfinished">Трансакција је успешно емитована! Идентификација трансакције (ID): %1</translation>
+    </message>
+    <message>
+        <source>Transaction broadcast failed: %1</source>
+        <translation type="unfinished">Неуспело емитовање трансакције: %1</translation>
+    </message>
+    <message>
+        <source>PSBT copied to clipboard.</source>
+        <translation type="unfinished">ПСБТ је копиран у међуспремник.</translation>
+    </message>
+    <message>
         <source>Save Transaction Data</source>
         <translation type="unfinished">Сачувај Податке Трансакције</translation>
+    </message>
+    <message>
+        <source>Partially Signed Transaction (Binary)</source>
+        <extracomment>Expanded name of the binary PSBT file format. See: BIP 174.</extracomment>
+        <translation type="unfinished">Делимично потписана трансакција (бинарна)</translation>
+    </message>
+    <message>
+        <source>PSBT saved to disk.</source>
+        <translation type="unfinished">ПСБТ је сачуван на диску.</translation>
+    </message>
+    <message>
+        <source> * Sends %1 to %2</source>
+        <translation type="unfinished">*Шаље %1 до %2</translation>
+    </message>
+    <message>
+        <source>Unable to calculate transaction fee or total transaction amount.</source>
+        <translation type="unfinished">Није могуће израчунати накнаду за трансакцију или укупан износ трансакције.</translation>
+    </message>
+    <message>
+        <source>Pays transaction fee: </source>
+        <translation type="unfinished">Плаћа накнаду за трансакцију:</translation>
     </message>
     <message>
         <source>Total Amount</source>
@@ -1516,6 +1841,30 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>or</source>
         <translation type="unfinished">или</translation>
+    </message>
+    <message>
+        <source>Transaction has %1 unsigned inputs.</source>
+        <translation type="unfinished">Трансакција има %1 непотписана поља.</translation>
+    </message>
+    <message>
+        <source>Transaction is missing some information about inputs.</source>
+        <translation type="unfinished">Трансакцији недостају неке информације о улазима.</translation>
+    </message>
+    <message>
+        <source>Transaction still needs signature(s).</source>
+        <translation type="unfinished">Трансакција и даље треба потпис(е).</translation>
+    </message>
+    <message>
+        <source>(But this wallet cannot sign transactions.)</source>
+        <translation type="unfinished">(Али овај новчаник не може да потписује трансакције.)</translation>
+    </message>
+    <message>
+        <source>(But this wallet does not have the right keys.)</source>
+        <translation type="unfinished">(Али овај новчаник нема праве кључеве.)</translation>
+    </message>
+    <message>
+        <source>Transaction is fully signed and ready for broadcast.</source>
+        <translation type="unfinished">Трансакција је у потпуности потписана и спремна за емитовање.</translation>
     </message>
     <message>
         <source>Transaction status is unknown.</source>
@@ -1541,6 +1890,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">'bitcoin://' није важећи URI. Уместо тога користити  'bitcoin:'.</translation>
     </message>
     <message>
+        <source>Cannot process payment request because BIP70 is not supported.
+Due to widespread security flaws in BIP70 it's strongly recommended that any merchant instructions to switch wallets be ignored.
+If you are receiving this error you should request the merchant provide a BIP21 compatible URI.</source>
+        <translation type="unfinished">Није могуће обрадити захтев за плаћање јер БИП70 није подржан.
+Због широко распрострањених безбедносних пропуста у БИП70, топло се препоручује да се игноришу сва упутства трговца за промену новчаника.
+Ако добијете ову грешку, требало би да затражите од трговца да достави УРИ компатибилан са БИП21.</translation>
+    </message>
+    <message>
         <source>URI cannot be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation type="unfinished">URI се не може рашчланити! Ово може бити проузроковано неважећом Биткоин адресом или погрешно форматираним URI параметрима.</translation>
     </message>
@@ -1560,6 +1917,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Ping</source>
         <extracomment>Title of Peers Table column which indicates the current latency of the connection with the peer.</extracomment>
         <translation type="unfinished">Пинг</translation>
+    </message>
+    <message>
+        <source>Peer</source>
+        <extracomment>Title of Peers Table column which contains a unique number used to identify a connection.</extracomment>
+        <translation type="unfinished">Пеер</translation>
     </message>
     <message>
         <source>Sent</source>
@@ -1590,6 +1952,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>QRImageWidget</name>
     <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">&amp;Сачували слику…</translation>
+    </message>
+    <message>
         <source>&amp;Copy Image</source>
         <translation type="unfinished">&amp;Копирај Слику</translation>
     </message>
@@ -1609,7 +1975,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Save QR Code</source>
         <translation type="unfinished">Упамти QR Код</translation>
     </message>
-    </context>
+    <message>
+        <source>PNG Image</source>
+        <extracomment>Expanded name of the PNG file format. See https://en.wikipedia.org/wiki/Portable_Network_Graphics</extracomment>
+        <translation type="unfinished">ПНГ слика</translation>
+    </message>
+</context>
 <context>
     <name>RPCConsole</name>
     <message>
@@ -1733,6 +2104,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Ноде прозор</translation>
     </message>
     <message>
+        <source>Current block height</source>
+        <translation type="unfinished">Тренутна висина блока</translation>
+    </message>
+    <message>
         <source>Open the %1 debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation type="unfinished">Отворите %1 датотеку са записима о отклоњеним грешкама из тренутног директоријума датотека. Ово може потрајати неколико секунди за велике датотеке записа.</translation>
     </message>
@@ -1745,12 +2120,60 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Увећај величину фонта</translation>
     </message>
     <message>
+        <source>Permissions</source>
+        <translation type="unfinished">Дозволе</translation>
+    </message>
+    <message>
+        <source>The direction and type of peer connection: %1</source>
+        <translation type="unfinished">Смер и тип конекције клијената: %1</translation>
+    </message>
+    <message>
+        <source>Direction/Type</source>
+        <translation type="unfinished">Смер/Тип</translation>
+    </message>
+    <message>
+        <source>The network protocol this peer is connected through: IPv4, IPv6, Onion, I2P, or CJDNS.</source>
+        <translation type="unfinished">Мрежни протокол који је овај пеер повезан преко: ИПв4, ИПв6, Онион, И2П или ЦЈДНС.</translation>
+    </message>
+    <message>
         <source>Services</source>
         <translation type="unfinished">Услуге</translation>
     </message>
     <message>
+        <source>Whether the peer requested us to relay transactions.</source>
+        <translation type="unfinished">Да ли је колега тражио од нас да пренесемо трансакције</translation>
+    </message>
+    <message>
+        <source>Wants Tx Relay</source>
+        <translation type="unfinished">Жели Тк Релаciju</translation>
+    </message>
+    <message>
+        <source>High bandwidth BIP152 compact block relay: %1</source>
+        <translation type="unfinished">Висок проток ”BIP152” преноса компактних блокова: %1</translation>
+    </message>
+    <message>
+        <source>High Bandwidth</source>
+        <translation type="unfinished">Висок проток</translation>
+    </message>
+    <message>
         <source>Connection Time</source>
         <translation type="unfinished">Време конекције</translation>
+    </message>
+    <message>
+        <source>Elapsed time since a novel block passing initial validity checks was received from this peer.</source>
+        <translation type="unfinished">Прошло је време од када је нови блок који је прошао почетне провере валидности примљен од овог равноправног корисника.</translation>
+    </message>
+    <message>
+        <source>Last Block</source>
+        <translation type="unfinished">Последњи блок</translation>
+    </message>
+    <message>
+        <source>Elapsed time since a novel transaction accepted into our mempool was received from this peer.</source>
+        <translation type="unfinished">Прошло је време од када је нова трансакција прихваћена у наш мемпул примљена од овог партнера</translation>
+    </message>
+    <message>
+        <source>Last Tx</source>
+        <translation type="unfinished">Последња трансакција</translation>
     </message>
     <message>
         <source>Last Send</source>
@@ -1817,12 +2240,52 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Одлазно:</translation>
     </message>
     <message>
+        <source>Inbound: initiated by peer</source>
+        <translation type="unfinished">Долазни: покренут од стране вршњака</translation>
+    </message>
+    <message>
+        <source>Outbound Full Relay: default</source>
+        <translation type="unfinished">Одлазни пуни релеј: подразумевано</translation>
+    </message>
+    <message>
+        <source>Outbound Block Relay: does not relay transactions or addresses</source>
+        <translation type="unfinished">Оутбоунд Блоцк Релаи: не преноси трансакције или адресе</translation>
+    </message>
+    <message>
+        <source>Outbound Manual: added using RPC %1 or %2/%3 configuration options</source>
+        <translation type="unfinished">Изворно упутство: додато је коришћење ”RPC” %1 или %2 / %3 конфигурационих опција</translation>
+    </message>
+    <message>
+        <source>Outbound Feeler: short-lived, for testing addresses</source>
+        <translation type="unfinished">Оутбоунд Феелер: краткотрајан, за тестирање адреса</translation>
+    </message>
+    <message>
+        <source>Outbound Address Fetch: short-lived, for soliciting addresses</source>
+        <translation type="unfinished">Дохваћање излазне адресе: краткотрајно, за тражење адреса</translation>
+    </message>
+    <message>
+        <source>we selected the peer for high bandwidth relay</source>
+        <translation type="unfinished">одабрали смо клијента за висок пренос података</translation>
+    </message>
+    <message>
+        <source>the peer selected us for high bandwidth relay</source>
+        <translation type="unfinished">клијент нас је одабрао за висок пренос података</translation>
+    </message>
+    <message>
+        <source>no high bandwidth relay selected</source>
+        <translation type="unfinished">није одабран проток за висок пренос података</translation>
+    </message>
+    <message>
         <source>&amp;Disconnect</source>
         <translation type="unfinished">&amp;Прекини везу</translation>
     </message>
     <message>
         <source>1 &amp;hour</source>
         <translation type="unfinished">1 &amp;Сат</translation>
+    </message>
+    <message>
+        <source>1 d&amp;ay</source>
+        <translation type="unfinished">1 дан</translation>
     </message>
     <message>
         <source>1 &amp;week</source>
@@ -1849,6 +2312,31 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Извршење команде коришћењем  "%1" новчаника</translation>
     </message>
     <message>
+        <source>Welcome to the %1 RPC console.
+Use up and down arrows to navigate history, and %2 to clear screen.
+Use %3 and %4 to increase or decrease the font size.
+Type %5 for an overview of available commands.
+For more information on using this console, type %6.
+
+%7WARNING: Scammers have been active, telling users to type commands here, stealing their wallet contents. Do not use this console without fully understanding the ramifications of a command.%8</source>
+        <extracomment>RPC console welcome message. Placeholders %7 and %8 are style tags for the warning content, and they are not space separated from the rest of the text intentionally.</extracomment>
+        <translation type="unfinished">Добродошли у %1 "RPC” конзолу.
+Користи тастере за горе и доле да наводиш историју, и %2 да очистиш екран.
+Користи %3 и %4 да увећаш и смањиш величину фонта.
+Унеси %5 за преглед доступних комади.
+За више информација о коришћењу конзоле, притисни %6
+%7 УПОЗОРЕЊЕ: Преваранти су се активирали, говорећи корисницима да уносе команде овде, и тако краду садржај новчаника. Не користи ову конзолу без потпуног схватања комплексности ове команде. %8</translation>
+    </message>
+    <message>
+        <source>Executing…</source>
+        <extracomment>A console message indicating an entered command is currently being executed.</extracomment>
+        <translation type="unfinished">Обрада...</translation>
+    </message>
+    <message>
+        <source>(peer: %1)</source>
+        <translation type="unfinished">(клијент: %1)</translation>
+    </message>
+    <message>
         <source>via %1</source>
         <translation type="unfinished">преко %1</translation>
     </message>
@@ -1871,6 +2359,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Ban for</source>
         <translation type="unfinished">Забрани за</translation>
+    </message>
+    <message>
+        <source>Never</source>
+        <translation type="unfinished">Никада</translation>
     </message>
     <message>
         <source>Unknown</source>
@@ -1960,12 +2452,36 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Копирај &amp;URI</translation>
     </message>
     <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Копирај адресу</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Копирај &amp;означи</translation>
+    </message>
+    <message>
+        <source>Copy &amp;message</source>
+        <translation type="unfinished">Копирај &amp;поруку</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Копирај &amp;износ</translation>
+    </message>
+    <message>
         <source>Could not unlock wallet.</source>
         <translation type="unfinished">Новчаник није могуће откључати.</translation>
     </message>
-    </context>
+    <message>
+        <source>Could not generate new %1 address</source>
+        <translation type="unfinished">Немогуће је генерисати нову %1 адресу</translation>
+    </message>
+</context>
 <context>
     <name>ReceiveRequestDialog</name>
+    <message>
+        <source>Request payment to …</source>
+        <translation type="unfinished">Захтевај уплату ка ...</translation>
+    </message>
     <message>
         <source>Address:</source>
         <translation type="unfinished">Адреса:</translation>
@@ -1993,6 +2509,18 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Copy &amp;Address</source>
         <translation type="unfinished">Копирај &amp;Адресу</translation>
+    </message>
+    <message>
+        <source>&amp;Verify</source>
+        <translation type="unfinished">&amp;Верификуј</translation>
+    </message>
+    <message>
+        <source>Verify this address on e.g. a hardware wallet screen</source>
+        <translation type="unfinished">Верификуј ову адресу на пример на екрану хардвер новчаника</translation>
+    </message>
+    <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">&amp;Сачували слику…</translation>
     </message>
     <message>
         <source>Payment information</source>
@@ -2125,12 +2653,28 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Очисти сва поља форме.</translation>
     </message>
     <message>
+        <source>Inputs…</source>
+        <translation type="unfinished">Поља...</translation>
+    </message>
+    <message>
         <source>Dust:</source>
         <translation type="unfinished">Прашина:</translation>
     </message>
     <message>
+        <source>Choose…</source>
+        <translation type="unfinished">Одабери...</translation>
+    </message>
+    <message>
         <source>Hide transaction fee settings</source>
         <translation type="unfinished">Сакријте износ накнаде за трансакцију</translation>
+    </message>
+    <message>
+        <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
+
+Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satoshis per kvB" for a transaction size of 500 virtual bytes (half of 1 kvB) would ultimately yield a fee of only 50 satoshis.</source>
+        <translation type="unfinished">Одредити прилагођену провизију по kB (1,000 битова) виртуелне величине трансакције. 
+
+Напомена: С обзиром да се провизија рачуна на основу броја бајтова, провизија за "100 сатошија по kB" за величину трансакције од 500 бајтова (пола од 1 kB) ће аутоматски износити само 50 сатошија.</translation>
     </message>
     <message>
         <source>When there is less transaction volume than space in the blocks, miners as well as relaying nodes may enforce a minimum fee. Paying only this minimum fee is just fine, but be aware that this can result in a never confirming transaction once there is more demand for bitcoin transactions than the network can process.</source>
@@ -2139,6 +2683,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>A too low fee might result in a never confirming transaction (read the tooltip)</source>
         <translation type="unfinished">Сувише ниска провизија може резултовати да трансакција никада не  буде потврђена (прочитајте опис)</translation>
+    </message>
+    <message>
+        <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
+        <translation type="unfinished">(Паметна провизија још није покренута. Ово уобичајено траје неколико блокова...)</translation>
     </message>
     <message>
         <source>Confirmation time target:</source>
@@ -2201,6 +2749,20 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">%1 (%2 блокова)</translation>
     </message>
     <message>
+        <source>Sign on device</source>
+        <extracomment>"device" usually means a hardware wallet</extracomment>
+        <translation type="unfinished">Потпиши на уређају</translation>
+    </message>
+    <message>
+        <source>Connect your hardware wallet first.</source>
+        <translation type="unfinished">Повежи прво свој хардвер новчаник.</translation>
+    </message>
+    <message>
+        <source>Set external signer script path in Options -&gt; Wallet</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Подси екстерну скрипту за потписивање у : Options -&gt; Wallet</translation>
+    </message>
+    <message>
         <source>Cr&amp;eate Unsigned</source>
         <translation type="unfinished">Креирај непотписано</translation>
     </message>
@@ -2229,12 +2791,47 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Да ли сте сигурни да желите да пошаљете?</translation>
     </message>
     <message>
+        <source>To review recipient list click "Show Details…"</source>
+        <translation type="unfinished">Да би сте прегледали листу примаоца кликните на "Прикажи детаље..."</translation>
+    </message>
+    <message>
+        <source>Create Unsigned</source>
+        <translation type="unfinished">Креирај непотписано</translation>
+    </message>
+    <message>
+        <source>Sign and send</source>
+        <translation type="unfinished">Потпиши и пошаљи</translation>
+    </message>
+    <message>
+        <source>Sign failed</source>
+        <translation type="unfinished">Потписивање је неуспело</translation>
+    </message>
+    <message>
+        <source>External signer not found</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Екстерни потписник није пронађен</translation>
+    </message>
+    <message>
+        <source>External signer failure</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Грешка при екстерном потписивању</translation>
+    </message>
+    <message>
         <source>Save Transaction Data</source>
         <translation type="unfinished">Сачувај Податке Трансакције</translation>
     </message>
     <message>
+        <source>Partially Signed Transaction (Binary)</source>
+        <extracomment>Expanded name of the binary PSBT file format. See: BIP 174.</extracomment>
+        <translation type="unfinished">Делимично потписана трансакција (бинарна)</translation>
+    </message>
+    <message>
         <source>PSBT saved</source>
         <translation type="unfinished">PSBT сачуван</translation>
+    </message>
+    <message>
+        <source>External balance:</source>
+        <translation type="unfinished">Екстерни баланс (стање):</translation>
     </message>
     <message>
         <source>or</source>
@@ -2243,6 +2840,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>You can increase the fee later (signals Replace-By-Fee, BIP-125).</source>
         <translation type="unfinished">Можете повећати провизију касније (сигнали Замени-са-Провизијом, BIP-125).</translation>
+    </message>
+    <message>
+        <source>Please, review your transaction proposal. This will produce a Partially Signed Bitcoin Transaction (PSBT) which you can save or copy and then sign with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
+        <translation type="unfinished">Молимо, проверите ваш предлог трансакције. Ово ће произвести делимично потписану Биткоин трансакцију (PSBT) коју можете копирати и онда потписати са нпр. офлајн %1 новчаником, или PSBT компатибилним хардверским новчаником.</translation>
     </message>
     <message>
         <source>Please, review your transaction.</source>
@@ -2307,9 +2908,9 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation>
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>Процењује се да ће започети потврду унутар %n блокова.</numerusform>
+            <numerusform>Процењује се да ће започети потврду унутар %n блокова.</numerusform>
+            <numerusform>Процењује се да ће започети потврду унутар %n блокова.</numerusform>
         </translation>
     </message>
     <message>
@@ -2548,13 +3149,20 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
 </context>
 <context>
+    <name>TrafficGraphWidget</name>
+    <message>
+        <source>kB/s</source>
+        <translation type="unfinished">KB/s</translation>
+    </message>
+</context>
+<context>
     <name>TransactionDesc</name>
     <message numerus="yes">
         <source>Open for %n more block(s)</source>
         <translation>
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>Отворено за још %n блок.</numerusform>
+            <numerusform>Отворено за још %n блокова</numerusform>
+            <numerusform>Отворено за још %n блокова</numerusform>
         </translation>
     </message>
     <message>
@@ -2632,9 +3240,9 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation>
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>Отворено за још %n блок.</numerusform>
+            <numerusform>сазрева за %n блокова</numerusform>
+            <numerusform>сазрева за %n блокова</numerusform>
         </translation>
     </message>
     <message>
@@ -2750,9 +3358,9 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>Open for %n more block(s)</source>
         <translation>
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>Отворено за још %n блок.</numerusform>
+            <numerusform>Отворено за још %n блокова</numerusform>
+            <numerusform>Отворено за још %n блокова</numerusform>
         </translation>
     </message>
     <message>
@@ -2895,8 +3503,49 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Минимални износ</translation>
     </message>
     <message>
+        <source>Range…</source>
+        <translation type="unfinished">Опсег:</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Копирај адресу</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Копирај &amp;означи</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Копирај &amp;износ</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">Копирај трансакцију &amp;ID</translation>
+    </message>
+    <message>
+        <source>Copy &amp;raw transaction</source>
+        <translation type="unfinished">Копирајте &amp;необрађену трансакцију</translation>
+    </message>
+    <message>
+        <source>Copy full transaction &amp;details</source>
+        <translation type="unfinished">Копирајте све детаље трансакције</translation>
+    </message>
+    <message>
+        <source>&amp;Show transaction details</source>
+        <translation type="unfinished">&amp;Прикажи детаље транакције</translation>
+    </message>
+    <message>
+        <source>Increase transaction &amp;fee</source>
+        <translation type="unfinished">Повећај провизију трансакције</translation>
+    </message>
+    <message>
         <source>Export Transaction History</source>
         <translation type="unfinished">Извези Детаље Трансакције</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See https://en.wikipedia.org/wiki/Comma-separated_values</extracomment>
+        <translation type="unfinished">CSV фајл</translation>
     </message>
     <message>
         <source>Confirmed</source>

--- a/src/qt/locale/bitcoin_sv.ts
+++ b/src/qt/locale/bitcoin_sv.ts
@@ -70,6 +70,11 @@
         <translation type="unfinished">Detta är dina Bitcoin-adresser för att skicka betalningar. Kontrollera alltid belopp och mottagaradress innan du skickar bitcoin.</translation>
     </message>
     <message>
+        <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
+Signing is only possible with addresses of the type 'legacy'.</source>
+        <translation type="unfinished">Detta är dina Bitcoinadresser för att ta emot betalningar. Använd knappen 'Skapa ny mottagaradress' i mottagsfliken för att skapa nya adresser. Signering är bara tillgänglig för adresser av typen 'legacy'</translation>
+    </message>
+    <message>
         <source>&amp;Copy Address</source>
         <translation type="unfinished">&amp;Kopiera adress</translation>
     </message>
@@ -84,6 +89,11 @@
     <message>
         <source>Export Address List</source>
         <translation type="unfinished">Exportera adresslista</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See https://en.wikipedia.org/wiki/Comma-separated_values</extracomment>
+        <translation type="unfinished">Kommaseparerad fil</translation>
     </message>
     <message>
         <source>There was an error trying to save the address list to %1. Please try again.</source>
@@ -234,6 +244,17 @@ Försök igen.</translation>
     </message>
 </context>
 <context>
+    <name>BitcoinApplication</name>
+    <message>
+        <source>Internal error</source>
+        <translation type="unfinished">Internt fel</translation>
+    </message>
+    <message>
+        <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
+        <translation type="unfinished">Ett internt fel har uppstått. %1 kommer försöka att fortsätta. Detta är en oväntad bugg som kan rapporteras enligt nedan beskrivning.</translation>
+    </message>
+</context>
+<context>
     <name>QObject</name>
     <message>
         <source>Error: Specified data directory "%1" does not exist.</source>
@@ -248,6 +269,14 @@ Försök igen.</translation>
         <translation type="unfinished">Fel: %1</translation>
     </message>
     <message>
+        <source>Error initializing settings: %1</source>
+        <translation type="unfinished">Fel vid initieringen av inställningen: %1</translation>
+    </message>
+    <message>
+        <source>%1 didn't yet exit safely…</source>
+        <translation type="unfinished">%1 har inte avslutats korrekt än...</translation>
+    </message>
+    <message>
         <source>unknown</source>
         <translation type="unfinished">okänd</translation>
     </message>
@@ -260,12 +289,20 @@ Försök igen.</translation>
         <translation type="unfinished">Ange en Bitcoin-adress (t.ex. %1)</translation>
     </message>
     <message>
+        <source>Internal</source>
+        <translation type="unfinished">Intern</translation>
+    </message>
+    <message>
         <source>Inbound</source>
         <translation type="unfinished">Inkommande</translation>
     </message>
     <message>
         <source>Outbound</source>
         <translation type="unfinished">Utgående</translation>
+    </message>
+    <message>
+        <source>Full Relay</source>
+        <translation type="unfinished">Fullt relä</translation>
     </message>
     <message>
         <source>None</source>
@@ -278,36 +315,36 @@ Försök igen.</translation>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation>
-            <numerusform />
-            <numerusform />
+            <numerusform>%n sekund</numerusform>
+            <numerusform>%n sekunder</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n minute(s)</source>
         <translation>
-            <numerusform />
-            <numerusform />
+            <numerusform>%n minut</numerusform>
+            <numerusform>%n minuter</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n timme</numerusform>
+            <numerusform>%n timmar</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n dag</numerusform>
+            <numerusform>%n dagar</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n vecka</numerusform>
+            <numerusform>%n veckor</numerusform>
         </translation>
     </message>
     <message>
@@ -317,8 +354,8 @@ Försök igen.</translation>
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n år</numerusform>
+            <numerusform>%n år</numerusform>
         </translation>
     </message>
     </context>
@@ -406,6 +443,10 @@ Försök igen.</translation>
         <translation>&amp;Ta emot</translation>
     </message>
     <message>
+        <source>&amp;Options…</source>
+        <translation type="unfinished">&amp;Inställningar</translation>
+    </message>
+    <message>
         <source>&amp;Show / Hide</source>
         <translation>&amp;Visa / Dölj</translation>
     </message>
@@ -414,16 +455,56 @@ Försök igen.</translation>
         <translation>Visa eller dölj huvudfönstret</translation>
     </message>
     <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation type="unfinished">&amp;Kryptera plånboken…</translation>
+    </message>
+    <message>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>Kryptera de privata nycklar som tillhör din plånbok</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation type="unfinished">&amp;Ändra lösenordsfras…</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation type="unfinished">Signera &amp;meddelandet...</translation>
     </message>
     <message>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation>Signera meddelanden med dina Bitcoin-adresser för att bevisa att du äger dem</translation>
     </message>
     <message>
+        <source>&amp;Verify message…</source>
+        <translation type="unfinished">&amp;Bekräfta meddelandet…</translation>
+    </message>
+    <message>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation>Verifiera meddelanden för att vara säker på att de signerades med angivna Bitcoin-adresser</translation>
+    </message>
+    <message>
+        <source>&amp;Load PSBT from file…</source>
+        <translation type="unfinished">&amp;Ladda PSBT från fil…</translation>
+    </message>
+    <message>
+        <source>Load PSBT from clipboard…</source>
+        <translation type="unfinished">Ladda PSBT från urklipp...</translation>
+    </message>
+    <message>
+        <source>Open &amp;URI…</source>
+        <translation type="unfinished">Öppna &amp;URI…</translation>
+    </message>
+    <message>
+        <source>Close Wallet…</source>
+        <translation type="unfinished">Stäng plånbok…</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation type="unfinished">Skapa Plånbok...</translation>
+    </message>
+    <message>
+        <source>Close All Wallets…</source>
+        <translation type="unfinished">Stäng Alla Plånböcker...</translation>
     </message>
     <message>
         <source>&amp;File</source>
@@ -440,6 +521,10 @@ Försök igen.</translation>
     <message>
         <source>Tabs toolbar</source>
         <translation>Verktygsfält för flikar</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation type="unfinished">Behandlar block på disken…</translation>
     </message>
     <message>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
@@ -469,6 +554,10 @@ Försök igen.</translation>
         <translation>%1 efter</translation>
     </message>
     <message>
+        <source>Catching up…</source>
+        <translation type="unfinished">Hämtar upp…</translation>
+    </message>
+    <message>
         <source>Last received block was generated %1 ago.</source>
         <translation>Senast mottagna block skapades för %1 sedan.</translation>
     </message>
@@ -487,6 +576,14 @@ Försök igen.</translation>
     <message>
         <source>Up to date</source>
         <translation>Uppdaterad</translation>
+    </message>
+    <message>
+        <source>Load Partially Signed Bitcoin Transaction</source>
+        <translation type="unfinished">Läs in Delvis signerad Bitcoin transaktion (PSBT)</translation>
+    </message>
+    <message>
+        <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
+        <translation type="unfinished">Läs in Delvis signerad Bitcoin transaktion (PSBT) från urklipp</translation>
     </message>
     <message>
         <source>Node window</source>
@@ -571,6 +668,11 @@ Försök igen.</translation>
             <numerusform />
             <numerusform />
         </translation>
+    </message>
+    <message>
+        <source>Disable network activity</source>
+        <extracomment>A context menu item.</extracomment>
+        <translation type="unfinished">Stäng av nätverksaktivitet</translation>
     </message>
     <message>
         <source>Error: %1</source>
@@ -731,6 +833,18 @@ Försök igen.</translation>
         <translation type="unfinished">Kopiera belopp</translation>
     </message>
     <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Kopiera adress</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Kopiera &amp;etikett</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Kopiera &amp;Belopp</translation>
+    </message>
+    <message>
         <source>Copy quantity</source>
         <translation type="unfinished">Kopiera kvantitet</translation>
     </message>
@@ -790,6 +904,10 @@ Försök igen.</translation>
 <context>
     <name>CreateWalletActivity</name>
     <message>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation type="unfinished">Skapar plånbok &lt;b&gt;%1&lt;/b&gt;…</translation>
+    </message>
+    <message>
         <source>Create wallet failed</source>
         <translation type="unfinished">Plånboken kunde inte skapas</translation>
     </message>
@@ -797,7 +915,11 @@ Försök igen.</translation>
         <source>Create wallet warning</source>
         <translation type="unfinished">Skapa plånboksvarning</translation>
     </message>
-    </context>
+    <message>
+        <source>Can't list signers</source>
+        <translation type="unfinished">Kan inte lista signerare</translation>
+    </message>
+</context>
 <context>
     <name>OpenWalletActivity</name>
     <message>
@@ -831,7 +953,11 @@ Försök igen.</translation>
         <source>Close all wallets</source>
         <translation type="unfinished">Stäng alla plånböcker</translation>
     </message>
-    </context>
+    <message>
+        <source>Are you sure you wish to close all wallets?</source>
+        <translation type="unfinished">Är du säker på att du vill stänga alla plånböcker?</translation>
+    </message>
+</context>
 <context>
     <name>CreateWalletDialog</name>
     <message>
@@ -853,6 +979,10 @@ Försök igen.</translation>
     <message>
         <source>Encrypt Wallet</source>
         <translation type="unfinished">Kryptera plånbok</translation>
+    </message>
+    <message>
+        <source>Advanced Options</source>
+        <translation type="unfinished">Avancerat</translation>
     </message>
     <message>
         <source>Disable private keys for this wallet. Wallets with private keys disabled will have no private keys and cannot have an HD seed or imported private keys. This is ideal for watch-only wallets.</source>
@@ -956,6 +1086,14 @@ Försök igen.</translation>
 <context>
     <name>Intro</name>
     <message>
+        <source>%1 GB of free space available</source>
+        <translation type="unfinished">%1 GB ledigt utrymme tillgängligt</translation>
+    </message>
+    <message>
+        <source>(of %1 GB needed)</source>
+        <translation type="unfinished">(av %1 GB krävs)</translation>
+    </message>
+    <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
         <translation type="unfinished">Minst %1 GB data kommer att sparas i den här katalogen, och de växer över tiden.</translation>
     </message>
@@ -1008,6 +1146,10 @@ Försök igen.</translation>
         <translation type="unfinished">Att återställa detta alternativ påbörjar en omstart av nedladdningen av hela blockkedjan. Det går snabbare att ladda ner hela kedjan först, och gallra den senare. Detta alternativ stänger av vissa avancerade funktioner.</translation>
     </message>
     <message>
+        <source> GB</source>
+        <translation type="unfinished">GB</translation>
+    </message>
+    <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
         <translation type="unfinished">Denna första synkronisering är väldigt krävande, och kan påvisa hårdvaruproblem hos din dator som tidigare inte visat sig. Varje gång du kör %1, kommer nerladdningen att fortsätta där den avslutades.</translation>
     </message>
@@ -1038,6 +1180,10 @@ Försök igen.</translation>
 <context>
     <name>ShutdownWindow</name>
     <message>
+        <source>%1 is shutting down…</source>
+        <translation type="unfinished">%1 stänger ner…</translation>
+    </message>
+    <message>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished">Stäng inte av datorn förrän denna ruta försvinner.</translation>
     </message>
@@ -1059,6 +1205,14 @@ Försök igen.</translation>
     <message>
         <source>Number of blocks left</source>
         <translation type="unfinished">Antal block kvar</translation>
+    </message>
+    <message>
+        <source>Unknown…</source>
+        <translation type="unfinished">Okänd…</translation>
+    </message>
+    <message>
+        <source>calculating…</source>
+        <translation type="unfinished">beräknar...</translation>
     </message>
     <message>
         <source>Last block time</source>
@@ -1219,6 +1373,10 @@ Försök igen.</translation>
         <translation>&amp;Fönster</translation>
     </message>
     <message>
+        <source>Show the icon in the system tray.</source>
+        <translation type="unfinished">Visa ikonen i systemfältet.</translation>
+    </message>
+    <message>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation>Visa endast en systemfältsikon vid minimering.</translation>
     </message>
@@ -1253,6 +1411,10 @@ Försök igen.</translation>
     <message>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished">Om myntkontrollfunktioner skall visas eller inte</translation>
+    </message>
+    <message>
+        <source>Connect to the Bitcoin network through a separate SOCKS5 proxy for Tor onion services.</source>
+        <translation type="unfinished">Anslut till Bitcoin-nätverket genom en separat SOCKS5-proxy för onion-tjänster genom Tor.</translation>
     </message>
     <message>
         <source>&amp;Third party transaction URLs</source>
@@ -1385,9 +1547,69 @@ Försök igen.</translation>
         <source>Current total balance in watch-only addresses</source>
         <translation type="unfinished">Aktuellt totalt saldo i granska-bara adresser</translation>
     </message>
-    </context>
+    <message>
+        <source>Privacy mode activated for the Overview tab. To unmask the values, uncheck Settings-&gt;Mask values.</source>
+        <translation type="unfinished">Privat läge aktiverad för fliken Översikt. För att visa data, bocka ur Inställningar &gt; Dölj data.</translation>
+    </message>
+</context>
 <context>
     <name>PSBTOperationsDialog</name>
+    <message>
+        <source>Sign Tx</source>
+        <translation type="unfinished">Signera transaktion</translation>
+    </message>
+    <message>
+        <source>Broadcast Tx</source>
+        <translation type="unfinished">Sänd Tx</translation>
+    </message>
+    <message>
+        <source>Copy to Clipboard</source>
+        <translation type="unfinished">Kopiera till Urklippshanteraren</translation>
+    </message>
+    <message>
+        <source>Save…</source>
+        <translation type="unfinished">Spara...</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation type="unfinished">Avsluta</translation>
+    </message>
+    <message>
+        <source>Failed to load transaction: %1</source>
+        <translation type="unfinished">Kunde inte läsa transaktion: %1</translation>
+    </message>
+    <message>
+        <source>Failed to sign transaction: %1</source>
+        <translation type="unfinished">Kunde inte signera transaktion: %1</translation>
+    </message>
+    <message>
+        <source>Could not sign any more inputs.</source>
+        <translation type="unfinished">Kunde inte signera några fler inmatningar.</translation>
+    </message>
+    <message>
+        <source>Unknown error processing transaction.</source>
+        <translation type="unfinished">Ett fel uppstod när transaktionen behandlades</translation>
+    </message>
+    <message>
+        <source>Save Transaction Data</source>
+        <translation type="unfinished">Spara transaktionsdetaljer</translation>
+    </message>
+    <message>
+        <source>PSBT saved to disk.</source>
+        <translation type="unfinished">PSBT sparad till disk.</translation>
+    </message>
+    <message>
+        <source> * Sends %1 to %2</source>
+        <translation type="unfinished">* Skickar %1 till %2</translation>
+    </message>
+    <message>
+        <source>Unable to calculate transaction fee or total transaction amount.</source>
+        <translation type="unfinished">Kunde inte beräkna transaktionsavgift eller totala transaktionssumman.</translation>
+    </message>
+    <message>
+        <source>Pays transaction fee: </source>
+        <translation type="unfinished">Betalar transaktionsavgift:</translation>
+    </message>
     <message>
         <source>Total Amount</source>
         <translation type="unfinished">Totalt belopp</translation>
@@ -1396,7 +1618,31 @@ Försök igen.</translation>
         <source>or</source>
         <translation type="unfinished">eller</translation>
     </message>
-    </context>
+    <message>
+        <source>Transaction has %1 unsigned inputs.</source>
+        <translation type="unfinished">Transaktion %1 har osignerad indata.</translation>
+    </message>
+    <message>
+        <source>Transaction is missing some information about inputs.</source>
+        <translation type="unfinished">Transaktionen saknar information om indata.</translation>
+    </message>
+    <message>
+        <source>Transaction still needs signature(s).</source>
+        <translation type="unfinished">Transaktionen behöver signatur(er).</translation>
+    </message>
+    <message>
+        <source>(But this wallet cannot sign transactions.)</source>
+        <translation type="unfinished">(Den här plånboken kan inte signera transaktioner.)</translation>
+    </message>
+    <message>
+        <source>(But this wallet does not have the right keys.)</source>
+        <translation type="unfinished">(Den här plånboken saknar korrekta nycklar.)</translation>
+    </message>
+    <message>
+        <source>Transaction status is unknown.</source>
+        <translation type="unfinished">Transaktionens status är okänd.</translation>
+    </message>
+</context>
 <context>
     <name>PaymentServer</name>
     <message>
@@ -1460,6 +1706,10 @@ Försök igen.</translation>
 <context>
     <name>QRImageWidget</name>
     <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">&amp;Spara Bild...</translation>
+    </message>
+    <message>
         <source>&amp;Copy Image</source>
         <translation type="unfinished">&amp;Kopiera Bild</translation>
     </message>
@@ -1479,7 +1729,12 @@ Försök igen.</translation>
         <source>Save QR Code</source>
         <translation type="unfinished">Spara QR-kod</translation>
     </message>
-    </context>
+    <message>
+        <source>PNG Image</source>
+        <extracomment>Expanded name of the PNG file format. See https://en.wikipedia.org/wiki/Portable_Network_Graphics</extracomment>
+        <translation type="unfinished">PNG-bild</translation>
+    </message>
+</context>
 <context>
     <name>RPCConsole</name>
     <message>
@@ -1587,6 +1842,10 @@ Försök igen.</translation>
         <translation type="unfinished">Synkade block</translation>
     </message>
     <message>
+        <source>Mapped AS</source>
+        <translation type="unfinished">Kartlagd AS</translation>
+    </message>
+    <message>
         <source>User Agent</source>
         <translation type="unfinished">Användaragent</translation>
     </message>
@@ -1607,12 +1866,28 @@ Försök igen.</translation>
         <translation type="unfinished">Öka fontstorleken</translation>
     </message>
     <message>
+        <source>Permissions</source>
+        <translation type="unfinished">Behörigheter</translation>
+    </message>
+    <message>
+        <source>Direction/Type</source>
+        <translation type="unfinished">Riktning/Typ</translation>
+    </message>
+    <message>
         <source>Services</source>
         <translation type="unfinished">Tjänster</translation>
     </message>
     <message>
+        <source>High Bandwidth</source>
+        <translation type="unfinished">Hög bandbredd</translation>
+    </message>
+    <message>
         <source>Connection Time</source>
         <translation type="unfinished">Anslutningstid</translation>
+    </message>
+    <message>
+        <source>Last Block</source>
+        <translation type="unfinished">Sista blocket</translation>
     </message>
     <message>
         <source>Last Send</source>
@@ -1679,6 +1954,10 @@ Försök igen.</translation>
         <translation type="unfinished">1 &amp;timme</translation>
     </message>
     <message>
+        <source>1 d&amp;ay</source>
+        <translation type="unfinished">1d&amp;ag</translation>
+    </message>
+    <message>
         <source>1 &amp;week</source>
         <translation type="unfinished">1 &amp;vecka</translation>
     </message>
@@ -1703,6 +1982,11 @@ Försök igen.</translation>
         <translation type="unfinished">Utför instruktion med plånbok "%1"</translation>
     </message>
     <message>
+        <source>Executing…</source>
+        <extracomment>A console message indicating an entered command is currently being executed.</extracomment>
+        <translation type="unfinished">Kör…</translation>
+    </message>
+    <message>
         <source>Yes</source>
         <translation type="unfinished">Ja</translation>
     </message>
@@ -1721,6 +2005,10 @@ Försök igen.</translation>
     <message>
         <source>Ban for</source>
         <translation type="unfinished">Bannlys i</translation>
+    </message>
+    <message>
+        <source>Never</source>
+        <translation type="unfinished">Aldrig</translation>
     </message>
     <message>
         <source>Unknown</source>
@@ -1802,12 +2090,36 @@ Försök igen.</translation>
         <translation type="unfinished">Kopiera &amp;URI</translation>
     </message>
     <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Kopiera adress</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Kopiera &amp;etikett</translation>
+    </message>
+    <message>
+        <source>Copy &amp;message</source>
+        <translation type="unfinished">Kopiera &amp;meddelande</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Kopiera &amp;Belopp</translation>
+    </message>
+    <message>
         <source>Could not unlock wallet.</source>
         <translation type="unfinished">Kunde inte låsa upp plånboken.</translation>
     </message>
-    </context>
+    <message>
+        <source>Could not generate new %1 address</source>
+        <translation type="unfinished">Kan inte generera ny %1 adress</translation>
+    </message>
+</context>
 <context>
     <name>ReceiveRequestDialog</name>
+    <message>
+        <source>Address:</source>
+        <translation type="unfinished">Adress</translation>
+    </message>
     <message>
         <source>Amount:</source>
         <translation type="unfinished">Belopp:</translation>
@@ -1831,6 +2143,14 @@ Försök igen.</translation>
     <message>
         <source>Copy &amp;Address</source>
         <translation type="unfinished">Kopiera &amp;Adress</translation>
+    </message>
+    <message>
+        <source>&amp;Verify</source>
+        <translation type="unfinished">&amp;Bekräfta</translation>
+    </message>
+    <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">&amp;Spara Bild...</translation>
     </message>
     <message>
         <source>Payment information</source>
@@ -1959,8 +2279,16 @@ Försök igen.</translation>
         <translation type="unfinished">Rensa alla formulärfälten</translation>
     </message>
     <message>
+        <source>Inputs…</source>
+        <translation type="unfinished">Inmatningar…</translation>
+    </message>
+    <message>
         <source>Dust:</source>
         <translation type="unfinished">Damm:</translation>
+    </message>
+    <message>
+        <source>Choose…</source>
+        <translation type="unfinished">Välj…</translation>
     </message>
     <message>
         <source>Hide transaction fee settings</source>
@@ -2039,6 +2367,10 @@ Försök igen.</translation>
         <translation type="unfinished">Sk&amp;apa Osignerad</translation>
     </message>
     <message>
+        <source>Creates a Partially Signed Bitcoin Transaction (PSBT) for use with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
+        <translation type="unfinished">Skapar en delvis signerad Bitcoin transaktion (PSBT) att använda vid t.ex. en offline %1 plånbok, eller en PSBT-kompatibel hårdvaruplånbok</translation>
+    </message>
+    <message>
         <source> from wallet '%1'</source>
         <translation type="unfinished">från plånbok: '%1'</translation>
     </message>
@@ -2059,8 +2391,24 @@ Försök igen.</translation>
         <translation type="unfinished">Är du säker på att du vill skicka?</translation>
     </message>
     <message>
+        <source>Create Unsigned</source>
+        <translation type="unfinished">Skapa osignerad</translation>
+    </message>
+    <message>
+        <source>Sign and send</source>
+        <translation type="unfinished">Signera och skicka</translation>
+    </message>
+    <message>
         <source>Sign failed</source>
         <translation type="unfinished">Signering misslyckades</translation>
+    </message>
+    <message>
+        <source>Save Transaction Data</source>
+        <translation type="unfinished">Spara transaktionsdetaljer</translation>
+    </message>
+    <message>
+        <source>PSBT saved</source>
+        <translation type="unfinished">PSBT sparad</translation>
     </message>
     <message>
         <source>or</source>
@@ -2069,6 +2417,10 @@ Försök igen.</translation>
     <message>
         <source>You can increase the fee later (signals Replace-By-Fee, BIP-125).</source>
         <translation type="unfinished">Du kan höja avgiften senare (signalerar Replace-By-Fee, BIP-125).</translation>
+    </message>
+    <message>
+        <source>Please, review your transaction proposal. This will produce a Partially Signed Bitcoin Transaction (PSBT) which you can save or copy and then sign with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
+        <translation type="unfinished">Verifiera ditt transaktionsförslag. Det kommer skapas en delvis signerad Bitcoin transaktion (PSBT) som du kan spara eller kopiera och sen signera med t.ex. en offline %1 plånbok, eller en PSBT-kompatibel hårdvaruplånbok.</translation>
     </message>
     <message>
         <source>Please, review your transaction.</source>
@@ -2298,6 +2650,10 @@ Försök igen.</translation>
     <message>
         <source>The signed message to verify</source>
         <translation type="unfinished">Signerat meddelande som ska verifieras</translation>
+    </message>
+    <message>
+        <source>The signature given when the message was signed</source>
+        <translation type="unfinished">Signatur när meddelandet signeraded</translation>
     </message>
     <message>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
@@ -2713,8 +3069,33 @@ Försök igen.</translation>
         <translation type="unfinished">Minsta belopp</translation>
     </message>
     <message>
+        <source>Range…</source>
+        <translation type="unfinished">Räckvidd…</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Kopiera adress</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Kopiera &amp;etikett</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Kopiera &amp;Belopp</translation>
+    </message>
+    <message>
+        <source>&amp;Show transaction details</source>
+        <translation type="unfinished">&amp;Visa detaljer för överföringen</translation>
+    </message>
+    <message>
         <source>Export Transaction History</source>
         <translation type="unfinished">Exportera Transaktionshistoriken</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See https://en.wikipedia.org/wiki/Comma-separated_values</extracomment>
+        <translation type="unfinished">Kommaseparerad fil</translation>
     </message>
     <message>
         <source>Confirmed</source>
@@ -2767,6 +3148,14 @@ Försök igen.</translation>
 </context>
 <context>
     <name>WalletFrame</name>
+    <message>
+        <source>No wallet has been loaded.
+Go to File &gt; Open Wallet to load a wallet.
+- OR -</source>
+        <translation type="unfinished">Ingen plånbok har lästs in.
+Gå till Fil &gt; Öppna plånbok för att läsa in en plånbok.
+- ELLER -</translation>
+    </message>
     <message>
         <source>Create a new wallet</source>
         <translation type="unfinished">Skapa ny plånbok</translation>
@@ -2823,6 +3212,10 @@ Försök igen.</translation>
         <translation type="unfinished">Kunde inte skicka transaktion</translation>
     </message>
     <message>
+        <source>Can't display address</source>
+        <translation type="unfinished">Kan inte visa adress</translation>
+    </message>
+    <message>
         <source>default wallet</source>
         <translation type="unfinished">Standardplånbok</translation>
     </message>
@@ -2840,6 +3233,26 @@ Försök igen.</translation>
     <message>
         <source>Error</source>
         <translation type="unfinished">Fel</translation>
+    </message>
+    <message>
+        <source>Unable to decode PSBT from clipboard (invalid base64)</source>
+        <translation type="unfinished">Kan inte läsa in PSBT från urklipp (ogiltig base64)</translation>
+    </message>
+    <message>
+        <source>Load Transaction Data</source>
+        <translation type="unfinished">Läs in transaktionsdata</translation>
+    </message>
+    <message>
+        <source>Partially Signed Transaction (*.psbt)</source>
+        <translation type="unfinished">Delvis signerad transaktion (*.psbt)</translation>
+    </message>
+    <message>
+        <source>PSBT file must be smaller than 100 MiB</source>
+        <translation type="unfinished">PSBT-filen måste vara mindre än 100 MiB</translation>
+    </message>
+    <message>
+        <source>Unable to decode PSBT</source>
+        <translation type="unfinished">Kan inte läsa in PSBT</translation>
     </message>
     <message>
         <source>Backup Wallet</source>
@@ -2871,6 +3284,10 @@ Försök igen.</translation>
     <message>
         <source>The %s developers</source>
         <translation type="unfinished">%s-utvecklarna</translation>
+    </message>
+    <message>
+        <source>%s corrupt. Try using the wallet tool bitcoin-wallet to salvage or restoring a backup.</source>
+        <translation type="unfinished">%s är korrupt. Testa att använda verktyget bitcoin-wallet för att rädda eller återställa en backup.</translation>
     </message>
     <message>
         <source>-maxtxfee is set very high! Fees this large could be paid on a single transaction.</source>
@@ -2905,6 +3322,10 @@ Försök igen.</translation>
         <translation type="unfinished">Ogiltigt belopp för -maxtxfee=&lt;amount&gt;: '%s' (måste vara åtminstone minrelay avgift %s för att förhindra att transaktioner fastnar)</translation>
     </message>
     <message>
+        <source>More than one onion bind address is provided. Using %s for the automatically created Tor onion service.</source>
+        <translation type="unfinished">Fler än en onion-adress finns tillgänglig. Den automatiskt skapade Tor-tjänsten kommer använda %s.</translation>
+    </message>
+    <message>
         <source>Please check that your computer's date and time are correct! If your clock is wrong, %s will not work properly.</source>
         <translation type="unfinished">Kontrollera att din dators datum och tid är korrekt! Om klockan går fel kommer %s inte att fungera korrekt.</translation>
     </message>
@@ -2921,12 +3342,20 @@ Försök igen.</translation>
         <translation type="unfinished">Gallring: senaste plånbokssynkroniseringen ligger utanför gallrade data. Du måste använda -reindex (ladda ner hela blockkedjan igen om noden gallrats)</translation>
     </message>
     <message>
+        <source>SQLiteDatabase: Unknown sqlite wallet schema version %d. Only version %d is supported</source>
+        <translation type="unfinished">SQLiteDatabase: Okänd sqlite plånboks schema version: %d. Det finns bara stöd för version: %d</translation>
+    </message>
+    <message>
         <source>The block database contains a block which appears to be from the future. This may be due to your computer's date and time being set incorrectly. Only rebuild the block database if you are sure that your computer's date and time are correct</source>
         <translation type="unfinished">Blockdatabasen innehåller ett block som verkar vara från framtiden. Detta kan vara på grund av att din dators datum och tid är felaktiga. Bygg bara om blockdatabasen om du är säker på att datorns datum och tid är korrekt</translation>
     </message>
     <message>
         <source>The transaction amount is too small to send after the fee has been deducted</source>
         <translation type="unfinished">Transaktionens belopp är för litet för att skickas efter att avgiften har dragits</translation>
+    </message>
+    <message>
+        <source>This error could occur if this wallet was not shutdown cleanly and was last loaded using a build with a newer version of Berkeley DB. If so, please use the software that last loaded this wallet</source>
+        <translation type="unfinished">Detta fel kan uppstå om plånboken inte stängdes ner säkert och lästes in med ett bygge med en senare version av Berkeley DB. Om detta stämmer in, använd samma mjukvara som sist läste in plåboken.</translation>
     </message>
     <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
@@ -2973,6 +3402,10 @@ Försök igen.</translation>
         <translation type="unfinished">Kan inte matcha -%s adress: '%s'</translation>
     </message>
     <message>
+        <source>Cannot set -peerblockfilters without -blockfilterindex.</source>
+        <translation type="unfinished">Kan inte använda -peerblockfilters utan -blockfilterindex.</translation>
+    </message>
+    <message>
         <source>Cannot write to data directory '%s'; check permissions.</source>
         <translation type="unfinished">Kan inte skriva till mapp "%s", var vänlig se över filbehörigheter.</translation>
     </message>
@@ -2989,12 +3422,28 @@ Försök igen.</translation>
         <translation type="unfinished">Korrupt blockdatabas har upptäckts</translation>
     </message>
     <message>
+        <source>Could not find asmap file %s</source>
+        <translation type="unfinished">Kan inte hitta asmap filen %s</translation>
+    </message>
+    <message>
+        <source>Could not parse asmap file %s</source>
+        <translation type="unfinished">Kan inte läsa in asmap filen %s</translation>
+    </message>
+    <message>
+        <source>Disk space is too low!</source>
+        <translation type="unfinished">Diskutrymmet är för lågt!</translation>
+    </message>
+    <message>
         <source>Do you want to rebuild the block database now?</source>
         <translation type="unfinished">Vill du bygga om blockdatabasen nu?</translation>
     </message>
     <message>
         <source>Done loading</source>
         <translation type="unfinished">Inläsning klar</translation>
+    </message>
+    <message>
+        <source>Dump file %s does not exist.</source>
+        <translation type="unfinished">Dump-filen %s existerar inte.</translation>
     </message>
     <message>
         <source>Error initializing block database</source>
@@ -3041,12 +3490,32 @@ Försök igen.</translation>
         <translation type="unfinished">Fel: Diskutrymme är lågt för %s</translation>
     </message>
     <message>
+        <source>Error: Missing checksum</source>
+        <translation type="unfinished">Fel: Kontrollsumma saknas</translation>
+    </message>
+    <message>
+        <source>Error: No %s addresses available.</source>
+        <translation type="unfinished">Fel: Inga %s-adresser tillgängliga.</translation>
+    </message>
+    <message>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished">Misslyckades att lyssna på någon port. Använd -listen=0 om du vill detta.</translation>
     </message>
     <message>
         <source>Failed to rescan the wallet during initialization</source>
         <translation type="unfinished">Misslyckades med att skanna om plånboken under initiering.</translation>
+    </message>
+    <message>
+        <source>Failed to verify database</source>
+        <translation type="unfinished">Kunde inte verifiera databas</translation>
+    </message>
+    <message>
+        <source>Ignoring duplicate -wallet %s.</source>
+        <translation type="unfinished">Ignorerar duplicerad -waller %s.</translation>
+    </message>
+    <message>
+        <source>Importing…</source>
+        <translation type="unfinished">Importerar…</translation>
     </message>
     <message>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
@@ -3093,8 +3562,20 @@ Försök igen.</translation>
         <translation type="unfinished">Ogiltig nätmask angiven i -whitelist: '%s'</translation>
     </message>
     <message>
+        <source>Loading P2P addresses…</source>
+        <translation type="unfinished">Laddar P2P-adresser…</translation>
+    </message>
+    <message>
+        <source>Loading wallet…</source>
+        <translation type="unfinished">Laddar plånboken…</translation>
+    </message>
+    <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
         <translation type="unfinished">Port måste anges med -whitelist: '%s'</translation>
+    </message>
+    <message>
+        <source>No proxy server specified. Use -proxy=&lt;ip&gt; or -proxy=&lt;ip:port&gt;.</source>
+        <translation type="unfinished">Ingen proxy-server vald. Använd -proxy=&lt;ip&gt; eller -proxy=&lt;ip:port&gt;.</translation>
     </message>
     <message>
         <source>Not enough file descriptors available.</source>
@@ -3111,6 +3592,26 @@ Försök igen.</translation>
     <message>
         <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
         <translation type="unfinished">Minskar -maxconnections från %d till %d, på grund av systembegränsningar.</translation>
+    </message>
+    <message>
+        <source>Rescanning…</source>
+        <translation type="unfinished">Skannar om igen…</translation>
+    </message>
+    <message>
+        <source>SQLiteDatabase: Failed to execute statement to verify database: %s</source>
+        <translation type="unfinished">SQLiteDatabase: Kunde inte exekvera förfrågan att verifiera databasen: %s</translation>
+    </message>
+    <message>
+        <source>SQLiteDatabase: Failed to prepare statement to verify database: %s</source>
+        <translation type="unfinished">SQLiteDatabase: Kunde inte förbereda förfrågan att verifiera databasen: %s</translation>
+    </message>
+    <message>
+        <source>SQLiteDatabase: Failed to read database verification error: %s</source>
+        <translation type="unfinished">SQLiteDatabase: Kunde inte läsa felet vid databas verifikation: %s</translation>
+    </message>
+    <message>
+        <source>SQLiteDatabase: Unexpected application id. Expected %u, got %u</source>
+        <translation type="unfinished">SQLiteDatabase: Okänt applikations-id. Förväntade %u, men var %u</translation>
     </message>
     <message>
         <source>Section [%s] is not recognized.</source>
@@ -3135,6 +3636,10 @@ Försök igen.</translation>
     <message>
         <source>Specified blocks directory "%s" does not exist.</source>
         <translation type="unfinished">Den specificerade mappen för block "%s" existerar inte.</translation>
+    </message>
+    <message>
+        <source>Starting network threads…</source>
+        <translation type="unfinished">Startar nätverkstrådar…</translation>
     </message>
     <message>
         <source>The source code is available from %s.</source>
@@ -3235,6 +3740,14 @@ Försök igen.</translation>
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
         <translation type="unfinished">Kommentaren i användaragent (%s) innehåller osäkra tecken.</translation>
+    </message>
+    <message>
+        <source>Verifying blocks…</source>
+        <translation type="unfinished">Verifierar block...</translation>
+    </message>
+    <message>
+        <source>Verifying wallet(s)…</source>
+        <translation type="unfinished">Verifierar plånboken(plånböckerna)...</translation>
     </message>
     <message>
         <source>Wallet needed to be rewritten: restart %s to complete</source>

--- a/src/qt/locale/bitcoin_sw.ts
+++ b/src/qt/locale/bitcoin_sw.ts
@@ -1,0 +1,178 @@
+<TS version="2.1" language="sw">
+<context>
+    <name>AddressBookPage</name>
+    <message>
+        <source>Right-click to edit address or label</source>
+        <translation type="unfinished">Bonyeza kitufe cha kulia kufanya mabadiliko kwenye anuani au lebo</translation>
+    </message>
+    <message>
+        <source>Create a new address</source>
+        <translation>Fungua anuani mpya</translation>
+    </message>
+    <message>
+        <source>&amp;New</source>
+        <translation type="unfinished">&amp;Mpya</translation>
+    </message>
+    <message>
+        <source>Copy the currently selected address to the system clipboard</source>
+        <translation>Nakili anwani iliyochaguliwa sasa kwenye ubao wa kunakili wa mfumo</translation>
+    </message>
+    <message>
+        <source>&amp;Copy</source>
+        <translation type="unfinished">&amp;nakili</translation>
+    </message>
+    <message>
+        <source>C&amp;lose</source>
+        <translation type="unfinished">C&amp;Funga</translation>
+    </message>
+    <message>
+        <source>Delete the currently selected address from the list</source>
+        <translation>Futa anwani iliyochaguliwa sasa kutoka kwenye orodha</translation>
+    </message>
+    <message>
+        <source>&amp;Delete</source>
+        <translation>&amp;Futa</translation>
+    </message>
+    <message>
+        <source>Sending addresses</source>
+        <translation type="unfinished">Kutuma anuani</translation>
+    </message>
+    <message>
+        <source>Receiving addresses</source>
+        <translation type="unfinished">Kupokea anuani</translation>
+    </message>
+    </context>
+<context>
+    <name>AddressTableModel</name>
+    <message>
+        <source>Address</source>
+        <translation type="unfinished">Anuani</translation>
+    </message>
+    </context>
+<context>
+    <name>QObject</name>
+    <message numerus="yes">
+        <source>%n second(s)</source>
+        <translation>
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n minute(s)</source>
+        <translation>
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n week(s)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n year(s)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    </context>
+<context>
+    <name>BitcoinGUI</name>
+    <message numerus="yes">
+        <source>Processed %n block(s) of transaction history.</source>
+        <translation>
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n active connection(s) to Bitcoin network.</source>
+        <extracomment>A substring of the tooltip.</extracomment>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    </context>
+<context>
+    <name>Intro</name>
+    <message numerus="yes">
+        <source>(sufficient to restore backups %n day(s) old)</source>
+        <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    </context>
+<context>
+    <name>PeerTableModel</name>
+    <message>
+        <source>Address</source>
+        <extracomment>Title of Peers Table column which contains the IP/Onion/I2P address of the connected peer.</extracomment>
+        <translation type="unfinished">Anuani</translation>
+    </message>
+    </context>
+<context>
+    <name>SendCoinsDialog</name>
+    <message numerus="yes">
+        <source>Estimated to begin confirmation within %n block(s).</source>
+        <translation>
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    </context>
+<context>
+    <name>TransactionDesc</name>
+    <message numerus="yes">
+        <source>Open for %n more block(s)</source>
+        <translation>
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>matures in %n more block(s)</source>
+        <translation>
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    </context>
+<context>
+    <name>TransactionTableModel</name>
+    <message numerus="yes">
+        <source>Open for %n more block(s)</source>
+        <translation>
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    </context>
+<context>
+    <name>TransactionView</name>
+    <message>
+        <source>Address</source>
+        <translation type="unfinished">Anuani</translation>
+    </message>
+    </context>
+</TS>

--- a/src/qt/locale/bitcoin_ta.ts
+++ b/src/qt/locale/bitcoin_ta.ts
@@ -650,7 +650,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Wallet குறியாக்கப்பட்டு தற்போது பூட்டப்பட்டுள்ளது</translation>
     </message>
-    </context>
+    <message>
+        <source>Original message:</source>
+        <translation type="unfinished">முதல் செய்தி:</translation>
+    </message>
+</context>
 <context>
     <name>UnitDisplayStatusBarControl</name>
     <message>
@@ -1085,6 +1089,13 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Hide</source>
         <translation type="unfinished">மறை</translation>
+    </message>
+    </context>
+<context>
+    <name>OpenURIDialog</name>
+    <message>
+        <source>Open bitcoin URI</source>
+        <translation type="unfinished">பிட்காயின் யூ. ஆர். ஐ.யை திர</translation>
     </message>
     </context>
 <context>
@@ -2067,6 +2078,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">%1 இருந்து %2</translation>
     </message>
     <message>
+        <source>Do you want to draft this transaction?</source>
+        <translation type="unfinished">இந்தப் பரிவர்த்தனையை வரைய விரும்புகிறீர்களா</translation>
+    </message>
+    <message>
         <source>Are you sure you want to send?</source>
         <translation type="unfinished">நீங்கள் நிச்சயமாக அனுப்ப விரும்புகிறீர்களா?</translation>
     </message>
@@ -2286,6 +2301,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>The Bitcoin address the message was signed with</source>
         <translation type="unfinished">செய்தி கையொப்பமிடப்பட்ட பிட்காயின் முகவரி</translation>
+    </message>
+    <message>
+        <source>The signed message to verify</source>
+        <translation type="unfinished">சரிபார்க்க கையொப்பமிடப்பட்ட செய்தி</translation>
     </message>
     <message>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>

--- a/src/qt/locale/bitcoin_th.ts
+++ b/src/qt/locale/bitcoin_th.ts
@@ -3,11 +3,11 @@
     <name>AddressBookPage</name>
     <message>
         <source>Right-click to edit address or label</source>
-        <translation type="unfinished">คลิกขวาเพื่อแก้ไขที่อยู่หรือป้ายชื่อ</translation>
+        <translation type="unfinished">คลิกขวาเพื่อแก้ไขแอดเดรสหรือเลเบล</translation>
     </message>
     <message>
         <source>Create a new address</source>
-        <translation>สร้างที่อยู่ใหม่</translation>
+        <translation>สร้างแอดเดรสใหม่</translation>
     </message>
     <message>
         <source>&amp;New</source>
@@ -15,7 +15,7 @@
     </message>
     <message>
         <source>Copy the currently selected address to the system clipboard</source>
-        <translation>คัดลอกที่อยู่ที่เลือกในปัจจุบันไปยังคลิปบอร์ดของระบบ</translation>
+        <translation>คัดลอกแอดเดรสที่เลือกในปัจจุบันไปยังคลิปบอร์ดของระบบ</translation>
     </message>
     <message>
         <source>&amp;Copy</source>
@@ -27,11 +27,11 @@
     </message>
     <message>
         <source>Delete the currently selected address from the list</source>
-        <translation>ลบที่อยู่ที่เลือกในปัจจุบันออกจากรายการ</translation>
+        <translation>ลบแอดเดรสที่เลือกในปัจจุบันออกจากรายการ</translation>
     </message>
     <message>
         <source>Enter address or label to search</source>
-        <translation type="unfinished">ป้อนที่อยู่หรือป้ายชื่อเพื่อค้นหา</translation>
+        <translation type="unfinished">ป้อนแอดเดรสหรือเลเบลเพื่อค้นหา</translation>
     </message>
     <message>
         <source>Export the data in the current tab to a file</source>
@@ -47,11 +47,11 @@
     </message>
     <message>
         <source>Choose the address to send coins to</source>
-        <translation type="unfinished">เลือกที่อยู่ที่จะส่งเหรียญ</translation>
+        <translation type="unfinished">เลือกแอดเดรสที่จะส่งเหรียญ</translation>
     </message>
     <message>
         <source>Choose the address to receive coins with</source>
-        <translation type="unfinished">เลือกที่อยู่ที่จะรับเหรียญ</translation>
+        <translation type="unfinished">เลือกแอดเดรสที่จะรับเหรียญ</translation>
     </message>
     <message>
         <source>C&amp;hoose</source>
@@ -59,23 +59,29 @@
     </message>
     <message>
         <source>Sending addresses</source>
-        <translation type="unfinished">ที่อยู่การส่ง</translation>
+        <translation type="unfinished">แอดเดรสการส่ง</translation>
     </message>
     <message>
         <source>Receiving addresses</source>
-        <translation type="unfinished">ที่อยู่การรับ</translation>
+        <translation type="unfinished">แอดเดรสการรับ</translation>
     </message>
     <message>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
-        <translation type="unfinished">ที่อยู่ Bitcoin ของคุณสำหรับการส่งการชำระเงิน โปรดตรวจสอบจำนวนเงินและที่อยู่รับก่อนที่จะส่งเหรียญ</translation>
+        <translation type="unfinished">แอดเดรส Bitcoin ของคุณสำหรับการส่งการชำระเงิน โปรดตรวจสอบจำนวนเงินและแอดเดรสการรับก่อนที่จะส่งเหรียญ</translation>
+    </message>
+    <message>
+        <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
+Signing is only possible with addresses of the type 'legacy'.</source>
+        <translation type="unfinished">นี่คือแอดเดรสสำหรับการรับ Bitcoin ของคุณ กดปุ่ม ‘สร้างแอดเดรสการรับใหม่’ ในแถบการรับ เพื่อสร้างแอดเดรสการรับใหม่
+การลงนามสามารถทำได้เฉพาะกับแอดเดรสในประเภท 'legacy'</translation>
     </message>
     <message>
         <source>&amp;Copy Address</source>
-        <translation type="unfinished">&amp;คัดลอกที่อยู่</translation>
+        <translation type="unfinished">&amp;คัดลอกแอดเดรส</translation>
     </message>
     <message>
         <source>Copy &amp;Label</source>
-        <translation type="unfinished">&amp;คัดลอกป้ายชื่อ</translation>
+        <translation type="unfinished">คัดลอก &amp;ป้ายชื่อ</translation>
     </message>
     <message>
         <source>&amp;Edit</source>
@@ -83,7 +89,12 @@
     </message>
     <message>
         <source>Export Address List</source>
-        <translation type="unfinished">ส่งออกรายการที่อยู่</translation>
+        <translation type="unfinished">ส่งออกรายการแอดเดรส</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See https://en.wikipedia.org/wiki/Comma-separated_values</extracomment>
+        <translation type="unfinished">ไฟล์ที่คั่นด้วยจุลภาค</translation>
     </message>
     <message>
         <source>There was an error trying to save the address list to %1. Please try again.</source>
@@ -99,125 +110,220 @@
     <name>AddressTableModel</name>
     <message>
         <source>Label</source>
-        <translation type="unfinished">ป้ายชื่อ</translation>
+        <translation type="unfinished">เลเบล</translation>
     </message>
     <message>
         <source>Address</source>
-        <translation type="unfinished">ที่อยู่</translation>
+        <translation type="unfinished">แอดเดรส</translation>
     </message>
     <message>
         <source>(no label)</source>
-        <translation type="unfinished">(ไม่มีป้ายชื่อ)</translation>
+        <translation type="unfinished">(ไม่มีเลเบล)</translation>
     </message>
 </context>
 <context>
     <name>AskPassphraseDialog</name>
     <message>
         <source>Passphrase Dialog</source>
-        <translation>กล่องโต้ตอบวลีรหัสผ่าน</translation>
+        <translation>พาสเฟสไดอะล็อก</translation>
     </message>
     <message>
         <source>Enter passphrase</source>
-        <translation>ป้อนวลีรหัสผ่าน</translation>
+        <translation>ป้อนพาสเฟส</translation>
     </message>
     <message>
         <source>New passphrase</source>
-        <translation>วลีรหัสผ่านใหม่</translation>
+        <translation>พาสดฟสใหม่</translation>
     </message>
     <message>
         <source>Repeat new passphrase</source>
-        <translation>ทำซ้ำวลีรหัสผ่านใหม่</translation>
+        <translation>พาสเฟสใหม่อีกครั้ง</translation>
     </message>
     <message>
         <source>Show passphrase</source>
-        <translation type="unfinished">แสดงวลีรหัสผ่าน</translation>
+        <translation type="unfinished">แสดงพาสเฟส</translation>
     </message>
     <message>
         <source>Encrypt wallet</source>
-        <translation type="unfinished">เข้ารหัสกระเป๋าสตางค์</translation>
+        <translation type="unfinished">เข้ารหัสวอลเลต</translation>
+    </message>
+    <message>
+        <source>This operation needs your wallet passphrase to unlock the wallet.</source>
+        <translation type="unfinished">การดำเนินการนี้ต้องการวอลเลตพาสเฟสของคุณเพื่อปลดล็อควอลเลต</translation>
     </message>
     <message>
         <source>Unlock wallet</source>
-        <translation type="unfinished">ปลดล็อคกระเป๋าสตางค์</translation>
+        <translation type="unfinished">ปลดล็อควอลเลต</translation>
     </message>
     <message>
         <source>Change passphrase</source>
-        <translation type="unfinished">เปลี่ยนวลีรหัสผ่าน</translation>
+        <translation type="unfinished">เปลี่ยนพาสเฟส</translation>
     </message>
     <message>
         <source>Confirm wallet encryption</source>
-        <translation type="unfinished">ยืนยันการเข้ารหัสกระเป๋าสตางค์</translation>
+        <translation type="unfinished">ยืนยันการเข้ารหัสวอลเลต</translation>
+    </message>
+    <message>
+        <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
+        <translation type="unfinished">คำเตือน: หากคุณเข้ารหัสวอลเลตของคุณและทำพาสเฟสหาย, คุณจะสูญเสีย &lt;b&gt;BITCOINS ทั้งหมดของคุณ&lt;/b&gt;!</translation>
     </message>
     <message>
         <source>Are you sure you wish to encrypt your wallet?</source>
-        <translation type="unfinished">คุณแน่ใจหรือไม่ว่าต้องการเข้ารหัสกระเป๋าสตางค์ของคุณ?</translation>
+        <translation type="unfinished">คุณแน่ใจหรือไม่ว่าต้องการเข้ารหัสวอลเลตของคุณ?</translation>
     </message>
     <message>
         <source>Wallet encrypted</source>
-        <translation type="unfinished">เข้ารหัสบัญชีเรียบร้อย</translation>
+        <translation type="unfinished">วอลเลตเข้ารหัสเรียบร้อยแล้ว</translation>
+    </message>
+    <message>
+        <source>Enter the new passphrase for the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
+        <translation type="unfinished">ป้อนพาสเฟสใหม่สำหรับวอลเลต&lt;br/&gt;กรุณาใช้พาสเฟสของ &lt;b&gt;สิบหรืออักขระสุ่มสิบตัวขึ้นไป&lt;/b&gt;, หรือ &lt;b&gt;แปดหรือแปดคำขึ้นไป&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <source>Enter the old passphrase and new passphrase for the wallet.</source>
+        <translation type="unfinished">ป้อนพาสเฟสเก่าและ พาสเฟสใหม่สำหรับวอลเลต</translation>
+    </message>
+    <message>
+        <source>Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
+        <translation type="unfinished">โปรดจำไว้ว่าการเข้ารหัสวอลเลตของคุณไม่สามารถปกป้อง bitcoins ของคุณได้อย่างเต็มที่จากการถูกขโมยโดยมัลแวร์ที่ติดไวรัสบนคอมพิวเตอร์ของคุณ</translation>
+    </message>
+    <message>
+        <source>Wallet to be encrypted</source>
+        <translation type="unfinished">วอลเลตเข้ารหัสเรียบร้อยแล้ว</translation>
     </message>
     <message>
         <source>Your wallet is about to be encrypted. </source>
-        <translation type="unfinished">บัญชีของคุณกำลังถูกเข้ารหัส</translation>
+        <translation type="unfinished">วอลเลตของคุณกำลังจะถูกเข้ารหัส</translation>
     </message>
     <message>
         <source>Your wallet is now encrypted. </source>
-        <translation type="unfinished">บัญชีของคุณถูกเข้ารหัสเรียบร้อยแล้ว</translation>
+        <translation type="unfinished">ขณะนี้วอลเลตของคุณได้เข้ารหัสเป็นที่เรียบร้อย</translation>
+    </message>
+    <message>
+        <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
+        <translation type="unfinished">สำคัญ: การสำรองข้อมูลใด ๆ ก่อนหน้านี้ที่คุณได้ทำขึ้นจากไฟล์วอลเลตของคุณควรถูกแทนที่ด้วยไฟล์วอลเลตที่เข้ารหัสที่สร้างขึ้นใหม่ ด้วยเหตุผลด้านความปลอดภัย การสำรองข้อมูลก่อนหน้าของไฟล์วอลเลตที่ไม่ได้เข้ารหัสจะไม่มีประโยชน์ทันทีที่คุณเริ่มใช้วอลเลตใหม่ที่เข้ารหัส</translation>
     </message>
     <message>
         <source>Wallet encryption failed</source>
-        <translation type="unfinished">การเข้ารหัสกระเป๋าสตางค์ล้มเหลว</translation>
+        <translation type="unfinished">การเข้ารหัสวอลเลตล้มเหลว</translation>
+    </message>
+    <message>
+        <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
+        <translation type="unfinished">การเข้ารหัสวอลเลตล้มเหลวเนื่องจากข้อผิดพลาดภายใน วอลเลตของคุณไม่ได้เข้ารหัส</translation>
+    </message>
+    <message>
+        <source>The supplied passphrases do not match.</source>
+        <translation type="unfinished">พาสเฟสที่ให้มาไม่ตรงกัน</translation>
     </message>
     <message>
         <source>Wallet unlock failed</source>
-        <translation type="unfinished">การปลดล็อคกระเป๋าสตางค์ล้มเหลว</translation>
+        <translation type="unfinished">การปลดล็อกวอลเลตล้มเหลว</translation>
     </message>
-    </context>
+    <message>
+        <source>The passphrase entered for the wallet decryption was incorrect.</source>
+        <translation type="unfinished">พาสเฟสที่ป้อนสำหรับการถอดรหัสวอลเลตไม่ถูกต้อง</translation>
+    </message>
+    <message>
+        <source>Wallet passphrase was successfully changed.</source>
+        <translation type="unfinished">เปลี่ยนพาสเฟสวอลเลตสำเร็จแล้ว</translation>
+    </message>
+    <message>
+        <source>Warning: The Caps Lock key is on!</source>
+        <translation type="unfinished">คำเตือน: ปุ่ม Caps Lock เปิดอยู่!</translation>
+    </message>
+</context>
 <context>
     <name>BanTableModel</name>
     <message>
         <source>Banned Until</source>
-        <translation type="unfinished">ห้ามจนถึง</translation>
+        <translation type="unfinished">ห้ามจนกว่า</translation>
+    </message>
+</context>
+<context>
+    <name>BitcoinApplication</name>
+    <message>
+        <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
+        <translation type="unfinished">เกิดข้อผิดพลาดร้ายแรง%1ไม่สามารถดำเนินการต่อได้อย่างปลอดภัยและจะยกเลิก</translation>
+    </message>
+    <message>
+        <source>Internal error</source>
+        <translation type="unfinished">ข้อผิดพลาดภายใน</translation>
+    </message>
+    <message>
+        <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
+        <translation type="unfinished">เกิดข้อผิดพลาดภายใน %1จะพยายามดำเนินการต่ออย่างปลอดภัย นี่เป็นข้อผิดพลาดที่ไม่คาดคิด ซึ่งสามารถรายงานได้ตามที่อธิบายไว้ด้านล่าง</translation>
     </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
+        <source>Error: Specified data directory "%1" does not exist.</source>
+        <translation type="unfinished">ข้อผิดพลาด: ไดเร็กทอรีข้อมูลที่ระบุ "%1" ไม่มีอยู่จริง</translation>
+    </message>
+    <message>
+        <source>Error: Cannot parse configuration file: %1.</source>
+        <translation type="unfinished">ข้อผิดพลาด: ไม่สามารถแยกวิเคราะห์ไฟล์การกำหนดค่า: %1.</translation>
+    </message>
+    <message>
         <source>Error: %1</source>
         <translation type="unfinished">ข้อผิดพลาด: %1</translation>
+    </message>
+    <message>
+        <source>Error initializing settings: %1</source>
+        <translation type="unfinished">เกิดข้อผิดพลาดในการเริ่มต้นการตั้งค่า: %1</translation>
+    </message>
+    <message>
+        <source>%1 didn't yet exit safely…</source>
+        <translation type="unfinished">%1 ยังไม่ออกอย่างปลอดภัย...</translation>
     </message>
     <message>
         <source>Amount</source>
         <translation type="unfinished">จำนวน</translation>
     </message>
+    <message>
+        <source>Internal</source>
+        <translation type="unfinished">ภายใน</translation>
+    </message>
+    <message>
+        <source>Inbound</source>
+        <translation type="unfinished">ขาเข้า</translation>
+    </message>
+    <message>
+        <source>Outbound</source>
+        <translation type="unfinished">ขาออก</translation>
+    </message>
+    <message>
+        <source>Manual</source>
+        <translation type="unfinished">คู่มือ</translation>
+    </message>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation>
-            <numerusform>%n seconds</numerusform>
+            <numerusform>%n วินาที</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n minute(s)</source>
         <translation>
-            <numerusform>%n minutes</numerusform>
+            <numerusform>%n นาที</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
         <translation type="unfinished">
-            <numerusform>%n hours</numerusform>
+            <numerusform>%n ชั่วโมง</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
-            <numerusform>%n days</numerusform>
+            <numerusform>%n วัน</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
-            <numerusform>%n weeks</numerusform>
+            <numerusform>%n สัปดาห์</numerusform>
         </translation>
     </message>
     <message>
@@ -227,10 +333,26 @@
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
-            <numerusform>%n years</numerusform>
+            <numerusform>%n ปี</numerusform>
         </translation>
     </message>
-    </context>
+    <message>
+        <source>%1 B</source>
+        <translation type="unfinished">%1 ไบต์</translation>
+    </message>
+    <message>
+        <source>%1 kB</source>
+        <translation type="unfinished">%1 กิโลไบต์</translation>
+    </message>
+    <message>
+        <source>%1 MB</source>
+        <translation type="unfinished">%1 เมกะไบต์</translation>
+    </message>
+    <message>
+        <source>%1 GB</source>
+        <translation type="unfinished">%1 จิกะไบต์</translation>
+    </message>
+</context>
 <context>
     <name>BitcoinGUI</name>
     <message>
@@ -239,19 +361,15 @@
     </message>
     <message>
         <source>Show general overview of wallet</source>
-        <translation>แสดงภาพรวมทั่วไปของกระเป๋าสตางค์</translation>
+        <translation>แสดงภาพรวมทั่วไปของวอลเลต</translation>
     </message>
     <message>
         <source>&amp;Transactions</source>
-        <translation>&amp;ธุรกรรม</translation>
+        <translation>&amp;การทำธุรกรรม</translation>
     </message>
     <message>
         <source>Browse transaction history</source>
         <translation>เรียกดูประวัติการทำธุรกรรม</translation>
-    </message>
-    <message>
-        <source>E&amp;xit</source>
-        <translation>&amp;ออก</translation>
     </message>
     <message>
         <source>Quit application</source>
@@ -271,31 +389,40 @@
     </message>
     <message>
         <source>Show information about Qt</source>
-        <translation>แสดงข้อมูลเกี่ยวกับ Qt</translation>
+        <translation>แสดงข้อมูล เกี่ยวกับ Qt</translation>
     </message>
     <message>
         <source>Modify configuration options for %1</source>
-        <translation type="unfinished">ปรับเปลี่ยนตัวเลือกการกำหนดค่าสำหรับ %1</translation>
+        <translation type="unfinished">แก้ไขตัวเลือกการกำหนดค่าสำหรับ%1</translation>
     </message>
     <message>
         <source>Create a new wallet</source>
-        <translation type="unfinished">สร้างกระเป๋าสตางค์</translation>
+        <translation type="unfinished">สร้างวอลเลตใหม่</translation>
     </message>
     <message>
         <source>Wallet:</source>
-        <translation type="unfinished">กระเป๋าสตางค์:</translation>
+        <translation type="unfinished">วอลเลต:</translation>
+    </message>
+    <message>
+        <source>Network activity disabled.</source>
+        <extracomment>A substring of the tooltip.</extracomment>
+        <translation type="unfinished">กิจกรรมเครือข่ายถูกปิดใช้งาน</translation>
+    </message>
+    <message>
+        <source>Proxy is &lt;b&gt;enabled&lt;/b&gt;: %1</source>
+        <translation type="unfinished">พร็อกซี่ ถูก &lt;b&gt;เปิดใช้งาน&lt;/b&gt;: %1</translation>
     </message>
     <message>
         <source>Send coins to a Bitcoin address</source>
-        <translation>ส่งเหรียญไปยังที่อยู่ Bitcoin</translation>
+        <translation>ส่งเหรียญไปยังแอดเดรส Bitcoin </translation>
     </message>
     <message>
         <source>Backup wallet to another location</source>
-        <translation>สำรองข้อมูลกระเป๋าสตางค์ไปยังตำแหน่งที่ตั้งอื่น</translation>
+        <translation>สำรองข้อมูลวอลเลตไปยังที่เก็บอื่น</translation>
     </message>
     <message>
         <source>Change the passphrase used for wallet encryption</source>
-        <translation>เปลี่ยนรหัสผ่านที่ใช้สำหรับการเข้ารหัสกระเป๋าเงิน</translation>
+        <translation>เปลี่ยนพาสเฟสที่เคยใช้ด้วยการเข้ารหัสวอลเลต</translation>
     </message>
     <message>
         <source>&amp;Send</source>
@@ -306,24 +433,72 @@
         <translation>&amp;รับ</translation>
     </message>
     <message>
+        <source>&amp;Options…</source>
+        <translation type="unfinished">&amp;ตัวเลือก…</translation>
+    </message>
+    <message>
         <source>&amp;Show / Hide</source>
         <translation>&amp;แสดง / ซ่อน</translation>
     </message>
     <message>
         <source>Show or hide the main Window</source>
-        <translation>แสดงหรือซ่อนหน้าต่างหลัก</translation>
+        <translation>แสดงหรือซ่อนหน้าวินโดว์หลัก</translation>
+    </message>
+    <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation type="unfinished">&amp;เข้ารหัสวอลเลต…</translation>
     </message>
     <message>
         <source>Encrypt the private keys that belong to your wallet</source>
-        <translation>เข้ารหัสกุญแจส่วนตัวที่เป็นของกระเป๋าสตางค์ของคุณ</translation>
+        <translation>เข้ารหัสคีย์ส่วนตัวที่เป็นของวอลเลตของคุณ</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation type="unfinished">&amp;สำรองข้อมูลวอลเลต…</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation type="unfinished">&amp;เปลี่ยนพาสเฟส…</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation type="unfinished"> เซ็นชื่อ &amp;ข้อความ…</translation>
     </message>
     <message>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
-        <translation>เซ็นชื่อด้วยข้อความ ที่เก็บ Bitcoin เพื่อแสดงว่าท่านเป็นเจ้าของ bitcoin นี้จริง</translation>
+        <translation>เซ็นชื่อข้อความด้วย Bitcoin แอดเดรสของคุณเพื่อพิสูจน์การเป็นเจ้าของ</translation>
+    </message>
+    <message>
+        <source>&amp;Verify message…</source>
+        <translation type="unfinished">&amp;ยืนยันข้อความ…</translation>
     </message>
     <message>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
-        <translation>ตรวจสอบ ข้อความ เพื่อให้แน่ใจว่า การเซ็นต์ชื่อ ด้วยที่เก็บ Bitcoin แล้ว</translation>
+        <translation>ยืนยันข้อความเพื่อให้แน่ใจว่าได้ลงนามด้วยแอดเดรส Bitcoin ที่ระบุ</translation>
+    </message>
+    <message>
+        <source>&amp;Load PSBT from file…</source>
+        <translation type="unfinished">&amp;โหลด PSBT จากไฟล์...</translation>
+    </message>
+    <message>
+        <source>Load PSBT from clipboard…</source>
+        <translation type="unfinished">โหลด PSBT จากคลิปบอร์ด...</translation>
+    </message>
+    <message>
+        <source>Open &amp;URI…</source>
+        <translation type="unfinished">เปิด &amp;URI…</translation>
+    </message>
+    <message>
+        <source>Close Wallet…</source>
+        <translation type="unfinished">ปิดวอลเลต…</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation type="unfinished">สร้างวอลเลต…</translation>
+    </message>
+    <message>
+        <source>Close All Wallets…</source>
+        <translation type="unfinished">ปิดวอลเลตทั้งหมด…</translation>
     </message>
     <message>
         <source>&amp;File</source>
@@ -339,41 +514,65 @@
     </message>
     <message>
         <source>Tabs toolbar</source>
-        <translation>แถบเครื่องมือแท็บ</translation>
+        <translation>แถบเครื่องมือ</translation>
+    </message>
+    <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation type="unfinished">กำลังซิงค์ส่วนหัว (%1%)…</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation type="unfinished">การซิงโครไนซ์กับเครือข่าย…</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation type="unfinished">การสร้างดัชนีบล็อกบนดิสก์…</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation type="unfinished">กำลังประมวลผลบล็อกบนดิสก์…</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation type="unfinished">การสร้างดัชนีบล็อกใหม่บนดิสก์…</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation type="unfinished">กำลังเชื่อมต่อไปยัง peers…</translation>
     </message>
     <message>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
-        <translation type="unfinished">เรียกเก็บ การชำระเงิน (สร้าง QR codes และ bitcoin: URIs)</translation>
+        <translation type="unfinished">ขอการชำระเงิน (สร้างรหัส QR และ bitcoin: URIs)</translation>
     </message>
     <message>
         <source>Show the list of used sending addresses and labels</source>
-        <translation type="unfinished">แสดงรายการ ที่เก็บเงินที่จะส่ง bitcoin ออก และป้ายชื่อ ที่ใช้ไปแล้ว</translation>
+        <translation type="unfinished">แสดงรายการที่ใช้ในการส่งแอดเดรสและเลเบลที่ใช้แล้ว</translation>
     </message>
     <message>
         <source>Show the list of used receiving addresses and labels</source>
-        <translation type="unfinished">แสดงรายการ ที่เก็บเงินที่จะรับ bitcoin เข้า และป้ายชื่อ ที่ใช้ไปแล้ว</translation>
-    </message>
-    <message>
-        <source>&amp;Command-line options</source>
-        <translation type="unfinished">&amp;ตัวเลือก Command-line</translation>
+        <translation type="unfinished">แสดงรายการที่ได้ใช้ในการรับแอดเดรสและเลเบล</translation>
     </message>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation>
-            <numerusform>Processed %n blocks of transaction history.</numerusform>
+            <numerusform>ประมวลผล %n บล็อกในประวัติการทำธุรกรรม </numerusform>
         </translation>
     </message>
     <message>
         <source>%1 behind</source>
-        <translation>%1 ตามหลัง</translation>
+        <translation>%1 เบื้องหลัง</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation type="unfinished">กำลังติดตามถึงรายการล่าสุด…</translation>
     </message>
     <message>
         <source>Last received block was generated %1 ago.</source>
-        <translation>บล็อกสุดท้ายที่ได้รับ สร้างขึ้นเมื่อ %1 มาแล้ว</translation>
+        <translation>บล็อกที่ได้รับล่าสุดถูกสร้างขึ้นเมื่อ %1 ที่แล้ว</translation>
     </message>
     <message>
         <source>Transactions after this will not yet be visible.</source>
-        <translation>ธุรกรรมหลังจากนี้จะยังไม่สามารถมองเห็น</translation>
+        <translation>ธุรกรรมหลังจากนี้จะยังไม่ปรากฏให้เห็น</translation>
     </message>
     <message>
         <source>Error</source>
@@ -389,55 +588,71 @@
     </message>
     <message>
         <source>Up to date</source>
-        <translation>ทันสมัย</translation>
+        <translation>ปัจจุบัน</translation>
+    </message>
+    <message>
+        <source>Load Partially Signed Bitcoin Transaction</source>
+        <translation type="unfinished">โหลดธุรกรรม Bitcoin ที่ลงนามบางส่วน</translation>
+    </message>
+    <message>
+        <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
+        <translation type="unfinished">โหลดธุรกรรม Bitcoin ที่ลงนามบางส่วนจากคลิปบอร์ด</translation>
     </message>
     <message>
         <source>Node window</source>
-        <translation type="unfinished">หน้าต่างโหนด</translation>
+        <translation type="unfinished">โหนด วินโดว์</translation>
+    </message>
+    <message>
+        <source>Open node debugging and diagnostic console</source>
+        <translation type="unfinished">เปิดการดีบักโหนดและคอนโซลการวินิจฉัย</translation>
     </message>
     <message>
         <source>&amp;Sending addresses</source>
-        <translation type="unfinished">&amp;ที่อยู่การส่ง</translation>
+        <translation type="unfinished">&amp;แอดเดรสในการส่ง</translation>
     </message>
     <message>
         <source>&amp;Receiving addresses</source>
-        <translation type="unfinished">&amp;ที่อยู่การรับ</translation>
+        <translation type="unfinished">&amp;แอดเดรสในการรับ</translation>
+    </message>
+    <message>
+        <source>Open a bitcoin: URI</source>
+        <translation type="unfinished">เปิด bitcoin: URI</translation>
     </message>
     <message>
         <source>Open Wallet</source>
-        <translation type="unfinished">เปิดกระเป๋าสตางค์</translation>
+        <translation type="unfinished">เปิดวอลเลต</translation>
     </message>
     <message>
         <source>Open a wallet</source>
-        <translation type="unfinished">เปิดกระเป๋าสตางค์</translation>
+        <translation type="unfinished">เปิดวอลเลต</translation>
     </message>
     <message>
         <source>Close wallet</source>
-        <translation type="unfinished">ปิดกระเป๋าสตางค์</translation>
+        <translation type="unfinished">ปิดวอลเลต…</translation>
     </message>
     <message>
         <source>Close all wallets</source>
-        <translation type="unfinished">ปิดกระเป๋าสตางค์ทั้งหมด</translation>
+        <translation type="unfinished">ปิดวอลเลตทั้งหมด…</translation>
     </message>
     <message>
-        <source>Show the %1 help message to get a list with possible Bitcoin command-line options</source>
-        <translation type="unfinished">แสดง %1 ข้อความช่วยเหลือ เพื่อแสดงรายการ ตัวเลือกที่เป็นไปได้สำหรับ Bitcoin command-line</translation>
+        <source>&amp;Mask values</source>
+        <translation type="unfinished">&amp;ค่ามาสก์</translation>
     </message>
     <message>
         <source>default wallet</source>
-        <translation type="unfinished">กระเป๋าสตางค์เริ่มต้น</translation>
+        <translation type="unfinished">วอลเลตเริ่มต้น</translation>
     </message>
     <message>
         <source>No wallets available</source>
-        <translation type="unfinished">ไม่มีกระเป๋าสตางค์</translation>
+        <translation type="unfinished">ไม่มีวอลเลตที่พร้อมใช้งาน</translation>
     </message>
     <message>
         <source>&amp;Window</source>
-        <translation type="unfinished">&amp;หน้าต่าง</translation>
+        <translation type="unfinished">&amp;วินโดว์</translation>
     </message>
     <message>
         <source>Minimize</source>
-        <translation type="unfinished">ย่อ</translation>
+        <translation type="unfinished">ย่อเล็กสุด</translation>
     </message>
     <message>
         <source>Zoom</source>
@@ -445,7 +660,7 @@
     </message>
     <message>
         <source>Main Window</source>
-        <translation type="unfinished">หน้าต่างหลัก</translation>
+        <translation type="unfinished">หน้าวินโดว์หลัก</translation>
     </message>
     <message>
         <source>%1 client</source>
@@ -455,8 +670,28 @@
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform>%n active connection(s) to Bitcoin network.</numerusform>
+            <numerusform>%n การเชื่อมต่อที่ใช้งานกับเครือข่าย Bitcoin</numerusform>
         </translation>
+    </message>
+    <message>
+        <source>Click for more actions.</source>
+        <extracomment>A substring of the tooltip. "More actions" are available via the context menu.</extracomment>
+        <translation type="unfinished">คลิกเพื่อดูการดำเนินการเพิ่มเติม</translation>
+    </message>
+    <message>
+        <source>Show Peers tab</source>
+        <extracomment>A context menu item. The "Peers tab" is an element of the "Node window".</extracomment>
+        <translation type="unfinished">แสดง Peers แท็ป</translation>
+    </message>
+    <message>
+        <source>Disable network activity</source>
+        <extracomment>A context menu item.</extracomment>
+        <translation type="unfinished">ปิดใช้งานกิจกรรมเครือข่าย</translation>
+    </message>
+    <message>
+        <source>Enable network activity</source>
+        <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
+        <translation type="unfinished">เปิดใช้งานกิจกรรมเครือข่าย</translation>
     </message>
     <message>
         <source>Error: %1</source>
@@ -481,61 +716,80 @@
     <message>
         <source>Wallet: %1
 </source>
-        <translation type="unfinished">กระเป๋าสตางค์: %1
+        <translation type="unfinished">วอลเลต: %1
 </translation>
     </message>
     <message>
         <source>Type: %1
 </source>
-        <translation type="unfinished">ชนิด: %1
+        <translation type="unfinished">รูปแบบ: %1
 </translation>
     </message>
     <message>
         <source>Label: %1
 </source>
-        <translation type="unfinished">ป้ายชื่อ: %1
+        <translation type="unfinished">เลเบล: %1
 </translation>
     </message>
     <message>
         <source>Address: %1
 </source>
-        <translation type="unfinished">ที่อยู่: %1
+        <translation type="unfinished">แอดเดรส: %1
 </translation>
     </message>
     <message>
         <source>Sent transaction</source>
-        <translation>รายการที่ส่ง</translation>
+        <translation>ส่งธุรกรรม</translation>
     </message>
     <message>
         <source>Incoming transaction</source>
-        <translation>การทำรายการขาเข้า</translation>
+        <translation>ธุรกรรมที่เข้ามา</translation>
+    </message>
+    <message>
+        <source>HD key generation is &lt;b&gt;enabled&lt;/b&gt;</source>
+        <translation type="unfinished">HD key generation ถูก &lt;b&gt;เปิดใช้งาน&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>HD key generation is &lt;b&gt;disabled&lt;/b&gt;</source>
+        <translation type="unfinished">HD key generation ถูก &lt;b&gt;ปิดใช้งาน&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Private key &lt;b&gt;disabled&lt;/b&gt;</source>
+        <translation type="unfinished">คีย์ส่วนตัว &lt;b&gt;ปิดใช้งาน&lt;/b&gt;</translation>
     </message>
     <message>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
-        <translation>ระเป๋าเงินถูก &lt;b&gt;เข้ารหัส&lt;/b&gt; และในขณะนี้ &lt;b&gt;ปลดล็อคแล้ว&lt;/b&gt;</translation>
+        <translation>วอลเลต ถูก &lt;b&gt;เข้ารหัส&lt;/b&gt; และปัจจุบัน&lt;b&gt;ปลดล็อค&lt;/b&gt;</translation>
     </message>
     <message>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
-        <translation>กระเป๋าเงินถูก &lt;b&gt;เข้ารหัส&lt;/b&gt; และในปัจจุบัน &lt;b&gt;ล็อค &lt;/b&gt;</translation>
+        <translation>วอลเลต ถูก&lt;b&gt;เข้ารหัส&lt;/b&gt;และปัจจุบัน&lt;b&gt;ล็อค&lt;/b&gt;</translation>
     </message>
     <message>
         <source>Original message:</source>
-        <translation type="unfinished">ข้อความดั้งเดิม:</translation>
+        <translation type="unfinished">ข้อความต้นฉบับ:</translation>
+    </message>
+</context>
+<context>
+    <name>UnitDisplayStatusBarControl</name>
+    <message>
+        <source>Unit to show amounts in. Click to select another unit.</source>
+        <translation type="unfinished">หน่วยแสดงจำนวนเงิน คลิกเพื่อเลือกหน่วยอื่น</translation>
     </message>
 </context>
 <context>
     <name>CoinControlDialog</name>
     <message>
         <source>Coin Selection</source>
-        <translation type="unfinished">การเลือกเหรียญ</translation>
+        <translation type="unfinished">การเลือกคอยน์</translation>
     </message>
     <message>
         <source>Quantity:</source>
-        <translation type="unfinished">จำนวน:</translation>
+        <translation type="unfinished">ปริมาณ:</translation>
     </message>
     <message>
         <source>Bytes:</source>
-        <translation type="unfinished">ไบต์:</translation>
+        <translation type="unfinished">ไบทส์:</translation>
     </message>
     <message>
         <source>Amount:</source>
@@ -547,27 +801,27 @@
     </message>
     <message>
         <source>Dust:</source>
-        <translation type="unfinished">เศษ:</translation>
+        <translation type="unfinished">ดัสท์:</translation>
     </message>
     <message>
         <source>After Fee:</source>
-        <translation type="unfinished">ส่วนที่เหลือจากค่าธรรมเนียม:</translation>
+        <translation type="unfinished">หลังค่าธรรมเนียม:</translation>
     </message>
     <message>
         <source>Change:</source>
-        <translation type="unfinished">เงินทอน:</translation>
+        <translation type="unfinished">เปลี่ยน:</translation>
     </message>
     <message>
         <source>(un)select all</source>
-        <translation type="unfinished">(ไม่)เลือกทั้งหมด</translation>
+        <translation type="unfinished">(un)เลือกทั้งหมด</translation>
     </message>
     <message>
         <source>Tree mode</source>
-        <translation type="unfinished">โหมดแบบต้นไม้</translation>
+        <translation type="unfinished">สามโหมด</translation>
     </message>
     <message>
         <source>List mode</source>
-        <translation type="unfinished">โหมดแบบรายการ</translation>
+        <translation type="unfinished">รายการโหมด</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -575,11 +829,11 @@
     </message>
     <message>
         <source>Received with label</source>
-        <translation type="unfinished">รับด้วยป้ายชื่อ</translation>
+        <translation type="unfinished">การรับด้วยเลเบล</translation>
     </message>
     <message>
         <source>Received with address</source>
-        <translation type="unfinished">รับด้วยที่อยู่</translation>
+        <translation type="unfinished">การรับด้วยแอดเดรส</translation>
     </message>
     <message>
         <source>Date</source>
@@ -587,7 +841,7 @@
     </message>
     <message>
         <source>Confirmations</source>
-        <translation type="unfinished">การยืนยัน</translation>
+        <translation type="unfinished">ทำการยืนยัน</translation>
     </message>
     <message>
         <source>Confirmed</source>
@@ -595,11 +849,71 @@
     </message>
     <message>
         <source>Copy amount</source>
-        <translation type="unfinished">คัดลอกจำนวนเงิน</translation>
+        <translation type="unfinished">คัดลอกจำนวน</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;คัดลอกแอดเดรส</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">คัดลอก &amp;เลเบล</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">คัดลอก &amp;จำนวน</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">คัดลอกธุรกรรม &amp;ไอดี</translation>
+    </message>
+    <message>
+        <source>L&amp;ock unspent</source>
+        <translation type="unfinished">L&amp;ock ที่ไม่ได้ใข้</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock unspent</source>
+        <translation type="unfinished">&amp;ปลดล็อค ที่ไม่ไดใช้</translation>
+    </message>
+    <message>
+        <source>Copy quantity</source>
+        <translation type="unfinished">คัดลอกปริมาณ</translation>
+    </message>
+    <message>
+        <source>Copy fee</source>
+        <translation type="unfinished">คัดลอกค่าธรรมเนียม</translation>
+    </message>
+    <message>
+        <source>Copy after fee</source>
+        <translation type="unfinished">คัดลอกหลังหักค่าธรรมเนียม</translation>
+    </message>
+    <message>
+        <source>Copy bytes</source>
+        <translation type="unfinished">คัดลอกไบทส์</translation>
+    </message>
+    <message>
+        <source>Copy dust</source>
+        <translation type="unfinished">คัดลอกดัสท์</translation>
+    </message>
+    <message>
+        <source>Copy change</source>
+        <translation type="unfinished">คัดลอกการเปลี่ยนแปลง</translation>
+    </message>
+    <message>
+        <source>(%1 locked)</source>
+        <translation type="unfinished">(%1 ล็อค)</translation>
+    </message>
+    <message>
+        <source>yes</source>
+        <translation type="unfinished">ใช่</translation>
+    </message>
+    <message>
+        <source>no</source>
+        <translation type="unfinished">ไม่</translation>
     </message>
     <message>
         <source>(no label)</source>
-        <translation type="unfinished">(ไม่มีป้ายชื่อ)</translation>
+        <translation type="unfinished">(ไม่มีเลเบล)</translation>
     </message>
     <message>
         <source>change from %1 (%2)</source>
@@ -611,140 +925,139 @@
     </message>
 </context>
 <context>
+    <name>CreateWalletActivity</name>
+    <message>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation type="unfinished">กำลังสร้างวอลเล็ต &lt;b&gt;%1&lt;/b&gt;…</translation>
+    </message>
+    <message>
+        <source>Create wallet failed</source>
+        <translation type="unfinished">การสร้างวอลเล็ตล้มเหลว</translation>
+    </message>
+    <message>
+        <source>Create wallet warning</source>
+        <translation type="unfinished">คำเตือนการสร้างวอลเลต</translation>
+    </message>
+    <message>
+        <source>Can't list signers</source>
+        <translation type="unfinished">ผู้ลงนามที่ลงรายการไม่ได้</translation>
+    </message>
+</context>
+<context>
     <name>OpenWalletActivity</name>
     <message>
-        <source>default wallet</source>
-        <translation type="unfinished">กระเป๋าสตางค์เริ่มต้น</translation>
+        <source>Open wallet failed</source>
+        <translation type="unfinished">การเปิดวอลเลตล้มเหลว</translation>
     </message>
-    </context>
+    <message>
+        <source>Open wallet warning</source>
+        <translation type="unfinished">คำเตือนการเปิดวอลเลต</translation>
+    </message>
+    <message>
+        <source>default wallet</source>
+        <translation type="unfinished">วอลเลตเริ่มต้น</translation>
+    </message>
+    <message>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation type="unfinished">กำลังเปิดวอลเลต &lt;b&gt;%1&lt;/b&gt;…</translation>
+    </message>
+</context>
 <context>
     <name>WalletController</name>
     <message>
         <source>Close wallet</source>
-        <translation type="unfinished">ปิดกระเป๋าสตางค์</translation>
+        <translation type="unfinished">ปิดวอลเล็ต</translation>
     </message>
     <message>
         <source>Close all wallets</source>
-        <translation type="unfinished">ปิดกระเป๋าสตางค์ทั้งหมด</translation>
+        <translation type="unfinished">ปิดวอลเล็ตทั้งหมด</translation>
     </message>
-    <message>
-        <source>Are you sure you wish to close all wallets?</source>
-        <translation type="unfinished">คุณแน่ใจหรือไม่ว่าต้องการปิดกระเป๋าสตางค์ทั้งหมด?</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>CreateWalletDialog</name>
     <message>
         <source>Create Wallet</source>
-        <translation type="unfinished">สร้างกระเป๋าสตางค์</translation>
+        <translation type="unfinished">สร้างวอลเลต…</translation>
     </message>
     <message>
         <source>Wallet Name</source>
-        <translation type="unfinished">ชื่อกระเป๋าสตางค์</translation>
+        <translation type="unfinished">ชื่อวอลเลต</translation>
     </message>
     <message>
         <source>Wallet</source>
-        <translation type="unfinished">กระเป๋าเงิน</translation>
+        <translation type="unfinished">วอลเลต:</translation>
     </message>
     <message>
         <source>Encrypt Wallet</source>
-        <translation type="unfinished">เข้ารหัสกระเป๋าสตางค์</translation>
+        <translation type="unfinished">เข้ารหัสวอลเลต</translation>
+    </message>
+    <message>
+        <source>Advanced Options</source>
+        <translation type="unfinished">ตัวเลือกขั้นสูง</translation>
     </message>
     <message>
         <source>Disable Private Keys</source>
-        <translation type="unfinished">ปิดใช้งานกุญแจส่วนตัว</translation>
-    </message>
-    <message>
-        <source>Make Blank Wallet</source>
-        <translation type="unfinished">สร้างกระเป๋าสตางค์เปล่า</translation>
-    </message>
-    <message>
-        <source>Create</source>
-        <translation type="unfinished">สร้าง</translation>
+        <translation type="unfinished">ปิดใช้งานไพรเวทคีย์</translation>
     </message>
     </context>
 <context>
     <name>EditAddressDialog</name>
     <message>
         <source>Edit Address</source>
-        <translation>แก้ไขที่อยู่</translation>
-    </message>
-    <message>
-        <source>&amp;Label</source>
-        <translation>&amp;ป้ายชื่อ</translation>
-    </message>
-    <message>
-        <source>The label associated with this address list entry</source>
-        <translation type="unfinished">รายการแสดง ป้ายชื่อที่เกี่ยวข้องกับที่เก็บนี้</translation>
-    </message>
-    <message>
-        <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
-        <translation type="unfinished">ที่เก็บที่เกี่ยวข้องกับ ที่เก็บที่แสดงรายการนี้ การปรับปรุงนี้ทำได้สำหรับ ที่เก็บเงินที่จะใช่ส่งเงิน เท่านั้น</translation>
-    </message>
-    <message>
-        <source>&amp;Address</source>
-        <translation>&amp;ที่อยู่</translation>
-    </message>
-    <message>
-        <source>New sending address</source>
-        <translation type="unfinished">ที่อยู่การส่งใหม่</translation>
-    </message>
-    <message>
-        <source>Edit receiving address</source>
-        <translation type="unfinished">แก้ไขที่อยู่การรับ</translation>
+        <translation>แก้ไขแอดเดรส</translation>
     </message>
     <message>
         <source>Edit sending address</source>
-        <translation type="unfinished">แก้ไขที่อยู่การส่ง</translation>
-    </message>
-    <message>
-        <source>Could not unlock wallet.</source>
-        <translation type="unfinished">ไม่สามารถปลดล็อคกระเป๋าสตางค์</translation>
+        <translation type="unfinished">แก้ไขแอดเดรสการส่ง</translation>
     </message>
     </context>
 <context>
     <name>FreespaceChecker</name>
     <message>
         <source>A new data directory will be created.</source>
-        <translation>ไดเร็กทอรี่ใหม่ที่ใช้เก็บข้อมูลจะถูกสร้างขึ้นมา</translation>
-    </message>
-    <message>
-        <source>name</source>
-        <translation>ชื่อ</translation>
-    </message>
-    <message>
-        <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
-        <translation>มีไดเรกทอรีอยู่แล้ว เพิ่ม %1 หากคุณต้องการสร้างไดเรกทอรีใหม่ที่นี่</translation>
-    </message>
-    <message>
-        <source>Path already exists, and is not a directory.</source>
-        <translation>มีเส้นทางอยู่แล้วและไม่ใช่ไดเรกทอรี</translation>
+        <translation>ไดเร็กทอรีข้อมูลใหม่จะถูกสร้างขึ้น</translation>
     </message>
     <message>
         <source>Cannot create data directory here.</source>
-        <translation>ไม่สามารถสร้างไดเรกทอรีข้อมูลที่นี่</translation>
+        <translation>ไม่สามารถสร้างไดเร็กทอรีข้อมูลที่นี่</translation>
     </message>
 </context>
 <context>
     <name>Intro</name>
     <message>
+        <source>%1 GB of free space available</source>
+        <translation type="unfinished">%1 GB ของพื้นที่ว่างบนดิสก์ที่ใช้ได้</translation>
+    </message>
+    <message>
+        <source>(of %1 GB needed)</source>
+        <translation type="unfinished">(ต้องการพื้นที่ %1 GB )</translation>
+    </message>
+    <message>
+        <source>(%1 GB needed for full chain)</source>
+        <translation type="unfinished">(ต้องการพื้นที่ %1 GB สำหรับห่วงโซ่ที่เต็ม)</translation>
+    </message>
+    <message>
+        <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
+        <translation type="unfinished">ข้อมูลอย่างน้อย %1 GB จะถูกเก็บไว้ในไดเร็กทอรีนี้ และจะเพิ่มขึ้นเรื่อย ๆ</translation>
+    </message>
+    <message>
         <source>Approximately %1 GB of data will be stored in this directory.</source>
-        <translation type="unfinished">ประมาณ %1 GB ของข้อมูลจะเก็บในไดเร็กทอรี่</translation>
+        <translation type="unfinished">ข้อมูลประมาณ %1 GB จะถูกเก็บไว้ในไดเร็กทอรีนี้</translation>
     </message>
     <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform>(sufficient to restore backups %n day(s) old)</numerusform>
+            <numerusform>(เพียงพอที่จะกู้คืนสำรองข้อมูลเก่า %n วันที่แล้ว)</numerusform>
         </translation>
     </message>
     <message>
-        <source>The wallet will also be stored in this directory.</source>
-        <translation type="unfinished">The wallet เก็บใว้ในไดเร็กทอรี่</translation>
+        <source>%1 will download and store a copy of the Bitcoin block chain.</source>
+        <translation type="unfinished">%1 จะดาวน์โหลดและจัดเก็บสำเนาของบล็อกเชน Bitcoin</translation>
     </message>
     <message>
-        <source>Error: Specified data directory "%1" cannot be created.</source>
-        <translation type="unfinished">ข้อผิดพลาด: ไดเร็กทอรี่ข้อมูลที่ต้องการ "%1" ไม่สามารถสร้างได้</translation>
+        <source>The wallet will also be stored in this directory.</source>
+        <translation type="unfinished">วอลเลตจะถูกเก็บไว้ในไดเรกทอรีนี้ด้วย</translation>
     </message>
     <message>
         <source>Error</source>
@@ -756,26 +1069,18 @@
     </message>
     <message>
         <source>Welcome to %1.</source>
-        <translation type="unfinished">ยินดีต้อนรับสู่ %1</translation>
+        <translation type="unfinished">ยินดีต้อนรับเข้าสู่ %1.</translation>
     </message>
     <message>
         <source>As this is the first time the program is launched, you can choose where %1 will store its data.</source>
-        <translation type="unfinished">นี่เป็นการรันโปรแกรมครั้งแรก ท่านสามารถเลือก ว่าจะเก็บข้อมูลไว้ที่ %1</translation>
+        <translation type="unfinished">เนื่องจากนี่เป็นครั้งแรกที่โปรแกรมเปิดตัว คุณสามารถเลือกได้ว่า %1 จะเก็บข้อมูลไว้ที่ใด</translation>
     </message>
-    <message>
-        <source>Use the default data directory</source>
-        <translation>ใช้ไดเรกทอรีข้อมูลเริ่มต้น</translation>
-    </message>
-    <message>
-        <source>Use a custom data directory:</source>
-        <translation>ใช้ไดเรกทอรีข้อมูลที่กำหนดเอง:</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>HelpMessageDialog</name>
     <message>
         <source>version</source>
-        <translation type="unfinished">รุ่น</translation>
+        <translation type="unfinished">เวอร์ชัน</translation>
     </message>
     <message>
         <source>About %1</source>
@@ -783,214 +1088,199 @@
     </message>
     <message>
         <source>Command-line options</source>
-        <translation type="unfinished">ตัวเลือกบรรทัดคำสั่ง</translation>
+        <translation type="unfinished">ตัวเลือก Command-line </translation>
     </message>
 </context>
 <context>
-    <name>ModalOverlay</name>
+    <name>ShutdownWindow</name>
     <message>
-        <source>Form</source>
-        <translation type="unfinished">รูป</translation>
+        <source>%1 is shutting down…</source>
+        <translation type="unfinished">%1 กำลังถูกปิดลง…</translation>
     </message>
     <message>
-        <source>Progress</source>
-        <translation type="unfinished">ความคืบหน้า</translation>
+        <source>Do not shut down the computer until this window disappears.</source>
+        <translation type="unfinished">อย่าปิดเครื่องคอมพิวเตอร์จนกว่าหน้าต่างนี้จะหายไป</translation>
     </message>
-    <message>
-        <source>Hide</source>
-        <translation type="unfinished">ซ่อน</translation>
-    </message>
-    </context>
+</context>
 <context>
     <name>OptionsDialog</name>
-    <message>
-        <source>Options</source>
-        <translation>ตัวเลือก</translation>
-    </message>
     <message>
         <source>&amp;Main</source>
         <translation>&amp;หลัก</translation>
     </message>
     <message>
-        <source>Automatically start %1 after logging in to the system.</source>
-        <translation type="unfinished">เริ่มต้นอัตโนมัติ %1 หลังจาก ล็อกอิน เข้าสู่ระบบแล้ว</translation>
-    </message>
-    <message>
-        <source>&amp;Start %1 on system login</source>
-        <translation type="unfinished">&amp;เริ่ม %1 ในการล็อกอินระบบ</translation>
-    </message>
-    <message>
-        <source>Size of &amp;database cache</source>
-        <translation type="unfinished">ขนาดของ &amp;database cache</translation>
-    </message>
-    <message>
-        <source>Number of script &amp;verification threads</source>
-        <translation type="unfinished">จำนวนของสคริปท์ &amp;verification threads</translation>
-    </message>
-    <message>
-        <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
-        <translation type="unfinished">IP แอดเดส ของ proxy (เช่น IPv4: 127.0.0.1 / IPv6: ::1)</translation>
-    </message>
-    <message>
-        <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
-        <translation type="unfinished">มินิไมซ์แอพ แทนการออกจากแอพพลิเคชั่น เมื่อวินโดว์ได้รับการปิด เมื่อเลือกตัวเลือกนี้ แอพพลิเคชั่น จะถูกปิด ก็ต่อเมื่อ มีการเลือกเมนู Exit/ออกจากระบบ เท่านั้น</translation>
-    </message>
-    <message>
-        <source>Third party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</source>
-        <translation type="unfinished">URL แบบอื่น (ยกตัวอย่าง เอ็กพลอเลอร์บล็อก) ที่อยู่ใน เมนูรายการ ลำดับ %s ใน URL จะถูกเปลี่ยนด้วย รายการแฮช URL ที่เป็นแบบหลายๆอัน จะถูกแยก โดย เครื่องหมายเส้นบาร์ตั้ง |</translation>
-    </message>
-    <message>
-        <source>Open Configuration File</source>
-        <translation type="unfinished">เปิดไฟล์การกำหนดค่า</translation>
-    </message>
-    <message>
-        <source>Reset all client options to default.</source>
-        <translation>รีเซต ไคลเอ็นออพชั่น กลับไปเป็นค่าเริ่มต้น</translation>
-    </message>
-    <message>
-        <source>&amp;Reset Options</source>
-        <translation>&amp;รีเซต ออพชั่น</translation>
-    </message>
-    <message>
-        <source>&amp;Network</source>
-        <translation>&amp;เครือข่าย</translation>
-    </message>
-    <message>
-        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
-        <translation type="unfinished">(0 = อัตโนมัติ, &lt;0 = ปล่อย คอร์ อิสระ)</translation>
-    </message>
-    <message>
-        <source>W&amp;allet</source>
-        <translation type="unfinished">&amp;กระเป๋าสตางค์</translation>
-    </message>
-    <message>
-        <source>Expert</source>
-        <translation type="unfinished">ผู้เชี่ยวชาญ</translation>
-    </message>
-    <message>
-        <source>Enable coin &amp;control features</source>
-        <translation type="unfinished">เปิดใช้ coin &amp; รูปแบบการควบคุม</translation>
-    </message>
-    <message>
-        <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
-        <translation type="unfinished">หากท่านไม่เปิดใช้ การใช้เงินทอนที่ยังไม่ยืนยัน เงินทอนจากการทำรายการจะไม่สามารถใช้ได้ จนกว่ารายการที่ทำการ จะได้รับการยืนยันหนึ่งครั้ง และจะกระทบการคำนวณยอดคงเหลือของท่านด้วย</translation>
-    </message>
-    <message>
-        <source>&amp;Spend unconfirmed change</source>
-        <translation type="unfinished">&amp;ใช้เงินทอนที่ยังไม่ยืนยัน</translation>
-    </message>
-    <message>
-        <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
-        <translation>เปิด Bitcoin ไคล์เอ็นท์พอร์ต/client port บน router โดยอัตโนมัติ วิธีนี้ใช้ได้เมื่อ router สนับสนุน UPnP และสถานะเปิดใช้งาน</translation>
-    </message>
-    <message>
-        <source>Map port using &amp;UPnP</source>
-        <translation>จองพอร์ต โดยใช้ &amp;UPnP</translation>
-    </message>
-    <message>
-        <source>Connect to the Bitcoin network through a SOCKS5 proxy.</source>
-        <translation type="unfinished">เชื่อมต่อกับ Bitcoin เน็ตเวิร์ก ผ่านพร็อกซี่แบบ SOCKS5</translation>
-    </message>
-    <message>
-        <source>&amp;Connect through SOCKS5 proxy (default proxy):</source>
-        <translation type="unfinished">&amp;เชื่อมต่อผ่าน พร็อกซี่ SOCKS5 (พร็อกซี่เริ่มต้น):</translation>
-    </message>
-    <message>
-        <source>Proxy &amp;IP:</source>
-        <translation>พร็อกซี่ &amp;IP:</translation>
-    </message>
-    <message>
-        <source>&amp;Port:</source>
-        <translation>&amp;พอร์ต</translation>
-    </message>
-    <message>
-        <source>Port of the proxy (e.g. 9050)</source>
-        <translation>พอร์ตของพร็อกซี่ (ตัวอย่าง 9050)</translation>
-    </message>
-    <message>
-        <source>Used for reaching peers via:</source>
-        <translation type="unfinished">ใช้ในการเข้าถึงอีกฝ่ายหนึ่ง peer โดย:</translation>
-    </message>
-    <message>
         <source>&amp;Window</source>
-        <translation>&amp;หน้าต่าง</translation>
-    </message>
-    <message>
-        <source>Show only a tray icon after minimizing the window.</source>
-        <translation>แสดงเฉพาะไอคอนถาดหลังจากย่อหน้าต่าง</translation>
-    </message>
-    <message>
-        <source>User Interface &amp;language:</source>
-        <translation>&amp;ภาษาส่วนติดต่อผู้ใช้:</translation>
+        <translation>&amp;วินโดว์</translation>
     </message>
     <message>
         <source>&amp;OK</source>
         <translation>&amp;ตกลง</translation>
     </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;ยกเลิก</translation>
-    </message>
-    <message>
-        <source>Configuration options</source>
-        <translation type="unfinished">ตัวเลือกการกำหนดค่า</translation>
-    </message>
-    <message>
-        <source>Error</source>
-        <translation type="unfinished">ข้อผิดพลาด</translation>
-    </message>
     </context>
 <context>
     <name>OverviewPage</name>
     <message>
-        <source>Form</source>
-        <translation>รูป</translation>
-    </message>
-    <message>
         <source>Balances</source>
-        <translation type="unfinished">ยอดดุล</translation>
+        <translation type="unfinished">ยอดคงเหลือ</translation>
     </message>
     </context>
 <context>
     <name>PSBTOperationsDialog</name>
     <message>
-        <source>Copy to Clipboard</source>
-        <translation type="unfinished">คัดลอกไปยังคลิปบอร์ด</translation>
+        <source>PSBT copied to clipboard.</source>
+        <translation type="unfinished">PSBT คัดลอกไปยังคลิปบอร์ดแล้ว</translation>
     </message>
     <message>
-        <source>Close</source>
-        <translation type="unfinished">ปิด</translation>
+        <source> * Sends %1 to %2</source>
+        <translation type="unfinished"> * ส่ง %1 ถึง %2</translation>
+    </message>
+    <message>
+        <source>Total Amount</source>
+        <translation type="unfinished">จำนวนทั้งหมด</translation>
+    </message>
+    <message>
+        <source>or</source>
+        <translation type="unfinished">หรือ</translation>
+    </message>
+    <message>
+        <source>Transaction has %1 unsigned inputs.</source>
+        <translation type="unfinished">ธุรกรรมมี %1 อินพุตที่ไม่ได้ลงนาม</translation>
     </message>
     </context>
 <context>
     <name>PeerTableModel</name>
     <message>
+        <source>Peer</source>
+        <extracomment>Title of Peers Table column which contains a unique number used to identify a connection.</extracomment>
+        <translation type="unfinished">เพียร์</translation>
+    </message>
+    <message>
+        <source>Sent</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have sent to the peer.</extracomment>
+        <translation type="unfinished">ส่งแล้ว</translation>
+    </message>
+    <message>
+        <source>Received</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have received from the peer.</extracomment>
+        <translation type="unfinished">ได้รับ</translation>
+    </message>
+    <message>
         <source>Address</source>
         <extracomment>Title of Peers Table column which contains the IP/Onion/I2P address of the connected peer.</extracomment>
-        <translation type="unfinished">ที่อยู่</translation>
+        <translation type="unfinished">แอดเดรส</translation>
     </message>
     <message>
         <source>Type</source>
         <extracomment>Title of Peers Table column which describes the type of peer connection. The "type" describes why the connection exists.</extracomment>
-        <translation type="unfinished">ชนิด</translation>
+        <translation type="unfinished">รูปแบบ</translation>
     </message>
-    </context>
+    <message>
+        <source>Network</source>
+        <extracomment>Title of Peers Table column which states the network the peer connected through.</extracomment>
+        <translation type="unfinished">เครือข่าย</translation>
+    </message>
+</context>
 <context>
     <name>QRImageWidget</name>
     <message>
-        <source>Save QR Code</source>
-        <translation type="unfinished">บันทึกรหัส QR</translation>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">&amp;บันทึกอิมเมจ…</translation>
     </message>
-    </context>
+    <message>
+        <source>&amp;Copy Image</source>
+        <translation type="unfinished">&amp;คัดลอกอิมเมจ</translation>
+    </message>
+    <message>
+        <source>Save QR Code</source>
+        <translation type="unfinished">บันทึก QR Code</translation>
+    </message>
+    <message>
+        <source>PNG Image</source>
+        <extracomment>Expanded name of the PNG file format. See https://en.wikipedia.org/wiki/Portable_Network_Graphics</extracomment>
+        <translation type="unfinished">ภาพ PNG </translation>
+    </message>
+</context>
 <context>
     <name>RPCConsole</name>
     <message>
+        <source>&amp;Information</source>
+        <translation>&amp;ข้อมูล</translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation type="unfinished">ทั่วไป</translation>
+    </message>
+    <message>
+        <source>Network</source>
+        <translation>เครือข่าย</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished">ชื่อ</translation>
+    </message>
+    <message>
+        <source>Block chain</source>
+        <translation>บล็อกเชน</translation>
+    </message>
+    <message>
+        <source>Memory Pool</source>
+        <translation type="unfinished">พูลเมมโมรี่</translation>
+    </message>
+    <message>
+        <source>Memory usage</source>
+        <translation type="unfinished">การใช้เมมโมรี่</translation>
+    </message>
+    <message>
         <source>Wallet: </source>
-        <translation type="unfinished">กระเป๋าสตางค์: </translation>
+        <translation type="unfinished">วอลเลต:</translation>
+    </message>
+    <message>
+        <source>&amp;Reset</source>
+        <translation type="unfinished">&amp;รีเซ็ต</translation>
+    </message>
+    <message>
+        <source>Received</source>
+        <translation type="unfinished">ได้รับ</translation>
+    </message>
+    <message>
+        <source>Sent</source>
+        <translation type="unfinished">ส่งแล้ว</translation>
+    </message>
+    <message>
+        <source>Version</source>
+        <translation type="unfinished">เวอร์ชัน</translation>
     </message>
     <message>
         <source>Node window</source>
-        <translation type="unfinished">หน้าต่างโหนด</translation>
+        <translation type="unfinished">โหนด วินโดว์</translation>
+    </message>
+    <message>
+        <source>High Bandwidth</source>
+        <translation type="unfinished">แบนด์วิดท์สูง</translation>
+    </message>
+    <message>
+        <source>Connection Time</source>
+        <translation type="unfinished">เวลาในการเชื่อมต่อ</translation>
+    </message>
+    <message>
+        <source>Last Send</source>
+        <translation type="unfinished">การส่งล่าสุด</translation>
+    </message>
+    <message>
+        <source>Last Receive</source>
+        <translation type="unfinished">การรับล่าสุด</translation>
+    </message>
+    <message>
+        <source>Ping Time</source>
+        <translation type="unfinished">เวลาในการ Ping</translation>
+    </message>
+    <message>
+        <source>Ping Wait</source>
+        <translation type="unfinished">คอยในการ Ping</translation>
+    </message>
+    <message>
+        <source>Min Ping</source>
+        <translation type="unfinished">วินาทีในการ Ping</translation>
     </message>
     <message>
         <source>&amp;Open</source>
@@ -1001,19 +1291,83 @@
         <translation>&amp;คอนโซล</translation>
     </message>
     <message>
+        <source>Totals</source>
+        <translation type="unfinished">ทั้งหมด</translation>
+    </message>
+    <message>
+        <source>Debug log file</source>
+        <translation>ไฟล์บันทึกการดีบัก</translation>
+    </message>
+    <message>
+        <source>In:</source>
+        <translation type="unfinished">เข้า:</translation>
+    </message>
+    <message>
+        <source>Out:</source>
+        <translation type="unfinished">ออก:</translation>
+    </message>
+    <message>
+        <source>Inbound: initiated by peer</source>
+        <translation type="unfinished">ขาเข้า: เริ่มต้นด้วย peer</translation>
+    </message>
+    <message>
+        <source>Outbound Full Relay: default</source>
+        <translation type="unfinished">ขาออก Full Relay: ค่าเริ่มต้น</translation>
+    </message>
+    <message>
+        <source>&amp;Disconnect</source>
+        <translation type="unfinished">&amp;ตัดการเชื่อมต่อ</translation>
+    </message>
+    <message>
+        <source>1 &amp;hour</source>
+        <translation type="unfinished">1 &amp;ชั่วโมง</translation>
+    </message>
+    <message>
+        <source>1 d&amp;ay</source>
+        <translation type="unfinished">1 &amp;วัน</translation>
+    </message>
+    <message>
+        <source>1 &amp;week</source>
+        <translation type="unfinished">1 &amp;สัปดาห์</translation>
+    </message>
+    <message>
+        <source>1 &amp;year</source>
+        <translation type="unfinished">1 &amp;ปี</translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished">ใช่</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished">ไม่</translation>
+    </message>
+    <message>
         <source>To</source>
-        <translation type="unfinished">ถึง</translation>
+        <translation type="unfinished">ไปยัง</translation>
     </message>
     <message>
         <source>From</source>
         <translation type="unfinished">จาก</translation>
     </message>
-    </context>
+    <message>
+        <source>Never</source>
+        <translation type="unfinished">ไม่เคย</translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">ไม่รู้จัก</translation>
+    </message>
+</context>
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
+        <source>&amp;Amount:</source>
+        <translation type="unfinished">&amp;จำนวน:</translation>
+    </message>
+    <message>
         <source>&amp;Label:</source>
-        <translation type="unfinished">&amp;ป้ายชื่อ:</translation>
+        <translation type="unfinished">&amp;เลเบล:</translation>
     </message>
     <message>
         <source>&amp;Message:</source>
@@ -1021,7 +1375,7 @@
     </message>
     <message>
         <source>Clear</source>
-        <translation type="unfinished">ล้าง</translation>
+        <translation type="unfinished">เคลียร์</translation>
     </message>
     <message>
         <source>Show</source>
@@ -1029,22 +1383,38 @@
     </message>
     <message>
         <source>Remove</source>
-        <translation type="unfinished">เอาออก</translation>
+        <translation type="unfinished">นำออก</translation>
     </message>
     <message>
         <source>Copy &amp;URI</source>
-        <translation type="unfinished">&amp;คัดลอก URI</translation>
+        <translation type="unfinished">คัดลอก &amp;URI</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;คัดลอกแอดเดรส</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">คัดลอก &amp;เลเบล</translation>
+    </message>
+    <message>
+        <source>Copy &amp;message</source>
+        <translation type="unfinished">คัดลอด &amp;ข้อความ</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">คัดลอก &amp;จำนวน</translation>
     </message>
     <message>
         <source>Could not unlock wallet.</source>
-        <translation type="unfinished">ไม่สามารถปลดล็อคกระเป๋าสตางค์</translation>
+        <translation type="unfinished">ไม่สามารถปลดล็อกวอลเล็ตได้</translation>
     </message>
     </context>
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
         <source>Address:</source>
-        <translation type="unfinished">ที่อยู่:</translation>
+        <translation type="unfinished">แอดเดรส:</translation>
     </message>
     <message>
         <source>Amount:</source>
@@ -1052,7 +1422,7 @@
     </message>
     <message>
         <source>Label:</source>
-        <translation type="unfinished">ป้ายชื่อ:</translation>
+        <translation type="unfinished">เลเบล:</translation>
     </message>
     <message>
         <source>Message:</source>
@@ -1060,15 +1430,23 @@
     </message>
     <message>
         <source>Wallet:</source>
-        <translation type="unfinished">กระเป๋าสตางค์:</translation>
+        <translation type="unfinished">วอลเลต:</translation>
     </message>
     <message>
         <source>Copy &amp;URI</source>
-        <translation type="unfinished">&amp;คัดลอก URI</translation>
+        <translation type="unfinished">คัดลอก &amp;URI</translation>
     </message>
     <message>
         <source>Copy &amp;Address</source>
-        <translation type="unfinished">&amp;คัดลอกที่อยู่</translation>
+        <translation type="unfinished">คัดลอก &amp;แอดเดรส</translation>
+    </message>
+    <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">&amp;บันทึกอิมเมจ…</translation>
+    </message>
+    <message>
+        <source>Payment information</source>
+        <translation type="unfinished">ข้อมูการชำระเงิน</translation>
     </message>
     </context>
 <context>
@@ -1079,7 +1457,7 @@
     </message>
     <message>
         <source>Label</source>
-        <translation type="unfinished">ป้ายชื่อ</translation>
+        <translation type="unfinished">เลเบล</translation>
     </message>
     <message>
         <source>Message</source>
@@ -1087,22 +1465,22 @@
     </message>
     <message>
         <source>(no label)</source>
-        <translation type="unfinished">(ไม่มีป้ายชื่อ)</translation>
+        <translation type="unfinished">(ไม่มีเลเบล)</translation>
+    </message>
+    <message>
+        <source>(no message)</source>
+        <translation type="unfinished">(ไม่มีข้อความ)</translation>
     </message>
     </context>
 <context>
     <name>SendCoinsDialog</name>
     <message>
         <source>Send Coins</source>
-        <translation>ส่งเหรียญ</translation>
+        <translation>ส่งคอยน์</translation>
     </message>
     <message>
         <source>Quantity:</source>
-        <translation type="unfinished">จำนวน:</translation>
-    </message>
-    <message>
-        <source>Bytes:</source>
-        <translation type="unfinished">ไบต์:</translation>
+        <translation type="unfinished">ปริมาณ:</translation>
     </message>
     <message>
         <source>Amount:</source>
@@ -1113,36 +1491,49 @@
         <translation type="unfinished">ค่าธรรมเนียม:</translation>
     </message>
     <message>
-        <source>After Fee:</source>
-        <translation type="unfinished">ส่วนที่เหลือจากค่าธรรมเนียม:</translation>
+        <source>Clear &amp;All</source>
+        <translation>เคลียร์ &amp;ทั้งหมด</translation>
     </message>
     <message>
-        <source>Change:</source>
-        <translation type="unfinished">เงินทอน:</translation>
-    </message>
-    <message>
-        <source>Hide</source>
-        <translation type="unfinished">ซ่อน</translation>
-    </message>
-    <message>
-        <source>Recommended:</source>
-        <translation type="unfinished">แนะนำ:</translation>
-    </message>
-    <message>
-        <source>Custom:</source>
-        <translation type="unfinished">กำหนดเอง:</translation>
-    </message>
-    <message>
-        <source>Dust:</source>
-        <translation type="unfinished">เศษ:</translation>
+        <source>Balance:</source>
+        <translation>ยอดคงเหลือ:</translation>
     </message>
     <message>
         <source>Copy amount</source>
-        <translation type="unfinished">คัดลอกจำนวนเงิน</translation>
+        <translation type="unfinished">คัดลอกจำนวน</translation>
     </message>
     <message>
-        <source> from wallet '%1'</source>
-        <translation type="unfinished">จากกระเป๋าสตางค์ '%1'</translation>
+        <source>Copy fee</source>
+        <translation type="unfinished">คัดลอกค่าธรรมเนียม</translation>
+    </message>
+    <message>
+        <source>Copy change</source>
+        <translation type="unfinished">คัดลอกการเปลี่ยนแปลง</translation>
+    </message>
+    <message>
+        <source>%1 (%2 blocks)</source>
+        <translation type="unfinished">%1 (%2 บล็อก)</translation>
+    </message>
+    <message>
+        <source>Sign on device</source>
+        <extracomment>"device" usually means a hardware wallet</extracomment>
+        <translation type="unfinished">ลงชื่อบนอุปกรณ์</translation>
+    </message>
+    <message>
+        <source>%1 to '%2'</source>
+        <translation type="unfinished">%1 ถึง '%2'</translation>
+    </message>
+    <message>
+        <source>Sign failed</source>
+        <translation type="unfinished">การลงนามล้มเหลว</translation>
+    </message>
+    <message>
+        <source>Please, review your transaction.</source>
+        <translation type="unfinished">โปรดตรวจสอบธุรกรรมของคุณ</translation>
+    </message>
+    <message>
+        <source>Payment request expired.</source>
+        <translation type="unfinished">คำขอชำระเงินหมดอายุ</translation>
     </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
@@ -1151,42 +1542,23 @@
         </translation>
     </message>
     <message>
+        <source>Confirm custom change address</source>
+        <translation type="unfinished">ยืนยันการเปลี่ยนแปลงแอดเดรสที่กำหนดเอง</translation>
+    </message>
+    <message>
         <source>(no label)</source>
-        <translation type="unfinished">(ไม่มีป้ายชื่อ)</translation>
+        <translation type="unfinished">(ไม่มีเลเบล)</translation>
     </message>
 </context>
 <context>
-    <name>SendCoinsEntry</name>
-    <message>
-        <source>&amp;Label:</source>
-        <translation>&amp;ป้ายชื่อ:</translation>
-    </message>
-    <message>
-        <source>Paste address from clipboard</source>
-        <translation>วางที่อยู่จากคลิปบอร์ด</translation>
-    </message>
-    <message>
-        <source>Message:</source>
-        <translation type="unfinished">ข้อความ:</translation>
-    </message>
-    </context>
-<context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <source>Paste address from clipboard</source>
-        <translation>วางที่อยู่จากคลิปบอร์ด</translation>
+        <source>&amp;Sign Message</source>
+        <translation>&amp;ลงชื่อข้อความ</translation>
     </message>
     <message>
-        <source>Signature</source>
-        <translation>ลายเซ็น</translation>
-    </message>
-    <message>
-        <source>Sign &amp;Message</source>
-        <translation>&amp;เซ็นข้อความ</translation>
-    </message>
-    <message>
-        <source>No error</source>
-        <translation type="unfinished">ไม่มีข้อผิดพลาด</translation>
+        <source>Please check the signature and try again.</source>
+        <translation type="unfinished">โปรดตรวจสอบลายเซ็นต์และลองใหม่อีกครั้ง</translation>
     </message>
     </context>
 <context>
@@ -1198,12 +1570,16 @@
         </translation>
     </message>
     <message>
-        <source>Status</source>
-        <translation type="unfinished">สถานะ</translation>
+        <source>Open until %1</source>
+        <translation type="unfinished">เปิดจนถึง %1</translation>
     </message>
     <message>
-        <source>Date</source>
-        <translation type="unfinished">วันที่</translation>
+        <source>conflicted with a transaction with %1 confirmations</source>
+        <translation type="unfinished">ขัดแย้งกับการทำธุรกรรมกับ %1 การยืนยัน</translation>
+    </message>
+    <message>
+        <source>%1 confirmations</source>
+        <translation type="unfinished">%1 ทำการยืนยัน</translation>
     </message>
     <message>
         <source>From</source>
@@ -1211,7 +1587,11 @@
     </message>
     <message>
         <source>To</source>
-        <translation type="unfinished">ถึง</translation>
+        <translation type="unfinished">ไปยัง</translation>
+    </message>
+    <message>
+        <source>own address</source>
+        <translation type="unfinished">แอดเดรสของตัวเอง</translation>
     </message>
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
@@ -1220,32 +1600,24 @@
         </translation>
     </message>
     <message>
+        <source>not accepted</source>
+        <translation type="unfinished">ไม่ยอมรับ</translation>
+    </message>
+    <message>
+        <source>Transaction fee</source>
+        <translation type="unfinished">ค่าธรรมเนียมการทำธุรกรรม</translation>
+    </message>
+    <message>
+        <source>Net amount</source>
+        <translation type="unfinished">จำนวนสุทธิ</translation>
+    </message>
+    <message>
         <source>Message</source>
         <translation type="unfinished">ข้อความ</translation>
-    </message>
-    <message>
-        <source>Comment</source>
-        <translation type="unfinished">ความคิดเห็น</translation>
-    </message>
-    <message>
-        <source>Amount</source>
-        <translation type="unfinished">จำนวน</translation>
     </message>
     </context>
 <context>
     <name>TransactionTableModel</name>
-    <message>
-        <source>Date</source>
-        <translation type="unfinished">วันที่</translation>
-    </message>
-    <message>
-        <source>Type</source>
-        <translation type="unfinished">ชนิด</translation>
-    </message>
-    <message>
-        <source>Label</source>
-        <translation type="unfinished">ป้ายชื่อ</translation>
-    </message>
     <message numerus="yes">
         <source>Open for %n more block(s)</source>
         <translation>
@@ -1253,81 +1625,50 @@
         </translation>
     </message>
     <message>
-        <source>(no label)</source>
-        <translation type="unfinished">(ไม่มีป้ายชื่อ)</translation>
+        <source>Sent to</source>
+        <translation type="unfinished">ส่งถึง</translation>
+    </message>
+    <message>
+        <source>Type of transaction.</source>
+        <translation type="unfinished">ชนิดของธุรกรรม</translation>
     </message>
     </context>
 <context>
     <name>TransactionView</name>
     <message>
-        <source>All</source>
-        <translation type="unfinished">ทั้งหมด</translation>
-    </message>
-    <message>
-        <source>Today</source>
-        <translation type="unfinished">วันนี้</translation>
-    </message>
-    <message>
         <source>This week</source>
         <translation type="unfinished">สัปดาห์นี้</translation>
     </message>
     <message>
-        <source>This month</source>
-        <translation type="unfinished">เดือนนี้</translation>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">คัดลอกธุรกรรม &amp;ไอดี</translation>
     </message>
     <message>
-        <source>Last month</source>
-        <translation type="unfinished">เดือนที่แล้ว</translation>
-    </message>
-    <message>
-        <source>This year</source>
-        <translation type="unfinished">ปีนี้</translation>
-    </message>
-    <message>
-        <source>Confirmed</source>
-        <translation type="unfinished">ยืนยันแล้ว</translation>
+        <source>Export Transaction History</source>
+        <translation type="unfinished">ส่งออกประวัติการทำธุรกรรม</translation>
     </message>
     <message>
         <source>Date</source>
         <translation type="unfinished">วันที่</translation>
     </message>
     <message>
-        <source>Type</source>
-        <translation type="unfinished">ชนิด</translation>
-    </message>
-    <message>
-        <source>Label</source>
-        <translation type="unfinished">ป้ายชื่อ</translation>
-    </message>
-    <message>
-        <source>Address</source>
-        <translation type="unfinished">ที่อยู่</translation>
-    </message>
-    <message>
-        <source>Exporting Failed</source>
-        <translation type="unfinished">การส่งออกล้มเหลว</translation>
+        <source>Exporting Successful</source>
+        <translation type="unfinished">ส่งออกสำเร็จ</translation>
     </message>
     </context>
 <context>
-    <name>WalletFrame</name>
-    <message>
-        <source>Create a new wallet</source>
-        <translation type="unfinished">สร้างกระเป๋าสตางค์</translation>
-    </message>
-</context>
-<context>
     <name>WalletModel</name>
     <message>
-        <source>Send Coins</source>
-        <translation type="unfinished">ส่งเหรียญ</translation>
+        <source>Do you want to draft a transaction with fee increase?</source>
+        <translation type="unfinished">คุณต้องการร่างรายการที่มีการเพิ่มค่าธรรมเนียมหรือไม่?</translation>
     </message>
     <message>
-        <source>PSBT copied</source>
-        <translation type="unfinished">คัดลอก PSBT แล้ว</translation>
+        <source>Confirm fee bump</source>
+        <translation type="unfinished">ยืนยันค่าธรรมเนียมที่เพิ่มขึ้น</translation>
     </message>
     <message>
         <source>default wallet</source>
-        <translation type="unfinished">กระเป๋าสตางค์เริ่มต้น</translation>
+        <translation type="unfinished">วอลเล็ตเริ่มต้น</translation>
     </message>
 </context>
 <context>
@@ -1337,20 +1678,45 @@
         <translation type="unfinished">&amp;ส่งออก</translation>
     </message>
     <message>
-        <source>Export the data in the current tab to a file</source>
-        <translation type="unfinished">ส่งออกข้อมูลในแท็บปัจจุบันไปยังไฟล์</translation>
-    </message>
-    <message>
         <source>Error</source>
         <translation type="unfinished">ข้อผิดพลาด</translation>
     </message>
     <message>
+        <source>Load Transaction Data</source>
+        <translation type="unfinished">โหลดข้อมูลการทำธุรกรรม</translation>
+    </message>
+    <message>
+        <source>Partially Signed Transaction (*.psbt)</source>
+        <translation type="unfinished">ธุรกรรมที่ลงนามบางส่วน (*.psbt)</translation>
+    </message>
+    <message>
+        <source>PSBT file must be smaller than 100 MiB</source>
+        <translation type="unfinished">ไฟล์ PSBT ต้องมีขนาดเล็กกว่า 100 MiB</translation>
+    </message>
+    <message>
+        <source>Unable to decode PSBT</source>
+        <translation type="unfinished">ไม่สามารถถอดรหัส PSBT</translation>
+    </message>
+    <message>
         <source>Backup Wallet</source>
-        <translation type="unfinished">สำรองข้อมูลกระเป๋าสตางค์</translation>
+        <translation type="unfinished">สำรองข้อมูลวอลเลต</translation>
+    </message>
+    <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">ข้อมูลวอลเลต</translation>
     </message>
     <message>
         <source>Backup Failed</source>
-        <translation type="unfinished">การสำรองข้อมูลล้มเหลว</translation>
+        <translation type="unfinished">สำรองข้อมูลล้มเหลว</translation>
+    </message>
+    <message>
+        <source>Backup Successful</source>
+        <translation type="unfinished">สำรองข้อมูลเสร็จสมบูรณ์</translation>
+    </message>
+    <message>
+        <source>The wallet data was successfully saved to %1.</source>
+        <translation type="unfinished">ข้อมูลวอลเลตถูกบันทึกไปยัง %1 เสร็จสมบูรณ์</translation>
     </message>
     <message>
         <source>Cancel</source>
@@ -1360,12 +1726,192 @@
 <context>
     <name>bitcoin-core</name>
     <message>
+        <source>Cannot provide specific connections and have addrman find outgoing connections at the same.</source>
+        <translation type="unfinished">ไม่สามารถให้การเชื่อมต่อเฉพาะและให้ addrman ค้นหาการเชื่อมต่อขาออกที่เดียวกัน</translation>
+    </message>
+    <message>
+        <source>Error: Legacy wallets only support the "legacy", "p2sh-segwit", and "bech32" address types</source>
+        <translation type="unfinished">ข้อผิดพลาด: เลกาซีวอลเล็ต เพียงสนับสนุน "legacy", "p2sh-segwit", และ "bech32" ชนิดแอดเดรส</translation>
+    </message>
+    <message>
+        <source>%s is set very high!</source>
+        <translation type="unfinished">%s ตั้งไว้สูงมาก</translation>
+    </message>
+    <message>
+        <source>Could not find asmap file %s</source>
+        <translation type="unfinished">ไม่ตรวจพบไฟล์ asmap %s</translation>
+    </message>
+    <message>
+        <source>Could not parse asmap file %s</source>
+        <translation type="unfinished">ไม่สามารถแยกวิเคราะห์ไฟล์ asmap %s</translation>
+    </message>
+    <message>
+        <source>Disk space is too low!</source>
+        <translation type="unfinished">พื้นที่ว่างดิสก์เหลือน้อยเกินไป!</translation>
+    </message>
+    <message>
+        <source>Do you want to rebuild the block database now?</source>
+        <translation type="unfinished">คุณต้องการาร้างฐานข้อมูลบล็อกใหม่ตอนนี้หรือไม่?</translation>
+    </message>
+    <message>
+        <source>Done loading</source>
+        <translation type="unfinished">การโหลดเสร็จสิ้น</translation>
+    </message>
+    <message>
+        <source>Dump file %s does not exist.</source>
+        <translation type="unfinished"> ไม่มีไฟล์ดัมพ์ %s </translation>
+    </message>
+    <message>
+        <source>Error creating %s</source>
+        <translation type="unfinished">เกิดข้อผิดพลาดในการสร้าง%s</translation>
+    </message>
+    <message>
+        <source>Error initializing block database</source>
+        <translation type="unfinished">เกิดข้อผิดพลาดในการเริ่มต้นฐานข้อมูลบล็อก</translation>
+    </message>
+    <message>
+        <source>Error loading %s</source>
+        <translation type="unfinished">การโหลดเกิดข้อผิดพลาด %s</translation>
+    </message>
+    <message>
+        <source>Error loading %s: Private keys can only be disabled during creation</source>
+        <translation type="unfinished">การโหลดเกิดข้อผิดพลาด %s: Private keys สามารถปิดการใช้งานระหว่างการสร้างขึ้นเท่านั้น</translation>
+    </message>
+    <message>
+        <source>Error: Disk space is low for %s</source>
+        <translation type="unfinished">ข้อผิดพลาด: พื้นที่ดิสก์เหลือน้อยสำหรับ %s</translation>
+    </message>
+    <message>
+        <source>Error: Missing checksum</source>
+        <translation type="unfinished">ข้อผิดพลาด: ไม่มีเช็คซัม</translation>
+    </message>
+    <message>
+        <source>Error: No %s addresses available.</source>
+        <translation type="unfinished">ข้อผิดพลาด: จำนวน %s แอดเดรสพร้อมใช้งาน</translation>
+    </message>
+    <message>
+        <source>Failed to verify database</source>
+        <translation type="unfinished">ไม่สามารถตรวจสอบฐานข้อมูล</translation>
+    </message>
+    <message>
+        <source>Importing…</source>
+        <translation type="unfinished">กำลังนำเข้า…</translation>
+    </message>
+    <message>
+        <source>Loading wallet…</source>
+        <translation type="unfinished">กำลังโหลดวอลเล็ต...</translation>
+    </message>
+    <message>
+        <source>Rescanning…</source>
+        <translation type="unfinished">ทำการสแกนซ้ำ…</translation>
+    </message>
+    <message>
+        <source>Specified -walletdir "%s" does not exist</source>
+        <translation type="unfinished">ไม่มี Specified -walletdir "%s" </translation>
+    </message>
+    <message>
+        <source>Specified -walletdir "%s" is a relative path</source>
+        <translation type="unfinished">Specified -walletdir "%s" เป็นพาธสัมพัทธ์</translation>
+    </message>
+    <message>
+        <source>Specified -walletdir "%s" is not a directory</source>
+        <translation type="unfinished">Specified -walletdir "%s" ไม่ใช่ไดเร็กทอรี</translation>
+    </message>
+    <message>
+        <source>Specified blocks directory "%s" does not exist.</source>
+        <translation type="unfinished">ไม่มีไดเร็กทอรีบล็อกที่ระบุ "%s" </translation>
+    </message>
+    <message>
+        <source>Starting network threads…</source>
+        <translation type="unfinished">การเริ่มเธรดเครือข่าย…</translation>
+    </message>
+    <message>
+        <source>The source code is available from %s.</source>
+        <translation type="unfinished">รหัสที่มาสามารถใช้ได้จาก %s.</translation>
+    </message>
+    <message>
+        <source>The specified config file %s does not exist</source>
+        <translation type="unfinished">ไฟล์กำหนดค่าที่ระบุ %s ไม่มีอยู่</translation>
+    </message>
+    <message>
+        <source>The transaction amount is too small to pay the fee</source>
+        <translation type="unfinished">จำนวนธุรกรรมน้อยเกินไปที่จะชำระค่าธรรมเนียม</translation>
+    </message>
+    <message>
+        <source>The wallet will avoid paying less than the minimum relay fee.</source>
+        <translation type="unfinished">วอลเลตจะหลีกเลี่ยงการจ่ายน้อยกว่าค่าธรรมเนียมการส่งต่อขั้นต่ำ</translation>
+    </message>
+    <message>
+        <source>This is experimental software.</source>
+        <translation type="unfinished">นี่คือซอฟต์แวร์ทดลอง</translation>
+    </message>
+    <message>
+        <source>This is the minimum transaction fee you pay on every transaction.</source>
+        <translation type="unfinished">นี่คือค่าธรรมเนียมการทำธุรกรรมขั้นต่ำที่คุณจ่ายในทุกธุรกรรม</translation>
+    </message>
+    <message>
+        <source>This is the transaction fee you will pay if you send a transaction.</source>
+        <translation type="unfinished">นี่คือค่าธรรมเนียมการทำธุรกรรมที่คุณจะจ่ายหากคุณส่งธุรกรรม</translation>
+    </message>
+    <message>
+        <source>Transaction amount too small</source>
+        <translation type="unfinished">จำนวนธุรกรรมน้อยเกินไป</translation>
+    </message>
+    <message>
+        <source>Transaction amounts must not be negative</source>
+        <translation type="unfinished">จำนวนเงินที่ทำธุรกรรมต้องไม่เป็นค่าติดลบ</translation>
+    </message>
+    <message>
+        <source>Transaction has too long of a mempool chain</source>
+        <translation type="unfinished">ธุรกรรมมี เชนเมมพูล ยาวเกินไป</translation>
+    </message>
+    <message>
+        <source>Transaction must have at least one recipient</source>
+        <translation type="unfinished">ธุรกรรมต้องมีผู้รับอย่างน้อยหนึ่งราย</translation>
+    </message>
+    <message>
+        <source>Transaction too large</source>
+        <translation type="unfinished">ธุรกรรมใหญ่เกินไป</translation>
+    </message>
+    <message>
+        <source>Unable to create the PID file '%s': %s</source>
+        <translation type="unfinished">ไม่สามารถสร้างไฟล์ PID '%s': %s</translation>
+    </message>
+    <message>
+        <source>Unable to generate initial keys</source>
+        <translation type="unfinished">ไม่สามารถสร้างคีย์เริ่มต้น</translation>
+    </message>
+    <message>
         <source>Unable to generate keys</source>
-        <translation type="unfinished">ไม่สามารถสร้างกุญแจ</translation>
+        <translation type="unfinished">ไม่สามารถสร้างคีย์</translation>
+    </message>
+    <message>
+        <source>Unable to open %s for writing</source>
+        <translation type="unfinished">ไม่สามารถเปิด %s สำหรับการเขียนข้อมูล</translation>
+    </message>
+    <message>
+        <source>Unknown address type '%s'</source>
+        <translation type="unfinished">ประเภทแอดเดรสที่ไม่รู้จัก '%s'</translation>
+    </message>
+    <message>
+        <source>Unknown change type '%s'</source>
+        <translation type="unfinished">ประเภทการเปลี่ยนแปลงที่ไม่รู้จัก '%s'</translation>
     </message>
     <message>
         <source>Upgrading UTXO database</source>
         <translation type="unfinished">กำลังอัปเกรดฐานข้อมูล UTXO</translation>
+    </message>
+    <message>
+        <source>Upgrading txindex database</source>
+        <translation type="unfinished">กำลังอัปเกรดฐานข้อมูล txindex</translation>
+    </message>
+    <message>
+        <source>Verifying blocks…</source>
+        <translation type="unfinished">กำลังตรวจสอบบล็อก…</translation>
+    </message>
+    <message>
+        <source>Verifying wallet(s)…</source>
+        <translation type="unfinished">กำลังตรวจสอบวอลเลต…</translation>
     </message>
     </context>
 </TS>

--- a/src/qt/locale/bitcoin_tk.ts
+++ b/src/qt/locale/bitcoin_tk.ts
@@ -1,0 +1,1527 @@
+<TS version="2.1" language="tk">
+<context>
+    <name>AddressBookPage</name>
+    <message>
+        <source>Right-click to edit address or label</source>
+        <translation type="unfinished">Salgyny ýa-da belligi rejelemek üçin syçanjygyň sag düwmesine basyň</translation>
+    </message>
+    <message>
+        <source>Create a new address</source>
+        <translation>Täze salgy döret</translation>
+    </message>
+    <message>
+        <source>&amp;New</source>
+        <translation type="unfinished">&amp;Täze</translation>
+    </message>
+    <message>
+        <source>Copy the currently selected address to the system clipboard</source>
+        <translation>Häzir saýlanan salgyny ulgamyň alyş-çalyş paneline göçür</translation>
+    </message>
+    <message>
+        <source>&amp;Copy</source>
+        <translation type="unfinished">&amp;Göçür</translation>
+    </message>
+    <message>
+        <source>C&amp;lose</source>
+        <translation type="unfinished">Ý&amp;ap</translation>
+    </message>
+    <message>
+        <source>Delete the currently selected address from the list</source>
+        <translation>Häzir saýlanan salgyny bu sanawdan poz</translation>
+    </message>
+    <message>
+        <source>Enter address or label to search</source>
+        <translation type="unfinished">Gözlemek üçin salgy ýa-da belligi ýaz</translation>
+    </message>
+    <message>
+        <source>Export the data in the current tab to a file</source>
+        <translation>Häzirki bellikdäki maglumaty faýla geçir</translation>
+    </message>
+    <message>
+        <source>&amp;Export</source>
+        <translation>&amp;Geçir</translation>
+    </message>
+    <message>
+        <source>&amp;Delete</source>
+        <translation>&amp;Poz</translation>
+    </message>
+    <message>
+        <source>Choose the address to send coins to</source>
+        <translation type="unfinished">Teňňeleriň iberiljek salgysyny saýlaň</translation>
+    </message>
+    <message>
+        <source>Choose the address to receive coins with</source>
+        <translation type="unfinished">Teňňeleriň haýsy salgydan alynjagyny saýlaň</translation>
+    </message>
+    <message>
+        <source>C&amp;hoose</source>
+        <translation type="unfinished">S&amp;aýla</translation>
+    </message>
+    <message>
+        <source>Sending addresses</source>
+        <translation type="unfinished">Iberýän salgylar</translation>
+    </message>
+    <message>
+        <source>Receiving addresses</source>
+        <translation type="unfinished">Kabul edýän salgylar</translation>
+    </message>
+    <message>
+        <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
+        <translation type="unfinished">Tölegleri ibermek üçin siziň Bitkoin salgylaryňyz şulardyr. Teňňeleri ibermezden ozal hemişe möçberi we kabul edýän salgyny barlaň.</translation>
+    </message>
+    <message>
+        <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
+Signing is only possible with addresses of the type 'legacy'.</source>
+        <translation type="unfinished">Tölegleri kabul etmek üçin siziň Bitkoin salgylaryňyz şulardyr. Täze salgylary döretmek üçin kabul etmek belliginde "Täze kabul ediji salgyny döret" düwmesini ulan.
+Diňe "miras" görnüşli salgylar bilen gol çekmek mümkin.</translation>
+    </message>
+    <message>
+        <source>&amp;Copy Address</source>
+        <translation type="unfinished">Salgyny göçür</translation>
+    </message>
+    <message>
+        <source>Copy &amp;Label</source>
+        <translation type="unfinished">&amp;Belligi göçür</translation>
+    </message>
+    <message>
+        <source>&amp;Edit</source>
+        <translation type="unfinished">&amp;Rejele</translation>
+    </message>
+    <message>
+        <source>Export Address List</source>
+        <translation type="unfinished">Salgylar sanawyny geçir</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See https://en.wikipedia.org/wiki/Comma-separated_values</extracomment>
+        <translation type="unfinished">Otur bilen aýrylan faýl</translation>
+    </message>
+    <message>
+        <source>There was an error trying to save the address list to %1. Please try again.</source>
+        <extracomment>An error message. %1 is a stand-in argument for the name of the file we attempted to save to.</extracomment>
+        <translation type="unfinished">Salgylar sanawyny %1 içine bellemäge çalşylanda ýalňyşlyk ýüze çykdy. Täzeden synap görüň.</translation>
+    </message>
+    <message>
+        <source>Exporting Failed</source>
+        <translation type="unfinished">Geçirip bolmady</translation>
+    </message>
+</context>
+<context>
+    <name>AddressTableModel</name>
+    <message>
+        <source>Label</source>
+        <translation type="unfinished">Bellik</translation>
+    </message>
+    <message>
+        <source>Address</source>
+        <translation type="unfinished">Salgy</translation>
+    </message>
+    <message>
+        <source>(no label)</source>
+        <translation type="unfinished">(bellik ýok)</translation>
+    </message>
+</context>
+<context>
+    <name>AskPassphraseDialog</name>
+    <message>
+        <source>Passphrase Dialog</source>
+        <translation>Parol sözlemi gepleşigi</translation>
+    </message>
+    <message>
+        <source>Enter passphrase</source>
+        <translation>Parol sözlemini ýaz</translation>
+    </message>
+    <message>
+        <source>New passphrase</source>
+        <translation>Täze parol sözlemi</translation>
+    </message>
+    <message>
+        <source>Repeat new passphrase</source>
+        <translation>Täze parol sözlemini gaýtala</translation>
+    </message>
+    <message>
+        <source>Show passphrase</source>
+        <translation type="unfinished">Parol sözlemini görkez</translation>
+    </message>
+    <message>
+        <source>Encrypt wallet</source>
+        <translation type="unfinished">Gapjygy şifrle</translation>
+    </message>
+    <message>
+        <source>This operation needs your wallet passphrase to unlock the wallet.</source>
+        <translation type="unfinished">Bu amal üçin gapjygyň parol sözlemi bilen gapjygyňyzy açmagyňyz gerek.</translation>
+    </message>
+    <message>
+        <source>Unlock wallet</source>
+        <translation type="unfinished">Gapjygyň gulpuny aç</translation>
+    </message>
+    <message>
+        <source>Change passphrase</source>
+        <translation type="unfinished">Parol sözlemini çalyş</translation>
+    </message>
+    <message>
+        <source>Confirm wallet encryption</source>
+        <translation type="unfinished">Gapjygyň şifrlenmegini tassykla</translation>
+    </message>
+    <message>
+        <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
+        <translation type="unfinished">Duýduryş: Eger gapjygyňy şifrleseň we parol sözlemiňi ýitirseň, sen &lt;b&gt;ÄHLI BITKOINLERIŇI ÝITIRERSIŇ&lt;/b&gt;!</translation>
+    </message>
+    <message>
+        <source>Are you sure you wish to encrypt your wallet?</source>
+        <translation type="unfinished">Gapjygyňy şifrlemek isleýäniň çynmy?</translation>
+    </message>
+    <message>
+        <source>Wallet encrypted</source>
+        <translation type="unfinished">Gapjyk şifrlenen</translation>
+    </message>
+    <message>
+        <source>Enter the new passphrase for the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
+        <translation type="unfinished">Gapjyk üçin täze parol sözlemini ýaz.&lt;br/&gt;&lt;b&gt;On ýa-da has köp tötänleýin nyşandan&lt;/b&gt; ýa-da &lt;b&gt;sekiz ýa-da has köp sözden&lt;/b&gt; ybarat parol sözlemini ulanyň.</translation>
+    </message>
+    <message>
+        <source>Enter the old passphrase and new passphrase for the wallet.</source>
+        <translation type="unfinished">Gapjyk üçin öňki we täze parol sözlemiňi ýaz.</translation>
+    </message>
+    <message>
+        <source>Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
+        <translation type="unfinished">Gapjygyňy şifrlemek kompýuteriňe zyýanly programma ýokuşmak arkaly bitkoinleriň ogurlanmagyndan doly gorap bilmejekdigini ýatdan çykarma.</translation>
+    </message>
+    <message>
+        <source>Wallet to be encrypted</source>
+        <translation type="unfinished">Şifrlenmeli gapjyk</translation>
+    </message>
+    <message>
+        <source>Your wallet is about to be encrypted. </source>
+        <translation type="unfinished">Gapjygyň şifrlener.</translation>
+    </message>
+    <message>
+        <source>Your wallet is now encrypted. </source>
+        <translation type="unfinished">Gapjygyň häzir şifrlenen.</translation>
+    </message>
+    <message>
+        <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
+        <translation type="unfinished">WAJYP: Gapjyk faýlyň islendik ozalky ätiýaçlyk nusgalary täze emele gelen, şifrlenen gapjyk faýly bilen çalşyrylmaly. Howpsuzlyk maksady bilen, şifrlenen gapjyk faýlynyň ozalky ätiýaçlyk nusgalary täze şifrlenen gapjygy ulanyp başlan badyňyza peýdasyz bolup galar.</translation>
+    </message>
+    <message>
+        <source>Wallet encryption failed</source>
+        <translation type="unfinished">Gapjygy şifrläp bolmady</translation>
+    </message>
+    <message>
+        <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
+        <translation type="unfinished">Içki ýalňyşlyk sebäpli gapjygy şifrläp bolmady. Gapjygyň şifrlenmedi.</translation>
+    </message>
+    <message>
+        <source>The supplied passphrases do not match.</source>
+        <translation type="unfinished">Üpjün edilen parol sözlemleri gabat gelenok.</translation>
+    </message>
+    <message>
+        <source>Wallet unlock failed</source>
+        <translation type="unfinished">Gapjygyň gulpuny açyp bolmady</translation>
+    </message>
+    <message>
+        <source>The passphrase entered for the wallet decryption was incorrect.</source>
+        <translation type="unfinished">Gapjygyň şifrini açmak üçin ýazylan parol sözlemi nädogry.</translation>
+    </message>
+    <message>
+        <source>Wallet passphrase was successfully changed.</source>
+        <translation type="unfinished">Gapjygyň parol sözlemi üstünlikli çalşyldy.</translation>
+    </message>
+    <message>
+        <source>Warning: The Caps Lock key is on!</source>
+        <translation type="unfinished">Duýduryş: Caps Lock düwmesi açyk!</translation>
+    </message>
+</context>
+<context>
+    <name>BanTableModel</name>
+    <message>
+        <source>Banned Until</source>
+        <translation type="unfinished">Gadagan edilen möhleti</translation>
+    </message>
+</context>
+<context>
+    <name>BitcoinApplication</name>
+    <message>
+        <source>Runaway exception</source>
+        <translation type="unfinished">Dolandyryp bolmaýan ýagdaý</translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
+        <translation type="unfinished">Ýowuz ýalňyşlyk ýüze çykdy. %1 indi ygtybarly dowam edip bilenok we çykar.</translation>
+    </message>
+    <message>
+        <source>Internal error</source>
+        <translation type="unfinished">Içki ýalňyşlyk</translation>
+    </message>
+    <message>
+        <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
+        <translation type="unfinished">Içki ýalňyşlyk ýüze çykdy. %1 ygtybarly dowam etmäge çalyşar. Bu garaşylmadyk näsazlyk we ol barada aşakda beýan edilişi ýaly hasabat berip bolar.</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <source>Error: Specified data directory "%1" does not exist.</source>
+        <translation type="unfinished">Ýalňyşlyk: Görkezilen maglumatlar katalogy "%1" ýok.</translation>
+    </message>
+    <message>
+        <source>Error: Cannot parse configuration file: %1.</source>
+        <translation type="unfinished">Ýalňyşlyk: %1 konfigurasiýa faýlyny derňäp bolanok.</translation>
+    </message>
+    <message>
+        <source>Error: %1</source>
+        <translation type="unfinished">Ýalňyşlyk: %1</translation>
+    </message>
+    <message>
+        <source>%1 didn't yet exit safely…</source>
+        <translation type="unfinished">%1 entek ygtybarly çykmady...</translation>
+    </message>
+    <message>
+        <source>Amount</source>
+        <translation type="unfinished">Möçber</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n second(s)</source>
+        <translation>
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n minute(s)</source>
+        <translation>
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n week(s)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n year(s)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    </context>
+<context>
+    <name>BitcoinGUI</name>
+    <message>
+        <source>&amp;Overview</source>
+        <translation>&amp;Gözden geçir</translation>
+    </message>
+    <message>
+        <source>Show general overview of wallet</source>
+        <translation>Gapjygyň umumy synyny görkez</translation>
+    </message>
+    <message>
+        <source>&amp;Transactions</source>
+        <translation>&amp;Geleşikler</translation>
+    </message>
+    <message>
+        <source>Browse transaction history</source>
+        <translation>Geleşikleriň geçmişine göz aýla</translation>
+    </message>
+    <message>
+        <source>E&amp;xit</source>
+        <translation>Ç&amp;yk</translation>
+    </message>
+    <message>
+        <source>Quit application</source>
+        <translation>Programmadan çyk</translation>
+    </message>
+    <message>
+        <source>&amp;About %1</source>
+        <translation type="unfinished">%1 &amp;barada</translation>
+    </message>
+    <message>
+        <source>Show information about %1</source>
+        <translation type="unfinished">%1 barada maglumat görkez</translation>
+    </message>
+    <message>
+        <source>About &amp;Qt</source>
+        <translation>&amp;Qt barada</translation>
+    </message>
+    <message>
+        <source>Show information about Qt</source>
+        <translation>Qt barada maglumat görkez</translation>
+    </message>
+    <message>
+        <source>Modify configuration options for %1</source>
+        <translation type="unfinished">%1 üçin konfigurasiýa opsiýalaryny üýtget</translation>
+    </message>
+    <message>
+        <source>Create a new wallet</source>
+        <translation type="unfinished">Taze gapjyk döret</translation>
+    </message>
+    <message>
+        <source>Wallet:</source>
+        <translation type="unfinished">Gapjyk:</translation>
+    </message>
+    <message>
+        <source>Network activity disabled.</source>
+        <extracomment>A substring of the tooltip.</extracomment>
+        <translation type="unfinished">Ulgamyň işleýşi ýapyk.</translation>
+    </message>
+    <message>
+        <source>Proxy is &lt;b&gt;enabled&lt;/b&gt;: %1</source>
+        <translation type="unfinished">Proksi &lt;b&gt;işleýär&lt;/b&gt;: %1</translation>
+    </message>
+    <message>
+        <source>Send coins to a Bitcoin address</source>
+        <translation>Bitkoin salgysyna teňňeleri iber</translation>
+    </message>
+    <message>
+        <source>Backup wallet to another location</source>
+        <translation>Gapjygyň ätiýaçlyk nusgasyny başga ýere goý</translation>
+    </message>
+    <message>
+        <source>Change the passphrase used for wallet encryption</source>
+        <translation>Gapjygy şifrlemek üçin ulanylan parol sözlemini üýtget</translation>
+    </message>
+    <message>
+        <source>&amp;Send</source>
+        <translation>&amp;Iber</translation>
+    </message>
+    <message>
+        <source>&amp;Receive</source>
+        <translation>&amp;Kabul edip al</translation>
+    </message>
+    <message>
+        <source>&amp;Options…</source>
+        <translation type="unfinished">&amp;Opsiýalar…</translation>
+    </message>
+    <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation type="unfinished">&amp;Gapjygy şifrle…</translation>
+    </message>
+    <message>
+        <source>Encrypt the private keys that belong to your wallet</source>
+        <translation>Gapjygyňa degişli hususy açarlary şifrle</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation type="unfinished">&amp;Gapjygyň ätiýaçlyk nusgasyny sakla…</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation type="unfinished">&amp;Parol sözlemini çalyş...</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation type="unfinished">&amp;Habara gol çek…</translation>
+    </message>
+    <message>
+        <source>Sign messages with your Bitcoin addresses to prove you own them</source>
+        <translation>Bitkoin salgylarynyň eýesidigini subut etmek üçin habarlara öz Bitkoin salgylaryň bilen gol çek</translation>
+    </message>
+    <message>
+        <source>&amp;Verify message…</source>
+        <translation type="unfinished">&amp;Habary tassykla…</translation>
+    </message>
+    <message>
+        <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
+        <translation>Habarlaryň görkezilen Bitkoin salgylary bilen gol çekilendigini kepillendirmek üçin habarlary tassykla</translation>
+    </message>
+    <message>
+        <source>&amp;Load PSBT from file…</source>
+        <translation type="unfinished">Faýldan BGÇBA &amp;ýükle…</translation>
+    </message>
+    <message>
+        <source>Open &amp;URI…</source>
+        <translation type="unfinished">&amp;URI aç…</translation>
+    </message>
+    <message>
+        <source>Close Wallet…</source>
+        <translation type="unfinished">Gapjygy ýap...</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation type="unfinished">Gapjyk döret...</translation>
+    </message>
+    <message>
+        <source>Close All Wallets…</source>
+        <translation type="unfinished">Ähli gapjyklary ýap...</translation>
+    </message>
+    <message>
+        <source>&amp;File</source>
+        <translation>&amp;Faýl</translation>
+    </message>
+    <message>
+        <source>&amp;Settings</source>
+        <translation>&amp;Sazlamalar</translation>
+    </message>
+    <message>
+        <source>&amp;Help</source>
+        <translation>&amp;Kömek</translation>
+    </message>
+    <message>
+        <source>Tabs toolbar</source>
+        <translation>Bölümler gurallar paneli</translation>
+    </message>
+    <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation type="unfinished">Sözbaşylary sinhron ýagdaýa getirmek (%1%)...</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation type="unfinished">Ulgam bilen utgaşdyrmak...</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation type="unfinished">Diskde bloklar indekslenýär...</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation type="unfinished">Diskde bloklar işlenýär...</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation type="unfinished">Diskde bloklar gaýtadan indekslenýär...</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation type="unfinished">Deňdeşlere baglanylýar...</translation>
+    </message>
+    <message>
+        <source>Request payments (generates QR codes and bitcoin: URIs)</source>
+        <translation type="unfinished">Tölegleri sora (QR kodlary we bitkoin: URIleri döredýär)</translation>
+    </message>
+    <message>
+        <source>Show the list of used sending addresses and labels</source>
+        <translation type="unfinished">Ulanylan iberilýän salgylaryň we bellikleriň sanawyny görkez</translation>
+    </message>
+    <message>
+        <source>Show the list of used receiving addresses and labels</source>
+        <translation type="unfinished">Ulanylan kabul edip alýan salgylaryň we bellikleriň sanawyny görkez</translation>
+    </message>
+    <message>
+        <source>&amp;Command-line options</source>
+        <translation type="unfinished">&amp;Buýruk setiri opsiýalary</translation>
+    </message>
+    <message numerus="yes">
+        <source>Processed %n block(s) of transaction history.</source>
+        <translation>
+            <numerusform>Geleşikler geçmişiniň %n blogy işlendi.</numerusform>
+            <numerusform>Geleşikler geçmişiniň %n blogy işlendi.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>%1 behind</source>
+        <translation>%1 galdy</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation type="unfinished">Tutulýar...</translation>
+    </message>
+    <message>
+        <source>Last received block was generated %1 ago.</source>
+        <translation>Soňky kabul edilen blok %1 öň döredilipdi.</translation>
+    </message>
+    <message>
+        <source>Transactions after this will not yet be visible.</source>
+        <translation>Mundan soňky geleşikler entek görünmez.</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation>Ýalňyşlyk</translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation>Duýduryş</translation>
+    </message>
+    <message>
+        <source>Information</source>
+        <translation>Maglumat</translation>
+    </message>
+    <message>
+        <source>Up to date</source>
+        <translation>Döwrebap</translation>
+    </message>
+    <message>
+        <source>Load Partially Signed Bitcoin Transaction</source>
+        <translation type="unfinished">Bölekleýýin gol çekilen bitkoin geleşigini ýükle</translation>
+    </message>
+    <message>
+        <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
+        <translation type="unfinished">Bölekleýin gol çekilen bitkoin geleşigini alyş-çalyş panelinden ýükle</translation>
+    </message>
+    <message>
+        <source>Node window</source>
+        <translation type="unfinished">Düwün penjiresi</translation>
+    </message>
+    <message>
+        <source>Open node debugging and diagnostic console</source>
+        <translation type="unfinished">Düwüni zyýansyzlaşdyrma we anyklaýyş konsolyny aç</translation>
+    </message>
+    <message>
+        <source>&amp;Sending addresses</source>
+        <translation type="unfinished">&amp;Iberilýän salgylar</translation>
+    </message>
+    <message>
+        <source>&amp;Receiving addresses</source>
+        <translation type="unfinished">&amp;Kabul edýän salgylar</translation>
+    </message>
+    <message>
+        <source>Open a bitcoin: URI</source>
+        <translation type="unfinished">Bitkoini aç: URI</translation>
+    </message>
+    <message>
+        <source>Open Wallet</source>
+        <translation type="unfinished">Gapjyk aç</translation>
+    </message>
+    <message>
+        <source>Open a wallet</source>
+        <translation type="unfinished">Gapjyk aç</translation>
+    </message>
+    <message>
+        <source>Close wallet</source>
+        <translation type="unfinished">Gapjygy ýap</translation>
+    </message>
+    <message>
+        <source>Close all wallets</source>
+        <translation type="unfinished">Ähli gapjyklary ýap</translation>
+    </message>
+    <message>
+        <source>Show the %1 help message to get a list with possible Bitcoin command-line options</source>
+        <translation type="unfinished">Mümkin bolan Bitkoin buýruk setiri opsiýalarynyň sanawyny görmek üçin %1 goldaw habaryny görkez</translation>
+    </message>
+    <message>
+        <source>&amp;Mask values</source>
+        <translation type="unfinished">&amp;Sanlaryň üstüni ört</translation>
+    </message>
+    <message>
+        <source>Mask the values in the Overview tab</source>
+        <translation type="unfinished">Gözden geçir bölüminde sanlaryň üstüni ört</translation>
+    </message>
+    <message>
+        <source>default wallet</source>
+        <translation type="unfinished">deslapky bellenen gapjyk</translation>
+    </message>
+    <message>
+        <source>No wallets available</source>
+        <translation type="unfinished">Elýeterli gapjyk ýok</translation>
+    </message>
+    <message>
+        <source>&amp;Window</source>
+        <translation type="unfinished">&amp;Penjire</translation>
+    </message>
+    <message>
+        <source>Minimize</source>
+        <translation type="unfinished">Kiçelt</translation>
+    </message>
+    <message>
+        <source>Zoom</source>
+        <translation type="unfinished">Ulalt</translation>
+    </message>
+    <message>
+        <source>Main Window</source>
+        <translation type="unfinished">Esasy penjire</translation>
+    </message>
+    <message>
+        <source>%1 client</source>
+        <translation type="unfinished">%1 müşderi</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n active connection(s) to Bitcoin network.</source>
+        <extracomment>A substring of the tooltip.</extracomment>
+        <translation type="unfinished">
+            <numerusform>Bitkoin toruna %n işjeň arabaglanyşyk.</numerusform>
+            <numerusform>Bitkoin ulgamyna %n işjeň arabaglanyşyk.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Click for more actions.</source>
+        <extracomment>A substring of the tooltip. "More actions" are available via the context menu.</extracomment>
+        <translation type="unfinished">Başga hereketler üçin bas.</translation>
+    </message>
+    <message>
+        <source>Show Peers tab</source>
+        <extracomment>A context menu item. The "Peers tab" is an element of the "Node window".</extracomment>
+        <translation type="unfinished">Deňdeşler bölümini görkez</translation>
+    </message>
+    <message>
+        <source>Disable network activity</source>
+        <extracomment>A context menu item.</extracomment>
+        <translation type="unfinished">Ulgamyň işjeňligini öçür</translation>
+    </message>
+    <message>
+        <source>Enable network activity</source>
+        <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
+        <translation type="unfinished">Ulgamyň işjeňligini aç</translation>
+    </message>
+    <message>
+        <source>Error: %1</source>
+        <translation type="unfinished">Ýalňyşlyk: %1</translation>
+    </message>
+    <message>
+        <source>Warning: %1</source>
+        <translation type="unfinished">Duýduryş: %1</translation>
+    </message>
+    <message>
+        <source>Date: %1
+</source>
+        <translation type="unfinished">Sene: %1
+</translation>
+    </message>
+    <message>
+        <source>Amount: %1
+</source>
+        <translation type="unfinished">Möçber: %1
+</translation>
+    </message>
+    <message>
+        <source>Wallet: %1
+</source>
+        <translation type="unfinished">Gapjyk: %1
+</translation>
+    </message>
+    <message>
+        <source>Type: %1
+</source>
+        <translation type="unfinished">Görnüş: %1
+</translation>
+    </message>
+    <message>
+        <source>Label: %1
+</source>
+        <translation type="unfinished">Bellik: %1
+</translation>
+    </message>
+    <message>
+        <source>Address: %1
+</source>
+        <translation type="unfinished">Salgy: %1
+</translation>
+    </message>
+    <message>
+        <source>Sent transaction</source>
+        <translation>Iberilen geleşik</translation>
+    </message>
+    <message>
+        <source>Incoming transaction</source>
+        <translation>Gelýän geleşik</translation>
+    </message>
+    <message>
+        <source>HD key generation is &lt;b&gt;enabled&lt;/b&gt;</source>
+        <translation type="unfinished">HD açar döretmeklik &lt;b&gt;işjeň&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>HD key generation is &lt;b&gt;disabled&lt;/b&gt;</source>
+        <translation type="unfinished">HD açar döretmeklik &lt;b&gt;öçük&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Private key &lt;b&gt;disabled&lt;/b&gt;</source>
+        <translation type="unfinished">Hususy açar &lt;b&gt;öçük&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
+        <translation>Gapjyk &lt;b&gt;şifrlenen&lt;/b&gt; we häzirki wagtda &lt;b&gt;gulpy açyk&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
+        <translation>Gapjyk &lt;b&gt;şifrlenen&lt;/b&gt; we häzirki wagtda &lt;b&gt;gulply&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Original message:</source>
+        <translation type="unfinished">Başdaky habar:</translation>
+    </message>
+</context>
+<context>
+    <name>UnitDisplayStatusBarControl</name>
+    <message>
+        <source>Unit to show amounts in. Click to select another unit.</source>
+        <translation type="unfinished">Möçberleri görkezmek üçin ölçeg birligi. Başga ölçeg birligini saýlamak üçin bas.</translation>
+    </message>
+</context>
+<context>
+    <name>CoinControlDialog</name>
+    <message>
+        <source>Coin Selection</source>
+        <translation type="unfinished">Teňňe saýlamak</translation>
+    </message>
+    <message>
+        <source>Quantity:</source>
+        <translation type="unfinished">Mukdar:</translation>
+    </message>
+    <message>
+        <source>Bytes:</source>
+        <translation type="unfinished">Baýtlar:</translation>
+    </message>
+    <message>
+        <source>Amount:</source>
+        <translation type="unfinished">Möçber:</translation>
+    </message>
+    <message>
+        <source>Fee:</source>
+        <translation type="unfinished">Töleg:</translation>
+    </message>
+    <message>
+        <source>Dust:</source>
+        <translation type="unfinished">Toz:</translation>
+    </message>
+    <message>
+        <source>After Fee:</source>
+        <translation type="unfinished">Tölegden soň:</translation>
+    </message>
+    <message>
+        <source>Change:</source>
+        <translation type="unfinished">Çalyş:</translation>
+    </message>
+    <message>
+        <source>(un)select all</source>
+        <translation type="unfinished">hemmesini saýla(ma)</translation>
+    </message>
+    <message>
+        <source>Tree mode</source>
+        <translation type="unfinished">Agaç tertibi</translation>
+    </message>
+    <message>
+        <source>List mode</source>
+        <translation type="unfinished">Sanaw tertibi</translation>
+    </message>
+    <message>
+        <source>Amount</source>
+        <translation type="unfinished">Möçber</translation>
+    </message>
+    <message>
+        <source>Received with label</source>
+        <translation type="unfinished">Bellik bilen kabul edildi</translation>
+    </message>
+    <message>
+        <source>Received with address</source>
+        <translation type="unfinished">Salgy bilen kabul edildi</translation>
+    </message>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">Sene</translation>
+    </message>
+    <message>
+        <source>Confirmations</source>
+        <translation type="unfinished">Tassyklamalar</translation>
+    </message>
+    <message>
+        <source>Confirmed</source>
+        <translation type="unfinished">Tassyklandy</translation>
+    </message>
+    <message>
+        <source>Copy amount</source>
+        <translation type="unfinished">Möçberi göçür</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Salgyny göçür</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">&amp;Belligi göçür</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">&amp;Möçberi göçür</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">Geleşigiň &amp;ID-sini göçür</translation>
+    </message>
+    <message>
+        <source>L&amp;ock unspent</source>
+        <translation type="unfinished">Ulanylmadygyny g&amp;ulpla</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock unspent</source>
+        <translation type="unfinished">Ulanylmadygynyň &amp;gulpuny aç</translation>
+    </message>
+    <message>
+        <source>Copy quantity</source>
+        <translation type="unfinished">Sany göçür</translation>
+    </message>
+    <message>
+        <source>Copy fee</source>
+        <translation type="unfinished">Tölegi göçür</translation>
+    </message>
+    <message>
+        <source>Copy after fee</source>
+        <translation type="unfinished">Soňundan gatanjy göçür</translation>
+    </message>
+    <message>
+        <source>Copy bytes</source>
+        <translation type="unfinished">Baýtlary göçür</translation>
+    </message>
+    <message>
+        <source>Copy dust</source>
+        <translation type="unfinished">Tozy göçür</translation>
+    </message>
+    <message>
+        <source>Copy change</source>
+        <translation type="unfinished">Gaýtargyny göçür</translation>
+    </message>
+    <message>
+        <source>(%1 locked)</source>
+        <translation type="unfinished">(%1 gulply)</translation>
+    </message>
+    <message>
+        <source>yes</source>
+        <translation type="unfinished">hawa</translation>
+    </message>
+    <message>
+        <source>no</source>
+        <translation type="unfinished">ýok</translation>
+    </message>
+    <message>
+        <source>This label turns red if any recipient receives an amount smaller than the current dust threshold.</source>
+        <translation type="unfinished">Islendik kabul ediji häzirki toz çäginden has kiçi möçberi kabul edip alsa, bu bellik gyzyla öwrülýär.</translation>
+    </message>
+    <message>
+        <source>Can vary +/- %1 satoshi(s) per input.</source>
+        <translation type="unfinished">Her giriş üçin +/- %1 satosi üýtgäp biler.</translation>
+    </message>
+    <message>
+        <source>(no label)</source>
+        <translation type="unfinished">(bellik ýok)</translation>
+    </message>
+    <message>
+        <source>change from %1 (%2)</source>
+        <translation type="unfinished">%1-den gaýtargy (%2)</translation>
+    </message>
+    <message>
+        <source>(change)</source>
+        <translation type="unfinished">(gaýtargy)</translation>
+    </message>
+</context>
+<context>
+    <name>CreateWalletActivity</name>
+    <message>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation type="unfinished">&lt;b&gt;%1&lt;/b&gt; gapjyk döredilýär...</translation>
+    </message>
+    <message>
+        <source>Create wallet failed</source>
+        <translation type="unfinished">Gapjyk döredip bolmady</translation>
+    </message>
+    <message>
+        <source>Create wallet warning</source>
+        <translation type="unfinished">Gapjyk döretmek duýduryşy</translation>
+    </message>
+    <message>
+        <source>Can't list signers</source>
+        <translation type="unfinished">Gol çekenleriň sanawyny görkezip bolanok</translation>
+    </message>
+</context>
+<context>
+    <name>OpenWalletActivity</name>
+    <message>
+        <source>Open wallet failed</source>
+        <translation type="unfinished">Gapjyk açyp bolmady</translation>
+    </message>
+    <message>
+        <source>Open wallet warning</source>
+        <translation type="unfinished">Gapjyk açmak duýduryşy</translation>
+    </message>
+    <message>
+        <source>default wallet</source>
+        <translation type="unfinished">deslapky bellenen gapjyk</translation>
+    </message>
+    <message>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation type="unfinished">&lt;b&gt;%1&lt;/b&gt; gapjyk açylýar...</translation>
+    </message>
+</context>
+<context>
+    <name>WalletController</name>
+    <message>
+        <source>Close wallet</source>
+        <translation type="unfinished">Gapjygy ýap</translation>
+    </message>
+    <message>
+        <source>Are you sure you wish to close the wallet &lt;i&gt;%1&lt;/i&gt;?</source>
+        <translation type="unfinished">&lt;i&gt;%1&lt;/i&gt; gapjygy ýapmak isleýäniňiz çynmy?</translation>
+    </message>
+    <message>
+        <source>Closing the wallet for too long can result in having to resync the entire chain if pruning is enabled.</source>
+        <translation type="unfinished">Kesip gysgaltmaklyk işjeň bolsa, aşa uzak wagtlap gapjygyň ýapylmagy tutuş zynjyryň gaýtadan utgaşmak zerurlygyna getirip biler.</translation>
+    </message>
+    <message>
+        <source>Close all wallets</source>
+        <translation type="unfinished">Ähli gapjyklary ýap</translation>
+    </message>
+    <message>
+        <source>Are you sure you wish to close all wallets?</source>
+        <translation type="unfinished">Ähli gapjyklary ýapmak isleýäniňiz çynmy?</translation>
+    </message>
+</context>
+<context>
+    <name>CreateWalletDialog</name>
+    <message>
+        <source>Create Wallet</source>
+        <translation type="unfinished">Gapjyk döret</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <translation type="unfinished">Gapjygyň ady</translation>
+    </message>
+    <message>
+        <source>Wallet</source>
+        <translation type="unfinished">Gapjyk</translation>
+    </message>
+    <message>
+        <source>Encrypt the wallet. The wallet will be encrypted with a passphrase of your choice.</source>
+        <translation type="unfinished">Gapjygy şifrle. Gapjyk siziň saýlan parol sözlemi bilen şifrlener.</translation>
+    </message>
+    <message>
+        <source>Encrypt Wallet</source>
+        <translation type="unfinished">Gapjygy şifrle</translation>
+    </message>
+    <message>
+        <source>Advanced Options</source>
+        <translation type="unfinished">Giňişleýin opsiýalar</translation>
+    </message>
+    <message>
+        <source>Disable private keys for this wallet. Wallets with private keys disabled will have no private keys and cannot have an HD seed or imported private keys. This is ideal for watch-only wallets.</source>
+        <translation type="unfinished">Bu gapjyk üçin hususy açarlary öçür. Hususy açarlary öçük gapjyklaryň hiçhili hususy açary bolmaz we HD esasy açary ýa-da import edilen hususy açary bolmaz. Diňe gözden geçirip bolýan gapjyklar üçin iň göwnejaýydyr.</translation>
+    </message>
+    <message>
+        <source>Disable Private Keys</source>
+        <translation type="unfinished">Hususy açarlary öçür</translation>
+    </message>
+    <message>
+        <source>Make a blank wallet. Blank wallets do not initially have private keys or scripts. Private keys and addresses can be imported, or an HD seed can be set, at a later time.</source>
+        <translation type="unfinished">Boş gapjyk emele getir. Boş gapjyklaryň başda hususy açary ýa-da skripti bolmaýar. Soňra hususy açarlar ýa-da salgylar import edilip bilner ýa-da HD esasy açar bellenip bilner.</translation>
+    </message>
+    <message>
+        <source>Make Blank Wallet</source>
+        <translation type="unfinished">Boş gapjyk emele getir</translation>
+    </message>
+    <message>
+        <source>Use descriptors for scriptPubKey management</source>
+        <translation type="unfinished">scriptPubKey dolandyryşy üçin beýan edijileri ulan</translation>
+    </message>
+    <message>
+        <source>Descriptor Wallet</source>
+        <translation type="unfinished">Beýan ediji gapjyk</translation>
+    </message>
+    <message>
+        <source>Use an external signing device such as a hardware wallet. Configure the external signer script in wallet preferences first.</source>
+        <translation type="unfinished">Enjam gapjygy ýaly daşyndan gol çekilýän enjamy ulan. Ilki bilen gapjygyň ileri tutmalarynda daşyndan gol çekiji skriptini sazla.</translation>
+    </message>
+    <message>
+        <source>External signer</source>
+        <translation type="unfinished">Daşyndan gol çekiji</translation>
+    </message>
+    <message>
+        <source>Create</source>
+        <translation type="unfinished">Döret</translation>
+    </message>
+    <message>
+        <source>Compiled without sqlite support (required for descriptor wallets)</source>
+        <translation type="unfinished">Sqlite goldawsyz (beýan ediji gapjyklar üçin gerek) düzüldi</translation>
+    </message>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Daşyndan gol çekmek üçin goldawsyz (daşyndan gol çekmek üçin gerek) düzüldi</translation>
+    </message>
+</context>
+<context>
+    <name>EditAddressDialog</name>
+    <message>
+        <source>Edit Address</source>
+        <translation>Salgyny rejele</translation>
+    </message>
+    <message>
+        <source>&amp;Label</source>
+        <translation>&amp;Bellik</translation>
+    </message>
+    <message>
+        <source>The label associated with this address list entry</source>
+        <translation type="unfinished">Bu salgy sanawyndaky ýazgy bilen baglanyşykly bellik</translation>
+    </message>
+    <message>
+        <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
+        <translation type="unfinished">Bu salgy sanawyndaky ýazgy bilen baglanyşykly salgy. Bu diňe iberýän salgylar üçin üýtgedilip bilner.</translation>
+    </message>
+    <message>
+        <source>&amp;Address</source>
+        <translation>&amp;Salgy</translation>
+    </message>
+    <message>
+        <source>New sending address</source>
+        <translation type="unfinished">Täze iberýän salgy</translation>
+    </message>
+    <message>
+        <source>Edit receiving address</source>
+        <translation type="unfinished">Kabul edýän salgyny rejele</translation>
+    </message>
+    <message>
+        <source>Edit sending address</source>
+        <translation type="unfinished">Iberýän salgyny rejele</translation>
+    </message>
+    <message>
+        <source>The entered address "%1" is not a valid Bitcoin address.</source>
+        <translation type="unfinished">Ýazylan salgy %1 ýaly Bitkoin salgysy ýok.</translation>
+    </message>
+    <message>
+        <source>Address "%1" already exists as a receiving address with label "%2" and so cannot be added as a sending address.</source>
+        <translation type="unfinished">%1 salgysy %2 bellikli kabul edýän salgy hökmünde eýýäm bar we şonuň üçin ony iberýän salgy hökmünde goşup bolanok.</translation>
+    </message>
+    <message>
+        <source>The entered address "%1" is already in the address book with label "%2".</source>
+        <translation type="unfinished">Ýazylan %1 salgysy salgylar kitabynda %2 belligi astynda eýýäm bar.</translation>
+    </message>
+    <message>
+        <source>Could not unlock wallet.</source>
+        <translation type="unfinished">Gapjygyň gulpuny açyp bolmady.</translation>
+    </message>
+    <message>
+        <source>New key generation failed.</source>
+        <translation type="unfinished">Täze açar döredip bolmady.</translation>
+    </message>
+</context>
+<context>
+    <name>FreespaceChecker</name>
+    <message>
+        <source>A new data directory will be created.</source>
+        <translation>Täze maglumat sanawy dörediler. </translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation>at</translation>
+    </message>
+    <message>
+        <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
+        <translation>Sanaw eýýäm bar. Bu ýerde täze sanaw döretmekçi bolsaňyz, %1 goşuň.</translation>
+    </message>
+    <message>
+        <source>Path already exists, and is not a directory.</source>
+        <translation>Ýol eýýäm bar we ol sanaw däldir.</translation>
+    </message>
+    <message>
+        <source>Cannot create data directory here.</source>
+        <translation>Bu ýerde maglumat sanawyny döredip bolanok.</translation>
+    </message>
+</context>
+<context>
+    <name>Intro</name>
+    <message>
+        <source>Bitcoin</source>
+        <translation type="unfinished">Bitkoin</translation>
+    </message>
+    <message>
+        <source>%1 GB of free space available</source>
+        <translation type="unfinished">%1 GB boş ýer bar</translation>
+    </message>
+    <message>
+        <source>(of %1 GB needed)</source>
+        <translation type="unfinished">(Zerur bolan %1 GB-dan)</translation>
+    </message>
+    <message>
+        <source>(%1 GB needed for full chain)</source>
+        <translation type="unfinished">(Doly zynjyr üçin %1 GB zerur)</translation>
+    </message>
+    <message>
+        <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
+        <translation type="unfinished">Bu sanawda azyndan %1 GB maglumat saklanar we ol wagtyň geçmegi bilen köpeler.</translation>
+    </message>
+    <message>
+        <source>Approximately %1 GB of data will be stored in this directory.</source>
+        <translation type="unfinished">Bu sanawda takmynan %1 GB maglumat saklanar.</translation>
+    </message>
+    <message numerus="yes">
+        <source>(sufficient to restore backups %n day(s) old)</source>
+        <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
+        <translation type="unfinished">
+            <numerusform>(%n gün geçen ätiýaçlyk nusgalaryny dikeltmek üçin ýeterlik)</numerusform>
+            <numerusform>(%n gün geçen ätiýaçlyk nusgalaryny dikeltmek üçin ýeterlik)</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>%1 will download and store a copy of the Bitcoin block chain.</source>
+        <translation type="unfinished">%1 Bitkoin blok zynjyrynyň nusgasyny ýükläp alar we göçürer.</translation>
+    </message>
+    <message>
+        <source>The wallet will also be stored in this directory.</source>
+        <translation type="unfinished">Gapjyk hem bu sanawa saklanar.</translation>
+    </message>
+    <message>
+        <source>Error: Specified data directory "%1" cannot be created.</source>
+        <translation type="unfinished">Ýalňyşlyk: Görkezilen %1 maglumat sanawyny döredip bolanok.</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation>Ýalňyşlyk</translation>
+    </message>
+    <message>
+        <source>Welcome</source>
+        <translation>Hoş geldiňiz</translation>
+    </message>
+    <message>
+        <source>Welcome to %1.</source>
+        <translation type="unfinished">%1-a hoş geldiňiz.</translation>
+    </message>
+    <message>
+        <source>As this is the first time the program is launched, you can choose where %1 will store its data.</source>
+        <translation type="unfinished">Bu programma ilkinji gezek başlandygy sebäpli, %1-nyň öz maglumatlaryny nirä saklajakdygyny saýlap bilersiň.</translation>
+    </message>
+    <message>
+        <source>Limit block chain storage to</source>
+        <translation type="unfinished">Blok zynjyrynyň saklanmagyny çäklendir</translation>
+    </message>
+    <message>
+        <source>Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</source>
+        <translation type="unfinished">Bu sazlamany yzyna gaýtarmaklyk tutuş blok zynjyryny gaýtadan ýükläp almak zerur. Ilki bilen tutuş zynjyry ýükläp almak we soň ony kesmek has çalt bolar. Käbir giňişleýin aýratynlyklary öçürer.</translation>
+    </message>
+    <message>
+        <source> GB</source>
+        <translation type="unfinished">GB</translation>
+    </message>
+    <message>
+        <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
+        <translation type="unfinished">Bu başdaky utgaşdyrma örän çylşyrymlydyr we kompýuteriňiziň ozal üns berilmedik enjam näsazlyklaryny ýüze çykaryp biler. Her sapar %1 işledeniňizde ol säginen ýerinden ýükläp almaga dowam eder.</translation>
+    </message>
+    <message>
+        <source>If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</source>
+        <translation type="unfinished">Blok zynjyrynyň saklanyşyny çäklendirmegi (kesip aýyrmagy) saýlan bolsaňyz, geçmiş maglumatlary ýene-de ýüklenip alynmaly we işlenmelidir, emma diskiňiziň ulanylyşyny azaltmak üçin soňundan pozular. </translation>
+    </message>
+    <message>
+        <source>Use the default data directory</source>
+        <translation>Deslapky bellenen maglumat sanawyny ulan</translation>
+    </message>
+    <message>
+        <source>Use a custom data directory:</source>
+        <translation>Aýratyn maglumat sanawyny ulan:</translation>
+    </message>
+</context>
+<context>
+    <name>HelpMessageDialog</name>
+    <message>
+        <source>version</source>
+        <translation type="unfinished">wersiýa</translation>
+    </message>
+    <message>
+        <source>About %1</source>
+        <translation type="unfinished">%1 barada</translation>
+    </message>
+    <message>
+        <source>Command-line options</source>
+        <translation type="unfinished">Buýruk setiri opsiýalary</translation>
+    </message>
+</context>
+<context>
+    <name>ShutdownWindow</name>
+    <message>
+        <source>%1 is shutting down…</source>
+        <translation type="unfinished">%1 ýapylýar...</translation>
+    </message>
+    <message>
+        <source>Do not shut down the computer until this window disappears.</source>
+        <translation type="unfinished">Bu penjire ýitýänçä kompýuteri ýapmaň.</translation>
+    </message>
+</context>
+<context>
+    <name>ModalOverlay</name>
+    <message>
+        <source>Form</source>
+        <translation type="unfinished">Forma</translation>
+    </message>
+    <message>
+        <source>Recent transactions may not yet be visible, and therefore your wallet's balance might be incorrect. This information will be correct once your wallet has finished synchronizing with the bitcoin network, as detailed below.</source>
+        <translation type="unfinished">Soňky geleşikler entek görünmän biler, şonuň üçin gapjygyňyzdaky galyndy nädogry bolup biler. Bu maglumat aşakda beýan edilişi ýaly gapjygyňyz bitkoin tory bilen utgaşmagy tamamlanda dogry bolar.</translation>
+    </message>
+    <message>
+        <source>Attempting to spend bitcoins that are affected by not-yet-displayed transactions will not be accepted by the network.</source>
+        <translation type="unfinished">Entek görkezilmedik geleşikleriň täsirine düşen bitkoinleri sarp etmek synanyşygy ulgam tarapyndan kabul edilmez.</translation>
+    </message>
+    </context>
+<context>
+    <name>OptionsDialog</name>
+    <message>
+        <source>&amp;Window</source>
+        <translation>&amp;Penjire</translation>
+    </message>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Daşyndan gol çekmek üçin goldawsyz (daşyndan gol çekmek üçin gerek) düzüldi</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Ýalňyşlyk</translation>
+    </message>
+    </context>
+<context>
+    <name>OverviewPage</name>
+    <message>
+        <source>Form</source>
+        <translation>Forma</translation>
+    </message>
+    </context>
+<context>
+    <name>PeerTableModel</name>
+    <message>
+        <source>Address</source>
+        <extracomment>Title of Peers Table column which contains the IP/Onion/I2P address of the connected peer.</extracomment>
+        <translation type="unfinished">Salgy</translation>
+    </message>
+    </context>
+<context>
+    <name>RPCConsole</name>
+    <message>
+        <source>Node window</source>
+        <translation type="unfinished">Düwün penjiresi</translation>
+    </message>
+    </context>
+<context>
+    <name>ReceiveCoinsDialog</name>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Salgyny göçür</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">&amp;Belligi göçür</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">&amp;Möçberi göçür</translation>
+    </message>
+    <message>
+        <source>Could not unlock wallet.</source>
+        <translation type="unfinished">Gapjygyň gulpuny açyp bolmady.</translation>
+    </message>
+    </context>
+<context>
+    <name>ReceiveRequestDialog</name>
+    <message>
+        <source>Amount:</source>
+        <translation type="unfinished">Möçber:</translation>
+    </message>
+    <message>
+        <source>Wallet:</source>
+        <translation type="unfinished">Gapjyk:</translation>
+    </message>
+    </context>
+<context>
+    <name>RecentRequestsTableModel</name>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">Sene</translation>
+    </message>
+    <message>
+        <source>Label</source>
+        <translation type="unfinished">Bellik</translation>
+    </message>
+    <message>
+        <source>(no label)</source>
+        <translation type="unfinished">(bellik ýok)</translation>
+    </message>
+    </context>
+<context>
+    <name>SendCoinsDialog</name>
+    <message>
+        <source>Quantity:</source>
+        <translation type="unfinished">Mukdar:</translation>
+    </message>
+    <message>
+        <source>Bytes:</source>
+        <translation type="unfinished">Baýtlar:</translation>
+    </message>
+    <message>
+        <source>Amount:</source>
+        <translation type="unfinished">Möçber:</translation>
+    </message>
+    <message>
+        <source>Fee:</source>
+        <translation type="unfinished">Töleg:</translation>
+    </message>
+    <message>
+        <source>After Fee:</source>
+        <translation type="unfinished">Tölegden soň:</translation>
+    </message>
+    <message>
+        <source>Change:</source>
+        <translation type="unfinished">Çalyş:</translation>
+    </message>
+    <message>
+        <source>Dust:</source>
+        <translation type="unfinished">Toz:</translation>
+    </message>
+    <message>
+        <source>Copy quantity</source>
+        <translation type="unfinished">Sany göçür</translation>
+    </message>
+    <message>
+        <source>Copy amount</source>
+        <translation type="unfinished">Möçberi göçür</translation>
+    </message>
+    <message>
+        <source>Copy fee</source>
+        <translation type="unfinished">Tölegi göçür</translation>
+    </message>
+    <message>
+        <source>Copy after fee</source>
+        <translation type="unfinished">Soňundan gatanjy göçür</translation>
+    </message>
+    <message>
+        <source>Copy bytes</source>
+        <translation type="unfinished">Baýtlary göçür</translation>
+    </message>
+    <message>
+        <source>Copy dust</source>
+        <translation type="unfinished">Tozy göçür</translation>
+    </message>
+    <message>
+        <source>Copy change</source>
+        <translation type="unfinished">Gaýtargyny göçür</translation>
+    </message>
+    <message numerus="yes">
+        <source>Estimated to begin confirmation within %n block(s).</source>
+        <translation>
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message>
+        <source>(no label)</source>
+        <translation type="unfinished">(bellik ýok)</translation>
+    </message>
+</context>
+<context>
+    <name>TransactionDesc</name>
+    <message numerus="yes">
+        <source>Open for %n more block(s)</source>
+        <translation>
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">Sene</translation>
+    </message>
+    <message numerus="yes">
+        <source>matures in %n more block(s)</source>
+        <translation>
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message>
+        <source>Amount</source>
+        <translation type="unfinished">Möçber</translation>
+    </message>
+    </context>
+<context>
+    <name>TransactionTableModel</name>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">Sene</translation>
+    </message>
+    <message>
+        <source>Label</source>
+        <translation type="unfinished">Bellik</translation>
+    </message>
+    <message numerus="yes">
+        <source>Open for %n more block(s)</source>
+        <translation>
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message>
+        <source>(no label)</source>
+        <translation type="unfinished">(bellik ýok)</translation>
+    </message>
+    </context>
+<context>
+    <name>TransactionView</name>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Salgyny göçür</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">&amp;Belligi göçür</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">&amp;Möçberi göçür</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">Amalyň &amp;ID-sini göçür</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See https://en.wikipedia.org/wiki/Comma-separated_values</extracomment>
+        <translation type="unfinished">Otur bilen aýrylan faýl</translation>
+    </message>
+    <message>
+        <source>Confirmed</source>
+        <translation type="unfinished">Tassyklandy</translation>
+    </message>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">Sene</translation>
+    </message>
+    <message>
+        <source>Label</source>
+        <translation type="unfinished">Bellik</translation>
+    </message>
+    <message>
+        <source>Address</source>
+        <translation type="unfinished">Salgy</translation>
+    </message>
+    <message>
+        <source>Exporting Failed</source>
+        <translation type="unfinished">Geçirip bolmady</translation>
+    </message>
+    </context>
+<context>
+    <name>WalletFrame</name>
+    <message>
+        <source>Create a new wallet</source>
+        <translation type="unfinished">Taze gapjyk döret</translation>
+    </message>
+</context>
+<context>
+    <name>WalletModel</name>
+    <message>
+        <source>default wallet</source>
+        <translation type="unfinished">deslapky bellenen gapjyk</translation>
+    </message>
+</context>
+<context>
+    <name>WalletView</name>
+    <message>
+        <source>&amp;Export</source>
+        <translation type="unfinished">&amp;Geçir</translation>
+    </message>
+    <message>
+        <source>Export the data in the current tab to a file</source>
+        <translation type="unfinished">Häzirki bellikdäki maglumaty faýla geçir</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Ýalňyşlyk</translation>
+    </message>
+    </context>
+</TS>

--- a/src/qt/locale/bitcoin_tl.ts
+++ b/src/qt/locale/bitcoin_tl.ts
@@ -1,0 +1,1465 @@
+<TS version="2.1" language="tl">
+<context>
+    <name>AddressBookPage</name>
+    <message>
+        <source>Right-click to edit address or label</source>
+        <translation type="unfinished">I-right-click upang i-edit ang address o label</translation>
+    </message>
+    <message>
+        <source>Create a new address</source>
+        <translation>Gumawa ng bagong address</translation>
+    </message>
+    <message>
+        <source>&amp;New</source>
+        <translation type="unfinished">&amp;Bago</translation>
+    </message>
+    <message>
+        <source>Copy the currently selected address to the system clipboard</source>
+        <translation>I-copy ang pinipiling address sa kasalakuyan sa clipboard ng sistema</translation>
+    </message>
+    <message>
+        <source>C&amp;lose</source>
+        <translation type="unfinished">Isara</translation>
+    </message>
+    <message>
+        <source>Delete the currently selected address from the list</source>
+        <translation>Tanggalin ang kasalukuyang napiling address sa listahan.</translation>
+    </message>
+    <message>
+        <source>Enter address or label to search</source>
+        <translation type="unfinished">Ilagay ang address o tatak na hahanapin</translation>
+    </message>
+    <message>
+        <source>Export the data in the current tab to a file</source>
+        <translation>I-export ang datos sa kasalukuyang tab sa isang file</translation>
+    </message>
+    <message>
+        <source>&amp;Export</source>
+        <translation>&amp;I-export</translation>
+    </message>
+    <message>
+        <source>&amp;Delete</source>
+        <translation>&amp;Tanggalin</translation>
+    </message>
+    <message>
+        <source>Choose the address to receive coins with</source>
+        <translation type="unfinished">Piliin ang addres kung saan tatanggap ng coins</translation>
+    </message>
+    <message>
+        <source>C&amp;hoose</source>
+        <translation type="unfinished">&amp;Pumili</translation>
+    </message>
+    <message>
+        <source>Sending addresses</source>
+        <translation type="unfinished">Pinapadala ang mga ♦address♦</translation>
+    </message>
+    <message>
+        <source>Receiving addresses</source>
+        <translation type="unfinished">Tinatanggap ang mga ♦address♦</translation>
+    </message>
+    <message>
+        <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
+        <translation type="unfinished">Ito ang mga address mong Bitcoin para pagpapadala ng bayad. Palagi i-check mo ang amount at tinatanggap na address bagong magsesend ka ng mga coin.</translation>
+    </message>
+    <message>
+        <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
+Signing is only possible with addresses of the type 'legacy'.</source>
+        <translation type="unfinished">Ito ang mga address ng Bitcoin para sa pagtanggap ng mga baya. Gamitin ang 'Create new receiving address' na button sa receive tab para gumawa ng bagong mga address. Ang pag-sign ay posible lamang sa uri ng mga address na 'legacy'.</translation>
+    </message>
+    <message>
+        <source>&amp;Copy Address</source>
+        <translation type="unfinished">&amp;Kopyahin ang ♦Address♦</translation>
+    </message>
+    <message>
+        <source>Copy &amp;Label</source>
+        <translation type="unfinished">Kopyahin ang &amp;Tatak</translation>
+    </message>
+    <message>
+        <source>&amp;Edit</source>
+        <translation type="unfinished">&amp;I-edit</translation>
+    </message>
+    <message>
+        <source>Export Address List</source>
+        <translation type="unfinished">I-Export ang Listahan ng Address</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See https://en.wikipedia.org/wiki/Comma-separated_values</extracomment>
+        <translation type="unfinished">Kuwir hiwalay na file</translation>
+    </message>
+    <message>
+        <source>There was an error trying to save the address list to %1. Please try again.</source>
+        <extracomment>An error message. %1 is a stand-in argument for the name of the file we attempted to save to.</extracomment>
+        <translation type="unfinished">May mali sa pagsubok na i-save ang listahan ng address  sa 1%1. Pakisubukan ulit.</translation>
+    </message>
+    <message>
+        <source>Exporting Failed</source>
+        <translation type="unfinished">Ang pag-export ay Nabigo</translation>
+    </message>
+</context>
+<context>
+    <name>AddressTableModel</name>
+    <message>
+        <source>Label</source>
+        <translation type="unfinished">Tatak</translation>
+    </message>
+    <message>
+        <source>Address</source>
+        <translation type="unfinished">♦Address♦</translation>
+    </message>
+    <message>
+        <source>(no label)</source>
+        <translation type="unfinished">(walang tatak)</translation>
+    </message>
+</context>
+<context>
+    <name>AskPassphraseDialog</name>
+    <message>
+        <source>Passphrase Dialog</source>
+        <translation>♦Passphrase♦ na ♦Dialog♦</translation>
+    </message>
+    <message>
+        <source>Enter passphrase</source>
+        <translation>Ilagay ang ♦passphrase♦</translation>
+    </message>
+    <message>
+        <source>New passphrase</source>
+        <translation>Bagong ♦passphrase♦</translation>
+    </message>
+    <message>
+        <source>Repeat new passphrase</source>
+        <translation>Ulitin ang bagong ♦passphrase♦</translation>
+    </message>
+    <message>
+        <source>Show passphrase</source>
+        <translation type="unfinished">Ipakita ang ♦passphrase♦</translation>
+    </message>
+    <message>
+        <source>Encrypt wallet</source>
+        <translation type="unfinished">I-encrypt ang pitaka</translation>
+    </message>
+    <message>
+        <source>This operation needs your wallet passphrase to unlock the wallet.</source>
+        <translation type="unfinished">Ang operasyon na ito ay nangangailangan ng iyong pitaka ♦passphrase♦ para i-unlock ang pitaka.</translation>
+    </message>
+    <message>
+        <source>Unlock wallet</source>
+        <translation type="unfinished">I-unlock ang pitaka</translation>
+    </message>
+    <message>
+        <source>Change passphrase</source>
+        <translation type="unfinished">Palitan ang ♦passphrase♦</translation>
+    </message>
+    <message>
+        <source>Confirm wallet encryption</source>
+        <translation type="unfinished">Kumpirmahin ang ♦encryption♦ ng pitaka</translation>
+    </message>
+    <message>
+        <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
+        <translation type="unfinished">Babala: Kung i-encrypt mo ang pitaka mo at mawala ang iyong ♦passphrase♦, &lt;b&gt;
+MAWAWALA MO ANG LAHAT NG IYONG MGA BITCOIN &lt;b&gt;!
+</translation>
+    </message>
+    <message>
+        <source>Are you sure you wish to encrypt your wallet?</source>
+        <translation type="unfinished">Sigurado ka ba na gusto mong i-encrypt ang iyong pitaka?</translation>
+    </message>
+    <message>
+        <source>Wallet encrypted</source>
+        <translation type="unfinished">Ang pitaka ay na-encrypt na</translation>
+    </message>
+    <message>
+        <source>Enter the new passphrase for the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
+        <translation type="unfinished">Ilagay ang bagong ♦passphrase♦ para sa pitaka.&lt;br/&gt;Pakigamit ang ♦passphrase♦ of &lt;b&gt;sampu o higit pa na mga ♦random♦ na mga karakter&lt;/b&gt;, o &lt;b&gt;walo o higit pang mga salita&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <source>Enter the old passphrase and new passphrase for the wallet.</source>
+        <translation type="unfinished">Ilagay ang lumang ♦passphrase♦ at ang bagong ♦passphrase♦ para sa pitaka.</translation>
+    </message>
+    <message>
+        <source>Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
+        <translation type="unfinished">Tandaan na ang pag-encrypt sa iyong pitaka ay hindi ganap na maprotektahan ang mga ♦bitcoin♦ sa pagnanakaw ng ♦malware♦ na makakahawa sa iyong kompyuter.</translation>
+    </message>
+    <message>
+        <source>Wallet to be encrypted</source>
+        <translation type="unfinished">Ang pitaka ay i-encrypt</translation>
+    </message>
+    <message>
+        <source>Your wallet is about to be encrypted. </source>
+        <translation type="unfinished">Ang iyong pitaka ay mae-encrypt na.</translation>
+    </message>
+    <message>
+        <source>Your wallet is now encrypted. </source>
+        <translation type="unfinished">Ang iyong pitaka ay na-encrypt na.</translation>
+    </message>
+    <message>
+        <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
+        <translation type="unfinished">MAHALAGA: Kahit anong dating mga ♦backup♦ na ginawa mo sa file ng pitaka mo ay dapat na mapalitan ng bagong gawang, na-encrypt na ♦file♦ ng pitaka. Para sa mga rason ng seguridad, dating mga ♦backup♦ sa hindi na-encrypt na ♦file♦ ng pitaka ay magiging walang silbi sa lalong madaling panahon na uumpisahan mong gamitin ang bago, na na-encrypt na pitaka.</translation>
+    </message>
+    <message>
+        <source>Wallet encryption failed</source>
+        <translation type="unfinished">Ang pag-encrypt sa pitaka ay nabigo</translation>
+    </message>
+    <message>
+        <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
+        <translation type="unfinished">Nabigo ang pag-encrypt sa pitaka dahil sa panloob na pagkakamali. Ang iyong pitaka ay hindi na-encrypt.</translation>
+    </message>
+    <message>
+        <source>The supplied passphrases do not match.</source>
+        <translation type="unfinished">Ang mga ibinigay na mga ♦passphrase♦ ay hindi nagtugma.</translation>
+    </message>
+    <message>
+        <source>Wallet unlock failed</source>
+        <translation type="unfinished">Ang pag-unlock sa pitaka ay nabigo</translation>
+    </message>
+    <message>
+        <source>The passphrase entered for the wallet decryption was incorrect.</source>
+        <translation type="unfinished">Ang ♦passphrase♦ na ipinasok sa ♦decryption♦ sa pitaka ay hindi tama.</translation>
+    </message>
+    <message>
+        <source>Wallet passphrase was successfully changed.</source>
+        <translation type="unfinished">Ang ♦passphrase♦ ng pitaka ay matagumpay na nabago.</translation>
+    </message>
+    <message>
+        <source>Warning: The Caps Lock key is on!</source>
+        <translation type="unfinished">Babala: Ang ♦Caps Lock Key♦ ay naka-on!</translation>
+    </message>
+</context>
+<context>
+    <name>BanTableModel</name>
+    <message>
+        <source>IP/Netmask</source>
+        <translation type="unfinished">♦IP/Netmask♦</translation>
+    </message>
+    <message>
+        <source>Banned Until</source>
+        <translation type="unfinished">Ipinagbabawal Hanggang</translation>
+    </message>
+</context>
+<context>
+    <name>BitcoinApplication</name>
+    <message>
+        <source>Runaway exception</source>
+        <translation type="unfinished">Pagbubukod sa pagtakbo papalayo </translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
+        <translation type="unfinished">Malubhang pagkakamali ay naganap. 1%1 hindi na pwedeng magpatuloy ng ligtas at ihihinto na.</translation>
+    </message>
+    <message>
+        <source>Internal error</source>
+        <translation type="unfinished">Panloob na pagkakamali</translation>
+    </message>
+    <message>
+        <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
+        <translation type="unfinished">May panloob na pagkakamali ang naganap. 1%1 ay magtatangkang ituloy na ligtas. Ito ay hindi inaasahan na problema na maaaring i-ulat katulad ng pagkalarawan sa ibaba.</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <source>Error: Specified data directory "%1" does not exist.</source>
+        <translation type="unfinished">Pagkakamali: Natukoy na datos na ♦directory♦ "1%1" ay wala.</translation>
+    </message>
+    <message>
+        <source>Error: Cannot parse configuration file: %1.</source>
+        <translation type="unfinished">Pagkakamali: Hindi ma-parse ang ♦configuration file♦: 1%1.</translation>
+    </message>
+    <message>
+        <source>Error: %1</source>
+        <translation type="unfinished">Pagkakamali: 1%1</translation>
+    </message>
+    <message>
+        <source>%1 didn't yet exit safely…</source>
+        <translation type="unfinished">1%1 hindi pa nag-exit ng ligtas...</translation>
+    </message>
+    <message>
+        <source>Amount</source>
+        <translation type="unfinished">Halaga</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n second(s)</source>
+        <translation>
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n minute(s)</source>
+        <translation>
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n week(s)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n year(s)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    </context>
+<context>
+    <name>BitcoinGUI</name>
+    <message>
+        <source>&amp;Overview</source>
+        <translation>&amp;Pangkalahatang ideya</translation>
+    </message>
+    <message>
+        <source>Show general overview of wallet</source>
+        <translation>Ipakita ang pangkalahatang ideya ng pitaka</translation>
+    </message>
+    <message>
+        <source>&amp;Transactions</source>
+        <translation>&amp;Mga transaksyon</translation>
+    </message>
+    <message>
+        <source>Browse transaction history</source>
+        <translation>Tignan ang kasaysayan ng transaksyon</translation>
+    </message>
+    <message>
+        <source>E&amp;xit</source>
+        <translation>♦E&amp;xit</translation>
+    </message>
+    <message>
+        <source>Quit application</source>
+        <translation>Ihinto ang aplikasyon</translation>
+    </message>
+    <message>
+        <source>&amp;About %1</source>
+        <translation type="unfinished">&amp;Tungkol sa %1</translation>
+    </message>
+    <message>
+        <source>Show information about %1</source>
+        <translation type="unfinished">Ipakita ang impormasyon tungkol sa %1</translation>
+    </message>
+    <message>
+        <source>About &amp;Qt</source>
+        <translation>Tungkol sa &amp;♦Qt♦</translation>
+    </message>
+    <message>
+        <source>Modify configuration options for %1</source>
+        <translation type="unfinished">Baguhin ang mga pagpipilian sa ♦configuration♦ para sa %1</translation>
+    </message>
+    <message>
+        <source>Create a new wallet</source>
+        <translation type="unfinished">Gumawa ng bagong pitaka</translation>
+    </message>
+    <message>
+        <source>Wallet:</source>
+        <translation type="unfinished">Pitaka:</translation>
+    </message>
+    <message>
+        <source>Network activity disabled.</source>
+        <extracomment>A substring of the tooltip.</extracomment>
+        <translation type="unfinished">Na-disable ang aktibidad ng ♦network♦</translation>
+    </message>
+    <message>
+        <source>Proxy is &lt;b&gt;enabled&lt;/b&gt;: %1</source>
+        <translation type="unfinished">Ang paghalili ay  &lt;b&gt;na-enable&lt;/b&gt;: %1</translation>
+    </message>
+    <message>
+        <source>Send coins to a Bitcoin address</source>
+        <translation>Magpadala ng mga ♦coin♦ sa ♦address♦ ng Bitcoin</translation>
+    </message>
+    <message>
+        <source>Backup wallet to another location</source>
+        <translation>I-backup ang pitaka sa ibang lokasyon</translation>
+    </message>
+    <message>
+        <source>Change the passphrase used for wallet encryption</source>
+        <translation>Palitan ang ♦passphrase♦ na ginamit para sa pag-encrypt sa pitaka</translation>
+    </message>
+    <message>
+        <source>&amp;Send</source>
+        <translation>&amp;Ipadala</translation>
+    </message>
+    <message>
+        <source>&amp;Receive</source>
+        <translation>&amp;Tumanggap</translation>
+    </message>
+    <message>
+        <source>&amp;Options…</source>
+        <translation type="unfinished">&amp;Mga pagpipilian...</translation>
+    </message>
+    <message>
+        <source>&amp;Show / Hide</source>
+        <translation>&amp;Ipakita / Itago</translation>
+    </message>
+    <message>
+        <source>Show or hide the main Window</source>
+        <translation>Ipakita o itago ang pangunahing ♦Window♦</translation>
+    </message>
+    <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation type="unfinished">&amp;I-encrypt ang Pitaka</translation>
+    </message>
+    <message>
+        <source>Encrypt the private keys that belong to your wallet</source>
+        <translation>I-encrypt ang mga pribadong mga susi na nabibilang sa iyong pitaka</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation type="unfinished">&amp;I-backup ang Pitaka...</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation type="unfinished">&amp;Palitan ang ♦Passphrase♦...</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation type="unfinished">Pirmahan &amp;magmensahe...</translation>
+    </message>
+    <message>
+        <source>Sign messages with your Bitcoin addresses to prove you own them</source>
+        <translation>Tanda na mga mensahe sa mga ♦address♦ ng iyong ♦Bitcoin♦ para patunayan na pagmamay-ari mo sila</translation>
+    </message>
+    <message>
+        <source>&amp;Verify message…</source>
+        <translation type="unfinished">&amp;Patunayan ang mensahe...</translation>
+    </message>
+    <message>
+        <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
+        <translation>Patunayan ang mga mensahe para matiyak na sila ay napirmahan ng may tinukoy na mga ♦Bitcoin address♦</translation>
+    </message>
+    <message>
+        <source>&amp;Load PSBT from file…</source>
+        <translation type="unfinished">&amp;I-load ang PSBT mula sa ♦file♦...</translation>
+    </message>
+    <message>
+        <source>Load PSBT from clipboard…</source>
+        <translation type="unfinished">I-load ang ♦PSBT♦ mula sa ♦clipboard♦...</translation>
+    </message>
+    <message>
+        <source>Open &amp;URI…</source>
+        <translation type="unfinished">Buksan ang &amp;♦URL♦...</translation>
+    </message>
+    <message>
+        <source>Close Wallet…</source>
+        <translation type="unfinished">Isara ang Pitaka...</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation type="unfinished">Gumawa ng Pitaka...</translation>
+    </message>
+    <message>
+        <source>Close All Wallets…</source>
+        <translation type="unfinished">Isara ang Lahat ng mga Pitaka...</translation>
+    </message>
+    <message>
+        <source>&amp;File</source>
+        <translation>&amp;♦File♦</translation>
+    </message>
+    <message>
+        <source>&amp;Settings</source>
+        <translation>Mga &amp;♦Setting♦</translation>
+    </message>
+    <message>
+        <source>&amp;Help</source>
+        <translation>&amp;Tulong</translation>
+    </message>
+    <message>
+        <source>Tabs toolbar</source>
+        <translation>♦Tabs toolbar♦</translation>
+    </message>
+    <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation type="unfinished">♦Syncing Headers♦ (%1%)…</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation type="unfinished">Sini-siynchronize sa ♦network♦...</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation type="unfinished">Ini-index ang mga bloke sa ♦disk♦...</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation type="unfinished">Pinoproseso ang mga bloke sa ♦disk♦...</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation type="unfinished">Ni-rere-index ang mga bloke sa ♦disk♦</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation type="unfinished">Kumokonekta sa mga ♦peers♦...</translation>
+    </message>
+    <message>
+        <source>Request payments (generates QR codes and bitcoin: URIs)</source>
+        <translation type="unfinished">Humiling ng mga bayad (gumagawa ng ♦QR codes♦ at ♦bitcoin: URIs♦)</translation>
+    </message>
+    <message>
+        <source>Show the list of used sending addresses and labels</source>
+        <translation type="unfinished">Ipakita ang listahan ng nagamit na pagpapadalhan na mga ♦address♦ at mga tatak</translation>
+    </message>
+    <message>
+        <source>Show the list of used receiving addresses and labels</source>
+        <translation type="unfinished">Ipakita ang listahan ng nagamit na pagtatanggapan na mga ♦address♦ at mga tatak</translation>
+    </message>
+    <message>
+        <source>&amp;Command-line options</source>
+        <translation type="unfinished">&amp;♦Command-line♦ na mga pagpipilian</translation>
+    </message>
+    <message numerus="yes">
+        <source>Processed %n block(s) of transaction history.</source>
+        <translation>
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message>
+        <source>%1 behind</source>
+        <translation>%1 sa likod</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation type="unfinished">Humahabol...</translation>
+    </message>
+    <message>
+        <source>Last received block was generated %1 ago.</source>
+        <translation>Ang huling natanggap na bloke ay nagawa %1kanina.</translation>
+    </message>
+    <message>
+        <source>Transactions after this will not yet be visible.</source>
+        <translation>Ang mga transaksyon pagkatapos nito ay hindi pa muna makikita.</translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation>Babala</translation>
+    </message>
+    <message>
+        <source>Information</source>
+        <translation>Impormasyon</translation>
+    </message>
+    <message>
+        <source>Load Partially Signed Bitcoin Transaction</source>
+        <translation type="unfinished">Ang ♦Load♦ ay Bahagyang Napirmahan na Transaksyon sa ♦Bitcoin♦</translation>
+    </message>
+    <message>
+        <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
+        <translation type="unfinished">Ang ♦Load♦ ay Bahagyang Napirmahan na Transaksyon sa ♦Bitcoin♦ mula sa ♦clipboard♦</translation>
+    </message>
+    <message>
+        <source>Node window</source>
+        <translation type="unfinished">♦Node window♦</translation>
+    </message>
+    <message>
+        <source>Open node debugging and diagnostic console</source>
+        <translation type="unfinished">Bukas na ♦node debugging♦ at ♦diagnostic console♦</translation>
+    </message>
+    <message>
+        <source>&amp;Sending addresses</source>
+        <translation type="unfinished">&amp;Pagpapadalhan na mga ♦address♦</translation>
+    </message>
+    <message>
+        <source>&amp;Receiving addresses</source>
+        <translation type="unfinished">&amp;Pagtatanggapan na mga ♦address♦</translation>
+    </message>
+    <message>
+        <source>Open a bitcoin: URI</source>
+        <translation type="unfinished">Buksan ang ♦bitcoin: URI♦</translation>
+    </message>
+    <message>
+        <source>Open Wallet</source>
+        <translation type="unfinished">Buksan ang pitaka</translation>
+    </message>
+    <message>
+        <source>Open a wallet</source>
+        <translation type="unfinished">Buksan ang pitaka</translation>
+    </message>
+    <message>
+        <source>Close wallet</source>
+        <translation type="unfinished">Isarado ang pitaka</translation>
+    </message>
+    <message>
+        <source>Close all wallets</source>
+        <translation type="unfinished">Isarado ang lahat na mga pitaka</translation>
+    </message>
+    <message>
+        <source>Show the %1 help message to get a list with possible Bitcoin command-line options</source>
+        <translation type="unfinished">Ipakita ang %1 tumulong sa mensahe na kumuha ng listahan ng posibleng ♦Bitcoin command-line♦ na mga pagpipilian</translation>
+    </message>
+    <message>
+        <source>&amp;Mask values</source>
+        <translation type="unfinished">&amp;♦Mask♦ na mga halaga</translation>
+    </message>
+    <message>
+        <source>Mask the values in the Overview tab</source>
+        <translation type="unfinished">I-mask ang  mga halaga sa loob ng ♦Overview tab♦</translation>
+    </message>
+    <message>
+        <source>default wallet</source>
+        <translation type="unfinished">pitaka na ♦default♦</translation>
+    </message>
+    <message>
+        <source>No wallets available</source>
+        <translation type="unfinished">Walang pitaka na mayroon</translation>
+    </message>
+    <message>
+        <source>&amp;Window</source>
+        <translation type="unfinished">&amp;♦Window♦</translation>
+    </message>
+    <message>
+        <source>Minimize</source>
+        <translation type="unfinished">Bawasan</translation>
+    </message>
+    <message>
+        <source>Zoom</source>
+        <translation type="unfinished">I-zoom</translation>
+    </message>
+    <message>
+        <source>Main Window</source>
+        <translation type="unfinished">Pangunahing ♦Window♦</translation>
+    </message>
+    <message>
+        <source>%1 client</source>
+        <translation type="unfinished">%1 na kliyente</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n active connection(s) to Bitcoin network.</source>
+        <extracomment>A substring of the tooltip.</extracomment>
+        <translation type="unfinished">
+            <numerusform>%n aktibo na mga ♦connection(s)♦ sa ♦Bitcoin network♦.</numerusform>
+            <numerusform>%n na aktibong mga koneksyon sa ♦Bitcoin network♦</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Click for more actions.</source>
+        <extracomment>A substring of the tooltip. "More actions" are available via the context menu.</extracomment>
+        <translation type="unfinished">Mag-click para sa marami pang gagawin.</translation>
+    </message>
+    <message>
+        <source>Show Peers tab</source>
+        <extracomment>A context menu item. The "Peers tab" is an element of the "Node window".</extracomment>
+        <translation type="unfinished">Ipakita ang ♦Peers tab♦</translation>
+    </message>
+    <message>
+        <source>Disable network activity</source>
+        <extracomment>A context menu item.</extracomment>
+        <translation type="unfinished">I-disable ang aktibidad ng ♦network♦</translation>
+    </message>
+    <message>
+        <source>Enable network activity</source>
+        <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
+        <translation type="unfinished">I-enable ang aktibidad ng ♦network♦</translation>
+    </message>
+    <message>
+        <source>Error: %1</source>
+        <translation type="unfinished">Pagkakamali: 1%1</translation>
+    </message>
+    <message>
+        <source>Warning: %1</source>
+        <translation type="unfinished">Babala: %1</translation>
+    </message>
+    <message>
+        <source>Date: %1
+</source>
+        <translation type="unfinished">Petsa: %1
+</translation>
+    </message>
+    <message>
+        <source>Amount: %1
+</source>
+        <translation type="unfinished">Halaga: %1
+</translation>
+    </message>
+    <message>
+        <source>Wallet: %1
+</source>
+        <translation type="unfinished">Pitaka: %1
+</translation>
+    </message>
+    <message>
+        <source>Type: %1
+</source>
+        <translation type="unfinished">Uri: %1
+</translation>
+    </message>
+    <message>
+        <source>Label: %1
+</source>
+        <translation type="unfinished">Tatak: %1
+</translation>
+    </message>
+    <message>
+        <source>Address: %1
+</source>
+        <translation type="unfinished">♦Address♦: %1
+</translation>
+    </message>
+    <message>
+        <source>Sent transaction</source>
+        <translation>Ipinadalang transaksyon</translation>
+    </message>
+    <message>
+        <source>Incoming transaction</source>
+        <translation>Paparating na transaksyon</translation>
+    </message>
+    <message>
+        <source>HD key generation is &lt;b&gt;enabled&lt;/b&gt;</source>
+        <translation type="unfinished">♦HD♦ na susi sa henerasyon ay &lt;b&gt;na-enable&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>HD key generation is &lt;b&gt;disabled&lt;/b&gt;</source>
+        <translation type="unfinished">♦HD key generation♦ ay &lt;b&gt;na-disable&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Private key &lt;b&gt;disabled&lt;/b&gt;</source>
+        <translation type="unfinished">Pribadong susi &lt;b&gt;na-disable&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
+        <translation>Ang pitaka ay &lt;b&gt;na-encrypt&lt;/b&gt; at kasalukuyang &lt;b&gt;na-unlock&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
+        <translation>Ang pitaka ay &lt;b&gt;na-encrypt&lt;/b&gt; at kasalukuyang &lt;b&gt;na-lock&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Original message:</source>
+        <translation type="unfinished">Orihinal na mensahe:</translation>
+    </message>
+</context>
+<context>
+    <name>UnitDisplayStatusBarControl</name>
+    <message>
+        <source>Unit to show amounts in. Click to select another unit.</source>
+        <translation type="unfinished">Yunit na ipakita sa mga halaga. Mag-click para pumili ng ibang yunit.</translation>
+    </message>
+</context>
+<context>
+    <name>CoinControlDialog</name>
+    <message>
+        <source>Coin Selection</source>
+        <translation type="unfinished">Pagpipilian ng ♦coin♦</translation>
+    </message>
+    <message>
+        <source>Quantity:</source>
+        <translation type="unfinished">Dami:</translation>
+    </message>
+    <message>
+        <source>Bytes:</source>
+        <translation type="unfinished">♦Bytes♦:</translation>
+    </message>
+    <message>
+        <source>Amount:</source>
+        <translation type="unfinished">Halaga:</translation>
+    </message>
+    <message>
+        <source>Fee:</source>
+        <translation type="unfinished">Bayad:</translation>
+    </message>
+    <message>
+        <source>Dust:</source>
+        <translation type="unfinished">Alikabok:</translation>
+    </message>
+    <message>
+        <source>After Fee:</source>
+        <translation type="unfinished">Pagkatapos na Bayad:</translation>
+    </message>
+    <message>
+        <source>Change:</source>
+        <translation type="unfinished">Sukli:</translation>
+    </message>
+    <message>
+        <source>(un)select all</source>
+        <translation type="unfinished">i-(un)select lahat</translation>
+    </message>
+    <message>
+        <source>Tree mode</source>
+        <translation type="unfinished">♦Tree mode♦</translation>
+    </message>
+    <message>
+        <source>List mode</source>
+        <translation type="unfinished">Listajhan na ♦mode♦</translation>
+    </message>
+    <message>
+        <source>Amount</source>
+        <translation type="unfinished">Halaga</translation>
+    </message>
+    <message>
+        <source>Received with label</source>
+        <translation type="unfinished">Natanggap na may kasamang ♦tatak♦</translation>
+    </message>
+    <message>
+        <source>Received with address</source>
+        <translation type="unfinished">Natanggap na may ♦address♦</translation>
+    </message>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">Petsa</translation>
+    </message>
+    <message>
+        <source>Confirmations</source>
+        <translation type="unfinished">Mga kumpirmasyon</translation>
+    </message>
+    <message>
+        <source>Confirmed</source>
+        <translation type="unfinished">Nakumpirma</translation>
+    </message>
+    <message>
+        <source>Copy amount</source>
+        <translation type="unfinished">Kopyahin ang halaga</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Kopyahin ang ♦address♦</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">&amp;Kopyahin ang &amp;tatak</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Kopyahin ang &amp;halaga</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">Kopyahin ang transaksyon  ng &amp;♦ID♦</translation>
+    </message>
+    <message>
+        <source>L&amp;ock unspent</source>
+        <translation type="unfinished">&amp;I-lock ang hindi nagastos</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock unspent</source>
+        <translation type="unfinished">&amp;I-unlock ang hindi nagastos</translation>
+    </message>
+    <message>
+        <source>Copy quantity</source>
+        <translation type="unfinished">Kopyahin ang dami</translation>
+    </message>
+    <message>
+        <source>Copy fee</source>
+        <translation type="unfinished">Bayad sa pagkopya</translation>
+    </message>
+    <message>
+        <source>Copy after fee</source>
+        <translation type="unfinished">Kopyahin pagkatapos ang bayad</translation>
+    </message>
+    <message>
+        <source>Copy bytes</source>
+        <translation type="unfinished">Kopyahin ang ♦bytes♦</translation>
+    </message>
+    <message>
+        <source>Copy dust</source>
+        <translation type="unfinished">Kopyahin ang ♦dust♦</translation>
+    </message>
+    <message>
+        <source>Copy change</source>
+        <translation type="unfinished">Kopyahin ang pagbabago</translation>
+    </message>
+    <message>
+        <source>(%1 locked)</source>
+        <translation type="unfinished">(%1 naka-lock)</translation>
+    </message>
+    <message>
+        <source>yes</source>
+        <translation type="unfinished">oo</translation>
+    </message>
+    <message>
+        <source>no</source>
+        <translation type="unfinished">hindi</translation>
+    </message>
+    <message>
+        <source>This label turns red if any recipient receives an amount smaller than the current dust threshold.</source>
+        <translation type="unfinished">Ang tatak na ito ay nagiging pula kung ang sinomang tatanggap ay tatanggap ng halaga na mas maliit  sa kasalukuyang ♦dust threshold♦</translation>
+    </message>
+    <message>
+        <source>Can vary +/- %1 satoshi(s) per input.</source>
+        <translation type="unfinished">Maaaring magbago ng +/- %1♦4satoshi(s)♦ kada ♦input♦.</translation>
+    </message>
+    <message>
+        <source>(no label)</source>
+        <translation type="unfinished">(walang tatak)</translation>
+    </message>
+    <message>
+        <source>change from %1 (%2)</source>
+        <translation type="unfinished">ang pagbabago ay mula sa %1 (%2)</translation>
+    </message>
+    <message>
+        <source>(change)</source>
+        <translation type="unfinished">(pagbabago)</translation>
+    </message>
+</context>
+<context>
+    <name>CreateWalletActivity</name>
+    <message>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation type="unfinished">Paggawa ng Pitaka &lt;b&gt;%1&lt;/b&gt;…</translation>
+    </message>
+    <message>
+        <source>Create wallet failed</source>
+        <translation type="unfinished">Ang paggawa ng pitaka ay nabigo</translation>
+    </message>
+    <message>
+        <source>Create wallet warning</source>
+        <translation type="unfinished">Babala sa paggawa ng pitaka</translation>
+    </message>
+    <message>
+        <source>Can't list signers</source>
+        <translation type="unfinished">Hindi mailista ang mga tagapirma</translation>
+    </message>
+</context>
+<context>
+    <name>OpenWalletActivity</name>
+    <message>
+        <source>Open wallet failed</source>
+        <translation type="unfinished">Pagbukas ng pitaka ay nabigo</translation>
+    </message>
+    <message>
+        <source>Open wallet warning</source>
+        <translation type="unfinished">Babala sa pagbukas ng pitaka</translation>
+    </message>
+    <message>
+        <source>default wallet</source>
+        <translation type="unfinished">pitaka na ♦default♦</translation>
+    </message>
+    <message>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation type="unfinished">Pagbukas sa Pitaka &lt;b&gt;%1&lt;/b&gt;…</translation>
+    </message>
+</context>
+<context>
+    <name>WalletController</name>
+    <message>
+        <source>Close wallet</source>
+        <translation type="unfinished">Isarado ang pitaka</translation>
+    </message>
+    <message>
+        <source>Are you sure you wish to close the wallet &lt;i&gt;%1&lt;/i&gt;?</source>
+        <translation type="unfinished">Sigurado ka ba na gusto mong isarado ang pitaka &lt;i&gt;%1&lt;/i&gt;?</translation>
+    </message>
+    <message>
+        <source>Closing the wallet for too long can result in having to resync the entire chain if pruning is enabled.</source>
+        <translation type="unfinished">Ang pagsasarod sa pitaka sa matagal ay maaaring humantong sa pag-resync ng kabuuang ♦chain♦ kung ang pagputol ay na-enable.</translation>
+    </message>
+    <message>
+        <source>Close all wallets</source>
+        <translation type="unfinished">Isarado ang lahat na mga pitaka</translation>
+    </message>
+    <message>
+        <source>Are you sure you wish to close all wallets?</source>
+        <translation type="unfinished">Sigurado ka ba na gusto mong isarado lahat ng mga pitaka?
+</translation>
+    </message>
+</context>
+<context>
+    <name>CreateWalletDialog</name>
+    <message>
+        <source>Create Wallet</source>
+        <translation type="unfinished">Gumawa ng pitaka</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <translation type="unfinished">Pangalan ng pitaka</translation>
+    </message>
+    <message>
+        <source>Wallet</source>
+        <translation type="unfinished">Pitaka</translation>
+    </message>
+    <message>
+        <source>Encrypt the wallet. The wallet will be encrypted with a passphrase of your choice.</source>
+        <translation type="unfinished">I-encrypt ang pitaka. Ang pitaka ay mae-encrypt na may ♦passphrase♦ ng iyong mapipili.</translation>
+    </message>
+    <message>
+        <source>Encrypt Wallet</source>
+        <translation type="unfinished">I-encrypt ang pitaka</translation>
+    </message>
+    <message>
+        <source>Advanced Options</source>
+        <translation type="unfinished">Mga Pagpipilian sa pagsulong</translation>
+    </message>
+    <message>
+        <source>Disable private keys for this wallet. Wallets with private keys disabled will have no private keys and cannot have an HD seed or imported private keys. This is ideal for watch-only wallets.</source>
+        <translation type="unfinished">I-disable ang mga pribadong mga susi para sa pitaka na ito. Ang mga pitaka na may mga pribadong mga susi na na-disable ay mawawalng ng pribadong mga susi at hindi magkakaroon ng ♦HD seed♦ o mga na-import na pribadong mga susi. Ito ay perpekto lamang para sa mga ♦watch-only♦ na mga pitaka.</translation>
+    </message>
+    <message>
+        <source>Disable Private Keys</source>
+        <translation type="unfinished">I-disable ang Pribadong mga Susi</translation>
+    </message>
+    <message>
+        <source>Make a blank wallet. Blank wallets do not initially have private keys or scripts. Private keys and addresses can be imported, or an HD seed can be set, at a later time.</source>
+        <translation type="unfinished">Gumawa ng blankong pitaka. Ang blankong mga pitaka hindi muna nagkakaroon ng pribadong mga susi o mga ♦script♦. Ang pribadong mga susi at mga ♦address♦ ay pwedeng ma-import, o ang ♦HD seed♦ ay pwedeng mai-set, mamaya.</translation>
+    </message>
+    <message>
+        <source>Make Blank Wallet</source>
+        <translation type="unfinished">Gumawa ng Blankong Pitaka</translation>
+    </message>
+    <message>
+        <source>Use descriptors for scriptPubKey management</source>
+        <translation type="unfinished">Gumawa ng  mga ♦descriptors♦ para sa pamamahala sa ♦scriptPubKey♦</translation>
+    </message>
+    <message>
+        <source>Descriptor Wallet</source>
+        <translation type="unfinished">♦Descriptor♦ na pitaka</translation>
+    </message>
+    <message>
+        <source>Use an external signing device such as a hardware wallet. Configure the external signer script in wallet preferences first.</source>
+        <translation type="unfinished">Gumamit ng panlabas na pagpirmang ♦device♦ katulad ng ♦hardware♦ na pitaka. I-configure ang panlabas na ♦signer script♦ sa loob ng ♦preferences♦ ng pitaka n listahan. </translation>
+    </message>
+    <message>
+        <source>External signer</source>
+        <translation type="unfinished">Panlabas na ♦signer♦</translation>
+    </message>
+    <message>
+        <source>Create</source>
+        <translation type="unfinished">Gumawa</translation>
+    </message>
+    <message>
+        <source>Compiled without sqlite support (required for descriptor wallets)</source>
+        <translation type="unfinished">Pinagsama-sama na walang suporta ng ♦sqlite♦ (kailangan para sa ♦descriptor♦ na pitaka)</translation>
+    </message>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Pinagsama-sama na walang suporta ng ♦pag-pirma♦ (kailangan para sa panlabasna pagpirma)</translation>
+    </message>
+</context>
+<context>
+    <name>EditAddressDialog</name>
+    <message>
+        <source>Edit Address</source>
+        <translation>I-edit ang ♦address♦</translation>
+    </message>
+    <message>
+        <source>&amp;Label</source>
+        <translation>&amp;Tatak</translation>
+    </message>
+    <message>
+        <source>The label associated with this address list entry</source>
+        <translation type="unfinished">Ang tatak na nauugnay sa ♦entry♦ ng listahan ng ♦address♦</translation>
+    </message>
+    <message>
+        <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
+        <translation type="unfinished">Ang ♦address♦ na may kaugnayan sa ipinasok sa listahan ng ♦address♦. Ito ay maaari lamang ng mabago para sa pagpapadalhan na mga ♦address♦.</translation>
+    </message>
+    <message>
+        <source>&amp;Address</source>
+        <translation>&amp;♦Address♦</translation>
+    </message>
+    <message>
+        <source>New sending address</source>
+        <translation type="unfinished">Bagong pagpapadalhan na ♦address♦</translation>
+    </message>
+    <message>
+        <source>Edit receiving address</source>
+        <translation type="unfinished">I-edit ang pagtatanggapang ♦address♦</translation>
+    </message>
+    <message>
+        <source>Edit sending address</source>
+        <translation type="unfinished">I-edit ang pagpapadalhan na ♦address♦</translation>
+    </message>
+    <message>
+        <source>The entered address "%1" is not a valid Bitcoin address.</source>
+        <translation type="unfinished">Ang naipasok na ♦address♦ "%1" ay hindi wasto na ♦Bitcoin address♦.</translation>
+    </message>
+    <message>
+        <source>Address "%1" already exists as a receiving address with label "%2" and so cannot be added as a sending address.</source>
+        <translation type="unfinished">Ang ♦Address♦ "%1" ay mayroon na bilang pagtatanggapang ♦address♦ na may tatak "%2" kaya hindi na maaaring maidagdag bilang pagpapadalhan na ♦address♦.</translation>
+    </message>
+    <message>
+        <source>The entered address "%1" is already in the address book with label "%2".</source>
+        <translation type="unfinished">Ang naipasok na ♦address♦ "%1" ay nasa aklat na ng ♦address♦ na may tatak "%2".</translation>
+    </message>
+    <message>
+        <source>Could not unlock wallet.</source>
+        <translation type="unfinished">Hindi maaaring ma-unlock ang pitaka.</translation>
+    </message>
+    <message>
+        <source>New key generation failed.</source>
+        <translation type="unfinished">Ang Bagong susi sa ♦generation♦ ay nabigo.</translation>
+    </message>
+</context>
+<context>
+    <name>FreespaceChecker</name>
+    <message>
+        <source>A new data directory will be created.</source>
+        <translation>May bagong datos na ♦directory♦ ay magagawa.</translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation>pangalan</translation>
+    </message>
+    <message>
+        <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
+        <translation>Ang ♦directory♦ ay mayroon na. Magdagdag ng%1kung balak mong gumawa ng bagong ♦directory♦ dito.</translation>
+    </message>
+    <message>
+        <source>Path already exists, and is not a directory.</source>
+        <translation>Ang ♦path♦ ay mayroon na, at hindi ♦directory♦.</translation>
+    </message>
+    <message>
+        <source>Cannot create data directory here.</source>
+        <translation>Hindi makakagawa ng datos na ♦directory♦ dito.</translation>
+    </message>
+</context>
+<context>
+    <name>Intro</name>
+    <message>
+        <source>Bitcoin</source>
+        <translation type="unfinished">♦Bitcoin♦</translation>
+    </message>
+    <message>
+        <source>%1 GB of free space available</source>
+        <translation type="unfinished">%1Mayroon ng ♦GB♦ ng libreng espasyo</translation>
+    </message>
+    <message>
+        <source>(of %1 GB needed)</source>
+        <translation type="unfinished">(ng %1♦GB♦ na kailangan)</translation>
+    </message>
+    <message>
+        <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
+        <translation type="unfinished">Hindi bababa sa %1 ng ♦GB♦ na dato ay mailalagay sa ♦directory♦, at lalaki sa paglipas ng panahon.</translation>
+    </message>
+    <message numerus="yes">
+        <source>(sufficient to restore backups %n day(s) old)</source>
+        <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    </context>
+<context>
+    <name>OptionsDialog</name>
+    <message>
+        <source>&amp;Main</source>
+        <translation>&amp;♦Main♦</translation>
+    </message>
+    <message>
+        <source>&amp;Start %1 on system login</source>
+        <translation type="unfinished">&amp;Simulan %1 sa pag-login sa sistema</translation>
+    </message>
+    <message>
+        <source>Size of &amp;database cache</source>
+        <translation type="unfinished">Laki ng &amp;♦database cache♦</translation>
+    </message>
+    <message>
+        <source>Number of script &amp;verification threads</source>
+        <translation type="unfinished">Bilang ng ♦script♦ &amp;pagpapatunay na mga ♦threads♦</translation>
+    </message>
+    <message>
+        <source>&amp;Reset Options</source>
+        <translation>Mga pagpipilian sa &amp;Pag-reset</translation>
+    </message>
+    <message>
+        <source>&amp;Network</source>
+        <translation>&amp;♦Network♦</translation>
+    </message>
+    <message>
+        <source>Prune &amp;block storage to</source>
+        <translation type="unfinished">Putulan &amp;i-block ang imbakan sa</translation>
+    </message>
+    <message>
+        <source>W&amp;allet</source>
+        <translation type="unfinished">&amp;Pitaka</translation>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation type="unfinished">I-enable ang pag-control na mga tampok ng ♦coin♦ </translation>
+    </message>
+    <message>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation type="unfinished">&amp;Gumastos ng hindi nakumpirmang pagbabago</translation>
+    </message>
+    <message>
+        <source>&amp;External signer script path</source>
+        <translation type="unfinished">&amp;Panlabas na ♦signer script♦ na daanan</translation>
+    </message>
+    <message>
+        <source>Map port using &amp;UPnP</source>
+        <translation>♦Port♦ ng mapa gamit ang &amp;♦UPnP♦</translation>
+    </message>
+    <message>
+        <source>Map port using NA&amp;T-PMP</source>
+        <translation type="unfinished">♦Port♦ ng mapa gamit ang NA&amp;T-PMP</translation>
+    </message>
+    <message>
+        <source>Allow incomin&amp;g connections</source>
+        <translation type="unfinished">Pahintulutan ang paparating na mga &amp;koneksyon</translation>
+    </message>
+    <message>
+        <source>&amp;Connect through SOCKS5 proxy (default proxy):</source>
+        <translation type="unfinished">&amp;Kumonketa sa pamamagitan ng ♦SOCKS5 proxy (default proxy)♦:</translation>
+    </message>
+    <message>
+        <source>&amp;Window</source>
+        <translation>&amp;♦Window♦</translation>
+    </message>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Pinagsama-sama na walang suporta ng ♦pag-pirma♦ (kailangan para sa panlabasna pagpirma)</translation>
+    </message>
+    </context>
+<context>
+    <name>PeerTableModel</name>
+    <message>
+        <source>Address</source>
+        <extracomment>Title of Peers Table column which contains the IP/Onion/I2P address of the connected peer.</extracomment>
+        <translation type="unfinished">♦Address♦</translation>
+    </message>
+    </context>
+<context>
+    <name>RPCConsole</name>
+    <message>
+        <source>Node window</source>
+        <translation type="unfinished">♦Node window♦</translation>
+    </message>
+    </context>
+<context>
+    <name>ReceiveCoinsDialog</name>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Kopyahin ang ♦address♦</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">&amp;Kopyahin ang &amp;tatak</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Kopyahin ang &amp;halaga</translation>
+    </message>
+    <message>
+        <source>Could not unlock wallet.</source>
+        <translation type="unfinished">Hindi maaaring ma-unlock ang pitaka.</translation>
+    </message>
+    </context>
+<context>
+    <name>ReceiveRequestDialog</name>
+    <message>
+        <source>Amount:</source>
+        <translation type="unfinished">Halaga:</translation>
+    </message>
+    <message>
+        <source>Wallet:</source>
+        <translation type="unfinished">Pitaka:</translation>
+    </message>
+    </context>
+<context>
+    <name>RecentRequestsTableModel</name>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">Petsa</translation>
+    </message>
+    <message>
+        <source>Label</source>
+        <translation type="unfinished">♦Label♦</translation>
+    </message>
+    <message>
+        <source>(no label)</source>
+        <translation type="unfinished">(walang tatak)</translation>
+    </message>
+    </context>
+<context>
+    <name>SendCoinsDialog</name>
+    <message>
+        <source>Quantity:</source>
+        <translation type="unfinished">Dami:</translation>
+    </message>
+    <message>
+        <source>Bytes:</source>
+        <translation type="unfinished">♦Bytes♦:</translation>
+    </message>
+    <message>
+        <source>Amount:</source>
+        <translation type="unfinished">Halaga:</translation>
+    </message>
+    <message>
+        <source>Fee:</source>
+        <translation type="unfinished">Bayad:</translation>
+    </message>
+    <message>
+        <source>After Fee:</source>
+        <translation type="unfinished">Pagkatapos na Bayad:</translation>
+    </message>
+    <message>
+        <source>Change:</source>
+        <translation type="unfinished">Sukli:</translation>
+    </message>
+    <message>
+        <source>Dust:</source>
+        <translation type="unfinished">Alikabok:</translation>
+    </message>
+    <message>
+        <source>Copy quantity</source>
+        <translation type="unfinished">Kopyahin ang dami</translation>
+    </message>
+    <message>
+        <source>Copy amount</source>
+        <translation type="unfinished">Kopyahin ang halaga</translation>
+    </message>
+    <message>
+        <source>Copy fee</source>
+        <translation type="unfinished">Bayad sa pagkopya</translation>
+    </message>
+    <message>
+        <source>Copy after fee</source>
+        <translation type="unfinished">Kopyahin pagkatapos ang bayad</translation>
+    </message>
+    <message>
+        <source>Copy bytes</source>
+        <translation type="unfinished">Kopyahin ang ♦bytes♦</translation>
+    </message>
+    <message>
+        <source>Copy dust</source>
+        <translation type="unfinished">Kopyahin ang ♦dust♦</translation>
+    </message>
+    <message>
+        <source>Copy change</source>
+        <translation type="unfinished">Kopyahin ang pagbabago</translation>
+    </message>
+    <message numerus="yes">
+        <source>Estimated to begin confirmation within %n block(s).</source>
+        <translation>
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message>
+        <source>(no label)</source>
+        <translation type="unfinished">(walang tatak)</translation>
+    </message>
+</context>
+<context>
+    <name>TransactionDesc</name>
+    <message numerus="yes">
+        <source>Open for %n more block(s)</source>
+        <translation>
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">Petsa</translation>
+    </message>
+    <message numerus="yes">
+        <source>matures in %n more block(s)</source>
+        <translation>
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message>
+        <source>Amount</source>
+        <translation type="unfinished">Halaga</translation>
+    </message>
+    </context>
+<context>
+    <name>TransactionTableModel</name>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">Petsa</translation>
+    </message>
+    <message>
+        <source>Label</source>
+        <translation type="unfinished">♦Label♦</translation>
+    </message>
+    <message numerus="yes">
+        <source>Open for %n more block(s)</source>
+        <translation>
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message>
+        <source>(no label)</source>
+        <translation type="unfinished">(walang tatak)</translation>
+    </message>
+    </context>
+<context>
+    <name>TransactionView</name>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Kopyahin ang ♦address♦</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">&amp;Kopyahin ang &amp;tatak</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Kopyahin ang &amp;halaga</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">Kopyahin ang transaksyon  ng &amp;♦ID♦</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See https://en.wikipedia.org/wiki/Comma-separated_values</extracomment>
+        <translation type="unfinished">Comma hiwalay na file</translation>
+    </message>
+    <message>
+        <source>Confirmed</source>
+        <translation type="unfinished">Nakumpirma</translation>
+    </message>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">Petsa</translation>
+    </message>
+    <message>
+        <source>Label</source>
+        <translation type="unfinished">♦Label♦</translation>
+    </message>
+    <message>
+        <source>Address</source>
+        <translation type="unfinished">♦Address♦</translation>
+    </message>
+    <message>
+        <source>Exporting Failed</source>
+        <translation type="unfinished">Ang pag-export ay Nabigo</translation>
+    </message>
+    </context>
+<context>
+    <name>WalletFrame</name>
+    <message>
+        <source>Create a new wallet</source>
+        <translation type="unfinished">Gumawa ng bagong pitaka</translation>
+    </message>
+</context>
+<context>
+    <name>WalletModel</name>
+    <message>
+        <source>default wallet</source>
+        <translation type="unfinished">pitaka na ♦default♦</translation>
+    </message>
+</context>
+<context>
+    <name>WalletView</name>
+    <message>
+        <source>&amp;Export</source>
+        <translation type="unfinished">&amp;I-export</translation>
+    </message>
+    <message>
+        <source>Export the data in the current tab to a file</source>
+        <translation type="unfinished">I-export ang datos sa kasalukuyang tab sa isang file</translation>
+    </message>
+    </context>
+</TS>

--- a/src/qt/locale/bitcoin_tr.ts
+++ b/src/qt/locale/bitcoin_tr.ts
@@ -27,7 +27,7 @@
     </message>
     <message>
         <source>Delete the currently selected address from the list</source>
-        <translation>Seçili adesi listeden silin</translation>
+        <translation>Seçili adresi listeden silin</translation>
     </message>
     <message>
         <source>Enter address or label to search</source>
@@ -51,7 +51,7 @@
     </message>
     <message>
         <source>Choose the address to receive coins with</source>
-        <translation type="unfinished">Bitcoinleri alacağınız adresi seçin</translation>
+        <translation type="unfinished">Coinleri alacağınız adresi seçin</translation>
     </message>
     <message>
         <source>C&amp;hoose</source>
@@ -150,7 +150,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
-        <translation type="unfinished">Bu işlemi yapabilmek için cüzdan parolanızı girmeniz gerekmektedir
+        <translation type="unfinished">kilidi açmakparolaBu işlemi yapabilmek için cüzdan parolanızı girmeniz gerekmektedir
 Cüzdan kilidini aç.</translation>
     </message>
     <message>
@@ -297,6 +297,10 @@ Cüzdan kilidini aç.</translation>
     <message>
         <source>Outbound</source>
         <translation type="unfinished">yurt dışı</translation>
+    </message>
+    <message>
+        <source>Manual</source>
+        <translation type="unfinished">Manuel</translation>
     </message>
     <message>
         <source>%1 d</source>
@@ -496,7 +500,7 @@ Cüzdan kilidini aç.</translation>
     </message>
     <message>
         <source>Load PSBT from clipboard…</source>
-        <translation type="unfinished">PBT'yi panodan yükle...</translation>
+        <translation type="unfinished">PSBT'yi panodan yükle...</translation>
     </message>
     <message>
         <source>Open &amp;URI…</source>
@@ -531,6 +535,10 @@ Cüzdan kilidini aç.</translation>
         <translation>Araç çubuğu sekmeleri</translation>
     </message>
     <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation type="unfinished">Başlıklar senkronize ediliyor (%1%)...</translation>
+    </message>
+    <message>
         <source>Synchronizing with network…</source>
         <translation type="unfinished">Ağ ile senkronize ediliyor...</translation>
     </message>
@@ -557,7 +565,7 @@ Cüzdan kilidini aç.</translation>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation>
-            <numerusform />
+            <numerusform>Processed %n block of transaction history.</numerusform>
         </translation>
     </message>
     <message>
@@ -672,13 +680,23 @@ Cüzdan kilidini aç.</translation>
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n active connection(s) to Bitcoin network.</numerusform>
         </translation>
     </message>
     <message>
         <source>Click for more actions.</source>
         <extracomment>A substring of the tooltip. "More actions" are available via the context menu.</extracomment>
         <translation type="unfinished">daha fazla seçenek için tıklayın.</translation>
+    </message>
+    <message>
+        <source>Disable network activity</source>
+        <extracomment>A context menu item.</extracomment>
+        <translation type="unfinished">Ağ etkinliğini devre dışı bırak</translation>
+    </message>
+    <message>
+        <source>Enable network activity</source>
+        <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
+        <translation type="unfinished">Ağ etkinliğini etkinleştir</translation>
     </message>
     <message>
         <source>Error: %1</source>
@@ -767,10 +785,6 @@ Cüzdan kilidini aç.</translation>
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <source>Coin Selection</source>
-        <translation type="unfinished">Koin Seçimi</translation>
-    </message>
-    <message>
         <source>Quantity:</source>
         <translation type="unfinished">Miktar</translation>
     </message>
@@ -839,6 +853,18 @@ Cüzdan kilidini aç.</translation>
         <translation type="unfinished">Miktar kopyala</translation>
     </message>
     <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Adresi kopyala</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">&amp;etiketi kopyala</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">&amp;miktarı kopyala</translation>
+    </message>
+    <message>
         <source>Copy quantity</source>
         <translation type="unfinished">Miktarı kopyala</translation>
     </message>
@@ -899,6 +925,10 @@ Cüzdan kilidini aç.</translation>
 <context>
     <name>CreateWalletActivity</name>
     <message>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation type="unfinished">Cüzdan oluşturuluyor&lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+    <message>
         <source>Create wallet failed</source>
         <translation type="unfinished">Cüzdan oluşturma başarısız</translation>
     </message>
@@ -921,7 +951,11 @@ Cüzdan kilidini aç.</translation>
         <source>default wallet</source>
         <translation type="unfinished">varsayılan cüzdan</translation>
     </message>
-    </context>
+    <message>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation type="unfinished">Cüzdan açılıyor&lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+</context>
 <context>
     <name>WalletController</name>
     <message>
@@ -1084,7 +1118,7 @@ Cüzdan kilidini aç.</translation>
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>(sufficient to restore backups %n day(s) old)</numerusform>
         </translation>
     </message>
     <message>
@@ -1335,6 +1369,10 @@ Cüzdan kilidini aç.</translation>
         <translation>&amp;Pencere</translation>
     </message>
     <message>
+        <source>&amp;Show tray icon</source>
+        <translation type="unfinished">Simgeyi &amp;Göster </translation>
+    </message>
+    <message>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation>Küçültüldükten sonra sadece tepsi simgesi göster.</translation>
     </message>
@@ -1549,6 +1587,10 @@ Cüzdan kilidini aç.</translation>
         <translation type="unfinished">İşlem imzalandı ve ağa duyurulmaya hazır.</translation>
     </message>
     <message>
+        <source>Unknown error processing transaction.</source>
+        <translation type="unfinished">İşlem sürerken bilinmeyen bir hata oluştu.</translation>
+    </message>
+    <message>
         <source>Transaction broadcast successfully! Transaction ID: %1</source>
         <translation type="unfinished">İşlem ağa duyuruldu! İşlem kodu: %1</translation>
     </message>
@@ -1565,6 +1607,10 @@ Cüzdan kilidini aç.</translation>
         <translation type="unfinished">PSBT diske kaydedildi.</translation>
     </message>
     <message>
+        <source>Unable to calculate transaction fee or total transaction amount.</source>
+        <translation type="unfinished">İşlem ücretini veya toplam işlem miktarını hesaplayamıyor.</translation>
+    </message>
+    <message>
         <source>Pays transaction fee: </source>
         <translation type="unfinished">İşlem ücreti:&lt;br&gt;</translation>
     </message>
@@ -1573,8 +1619,20 @@ Cüzdan kilidini aç.</translation>
         <translation type="unfinished">veya</translation>
     </message>
     <message>
+        <source>Transaction is missing some information about inputs.</source>
+        <translation type="unfinished">İşlem girdileri hakkında bazı bilgiler eksik. </translation>
+    </message>
+    <message>
         <source>Transaction still needs signature(s).</source>
         <translation type="unfinished">İşlemin hala imza(lar)a ihtiyacı var.</translation>
+    </message>
+    <message>
+        <source>(But this wallet cannot sign transactions.)</source>
+        <translation type="unfinished">(Ancak bu cüzdan işlemleri imzalayamaz.)</translation>
+    </message>
+    <message>
+        <source>Transaction is fully signed and ready for broadcast.</source>
+        <translation type="unfinished">İşlem tamamen imzalandı ve yayın için hazır.</translation>
     </message>
     <message>
         <source>Transaction status is unknown.</source>
@@ -2032,6 +2090,22 @@ Cüzdan kilidini aç.</translation>
         <translation type="unfinished">&amp;URI'yi Kopyala</translation>
     </message>
     <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Adresi kopyala</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">&amp;etiketi kopyala</translation>
+    </message>
+    <message>
+        <source>Copy &amp;message</source>
+        <translation type="unfinished">&amp;mesajı kopyala</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">&amp;miktarı kopyala</translation>
+    </message>
+    <message>
         <source>Could not unlock wallet.</source>
         <translation type="unfinished">Cüzdanın kilidi açılamadı.</translation>
     </message>
@@ -2065,6 +2139,10 @@ Cüzdan kilidini aç.</translation>
     <message>
         <source>Copy &amp;Address</source>
         <translation type="unfinished">&amp;Adresi Kopyala</translation>
+    </message>
+    <message>
+        <source>&amp;Verify</source>
+        <translation type="unfinished">&amp;Onayla</translation>
     </message>
     <message>
         <source>&amp;Save Image…</source>
@@ -2270,8 +2348,16 @@ Cüzdan kilidini aç.</translation>
         <translation type="unfinished">%1 den %2'ye</translation>
     </message>
     <message>
+        <source>Do you want to draft this transaction?</source>
+        <translation type="unfinished">Bu işlemi taslak yapmak ister misiniz?</translation>
+    </message>
+    <message>
         <source>Are you sure you want to send?</source>
         <translation type="unfinished">Göndermek istediğinizden emin misiniz?</translation>
+    </message>
+    <message>
+        <source>Create Unsigned</source>
+        <translation type="unfinished">İmzasız Oluştur</translation>
     </message>
     <message>
         <source>Sign failed</source>
@@ -2300,6 +2386,10 @@ Cüzdan kilidini aç.</translation>
     <message>
         <source>Confirm send coins</source>
         <translation type="unfinished">Bitcoin gönderimini onaylayın</translation>
+    </message>
+    <message>
+        <source>Confirm transaction proposal</source>
+        <translation type="unfinished">İşlem teklifini onaylayın</translation>
     </message>
     <message>
         <source>The recipient address is not valid. Please recheck.</source>
@@ -2336,7 +2426,7 @@ Cüzdan kilidini aç.</translation>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation>
-            <numerusform />
+            <numerusform>Estimated to begin confirmation within %n block.</numerusform>
         </translation>
     </message>
     <message>
@@ -2498,6 +2588,10 @@ Cüzdan kilidini aç.</translation>
         <translation type="unfinished">İletinin imzalanmasında kullanılan Bitcoin adresi</translation>
     </message>
     <message>
+        <source>The signed message to verify</source>
+        <translation type="unfinished">Doğrulamak için imzalanmış mesaj</translation>
+    </message>
+    <message>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation>Belirtilen Bitcoin adresi ile imzalandığını doğrulamak için iletiyi kontrol et</translation>
     </message>
@@ -2571,7 +2665,7 @@ Cüzdan kilidini aç.</translation>
     <message numerus="yes">
         <source>Open for %n more block(s)</source>
         <translation>
-            <numerusform />
+            <numerusform>Open for %n more block</numerusform>
         </translation>
     </message>
     <message>
@@ -2653,7 +2747,7 @@ Cüzdan kilidini aç.</translation>
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation>
-            <numerusform />
+            <numerusform>matures in %n more block</numerusform>
         </translation>
     </message>
     <message>
@@ -2695,6 +2789,10 @@ Cüzdan kilidini aç.</translation>
     <message>
         <source>Transaction total size</source>
         <translation type="unfinished">İşlemin toplam boyutu</translation>
+    </message>
+    <message>
+        <source>Transaction virtual size</source>
+        <translation type="unfinished">İşlemin sanal boyutu</translation>
     </message>
     <message>
         <source>Output index</source>
@@ -2765,7 +2863,7 @@ Cüzdan kilidini aç.</translation>
     <message numerus="yes">
         <source>Open for %n more block(s)</source>
         <translation>
-            <numerusform />
+            <numerusform>Open for %n more block</numerusform>
         </translation>
     </message>
     <message>
@@ -2916,6 +3014,18 @@ Cüzdan kilidini aç.</translation>
         <translation type="unfinished">Aralık...</translation>
     </message>
     <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Adresi kopyala</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">&amp;etiketi kopyala</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">&amp;miktarı kopyala</translation>
+    </message>
+    <message>
         <source>Export Transaction History</source>
         <translation type="unfinished">İşlem Tarihçesini Dışarı Aktar</translation>
     </message>
@@ -2987,6 +3097,10 @@ Cüzdan kilidini aç.</translation>
         <translation type="unfinished">Bitcoini Gönder</translation>
     </message>
     <message>
+        <source>Fee bump error</source>
+        <translation type="unfinished">Ücret yükselişi hatası</translation>
+    </message>
+    <message>
         <source>Increasing transaction fee failed</source>
         <translation type="unfinished">İşlem ücreti artırma başarısız oldu</translation>
     </message>
@@ -3036,6 +3150,10 @@ Cüzdan kilidini aç.</translation>
     <message>
         <source>Error</source>
         <translation type="unfinished">Hata</translation>
+    </message>
+    <message>
+        <source>Load Transaction Data</source>
+        <translation type="unfinished">İşlem Verilerini Yükle</translation>
     </message>
     <message>
         <source>Backup Wallet</source>
@@ -3224,6 +3342,10 @@ Cüzdan kilidini aç.</translation>
     <message>
         <source>Failed to rescan the wallet during initialization</source>
         <translation type="unfinished">Başlatma sırasında cüzdanı yeniden tarama işlemi başarısız oldu</translation>
+    </message>
+    <message>
+        <source>Failed to verify database</source>
+        <translation type="unfinished">Veritabanı doğrulanamadı</translation>
     </message>
     <message>
         <source>Importing…</source>

--- a/src/qt/locale/bitcoin_ug.ts
+++ b/src/qt/locale/bitcoin_ug.ts
@@ -163,6 +163,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
             <numerusform />
         </translation>
     </message>
+    <message>
+        <source>Error</source>
+        <translation>خاتالىق</translation>
+    </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
@@ -180,6 +184,13 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     </context>
 <context>
+    <name>EditAddressDialog</name>
+    <message>
+        <source>&amp;Label</source>
+        <translation>&amp;خەتكۈچ</translation>
+    </message>
+    </context>
+<context>
     <name>Intro</name>
     <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
@@ -188,6 +199,17 @@ Signing is only possible with addresses of the type 'legacy'.</source>
             <numerusform />
             <numerusform />
         </translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation>خاتالىق</translation>
+    </message>
+    </context>
+<context>
+    <name>OptionsDialog</name>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">خاتالىق</translation>
     </message>
     </context>
 <context>
@@ -261,6 +283,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>TransactionView</name>
     <message>
+        <source>Other</source>
+        <translation type="unfinished">باشقىلىرى</translation>
+    </message>
+    <message>
         <source>Comma separated file</source>
         <extracomment>Expanded name of the CSV file format. See https://en.wikipedia.org/wiki/Comma-separated_values</extracomment>
         <translation type="unfinished">ھۆججەت پەش بىلەن ئايرىلىدۇ</translation>
@@ -287,6 +313,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished">نۆۋەتتىكى بەتكۈچتىكى سانلىق مەلۇماتنى ھۆججەتكە چىقىرىدۇ</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">خاتالىق</translation>
     </message>
     </context>
 </TS>

--- a/src/qt/locale/bitcoin_ur.ts
+++ b/src/qt/locale/bitcoin_ur.ts
@@ -284,8 +284,28 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">%1ابھی تک سلامتی سے باہر نہیں نکلا…</translation>
     </message>
     <message>
+        <source>unknown</source>
+        <translation type="unfinished">نامعلوم</translation>
+    </message>
+    <message>
         <source>Amount</source>
         <translation type="unfinished">رقم</translation>
+    </message>
+    <message>
+        <source>Unroutable</source>
+        <translation type="unfinished">ناقابل استعمال</translation>
+    </message>
+    <message>
+        <source>Internal</source>
+        <translation type="unfinished">اندرونی</translation>
+    </message>
+    <message>
+        <source>Address Fetch</source>
+        <translation type="unfinished">پتہ بازیافت کریں۔</translation>
+    </message>
+    <message>
+        <source>%1 ms</source>
+        <translation type="unfinished">ملی سیکنڈز %1</translation>
     </message>
     <message numerus="yes">
         <source>%n second(s)</source>
@@ -465,6 +485,70 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Close Wallet…</source>
         <translation type="unfinished">پرس بند کریں…</translation>
     </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation type="unfinished">والیٹ بنائیں…</translation>
+    </message>
+    <message>
+        <source>Close All Wallets…</source>
+        <translation type="unfinished">تمام والیٹس بند کردیں</translation>
+    </message>
+    <message>
+        <source>&amp;File</source>
+        <translation>اور فائل</translation>
+    </message>
+    <message>
+        <source>&amp;Settings</source>
+        <translation>اور ترتیبات</translation>
+    </message>
+    <message>
+        <source>&amp;Help</source>
+        <translation>اور مدد</translation>
+    </message>
+    <message>
+        <source>Tabs toolbar</source>
+        <translation>ٹیبز ٹول بار</translation>
+    </message>
+    <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation type="unfinished"> '%1%' ہیڈرز کی مطابقت پذیری</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation type="unfinished">نیٹ ورک کے ساتھ ہم آہنگ ہو کر</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation type="unfinished">ڈسک پر بلاکس کو ترتیب دینا</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation type="unfinished">ڈسک پر بلاکس کو پراسیس کرنا</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation type="unfinished">ڈسک پر بلاکس کو دوبارہ ترتیب دینا</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation type="unfinished">ساتھیوں سے منسلک کرنے</translation>
+    </message>
+    <message>
+        <source>Request payments (generates QR codes and bitcoin: URIs)</source>
+        <translation type="unfinished">ادائیگی کی درخواست کریں: ( کوئیک رسپانس ( کیو۔آر ) کوڈ اور بٹ کوائن ( یونیورسل ادائیگیوں کا نظام) کے ذریعے سے</translation>
+    </message>
+    <message>
+        <source>Show the list of used sending addresses and labels</source>
+        <translation type="unfinished">استعمال شدہ بھیجنے والے پتے اور لیبلز کی فہرست دکھائیں۔</translation>
+    </message>
+    <message>
+        <source>Show the list of used receiving addresses and labels</source>
+        <translation type="unfinished">استعمال شدہ وصول کرنے والے پتوں اور لیبلز کی فہرست دکھائیں۔</translation>
+    </message>
+    <message>
+        <source>&amp;Command-line options</source>
+        <translation type="unfinished">اور کمانڈ لائن اختیارات</translation>
+    </message>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation>
@@ -473,8 +557,120 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         </translation>
     </message>
     <message>
+        <source>%1 behind</source>
+        <translation>'%1'پیچھے</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation type="unfinished">پکڑنا</translation>
+    </message>
+    <message>
+        <source>Last received block was generated %1 ago.</source>
+        <translation>آخری موصول شدہ 1 '%1' پہلے تیار کیا گیا تھا۔</translation>
+    </message>
+    <message>
+        <source>Transactions after this will not yet be visible.</source>
+        <translation>اس کے بعد کی لین دین ابھی نظر نہیں آئے گی۔</translation>
+    </message>
+    <message>
         <source>Error</source>
         <translation>نقص</translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation>انتباہ</translation>
+    </message>
+    <message>
+        <source>Information</source>
+        <translation>معلومات</translation>
+    </message>
+    <message>
+        <source>Up to date</source>
+        <translation>سب سے نیا</translation>
+    </message>
+    <message>
+        <source>Load Partially Signed Bitcoin Transaction</source>
+        <translation type="unfinished">جزوی طور پر دستخط شدہ بٹ کوائن ٹرانزیکشن لوڈ کریں۔</translation>
+    </message>
+    <message>
+        <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
+        <translation type="unfinished">کلپ بورڈ سے جزوی طور پر دستخط شدہ بٹ کوائن ٹرانزیکشن لوڈ کریں۔</translation>
+    </message>
+    <message>
+        <source>Node window</source>
+        <translation type="unfinished">نوڈ ونڈو</translation>
+    </message>
+    <message>
+        <source>Open node debugging and diagnostic console</source>
+        <translation type="unfinished">نوڈ ڈیبگنگ اور تشخیصی کنسول کھولیں۔</translation>
+    </message>
+    <message>
+        <source>&amp;Sending addresses</source>
+        <translation type="unfinished">اور بھیجنے والے پتے</translation>
+    </message>
+    <message>
+        <source>&amp;Receiving addresses</source>
+        <translation type="unfinished">اور پتے وصول کرنا</translation>
+    </message>
+    <message>
+        <source>Open a bitcoin: URI</source>
+        <translation type="unfinished">بٹ کوائن کا یو۔آر۔آئی۔ کھولیں</translation>
+    </message>
+    <message>
+        <source>Open Wallet</source>
+        <translation type="unfinished">والیٹ کھولیں</translation>
+    </message>
+    <message>
+        <source>Open a wallet</source>
+        <translation type="unfinished">والیٹ کھولیں</translation>
+    </message>
+    <message>
+        <source>Close wallet</source>
+        <translation type="unfinished">والیٹ بند کریں</translation>
+    </message>
+    <message>
+        <source>Close all wallets</source>
+        <translation type="unfinished">تمام والیٹس بند کریں</translation>
+    </message>
+    <message>
+        <source>Show the %1 help message to get a list with possible Bitcoin command-line options</source>
+        <translation type="unfinished">ممکنہ بٹ کوائن کمانڈ لائن اختیارات کے ساتھ فہرست حاصل کرنے کے لیے %1 مدد کا پیغام دکھائیں۔</translation>
+    </message>
+    <message>
+        <source>&amp;Mask values</source>
+        <translation type="unfinished">قدروں کو چھپائیں</translation>
+    </message>
+    <message>
+        <source>Mask the values in the Overview tab</source>
+        <translation type="unfinished">جائزہ ٹیب میں اقدار کو ماسک کریں۔</translation>
+    </message>
+    <message>
+        <source>default wallet</source>
+        <translation type="unfinished">پہلے سے طے شدہ والیٹ</translation>
+    </message>
+    <message>
+        <source>No wallets available</source>
+        <translation type="unfinished">کوئی والیٹ دستیاب نہیں ہیں۔</translation>
+    </message>
+    <message>
+        <source>&amp;Window</source>
+        <translation type="unfinished">اور ونڈو</translation>
+    </message>
+    <message>
+        <source>Minimize</source>
+        <translation type="unfinished">کم سے کم کرنا</translation>
+    </message>
+    <message>
+        <source>Zoom</source>
+        <translation type="unfinished">بغور جائزہ لینا</translation>
+    </message>
+    <message>
+        <source>Main Window</source>
+        <translation type="unfinished">مین ونڈو</translation>
+    </message>
+    <message>
+        <source>%1 client</source>
+        <translation type="unfinished">'%1'کلائنٹ</translation>
     </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
@@ -485,42 +681,449 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         </translation>
     </message>
     <message>
+        <source>Click for more actions.</source>
+        <extracomment>A substring of the tooltip. "More actions" are available via the context menu.</extracomment>
+        <translation type="unfinished">مزید کارروائی کے لیے کلک کریں۔</translation>
+    </message>
+    <message>
+        <source>Show Peers tab</source>
+        <extracomment>A context menu item. The "Peers tab" is an element of the "Node window".</extracomment>
+        <translation type="unfinished">پیئرز ٹیب دکھائیں۔</translation>
+    </message>
+    <message>
+        <source>Disable network activity</source>
+        <extracomment>A context menu item.</extracomment>
+        <translation type="unfinished">نیٹ ورک کی سرگرمی کو غیر فعال کریں۔</translation>
+    </message>
+    <message>
+        <source>Enable network activity</source>
+        <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
+        <translation type="unfinished">نیٹ ورک کی سرگرمی کو فعال کریں۔</translation>
+    </message>
+    <message>
         <source>Error: %1</source>
         <translation type="unfinished">خرابی:%1</translation>
     </message>
-    </context>
+    <message>
+        <source>Warning: %1</source>
+        <translation type="unfinished">1%1 انتباہ</translation>
+    </message>
+    <message>
+        <source>Date: %1
+</source>
+        <translation type="unfinished">1%1' تاریخ۔
+</translation>
+    </message>
+    <message>
+        <source>Amount: %1
+</source>
+        <translation type="unfinished">1%1' مقدار
+</translation>
+    </message>
+    <message>
+        <source>Wallet: %1
+</source>
+        <translation type="unfinished">1%1' والیٹ
+</translation>
+    </message>
+    <message>
+        <source>Type: %1
+</source>
+        <translation type="unfinished">1 %1'قسم
+</translation>
+    </message>
+    <message>
+        <source>Label: %1
+</source>
+        <translation type="unfinished">1%1'لیبل
+</translation>
+    </message>
+    <message>
+        <source>Address: %1
+</source>
+        <translation type="unfinished">1%1' پتہ
+</translation>
+    </message>
+    <message>
+        <source>Sent transaction</source>
+        <translation>بھیجی گئی ٹرانزیکشن</translation>
+    </message>
+    <message>
+        <source>Incoming transaction</source>
+        <translation>آنے والی ٹرانزیکشن</translation>
+    </message>
+    <message>
+        <source>HD key generation is &lt;b&gt;enabled&lt;/b&gt;</source>
+        <translation type="unfinished">درجہ بندی کا تعین کرنے والی ایچ۔ڈی کلیدی جنریشن &lt;b&gt;فعال&lt;/b&gt; ہے</translation>
+    </message>
+    <message>
+        <source>HD key generation is &lt;b&gt;disabled&lt;/b&gt;</source>
+        <translation type="unfinished">درجہ بندی کا تعین کرنے والی ایچ۔ ڈی کلیدی جنریشن&lt;b&gt; غیر فعال&lt;/b&gt; ہے</translation>
+    </message>
+    <message>
+        <source>Private key &lt;b&gt;disabled&lt;/b&gt;</source>
+        <translation type="unfinished">نجی کلید &lt;b&gt;غیر فعال &lt;b/&gt;ہے۔</translation>
+    </message>
+    <message>
+        <source>Original message:</source>
+        <translation type="unfinished">اصل پیغام:</translation>
+    </message>
+</context>
+<context>
+    <name>UnitDisplayStatusBarControl</name>
+    <message>
+        <source>Unit to show amounts in. Click to select another unit.</source>
+        <translation type="unfinished">رقم ظاہر کرنے کے لیے یونٹ۔ دوسری اکائی کو منتخب کرنے کے لیے کلک کریں۔</translation>
+    </message>
+</context>
 <context>
     <name>CoinControlDialog</name>
     <message>
+        <source>Coin Selection</source>
+        <translation type="unfinished">سکے کا انتخاب</translation>
+    </message>
+    <message>
+        <source>Quantity:</source>
+        <translation type="unfinished">مقدار:</translation>
+    </message>
+    <message>
+        <source>Bytes:</source>
+        <translation type="unfinished">بائٹس:</translation>
+    </message>
+    <message>
         <source>Amount:</source>
         <translation type="unfinished">رقم:</translation>
+    </message>
+    <message>
+        <source>Fee:</source>
+        <translation type="unfinished">فیس:</translation>
+    </message>
+    <message>
+        <source>Dust:</source>
+        <translation type="unfinished">نہ ہونے کے برابر</translation>
+    </message>
+    <message>
+        <source>After Fee:</source>
+        <translation type="unfinished">فیس کے بعد:</translation>
+    </message>
+    <message>
+        <source>Change:</source>
+        <translation type="unfinished">تبدیلی:</translation>
+    </message>
+    <message>
+        <source>(un)select all</source>
+        <translation type="unfinished">سب کو غیر منتخب کریں</translation>
+    </message>
+    <message>
+        <source>Tree mode</source>
+        <translation type="unfinished">ٹری موڈ</translation>
+    </message>
+    <message>
+        <source>List mode</source>
+        <translation type="unfinished">فہرست موڈ</translation>
     </message>
     <message>
         <source>Amount</source>
         <translation type="unfinished">رقم</translation>
     </message>
     <message>
+        <source>Received with label</source>
+        <translation type="unfinished">لیبل کے ساتھ موصول ہوا۔</translation>
+    </message>
+    <message>
+        <source>Received with address</source>
+        <translation type="unfinished">پتے کے ساتھ موصول ہوا۔</translation>
+    </message>
+    <message>
         <source>Date</source>
         <translation type="unfinished">تاریخ</translation>
+    </message>
+    <message>
+        <source>Confirmations</source>
+        <translation type="unfinished">تصدیقات</translation>
+    </message>
+    <message>
+        <source>Confirmed</source>
+        <translation type="unfinished">تصدیق شدہ</translation>
+    </message>
+    <message>
+        <source>Copy amount</source>
+        <translation type="unfinished">رقم کاپی کریں۔</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">ایڈریس کاپی کریں۔</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">کاپی اور لیبل</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">کاپی اور رقم</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">لین دین اور شناخت کی تفصیلات(ID) کاپی کریں۔</translation>
+    </message>
+    <message>
+        <source>L&amp;ock unspent</source>
+        <translation type="unfinished">غیر خرچ شدہ آؤٹ پٹ بند کریں</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock unspent</source>
+        <translation type="unfinished">غیر خرچ شدہ کھولیں</translation>
+    </message>
+    <message>
+        <source>Copy quantity</source>
+        <translation type="unfinished">مقدار کاپی کریں</translation>
+    </message>
+    <message>
+        <source>Copy fee</source>
+        <translation type="unfinished">فیس کاپی کریں</translation>
+    </message>
+    <message>
+        <source>Copy after fee</source>
+        <translation type="unfinished">فیس کے بعد کاپی کریں۔</translation>
+    </message>
+    <message>
+        <source>Copy bytes</source>
+        <translation type="unfinished">بائٹس کاپی کریں</translation>
+    </message>
+    <message>
+        <source>Copy dust</source>
+        <translation type="unfinished">باقی شدہ کاپی کریں</translation>
+    </message>
+    <message>
+        <source>Copy change</source>
+        <translation type="unfinished">تبدیلی کاپی کریں</translation>
+    </message>
+    <message>
+        <source>(%1 locked)</source>
+        <translation type="unfinished">مقفل'%1</translation>
+    </message>
+    <message>
+        <source>yes</source>
+        <translation type="unfinished">جی ہاں</translation>
+    </message>
+    <message>
+        <source>no</source>
+        <translation type="unfinished">نہیں</translation>
+    </message>
+    <message>
+        <source>This label turns red if any recipient receives an amount smaller than the current dust threshold.</source>
+        <translation type="unfinished">یہ لیبل سرخ ہو جاتا ہے اگر کوئی وصول کنندہ موجودہ کم سے کم مقرر کردہ حد سے کم رقم وصول کرتا ہے۔</translation>
+    </message>
+    <message>
+        <source>Can vary +/- %1 satoshi(s) per input.</source>
+        <translation type="unfinished">مختلف ہو سکتے ہیں%1 +/- ساتوشی فی ان پٹ۔</translation>
     </message>
     <message>
         <source>(no label)</source>
         <translation type="unfinished">(کوئی لیبل نہیں)</translation>
     </message>
+    <message>
+        <source>change from %1 (%2)</source>
+        <translation type="unfinished">%1 (%2)سے تبدیل کریں</translation>
+    </message>
+    <message>
+        <source>(change)</source>
+        <translation type="unfinished">تبدیلی</translation>
+    </message>
+</context>
+<context>
+    <name>CreateWalletActivity</name>
+    <message>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation type="unfinished">والیٹ بنانا &lt;b&gt; %1&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Create wallet failed</source>
+        <translation type="unfinished">والیٹ بنانا ناکام ہوگیا۔</translation>
+    </message>
+    <message>
+        <source>Create wallet warning</source>
+        <translation type="unfinished">والیٹ بنانے کےلئے انتباہ</translation>
+    </message>
+    <message>
+        <source>Can't list signers</source>
+        <translation type="unfinished">دستخط کنندگان کی فہرست نہیں بن سکتی</translation>
+    </message>
+</context>
+<context>
+    <name>OpenWalletActivity</name>
+    <message>
+        <source>Open wallet failed</source>
+        <translation type="unfinished">والیٹ کھولنا ناکم ہو گیا</translation>
+    </message>
+    <message>
+        <source>Open wallet warning</source>
+        <translation type="unfinished">والیٹ کھولنے کی انتباہ</translation>
+    </message>
+    <message>
+        <source>default wallet</source>
+        <translation type="unfinished">پہلے سے طے شدہ والیٹ</translation>
+    </message>
     </context>
 <context>
+    <name>WalletController</name>
+    <message>
+        <source>Close wallet</source>
+        <translation type="unfinished">والیٹ بند کریں</translation>
+    </message>
+    <message>
+        <source>Closing the wallet for too long can result in having to resync the entire chain if pruning is enabled.</source>
+        <translation type="unfinished">والیٹ کو زیادہ دیر تک بند کرنے کے نتیجے میں اگر کانٹ چھانٹ کو فعال کیا جاتا ہے تو پوری چین کو دوبارہ ہم آہنگ کرنا پڑ سکتا ہے۔</translation>
+    </message>
+    <message>
+        <source>Close all wallets</source>
+        <translation type="unfinished">تمام والیٹس بند کریں</translation>
+    </message>
+    <message>
+        <source>Are you sure you wish to close all wallets?</source>
+        <translation type="unfinished">کیا آپ واقعی تمام والیٹس بند کرنا چاہتے ہیں؟</translation>
+    </message>
+</context>
+<context>
+    <name>CreateWalletDialog</name>
+    <message>
+        <source>Create Wallet</source>
+        <translation type="unfinished">والیٹ بنائیں</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <translation type="unfinished">والیٹ کا نام</translation>
+    </message>
+    <message>
+        <source>Wallet</source>
+        <translation type="unfinished">والیٹ</translation>
+    </message>
+    <message>
+        <source>Encrypt the wallet. The wallet will be encrypted with a passphrase of your choice.</source>
+        <translation type="unfinished">والیٹ کو خفیہ کریں۔ والیٹ کو آپ کی پسند کے پاسفریز کے ساتھ خفیہ کیا جائے گا۔</translation>
+    </message>
+    <message>
+        <source>Encrypt Wallet</source>
+        <translation type="unfinished">والیٹ کو خفیہ کریں۔</translation>
+    </message>
+    <message>
+        <source>Advanced Options</source>
+        <translation type="unfinished">اعلی درجے کے اختیارات</translation>
+    </message>
+    <message>
+        <source>Disable private keys for this wallet. Wallets with private keys disabled will have no private keys and cannot have an HD seed or imported private keys. This is ideal for watch-only wallets.</source>
+        <translation type="unfinished">اس والیٹ کے لیے نجی چابیوں کو غیر فعال کریں۔ غیر فعال نجی چابیوں والے والیٹ میں کوئی نجی چابیاں نہیں ہوں گی اور اس میں HD بیج یا درآمد شدہ نجی چابیاں نہیں ہو سکتیں۔ یہ صرف دیکھنے والے والیٹ کے لیے مثالی ہے۔</translation>
+    </message>
+    <message>
+        <source>Disable Private Keys</source>
+        <translation type="unfinished">نجی چابیاں غیر فعال کریں۔</translation>
+    </message>
+    <message>
+        <source>Make a blank wallet. Blank wallets do not initially have private keys or scripts. Private keys and addresses can be imported, or an HD seed can be set, at a later time.</source>
+        <translation type="unfinished">ایک خالی والیٹ بنائیں۔ خالی والیٹ میں ابتدائی طور پر نجی چابیاں یا اسکرپٹ نہیں ہوتے ہیں۔ نجی چابیاں اور پتے درآمد کیے جا سکتے ہیں، یا بعد میں ایک HD بیج سیٹ کیا جا سکتا ہے۔</translation>
+    </message>
+    <message>
+        <source>Make Blank Wallet</source>
+        <translation type="unfinished">خالی والیٹ بنائیں</translation>
+    </message>
+    <message>
+        <source>Use descriptors for scriptPubKey management</source>
+        <translation type="unfinished">ScriptPubKeys کے انتظام کے لیے وضاحت کنندگان کا استعمال کریں۔</translation>
+    </message>
+    <message>
+        <source>Descriptor Wallet</source>
+        <translation type="unfinished">وضاحتی والیٹ</translation>
+    </message>
+    <message>
+        <source>Use an external signing device such as a hardware wallet. Configure the external signer script in wallet preferences first.</source>
+        <translation type="unfinished">بیرونی دستخط کرنے والا آلہ استعمال کریں جیسے ہارڈ ویئر والیٹ۔ پہلے والیٹ کی ترجیحات میں بیرونی دستخط کنندہ اسکرپٹ کو ترتیب دیں۔</translation>
+    </message>
+    <message>
+        <source>External signer</source>
+        <translation type="unfinished">بیرونی دستخط کنندہ</translation>
+    </message>
+    <message>
+        <source>Create</source>
+        <translation type="unfinished">بنائیں</translation>
+    </message>
+    <message>
+        <source>Compiled without sqlite support (required for descriptor wallets)</source>
+        <translation type="unfinished"> SQliteسپورٹ کے بغیر مرتب کیا گیا (ڈسکرپٹر والیٹس کے لیے درکار)</translation>
+    </message>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">بیرونی دستخطی معاونت کے بغیر مرتب کیا گیا (بیرونی دستخط کے لیے درکار)</translation>
+    </message>
+</context>
+<context>
     <name>EditAddressDialog</name>
+    <message>
+        <source>Edit Address</source>
+        <translation>ایڈریس میں ترمیم کریں۔</translation>
+    </message>
     <message>
         <source>&amp;Label</source>
         <translation>چٹ</translation>
     </message>
     <message>
+        <source>The label associated with this address list entry</source>
+        <translation type="unfinished">اس ایڈریس لسٹ کے اندراج سے وابستہ لیبل</translation>
+    </message>
+    <message>
+        <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
+        <translation type="unfinished">اس ایڈریس لسٹ کے اندراج سے وابستہ پتہ۔ اس میں صرف ایڈریس بھیجنے کے لیے ترمیم کی جا سکتی ہے۔</translation>
+    </message>
+    <message>
         <source>&amp;Address</source>
         <translation>پتہ</translation>
     </message>
-    </context>
+    <message>
+        <source>New sending address</source>
+        <translation type="unfinished">نیا بھیجنے کا پتہ</translation>
+    </message>
+    <message>
+        <source>Edit receiving address</source>
+        <translation type="unfinished">وصول کنندہ ایڈریس میں ترمیم کریں۔</translation>
+    </message>
+    <message>
+        <source>Edit sending address</source>
+        <translation type="unfinished">بھیجنے کے پتے میں ترمیم کریں۔</translation>
+    </message>
+    <message>
+        <source>Could not unlock wallet.</source>
+        <translation type="unfinished">والیٹ کو غیر مقفل نہیں کیا جا سکا۔</translation>
+    </message>
+    <message>
+        <source>New key generation failed.</source>
+        <translation type="unfinished">نئی کلیدی نسل ناکام ہوگئی۔</translation>
+    </message>
+</context>
+<context>
+    <name>FreespaceChecker</name>
+    <message>
+        <source>A new data directory will be created.</source>
+        <translation>ایک نئی ڈیٹا ڈائرکٹری بنائی جائے گی۔</translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation>نام</translation>
+    </message>
+    <message>
+        <source>Path already exists, and is not a directory.</source>
+        <translation>پاتھ پہلے سے موجود ہے، اور ڈائرکٹری نہیں ہے۔</translation>
+    </message>
+    <message>
+        <source>Cannot create data directory here.</source>
+        <translation>یہاں ڈیٹا ڈائرکٹری نہیں بن سکتی۔</translation>
+    </message>
+</context>
 <context>
     <name>Intro</name>
+    <message>
+        <source>Bitcoin</source>
+        <translation type="unfinished">بٹ کوائن</translation>
+    </message>
     <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
@@ -530,30 +1133,694 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         </translation>
     </message>
     <message>
+        <source>The wallet will also be stored in this directory.</source>
+        <translation type="unfinished">والیٹ بھی اس ڈائرکٹری میں محفوظ کیا جائے گا۔</translation>
+    </message>
+    <message>
         <source>Error</source>
         <translation>نقص</translation>
     </message>
+    <message>
+        <source>Welcome</source>
+        <translation>خوش آمدید</translation>
+    </message>
+    <message>
+        <source>Limit block chain storage to</source>
+        <translation type="unfinished">بلاک چین اسٹوریج کو محدود کریں۔</translation>
+    </message>
+    <message>
+        <source>Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</source>
+        <translation type="unfinished">اس ترتیب کو واپس کرنے کے لیے پورے بلاکچین کو دوبارہ ڈاؤن لوڈ کرنے کی ضرورت ہے۔ پہلے پوری چین کو ڈاؤن لوڈ کرنا اور بعد میں اسے کاٹنا تیز تر ہے۔ کچھ جدید خصوصیات کو غیر فعال کرتا ہے۔</translation>
+    </message>
+    <message>
+        <source> GB</source>
+        <translation type="unfinished">جی بی</translation>
+    </message>
+    <message>
+        <source>If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</source>
+        <translation type="unfinished">اگر آپ نے بلاک چین اسٹوریج کو محدود کرنے کا انتخاب کیا ہے (کاٹنا)، تو تاریخی ڈیٹا کو ابھی بھی ڈاؤن لوڈ اور پروسیس کیا جانا چاہیے، لیکن آپ کے ڈسک کے استعمال کو کم رکھنے کے لیے اسے بعد میں حذف کر دیا جائے گا۔</translation>
+    </message>
+    <message>
+        <source>Use the default data directory</source>
+        <translation>پہلے سے طے شدہ ڈیٹا ڈائرکٹری استعمال کریں۔</translation>
+    </message>
+    <message>
+        <source>Use a custom data directory:</source>
+        <translation>اپنی مرضی کے مطابق ڈیٹا ڈائرکٹری کا استعمال کریں:</translation>
+    </message>
+</context>
+<context>
+    <name>HelpMessageDialog</name>
+    <message>
+        <source>version</source>
+        <translation type="unfinished">ورژن</translation>
+    </message>
+    <message>
+        <source>About %1</source>
+        <translation type="unfinished">تقریبآ %1</translation>
+    </message>
+    <message>
+        <source>Command-line options</source>
+        <translation type="unfinished">کمانڈ لائن کے اختیارات</translation>
+    </message>
+</context>
+<context>
+    <name>ShutdownWindow</name>
+    <message>
+        <source>Do not shut down the computer until this window disappears.</source>
+        <translation type="unfinished">جب تک یہ ونڈو غائب نہ ہوجائے کمپیوٹر کو بند نہ کریں۔</translation>
+    </message>
+</context>
+<context>
+    <name>ModalOverlay</name>
+    <message>
+        <source>Form</source>
+        <translation type="unfinished">فارم</translation>
+    </message>
+    <message>
+        <source>Recent transactions may not yet be visible, and therefore your wallet's balance might be incorrect. This information will be correct once your wallet has finished synchronizing with the bitcoin network, as detailed below.</source>
+        <translation type="unfinished">ہو سکتا ہے حالیہ لین دین ابھی تک نظر نہ آئے، اور اس وجہ سے آپ کے والیٹ کا بیلنس غلط ہو سکتا ہے۔ یہ معلومات درست ہوں گی جب آپ کے والیٹ نے بٹ کوائن نیٹ ورک کے ساتھ مطابقت پذیری مکمل کر لی ہو، جیسا کہ ذیل میں تفصیل ہے۔</translation>
+    </message>
+    <message>
+        <source>Attempting to spend bitcoins that are affected by not-yet-displayed transactions will not be accepted by the network.</source>
+        <translation type="unfinished">ایسے بٹ کوائنز خرچ کرنے کی کوشش کرنا جو ابھی تک ظاہر نہ ہونے والے لین دین سے متاثر ہوں نیٹ ورک کے ذریعے قبول نہیں کیا جائے گا۔</translation>
+    </message>
+    <message>
+        <source>Number of blocks left</source>
+        <translation type="unfinished">باقی بلاکس کی تعداد</translation>
+    </message>
+    <message>
+        <source>Unknown…</source>
+        <translation type="unfinished">نامعلوم</translation>
+    </message>
+    <message>
+        <source>calculating…</source>
+        <translation type="unfinished">حساب لگانا</translation>
+    </message>
+    <message>
+        <source>Last block time</source>
+        <translation type="unfinished">آخری بلاک کا وقت</translation>
+    </message>
+    <message>
+        <source>Progress</source>
+        <translation type="unfinished">پیش رفت</translation>
+    </message>
+    <message>
+        <source>Progress increase per hour</source>
+        <translation type="unfinished">فی گھنٹہ پیش رفت میں اضافہ</translation>
+    </message>
+    <message>
+        <source>Estimated time left until synced</source>
+        <translation type="unfinished">مطابقت پذیر ہونے میں تخمینی وقت باقی ہے۔</translation>
+    </message>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished">چھپائیں</translation>
+    </message>
     </context>
+<context>
+    <name>OpenURIDialog</name>
+    <message>
+        <source>Open bitcoin URI</source>
+        <translation type="unfinished">بٹ کوائن URI کھولیں۔</translation>
+    </message>
+    <message>
+        <source>URI:</source>
+        <translation type="unfinished">URI</translation>
+    </message>
+</context>
 <context>
     <name>OptionsDialog</name>
     <message>
+        <source>Options</source>
+        <translation>اختیارات</translation>
+    </message>
+    <message>
+        <source>&amp;Main</source>
+        <translation>اور مرکزی</translation>
+    </message>
+    <message>
+        <source>Enabling pruning significantly reduces the disk space required to store transactions. All blocks are still fully validated. Reverting this setting requires re-downloading the entire blockchain.</source>
+        <translation type="unfinished">کٹائی کو فعال کرنا لین دین کو ذخیرہ کرنے کے لیے درکار ڈسک کی جگہ کو نمایاں طور پر کم کرتا ہے۔ تمام بلاکس اب بھی مکمل طور پر درست ہیں۔ اس ترتیب کو واپس کرنے کے لیے پورے بلاکچین کو دوبارہ ڈاؤن لوڈ کرنے کی ضرورت ہے۔</translation>
+    </message>
+    <message>
+        <source>Size of &amp;database cache</source>
+        <translation type="unfinished">ڈیٹا بیس کیشے کا سائز</translation>
+    </message>
+    <message>
+        <source>Number of script &amp;verification threads</source>
+        <translation type="unfinished">اسکرپٹ اور تصدیقی دھاگوں کی تعداد</translation>
+    </message>
+    <message>
+        <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
+        <translation type="unfinished">پراکسی کا IP پتہ (جیسے IPv4: 127.0.0.1 / IPv6: ::1)</translation>
+    </message>
+    <message>
+        <source>Shows if the supplied default SOCKS5 proxy is used to reach peers via this network type.</source>
+        <translation type="unfinished">یہ دکھاتا ہے کہ کیا فراہم کردہ ڈیفالٹ SOCKS5 پراکسی اس نیٹ ورک کی قسم کے ذریعے ساتھی تک پہنچنے کے لیے استعمال ہوتی ہے۔</translation>
+    </message>
+    <message>
+        <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
+        <translation type="unfinished">ونڈو بند ہونے پر ایپلیکیشن سے باہر نکلنے کے بجائے چھوٹا کریں۔ جب یہ آپشن فعال ہو جائے گا تو مینو میں ایگزٹ کو منتخب کرنے کے بعد ہی ایپلیکیشن بند ہو جائے گی۔</translation>
+    </message>
+    <message>
+        <source>Open Configuration File</source>
+        <translation type="unfinished">ترتیب والی فائل کھولیں۔</translation>
+    </message>
+    <message>
+        <source>Reset all client options to default.</source>
+        <translation>کلائنٹ کے تمام اختیارات کو ڈیفالٹ پر دوبارہ ترتیب دیں۔</translation>
+    </message>
+    <message>
+        <source>&amp;Reset Options</source>
+        <translation>اور دوبارہ ترتیب دینے کے اختیارات</translation>
+    </message>
+    <message>
+        <source>&amp;Network</source>
+        <translation>اور نیٹ ورک</translation>
+    </message>
+    <message>
+        <source>GB</source>
+        <translation type="unfinished">جی بی</translation>
+    </message>
+    <message>
+        <source>Reverting this setting requires re-downloading the entire blockchain.</source>
+        <translation type="unfinished">اس ترتیب کو واپس کرنے کے لیے پورے بلاکچین کو دوبارہ ڈاؤن لوڈ کرنے کی ضرورت ہے۔</translation>
+    </message>
+    <message>
+        <source>Expert</source>
+        <translation type="unfinished">ماہر</translation>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation type="unfinished">سکے اور کنٹرول کی خصوصیات کو فعال کریں۔</translation>
+    </message>
+    <message>
+        <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
+        <translation type="unfinished">اگر آپ غیر مصدقہ تبدیلی کے اخراجات کو غیر فعال کرتے ہیں، تو کسی لین دین کی تبدیلی کو اس وقت تک استعمال نہیں کیا جا سکتا جب تک کہ اس لین دین کی کم از کم ایک تصدیق نہ ہو۔ اس سے یہ بھی متاثر ہوتا ہے کہ آپ کے بیلنس کا حساب کیسے لیا جاتا ہے۔</translation>
+    </message>
+    <message>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation type="unfinished">اور غیر مصدقہ تبدیلی خرچ کریں۔</translation>
+    </message>
+    <message>
+        <source>&amp;Window</source>
+        <translation>براؤزر ونڈو</translation>
+    </message>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">بیرونی دستخطی معاونت کے بغیر مرتب کیا گیا (بیرونی دستخط کے لیے درکار)</translation>
+    </message>
+    <message>
+        <source>default</source>
+        <translation>پہلے سے طے شدہ</translation>
+    </message>
+    <message>
+        <source>none</source>
+        <translation type="unfinished">کوئی نہیں</translation>
+    </message>
+    <message>
+        <source>Confirm options reset</source>
+        <translation>اختیارات کو دوبارہ ترتیب دینے کی تصدیق کریں۔</translation>
+    </message>
+    <message>
+        <source>Client restart required to activate changes.</source>
+        <translation type="unfinished">تبدیلیوں کو چالو کرنے کے لیے کلائنٹ کو دوبارہ شروع کرنا ضروری ہے۔</translation>
+    </message>
+    <message>
+        <source>Client will be shut down. Do you want to proceed?</source>
+        <translation type="unfinished">کلائنٹ کو بند کر دیا جائے گا۔ کیا آپ آگے بڑھنا چاہتے ہیں؟</translation>
+    </message>
+    <message>
+        <source>Configuration options</source>
+        <translation type="unfinished">کنفیگریشن کے اختیارات</translation>
+    </message>
+    <message>
         <source>Error</source>
         <translation type="unfinished">نقص</translation>
+    </message>
+    <message>
+        <source>This change would require a client restart.</source>
+        <translation type="unfinished">اس تبدیلی کو کلائنٹ کو دوبارہ شروع کرنے کی ضرورت ہوگی۔</translation>
+    </message>
+    <message>
+        <source>The supplied proxy address is invalid.</source>
+        <translation>فراہم کردہ پراکسی پتہ غلط ہے۔</translation>
+    </message>
+</context>
+<context>
+    <name>OverviewPage</name>
+    <message>
+        <source>Form</source>
+        <translation>فارم</translation>
+    </message>
+    <message>
+        <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
+        <translation>ظاہر کی گئی معلومات پرانی ہو سکتی ہے۔ کنکشن قائم ہونے کے بعد آپ کا والیٹ خود بخود بٹ کوائن نیٹ ورک کے ساتھ ہم آہنگ ہوجاتا ہے، لیکن یہ عمل ابھی مکمل نہیں ہوا ہے۔</translation>
+    </message>
+    <message>
+        <source>Watch-only:</source>
+        <translation type="unfinished">صرف دیکھنے کے لیے:</translation>
+    </message>
+    <message>
+        <source>Available:</source>
+        <translation type="unfinished">دستیاب:</translation>
+    </message>
+    <message>
+        <source>Your current spendable balance</source>
+        <translation>آپ کا موجودہ قابل خرچ بیلنس</translation>
+    </message>
+    <message>
+        <source>Pending:</source>
+        <translation type="unfinished">زیر التواء</translation>
+    </message>
+    <message>
+        <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
+        <translation>کل ٹرانزیکشنز جن کی تصدیق ہونا باقی ہے، اور ابھی تک قابل خرچ بیلنس میں شمار نہیں ہوتے </translation>
+    </message>
+    <message>
+        <source>Immature:</source>
+        <translation>خام</translation>
+    </message>
+    <message>
+        <source>Mined balance that has not yet matured</source>
+        <translation>کان کنی کا توازن جو ابھی پختہ نہیں ہوا ہے۔</translation>
+    </message>
+    <message>
+        <source>Balances</source>
+        <translation type="unfinished">بیلنس</translation>
+    </message>
+    <message>
+        <source>Total:</source>
+        <translation>کل:</translation>
+    </message>
+    <message>
+        <source>Your current total balance</source>
+        <translation>آپ کا کل موجودہ بیلنس</translation>
+    </message>
+    <message>
+        <source>Your current balance in watch-only addresses</source>
+        <translation type="unfinished">صرف دیکھنے والے ایڈریسز میں آپ کا موجودہ بیلنس</translation>
+    </message>
+    <message>
+        <source>Spendable:</source>
+        <translation type="unfinished">قابل خرچ:</translation>
+    </message>
+    <message>
+        <source>Recent transactions</source>
+        <translation type="unfinished">حالیہ لین دین</translation>
+    </message>
+    <message>
+        <source>Unconfirmed transactions to watch-only addresses</source>
+        <translation type="unfinished">صرف دیکھنے والے پتوں پر غیر تصدیق شدہ لین دین</translation>
+    </message>
+    <message>
+        <source>Current total balance in watch-only addresses</source>
+        <translation type="unfinished">صرف دیکھنے کے پتوں میں کل موجودہ بیلنس</translation>
+    </message>
+    <message>
+        <source>Privacy mode activated for the Overview tab. To unmask the values, uncheck Settings-&gt;Mask values.</source>
+        <translation type="unfinished">جائزہ ٹیب کے لیے پرائیویسی موڈ کو فعال کر دیا گیا ہے۔ اقدار کو ہٹانے کے لیے، سیٹنگز-&gt;ماسک ویلیوز کو غیر چیک کریں۔</translation>
+    </message>
+</context>
+<context>
+    <name>PSBTOperationsDialog</name>
+    <message>
+        <source>Copy to Clipboard</source>
+        <translation type="unfinished">کلپ بورڈ پر کاپی کریں۔</translation>
+    </message>
+    <message>
+        <source>Save…</source>
+        <translation type="unfinished">محفوظ کریں۔</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation type="unfinished">بند کریں</translation>
+    </message>
+    <message>
+        <source>Failed to load transaction: %1</source>
+        <translation type="unfinished">لین دین لوڈ کرنے میں ناکام:%1</translation>
+    </message>
+    <message>
+        <source>Failed to sign transaction: %1</source>
+        <translation type="unfinished">لین دین پر دستخط کرنے میں ناکام:%1</translation>
+    </message>
+    <message>
+        <source>Could not sign any more inputs.</source>
+        <translation type="unfinished">مزید ان پٹ پر دستخط نہیں ہو سکے۔</translation>
+    </message>
+    <message>
+        <source>Save Transaction Data</source>
+        <translation type="unfinished">لین دین کا ڈیٹا محفوظ کریں۔</translation>
+    </message>
+    <message>
+        <source>Total Amount</source>
+        <translation type="unfinished">کل رقم</translation>
+    </message>
+    <message>
+        <source>or</source>
+        <translation type="unfinished">یا</translation>
+    </message>
+    <message>
+        <source>Transaction still needs signature(s).</source>
+        <translation type="unfinished">لین دین کو ابھی بھی دستخط کی ضرورت ہے۔</translation>
+    </message>
+    <message>
+        <source>(But this wallet cannot sign transactions.)</source>
+        <translation type="unfinished">(لیکن یہ والیٹ لین دین پر دستخط نہیں کر سکتا۔)</translation>
+    </message>
+    <message>
+        <source>Transaction status is unknown.</source>
+        <translation type="unfinished">لین دین کی حیثیت نامعلوم ہے۔</translation>
+    </message>
+</context>
+<context>
+    <name>PaymentServer</name>
+    <message>
+        <source>Payment request error</source>
+        <translation type="unfinished">ادائیگی کی درخواست کی خرابی۔</translation>
+    </message>
+    <message>
+        <source>Cannot process payment request because BIP70 is not supported.
+Due to widespread security flaws in BIP70 it's strongly recommended that any merchant instructions to switch wallets be ignored.
+If you are receiving this error you should request the merchant provide a BIP21 compatible URI.</source>
+        <translation type="unfinished">ادائیگی کی درخواست پر کارروائی نہیں کی جا سکتی کیونکہ BIP70 تعاون یافتہ نہیں ہے۔ BIP70 میں سیکورٹی کی وسیع خامیوں کی وجہ سے یہ پرزور مشورہ دیا جاتا ہے کہ والیٹ کو تبدیل کرنے کے لیے کسی بھی تاجر کی ہدایات کو نظر انداز کر دیا جائے۔ اگر آپ کو یہ خرابی موصول ہو رہی ہے تو آپ کو مرچنٹ سے BIP21 مطابقت پذیر URI فراہم کرنے کی درخواست کرنی چاہیے۔</translation>
     </message>
     </context>
 <context>
     <name>PeerTableModel</name>
     <message>
+        <source>User Agent</source>
+        <extracomment>Title of Peers Table column which contains the peer's User Agent string.</extracomment>
+        <translation type="unfinished">صارف ایجنٹ</translation>
+    </message>
+    <message>
+        <source>Ping</source>
+        <extracomment>Title of Peers Table column which indicates the current latency of the connection with the peer.</extracomment>
+        <translation type="unfinished">پنگ</translation>
+    </message>
+    <message>
+        <source>Peer</source>
+        <extracomment>Title of Peers Table column which contains a unique number used to identify a connection.</extracomment>
+        <translation type="unfinished">فریق</translation>
+    </message>
+    <message>
+        <source>Sent</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have sent to the peer.</extracomment>
+        <translation type="unfinished">بھیجا</translation>
+    </message>
+    <message>
+        <source>Received</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have received from the peer.</extracomment>
+        <translation type="unfinished">موصول ہوا۔</translation>
+    </message>
+    <message>
         <source>Address</source>
         <extracomment>Title of Peers Table column which contains the IP/Onion/I2P address of the connected peer.</extracomment>
         <translation type="unfinished">پتہ</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <extracomment>Title of Peers Table column which describes the type of peer connection. The "type" describes why the connection exists.</extracomment>
+        <translation type="unfinished">قسم</translation>
+    </message>
+    <message>
+        <source>Network</source>
+        <extracomment>Title of Peers Table column which states the network the peer connected through.</extracomment>
+        <translation type="unfinished">نیٹ ورک</translation>
+    </message>
+</context>
+<context>
+    <name>QRImageWidget</name>
+    <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">اور تصویر محفوظ کریں…</translation>
+    </message>
+    <message>
+        <source>&amp;Copy Image</source>
+        <translation type="unfinished">اور تصویر کاپی کریں۔</translation>
+    </message>
+    <message>
+        <source>Save QR Code</source>
+        <translation type="unfinished">کیو آر کوڈ محفوظ کریں۔</translation>
+    </message>
+    </context>
+<context>
+    <name>RPCConsole</name>
+    <message>
+        <source>&amp;Information</source>
+        <translation>اور معلومات</translation>
+    </message>
+    <message>
+        <source>Startup time</source>
+        <translation>آغاز کا وقت</translation>
+    </message>
+    <message>
+        <source>Network</source>
+        <translation>نیٹ ورک</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished">نام</translation>
+    </message>
+    <message>
+        <source>Number of connections</source>
+        <translation>رابطوں کی تعداد</translation>
+    </message>
+    <message>
+        <source>Block chain</source>
+        <translation>بلاک چین</translation>
+    </message>
+    <message>
+        <source>Current number of transactions</source>
+        <translation type="unfinished">لین دین کی موجودہ تعداد</translation>
+    </message>
+    <message>
+        <source>Memory usage</source>
+        <translation type="unfinished">استعمال یاد داشت</translation>
+    </message>
+    <message>
+        <source>Wallet: </source>
+        <translation type="unfinished">والیٹ</translation>
+    </message>
+    <message>
+        <source>(none)</source>
+        <translation type="unfinished">(کوئی نہیں)</translation>
+    </message>
+    <message>
+        <source>Received</source>
+        <translation type="unfinished">موصول ہوا۔</translation>
+    </message>
+    <message>
+        <source>Sent</source>
+        <translation type="unfinished">بھیجا</translation>
+    </message>
+    <message>
+        <source>&amp;Peers</source>
+        <translation type="unfinished">اور فریق</translation>
+    </message>
+    <message>
+        <source>Banned peers</source>
+        <translation type="unfinished">ممنوعہ فریقوں</translation>
+    </message>
+    <message>
+        <source>Select a peer to view detailed information.</source>
+        <translation type="unfinished">تفصیلی معلومات دیکھنے کے لیے فریق کا انتخاب کریں۔</translation>
+    </message>
+    <message>
+        <source>Starting Block</source>
+        <translation type="unfinished">شروع ہونے والا بلاک</translation>
+    </message>
+    <message>
+        <source>Synced Blocks</source>
+        <translation type="unfinished">مطابقت پذیر بلاکس</translation>
+    </message>
+    <message>
+        <source>User Agent</source>
+        <translation type="unfinished">صارف ایجنٹ</translation>
+    </message>
+    <message>
+        <source>Node window</source>
+        <translation type="unfinished">نوڈ ونڈو</translation>
+    </message>
+    <message>
+        <source>Current block height</source>
+        <translation type="unfinished">موجودہ بلاک کی اونچائی</translation>
+    </message>
+    <message>
+        <source>Decrease font size</source>
+        <translation type="unfinished">فونٹ کا سائز کم کریں۔</translation>
+    </message>
+    <message>
+        <source>Increase font size</source>
+        <translation type="unfinished">فونٹ سائز میں اضافہ کریں</translation>
+    </message>
+    <message>
+        <source>Permissions</source>
+        <translation type="unfinished">اجازتیں</translation>
+    </message>
+    <message>
+        <source>Services</source>
+        <translation type="unfinished">خدمات</translation>
+    </message>
+    <message>
+        <source>Connection Time</source>
+        <translation type="unfinished">کنکشن کا وقت</translation>
+    </message>
+    <message>
+        <source>Elapsed time since a novel block passing initial validity checks was received from this peer.</source>
+        <translation type="unfinished">اس فریق کی جانب سے ابتدائی درستگی کی جانچ پڑتال کرنے والا ایک نیا بلاک موصول ہونے کے بعد گزرا ہوا وقت۔</translation>
+    </message>
+    <message>
+        <source>Last Block</source>
+        <translation type="unfinished">آخری بلاک</translation>
+    </message>
+    <message>
+        <source>Last Send</source>
+        <translation type="unfinished">آخری بھیجا۔</translation>
+    </message>
+    <message>
+        <source>Last Receive</source>
+        <translation type="unfinished">آخری موصول</translation>
+    </message>
+    <message>
+        <source>Last block time</source>
+        <translation>آخری بلاک کا وقت</translation>
+    </message>
+    <message>
+        <source>Totals</source>
+        <translation type="unfinished">کل</translation>
+    </message>
+    <message>
+        <source>Clear console</source>
+        <translation>کنسول صاف کریں۔</translation>
+    </message>
+    <message>
+        <source>In:</source>
+        <translation type="unfinished">میں:</translation>
+    </message>
+    <message>
+        <source>Out:</source>
+        <translation type="unfinished">باہر:</translation>
+    </message>
+    <message>
+        <source>&amp;Disconnect</source>
+        <translation type="unfinished">اور منقطع کریں۔</translation>
+    </message>
+    <message>
+        <source>Network activity disabled</source>
+        <translation type="unfinished">نیٹ ورک کی سرگرمی غیر فعال ہے۔</translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished">جی ہاں</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished">نہیں</translation>
+    </message>
+    <message>
+        <source>To</source>
+        <translation type="unfinished">کو</translation>
+    </message>
+    <message>
+        <source>From</source>
+        <translation type="unfinished">سے</translation>
+    </message>
+    <message>
+        <source>Ban for</source>
+        <translation type="unfinished">کے لیے پابندی</translation>
+    </message>
+    <message>
+        <source>Never</source>
+        <translation type="unfinished">کبھی نہیں</translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">نامعلوم</translation>
+    </message>
+</context>
+<context>
+    <name>ReceiveCoinsDialog</name>
+    <message>
+        <source>&amp;Amount:</source>
+        <translation type="unfinished">اور رقم</translation>
+    </message>
+    <message>
+        <source>&amp;Label:</source>
+        <translation type="unfinished">اور لیبل</translation>
+    </message>
+    <message>
+        <source>&amp;Message:</source>
+        <translation type="unfinished">اور پیغام</translation>
+    </message>
+    <message>
+        <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
+        <translation type="unfinished">ادائیگی کی درخواست کے ساتھ منسلک کرنے کے لیے ایک اختیاری پیغام، جو درخواست کے کھلنے پر ظاہر ہوگا۔ نوٹ: پیغام بٹ کوائن نیٹ ورک پر ادائیگی کے ساتھ نہیں بھیجا جائے گا۔</translation>
+    </message>
+    <message>
+        <source>An optional label to associate with the new receiving address.</source>
+        <translation type="unfinished">نئے وصول کنندہ پتے کے ساتھ منسلک کرنے کے لیے ایک اختیاری لیبل۔</translation>
+    </message>
+    <message>
+        <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
+        <translation type="unfinished">درخواست کرنے کے لیے ایک اختیاری رقم۔ کسی مخصوص رقم کی درخواست نہ کرنے کے لیے اسے خالی یا صفر چھوڑ دیں۔</translation>
+    </message>
+    <message>
+        <source>An optional label to associate with the new receiving address (used by you to identify an invoice).  It is also attached to the payment request.</source>
+        <translation type="unfinished">وصول کرنے والے نئے پتے کے ساتھ منسلک کرنے کے لیے ایک اختیاری لیبل (آپ کی طرف سے رسید کی شناخت کے لیے استعمال کیا جاتا ہے)۔ یہ ادائیگی کی درخواست کے ساتھ بھی منسلک ہے۔</translation>
+    </message>
+    <message>
+        <source>An optional message that is attached to the payment request and may be displayed to the sender.</source>
+        <translation type="unfinished">ایک اختیاری پیغام جو ادائیگی کی درخواست کے ساتھ منسلک ہے اور بھیجنے والے کو دکھایا جا سکتا ہے۔</translation>
+    </message>
+    <message>
+        <source>&amp;Create new receiving address</source>
+        <translation type="unfinished">اور وصول کرنے کا نیا پتہ بنائیں</translation>
+    </message>
+    <message>
+        <source>Clear</source>
+        <translation type="unfinished">صاف</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">ایڈریس کاپی کریں۔</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">کاپی اور لیبل</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">کاپی اور رقم</translation>
+    </message>
+    <message>
+        <source>Could not unlock wallet.</source>
+        <translation type="unfinished">والیٹ کو غیر مقفل نہیں کیا جا سکا۔</translation>
     </message>
     </context>
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
+        <source>Request payment to …</source>
+        <translation type="unfinished">ادائیگی کی درخواست کریں…</translation>
+    </message>
+    <message>
+        <source>Address:</source>
+        <translation type="unfinished">پتہ:</translation>
+    </message>
+    <message>
         <source>Amount:</source>
         <translation type="unfinished">رقم:</translation>
+    </message>
+    <message>
+        <source>Label:</source>
+        <translation type="unfinished">لیبل</translation>
+    </message>
+    <message>
+        <source>Message:</source>
+        <translation type="unfinished">پیغام</translation>
     </message>
     <message>
         <source>Wallet:</source>
@@ -562,6 +1829,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Copy &amp;Address</source>
         <translation type="unfinished">کاپی پتہ</translation>
+    </message>
+    <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">اور تصویر محفوظ کریں…</translation>
     </message>
     </context>
 <context>
@@ -575,23 +1846,237 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">لیبل</translation>
     </message>
     <message>
+        <source>Message</source>
+        <translation type="unfinished">پیغام</translation>
+    </message>
+    <message>
         <source>(no label)</source>
         <translation type="unfinished">(کوئی لیبل نہیں)</translation>
     </message>
-    </context>
+    <message>
+        <source>Requested</source>
+        <translation type="unfinished">درخواست کی۔</translation>
+    </message>
+</context>
 <context>
     <name>SendCoinsDialog</name>
     <message>
+        <source>Send Coins</source>
+        <translation>سکے بھیجیں۔</translation>
+    </message>
+    <message>
+        <source>Coin Control Features</source>
+        <translation type="unfinished">سکوں کے کنٹرول کی خصوصیات</translation>
+    </message>
+    <message>
+        <source>automatically selected</source>
+        <translation type="unfinished">خود بخود منتخب</translation>
+    </message>
+    <message>
         <source>Insufficient funds!</source>
         <translation type="unfinished">ناکافی فنڈز</translation>
+    </message>
+    <message>
+        <source>Quantity:</source>
+        <translation type="unfinished">مقدار:</translation>
+    </message>
+    <message>
+        <source>Bytes:</source>
+        <translation type="unfinished">بائٹس:</translation>
     </message>
     <message>
         <source>Amount:</source>
         <translation type="unfinished">رقم:</translation>
     </message>
     <message>
+        <source>Fee:</source>
+        <translation type="unfinished">فیس:</translation>
+    </message>
+    <message>
+        <source>After Fee:</source>
+        <translation type="unfinished">فیس کے بعد:</translation>
+    </message>
+    <message>
+        <source>Change:</source>
+        <translation type="unfinished">تبدیلی:</translation>
+    </message>
+    <message>
+        <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
+        <translation type="unfinished">اگر یہ فعال ہے، لیکن تبدیلی کا پتہ خالی یا غلط ہے، تبدیلی کو نئے پیدا کردہ پتے پر بھیج دیا جائے گا۔</translation>
+    </message>
+    <message>
+        <source>Transaction Fee:</source>
+        <translation type="unfinished">ٹرانزیکشن فیس:</translation>
+    </message>
+    <message>
+        <source>Warning: Fee estimation is currently not possible.</source>
+        <translation type="unfinished">انتباہ: فیس کا تخمینہ فی الحال ممکن نہیں ہے۔</translation>
+    </message>
+    <message>
+        <source>per kilobyte</source>
+        <translation type="unfinished">فی کلو بائٹ(kb)</translation>
+    </message>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished">چھپائیں</translation>
+    </message>
+    <message>
+        <source>Recommended:</source>
+        <translation type="unfinished">تجویز کردہ:</translation>
+    </message>
+    <message>
+        <source>Custom:</source>
+        <translation type="unfinished">اپنی مرضی کے مطابق:</translation>
+    </message>
+    <message>
+        <source>Send to multiple recipients at once</source>
+        <translation>ایک ساتھ متعدد وصول کنندگان کو بھیجیں۔</translation>
+    </message>
+    <message>
+        <source>Dust:</source>
+        <translation type="unfinished">نہ ہونے کے برابر</translation>
+    </message>
+    <message>
+        <source>Choose…</source>
+        <translation type="unfinished">منتخب کریں…</translation>
+    </message>
+    <message>
+        <source>Hide transaction fee settings</source>
+        <translation type="unfinished">لین دین کی فیس کی ترتیبات چھپائیں۔</translation>
+    </message>
+    <message>
+        <source>A too low fee might result in a never confirming transaction (read the tooltip)</source>
+        <translation type="unfinished">بہت کم فیس کے نتیجے میں کبھی بھی تصدیق نہ ہونے والی لین دین ہو سکتی ہے (ٹول ٹپ پڑھیں)</translation>
+    </message>
+    <message>
+        <source>Confirmation time target:</source>
+        <translation type="unfinished">تصدیقی وقت کا ہدف:</translation>
+    </message>
+    <message>
         <source>Balance:</source>
         <translation>بیلنس:</translation>
+    </message>
+    <message>
+        <source>Confirm the send action</source>
+        <translation>بھیجنے کی کارروائی کی تصدیق کریں۔</translation>
+    </message>
+    <message>
+        <source>Copy quantity</source>
+        <translation type="unfinished">مقدار کاپی کریں</translation>
+    </message>
+    <message>
+        <source>Copy amount</source>
+        <translation type="unfinished">رقم کاپی کریں۔</translation>
+    </message>
+    <message>
+        <source>Copy fee</source>
+        <translation type="unfinished">فیس کاپی کریں</translation>
+    </message>
+    <message>
+        <source>Copy after fee</source>
+        <translation type="unfinished">فیس کے بعد کاپی کریں۔</translation>
+    </message>
+    <message>
+        <source>Copy bytes</source>
+        <translation type="unfinished">بائٹس کاپی کریں</translation>
+    </message>
+    <message>
+        <source>Copy dust</source>
+        <translation type="unfinished">باقی شدہ کاپی کریں</translation>
+    </message>
+    <message>
+        <source>Copy change</source>
+        <translation type="unfinished">تبدیلی کاپی کریں</translation>
+    </message>
+    <message>
+        <source>Connect your hardware wallet first.</source>
+        <translation type="unfinished">پہلے اپنے ہارڈویئر والیٹ کو جوڑیں۔</translation>
+    </message>
+    <message>
+        <source>Do you want to draft this transaction?</source>
+        <translation type="unfinished">کیا آپ اس لین دین کا مسودہ تیار کرنا چاہتے ہیں؟</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to send?</source>
+        <translation type="unfinished">کیا آپ واقعی بھیجنا چاہتے ہیں؟</translation>
+    </message>
+    <message>
+        <source>To review recipient list click "Show Details…"</source>
+        <translation type="unfinished">وصول کنندگان کی فہرست کا جائزہ لینے کے لیے "تفصیلات دکھائیں..." پر کلک کریں۔</translation>
+    </message>
+    <message>
+        <source>Sign and send</source>
+        <translation type="unfinished">دستخط کرکے بھیجیں۔</translation>
+    </message>
+    <message>
+        <source>Sign failed</source>
+        <translation type="unfinished">دستخط ناکام ہوگیا</translation>
+    </message>
+    <message>
+        <source>External signer not found</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">بیرونی دستخط کنندہ نہیں ملا</translation>
+    </message>
+    <message>
+        <source>External signer failure</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">بیرونی دستخط کنندہ کی ناکامی۔</translation>
+    </message>
+    <message>
+        <source>Save Transaction Data</source>
+        <translation type="unfinished">لین دین کا ڈیٹا محفوظ کریں۔</translation>
+    </message>
+    <message>
+        <source>External balance:</source>
+        <translation type="unfinished">بیرونی توازن:</translation>
+    </message>
+    <message>
+        <source>or</source>
+        <translation type="unfinished">یا</translation>
+    </message>
+    <message>
+        <source>Please, review your transaction.</source>
+        <translation type="unfinished">براہ کرم، اپنے لین دین کا جائزہ لیں۔</translation>
+    </message>
+    <message>
+        <source>Transaction fee</source>
+        <translation type="unfinished">ٹرانزیکشن فیس</translation>
+    </message>
+    <message>
+        <source>Total Amount</source>
+        <translation type="unfinished">کل رقم</translation>
+    </message>
+    <message>
+        <source>Confirm send coins</source>
+        <translation type="unfinished">سکے بھیجنے کی تصدیق کریں۔</translation>
+    </message>
+    <message>
+        <source>Confirm transaction proposal</source>
+        <translation type="unfinished">لین دین کی تجویز کی تصدیق کریں۔</translation>
+    </message>
+    <message>
+        <source>The recipient address is not valid. Please recheck.</source>
+        <translation type="unfinished">وصول کنندہ کا پتہ درست نہیں ہے۔ براہ کرم دوبارہ چیک کریں۔</translation>
+    </message>
+    <message>
+        <source>The amount to pay must be larger than 0.</source>
+        <translation type="unfinished">ادا کرنے کی رقم 0 سے زیادہ ہونی چاہیے۔</translation>
+    </message>
+    <message>
+        <source>The amount exceeds your balance.</source>
+        <translation type="unfinished">رقم آپ کے بیلنس سے زیادہ ہے۔</translation>
+    </message>
+    <message>
+        <source>Duplicate address found: addresses should only be used once each.</source>
+        <translation type="unfinished">ڈپلیکیٹ پتہ ملا: پتے صرف ایک بار استعمال کیے جائیں۔</translation>
+    </message>
+    <message>
+        <source>Transaction creation failed!</source>
+        <translation type="unfinished">لین دین کی تخلیق ناکام ہو گئی!</translation>
+    </message>
+    <message>
+        <source>Payment request expired.</source>
+        <translation type="unfinished">ادائیگی کی درخواست کی میعاد ختم ہوگئی۔</translation>
     </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
@@ -601,8 +2086,142 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         </translation>
     </message>
     <message>
+        <source>Warning: Invalid Bitcoin address</source>
+        <translation type="unfinished">انتباہ: غلط بٹ کوائن ایڈریس</translation>
+    </message>
+    <message>
+        <source>Warning: Unknown change address</source>
+        <translation type="unfinished">انتباہ: نامعلوم تبدیلی کا پتہ</translation>
+    </message>
+    <message>
+        <source>Confirm custom change address</source>
+        <translation type="unfinished">اپنی مرضی کے مطابق ایڈریس کی تبدیلی کی تصدیق کریں۔</translation>
+    </message>
+    <message>
+        <source>The address you selected for change is not part of this wallet. Any or all funds in your wallet may be sent to this address. Are you sure?</source>
+        <translation type="unfinished">آپ نے تبدیلی کے لیے جو پتہ منتخب کیا ہے وہ اس والیٹ کا حصہ نہیں ہے۔ آپ کے والیٹ میں موجود کوئی بھی یا تمام فنڈز اس پتے پر بھیجے جا سکتے ہیں۔ کیا آپ کو یقین ہے؟</translation>
+    </message>
+    <message>
         <source>(no label)</source>
         <translation type="unfinished">(کوئی لیبل نہیں)</translation>
+    </message>
+</context>
+<context>
+    <name>SendCoinsEntry</name>
+    <message>
+        <source>&amp;Label:</source>
+        <translation>اور لیبل</translation>
+    </message>
+    <message>
+        <source>Choose previously used address</source>
+        <translation type="unfinished">پہلے استعمال شدہ پتہ کا انتخاب کریں۔</translation>
+    </message>
+    <message>
+        <source>The Bitcoin address to send the payment to</source>
+        <translation type="unfinished">ادائیگی بھیجنے کے لیے بٹ کوائن کا پتہ</translation>
+    </message>
+    <message>
+        <source>Paste address from clipboard</source>
+        <translation>کلپ بورڈ سے پتہ چسپاں کریں۔</translation>
+    </message>
+    <message>
+        <source>Remove this entry</source>
+        <translation type="unfinished">اس اندراج کو ہٹا دیں۔</translation>
+    </message>
+    <message>
+        <source>The amount to send in the selected unit</source>
+        <translation type="unfinished">منتخب یونٹ میں بھیجی جانے والی رقم</translation>
+    </message>
+    <message>
+        <source>The fee will be deducted from the amount being sent. The recipient will receive less bitcoins than you enter in the amount field. If multiple recipients are selected, the fee is split equally.</source>
+        <translation type="unfinished">بھیجی جانے والی رقم سے فیس کاٹی جائے گی۔ وصول کنندہ کو اس سے کم بٹ کوائنز موصول ہوں گے جو آپ رقم کے خانے میں داخل کریں گے۔ اگر متعدد وصول کنندگان کو منتخب کیا جاتا ہے، تو فیس کو برابر تقسیم کیا جاتا ہے۔</translation>
+    </message>
+    <message>
+        <source>Use available balance</source>
+        <translation type="unfinished">دستیاب بیلنس استعمال کریں۔</translation>
+    </message>
+    <message>
+        <source>Message:</source>
+        <translation type="unfinished">پیغام</translation>
+    </message>
+    <message>
+        <source>This is an unauthenticated payment request.</source>
+        <translation type="unfinished">یہ ایک غیر مستند ادائیگی کی درخواست ہے۔</translation>
+    </message>
+    <message>
+        <source>This is an authenticated payment request.</source>
+        <translation type="unfinished">یہ ایک تصدیق شدہ ادائیگی کی درخواست ہے۔</translation>
+    </message>
+    <message>
+        <source>Enter a label for this address to add it to the list of used addresses</source>
+        <translation type="unfinished">استعمال شدہ پتوں کی فہرست میں شامل کرنے کے لیے اس پتے کے لیے ایک لیبل درج کریں۔</translation>
+    </message>
+    <message>
+        <source>Pay To:</source>
+        <translation type="unfinished">ادائیگی کریں:</translation>
+    </message>
+    </context>
+<context>
+    <name>SignVerifyMessageDialog</name>
+    <message>
+        <source>Signatures - Sign / Verify a Message</source>
+        <translation>دستخط - ایک پیغام پر دستخط / تصدیق کریں۔</translation>
+    </message>
+    <message>
+        <source>You can sign messages/agreements with your addresses to prove you can receive bitcoins sent to them. Be careful not to sign anything vague or random, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
+        <translation type="unfinished">آپ یہ ثابت کرنے کے لیے اپنے پتوں کے ساتھ پیغامات/معاہدوں پر دستخط کر سکتے ہیں کہ آپ ان پر بھیجے گئے بٹ کوائنز وصول کر سکتے ہیں۔ ہوشیار رہیں کہ کسی بھی مبہم یا بے ترتیب پر دستخط نہ کریں، کیونکہ فریب دہی کے حملے آپ کو اپنی شناخت پر دستخط کرنے کے لیے دھوکہ دینے کی کوشش کر سکتے ہیں۔ صرف مکمل تفصیلی بیانات پر دستخط کریں جن سے آپ اتفاق کرتے ہیں۔</translation>
+    </message>
+    <message>
+        <source>The Bitcoin address to sign the message with</source>
+        <translation type="unfinished">پیغام پر دستخط کرنے کے لیے بٹ کوائن کا پتہ</translation>
+    </message>
+    <message>
+        <source>Choose previously used address</source>
+        <translation type="unfinished">پہلے استعمال شدہ پتہ کا انتخاب کریں۔</translation>
+    </message>
+    <message>
+        <source>Paste address from clipboard</source>
+        <translation>کلپ بورڈ سے پتہ چسپاں کریں۔</translation>
+    </message>
+    <message>
+        <source>Enter the message you want to sign here</source>
+        <translation>وہ پیغام درج کریں جس پر آپ دستخط کرنا چاہتے ہیں۔</translation>
+    </message>
+    <message>
+        <source>Signature</source>
+        <translation>دستخط</translation>
+    </message>
+    <message>
+        <source>The entered address is invalid.</source>
+        <translation type="unfinished">درج کیا گیا پتہ غلط ہے۔</translation>
+    </message>
+    <message>
+        <source>Please check the address and try again.</source>
+        <translation type="unfinished">براہ کرم پتہ چیک کریں اور دوبارہ کوشش کریں۔</translation>
+    </message>
+    <message>
+        <source>No error</source>
+        <translation type="unfinished">کوئی غلطی نہیں۔</translation>
+    </message>
+    <message>
+        <source>Message signing failed.</source>
+        <translation type="unfinished">پیغام پر دستخط ناکام ہو گئے۔</translation>
+    </message>
+    <message>
+        <source>The signature could not be decoded.</source>
+        <translation type="unfinished">دستخط کو ڈی کوڈ نہیں کیا جا سکا۔</translation>
+    </message>
+    <message>
+        <source>Please check the signature and try again.</source>
+        <translation type="unfinished">براہ کرم دستخط چیک کریں اور دوبارہ کوشش کریں۔</translation>
+    </message>
+    <message>
+        <source>Message verification failed.</source>
+        <translation type="unfinished">پیغام کی تصدیق ناکام ہو گئی۔</translation>
+    </message>
+    <message>
+        <source>Message verified.</source>
+        <translation type="unfinished">پیغام کی تصدیق ہو گئی۔</translation>
     </message>
 </context>
 <context>
@@ -618,12 +2237,32 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Date</source>
         <translation type="unfinished">تاریخ</translation>
     </message>
+    <message>
+        <source>From</source>
+        <translation type="unfinished">سے</translation>
+    </message>
+    <message>
+        <source>unknown</source>
+        <translation type="unfinished">نامعلوم</translation>
+    </message>
+    <message>
+        <source>To</source>
+        <translation type="unfinished">کو</translation>
+    </message>
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation>
             <numerusform />
             <numerusform />
         </translation>
+    </message>
+    <message>
+        <source>Transaction fee</source>
+        <translation type="unfinished">ٹرانزیکشن فیس</translation>
+    </message>
+    <message>
+        <source>Message</source>
+        <translation type="unfinished">پیغام</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -635,6 +2274,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Date</source>
         <translation type="unfinished">تاریخ</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished">قسم</translation>
     </message>
     <message>
         <source>Label</source>
@@ -655,13 +2298,37 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>TransactionView</name>
     <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">ایڈریس کاپی کریں۔</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">کاپی اور لیبل</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">کاپی اور رقم</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">لین دین اور شناخت کی تفصیلات(ID) کاپی کریں۔</translation>
+    </message>
+    <message>
         <source>Comma separated file</source>
         <extracomment>Expanded name of the CSV file format. See https://en.wikipedia.org/wiki/Comma-separated_values</extracomment>
         <translation type="unfinished">کوما سے الگ فائل</translation>
     </message>
     <message>
+        <source>Confirmed</source>
+        <translation type="unfinished">تصدیق شدہ</translation>
+    </message>
+    <message>
         <source>Date</source>
         <translation type="unfinished">تاریخ</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished">قسم</translation>
     </message>
     <message>
         <source>Label</source>
@@ -681,6 +2348,17 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Create a new wallet</source>
         <translation type="unfinished">ایک نیا پرس بنائیں</translation>
+    </message>
+</context>
+<context>
+    <name>WalletModel</name>
+    <message>
+        <source>Send Coins</source>
+        <translation type="unfinished">سکے بھیجیں۔</translation>
+    </message>
+    <message>
+        <source>default wallet</source>
+        <translation type="unfinished">پہلے سے طے شدہ والیٹ</translation>
     </message>
 </context>
 <context>

--- a/src/qt/locale/bitcoin_uz@Cyrl.ts
+++ b/src/qt/locale/bitcoin_uz@Cyrl.ts
@@ -70,6 +70,12 @@
         <translation type="unfinished">Улар тўловларни жўнатиш учун сизнинг Bitcoin манзилларингиз. Доимо тангаларни жўнатишдан олдин сумма ва қабул қилувчи манзилни текшириб кўринг. </translation>
     </message>
     <message>
+        <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
+Signing is only possible with addresses of the type 'legacy'.</source>
+        <translation type="unfinished">Улар тўловларни қабул қилиш учун сизнинг Bitcoin манзилларингиз. Янги манзилларни яратиш учун қабул қилиш варағидаги "Янги қабул қилиш манзилини яратиш" устига босинг. 
+Фақат 'legacy' туридаги манзиллар билан ҳисобга кириш мумкин.</translation>
+    </message>
+    <message>
         <source>&amp;Copy Address</source>
         <translation type="unfinished">Манзилдан &amp;нусха олиш</translation>
     </message>
@@ -84,6 +90,11 @@
     <message>
         <source>Export Address List</source>
         <translation type="unfinished">Манзил рўйхатини экспорт қилиш</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See https://en.wikipedia.org/wiki/Comma-separated_values</extracomment>
+        <translation type="unfinished">Вергул билан ажратилган файл</translation>
     </message>
     <message>
         <source>There was an error trying to save the address list to %1. Please try again.</source>
@@ -118,23 +129,27 @@
     </message>
     <message>
         <source>Enter passphrase</source>
-        <translation>Махфий сузни киритинг</translation>
+        <translation>Махфий сўзни киритинг</translation>
     </message>
     <message>
         <source>New passphrase</source>
-        <translation>Янги махфий суз</translation>
+        <translation>Янги махфий сўз</translation>
     </message>
     <message>
         <source>Repeat new passphrase</source>
-        <translation>Янги махфий сузни такрорланг</translation>
+        <translation>Янги махфий сўзни такрорланг</translation>
+    </message>
+    <message>
+        <source>Show passphrase</source>
+        <translation type="unfinished">Махфий сўзни кўрсатиш</translation>
     </message>
     <message>
         <source>Encrypt wallet</source>
-        <translation type="unfinished">Ҳамённи қодлаш</translation>
+        <translation type="unfinished">Ҳамённи шифрлаш</translation>
     </message>
     <message>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
-        <translation type="unfinished">Ушбу операцияни амалга ошириш учун ҳамённи қулфдан чиқариш парол сўзини талаб қилади.</translation>
+        <translation type="unfinished">Ушбу операцияни амалга ошириш учун ҳамённи қулфдан чиқариш махфий сўзини талаб қилади.</translation>
     </message>
     <message>
         <source>Unlock wallet</source>
@@ -158,7 +173,19 @@
     </message>
     <message>
         <source>Wallet encrypted</source>
-        <translation type="unfinished">Ҳамёни кодланган</translation>
+        <translation type="unfinished">Ҳамён шифрланган</translation>
+    </message>
+    <message>
+        <source>Wallet to be encrypted</source>
+        <translation type="unfinished">Шифрланадиган ҳамён</translation>
+    </message>
+    <message>
+        <source>Your wallet is about to be encrypted. </source>
+        <translation type="unfinished">Ҳамёнингиз шифрланиш арафасида.</translation>
+    </message>
+    <message>
+        <source>Your wallet is now encrypted. </source>
+        <translation type="unfinished">Ҳамёнингиз энди шифрланади.</translation>
     </message>
     <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
@@ -1638,6 +1665,11 @@
     <message>
         <source>Export Transaction History</source>
         <translation type="unfinished">Ўтказмалар тарихини экспорт қилиш</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See https://en.wikipedia.org/wiki/Comma-separated_values</extracomment>
+        <translation type="unfinished">Вергул билан ажратилган файл</translation>
     </message>
     <message>
         <source>Confirmed</source>

--- a/src/qt/locale/bitcoin_zh-Hans.ts
+++ b/src/qt/locale/bitcoin_zh-Hans.ts
@@ -2,10 +2,6 @@
 <context>
     <name>AddressBookPage</name>
     <message>
-        <source>Right-click to edit address or label</source>
-        <translation type="unfinished">右击编辑地址或标签</translation>
-    </message>
-    <message>
         <source>Create a new address</source>
         <translation>创建一个新的地址</translation>
     </message>
@@ -149,6 +145,54 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Unlock wallet</source>
         <translation type="unfinished">解锁钱包</translation>
+    </message>
+    <message>
+        <source>Change passphrase</source>
+        <translation type="unfinished">修改密码</translation>
+    </message>
+    <message>
+        <source>Confirm wallet encryption</source>
+        <translation type="unfinished">确认钱包加密</translation>
+    </message>
+    <message>
+        <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
+        <translation type="unfinished">注意:如果你加密了钱包又忘记了密码，你将会丢失所有的比特币！</translation>
+    </message>
+    <message>
+        <source>Are you sure you wish to encrypt your wallet?</source>
+        <translation type="unfinished">你确定要将钱包加密吗？</translation>
+    </message>
+    <message>
+        <source>Wallet encrypted</source>
+        <translation type="unfinished">钱包已加密</translation>
+    </message>
+    <message>
+        <source>Enter the new passphrase for the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
+        <translation type="unfinished">输入钱包的新密码。&lt;br/&gt;密码中请使用&lt;b&gt;10个或更多随机字符&lt;/b&gt;，或&lt;b&gt;8个或更多的单词&lt;/b&gt;。</translation>
+    </message>
+    <message>
+        <source>Enter the old passphrase and new passphrase for the wallet.</source>
+        <translation type="unfinished">输入钱包的旧密码和新密码。</translation>
+    </message>
+    <message>
+        <source>Wallet to be encrypted</source>
+        <translation type="unfinished">需要加密的钱包</translation>
+    </message>
+    <message>
+        <source>Your wallet is about to be encrypted. </source>
+        <translation type="unfinished">你的钱包将要被加密</translation>
+    </message>
+    <message>
+        <source>Your wallet is now encrypted. </source>
+        <translation type="unfinished">你的钱包已被加密</translation>
+    </message>
+    <message>
+        <source>Wallet encryption failed</source>
+        <translation type="unfinished">钱包加密失败</translation>
+    </message>
+    <message>
+        <source>Wallet unlock failed</source>
+        <translation type="unfinished">钱包解锁失败</translation>
     </message>
     </context>
 <context>

--- a/src/qt/locale/bitcoin_zh_CN.ts
+++ b/src/qt/locale/bitcoin_zh_CN.ts
@@ -1077,7 +1077,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Encrypt the wallet. The wallet will be encrypted with a passphrase of your choice.</source>
-        <translation type="unfinished">加密钱包。将会使用您指定的密码将钱包钱包。</translation>
+        <translation type="unfinished">加密钱包。将会使用您指定的密码将钱包加密。</translation>
     </message>
     <message>
         <source>Encrypt Wallet</source>

--- a/src/qt/locale/bitcoin_zh_TW.ts
+++ b/src/qt/locale/bitcoin_zh_TW.ts
@@ -35,7 +35,7 @@
     </message>
     <message>
         <source>&amp;Export</source>
-        <translation>匯出(&amp;E)</translation>
+        <translation>&amp;匯出</translation>
     </message>
     <message>
         <source>&amp;Delete</source>
@@ -81,6 +81,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Export Address List</source>
         <translation type="unfinished">匯出地址清單</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See https://en.wikipedia.org/wiki/Comma-separated_values</extracomment>
+        <translation type="unfinished">逗號分隔文件</translation>
     </message>
     <message>
         <source>There was an error trying to save the address list to %1. Please try again.</source>
@@ -163,7 +168,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Enter the new passphrase for the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
-        <translation type="unfinished">輸入錢包的新密碼短語。&lt;br/&gt;請使用&lt;b&gt;個或10個以上隨機字符&lt;/b&gt;或&lt;b&gt;個8個以上單詞3的密碼。</translation>
+        <translation type="unfinished">輸入錢包的新密碼短語。&lt;br/&gt;請使用&lt;b&gt;個或10個以上隨機字符&lt;/b&gt;或&lt;b&gt;個8個以上單詞&lt;/b&gt;的密碼。</translation>
     </message>
     <message>
         <source>Enter the old passphrase and new passphrase for the wallet.</source>
@@ -230,6 +235,21 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
 </context>
 <context>
+    <name>BitcoinApplication</name>
+    <message>
+        <source>Runaway exception</source>
+        <translation type="unfinished">失控異常</translation>
+    </message>
+    <message>
+        <source>Internal error</source>
+        <translation type="unfinished">內部錯誤</translation>
+    </message>
+    <message>
+        <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
+        <translation type="unfinished">發生了內部錯誤%1 將嘗試安全地繼續。 這是一個意外錯誤，可以按如下所述進行報告。</translation>
+    </message>
+</context>
+<context>
     <name>QObject</name>
     <message>
         <source>Error: Specified data directory "%1" does not exist.</source>
@@ -244,6 +264,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">错误：%1</translation>
     </message>
     <message>
+        <source>%1 didn't yet exit safely…</source>
+        <translation type="unfinished">%1還沒有安全退出……</translation>
+    </message>
+    <message>
         <source>unknown</source>
         <translation type="unfinished">未知</translation>
     </message>
@@ -254,6 +278,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Enter a Bitcoin address (e.g. %1)</source>
         <translation type="unfinished">輸入 比特幣地址 (比如說 %1)</translation>
+    </message>
+    <message>
+        <source>Unroutable</source>
+        <translation type="unfinished">不可路由</translation>
     </message>
     <message>
         <source>Inbound</source>
@@ -420,6 +448,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation>&amp;接收</translation>
     </message>
     <message>
+        <source>&amp;Options…</source>
+        <translation type="unfinished">&amp;選項...</translation>
+    </message>
+    <message>
         <source>&amp;Show / Hide</source>
         <translation>&amp;顯示或隱藏</translation>
     </message>
@@ -428,16 +460,61 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation>顯示或隱藏主視窗</translation>
     </message>
     <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation type="unfinished">&amp;加密錢包...</translation>
+    </message>
+    <message>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>將錢包中之密鑰加密</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation type="unfinished">&amp;备用钱包...</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation type="unfinished">&amp;更改密碼短語...</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation type="unfinished">簽名 &amp;信息…</translation>
     </message>
     <message>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation>用比特幣地址簽名訊息來證明位址是你的</translation>
     </message>
     <message>
+        <source>&amp;Verify message…</source>
+        <translation type="unfinished">&amp;驗證
+訊息...</translation>
+    </message>
+    <message>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation>驗證訊息是用來確定訊息是用指定的比特幣地址簽名的</translation>
+    </message>
+    <message>
+        <source>&amp;Load PSBT from file…</source>
+        <translation type="unfinished">&amp;從檔案載入PSBT...</translation>
+    </message>
+    <message>
+        <source>Load PSBT from clipboard…</source>
+        <translation type="unfinished">從剪貼簿載入PSBT...</translation>
+    </message>
+    <message>
+        <source>Open &amp;URI…</source>
+        <translation type="unfinished">開啟 &amp;URI...</translation>
+    </message>
+    <message>
+        <source>Close Wallet…</source>
+        <translation type="unfinished">关钱包...</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation type="unfinished">创建钱包...</translation>
+    </message>
+    <message>
+        <source>Close All Wallets…</source>
+        <translation type="unfinished">关所有钱包...</translation>
     </message>
     <message>
         <source>&amp;File</source>
@@ -454,6 +531,30 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Tabs toolbar</source>
         <translation>分頁工具列</translation>
+    </message>
+    <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation type="unfinished">同步區塊頭 (%1%)…</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation type="unfinished">正在與網絡同步…</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation type="unfinished">索引磁盤上的索引塊中...</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation type="unfinished">處理磁碟裡的區塊中...</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation type="unfinished">正在重新索引磁盤上的區塊...</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation type="unfinished">连到同行...</translation>
     </message>
     <message>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
@@ -474,12 +575,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation>
-            <numerusform />
+            <numerusform>已處理%n個區塊的交易歷史。</numerusform>
         </translation>
     </message>
     <message>
         <source>%1 behind</source>
         <translation>落後 %1</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation type="unfinished">赶上...</translation>
     </message>
     <message>
         <source>Last received block was generated %1 ago.</source>
@@ -593,8 +698,28 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>已處理%n個區塊的交易歷史。</numerusform>
         </translation>
+    </message>
+    <message>
+        <source>Click for more actions.</source>
+        <extracomment>A substring of the tooltip. "More actions" are available via the context menu.</extracomment>
+        <translation type="unfinished">點擊查看更多操作</translation>
+    </message>
+    <message>
+        <source>Show Peers tab</source>
+        <extracomment>A context menu item. The "Peers tab" is an element of the "Node window".</extracomment>
+        <translation type="unfinished">顯示節點選項卡</translation>
+    </message>
+    <message>
+        <source>Disable network activity</source>
+        <extracomment>A context menu item.</extracomment>
+        <translation type="unfinished">關閉網路紀錄</translation>
+    </message>
+    <message>
+        <source>Enable network activity</source>
+        <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
+        <translation type="unfinished">關閉網路紀錄</translation>
     </message>
     <message>
         <source>Error: %1</source>
@@ -755,6 +880,30 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">複製金額</translation>
     </message>
     <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;复制地址</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">复制和标签</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">复制和数量</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">複製交易 &amp;ID</translation>
+    </message>
+    <message>
+        <source>L&amp;ock unspent</source>
+        <translation type="unfinished">鎖定未消費金額額</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock unspent</source>
+        <translation type="unfinished">解鎖未花費金額</translation>
+    </message>
+    <message>
         <source>Copy quantity</source>
         <translation type="unfinished">複製數目</translation>
     </message>
@@ -813,6 +962,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 </context>
 <context>
     <name>CreateWalletActivity</name>
+    <message>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <translation type="unfinished">正在創建錢包&lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
     <message>
         <source>Create wallet failed</source>
         <translation type="unfinished">創建錢包失敗&lt;br&gt;</translation>
@@ -1094,6 +1247,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Number of blocks left</source>
         <translation type="unfinished">剩餘區塊數</translation>
+    </message>
+    <message>
+        <source>Unknown…</source>
+        <translation type="unfinished">不明...</translation>
+    </message>
+    <message>
+        <source>calculating…</source>
+        <translation type="unfinished">计算...</translation>
     </message>
     <message>
         <source>Last block time</source>
@@ -1472,6 +1633,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">複製到剪貼簿</translation>
     </message>
     <message>
+        <source>Save…</source>
+        <translation type="unfinished">拯救...</translation>
+    </message>
+    <message>
         <source>Close</source>
         <translation type="unfinished">關閉</translation>
     </message>
@@ -1578,6 +1743,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Ping</source>
         <extracomment>Title of Peers Table column which indicates the current latency of the connection with the peer.</extracomment>
         <translation type="unfinished">Ping  時間</translation>
+    </message>
+    <message>
+        <source>Peer</source>
+        <extracomment>Title of Peers Table column which contains a unique number used to identify a connection.</extracomment>
+        <translation type="unfinished">同行</translation>
     </message>
     <message>
         <source>Sent</source>
@@ -1992,6 +2162,18 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Copy &amp;URI</source>
         <translation type="unfinished">複製 &amp;URI</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;复制地址</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">复制和标签</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">复制和数量</translation>
     </message>
     <message>
         <source>Could not unlock wallet.</source>
@@ -2937,8 +3119,29 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">最小金額</translation>
     </message>
     <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;复制地址</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">复制和标签</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">复制和数量</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">复制交易 &amp;ID</translation>
+    </message>
+    <message>
         <source>Export Transaction History</source>
         <translation type="unfinished">匯出交易記錄</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See https://en.wikipedia.org/wiki/Comma-separated_values</extracomment>
+        <translation type="unfinished">逗號分隔文件</translation>
     </message>
     <message>
         <source>Confirmed</source>
@@ -3337,6 +3540,10 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished">初始化時重新掃描錢包失敗了</translation>
     </message>
     <message>
+        <source>Importing…</source>
+        <translation type="unfinished">匯入中...</translation>
+    </message>
+    <message>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation type="unfinished">創世區塊不正確或找不到。資料目錄錯了嗎？</translation>
     </message>
@@ -3381,6 +3588,22 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished">指定在 -whitelist 的網段無效: '%s'</translation>
     </message>
     <message>
+        <source>Loading P2P addresses…</source>
+        <translation type="unfinished">載入P2P地址中...</translation>
+    </message>
+    <message>
+        <source>Loading banlist…</source>
+        <translation type="unfinished">正在載入黑名單中...</translation>
+    </message>
+    <message>
+        <source>Loading block index…</source>
+        <translation type="unfinished">載入區塊索引中...</translation>
+    </message>
+    <message>
+        <source>Loading wallet…</source>
+        <translation type="unfinished">載入錢包中...</translation>
+    </message>
+    <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
         <translation type="unfinished">指定 -whitebind 時必須包含通訊埠: '%s'</translation>
     </message>
@@ -3397,12 +3620,28 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished">修剪值不能設定為負的。</translation>
     </message>
     <message>
+        <source>Prune mode is incompatible with -coinstatsindex.</source>
+        <translation type="unfinished">修剪模式和 -硬幣統計指數 不相容</translation>
+    </message>
+    <message>
         <source>Prune mode is incompatible with -txindex.</source>
         <translation type="unfinished">修剪模式和 -txindex 參數不相容。</translation>
     </message>
     <message>
+        <source>Pruning blockstore…</source>
+        <translation type="unfinished">修剪區塊資料庫中...</translation>
+    </message>
+    <message>
         <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
         <translation type="unfinished">因為系統的限制，將 -maxconnections 參數從 %d 降到了 %d</translation>
+    </message>
+    <message>
+        <source>Replaying blocks…</source>
+        <translation type="unfinished">正在對區塊進行重新計算...</translation>
+    </message>
+    <message>
+        <source>Rescanning…</source>
+        <translation type="unfinished">重新掃描中...</translation>
     </message>
     <message>
         <source>Section [%s] is not recognized.</source>
@@ -3429,8 +3668,16 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished">指定的區塊目錄 "%s" 不存在。</translation>
     </message>
     <message>
+        <source>Starting network threads…</source>
+        <translation type="unfinished">正在開始網路線程...</translation>
+    </message>
+    <message>
         <source>The source code is available from %s.</source>
         <translation type="unfinished">原始碼可以在 %s 取得。</translation>
+    </message>
+    <message>
+        <source>The specified config file %s does not exist</source>
+        <translation type="unfinished">這個指定的配置檔案%s不存在</translation>
     </message>
     <message>
         <source>The transaction amount is too small to pay the fee</source>
@@ -3493,6 +3740,10 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished">沒辦法產生密鑰</translation>
     </message>
     <message>
+        <source>Unable to open %s for writing</source>
+        <translation type="unfinished">無法開啟%s來寫入</translation>
+    </message>
+    <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
         <translation type="unfinished">無法啟動 HTTP 伺服器。詳情請看除錯紀錄。</translation>
     </message>
@@ -3513,6 +3764,10 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished">在 -onlynet 指定了不明的網路別: '%s'</translation>
     </message>
     <message>
+        <source>Unknown new rules activated (versionbit %i)</source>
+        <translation type="unfinished">未知的交易已經有新規則激活 (versionbit %i)</translation>
+    </message>
+    <message>
         <source>Unsupported logging category %s=%s.</source>
         <translation type="unfinished">不支援的紀錄類別 %s=%s。</translation>
     </message>
@@ -3527,6 +3782,14 @@ Go to File &gt; Open Wallet to load a wallet.
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
         <translation type="unfinished">使用者代理註解(%s)中含有不安全的字元。</translation>
+    </message>
+    <message>
+        <source>Verifying blocks…</source>
+        <translation type="unfinished">正在驗證區塊數據...</translation>
+    </message>
+    <message>
+        <source>Verifying wallet(s)…</source>
+        <translation type="unfinished">正在驗證錢包...</translation>
     </message>
     <message>
         <source>Wallet needed to be rewritten: restart %s to complete</source>

--- a/src/qt/locale/bitcoin_zu.ts
+++ b/src/qt/locale/bitcoin_zu.ts
@@ -1,0 +1,239 @@
+<TS version="2.1" language="zu">
+<context>
+    <name>AddressBookPage</name>
+    <message>
+        <source>&amp;New</source>
+        <translation type="unfinished">&amp;Okusha</translation>
+    </message>
+    <message>
+        <source>&amp;Copy</source>
+        <translation type="unfinished">&amp;Kopisha</translation>
+    </message>
+    <message>
+        <source>Receiving addresses</source>
+        <translation type="unfinished">Amakheli ukuthola</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See https://en.wikipedia.org/wiki/Comma-separated_values</extracomment>
+        <translation type="unfinished">Ifayela elehlukaniswe ngo khefana.</translation>
+    </message>
+    </context>
+<context>
+    <name>BitcoinApplication</name>
+    <message>
+        <source>Internal error</source>
+        <translation type="unfinished">Iphutha langaphakathi.</translation>
+    </message>
+    <message>
+        <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
+        <translation type="unfinished">Sekwenzeke iphutha ngaphakathi. %1kuzozama ukuqhubeka ngokuphepha. Leli iphutha ebelingalindelekanga elingabikwa njengoba kuchaziwe ngezansi.</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <source>%1 didn't yet exit safely…</source>
+        <translation type="unfinished">%1Ingakatholakali ngokuphepha okwamanje.</translation>
+    </message>
+    <message>
+        <source>Internal</source>
+        <translation type="unfinished">Okwangaphakathi</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n second(s)</source>
+        <translation>
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n minute(s)</source>
+        <translation>
+            <numerusform>%n imizuzu</numerusform>
+            <numerusform>%n imizuzu</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform>%n amahora</numerusform>
+            <numerusform>%n amahora</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform>%n usuku</numerusform>
+            <numerusform>%nizinsuku</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n week(s)</source>
+        <translation type="unfinished">
+            <numerusform>%namaviki</numerusform>
+            <numerusform>%n amaviki</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n year(s)</source>
+        <translation type="unfinished">
+            <numerusform>%n iminyaka</numerusform>
+            <numerusform>%n iminyaka</numerusform>
+        </translation>
+    </message>
+    </context>
+<context>
+    <name>BitcoinGUI</name>
+    <message>
+        <source>&amp;Options…</source>
+        <translation type="unfinished">&amp;Ongakukhetha...</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation type="unfinished">&amp;Shintsha Umushwana wokungena...</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation type="unfinished">Sayina &amp;umlayezo...</translation>
+    </message>
+    <message>
+        <source>&amp;Verify message…</source>
+        <translation type="unfinished">&amp;Qinisekisa umlayezo...</translation>
+    </message>
+    <message>
+        <source>Close Wallet…</source>
+        <translation type="unfinished">Vala isikhwama semali.</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation type="unfinished">Yakha isikhwama semali.</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation type="unfinished">Ukuxhumana no ntanga.</translation>
+    </message>
+    <message numerus="yes">
+        <source>Processed %n block(s) of transaction history.</source>
+        <translation>
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n active connection(s) to Bitcoin network.</source>
+        <extracomment>A substring of the tooltip.</extracomment>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message>
+        <source>Click for more actions.</source>
+        <extracomment>A substring of the tooltip. "More actions" are available via the context menu.</extracomment>
+        <translation type="unfinished">Chofa ukuveza ezinye izenzo.</translation>
+    </message>
+    <message>
+        <source>Disable network activity</source>
+        <extracomment>A context menu item.</extracomment>
+        <translation type="unfinished">Khubaza umsebenzi we nethiwekhi</translation>
+    </message>
+    </context>
+<context>
+    <name>CreateWalletActivity</name>
+    <message>
+        <source>Can't list signers</source>
+        <translation type="unfinished">Akukwazi ukwenza uhlu lwabasayini.</translation>
+    </message>
+</context>
+<context>
+    <name>CreateWalletDialog</name>
+    <message>
+        <source>External signer</source>
+        <translation type="unfinished">Umusayini wa ngaphandle</translation>
+    </message>
+    </context>
+<context>
+    <name>Intro</name>
+    <message>
+        <source>%1 GB of free space available</source>
+        <translation type="unfinished">%1 GB owesikhala otholakalayo</translation>
+    </message>
+    <message>
+        <source>(of %1 GB needed)</source>
+        <translation type="unfinished">(ku %1 GB odingakalayo)</translation>
+    </message>
+    <message numerus="yes">
+        <source>(sufficient to restore backups %n day(s) old)</source>
+        <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    </context>
+<context>
+    <name>PeerTableModel</name>
+    <message>
+        <source>Peer</source>
+        <extracomment>Title of Peers Table column which contains a unique number used to identify a connection.</extracomment>
+        <translation type="unfinished">Untanga</translation>
+    </message>
+    </context>
+<context>
+    <name>SendCoinsDialog</name>
+    <message>
+        <source>Sign failed</source>
+        <translation type="unfinished">Uphawu lwehlulekile</translation>
+    </message>
+    <message numerus="yes">
+        <source>Estimated to begin confirmation within %n block(s).</source>
+        <translation>
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    </context>
+<context>
+    <name>TransactionDesc</name>
+    <message numerus="yes">
+        <source>Open for %n more block(s)</source>
+        <translation>
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>matures in %n more block(s)</source>
+        <translation>
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    </context>
+<context>
+    <name>TransactionTableModel</name>
+    <message numerus="yes">
+        <source>Open for %n more block(s)</source>
+        <translation>
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    </context>
+<context>
+    <name>TransactionView</name>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See https://en.wikipedia.org/wiki/Comma-separated_values</extracomment>
+        <translation type="unfinished">Ifayela elehlukaniswe nge khefu.</translation>
+    </message>
+    </context>
+<context>
+    <name>bitcoin-core</name>
+    <message>
+        <source>Error: Missing checksum</source>
+        <translation type="unfinished">Iphutha: iChecksum engekho</translation>
+    </message>
+    </context>
+</TS>


### PR DESCRIPTION
This PR pulls the recent translations from the [Transifex.com](https://www.transifex.com/bitcoin/bitcoin) using the [`bitcoin-maintainer-tools/update-translations.py`](https://github.com/bitcoin-core/bitcoin-maintainer-tools/blob/main/update-translations.py) tool.

According to our [Release Process docs](https://github.com/bitcoin/bitcoin/blob/master/doc/release-process.md#before-every-release-candidate), it is supposed to be merged before `v22.1rc1` tagging.

Will keep this PR updated regularly until merging.

The `bitcoin_vi.ts` translation is damaged, therefore its changes were rejected manually.