### PR TITLE
wallet: Migrate non-HD keys with single combo containing a list of keys

### DIFF
--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -85,6 +85,8 @@ bench_bench_bitcoin_SOURCES += bench/coin_selection.cpp
 bench_bench_bitcoin_SOURCES += bench/wallet_balance.cpp
 bench_bench_bitcoin_SOURCES += bench/wallet_loading.cpp
 bench_bench_bitcoin_SOURCES += bench/wallet_create_tx.cpp
+bench_bench_bitcoin_SOURCES += bench/wallet_ismine.cpp
+
 bench_bench_bitcoin_LDADD += $(BDB_LIBS) $(SQLITE_LIBS)
 endif
 

--- a/src/bench/wallet_ismine.cpp
+++ b/src/bench/wallet_ismine.cpp
@@ -1,0 +1,95 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <bench/bench.h>
+#include <interfaces/chain.h>
+#include <key.h>
+#include <key_io.h>
+#include <node/context.h>
+#include <test/util/setup_common.h>
+#include <util/translation.h>
+#include <validationinterface.h>
+#include <wallet/context.h>
+#include <wallet/wallet.h>
+#include <wallet/walletutil.h>
+#include <wallet/test/util.h>
+
+namespace wallet {
+static void WalletIsMine(benchmark::Bench& bench, bool legacy_wallet, int num_combo = 0, bool keys_list = false)
+{
+    const auto test_setup = MakeNoLogFileContext<TestingSetup>();
+    test_setup->m_args.ForceSetArg("-unsafesqlitesync", "1");
+
+    WalletContext context;
+    context.args = &test_setup->m_args;
+    context.chain = test_setup->m_node.chain.get();
+
+    // Setup the wallet
+    // Loading the wallet will also create it
+    uint64_t create_flags = 0;
+    if (!legacy_wallet) {
+        create_flags = WALLET_FLAG_DESCRIPTORS;
+    }
+    auto database = CreateMockableWalletDatabase();
+    auto wallet = TestLoadWallet(std::move(database), context, create_flags);
+
+    // For a descriptor wallet, fill with num_combo combo descriptors with random keys
+    // This benchmarks a non-HD wallet migrated to descriptors
+    if (!legacy_wallet && num_combo > 0) {
+        LOCK(wallet->cs_wallet);
+        if (keys_list) {
+            std::string desc_str = "combo({";
+            for (int i = 0; i < num_combo; ++i) {
+                CKey key;
+                key.MakeNewKey(/*fCompressed=*/true);
+                desc_str += EncodeSecret(key) + ",";
+            }
+            desc_str.pop_back();
+            desc_str += "})";
+
+            FlatSigningProvider keys;
+            std::string error;
+            std::unique_ptr<Descriptor> desc = Parse(desc_str, keys, error, /*require_checksum=*/false);
+            WalletDescriptor w_desc(std::move(desc), /*creation_time=*/0, /*range_start=*/0, /*range_end=*/0, /*next_index=*/0);
+            auto spkm = wallet->AddWalletDescriptor(w_desc, keys, /*label=*/"", /*internal=*/false);
+            assert(spkm);
+        } else {
+            for (int i = 0; i < num_combo; ++i) {
+                CKey key;
+                key.MakeNewKey(/*fCompressed=*/true);
+                FlatSigningProvider keys;
+                std::string error;
+                std::unique_ptr<Descriptor> desc = Parse("combo(" + EncodeSecret(key) + ")", keys, error, /*require_checksum=*/false);
+                WalletDescriptor w_desc(std::move(desc), /*creation_time=*/0, /*range_start=*/0, /*range_end=*/0, /*next_index=*/0);
+                auto spkm = wallet->AddWalletDescriptor(w_desc, keys, /*label=*/"", /*internal=*/false);
+                assert(spkm);
+            }
+        }
+    }
+
+    const CScript script = GetScriptForDestination(DecodeDestination(ADDRESS_BCRT1_UNSPENDABLE));
+
+    bench.run([&] {
+        LOCK(wallet->cs_wallet);
+        isminetype mine = wallet->IsMine(script);
+        assert(mine == ISMINE_NO);
+    });
+
+    TestUnloadWallet(std::move(wallet));
+}
+
+#ifdef USE_BDB
+static void WalletIsMineLegacy(benchmark::Bench& bench) { WalletIsMine(bench, /*legacy_wallet=*/true); }
+BENCHMARK(WalletIsMineLegacy, benchmark::PriorityLevel::LOW);
+#endif
+
+#ifdef USE_SQLITE
+static void WalletIsMineDescriptors(benchmark::Bench& bench) { WalletIsMine(bench, /*legacy_wallet=*/false); }
+static void WalletIsMineManyDescriptors(benchmark::Bench& bench) { WalletIsMine(bench, /*legacy_wallet=*/false, /*num_combo=*/2000); }
+static void WalletIsMineDescriptorsKeysList(benchmark::Bench& bench) { WalletIsMine(bench, /*legacy_wallet=*/false, /*num_combo=*/2000, /*keys_list=*/true); }
+BENCHMARK(WalletIsMineDescriptors, benchmark::PriorityLevel::LOW);
+BENCHMARK(WalletIsMineManyDescriptors, benchmark::PriorityLevel::LOW);
+BENCHMARK(WalletIsMineDescriptorsKeysList, benchmark::PriorityLevel::LOW);
+#endif
+} // namespace wallet

