### PR TITLE
CI: Bump CI Lint base image from bionic to jammy

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -64,10 +64,10 @@ compute_credits_template: &CREDITS_TEMPLATE
   use_compute_credits: $CIRRUS_REPO_FULL_NAME == 'bitcoin/bitcoin' && $CIRRUS_PR != ""
 
 task:
-  name: 'lint [bionic]'
+  name: 'lint [jammy]'
   << : *BASE_TEMPLATE
   container:
-    image: ubuntu:bionic  # For python 3.6, oldest supported version according to doc/dependencies.md
+    image: ubuntu:jammy  # For python 3.6, oldest supported version according to doc/dependencies.md
     cpu: 1
     memory: 1G
   # For faster CI feedback, immediately schedule the linters

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -67,9 +67,16 @@ task:
   name: 'lint [jammy]'
   << : *BASE_TEMPLATE
   container:
-    image: ubuntu:jammy  # For python 3.6, oldest supported version according to doc/dependencies.md
-    cpu: 1
-    memory: 1G
+    image: ubuntu:jammy
+    cpu: 2 # Assign 2 cores and 4G of ram in case .python-version has changed and cirrus has to rebuild python
+    memory: 4G
+  python_cache:
+    folder: /tmp/python-build # Uses intermediary directory for python caching. See the install.sh script in ci/lint/
+    fingerprint_script:
+      - echo $CIRRUS_OS
+      - cat .python-version
+      - cat ./ci/lint_run_all.sh
+      - cat ./ci/lint/*.sh
   # For faster CI feedback, immediately schedule the linters
   << : *CREDITS_TEMPLATE
   lint_script:


### PR DESCRIPTION
As the title says, this PR aims to address https://github.com/bitcoin/bitcoin/issues/26548 by switching the lint CI job from ubuntu's bionic base image which has python 3.6.5 to ubuntu jammy and use pyenv to install the correct python version as dictated in the project's .python-version file.

DISCLAIMER: This PR is a copy of https://github.com/bitcoin/bitcoin/pull/26572 as there were issues with that PR and how merging and squashing from the master branch were done