### PR TITLE
wallet: Refactor database cursor into its own object with proper return codes

### DIFF
--- a/src/wallet/bdb.cpp
+++ b/src/wallet/bdb.cpp
@@ -220,17 +220,17 @@ BerkeleyEnvironment::BerkeleyEnvironment() : m_use_shared_memory(false)
     fMockDb = true;
 }
 
-BerkeleyBatch::SafeDbt::SafeDbt()
+SafeDbt::SafeDbt()
 {
     m_dbt.set_flags(DB_DBT_MALLOC);
 }
 
-BerkeleyBatch::SafeDbt::SafeDbt(void* data, size_t size)
+SafeDbt::SafeDbt(void* data, size_t size)
     : m_dbt(data, size)
 {
 }
 
-BerkeleyBatch::SafeDbt::~SafeDbt()
+SafeDbt::~SafeDbt()
 {
     if (m_dbt.get_data() != nullptr) {
         // Clear memory, e.g. in case it was a private key
@@ -244,17 +244,17 @@ BerkeleyBatch::SafeDbt::~SafeDbt()
     }
 }
 
-const void* BerkeleyBatch::SafeDbt::get_data() const
+const void* SafeDbt::get_data() const
 {
     return m_dbt.get_data();
 }
 
-uint32_t BerkeleyBatch::SafeDbt::get_size() const
+uint32_t SafeDbt::get_size() const
 {
     return m_dbt.get_size();
 }
 
-BerkeleyBatch::SafeDbt::operator Dbt*()
+SafeDbt::operator Dbt*()
 {
     return &m_dbt;
 }

--- a/src/wallet/bdb.h
+++ b/src/wallet/bdb.h
@@ -194,7 +194,7 @@ public:
     explicit BerkeleyCursor(BerkeleyDatabase& database);
     ~BerkeleyCursor() override;
 
-    bool Next(CDataStream& key, CDataStream& value, bool& complete) override;
+    Status Next(CDataStream& key, CDataStream& value) override;
 };
 
 /** RAII class that provides access to a Berkeley database */

--- a/src/wallet/bdb.h
+++ b/src/wallet/bdb.h
@@ -165,29 +165,29 @@ public:
     std::unique_ptr<DatabaseBatch> MakeBatch(bool flush_on_close = true) override;
 };
 
+/** RAII class that automatically cleanses its data on destruction */
+class SafeDbt final
+{
+    Dbt m_dbt;
+
+public:
+    // construct Dbt with internally-managed data
+    SafeDbt();
+    // construct Dbt with provided data
+    SafeDbt(void* data, size_t size);
+    ~SafeDbt();
+
+    // delegate to Dbt
+    const void* get_data() const;
+    uint32_t get_size() const;
+
+    // conversion operator to access the underlying Dbt
+    operator Dbt*();
+};
+
 /** RAII class that provides access to a Berkeley database */
 class BerkeleyBatch : public DatabaseBatch
 {
-    /** RAII class that automatically cleanses its data on destruction */
-    class SafeDbt final
-    {
-        Dbt m_dbt;
-
-    public:
-        // construct Dbt with internally-managed data
-        SafeDbt();
-        // construct Dbt with provided data
-        SafeDbt(void* data, size_t size);
-        ~SafeDbt();
-
-        // delegate to Dbt
-        const void* get_data() const;
-        uint32_t get_size() const;
-
-        // conversion operator to access the underlying Dbt
-        operator Dbt*();
-    };
-
 private:
     bool ReadKey(CDataStream&& key, CDataStream& value) override;
     bool WriteKey(CDataStream&& key, CDataStream&& value, bool overwrite = true) override;

--- a/src/wallet/bdb.h
+++ b/src/wallet/bdb.h
@@ -185,6 +185,18 @@ public:
     operator Dbt*();
 };
 
