### PR TITLE
bench: add readblock benchmark

### DIFF
--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -46,6 +46,7 @@ bench_bench_bitcoin_SOURCES = \
   bench/poly1305.cpp \
   bench/pool.cpp \
   bench/prevector.cpp \
+  bench/readblock.cpp \
   bench/rollingbloom.cpp \
   bench/rpc_blockchain.cpp \
   bench/rpc_mempool.cpp \

--- a/src/bench/readblock.cpp
+++ b/src/bench/readblock.cpp
@@ -1,0 +1,53 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <bench/bench.h>
+#include <bench/data.h>
+
+#include <consensus/validation.h>
+#include <node/blockstorage.h>
+#include <streams.h>
+#include <test/util/setup_common.h>
+#include <util/chaintype.h>
+#include <validation.h>
+
+static FlatFilePos WriteBlockToDisk(ChainstateManager& chainman)
+{
+    DataStream stream{benchmark::data::block413567};
+    CBlock block;
+    stream >> TX_WITH_WITNESS(block);
+
+    return chainman.m_blockman.SaveBlockToDisk(block, 0, nullptr);
+}
+
+static void ReadBlockFromDiskTest(benchmark::Bench& bench)
+{
+    const auto testing_setup{MakeNoLogFileContext<const TestingSetup>(ChainType::MAIN)};
+    ChainstateManager& chainman{*testing_setup->m_node.chainman};
+
+    CBlock block;
+    const auto pos{WriteBlockToDisk(chainman)};
+
+    bench.run([&] {
+        const auto success{chainman.m_blockman.ReadBlockFromDisk(block, pos)};
+        assert(success);
+    });
+}
+
+static void ReadRawBlockFromDiskTest(benchmark::Bench& bench)
+{
+    const auto testing_setup{MakeNoLogFileContext<const TestingSetup>(ChainType::MAIN)};
+    ChainstateManager& chainman{*testing_setup->m_node.chainman};
+
+    std::vector<uint8_t> block_data;
+    const auto pos{WriteBlockToDisk(chainman)};
+
+    bench.run([&] {
+        const auto success{chainman.m_blockman.ReadRawBlockFromDisk(block_data, pos)};
+        assert(success);
+    });
+}
+
+BENCHMARK(ReadBlockFromDiskTest, benchmark::PriorityLevel::HIGH);
+BENCHMARK(ReadRawBlockFromDiskTest, benchmark::PriorityLevel::HIGH);


### PR DESCRIPTION
Requested in https://github.com/bitcoin/bitcoin/pull/13151#issuecomment-385962450.
See https://github.com/bitcoin/bitcoin/pull/26415 and https://github.com/bitcoin/bitcoin/pull/21319.

Benchmarking shows a >50x increase in speed on both nvme and spinning disk.

Benchmark results:
|               ns/op |                op/s |    err% |          ins/op |          cyc/op |    IPC |         bra/op |   miss% |     total | benchmark
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:----------
|        5,377,375.00 |              185.96 |    0.2% |   60,125,513.00 |   11,633,676.00 |  5.168 |   3,588,800.00 |    0.4% |      0.09 | `ReadBlockFromDiskTest`

|               ns/op |                op/s |    err% |          ins/op |          cyc/op |    IPC |         bra/op |   miss% |     total | benchmark
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:----------
|           89,945.58 |           11,117.83 |    0.7% |       12,743.90 |       64,530.33 |  0.197 |       2,595.20 |    0.2% |      0.01 | `ReadRawBlockFromDiskTest`