### PR TITLE
[24.x] ci: Skip COMMIT_RANGE if no CIRRUS_PR

### DIFF
--- a/ci/lint/06_script.sh
+++ b/ci/lint/06_script.sh
@@ -9,7 +9,12 @@ export LC_ALL=C
 GIT_HEAD=$(git rev-parse HEAD)
 if [ -n "$CIRRUS_PR" ]; then
   COMMIT_RANGE="${CIRRUS_BASE_SHA}..$GIT_HEAD"
+  echo
+  git log --no-merges --oneline "$COMMIT_RANGE"
+  echo
   test/lint/commit-script-check.sh "$COMMIT_RANGE"
+else
+  COMMIT_RANGE="SKIP_EMPTY_NOT_A_PR"
 fi
 export COMMIT_RANGE
 
@@ -33,9 +38,4 @@ if [ "$CIRRUS_REPO_FULL_NAME" = "bitcoin/bitcoin" ] && [ "$CIRRUS_PR" = "" ] ; t
     mapfile -t KEYS < contrib/verify-commits/trusted-keys
     ${CI_RETRY_EXE} gpg --keyserver hkps://keys.openpgp.org --recv-keys "${KEYS[@]}" &&
     ./contrib/verify-commits/verify-commits.py;
-fi
-
-if [ -n "$COMMIT_RANGE" ]; then
-  echo
-  git log --no-merges --oneline "$COMMIT_RANGE"
 fi

--- a/test/lint/lint-git-commit-check.py
+++ b/test/lint/lint-git-commit-check.py
@@ -46,6 +46,8 @@ def main():
             commit_range = merge_base + "..HEAD"
     else:
         commit_range = os.getenv("COMMIT_RANGE")
+        if commit_range == "SKIP_EMPTY_NOT_A_PR":
+            sys.exit(0)
 
     commit_hashes = check_output(["git", "log", commit_range, "--format=%H"], universal_newlines=True, encoding="utf8").splitlines()
 

--- a/test/lint/lint-whitespace.py
+++ b/test/lint/lint-whitespace.py
@@ -97,6 +97,8 @@ def main():
             commit_range = merge_base + "..HEAD"
     else:
         commit_range = os.getenv("COMMIT_RANGE")
+        if commit_range == "SKIP_EMPTY_NOT_A_PR":
+            sys.exit(0)
 
     whitespace_selection = []
     tab_selection = []


### PR DESCRIPTION
Identical commit from https://github.com/bitcoin/bitcoin/pull/26588

Untested, but this may fix the red-ness in https://cirrus-ci.com/github/bitcoin/bitcoin/24.x, e.g. https://cirrus-ci.com/task/4697153604419584:

Backport requested in https://github.com/bitcoin/bitcoin/pull/26588#issuecomment-1328916876