### PR TITLE
util: Include full version id in bug reports

### DIFF
--- a/src/util/check.cpp
+++ b/src/util/check.cpp
@@ -8,6 +8,7 @@
 #include <config/bitcoin-config.h>
 #endif
 
+#include <clientversion.h>
 #include <tinyformat.h>
 
 #include <cstdio>
@@ -16,7 +17,10 @@
 
 std::string StrFormatInternalBug(const char* msg, const char* file, int line, const char* func)
 {
-    return strprintf("Internal bug detected: \"%s\"\n%s:%d (%s)\nPlease report this issue here: %s\n", msg, file, line, func, PACKAGE_BUGREPORT);
+    return strprintf("Internal bug detected: \"%s\"\n%s:%d (%s)\n"
+                     "%s %s\n"
+                     "Please report this issue here: %s\n",
+                     msg, file, line, func, PACKAGE_NAME, FormatFullVersion(), PACKAGE_BUGREPORT);
 }
 
 NonFatalCheckError::NonFatalCheckError(const char* msg, const char* file, int line, const char* func)


### PR DESCRIPTION
This will show the unique id of the full source code when the bug occurred, which can help debugging