### PR TITLE
test: Drop no longer needed `race:epoll_ctl` TSan suppression

### DIFF
--- a/test/sanitizer_suppressions/tsan
+++ b/test/sanitizer_suppressions/tsan
@@ -35,8 +35,5 @@ race:libzmq
 # https://github.com/bitcoin/bitcoin/issues/20618
 race:CZMQAbstractPublishNotifier::SendZmqMessage
 
-# https://github.com/bitcoin/bitcoin/pull/20218, https://github.com/bitcoin/bitcoin/pull/20745
-race:epoll_ctl
-
 # https://github.com/bitcoin/bitcoin/issues/23366
 race:std::__1::ios_base::*


### PR DESCRIPTION
The removed suppression seems no needed.

I cannot point the exact commit/PR which makes this change possible.