### PR TITLE
validate package transactions with their in-package ancestor sets

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -237,6 +237,7 @@ BITCOIN_CORE_H = \
   node/validation_cache_args.h \
   noui.h \
   outputtype.h \
+  policy/ancestor_packages.h \
   policy/feerate.h \
   policy/fees.h \
   policy/fees_args.h \
@@ -438,6 +439,7 @@ libbitcoin_node_a_SOURCES = \
   node/utxo_snapshot.cpp \
   node/validation_cache_args.cpp \
   noui.cpp \
+  policy/ancestor_packages.cpp \
   policy/fees.cpp \
   policy/fees_args.cpp \
   policy/packages.cpp \
@@ -952,7 +954,9 @@ libbitcoinkernel_la_SOURCES = \
   logging.cpp \
   node/blockstorage.cpp \
   node/chainstate.cpp \
+  node/mini_miner.cpp \
   node/utxo_snapshot.cpp \
+  policy/ancestor_packages.cpp \
   policy/feerate.cpp \
   policy/fees.cpp \
   policy/packages.cpp \

--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -13,6 +13,7 @@ GENERATED_BENCH_FILES = $(RAW_BENCH_FILES:.raw=.raw.h)
 bench_bench_bitcoin_SOURCES = \
   $(RAW_BENCH_FILES) \
   bench/addrman.cpp \
+  bench/ancestorpackage.cpp \
   bench/base58.cpp \
   bench/bech32.cpp \
   bench/bench.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -243,6 +243,7 @@ test_fuzz_fuzz_SOURCES = \
  $(FUZZ_WALLET_SRC) \
  test/fuzz/addition_overflow.cpp \
  test/fuzz/addrman.cpp \
+ test/fuzz/ancestorpackage.cpp \
  test/fuzz/asmap.cpp \
  test/fuzz/asmap_direct.cpp \
  test/fuzz/autofile.cpp \

--- a/src/bench/ancestorpackage.cpp
+++ b/src/bench/ancestorpackage.cpp
@@ -1,0 +1,128 @@
+// Copyright (c) 2011-2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <bench/bench.h>
+#include <consensus/validation.h>
+#include <node/mini_miner.h>
+#include <policy/ancestor_packages.h>
+#include <random.h>
+#include <test/util/script.h>
+#include <test/util/setup_common.h>
+
+#include <deque>
+
+static void AncestorPackageRandom(benchmark::Bench& bench)
+{
+    FastRandomContext rand{true};
+    Package txns;
+
+    int cluster_size = 100;
+    if (bench.complexityN() > 1) {
+        cluster_size = static_cast<int>(bench.complexityN());
+    }
+
+    std::deque<COutPoint> available_coins;
+    for (uint32_t i = 0; i < uint32_t{100}; ++i) {
+        available_coins.emplace_back(uint256::ZERO, i);
+    }
+
+    for (uint32_t count = cluster_size - 1; !available_coins.empty() && count; --count)
+    {
+        CMutableTransaction mtx = CMutableTransaction();
+        const size_t num_inputs = rand.randrange(available_coins.size()) + 1;
+        const size_t num_outputs = rand.randrange(50) + 1;
+        for (size_t n{0}; n < num_inputs; ++n) {
+            auto prevout = available_coins.front();
+            mtx.vin.emplace_back(prevout, CScript());
+            available_coins.pop_front();
+        }
+        for (uint32_t n{0}; n < num_outputs; ++n) {
+            mtx.vout.emplace_back(100, P2WSH_OP_TRUE);
+        }
+        CTransactionRef tx = MakeTransactionRef(mtx);
+        txns.emplace_back(tx);
+
+        // At least one output is available for spending by descendant
+        for (uint32_t n{0}; n < num_outputs; ++n) {
+            if (n == 0 || rand.randbool()) {
+                available_coins.emplace_back(tx->GetHash(), n);
+            }
+        }
+    }
+
+    assert(!available_coins.empty());
+
+    // Now spend all available coins to make sure it's an ancestor package
+    size_t num_coins = available_coins.size();
+    CMutableTransaction child_mtx;
+    for (size_t avail = 0; avail < num_coins; avail++) {
+        auto prevout = available_coins[0];
+        child_mtx.vin.emplace_back(prevout, CScript());
+        available_coins.pop_front();
+    }
+    child_mtx.vout.emplace_back(100, P2WSH_OP_TRUE);
+    CTransactionRef child_tx = MakeTransactionRef(child_mtx);
+    txns.emplace_back(child_tx);
+
+    bench.run([&]() NO_THREAD_SAFETY_ANALYSIS {
+        AncestorPackage ancestor_package(txns);
+        assert(ancestor_package.IsAncestorPackage());
+        for (size_t i = 0; i < txns.size(); i++) {
+            ancestor_package.AddFeeAndVsize(txns[i]->GetHash(), rand.randrange(1000000), rand.randrange(1000));
+        }
+        ancestor_package.LinearizeWithFees();
+    });
+}
+
+static void AncestorPackageChain(benchmark::Bench& bench)
+{
+    FastRandomContext det_rand{true};
+
+    // A chain of 25 97-in-1-out transactions, where the nth tx spends the n-1th.  We are trying to
+    // maximize the number of transactions in the package (within MAX_PACKAGE_COUNT) and number of
+    // inputs to look up (while staying within MAX_PACKAGE_WEIGHT) for the "worst case" package.
+    const uint32_t num_txns{25};
+    int32_t total_weight{0};
+    Package txns;
+    txns.reserve(num_txns);
+
+    uint256 starting_txid{det_rand.rand256()};
+    uint256& last_txid = starting_txid;
+    for (uint32_t count{0}; count < num_txns; ++count) {
+        CMutableTransaction mtx = CMutableTransaction();
+        mtx.vin.reserve(97);
+        // First input is the output from the last tx.
+        mtx.vin.emplace_back(last_txid, 0);
+        // The rest are random.
+        for (uint32_t i{1}; i < 97; ++i) {
+            mtx.vin.emplace_back(det_rand.rand256(), count * 100 + i);
+        }
+
+        mtx.vout.emplace_back(1000, P2WSH_OP_TRUE);
+        CTransactionRef tx = MakeTransactionRef(mtx);
+        txns.emplace_back(tx);
+        last_txid = tx->GetHash();
+        total_weight += GetTransactionWeight(*tx);
+    }
+
+    // Just barely below MAX_PACKAGE_WEIGHT.
+    assert(total_weight == 403000);
+
+    // Pass the transactions in backwards for worst-case sorting.
+    Package reversed_txns(txns.rbegin(), txns.rend());
+
+    bench.minEpochIterations(10).run([&]() NO_THREAD_SAFETY_ANALYSIS {
+        AncestorPackage ancestor_package(reversed_txns);
+        assert(ancestor_package.IsAncestorPackage());
+        for (size_t i = 0; i < txns.size(); ++i) {
+            // Decreasing feerate so that "mining" each transaction requires updating all the rest.
+            // Make each transaction 100vB bigger than the previous one.
+            ancestor_package.AddFeeAndVsize(txns.at(i)->GetHash(), 10000000, 100 * (i + 1));
+        }
+        ancestor_package.LinearizeWithFees();
+    });
+}
+
+BENCHMARK(AncestorPackageRandom, benchmark::PriorityLevel::HIGH);
+BENCHMARK(AncestorPackageChain, benchmark::PriorityLevel::HIGH);

