### PR TITLE
test: Run mempool_packages.py with MiniWallet

### DIFF
--- a/test/functional/mempool_package_limits.py
+++ b/test/functional/mempool_package_limits.py
@@ -45,7 +45,7 @@ class MempoolPackageLimitsTest(BitcoinTestFramework):
         assert_equal(0, node.getmempoolinfo()["size"])
         chain_hex = []
 
-        chaintip_utxo = self.wallet.send_self_transfer_chain(from_node=node, chain_length=mempool_count)
+        chaintip_utxo = self.wallet.send_self_transfer_chain(from_node=node, chain_length=mempool_count)[-1]["new_utxo"]
         # in-package transactions
         for _ in range(package_count):
             tx = self.wallet.create_self_transfer(utxo_to_spend=chaintip_utxo)
@@ -100,13 +100,13 @@ class MempoolPackageLimitsTest(BitcoinTestFramework):
 
         package_hex = []
         # Chain A (M2a... M12a)
-        chain_a_tip_utxo = self.wallet.send_self_transfer_chain(from_node=node, chain_length=11, utxo_to_spend=m1_utxos[0])
+        chain_a_tip_utxo = self.wallet.send_self_transfer_chain(from_node=node, chain_length=11, utxo_to_spend=m1_utxos[0])[-1]["new_utxo"]
         # Pa
         pa_hex = self.wallet.create_self_transfer(utxo_to_spend=chain_a_tip_utxo)["hex"]
         package_hex.append(pa_hex)
 
         # Chain B (M2b... M13b)
-        chain_b_tip_utxo = self.wallet.send_self_transfer_chain(from_node=node, chain_length=12, utxo_to_spend=m1_utxos[1])
+        chain_b_tip_utxo = self.wallet.send_self_transfer_chain(from_node=node, chain_length=12, utxo_to_spend=m1_utxos[1])[-1]["new_utxo"]
         # Pb
         pb_hex = self.wallet.create_self_transfer(utxo_to_spend=chain_b_tip_utxo)["hex"]
         package_hex.append(pb_hex)
@@ -145,7 +145,7 @@ class MempoolPackageLimitsTest(BitcoinTestFramework):
         m1_utxos = self.wallet.send_self_transfer_multi(from_node=node, num_outputs=2)['new_utxos']
 
         # Chain M2...M24
-        self.wallet.send_self_transfer_chain(from_node=node, chain_length=23, utxo_to_spend=m1_utxos[0])
+        self.wallet.send_self_transfer_chain(from_node=node, chain_length=23, utxo_to_spend=m1_utxos[0])[-1]["new_utxo"]
 
         # P1
         p1_tx = self.wallet.create_self_transfer(utxo_to_spend=m1_utxos[1])
@@ -191,7 +191,7 @@ class MempoolPackageLimitsTest(BitcoinTestFramework):
 
         # Two chains of 13 transactions each
         for _ in range(2):
-            chain_tip_utxo = self.wallet.send_self_transfer_chain(from_node=node, chain_length=12)
+            chain_tip_utxo = self.wallet.send_self_transfer_chain(from_node=node, chain_length=12)[-1]["new_utxo"]
             # Save the 13th transaction for the package
             tx = self.wallet.create_self_transfer(utxo_to_spend=chain_tip_utxo)
             package_hex.append(tx["hex"])
@@ -234,7 +234,7 @@ class MempoolPackageLimitsTest(BitcoinTestFramework):
         self.log.info("Check that in-mempool and in-package ancestors are calculated properly in packages")
         # Two chains of 12 transactions each
         for _ in range(2):
-            chaintip_utxo = self.wallet.send_self_transfer_chain(from_node=node, chain_length=12)
+            chaintip_utxo = self.wallet.send_self_transfer_chain(from_node=node, chain_length=12)[-1]["new_utxo"]
             # last 2 transactions will be the parents of Pc
             pc_parent_utxos.append(chaintip_utxo)
 

--- a/test/functional/mempool_packages.py
+++ b/test/functional/mempool_packages.py
@@ -6,7 +6,6 @@
 
 from decimal import Decimal
 
-from test_framework.blocktools import COINBASE_MATURITY
 from test_framework.messages import (
     COIN,
     DEFAULT_ANCESTOR_LIMIT,
@@ -17,9 +16,8 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
-    chain_transaction,
 )
-
+from test_framework.wallet import MiniWallet
 
 # custom limits for node1
 CUSTOM_ANCESTOR_LIMIT = 5
@@ -45,43 +43,33 @@ class MempoolPackagesTest(BitcoinTestFramework):
             ],
         ]
 
