### PR TITLE
ci: Use pyenv for the lint task

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -64,18 +64,23 @@ compute_credits_template: &CREDITS_TEMPLATE
   use_compute_credits: $CIRRUS_REPO_FULL_NAME == 'bitcoin/bitcoin' && $CIRRUS_PR != ""
 
 task:
-  name: 'lint [bionic]'
+  name: 'lint [jammy]'
   << : *BASE_TEMPLATE
   container:
-    image: ubuntu:bionic  # For python 3.6, oldest supported version according to doc/dependencies.md
+    image: ubuntu:jammy
     cpu: 1
-    memory: 1G
+    memory: 2G
+  pyenv_cache:
+    folder: '$PYENV_ROOT'
+    fingerprint_script:
+      - cat .python-version
   # For faster CI feedback, immediately schedule the linters
   << : *CREDITS_TEMPLATE
   lint_script:
     - ./ci/lint_run_all.sh
   env:
     << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
+    PYENV_ROOT: '/tmp/pyenv_dir'
 
 task:
   name: 'tidy [jammy]'

--- a/ci/lint/04_install.sh
+++ b/ci/lint/04_install.sh
@@ -7,14 +7,18 @@
 export LC_ALL=C
 
 ${CI_RETRY_EXE} apt-get update
-${CI_RETRY_EXE} apt-get install -y python3-pip curl git gawk jq
-(
-  # Temporary workaround for https://github.com/bitcoin/bitcoin/pull/26130#issuecomment-1260499544
-  # Can be removed once the underlying image is bumped to something that includes git2.34 or later
-  sed -i -e 's/bionic/jammy/g' /etc/apt/sources.list
-  ${CI_RETRY_EXE} apt-get update
-  ${CI_RETRY_EXE} apt-get install -y --reinstall git
-)
+${CI_RETRY_EXE} apt-get install -y --no-install-recommends \
+    curl git gawk jq build-essential clang libbz2-dev \
+    libffi-dev liblzma-dev libncursesw5-dev libreadline-dev \
+    libsqlite3-dev libssl-dev zlib1g-dev
+
+INSTALL_PYENV=$([[ ! -d "${PYENV_ROOT}" ]] && echo true || echo false)
+[[ "${INSTALL_PYENV}" == 'true' ]] && ${CI_RETRY_EXE} curl -sL https://pyenv.run | bash
+export PATH="${PYENV_ROOT}/bin:${PATH}"
+eval "$(pyenv init -)"
+# Python version is determined by the .python-version file in the project root.
+[[ "${INSTALL_PYENV}" == 'true' ]] && CC=clang ${CI_RETRY_EXE} pyenv install
+pyenv local
 
 ${CI_RETRY_EXE} pip3 install codespell==2.2.1
 ${CI_RETRY_EXE} pip3 install flake8==4.0.1


### PR DESCRIPTION
Closes #26548.

1. upgrade Ubuntu Bionic to Jammy
2. use Pyenv to install Python 3.6.5 (The Python version is determined by the [.python-version](https://github.com/bitcoin/bitcoin/blob/master/.python-version) file in the project root)
3. cache `PYENV_ROOT` to skip compiling Python source code after the first run.