--- a/src/policy/ancestor_packages.cpp
+++ b/src/policy/ancestor_packages.cpp
@@ -218,11 +218,11 @@ bool AncestorPackage::LinearizeWithFees()
 
         auto fee_and_vsize_info = FilteredSubpackageInfo(entry.tx);
         if (!Assume(fee_and_vsize_info.has_value())) continue;
-        miniminer_info.emplace_back(/*fee_self=*/fee_and_vsize_info->m_self_fee,
-                                    /*fee_ancestor=*/fee_and_vsize_info->m_ancestor_fee,
+        miniminer_info.emplace_back(/*tx_in=*/entry.tx,
                                     /*vsize_self=*/fee_and_vsize_info->m_self_vsize,
                                     /*vsize_ancestor=*/fee_and_vsize_info->m_ancestor_vsize,
-                                    /*tx_in=*/entry.tx);
+                                    /*fee_self=*/fee_and_vsize_info->m_self_fee,
+                                    /*fee_ancestor=*/fee_and_vsize_info->m_ancestor_fee);
 
         // Provide descendant cache, again skipping transactions that are MEMPOOL or DANGLING.
         std::set<Txid>& descendant_cache_to_populate = descendant_caches.try_emplace(txid).first->second;

--- a/src/policy/ancestor_packages.cpp
+++ b/src/policy/ancestor_packages.cpp
@@ -1,0 +1,267 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#include <policy/ancestor_packages.h>
+
+#include <node/mini_miner.h>
+#include <util/check.h>
+
+#include <algorithm>
+#include <iterator>
+#include <memory>
+#include <numeric>
+
+
+/**Comparator for sorting m_txns which contains reference wrappers.*/
+struct CompareEntry {
+    template<typename T>
+    bool operator()(const std::reference_wrapper<T> a, const std::reference_wrapper<T> b) const
+    {
+        return a.get() < b.get();
+    }
+};
+// Calculates curr_tx's in-package ancestor set. If the tx spends another tx in the package, calls
+// visit() for that transaction first, since any transaction's ancestor set includes its parents'
+// ancestor sets. Transaction dependency cycles are not possible without breaking sha256 and
+// duplicate transactions were checked in the AncestorPackage() ctor, so this won't recurse infinitely.
+// After this function returns, entry is guaranteed to contain a non-empty ancestor_subset.
+void AncestorPackage::visit(const CTransactionRef& curr_tx)
+{
+    const Txid& curr_txid = curr_tx->GetHash();
+    auto& entry = m_txid_to_entry.at(curr_txid);
+    if (!entry.ancestor_subset.empty()) return;
+    std::set<Txid> my_ancestors;
+    my_ancestors.insert(curr_txid);
+    for (const auto& input : curr_tx->vin) {
+        const auto& parent_txid = Txid::FromUint256(input.prevout.hash);
+        if (m_txid_to_entry.count(parent_txid) == 0) continue;
+        auto parent_entry = m_txid_to_entry.at(parent_txid);
+        if (parent_entry.ancestor_subset.empty()) {
+            visit(parent_entry.tx);
+        }
+        auto parent_ancestor_set = m_txid_to_entry.at(parent_txid).ancestor_subset;
+        Assume(!parent_ancestor_set.empty());
+        // This recursive call should not have included ourselves; it should be impossible for this
+        // tx to be both an ancestor and a descendant of us.
+        Assume(m_txid_to_entry.at(curr_txid).ancestor_subset.empty());
+        my_ancestors.insert(parent_ancestor_set.cbegin(), parent_ancestor_set.cend());
+    }
+    entry.ancestor_subset = std::move(my_ancestors);
+}
+
+AncestorPackage::AncestorPackage(const Package& txns_in)
+{
+    if (txns_in.empty()) return;
+    // Duplicate transactions are not allowed, as they will result in infinite visit() recursion.
+    if (!IsConsistentPackage(txns_in)) return;
+
+    // Populate m_txid_to_entry for quick lookup
+    for (const auto& tx : txns_in) {
+        m_txid_to_entry.emplace(tx->GetHash(), PackageEntry{tx});
+        m_txns.emplace_back(std::ref(m_txid_to_entry.at(tx->GetHash())));
+    }
+
+    // Every tx must have a unique txid. We are indexing by Txid to make it easy to look up parents
+    // using prevouts. IsConsistentPackage() should have checked for duplicate transactions.
+    if (!Assume(txns_in.size() == m_txid_to_entry.size())) return;
+
+    // DFS-based algorithm to sort transactions by ancestor count and populate ancestor_subset.
+    // Best case runtime is if the package is already sorted and no recursive calls happen.
+    // An empty PackageEntry::ancestor_subset is equivalent to not yet being processed.
+    for (const auto& tx : txns_in) {
+        if (m_txid_to_entry.at(tx->GetHash()).ancestor_subset.empty()) visit(tx);
+        Assume(!m_txid_to_entry.at(tx->GetHash()).ancestor_subset.empty());
+    }
+    // Sort by the number of in-package ancestors.
+    std::vector<std::reference_wrapper<PackageEntry>> txns_copy(m_txns);
+    std::sort(m_txns.begin(), m_txns.end(), CompareEntry());
+    if (!Assume(m_txns.size() == txns_in.size() && IsTopoSortedPackage(Txns()))) {
+        // If something went wrong with the sorting, just revert to the original order.
+        m_txns = txns_copy;
+    }
+    // This package is ancestor package-shaped if every transaction is an ancestor of the last tx.
+    // We just check if the number of unique txids in ancestor_subset is equal to the number of
+    // transactions in the package.
+    m_ancestor_package_shaped = m_txns.back().get().ancestor_subset.size() == m_txns.size();
+    // Now populate the descendant caches
+    for (const auto& [txid, entry] : m_txid_to_entry) {
+        for (const auto& anc_txid : entry.ancestor_subset) {
+            m_txid_to_entry.at(anc_txid).descendant_subset.insert(txid);
+        }
+    }
+}
+
+Package AncestorPackage::Txns() const
+{
+    Package result;
+    std::transform(m_txns.cbegin(), m_txns.cend(), std::back_inserter(result),
+                   [](const auto refentry){ return refentry.get().tx; });
+    return result;
+}
+
+Package AncestorPackage::FilteredTxns() const
+{
+    Package result;
+    for (const auto entryref : m_txns) {
+        if (entryref.get().m_state == PackageEntry::State::PACKAGE) result.emplace_back(entryref.get().tx);
+    }
+    return result;
+}
+
+std::optional<std::vector<CTransactionRef>> AncestorPackage::FilteredAncestorSet(const CTransactionRef& tx) const
+{
+    const auto& entry_it = m_txid_to_entry.find(tx->GetHash());
+    if (entry_it == m_txid_to_entry.end()) return std::nullopt;
+    const auto& entry = entry_it->second;
+    if (entry.m_state == PackageEntry::State::DANGLING) return std::nullopt;
+
+    std::vector<CTransactionRef> result;
+    result.reserve(entry.ancestor_subset.size());
+    for (const auto entryref : m_txns) {
+        if (entry.ancestor_subset.count(entryref.get().tx->GetHash()) > 0) {
+            // All non-PACKAGE ancestor_subset transactions should have been removed when the
+            // transaction was first skipped.
+            if (Assume(entryref.get().m_state == PackageEntry::State::PACKAGE)) {
+                result.emplace_back(entryref.get().tx);
+            }
+        }
+    }
+    return result;
+}
+
+std::optional<AncestorPackage::SubpackageInfo> AncestorPackage::FilteredSubpackageInfo(const CTransactionRef& tx) const
+{
+    const auto& entry_it = m_txid_to_entry.find(tx->GetHash());
+    if (entry_it == m_txid_to_entry.end()) return std::nullopt;
+    const auto& entry = entry_it->second;
+    if (entry.m_state == PackageEntry::State::DANGLING || !entry.fee.has_value() || !entry.vsize.has_value()) return std::nullopt;
+
+    CAmount total_fee{0};
+    int64_t total_vsize{0};
+    for (const auto& txid : entry.ancestor_subset) {
+        const auto& anc_entry = m_txid_to_entry.at(txid);
+        // All non-PACKAGE ancestor_subset transactions should have been removed when the
+        // transaction was first skipped.
+        if (Assume(anc_entry.m_state == PackageEntry::State::PACKAGE)) {
+            if (anc_entry.fee.has_value() && anc_entry.vsize.has_value()) {
+                total_fee += anc_entry.fee.value();
+                total_vsize += anc_entry.vsize.value();
+            } else {
+                // If any fee or vsize information is missing, we can't return an accurate result.
+                return std::nullopt;
+            }
+        }
+    }
+
+    return SubpackageInfo{
+        .m_self_vsize = entry.vsize.value(),
+        .m_ancestor_vsize = total_vsize,
+        .m_self_fee = entry.fee.value(),
+        .m_ancestor_fee = total_fee
+    };
+}
+
+void AncestorPackage::MarkAsInMempool(const CTransactionRef& transaction)
+{
+    const auto& txid{transaction->GetHash()};
+    if (m_txid_to_entry.count(txid) == 0) return;
+
+    Assume(m_txid_to_entry.at(txid).m_state != PackageEntry::State::DANGLING);
+    m_txid_to_entry.at(txid).m_state = PackageEntry::State::MEMPOOL;
+
+    // Delete this tx from the descendant's ancestor_subset.
+    for (const auto& descendant_txid : m_txid_to_entry.at(transaction->GetHash()).descendant_subset) {
+        m_txid_to_entry.at(descendant_txid).ancestor_subset.erase(txid);
+    }
+}
+void AncestorPackage::IsDanglingWithDescendants(const CTransactionRef& transaction)
+{
+    const auto& txid{transaction->GetHash()};
+    if (m_txid_to_entry.count(txid) == 0) return;
+    m_txid_to_entry.at(txid).m_state = PackageEntry::State::DANGLING;
+
+    // Set all descendants to DANGLING, as they depend on something that is being discarded.
+    // Delete this tx from the descendant's ancestor_subset.
+    for (const auto& descendant_txid : m_txid_to_entry.at(txid).descendant_subset) {
+        Assume(m_txid_to_entry.at(descendant_txid).m_state != PackageEntry::State::MEMPOOL);
+        m_txid_to_entry.at(descendant_txid).m_state = PackageEntry::State::DANGLING;
+        m_txid_to_entry.at(descendant_txid).ancestor_subset.erase(txid);
+    }
+}
+
+void AncestorPackage::AddFeeAndVsize(const Txid& txid, CAmount fee, int64_t vsize)
+{
+    if (auto it = m_txid_to_entry.find(txid); it != m_txid_to_entry.end()) {
+        it->second.fee = fee;
+        it->second.vsize = vsize;
+    }
+}
+
+bool AncestorPackage::LinearizeWithFees()
+{
+    if (!m_ancestor_package_shaped) return false;
+    // All fee and vsize information for PACKAGE txns must be available to do linearization.
+    if (!std::all_of(m_txid_to_entry.cbegin(), m_txid_to_entry.cend(),
+        [](const auto& entry) { return entry.second.m_state != PackageEntry::State::PACKAGE ||
+                                 (entry.second.fee.has_value() && entry.second.vsize.has_value()); })) {
+        return false;
+    }
+    // Clear any previously-calculated mining sequences for all transactions.
+    for (auto& [_, entry] : m_txid_to_entry) entry.mining_sequence = std::nullopt;
+
+    // Construct mempool entries for MiniMiner
+    std::vector<node::MiniMinerMempoolEntry> miniminer_info;
+    std::map<Txid, std::set<Txid>> descendant_caches;
+    for (const auto& [txid, entry] : m_txid_to_entry) {
+        // Skip transactions that are not being considered for submission.
+        if (entry.m_state != PackageEntry::State::PACKAGE) continue;
+
+        auto fee_and_vsize_info = FilteredSubpackageInfo(entry.tx);
+        if (!Assume(fee_and_vsize_info.has_value())) continue;
+        miniminer_info.emplace_back(/*fee_self=*/fee_and_vsize_info->m_self_fee,
+                                    /*fee_ancestor=*/fee_and_vsize_info->m_ancestor_fee,
+                                    /*vsize_self=*/fee_and_vsize_info->m_self_vsize,
+                                    /*vsize_ancestor=*/fee_and_vsize_info->m_ancestor_vsize,
+                                    /*tx_in=*/entry.tx);
+
+        // Provide descendant cache, again skipping transactions that are MEMPOOL or DANGLING.
+        std::set<Txid>& descendant_cache_to_populate = descendant_caches.try_emplace(txid).first->second;
+        for (const auto& txid : entry.descendant_subset) {
+            if (!Assume(m_txid_to_entry.count(txid) > 0)) continue;
+
+            const auto& entry = m_txid_to_entry.at(txid);
+            if (entry.m_state == PackageEntry::State::PACKAGE) {
+                descendant_cache_to_populate.insert(txid);
+            } else {
+                // Descendant shouldn't be MEMPOOL as that would mean submitting a tx without its ancestor.
+                Assume(entry.m_state == PackageEntry::State::DANGLING);
+            }
+        }
+    }
+
+    // Use MiniMiner to calculate the order in which these transactions would be selected for mining.
+    node::MiniMiner miniminer(miniminer_info, descendant_caches);
+    if (!miniminer.IsReadyToCalculate()) return false;
+    for (const auto& [txid, mining_sequence] : miniminer.Linearize()) {
+        m_txid_to_entry.at(txid).mining_sequence = mining_sequence;
+    }
+    // Sort again, this time including mining scores and individual feerates.
+    std::vector<std::reference_wrapper<PackageEntry>> txns_copy(m_txns);
+    std::sort(m_txns.begin(), m_txns.end(), CompareEntry());
+    Assume(std::all_of(m_txid_to_entry.cbegin(), m_txid_to_entry.cend(), [](const auto& entry) {
+        bool should_have_sequence = (entry.second.m_state == PackageEntry::State::PACKAGE);
+        return entry.second.mining_sequence.has_value() == should_have_sequence;
+    }));
+
+    // If something went wrong with the linearization, just revert to the original order and reset
+    // mining_sequences.
+    if (!Assume(IsTopoSortedPackage(Txns()))) {
+        m_txns = txns_copy;
+        for (auto& [txid, entry] : m_txid_to_entry) {
+            entry.mining_sequence = std::nullopt;
+        }
+        Assume(IsTopoSortedPackage(Txns()));
+        return false;
+    }
+    return true;
+}

