### PR TITLE
test, lint: add `crypted` to `ignore-words`

### DIFF
--- a/test/lint/spelling.ignore-words.txt
+++ b/test/lint/spelling.ignore-words.txt
@@ -4,6 +4,7 @@ blockin
 bu
 cachable
 clen
+crypted
 fo
 fpr
 hights


### PR DESCRIPTION
Fixes #26719

"Crypted" is used in some comments at `walletload_tests` because it refers to `DBKeys::CRYPTED_KEY`, it's not necessary 
a mistake.

Obs: I can change the approach (changing `walletload_tests` comments to use `encrypted` word instead of adding it to the `ignore_words`) if reviewers think it makes more sense.