### PR TITLE
rpc: Prevent unloading a wallet when rescanning

### DIFF
--- a/doc/release-notes-26618.md
+++ b/doc/release-notes-26618.md
@@ -1,0 +1,4 @@
+RPC Wallet
+----------
+
+- RPC `unloadwallet` now fails if a rescan is in progress. (#26618)

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -437,13 +437,20 @@ static RPCHelpMan unloadwallet()
         throw JSONRPCError(RPC_WALLET_NOT_FOUND, "Requested wallet does not exist or is not loaded");
     }
 
-    // Release the "main" shared pointer and prevent further notifications.
-    // Note that any attempt to load the same wallet would fail until the wallet
-    // is destroyed (see CheckUniqueFileid).
     std::vector<bilingual_str> warnings;
-    std::optional<bool> load_on_start = request.params[1].isNull() ? std::nullopt : std::optional<bool>(request.params[1].get_bool());
-    if (!RemoveWallet(context, wallet, load_on_start, warnings)) {
-        throw JSONRPCError(RPC_MISC_ERROR, "Requested wallet already unloaded");
+    {
+        WalletRescanReserver reserver(*wallet);
+        if (!reserver.reserve()) {
+            throw JSONRPCError(RPC_WALLET_ERROR, "Wallet is currently rescanning. Abort existing rescan or wait.");
+        }
+
+        // Release the "main" shared pointer and prevent further notifications.
+        // Note that any attempt to load the same wallet would fail until the wallet
+        // is destroyed (see CheckUniqueFileid).
+        std::optional<bool> load_on_start = request.params[1].isNull() ? std::nullopt : std::optional<bool>(request.params[1].get_bool());
+        if (!RemoveWallet(context, wallet, load_on_start, warnings)) {
+            throw JSONRPCError(RPC_MISC_ERROR, "Requested wallet already unloaded");
+        }
     }
 
     UnloadWallet(std::move(wallet));


### PR DESCRIPTION
Fixes #26463.

This PR prevents a user from unloading a wallet if it is currently rescanning.

To test:

```bash
./src/bitcoin-cli -testnet -named createwallet wallet_name=wo disable_private_keys=true
./src/bitcoin-cli -testnet -rpcwallet=wo importdescriptors '[{
	  "desc": "addr(mmcuW74MyJUZuLnWXGQLoNXPrS9RbFz6gD)#tpnrahgc",
      "timestamp": 0,
      "active": false,
      "internal": false,
      "next": 0
}]'
./src/bitcoin-cli -testnet unloadwallet wo
error code: -4
error message:
Wallet is currently rescanning. Abort existing rescan or wait.