### PR TITLE
test: Changed small_txpuzzle_randfee to return the virtual size instead of the transaction hex for feerate calculation.

### DIFF
--- a/test/functional/feature_fee_estimation.py
+++ b/test/functional/feature_fee_estimation.py
@@ -62,7 +62,7 @@ def small_txpuzzle_randfee(
     unconflist.append({"txid": txid, "vout": 0, "value": total_in - amount - fee})
     unconflist.append({"txid": txid, "vout": 1, "value": amount})
 
-    return (tx.serialize().hex(), fee)
+    return (tx.get_vsize(), fee)
 
 
 def check_raw_estimates(node, fees_seen):
@@ -158,7 +158,7 @@ class EstimateFeeTest(BitcoinTestFramework):
             random.shuffle(self.confutxo)
             for _ in range(random.randrange(100 - 50, 100 + 50)):
                 from_index = random.randint(1, 2)
-                (txhex, fee) = small_txpuzzle_randfee(
+                (tx_bytes, fee) = small_txpuzzle_randfee(
                     self.wallet,
                     self.nodes[from_index],
                     self.confutxo,
@@ -167,7 +167,7 @@ class EstimateFeeTest(BitcoinTestFramework):
                     min_fee,
                     min_fee,
                 )
-                tx_kbytes = (len(txhex) // 2) / 1000.0
+                tx_kbytes = tx_bytes / 1000.0
                 self.fees_per_kb.append(float(fee) / tx_kbytes)
             self.sync_mempools(wait=0.1)
             mined = mining_node.getblock(self.generate(mining_node, 1)[0], True)["tx"]


### PR DESCRIPTION
The fee rates used in feature_fee_estimation.py are calculated using the raw transaction size instead of the virtual transaction size (which is used in 'CBlockPolicyEstimator::processBlockTx' and 'CBlockPolicyEstimator::processBlock'). This leads to inconsistencies as the fee rates used in check_raw_estimates are incorrect and can cause assertions to fail.

refs #25179