### PR TITLE
Move `CopyrightHolders()` and `LicenseInfo()` into `libbitcoin_common`

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -133,6 +133,7 @@ BITCOIN_CORE_H = \
   clientversion.h \
   coins.h \
   common/bloom.h \
+  common/license.h \
   common/run_command.h \
   common/url.h \
   compat/assumptions.h \
@@ -634,6 +635,7 @@ libbitcoin_common_a_SOURCES = \
   coins.cpp \
   common/bloom.cpp \
   common/interfaces.cpp \
+  common/license.cpp \
   common/run_command.cpp \
   compressor.cpp \
   core_read.cpp \

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -9,6 +9,7 @@
 
 #include <chainparamsbase.h>
 #include <clientversion.h>
+#include <common/license.h>
 #include <common/url.h>
 #include <compat/compat.h>
 #include <compat/stdin.h>

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -8,6 +8,7 @@
 
 #include <clientversion.h>
 #include <coins.h>
+#include <common/license.h>
 #include <compat/compat.h>
 #include <consensus/amount.h>
 #include <consensus/consensus.h>

--- a/src/bitcoin-util.cpp
+++ b/src/bitcoin-util.cpp
@@ -11,6 +11,7 @@
 #include <chainparams.h>
 #include <chainparamsbase.h>
 #include <clientversion.h>
+#include <common/license.h>
 #include <compat/compat.h>
 #include <core_io.h>
 #include <streams.h>

--- a/src/bitcoin-wallet.cpp
+++ b/src/bitcoin-wallet.cpp
@@ -9,6 +9,7 @@
 #include <chainparams.h>
 #include <chainparamsbase.h>
 #include <clientversion.h>
+#include <common/license.h>
 #include <common/url.h>
 #include <compat/compat.h>
 #include <interfaces/init.h>

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -9,6 +9,7 @@
 
 #include <chainparams.h>
 #include <clientversion.h>
+#include <common/license.h>
 #include <common/url.h>
 #include <compat/compat.h>
 #include <init.h>

--- a/src/clientversion.cpp
+++ b/src/clientversion.cpp
@@ -3,7 +3,6 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <clientversion.h>
-#include <util/translation.h>
 
 #include <tinyformat.h>
 
@@ -75,33 +74,4 @@ std::string FormatSubVersion(const std::string& name, int nClientVersion, const 
     }
     ss << "/";
     return ss.str();
-}
-
-std::string CopyrightHolders(const std::string& strPrefix)
-{
-    const auto copyright_devs = strprintf(_(COPYRIGHT_HOLDERS).translated, COPYRIGHT_HOLDERS_SUBSTITUTION);
-    std::string strCopyrightHolders = strPrefix + copyright_devs;
-
-    // Make sure Bitcoin Core copyright is not removed by accident
-    if (copyright_devs.find("Bitcoin Core") == std::string::npos) {
-        strCopyrightHolders += "\n" + strPrefix + "The Bitcoin Core developers";
-    }
-    return strCopyrightHolders;
-}
-
-std::string LicenseInfo()
-{
-    const std::string URL_SOURCE_CODE = "<https://github.com/bitcoin/bitcoin>";
-
-    return CopyrightHolders(strprintf(_("Copyright (C) %i-%i").translated, 2009, COPYRIGHT_YEAR) + " ") + "\n" +
-           "\n" +
-           strprintf(_("Please contribute if you find %s useful. "
-                       "Visit %s for further information about the software.").translated, PACKAGE_NAME, "<" PACKAGE_URL ">") +
-           "\n" +
-           strprintf(_("The source code is available from %s.").translated, URL_SOURCE_CODE) +
-           "\n" +
-           "\n" +
-           _("This is experimental software.").translated + "\n" +
-           strprintf(_("Distributed under the MIT software license, see the accompanying file %s or %s").translated, "COPYING", "<https://opensource.org/licenses/MIT>") +
-           "\n";
 }

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -41,11 +41,6 @@ extern const std::string CLIENT_NAME;
 std::string FormatFullVersion();
 std::string FormatSubVersion(const std::string& name, int nClientVersion, const std::vector<std::string>& comments);
 
-std::string CopyrightHolders(const std::string& strPrefix);
-
-/** Returns licensing information (for -version) */
-std::string LicenseInfo();
-
 #endif // WINDRES_PREPROC
 
 #endif // BITCOIN_CLIENTVERSION_H

