### PR TITLE
ci: only run USDT interface tests on CirrusCI

### DIFF
--- a/ci/test/00_setup_env_native_asan.sh
+++ b/ci/test/00_setup_env_native_asan.sh
@@ -6,14 +6,21 @@
 
 export LC_ALL=C.UTF-8
 
-# We install an up-to-date 'bpfcc-tools' package from an untrusted PPA.
-# This can be dropped with the next Ubuntu or Debian release that includes up-to-date packages.
-# See the if-then in ci/test/04_install.sh too.
-export ADD_UNTRUSTED_BPFCC_PPA=true
+# Only install BCC tracing packages in Cirrus CI.
+if [[ "${CIRRUS_CI}" == "true" ]]; then
+  # We install an up-to-date 'bpfcc-tools' package from an untrusted PPA.
+  # This can be dropped with the next Ubuntu or Debian release that includes up-to-date packages.
+  # See the if-then in ci/test/04_install.sh too.
+  export ADD_UNTRUSTED_BPFCC_PPA=true
+  export BPFCC_PACKAGE="bpfcc-tools"
+else
+  export ADD_UNTRUSTED_BPFCC_PPA=false
+  export BPFCC_PACKAGE=""
+fi
 
 export CONTAINER_NAME=ci_native_asan
-export PACKAGES="systemtap-sdt-dev bpfcc-tools clang llvm python3-zmq qtbase5-dev qttools5-dev-tools libevent-dev bsdmainutils libboost-dev libdb5.3++-dev libminiupnpc-dev libnatpmp-dev libzmq3-dev libqrencode-dev libsqlite3-dev"
-export DOCKER_NAME_TAG=ubuntu:22.04  # May not run in docker unless --enable-usdt is dropped
+export PACKAGES="systemtap-sdt-dev clang llvm python3-zmq qtbase5-dev qttools5-dev-tools libevent-dev bsdmainutils libboost-dev libdb5.3++-dev libminiupnpc-dev libnatpmp-dev libzmq3-dev libqrencode-dev libsqlite3-dev ${BPFCC_PACKAGE}"
+export DOCKER_NAME_TAG=ubuntu:22.04
 export NO_DEPENDS=1
 export GOAL="install"
 export BITCOIN_CONFIG="--enable-usdt --enable-zmq --with-incompatible-bdb --with-gui=qt5 CPPFLAGS='-DARENA_DEBUG -DDEBUG_LOCKORDER' --with-sanitizers=address,integer,undefined CC=clang CXX=clang++"


### PR DESCRIPTION
As mentioned in #26571, the task running the USDT interface tests fail when run in docker. cc7335edc87c6ef34429b4df94f53973db520aac in #25528 added that the tests are run in a **VM** in Cirrus CI. Running them locally in docker containers might not work:

- We use [bcc] as tracing toolkit which requires the kernel headers to compile the BPF bytecode. As docker containers use the hosts kernel and don't run their own, there is a potential for mismatches between kernel headers available in the container and the host kernel. This results in a failure loading the BPF byte code.
- Privilges are required to load the BPF byte code into the kernel. Normally, the docker containers aren't run with these.
- We currently use an untrusted third-party PPA to install the bpfcc-tools package on Ubuntu 22.04. Using this on a local dev system could be a security risk.

To not hinder the ASan + LSan + UBSan part of the CI task, the USDT tests are disabled on non-CirrusCI runs.

[bcc]: https://github.com/iovisor/bcc
