### PR TITLE
ci: Build python from source in "lint" task

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -64,10 +64,10 @@ compute_credits_template: &CREDITS_TEMPLATE
   use_compute_credits: $CIRRUS_REPO_FULL_NAME == 'bitcoin/bitcoin' && $CIRRUS_PR != ""
 
 task:
-  name: 'lint [bionic]'
+  name: 'lint [jammy]'
   << : *BASE_TEMPLATE
   container:
-    image: ubuntu:bionic
+    image: ubuntu:jammy
     cpu: 1
     memory: 1G
   # For faster CI feedback, immediately schedule the linters

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -67,11 +67,14 @@ task:
   name: 'lint [bionic]'
   << : *BASE_TEMPLATE
   container:
-    image: ubuntu:bionic  # For python 3.6, oldest supported version according to doc/dependencies.md
+    image: ubuntu:bionic
     cpu: 1
     memory: 1G
   # For faster CI feedback, immediately schedule the linters
   << : *CREDITS_TEMPLATE
+  python_cache:
+    folder: "/tmp/python"
+    fingerprint_script: cat .python-version /etc/os-release
   lint_script:
     - ./ci/lint_run_all.sh
   env:

--- a/ci/lint/04_install.sh
+++ b/ci/lint/04_install.sh
@@ -27,14 +27,6 @@ export PATH="${PYTHON_PATH}/bin:${PATH}"
 command -v python3
 python3 --version
 
-(
-  # Temporary workaround for https://github.com/bitcoin/bitcoin/pull/26130#issuecomment-1260499544
-  # Can be removed once the underlying image is bumped to something that includes git2.34 or later
-  sed -i -e 's/bionic/jammy/g' /etc/apt/sources.list
-  ${CI_RETRY_EXE} apt-get update
-  ${CI_RETRY_EXE} apt-get install -y --reinstall git
-)
-
 ${CI_RETRY_EXE} pip3 install codespell==2.2.1
 ${CI_RETRY_EXE} pip3 install flake8==4.0.1
 ${CI_RETRY_EXE} pip3 install mypy==0.942

--- a/ci/lint/04_install.sh
+++ b/ci/lint/04_install.sh
@@ -7,7 +7,26 @@
 export LC_ALL=C
 
 ${CI_RETRY_EXE} apt-get update
-${CI_RETRY_EXE} apt-get install -y python3-pip curl git gawk jq
+${CI_RETRY_EXE} apt-get install -y curl git gawk jq xz-utils
+
+PYTHON_PATH=/tmp/python
+if [ ! -d "${PYTHON_PATH}/bin" ]; then
+  (
+    git clone https://github.com/pyenv/pyenv.git
+    cd pyenv/plugins/python-build || exit 1
+    ./install.sh
+  )
+  # For dependencies see https://github.com/pyenv/pyenv/wiki#suggested-build-environment
+  ${CI_RETRY_EXE} apt-get install -y build-essential libssl-dev zlib1g-dev \
+    libbz2-dev libreadline-dev libsqlite3-dev curl llvm \
+    libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev \
+    clang
+  env CC=clang python-build "$(cat "${BASE_ROOT_DIR}/.python-version")" "${PYTHON_PATH}"
+fi
+export PATH="${PYTHON_PATH}/bin:${PATH}"
+command -v python3
+python3 --version
+
 (
   # Temporary workaround for https://github.com/bitcoin/bitcoin/pull/26130#issuecomment-1260499544
   # Can be removed once the underlying image is bumped to something that includes git2.34 or later


### PR DESCRIPTION
This PR:
- is an alternative to bitcoin/bitcoin#26581 and bitcoin/bitcoin#26637
- closes bitcoin/bitcoin#26548

Key advantages of this PR over others:
- it uses pyenv's `python-build` [standalone](https://github.com/pyenv/pyenv/tree/master/plugins/python-build#using-python-build-standalone)
- requires no additional computational resources

Note for testing. The lint task must success regardless of whether the `python_cache` is populated or invalidated.