### PR TITLE
contrib: Bugfix for checking bad dns seeds without casting in `makeseeds.py`

### DIFF
--- a/contrib/seeds/makeseeds.py
+++ b/contrib/seeds/makeseeds.py
@@ -46,9 +46,15 @@ def parseline(line: str) -> Union[dict, None]:
     """ Parses a line from `seeds_main.txt` into a dictionary of details for that line.
     or `None`, if the line could not be parsed.
     """
+    if line.startswith('#'):
+        # Ignore line that starts with comment
+        return None
     sline = line.split()
     if len(sline) < 11:
         # line too short to be valid, skip it.
+        return None
+    # Skip bad results.
+    if int(sline[1]) == 0:
         return None
     m = PATTERN_IPV4.match(sline[0])
     sortkey = None
@@ -83,9 +89,6 @@ def parseline(line: str) -> Union[dict, None]:
         sortkey = ip
         ipstr = m.group(1)
         port = int(m.group(6))
-    # Skip bad results.
-    if sline[1] == 0:
-        return None
     # Extract uptime %.
     uptime30 = float(sline[7][:-1])
     # Extract Unix timestamp of last success.


### PR DESCRIPTION
- Since seed lines comes with `str` type, comparing `good` column directly with **0** (`int` type) in the if statement was not working at all. This is fixed by casting `int` type to the values in the `good` column of seeds text file.
- Lines that starts with comment in the seeds text file are now ignored.
- If statement for checking bad seeds are moved to the top of the `parseline` function as if a seed is bad; there is no point of going forward from there.

Since this bug-fix eliminates bad seeds over **550k** in the first place, in my case; particular job for parsing all seeds speed is up by **600%** and whole script's speed is up by **%30**.

Note that **stats** in the terminal are not going to include bad seeds after this fix, which would be the same if this bug were never there before.