### PR TITLE
Drop unneeded UBSan suppression

### DIFF
--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -63,7 +63,6 @@ implicit-integer-sign-change:script/bitcoinconsensus.cpp
 implicit-integer-sign-change:script/interpreter.cpp
 implicit-integer-sign-change:serialize.h
 implicit-integer-sign-change:txmempool.cpp
-implicit-integer-sign-change:txmempool_entry.h
 implicit-signed-integer-truncation:crypto/
 implicit-unsigned-integer-truncation:crypto/
 shift-base:arith_uint256.cpp


### PR DESCRIPTION
The needlessness of this suppression was [overlooked](https://github.com/bitcoin/bitcoin/pull/17786#discussion_r1027818707) in https://github.com/bitcoin/bitcoin/pull/17786.