--- a/src/policy/ancestor_packages.h
+++ b/src/policy/ancestor_packages.h
@@ -1,0 +1,172 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_POLICY_ANCESTOR_PACKAGES_H
+#define BITCOIN_POLICY_ANCESTOR_PACKAGES_H
+
+#include <policy/feerate.h>
+#include <policy/packages.h>
+
+#include <vector>
+
+/** A potential ancestor package, i.e. one transaction with its set of unconfirmed ancestors.
+ * This class does not have any knowledge of chainstate, so it cannot determine whether all
+ * unconfirmed ancestors are present. Its constructor accepts any list of transactions that
+ * IsConsistentPackage(), linearizes them topologically, and determines whether it IsAncestorPackage().
+ * If fee and vsizes are given for each transaction, it can also linearize the transactions using
+ * the ancestor score-based mining algorithm via MiniMiner.
+ *
+ * IsIsInMempool() and IsDanglingWithDescendants() can be used to omit transactions.
+ * Txns() and FilteredTxns() return the linearized transactions; FilteredTxns excludes non-PACKAGE ones.
+ * FilteredAncestorSet() can be used to get a transaction's "subpackage," i.e. ancestor set within the
+ * package. Also excludes non-PACKAGE ones.
+ * */
+class AncestorPackage
+{
+    /** Whether m_txns contains a connected package in which all transactions are ancestors of the
+     * last transaction. This object is not aware of chainstate. So if m_txns only includes a
+     * grandparent and not the "connecting" parent, this will (incorrectly) determine that the
+     * grandparent is not an ancestor.
+     * Set in the constructor and then does not change, even if transactions are skipped.
+     * */
+    bool m_ancestor_package_shaped{false};
+
+    struct PackageEntry {
+        enum class State : uint8_t {
+            /** Default value.
+             * If calling LinearizeWithFees(), this tx must have a fee and vsize. */
+            PACKAGE,
+            /** Excluded from FilteredAncestor{Set,FeeAndVsize}.
+             * Should not appear in any transaction's ancestor_subset.
+             * Excluded in LinearizeWithFees().
+             * Set by calling IsIsInMempool() on this tx. */
+            MEMPOOL,
+            /** This and all descendant's FilteredAncestor{Set,FeeAndVsize} will be std::nullopt.
+             * Should not appear in any transaction's ancestor_subset.
+             * Excluded in LinearizeWithFees().
+             * Set by calling IsDanglingWithDescendants() on this tx or its ancestor. */
+            DANGLING,
+        // If a parent is DANGLING, all descendants must also be DANGLING.
+        // If a child is MEMPOOL, all ancestors should also be MEMPOOL.
+        };
+
+        CTransactionRef tx;
+
+        State m_state{State::PACKAGE};
+
+        /** This value starts as std::nullopt when we don't have any fee information yet. It can be
+         * updated by calling LinearizeWithFees() if this entry isn't MEMPOOL or DANGLING. */
+        std::optional<uint32_t> mining_sequence;
+
+        /** Fees of this transaction. Starts as std::nullopt, can be updated using AddFeeAndVsize(). */
+        std::optional<CAmount> fee;
+
+        /** Virtual size of this transaction (depends on policy, calculated externally). Starts as
+         * std::nullopt. Can be updated using AddFeeAndVsize(). */
+        std::optional<int64_t> vsize;
+
+        /** Txids of all PACKAGE ancestors. Populated in AncestorPackage ctor. If an ancestor
+         * becomes MEMPOOL or DANGLING, it is erased from this set. Use FilteredAncestorSet to get
+         * filtered ancestor sets. */
+        std::set<Txid> ancestor_subset;
+
+        /** Txids of all in-package descendant. Populated in AncestorPackage ctor and does not
+         * change within AncestorPackage lifetime. */
+        std::set<Txid> descendant_subset;
+
+        explicit PackageEntry(CTransactionRef tx_in) : tx(tx_in) {}
+
+        // Used to sort the result of Txns, FilteredTxns, and FilteredAncestorSet. Always guarantees
+        // topological sort. If LinearizeWithFees() was called, also uses mining sequence.
+        //
+        // If ancestor score-based linearization sequence exists for both transactions, the
+        // transaction with the lower sequence number comes first.
+        //    If there is a tie, the transaction with fewer in-package ancestors comes first (topological sort).
+        //       If there is still a tie, the transaction with the higher base feerate comes first.
+        // Otherwise, the transaction with fewer in-package ancestors comes first (topological sort).
+        bool operator<(const PackageEntry& rhs) const {
+            if (mining_sequence == std::nullopt || rhs.mining_sequence == std::nullopt) {
+                // If mining sequence is missing for either entry, default to topological order.
+                return ancestor_subset.size() < rhs.ancestor_subset.size();
+            } else {
+                if (mining_sequence.value() == rhs.mining_sequence.value()) {
+                    // Identical mining sequence means they would be included in the same ancestor
+                    // set. The one with fewer ancestors comes first.
+                    if (ancestor_subset.size() == rhs.ancestor_subset.size()) {
+                        // Individual feerate. This is not necessarily fee-optimal, but helps in some situations.
+                        // (a.fee * b.vsize > b.fee * a.vsize) is a shortcut for (a.fee / a.vsize > b.fee / b.vsize)
+                        return *fee * *rhs.vsize  > *rhs.fee * *vsize;
+                    }
+                    return ancestor_subset.size() < rhs.ancestor_subset.size();
+                } else {
+                    return mining_sequence.value() < rhs.mining_sequence.value();
+                }
+            }
+        }
+    };
+    /** Map from each txid to PackageEntry */
+    std::map<Txid, PackageEntry> m_txid_to_entry;
+
+    /** Linearized transactions. Always topologically sorted (IsSorted()). If fee information is
+     * provided through LinearizeWithFees(), using mining_sequence scores. */
+    std::vector<std::reference_wrapper<PackageEntry>> m_txns;
+
+    /** Helper function for recursively constructing ancestor caches in ctor. */
+    void visit(const CTransactionRef&);
+public:
+    /** Constructs ancestor package, sorting the transactions topologically and constructing the
+     * txid_to_tx and ancestor_subsets maps. It is ok if the input txns is not sorted.
+     * Expects:
+     * - No duplicate transactions.
+     * - No conflicts between transactions.
+     */
+    AncestorPackage(const Package& txns_in);
+
+    bool IsAncestorPackage() const { return m_ancestor_package_shaped; }
+
+    /** Returns all of the transactions, linearized. */
+    Package Txns() const;
+
+    /** Returns all of the transactions, without the skipped and dangling ones, linearized. */
+    Package FilteredTxns() const;
+
+    struct SubpackageInfo
+    {
+        std::vector<CTransactionRef> m_subpackage_txns;
+        int64_t m_self_vsize;
+        int64_t m_ancestor_vsize;
+        CAmount m_self_fee;
+        CAmount m_ancestor_fee;
+    };
+
+    /** Get the sorted, filtered ancestor subpackage for a tx. Includes the tx. Does not include
+     * ancestors that are MEMPOOL. If this tx or any ancestors are DANGLING, returns std::nullopt. */
+    std::optional<std::vector<CTransactionRef>> FilteredAncestorSet(const CTransactionRef& tx) const;
+
+    /** Get SubpackageInfo for this tx and its filtered ancestors. Does not include ancestors that
+     * are MEMPOOL. If this tx or any ancestors are DANGLING, returns std::nullopt. This result is
+     * always consistent with FilteredAncestorSet(). */
+    std::optional<SubpackageInfo> FilteredSubpackageInfo(const CTransactionRef& tx) const;
+
+    /** Should be called if a tx or same txid transaction is found in mempool or submitted to it.
+     * From now on, skip this tx from any result in FilteredAncestorSet(). Does not affect Txns(). */
+    void MarkAsInMempool(const CTransactionRef& transaction);
+
+    /** Should be called if a tx will not be considered because it is missing inputs or is
+     * conflicting with another transaction that is already in mempool.
+     * Skip a transaction and all of its descendants. From now on, if this transaction is present
+     * in the ancestor set, FilteredAncestorSet() returns std::nullopt for that tx. Does not affect Txns(). */
+    void IsDanglingWithDescendants(const CTransactionRef& transaction);
+
+    /** Add information about fee and vsize for a transaction. */
+    void AddFeeAndVsize(const Txid& txid, CAmount fee, int64_t vsize);
+
+    /** Re-linearize transactions using the fee and vsize information given. Updates Txns().
+     * Information must have been provided for all non-skipped transactions via AddFeeAndVsize().
+     * @returns true if successful, false if not enough information was provided or an error
+     * occurred - in that case, the transactions are still IsTopoSortedPackage() and it is safe to
+     * still validate them, but we may not have a fee-optimal result. */
+    bool LinearizeWithFees();
+};
+#endif // BITCOIN_POLICY_ANCESTOR_PACKAGES_H

