### PR TITLE
test: Wallet interactions with rescanning wallet

### DIFF
--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -82,7 +82,7 @@ TEST_FRAMEWORK_MODULES = [
 EXTENDED_SCRIPTS = [
     # These tests are not run by default.
     # Longest test should go first, to favor running tests in parallel
-    'feature_pruning.py',
+    'feature_large_chain.py',
     'feature_dbcrash.py',
     'feature_index_prune.py',
     'wallet_pruning.py --legacy-wallet',


### PR DESCRIPTION
This pull request tests that interacting with a wallet while rescanning will fail with `Wallet is currently rescanning. Abort existing rescan or wait.`.

I'm running a rescan for each RPC command being tested instead of only one for all to avoid intermittent failures.
Each rescan takes about 2 seconds, enough time to run the tested RPC commands simultaneously.
I added this test in `feature_pruning.py` to use the large chain generated and renamed it to `feature_large_chain.py` as I think it is more appropriate now.
