### PR TITLE
ci: Install required packages when running in container

### DIFF
--- a/ci/test/04_install.sh
+++ b/ci/test/04_install.sh
@@ -86,6 +86,8 @@ elif [ "$CI_USE_APT_INSTALL" != "no" ]; then
     # packages. Meanwhile, use an untrusted PPA to install an up-to-date version of the bpfcc-tools
     # package.
     # TODO: drop this once we can use newer images in GCE
+    ${CI_RETRY_EXE} CI_EXEC_ROOT apt-get update
+    ${CI_RETRY_EXE} CI_EXEC_ROOT apt-get install --no-install-recommends --no-upgrade -y gpg gpg-agent software-properties-common
     CI_EXEC_ROOT add-apt-repository ppa:hadret/bpfcc
   fi
   ${CI_RETRY_EXE} CI_EXEC_ROOT apt-get update


### PR DESCRIPTION
On the master branch, the "[ASan + LSan + UBSan + integer, no depends, USDT] [jammy]" CI task fails when being run in a Docker container:
```
$ MAKEJOBS="-j16" FILE_ENV="./ci/test/00_setup_env_native_asan.sh" ./ci/test_run_all.sh
...
bash: line 1: add-apt-repository: command not found
```

This PR installs all required packages.