### PR TITLE
test, init: perturb file to ensure failure instead of only deleting them

### DIFF
--- a/test/functional/feature_init.py
+++ b/test/functional/feature_init.py
@@ -45,6 +45,13 @@ class InitStressTest(BitcoinTestFramework):
             node.process.terminate()
             node.process.wait()
 
+        def start_expecting_error(err_fragment):
+            node.assert_start_raises_init_error(
+                extra_args=['-txindex=1', '-blockfilterindex=1', '-coinstatsindex=1'],
+                expected_msg=err_fragment,
+                match=ErrorMatch.PARTIAL_REGEX,
+            )
+
         def check_clean_start():
             """Ensure that node restarts successfully after various interrupts."""
             node.start()
@@ -87,36 +94,27 @@ class InitStressTest(BitcoinTestFramework):
 
         self.log.info("Test startup errors after removing certain essential files")
 
-        files_to_disturb = {
+        files_to_delete = {
             'blocks/index/*.ldb': 'Error opening block database.',
             'chainstate/*.ldb': 'Error opening block database.',
             'blocks/blk*.dat': 'Error loading block database.',
         }
 
-        for file_patt, err_fragment in files_to_disturb.items():
+        files_to_perturb = {
+            'blocks/index/*.ldb': 'Error opening block database.',
+            'chainstate/*.ldb': 'Error opening block database.',
+            'blocks/blk*.dat': 'Error opening block database.',
+        }
+
+        for file_patt, err_fragment in files_to_delete.items():
             target_files = list(node.chain_path.glob(file_patt))
 
             for target_file in target_files:
-                self.log.info(f"Tweaking file to ensure failure {target_file}")
+                self.log.info(f"Deleting file to ensure failure {target_file}")
                 bak_path = str(target_file) + ".bak"
                 target_file.rename(bak_path)
 
-            # TODO: at some point, we should test perturbing the files instead of removing
-            # them, e.g.
-            #
-            # contents = target_file.read_bytes()
-            # tweaked_contents = bytearray(contents)
-            # tweaked_contents[50:250] = b'1' * 200
-            # target_file.write_bytes(bytes(tweaked_contents))
-            #
-            # At the moment I can't get this to work (bitcoind loads successfully?) so
-            # investigate doing this later.
-
-            node.assert_start_raises_init_error(
-                extra_args=['-txindex=1', '-blockfilterindex=1', '-coinstatsindex=1'],
-                expected_msg=err_fragment,
-                match=ErrorMatch.PARTIAL_REGEX,
-            )
+            start_expecting_error(err_fragment)
 
             for target_file in target_files:
                 bak_path = str(target_file) + ".bak"
@@ -126,6 +124,18 @@ class InitStressTest(BitcoinTestFramework):
             check_clean_start()
             self.stop_node(0)
 
+        for file_patt, err_fragment in files_to_perturb.items():
+            target_files = list(node.chain_path.glob(file_patt))
+
+            for target_file in target_files:
+                self.log.info(f"Perturbing file to ensure failure {target_file}")
+                with open(target_file, "rb") as tf_read, open(target_file, "wb") as tf_write:
+                    contents = tf_read.read()
+                    tweaked_contents = bytearray(contents)
+                    tweaked_contents[50:250] = b'1' * 200
+                    tf_write.write(bytes(tweaked_contents))
+
+            start_expecting_error(err_fragment)
 
 if __name__ == '__main__':
     InitStressTest().main()


### PR DESCRIPTION
In `feature_init.py` there is a TODO about perturbing the files instead of only testing by deleting them.
```py
            # TODO: at some point, we should test perturbing the files instead of removing
            # them, e.g.
            #
            # contents = target_file.read_bytes()
            # tweaked_contents = bytearray(contents)
            # tweaked_contents[50:250] = b'1' * 200
            # target_file.write_bytes(bytes(tweaked_contents))
            #
            # At the moment I can't get this to work (bitcoind loads successfully?) so
            # investigate doing this later.
```

This PR adds it by writing into the file random bytes and checking whether it throws an error when starting.