### PR TITLE
contrib: Speed up systemd boot

### DIFF
--- a/contrib/init/bitcoind.service
+++ b/contrib/init/bitcoind.service
@@ -14,8 +14,7 @@ Description=Bitcoin daemon
 Documentation=https://github.com/bitcoin/bitcoin/blob/master/doc/init.md
 
 # https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/
-After=network-online.target
-Wants=network-online.target
+After=network.target
 
 [Service]
 ExecStart=/usr/bin/bitcoind -daemonwait \


### PR DESCRIPTION
Relevant issue: https://github.com/bitcoin/bitcoin/issues/26493

The currently used pattern is supposed to help some super fragile programs which can crash or get stuck if they fail to execute some network requests. Bitcoin Core is far from being fragile so no one benefits from the current setup.

It's also possible to avoid adding any network hints to the unit file, but would prevent Bitcoin Core from closing the network connections gracefully on shutdown.

> Services using the network should hence simply place an After=network.target stanza in their unit files, without Wants=network.target or Requires=network.target.

https://systemd.io/NETWORK_ONLINE/

Adding `After=network.target` is beneficial for shutdown and it has no effect on the boot process, so I think it makes sense to replace the current network hooks with the less invasive and officially endorsed one.