--- a/src/test/fuzz/ancestorpackage.cpp
+++ b/src/test/fuzz/ancestorpackage.cpp
@@ -1,0 +1,99 @@
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+#include <test/util/script.h>
+#include <test/util/setup_common.h>
+
+#include <policy/ancestor_packages.h>
+
+#include <set>
+#include <vector>
+
+namespace {
+FUZZ_TARGET(ancestorpackage)
+{
+    FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
+    std::vector<CTransactionRef> txns_in;
+    // Avoid repeat coins, as they may cause transactions to conflict
+    std::set<COutPoint> available_coins;
+    for (auto i{0}; i < 100; ++i) {
+        if (auto mtx{ConsumeDeserializable<CMutableTransaction>(fuzzed_data_provider)}) {
+            available_coins.insert(COutPoint{MakeTransactionRef(*mtx)->GetHash(), fuzzed_data_provider.ConsumeIntegralInRange<uint32_t>(0, 10)});
+        }
+    }
+    // Create up to 50 transactions with variable inputs and outputs.
+    LIMITED_WHILE(!available_coins.empty() && fuzzed_data_provider.ConsumeBool(), 50)
+    {
+        // If we're making the "bottom" tx, spend all available coins to make an ancestor package,
+        // and exit this loop afterwards.
+        const bool make_bottom_tx{fuzzed_data_provider.ConsumeBool()};
+
+        CMutableTransaction mtx = CMutableTransaction();
+        const size_t num_inputs = make_bottom_tx ? available_coins.size() :
+            fuzzed_data_provider.ConsumeIntegralInRange<size_t>(1, available_coins.size());
+        const size_t num_outputs = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(1, 50);
+        for (size_t n{0}; n < num_inputs; ++n) {
+            auto prevout = available_coins.begin();
+            mtx.vin.emplace_back(*prevout, CScript());
+            available_coins.erase(prevout);
+        }
+        for (uint32_t n{0}; n < num_outputs; ++n) {
+            mtx.vout.emplace_back(100, P2WSH_OP_TRUE);
+        }
+        CTransactionRef tx = MakeTransactionRef(mtx);
+
+        if (txns_in.empty()) {
+            txns_in.emplace_back(tx);
+        } else {
+            // Place tx in a random spot in the vector, swapping the existing tx at that index to the
+            // back, so the package is not necessarily sorted.
+            const size_t index = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, txns_in.size() - 1);
+            txns_in.emplace_back(txns_in.at(index));
+            txns_in.at(index) = tx;
+        }
+
+        // Make outputs available to spend, unless we want this to be the last tx and have just
+        // swept available_coins.
+        if (!make_bottom_tx) {
+            for (uint32_t n{0}; n < num_outputs; ++n) {
+                COutPoint new_coin{tx->GetHash(), n};
+                // Always add the first output to ensure each tx has an outgoing output we can use
+                // to create an ancestor package.
+                if (n > 0 && fuzzed_data_provider.ConsumeBool()) {
+                    available_coins.insert(new_coin);
+                }
+            }
+        }
+    }
+
+    // AncestorPackage may need to topologically sort txns_in. Find bugs in topological sort and
+    // skipping as a result of MarkAsInMempool() and IsDanglingWithDescendants() functions.
+    AncestorPackage packageified(txns_in);
+    Assert(IsTopoSortedPackage(packageified.Txns()));
+    if (packageified.IsAncestorPackage()) {
+        // Optionally MarkAsInMempool() the first n transactions. These must be at the beginning of the
+        // package as it doesn't make sense for a transaction to be in mempool if its ancestors
+        // aren't as well.  The ith transaction is not necessarily an ancestor of the i+1th
+        // transaction, but just call MarkAsInMempool() for transactions 1...n to keep things simple.
+        // For the rest of the transactions, optionally call IsDanglingWithDescendants().
+        bool skipping = true;
+        for (const auto& tx : packageified.Txns()) {
+            if (skipping) {
+                packageified.MarkAsInMempool(tx);
+                if (fuzzed_data_provider.ConsumeBool()) {
+                    skipping = false;
+                }
+            } else {
+                // Not skipping anymore. Maybe do a IsDanglingWithDescendants().
+                if (fuzzed_data_provider.ConsumeBool()) {
+                    packageified.IsDanglingWithDescendants(tx);
+                }
+            }
+        }
+        Assert(IsTopoSortedPackage(packageified.FilteredTxns()));
+        for (const auto& tx : packageified.FilteredTxns()) {
+            assert(IsTopoSortedPackage(*packageified.FilteredAncestorSet(tx)));
+        }
+    }
+}
+} // namespace