--- a/src/key.h
+++ b/src/key.h
@@ -73,6 +73,10 @@ public:
             a.size() == b.size() &&
             memcmp(a.keydata.data(), b.keydata.data(), a.size()) == 0;
     }
+    friend bool operator<(const CKey& a, const CKey& b)
+    {
+        return a.GetPubKey() < b.GetPubKey();
+    }
 
     //! Initialize using begin and end iterators to byte data.
     template <typename T>

--- a/src/script/descriptor.cpp
+++ b/src/script/descriptor.cpp
@@ -186,7 +186,7 @@ public:
      *  write_cache is the cache to write keys to (if not nullptr)
      *  Caches are not exclusive but this is not tested. Currently we use them exclusively
      */
-    virtual bool GetPubKey(int pos, const SigningProvider& arg, CPubKey& key, KeyOriginInfo& info, const DescriptorCache* read_cache = nullptr, DescriptorCache* write_cache = nullptr) const = 0;
+    virtual bool GetPubKey(uint32_t pos, const SigningProvider& arg, CPubKey& key, KeyOriginInfo& info, const DescriptorCache* read_cache = nullptr, DescriptorCache* write_cache = nullptr) const = 0;
 
     /** Whether this represent multiple public keys at different positions. */
     virtual bool IsRange() const = 0;
@@ -229,7 +229,7 @@ class OriginPubkeyProvider final : public PubkeyProvider
 
 public:
     OriginPubkeyProvider(uint32_t exp_index, KeyOriginInfo info, std::unique_ptr<PubkeyProvider> provider, bool apostrophe) : PubkeyProvider(exp_index), m_origin(std::move(info)), m_provider(std::move(provider)), m_apostrophe(apostrophe) {}
-    bool GetPubKey(int pos, const SigningProvider& arg, CPubKey& key, KeyOriginInfo& info, const DescriptorCache* read_cache = nullptr, DescriptorCache* write_cache = nullptr) const override
+    bool GetPubKey(uint32_t pos, const SigningProvider& arg, CPubKey& key, KeyOriginInfo& info, const DescriptorCache* read_cache = nullptr, DescriptorCache* write_cache = nullptr) const override
     {
         if (!m_provider->GetPubKey(pos, arg, key, info, read_cache, write_cache)) return false;
         std::copy(std::begin(m_origin.fingerprint), std::end(m_origin.fingerprint), info.fingerprint);
@@ -275,7 +275,7 @@ class ConstPubkeyProvider final : public PubkeyProvider
 
 public:
     ConstPubkeyProvider(uint32_t exp_index, const CPubKey& pubkey, bool xonly) : PubkeyProvider(exp_index), m_pubkey(pubkey), m_xonly(xonly) {}
-    bool GetPubKey(int pos, const SigningProvider& arg, CPubKey& key, KeyOriginInfo& info, const DescriptorCache* read_cache = nullptr, DescriptorCache* write_cache = nullptr) const override
+    bool GetPubKey(uint32_t pos, const SigningProvider& arg, CPubKey& key, KeyOriginInfo& info, const DescriptorCache* read_cache = nullptr, DescriptorCache* write_cache = nullptr) const override
     {
         key = m_pubkey;
         info.path.clear();
@@ -319,7 +319,7 @@ class ListPubkeyProvider final : public PubkeyProvider
 
 public:
     ListPubkeyProvider(uint32_t exp_index, std::vector<std::unique_ptr<PubkeyProvider>> pubkeys) : PubkeyProvider(exp_index), m_pubkeys(std::move(pubkeys)) {}
-    bool GetPubKey(int pos, const SigningProvider& arg, CPubKey& key, KeyOriginInfo& info, const DescriptorCache* read_cache = nullptr, DescriptorCache* write_cache = nullptr) const override
+    bool GetPubKey(uint32_t pos, const SigningProvider& arg, CPubKey& key, KeyOriginInfo& info, const DescriptorCache* read_cache = nullptr, DescriptorCache* write_cache = nullptr) const override
     {
         if ((size_t)pos >= m_pubkeys.size()) {
             return false;
@@ -429,7 +429,7 @@ public:
     BIP32PubkeyProvider(uint32_t exp_index, const CExtPubKey& extkey, KeyPath path, DeriveType derive, bool apostrophe) : PubkeyProvider(exp_index), m_root_extkey(extkey), m_path(std::move(path)), m_derive(derive), m_apostrophe(apostrophe) {}
     bool IsRange() const override { return m_derive != DeriveType::NO; }
     size_t GetSize() const override { return 33; }
-    bool GetPubKey(int pos, const SigningProvider& arg, CPubKey& key_out, KeyOriginInfo& final_info_out, const DescriptorCache* read_cache = nullptr, DescriptorCache* write_cache = nullptr) const override
+    bool GetPubKey(uint32_t pos, const SigningProvider& arg, CPubKey& key_out, KeyOriginInfo& final_info_out, const DescriptorCache* read_cache = nullptr, DescriptorCache* write_cache = nullptr) const override
     {
         // Info of parent of the to be derived pubkey
         KeyOriginInfo parent_info;


### PR DESCRIPTION
Based on #26626

This PR changes the legacy to descriptor wallet migration from creating a new `combo()` for every individual key to creating one large `combo()` that has a list of every key. This improves the performance of the migrated wallet as it will only have one DescriptorSPKM for all of the non-HD keys.

Note that this does not affect previously migrated wallets. Such wallets will still have a `combo()` for every key.