--- a/src/common/license.cpp
+++ b/src/common/license.cpp
@@ -1,0 +1,43 @@
+// Copyright (c) 2015-2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <common/license.h>
+
+#if defined(HAVE_CONFIG_H)
+#include <config/bitcoin-config.h>
+#endif // HAVE_CONFIG_H
+
+#include <tinyformat.h>
+#include <util/translation.h>
+
+#include <string>
+
+std::string CopyrightHolders(const std::string& strPrefix)
+{
+    const auto copyright_devs = strprintf(_(COPYRIGHT_HOLDERS).translated, COPYRIGHT_HOLDERS_SUBSTITUTION);
+    std::string strCopyrightHolders = strPrefix + copyright_devs;
+
+    // Make sure Bitcoin Core copyright is not removed by accident
+    if (copyright_devs.find("Bitcoin Core") == std::string::npos) {
+        strCopyrightHolders += "\n" + strPrefix + "The Bitcoin Core developers";
+    }
+    return strCopyrightHolders;
+}
+
+std::string LicenseInfo()
+{
+    const std::string URL_SOURCE_CODE = "<https://github.com/bitcoin/bitcoin>";
+
+    return CopyrightHolders(strprintf(_("Copyright (C) %i-%i").translated, 2009, COPYRIGHT_YEAR) + " ") + "\n" +
+           "\n" +
+           strprintf(_("Please contribute if you find %s useful. "
+                       "Visit %s for further information about the software.").translated, PACKAGE_NAME, "<" PACKAGE_URL ">") +
+           "\n" +
+           strprintf(_("The source code is available from %s.").translated, URL_SOURCE_CODE) +
+           "\n" +
+           "\n" +
+           _("This is experimental software.").translated + "\n" +
+           strprintf(_("Distributed under the MIT software license, see the accompanying file %s or %s").translated, "COPYING", "<https://opensource.org/licenses/MIT>") +
+           "\n";
+}

--- a/src/common/license.h
+++ b/src/common/license.h
@@ -1,0 +1,15 @@
+// Copyright (c) 2015-2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_COMMON_LICENSE_H
+#define BITCOIN_COMMON_LICENSE_H
+
+#include <string>
+
+std::string CopyrightHolders(const std::string& strPrefix);
+
+/** Returns licensing information (for -version) */
+std::string LicenseInfo();
+
+#endif // BITCOIN_COMMON_LICENSE_H

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -9,6 +9,7 @@
 #include <qt/splashscreen.h>
 
 #include <clientversion.h>
+#include <common/license.h>
 #include <interfaces/handler.h>
 #include <interfaces/node.h>
 #include <interfaces/wallet.h>

--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -13,6 +13,7 @@
 #include <qt/guiutil.h>
 
 #include <clientversion.h>
+#include <common/license.h>
 #include <init.h>
 #include <util/system.h>
 #include <util/strencodings.h>

--- a/src/test/fuzz/string.cpp
+++ b/src/test/fuzz/string.cpp
@@ -4,6 +4,7 @@
 
 #include <blockfilter.h>
 #include <clientversion.h>
+#include <common/license.h>
 #include <common/url.h>
 #include <logging.h>
 #include <netaddress.h>

