### PR TITLE
[23.x] qt: 23.1rc2 translations update

### DIFF
--- a/src/qt/locale/bitcoin_el.ts
+++ b/src/qt/locale/bitcoin_el.ts
@@ -1236,8 +1236,8 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n active connection(s) to Bitcoin network.</numerusform>
+            <numerusform>%n active connection(s) to Bitcoin network.</numerusform>
         </translation>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_hi.ts
+++ b/src/qt/locale/bitcoin_hi.ts
@@ -11,8 +11,7 @@
     </message>
     <message>
         <source>&amp;New</source>
-        <translation type="unfinished">&amp;न्यू
- </translation>
+        <translation type="unfinished">नया </translation>
     </message>
     <message>
         <source>Copy the currently selected address to the system clipboard</source>
@@ -24,7 +23,7 @@
     </message>
     <message>
         <source>C&amp;lose</source>
-        <translation type="unfinished">&amp;क्लोज़</translation>
+        <translation type="unfinished">बंद करें</translation>
     </message>
     <message>
         <source>Delete the currently selected address from the list</source>
@@ -756,23 +755,1444 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     </context>
 <context>
+    <name>RPCConsole</name>
+    <message>
+        <source>To specify a non-default location of the data directory use the '%1' option.</source>
+        <translation type="unfinished">डेटा निर्देशिका का गैर-डिफ़ॉल्ट स्थान निर्दिष्ट करने के लिए '%1' विकल्प का उपयोग करें।</translation>
+    </message>
+    <message>
+        <source>Blocksdir</source>
+        <translation type="unfinished">ब्लॉकडिर</translation>
+    </message>
+    <message>
+        <source>To specify a non-default location of the blocks directory use the '%1' option.</source>
+        <translation type="unfinished">ब्लॉक निर्देशिका का गैर-डिफ़ॉल्ट स्थान निर्दिष्ट करने के लिए '%1' विकल्प का उपयोग करें।</translation>
+    </message>
+    <message>
+        <source>Startup time</source>
+        <translation type="unfinished">स्टार्टअप का समय</translation>
+    </message>
+    <message>
+        <source>Network</source>
+        <translation type="unfinished">नेटवर्क</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished">नाम</translation>
+    </message>
+    <message>
+        <source>Number of connections</source>
+        <translation type="unfinished">कनेक्शन की संख्या</translation>
+    </message>
+    <message>
+        <source>Block chain</source>
+        <translation type="unfinished">ब्लॉक चेन</translation>
+    </message>
+    <message>
+        <source>Memory Pool</source>
+        <translation type="unfinished">मेमोरी पूल</translation>
+    </message>
+    <message>
+        <source>Current number of transactions</source>
+        <translation type="unfinished">लेनदेन की वर्तमान संख्या</translation>
+    </message>
+    <message>
+        <source>Memory usage</source>
+        <translation type="unfinished">स्मृति प्रयोग</translation>
+    </message>
+    <message>
+        <source>Wallet: </source>
+        <translation type="unfinished">बटुआ</translation>
+    </message>
+    <message>
+        <source>(none)</source>
+        <translation type="unfinished">(कोई भी नहीं)</translation>
+    </message>
+    <message>
+        <source>&amp;Reset</source>
+        <translation type="unfinished">रीसेट</translation>
+    </message>
+    <message>
+        <source>Received</source>
+        <translation type="unfinished">प्राप्त हुआ</translation>
+    </message>
+    <message>
+        <source>Sent</source>
+        <translation type="unfinished">भेज दिया</translation>
+    </message>
+    <message>
+        <source>&amp;Peers</source>
+        <translation type="unfinished">समकक्ष लोग</translation>
+    </message>
+    <message>
+        <source>Banned peers</source>
+        <translation type="unfinished">प्रतिबंधित साथियों</translation>
+    </message>
+    <message>
+        <source>Select a peer to view detailed information.</source>
+        <translation type="unfinished">विस्तृत जानकारी देखने के लिए किसी सहकर्मी का चयन करें।</translation>
+    </message>
+    <message>
+        <source>Version</source>
+        <translation type="unfinished">संस्करण</translation>
+    </message>
+    <message>
+        <source>Starting Block</source>
+        <translation type="unfinished">प्रारम्भिक खण्ड</translation>
+    </message>
+    <message>
+        <source>Synced Headers</source>
+        <translation type="unfinished">सिंक किए गए हेडर</translation>
+    </message>
+    <message>
+        <source>Synced Blocks</source>
+        <translation type="unfinished">सिंक किए गए ब्लॉक</translation>
+    </message>
+    <message>
+        <source>Last Transaction</source>
+        <translation type="unfinished">अंतिम लेनदेन</translation>
+    </message>
+    <message>
+        <source>The mapped Autonomous System used for diversifying peer selection.</source>
+        <translation type="unfinished">सहकर्मी चयन में विविधता लाने के लिए उपयोग की गई मैप की गई स्वायत्त प्रणाली।</translation>
+    </message>
+    <message>
+        <source>Mapped AS</source>
+        <translation type="unfinished">मैप किए गए AS</translation>
+    </message>
+    <message>
+        <source>Whether we relay addresses to this peer.</source>
+        <extracomment>Tooltip text for the Address Relay field in the peer details area.</extracomment>
+        <translation type="unfinished">क्या हम इस सहकर्मी को पते रिले करते हैं।</translation>
+    </message>
+    <message>
+        <source>Address Relay</source>
+        <translation type="unfinished">पता रिले</translation>
+    </message>
+    <message>
+        <source>Addresses Processed</source>
+        <translation type="unfinished">संसाधित पते</translation>
+    </message>
+    <message>
+        <source>Total number of addresses dropped due to rate-limiting.</source>
+        <extracomment>Tooltip text for the Addresses Rate-Limited field in the peer details area.</extracomment>
+        <translation type="unfinished">दर-सीमित करने के कारण पतों की कुल संख्या गिर गई।</translation>
+    </message>
+    <message>
+        <source>Addresses Rate-Limited</source>
+        <translation type="unfinished">पते दर-सीमित</translation>
+    </message>
+    <message>
+        <source>User Agent</source>
+        <translation type="unfinished">उपभोक्ता अभिकर्ता</translation>
+    </message>
+    <message>
+        <source>Node window</source>
+        <translation type="unfinished">नोड विंडो</translation>
+    </message>
+    <message>
+        <source>Current block height</source>
+        <translation type="unfinished">वर्तमान ब्लॉक ऊंचाई</translation>
+    </message>
+    <message>
+        <source>Open the %1 debug log file from the current data directory. This can take a few seconds for large log files.</source>
+        <translation type="unfinished">वर्तमान डेटा निर्देशिका से %1 डीबग लॉग फ़ाइल खोलें। बड़ी लॉग फ़ाइलों के लिए इसमें कुछ सेकंड लग सकते हैं।</translation>
+    </message>
+    <message>
+        <source>Decrease font size</source>
+        <translation type="unfinished">फ़ॉन्ट आकार घटाएं</translation>
+    </message>
+    <message>
+        <source>Increase font size</source>
+        <translation type="unfinished">फ़ॉन्ट आकार बढ़ाएँ</translation>
+    </message>
+    <message>
+        <source>Permissions</source>
+        <translation type="unfinished">अनुमतियां</translation>
+    </message>
+    <message>
+        <source>The direction and type of peer connection: %1</source>
+        <translation type="unfinished">पीयर कनेक्शन की दिशा और प्रकार: %1</translation>
+    </message>
+    <message>
+        <source>Direction/Type</source>
+        <translation type="unfinished">दिशा / प्रकार</translation>
+    </message>
+    <message>
+        <source>The network protocol this peer is connected through: IPv4, IPv6, Onion, I2P, or CJDNS.</source>
+        <translation type="unfinished">यह पीयर नेटवर्क प्रोटोकॉल के माध्यम से जुड़ा हुआ है: आईपीवी 4, आईपीवी 6, प्याज, आई 2 पी, या सीजेडीएनएस।</translation>
+    </message>
+    <message>
+        <source>Services</source>
+        <translation type="unfinished">सेवाएं</translation>
+    </message>
+    <message>
+        <source>Whether the peer requested us to relay transactions.</source>
+        <translation type="unfinished">क्या सहकर्मी ने हमसे लेन-देन रिले करने का अनुरोध किया है।</translation>
+    </message>
+    <message>
+        <source>Wants Tx Relay</source>
+        <translation type="unfinished">टीएक्स रिले चाहता है</translation>
+    </message>
+    <message>
+        <source>High bandwidth BIP152 compact block relay: %1</source>
+        <translation type="unfinished">उच्च बैंडविड्थ BIP152 कॉम्पैक्ट ब्लॉक रिले: %1</translation>
+    </message>
+    <message>
+        <source>High Bandwidth</source>
+        <translation type="unfinished">उच्च बैंडविड्थ</translation>
+    </message>
+    <message>
+        <source>Connection Time</source>
+        <translation type="unfinished">कनेक्शन का समय</translation>
+    </message>
+    <message>
+        <source>Elapsed time since a novel block passing initial validity checks was received from this peer.</source>
+        <translation type="unfinished">इस सहकर्मी से प्रारंभिक वैधता जांच प्राप्त करने वाले एक उपन्यास ब्लॉक के बाद से बीता हुआ समय।</translation>
+    </message>
+    <message>
+        <source>Last Block</source>
+        <translation type="unfinished">अंतिम ब्लॉक</translation>
+    </message>
+    <message>
+        <source>Elapsed time since a novel transaction accepted into our mempool was received from this peer.</source>
+        <extracomment>Tooltip text for the Last Transaction field in the peer details area.</extracomment>
+        <translation type="unfinished">हमारे मेमपूल में स्वीकार किए गए एक उपन्यास लेनदेन के बाद से इस सहकर्मी से प्राप्त हुआ समय बीत चुका है।</translation>
+    </message>
+    <message>
+        <source>Last Send</source>
+        <translation type="unfinished">अंतिम भेजें</translation>
+    </message>
+    <message>
+        <source>Last Receive</source>
+        <translation type="unfinished">अंतिम प्राप्ति</translation>
+    </message>
+    <message>
+        <source>Ping Time</source>
+        <translation type="unfinished">पिंग टाइम</translation>
+    </message>
+    <message>
+        <source>The duration of a currently outstanding ping.</source>
+        <translation type="unfinished">वर्तमान में बकाया पिंग की अवधि।</translation>
+    </message>
+    <message>
+        <source>Ping Wait</source>
+        <translation type="unfinished">पिंग रुको</translation>
+    </message>
+    <message>
+        <source>Min Ping</source>
+        <translation type="unfinished">मिन पिंग</translation>
+    </message>
+    <message>
+        <source>Time Offset</source>
+        <translation type="unfinished">समय का निर्धारण</translation>
+    </message>
+    <message>
+        <source>Last block time</source>
+        <translation type="unfinished">अंतिम ब्लॉक समय</translation>
+    </message>
+    <message>
+        <source>&amp;Open</source>
+        <translation type="unfinished">खुला हुआ</translation>
+    </message>
+    <message>
+        <source>&amp;Console</source>
+        <translation type="unfinished">कंसोल</translation>
+    </message>
+    <message>
+        <source>&amp;Network Traffic</source>
+        <translation type="unfinished">&amp;प्रसार यातायात</translation>
+    </message>
+    <message>
+        <source>Totals</source>
+        <translation type="unfinished">योग</translation>
+    </message>
+    <message>
+        <source>Debug log file</source>
+        <translation type="unfinished">डीबग लॉग फ़ाइल</translation>
+    </message>
+    <message>
+        <source>Clear console</source>
+        <translation type="unfinished">साफ़ कंसोल</translation>
+    </message>
+    <message>
+        <source>In:</source>
+        <translation type="unfinished">में</translation>
+    </message>
+    <message>
+        <source>Out:</source>
+        <translation type="unfinished">बाहर:</translation>
+    </message>
+    <message>
+        <source>Inbound: initiated by peer</source>
+        <extracomment>Explanatory text for an inbound peer connection.</extracomment>
+        <translation type="unfinished">इनबाउंड: सहकर्मी द्वारा शुरू किया गया</translation>
+    </message>
+    <message>
+        <source>Outbound Full Relay: default</source>
+        <extracomment>Explanatory text for an outbound peer connection that relays all network information. This is the default behavior for outbound connections.</extracomment>
+        <translation type="unfinished">आउटबाउंड पूर्ण रिले: डिफ़ॉल्ट</translation>
+    </message>
+    <message>
+        <source>Outbound Block Relay: does not relay transactions or addresses</source>
+        <extracomment>Explanatory text for an outbound peer connection that relays network information about blocks and not transactions or addresses.</extracomment>
+        <translation type="unfinished">आउटबाउंड ब्लॉक रिले: लेनदेन या पते को रिले नहीं करता है</translation>
+    </message>
+    <message>
+        <source>Outbound Manual: added using RPC %1 or %2/%3 configuration options</source>
+        <extracomment>Explanatory text for an outbound peer connection that was established manually through one of several methods. The numbered arguments are stand-ins for the methods available to establish manual connections.</extracomment>
+        <translation type="unfinished">आउटबाउंड मैनुअल: RPC %1 या %2/ %3 कॉन्फ़िगरेशन विकल्पों का उपयोग करके जोड़ा गया</translation>
+    </message>
+    <message>
+        <source>Outbound Feeler: short-lived, for testing addresses</source>
+        <extracomment>Explanatory text for a short-lived outbound peer connection that is used to test the aliveness of known addresses.</extracomment>
+        <translation type="unfinished">आउटबाउंड फीलर: अल्पकालिक, परीक्षण पतों के लिए</translation>
+    </message>
+    <message>
+        <source>Outbound Address Fetch: short-lived, for soliciting addresses</source>
+        <extracomment>Explanatory text for a short-lived outbound peer connection that is used to request addresses from a peer.</extracomment>
+        <translation type="unfinished">आउटबाउंड एड्रेस फ़ेच: अल्पकालिक, याचना पतों के लिए</translation>
+    </message>
+    <message>
+        <source>we selected the peer for high bandwidth relay</source>
+        <translation type="unfinished">हमने उच्च बैंडविड्थ रिले के लिए पीयर का चयन किया</translation>
+    </message>
+    <message>
+        <source>the peer selected us for high bandwidth relay</source>
+        <translation type="unfinished">सहकर्मी ने हमें उच्च बैंडविड्थ रिले के लिए चुना</translation>
+    </message>
+    <message>
+        <source>no high bandwidth relay selected</source>
+        <translation type="unfinished">कोई उच्च बैंडविड्थ रिले नहीं चुना गया</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <extracomment>Context menu action to copy the address of a peer.</extracomment>
+        <translation type="unfinished">&amp;कॉपी पता</translation>
+    </message>
+    <message>
+        <source>&amp;Disconnect</source>
+        <translation type="unfinished">&amp;डिस्कनेक्ट</translation>
+    </message>
+    <message>
+        <source>1 &amp;hour</source>
+        <translation type="unfinished">1 घंटा</translation>
+    </message>
+    <message>
+        <source>1 d&amp;ay</source>
+        <translation type="unfinished">1 दिन</translation>
+    </message>
+    <message>
+        <source>1 &amp;week</source>
+        <translation type="unfinished">1 सप्ताह</translation>
+    </message>
+    <message>
+        <source>1 &amp;year</source>
+        <translation type="unfinished">1 साल</translation>
+    </message>
+    <message>
+        <source>&amp;Copy IP/Netmask</source>
+        <extracomment>Context menu action to copy the IP/Netmask of a banned peer. IP/Netmask is the combination of a peer's IP address and its Netmask. For IP address, see: https://en.wikipedia.org/wiki/IP_address.</extracomment>
+        <translation type="unfinished">&amp;कॉपी आईपी/नेटमास्क</translation>
+    </message>
+    <message>
+        <source>&amp;Unban</source>
+        <translation type="unfinished">अप्रतिबंधित करें</translation>
+    </message>
+    <message>
+        <source>Network activity disabled</source>
+        <translation type="unfinished">नेटवर्क गतिविधि अक्षम</translation>
+    </message>
+    <message>
+        <source>Executing command without any wallet</source>
+        <translation type="unfinished">बिना किसी वॉलेट के कमांड निष्पादित करना</translation>
+    </message>
+    <message>
+        <source>Executing command using "%1" wallet</source>
+        <translation type="unfinished">"%1" वॉलेट का प्रयोग कर कमांड निष्पादित करना</translation>
+    </message>
+    <message>
+        <source>Welcome to the %1 RPC console.
+Use up and down arrows to navigate history, and %2 to clear screen.
+Use %3 and %4 to increase or decrease the font size.
+Type %5 for an overview of available commands.
+For more information on using this console, type %6.
+
+%7WARNING: Scammers have been active, telling users to type commands here, stealing their wallet contents. Do not use this console without fully understanding the ramifications of a command.%8</source>
+        <extracomment>RPC console welcome message. Placeholders %7 and %8 are style tags for the warning content, and they are not space separated from the rest of the text intentionally.</extracomment>
+        <translation type="unfinished">%1 आरपीसी कंसोल में आपका स्वागत है।
+इतिहास नेविगेट करने के लिए ऊपर और नीचे तीरों का उपयोग करें, और स्क्रीन को साफ़ करने के लिए %2 का उपयोग करें।
+फॉन्ट साइज बढ़ाने या घटाने के लिए %3 और %4 का प्रयोग करें।
+उपलब्ध कमांड के ओवरव्यू के लिए %5 टाइप करें।
+इस कंसोल का उपयोग करने के बारे में अधिक जानकारी के लिए %6 टाइप करें।
+
+%7 चेतावनी: स्कैमर्स सक्रिय हैं, उपयोगकर्ताओं को यहां कमांड टाइप करने के लिए कह रहे हैं, उनके वॉलेट सामग्री को चुरा रहे हैं। कमांड के प्रभाव को पूरी तरह समझे बिना इस कंसोल का उपयोग न करें। %8</translation>
+    </message>
+    <message>
+        <source>Executing…</source>
+        <extracomment>A console message indicating an entered command is currently being executed.</extracomment>
+        <translation type="unfinished">निष्पादित किया जा रहा है…</translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished">हाँ</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished">नहीं</translation>
+    </message>
+    <message>
+        <source>To</source>
+        <translation type="unfinished">प्रति</translation>
+    </message>
+    <message>
+        <source>From</source>
+        <translation type="unfinished">से</translation>
+    </message>
+    <message>
+        <source>Ban for</source>
+        <translation type="unfinished">के लिए प्रतिबंध</translation>
+    </message>
+    <message>
+        <source>Never</source>
+        <translation type="unfinished">कभी नहीँ</translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">अनजान</translation>
+    </message>
+</context>
+<context>
+    <name>ReceiveCoinsDialog</name>
+    <message>
+        <source>&amp;Amount:</source>
+        <translation type="unfinished">&amp;राशि:</translation>
+    </message>
+    <message>
+        <source>&amp;Label:</source>
+        <translation type="unfinished">&amp;लेबल:</translation>
+    </message>
+    <message>
+        <source>&amp;Message:</source>
+        <translation type="unfinished">&amp;संदेश:</translation>
+    </message>
+    <message>
+        <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
+        <translation type="unfinished">भुगतान अनुरोध के साथ संलग्न करने के लिए एक वैकल्पिक संदेश, जिसे अनुरोध खोले जाने पर प्रदर्शित किया जाएगा। नोट: बिटकॉइन नेटवर्क पर भुगतान के साथ संदेश नहीं भेजा जाएगा।</translation>
+    </message>
+    <message>
+        <source>An optional label to associate with the new receiving address.</source>
+        <translation type="unfinished">नए प्राप्तकर्ता पते के साथ संबद्ध करने के लिए एक वैकल्पिक लेबल।</translation>
+    </message>
+    <message>
+        <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
+        <translation type="unfinished">भुगतान का अनुरोध करने के लिए इस फ़ॉर्म का उपयोग करें। सभी फ़ील्ड &lt;b&gt;वैकल्पिक&lt;/b&gt;हैं।</translation>
+    </message>
+    <message>
+        <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
+        <translation type="unfinished">अनुरोध करने के लिए एक वैकल्पिक राशि। किसी विशिष्ट राशि का अनुरोध न करने के लिए इसे खाली या शून्य छोड़ दें।</translation>
+    </message>
+    <message>
+        <source>An optional label to associate with the new receiving address (used by you to identify an invoice).  It is also attached to the payment request.</source>
+        <translation type="unfinished">नए प्राप्तकर्ता पते के साथ संबद्ध करने के लिए एक वैकल्पिक लेबल (इनवॉइस की पहचान करने के लिए आपके द्वारा उपयोग किया जाता है)। यह भुगतान अनुरोध से भी जुड़ा हुआ है।</translation>
+    </message>
+    <message>
+        <source>An optional message that is attached to the payment request and may be displayed to the sender.</source>
+        <translation type="unfinished">एक वैकल्पिक संदेश जो भुगतान अनुरोध से जुड़ा होता है और प्रेषक को प्रदर्शित किया जा सकता है।</translation>
+    </message>
+    <message>
+        <source>&amp;Create new receiving address</source>
+        <translation type="unfinished">&amp;नया प्राप्तकर्ता पता बनाएं</translation>
+    </message>
+    <message>
+        <source>Clear all fields of the form.</source>
+        <translation type="unfinished">फार्म के सभी फ़ील्ड क्लिअर करें।</translation>
+    </message>
+    <message>
+        <source>Clear</source>
+        <translation type="unfinished">क्लिअर </translation>
+    </message>
+    <message>
+        <source>Requested payments history</source>
+        <translation type="unfinished">अनुरोधित भुगतान इतिहास</translation>
+    </message>
+    <message>
+        <source>Show the selected request (does the same as double clicking an entry)</source>
+        <translation type="unfinished">चयनित अनुरोध दिखाएं (यह एक प्रविष्टि पर डबल क्लिक करने जैसा ही है)</translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished">शो</translation>
+    </message>
+    <message>
+        <source>Remove the selected entries from the list</source>
+        <translation type="unfinished">सूची से चयनित प्रविष्टियों को हटा दें</translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation type="unfinished">रिमूव</translation>
+    </message>
+    <message>
+        <source>Copy &amp;URI</source>
+        <translation type="unfinished">कॉपी &amp; यूआरआई</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;कॉपी अड्रेस</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">कॉपी  &amp;लेबल</translation>
+    </message>
+    <message>
+        <source>Copy &amp;message</source>
+        <translation type="unfinished">कॉपी  &amp;मेसेज</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">कॉपी &amp;अमाउंट</translation>
+    </message>
+    <message>
+        <source>Could not unlock wallet.</source>
+        <translation type="unfinished">वॉलेट अनलॉक नहीं किया जा सकता |</translation>
+    </message>
+    <message>
+        <source>Could not generate new %1 address</source>
+        <translation type="unfinished">नया पता उत्पन्न नहीं कर सका %1 </translation>
+    </message>
+</context>
+<context>
+    <name>ReceiveRequestDialog</name>
+    <message>
+        <source>Request payment to …</source>
+        <translation type="unfinished">भुगतान का अनुरोध करें …</translation>
+    </message>
+    <message>
+        <source>Address:</source>
+        <translation type="unfinished">अड्रेस:</translation>
+    </message>
+    <message>
+        <source>Amount:</source>
+        <translation type="unfinished">अमाउंट:</translation>
+    </message>
+    <message>
+        <source>Label:</source>
+        <translation type="unfinished">लेबल:</translation>
+    </message>
+    <message>
+        <source>Message:</source>
+        <translation type="unfinished">मेसेज:</translation>
+    </message>
+    <message>
+        <source>Wallet:</source>
+        <translation type="unfinished">वॉलेट:</translation>
+    </message>
+    <message>
+        <source>Copy &amp;URI</source>
+        <translation type="unfinished">कॉपी &amp; यूआरआई</translation>
+    </message>
+    <message>
+        <source>Copy &amp;Address</source>
+        <translation type="unfinished">कॉपी  &amp;अड्रेस</translation>
+    </message>
+    <message>
+        <source>&amp;Verify</source>
+        <translation type="unfinished">&amp;वेरीफाय</translation>
+    </message>
+    <message>
+        <source>Verify this address on e.g. a hardware wallet screen</source>
+        <translation type="unfinished">इस पते को वेरीफाय करें उदा.  एक हार्डवेयर वॉलेट स्क्रीन</translation>
+    </message>
+    <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">&amp;सेव इमेज…</translation>
+    </message>
+    <message>
+        <source>Payment information</source>
+        <translation type="unfinished">भुगतान की जानकारी</translation>
+    </message>
+    <message>
+        <source>Request payment to %1</source>
+        <translation type="unfinished">भुगतान का अनुरोध करें %1</translation>
+    </message>
+</context>
+<context>
+    <name>RecentRequestsTableModel</name>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">डेट</translation>
+    </message>
+    <message>
+        <source>Label</source>
+        <translation type="unfinished">लेबल</translation>
+    </message>
+    <message>
+        <source>Message</source>
+        <translation type="unfinished">मेसेज</translation>
+    </message>
+    <message>
+        <source>(no label)</source>
+        <translation type="unfinished">(नो लेबल)</translation>
+    </message>
+    <message>
+        <source>(no message)</source>
+        <translation type="unfinished">(नो मेसेज)</translation>
+    </message>
+    <message>
+        <source>(no amount requested)</source>
+        <translation type="unfinished">(कोई अमाउंट नहीं मांगी गई)</translation>
+    </message>
+    <message>
+        <source>Requested</source>
+        <translation type="unfinished">रिक्वेस्टेड</translation>
+    </message>
+</context>
+<context>
     <name>SendCoinsDialog</name>
