### PR TITLE
test: generalize MuHash calculation in `feature_utxo_set_hash.py`

### DIFF
--- a/test/functional/feature_utxo_set_hash.py
+++ b/test/functional/feature_utxo_set_hash.py
@@ -3,18 +3,27 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test UTXO set hash value calculation in gettxoutsetinfo."""
-
-import struct
+from decimal import Decimal
 
 from test_framework.messages import (
-    CBlock,
+    COIN,
     COutPoint,
-    from_hex,
+    CTxOut,
 )
 from test_framework.muhash import MuHash3072
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
 from test_framework.wallet import MiniWallet
+
+
+def txout_serialize(txid_hex: str, output_index: int, height: int,
+                    is_coinbase: bool, value: Decimal, scriptPubKey_hex: str):
+    """Serialize UTXO for MuHash (see function `TxOutSer` in the coinstats module)."""
+    data = COutPoint(int(txid_hex, 16), output_index).serialize()
+    data += (height * 2 + is_coinbase).to_bytes(4, 'little')
+    data += CTxOut(int(value * COIN), bytes.fromhex(scriptPubKey_hex)).serialize()
+    return data
+
 
 class UTXOSetHashTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -29,39 +38,29 @@ class UTXOSetHashTest(BitcoinTestFramework):
         mocktime = node.getblockheader(node.getblockhash(0))['time'] + 1
         node.setmocktime(mocktime)
 
-        # Generate 100 blocks and remove the first since we plan to spend its
-        # coinbase
-        block_hashes = self.generate(wallet, 1) + self.generate(node, 99)
-        blocks = list(map(lambda block: from_hex(CBlock(), node.getblock(block, False)), block_hashes))
-        blocks.pop(0)
-
-        # Create a spending transaction and mine a block which includes it
+        # Generate 100 blocks, create spending transaction and mine another block
+        self.generate(wallet, 1) + self.generate(node, 99)
         txid = wallet.send_self_transfer(from_node=node)['txid']
-        tx_block = self.generateblock(node, output=wallet.get_address(), transactions=[txid])
-        blocks.append(from_hex(CBlock(), node.getblock(tx_block['hash'], False)))
+        self.generateblock(node, output=wallet.get_address(), transactions=[txid])
 
-        # Serialize the outputs that should be in the UTXO set and add them to
-        # a MuHash object
+        # Serialize (created/spent) transaction outputs in each block and
+        # apply (add/remove) them to the MuHash object accordingly
         muhash = MuHash3072()
 
-        for height, block in enumerate(blocks):
-            # The Genesis block coinbase is not part of the UTXO set and we
-            # spent the first mined block
-            height += 2
-
-            for tx in block.vtx:
-                for n, tx_out in enumerate(tx.vout):
-                    coinbase = 1 if not tx.vin[0].prevout.hash else 0
-
-                    # Skip witness commitment
-                    if (coinbase and n > 0):
-                        continue
-
-                    data = COutPoint(int(tx.rehash(), 16), n).serialize()
-                    data += struct.pack("<i", height * 2 + coinbase)
-                    data += tx_out.serialize()
-
-                    muhash.insert(data)
+        for height in range(1, node.getblockcount() + 1):
+            for tx in node.getblock(blockhash=node.getblockhash(height), verbosity=3)['tx']:
+                # add created coins
+                is_coinbase_tx = 'coinbase' in tx['vin'][0]
+                for o in tx['vout']:
+                    if o['scriptPubKey']['type'] != 'nulldata':
+                        muhash.insert(txout_serialize(tx['txid'], o['n'], height, is_coinbase_tx,
+                                                      o['value'], o['scriptPubKey']['hex']))
+                # remove spent coins
+                if not is_coinbase_tx:
+                    for i in tx['vin']:
+                        prev = i['prevout']
+                        muhash.remove(txout_serialize(i['txid'], i['vout'], prev['height'], prev['generated'],
+                                                      prev['value'], prev['scriptPubKey']['hex']))
 
         finalized = muhash.digest()
         node_muhash = node.gettxoutsetinfo("muhash")['muhash']


### PR DESCRIPTION
Right now the MuHash calculation in the functional test `feature_utxo_set_hash.py` is dependent on the specific chain we generate, e.g. it only works as long as the only spent coin is created in block number 1 (and no other UTXO is created in that same block) and uses that quirk to avoid the need to ever remove anything from the MuHash object.

This PR generalizes the MuHash calculation by systematically going through all blocks and taking all spent/created coins into account (reflecting the actual behaviour on the coinstatsindex), which allows to potentially create more complex test-cases for UTXO set hashes in the future.