### PR TITLE
[23.x] guix: use `--build={arch}-guix-linux-gnu` in cross toolchain

### DIFF
--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -78,6 +78,11 @@ http://www.linuxfromscratch.org/hlfs/view/development/chapter05/gcc-pass1.html"
                  (("-rpath=") "-rpath-link="))
                #t))))))))
 
+(define building-on (string-append (list-ref (string-split (%current-system) #\-) 0) "-guix-linux-gnu"))
+
+(define (explicit-cross-configure package)
+  (package-with-extra-configure-variable package "--build" building-on))
+
 (define (make-cross-toolchain target
                               base-gcc-for-libc
                               base-kernel-headers
@@ -87,9 +92,9 @@ http://www.linuxfromscratch.org/hlfs/view/development/chapter05/gcc-pass1.html"
   (let* ((xbinutils (cross-binutils target))
          ;; 1. Build a cross-compiling gcc without targeting any libc, derived
          ;; from BASE-GCC-FOR-LIBC
-         (xgcc-sans-libc (cross-gcc target
-                                    #:xgcc base-gcc-for-libc
-                                    #:xbinutils xbinutils))
+         (xgcc-sans-libc (explicit-cross-configure (cross-gcc target
+                                                              #:xgcc base-gcc-for-libc
+                                                              #:xbinutils xbinutils)))
          ;; 2. Build cross-compiled kernel headers with XGCC-SANS-LIBC, derived
          ;; from BASE-KERNEL-HEADERS
          (xkernel (cross-kernel-headers target
@@ -98,17 +103,17 @@ http://www.linuxfromscratch.org/hlfs/view/development/chapter05/gcc-pass1.html"
                                         xbinutils))
          ;; 3. Build a cross-compiled libc with XGCC-SANS-LIBC and XKERNEL,
          ;; derived from BASE-LIBC
-         (xlibc (cross-libc target
-                            base-libc
-                            xgcc-sans-libc
-                            xbinutils
-                            xkernel))
+         (xlibc (explicit-cross-configure (cross-libc target
+                                                      base-libc
+                                                      xgcc-sans-libc
+                                                      xbinutils
+                                                      xkernel)))
          ;; 4. Build a cross-compiling gcc targeting XLIBC, derived from
          ;; BASE-GCC
-         (xgcc (cross-gcc target
-                          #:xgcc base-gcc
-                          #:xbinutils xbinutils
-                          #:libc xlibc)))
+         (xgcc (explicit-cross-configure (cross-gcc target
+                                                    #:xgcc base-gcc
+                                                    #:xbinutils xbinutils
+                                                    #:libc xlibc))))
     ;; Define a meta-package that propagates the resulting XBINUTILS, XLIBC, and
     ;; XGCC
     (package


### PR DESCRIPTION
This backports https://github.com/bitcoin/bitcoin/pull/25861 to the 23.x branch, which fixes Guix building for `aarch64-linux-gnu` on aarch64 hardware. Fixing Guix building for this `HOST`, for the current release branch, seems like a worthwhile change, especially given more Guix builders are using aarch64 hardware. I thought I'd already backported this; noticed while building [sigs for 23.1rc1](https://github.com/bitcoin-core/guix.sigs/pull/380), which I started doing on aarch64.

Guix Build (aarch64, no `x86_64-apple-darwin` or `arm64-apple-darwin`):
```bash
9fd4601412738e9135e2732cfc8af911c54af8a1349c2af568b4748dd1907c3d  guix-build-0f4583e5c114/output/aarch64-linux-gnu/SHA256SUMS.part
36df2797cd7845ccb4f416b52f9dbd4cc7dd0242782c3143206d0c15239e8b02  guix-build-0f4583e5c114/output/aarch64-linux-gnu/bitcoin-0f4583e5c114-aarch64-linux-gnu-debug.tar.gz
6aa022173b23827ec2690823178b9d2d06108e159a9074e1a54a7d1a74b6c5db  guix-build-0f4583e5c114/output/aarch64-linux-gnu/bitcoin-0f4583e5c114-aarch64-linux-gnu.tar.gz
1e98b6b5e2b58387106eb8f46367c4a42d03d6a881307ed115e7b6bfa1b2785a  guix-build-0f4583e5c114/output/arm-linux-gnueabihf/SHA256SUMS.part
b9ecbfbec1ee941acb7f19fb2ba02bfa24ef5feb0e072a9a8c39263f2cdfb172  guix-build-0f4583e5c114/output/arm-linux-gnueabihf/bitcoin-0f4583e5c114-arm-linux-gnueabihf-debug.tar.gz
2834aa08f19c03e88e22009e3f860b470fe5942c42ae08041b8e79e28673154b  guix-build-0f4583e5c114/output/arm-linux-gnueabihf/bitcoin-0f4583e5c114-arm-linux-gnueabihf.tar.gz
9c787047070b1fe8c2beead22093dc73481e7c921993d95fb0e4ce8739f8e515  guix-build-0f4583e5c114/output/dist-archive/bitcoin-0f4583e5c114.tar.gz
1a82b19a5d07bccdead69b5d9fe9559e01a263b458ea48ff0a701ee9adf55a3c  guix-build-0f4583e5c114/output/powerpc64-linux-gnu/SHA256SUMS.part
3482de0ff01839aa98ca61b3c8a18de4773dd70e2b306f094b210a6c83839289  guix-build-0f4583e5c114/output/powerpc64-linux-gnu/bitcoin-0f4583e5c114-powerpc64-linux-gnu-debug.tar.gz
5bb8b7ab8740d6c4a49e8fe700f0305bcc7318eaffc0e3c967492f218774f371  guix-build-0f4583e5c114/output/powerpc64-linux-gnu/bitcoin-0f4583e5c114-powerpc64-linux-gnu.tar.gz
5442e495049b386b8ec5bc50c06feb401fb263e25f0807aa58e7e8c091c42be7  guix-build-0f4583e5c114/output/powerpc64le-linux-gnu/SHA256SUMS.part
d685b1449379a3a1be139f243917d9987169cbc9901c7658a12044d27ce2762d  guix-build-0f4583e5c114/output/powerpc64le-linux-gnu/bitcoin-0f4583e5c114-powerpc64le-linux-gnu-debug.tar.gz
14edbaf4c93346460ecff72ca22285c433c7dea5f9ccaccb4b49730f95d2d264  guix-build-0f4583e5c114/output/powerpc64le-linux-gnu/bitcoin-0f4583e5c114-powerpc64le-linux-gnu.tar.gz
dec22e0f59513c3697de3c6906deb355010af36836285ab306de1ea8e4b88ff3  guix-build-0f4583e5c114/output/riscv64-linux-gnu/SHA256SUMS.part
d70b6b6d1a2950292e820898af8a79d850b415829bbb94db97b742f3ab7cc7d3  guix-build-0f4583e5c114/output/riscv64-linux-gnu/bitcoin-0f4583e5c114-riscv64-linux-gnu-debug.tar.gz
b5fd33257a81efacc61946b544e5af1582c9729fa57641ff3625d34f0e785cfd  guix-build-0f4583e5c114/output/riscv64-linux-gnu/bitcoin-0f4583e5c114-riscv64-linux-gnu.tar.gz
30b6668d9e84503d2e2113a87051d3c5baeae8ad6b3fa3df7509d447c8d5f341  guix-build-0f4583e5c114/output/x86_64-linux-gnu/SHA256SUMS.part
33a6c5072328281872678fc0d709629f934fac05bdfb2e41cccf2ddd5724925b  guix-build-0f4583e5c114/output/x86_64-linux-gnu/bitcoin-0f4583e5c114-x86_64-linux-gnu-debug.tar.gz
c1c2ec074a88c6f0202ab067bd126c217573d028b3b1eb538db100eb0e316b53  guix-build-0f4583e5c114/output/x86_64-linux-gnu/bitcoin-0f4583e5c114-x86_64-linux-gnu.tar.gz
2689a7cce5d1fc6decbb5dfd1361db21adc1c485ee4c644cdebf403b1d533be6  guix-build-0f4583e5c114/output/x86_64-w64-mingw32/SHA256SUMS.part
9d6259432febdc1be728db0088a0464fa844dc4ad20e7b752be6de312588a695  guix-build-0f4583e5c114/output/x86_64-w64-mingw32/bitcoin-0f4583e5c114-win64-debug.zip
e3e7cd45b6ed6e8a589efe2436e151120af0c1146772ce295c06300289e0b758  guix-build-0f4583e5c114/output/x86_64-w64-mingw32/bitcoin-0f4583e5c114-win64-setup-unsigned.exe
1da1569b0140ad917b938ce8b087d3d8990331df3042d62a36d1366d9e5f0f42  guix-build-0f4583e5c114/output/x86_64-w64-mingw32/bitcoin-0f4583e5c114-win64-unsigned.tar.gz
cbd74726e5704f6007e2344422197a25b9872a3a5f525a1a0b5774c833fc7e78  guix-build-0f4583e5c114/output/x86_64-w64-mingw32/bitcoin-0f4583e5c114-win64.zip
```