### PR TITLE
test: remove unused `CHANGE_{XPRV,XPUB}` constants

### DIFF
--- a/test/functional/wallet_taproot.py
+++ b/test/functional/wallet_taproot.py
@@ -156,9 +156,6 @@ KEYS = [
     }
 ]
 
-CHANGE_XPRV = "tprv8ZgxMBicQKsPcyDrWwiecVnTtFmfRwbfFqEfR4ZGWvq5aTTwLBWmAm5zrbMcYtb9gQNFfhRfqhhrBG37U3nhmXxEgeEPBJGHAPrHCrAd1WX"
-CHANGE_XPUB = "tpubD6NzVbkrYhZ4WSFeQbPF1uSaTHHbbGnZq8qShabZwCdUQwihxaLMMFhs2kidGF2qrRKiQVqw8VoyuTHj1bZqmMXMeciaU1gBjWA1sim2zUB"
-
 
 def key(hex_key):
     """Construct an x-only pubkey from its hex representation."""


### PR DESCRIPTION
These constants exist since the introduction of the functional test wallet_taproot.py (2667366aaa69447a9de4d819669d254a5ebd4d4b), but they have never been used.