### PR TITLE
test: Fix backwards compatibility intermittent failure

### DIFF
--- a/test/functional/feature_backwards_compatibility.py
+++ b/test/functional/feature_backwards_compatibility.py
@@ -274,6 +274,7 @@ class BackwardsCompatibilityTest(BitcoinTestFramework):
             assert_equal(info["desc"], descsum_create(descriptor))
 
             # Now copy that same wallet back to 0.16 to make sure no automatic upgrade breaks it
+            node_master.unloadwallet("u1_v16")
             os.remove(os.path.join(node_v16_wallets_dir, "wallets/u1_v16"))
             shutil.copyfile(
                 os.path.join(node_master_wallets_dir, "u1_v16"),


### PR DESCRIPTION
Fixes #24400.

See https://github.com/bitcoin/bitcoin/issues/24400#issuecomment-1341531696 to reproduce the failure.

As MarcoFalke suggested in https://github.com/bitcoin/bitcoin/issues/24400#issuecomment-1342282165, it can happen that the wallet is not fully flushed before being copied over to the other node. Fixed by unloading the wallet before copying the file.