--- a/test/lint/run-lint-format-strings.py
+++ b/test/lint/run-lint-format-strings.py
@@ -13,10 +13,10 @@ import re
 import sys
 
 FALSE_POSITIVES = [
+    ("src/common/license.cpp", "strprintf(_(COPYRIGHT_HOLDERS).translated, COPYRIGHT_HOLDERS_SUBSTITUTION)"),
     ("src/dbwrapper.cpp", "vsnprintf(p, limit - p, format, backup_ap)"),
     ("src/index/base.cpp", "FatalError(const char* fmt, const Args&... args)"),
     ("src/netbase.cpp", "LogConnectFailure(bool manual_connection, const char* fmt, const Args&... args)"),
-    ("src/clientversion.cpp", "strprintf(_(COPYRIGHT_HOLDERS).translated, COPYRIGHT_HOLDERS_SUBSTITUTION)"),
     ("src/validationinterface.cpp", "LogPrint(BCLog::VALIDATION, fmt \"\\n\", __VA_ARGS__)"),
     ("src/wallet/wallet.h",  "WalletLogPrintf(std::string fmt, Params... parameters)"),
     ("src/wallet/wallet.h", "LogPrintf((\"%s \" + fmt).c_str(), GetDisplayName(), parameters...)"),


### PR DESCRIPTION
After https://github.com/bitcoin/bitcoin/pull/26645, this change is required to be able to `#include clientversion.h` in the `libbitcoinconsensus` code without dependency on `util/translation.h`.

## Steps to reproduce the problem

To demonstrate the problem, let's consider the `x86_64-w64-mingw32` platform as it guarantees that all symbols are defined in a library:
```
$ make -C depends HOST=x86_64-w64-mingw32 NO_QT=1 NO_WALLET=1 NO_NATPMP=1 NO_UPNP=1 NO_ZMQ=1
$ ./autogen.sh && ./configure CONFIG_SITE=$PWD/depends/x86_64-w64-mingw32/share/config.site && make clean
```

And now, let's apply a diff as follows:
```diff
--- a/src/script/bitcoinconsensus.cpp
+++ b/src/script/bitcoinconsensus.cpp
@@ -8,6 +8,7 @@
 #include <primitives/transaction.h>
 #include <pubkey.h>
 #include <script/interpreter.h>
+#include <util/check.h>
 #include <version.h>
 
 namespace {
@@ -25,7 +26,7 @@ public:
     void read(Span<std::byte> dst)
     {
         if (dst.size() > m_remaining) {
-            throw std::ios_base::failure(std::string(__func__) + ": end of data");
+            throw std::ios_base::failure(STR_INTERNAL_BUG("end of data"));
         }
 
         if (dst.data() == nullptr) {
```

The resulted code fails to compile:
```
$ make
...
  CXXLD    libbitcoinconsensus.la
/usr/bin/x86_64-w64-mingw32-ld: script/.libs/libbitcoinconsensus_la-bitcoinconsensus.o:bitcoinconsensus.cpp:(.text+0x1db): undefined reference to `StrFormatInternalBug[abi:cxx11](char const*, char const*, int, char const*)'
...
```

Obviously, the `util/check.cpp` needs to be added to the library sources:
```diff
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -972,6 +972,7 @@ lib_LTLIBRARIES += $(LIBBITCOINCONSENSUS)
 
 include_HEADERS = script/bitcoinconsensus.h
 libbitcoinconsensus_la_SOURCES = support/cleanse.cpp $(crypto_libbitcoin_crypto_base_la_SOURCES) $(libbitcoin_consensus_a_SOURCES)
+libbitcoinconsensus_la_SOURCES += util/check.cpp
 
 libbitcoinconsensus_la_LDFLAGS = $(AM_LDFLAGS) -no-undefined $(RELDFLAGS)
 libbitcoinconsensus_la_LIBADD = $(LIBSECP256K1)
```

Now, a linker complains about another symbol:
```
$ make
...
  CXXLD    libbitcoinconsensus.la
/usr/bin/x86_64-w64-mingw32-ld: util/.libs/libbitcoinconsensus_la-check.o:check.cpp:(.text+0x8c): undefined reference to `FormatFullVersion[abi:cxx11]()'
...
```

which is defined in the `clientversion.cpp`:
```diff
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -972,6 +972,7 @@ lib_LTLIBRARIES += $(LIBBITCOINCONSENSUS)
 
 include_HEADERS = script/bitcoinconsensus.h
 libbitcoinconsensus_la_SOURCES = support/cleanse.cpp $(crypto_libbitcoin_crypto_base_la_SOURCES) $(libbitcoin_consensus_a_SOURCES)
+libbitcoinconsensus_la_SOURCES += clientversion.cpp util/check.cpp
 
 libbitcoinconsensus_la_LDFLAGS = $(AM_LDFLAGS) -no-undefined $(RELDFLAGS)
 libbitcoinconsensus_la_LIBADD = $(LIBSECP256K1)
```

This time a linker error is:
```
$ make
...
  CXXLD    libbitcoinconsensus.la
/usr/bin/x86_64-w64-mingw32-ld: .libs/libbitcoinconsensus_la-clientversion.o:clientversion.:(.rdata$.refptr._Z17G_TRANSLATION_FUNB5cxx11[.refptr._Z17G_TRANSLATION_FUNB5cxx11]+0x0): undefined reference to `G_TRANSLATION_FUN[abi:cxx11]'
...
```

which is supposed to be solved by this PR.

---

See https://github.com/bitcoin/bitcoin/pull/26504.

The last time those functions were moved in https://github.com/bitcoin/bitcoin/pull/24409.