### PR TITLE
test: speed up the two slowest functional tests by 18-35% via `keypoolrefill()`

### DIFF
--- a/test/functional/wallet_fundrawtransaction.py
+++ b/test/functional/wallet_fundrawtransaction.py
@@ -983,6 +983,8 @@ class RawTransactionsTest(BitcoinTestFramework):
         # are selected, the transaction will end up being too large, so it
         # shouldn't use BnB and instead fall back to Knapsack but that behavior
         # is not implemented yet. For now we just check that we get an error.
+        # First, force the wallet to bulk-generate the addresses we'll need.
+        recipient.keypoolrefill(1500)
         for _ in range(1500):
             outputs[recipient.getnewaddress()] = 0.1
         wallet.sendmany("", outputs)

--- a/test/functional/wallet_sendall.py
+++ b/test/functional/wallet_sendall.py
@@ -320,6 +320,10 @@ class SendallTest(BitcoinTestFramework):
     # This tests needs to be the last one otherwise @cleanup will fail with "Transaction too large" error
     def sendall_fails_with_transaction_too_large(self):
         self.log.info("Test that sendall fails if resulting transaction is too large")
+
+        # Force the wallet to bulk-generate the addresses we'll need
+        self.wallet.keypoolrefill(1600)
+
         # create many inputs
         outputs = {self.wallet.getnewaddress(): 0.000025 for _ in range(1600)}
         self.def_wallet.sendmany(amounts=outputs)


### PR DESCRIPTION
## Problem
`wallet_fundrawtransaction.py` and `wallet_sendall.py` are the two slowest functional tests *when running without a RAM disk*.
```
# M1 MacBook Pro timings
wallet_fundrawtransaction.py --descriptors   | ✓ Passed  | 55 s
wallet_fundrawtransaction.py --legacy-wallet | ✓ Passed  | 381 s

wallet_sendall.py --descriptors   | ✓ Passed  | 43 s
wallet_sendall.py --legacy-wallet | ✓ Passed  | 327 s
```

In each case, the majority of the time is spent iterating through 1500 to 1600 `getnewaddress()` calls. This is particularly slow in the `--legacy-wallet` runs.

see:  https://github.com/bitcoin/bitcoin/blob/master/test/functional/wallet_fundrawtransaction.py#L986-L987
see:  https://github.com/bitcoin/bitcoin/blob/master/test/functional/wallet_sendall.py#L324


## Solution
Pre-fill the keypool before iterating through those `getnewaddress()` calls.

With this change, the execution time drops to:
```
wallet_fundrawtransaction.py --descriptors   | ✓ Passed  | 52 s     # -3s diff
wallet_fundrawtransaction.py --legacy-wallet | ✓ Passed  | 291 s    # -90s diff

wallet_sendall.py --descriptors   | ✓ Passed  | 27 s     # -16s diff
wallet_sendall.py --legacy-wallet | ✓ Passed  | 228 s    # -99s diff
```

---

Tagging @ Sjors as he had encouraged me to take a look at speeding up the tests.