### PR TITLE
wallet: Change coin selection fee assert to error

### DIFF
--- a/src/util/check.cpp
+++ b/src/util/check.cpp
@@ -14,10 +14,13 @@
 #include <cstdlib>
 #include <string>
 
+std::string StrFormatInternalBug(const char* msg, const char* file, int line, const char* func)
+{
+    return strprintf("Internal bug detected: \"%s\"\n%s:%d (%s)\nPlease report this issue here: %s\n", msg, file, line, func, PACKAGE_BUGREPORT);
+}
 
 NonFatalCheckError::NonFatalCheckError(const char* msg, const char* file, int line, const char* func)
-    : std::runtime_error{
-          strprintf("Internal bug detected: \"%s\"\n%s:%d (%s)\nPlease report this issue here: %s\n", msg, file, line, func, PACKAGE_BUGREPORT)}
+    : std::runtime_error{StrFormatInternalBug(msg, file, line, func)}
 {
 }
 

--- a/src/util/check.h
+++ b/src/util/check.h
@@ -10,11 +10,15 @@
 #include <stdexcept>
 #include <utility>
 
+std::string StrFormatInternalBug(const char* msg, const char* file, int line, const char* func);
+
 class NonFatalCheckError : public std::runtime_error
 {
 public:
     NonFatalCheckError(const char* msg, const char* file, int line, const char* func);
 };
+
+#define STR_INTERNAL_BUG(msg) StrFormatInternalBug((msg), __FILE__, __LINE__, __func__)
 
 /** Helper for CHECK_NONFATAL() */
 template <typename T>

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -940,7 +940,9 @@ static util::Result<CreatedTransactionResult> CreateTransactionInternal(
 
     // The only time that fee_needed should be less than the amount available for fees is when
     // we are subtracting the fee from the outputs. If this occurs at any other time, it is a bug.
-    assert(coin_selection_params.m_subtract_fee_outputs || fee_needed <= nFeeRet);
+    if (!coin_selection_params.m_subtract_fee_outputs && fee_needed > nFeeRet) {
+        return util::Error{Untranslated(STR_INTERNAL_BUG("Fee needed > fee paid"))};
+    }
 
     // If there is a change output and we overpay the fees then increase the change to match the fee needed
     if (nChangePosInOut != -1 && fee_needed < nFeeRet) {


### PR DESCRIPTION
Returning an error instead of asserting for the low fee check will be better as it does not crash the node and instructs users to report the bug.