+    <message>
+        <source>Send Coins</source>
+        <translation type="unfinished">सेन्ड कॉइन्स</translation>
+    </message>
+    <message>
+        <source>Coin Control Features</source>
+        <translation type="unfinished">कॉइन कंट्रोल फिचर्स</translation>
+    </message>
+    <message>
+        <source>automatically selected</source>
+        <translation type="unfinished">स्वचालित रूप से चयनित</translation>
+    </message>
+    <message>
+        <source>Insufficient funds!</source>
+        <translation type="unfinished">अपर्याप्त कोष!</translation>
+    </message>
+    <message>
+        <source>Quantity:</source>
+        <translation type="unfinished">क्वांटिटी:</translation>
+    </message>
+    <message>
+        <source>Bytes:</source>
+        <translation type="unfinished">बाइट्स:</translation>
+    </message>
+    <message>
+        <source>Amount:</source>
+        <translation type="unfinished">अमाउंट:</translation>
+    </message>
+    <message>
+        <source>Fee:</source>
+        <translation type="unfinished">फी:</translation>
+    </message>
+    <message>
+        <source>After Fee:</source>
+        <translation type="unfinished">आफ़्टर फी:</translation>
+    </message>
+    <message>
+        <source>Change:</source>
+        <translation type="unfinished">चेइन्ज:</translation>
+    </message>
+    <message>
+        <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
+        <translation type="unfinished">यदि यह सक्रिय है, लेकिन परिवर्तन का पता खाली या अमान्य है, तो परिवर्तन नए जनरेट किए गए पते पर भेजा जाएगा।</translation>
+    </message>
+    <message>
+        <source>Custom change address</source>
+        <translation type="unfinished">कस्टम परिवर्तन पता</translation>
+    </message>
+    <message>
+        <source>Transaction Fee:</source>
+        <translation type="unfinished">लेनदेन शुल्क:</translation>
+    </message>
+    <message>
+        <source>Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until you have validated the complete chain.</source>
+        <translation type="unfinished">फ़ॉलबैक शुल्क का उपयोग करने से एक लेन-देन भेजा जा सकता है जिसकी पुष्टि करने में कई घंटे या दिन (या कभी नहीं) लगेंगे। अपना शुल्क मैन्युअल रूप से चुनने पर विचार करें या तब तक प्रतीक्षा करें जब तक आप पूरी श्रृंखला को मान्य नहीं कर लेते।</translation>
+    </message>
+    <message>
+        <source>Warning: Fee estimation is currently not possible.</source>
+        <translation type="unfinished">चेतावनी: शुल्क का अनुमान फिलहाल संभव नहीं है।</translation>
+    </message>
+    <message>
+        <source>per kilobyte</source>
+        <translation type="unfinished">प्रति किलोबाइट</translation>
+    </message>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished">हाइड</translation>
+    </message>
+    <message>
+        <source>Recommended:</source>
+        <translation type="unfinished">रेकमेन्डेड:</translation>
+    </message>
+    <message>
+        <source>Custom:</source>
+        <translation type="unfinished">कस्टम:</translation>
+    </message>
+    <message>
+        <source>Send to multiple recipients at once</source>
+        <translation type="unfinished">एक साथ कई प्राप्तकर्ताओं को भेजें</translation>
+    </message>
+    <message>
+        <source>Add &amp;Recipient</source>
+        <translation type="unfinished">अड &amp;रिसिपिएंट</translation>
+    </message>
+    <message>
+        <source>Clear all fields of the form.</source>
+        <translation type="unfinished">फार्म के सभी फ़ील्ड क्लिअर करें।</translation>
+    </message>
+    <message>
+        <source>Inputs…</source>
+        <translation type="unfinished">इनपुट्स…</translation>
+    </message>
+    <message>
+        <source>Dust:</source>
+        <translation type="unfinished">डस्ट:</translation>
+    </message>
+    <message>
+        <source>Choose…</source>
+        <translation type="unfinished">चुज…</translation>
+    </message>
+    <message>
+        <source>Hide transaction fee settings</source>
+        <translation type="unfinished">लेनदेन शुल्क सेटिंग छुपाएं</translation>
+    </message>
+    <message>
+        <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
+
+Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satoshis per kvB" for a transaction size of 500 virtual bytes (half of 1 kvB) would ultimately yield a fee of only 50 satoshis.</source>
+        <translation type="unfinished">लेन-देन के आभासी आकार के प्रति kB (1,000 बाइट्स) के लिए एक कस्टम शुल्क निर्दिष्ट करें।
+
+नोट: चूंकि शुल्क की गणना प्रति-बाइट के आधार पर की जाती है, इसलिए 500 वर्चुअल बाइट्स (1 केवीबी का आधा) के लेन-देन के आकार के लिए "100 सतोशी प्रति केवीबी" की शुल्क दर अंततः केवल 50 सतोशी का शुल्क देगी।</translation>
+    </message>
+    <message>
+        <source>When there is less transaction volume than space in the blocks, miners as well as relaying nodes may enforce a minimum fee. Paying only this minimum fee is just fine, but be aware that this can result in a never confirming transaction once there is more demand for bitcoin transactions than the network can process.</source>
+        <translation type="unfinished">जब ब्लॉक में स्थान की तुलना में कम लेन-देन की मात्रा होती है, तो खनिकों के साथ-साथ रिलेइंग नोड्स न्यूनतम शुल्क लागू कर सकते हैं। केवल इस न्यूनतम शुल्क का भुगतान करना ठीक है, लेकिन ध्यान रखें कि नेटवर्क की प्रक्रिया की तुलना में बिटकॉइन लेनदेन की अधिक मांग होने पर इसका परिणाम कभी भी पुष्टिकरण लेनदेन में नहीं हो सकता है।</translation>
+    </message>
+    <message>
+        <source>A too low fee might result in a never confirming transaction (read the tooltip)</source>
+        <translation type="unfinished">बहुत कम शुल्क के परिणामस्वरूप कभी भी पुष्टिकरण लेनदेन नहीं हो सकता है (टूलटिप पढ़ें)</translation>
+    </message>
+    <message>
+        <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
+        <translation type="unfinished">(स्मार्ट शुल्क अभी शुरू नहीं हुआ है। इसमें आमतौर पर कुछ ब्लॉक लगते हैं…)</translation>
+    </message>
+    <message>
+        <source>Confirmation time target:</source>
+        <translation type="unfinished">पुष्टि समय लक्ष्य:</translation>
+    </message>
+    <message>
+        <source>Enable Replace-By-Fee</source>
+        <translation type="unfinished">प्रतिस्थापन-दर-शुल्क सक्षम करें</translation>
+    </message>
+    <message>
+        <source>With Replace-By-Fee (BIP-125) you can increase a transaction's fee after it is sent. Without this, a higher fee may be recommended to compensate for increased transaction delay risk.</source>
+        <translation type="unfinished">प्रतिस्थापन-दर-शुल्क (बीआईपी-125) के साथ आप लेनदेन के शुल्क को भेजने के बाद बढ़ा सकते हैं। इसके बिना, बढ़े हुए लेन-देन में देरी के जोखिम की भरपाई के लिए एक उच्च शुल्क की सिफारिश की जा सकती है।</translation>
+    </message>
+    <message>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished">क्लीयर &amp;अल</translation>
+    </message>
+    <message>
+        <source>Balance:</source>
+        <translation type="unfinished">बेलेंस:</translation>
+    </message>
+    <message>
+        <source>Confirm the send action</source>
+        <translation type="unfinished">भेजें कार्रवाई की पुष्टि करें</translation>
+    </message>
+    <message>
+        <source>S&amp;end</source>
+        <translation type="unfinished">सेन्ड&amp;</translation>
+    </message>
+    <message>
+        <source>Copy quantity</source>
+        <translation type="unfinished">कॉपी क्वांटिटी</translation>
+    </message>
+    <message>
+        <source>Copy amount</source>
+        <translation type="unfinished">कॉपी अमाउंट</translation>
+    </message>
+    <message>
+        <source>Copy fee</source>
+        <translation type="unfinished">कॉपी फी</translation>
+    </message>
+    <message>
+        <source>Copy after fee</source>
+        <translation type="unfinished">कॉपी आफ़्टर फी</translation>
+    </message>
+    <message>
+        <source>Copy bytes</source>
+        <translation type="unfinished">कॉपी बाइट्स</translation>
+    </message>
+    <message>
+        <source>Copy dust</source>
+        <translation type="unfinished">कॉपी डस्ट</translation>
+    </message>
+    <message>
+        <source>Copy change</source>
+        <translation type="unfinished">कॉपी चैंज</translation>
+    </message>
+    <message>
+        <source>%1 (%2 blocks)</source>
+        <translation type="unfinished">%1 (%2 ब्लाकस)</translation>
+    </message>
+    <message>
+        <source>Sign on device</source>
+        <extracomment>"device" usually means a hardware wallet.</extracomment>
+        <translation type="unfinished">डिवाइस पर साइन करें</translation>
+    </message>
+    <message>
+        <source>Connect your hardware wallet first.</source>
+        <translation type="unfinished">पहले अपना हार्डवेयर वॉलेट कनेक्ट करें।</translation>
+    </message>
+    <message>
+        <source>Set external signer script path in Options -&gt; Wallet</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">विकल्प में बाहरी हस्ताक्षरकर्ता स्क्रिप्ट पथ सेट करें -&gt; वॉलेट </translation>
+    </message>
+    <message>
+        <source>Cr&amp;eate Unsigned</source>
+        <translation type="unfinished">&amp;अहस्ताक्षरित बनाएं</translation>
+    </message>
+    <message>
+        <source>Creates a Partially Signed Bitcoin Transaction (PSBT) for use with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
+        <translation type="unfinished">उदाहरण के लिए उपयोग के लिए आंशिक रूप से हस्ताक्षरित बिटकॉइन लेनदेन (PSBT) बनाता है। एक ऑफ़लाइन% 1 %1  वॉलेट, या एक PSBT-संगत हार्डवेयर वॉलेट।</translation>
+    </message>
+    <message>
+        <source> from wallet '%1'</source>
+        <translation type="unfinished">वॉलिट से '%1'</translation>
+    </message>
+    <message>
+        <source>%1 to '%2'</source>
+        <translation type="unfinished">%1टु '%2'</translation>
+    </message>
+    <message>
+        <source>%1 to %2</source>
+        <translation type="unfinished">%1 टु %2</translation>
+    </message>
+    <message>
+        <source>To review recipient list click "Show Details…"</source>
+        <translation type="unfinished">प्राप्तकर्ता सूची की समीक्षा करने के लिए "शो डिटैइल्स ..." पर क्लिक करें।</translation>
+    </message>
+    <message>
+        <source>Sign failed</source>
+        <translation type="unfinished">साइन फेल्ड</translation>
+    </message>
+    <message>
+        <source>External signer not found</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">बाहरी हस्ताक्षरकर्ता नहीं मिला</translation>
+    </message>
+    <message>
+        <source>External signer failure</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">बाहरी हस्ताक्षरकर्ता विफलता</translation>
+    </message>
+    <message>
+        <source>Save Transaction Data</source>
+        <translation type="unfinished">लेन-देन डेटा सहेजें</translation>
+    </message>
+    <message>
+        <source>Partially Signed Transaction (Binary)</source>
+        <extracomment>Expanded name of the binary PSBT file format. See: BIP 174.</extracomment>
+        <translation type="unfinished">आंशिक रूप से हस्ताक्षरित लेनदेन (बाइनरी)</translation>
+    </message>
+    <message>
+        <source>PSBT saved</source>
+        <translation type="unfinished">पीएसबीटी सहेजा गया
+ </translation>
+    </message>
+    <message>
+        <source>External balance:</source>
+        <translation type="unfinished">बाहरी संतुलन:</translation>
+    </message>
+    <message>
+        <source>or</source>
+        <translation type="unfinished">और</translation>
+    </message>
+    <message>
+        <source>You can increase the fee later (signals Replace-By-Fee, BIP-125).</source>
+        <translation type="unfinished">आप बाद में शुल्क बढ़ा सकते हैं (सिग्नलस रिप्लेसमेंट-बाय-फी, बीआईपी-125)।</translation>
+    </message>
+    <message>
+        <source>Please, review your transaction proposal. This will produce a Partially Signed Bitcoin Transaction (PSBT) which you can save or copy and then sign with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
+        <extracomment>Text to inform a user attempting to create a transaction of their current options. At this stage, a user can only create a PSBT. This string is displayed when private keys are disabled and an external signer is not available.</extracomment>
+        <translation type="unfinished">कृपया, अपने लेनदेन प्रस्ताव की समीक्षा करें। यह एक आंशिक रूप से हस्ताक्षरित बिटकॉइन लेनदेन (PSBT) का उत्पादन करेगा जिसे आप सहेज सकते हैं या कॉपी कर सकते हैं और फिर उदा। एक ऑफ़लाइन %1  वॉलेट, या एक PSBT-संगत हार्डवेयर वॉलेट।</translation>
+    </message>
+    <message>
+        <source>Do you want to create this transaction?</source>
+        <extracomment>Message displayed when attempting to create a transaction. Cautionary text to prompt the user to verify that the displayed transaction details represent the transaction the user intends to create.</extracomment>
+        <translation type="unfinished">क्या आप यह लेन-देन बनाना चाहते हैं?</translation>
+    </message>
+    <message>
+        <source>Please, review your transaction. You can create and send this transaction or create a Partially Signed Bitcoin Transaction (PSBT), which you can save or copy and then sign with, e.g., an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
+        <extracomment>Text to inform a user attempting to create a transaction of their current options. At this stage, a user can send their transaction or create a PSBT. This string is displayed when both private keys and PSBT controls are enabled.</extracomment>
+        <translation type="unfinished">कृपया, अपने लेन-देन की समीक्षा करें। आप इस लेन-देन को बना और भेज सकते हैं या आंशिक रूप से हस्ताक्षरित बिटकॉइन लेनदेन (पीएसबीटी) बना सकते हैं, जिसे आप सहेज सकते हैं या कॉपी कर सकते हैं और फिर हस्ताक्षर कर सकते हैं, उदाहरण के लिए, ऑफ़लाइन %1 वॉलेट, या पीएसबीटी-संगत हार्डवेयर वॉलेट।</translation>
+    </message>
+    <message>
+        <source>Please, review your transaction.</source>
+        <extracomment>Text to prompt a user to review the details of the transaction they are attempting to send.</extracomment>
+        <translation type="unfinished">कृपया, अपने लेन-देन की समीक्षा करें।</translation>
+    </message>
+    <message>
+        <source>Transaction fee</source>
+        <translation type="unfinished">लेनदेन शुल्क</translation>
+    </message>
+    <message>
+        <source>Not signalling Replace-By-Fee, BIP-125.</source>
+        <translation type="unfinished">रिप्लेसमेंट-बाय-फी, बीआईपी-125 सिग्नलिंग नहीं।</translation>
+    </message>
+    <message>
+        <source>Total Amount</source>
+        <translation type="unfinished">कुल राशि</translation>
+    </message>
+    <message>
+        <source>Confirm send coins</source>
+        <translation type="unfinished">सिक्के भेजने की पुष्टि करें</translation>
+    </message>
+    <message>
+        <source>Watch-only balance:</source>
+        <translation type="unfinished">केवल देखने के लिए शेष राशि</translation>
+    </message>
+    <message>
+        <source>The recipient address is not valid. Please recheck.</source>
+        <translation type="unfinished">प्राप्तकर्ता का पता मान्य नहीं है। कृपया पुनः जाँच करें</translation>
+    </message>
+    <message>
+        <source>The amount to pay must be larger than 0.</source>
+        <translation type="unfinished">भुगतान की जाने वाली राशि 0 से अधिक होनी चाहिए।</translation>
+    </message>
+    <message>
+        <source>The amount exceeds your balance.</source>
+        <translation type="unfinished">राशि आपकी शेष राशि से अधिक है।</translation>
+    </message>
+    <message>
+        <source>The total exceeds your balance when the %1 transaction fee is included.</source>
+        <translation type="unfinished"> %1 जब लेन-देन शुल्क शामिल किया जाता है, तो कुल आपकी शेष राशि से अधिक हो जाती है।</translation>
+    </message>
+    <message>
+        <source>Duplicate address found: addresses should only be used once each.</source>
+        <translation type="unfinished">डुप्लिकेट पता मिला: पतों का उपयोग केवल एक बार किया जाना चाहिए।</translation>
+    </message>
+    <message>
+        <source>Transaction creation failed!</source>
+        <translation type="unfinished">लेन-देन निर्माण विफल!</translation>
+    </message>
+    <message>
+        <source>A fee higher than %1 is considered an absurdly high fee.</source>
+        <translation type="unfinished"> %1 से अधिक शुल्क एक बेतुका उच्च शुल्क माना जाता है।</translation>
+    </message>
+    <message>
+        <source>Payment request expired.</source>
+        <translation type="unfinished">भुगतान अनुरोध समाप्त हो गया।</translation>
+    </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
             <numerusform>Estimated to begin confirmation within %n block(s).</numerusform>
-            <numerusform>Estimated to begin confirmation within %n block(s).</numerusform>
+            <numerusform> %n ब्लॉक (ब्लॉकों) के भीतर पुष्टि शुरू करने का अनुमान है।</numerusform>
         </translation>
     </message>
