### PR TITLE
wallet: if only have one output type, don't perform "mixed" coin selection

### DIFF
--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -524,8 +524,9 @@ std::optional<SelectionResult> AttemptSelection(const CWallet& wallet, const CAm
     if (results.size() > 0) return *std::min_element(results.begin(), results.end());
 
     // If we can't fund the transaction from any individual OutputType, run coin selection one last time
-    // over all available coins, which would allow mixing
-    if (allow_mixed_output_types) {
+    // over all available coins, which would allow mixing.
+    // If TypesCount() <= 1, there is nothing to mix.
+    if (allow_mixed_output_types && available_coins.TypesCount() > 1) {
         if (auto result{ChooseSelectionResult(wallet, nTargetValue, eligibility_filter, available_coins.All(), coin_selection_params)}) {
             return result;
         }

--- a/src/wallet/spend.h
+++ b/src/wallet/spend.h
@@ -46,6 +46,8 @@ struct CoinsResult {
     /** The following methods are provided so that CoinsResult can mimic a vector,
      * i.e., methods can work with individual OutputType vectors or on the entire object */
     size_t Size() const;
+    /** Return how many different output types this struct stores */
+    size_t TypesCount() const { return coins.size(); }
     void Clear();
     void Erase(const std::unordered_set<COutPoint, SaltedOutpointHasher>& coins_to_remove);
     void Shuffle(FastRandomContext& rng_fast);


### PR DESCRIPTION
For wallets that only have one output type, we are currently performing the same
selection process over the same coins twice.

The "mixed coin selection" doesn't add any value to the result
(there is nothing to mix if the available coins struct has only one type).