+class BerkeleyCursor : public DatabaseCursor
+{
+private:
+    Dbc* m_cursor;
+
+public:
+    explicit BerkeleyCursor(BerkeleyDatabase& database);
+    ~BerkeleyCursor() override;
+
+    bool Next(CDataStream& key, CDataStream& value, bool& complete) override;
+};
+
 /** RAII class that provides access to a Berkeley database */
 class BerkeleyBatch : public DatabaseBatch
 {
@@ -198,7 +210,6 @@ protected:
     Db* pdb;
     std::string strFile;
     DbTxn* activeTxn;
-    Dbc* m_cursor;
     bool fReadOnly;
     bool fFlushOnClose;
     BerkeleyEnvironment *env;
@@ -214,9 +225,7 @@ public:
     void Flush() override;
     void Close() override;
 
-    bool StartCursor() override;
-    bool ReadAtCursor(CDataStream& ssKey, CDataStream& ssValue, bool& complete) override;
-    void CloseCursor() override;
+    std::unique_ptr<DatabaseCursor> GetNewCursor() override;
     bool TxnBegin() override;
     bool TxnCommit() override;
     bool TxnAbort() override;

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -38,8 +38,6 @@ public:
 class DatabaseBatch
 {
 private:
-    std::unique_ptr<DatabaseCursor> m_cursor;
-
     virtual bool ReadKey(CDataStream&& key, CDataStream& value) = 0;
     virtual bool WriteKey(CDataStream&& key, CDataStream&& value, bool overwrite=true) = 0;
     virtual bool EraseKey(CDataStream&& key) = 0;
@@ -107,20 +105,6 @@ public:
     }
 
     virtual std::unique_ptr<DatabaseCursor> GetNewCursor() = 0;
-    bool StartCursor()
-    {
-        m_cursor = GetNewCursor();
-        return m_cursor != nullptr;
-    }
-    bool ReadAtCursor(CDataStream& ssKey, CDataStream& ssValue, bool& complete)
-    {
-        if (!m_cursor) return false;
-        return m_cursor->Next(ssKey, ssValue, complete);
-    }
-    void CloseCursor()
-    {
-        m_cursor.reset();
-    }
     virtual bool TxnBegin() = 0;
     virtual bool TxnCommit() = 0;
     virtual bool TxnAbort() = 0;

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -31,7 +31,14 @@ public:
     DatabaseCursor(const DatabaseCursor&) = delete;
     DatabaseCursor& operator=(const DatabaseCursor&) = delete;
 
-    virtual bool Next(CDataStream& key, CDataStream& value, bool& complete) { return false; }
+    enum class Status
+    {
+        FAIL,
+        MORE,
+        DONE,
+    };
+
+    virtual Status Next(CDataStream& key, CDataStream& value) { return Status::FAIL; }
 };
 
 /** RAII class that provides access to a WalletDatabase */
@@ -168,7 +175,7 @@ public:
 
 class DummyCursor : public DatabaseCursor
 {
-    bool Next(CDataStream& key, CDataStream& value, bool& complete) override { return false; }
+    Status Next(CDataStream& key, CDataStream& value) override { return Status::FAIL; }
 };
 
 /** RAII class that provides access to a DummyDatabase. Never fails. */

--- a/src/wallet/dump.cpp
+++ b/src/wallet/dump.cpp
@@ -47,7 +47,8 @@ bool DumpWallet(const ArgsManager& args, CWallet& wallet, bilingual_str& error)
     std::unique_ptr<DatabaseBatch> batch = db.MakeBatch();
 
     bool ret = true;
-    if (!batch->StartCursor()) {
+    std::unique_ptr<DatabaseCursor> cursor = batch->GetNewCursor();
+    if (!cursor) {
         error = _("Error: Couldn't create cursor into database");
         ret = false;
     }
@@ -69,7 +70,7 @@ bool DumpWallet(const ArgsManager& args, CWallet& wallet, bilingual_str& error)
             CDataStream ss_key(SER_DISK, CLIENT_VERSION);
             CDataStream ss_value(SER_DISK, CLIENT_VERSION);
             bool complete;
-            ret = batch->ReadAtCursor(ss_key, ss_value, complete);
+            ret = cursor->Next(ss_key, ss_value, complete);
             if (complete) {
                 ret = true;
                 break;
@@ -85,7 +86,7 @@ bool DumpWallet(const ArgsManager& args, CWallet& wallet, bilingual_str& error)
         }
     }
 
