### PR TITLE
[24.x] Remove mempoolfullrbf option

### DIFF
--- a/doc/man/bitcoin-qt.1
+++ b/doc/man/bitcoin-qt.1
@@ -669,11 +669,6 @@ Relay and mine data carrier transactions (default: 1)
 Maximum size of data in data carrier transactions we relay and mine
 (default: 83)
 .HP
-\fB\-mempoolfullrbf\fR
-.IP
-Accept transaction replace\-by\-fee without requiring replaceability
-signaling (default: 0)
-.HP
 \fB\-minrelaytxfee=\fR<amt>
 .IP
 Fees (in BTC/kvB) smaller than this are considered zero fee for

--- a/doc/man/bitcoind.1
+++ b/doc/man/bitcoind.1
@@ -669,11 +669,6 @@ Relay and mine data carrier transactions (default: 1)
 Maximum size of data in data carrier transactions we relay and mine
 (default: 83)
 .HP
-\fB\-mempoolfullrbf\fR
-.IP
-Accept transaction replace\-by\-fee without requiring replaceability
-signaling (default: 0)
-.HP
 \fB\-minrelaytxfee=\fR<amt>
 .IP
 Fees (in BTC/kvB) smaller than this are considered zero fee for

--- a/doc/policy/mempool-replacements.md
+++ b/doc/policy/mempool-replacements.md
@@ -15,8 +15,6 @@ other consensus and policy rules, each of the following conditions are met:
 
    *Rationale*: See [BIP125
    explanation](https://github.com/bitcoin/bips/blob/master/bip-0125.mediawiki#motivation).
-   Use the (`-mempoolfullrbf`) configuration option to allow transaction replacement without enforcement of the
-   opt-in signaling rule.
 
 2. The replacement transaction only include an unconfirmed input if that input was included in
    one of the directly conflicting transactions. An unconfirmed input spends an output from a
@@ -76,6 +74,3 @@ This set of rules is similar but distinct from BIP125.
 
 * RBF enabled by default in the wallet GUI as of **v0.18.1** ([PR
   #11605](https://github.com/bitcoin/bitcoin/pull/11605)).
-
-* Full replace-by-fee enabled as a configurable mempool policy as of **v24.0** ([PR
-  #25353](https://github.com/bitcoin/bitcoin/pull/25353)).

--- a/share/examples/bitcoin.conf
+++ b/share/examples/bitcoin.conf
@@ -564,10 +564,6 @@
 # (default: 83)
 #datacarriersize=1
 
-# Accept transaction replace-by-fee without requiring replaceability
-# signaling (default: 0)
-#mempoolfullrbf=1
-
 # Fees (in BTC/kvB) smaller than this are considered zero fee for
 # relaying, mining and transaction creation (default: 0.00001)
 #minrelaytxfee=<amt>

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -564,7 +564,6 @@ void SetupServerArgs(ArgsManager& argsman)
     argsman.AddArg("-bytespersigop", strprintf("Equivalent bytes per sigop in transactions for relay and mining (default: %u)", DEFAULT_BYTES_PER_SIGOP), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-datacarrier", strprintf("Relay and mine data carrier transactions (default: %u)", DEFAULT_ACCEPT_DATACARRIER), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-datacarriersize", strprintf("Maximum size of data in data carrier transactions we relay and mine (default: %u)", MAX_OP_RETURN_RELAY), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
-    argsman.AddArg("-mempoolfullrbf", strprintf("Accept transaction replace-by-fee without requiring replaceability signaling (default: %u)", DEFAULT_MEMPOOL_FULL_RBF), ArgsManager::ALLOW_ANY, OptionsCategory::NODE_RELAY);
     argsman.AddArg("-permitbaremultisig", strprintf("Relay non-P2SH multisig (default: %u)", DEFAULT_PERMIT_BAREMULTISIG), ArgsManager::ALLOW_ANY,
                    OptionsCategory::NODE_RELAY);
     argsman.AddArg("-minrelaytxfee=<amt>", strprintf("Fees (in %s/kvB) smaller than this are considered zero fee for relaying, mining and transaction creation (default: %s)",

--- a/src/kernel/mempool_options.h
+++ b/src/kernel/mempool_options.h
@@ -20,8 +20,6 @@ class CBlockPolicyEstimator;
 static constexpr unsigned int DEFAULT_MAX_MEMPOOL_SIZE_MB{300};
 /** Default for -mempoolexpiry, expiration time for mempool transactions in hours */
 static constexpr unsigned int DEFAULT_MEMPOOL_EXPIRY_HOURS{336};
-/** Default for -mempoolfullrbf, if the transaction replaceability signaling is ignored */
-static constexpr bool DEFAULT_MEMPOOL_FULL_RBF{false};
 
 namespace kernel {
 /**
@@ -52,7 +50,6 @@ struct MemPoolOptions {
     std::optional<unsigned> max_datacarrier_bytes{DEFAULT_ACCEPT_DATACARRIER ? std::optional{MAX_OP_RETURN_RELAY} : std::nullopt};
     bool permit_bare_multisig{DEFAULT_PERMIT_BAREMULTISIG};
     bool require_standard{true};
-    bool full_rbf{DEFAULT_MEMPOOL_FULL_RBF};
     MemPoolLimits limits{};
 };
 } // namespace kernel

--- a/src/node/mempool_args.cpp
+++ b/src/node/mempool_args.cpp
@@ -92,8 +92,6 @@ std::optional<bilingual_str> ApplyArgsManOptions(const ArgsManager& argsman, con
         return strprintf(Untranslated("acceptnonstdtxn is not currently supported for %s chain"), chainparams.NetworkIDString());
     }
 
-    mempool_opts.full_rbf = argsman.GetBoolArg("-mempoolfullrbf", mempool_opts.full_rbf);
-
     ApplyArgsManOptions(argsman, mempool_opts.limits);
 
     return std::nullopt;

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -670,7 +670,6 @@ UniValue MempoolInfoToJSON(const CTxMemPool& pool)
     ret.pushKV("minrelaytxfee", ValueFromAmount(pool.m_min_relay_feerate.GetFeePerK()));
     ret.pushKV("incrementalrelayfee", ValueFromAmount(pool.m_incremental_relay_feerate.GetFeePerK()));
     ret.pushKV("unbroadcastcount", uint64_t{pool.GetUnbroadcastTxs().size()});
-    ret.pushKV("fullrbf", pool.m_full_rbf);
     return ret;
 }
 
@@ -692,7 +691,6 @@ static RPCHelpMan getmempoolinfo()
                 {RPCResult::Type::STR_AMOUNT, "minrelaytxfee", "Current minimum relay fee for transactions"},
                 {RPCResult::Type::NUM, "incrementalrelayfee", "minimum fee rate increment for mempool limiting or replacement in " + CURRENCY_UNIT + "/kvB"},
                 {RPCResult::Type::NUM, "unbroadcastcount", "Current number of transactions that haven't passed initial broadcast yet"},
-                {RPCResult::Type::BOOL, "fullrbf", "True if the mempool accepts RBF without replaceability signaling inspection"},
             }},
         RPCExamples{
             HelpExampleCli("getmempoolinfo", "")

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -434,7 +434,6 @@ CTxMemPool::CTxMemPool(const Options& opts)
       m_permit_bare_multisig{opts.permit_bare_multisig},
       m_max_datacarrier_bytes{opts.max_datacarrier_bytes},
       m_require_standard{opts.require_standard},
-      m_full_rbf{opts.full_rbf},
       m_limits{opts.limits}
 {
     _clear(); //lock free clear

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -574,7 +574,6 @@ public:
     const bool m_permit_bare_multisig;
     const std::optional<unsigned> m_max_datacarrier_bytes;
     const bool m_require_standard;
-    const bool m_full_rbf;
 
     using Limits = kernel::MemPoolLimits;
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -744,10 +744,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
                 // Applications relying on first-seen mempool behavior should
                 // check all unconfirmed ancestors; otherwise an opt-in ancestor
                 // might be replaced, causing removal of this descendant.
-                //
-                // If replaceability signaling is ignored due to node setting,
-                // replacement is always allowed.
-                if (!m_pool.m_full_rbf && !SignalsOptInRBF(*ptxConflicting)) {
+                if (!SignalsOptInRBF(*ptxConflicting)) {
                     return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "txn-mempool-conflict");
                 }
 


### PR DESCRIPTION
Reverts #25353 for 24.x only. Alternative to #26438 and #26287.

Note that this is not a backport. This is not intended to be merged into master, nor is it a followup to #26438. This is a standalone PR for 24.x only.

It's clear that the discussion around the mempoolfullrbf option is holding up the 24.0 release. Release candidates have been taking longer than usual with the hope that a resolution will be found before the next RC. But it seems that we are deadlocked on this issue. I believe that the release maintainer is hesitant to tag the release while this discussion is ongoing.

In the interest of getting the 24.0 release out sooner, I am opening this PR to remove the mempoolfullrbf option from **24.0 only**. The option will remain in master so that we can continue to discuss it. This maintains the current status quo - the option is new, and similar options have not been in releases for several years.

While our general policy is that only backports of bug fixes are merged into release branches after feature freeze, I think it is reasonable to make an exception considering the magnitude of the disagreement mempoolfullrbf is causing. Maintaining the status quo allows the discussion to resolve in its own timeframe without holding up the release.