### PR TITLE
wallet: bugfix, 'wallet_load_ckey' unit test fails with bdb

### DIFF
--- a/src/wallet/bdb.cpp
+++ b/src/wallet/bdb.cpp
@@ -713,7 +713,7 @@ BerkeleyCursor::~BerkeleyCursor()
 std::unique_ptr<DatabaseCursor> BerkeleyBatch::GetNewCursor()
 {
     if (!pdb) return nullptr;
-    return std::make_unique<BerkeleyCursor>(m_database);
+    return std::make_unique<BerkeleyCursor>(m_database, this);
 }
 
 bool BerkeleyBatch::TxnBegin()


### PR DESCRIPTION
Currently, the test `wallet_load_verif_crypted_key_checksum` fails if configured without sqlite.

There are few reasons for it (chained bugs):

1) As in the test we encrypt the wallet, and the encryption process
requires a db rewrite + environment reload, we cannot use mock dbs
(mock dbs are memory-only).

2) Once the first issue gets solved, the next one is a deadlock inside
`DeleteRecords` due a lack of sync between the opened cursor and
each of the `Erase` calls (they happen on different db txn contexts
so while we traverse the db, we aren't able to erase records).

   Note: I do have a pending research here. Because this should
be affecting other places as well.. (ideally, read-only operations
shouldn't lock the db)

Extra Info:
Have renamed the long and ugly `wallet_load_verif_crypted_key_checksum`
test name to `wallet_load_ckey`.