### PR TITLE
test: add add_wallet_options to TestShell

### DIFF
--- a/test/functional/test_framework/test_shell.py
+++ b/test/functional/test_framework/test_shell.py
@@ -16,6 +16,9 @@ class TestShell:
     start a single TestShell at a time."""
 
     class __TestShell(BitcoinTestFramework):
+        def add_options(self, parser):
+            self.add_wallet_options(parser)
+
         def set_test_params(self):
             pass
 


### PR DESCRIPTION
following https://github.com/bitcoin/bitcoin/pull/26480/commits/555519d082fbe5e047595f06d7f301e441bb7149, `TestShell` now always runs with `-disablewallet`. simple fix is to add `add_wallet_options` to `add_options`; looks like testshell was overlooked when adding in the `add_wallet_options` call to the functional tests in #26480 