### PR TITLE
lint: fix lint-tests.py failing on correct names

### DIFF
--- a/test/lint/lint-tests.py
+++ b/test/lint/lint-tests.py
@@ -27,16 +27,13 @@ def grep_boost_fixture_test_suite():
 
 
 def check_matching_test_names(test_suite_list):
-    not_matching = [
-        x
-        for x in test_suite_list
-        if re.search(r"/(.*?)\.cpp:BOOST_FIXTURE_TEST_SUITE\(\1, .*\)", x) is None
-    ]
+    _test_suite_list = [test.split(".cpp")[0] for test in test_suite_list]
+    not_matching = [f"{test}.cpp" for test in _test_suite_list if not test.endswith("_tests")]
     if len(not_matching) > 0:
         not_matching = "\n".join(not_matching)
         error_msg = (
             "The test suite in file src/test/foo_tests.cpp should be named\n"
-            '"foo_tests". Please make sure the following test suites follow\n'
+            "\"foo_tests\". Please make sure the following test suites follow\n"
             "that convention:\n\n"
             f"{not_matching}\n"
         )


### PR DESCRIPTION
lint-tests.py is currently failing to detect that filenames are correct and therefore returning incorrect result and error code from the script. This fixes the matching.

Ouput before:

```
❯ test/lint/lint-tests.py
The test suite in file src/test/foo_tests.cpp should be named
"foo_tests". Please make sure the following test suites follow
that convention:

src/test/addrman_tests.cpp:61:BOOST_FIXTURE_TEST_SUITE(addrman_tests, BasicTestingSetup)
src/test/argsman_tests.cpp:22:BOOST_FIXTURE_TEST_SUITE(argsman_tests, BasicTestingSetup)
src/test/banman_tests.cpp:16:BOOST_FIXTURE_TEST_SUITE(banman_tests, BasicTestingSetup)
src/test/base58_tests.cpp:21:BOOST_FIXTURE_TEST_SUITE(base58_tests, BasicTestingSetup)
src/test/bip32_tests.cpp:160:BOOST_FIXTURE_TEST_SUITE(bip32_tests, BasicTestingSetup)
...
etc.
```
Output after (all tests ok):

```
❯ test/lint/lint-tests.py; echo $status
0
```


Output after (with an intentially renamed test):
```
❯ git mv src/test/addrman_tests.cpp src/test/addrman_tests_incorrect.cpp

will@ubuntu in bitcoin on  lint-name-test [$»] via 🐍 v3.6.15
❯ test/lint/lint-tests.py; and $status
The test suite in file src/test/foo_tests.cpp should be named
"foo_tests". Please make sure the following test suites follow
that convention:

src/test/addrman_tests_incorrect.cpp

1
```