### PR TITLE
doc: add tr() descriptor example to deriveaddresses

### DIFF
--- a/src/rpc/output_script.cpp
+++ b/src/rpc/output_script.cpp
@@ -222,10 +222,11 @@ static RPCHelpMan deriveaddresses()
     return RPCHelpMan{"deriveaddresses",
         {"\nDerives one or more addresses corresponding to an output descriptor.\n"
          "Examples of output descriptors are:\n"
-         "    pkh(<pubkey>)                        P2PKH outputs for the given pubkey\n"
-         "    wpkh(<pubkey>)                       Native segwit P2PKH outputs for the given pubkey\n"
-         "    sh(multi(<n>,<pubkey>,<pubkey>,...)) P2SH-multisig outputs for the given threshold and pubkeys\n"
-         "    raw(<hex script>)                    Outputs whose scriptPubKey equals the specified hex scripts\n"
+         "    pkh(<pubkey>)                                     P2PKH outputs for the given pubkey\n"
+         "    wpkh(<pubkey>)                                    Native segwit P2PKH outputs for the given pubkey\n"
+         "    sh(multi(<n>,<pubkey>,<pubkey>,...))              P2SH-multisig outputs for the given threshold and pubkeys\n"
+         "    raw(<hex script>)                                 Outputs whose scriptPubKey equals the specified hex scripts\n"
+         "    tr(<pubkey>,multi_a(<n>,<pubkey>,<pubkey>,...))   P2TR-multisig outputs for the given threshold and pubkeys\n"
          "\nIn the above, <pubkey> either refers to a fixed public key in hexadecimal notation, or to an xpub/xprv optionally followed by one\n"
          "or more path elements separated by \"/\", where \"h\" represents a hardened child key.\n"
          "For more information on output descriptors, see the documentation in the doc/descriptors.md file.\n"},


### PR DESCRIPTION
This simple PR adds a missing tr() descriptor example to the `help deriveaddresses` examples. 

- The functionality added in https://github.com/bitcoin/bitcoin/pull/24043 is a significant departure from legacy multisig address creation, yet there is no corresponding tr() descriptor example in the help. 
- Having this example in combination with the examples in the descriptors documentation will be helpful to users.


I needed this information to correctly create a tr multisig address but was unable. I had to leave the software and use a 3rd party site to ask two separate questions ([1](https://bitcoin.stackexchange.com/questions/115700/how-do-i-create-a-taproot-multisig-address-requiring-21-of-210-keys-to-spend), [2](https://bitcoin.stackexchange.com/questions/115742/signing-psbts-to-spend-from-taproot-multisig-address)) to create an address using the new functionality. 

Note: This specific example is not provided in the [descriptors.md ](https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md) documentation, though there is a similar example with `sortedmulti_a. ` 