### PR DESCRIPTION
This contains everything to make mempool/validation logic ready for package relay (see #27463).

Design goals:
- Be able to gracefully deal with any arbitrary list of transactions (these come from p2p)
- Validate any ancestor package so that the incentive-compatible transactions end up in our mempool.
  - If the transactions would be accepted individually, they should also be accepted through `AcceptPackage`. We don't want to accidentally reject things just because we happened to download them as a package.
  - Bug prior to these changes: we required `IsChildWithParents` but if there were dependencies between the parents, we could end up (1) accepting a low-feerate child or (2) rejecting a high-feerate parent CPFPing another parent. See the "interdependent parents" test case for a specific example.
- Be DoS-resistant.
   - Avoid quadratic validation costs.
   - Avoid loading a lot of stuff from disk, or loading repeatedly.

There are 2 main improvements to package evaluation here:
(1) We submit transactions with their in-package ancestor sets.
	-  See unit test `package_ppfp`: without this change, we would reject everything.
	- See unit test `package_ppfc`: shows that this doesn't let us do "parent pays for child;" we only do this when the individual and ancestor feerates meet mempool minimum feerate
(2) We linearize the package transactions based on ancestor set scoring.
	- See unit test `package_needs_reorder`: without this change, if we use the original order of transactions, we would only accept 1 grandparent, even if we submit subpackages.
	- See unit test `package_desc_limits`: without this change, we accept one of the lower-feerate transactions (a bit more of a "nice to have" than a "must have" example).

A description of the package validation logic (originally https://github.com/bitcoin/bitcoin/pull/26711#issuecomment-1647523520):

- Basic sanitization. Quit if it's too big, inconsistent, etc.
- Linearize (Topological sort only)
- **PreChecks loop** For each tx, grab UTXOs to calculate fees and filter out anything we should skip:
    - If already in mempool (or same txid in mempool), mark as skip
    - If missing inputs or conflict, record this failure and mark this and all descendants as skip.
    - If no failures or TX_SINGLE_FAILURE, continue
    - For some failures that we expect due to differing chainstates, skip these transactions and their descendants, but continue.
    - Otherwise, record this failure and mark that we will `quit_early` (i.e. not do the Subpackage validation loop).
- Refine our linearization using the fee information.
- **Subpackage validation loop** For each transaction in the new linearized order:
    - Get the transaction's ancestor subpackage.
    - If the feerate of this transaction is insufficient, continue;
    - If the feerate of this subpackage is insufficient, continue;
    - Otherwise, try to submit the subpackage, using `AcceptSingleTransaction()` if it's just 1 tx
    - if at any point we get a non-fee-related error, abort all.
- Call `LimitMempoolSize`
- Backfill results:
    - If the transaction was in mempool, check to see if it's still there in case it was trimmed in `LimitMempoolSize`.
    - Try to use results from the subpackage validation loop.
    - If that doesn't exist (i.e. we quit early), use results from prechecks loop.
    - If that doesn't exist (i.e. we quit early and we hadn't found a failure with it yet), fill with `TX_UNKNOWN`.

This means we will call `PreChecks` for each transaction 2 times (fewer if we quit early), and run all other validation checks at most 1 time. A transaction shouldn't be validated in the subpackage validation loop more than once.