### PR TITLE
Enforce incentive compatibility for all RBF replacements

### DIFF
--- a/src/policy/rbf.cpp
+++ b/src/policy/rbf.cpp
@@ -139,11 +139,6 @@ std::optional<std::string> PaysMoreThanConflicts(const CTxMemPool::setEntries& i
         // We usually don't want to accept replacements with lower feerates than what they replaced
         // as that would lower the feerate of the next block. Requiring that the feerate always be
         // increased is also an easy-to-reason about way to prevent DoS attacks via replacements.
-        //
-        // We only consider the feerates of transactions being directly replaced, not their indirect
-        // descendants. While that does mean high feerate children are ignored when deciding whether
-        // or not to replace, we do require the replacement to pay more overall fees too, mitigating
-        // most cases.
         CFeeRate original_feerate(mi->GetModifiedFee(), mi->GetTxSize());
         if (replacement_feerate <= original_feerate) {
             return strprintf("rejecting replacement %s; new feerate %s <= old feerate %s",

--- a/test/functional/feature_rbf.py
+++ b/test/functional/feature_rbf.py
@@ -59,6 +59,9 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         self.log.info("Running test replacement ancestorfeeperkb")
         self.test_replacement_ancestorfeeperkb()
 
+        self.log.info("Running test new unconfirmed inputs...")
+        self.test_new_unconfirmed_inputs()
+
         self.log.info("Running test spends of conflicting outputs...")
         self.test_spends_of_conflicting_outputs()
 
@@ -362,6 +365,27 @@ class ReplaceByFeeTest(BitcoinTestFramework):
 
         # This will raise an exception
         assert_raises_rpc_error(-26, "bad-txns-spends-conflicting-tx", self.nodes[0].sendrawtransaction, tx2_hex, 0)
+
+    def test_new_unconfirmed_inputs(self):
+        """Replacements that add new unconfirmed inputs are permitted"""
+        confirmed_utxo = self.make_utxo(self.nodes[0], int(1.1 * COIN))
+        unconfirmed_utxo = self.make_utxo(self.nodes[0], int(0.1 * COIN), confirmed=False)
+
+        self.wallet.send_self_transfer(
+            from_node=self.nodes[0],
+            utxo_to_spend=confirmed_utxo,
+            sequence=0,
+            fee=Decimal("0.000002"),
+        )
+
+        tx2_hex = self.wallet.create_self_transfer_multi(
+            utxos_to_spend=[confirmed_utxo, unconfirmed_utxo],
+            sequence=0,
+            amount_per_output=1 * COIN,
+        )["hex"]
+
+        tx2_txid = self.nodes[0].sendrawtransaction(tx2_hex, 0)
+        assert tx2_txid in self.nodes[0].getrawmempool()
 
     def test_too_many_replacements(self):
         """Replacements that evict too many transactions are rejected"""


### PR DESCRIPTION
Opening this for discussion.

Currently it's possible in our RBF rules to evict a transaction with higher mining score from our mempool, in favor of a transaction with a higher total fee but lower feerate.  This patch would fix this incentive incompatibility, by requiring that any new transaction have a mining score (as defined by the minimum of its feerate and its feerate including ancestors) to be greater than the individual feerates of all transactions that would be evicted.

Because this new feerate criteria includes the ancestors of a new transaction in the score, we are able to eliminate the prohibition against including new unconfirmed parents in a replacement transaction, a slight relaxation of the prior rules.