### PR TITLE
test: remove unused class `NodePongAdd1`

### DIFF
--- a/test/functional/p2p_ping.py
+++ b/test/functional/p2p_ping.py
@@ -12,7 +12,9 @@ from test_framework.p2p import P2PInterface
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
 
+
 PING_INTERVAL = 2 * 60
+TIMEOUT_INTERVAL = 20 * 60
 
 
 class msg_pong_corrupt(msg_pong):
@@ -20,17 +22,9 @@ class msg_pong_corrupt(msg_pong):
         return b""
 
 
-class NodePongAdd1(P2PInterface):
-    def on_ping(self, message):
-        self.send_message(msg_pong(message.nonce + 1))
-
-
 class NodeNoPong(P2PInterface):
     def on_ping(self, message):
         pass
-
-
-TIMEOUT_INTERVAL = 20 * 60
 
 
 class PingPongTest(BitcoinTestFramework):


### PR DESCRIPTION
This class was introduced in commit fa3365430c5fb57d7c0b5f2bce9fbbe290be93c3 ("net: Use mockable time for ping/pong, add tests"), but actually never used.