-    def skip_test_if_missing_module(self):
-        self.skip_if_no_wallet()
-
     def run_test(self):
-        # Mine some blocks and have them mature.
-        peer_inv_store = self.nodes[0].add_p2p_connection(P2PTxInvStore()) # keep track of invs
-        self.generate(self.nodes[0], COINBASE_MATURITY + 1)
-        utxo = self.nodes[0].listunspent(10)
-        txid = utxo[0]['txid']
-        vout = utxo[0]['vout']
-        value = utxo[0]['amount']
-        assert 'ancestorcount' not in utxo[0]
-        assert 'ancestorsize' not in utxo[0]
-        assert 'ancestorfees' not in utxo[0]
+        self.wallet = MiniWallet(self.nodes[0])
+        self.wallet.rescan_utxos()
 
-        fee = Decimal("0.0001")
+        if self.is_specified_wallet_compiled():
+            self.nodes[0].createwallet("watch_wallet", disable_private_keys=True)
+            self.nodes[0].importaddress(self.wallet.get_address())
+
+        peer_inv_store = self.nodes[0].add_p2p_connection(P2PTxInvStore()) # keep track of invs
+
         # DEFAULT_ANCESTOR_LIMIT transactions off a confirmed tx should be fine
-        chain = []
-        witness_chain = []
+        chain = self.wallet.create_self_transfer_chain(chain_length=DEFAULT_ANCESTOR_LIMIT)
+        witness_chain = [t["wtxid"] for t in chain]
         ancestor_vsize = 0
         ancestor_fees = Decimal(0)
-        for i in range(DEFAULT_ANCESTOR_LIMIT):
-            (txid, sent_value) = chain_transaction(self.nodes[0], [txid], [0], value, fee, 1)
-            value = sent_value
-            chain.append(txid)
-            # We need the wtxids to check P2P announcements
-            witnesstx = self.nodes[0].gettransaction(txid=txid, verbose=True)['decoded']
-            witness_chain.append(witnesstx['hash'])
 
+        for i, t in enumerate(chain):
+            ancestor_vsize += t["tx"].get_vsize()
+            ancestor_fees += t["fee"]
+            self.wallet.sendrawtransaction(from_node=self.nodes[0], tx_hex=t["hex"])
             # Check that listunspent ancestor{count, size, fees} yield the correct results
-            wallet_unspent = self.nodes[0].listunspent(minconf=0)
-            this_unspent = next(utxo_info for utxo_info in wallet_unspent if utxo_info['txid'] == txid)
-            assert_equal(this_unspent['ancestorcount'], i + 1)
-            ancestor_vsize += self.nodes[0].getrawtransaction(txid=txid, verbose=True)['vsize']
-            assert_equal(this_unspent['ancestorsize'], ancestor_vsize)
-            ancestor_fees -= self.nodes[0].gettransaction(txid=txid)['fee']
-            assert_equal(this_unspent['ancestorfees'], ancestor_fees * COIN)
+            if self.is_specified_wallet_compiled():
+                wallet_unspent = self.nodes[0].listunspent(minconf=0)
+                this_unspent = next(utxo_info for utxo_info in wallet_unspent if utxo_info["txid"] == t["txid"])
+                assert_equal(this_unspent['ancestorcount'], i + 1)
+                assert_equal(this_unspent['ancestorsize'], ancestor_vsize)
+                assert_equal(this_unspent['ancestorfees'], ancestor_fees * COIN)
 
         # Wait until mempool transactions have passed initial broadcast (sent inv and received getdata)
         # Otherwise, getrawmempool may be inconsistent with getmempoolentry if unbroadcast changes in between
@@ -99,15 +87,20 @@ class MempoolPackagesTest(BitcoinTestFramework):
         ancestor_count = DEFAULT_ANCESTOR_LIMIT
         assert_equal(ancestor_fees, sum([mempool[tx]['fees']['base'] for tx in mempool]))
 
+        # Adding one more transaction on to the chain should fail.
+        next_hop = self.wallet.create_self_transfer(utxo_to_spend=chain[-1]["new_utxo"])["hex"]
+        assert_raises_rpc_error(-26, "too-long-mempool-chain", lambda: self.nodes[0].sendrawtransaction(next_hop))
+
         descendants = []
-        ancestors = list(chain)
+        ancestors = [t["txid"] for t in chain]
+        chain = [t["txid"] for t in chain]
         for x in reversed(chain):
             # Check that getmempoolentry is consistent with getrawmempool
             entry = self.nodes[0].getmempoolentry(x)
             assert_equal(entry, mempool[x])
 
             # Check that gettxspendingprevout is consistent with getrawmempool
