### PR TITLE
wallet: Allow `bumpfee` for txs that don't signal BIP-125

### DIFF
--- a/src/wallet/feebumper.cpp
+++ b/src/wallet/feebumper.cpp
@@ -39,11 +39,6 @@ static feebumper::Result PreconditionChecks(const CWallet& wallet, const CWallet
         return feebumper::Result::WALLET_ERROR;
     }
 
-    if (!SignalsOptInRBF(*wtx.tx)) {
-        errors.push_back(Untranslated("Transaction is not BIP 125 replaceable"));
-        return feebumper::Result::WALLET_ERROR;
-    }
-
     if (wtx.mapValue.count("replaced_by_txid")) {
         errors.push_back(strprintf(Untranslated("Cannot bump transaction %s which was already bumped by transaction %s"), wtx.GetHash().ToString(), wtx.mapValue.at("replaced_by_txid")));
         return feebumper::Result::WALLET_ERROR;


### PR DESCRIPTION
There is no technical reason to prevent this, though of course, non-signalling transactions are less likely to actually get mined. There is no consensus over the mempool, and especially in times of congestion, a higher fee transaction may be able to replace a lower fee one regardless of fee rate.

No changes to the tests were required, as this case is not tested. If `-mempoolfullrbf` (https://github.com/bitcoin/bitcoin/pull/25353) is enabled, the replacement is of course added to the mempool. If not, the replacement is added to the wallet and may be broadcast later.

Question: What would be the best way to force the transaction to be added to the mempool, with broadcast?