### PR TITLE
test: Fix intermittent failure in rpc_net.py

### DIFF
--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -112,7 +112,7 @@ class NetTest(BitcoinTestFramework):
         no_version_peer_conntime = int(time.time())
         self.nodes[0].setmocktime(no_version_peer_conntime)
         with self.nodes[0].assert_debug_log([f"Added connection peer={no_version_peer_id}"]):
-            self.nodes[0].add_p2p_connection(P2PInterface(), send_version=False, wait_for_verack=False)
+            no_version_peer = self.nodes[0].add_p2p_connection(P2PInterface(), send_version=False, wait_for_verack=False)
         self.nodes[0].setmocktime(0)
         peer_info = self.nodes[0].getpeerinfo()[no_version_peer_id]
         peer_info.pop("addr")
@@ -153,7 +153,8 @@ class NetTest(BitcoinTestFramework):
                 "version": 0,
             },
         )
-        self.nodes[0].disconnect_p2ps()
+        no_version_peer.peer_disconnect()
+        self.wait_until(lambda: len(self.nodes[0].getpeerinfo()) == 2)
 
     def test_getnettotals(self):
         self.log.info("Test getnettotals")

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -656,7 +656,8 @@ class TestNode():
         return len([peer for peer in self.getpeerinfo() if peer['subver'] == P2P_SUBVERSION])
 
     def disconnect_p2ps(self):
-        """Close all p2p connections to the node."""
+        """Close all p2p connections to the node.
+        Use only after each p2p has sent a version message to ensure the wait works."""
         for p in self.p2ps:
             p.peer_disconnect()
         del self.p2ps[:]


### PR DESCRIPTION
Fixes #26552.

The problem was that calling `disconnect_p2ps` waits until `self.num_test_p2p_connections() == 0`.
`num_test_p2p_connections()` checks the field `subver` in `getpeerinfo` to distinguish p2p nodes from full nodes.
However, if we are dealing with a p2p connection that has never sent a version, the node has never received the special subversion and the wait is ineffective (we continue even though the disconnection is not yet completed).

Fix this by not using `disconnect_p2ps`. 