-            witnesstx = self.nodes[0].gettransaction(txid=x, verbose=True)['decoded']
+            witnesstx = self.nodes[0].getrawtransaction(txid=x, verbose=True)
             for tx_in in witnesstx["vin"]:
                 spending_result = self.nodes[0].gettxspendingprevout([ {'txid' : tx_in["txid"], 'vout' : tx_in["vout"]} ])
                 assert_equal(spending_result, [ {'txid' : tx_in["txid"], 'vout' : tx_in["vout"], 'spendingtxid' : x} ])
@@ -193,9 +186,6 @@ class MempoolPackagesTest(BitcoinTestFramework):
             descendant_fees += entry['fees']['base']
             assert_equal(entry['fees']['descendant'], descendant_fees + Decimal('0.00001'))
 
-        # Adding one more transaction on to the chain should fail.
-        assert_raises_rpc_error(-26, "too-long-mempool-chain", chain_transaction, self.nodes[0], [txid], [vout], value, fee, 1)
-
         # Check that prioritising a tx before it's added to the mempool works
         # First clear the mempool by mining a block.
         self.generate(self.nodes[0], 1)
@@ -232,28 +222,23 @@ class MempoolPackagesTest(BitcoinTestFramework):
         # TODO: test ancestor size limits
 
         # Now test descendant chain limits
-        txid = utxo[1]['txid']
-        value = utxo[1]['amount']
-        vout = utxo[1]['vout']
 
-        transaction_package = []
         tx_children = []
         # First create one parent tx with 10 children
-        (txid, sent_value) = chain_transaction(self.nodes[0], [txid], [vout], value, fee, 10)
-        parent_transaction = txid
-        for i in range(10):
-            transaction_package.append({'txid': txid, 'vout': i, 'amount': sent_value})
+        tx_with_children = self.wallet.send_self_transfer_multi(from_node=self.nodes[0], num_outputs=10)
+        parent_transaction = tx_with_children["txid"]
+        transaction_package = tx_with_children["new_utxos"]
 
         # Sign and send up to MAX_DESCENDANT transactions chained off the parent tx
         chain = [] # save sent txs for the purpose of checking node1's mempool later (see below)
         for _ in range(DEFAULT_DESCENDANT_LIMIT - 1):
             utxo = transaction_package.pop(0)
-            (txid, sent_value) = chain_transaction(self.nodes[0], [utxo['txid']], [utxo['vout']], utxo['amount'], fee, 10)
+            new_tx = self.wallet.send_self_transfer_multi(from_node=self.nodes[0], num_outputs=10, utxos_to_spend=[utxo])
+            txid = new_tx["txid"]
             chain.append(txid)
             if utxo['txid'] is parent_transaction:
                 tx_children.append(txid)
-            for j in range(10):
-                transaction_package.append({'txid': txid, 'vout': j, 'amount': sent_value})
+            transaction_package.extend(new_tx["new_utxos"])
 
         mempool = self.nodes[0].getrawmempool(True)
         assert_equal(mempool[parent_transaction]['descendantcount'], DEFAULT_DESCENDANT_LIMIT)
@@ -263,8 +248,8 @@ class MempoolPackagesTest(BitcoinTestFramework):
             assert_equal(mempool[child]['depends'], [parent_transaction])
 
         # Sending one more chained transaction will fail
-        utxo = transaction_package.pop(0)
-        assert_raises_rpc_error(-26, "too-long-mempool-chain", chain_transaction, self.nodes[0], [utxo['txid']], [utxo['vout']], utxo['amount'], fee, 10)
+        next_hop = self.wallet.create_self_transfer(utxo_to_spend=transaction_package.pop(0))["hex"]
+        assert_raises_rpc_error(-26, "too-long-mempool-chain", lambda: self.nodes[0].sendrawtransaction(next_hop))
 
         # Check that node1's mempool is as expected, containing:
         # - txs from previous ancestor test (-> custom ancestor limit)
@@ -304,42 +289,19 @@ class MempoolPackagesTest(BitcoinTestFramework):
         # last block.
 
         # Create tx0 with 2 outputs
-        utxo = self.nodes[0].listunspent()
-        txid = utxo[0]['txid']
-        value = utxo[0]['amount']
-        vout = utxo[0]['vout']
-
-        send_value = (value - fee) / 2
-        inputs = [ {'txid' : txid, 'vout' : vout} ]
-        outputs = {}
-        for _ in range(2):
-            outputs[self.nodes[0].getnewaddress()] = send_value
-        rawtx = self.nodes[0].createrawtransaction(inputs, outputs)
-        signedtx = self.nodes[0].signrawtransactionwithwallet(rawtx)
-        txid = self.nodes[0].sendrawtransaction(signedtx['hex'])
-        tx0_id = txid
-        value = send_value
+        tx0 = self.wallet.send_self_transfer_multi(from_node=self.nodes[0], num_outputs=2)
 
         # Create tx1
