### PR TITLE
doc: FreeBSD DataDirectoryGroupReadable Setting

### DIFF
--- a/doc/tor.md
+++ b/doc/tor.md
@@ -92,18 +92,12 @@ out by default (if not, add them):
 ControlPort 9051
 CookieAuthentication 1
 CookieAuthFileGroupReadable 1
+DataDirectoryGroupReadable 1
 ```
 
 Add or uncomment those, save, and restart Tor (usually `systemctl restart tor`
 or `sudo systemctl restart tor` on most systemd-based systems, including recent
 Debian and Ubuntu, or just restart the computer).
-
-On some systems (such as Arch Linux), you may also need to add the following
-line:
-
-```
-DataDirectoryGroupReadable 1
-```
 
 ### Authentication
 


### PR DESCRIPTION
Updating tor.md doc to include mention of FreeBSD requiring the DataDirectoryGroupReadable be set to 1. 
Default per the FreeBSD man page is 0.


       DataDirectoryGroupReadable 0|1
	   If this option is set to 0, don't allow the filesystem group	to
	   read	the DataDirectory. If the option is set	to 1, make the
	   DataDirectory readable by the default GID. (Default:	0)

