### PR TITLE
[WIP] wallet: tx creation, don't select outputs from txes that are being replaced

### DIFF
--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -204,6 +204,9 @@ public:
     //! Check if transaction is in mempool.
     virtual bool isInMempool(const uint256& txid) = 0;
 
+    //! Check if outpoint was spent in the mempool
+    virtual bool isSpentInMempool(const COutPoint& outpoint) = 0;
+
     //! Check if transaction has descendants in mempool.
     virtual bool hasDescendantsInMempool(const uint256& txid) = 0;
 

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -650,6 +650,11 @@ public:
         LOCK(m_node.mempool->cs);
         return m_node.mempool->exists(GenTxid::Txid(txid));
     }
+    bool isSpentInMempool(const COutPoint& outpoint) override
+    {
+        if (!m_node.mempool) return false;
+        return m_node.mempool->isSpent(outpoint);
+    }
     bool hasDescendantsInMempool(const uint256& txid) override
     {
         if (!m_node.mempool) return false;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -743,7 +743,7 @@ void CWallet::SyncMetaData(std::pair<TxSpends::iterator, TxSpends::iterator> ran
  * Outpoint is spent if any non-conflicted transaction
  * spends it:
  */
-bool CWallet::IsSpent(const COutPoint& outpoint) const
+bool CWallet::IsSpent(const COutPoint& outpoint, bool* in_mempool) const
 {
     std::pair<TxSpends::const_iterator, TxSpends::const_iterator> range;
     range = mapTxSpends.equal_range(outpoint);
@@ -753,8 +753,10 @@ bool CWallet::IsSpent(const COutPoint& outpoint) const
         const auto mit = mapWallet.find(wtxid);
         if (mit != mapWallet.end()) {
             const auto& wtx = mit->second;
-            if (!wtx.isAbandoned() && !wtx.isBlockConflicted() && !wtx.isMempoolConflicted())
+            if (!wtx.isAbandoned() && !wtx.isBlockConflicted() && !wtx.isMempoolConflicted()) {
+                if (in_mempool) *in_mempool = wtx.InMempool();
                 return true; // Spent
+            }
         }
     }
     return false;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -531,7 +531,9 @@ public:
     //! check whether we support the named feature
     bool CanSupportFeature(enum WalletFeature wf) const override EXCLUSIVE_LOCKS_REQUIRED(cs_wallet) { AssertLockHeld(cs_wallet); return IsFeatureSupported(nWalletVersion, wf); }
 
-    bool IsSpent(const COutPoint& outpoint) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    //! returns true if the wallet owns the outpoint and the pointed output was spent already.
+    //! note: abandoned txes outputs are not defined as "spent".
+    bool IsSpent(const COutPoint& outpoint, bool* in_mempool=nullptr) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     // Whether this or any known scriptPubKey with the same single key has been spent.
     bool IsSpentKey(const CScript& scriptPubKey) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);


### PR DESCRIPTION
Depends on #27601.

Adding test coverage and the needed checks for two scenarios
where the wallet create invalid transactions.


#### First Scenario, Do Not Use Outputs From the Tx Being Replaced

When the wallet creates/fund a replacement transaction, it should
not fund the new transaction with outputs belonging to the tx
being replaced.

Reason:
Once replaced, those outputs are no longer going to exist, there
by the created/funded transaction will be invalid.

#### Second Scenario, Do Not Create BIP125 Rule 2 Invalid Txes

Prevent adding new unconfirmed outputs to the transaction being
created/funded If any preset input was already spent by a mempool
transaction.

Note:
Both scenarios can can be verified cherry-picking the tests commits
on master. They will fail.