-    </context>
+    <message>
+        <source>Warning: Invalid Bitcoin address</source>
+        <translation type="unfinished">चेतावनी: अमान्य बिटकॉइन पता</translation>
+    </message>
+    <message>
+        <source>Warning: Unknown change address</source>
+        <translation type="unfinished">चेतावनी: अज्ञात परिवर्तन पता</translation>
+    </message>
+    <message>
+        <source>Confirm custom change address</source>
+        <translation type="unfinished">कस्टम परिवर्तन पते की पुष्टि करें</translation>
+    </message>
+    <message>
+        <source>The address you selected for change is not part of this wallet. Any or all funds in your wallet may be sent to this address. Are you sure?</source>
+        <translation type="unfinished">आपके द्वारा परिवर्तन के लिए चुना गया पता इस वॉलेट का हिस्सा नहीं है। आपके वॉलेट में कोई भी या सभी धनराशि इस पते पर भेजी जा सकती है। क्या आपको यकीन है?</translation>
+    </message>
+    <message>
+        <source>(no label)</source>
+        <translation type="unfinished">(नो लेबल)</translation>
+    </message>
+</context>
+<context>
+    <name>SendCoinsEntry</name>
+    <message>
+        <source>A&amp;mount:</source>
+        <translation type="unfinished">&amp;अमौंट</translation>
+    </message>
+    <message>
+        <source>Pay &amp;To:</source>
+        <translation type="unfinished">पें &amp;टु:</translation>
+    </message>
+    <message>
+        <source>&amp;Label:</source>
+        <translation type="unfinished">&amp;लेबल:</translation>
+    </message>
+    <message>
+        <source>Choose previously used address</source>
+        <translation type="unfinished">पहले इस्तेमाल किया गया पता चुनें</translation>
+    </message>
+    <message>
+        <source>The Bitcoin address to send the payment to</source>
+        <translation type="unfinished">भुगतान भेजने के लिए बिटकॉइन पता</translation>
+    </message>
+    <message>
+        <source>Alt+A</source>
+        <translation type="unfinished">Alt+A </translation>
+    </message>
+    <message>
+        <source>Paste address from clipboard</source>
+        <translation type="unfinished">क्लिपबोर्ड से पता चिपकाएं</translation>
+    </message>
+    <message>
+        <source>Alt+P</source>
+        <translation type="unfinished">Alt+P </translation>
+    </message>
+    <message>
+        <source>Remove this entry</source>
+        <translation type="unfinished">इस प्रविष्टि को हटाएं</translation>
+    </message>
+    <message>
+        <source>The amount to send in the selected unit</source>
+        <translation type="unfinished">चयनित इकाई में भेजने के लिए राशि</translation>
+    </message>
+    <message>
+        <source>The fee will be deducted from the amount being sent. The recipient will receive less bitcoins than you enter in the amount field. If multiple recipients are selected, the fee is split equally.</source>
+        <translation type="unfinished">भेजी जाने वाली राशि से शुल्क की कटौती की जाएगी। प्राप्तकर्ता को आपके द्वारा राशि फ़ील्ड में दर्ज किए जाने से कम बिटकॉइन प्राप्त होंगे। यदि कई प्राप्तकर्ताओं का चयन किया जाता है, तो शुल्क समान रूप से विभाजित किया जाता है।</translation>
+    </message>
+    <message>
+        <source>S&amp;ubtract fee from amount</source>
+        <translation type="unfinished">&amp;राशि से शुल्क घटाएं</translation>
+    </message>
+    <message>
+        <source>Use available balance</source>
+        <translation type="unfinished">उपलब्ध शेष राशि का उपयोग करें</translation>
+    </message>
+    <message>
+        <source>Message:</source>
+        <translation type="unfinished">मेसेज:</translation>
+    </message>
+    <message>
+        <source>This is an unauthenticated payment request.</source>
+        <translation type="unfinished">यह एक अनधिकृत भुगतान अनुरोध है।</translation>
+    </message>
+    <message>
+        <source>This is an authenticated payment request.</source>
+        <translation type="unfinished">यह एक प्रमाणित भुगतान अनुरोध है।</translation>
+    </message>
+    <message>
+        <source>Enter a label for this address to add it to the list of used addresses</source>
+        <translation type="unfinished">इस पते के लिए उपयोग किए गए पतों की सूची में जोड़ने के लिए एक लेबल दर्ज करें</translation>
+    </message>
+    <message>
+        <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
+        <translation type="unfinished">एक संदेश जो बिटकॉइन से जुड़ा था: यूआरआई जो आपके संदर्भ के लिए लेनदेन के साथ संग्रहीत किया जाएगा। नोट: यह संदेश बिटकॉइन नेटवर्क पर नहीं भेजा जाएगा।</translation>
+    </message>
+    <message>
+        <source>Pay To:</source>
+        <translation type="unfinished">पे टु:</translation>
+    </message>
+    <message>
+        <source>Memo:</source>
+        <translation type="unfinished">मेमो:</translation>
+    </message>
+</context>
+<context>
+    <name>SendConfirmationDialog</name>
+    <message>
+        <source>Send</source>
+        <translation type="unfinished">सेइंड</translation>
+    </message>
+    <message>
+        <source>Create Unsigned</source>
+        <translation type="unfinished">अहस्ताक्षरित बनाएं</translation>
+    </message>
+</context>
+<context>
+    <name>SignVerifyMessageDialog</name>
+    <message>
+        <source>Signatures - Sign / Verify a Message</source>
+        <translation type="unfinished">हस्ताक्षर - एक संदेश पर हस्ताक्षर करें / सत्यापित करें</translation>
+    </message>
+    <message>
+        <source>&amp;Sign Message</source>
+        <translation type="unfinished">&amp;संदेश पर हस्ताक्षर करें</translation>
+    </message>
+    <message>
+        <source>You can sign messages/agreements with your addresses to prove you can receive bitcoins sent to them. Be careful not to sign anything vague or random, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
+        <translation type="unfinished">आप अपने पते के साथ संदेशों/समझौतों पर हस्ताक्षर करके यह साबित कर सकते हैं कि आप उन्हें भेजे गए बिटकॉइन प्राप्त कर सकते हैं। सावधान रहें कि कुछ भी अस्पष्ट या यादृच्छिक पर हस्ताक्षर न करें, क्योंकि फ़िशिंग हमले आपको अपनी पहचान पर हस्ताक्षर करने के लिए छल करने का प्रयास कर सकते हैं। केवल पूरी तरह से विस्तृत बयानों पर हस्ताक्षर करें जिनसे आप सहमत हैं।</translation>
+    </message>
+    <message>
+        <source>The Bitcoin address to sign the message with</source>
+        <translation type="unfinished">संदेश पर हस्ताक्षर करने के लिए बिटकॉइन पता</translation>
+    </message>
+    <message>
+        <source>Choose previously used address</source>
+        <translation type="unfinished">पहले इस्तेमाल किया गया पता चुनें</translation>
+    </message>
+    <message>
+        <source>Alt+A</source>
+        <translation type="unfinished">Alt+A </translation>
+    </message>
+    <message>
+        <source>Paste address from clipboard</source>
+        <translation type="unfinished">क्लिपबोर्ड से पता चिपकाएं</translation>
+    </message>
+    <message>
+        <source>Alt+P</source>
+        <translation type="unfinished">Alt+P </translation>
+    </message>
+    <message>
+        <source>Enter the message you want to sign here</source>
+        <translation type="unfinished">वह संदेश दर्ज करें जिस पर आप हस्ताक्षर करना चाहते हैं</translation>
+    </message>
+    <message>
+        <source>Signature</source>
+        <translation type="unfinished">हस्ताक्षर</translation>
+    </message>
+    <message>
+        <source>Copy the current signature to the system clipboard</source>
+        <translation type="unfinished">वर्तमान हस्ताक्षर को सिस्टम क्लिपबोर्ड पर कॉपी करें</translation>
+    </message>
+    <message>
+        <source>Sign the message to prove you own this Bitcoin address</source>
+        <translation type="unfinished">यह साबित करने के लिए संदेश पर हस्ताक्षर करें कि आप इस बिटकॉइन पते के स्वामी हैं</translation>
+    </message>
+    <message>
+        <source>Sign &amp;Message</source>
+        <translation type="unfinished">साइन &amp; मैसेज</translation>
+    </message>
+    <message>
+        <source>Reset all sign message fields</source>
+        <translation type="unfinished">सभी साइन संदेश फ़ील्ड रीसेट करें</translation>
+    </message>
+    <message>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished">&amp;सभी साफ करें</translation>
+    </message>
+    <message>
+        <source>&amp;Verify Message</source>
+        <translation type="unfinished">&amp;संदेश सत्यापित करें</translation>
+    </message>
+    <message>
+        <source>Enter the receiver's address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack. Note that this only proves the signing party receives with the address, it cannot prove sendership of any transaction!</source>
+        <translation type="unfinished">संदेश को सत्यापित करने के लिए नीचे प्राप्तकर्ता का पता, संदेश (सुनिश्चित करें कि आप लाइन ब्रेक, रिक्त स्थान, टैब आदि की प्रतिलिपि बनाते हैं) और हस्ताक्षर दर्ज करें। सावधान रहें कि हस्ताक्षरित संदेश में जो लिखा है, उससे अधिक हस्ताक्षर में न पढ़ें, ताकि बीच-बीच में किसी व्यक्ति द्वारा छल किए जाने से बचा जा सके। ध्यान दें कि यह केवल यह साबित करता है कि हस्ताक्षर करने वाला पक्ष पते के साथ प्राप्त करता है, यह किसी भी लेनदेन की प्रेषकता साबित नहीं कर सकता है!</translation>
+    </message>
+    <message>
+        <source>The Bitcoin address the message was signed with</source>
+        <translation type="unfinished">संदेश के साथ हस्ताक्षर किए गए बिटकॉइन पते</translation>
+    </message>
+    <message>
+        <source>The signed message to verify</source>
+        <translation type="unfinished">सत्यापित करने के लिए हस्ताक्षरित संदेश</translation>
+    </message>
+    <message>
+        <source>The signature given when the message was signed</source>
+        <translation type="unfinished">संदेश पर हस्ताक्षर किए जाने पर दिए गए हस्ताक्षर</translation>
+    </message>
+    <message>
+        <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
+        <translation type="unfinished">यह सुनिश्चित करने के लिए संदेश सत्यापित करें कि यह निर्दिष्ट बिटकॉइन पते के साथ हस्ताक्षरित था</translation>
+    </message>
+    <message>
+        <source>Verify &amp;Message</source>
+        <translation type="unfinished">सत्यापित करें और संदेश</translation>
+    </message>
+    <message>
+        <source>Reset all verify message fields</source>
+        <translation type="unfinished">सभी सत्यापित संदेश फ़ील्ड रीसेट करें</translation>
+    </message>
+    <message>
+        <source>Click "Sign Message" to generate signature</source>
+        <translation type="unfinished">हस्ताक्षर उत्पन्न करने के लिए "साईन मेसेज" पर क्लिक करें</translation>
+    </message>
+    <message>
+        <source>The entered address is invalid.</source>
+        <translation type="unfinished">दर्ज किया गया पता अमान्य है।</translation>
+    </message>
+    <message>
+        <source>Please check the address and try again.</source>
+        <translation type="unfinished">कृपया पते की जांच करें और पुनः प्रयास करें।</translation>
+    </message>
+    <message>
+        <source>The entered address does not refer to a key.</source>
+        <translation type="unfinished">दर्ज किया गया पता एक कुंजी को संदर्भित नहीं करता है।</translation>
+    </message>
+    <message>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished">वॉलेट अनलॉक रद्द कर दिया गया था।
+ </translation>
+    </message>
+    <message>
+        <source>No error</source>
+        <translation type="unfinished">कोई त्रुटि नहीं</translation>
+    </message>
+    <message>
+        <source>Private key for the entered address is not available.</source>
+        <translation type="unfinished">दर्ज पते के लिए निजी कुंजी उपलब्ध नहीं है।</translation>
+    </message>
+    <message>
+        <source>Message signing failed.</source>
+        <translation type="unfinished">संदेश हस्ताक्षर विफल।</translation>
+    </message>
+    <message>
+        <source>Message signed.</source>
+        <translation type="unfinished">संदेश पर हस्ताक्षर किए।</translation>
+    </message>
+    <message>
+        <source>The signature could not be decoded.</source>
+        <translation type="unfinished">हस्ताक्षर को डिकोड नहीं किया जा सका।</translation>
+    </message>
+    <message>
+        <source>Please check the signature and try again.</source>
+        <translation type="unfinished">कृपया हस्ताक्षर जांचें और पुन: प्रयास करें।</translation>
+    </message>
+    <message>
+        <source>The signature did not match the message digest.</source>
+        <translation type="unfinished">हस्ताक्षर संदेश डाइजेस्ट से मेल नहीं खाते।</translation>
+    </message>
+    <message>
+        <source>Message verification failed.</source>
+        <translation type="unfinished">संदेश सत्यापन विफल।</translation>
+    </message>
+    <message>
+        <source>Message verified.</source>
+        <translation type="unfinished">संदेश सत्यापित।</translation>
+    </message>
+</context>
+<context>
+    <name>SplashScreen</name>
+    <message>
+        <source>(press q to shutdown and continue later)</source>
+        <translation type="unfinished">(बंद करने के लिए q दबाएं और बाद में जारी रखें)</translation>
+    </message>
+    <message>
+        <source>press q to shutdown</source>
+        <translation type="unfinished">शटडाउन करने के लिए q दबाएं</translation>
+    </message>
+</context>
+<context>
+    <name>TrafficGraphWidget</name>
+    <message>
+        <source>kB/s</source>
+        <translation type="unfinished">kB/s </translation>
+    </message>
+</context>
 <context>
     <name>TransactionDesc</name>
+    <message>
+        <source>conflicted with a transaction with %1 confirmations</source>
+        <translation type="unfinished"> %1 पुष्टिकरण के साथ लेन-देन के साथ विरोधाभासी</translation>
+    </message>
+    <message>
+        <source>0/unconfirmed, %1</source>
+        <translation type="unfinished">0/अपुष्ट, %1</translation>
+    </message>
+    <message>
+        <source>in memory pool</source>
+        <translation type="unfinished">&lt;div&gt;मेमोरी पूल में&lt;/div&gt;</translation>
+    </message>
+    <message>
+        <source>not in memory pool</source>
+        <translation type="unfinished">मेमोरी पूल में नहीं</translation>
+    </message>
+    <message>
+        <source>abandoned</source>
+        <translation type="unfinished">अबॅन्डन्ड</translation>
+    </message>
+    <message>
+        <source>%1/unconfirmed</source>
+        <translation type="unfinished">%1/अपुष्ट</translation>
+    </message>
+    <message>
+        <source>%1 confirmations</source>
+        <translation type="unfinished">%1 पुष्टियों</translation>
+    </message>
+    <message>
+        <source>Status</source>
+        <translation type="unfinished">दर्जा</translation>
+    </message>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">डेट</translation>
+    </message>
+    <message>
+        <source>Source</source>
+        <translation type="unfinished">सॉSस</translation>
+    </message>
+    <message>
+        <source>Generated</source>
+        <translation type="unfinished">जनरेट किया गया</translation>
+    </message>
+    <message>
+        <source>From</source>
+        <translation type="unfinished">से</translation>
+    </message>
+    <message>
+        <source>unknown</source>
+        <translation type="unfinished">अनजान</translation>
+    </message>
+    <message>
+        <source>To</source>
+        <translation type="unfinished">प्रति</translation>
+    </message>
+    <message>
+        <source>own address</source>
+        <translation type="unfinished">खुद का पता</translation>
+    </message>
+    <message>
+        <source>watch-only</source>
+        <translation type="unfinished">निगरानी-केवल</translation>
+    </message>
+    <message>
+        <source>label</source>
+        <translation type="unfinished">लेबल</translation>
+    </message>
+    <message>
+        <source>Credit</source>
+        <translation type="unfinished">श्रेय</translation>
+    </message>
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform>matures in %n more block(s)</numerusform>
-            <numerusform>matures in %n more block(s)</numerusform>
+            <numerusform> %nअधिक ब्लॉक (ब्लॉकों) में परिपक्व</numerusform>
         </translation>
+    </message>
+    <message>
+        <source>not accepted</source>
+        <translation type="unfinished">मंजूर नहीं</translation>
+    </message>
+    <message>
+        <source>Debit</source>
+        <translation type="unfinished">जमा</translation>
+    </message>
+    <message>
+        <source>Total debit</source>
+        <translation type="unfinished">कुल डेबिट</translation>
+    </message>
+    <message>
+        <source>Total credit</source>
+        <translation type="unfinished">कुल क्रेडिट</translation>
+    </message>
+    <message>
+        <source>Transaction fee</source>
+        <translation type="unfinished">लेनदेन शुल्क</translation>
+    </message>
+    <message>
+        <source>Net amount</source>
+        <translation type="unfinished">निवल राशि</translation>
+    </message>
+    <message>
+        <source>Message</source>
+        <translation type="unfinished">मेसेज</translation>
+    </message>
+    <message>
+        <source>Comment</source>
+        <translation type="unfinished">कमेंट</translation>
+    </message>
+    <message>
+        <source>Transaction ID</source>
+        <translation type="unfinished">लेन-देन आईडी</translation>
+    </message>
+    <message>
+        <source>Transaction total size</source>
+        <translation type="unfinished">लेन-देन कुल आकार</translation>
+    </message>
+    <message>
+        <source>Transaction virtual size</source>
+        <translation type="unfinished">लेनदेन आभासी आकार</translation>
+    </message>
+    <message>
+        <source>Output index</source>
+        <translation type="unfinished">आउटपुट इंडेक्स</translation>
+    </message>
+    <message>
+        <source> (Certificate was not verified)</source>
+        <translation type="unfinished">(प्रमाणपत्र सत्यापित नहीं किया गया था)</translation>
+    </message>
+    <message>
+        <source>Merchant</source>
+        <translation type="unfinished">सौदागर</translation>
+    </message>
+    <message>
+        <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to "not accepted" and it won't be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
+        <translation type="unfinished"> %1 सृजित सिक्कों को खर्च करने से पहले ब्लॉक में परिपक्व होना चाहिए। जब आपने इस ब्लॉक को जनरेट किया था, तो इसे नेटवर्क में प्रसारित किया गया था ताकि इसे ब्लॉक चेन में जोड़ा जा सके। यदि यह श्रृंखला में शामिल होने में विफल रहता है, तो इसकी स्थिति "स्वीकृत नहीं" में बदल जाएगी और यह खर्च करने योग्य नहीं होगी। यह कभी-कभी हो सकता है यदि कोई अन्य नोड आपके कुछ सेकंड के भीतर एक ब्लॉक उत्पन्न करता है।</translation>
+    </message>
+    <message>
+        <source>Debug information</source>
+        <translation type="unfinished">डीबग जानकारी</translation>
+    </message>
+    <message>
+        <source>Transaction</source>
+        <translation type="unfinished">लेन-देन</translation>
+    </message>
+    <message>
+        <source>Inputs</source>
+        <translation type="unfinished">इनपुट</translation>
+    </message>
+    <message>
+        <source>Amount</source>
+        <translation type="unfinished">राशि</translation>
+    </message>
+    <message>
+        <source>true</source>
+        <translation type="unfinished">सच</translation>
+    </message>
+    <message>
+        <source>false</source>
+        <translation type="unfinished">असत्य</translation>
+    </message>
+</context>
+<context>
+    <name>TransactionDescDialog</name>
+    <message>
+        <source>This pane shows a detailed description of the transaction</source>
+        <translation type="unfinished">यह फलक लेन-देन का विस्तृत विवरण दिखाता है</translation>
+    </message>
+    <message>
+        <source>Details for %1</source>
+        <translation type="unfinished">के लिए विवरण %1</translation>
+    </message>
+</context>
+<context>
+    <name>TransactionTableModel</name>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">डेट</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished">टाइप</translation>
+    </message>
+    <message>
+        <source>Label</source>
+        <translation type="unfinished">लेबल</translation>
+    </message>
+    <message>
+        <source>Unconfirmed</source>
+        <translation type="unfinished">अपुष्ट</translation>
+    </message>
+    <message>
+        <source>Abandoned</source>
+        <translation type="unfinished">अबॅन्डन्ड</translation>
+    </message>
+    <message>
+        <source>Confirming (%1 of %2 recommended confirmations)</source>
+        <translation type="unfinished">पुष्टिकरण (%1 में से  %2 अनुशंसित पुष्टिकरण)</translation>
+    </message>
+    <message>
+        <source>Confirmed (%1 confirmations)</source>
+        <translation type="unfinished">की पुष्टि की (%1 पुष्टिकरण)</translation>
+    </message>
+    <message>
+        <source>Conflicted</source>
+        <translation type="unfinished">विरोध हुआ</translation>
+    </message>
+    <message>
+        <source>Immature (%1 confirmations, will be available after %2)</source>
+        <translation type="unfinished">अपरिपक्व (%1 पुष्टिकरण, %2के बाद उपलब्ध होंगे)</translation>
+    </message>
+    <message>
+        <source>Generated but not accepted</source>
+        <translation type="unfinished">जनरेट किया गया लेकिन स्वीकार नहीं किया गया</translation>
     </message>
     </context>
 </TS>

--- a/src/qt/locale/bitcoin_mr_IN.ts
+++ b/src/qt/locale/bitcoin_mr_IN.ts
@@ -86,6 +86,16 @@
         <translation type="unfinished">पत्त्याची निर्यात करा</translation>
     </message>
     <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">कॉमा सेपरेटेड फ़ाइल</translation>
+    </message>
+    <message>
+        <source>There was an error trying to save the address list to %1. Please try again.</source>
+        <extracomment>An error message. %1 is a stand-in argument for the name of the file we attempted to save to.</extracomment>
+        <translation type="unfinished">पत्ता सूची  वर जतन करण्याचा प्रयत्न करताना त्रुटी आली. कृपया पुन्हा प्रयत्न करा.%1</translation>
+    </message>
+    <message>
         <source>Exporting Failed</source>
         <translation type="unfinished">निर्यात अयशस्वी</translation>
     </message>
@@ -106,7 +116,66 @@
     </message>
 </context>
 <context>
+    <name>AskPassphraseDialog</name>
+    <message>
+        <source>Passphrase Dialog</source>
+        <translation type="unfinished">पासफ़्रेज़ डाएलोग</translation>
+    </message>
+    <message>
+        <source>Enter passphrase</source>
+        <translation type="unfinished">पासफ़्रेज़  प्रविष्ट करा</translation>
+    </message>
+    <message>
+        <source>New passphrase</source>
+        <translation type="unfinished">नवीन पासफ़्रेज़ </translation>
+    </message>
+    <message>
+        <source>Repeat new passphrase</source>
+        <translation type="unfinished">नवीन पासफ़्रेज़  पुनरावृत्ती करा</translation>
+    </message>
+    <message>
+        <source>Show passphrase</source>
+        <translation type="unfinished">पासफ़्रेज़ दाखवा</translation>
+    </message>
+    <message>
+        <source>Encrypt wallet</source>
+        <translation type="unfinished">वॉलेट एनक्रिप्ट करा</translation>
+    </message>
+    <message>
+        <source>This operation needs your wallet passphrase to unlock the wallet.</source>
+        <translation type="unfinished">वॉलेट अनलॉक करण्यासाठी या ऑपरेशनला तुमच्या वॉलेट पासफ़्रेज़ची आवश्यकता आहे.</translation>
+    </message>
+    <message>
+        <source>Unlock wallet</source>
+        <translation type="unfinished">वॉलेट अनलॉक करा</translation>
+    </message>
+    <message>
+        <source>Change passphrase</source>
+        <translation type="unfinished">पासफ़्रेज़ बदला</translation>
+    </message>
+    <message>
+        <source>Confirm wallet encryption</source>
+        <translation type="unfinished">वॉलेट एन्क्रिप्शनची पुष्टी करा
+ </translation>
+    </message>
+    </context>
+<context>
+    <name>BitcoinApplication</name>
+    <message>
+        <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
+        <translation type="unfinished">एक गंभीर त्रुटी आली. %1यापुढे सुरक्षितपणे सुरू ठेवू शकत नाही आणि संपेल.</translation>
+    </message>
+    <message>
+        <source>Internal error</source>
+        <translation type="unfinished">अंतर्गत त्रुटी</translation>
+    </message>
+    </context>
+<context>
     <name>QObject</name>
