### PR TITLE
test: Use last release in compatibility tests

### DIFF
--- a/test/functional/feature_txindex_compatibility.py
+++ b/test/functional/feature_txindex_compatibility.py
@@ -14,7 +14,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.wallet import MiniWallet
 
 
-class MempoolCompatibilityTest(BitcoinTestFramework):
+class TxindexCompatibilityTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 3
         self.extra_args = [
@@ -33,7 +33,7 @@ class MempoolCompatibilityTest(BitcoinTestFramework):
             versions=[
                 160300,  # Last release with legacy txindex
                 None,  # For MiniWallet, without migration code
-                200100,  # Any release with migration code (0.17.x - 22.x)
+                220000,  # Last release with migration code (0.17.x - 22.x)
             ],
         )
         self.start_nodes()
@@ -89,4 +89,4 @@ class MempoolCompatibilityTest(BitcoinTestFramework):
 
 
 if __name__ == "__main__":
-    MempoolCompatibilityTest().main()
+    TxindexCompatibilityTest().main()

--- a/test/functional/mempool_compatibility.py
+++ b/test/functional/mempool_compatibility.py
@@ -7,7 +7,7 @@
 NOTE: The test is designed to prevent cases when compatibility is broken accidentally.
 In case we need to break mempool compatibility we can continue to use the test by just bumping the version number.
 
-The previous release v0.19.1 is required by this test, see test/README.md.
+Previous releases are required by this test, see test/README.md.
 """
 
 import os
@@ -29,7 +29,7 @@ class MempoolCompatibilityTest(BitcoinTestFramework):
 
     def setup_network(self):
         self.add_nodes(self.num_nodes, versions=[
-            190100,  # oldest version with getmempoolinfo.loaded (used to avoid intermittent issues)
+            200100,  # Last release with previous mempool format
             None,
         ])
         self.start_nodes()
@@ -38,6 +38,7 @@ class MempoolCompatibilityTest(BitcoinTestFramework):
         self.log.info("Test that mempool.dat is compatible between versions")
 
         old_node, new_node = self.nodes
+        assert "unbroadcastcount" not in old_node.getmempoolinfo()
         new_wallet = MiniWallet(new_node, mode=MiniWalletMode.RAW_P2PK)
         self.generate(new_wallet, 1, sync_fun=self.no_op)
         self.generate(new_node, COINBASE_MATURITY, sync_fun=self.no_op)


### PR DESCRIPTION
In compatibility tests it makes sense to always use the last release without the new feature, as it is likely more in use than any even older previous release.