### PR TITLE
doc: install binutils, not binutils-gold in depends

### DIFF
--- a/depends/README.md
+++ b/depends/README.md
@@ -62,7 +62,7 @@ For more information, see [SDK Extraction](../contrib/macdeploy/README.md#sdk-ex
 
 Common linux dependencies:
 
-    sudo apt-get install make automake cmake curl g++-multilib libtool binutils-gold bsdmainutils pkg-config python3 patch bison
+    sudo apt-get install make automake cmake curl g++-multilib libtool binutils bsdmainutils pkg-config python3 patch bison
 
 For linux ARM cross compilation:
 


### PR DESCRIPTION
We don't use the gold linker.
binutils-gold just installs binutils (and the gold linker) in any case.