### PR TITLE
Accurately account for mempool index memory 

### DIFF
--- a/src/indirectmap.h
+++ b/src/indirectmap.h
@@ -6,6 +6,7 @@
 #define BITCOIN_INDIRECTMAP_H
 
 #include <map>
+#include <memory>
 
 template <class T>
 struct DereferencingComparator { bool operator()(const T a, const T b) const { return *a < *b; } };
@@ -20,16 +21,20 @@ struct DereferencingComparator { bool operator()(const T a, const T b) const { r
  * Objects pointed to by keys must not be modified in any way that changes the
  * result of DereferencingComparator.
  */
-template <class K, class T>
-class indirectmap {
+template <class K, class T, class A = std::allocator<std::pair<const K* const, T>>>
+class indirectmap
+{
 private:
-    typedef std::map<const K*, T, DereferencingComparator<const K*> > base;
+    typedef std::map<const K*, T, DereferencingComparator<const K*>, A> base;
     base m;
 public:
     typedef typename base::iterator iterator;
     typedef typename base::const_iterator const_iterator;
     typedef typename base::size_type size_type;
     typedef typename base::value_type value_type;
+
+    indirectmap() = default;
+    explicit indirectmap(const A& alloc) : m({}, DereferencingComparator<const K*>(), alloc) {}
 
     // passthrough (pointer interface)
     std::pair<iterator, bool> insert(const value_type& value) { return m.insert(value); }

--- a/src/memusage.h
+++ b/src/memusage.h
@@ -17,12 +17,94 @@
 #include <unordered_map>
 #include <unordered_set>
 
-
 namespace memusage
 {
 
 /** Compute the total memory used by allocating alloc bytes. */
 static size_t MallocUsage(size_t alloc);
+
+/** Wrapping allocator that accounts accurately.
+ *
+ * To use accounting, the AccountAllocator(size_t&) constructor must be used.
+ * Any containers using such an allocator, and containers move constructed or
+ * move assigned from such containers will then increment/decrement size_t when
+ * allocating/deallocating memory.
+ */
+template <typename T>
+class AccountingAllocator
+{
+    using base = std::allocator<T>;
+
+    //! Base allocator
+    base m_base;
+
+    //! Pointer to accounting variable, if any.
+    size_t* m_allocated = nullptr;
+
+    template <typename U>
+    friend class AccountingAllocator;
+
+public:
+    using value_type = typename base::value_type;
+    using size_type = typename base::size_type;
+    using difference_type = typename base::size_type;
+
+    //! Default constructor constructs a non-accounting allocator.
+    AccountingAllocator() = default;
+
+    /** Construct an allocator that increments/decrements 'allocated' on allocate/free.
+     *
+     * In a multithreaded environment, the accounting variable needs to be
+     * protected by the same lock as the container(s) that use this allocator.
+     */
+#if __cplusplus >= 202002L
+    constexpr
+#endif
+    explicit AccountingAllocator(size_t& allocated) noexcept : m_allocated{&allocated} {}
+
+    //! A copy-constructed container will be non-accounting.
+    AccountingAllocator select_on_container_copy_construction() const { return {}; }
+    //! A copy-assigned container will be non-accounting.
+    using propagate_on_container_copy_assignment = std::false_type;
+    //! The accounting will follow a container as it's moved.
+    using propagate_on_container_move_assignment = std::true_type;
+    //! The accounting will follow a container as it's swapped.
+    using propagate_on_container_swap = std::true_type;
+
+    using is_always_equal = std::false_type;
+
+    // Construct an allocator for a different data type, inheriting the accounting.
+    template <typename U>
+    AccountingAllocator(AccountingAllocator<U>&& a) noexcept : m_base(std::move(a.m_base)), m_allocated(a.m_allocated) {}
+    template <typename U>
+    AccountingAllocator(const AccountingAllocator<U>& a) noexcept : m_base(a.m_base), m_allocated(a.m_allocated) {}
+
+#if __cplusplus >= 202002L
+    [[nodiscard]] constexpr
+#endif
+    value_type* allocate(std::size_t n)
+    {
+        if (m_allocated) *m_allocated += MallocUsage(sizeof(value_type) * n);
+        return m_base.allocate(n);
+    }
+
+#if __cplusplus >= 202002L
+    constexpr
+#endif
+    void deallocate(typename base::value_type* p, std::size_t n)
+    {
+        m_base.deallocate(p, n);
+        if (m_allocated) *m_allocated -= MallocUsage(sizeof(value_type) * n);
+    }
+
+    template <typename U>
+    struct rebind {
+        typedef AccountingAllocator<U> other;
+    };
+
+    friend bool operator==(const AccountingAllocator<T>& a, const AccountingAllocator<T>& b) noexcept { return a.m_allocated == b.m_allocated; }
+    friend bool operator!=(const AccountingAllocator<T>& a, const AccountingAllocator<T>& b) noexcept { return a.m_allocated != b.m_allocated; }
+};
 
 /** Dynamic memory usage for built-in types is zero. */
 static inline size_t DynamicUsage(const int8_t& v) { return 0; }

--- a/src/test/validation_flush_tests.cpp
+++ b/src/test/validation_flush_tests.cpp
@@ -105,16 +105,18 @@ BOOST_AUTO_TEST_CASE(getcoinscachesizestate)
         chainstate.GetCoinsCacheSizeState(MAX_COINS_CACHE_BYTES, /*max_mempool_size_bytes=*/0),
         CoinsCacheSizeState::CRITICAL);
 
+    const auto saved_memory_usage{chainstate.GetMempool()->DynamicMemoryUsage()};
+
     // Passing non-zero max mempool usage should allow us more headroom.
     BOOST_CHECK_EQUAL(
-        chainstate.GetCoinsCacheSizeState(MAX_COINS_CACHE_BYTES, /*max_mempool_size_bytes=*/1 << 10),
+        chainstate.GetCoinsCacheSizeState(MAX_COINS_CACHE_BYTES, /*max_mempool_size_bytes=*/(1 << 10) + saved_memory_usage),
         CoinsCacheSizeState::OK);
 
     for (int i{0}; i < 3; ++i) {
         add_coin(view);
         print_view_mem_usage(view);
         BOOST_CHECK_EQUAL(
-            chainstate.GetCoinsCacheSizeState(MAX_COINS_CACHE_BYTES, /*max_mempool_size_bytes=*/1 << 10),
+            chainstate.GetCoinsCacheSizeState(MAX_COINS_CACHE_BYTES, /*max_mempool_size_bytes=*/(1 << 10) + saved_memory_usage),
             CoinsCacheSizeState::OK);
     }
 
@@ -130,7 +132,7 @@ BOOST_AUTO_TEST_CASE(getcoinscachesizestate)
         BOOST_CHECK(usage_percentage >= 0.9);
         BOOST_CHECK(usage_percentage < 1);
         BOOST_CHECK_EQUAL(
-            chainstate.GetCoinsCacheSizeState(MAX_COINS_CACHE_BYTES, 1 << 10),
+            chainstate.GetCoinsCacheSizeState(MAX_COINS_CACHE_BYTES, /*max_mempool_size_bytes=*/(1 << 10) + saved_memory_usage),
             CoinsCacheSizeState::LARGE);
     }
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -381,6 +381,7 @@ CTxMemPool::CTxMemPool(const Options& opts)
       m_allocation_counter{0},
       mapTx{memusage::AccountingAllocator<CTxMemPoolEntry>{m_allocation_counter}},
       vTxHashes{memusage::AccountingAllocator<std::pair<uint256, txiter>>{m_allocation_counter}},
+      mapNextTx{memusage::AccountingAllocator<std::pair<const COutPoint* const, const CTransaction*>>{m_allocation_counter}},
       mapDeltas{memusage::AccountingAllocator<std::pair<const uint256, CAmount>>{m_allocation_counter}},
       m_max_size_bytes{opts.max_size_bytes},
       m_expiry{opts.expiry},
@@ -962,7 +963,7 @@ void CCoinsViewMemPool::PackageAddTransaction(const CTransactionRef& tx)
 
 size_t CTxMemPool::DynamicMemoryUsage() const {
     LOCK(cs);
-    return m_allocation_counter + memusage::DynamicUsage(mapNextTx) + cachedInnerUsage;
+    return m_allocation_counter + cachedInnerUsage;
 }
 
 void CTxMemPool::RemoveUnbroadcastTx(const uint256& txid, const bool unchecked) {

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -380,6 +380,7 @@ CTxMemPool::CTxMemPool(const Options& opts)
       minerPolicyEstimator{opts.estimator},
       m_allocation_counter{0},
       mapTx{memusage::AccountingAllocator<CTxMemPoolEntry>{m_allocation_counter}},
+      vTxHashes{memusage::AccountingAllocator<std::pair<uint256, txiter>>{m_allocation_counter}},
       mapDeltas{memusage::AccountingAllocator<std::pair<const uint256, CAmount>>{m_allocation_counter}},
       m_max_size_bytes{opts.max_size_bytes},
       m_expiry{opts.expiry},
@@ -961,7 +962,7 @@ void CCoinsViewMemPool::PackageAddTransaction(const CTransactionRef& tx)
 
 size_t CTxMemPool::DynamicMemoryUsage() const {
     LOCK(cs);
-    return m_allocation_counter + memusage::DynamicUsage(mapNextTx) + memusage::DynamicUsage(vTxHashes) + cachedInnerUsage;
+    return m_allocation_counter + memusage::DynamicUsage(mapNextTx) + cachedInnerUsage;
 }
 
 void CTxMemPool::RemoveUnbroadcastTx(const uint256& txid, const bool unchecked) {

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -450,7 +450,7 @@ private:
                                           std::string &errString) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
 public:
-    indirectmap<COutPoint, const CTransaction*> mapNextTx GUARDED_BY(cs);
+    indirectmap<COutPoint, const CTransaction*, memusage::AccountingAllocator<std::pair<const COutPoint* const, const CTransaction*>>> mapNextTx GUARDED_BY(cs);
     std::map<uint256, CAmount, std::less<uint256>, memusage::AccountingAllocator<std::pair<const uint256, CAmount>>> mapDeltas GUARDED_BY(cs);
 
     using Options = kernel::MemPoolOptions;

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -845,7 +845,8 @@ struct DisconnectedBlockTransactions {
             boost::multi_index::sequenced<
                 boost::multi_index::tag<insertion_order>
             >
-        >
+        >,
+        memusage::AccountingAllocator<CTransactionRef>
     > indexed_disconnected_transactions;
 
     // It's almost certainly a logic bug if we don't clear out queuedTx before
@@ -858,13 +859,14 @@ struct DisconnectedBlockTransactions {
     // reorg, besides draining this object).
     ~DisconnectedBlockTransactions() { assert(queuedTx.empty()); }
 
+    size_t m_allocation_counter;
     indexed_disconnected_transactions queuedTx;
     uint64_t cachedInnerUsage = 0;
 
-    // Estimate the overhead of queuedTx to be 6 pointers + an allocation, as
-    // no exact formula for boost::multi_index_contained is implemented.
+    DisconnectedBlockTransactions() : m_allocation_counter(0), queuedTx(memusage::AccountingAllocator<CTransactionRef>(m_allocation_counter)) {}
+
     size_t DynamicMemoryUsage() const {
-        return memusage::MallocUsage(sizeof(CTransactionRef) + 6 * sizeof(void*)) * queuedTx.size() + cachedInnerUsage;
+        return m_allocation_counter + cachedInnerUsage;
     }
 
     void addTransaction(const CTransactionRef& tx)

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -406,7 +406,7 @@ public:
     indexed_transaction_set mapTx GUARDED_BY(cs);
 
     using txiter = indexed_transaction_set::nth_index<0>::type::const_iterator;
-    std::vector<std::pair<uint256, txiter>> vTxHashes GUARDED_BY(cs); //!< All tx witness hashes/entries in mapTx, in random order
+    std::vector<std::pair<uint256, txiter>, memusage::AccountingAllocator<std::pair<uint256, txiter>>> vTxHashes GUARDED_BY(cs); //!< All tx witness hashes/entries in mapTx, in random order
 
     typedef std::set<txiter, CompareIteratorByHash> setEntries;
 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -320,6 +320,7 @@ protected:
     uint64_t totalTxSize GUARDED_BY(cs);      //!< sum of all mempool tx's virtual sizes. Differs from serialized tx size since witness data is discounted. Defined in BIP 141.
     CAmount m_total_fee GUARDED_BY(cs);       //!< sum of all mempool tx's fees (NOT modified fee)
     uint64_t cachedInnerUsage GUARDED_BY(cs); //!< sum of dynamic memory usage of all the map elements (NOT the maps themselves)
+    size_t m_allocation_counter GUARDED_BY(cs); //!< Accounting variable for AccountingAllocator-managed containers
 
     mutable int64_t lastRollingFeeUpdate GUARDED_BY(cs);
     mutable bool blockSinceLastRollingFeeBump GUARDED_BY(cs);
@@ -370,7 +371,8 @@ public:
                 boost::multi_index::identity<CTxMemPoolEntry>,
                 CompareTxMemPoolEntryByAncestorFee
             >
-        >
+        >,
+        memusage::AccountingAllocator<CTxMemPoolEntry>
     > indexed_transaction_set;
 
     /**

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -451,7 +451,7 @@ private:
 
 public:
     indirectmap<COutPoint, const CTransaction*> mapNextTx GUARDED_BY(cs);
-    std::map<uint256, CAmount> mapDeltas GUARDED_BY(cs);
+    std::map<uint256, CAmount, std::less<uint256>, memusage::AccountingAllocator<std::pair<const uint256, CAmount>>> mapDeltas GUARDED_BY(cs);
 
     using Options = kernel::MemPoolOptions;
 


### PR DESCRIPTION
Picked https://github.com/bitcoin/bitcoin/pull/18086:

> This introduces a C++ allocator class (`memusage::AccountingAllocator`) which enables containers that accurately account for all their memory allocations in a tracker variable.
>
> This is then used to replace the heuristics in the mempool to guess memory usage.
