### PR TITLE
univalue: Remove confusing getBool method

### DIFF
--- a/src/test/system_tests.cpp
+++ b/src/test/system_tests.cpp
@@ -47,7 +47,7 @@ BOOST_AUTO_TEST_CASE(run_command)
         BOOST_CHECK(result.isObject());
         const UniValue& success = find_value(result, "success");
         BOOST_CHECK(!success.isNull());
-        BOOST_CHECK_EQUAL(success.getBool(), true);
+        BOOST_CHECK_EQUAL(success.get_bool(), true);
     }
     {
         // An invalid command is handled by Boost
@@ -95,7 +95,7 @@ BOOST_AUTO_TEST_CASE(run_command)
         BOOST_CHECK(result.isObject());
         const UniValue& success = find_value(result, "success");
         BOOST_CHECK(!success.isNull());
-        BOOST_CHECK_EQUAL(success.getBool(), true);
+        BOOST_CHECK_EQUAL(success.get_bool(), true);
     }
 #endif
 }

--- a/src/univalue/include/univalue.h
+++ b/src/univalue/include/univalue.h
@@ -66,7 +66,6 @@ public:
 
     size_t size() const { return values.size(); }
 
-    bool getBool() const { return isTrue(); }
     void getObjMap(std::map<std::string,UniValue>& kv) const;
     bool checkObject(const std::map<std::string,UniValue::VType>& memberTypes) const;
     const UniValue& operator[](const std::string& key) const;

--- a/src/univalue/lib/univalue_get.cpp
+++ b/src/univalue/lib/univalue_get.cpp
@@ -60,7 +60,7 @@ const std::vector<UniValue>& UniValue::getValues() const
 bool UniValue::get_bool() const
 {
     checkType(VBOOL);
-    return getBool();
+    return isTrue();
 }
 
 const std::string& UniValue::get_str() const

--- a/src/univalue/test/object.cpp
+++ b/src/univalue/test/object.cpp
@@ -193,13 +193,13 @@ void univalue_set()
     BOOST_CHECK_EQUAL(v.isBool(), true);
     BOOST_CHECK_EQUAL(v.isTrue(), false);
     BOOST_CHECK_EQUAL(v.isFalse(), true);
-    BOOST_CHECK_EQUAL(v.getBool(), false);
+    BOOST_CHECK_EQUAL(v.get_bool(), false);
 
     v.setBool(true);
     BOOST_CHECK_EQUAL(v.isBool(), true);
     BOOST_CHECK_EQUAL(v.isTrue(), true);
     BOOST_CHECK_EQUAL(v.isFalse(), false);
-    BOOST_CHECK_EQUAL(v.getBool(), true);
+    BOOST_CHECK_EQUAL(v.get_bool(), true);
 
     BOOST_CHECK_THROW(v.setNumStr("zombocom"), std::runtime_error);
 


### PR DESCRIPTION
Drop `UniValue::getBool` method because it is easy to confuse with the `UniValue::get_bool` method, and could potentially cause bugs. Unlike `get_bool`, `getBool` doesn't ensure that the value is a boolean and returns false for all integer, string, array, and object values instead of throwing an exception.

The `getBool` method is also redundant because it is an alias for `isTrue`. There were only 5 `getBool()` calls in the codebase, so this commit replaces them with `isTrue()` or `get_bool()` calls as appropriate.

These changes were originally made by MarcoFalke in https://github.com/bitcoin/bitcoin/pull/26213 but were dropped to limit the scope of that PR.