+    <message>
+        <source>%1 didn't yet exit safely…</source>
+        <translation type="unfinished">%1अजून सुरक्षितपणे बाहेर पडलो नाही...</translation>
+    </message>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation type="unfinished">
@@ -151,7 +220,78 @@
     </message>
     </context>
 <context>
+    <name>bitcoin-core</name>
+    <message>
+        <source>Settings file could not be read</source>
+        <translation type="unfinished">सेटिंग्ज फाइल वाचता आली नाही</translation>
+    </message>
+    <message>
+        <source>Settings file could not be written</source>
+        <translation type="unfinished">सेटिंग्ज फाइल लिहिता आली नाही</translation>
+    </message>
+    </context>
+<context>
     <name>BitcoinGUI</name>
+    <message>
+        <source>&amp;Minimize</source>
+        <translation type="unfinished">&amp;मिनीमाइज़</translation>
+    </message>
+    <message>
+        <source>&amp;Options…</source>
+        <translation type="unfinished">&amp;पर्याय</translation>
+    </message>
+    <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation type="unfinished">&amp;एनक्रिप्ट वॉलेट</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation type="unfinished">&amp;बॅकअप वॉलेट...</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation type="unfinished">&amp;पासफ्रेज बदला...</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation type="unfinished">स्वाक्षरी आणि संदेश...</translation>
+    </message>
+    <message>
+        <source>&amp;Verify message…</source>
+        <translation type="unfinished">&amp;संदेश सत्यापित करा...</translation>
+    </message>
+    <message>
+        <source>&amp;Load PSBT from file…</source>
+        <translation type="unfinished">फाइलमधून PSBT &amp;लोड करा...</translation>
+    </message>
+    <message>
+        <source>Close Wallet…</source>
+        <translation type="unfinished">वॉलेट बंद करा...</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation type="unfinished">वॉलेट तयार करा...</translation>
+    </message>
+    <message>
+        <source>Close All Wallets…</source>
+        <translation type="unfinished">सर्व वॉलेट बंद करा...</translation>
+    </message>
+    <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation type="unfinished">शीर्षलेख समक्रमित करत आहे (%1%)…</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation type="unfinished">नेटवर्कसह सिंक्रोनाइझ करत आहे...</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation type="unfinished">डिस्कवर ब्लॉक अनुक्रमित करत आहे...</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation type="unfinished">डिस्कवर ब्लॉक्सवर प्रक्रिया करत आहे...</translation>
+    </message>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation type="unfinished">
@@ -242,6 +382,11 @@
     </context>
 <context>
     <name>TransactionView</name>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">कॉमा सेपरेटेड फ़ाइल</translation>
+    </message>
     <message>
         <source>Label</source>
         <translation type="unfinished">लेबल</translation>

--- a/src/qt/locale/bitcoin_sr.ts
+++ b/src/qt/locale/bitcoin_sr.ts
@@ -265,6 +265,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>QObject</name>
     <message>
+        <source>Do you want to reset settings to default values, or to abort without making changes?</source>
+        <extracomment>Explanatory text shown on startup when the settings file cannot be read. Prompts user to make a choice between resetting or aborting.</extracomment>
+        <translation type="unfinished">Da li želiš da poništiš podešavanja na početne vrednosti, ili da prekineš bez promena?</translation>
+    </message>
+    <message>
         <source>Error: Specified data directory "%1" does not exist.</source>
         <translation type="unfinished">Грешка: Одабрани директорјиум датотеке "%1" не постоји.</translation>
     </message>
@@ -834,6 +839,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Направи нови ночаник</translation>
     </message>
     <message>
+        <source>&amp;Minimize</source>
+        <translation type="unfinished">&amp;Minimalizuj</translation>
+    </message>
+    <message>
         <source>Wallet:</source>
         <translation type="unfinished">Новчаник:</translation>
     </message>
@@ -1089,6 +1098,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>%1 client</source>
         <translation type="unfinished">%1 клијент</translation>
+    </message>
+    <message>
+        <source>&amp;Hide</source>
+        <translation type="unfinished">&amp;Sakrij</translation>
     </message>
     <message>
         <source>S&amp;how</source>
@@ -1376,6 +1389,19 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Can't list signers</source>
         <translation type="unfinished">Не могу да излистам потписнике</translation>
+    </message>
+</context>
+<context>
+    <name>LoadWalletsActivity</name>
+    <message>
+        <source>Load Wallets</source>
+        <extracomment>Title of progress window which is displayed when wallets are being loaded.</extracomment>
+        <translation type="unfinished">Učitaj Novčanik</translation>
+    </message>
+    <message>
+        <source>Loading wallets…</source>
+        <extracomment>Descriptive text of the load wallets progress window which indicates to the user that wallets are currently being loaded.</extracomment>
+        <translation type="unfinished">Učitavanje Novčanika...</translation>
     </message>
 </context>
 <context>
@@ -1841,6 +1867,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">(0 = аутоматски одреди, &lt;0 = остави слободно толико језгара)</translation>
     </message>
     <message>
+        <source>Enable R&amp;PC server</source>
+        <extracomment>An Options window setting to enable the RPC server.</extracomment>
+        <translation type="unfinished">Omogući R&amp;PC server</translation>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished">Н&amp;овчаник</translation>
     </message>
@@ -2034,6 +2065,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>The configuration file is used to specify advanced user options which override GUI settings. Additionally, any command-line options will override this configuration file.</source>
         <extracomment>Explanatory text about the priority order of instructions considered by client. The order from high to low being: command-line, configuration file, GUI settings.</extracomment>
         <translation type="unfinished">Конфигурациона датотека се користи да одреди напредне корисничке опције које поништају подешавања у графичком корисничком интерфејсу.</translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation type="unfinished">Nastavi</translation>
     </message>
     <message>
         <source>Cancel</source>
@@ -2707,6 +2742,11 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <translation type="unfinished">1 &amp;година</translation>
     </message>
     <message>
+        <source>&amp;Copy IP/Netmask</source>
+        <extracomment>Context menu action to copy the IP/Netmask of a banned peer. IP/Netmask is the combination of a peer's IP address and its Netmask. For IP address, see: https://en.wikipedia.org/wiki/IP_address.</extracomment>
+        <translation type="unfinished">&amp;Kopiraj IP/Netmask</translation>
+    </message>
+    <message>
         <source>&amp;Unban</source>
         <translation type="unfinished">&amp;Уклони забрану</translation>
     </message>
@@ -3230,6 +3270,11 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
         <translation type="unfinished">Молимо, проверите ваш предлог трансакције. Ово ће произвести делимично потписану Биткоин трансакцију (PSBT) коју можете копирати и онда потписати са нпр. офлајн %1 новчаником, или PSBT компатибилним хардверским новчаником.</translation>
     </message>
     <message>
+        <source>Do you want to create this transaction?</source>
+        <extracomment>Message displayed when attempting to create a transaction. Cautionary text to prompt the user to verify that the displayed transaction details represent the transaction the user intends to create.</extracomment>
+        <translation type="unfinished">Da li želite da napravite ovu transakciju?</translation>
+    </message>
+    <message>
         <source>Please, review your transaction.</source>
         <extracomment>Text to prompt a user to review the details of the transaction they are attempting to send.</extracomment>
         <translation type="unfinished">Молим, размотрите вашу трансакцију.</translation>
@@ -3538,6 +3583,13 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     <message>
         <source>Message verified.</source>
         <translation type="unfinished">Порука је проверена.</translation>
+    </message>
+</context>
+<context>
+    <name>SplashScreen</name>
+    <message>
+        <source>press q to shutdown</source>
+        <translation type="unfinished">pritisni q za gašenje</translation>
     </message>
 </context>
 <context>
@@ -3905,6 +3957,10 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     <message>
         <source>Increase transaction &amp;fee</source>
         <translation type="unfinished">Повећај провизију трансакције</translation>
+    </message>
+    <message>
+        <source>&amp;Edit address label</source>
+        <translation type="unfinished">&amp;Promeni adresu etikete</translation>
     </message>
     <message>
         <source>Export Transaction History</source>

--- a/src/qt/locale/bitcoin_ta.ts
+++ b/src/qt/locale/bitcoin_ta.ts
@@ -15,15 +15,11 @@
     </message>
     <message>
         <source>Copy the currently selected address to the system clipboard</source>
-        <translation type="unfinished">தற்போது தேர்ந்தெடுக்கப்பட்ட முகவரியை கணினி கிளிப்போர்டுக்கு காபி செய்யவும்.</translation>
+        <translation type="unfinished">தற்போது தேர்ந்தெடுக்கப்பட்ட முகவரியை கணினி கிளிப்போர்டுக்கு காபி செய்யவும்</translation>
     </message>
     <message>
         <source>&amp;Copy</source>
         <translation type="unfinished">&amp;காபி</translation>
-    </message>
-    <message>
-        <source>C&amp;lose</source>
-        <translation type="unfinished">&amp;மூடு</translation>
     </message>
     <message>
         <source>Delete the currently selected address from the list</source>
@@ -253,9 +249,23 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Internal error</source>
         <translation type="unfinished">உள் எறர்</translation>
     </message>
-    </context>
+    <message>
+        <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
+        <translation type="unfinished">உள் பிழை ஏற்பட்டது. 1%1  தொடர முயற்சிக்கும். இது எதிர்பாராத பிழை, கீழே விவரிக்கப்பட்டுள்ளபடி புகாரளிக்கலாம்.</translation>
+    </message>
+</context>
 <context>
     <name>QObject</name>
+    <message>
+        <source>Do you want to reset settings to default values, or to abort without making changes?</source>
+        <extracomment>Explanatory text shown on startup when the settings file cannot be read. Prompts user to make a choice between resetting or aborting.</extracomment>
+        <translation type="unfinished">அமைப்புகளை இயல்புநிலை மதிப்புகளுக்கு மீட்டமைக்க வேண்டுமா அல்லது மாற்றங்களைச் செய்யாமல் நிறுத்த வேண்டுமா?</translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. Check that settings file is writable, or try running with -nosettings.</source>
+        <extracomment>Explanatory text shown on startup when the settings file could not be written. Prompts user to check that we have the ability to write to the file. Explains that the user has the option of running without a settings file.</extracomment>
+        <translation type="unfinished">ஒரு அபாயகரமான பிழை ஏற்பட்டது. அமைப்புகள் கோப்பு எழுதக்கூடியதா என்பதைச் சரிபார்க்கவும் அல்லது -nosettings மூலம் இயக்க முயற்சிக்கவும்.</translation>
+    </message>
     <message>
         <source>Error: Specified data directory "%1" does not exist.</source>
         <translation type="unfinished">பிழை: குறிப்பிட்ட தரவு அடைவு "%1" இல்லை.</translation>
@@ -347,6 +357,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </context>
 <context>
     <name>bitcoin-core</name>
+    <message>
+        <source>Settings file could not be read</source>
+        <translation type="unfinished">அமைப்புகள் கோப்பைப் படிக்க முடியவில்லை</translation>
+    </message>
+    <message>
+        <source>Settings file could not be written</source>
+        <translation type="unfinished">அமைப்புகள் கோப்பை எழுத முடியவில்லை</translation>
+    </message>
     <message>
         <source>The %s developers</source>
         <translation type="unfinished">%s டெவலப்பர்கள்</translation>
@@ -718,6 +736,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>&amp;Receive</source>
         <translation type="unfinished">&amp;பெறு</translation>
+    </message>
+    <message>
+        <source>&amp;Options…</source>
+        <translation type="unfinished">&amp;விருப்பங்கள்</translation>
     </message>
     <message>
         <source>Encrypt the private keys that belong to your wallet</source>

--- a/src/qt/locale/bitcoin_te.ts
+++ b/src/qt/locale/bitcoin_te.ts
@@ -3,7 +3,7 @@
     <name>AddressBookPage</name>
     <message>
         <source>Right-click to edit address or label</source>
-        <translation type="unfinished">చిరునామా లేదా లేబుల్ సవరించు -క్లిక్ చేయండి</translation>
+        <translation type="unfinished">చిరునామా లేదా లేబుల్ సవరించడానికి రైట్-క్లిక్ చేయండి</translation>
     </message>
     <message>
         <source>Create a new address</source>
@@ -23,7 +23,7 @@
     </message>
     <message>
         <source>C&amp;lose</source>
-        <translation type="unfinished">C&amp;కోల్పోవు</translation>
+        <translation type="unfinished">క్లో&amp;జ్</translation>
     </message>
     <message>
         <source>Delete the currently selected address from the list</source>
@@ -55,7 +55,7 @@
     </message>
     <message>
         <source>C&amp;hoose</source>
-        <translation type="unfinished">ఎంచుకోండి</translation>
+        <translation type="unfinished">ఎం&amp;చుకోండి</translation>
     </message>
     <message>
         <source>Sending addresses</source>
@@ -68,6 +68,11 @@
     <message>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation type="unfinished">ఇవి మీరు పంపే చెల్లింపుల బిట్‌కాయిన్ చిరునామాలు. నాణేలు పంపే ముందు ప్రతిసారి అందుకునే చిరునామా మరియు చెల్లింపు మొత్తం సరిచూసుకోండి.</translation>
+    </message>
+    <message>
+        <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
+Signing is only possible with addresses of the type 'legacy'.</source>
+        <translation type="unfinished">చెల్లింపులను స్వీకరించడానికి ఇవి మీ బిట్‌కాయిన్ చిరునామాలు. కొత్త చిరునామాలను సృష్టించడానికి స్వీకరించే ట్యాబ్‌లోని 'కొత్త స్వీకరించే చిరునామాను సృష్టించు' బటన్‌ను ఉపయోగించండి. 'లెగసీ' రకం చిరునామాలతో మాత్రమే సంతకం చేయడం సాధ్యమవుతుంది.</translation>
     </message>
     <message>
         <source>&amp;Copy Address</source>
@@ -84,6 +89,11 @@
     <message>
         <source>Export Address List</source>
         <translation type="unfinished">చిరునామా జాబితాను ఎగుమతి చేయండి</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">కామాతో వేరు చేయబడిన ఫైల్</translation>
     </message>
     <message>
         <source>There was an error trying to save the address list to %1. Please try again.</source>
@@ -229,7 +239,52 @@
     </message>
 </context>
 <context>
+    <name>BitcoinApplication</name>
+    <message>
+        <source>Runaway exception</source>
+        <translation type="unfinished">రన్అవే మినహాయింపు</translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
+        <translation type="unfinished">ఘోరమైన లోపం సంభవించింది. 1 %1 ఇకపై సురక్షితంగా కొనసాగదు మరియు నిష్క్రమిస్తుంది.</translation>
+    </message>
+    <message>
+        <source>Internal error</source>
+        <translation type="unfinished">అంతర్గత లోపం</translation>
+    </message>
+    <message>
+        <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
+        <translation type="unfinished">అంతర్గత లోపం సంభవించింది. 1 %1 సురక్షితంగా కొనసాగించడానికి ప్రయత్నిస్తుంది. ఇది ఊహించని బగ్, దీనిని దిగువ వివరించిన విధంగా నివేదించవచ్చు.</translation>
+    </message>
+</context>
+<context>
     <name>QObject</name>
+    <message>
+        <source>Do you want to reset settings to default values, or to abort without making changes?</source>
+        <extracomment>Explanatory text shown on startup when the settings file cannot be read. Prompts user to make a choice between resetting or aborting.</extracomment>
+        <translation type="unfinished">మీరు సెట్టింగ్‌లను డిఫాల్ట్ విలువలకు రీసెట్ చేయాలనుకుంటున్నారా లేదా మార్పులు చేయకుండానే నిలిపివేయాలనుకుంటున్నారా?</translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. Check that settings file is writable, or try running with -nosettings.</source>
+        <extracomment>Explanatory text shown on startup when the settings file could not be written. Prompts user to check that we have the ability to write to the file. Explains that the user has the option of running without a settings file.</extracomment>
+        <translation type="unfinished">ఘోరమైన లోపం సంభవించింది. సెట్టింగుల ఫైల్ వ్రాయదగినదో లేదో తనిఖీ చేయండి లేదా - నోసెట్టింగ్స్ తో అమలు చేయడానికి ప్రయత్నించండి.</translation>
+    </message>
+    <message>
+        <source>Error: Specified data directory "%1" does not exist.</source>
+        <translation type="unfinished">లోపం: పేర్కొన్న డేటా డైరెక్టరీ " %1 " లేదు.</translation>
+    </message>
+    <message>
+        <source>Error: Cannot parse configuration file: %1.</source>
+        <translation type="unfinished">లోపం: కాన్ఫిగరేషన్ ఫైల్‌ను అన్వయించలేరు: %1 .</translation>
+    </message>
+    <message>
+        <source>Error: %1</source>
+        <translation type="unfinished">లోపం: %1</translation>
+    </message>
+    <message>
+        <source>%1 didn't yet exit safely…</source>
+        <translation type="unfinished">%1 ఇంకా సురక్షితంగా బయటకు రాలేదు...</translation>
+    </message>
     <message>
         <source>unknown</source>
         <translation type="unfinished">తెలియదు</translation>
@@ -237,6 +292,61 @@
     <message>
         <source>Amount</source>
         <translation type="unfinished">మొత్తం</translation>
+    </message>
+    <message>
+        <source>Enter a Bitcoin address (e.g. %1)</source>
+        <translation type="unfinished">బిట్‌కాయిన్ చిరునామాను నమోదు చేయండి (ఉదా. %1)</translation>
+    </message>
+    <message>
+        <source>Unroutable</source>
+        <translation type="unfinished">రూట్ చేయలేనిది</translation>
+    </message>
+    <message>
+        <source>Internal</source>
+        <translation type="unfinished">అంతర్గత</translation>
+    </message>
+    <message>
+        <source>Inbound</source>
+        <extracomment>An inbound connection from a peer. An inbound connection is a connection initiated by a peer.</extracomment>
+        <translation type="unfinished">ఇన్‌బౌండ్</translation>
+    </message>
+    <message>
+        <source>Outbound</source>
+        <extracomment>An outbound connection to a peer. An outbound connection is a connection initiated by us.</extracomment>
+        <translation type="unfinished">అవుట్ బౌండ్</translation>
+    </message>
+    <message>
+        <source>Full Relay</source>
+        <extracomment>Peer connection type that relays all network information.</extracomment>
+        <translation type="unfinished">పూర్తిగా  ఏర్పరచుట</translation>
+    </message>
+    <message>
+        <source>Block Relay</source>
+        <extracomment>Peer connection type that relays network information about blocks and not transactions or addresses.</extracomment>
+        <translation type="unfinished">ఏర్పాటు చేయుటను నిరోధించండి</translation>
+    </message>
+    <message>
+        <source>Manual</source>
+        <extracomment>Peer connection type established manually through one of several methods.</extracomment>
+        <translation type="unfinished">మానవీయంగా</translation>
+    </message>
+    <message>
+        <source>Feeler</source>
+        <extracomment>Short-lived peer connection type that tests the aliveness of known addresses.</extracomment>
+        <translation type="unfinished">అనుభూతి</translation>
+    </message>
+    <message>
+        <source>Address Fetch</source>
+        <extracomment>Short-lived peer connection type that solicits known addresses from a peer.</extracomment>
+        <translation type="unfinished">చిరునామా పొందండి</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished">ఏదీ లేదు</translation>
+    </message>
+    <message>
+        <source>N/A</source>
+        <translation type="unfinished">వర్తించదు</translation>
     </message>
     <message numerus="yes">
         <source>%n second(s)</source>
@@ -273,6 +383,10 @@
             <numerusform />
         </translation>
     </message>
+    <message>
+        <source>%1 and %2</source>
+        <translation type="unfinished">%1 మరియు %2</translation>
+    </message>
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
@@ -281,6 +395,177 @@
         </translation>
     </message>
     </context>
