### PR TITLE
build: special instruction check script

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -48,6 +48,7 @@ DIST_SHARE = \
   $(top_srcdir)/share/rpcauth
 
 BIN_CHECKS=$(top_srcdir)/contrib/devtools/symbol-check.py \
+           $(top_srcdir)/contrib/devtools/special-instruction-check.py \
            $(top_srcdir)/contrib/devtools/security-check.py \
            $(top_srcdir)/contrib/devtools/utils.py
 

--- a/contrib/devtools/special-instruction-check.py
+++ b/contrib/devtools/special-instruction-check.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""
+Check that generated out files which use special compilation units do not
+contain any disallowed sections. See #18553 for additional context.
+
+Special instructions include:
+
+    SSE42
+    SSE41
+    AVX
+    AVX2
+    SHANI
+
+Disallowed sections include:
+
+    .text.startup
+
+Example usage:
+
+    python3 contrib/devtools/special-instruction-check.py
+"""
+import glob
+import os
+import re
+import sys
+
+import lief #type:ignore
+
+cwd = os.getcwd()
+DISALLOWED_SECTIONS = [
+    ".text.startup",
+]
+
+# Compile the regex of special instructions to search for
+pattern = re.compile(r".*(SSE42|SSE41|AVX|AVX2|SHANI).*", re.IGNORECASE)
+
+# Perform the search over file names.
+files = [file for file in glob.glob(f"{cwd}/**/*.o", recursive=True) if pattern.search(file)]
+
+# Fail if we didn't find any files to check. This is likely a runtime mistake
+if not files:
+    print(f"{__file__}: no special instruction *.o files found in {cwd}", file=sys.stderr)
+    sys.exit(1)
+else:
+    print(f"{__file__}: checking for disallowed sections in {', '.join(files)}", file=sys.stdout)
+
+# Parse files for disallowed sections
+error = False
+for file in files:
+    binary = lief.parse(file)
+    if not binary:
+        print(f"ERROR: {file} was not the correct format for lief parsing")
+        error = True
+        continue
+    out_file_sections = [section.name for section in binary.sections]
+    for section in DISALLOWED_SECTIONS:
+        if section in out_file_sections:
+            print(f"{__file__}: ERROR {file} contains disallowed section {section}", file=sys.stderr)
+            error = True
+
+if error:
+    print("ERROR: special instruction check did not complete successfully")
+    sys.exit(1)
+else:
+    print("SUCCESS: special instruction check completed successfully")
+    sys.exit(0)


### PR DESCRIPTION
Fixes #18603 

Checks that generated files with special compilation units do not contain disallowed sections. Special instructions and disallowed sections are defined in the script and include `SSE42`, `SSE41`, `AVX`, `AVX2`, `SHANI`, and `.text.startup`, respectively. 

The script uses `glob` to search and `lief` to parse files. If any disallowed sections are found in a file the script will print an error to `stderr` and exit with a non-zero exit code. Otherwise, the script will exit with a zero exit code indicating success.

I also have another version on [this branch](https://github.com/bitcoin/bitcoin/compare/master...willcl-ark:bitcoin:18603_si_check_test) which more closely mimics the interface of `symbol-check.py` (accepting a list of files as arguments), along with including a test which can be used to check that the script itself is working, but as it's quite a lot more code overall, I thought this branch might be preferable...