### PR TITLE
contrib: Add CFLAG env variable when MacOS version > 11.0.0

### DIFF
--- a/contrib/install_db4.sh
+++ b/contrib/install_db4.sh
@@ -8,6 +8,18 @@
 export LC_ALL=C
 set -e
 
+# Set C_FLAG for Mac OS version > 11.0.0
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  os_ver_str=$(sw_vers -productVersion)
+  os_ver=${os_ver_str//.}
+  required_ver=1100
+
+  if (($os_ver > $required_ver)); then
+	  export CFLAGS="-Wno-error=implicit-function-declaration"
+  fi
+fi
+
 if [ -z "${1}" ]; then
   echo "Usage: $0 <base-dir> [<extra-bdb-configure-flag> ...]"
   echo


### PR DESCRIPTION
On Mac OS Version > 11.0.0,  running ./contrib/install/db4.sh \`pwd\` on master leads to the following error.
\
```
WARNING: NO SHARED LATCH IMPLEMENTATION FOUND FOR THIS PLATFORM.
configure: error: Unable to find a mutex implementation
```

As documented in #20195, the reason for this error is that [Apple has enabled -Werror=implicit-function-declaration by default](https://developer.apple.com/documentation/xcode-release-notes/xcode-12-release-notes).

The fix noticed in that PR was to set **CFLAGS** to "-Wno-error=implicit-function-declaration".
This PR adds that fix to the `contrib/install_db4.sh` file so that it can run smoothly for Mac OS version > 11.0.0