### PR TITLE
test: add coverage for invalid parameter in `keypoolrefill`

### DIFF
--- a/test/functional/wallet_keypool.py
+++ b/test/functional/wallet_keypool.py
@@ -133,6 +133,7 @@ class KeyPoolTest(BitcoinTestFramework):
 
         nodes[0].walletpassphrase('test', 100)
         nodes[0].keypoolrefill(100)
+        assert_raises_rpc_error(-8, "Invalid parameter, expected valid size.", nodes[0].keypoolrefill, -1)
         wi = nodes[0].getwalletinfo()
         if self.options.descriptors:
             assert_equal(wi['keypoolsize_hd_internal'], 400)


### PR DESCRIPTION
This PR adds test coverage for the following error:
https://github.com/bitcoin/bitcoin/blob/dcdfd72861c09a7945b9facc3726177a2d06fa64/src/wallet/rpc/addresses.cpp#L339-L344