### PR TITLE
refactor: Fix `performance-for-range-copy` in headers

### DIFF
--- a/src/psbt.h
+++ b/src/psbt.h
@@ -178,7 +178,7 @@ void SerializeHDKeypath(Stream& s, KeyOriginInfo hd_keypath)
 template<typename Stream>
 void SerializeHDKeypaths(Stream& s, const std::map<CPubKey, KeyOriginInfo>& hd_keypaths, CompactSizeWriter type)
 {
-    for (auto keypath_pair : hd_keypaths) {
+    for (const auto& keypath_pair : hd_keypaths) {
         if (!keypath_pair.first.IsValid()) {
             throw std::ios_base::failure("Invalid CPubKey being serialized");
         }


### PR DESCRIPTION
Split from bitcoin/bitcoin#26705 as was requested in https://github.com/bitcoin/bitcoin/pull/26705#issuecomment-1353293405.

To test this PR, consider applying a diff as follows:
```diff
--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -12,17 +12,9 @@ readability-redundant-declaration,
 readability-redundant-string-init,
 '
 WarningsAsErrors: '
-bugprone-argument-comment,
-bugprone-use-after-move,
-misc-unused-using-decls,
-modernize-use-default-member-init,
-modernize-use-nullptr,
 performance-for-range-copy,
-performance-move-const-arg,
-performance-unnecessary-copy-initialization,
-readability-redundant-declaration,
-readability-redundant-string-init,
 '
 CheckOptions:
  - key: performance-move-const-arg.CheckTriviallyCopyableMove
    value: false
+HeaderFilterRegex: '.'
```