+<context>
+    <name>bitcoin-core</name>
+    <message>
+        <source>Settings file could not be read</source>
+        <translation type="unfinished">సెట్టింగ్‌ల ఫైల్ చదవడం సాధ్యం కాలేదు</translation>
+    </message>
+    <message>
+        <source>Settings file could not be written</source>
+        <translation type="unfinished">సెట్టింగుల ఫైల్ వ్రాయబడదు</translation>
+    </message>
+    <message>
+        <source>Cannot set -peerblockfilters without -blockfilterindex.</source>
+        <translation type="unfinished">-blockfilterindex లేకుండా -peerblockfilters సెట్ చేయలేము.</translation>
+    </message>
+    <message>
+        <source>Error reading from database, shutting down.</source>
+        <translation type="unfinished">డేటాబేస్ నుండి చదవడంలో లోపం, షట్ డౌన్.</translation>
+    </message>
+    <message>
+        <source>Missing solving data for estimating transaction size</source>
+        <translation type="unfinished">లావాదేవీ పరిమాణాన్ని అంచనా వేయడానికి పరిష్కార డేటా లేదు</translation>
+    </message>
+    <message>
+        <source>Prune cannot be configured with a negative value.</source>
+        <translation type="unfinished">ప్రూనే ప్రతికూల విలువతో కాన్ఫిగర్ చేయబడదు.</translation>
+    </message>
+    <message>
+        <source>Prune mode is incompatible with -txindex.</source>
+        <translation type="unfinished">ప్రూన్ మోడ్ -txindexకి అనుకూలంగా లేదు.</translation>
+    </message>
+    <message>
+        <source>Section [%s] is not recognized.</source>
+        <translation type="unfinished">విభాగం [%s] గుర్తించబడలేదు.</translation>
+    </message>
+    <message>
+        <source>Specified blocks directory "%s" does not exist.</source>
+        <translation type="unfinished">పేర్కొన్న బ్లాక్‌ల డైరెక్టరీ "%s" ఉనికిలో లేదు.</translation>
+    </message>
+    <message>
+        <source>Starting network threads…</source>
+        <translation type="unfinished">నెట్‌వర్క్ థ్రెడ్‌లను ప్రారంభిస్తోంది…</translation>
+    </message>
+    <message>
+        <source>The source code is available from %s.</source>
+        <translation type="unfinished">%s నుండి సోర్స్ కోడ్ అందుబాటులో ఉంది.</translation>
+    </message>
+    <message>
+        <source>The specified config file %s does not exist</source>
+        <translation type="unfinished">పేర్కొన్న కాన్ఫిగర్ ఫైల్ %s ఉనికిలో లేదు</translation>
+    </message>
+    <message>
+        <source>The transaction amount is too small to pay the fee</source>
+        <translation type="unfinished">రుసుము చెల్లించడానికి లావాదేవీ మొత్తం చాలా చిన్నది</translation>
+    </message>
+    <message>
+        <source>The wallet will avoid paying less than the minimum relay fee.</source>
+        <translation type="unfinished">వాలెట్ కనీస రిలే రుసుము కంటే తక్కువ చెల్లించడాన్ని నివారిస్తుంది.</translation>
+    </message>
+    <message>
+        <source>This is experimental software.</source>
+        <translation type="unfinished">ఇది ప్రయోగాత్మక సాఫ్ట్‌వేర్.</translation>
+    </message>
+    <message>
+        <source>This is the minimum transaction fee you pay on every transaction.</source>
+        <translation type="unfinished">ఇది ప్రతి లావాదేవీకి మీరు చెల్లించే కనీస లావాదేవీ రుసుము.</translation>
+    </message>
+    <message>
+        <source>This is the transaction fee you will pay if you send a transaction.</source>
+        <translation type="unfinished">మీరు లావాదేవీని పంపితే మీరు చెల్లించే లావాదేవీ రుసుము ఇది.</translation>
+    </message>
+    <message>
+        <source>Transaction amount too small</source>
+        <translation type="unfinished">లావాదేవీ మొత్తం చాలా చిన్నది</translation>
+    </message>
+    <message>
+        <source>Transaction amounts must not be negative</source>
+        <translation type="unfinished">లావాదేవీ మొత్తాలు ప్రతికూలంగా ఉండకూడదు</translation>
+    </message>
+    <message>
+        <source>Transaction change output index out of range</source>
+        <translation type="unfinished">లావాదేవీ మార్పు అవుట్‌పుట్ సూచిక పరిధి వెలుపల ఉంది</translation>
+    </message>
+    <message>
+        <source>Transaction has too long of a mempool chain</source>
+        <translation type="unfinished">లావాదేవీ మెంపూల్ చైన్‌లో చాలా పొడవుగా ఉంది</translation>
+    </message>
+    <message>
+        <source>Transaction must have at least one recipient</source>
+        <translation type="unfinished">లావాదేవీకి కనీసం ఒక గ్రహీత ఉండాలి</translation>
+    </message>
+    <message>
+        <source>Transaction needs a change address, but we can't generate it.</source>
+        <translation type="unfinished">లావాదేవీకి చిరునామా మార్పు అవసరం, కానీ మేము దానిని రూపొందించలేము.</translation>
+    </message>
+    <message>
+        <source>Transaction too large</source>
+        <translation type="unfinished">లావాదేవీ చాలా పెద్దది</translation>
+    </message>
+    <message>
+        <source>Unable to bind to %s on this computer (bind returned error %s)</source>
+        <translation type="unfinished">బైండ్ చేయడం సాధ్యపడలేదు %s ఈ కంప్యూటర్‌లో  (బైండ్ రిటర్న్ ఎర్రర్ %s)</translation>
+    </message>
+    <message>
+        <source>Unable to bind to %s on this computer. %s is probably already running.</source>
+        <translation type="unfinished">బైండ్ చేయడం సాధ్యపడలేదు %s ఈ కంప్యూటర్‌లో. %s బహుశా ఇప్పటికే అమలులో ఉంది.</translation>
+    </message>
+    <message>
+        <source>Unable to create the PID file '%s': %s</source>
+        <translation type="unfinished">PID ఫైల్‌ని సృష్టించడం సాధ్యం కాలేదు '%s': %s</translation>
+    </message>
+    <message>
+        <source>Unable to generate initial keys</source>
+        <translation type="unfinished">ప్రారంభ కీలను రూపొందించడం సాధ్యం కాలేదు</translation>
+    </message>
+    <message>
+        <source>Unable to generate keys</source>
+        <translation type="unfinished">కీలను రూపొందించడం సాధ్యం కాలేదు</translation>
+    </message>
+    <message>
+        <source>Unable to open %s for writing</source>
+        <translation type="unfinished">తెరవడం సాధ్యం కాదు %s రాయడం కోసం</translation>
+    </message>
+    <message>
+        <source>Unable to parse -maxuploadtarget: '%s'</source>
+        <translation type="unfinished">-maxuploadtarget అన్వయించడం సాధ్యం కాలేదు: '%s'</translation>
+    </message>
+    <message>
+        <source>Unable to start HTTP server. See debug log for details.</source>
+        <translation type="unfinished">HTTP సర్వర్‌ని ప్రారంభించడం సాధ్యం కాలేదు. వివరాల కోసం డీబగ్ లాగ్ చూడండి.</translation>
+    </message>
+    <message>
+        <source>Unknown -blockfilterindex value %s.</source>
+        <translation type="unfinished">తెలియని -blockfilterindex విలువ %s.</translation>
+    </message>
+    <message>
+        <source>Unknown address type '%s'</source>
+        <translation type="unfinished">తెలియని చిరునామా రకం '%s'</translation>
+    </message>
+    <message>
+        <source>Unknown change type '%s'</source>
+        <translation type="unfinished">తెలియని మార్పు రకం '%s'</translation>
+    </message>
+    <message>
+        <source>Unknown network specified in -onlynet: '%s'</source>
+        <translation type="unfinished">తెలియని నెట్‌వర్క్ -onlynetలో పేర్కొనబడింది: '%s'</translation>
+    </message>
+    <message>
+        <source>Unknown new rules activated (versionbit %i)</source>
+        <translation type="unfinished">తెలియని కొత్త నియమాలు (వెర్షన్‌బిట్‌ %i)ని యాక్టివేట్ చేశాయి</translation>
+    </message>
+    <message>
+        <source>Unsupported logging category %s=%s.</source>
+        <translation type="unfinished">మద్దతు లేని లాగింగ్ వర్గం %s=%s</translation>
+    </message>
+    <message>
+        <source>User Agent comment (%s) contains unsafe characters.</source>
+        <translation type="unfinished">వినియోగదారు ఏజెంట్ వ్యాఖ్య (%s)లో అసురక్షిత అక్షరాలు ఉన్నాయి.</translation>
+    </message>
+    <message>
+        <source>Verifying blocks…</source>
+        <translation type="unfinished">బ్లాక్‌లను ధృవీకరిస్తోంది…</translation>
+    </message>
+    <message>
+        <source>Verifying wallet(s)…</source>
+        <translation type="unfinished">వాలెట్(ల)ని ధృవీకరిస్తోంది...</translation>
+    </message>
+    <message>
+        <source>Wallet needed to be rewritten: restart %s to complete</source>
+        <translation type="unfinished">వాలెట్‌ని మళ్లీ వ్రాయాలి: పూర్తి చేయడానికి పునఃప్రారంభించండి %s</translation>
+    </message>
+</context>
 <context>
     <name>BitcoinGUI</name>
     <message>
@@ -332,6 +617,10 @@
         <translation type="unfinished">&lt;div&gt;&lt;/div&gt;</translation>
     </message>
     <message>
+        <source>&amp;Minimize</source>
+        <translation type="unfinished">&amp;తగ్గించడానికి</translation>
+    </message>
+    <message>
         <source>Wallet:</source>
         <translation type="unfinished">ధనమును తీసుకొనిపోవు సంచి</translation>
     </message>
@@ -339,6 +628,10 @@
         <source>Network activity disabled.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">నెట్‌వర్క్ కార్యాచరణ నిలిపివేయబడింది.</translation>
+    </message>
+    <message>
+        <source>Proxy is &lt;b&gt;enabled&lt;/b&gt;: %1</source>
+        <translation type="unfinished">ప్రాక్సీ &lt;b&gt;ప్రారంభించబడింది&lt;/b&gt;: %1</translation>
     </message>
     <message>
         <source>Send coins to a Bitcoin address</source>
@@ -360,12 +653,140 @@
         <source>&amp;Receive</source>
         <translation type="unfinished">స్వీకరించండి</translation>
     </message>
+    <message>
+        <source>&amp;Options…</source>
+        <translation type="unfinished">&amp;ఎంపికలు...</translation>
+    </message>
+    <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation type="unfinished">&amp;వాలెట్‌ని ఎన్‌క్రిప్ట్ చేయండి...</translation>
+    </message>
+    <message>
+        <source>Encrypt the private keys that belong to your wallet</source>
+        <translation type="unfinished">మీ వాలెట్‌కు చెందిన ప్రైవేట్ కీలను గుప్తీకరించండి</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation type="unfinished">&amp;బ్యాకప్ వాలెట్...</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation type="unfinished">&amp;సంకేతపదం మార్చండి</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation type="unfinished">సంతకం &amp;సందేశం...</translation>
+    </message>
+    <message>
+        <source>Sign messages with your Bitcoin addresses to prove you own them</source>
+        <translation type="unfinished">మీ బిట్‌కాయిన్ చిరునామాలు మీ స్వంతమని నిరూపించుకోవడానికి వాటితో సందేశాలను సంతకం చేయండి</translation>
+    </message>
+    <message>
+        <source>&amp;Verify message…</source>
+        <translation type="unfinished">&amp;సందేశాన్ని ధృవీకరించండి...</translation>
+    </message>
+    <message>
+        <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
+        <translation type="unfinished">సందేశాలు పేర్కొన్న బిట్‌కాయిన్ చిరునామాలతో సంతకం చేసినట్లు నిర్ధారించుకోవడానికి వాటిని ధృవీకరించండి</translation>
+    </message>
+    <message>
+        <source>&amp;Load PSBT from file…</source>
+        <translation type="unfinished">&amp;ఫైల్ నుండి PSBTని లోడ్ చేయండి...</translation>
+    </message>
+    <message>
+        <source>Open &amp;URI…</source>
+        <translation type="unfinished">&amp;URI ని తెరవండి...</translation>
+    </message>
+    <message>
+        <source>Close Wallet…</source>
+        <translation type="unfinished">వాలెట్ ని మూసివేయి...</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation type="unfinished">వాలెట్ ని సృష్టించండి...</translation>
+    </message>
+    <message>
+        <source>Close All Wallets…</source>
+        <translation type="unfinished">అన్ని వాలెట్లను మూసివేయి…</translation>
+    </message>
+    <message>
+        <source>&amp;File</source>
+        <translation type="unfinished">&amp;ఫైల్</translation>
+    </message>
+    <message>
+        <source>&amp;Settings</source>
+        <translation type="unfinished">&amp;సెట్టింగ్‌లు</translation>
+    </message>
+    <message>
+        <source>&amp;Help</source>
+        <translation type="unfinished">&amp;సహాయం</translation>
+    </message>
+    <message>
+        <source>Tabs toolbar</source>
+        <translation type="unfinished">ట్యాబ్‌ల టూల్‌బార్</translation>
+    </message>
+    <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation type="unfinished">శీర్షికలను సమకాలీకరించడం (%1%)...</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation type="unfinished">నెట్‌వర్క్‌తో సమకాలీకరించబడుతోంది...</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation type="unfinished">డిస్క్‌లో బ్లాక్‌లను సూచిక చేస్తోంది…</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation type="unfinished">డిస్క్‌లో బ్లాక్‌లను ప్రాసెస్ చేస్తోంది...</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation type="unfinished">డిస్క్‌లోని బ్లాక్‌లను రీఇండెక్సింగ్ చేస్తోంది...</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation type="unfinished">తోటివారితో కలుస్తుంది…</translation>
+    </message>
+    <message>
+        <source>Request payments (generates QR codes and bitcoin: URIs)</source>
+        <translation type="unfinished">చెల్లింపులను అభ్యర్థించండి (QR కోడ్‌లు మరియు బిట్‌కాయిన్‌లను ఉత్పత్తి చేస్తుంది: URIలు)</translation>
+    </message>
+    <message>
+        <source>Show the list of used sending addresses and labels</source>
+        <translation type="unfinished">ఉపయోగించిన పంపే చిరునామాలు మరియు లేబుల్‌ల జాబితాను చూపండి</translation>
+    </message>
+    <message>
+        <source>Show the list of used receiving addresses and labels</source>
+        <translation type="unfinished">ఉపయోగించిన స్వీకరించే చిరునామాలు మరియు లేబుల్‌ల జాబితాను చూపండి</translation>
+    </message>
+    <message>
+        <source>&amp;Command-line options</source>
+        <translation type="unfinished">&amp;కమాండ్-లైన్ ఎంపికలు</translation>
+    </message>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>లావాదేవీ చరిత్ర యొక్క %n బ్లాక్(లు) ప్రాసెస్ చేయబడింది.</numerusform>
+            <numerusform>లావాదేవీ చరిత్ర యొక్క %n బ్లాక్(లు) ప్రాసెస్ చేయబడింది.</numerusform>
         </translation>
+    </message>
+    <message>
+        <source>%1 behind</source>
+        <translation type="unfinished">%1 వెనుక</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation type="unfinished">పట్టుకోవడం...</translation>
+    </message>
+    <message>
+        <source>Last received block was generated %1 ago.</source>
+        <translation type="unfinished">చివరిగా అందుకున్న బ్లాక్ రూపొందించబడింది %1 క్రితం</translation>
+    </message>
+    <message>
+        <source>Transactions after this will not yet be visible.</source>
+        <translation type="unfinished">దీని తర్వాత లావాదేవీలు ఇంకా కనిపించవు.</translation>
     </message>
     <message>
         <source>Error</source>
@@ -383,15 +804,206 @@
         <source>Up to date</source>
         <translation type="unfinished">తాజాగా ఉంది</translation>
     </message>
+    <message>
+        <source>Load Partially Signed Bitcoin Transaction</source>
+        <translation type="unfinished">పాక్షికంగా సంతకం చేసిన బిట్‌కాయిన్ లావాదేవీని లోడ్ చేయండి</translation>
+    </message>
+    <message>
+        <source>Load PSBT from &amp;clipboard…</source>
+        <translation type="unfinished">&amp;క్లిప్‌బోర్డ్ నుండి PSBTని లోడ్ చేయండి...</translation>
+    </message>
+    <message>
+        <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
+        <translation type="unfinished">క్లిప్‌బోర్డ్ నుండి పాక్షికంగా సంతకం చేసిన బిట్‌కాయిన్ లావాదేవీని లోడ్ చేయండి</translation>
+    </message>
+    <message>
+        <source>Node window</source>
+        <translation type="unfinished">నోడ్ విండో</translation>
+    </message>
+    <message>
+        <source>Open node debugging and diagnostic console</source>
+        <translation type="unfinished">నోడ్ డీబగ్గింగ్ మరియు డయాగ్నస్టిక్ కన్సోల్ తెరవండి</translation>
+    </message>
+    <message>
+        <source>&amp;Sending addresses</source>
+        <translation type="unfinished">&amp;చిరునామా పంపుతోంది</translation>
+    </message>
+    <message>
+        <source>&amp;Receiving addresses</source>
+        <translation type="unfinished">&amp;చిరునామాలను స్వీకరిస్తోంది</translation>
+    </message>
+    <message>
+        <source>Open a bitcoin: URI</source>
+        <translation type="unfinished">బిట్‌కాయిన్‌ను తెరవండి: URI</translation>
+    </message>
+    <message>
+        <source>Open Wallet</source>
+        <translation type="unfinished">వాలెట్ తెరవండి</translation>
+    </message>
+    <message>
+        <source>Open a wallet</source>
+        <translation type="unfinished">ఒక వాలెట్ తెరవండి</translation>
+    </message>
+    <message>
+        <source>Close wallet</source>
+        <translation type="unfinished">వాలెట్‌ని మూసివేయండి</translation>
+    </message>
+    <message>
+        <source>Close all wallets</source>
+        <translation type="unfinished">అన్ని వాలెట్లను మూసివేయండి</translation>
+    </message>
+    <message>
+        <source>&amp;Mask values</source>
+        <translation type="unfinished">&amp;విలువలను కప్పిపుచ్చు</translation>
+    </message>
+    <message>
+        <source>Mask the values in the Overview tab</source>
+        <translation type="unfinished">ఓవర్‌వ్యూ ట్యాబ్‌లోని విలువలను కప్పిపుచ్చడం చేయండి</translation>
+    </message>
+    <message>
+        <source>default wallet</source>
+        <translation type="unfinished">డిఫాల్ట్ వాలెట్</translation>
+    </message>
+    <message>
+        <source>No wallets available</source>
+        <translation type="unfinished">వాలెట్లు అందుబాటులో లేవు</translation>
+    </message>
+    <message>
+        <source>&amp;Window</source>
+        <translation type="unfinished">&amp;విండో</translation>
+    </message>
+    <message>
+        <source>Zoom</source>
+        <translation type="unfinished">జూమ్ చేయండి</translation>
+    </message>
+    <message>
+        <source>Main Window</source>
+        <translation type="unfinished">ప్రధాన విండో</translation>
+    </message>
+    <message>
+        <source>%1 client</source>
+        <translation type="unfinished">%1 క్లయింట్</translation>
+    </message>
+    <message>
+        <source>&amp;Hide</source>
+        <translation type="unfinished">&amp;దాచు</translation>
+    </message>
+    <message>
+        <source>S&amp;how</source>
+        <translation type="unfinished">&amp;చూపించు</translation>
+    </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n బిట్‌కాయిన్ నెట్‌వర్క్‌కు క్రియాశీల కనెక్షన్(లు).</numerusform>
+            <numerusform>%n బిట్‌కాయిన్ నెట్‌వర్క్‌కు క్రియాశీల కనెక్షన్(లు).</numerusform>
         </translation>
     </message>
-    </context>
+    <message>
+        <source>Click for more actions.</source>
+        <extracomment>A substring of the tooltip. "More actions" are available via the context menu.</extracomment>
+        <translation type="unfinished">మరిన్ని చర్యల కోసం క్లిక్ చేయండి.</translation>
+    </message>
+    <message>
+        <source>Show Peers tab</source>
+        <extracomment>A context menu item. The "Peers tab" is an element of the "Node window".</extracomment>
+        <translation type="unfinished">పీర్స్ ట్యాబ్‌ని చూపించు</translation>
+    </message>
+    <message>
+        <source>Disable network activity</source>
+        <extracomment>A context menu item.</extracomment>
+        <translation type="unfinished">నెట్‌వర్క్ కార్యాచరణను నిలిపివేయండి</translation>
+    </message>
+    <message>
+        <source>Enable network activity</source>
+        <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
+        <translation type="unfinished">నెట్‌వర్క్ కార్యాచరణను ప్రారంభించండి</translation>
+    </message>
+    <message>
+        <source>Error: %1</source>
+        <translation type="unfinished">లోపం: %1</translation>
+    </message>
+    <message>
+        <source>Warning: %1</source>
+        <translation type="unfinished">హెచ్చరిక: %1</translation>
+    </message>
+    <message>
+        <source>Date: %1
+</source>
+        <translation type="unfinished">తేదీ: %1
+</translation>
+    </message>
+    <message>
+        <source>Amount: %1
+</source>
+        <translation type="unfinished">మొత్తం: %1
+</translation>
+    </message>
+    <message>
+        <source>Wallet: %1
+</source>
+        <translation type="unfinished">వాలెట్: %1
+</translation>
+    </message>
+    <message>
+        <source>Type: %1
+</source>
+        <translation type="unfinished">రకం: %1
+</translation>
+    </message>
+    <message>
+        <source>Label: %1
+</source>
+        <translation type="unfinished">లేబుల్: %1
+</translation>
+    </message>
+    <message>
+        <source>Address: %1
+</source>
+        <translation type="unfinished">చిరునామా: %1
+</translation>
+    </message>
+    <message>
+        <source>Sent transaction</source>
+        <translation type="unfinished">పంపిన లావాదేవీ</translation>
+    </message>
+    <message>
+        <source>Incoming transaction</source>
+        <translation type="unfinished"> వచ్చే లావాదేవీ</translation>
+    </message>
+    <message>
+        <source>HD key generation is &lt;b&gt;enabled&lt;/b&gt;</source>
+        <translation type="unfinished">HD కీ ఉత్పత్తి &lt;b&gt;ప్రారంభించబడింది&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>HD key generation is &lt;b&gt;disabled&lt;/b&gt;</source>
+        <translation type="unfinished">HD కీ ఉత్పత్తి &lt;b&gt;నిలిపివేయబడింది&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Private key &lt;b&gt;disabled&lt;/b&gt;</source>
+        <translation type="unfinished">ప్రైవేట్ కీ &lt;b&gt;నిలిపివేయబడింది&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
+        <translation type="unfinished">వాలెట్ &lt;b&gt;ఎన్‌క్రిప్ట్ చేయబడింది&lt;/b&gt; మరియు ప్రస్తుతం &lt;b&gt;అన్‌లాక్ చేయబడింది&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
+        <translation type="unfinished">వాలెట్ &lt;b&gt;ఎన్‌క్రిప్ట్ చేయబడింది&lt;/b&gt; మరియు ప్రస్తుతం &lt;b&gt;లాక్ చేయబడింది&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Original message:</source>
+        <translation type="unfinished">అసలు సందేశం:</translation>
+    </message>
+</context>
+<context>
+    <name>UnitDisplayStatusBarControl</name>
+    <message>
+        <source>Unit to show amounts in. Click to select another unit.</source>
+        <translation type="unfinished">అమౌంట్ ని చూపించడానికి యూనిట్. మరొక యూనిట్‌ని ఎంచుకోవడానికి క్లిక్ చేయండి.</translation>
+    </message>
+</context>
 <context>
     <name>CoinControlDialog</name>
     <message>
@@ -403,61 +1015,1270 @@
         <translation type="unfinished">పరిమాణం</translation>
     </message>
     <message>
+        <source>Bytes:</source>
+        <translation type="unfinished">బైట్‌లు:</translation>
+    </message>
+    <message>
+        <source>Amount:</source>
+        <translation type="unfinished">మొత్తం:</translation>
+    </message>
+    <message>
+        <source>Fee:</source>
+        <translation type="unfinished">రుసుము:</translation>
+    </message>
+    <message>
+        <source>Dust:</source>
+        <translation type="unfinished">దుమ్ము:</translation>
+    </message>
+    <message>
+        <source>After Fee:</source>
+        <translation type="unfinished">రుసుము తర్వాత:</translation>
+    </message>
+    <message>
+        <source>Change:</source>
+        <translation type="unfinished">మార్చు:</translation>
+    </message>
+    <message>
+        <source>(un)select all</source>
+        <translation type="unfinished">ఎంచుకున్నవన్నీ తొలగించు</translation>
+    </message>
+    <message>
+        <source>Tree mode</source>
+        <translation type="unfinished">చెట్టు విధానం</translation>
+    </message>
+    <message>
+        <source>List mode</source>
+        <translation type="unfinished">జాబితా </translation>
+    </message>
+    <message>
         <source>Amount</source>
         <translation type="unfinished">మొత్తం</translation>
