### PR TITLE
init: Evaluate sysperms before config file

### DIFF
--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -31,6 +31,10 @@
 #include <functional>
 #include <optional>
 
+#ifndef WIN32
+#include <sys/stat.h>
+#endif
+
 using node::NodeContext;
 
 const std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;
@@ -150,6 +154,12 @@ static bool AppInit(NodeContext& node, int argc, char* argv[])
     std::any context{&node};
     try
     {
+#ifndef WIN32
+        // Set the umask before acessing config files, otherwise they might be created with incorrect permissions.
+        if (!args.GetBoolArg("-sysperms", false)) {
+            umask(077);
+        }
+#endif
         if (!CheckDataDirOption()) {
             return InitError(Untranslated(strprintf("Specified data directory \"%s\" does not exist.\n", args.GetArg("-datadir", ""))));
         }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -97,7 +97,6 @@
 #ifndef WIN32
 #include <cerrno>
 #include <signal.h>
-#include <sys/stat.h>
 #endif
 
 #include <boost/signals2/signal.hpp>
@@ -801,9 +800,6 @@ bool AppInitBasicSetup(const ArgsManager& args)
     }
 
 #ifndef WIN32
-    if (!args.GetBoolArg("-sysperms", false)) {
-        umask(077);
-    }
 
     // Clean shutdown on SIGTERM
     registerSignalHandler(SIGTERM, HandleSIGTERM);


### PR DESCRIPTION
Fixes #13371

Currently we check the config file before applying the effect of the `-sysperms` program option. On first boot with no datadirectory this can result in directories (and settings.json file) being created with incorrect permissions.

As I mention in #13371 this will change **default** file permissions from what they are currently which might risk breaking changes to upstream projects. If this is not desirable, then the alternative would be to leave the current behaviour and perhaps update the docs slightly.

