### PR TITLE
test: Improve `check-doc.py` pattern

### DIFF
--- a/test/lint/check-doc.py
+++ b/test/lint/check-doc.py
@@ -15,7 +15,7 @@ import re
 
 FOLDER_GREP = 'src'
 FOLDER_TEST = 'src/test/'
-REGEX_ARG = r'(?:ForceSet|SoftSet|Get|Is)(?:Bool)?Args?(?:Set)?\("(-[^"]+)"'
+REGEX_ARG = r'\b(?:GetArg|GetArgs|GetBoolArg|GetIntArg|GetPathArg|IsArgSet|get_net)\("(-[^"]+)"'
 REGEX_DOC = r'AddArg\("(-[^"=]+?)(?:=|")'
 CMD_ROOT_DIR = '$(git rev-parse --show-toplevel)/{}'.format(FOLDER_GREP)
 CMD_GREP_ARGS = r"git grep --perl-regexp '{}' -- {} ':(exclude){}'".format(REGEX_ARG, CMD_ROOT_DIR, FOLDER_TEST)


### PR DESCRIPTION
On master (cb32328d1b80d0ccd6eb9532bd8fe4e0a4de385e):
```
$ ./test/lint/check-doc.py 
Args used        : 158
Args documented  : 219
Args undocumented: 0
set()
Args unknown     : 61
{'-stopatheight', '-maxtipage', '-maxreceivebuffer', '-txconfirmtarget', '-maxconnections', '-maxsigcachesize', '-peertimeout', '-limitancestorsize', '-output-csv', '-blockmaxweight', '-par', '-rpcclienttimeout', '-dbcrashratio', '-zmqpubsequence', '-zmqpubhashtxhwm', '-zmqpubrawblock', '-dbbatchsize', '-zmqpubrawtxhwm', '-includeconf', '-checkblocks', '-limitancestorcount', '-zmqpubrawtx', '-checklevel', '-checkmempool', '-rpcthreads', '-rpcworkqueue', '-zmqpubsequencehwm', '-zmqpubrawblockhwm', '-rpcservertimeout', '-testnet', '-zmqpubhashtx', '-signet', '-rpcwaittimeout', '-limitdescendantcount', '-output-json', '-maxmempool', '-mocktime', '-datacarriersize', '-rpcport', '-dbcache', '-zmqpubhashblockhwm', '-mempoolexpiry', '-settings', '-min-time', '-maxtimeadjustment', '-bytespersigop', '-blockversion', '-limitdescendantsize', '-maxorphantx', '-rpccookiefile', '-rpcserialversion', '-bantime', '-blockreconstructionextratxn', '-checkaddrman', '-debuglogfile', '-pid', '-dblogsize', '-timeout', '-zmqpubhashblock', '-maxsendbuffer', '-regtest'}
```

With this PR:
```
$ ./test/lint/check-doc.py 
Args used        : 208
Args documented  : 219
Args undocumented: 0
set()
Args unknown     : 11
{'-zmqpubrawblock', '-zmqpubhashblockhwm', '-zmqpubsequencehwm', '-zmqpubrawtx', '-zmqpubhashblock', '-zmqpubhashtx', '-includeconf', '-zmqpubhashtxhwm', '-zmqpubrawblockhwm', '-zmqpubrawtxhwm', '-zmqpubsequence'}
```