-        tx1_id, _ = chain_transaction(self.nodes[0], [tx0_id], [0], value, fee, 1)
+        tx1 = self.wallet.send_self_transfer(from_node=self.nodes[0], utxo_to_spend=tx0["new_utxos"][0])
 
         # Create tx2-7
-        vout = 1
-        txid = tx0_id
-        for _ in range(6):
-            (txid, sent_value) = chain_transaction(self.nodes[0], [txid], [vout], value, fee, 1)
-            vout = 0
-            value = sent_value
+        tx7 = self.wallet.send_self_transfer_chain(from_node=self.nodes[0], utxo_to_spend=tx0["new_utxos"][1], chain_length=6)[-1]
 
         # Mine these in a block
         self.generate(self.nodes[0], 1)
 
         # Now generate tx8, with a big fee
-        inputs = [ {'txid' : tx1_id, 'vout': 0}, {'txid' : txid, 'vout': 0} ]
-        outputs = { self.nodes[0].getnewaddress() : send_value + value - 4*fee }
-        rawtx = self.nodes[0].createrawtransaction(inputs, outputs)
-        signedtx = self.nodes[0].signrawtransactionwithwallet(rawtx)
-        txid = self.nodes[0].sendrawtransaction(signedtx['hex'])
+        self.wallet.send_self_transfer_multi(from_node=self.nodes[0], utxos_to_spend=[tx1["new_utxo"], tx7["new_utxo"]], fee_per_output=40000)
         self.sync_mempools()
 
         # Now try to disconnect the tip on each node...

--- a/test/functional/rpc_packages.py
+++ b/test/functional/rpc_packages.py
@@ -128,8 +128,8 @@ class RPCPackagesTest(BitcoinTestFramework):
         node = self.nodes[0]
 
         chain = self.wallet.create_self_transfer_chain(chain_length=25)
-        chain_hex = chain["chain_hex"]
-        chain_txns = chain["chain_txns"]
+        chain_hex = [t["hex"] for t in chain]
+        chain_txns = [t["tx"] for t in chain]
 
         self.log.info("Check that testmempoolaccept requires packages to be sorted by dependency")
         assert_equal(node.testmempoolaccept(rawtxs=chain_hex[::-1]),
@@ -374,7 +374,7 @@ class RPCPackagesTest(BitcoinTestFramework):
 
         self.log.info("Submitpackage only allows packages of 1 child with its parents")
         # Chain of 3 transactions has too many generations
-        chain_hex = self.wallet.create_self_transfer_chain(chain_length=25)["chain_hex"]
+        chain_hex = [t["hex"] for t in self.wallet.create_self_transfer_chain(chain_length=25)]
         assert_raises_rpc_error(-25, "not-child-with-parents", node.submitpackage, chain_hex)
 
 

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -488,28 +488,6 @@ def find_output(node, txid, amount, *, blockhash=None):
     raise RuntimeError("find_output txid %s : %s not found" % (txid, str(amount)))
 
 
-def chain_transaction(node, parent_txids, vouts, value, fee, num_outputs):
-    """Build and send a transaction that spends the given inputs (specified
-    by lists of parent_txid:vout each), with the desired total value and fee,
-    equally divided up to the desired number of outputs.
-
-    Returns a tuple with the txid and the amount sent per output.
-    """
-    send_value = satoshi_round((value - fee)/num_outputs)
-    inputs = []
-    for (txid, vout) in zip(parent_txids, vouts):
-        inputs.append({'txid' : txid, 'vout' : vout})
-    outputs = {}
-    for _ in range(num_outputs):
-        outputs[node.getnewaddress()] = send_value
-    rawtx = node.createrawtransaction(inputs, outputs, 0, True)
-    signedtx = node.signrawtransactionwithwallet(rawtx)
-    txid = node.sendrawtransaction(signedtx['hex'])
-    fulltx = node.getrawtransaction(txid, 1)
-    assert len(fulltx['vout']) == num_outputs  # make sure we didn't generate a change output
-    return (txid, send_value)
-
-
 # Create large OP_RETURN txouts that can be appended to a transaction
 # to make it large (helper for constructing large transactions). The
 # total serialized size of the txouts is about 66k vbytes.

--- a/test/functional/test_framework/wallet.py
+++ b/test/functional/test_framework/wallet.py
@@ -298,6 +298,9 @@ class MiniWallet:
         inputs_value_total = sum([int(COIN * utxo['value']) for utxo in utxos_to_spend])
         outputs_value_total = inputs_value_total - fee_per_output * num_outputs
         amount_per_output = amount_per_output or (outputs_value_total // num_outputs)
+        assert amount_per_output > 0
+        outputs_value_total = amount_per_output * num_outputs
+        fee = Decimal(inputs_value_total - outputs_value_total) / COIN
 
         # create tx
         tx = CTransaction()
@@ -320,6 +323,7 @@ class MiniWallet:
                 coinbase=False,
                 confirmations=0,
             ) for i in range(len(tx.vout))],
