### PR TITLE
test: Set wallet type in test_runner when only one type is allowed

### DIFF
--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -448,11 +448,13 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
     # Public helper methods. These can be accessed by the subclass test scripts.
 
     def add_wallet_options(self, parser, *, descriptors=True, legacy=True):
-        group = parser.add_mutually_exclusive_group()
         kwargs = {}
         if descriptors + legacy == 1:
             # If only one type can be chosen, set it as default
             kwargs["default"] = descriptors
+        group = parser.add_mutually_exclusive_group(
+            # If only one type is allowed, require it to be set in test_runner.py
+            required=os.getenv("REQUIRE_WALLET_TYPE_SET") == "1" and "default" in kwargs)
         if descriptors:
             group.add_argument("--descriptors", action='store_const', const=True, **kwargs,
                                help="Run test using a descriptor wallet", dest='descriptors')

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -27,6 +27,8 @@ import re
 import logging
 import unittest
 
+os.environ["REQUIRE_WALLET_TYPE_SET"] = "1"
+
 # Formatting. Default colors to empty strings.
 DEFAULT, BOLD, GREEN, RED = ("", ""), ("", ""), ("", ""), ("", "")
 try:
@@ -159,7 +161,7 @@ BASE_SCRIPTS = [
     'wallet_avoidreuse.py --descriptors',
     'wallet_avoid_mixing_output_types.py --descriptors',
     'mempool_reorg.py',
-    'mempool_persist.py',
+    'mempool_persist.py --descriptors',
     'p2p_block_sync.py',
     'wallet_multiwallet.py --legacy-wallet',
     'wallet_multiwallet.py --descriptors',
@@ -208,7 +210,7 @@ BASE_SCRIPTS = [
     'wallet_keypool.py --legacy-wallet',
     'wallet_keypool.py --descriptors',
     'wallet_descriptor.py --descriptors',
-    'wallet_miniscript.py',
+    'wallet_miniscript.py --descriptors',
     'feature_maxtipage.py',
     'p2p_nobloomfilter_messages.py',
     'p2p_filter.py',
@@ -222,7 +224,7 @@ BASE_SCRIPTS = [
     'feature_assumevalid.py',
     'example_test.py',
     'wallet_txn_doublespend.py --legacy-wallet',
-    'wallet_multisig_descriptor_psbt.py',
+    'wallet_multisig_descriptor_psbt.py --descriptors',
     'wallet_txn_doublespend.py --descriptors',
     'feature_backwards_compatibility.py --legacy-wallet',
     'feature_backwards_compatibility.py --descriptors',
@@ -294,8 +296,8 @@ BASE_SCRIPTS = [
     'wallet_sendall.py --legacy-wallet',
     'wallet_sendall.py --descriptors',
     'wallet_create_tx.py --descriptors',
-    'wallet_taproot.py',
-    'wallet_inactive_hdchains.py',
+    'wallet_taproot.py --descriptors',
+    'wallet_inactive_hdchains.py --legacy-wallet',
     'p2p_fingerprint.py',
     'feature_uacomment.py',
     'feature_init.py',


### PR DESCRIPTION
Currently devs are free to set or not set the wallet type in the test_runner when only one type is allowed to be set.

This is inconsistent and causes review comments such as:

* https://github.com/bitcoin/bitcoin/pull/24865#discussion_r1009752111
