### PR TITLE
Add `UNREACHABLE` macro

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -844,11 +844,11 @@ int GetInt(Tabs tab)
     case Tabs::network_graph: return 2;
     case Tabs::peers: return 3;
     } // no default case, so the compiler can warn about missing cases
-    assert(false);
+    UNREACHABLE();
 }
 ```
 
-*Rationale*: The comment documents skipping `default:` label, and it complies with `clang-format` rules. The assertion prevents firing of `-Wreturn-type` warning on some compilers.
+*Rationale*: The comment documents skipping the `default:` case, and it complies with `clang-format` rules. The `UNREACHABLE` macro prevents firing of `-Wreturn-type`/`C4715` warnings on some compilers. In the RPC code, the `NONFATAL_UNREACHABLE` macro might be more appropriate instead.
 
 Strings and formatting
 ------------------------

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -12,6 +12,7 @@
 #include <logging.h>
 #include <tinyformat.h>
 #include <util/chaintype.h>
+#include <util/check.h>
 #include <util/strencodings.h>
 #include <util/string.h>
 
@@ -123,8 +124,8 @@ std::unique_ptr<const CChainParams> CreateChainParams(const ArgsManager& args, c
         ReadRegTestArgs(args, opts);
         return CChainParams::RegTest(opts);
     }
-    }
-    assert(false);
+    } // no default case, so the compiler can warn about missing cases
+    UNREACHABLE();
 }
 
 void SelectParams(const ChainType chain)

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -8,6 +8,7 @@
 #include <common/args.h>
 #include <tinyformat.h>
 #include <util/chaintype.h>
+#include <util/check.h>
 
 #include <assert.h>
 
@@ -47,8 +48,8 @@ std::unique_ptr<CBaseChainParams> CreateBaseChainParams(const ChainType chain)
         return std::make_unique<CBaseChainParams>("signet", 38332, 38334);
     case ChainType::REGTEST:
         return std::make_unique<CBaseChainParams>("regtest", 18443, 18445);
-    }
-    assert(false);
+    } // no default case, so the compiler can warn about missing cases
+    UNREACHABLE();
 }
 
 void SelectBaseParams(const ChainType chain)

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -17,6 +17,7 @@
 #include <rpc/protocol.h> // For HTTP status codes
 #include <shutdown.h>
 #include <sync.h>
+#include <util/check.h>
 #include <util/strencodings.h>
 #include <util/threadnames.h>
 #include <util/translation.h>
@@ -204,7 +205,7 @@ std::string RequestMethodString(HTTPRequest::RequestMethod m)
     case HTTPRequest::UNKNOWN:
         return "unknown";
     } // no default case, so the compiler can warn about missing cases
-    assert(false);
+    UNREACHABLE();
 }
 
 /** HTTP request callback */

--- a/src/kernel/coinstats.cpp
+++ b/src/kernel/coinstats.cpp
@@ -171,7 +171,7 @@ std::optional<CCoinsStats> ComputeUTXOStats(CoinStatsHashType hash_type, CCoinsV
             return ComputeUTXOStats(view, stats, nullptr, interruption_point);
         }
         } // no default case, so the compiler can warn about missing cases
-        assert(false);
+        UNREACHABLE();
     }();
 
     if (!success) {

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -4,6 +4,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <logging.h>
+#include <util/check.h>
 #include <util/fs.h>
 #include <util/string.h>
 #include <util/threadnames.h>
@@ -216,8 +217,8 @@ std::string BCLog::Logger::LogLevelToStr(BCLog::Level level) const
         return "error";
     case BCLog::Level::None:
         return "";
-    }
-    assert(false);
+    } // no default case, so the compiler can warn about missing cases
+    UNREACHABLE();
 }
 
 std::string LogCategoryToStr(BCLog::LogFlags category)
@@ -288,8 +289,8 @@ std::string LogCategoryToStr(BCLog::LogFlags category)
         return "scan";
     case BCLog::LogFlags::ALL:
         return "all";
-    }
-    assert(false);
+    } // no default case, so the compiler can warn about missing cases
+    UNREACHABLE();
 }
 
 static std::optional<BCLog::Level> GetLogLevel(const std::string& level_str)

--- a/src/net.h
+++ b/src/net.h
@@ -453,8 +453,7 @@ public:
             case ConnectionType::FEELER:
                 return false;
         } // no default case, so the compiler can warn about missing cases
-
-        assert(false);
+        UNREACHABLE();
     }
 
     bool IsFullOutboundConn() const {
@@ -492,8 +491,7 @@ public:
             case ConnectionType::ADDR_FETCH:
                 return true;
         } // no default case, so the compiler can warn about missing cases
-
-        assert(false);
+        UNREACHABLE();
     }
 
     /**

--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -10,6 +10,7 @@
 #include <hash.h>
 #include <prevector.h>
 #include <tinyformat.h>
+#include <util/check.h>
 #include <util/strencodings.h>
 #include <util/string.h>
 
@@ -38,8 +39,7 @@ CNetAddr::BIP155Network CNetAddr::GetBIP155Network() const
     case NET_MAX:        // m_net is never and should not be set to NET_MAX
         assert(false);
     } // no default case, so the compiler can warn about missing cases
-
-    assert(false);
+    UNREACHABLE();
 }
 
 bool CNetAddr::SetNetFromBIP155Network(uint8_t possible_bip155_net, size_t address_size)
@@ -511,8 +511,7 @@ bool CNetAddr::IsAddrV1Compatible() const
     case NET_MAX:        // m_net is never and should not be set to NET_MAX
         assert(false);
     } // no default case, so the compiler can warn about missing cases
-
-    assert(false);
+    UNREACHABLE();
 }
 
 enum Network CNetAddr::GetNetwork() const
@@ -618,8 +617,7 @@ std::string CNetAddr::ToStringAddr() const
     case NET_MAX:        // m_net is never and should not be set to NET_MAX
         assert(false);
     } // no default case, so the compiler can warn about missing cases
-
-    assert(false);
+    UNREACHABLE();
 }
 
 bool operator==(const CNetAddr& a, const CNetAddr& b)
@@ -690,7 +688,7 @@ uint32_t CNetAddr::GetLinkedIPv4() const
         // Teredo tunneled IPv4: the IPv4 address is in the last 4 bytes of the address, but bitflipped
         return ~ReadBE32(Span{m_addr}.last(ADDR_IPV4_SIZE).data());
     }
-    assert(false);
+    UNREACHABLE();
 }
 
 Network CNetAddr::GetNetClass() const

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -9,6 +9,7 @@
 #include <logging.h>
 #include <sync.h>
 #include <tinyformat.h>
+#include <util/check.h>
 #include <util/sock.h>
 #include <util/strencodings.h>
 #include <util/string.h>
@@ -106,8 +107,7 @@ std::string GetNetworkName(enum Network net)
     case NET_INTERNAL: return "internal";
     case NET_MAX: assert(false);
     } // no default case, so the compiler can warn about missing cases
-
-    assert(false);
+    UNREACHABLE();
 }
 
 std::vector<std::string> GetNetworkNames(bool append_unroutable)

--- a/src/node/connection_types.cpp
+++ b/src/node/connection_types.cpp
@@ -3,7 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <node/connection_types.h>
-#include <cassert>
+#include <util/check.h>
 
 std::string ConnectionTypeAsString(ConnectionType conn_type)
 {
@@ -21,6 +21,5 @@ std::string ConnectionTypeAsString(ConnectionType conn_type)
     case ConnectionType::ADDR_FETCH:
         return "addr-fetch";
     } // no default case, so the compiler can warn about missing cases
-
-    assert(false);
+    UNREACHABLE();
 }

--- a/src/outputtype.cpp
+++ b/src/outputtype.cpp
@@ -10,6 +10,7 @@
 #include <script/sign.h>
 #include <script/signingprovider.h>
 #include <script/standard.h>
+#include <util/check.h>
 #include <util/vector.h>
 
 #include <assert.h>
@@ -45,7 +46,7 @@ const std::string& FormatOutputType(OutputType type)
     case OutputType::BECH32M: return OUTPUT_TYPE_STRING_BECH32M;
     case OutputType::UNKNOWN: return OUTPUT_TYPE_STRING_UNKNOWN;
     } // no default case, so the compiler can warn about missing cases
-    assert(false);
+    UNREACHABLE();
 }
 
 CTxDestination GetDestinationForKey(const CPubKey& key, OutputType type)
@@ -66,7 +67,7 @@ CTxDestination GetDestinationForKey(const CPubKey& key, OutputType type)
     case OutputType::BECH32M:
     case OutputType::UNKNOWN: {} // This function should never be used with BECH32M or UNKNOWN, so let it assert
     } // no default case, so the compiler can warn about missing cases
-    assert(false);
+    UNREACHABLE();
 }
 
 std::vector<CTxDestination> GetAllDestinationsForKey(const CPubKey& key)
@@ -105,7 +106,7 @@ CTxDestination AddAndGetDestinationForScript(FillableSigningProvider& keystore, 
     case OutputType::BECH32M:
     case OutputType::UNKNOWN: {} // This function should not be used for BECH32M or UNKNOWN, so let it assert
     } // no default case, so the compiler can warn about missing cases
-    assert(false);
+    UNREACHABLE();
 }
 
 std::optional<OutputType> OutputTypeFromDestination(const CTxDestination& dest) {

--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -18,6 +18,7 @@
 #include <sync.h>
 #include <tinyformat.h>
 #include <uint256.h>
+#include <util/check.h>
 #include <util/fs.h>
 #include <util/serfloat.h>
 #include <util/time.h>
@@ -41,7 +42,7 @@ std::string StringForFeeEstimateHorizon(FeeEstimateHorizon horizon)
     case FeeEstimateHorizon::MED_HALFLIFE: return "medium";
     case FeeEstimateHorizon::LONG_HALFLIFE: return "long";
     } // no default case, so the compiler can warn about missing cases
-    assert(false);
+    UNREACHABLE();
 }
 
 namespace {
@@ -743,7 +744,7 @@ unsigned int CBlockPolicyEstimator::HighestTargetTracked(FeeEstimateHorizon hori
         return longStats->GetMaxConfirms();
     }
     } // no default case, so the compiler can warn about missing cases
-    assert(false);
+    UNREACHABLE();
 }
 
 unsigned int CBlockPolicyEstimator::BlockSpan() const

--- a/src/psbt.cpp
+++ b/src/psbt.cpp
@@ -525,9 +525,8 @@ std::string PSBTRoleName(PSBTRole role) {
     case PSBTRole::SIGNER: return "signer";
     case PSBTRole::FINALIZER: return "finalizer";
     case PSBTRole::EXTRACTOR: return "extractor";
-        // no default case, so the compiler can warn about missing cases
-    }
-    assert(false);
+    } // no default case, so the compiler can warn about missing cases
+    UNREACHABLE();
 }
 
 bool DecodeBase64PSBT(PartiallySignedTransaction& psbt, const std::string& base64_tx, std::string& error)

--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -8,6 +8,7 @@
 #include <qt/walletmodel.h>
 
 #include <key_io.h>
+#include <util/check.h>
 #include <wallet/types.h>
 #include <wallet/wallet.h>
 
@@ -61,7 +62,7 @@ constexpr AddressTableEntry::Type translateTransactionType(wallet::AddressPurpos
     case wallet::AddressPurpose::RECEIVE: return AddressTableEntry::Receiving;
     case wallet::AddressPurpose::REFUND: return AddressTableEntry::Hidden;
     } // no default case, so the compiler can warn about missing cases
-    assert(false);
+    UNREACHABLE();
 }
 
 // Private implementation

--- a/src/qt/bantablemodel.cpp
+++ b/src/qt/bantablemodel.cpp
@@ -6,6 +6,7 @@
 
 #include <interfaces/node.h>
 #include <net_types.h> // For banmap_t
+#include <util/check.h>
 
 #include <utility>
 
@@ -29,7 +30,7 @@ bool BannedNodeLessThan::operator()(const CCombinedBan& left, const CCombinedBan
     case BanTableModel::Bantime:
         return pLeft->banEntry.nBanUntil < pRight->banEntry.nBanUntil;
     } // no default case, so the compiler can warn about missing cases
-    assert(false);
+    UNREACHABLE();
 }
 
 // private implementation

--- a/src/qt/bitcoinunits.cpp
+++ b/src/qt/bitcoinunits.cpp
@@ -5,6 +5,7 @@
 #include <qt/bitcoinunits.h>
 
 #include <consensus/amount.h>
+#include <util/check.h>
 
 #include <QStringList>
 
@@ -36,7 +37,7 @@ QString BitcoinUnits::longName(Unit unit)
     case Unit::uBTC: return QString::fromUtf8("µBTC (bits)");
     case Unit::SAT: return QString("Satoshi (sat)");
     } // no default case, so the compiler can warn about missing cases
-    assert(false);
+    UNREACHABLE();
 }
 
 QString BitcoinUnits::shortName(Unit unit)
@@ -47,7 +48,7 @@ QString BitcoinUnits::shortName(Unit unit)
     case Unit::uBTC: return QString("bits");
     case Unit::SAT: return QString("sat");
     } // no default case, so the compiler can warn about missing cases
-    assert(false);
+    UNREACHABLE();
 }
 
 QString BitcoinUnits::description(Unit unit)
@@ -58,7 +59,7 @@ QString BitcoinUnits::description(Unit unit)
     case Unit::uBTC: return QString("Micro-Bitcoins (bits) (1 / 1" THIN_SP_UTF8 "000" THIN_SP_UTF8 "000)");
     case Unit::SAT: return QString("Satoshi (sat) (1 / 100" THIN_SP_UTF8 "000" THIN_SP_UTF8 "000)");
     } // no default case, so the compiler can warn about missing cases
-    assert(false);
+    UNREACHABLE();
 }
 
 qint64 BitcoinUnits::factor(Unit unit)
@@ -69,7 +70,7 @@ qint64 BitcoinUnits::factor(Unit unit)
     case Unit::uBTC: return 100;
     case Unit::SAT: return 1;
     } // no default case, so the compiler can warn about missing cases
-    assert(false);
+    UNREACHABLE();
 }
 
 int BitcoinUnits::decimals(Unit unit)
@@ -80,7 +81,7 @@ int BitcoinUnits::decimals(Unit unit)
     case Unit::uBTC: return 2;
     case Unit::SAT: return 0;
     } // no default case, so the compiler can warn about missing cases
-    assert(false);
+    UNREACHABLE();
 }
 
 QString BitcoinUnits::format(Unit unit, const CAmount& nIn, bool fPlus, SeparatorStyle separators, bool justify)
@@ -237,7 +238,7 @@ qint8 ToQint8(BitcoinUnit unit)
     case BitcoinUnit::uBTC: return 2;
     case BitcoinUnit::SAT: return 3;
     } // no default case, so the compiler can warn about missing cases
-    assert(false);
+    UNREACHABLE();
 }
 
 BitcoinUnit FromQint8(qint8 num)
@@ -248,7 +249,7 @@ BitcoinUnit FromQint8(qint8 num)
     case 2: return BitcoinUnit::uBTC;
     case 3: return BitcoinUnit::SAT;
     }
-    assert(false);
+    UNREACHABLE();
 }
 } // namespace
 

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -22,6 +22,7 @@
 #include <script/script.h>
 #include <script/standard.h>
 #include <util/chaintype.h>
+#include <util/check.h>
 #include <util/exception.h>
 #include <util/fs.h>
 #include <util/fs_helpers.h>
@@ -689,7 +690,7 @@ QString NetworkToQString(Network net)
     case NET_INTERNAL: return "Internal";  // should never actually happen
     case NET_MAX: assert(false);
     } // no default case, so the compiler can warn about missing cases
-    assert(false);
+    UNREACHABLE();
 }
 
 QString ConnectionTypeToQString(ConnectionType conn_type, bool prepend_direction)
@@ -718,7 +719,7 @@ QString ConnectionTypeToQString(ConnectionType conn_type, bool prepend_direction
     //: Short-lived peer connection type that solicits known addresses from a peer.
     case ConnectionType::ADDR_FETCH: return prefix + QObject::tr("Address Fetch");
     } // no default case, so the compiler can warn about missing cases
-    assert(false);
+    UNREACHABLE();
 }
 
 QString formatDurationStr(std::chrono::seconds dur)

--- a/src/qt/peertablesortproxy.cpp
+++ b/src/qt/peertablesortproxy.cpp
@@ -43,5 +43,5 @@ bool PeerTableSortProxy::lessThan(const QModelIndex& left_index, const QModelInd
     case PeerTableModel::Subversion:
         return left_stats.cleanSubVer.compare(right_stats.cleanSubVer) < 0;
     } // no default case, so the compiler can warn about missing cases
-    assert(false);
+    UNREACHABLE();
 }

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -20,6 +20,7 @@
 #include <qt/walletmodel.h>
 #include <rpc/client.h>
 #include <rpc/server.h>
+#include <util/check.h>
 #include <util/strencodings.h>
 #include <util/string.h>
 #include <util/threadnames.h>
@@ -1359,8 +1360,7 @@ QKeySequence RPCConsole::tabShortcut(TabTypes tab_type) const
     case TabTypes::GRAPH: return QKeySequence(tr("Ctrl+N"));
     case TabTypes::PEERS: return QKeySequence(tr("Ctrl+P"));
     } // no default case, so the compiler can warn about missing cases
-
-    assert(false);
+    UNREACHABLE();
 }
 
 void RPCConsole::updateAlerts(const QString& warnings)

--- a/src/script/miniscript.cpp
+++ b/src/script/miniscript.cpp
@@ -7,6 +7,7 @@
 #include <script/script.h>
 #include <script/standard.h>
 #include <script/miniscript.h>
+#include <util/check.h>
 
 #include <assert.h>
 
@@ -243,8 +244,8 @@ Type ComputeType(Fragment fragment, Type x, Type y, Type z, const std::vector<Ty
                    "s"_mst.If(num_s >= n_subs - k + 1) |  // s= >=(n-k+1) s
                    acc_tl; // timelock info
             }
-    }
-    assert(false);
+    } // no default case, so the compiler can warn about missing cases
+    UNREACHABLE();
 }
 
 size_t ComputeScriptLen(Fragment fragment, Type sub0typ, size_t subsize, uint32_t k, size_t n_subs, size_t n_keys) {
@@ -275,8 +276,8 @@ size_t ComputeScriptLen(Fragment fragment, Type sub0typ, size_t subsize, uint32_
         case Fragment::ANDOR: return subsize + 3;
         case Fragment::WRAP_J: return subsize + 4;
         case Fragment::THRESH: return subsize + n_subs + BuildScript(k).size();
-    }
-    assert(false);
+    } // no default case, so the compiler can warn about missing cases
+    UNREACHABLE();
 }
 
 InputStack& InputStack::SetAvailable(Availability avail) {

--- a/src/script/miniscript.h
+++ b/src/script/miniscript.h
@@ -20,6 +20,7 @@
 #include <primitives/transaction.h>
 #include <script/script.h>
 #include <span.h>
+#include <util/check.h>
 #include <util/spanparsing.h>
 #include <util/strencodings.h>
 #include <util/string.h>
@@ -613,8 +614,8 @@ public:
                     }
                     return BuildScript(std::move(script), node.k, verify ? OP_EQUALVERIFY : OP_EQUAL);
                 }
-            }
-            assert(false);
+            } // no default case, so the compiler can warn about missing cases
+            UNREACHABLE();
         };
         return TreeEval<CScript>(false, downfn, upfn);
     }
@@ -716,7 +717,7 @@ public:
                 }
                 default: break;
             }
-            assert(false);
+            UNREACHABLE();
         };
 
         return TreeEvalMaybe<std::string>(false, downfn, upfn);
@@ -792,8 +793,8 @@ private:
                 assert(k <= sats.size());
                 return {count, sats[k], sats[0]};
             }
-        }
-        assert(false);
+        } // no default case, so the compiler can warn about missing cases
+        UNREACHABLE();
     }
 
     internal::StackSize CalcStackSize() const {
@@ -842,8 +843,8 @@ private:
                 assert(k <= sats.size());
                 return {sats[k], sats[0]};
             }
-        }
-        assert(false);
+        } // no default case, so the compiler can warn about missing cases
+        UNREACHABLE();
     }
 
     template<typename Ctx>

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -14,6 +14,7 @@
 #include <script/signingprovider.h>
 #include <script/standard.h>
 #include <uint256.h>
+#include <util/check.h>
 #include <util/translation.h>
 #include <util/vector.h>
 
@@ -361,7 +362,7 @@ static bool SignStep(const SigningProvider& provider, const BaseSignatureCreator
     case TxoutType::WITNESS_V1_TAPROOT:
         return SignTaproot(provider, creator, WitnessV1Taproot(XOnlyPubKey{vSolutions[0]}), sigdata, ret);
     } // no default case, so the compiler can warn about missing cases
-    assert(false);
+    UNREACHABLE();
 }
 
 static CScript PushAll(const std::vector<valtype>& values)

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -10,6 +10,7 @@
 #include <pubkey.h>
 #include <script/interpreter.h>
 #include <script/script.h>
+#include <util/check.h>
 #include <util/strencodings.h>
 
 #include <string>
@@ -57,7 +58,7 @@ std::string GetTxnOutputType(TxoutType t)
     case TxoutType::WITNESS_V1_TAPROOT: return "witness_v1_taproot";
     case TxoutType::WITNESS_UNKNOWN: return "witness_unknown";
     } // no default case, so the compiler can warn about missing cases
-    assert(false);
+    UNREACHABLE();
 }
 
 static bool MatchPayToPubkey(const CScript& script, valtype& pubkey)
@@ -287,7 +288,7 @@ bool ExtractDestination(const CScript& scriptPubKey, CTxDestination& addressRet)
     case TxoutType::NONSTANDARD:
         return false;
     } // no default case, so the compiler can warn about missing cases
-    assert(false);
+    UNREACHABLE();
 }
 
 namespace {

--- a/src/test/validation_chainstate_tests.cpp
+++ b/src/test/validation_chainstate_tests.cpp
@@ -12,6 +12,7 @@
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <uint256.h>
+#include <util/check.h>
 #include <validation.h>
 
 #include <vector>
@@ -101,7 +102,7 @@ BOOST_FIXTURE_TEST_CASE(chainstate_update_tip, TestChain100Setup)
                 return cs;
             }
         }
-        assert(false);
+        UNREACHABLE();
     }()};
 
     // Create a block to append to the validation chain.

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1195,8 +1195,8 @@ std::string RemovalReasonToString(const MemPoolRemovalReason& r) noexcept
         case MemPoolRemovalReason::BLOCK: return "block";
         case MemPoolRemovalReason::CONFLICT: return "conflict";
         case MemPoolRemovalReason::REPLACED: return "replaced";
-    }
-    assert(false);
+    } // no default case, so the compiler can warn about missing cases
+    UNREACHABLE();
 }
 
 std::vector<CTxMemPool::txiter> CTxMemPool::GatherClusters(const std::vector<uint256>& txids) const

--- a/src/util/chaintype.cpp
+++ b/src/util/chaintype.cpp
@@ -4,6 +4,8 @@
 
 #include <util/chaintype.h>
 
+#include <util/check.h>
+
 #include <cassert>
 #include <optional>
 #include <string>
@@ -19,8 +21,8 @@ std::string ChainTypeToString(ChainType chain)
         return "signet";
     case ChainType::REGTEST:
         return "regtest";
-    }
-    assert(false);
+    } // no default case, so the compiler can warn about missing cases
+    UNREACHABLE();
 }
 
 std::optional<ChainType> ChainTypeFromString(std::string_view chain)

--- a/src/util/check.cpp
+++ b/src/util/check.cpp
@@ -35,3 +35,9 @@ void assertion_fail(std::string_view file, int line, std::string_view func, std:
     fwrite(str.data(), 1, str.size(), stderr);
     std::abort();
 }
+
+void unreachable_fail(const char* file, int line, const char* func)
+{
+    std::cerr << StrFormatInternalBug("Unreachable code reached (fatal, aborting)", file, line, func);
+    std::abort();
+}

--- a/src/util/check.h
+++ b/src/util/check.h
@@ -91,4 +91,12 @@ T&& inline_assertion_check(LIFETIMEBOUND T&& val, [[maybe_unused]] const char* f
     throw NonFatalCheckError(                                         \
         "Unreachable code reached (non-fatal)", __FILE__, __LINE__, __func__)
 
+[[noreturn]] void unreachable_fail(const char* file, int line, const char* func);
+
+/**
+ * UNREACHABLE is a macro that is used to mark unreachable code.
+ * It aborts the program.
+ */
+#define UNREACHABLE() unreachable_fail(__FILE__, __LINE__, __func__)
+
 #endif // BITCOIN_UTIL_CHECK_H

--- a/src/util/error.cpp
+++ b/src/util/error.cpp
@@ -5,6 +5,7 @@
 #include <util/error.h>
 
 #include <tinyformat.h>
+#include <util/check.h>
 #include <util/translation.h>
 
 #include <cassert>
@@ -41,9 +42,8 @@ bilingual_str TransactionErrorString(const TransactionError err)
             return Untranslated("External signer failed to sign");
         case TransactionError::INVALID_PACKAGE:
             return Untranslated("Transaction rejected due to invalid package");
-        // no default case, so the compiler can warn about missing cases
-    }
-    assert(false);
+    } // no default case, so the compiler can warn about missing cases
+    UNREACHABLE();
 }
 
 bilingual_str ResolveErrMsg(const std::string& optname, const std::string& strBind)

--- a/src/util/message.cpp
+++ b/src/util/message.cpp
@@ -9,6 +9,7 @@
 #include <pubkey.h>
 #include <script/standard.h>
 #include <uint256.h>
+#include <util/check.h>
 #include <util/message.h>
 #include <util/strencodings.h>
 
@@ -88,7 +89,6 @@ std::string SigningResultString(const SigningResult res)
             return "Private key not available";
         case SigningResult::SIGNING_FAILED:
             return "Sign failed";
-        // no default case, so the compiler can warn about missing cases
-    }
-    assert(false);
+    } // no default case, so the compiler can warn about missing cases
+    UNREACHABLE();
 }

--- a/src/wallet/coinselection.cpp
+++ b/src/wallet/coinselection.cpp
@@ -588,9 +588,8 @@ std::string GetAlgorithmName(const SelectionAlgorithm algo)
     case SelectionAlgorithm::KNAPSACK: return "knapsack";
     case SelectionAlgorithm::SRD: return "srd";
     case SelectionAlgorithm::MANUAL: return "manual";
-    // No default case to allow for compiler to warn
-    }
-    assert(false);
+    } // no default case, so the compiler can warn about missing cases
+    UNREACHABLE();
 }
 
 CAmount SelectionResult::GetChange(const CAmount min_viable_change, const CAmount change_fee) const

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -9,6 +9,7 @@
 #include <script/descriptor.h>
 #include <script/sign.h>
 #include <util/bip32.h>
+#include <util/check.h>
 #include <util/strencodings.h>
 #include <util/string.h>
 #include <util/time.h>
@@ -219,8 +220,8 @@ isminetype LegacyScriptPubKeyMan::IsMine(const CScript& script) const
         return ISMINE_WATCH_ONLY;
     case IsMineResult::SPENDABLE:
         return ISMINE_SPENDABLE;
-    }
-    assert(false);
+    } // no default case, so the compiler can warn about missing cases
+    UNREACHABLE();
 }
 
 bool LegacyScriptPubKeyMan::CheckDecryptionKey(const CKeyingMaterial& master_key, bool accept_no_keys)

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -15,6 +15,7 @@
 #include <policy/feerate.h>
 #include <psbt.h>
 #include <tinyformat.h>
+#include <util/check.h>
 #include <util/fs.h>
 #include <util/hasher.h>
 #include <util/message.h>
@@ -251,7 +252,7 @@ inline std::string PurposeToString(AddressPurpose p)
     case AddressPurpose::SEND: return "send";
     case AddressPurpose::REFUND: return "refund";
     } // no default case so the compiler will warn when a new enum as added
-    assert(false);
+    UNREACHABLE();
 }
 
 inline std::optional<AddressPurpose> PurposeFromString(std::string_view s)


### PR DESCRIPTION
The `UNREACHABLE` macro was suggested in https://github.com/bitcoin/bitcoin/pull/24812, but during reviewing it has been [dropped](https://github.com/bitcoin/bitcoin/pull/24812#discussion_r851597471):
> This is unused and on a second thought I wonder if there is any value in it. The current code can already use `assert(false)` just fine. Introducing another way to write `assert(false)` will just lead to bike-shedding without any benefit.

This macro prevents compiler warnings -- `-Wreturn-type` (GCC) and `C4715` (MSVC) -- when building for/on Windows.