+    </message>
+    <message>
+        <source>Received with label</source>
+        <translation type="unfinished">లేబుల్‌తో స్వీకరించబడింది</translation>
+    </message>
+    <message>
+        <source>Received with address</source>
+        <translation type="unfinished">చిరునామాతో స్వీకరించబడింది</translation>
     </message>
     <message>
         <source>Date</source>
         <translation type="unfinished">తేదీ</translation>
     </message>
     <message>
+        <source>Confirmations</source>
+        <translation type="unfinished">నిర్ధారణలు</translation>
+    </message>
+    <message>
+        <source>Confirmed</source>
+        <translation type="unfinished">నిర్ధారించబడినది</translation>
+    </message>
+    <message>
+        <source>Copy amount</source>
+        <translation type="unfinished">కాపీ అమౌంట్</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;కాపీ చిరునామా</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">కాపీ &amp;లేబుల్</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">కాపీ &amp;అమౌంట్</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID and output index</source>
+        <translation type="unfinished">లావాదేవీ &amp;ID మరియు అవుట్‌పుట్ సూచికను కాపీ చేయండి</translation>
+    </message>
+    <message>
+        <source>L&amp;ock unspent</source>
+        <translation type="unfinished">ఖర్చు చేయని లాక్</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock unspent</source>
+        <translation type="unfinished">&amp;ఖర్చు చేయనిది విడిపించండి</translation>
+    </message>
+    <message>
+        <source>Copy quantity</source>
+        <translation type="unfinished">కాపీ పరిమాణం</translation>
+    </message>
+    <message>
+        <source>Copy fee</source>
+        <translation type="unfinished">రుసుము కాపీ</translation>
+    </message>
+    <message>
+        <source>Copy after fee</source>
+        <translation type="unfinished">రుసుము తర్వాత కాపీ చేయండి</translation>
+    </message>
+    <message>
+        <source>Copy bytes</source>
+        <translation type="unfinished">బైట్‌లను కాపీ చేయండి</translation>
+    </message>
+    <message>
+        <source>Copy dust</source>
+        <translation type="unfinished">దుమ్మును కాపీ చేయండి</translation>
+    </message>
+    <message>
+        <source>Copy change</source>
+        <translation type="unfinished">మార్పుని కాపీ చేయండి</translation>
+    </message>
+    <message>
+        <source>(%1 locked)</source>
+        <translation type="unfinished">(%1 లాక్ చేయబడింది)</translation>
+    </message>
+    <message>
+        <source>yes</source>
+        <translation type="unfinished">అవును</translation>
+    </message>
+    <message>
+        <source>no</source>
+        <translation type="unfinished">లేదు</translation>
+    </message>
+    <message>
+        <source>This label turns red if any recipient receives an amount smaller than the current dust threshold.</source>
+        <translation type="unfinished">ఏదైనా గ్రహీత ప్రస్తుత ధూళి థ్రెషోల్డ్ కంటే చిన్న మొత్తాన్ని స్వీకరిస్తే ఈ లేబుల్ ఎరుపు రంగులోకి మారుతుంది.</translation>
+    </message>
+    <message>
+        <source>Can vary +/- %1 satoshi(s) per input.</source>
+        <translation type="unfinished">ఒక్కో ఇన్‌పుట్‌కు +/- %1 సతోషి(లు) మారవచ్చు.</translation>
+    </message>
+    <message>
         <source>(no label)</source>
         <translation type="unfinished">( ఉల్లాకు లేదు )</translation>
     </message>
-    </context>
+    <message>
+        <source>change from %1 (%2)</source>
+        <translation type="unfinished">నుండి మార్చండి %1 (%2)</translation>
+    </message>
+    <message>
+        <source>(change)</source>
+        <translation type="unfinished">(మార్పు)</translation>
+    </message>
+</context>
+<context>
+    <name>CreateWalletActivity</name>
+    <message>
+        <source>Create Wallet</source>
+        <extracomment>Title of window indicating the progress of creation of a new wallet.</extracomment>
+        <translation type="unfinished">వాలెట్‌ని సృష్టించండి</translation>
+    </message>
+    <message>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the create wallet progress window which indicates to the user which wallet is currently being created.</extracomment>
+        <translation type="unfinished">వాలెట్‌ని సృష్టించండి &lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+    <message>
+        <source>Create wallet failed</source>
+        <translation type="unfinished">వాలెట్‌ని సృష్టించడం విఫలమైంది</translation>
+    </message>
+    <message>
+        <source>Create wallet warning</source>
+        <translation type="unfinished">వాలెట్ హెచ్చరికను సృష్టించండి</translation>
+    </message>
+    <message>
+        <source>Can't list signers</source>
+        <translation type="unfinished">సంతకం చేసేవారిని జాబితా చేయలేరు</translation>
+    </message>
+</context>
+<context>
+    <name>LoadWalletsActivity</name>
+    <message>
+        <source>Load Wallets</source>
+        <extracomment>Title of progress window which is displayed when wallets are being loaded.</extracomment>
+        <translation type="unfinished">వాలెట్లను లోడ్ చేయండి</translation>
+    </message>
+    <message>
+        <source>Loading wallets…</source>
+        <extracomment>Descriptive text of the load wallets progress window which indicates to the user that wallets are currently being loaded.</extracomment>
+        <translation type="unfinished">వాలెట్లను లోడ్ చేస్తోంది…</translation>
+    </message>
+</context>
+<context>
+    <name>OpenWalletActivity</name>
+    <message>
+        <source>Open wallet failed</source>
+        <translation type="unfinished">ఓపెన్ వాలెట్ విఫలమైంది</translation>
+    </message>
+    <message>
+        <source>Open wallet warning</source>
+        <translation type="unfinished">ఓపెన్ వాలెట్ హెచ్చరిక</translation>
+    </message>
+    <message>
+        <source>default wallet</source>
+        <translation type="unfinished">డిఫాల్ట్ వాలెట్</translation>
+    </message>
+    <message>
+        <source>Open Wallet</source>
+        <extracomment>Title of window indicating the progress of opening of a wallet.</extracomment>
+        <translation type="unfinished">వాలెట్ తెరవండి</translation>
+    </message>
+    <message>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the open wallet progress window which indicates to the user which wallet is currently being opened.</extracomment>
+        <translation type="unfinished">వాలెట్‌ని తెరుస్తోంది &lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+</context>
+<context>
+    <name>WalletController</name>
+    <message>
+        <source>Close wallet</source>
+        <translation type="unfinished">వాలెట్‌ని మూసివేయండి</translation>
+    </message>
+    <message>
+        <source>Are you sure you wish to close the wallet &lt;i&gt;%1&lt;/i&gt;?</source>
+        <translation type="unfinished">మీరు ఖచ్చితంగా వాలెట్‌ని మూసివేయాలనుకుంటున్నారా &lt;i&gt;%1&lt;/i&gt;?</translation>
+    </message>
+    <message>
+        <source>Closing the wallet for too long can result in having to resync the entire chain if pruning is enabled.</source>
+        <translation type="unfinished">కత్తిరింపు ప్రారంభించబడితే, వాలెట్‌ను ఎక్కువసేపు మూసివేయడం వలన మొత్తం గొలుసును మళ్లీ సమకాలీకరించవలసి ఉంటుంది.</translation>
+    </message>
+    <message>
+        <source>Close all wallets</source>
+        <translation type="unfinished">అన్ని వాలెట్లను మూసివేయండి</translation>
+    </message>
+    <message>
+        <source>Are you sure you wish to close all wallets?</source>
+        <translation type="unfinished">మీరు ఖచ్చితంగా అన్ని వాలెట్లను మూసివేయాలనుకుంటున్నారా?</translation>
+    </message>
+</context>
 <context>
     <name>CreateWalletDialog</name>
+    <message>
+        <source>Create Wallet</source>
+        <translation type="unfinished">వాలెట్‌ని సృష్టించండి</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <translation type="unfinished">వాలెట్ పేరు</translation>
+    </message>
     <message>
         <source>Wallet</source>
         <translation type="unfinished">వాలెట్</translation>
     </message>
-    </context>
+    <message>
+        <source>Encrypt the wallet. The wallet will be encrypted with a passphrase of your choice.</source>
+        <translation type="unfinished">వాలెట్‌ని ఎన్‌క్రిప్ట్ చేయండి. వాలెట్ మీకు నచ్చిన పాస్‌ఫ్రేజ్‌తో ఎన్‌క్రిప్ట్ చేయబడుతుంది.</translation>
+    </message>
+    <message>
+        <source>Encrypt Wallet</source>
+        <translation type="unfinished">వాలెట్‌ని గుప్తీకరించండి</translation>
+    </message>
+    <message>
+        <source>Advanced Options</source>
+        <translation type="unfinished">అధునాతన ఎంపికలు</translation>
+    </message>
+    <message>
+        <source>Disable Private Keys</source>
+        <translation type="unfinished">ప్రైవేట్ కీలను నిలిపివేయండి</translation>
+    </message>
+    <message>
+        <source>Make Blank Wallet</source>
+        <translation type="unfinished">ఖాళీ వాలెట్‌ని తయారు చేయండి</translation>
+    </message>
+    <message>
+        <source>Use descriptors for scriptPubKey management</source>
+        <translation type="unfinished">scriptPubKey నిర్వహణ కోసం డిస్క్రిప్టర్‌లను ఉపయోగించండి</translation>
+    </message>
+    <message>
+        <source>Descriptor Wallet</source>
+        <translation type="unfinished">డిస్క్రిప్టర్ వాలెట్</translation>
+    </message>
+    <message>
+        <source>External signer</source>
+        <translation type="unfinished">బాహ్య సంతకందారు</translation>
+    </message>
+    <message>
+        <source>Create</source>
+        <translation type="unfinished">సృష్టించు</translation>
+    </message>
+    <message>
+        <source>Compiled without sqlite support (required for descriptor wallets)</source>
+        <translation type="unfinished">Sqlite మద్దతు లేకుండా కంపైల్ చేయబడింది (డిస్క్రిప్టర్ వాలెట్‌లకు అవసరం)</translation>
+    </message>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">బాహ్య సంతకం మద్దతు లేకుండా సంకలనం చేయబడింది (బాహ్య సంతకం కోసం అవసరం)</translation>
+    </message>
+</context>
+<context>
+    <name>EditAddressDialog</name>
+    <message>
+        <source>Edit Address</source>
+        <translation type="unfinished">చిరునామాను సవరించండి</translation>
+    </message>
+    <message>
+        <source>&amp;Label</source>
+        <translation type="unfinished">&amp;లేబుల్</translation>
+    </message>
+    <message>
+        <source>The label associated with this address list entry</source>
+        <translation type="unfinished">ఈ చిరునామా జాబితా నమోదుతో అనుబంధించబడిన లేబుల్</translation>
+    </message>
+    <message>
+        <source>&amp;Address</source>
+        <translation type="unfinished">&amp;చిరునామా</translation>
+    </message>
+    <message>
+        <source>New sending address</source>
+        <translation type="unfinished">కొత్త పంపే చిరునామా</translation>
+    </message>
+    <message>
+        <source>Edit receiving address</source>
+        <translation type="unfinished">స్వీకరించే చిరునామాను సవరించండి</translation>
+    </message>
+    <message>
+        <source>Edit sending address</source>
+        <translation type="unfinished">పంపే చిరునామాను సవరించండి</translation>
+    </message>
+    <message>
+        <source>The entered address "%1" is not a valid Bitcoin address.</source>
+        <translation type="unfinished">నమోదు చేసిన చిరునామా "%1" చెల్లుబాటు అయ్యే బిట్‌కాయిన్ చిరునామా కాదు.</translation>
+    </message>
+    <message>
+        <source>Address "%1" already exists as a receiving address with label "%2" and so cannot be added as a sending address.</source>
+        <translation type="unfinished">చిరునామా "%1" ఇప్పటికే "%2" లేబుల్‌తో స్వీకరించే చిరునామాగా ఉంది మరియు పంపే చిరునామాగా జోడించబడదు.</translation>
+    </message>
+    <message>
+        <source>The entered address "%1" is already in the address book with label "%2".</source>
+        <translation type="unfinished">నమోదు చేసిన చిరునామా "%1" ఇప్పటికే చిరునామా పుస్తకంలో "%2" లేబుల్‌తో ఉంది.</translation>
+    </message>
+    <message>
+        <source>Could not unlock wallet.</source>
+        <translation type="unfinished">వాలెట్‌ని అన్‌లాక్ చేయడం సాధ్యపడలేదు.</translation>
+    </message>
+    <message>
+        <source>New key generation failed.</source>
+        <translation type="unfinished">కొత్త కీ జనరేషన్ విఫలమైంది.</translation>
+    </message>
+</context>
+<context>
+    <name>FreespaceChecker</name>
+    <message>
+        <source>A new data directory will be created.</source>
+        <translation type="unfinished">కొత్త డేటా డైరెక్టరీ సృష్టించబడుతుంది.</translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished">పేరు</translation>
+    </message>
+    <message>
+        <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
+        <translation type="unfinished">డైరెక్టరీ ఇప్పటికే ఉంది. %1 మీరు ఇక్కడ కొత్త డైరెక్టరీని సృష్టించాలనుకుంటే జోడించండి.</translation>
+    </message>
+    <message>
+        <source>Path already exists, and is not a directory.</source>
+        <translation type="unfinished">మార్గం ఇప్పటికే ఉంది మరియు ఇది డైరెక్టరీ కాదు.</translation>
+    </message>
+    <message>
+        <source>Cannot create data directory here.</source>
+        <translation type="unfinished">ఇక్కడ డేటా డైరెక్టరీని సృష్టించలేరు.</translation>
+    </message>
+</context>
 <context>
     <name>Intro</name>
     <message>
         <source>Bitcoin</source>
         <translation type="unfinished">బిట్కోయిన్</translation>
     </message>
+    <message>
+        <source>%1 GB of space available</source>
+        <translation type="unfinished">%1 GB స్థలం అందుబాటులో ఉంది</translation>
+    </message>
+    <message>
+        <source>(of %1 GB needed)</source>
+        <translation type="unfinished">(అవసరమైన %1 GB)</translation>
+    </message>
+    <message>
+        <source>(%1 GB needed for full chain)</source>
+        <translation type="unfinished">(పూర్తి గొలుసు కోసం %1 GB అవసరం)</translation>
+    </message>
+    <message>
+        <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
+        <translation type="unfinished">ఈ డైరెక్టరీలో కనీసం %1 GB డేటా నిల్వ చేయబడుతుంది మరియు ఇది కాలక్రమేణా పెరుగుతుంది.</translation>
+    </message>
+    <message>
+        <source>Approximately %1 GB of data will be stored in this directory.</source>
+        <translation type="unfinished">ఈ డైరెక్టరీలో సుమారు %1 GB డేటా నిల్వ చేయబడుతుంది.</translation>
+    </message>
     <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>(బ్యాకప్ %n రోజులను పునరుద్ధరించడానికి సరిపోతుంది) పాతది)</numerusform>
+            <numerusform>(బ్యాకప్ %n రోజులను పునరుద్ధరించడానికి సరిపోతుంది) పాతది)</numerusform>
         </translation>
     </message>
     <message>
-        <source>Error</source>
-        <translation type="unfinished">లోపం</translation>
+        <source>%1 will download and store a copy of the Bitcoin block chain.</source>
+        <translation type="unfinished">%1 బిట్‌కాయిన్ బ్లాక్ చైన్ కాపీని డౌన్‌లోడ్ చేసి నిల్వ చేస్తుంది.</translation>
     </message>
-    </context>
-<context>
-    <name>OptionsDialog</name>
+    <message>
+        <source>The wallet will also be stored in this directory.</source>
+        <translation type="unfinished">వాలెట్ కూడా ఈ డైరెక్టరీలో నిల్వ చేయబడుతుంది.</translation>
+    </message>
+    <message>
+        <source>Error: Specified data directory "%1" cannot be created.</source>
+        <translation type="unfinished">లోపం: పేర్కొన్న డేటా డైరెక్టరీ "%1" సృష్టించబడదు.</translation>
+    </message>
     <message>
         <source>Error</source>
         <translation type="unfinished">లోపం</translation>
     </message>
