### PR TITLE
contrib: make DNS seeds file an argument in CLI (`makeseeds`)

### DIFF
--- a/contrib/seeds/README.md
+++ b/contrib/seeds/README.md
@@ -13,6 +13,6 @@ data. Run the following commands from the `/contrib/seeds` directory:
 
     curl https://bitcoin.sipa.be/seeds.txt.gz | gzip -dc > seeds_main.txt
     curl https://bitcoin.sipa.be/asmap-filled.dat > asmap-filled.dat
-    python3 makeseeds.py -a asmap-filled.dat < seeds_main.txt > nodes_main.txt
+    python3 makeseeds.py -a asmap-filled.dat -s seeds_main.txt > nodes_main.txt
     cat nodes_main_manual.txt >> nodes_main.txt
     python3 generate-seeds.py . > ../../src/chainparamsseeds.h

--- a/contrib/seeds/makeseeds.py
+++ b/contrib/seeds/makeseeds.py
@@ -173,6 +173,7 @@ def ip_stats(ips: List[Dict]) -> str:
 def parse_args():
     argparser = argparse.ArgumentParser(description='Generate a list of bitcoin node seed ip addresses.')
     argparser.add_argument("-a","--asmap", help='the location of the asmap asn database file (required)', required=True)
+    argparser.add_argument("-s","--seeds", help='the location of the DNS seeds file (required)', required=True)
     return argparser.parse_args()
 
 def main():
@@ -184,7 +185,8 @@ def main():
     print('Done.', file=sys.stderr)
 
     print('Loading and parsing DNS seeds…', end='', file=sys.stderr, flush=True)
-    lines = sys.stdin.readlines()
+    with open(args.seeds, 'r', encoding='utf8') as f:
+        lines = f.readlines()
     ips = [parseline(line) for line in lines]
     print('Done.', file=sys.stderr)
 


### PR DESCRIPTION
Instead of using `makeseeds.py` this way:
```sh
python3 makeseeds.py -a asmap-filled.dat < seeds_main.txt > nodes_main.txt
```

We could use the DNS seeds file as an argument since it is a required one. It improves the way the script handles it when that file is missing as well as makes this script more friendly.
E.g:
```sh
python3 makeseeds.py -a asmap-filled.dat -s seeds_main.txt > nodes_main.txt
```