### PR TITLE
rpc, p2p: allow `disconnectnode` with subnet

### DIFF
--- a/doc/release-notes-26576.md
+++ b/doc/release-notes-26576.md
@@ -1,0 +1,5 @@
+Updated RPCs
+----------
+
+- RPC `disconnectnode` now accepts a subnet into `address`
+  argument. (#26576)

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -394,7 +394,7 @@ static RPCHelpMan disconnectnode()
                 "\nStrictly one out of 'address' and 'nodeid' can be provided to identify the node.\n"
                 "\nTo disconnect by nodeid, either set 'address' to the empty string, or call using the named 'nodeid' argument only.\n",
                 {
-                    {"address", RPCArg::Type::STR, RPCArg::DefaultHint{"fallback to nodeid"}, "The IP address/port of the node"},
+                    {"address", RPCArg::Type::STR, RPCArg::DefaultHint{"fallback to nodeid"}, "The IP address/port of the node or subnet"},
                     {"nodeid", RPCArg::Type::NUM, RPCArg::DefaultHint{"fallback to address"}, "The node ID (see getpeerinfo for node IDs)"},
                 },
                 RPCResult{RPCResult::Type::NONE, "", ""},
@@ -415,7 +415,16 @@ static RPCHelpMan disconnectnode()
 
     if (!address_arg.isNull() && id_arg.isNull()) {
         /* handle disconnect-by-address */
-        success = connman.DisconnectNode(address_arg.get_str());
+        if (address_arg.get_str().find('/') != std::string::npos) {
+            CSubNet subnet;
+            if (LookupSubNet(address_arg.get_str(), subnet)) {
+                success = connman.DisconnectNode(subnet);
+            } else {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid subnet");
+            }
+        } else {
+            success = connman.DisconnectNode(address_arg.get_str());
+        }
     } else if (!id_arg.isNull() && (address_arg.isNull() || (address_arg.isStr() && address_arg.get_str().empty()))) {
         /* handle disconnect-by-id */
         NodeId nodeid = (NodeId) id_arg.getInt<int64_t>();

--- a/test/functional/p2p_disconnect_ban.py
+++ b/test/functional/p2p_disconnect_ban.py
@@ -102,6 +102,9 @@ class DisconnectBanTest(BitcoinTestFramework):
         self.log.info("disconnectnode: fail to disconnect when calling with junk address")
         assert_raises_rpc_error(-29, "Node not found in connected nodes", self.nodes[0].disconnectnode, address="221B Baker Street")
 
+        self.log.info("disconnectnode: fail to disconnect when calling with invalid subnet")
+        assert_raises_rpc_error(-8, "Invalid subnet", self.nodes[0].disconnectnode, address="1.2.3.0/24\0")
+
         self.log.info("disconnectnode: successfully disconnect node by address")
         address1 = self.nodes[0].getpeerinfo()[0]['addr']
         self.nodes[0].disconnectnode(address=address1)
@@ -118,6 +121,10 @@ class DisconnectBanTest(BitcoinTestFramework):
         self.nodes[0].disconnectnode(nodeid=id1)
         self.wait_until(lambda: len(self.nodes[0].getpeerinfo()) == 1, timeout=10)
         assert not [node for node in self.nodes[0].getpeerinfo() if node['id'] == id1]
+
+        self.log.info("disconnectnode: successfully disconnect node by subnet")
+        self.nodes[0].disconnectnode(address='127.0.0.1/24')
+        self.wait_until(lambda: len(self.nodes[0].getpeerinfo()) == 0, timeout=10)
 
 if __name__ == '__main__':
     DisconnectBanTest().main()


### PR DESCRIPTION
Since `disconnectnode` function allows to be used with a subnet, e.g.:
https://github.com/bitcoin/bitcoin/blob/38d06e1561013f4ca845fd5ba6ffcc64de67f9c0/src/net.h#L826-L829
https://github.com/bitcoin/bitcoin/blob/38d06e1561013f4ca845fd5ba6ffcc64de67f9c0/src/net.cpp#L2589-L2601

This PR adds support for `subnet` in `address` parameter in `disconnectnode` RPC. When passing a string with `/` in `address`, it is gonna recognize it as a `subnet.`. It allows us to disconnect multiple nodes from all ports on the same IP. The only way to do it before was banning them for 1sec which seems a bad UX.

Also, when there are multiples nodes connected to a node in a functional test and we want to disconnect them all, we could call `disconnectnode` with a subnet instead of calling `disconnect_nodes` multiple times. 
A simple example:
```diff
-        for i in range(1, 6):
-            self.disconnect_nodes(i, 0)
-
+        self.nodes[0].disconnectnode(address="127.0.0.1/24")
+        self.wait_until(lambda: len(self.nodes[0].getpeerinfo()) == 0, timeout=10)
```