+            "fee": fee,
             "txid": txid,
             "wtxid": tx.getwtxid(),
             "hex": tx.serialize().hex(),
@@ -339,7 +343,6 @@ class MiniWallet:
         else:
             assert False
         send_value = utxo_to_spend["value"] - (fee or (fee_rate * vsize / 1000))
-        assert send_value > 0
 
         # create tx
         tx = self.create_self_transfer_multi(utxos_to_spend=[utxo_to_spend], locktime=locktime, sequence=sequence, amount_per_output=int(COIN * send_value), target_weight=target_weight)

--- a/test/functional/test_framework/wallet.py
+++ b/test/functional/test_framework/wallet.py
@@ -321,6 +321,7 @@ class MiniWallet:
                 confirmations=0,
             ) for i in range(len(tx.vout))],
             "txid": txid,
+            "wtxid": tx.getwtxid(),
             "hex": tx.serialize().hex(),
             "tx": tx,
         }
@@ -344,8 +345,9 @@ class MiniWallet:
         tx = self.create_self_transfer_multi(utxos_to_spend=[utxo_to_spend], locktime=locktime, sequence=sequence, amount_per_output=int(COIN * send_value), target_weight=target_weight)
         if not target_weight:
             assert_equal(tx["tx"].get_vsize(), vsize)
+        tx["new_utxo"] = tx.pop("new_utxos")[0]
 
-        return {"txid": tx["txid"], "wtxid": tx["tx"].getwtxid(), "hex": tx["hex"], "tx": tx["tx"], "new_utxo": tx["new_utxos"][0]}
+        return tx
 
     def sendrawtransaction(self, *, from_node, tx_hex, maxfeerate=0, **kwargs):
         txid = from_node.sendrawtransaction(hexstring=tx_hex, maxfeerate=maxfeerate, **kwargs)

--- a/test/functional/test_framework/wallet.py
+++ b/test/functional/test_framework/wallet.py
@@ -180,12 +180,12 @@ class MiniWallet:
             tx.vin[0].scriptSig = CScript([der_sig + bytes(bytearray([SIGHASH_ALL]))])
             tx.rehash()
         elif self._mode == MiniWalletMode.RAW_OP_TRUE:
-            for i in range(len(tx.vin)):
-                tx.vin[i].scriptSig = CScript([OP_NOP] * 43)  # pad to identical size
+            for i in tx.vin:
+                i.scriptSig = CScript([OP_NOP] * 43)  # pad to identical size
         elif self._mode == MiniWalletMode.ADDRESS_OP_TRUE:
             tx.wit.vtxinwit = [CTxInWitness()] * len(tx.vin)
-            for i in range(len(tx.vin)):
-                tx.wit.vtxinwit[i].scriptWitness.stack = [CScript([OP_TRUE]), bytes([LEAF_VERSION_TAPSCRIPT]) + self._internal_key]
+            for i in tx.wit.vtxinwit:
+                i.scriptWitness.stack = [CScript([OP_TRUE]), bytes([LEAF_VERSION_TAPSCRIPT]) + self._internal_key]
         else:
             assert False
 
@@ -301,7 +301,7 @@ class MiniWallet:
 
         # create tx
         tx = CTransaction()
-        tx.vin = [CTxIn(COutPoint(int(utxo_to_spend['txid'], 16), utxo_to_spend['vout']), nSequence=seq) for utxo_to_spend,seq in zip(utxos_to_spend, sequence)]
+        tx.vin = [CTxIn(COutPoint(int(utxo_to_spend['txid'], 16), utxo_to_spend['vout']), nSequence=seq) for utxo_to_spend, seq in zip(utxos_to_spend, sequence)]
         tx.vout = [CTxOut(amount_per_output, bytearray(self._scriptPubKey)) for _ in range(num_outputs)]
         tx.nLockTime = locktime
 


### PR DESCRIPTION
This allows to run the test even when no wallet is compiled in.

Also, it is a lot nicer to read now.