### PR TITLE
bench: Suppress output when running with `-sanity-check` option

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -175,7 +175,7 @@ task:
     - ccache --show-stats
   check_script:
     - src\test_bitcoin.exe -l test_suite
-    - src\bench_bitcoin.exe --sanity-check > NUL
+    - src\bench_bitcoin.exe --sanity-check
     - python test\util\test_runner.py
     - python test\util\rpcauth-test.py
   functional_tests_script:

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -377,7 +377,7 @@ if TARGET_WINDOWS
 else
 if ENABLE_BENCH
 	@echo "Running bench/bench_bitcoin (one iteration sanity check, only high priority)..."
-	$(BENCH_BINARY) -sanity-check -priority-level=high > /dev/null
+	$(BENCH_BINARY) -sanity-check -priority-level=high
 endif
 endif
 	$(AM_V_at)$(MAKE) $(AM_MAKEFLAGS) -C secp256k1 check

--- a/src/bench/bench.cpp
+++ b/src/bench/bench.cpp
@@ -83,7 +83,7 @@ void BenchRunner::RunAll(const Args& args)
     std::smatch baseMatch;
 
     if (args.sanity_check) {
-        std::cout << "Running with --sanity-check option, benchmark results will be useless." << std::endl;
+        std::cout << "Running with -sanity-check option, output is being suppressed as benchmark results will be useless." << std::endl;
     }
 
     std::vector<ankerl::nanobench::Result> benchmarkResults;
@@ -106,6 +106,7 @@ void BenchRunner::RunAll(const Args& args)
         Bench bench;
         if (args.sanity_check) {
             bench.epochs(1).epochIterations(1);
+            bench.output(nullptr);
         }
         bench.name(name);
         if (args.min_time > 0ms) {

--- a/src/bench/bench_bitcoin.cpp
+++ b/src/bench/bench_bitcoin.cpp
@@ -31,7 +31,7 @@ static void SetupBenchArgs(ArgsManager& argsman)
     argsman.AddArg("-min-time=<milliseconds>", strprintf("Minimum runtime per benchmark, in milliseconds (default: %d)", DEFAULT_MIN_TIME_MS), ArgsManager::ALLOW_ANY | ArgsManager::DISALLOW_NEGATION, OptionsCategory::OPTIONS);
     argsman.AddArg("-output-csv=<output.csv>", "Generate CSV file with the most important benchmark results", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-output-json=<output.json>", "Generate JSON file with all benchmark results", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
-    argsman.AddArg("-sanity-check", "Run benchmarks for only one iteration", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    argsman.AddArg("-sanity-check", "Run benchmarks for only one iteration with no output", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-priority-level=<l1,l2,l3>", strprintf("Run benchmarks of one or multiple priority level(s) (%s), default: '%s'",
                                                            benchmark::ListPriorities(), DEFAULT_PRIORITY), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
 }


### PR DESCRIPTION
This change allows to simplify CI tests, and makes it easier to integrate the `bench_bitcoin` binary into CMake custom [targets](https://cmake.org/cmake/help/latest/command/add_custom_target.html) or [commands](https://cmake.org/cmake/help/latest/command/add_custom_command.html), as `COMMAND` does not support output redirection.