-    </context>
+    <message>
+        <source>Welcome</source>
+        <translation type="unfinished">స్వాగతం</translation>
+    </message>
+    <message>
+        <source>Welcome to %1.</source>
+        <translation type="unfinished">%1 కు స్వాగతం</translation>
+    </message>
+    <message>
+        <source>As this is the first time the program is launched, you can choose where %1 will store its data.</source>
+        <translation type="unfinished">ప్రోగ్రామ్ ప్రారంభించబడటం ఇదే మొదటిసారి కాబట్టి, %1 దాని డేటాను ఎక్కడ నిల్వ చేయాలో మీరు ఎంచుకోవచ్చు.</translation>
+    </message>
+    <message>
+        <source>Limit block chain storage to</source>
+        <translation type="unfinished">బ్లాక్ చైన్ నిల్వను పరిమితం చేయండి</translation>
+    </message>
+    <message>
+        <source> GB</source>
+        <translation type="unfinished">GB</translation>
+    </message>
+    <message>
+        <source>Use the default data directory</source>
+        <translation type="unfinished">డిఫాల్ట్ డేటా డైరెక్టరీని ఉపయోగించండి</translation>
+    </message>
+    <message>
+        <source>Use a custom data directory:</source>
+        <translation type="unfinished">అనుకూల డేటా డైరెక్టరీని ఉపయోగించండి:</translation>
+    </message>
+</context>
+<context>
+    <name>HelpMessageDialog</name>
+    <message>
+        <source>version</source>
+        <translation type="unfinished">సంస్కరణ</translation>
+    </message>
+    <message>
+        <source>About %1</source>
+        <translation type="unfinished">గురించి %1</translation>
+    </message>
+    <message>
+        <source>Command-line options</source>
+        <translation type="unfinished">కమాండ్ లైన్ ఎంపికలు</translation>
+    </message>
+</context>
+<context>
+    <name>ShutdownWindow</name>
+    <message>
+        <source>%1 is shutting down…</source>
+        <translation type="unfinished">%1 షట్ డౌన్ అవుతోంది…</translation>
+    </message>
+    <message>
+        <source>Do not shut down the computer until this window disappears.</source>
+        <translation type="unfinished">ఈ విండో అదృశ్యమయ్యే వరకు కంప్యూటర్‌ను ఆపివేయవద్దు.</translation>
+    </message>
+</context>
+<context>
+    <name>ModalOverlay</name>
+    <message>
+        <source>Form</source>
+        <translation type="unfinished">రూపం</translation>
+    </message>
+    <message>
+        <source>Number of blocks left</source>
+        <translation type="unfinished">మిగిలి ఉన్న బ్లాక్‌ల సంఖ్య</translation>
+    </message>
+    <message>
+        <source>Unknown…</source>
+        <translation type="unfinished">తెలియని…</translation>
+    </message>
+    <message>
+        <source>calculating…</source>
+        <translation type="unfinished">లెక్కిస్తోంది...</translation>
+    </message>
+    <message>
+        <source>Last block time</source>
+        <translation type="unfinished">చివరి బ్లాక్ సమయం</translation>
+    </message>
+    <message>
+        <source>Progress</source>
+        <translation type="unfinished">పురోగతి</translation>
+    </message>
+    <message>
+        <source>Progress increase per hour</source>
+        <translation type="unfinished">గంటకు పురోగతి పెరుగుతుంది</translation>
+    </message>
+    <message>
+        <source>Estimated time left until synced</source>
+        <translation type="unfinished">సమకాలీకరించబడే వరకు అంచనా సమయం మిగిలి ఉంది</translation>
+    </message>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished">దాచు</translation>
+    </message>
+    <message>
+        <source>Unknown. Syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">తెలియదు. శీర్షికలను సమకాలీకరించడం (%1, %2%)...</translation>
+    </message>
+</context>
+<context>
+    <name>OpenURIDialog</name>
+    <message>
+        <source>Open bitcoin URI</source>
+        <translation type="unfinished">బిట్‌కాయిన్ URIని తెరవండి</translation>
+    </message>
+    <message>
+        <source>Paste address from clipboard</source>
+        <extracomment>Tooltip text for button that allows you to paste an address that is in your clipboard.</extracomment>
+        <translation type="unfinished">క్లిప్‌బోర్డ్ నుండి చిరునామాను అతికించండి</translation>
+    </message>
+</context>
+<context>
+    <name>OptionsDialog</name>
+    <message>
+        <source>Options</source>
+        <translation type="unfinished">ఎంపికలు</translation>
+    </message>
+    <message>
+        <source>&amp;Main</source>
+        <translation type="unfinished">&amp;ప్రధాన</translation>
+    </message>
+    <message>
+        <source>Automatically start %1 after logging in to the system.</source>
+        <translation type="unfinished">సిస్టమ్‌కు లాగిన్ అయిన తర్వాత స్వయంచాలకంగా "%1" ని ప్రారంభించండి.</translation>
+    </message>
+    <message>
+        <source>&amp;Start %1 on system login</source>
+        <translation type="unfinished">సిస్టమ్ లాగిన్‌లో "%1" ని &amp;ప్రారంభించండి</translation>
+    </message>
+    <message>
+        <source>Size of &amp;database cache</source>
+        <translation type="unfinished">డేటాబేస్ కాష్ యొక్క పరిమాణం</translation>
+    </message>
+    <message>
+        <source>Number of script &amp;verification threads</source>
+        <translation type="unfinished">స్క్రిప్ట్ &amp; ధృవీకరణ థ్రెడ్‌ల సంఖ్య</translation>
+    </message>
+    <message>
+        <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
+        <translation type="unfinished">ప్రాక్సీ యొక్క IP చిరునామా (ఉదా. IPv4: 127.0.0.1 / IPv6: ::1)</translation>
+    </message>
+    <message>
+        <source>Open Configuration File</source>
+        <translation type="unfinished">కాన్ఫిగరేషన్ ఫైల్‌ని తెరవండి</translation>
+    </message>
+    <message>
+        <source>Reset all client options to default.</source>
+        <translation type="unfinished">అన్ని క్లయింట్ ఎంపికలను డిఫాల్ట్‌గా రీసెట్ చేయండి.</translation>
+    </message>
+    <message>
+        <source>&amp;Reset Options</source>
+        <translation type="unfinished">&amp;రీసెట్ ఎంపికలు</translation>
+    </message>
+    <message>
+        <source>&amp;Network</source>
+        <translation type="unfinished">&amp;నెట్‌వర్క్</translation>
+    </message>
+    <message>
+        <source>Prune &amp;block storage to</source>
+        <translation type="unfinished">స్టోరేజ్‌ను కత్తిరించు &amp; బ్లాక్ చేయండి</translation>
+    </message>
+    <message>
+        <source>Reverting this setting requires re-downloading the entire blockchain.</source>
+        <translation type="unfinished">ఈ సెట్టింగ్‌ని తిరిగి మార్చడానికి మొత్తం బ్లాక్‌చెయిన్‌ను మళ్లీ డౌన్‌లోడ్ చేయడం అవసరం.</translation>
+    </message>
+    <message>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation type="unfinished">(0 = ఆటో, &lt;0 = చాలా కోర్లను ఉచితంగా వదిలివేయండి)</translation>
+    </message>
+    <message>
+        <source>This allows you or a third party tool to communicate with the node through command-line and JSON-RPC commands.</source>
+        <extracomment>Tooltip text for Options window setting that enables the RPC server.</extracomment>
+        <translation type="unfinished">కమాండ్-లైన్ మరియు JSON-RPC ఆదేశాల ద్వారా నోడ్‌తో కమ్యూనికేట్ చేయడానికి ఇది మిమ్మల్ని లేదా మూడవ పక్షం సాధనాన్ని అనుమతిస్తుంది.</translation>
+    </message>
+    <message>
+        <source>Enable R&amp;PC server</source>
+        <extracomment>An Options window setting to enable the RPC server.</extracomment>
+        <translation type="unfinished">R&amp;PC సర్వర్‌ని ప్రారంభించండి</translation>
+    </message>
+    <message>
+        <source>W&amp;allet</source>
+        <translation type="unfinished">వా&amp;లెట్</translation>
+    </message>
+    <message>
+        <source>Whether to set subtract fee from amount as default or not.</source>
+        <extracomment>Tooltip text for Options window setting that sets subtracting the fee from a sending amount as default.</extracomment>
+        <translation type="unfinished">డిఫాల్ట్‌గా మొత్తం నుండి రుసుమును తీసివేయాలా లేదా అని సెట్ చేయాలా.</translation>
+    </message>
+    <message>
+        <source>Subtract &amp;fee from amount by default</source>
+        <extracomment>An Options window setting to set subtracting the fee from a sending amount as default.</extracomment>
+        <translation type="unfinished">డిఫాల్ట్‌గా మొత్తం నుండి &amp;ఫీజును తీసివేయండి</translation>
+    </message>
+    <message>
+        <source>Expert</source>
+        <translation type="unfinished">నిపుణుడు</translation>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation type="unfinished">నాణెం &amp;నియంత్రణ లక్షణాలను ప్రారంభించండి</translation>
+    </message>
+    <message>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation type="unfinished">&amp;ధృవీకరించబడని మార్పును ఖర్చు చేయండి</translation>
+    </message>
+    <message>
+        <source>Enable &amp;PSBT controls</source>
+        <extracomment>An options window setting to enable PSBT controls.</extracomment>
+        <translation type="unfinished">&amp;PSBT నియంత్రణలను ప్రారంభించండి</translation>
+    </message>
+    <message>
+        <source>Whether to show PSBT controls.</source>
+        <extracomment>Tooltip text for options window setting that enables PSBT controls.</extracomment>
+        <translation type="unfinished">PSBT నియంత్రణలను చూపాలా వద్దా.</translation>
+    </message>
+    <message>
+        <source>External Signer (e.g. hardware wallet)</source>
+        <translation type="unfinished">బాహ్య సంతకం (ఉదా. హార్డ్‌వేర్ వాలెట్)</translation>
+    </message>
+    <message>
+        <source>&amp;External signer script path</source>
+        <translation type="unfinished">&amp;బాహ్య సంతకం స్క్రిప్ట్ మార్గం</translation>
+    </message>
+    <message>
+        <source>Full path to a Bitcoin Core compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</source>
+        <translation type="unfinished">బిట్‌కాయిన్ కోర్ అనుకూల స్క్రిప్ట్‌కి పూర్తి మార్గం (ఉదా. C:\Downloads\hwi.exe లేదా /Users/you/Downloads/hwi.py). జాగ్రత్త: మాల్వేర్ మీ నాణేలను దొంగిలించగలదు!</translation>
+    </message>
+    <message>
+        <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
+        <translation type="unfinished">రౌటర్‌లో బిట్‌కాయిన్ క్లయింట్ పోర్ట్‌ను స్వయంచాలకంగా తెరవండి. ఇది మీ రూటర్ UPnPకి మద్దతు ఇచ్చినప్పుడు మరియు అది ప్రారంభించబడినప్పుడు మాత్రమే పని చేస్తుంది.</translation>
+    </message>
+    <message>
+        <source>Map port using &amp;UPnP</source>
+        <translation type="unfinished">&amp;UPnPని ఉపయోగించి మ్యాప్ పోర్ట్</translation>
+    </message>
+    <message>
+        <source>Map port using NA&amp;T-PMP</source>
+        <translation type="unfinished">NA&amp;T-PMPని ఉపయోగించి మ్యాప్ పోర్ట్</translation>
+    </message>
+    <message>
+        <source>Accept connections from outside.</source>
+        <translation type="unfinished">బయటి నుండి కనెక్షన్లను అంగీకరించండి.</translation>
+    </message>
+    <message>
+        <source>Allow incomin&amp;g connections</source>
+        <translation type="unfinished">&amp;ఇన్‌కమింగ్ కనెక్షన్‌లను అనుమతించండి</translation>
+    </message>
+    <message>
+        <source>Connect to the Bitcoin network through a SOCKS5 proxy.</source>
+        <translation type="unfinished">SOCKS5 ప్రాక్సీ ద్వారా బిట్‌కాయిన్ నెట్‌వర్క్‌కు కనెక్ట్ చేయండి.</translation>
+    </message>
+    <message>
+        <source>&amp;Connect through SOCKS5 proxy (default proxy):</source>
+        <translation type="unfinished">&amp;SOCKS5 ప్రాక్సీ ద్వారా కనెక్ట్ చేయండి (డిఫాల్ట్ ప్రాక్సీ):</translation>
+    </message>
+    <message>
+        <source>Proxy &amp;IP:</source>
+        <translation type="unfinished">ప్రాక్సీ &amp;IP:</translation>
+    </message>
+    <message>
+        <source>&amp;Port:</source>
+        <translation type="unfinished">&amp;పోర్ట్:</translation>
+    </message>
+    <message>
+        <source>Port of the proxy (e.g. 9050)</source>
+        <translation type="unfinished">ప్రాక్సీ పోర్ట్ (ఉదా. 9050)</translation>
+    </message>
+    <message>
+        <source>Used for reaching peers via:</source>
+        <translation type="unfinished">దీని ద్వారా సహచరులను చేరుకోవడానికి ఉపయోగించబడుతుంది:</translation>
+    </message>
+    <message>
+        <source>&amp;Window</source>
+        <translation type="unfinished">&amp;విండో</translation>
+    </message>
+    <message>
+        <source>Show the icon in the system tray.</source>
+        <translation type="unfinished">సిస్టమ్ ట్రేలో చిహ్నాన్ని చూపించు.</translation>
+    </message>
+    <message>
+        <source>&amp;Show tray icon</source>
+        <translation type="unfinished">&amp;ట్రే చిహ్నాన్ని చూపు</translation>
+    </message>
+    <message>
+        <source>Show only a tray icon after minimizing the window.</source>
+        <translation type="unfinished">విండోను కనిష్టీకరించిన తర్వాత ట్రే చిహ్నాన్ని మాత్రమే చూపించు.</translation>
+    </message>
+    <message>
+        <source>&amp;Minimize to the tray instead of the taskbar</source>
+        <translation type="unfinished">&amp;టాస్క్‌బార్‌కు బదులుగా ట్రేకి కనిష్టీకరించండి</translation>
+    </message>
+    <message>
+        <source>M&amp;inimize on close</source>
+        <translation type="unfinished">ద&amp;గ్గరగా కనిష్టీకరించండి</translation>
+    </message>
+    <message>
+        <source>&amp;Display</source>
+        <translation type="unfinished">&amp;ప్రదర్శన</translation>
+    </message>
+    <message>
+        <source>User Interface &amp;language:</source>
+        <translation type="unfinished">వినియోగదారు ఇంటర్‌ఫేస్ &amp;భాష:</translation>
+    </message>
+    <message>
+        <source>The user interface language can be set here. This setting will take effect after restarting %1.</source>
+        <translation type="unfinished">వినియోగదారు ఇంటర్‌ఫేస్ భాషను ఇక్కడ సెట్ చేయవచ్చు. పునఃప్రారంభించిన తర్వాత ఈ సెట్టింగ్ ప్రభావం చూపుతుంది %1.</translation>
+    </message>
+    <message>
+        <source>&amp;Unit to show amounts in:</source>
+        <translation type="unfinished">&amp;యూనిట్‌లో మొత్తాలను చూపడానికి:</translation>
+    </message>
+    <message>
+        <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
+        <translation type="unfinished">ఇంటర్‌ఫేస్‌లో మరియు నాణేలను పంపేటప్పుడు చూపించడానికి డిఫాల్ట్ సబ్‌డివిజన్ యూనిట్‌ని ఎంచుకోండి.</translation>
+    </message>
+    <message>
+        <source>&amp;Third-party transaction URLs</source>
+        <translation type="unfinished">&amp;మూడవ పక్షం లావాదేవీ URLలు</translation>
+    </message>
+    <message>
+        <source>Whether to show coin control features or not.</source>
+        <translation type="unfinished">కాయిన్ కంట్రోల్ ఫీచర్‌లను చూపించాలా వద్దా.</translation>
+    </message>
+    <message>
+        <source>Connect to the Bitcoin network through a separate SOCKS5 proxy for Tor onion services.</source>
+        <translation type="unfinished">Tor onion సేవల కోసం ప్రత్యేక SOCKS5 ప్రాక్సీ ద్వారా బిట్‌కాయిన్ నెట్‌వర్క్‌కు కనెక్ట్ చేయండి.</translation>
+    </message>
+    <message>
+        <source>Use separate SOCKS&amp;5 proxy to reach peers via Tor onion services:</source>
+        <translation type="unfinished">Tor onion సేవల ద్వారా సహచరులను చేరుకోవడానికి ప్రత్యేక సాక్స్&amp;5 ప్రాక్సీని ఉపయోగించండి:</translation>
+    </message>
+    <message>
+        <source>Monospaced font in the Overview tab:</source>
+        <translation type="unfinished">ఓవర్‌వ్యూ ట్యాబ్‌లో మోనోస్పేస్డ్ ఫాంట్:</translation>
+    </message>
+    <message>
+        <source>embedded "%1"</source>
+        <translation type="unfinished">పొందుపరిచారు "%1"</translation>
+    </message>
+    <message>
+        <source>closest matching "%1"</source>
+        <translation type="unfinished">సన్నిహిత సరిపోలిక "%1"</translation>
+    </message>
+    <message>
+        <source>&amp;OK</source>
+        <translation type="unfinished">&amp;అలాగే</translation>
+    </message>
+    <message>
+        <source>&amp;Cancel</source>
+        <translation type="unfinished">&amp;రద్దు చేయండి</translation>
+    </message>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">బాహ్య సంతకం మద్దతు లేకుండా సంకలనం చేయబడింది (బాహ్య సంతకం కోసం అవసరం)</translation>
+    </message>
+    <message>
+        <source>default</source>
+        <translation type="unfinished">డిఫాల్ట్</translation>
+    </message>
+    <message>
+        <source>none</source>
+        <translation type="unfinished">ఏదీ లేదు</translation>
+    </message>
+    <message>
+        <source>Confirm options reset</source>
+        <translation type="unfinished">ఎంపికల రీసెట్‌ని నిర్ధారించండి</translation>
+    </message>
+    <message>
+        <source>Client restart required to activate changes.</source>
+        <translation type="unfinished">మార్పులను సక్రియం చేయడానికి క్లయింట్ పునఃప్రారంభించాల్సిన అవసరం ఉంది.</translation>
+    </message>
+    <message>
+        <source>Client will be shut down. Do you want to proceed?</source>
+        <translation type="unfinished">క్లయింట్ మూసివేయబడుతుంది. మీరు కొనసాగించాలనుకుంటున్నారా?</translation>
+    </message>
+    <message>
+        <source>Configuration options</source>
+        <extracomment>Window title text of pop-up box that allows opening up of configuration file.</extracomment>
+        <translation type="unfinished">కాన్ఫిగరేషన్ ఎంపికలు</translation>
+    </message>
+    <message>
+        <source>The configuration file is used to specify advanced user options which override GUI settings. Additionally, any command-line options will override this configuration file.</source>
+        <extracomment>Explanatory text about the priority order of instructions considered by client. The order from high to low being: command-line, configuration file, GUI settings.</extracomment>
+        <translation type="unfinished">GUI సెట్టింగ్‌లను భర్తీ చేసే అధునాతన వినియోగదారు ఎంపికలను పేర్కొనడానికి కాన్ఫిగరేషన్ ఫైల్ ఉపయోగించబడుతుంది. అదనంగా, ఏదైనా కమాండ్-లైన్ ఎంపికలు ఈ కాన్ఫిగరేషన్ ఫైల్‌ను భర్తీ చేస్తాయి.</translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation type="unfinished">కొనసాగించు</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">రద్దు చేయండి</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">లోపం</translation>
+    </message>
+    <message>
+        <source>The configuration file could not be opened.</source>
+        <translation type="unfinished">కాన్ఫిగరేషన్ ఫైల్ తెరవబడలేదు.</translation>
+    </message>
+    <message>
+        <source>This change would require a client restart.</source>
+        <translation type="unfinished">ఈ మార్పుకు క్లయింట్ పునఃప్రారంభం అవసరం.</translation>
+    </message>
+    <message>
+        <source>The supplied proxy address is invalid.</source>
+        <translation type="unfinished">సరఫరా చేయబడిన ప్రాక్సీ చిరునామా చెల్లదు.</translation>
+    </message>
+</context>
+<context>
+    <name>OverviewPage</name>
+    <message>
+        <source>Form</source>
+        <translation type="unfinished">రూపం</translation>
+    </message>
+    <message>
+        <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
+        <translation type="unfinished">ప్రదర్శించబడిన సమాచారం పాతది కావచ్చు. కనెక్షన్ స్థాపించబడిన తర్వాత మీ వాలెట్ స్వయంచాలకంగా బిట్‌కాయిన్ నెట్‌వర్క్‌తో సమకాలీకరించబడుతుంది, కానీ ఈ ప్రక్రియ ఇంకా పూర్తి కాలేదు.</translation>
+    </message>
+    <message>
+        <source>Watch-only:</source>
+        <translation type="unfinished">చూడటానికి మాత్రమే:</translation>
+    </message>
+    <message>
+        <source>Available:</source>
+        <translation type="unfinished">అందుబాటులో ఉంది:</translation>
+    </message>
+    <message>
+        <source>Your current spendable balance</source>
+        <translation type="unfinished">మీ ప్రస్తుత ఖర్చు చేయదగిన బ్యాలెన్స్</translation>
+    </message>
+    <message>
+        <source>Pending:</source>
+        <translation type="unfinished">పెండింగ్‌లో ఉంది:</translation>
+    </message>
+    <message>
+        <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
+        <translation type="unfinished">ఇంకా ధృవీకరించబడని లావాదేవీల మొత్తం మరియు ఇంకా ఖర్చు చేయదగిన బ్యాలెన్స్‌లో లెక్కించబడదు</translation>
+    </message>
+    <message>
+        <source>Immature:</source>
+        <translation type="unfinished">పరిపక్వత లేని:</translation>
+    </message>
+    <message>
+        <source>Mined balance that has not yet matured</source>
+        <translation type="unfinished">ఇంకా పరిపక్వం చెందని సంతులనం తవ్వబడింది</translation>
+    </message>
+    <message>
+        <source>Balances</source>
+        <translation type="unfinished">బ్యాలెన్స్‌లు</translation>
+    </message>
+    <message>
+        <source>Total:</source>
+        <translation type="unfinished">మొత్తం:</translation>
+    </message>
+    <message>
+        <source>Your current total balance</source>
+        <translation type="unfinished">మీ ప్రస్తుత మొత్తం బ్యాలెన్స్</translation>
+    </message>
+    <message>
+        <source>Your current balance in watch-only addresses</source>
+        <translation type="unfinished">వీక్షణ-మాత్రమే చిరునామాలలో మీ ప్రస్తుత బ్యాలెన్స్</translation>
+    </message>
+    <message>
+        <source>Spendable:</source>
+        <translation type="unfinished">ఖర్చు చేయదగినది:</translation>
+    </message>
+    <message>
+        <source>Recent transactions</source>
+        <translation type="unfinished">ఇటీవలి లావాదేవీలు</translation>
+    </message>
+    <message>
+        <source>Unconfirmed transactions to watch-only addresses</source>
+        <translation type="unfinished">వీక్షణ-మాత్రమే చిరునామాలకు ధృవీకరించబడని లావాదేవీలు</translation>
+    </message>
+    <message>
+        <source>Mined balance in watch-only addresses that has not yet matured</source>
+        <translation type="unfinished">ఇంకా మెచ్యూర్ కాని వాచ్-ఓన్లీ అడ్రస్‌లలో మైన్ చేయబడిన బ్యాలెన్స్</translation>
+    </message>
+    <message>
+        <source>Current total balance in watch-only addresses</source>
+        <translation type="unfinished">వీక్షణ-మాత్రమే చిరునామాలలో ప్రస్తుత మొత్తం బ్యాలెన్స్</translation>
+    </message>
+    <message>
+        <source>Privacy mode activated for the Overview tab. To unmask the values, uncheck Settings-&gt;Mask values.</source>
+        <translation type="unfinished">అవలోకనం ట్యాబ్ కోసం గోప్యతా మోడ్ సక్రియం చేయబడింది. విలువలను అన్‌మాస్క్ చేయడానికి, సెట్టింగ్‌లు-&gt;మాస్క్ విలువల ఎంపికను తీసివేయండి.</translation>
+    </message>
+</context>
+<context>
+    <name>PSBTOperationsDialog</name>
+    <message>
+        <source>Dialog</source>
+        <translation type="unfinished">డైలాగ్</translation>
+    </message>
+    <message>
+        <source>Sign Tx</source>
+        <translation type="unfinished">Txపై సంతకం చేయండి</translation>
+    </message>
+    <message>
+        <source>Broadcast Tx</source>
+        <translation type="unfinished">ప్రసారం చేయు లావాదేవీ</translation>
+    </message>
+    <message>
+        <source>Copy to Clipboard</source>
+        <translation type="unfinished">క్లిప్‌బోర్డ్‌కి కాపీ చేయండి</translation>
+    </message>
+    <message>
+        <source>Save…</source>
+        <translation type="unfinished">సేవ్ చేయి...</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation type="unfinished">మూసివేయి</translation>
+    </message>
+    <message>
+        <source>Failed to load transaction: %1</source>
+        <translation type="unfinished">లావాదేవీని లోడ్ చేయడంలో విఫలమైంది: %1</translation>
+    </message>
+    <message>
+        <source>Cannot sign inputs while wallet is locked.</source>
+        <translation type="unfinished">వాలెట్ లాక్ చేయబడినప్పుడు ఇన్‌పుట్‌లపై సంతకం చేయలేరు.</translation>
+    </message>
+    <message>
+        <source>Could not sign any more inputs.</source>
+        <translation type="unfinished">మరిన్ని ఇన్‌పుట్‌లపై సంతకం చేయడం సాధ్యపడలేదు.</translation>
+    </message>
+    <message>
+        <source>Signed %1 inputs, but more signatures are still required.</source>
+        <translation type="unfinished">సంతకం చేయబడిన %1 ఇన్‌పుట్‌లు, కానీ మరిన్ని సంతకాలు ఇంకా అవసరం.</translation>
+    </message>
+    <message>
+        <source>Signed transaction successfully. Transaction is ready to broadcast.</source>
+        <translation type="unfinished">లావాదేవీ విజయవంతంగా సంతకం చేయబడింది. లావాదేవీ ప్రసారానికి సిద్ధంగా ఉంది.</translation>
+    </message>
+    <message>
+        <source>Unknown error processing transaction.</source>
+        <translation type="unfinished">లావాదేవీని ప్రాసెస్ చేయడంలో తెలియని లోపం.</translation>
+    </message>
+    <message>
+        <source>Transaction broadcast successfully! Transaction ID: %1</source>
+        <translation type="unfinished">లావాదేవీ విజయవంతంగా ప్రసారం చేయబడింది! లావాదేవి ఐడి: %1</translation>
+    </message>
+    <message>
+        <source>Transaction broadcast failed: %1</source>
+        <translation type="unfinished">లావాదేవీ ప్రసారం విఫలమైంది: %1</translation>
+    </message>
+    <message>
+        <source>PSBT copied to clipboard.</source>
+        <translation type="unfinished">PSBT క్లిప్‌బోర్డ్‌కి కాపీ చేయబడింది.</translation>
+    </message>
+    <message>
+        <source>Save Transaction Data</source>
+        <translation type="unfinished">లావాదేవీ డేటాను సేవ్ చేయండి</translation>
+    </message>
+    <message>
+        <source>Partially Signed Transaction (Binary)</source>
+        <extracomment>Expanded name of the binary PSBT file format. See: BIP 174.</extracomment>
+        <translation type="unfinished">పాక్షికంగా సంతకం చేసిన లావాదేవీ (బైనరీ)</translation>
+    </message>
+    <message>
+        <source>PSBT saved to disk.</source>
+        <translation type="unfinished">PSBT డిస్క్‌లో సేవ్ చేయబడింది.</translation>
+    </message>
+    <message>
+        <source> * Sends %1 to %2</source>
+        <translation type="unfinished">* %1 ని %2 కి పంపుతుంది</translation>
+    </message>
+    <message>
+        <source>Unable to calculate transaction fee or total transaction amount.</source>
+        <translation type="unfinished">లావాదేవీ రుసుము లేదా మొత్తం లావాదేవీ మొత్తాన్ని లెక్కించడం సాధ్యం కాలేదు.</translation>
+    </message>
+    <message>
+        <source>Pays transaction fee: </source>
+        <translation type="unfinished">లావాదేవీ రుసుము చెల్లిస్తుంది:</translation>
+    </message>
+    <message>
+        <source>Total Amount</source>
+        <translation type="unfinished">పూర్తి మొత్తము</translation>
+    </message>
+    <message>
+        <source>or</source>
+        <translation type="unfinished">లేదా</translation>
+    </message>
+    <message>
+        <source>Transaction has %1 unsigned inputs.</source>
+        <translation type="unfinished">లావాదేవీ %1 సంతకం చేయని ఇన్‌పుట్‌లను కలిగి ఉంది.</translation>
+    </message>
+    <message>
+        <source>Transaction is missing some information about inputs.</source>
+        <translation type="unfinished">లావాదేవీ ఇన్‌పుట్‌ల గురించి కొంత సమాచారం లేదు.</translation>
+    </message>
+    <message>
+        <source>Transaction still needs signature(s).</source>
+        <translation type="unfinished">లావాదేవీకి ఇంకా సంతకం(లు) అవసరం.</translation>
+    </message>
+    <message>
+        <source>(But no wallet is loaded.)</source>
+        <translation type="unfinished">(కానీ వాలెట్ లోడ్ చేయబడలేదు.)</translation>
+    </message>
+    <message>
+        <source>(But this wallet cannot sign transactions.)</source>
+        <translation type="unfinished">(కానీ ఈ వాలెట్ లావాదేవీలపై సంతకం చేయదు.)</translation>
+    </message>
+    <message>
+        <source>(But this wallet does not have the right keys.)</source>
+        <translation type="unfinished">(కానీ ఈ వాలెట్‌లో సరైన కీలు లేవు.)</translation>
+    </message>
+    <message>
+        <source>Transaction is fully signed and ready for broadcast.</source>
+        <translation type="unfinished">లావాదేవీ పూర్తిగా సంతకం చేయబడింది మరియు ప్రసారానికి సిద్ధంగా ఉంది.</translation>
+    </message>
+    <message>
+        <source>Transaction status is unknown.</source>
+        <translation type="unfinished">లావాదేవీ స్థితి తెలియదు.</translation>
+    </message>
+</context>
+<context>
+    <name>PaymentServer</name>
+    <message>
+        <source>Payment request error</source>
+        <translation type="unfinished">చెల్లింపు అభ్యర్ధన లోపం</translation>
+    </message>
+    <message>
+        <source>Cannot start bitcoin: click-to-pay handler</source>
+        <translation type="unfinished">బిట్‌కాయిన్‌ను ప్రారంభించడం సాధ్యం కాదు: క్లిక్-టు-పే హ్యాండ్లర్</translation>
+    </message>
+    <message>
+        <source>URI handling</source>
+        <translation type="unfinished">URI నిర్వహణ</translation>
+    </message>
+    <message>
+        <source>'bitcoin://' is not a valid URI. Use 'bitcoin:' instead.</source>
+        <translation type="unfinished">'bitcoin://' చెల్లుబాటు అయ్యే URI కాదు. బదులుగా 'bitcoin:' ఉపయోగించండి.</translation>
+    </message>
+    <message>
+        <source>URI cannot be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
+        <translation type="unfinished">URI అన్వయించబడదు! ఇది చెల్లని బిట్‌కాయిన్ చిరునామా లేదా తప్పుగా రూపొందించబడిన URI పారామీటర్‌ల వల్ల సంభవించవచ్చు.</translation>
+    </message>
+    <message>
+        <source>Payment request file handling</source>
+        <translation type="unfinished">చెల్లింపు అభ్యర్థన ఫైల్ నిర్వహణ</translation>
+    </message>
+</context>
 <context>
     <name>PeerTableModel</name>
