### PR TITLE
RPC/Blockchain: Minor improvements for scanblocks & scantxoutset docs/errors

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2205,7 +2205,7 @@ static RPCHelpMan scantxoutset()
         result.pushKV("unspents", unspents);
         result.pushKV("total_amount", ValueFromAmount(total_in));
     } else {
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid command");
+        throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Invalid action '%s'", request.params[0].get_str()));
     }
     return result;
 },
@@ -2402,7 +2402,7 @@ static RPCHelpMan scanblocks()
         ret.pushKV("relevant_blocks", blocks);
     }
     else {
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid command");
+        throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Invalid action '%s'", request.params[0].get_str()));
     }
     return ret;
 },

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2254,12 +2254,13 @@ static RPCHelpMan scanblocks()
         },
         {
             scan_result_status_none,
-            RPCResult{"When action=='start'", RPCResult::Type::OBJ, "", "", {
+            RPCResult{"When action=='start'; only returns after scan completes", RPCResult::Type::OBJ, "", "", {
                 {RPCResult::Type::NUM, "from_height", "The height we started the scan from"},
                 {RPCResult::Type::NUM, "to_height", "The height we ended the scan at"},
-                {RPCResult::Type::ARR, "relevant_blocks", "", {{RPCResult::Type::STR_HEX, "blockhash", "A relevant blockhash"},}},
-                },
-            },
+                {RPCResult::Type::ARR, "relevant_blocks", "Blocks that may have matched a scanobject.", {
+                    {RPCResult::Type::STR_HEX, "blockhash", "A relevant blockhash"},
+                }},
+            }},
             RPCResult{"when action=='status' and a scan is currently in progress", RPCResult::Type::OBJ, "", "", {
                     {RPCResult::Type::NUM, "progress", "Approximate percent complete"},
                     {RPCResult::Type::NUM, "current_height", "Height of the block currently being scanned"},

--- a/test/functional/rpc_scanblocks.py
+++ b/test/functional/rpc_scanblocks.py
@@ -122,7 +122,7 @@ class ScanblocksTest(BitcoinTestFramework):
         assert_equal(node.scanblocks("abort"), False)
 
         # test invalid command
-        assert_raises_rpc_error(-8, "Invalid command", node.scanblocks, "foobar")
+        assert_raises_rpc_error(-8, "Invalid action 'foobar'", node.scanblocks, "foobar")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* Clarify invalid-action error in scanblocks & scantxoutset
* Mention action=='start' only returns after scan completes (already in scantxoutset)
* Document `relevant_blocks`