### PR TITLE
test: small fixups/improvements for get_previous_releases.py

### DIFF
--- a/test/get_previous_releases.py
+++ b/test/get_previous_releases.py
@@ -136,7 +136,7 @@ def download_binary(tag, args) -> int:
     tarballHash = hasher.hexdigest()
 
     if tarballHash not in SHA256_SUMS or SHA256_SUMS[tarballHash]['tarball'] != tarball:
-        if tarball in SHA256_SUMS.values():
+        if tarball in [v['tarball'] for v in SHA256_SUMS.values()]:
             print("Checksum did not match")
             return 1
 
@@ -260,11 +260,10 @@ if __name__ == '__main__':
                         help='download release binary.')
     parser.add_argument('-t', '--target-dir', action='store',
                         help='target directory.', default='releases')
-    parser.add_argument('tags', nargs='*', default=set(
-                            [v['tag'] for v in SHA256_SUMS.values()]
-                        ),
+    all_tags = sorted([*set([v['tag'] for v in SHA256_SUMS.values()])])
+    parser.add_argument('tags', nargs='*', default=all_tags,
                         help='release tags. e.g.: v0.18.1 v0.20.0rc2 '
-                        '(if not specified, the full list needed for'
+                        '(if not specified, the full list needed for '
                         'backwards compatibility tests will be used)'
                         )
     args = parser.parse_args()


### PR DESCRIPTION
This is a small follow-up to #25650 (commit 614d4682badaadac74b825a45aaee9c2309a3e81) with three fixes/improvements:

- fix "Checksum did not match" detection, which was not adapted to the new `SHA256_SUMS` structure and hence never executed (the list of tarball names isn't directly in the dictionary's values anymore, but has to be extracted from the `'tarball'` field of each value)
- make both help text and default tag download order deterministic by sorting default tags
- `--tags` argument help text: add missing space between "for" and "backwards"