### PR TITLE
test: call `keypoolrefill` with priv key disabled should throw an error

### DIFF
--- a/test/functional/wallet_keypool.py
+++ b/test/functional/wallet_keypool.py
@@ -204,6 +204,9 @@ class KeyPoolTest(BitcoinTestFramework):
         res = w2.walletcreatefundedpsbt(inputs=[], outputs=[{destination: 0.00010000}], options={"subtractFeeFromOutputs": [0], "feeRate": 0.00010, "changeAddress": addr.pop()})
         assert_equal("psbt" in res, True)
 
+        if not self.options.descriptors:
+            msg = "Error: Private keys are disabled for this wallet"
+            assert_raises_rpc_error(-4, msg, w2.keypoolrefill, 100)
 
 if __name__ == '__main__':
     KeyPoolTest().main()


### PR DESCRIPTION
This PR adds test coverage for the following error:
https://github.com/bitcoin/bitcoin/blob/cb32328d1b80d0ccd6eb9532bd8fe4e0a4de385e/src/wallet/rpc/addresses.cpp#L332-L334