+    <message>
+        <source>User Agent</source>
+        <extracomment>Title of Peers Table column which contains the peer's User Agent string.</extracomment>
+        <translation type="unfinished">వినియోగదారు ఏజెంట్</translation>
+    </message>
+    <message>
+        <source>Ping</source>
+        <extracomment>Title of Peers Table column which indicates the current latency of the connection with the peer.</extracomment>
+        <translation type="unfinished">పింగ్</translation>
+    </message>
+    <message>
+        <source>Peer</source>
+        <extracomment>Title of Peers Table column which contains a unique number used to identify a connection.</extracomment>
+        <translation type="unfinished">పీర్</translation>
+    </message>
+    <message>
+        <source>Direction</source>
+        <extracomment>Title of Peers Table column which indicates the direction the peer connection was initiated from.</extracomment>
+        <translation type="unfinished">దిశ</translation>
+    </message>
+    <message>
+        <source>Sent</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have sent to the peer.</extracomment>
+        <translation type="unfinished">పంపారు</translation>
+    </message>
+    <message>
+        <source>Received</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have received from the peer.</extracomment>
+        <translation type="unfinished">స్వీకరించబడింది</translation>
+    </message>
     <message>
         <source>Address</source>
         <extracomment>Title of Peers Table column which contains the IP/Onion/I2P address of the connected peer.</extracomment>
         <translation type="unfinished">చిరునామా</translation>
     </message>
-    </context>
+    <message>
+        <source>Type</source>
+        <extracomment>Title of Peers Table column which describes the type of peer connection. The "type" describes why the connection exists.</extracomment>
+        <translation type="unfinished">రకము</translation>
+    </message>
+    <message>
+        <source>Network</source>
+        <extracomment>Title of Peers Table column which states the network the peer connected through.</extracomment>
+        <translation type="unfinished">నెట్‌వర్క్</translation>
+    </message>
+    <message>
+        <source>Inbound</source>
+        <extracomment>An Inbound Connection from a Peer.</extracomment>
+        <translation type="unfinished">ఇన్‌బౌండ్</translation>
+    </message>
+    <message>
+        <source>Outbound</source>
+        <extracomment>An Outbound Connection to a Peer.</extracomment>
+        <translation type="unfinished">అవుట్ బౌండ్</translation>
+    </message>
+</context>
+<context>
+    <name>QRImageWidget</name>
+    <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">&amp;చిత్రాన్ని సేవ్ చేయి...</translation>
+    </message>
+    <message>
+        <source>&amp;Copy Image</source>
+        <translation type="unfinished">&amp;ఇమేజ్ కాపీ చేయి</translation>
+    </message>
+    <message>
+        <source>Resulting URI too long, try to reduce the text for label / message.</source>
+        <translation type="unfinished">URI చాలా పొడవుగా ఉంది, లేబుల్ / సందేశం కోసం వచనాన్ని తగ్గించడానికి ప్రయత్నించండి.</translation>
+    </message>
+    <message>
+        <source>Error encoding URI into QR Code.</source>
+        <translation type="unfinished">URIని QR కోడ్‌లోకి ఎన్‌కోడ్ చేయడంలో లోపం.</translation>
+    </message>
+    <message>
+        <source>QR code support not available.</source>
+        <translation type="unfinished">QR కోడ్ మద్దతు అందుబాటులో లేదు.</translation>
+    </message>
+    <message>
+        <source>Save QR Code</source>
+        <translation type="unfinished">QR కోడ్‌ని సేవ్ చేయండి</translation>
+    </message>
+    <message>
+        <source>PNG Image</source>
+        <extracomment>Expanded name of the PNG file format. See: https://en.wikipedia.org/wiki/Portable_Network_Graphics.</extracomment>
+        <translation type="unfinished">PNG చిత్రం</translation>
+    </message>
+</context>
 <context>
     <name>RPCConsole</name>
+    <message>
+        <source>N/A</source>
+        <translation type="unfinished">వర్తించదు</translation>
+    </message>
+    <message>
+        <source>Client version</source>
+        <translation type="unfinished">క్లయింట్ వెర్షన్</translation>
+    </message>
+    <message>
+        <source>&amp;Information</source>
+        <translation type="unfinished">&amp;సమాచారం</translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation type="unfinished">సాధారణ</translation>
+    </message>
+    <message>
+        <source>Datadir</source>
+        <translation type="unfinished">సమాచార డైరెక్టరీ</translation>
+    </message>
+    <message>
+        <source>To specify a non-default location of the data directory use the '%1' option.</source>
+        <translation type="unfinished">డేటా డైరెక్టరీ యొక్క నాన్-డిఫాల్ట్ స్థానాన్ని పేర్కొనడానికి '%1' ఎంపికను ఉపయోగించండి.</translation>
+    </message>
+    <message>
+        <source>Blocksdir</source>
+        <translation type="unfinished">బ్లాక్స్ డైరెక్టరీ</translation>
+    </message>
+    <message>
+        <source>To specify a non-default location of the blocks directory use the '%1' option.</source>
+        <translation type="unfinished">బ్లాక్స్ డైరెక్టరీ యొక్క నాన్-డిఫాల్ట్ స్థానాన్ని పేర్కొనడానికి '%1' ఎంపికను ఉపయోగించండి.</translation>
+    </message>
+    <message>
+        <source>Startup time</source>
+        <translation type="unfinished">ప్రారంభ సమయం</translation>
+    </message>
+    <message>
+        <source>Network</source>
+        <translation type="unfinished">నెట్‌వర్క్</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished">పేరు</translation>
+    </message>
+    <message>
+        <source>Number of connections</source>
+        <translation type="unfinished">కనెక్షన్ల సంఖ్య</translation>
+    </message>
+    <message>
+        <source>Block chain</source>
+        <translation type="unfinished">బ్లాక్ చైన్</translation>
+    </message>
+    <message>
+        <source>Memory Pool</source>
+        <translation type="unfinished">మెమరీ పూల్</translation>
+    </message>
+    <message>
+        <source>Current number of transactions</source>
+        <translation type="unfinished">ప్రస్తుత లావాదేవీల సంఖ్య</translation>
+    </message>
+    <message>
+        <source>Memory usage</source>
+        <translation type="unfinished">మెమరీ వినియోగం</translation>
+    </message>
+    <message>
+        <source>(none)</source>
+        <translation type="unfinished">(ఏదీ లేదు)</translation>
+    </message>
+    <message>
+        <source>&amp;Reset</source>
+        <translation type="unfinished">&amp;రీసెట్</translation>
+    </message>
+    <message>
+        <source>Received</source>
+        <translation type="unfinished">స్వీకరించబడింది</translation>
+    </message>
+    <message>
+        <source>Sent</source>
+        <translation type="unfinished">పంపారు</translation>
+    </message>
+    <message>
+        <source>&amp;Peers</source>
+        <translation type="unfinished">&amp;తోటివారి</translation>
+    </message>
+    <message>
+        <source>Banned peers</source>
+        <translation type="unfinished">సహచరులను నిషేధించారు</translation>
+    </message>
+    <message>
+        <source>Select a peer to view detailed information.</source>
+        <translation type="unfinished">వివరణాత్మక సమాచారాన్ని వీక్షించడానికి పీర్‌ని ఎంచుకోండి.</translation>
+    </message>
+    <message>
+        <source>Total number of addresses processed, excluding those dropped due to rate-limiting.</source>
+        <extracomment>Tooltip text for the Addresses Processed field in the peer details area.</extracomment>
+        <translation type="unfinished">రేటు-పరిమితి కారణంగా తొలగించబడిన చిరునామాలను మినహాయించి, ప్రాసెస్ చేయబడిన మొత్తం చిరునామాల సంఖ్య.</translation>
+    </message>
+    <message>
+        <source>User Agent</source>
+        <translation type="unfinished">వినియోగదారు ఏజెంట్</translation>
+    </message>
+    <message>
+        <source>Node window</source>
+        <translation type="unfinished">నోడ్ విండో</translation>
+    </message>
+    <message>
+        <source>Last block time</source>
+        <translation type="unfinished">చివరి బ్లాక్ సమయం</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <extracomment>Context menu action to copy the address of a peer.</extracomment>
+        <translation type="unfinished">&amp;కాపీ చిరునామా</translation>
+    </message>
     <message>
         <source>To</source>
         <translation type="unfinished">కు</translation>
@@ -468,10 +2289,81 @@
     </message>
     </context>
 <context>
+    <name>ReceiveCoinsDialog</name>
+    <message>
+        <source>Remove the selected entries from the list</source>
+        <translation type="unfinished">జాబితా నుండి ఎంచుకున్న ఎంట్రీలను తీసివేయండి</translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation type="unfinished">తొలగించు</translation>
+    </message>
+    <message>
+        <source>Copy &amp;URI</source>
+        <translation type="unfinished">కాపీ &amp;URI</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;కాపీ చిరునామా</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">కాపీ &amp;లేబుల్</translation>
+    </message>
+    <message>
+        <source>Copy &amp;message</source>
+        <translation type="unfinished">కాపీ &amp;సందేశం</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">కాపీ &amp;అమౌంట్</translation>
+    </message>
+    <message>
+        <source>Could not unlock wallet.</source>
+        <translation type="unfinished">వాలెట్‌ని అన్‌లాక్ చేయడం సాధ్యపడలేదు.</translation>
+    </message>
+    <message>
+        <source>Could not generate new %1 address</source>
+        <translation type="unfinished">కొత్త %1 చిరునామాను రూపొందించడం సాధ్యం కాలేదు</translation>
+    </message>
+</context>
+<context>
     <name>ReceiveRequestDialog</name>
+    <message>
+        <source>Request payment to …</source>
+        <translation type="unfinished">దీనికి చెల్లింపును అభ్యర్థించండి…</translation>
+    </message>
+    <message>
+        <source>Address:</source>
+        <translation type="unfinished">చిరునామా:</translation>
+    </message>
+    <message>
+        <source>Amount:</source>
+        <translation type="unfinished">మొత్తం:</translation>
+    </message>
+    <message>
+        <source>Label:</source>
+        <translation type="unfinished">లేబుల్:</translation>
+    </message>
+    <message>
+        <source>Message:</source>
+        <translation type="unfinished">సందేశం:</translation>
+    </message>
     <message>
         <source>Wallet:</source>
         <translation type="unfinished">ధనమును తీసుకొనిపోవు సంచి</translation>
+    </message>
+    <message>
+        <source>Copy &amp;URI</source>
+        <translation type="unfinished">కాపీ &amp;URI</translation>
+    </message>
+    <message>
+        <source>Copy &amp;Address</source>
+        <translation type="unfinished">కాపీ &amp;చిరునామా </translation>
+    </message>
+    <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">&amp;చిత్రాన్ని సేవ్ చేయి...</translation>
     </message>
     </context>
 <context>
@@ -499,6 +2391,99 @@
         <source>Quantity:</source>
         <translation type="unfinished">పరిమాణం</translation>
     </message>
+    <message>
+        <source>Bytes:</source>
+        <translation type="unfinished">బైట్‌లు:</translation>
+    </message>
+    <message>
+        <source>Amount:</source>
+        <translation type="unfinished">మొత్తం:</translation>
+    </message>
+    <message>
+        <source>Fee:</source>
+        <translation type="unfinished">రుసుము:</translation>
+    </message>
+    <message>
+        <source>After Fee:</source>
+        <translation type="unfinished">రుసుము తర్వాత:</translation>
+    </message>
+    <message>
+        <source>Change:</source>
+        <translation type="unfinished">మార్చు:</translation>
+    </message>
+    <message>
+        <source>Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until you have validated the complete chain.</source>
+        <translation type="unfinished">ఫాల్‌బ్యాక్‌ఫీని ఉపయోగించడం వలన లావాదేవీని పంపడం ద్వారా నిర్ధారించడానికి చాలా గంటలు లేదా రోజులు (లేదా ఎప్పుడూ) పట్టవచ్చు. మీ రుసుమును మాన్యువల్‌గా ఎంచుకోవడాన్ని పరిగణించండి లేదా మీరు పూర్తి గొలుసును ధృవీకరించే వరకు వేచి ఉండండి.</translation>
+    </message>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished">దాచు</translation>
+    </message>
+    <message>
+        <source>Dust:</source>
+        <translation type="unfinished">దుమ్ము:</translation>
+    </message>
+    <message>
+        <source>Copy quantity</source>
+        <translation type="unfinished">కాపీ పరిమాణం</translation>
+    </message>
+    <message>
+        <source>Copy amount</source>
+        <translation type="unfinished">కాపీ అమౌంట్</translation>
+    </message>
+    <message>
+        <source>Copy fee</source>
+        <translation type="unfinished">రుసుము కాపీ</translation>
+    </message>
+    <message>
+        <source>Copy after fee</source>
+        <translation type="unfinished">రుసుము తర్వాత కాపీ చేయండి</translation>
+    </message>
+    <message>
+        <source>Copy bytes</source>
+        <translation type="unfinished">బైట్‌లను కాపీ చేయండి</translation>
+    </message>
+    <message>
+        <source>Copy dust</source>
+        <translation type="unfinished">దుమ్మును కాపీ చేయండి</translation>
+    </message>
+    <message>
+        <source>Copy change</source>
+        <translation type="unfinished">మార్పుని కాపీ చేయండి</translation>
+    </message>
+    <message>
+        <source>%1 (%2 blocks)</source>
+        <translation type="unfinished">%1 (%2 బ్లాక్‌లు)</translation>
+    </message>
+    <message>
+        <source> from wallet '%1'</source>
+        <translation type="unfinished">వాలెట్ నుండి '%1'</translation>
+    </message>
+    <message>
+        <source>%1 to '%2'</source>
+        <translation type="unfinished">%1 కు '%2'</translation>
+    </message>
+    <message>
+        <source>%1 to %2</source>
+        <translation type="unfinished">%1 కు %2</translation>
+    </message>
+    <message>
+        <source>Save Transaction Data</source>
+        <translation type="unfinished">లావాదేవీ డేటాను సేవ్ చేయండి</translation>
+    </message>
+    <message>
+        <source>Partially Signed Transaction (Binary)</source>
+        <extracomment>Expanded name of the binary PSBT file format. See: BIP 174.</extracomment>
+        <translation type="unfinished">పాక్షికంగా సంతకం చేసిన లావాదేవీ (బైనరీ)</translation>
+    </message>
+    <message>
+        <source>or</source>
+        <translation type="unfinished">లేదా</translation>
+    </message>
+    <message>
+        <source>Total Amount</source>
+        <translation type="unfinished">పూర్తి మొత్తము</translation>
+    </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
@@ -509,6 +2494,39 @@
     <message>
         <source>(no label)</source>
         <translation type="unfinished">( ఉల్లాకు లేదు )</translation>
+    </message>
+</context>
+<context>
+    <name>SendCoinsEntry</name>
+    <message>
+        <source>Paste address from clipboard</source>
+        <translation type="unfinished">క్లిప్‌బోర్డ్ నుండి చిరునామాను అతికించండి</translation>
+    </message>
+    <message>
+        <source>Message:</source>
+        <translation type="unfinished">సందేశం:</translation>
+    </message>
+    </context>
+<context>
+    <name>SignVerifyMessageDialog</name>
+    <message>
+        <source>Paste address from clipboard</source>
+        <translation type="unfinished">క్లిప్‌బోర్డ్ నుండి చిరునామాను అతికించండి</translation>
+    </message>
+    <message>
+        <source>Enter the message you want to sign here</source>
+        <translation type="unfinished">మీరు సంతకం చేయాలనుకుంటున్న సందేశాన్ని ఇక్కడ నమోదు చేయండి</translation>
+    </message>
+    <message>
+        <source>Signature</source>
+        <translation type="unfinished">సంతకం</translation>
+    </message>
+    </context>
+<context>
+    <name>SplashScreen</name>
+    <message>
+        <source>press q to shutdown</source>
+        <translation type="unfinished">షట్‌డౌన్ చేయడానికి q నొక్కండి</translation>
     </message>
 </context>
 <context>
@@ -560,6 +2578,10 @@
         <translation type="unfinished">తేదీ</translation>
     </message>
     <message>
+        <source>Type</source>
+        <translation type="unfinished">రకము</translation>
+    </message>
+    <message>
         <source>Label</source>
         <translation type="unfinished">ఉల్లాకు</translation>
     </message>
@@ -571,8 +2593,33 @@
 <context>
     <name>TransactionView</name>
     <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;కాపీ చిరునామా</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">కాపీ &amp;లేబుల్</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">కాపీ &amp;అమౌంట్</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">కామాతో వేరు చేయబడిన ఫైల్</translation>
+    </message>
+    <message>
+        <source>Confirmed</source>
+        <translation type="unfinished">నిర్ధారించబడినది</translation>
+    </message>
+    <message>
         <source>Date</source>
         <translation type="unfinished">తేదీ</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished">రకము</translation>
     </message>
     <message>
         <source>Label</source>
@@ -603,6 +2650,13 @@
     </message>
     </context>
 <context>
+    <name>WalletModel</name>
+    <message>
+        <source>default wallet</source>
+        <translation type="unfinished">డిఫాల్ట్ వాలెట్</translation>
+    </message>
+</context>
+<context>
     <name>WalletView</name>
     <message>
         <source>&amp;Export</source>
@@ -612,5 +2666,18 @@
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished">ప్రస్తుతం ఉన్న సమాచారాన్ని ఫైల్ లోనికి ఎగుమతి చేసుకోండి</translation>
     </message>
-    </context>
+    <message>
+        <source>Backup Wallet</source>
+        <translation type="unfinished">బ్యాకప్ వాలెట్</translation>
+    </message>
+    <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">వాలెట్ సమాచారం</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">రద్దు చేయండి</translation>
+    </message>
+</context>
 </TS>


### PR DESCRIPTION
This PR pulls the recent translations from the [Transifex.com](https://www.transifex.com/bitcoin/bitcoin) using the [`bitcoin-maintainer-tools/update-translations.py`](https://github.com/bitcoin-core/bitcoin-maintainer-tools/blob/main/update-translations.py) tool.

According to our [Release Process docs](https://github.com/bitcoin/bitcoin/blob/master/doc/release-process.md#before-every-release-candidate), it is supposed to be merged before `v23.1rc2` tagging.

Will keep this PR updated regularly until merging.

The `bitcoin_id.ts` translation is damaged, therefore its changes were rejected manually.