### PR TITLE
refactor: Rename local variable to distinguish it from type alias

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2291,9 +2291,9 @@ void PeerManagerImpl::ProcessGetData(CNode& pfrom, Peer& peer, const std::atomic
             std::vector<uint256> parent_ids_to_add;
             {
                 LOCK(m_mempool.cs);
-                auto txiter = m_mempool.GetIter(tx->GetHash());
-                if (txiter) {
-                    const CTxMemPoolEntry::Parents& parents = (*txiter)->GetMemPoolParentsConst();
+                auto tx_iter = m_mempool.GetIter(tx->GetHash());
+                if (tx_iter) {
+                    const CTxMemPoolEntry::Parents& parents = (*tx_iter)->GetMemPoolParentsConst();
                     parent_ids_to_add.reserve(parents.size());
                     for (const CTxMemPoolEntry& parent : parents) {
                         if (parent.GetTime() > now - UNCONDITIONAL_RELAY_DELAY) {


### PR DESCRIPTION
The `txiter` type alias is declared in the `txmempool.h`: https://github.com/bitcoin/bitcoin/blob/9e59d21fbe5746b220f35b0a5a735198c3e6dcdb/src/txmempool.h#L406