### PR TITLE
rpc: Always return getpeerinfo "relaytxes" field

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -478,7 +478,7 @@ public:
             const int8_t network_id{NetworkStringToId(network)};
             if (network_id == UNKNOWN_NETWORK) continue;
             const bool is_outbound{!peer["inbound"].get_bool()};
-            const bool is_tx_relay{peer["relaytxes"].isNull() ? true : peer["relaytxes"].get_bool()};
+            const bool is_tx_relay{peer["relaytxes"].get_bool()};
             const std::string conn_type{peer["connection_type"].get_str()};
             ++m_counts.at(is_outbound).at(network_id);      // in/out by network
             ++m_counts.at(is_outbound).at(NETWORKS.size()); // in/out overall
@@ -642,7 +642,7 @@ public:
         "  send     Time since last message sent to the peer, in seconds\n"
         "  recv     Time since last message received from the peer, in seconds\n"
         "  txn      Time since last novel transaction received from the peer and accepted into our mempool, in minutes\n"
-        "           \"*\" - whether we relay transactions to this peer (relaytxes is false)\n"
+        "           \"*\" - we do not relay transactions to this peer (relaytxes is false)\n"
         "  blk      Time since last novel block passing initial validity checks received from the peer, in minutes\n"
         "  hb       High-bandwidth BIP152 compact block relay\n"
         "           \".\" (to)   - we selected the peer as a high-bandwidth peer\n"

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -114,7 +114,7 @@ static RPCHelpMan getpeerinfo()
                     {
                         {RPCResult::Type::STR, "SERVICE_NAME", "the service name if it is recognised"}
                     }},
-                    {RPCResult::Type::BOOL, "relaytxes", /*optional=*/true, "Whether we relay transactions to this peer"},
+                    {RPCResult::Type::BOOL, "relaytxes", "Whether we relay transactions to this peer"},
                     {RPCResult::Type::NUM_TIME, "lastsend", "The " + UNIX_EPOCH_TIME + " of the last send"},
                     {RPCResult::Type::NUM_TIME, "lastrecv", "The " + UNIX_EPOCH_TIME + " of the last receive"},
                     {RPCResult::Type::NUM_TIME, "last_transaction", "The " + UNIX_EPOCH_TIME + " of the last valid transaction received from this peer"},
@@ -200,9 +200,7 @@ static RPCHelpMan getpeerinfo()
         ServiceFlags services{fStateStats ? statestats.their_services : ServiceFlags::NODE_NONE};
         obj.pushKV("services", strprintf("%016x", services));
         obj.pushKV("servicesnames", GetServicesNames(services));
-        if (fStateStats) {
-            obj.pushKV("relaytxes", statestats.m_relay_txs);
-        }
+        obj.pushKV("relaytxes", fStateStats ? statestats.m_relay_txs : false);
         obj.pushKV("lastsend", count_seconds(stats.m_last_send));
         obj.pushKV("lastrecv", count_seconds(stats.m_last_recv));
         obj.pushKV("last_transaction", count_seconds(stats.m_last_tx_time));


### PR DESCRIPTION
with its pre-existing v23 default value of false, as it is intermittently absent during peer disconnection -- see https://github.com/bitcoin/bitcoin/pull/26457#pullrequestreview-1181641835.  Credit to Martin Zumsande for finding this. 

This allows dropping the patch in #25176 here, and, if backported to v24, provides API continuity as relaytxes was always present in getpeerinfo since it was introduced in 2015.

Also fix -netinfo relaytxes doc to address https://github.com/bitcoin/bitcoin/pull/26109#discussion_r995502563.

Co-authored-by: Martin Zumsande <mzumsande@gmail.com>