-    batch->CloseCursor();
+    cursor.reset();
     batch.reset();
 
     // Close the wallet after we're done with it. The caller won't be doing this

--- a/src/wallet/dump.cpp
+++ b/src/wallet/dump.cpp
@@ -69,13 +69,13 @@ bool DumpWallet(const ArgsManager& args, CWallet& wallet, bilingual_str& error)
         while (true) {
             CDataStream ss_key(SER_DISK, CLIENT_VERSION);
             CDataStream ss_value(SER_DISK, CLIENT_VERSION);
-            bool complete;
-            ret = cursor->Next(ss_key, ss_value, complete);
-            if (complete) {
+            DatabaseCursor::Status status = cursor->Next(ss_key, ss_value);
+            if (status == DatabaseCursor::Status::DONE) {
                 ret = true;
                 break;
-            } else if (!ret) {
+            } else if (status == DatabaseCursor::Status::FAIL) {
                 error = _("Error reading next record from wallet database");
+                ret = false;
                 break;
             }
             std::string key_str = HexStr(ss_key);

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -125,7 +125,6 @@ void SQLiteBatch::SetupSQLStatements()
         {&m_insert_stmt, "INSERT INTO main VALUES(?, ?)"},
         {&m_overwrite_stmt, "INSERT or REPLACE into main values(?, ?)"},
         {&m_delete_stmt, "DELETE FROM main WHERE key = ?"},
-        {&m_cursor_stmt, "SELECT key, value FROM main"},
     };
 
     for (const auto& [stmt_prepared, stmt_text] : statements) {
@@ -374,7 +373,6 @@ void SQLiteBatch::Close()
         {&m_insert_stmt, "insert"},
         {&m_overwrite_stmt, "overwrite"},
         {&m_delete_stmt, "delete"},
-        {&m_cursor_stmt, "cursor"},
     };
 
     for (const auto& [stmt_prepared, stmt_description] : statements) {
@@ -472,19 +470,9 @@ bool SQLiteBatch::HasKey(CDataStream&& key)
     return res == SQLITE_ROW;
 }
 
-bool SQLiteBatch::StartCursor()
-{
-    assert(!m_cursor_init);
-    if (!m_database.m_db) return false;
-    m_cursor_init = true;
-    return true;
-}
-
-bool SQLiteBatch::ReadAtCursor(CDataStream& key, CDataStream& value, bool& complete)
+bool SQLiteCursor::Next(CDataStream& key, CDataStream& value, bool& complete)
 {
     complete = false;
-
-    if (!m_cursor_init) return false;
 
     int res = sqlite3_step(m_cursor_stmt);
     if (res == SQLITE_DONE) {
@@ -492,7 +480,7 @@ bool SQLiteBatch::ReadAtCursor(CDataStream& key, CDataStream& value, bool& compl
         return true;
     }
     if (res != SQLITE_ROW) {
-        LogPrintf("SQLiteBatch::ReadAtCursor: Unable to execute cursor step: %s\n", sqlite3_errstr(res));
+        LogPrintf("%s: Unable to execute cursor step: %s\n", __func__, sqlite3_errstr(res));
         return false;
     }
 
@@ -506,10 +494,29 @@ bool SQLiteBatch::ReadAtCursor(CDataStream& key, CDataStream& value, bool& compl
     return true;
 }
 
-void SQLiteBatch::CloseCursor()
+SQLiteCursor::~SQLiteCursor()
 {
     sqlite3_reset(m_cursor_stmt);
-    m_cursor_init = false;
+    int res = sqlite3_finalize(m_cursor_stmt);
+    if (res != SQLITE_OK) {
+        LogPrintf("%s: cursor closed but could not finalize cursor statement: %s\n",
+                  __func__, sqlite3_errstr(res));
+    }
+}
+
+std::unique_ptr<DatabaseCursor> SQLiteBatch::GetNewCursor()
+{
+    if (!m_database.m_db) return nullptr;
+    auto cursor = std::make_unique<SQLiteCursor>();
+
+    const char* stmt_text = "SELECT key, value FROM main";
+    int res = sqlite3_prepare_v2(m_database.m_db, stmt_text, -1, &cursor->m_cursor_stmt, nullptr);
+    if (res != SQLITE_OK) {
+        throw std::runtime_error(strprintf(
+            "%s: Failed to setup cursor SQL statement: %s\n", __func__, sqlite3_errstr(res)));
+    }
+
+    return cursor;
 }
 
 bool SQLiteBatch::TxnBegin()

--- a/src/wallet/sqlite.h
+++ b/src/wallet/sqlite.h
@@ -14,19 +14,27 @@ struct bilingual_str;
 namespace wallet {
 class SQLiteDatabase;
 
+class SQLiteCursor : public DatabaseCursor
+{
+public:
+    sqlite3_stmt* m_cursor_stmt{nullptr};
+
+    explicit SQLiteCursor() {}
+    ~SQLiteCursor() override;
+
+    bool Next(CDataStream& key, CDataStream& value, bool& complete) override;
+};
+
 /** RAII class that provides access to a WalletDatabase */
 class SQLiteBatch : public DatabaseBatch
 {
 private:
     SQLiteDatabase& m_database;
 
-    bool m_cursor_init = false;
-
     sqlite3_stmt* m_read_stmt{nullptr};
     sqlite3_stmt* m_insert_stmt{nullptr};
     sqlite3_stmt* m_overwrite_stmt{nullptr};
     sqlite3_stmt* m_delete_stmt{nullptr};
-    sqlite3_stmt* m_cursor_stmt{nullptr};
 
     void SetupSQLStatements();
 
@@ -44,9 +52,7 @@ public:
 
     void Close() override;
 
-    bool StartCursor() override;
-    bool ReadAtCursor(CDataStream& key, CDataStream& value, bool& complete) override;
-    void CloseCursor() override;
+    std::unique_ptr<DatabaseCursor> GetNewCursor() override;
     bool TxnBegin() override;
     bool TxnCommit() override;
     bool TxnAbort() override;

--- a/src/wallet/sqlite.h
+++ b/src/wallet/sqlite.h
@@ -22,7 +22,7 @@ public:
     explicit SQLiteCursor() {}
     ~SQLiteCursor() override;
 
-    bool Next(CDataStream& key, CDataStream& value, bool& complete) override;
+    Status Next(CDataStream& key, CDataStream& value) override;
 };
 
 /** RAII class that provides access to a WalletDatabase */

--- a/src/wallet/test/util.cpp
+++ b/src/wallet/test/util.cpp
@@ -50,7 +50,7 @@ std::unique_ptr<WalletDatabase> DuplicateMockDatabase(WalletDatabase& database, 
 
     // Get a cursor to the original database
     auto batch = database.MakeBatch();
-    batch->StartCursor();
+    std::unique_ptr<wallet::DatabaseCursor> cursor = batch->GetNewCursor();
 
     // Get a batch for the new database
     auto new_batch = new_database->MakeBatch();
@@ -60,7 +60,7 @@ std::unique_ptr<WalletDatabase> DuplicateMockDatabase(WalletDatabase& database, 
         CDataStream key(SER_DISK, CLIENT_VERSION);
         CDataStream value(SER_DISK, CLIENT_VERSION);
         bool complete;
-        batch->ReadAtCursor(key, value, complete);
+        cursor->Next(key, value, complete);
         if (complete) break;
         new_batch->Write(key, value);
     }

--- a/src/wallet/test/util.cpp
+++ b/src/wallet/test/util.cpp
@@ -59,9 +59,9 @@ std::unique_ptr<WalletDatabase> DuplicateMockDatabase(WalletDatabase& database, 
     while (true) {
         CDataStream key(SER_DISK, CLIENT_VERSION);
         CDataStream value(SER_DISK, CLIENT_VERSION);
-        bool complete;
-        cursor->Next(key, value, complete);
-        if (complete) break;
+        DatabaseCursor::Status status = cursor->Next(key, value);
+        assert(status != DatabaseCursor::Status::FAIL);
+        if (status == DatabaseCursor::Status::DONE) break;
         new_batch->Write(key, value);
     }
 

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -867,6 +867,12 @@ BOOST_FIXTURE_TEST_CASE(ZapSelectTx, TestChain100Setup)
     TestUnloadWallet(std::move(wallet));
 }
 
+class FailCursor : public DatabaseCursor
+{
+public:
+    bool Next(CDataStream& key, CDataStream& value, bool& complete) override { return false; }
+};
+
 /** RAII class that provides access to a FailDatabase. Which fails if needed. */
 class FailBatch : public DatabaseBatch
 {
@@ -882,9 +888,7 @@ public:
     void Flush() override {}
     void Close() override {}
 
-    bool StartCursor() override { return true; }
-    bool ReadAtCursor(CDataStream& ssKey, CDataStream& ssValue, bool& complete) override { return false; }
-    void CloseCursor() override {}
+    std::unique_ptr<DatabaseCursor> GetNewCursor() override { return std::make_unique<FailCursor>(); }
     bool TxnBegin() override { return false; }
     bool TxnCommit() override { return false; }
     bool TxnAbort() override { return false; }

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -870,7 +870,7 @@ BOOST_FIXTURE_TEST_CASE(ZapSelectTx, TestChain100Setup)
 class FailCursor : public DatabaseCursor
 {
 public:
-    bool Next(CDataStream& key, CDataStream& value, bool& complete) override { return false; }
+    Status Next(CDataStream& key, CDataStream& value) override { return Status::FAIL; }
 };
 
 /** RAII class that provides access to a FailDatabase. Which fails if needed. */

--- a/src/wallet/test/walletload_tests.cpp
+++ b/src/wallet/test/walletload_tests.cpp
@@ -54,12 +54,14 @@ BOOST_FIXTURE_TEST_CASE(wallet_load_unknown_descriptor, TestingSetup)
 bool HasAnyRecordOfType(WalletDatabase& db, const std::string& key)
 {
     std::unique_ptr<DatabaseBatch> batch = db.MakeBatch(false);
-    BOOST_CHECK(batch->StartCursor());
+    BOOST_CHECK(batch);
+    std::unique_ptr<DatabaseCursor> cursor = batch->GetNewCursor();
+    BOOST_CHECK(cursor);
     while (true) {
         CDataStream ssKey(SER_DISK, CLIENT_VERSION);
         CDataStream ssValue(SER_DISK, CLIENT_VERSION);
         bool complete;
-        BOOST_CHECK(batch->ReadAtCursor(ssKey, ssValue, complete));
+        BOOST_CHECK(cursor->Next(ssKey, ssValue, complete));
         if (complete) break;
         std::string type;
         ssKey >> type;

--- a/src/wallet/test/walletload_tests.cpp
+++ b/src/wallet/test/walletload_tests.cpp
@@ -60,9 +60,9 @@ bool HasAnyRecordOfType(WalletDatabase& db, const std::string& key)
     while (true) {
         CDataStream ssKey(SER_DISK, CLIENT_VERSION);
         CDataStream ssValue(SER_DISK, CLIENT_VERSION);
-        bool complete;
-        BOOST_CHECK(cursor->Next(ssKey, ssValue, complete));
-        if (complete) break;
+        DatabaseCursor::Status status = cursor->Next(ssKey, ssValue);
+        assert(status != DatabaseCursor::Status::FAIL);
+        if (status == DatabaseCursor::Status::DONE) break;
         std::string type;
         ssKey >> type;
         if (type == key) return true;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3776,12 +3776,12 @@ bool CWallet::MigrateToSQLite(bilingual_str& error)
         error = _("Error: Unable to begin reading all records in the database");
         return false;
     }
-    bool complete = false;
+    DatabaseCursor::Status status = DatabaseCursor::Status::FAIL;
     while (true) {
         CDataStream ss_key(SER_DISK, CLIENT_VERSION);
         CDataStream ss_value(SER_DISK, CLIENT_VERSION);
-        bool ret = cursor->Next(ss_key, ss_value, complete);
-        if (complete || !ret) {
+        status = cursor->Next(ss_key, ss_value);
+        if (status != DatabaseCursor::Status::MORE) {
             break;
         }
         SerializeData key(ss_key.begin(), ss_key.end());
@@ -3790,7 +3790,7 @@ bool CWallet::MigrateToSQLite(bilingual_str& error)
     }
     cursor.reset();
     batch.reset();
-    if (!complete) {
+    if (status != DatabaseCursor::Status::DONE) {
         error = _("Error: Unable to read all records in the database");
         return false;
     }

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -824,13 +824,10 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
             // Read next record
             CDataStream ssKey(SER_DISK, CLIENT_VERSION);
             CDataStream ssValue(SER_DISK, CLIENT_VERSION);
-            bool complete;
-            bool ret = cursor->Next(ssKey, ssValue, complete);
-            if (complete) {
+            DatabaseCursor::Status status = cursor->Next(ssKey, ssValue);
+            if (status == DatabaseCursor::Status::DONE) {
                 break;
-            }
-            else if (!ret)
-            {
+            } else if (status == DatabaseCursor::Status::FAIL) {
                 cursor.reset();
                 pwallet->WalletLogPrintf("Error reading next record from wallet database\n");
                 return DBErrors::CORRUPT;
@@ -998,11 +995,10 @@ DBErrors WalletBatch::FindWalletTx(std::vector<uint256>& vTxHash, std::list<CWal
             // Read next record
             CDataStream ssKey(SER_DISK, CLIENT_VERSION);
             CDataStream ssValue(SER_DISK, CLIENT_VERSION);
-            bool complete;
-            bool ret = cursor->Next(ssKey, ssValue, complete);
-            if (complete) {
+            DatabaseCursor::Status status = cursor->Next(ssKey, ssValue);
+            if (status == DatabaseCursor::Status::DONE) {
                 break;
-            } else if (!ret) {
+            } else if (status == DatabaseCursor::Status::FAIL) {
                 LogPrintf("Error reading next record from wallet database\n");
                 return DBErrors::CORRUPT;
             }
@@ -1125,13 +1121,10 @@ bool WalletBatch::EraseRecords(const std::unordered_set<std::string>& types)
         // Read next record
         CDataStream key(SER_DISK, CLIENT_VERSION);
         CDataStream value(SER_DISK, CLIENT_VERSION);
-        bool complete;
-        bool ret = cursor->Next(key, value, complete);
-        if (complete) {
+        DatabaseCursor::Status status = cursor->Next(key, value);
+        if (status == DatabaseCursor::Status::DONE) {
             break;
-        }
-        else if (!ret)
-        {
+        } else if (status == DatabaseCursor::Status::FAIL) {
             return false;
         }
 


### PR DESCRIPTION
Instead of having database cursors be tied to a particular `DatabaseBatch` object and requiring its setup and teardown be separate functions in that batch, we can have cursors be separate RAII classes. This makes it easier to create and destroy cursors as well as having cursors that have slightly different behaviors.

Additionally, since reading data from a cursor is a tri-state, this PR changes the return value of the `Next` function (formerly `ReadAtCursor`) to return an Enum rather than the current system of 2 booleans. This greatly simplifies and unifies the code that deals with cursors as now there is no confusion as to what the function returns when there are no records left to be read.

Extracted from #24914