### PR TITLE
ci: Skip COMMIT_RANGE if no CIRRUS_PR

### DIFF
--- a/ci/lint/06_script.sh
+++ b/ci/lint/06_script.sh
@@ -9,7 +9,12 @@ export LC_ALL=C
 GIT_HEAD=$(git rev-parse HEAD)
 if [ -n "$CIRRUS_PR" ]; then
   COMMIT_RANGE="${CIRRUS_BASE_SHA}..$GIT_HEAD"
+  echo
+  git log --no-merges --oneline "$COMMIT_RANGE"
+  echo
   test/lint/commit-script-check.sh "$COMMIT_RANGE"
+else
+  COMMIT_RANGE="SKIP_EMPTY_NOT_A_PR"
 fi
 export COMMIT_RANGE
 
@@ -33,9 +38,4 @@ if [ "$CIRRUS_REPO_FULL_NAME" = "bitcoin/bitcoin" ] && [ "$CIRRUS_PR" = "" ] ; t
     mapfile -t KEYS < contrib/verify-commits/trusted-keys
     ${CI_RETRY_EXE} gpg --keyserver hkps://keys.openpgp.org --recv-keys "${KEYS[@]}" &&
     ./contrib/verify-commits/verify-commits.py;
-fi
-
-if [ -n "$COMMIT_RANGE" ]; then
-  echo
-  git log --no-merges --oneline "$COMMIT_RANGE"
 fi

--- a/test/lint/lint-git-commit-check.py
+++ b/test/lint/lint-git-commit-check.py
@@ -46,6 +46,8 @@ def main():
             commit_range = merge_base + "..HEAD"
     else:
         commit_range = os.getenv("COMMIT_RANGE")
+        if commit_range == "SKIP_EMPTY_NOT_A_PR":
+            sys.exit(0)
 
     commit_hashes = check_output(["git", "log", commit_range, "--format=%H"], universal_newlines=True, encoding="utf8").splitlines()
 

--- a/test/lint/lint-whitespace.py
+++ b/test/lint/lint-whitespace.py
@@ -97,6 +97,8 @@ def main():
             commit_range = merge_base + "..HEAD"
     else:
         commit_range = os.getenv("COMMIT_RANGE")
+        if commit_range == "SKIP_EMPTY_NOT_A_PR":
+            sys.exit(0)
 
     whitespace_selection = []
     tab_selection = []


### PR DESCRIPTION
It doesn't make sense to run this for non-PRs, because:

* There are known whitespace "violations" in previous commits, so the lint may fail
* Once the changes are merged, it is too late to fix them up (force pushes are illegal)
* It isn't possible to determine which commits to run on if there is no reference branch (target branch of the pull request)

Moreover, the test fails on non-master:

* https://github.com/bitcoin/bitcoin/runs/8664441400

Fix all issues by skipping it.