### PR TITLE
ci: Use clang-15 and IWYU v0.19 in "tidy" task

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -78,10 +78,10 @@ task:
     << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
 
 task:
-  name: 'tidy [jammy]'
+  name: 'tidy [kinetic]'
   << : *GLOBAL_TASK_TEMPLATE
   container:
-    image: ubuntu:jammy
+    image: ubuntu:kinetic
     cpu: 2
     memory: 5G
   # For faster CI feedback, immediately schedule the linters

--- a/ci/test/00_setup_env_native_tidy.sh
+++ b/ci/test/00_setup_env_native_tidy.sh
@@ -6,9 +6,9 @@
 
 export LC_ALL=C.UTF-8
 
-export DOCKER_NAME_TAG="ubuntu:22.04"
+export DOCKER_NAME_TAG="ubuntu:22.10"
 export CONTAINER_NAME=ci_native_tidy
-export PACKAGES="clang libclang-dev llvm-dev clang-tidy bear cmake libevent-dev libboost-dev libminiupnpc-dev libnatpmp-dev libzmq3-dev systemtap-sdt-dev libqt5gui5 libqt5core5a libqt5dbus5 qttools5-dev qttools5-dev-tools libqrencode-dev libsqlite3-dev libdb++-dev"
+export PACKAGES="clang libclang-dev llvm-dev mlir-15-tools libmlir-15-dev clang-format clangd clang-tidy bear cmake libevent-dev libboost-dev libminiupnpc-dev libnatpmp-dev libzmq3-dev systemtap-sdt-dev libqt5gui5 libqt5core5a libqt5dbus5 qttools5-dev qttools5-dev-tools libqrencode-dev libsqlite3-dev libdb++-dev"
 export NO_DEPENDS=1
 export RUN_UNIT_TESTS=false
 export RUN_FUNCTIONAL_TESTS=false

--- a/ci/test/04_install.sh
+++ b/ci/test/04_install.sh
@@ -142,8 +142,8 @@ if [[ "${RUN_TIDY}" == "true" ]]; then
   export DIR_IWYU="${BASE_SCRATCH_DIR}/iwyu"
   if [ ! -d "${DIR_IWYU}" ]; then
     CI_EXEC "mkdir -p ${DIR_IWYU}/build/"
-    CI_EXEC "git clone --depth=1 https://github.com/include-what-you-use/include-what-you-use -b clang_14 ${DIR_IWYU}/include-what-you-use"
-    CI_EXEC "cd ${DIR_IWYU}/build && cmake -G 'Unix Makefiles' -DCMAKE_PREFIX_PATH=/usr/lib/llvm-14 ../include-what-you-use"
+    CI_EXEC "git clone --depth=1 https://github.com/include-what-you-use/include-what-you-use -b clang_15 ${DIR_IWYU}/include-what-you-use"
+    CI_EXEC "cd ${DIR_IWYU}/build && cmake -G 'Unix Makefiles' -DCMAKE_PREFIX_PATH=/usr/lib/llvm-15 ../include-what-you-use"
     CI_EXEC_ROOT "cd ${DIR_IWYU}/build && make install $MAKEJOBS"
   fi
 fi

--- a/ci/test/06_script_b.sh
+++ b/ci/test/06_script_b.sh
@@ -72,7 +72,7 @@ if [ "${RUN_TIDY}" = "true" ]; then
           " src/util/syserror.cpp"\
           " src/util/threadinterrupt.cpp"\
           " src/zmq"\
-          " -p . ${MAKEJOBS} -- -Xiwyu --cxx17ns -Xiwyu --mapping_file=${BASE_BUILD_DIR}/bitcoin-$HOST/contrib/devtools/iwyu/bitcoin.core.imp"
+          " -p . ${MAKEJOBS} -- -Xiwyu --error -Xiwyu --cxx17ns -Xiwyu --mapping_file=${BASE_BUILD_DIR}/bitcoin-$HOST/contrib/devtools/iwyu/bitcoin.core.imp"
 fi
 
 if [ "$RUN_SECURITY_TESTS" = "true" ]; then

--- a/contrib/devtools/iwyu/bitcoin.core.imp
+++ b/contrib/devtools/iwyu/bitcoin.core.imp
@@ -1,8 +1,5 @@
 # Fixups / upstreamed changes
 [
-  { include: [ "<bits/termios-c_lflag.h>", private, "<termios.h>", public ] },
-  { include: [ "<bits/termios-struct.h>", private, "<termios.h>", public ] },
-  { include: [ "<bits/termios-tcflow.h>", private, "<termios.h>", public ] },
   { include: [ "<bits/chrono.h>", private, "<chrono>", public ] },
 
   # workaround: https://github.com/include-what-you-use/include-what-you-use/issues/908

--- a/contrib/devtools/iwyu/bitcoin.core.imp
+++ b/contrib/devtools/iwyu/bitcoin.core.imp
@@ -4,4 +4,9 @@
   { include: [ "<bits/termios-struct.h>", private, "<termios.h>", public ] },
   { include: [ "<bits/termios-tcflow.h>", private, "<termios.h>", public ] },
   { include: [ "<bits/chrono.h>", private, "<chrono>", public ] },
+
+  # workaround: https://github.com/include-what-you-use/include-what-you-use/issues/908
+  # the symbol is OK from either header
+  { symbol: ["std::max", "private", "<vector>", "public" ] },
+  { symbol: ["std::max", "private", "<algorithm>", "public" ] },
 ]

--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -4,6 +4,8 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chain.h>
+
+#include <consensus/params.h>
 #include <tinyformat.h>
 #include <util/time.h>
 

--- a/src/chain.h
+++ b/src/chain.h
@@ -7,14 +7,24 @@
 #define BITCOIN_CHAIN_H
 
 #include <arith_uint256.h>
-#include <consensus/params.h>
 #include <flatfile.h>
 #include <primitives/block.h>
+#include <serialize.h>
 #include <sync.h>
+#include <threadsafety.h>
 #include <uint256.h>
 #include <util/time.h>
 
+#include <algorithm>
+#include <cassert>
+#include <chrono>
+#include <cstdint>
+#include <string>
 #include <vector>
+
+namespace Consensus {
+struct Params;
+}
 
 /**
  * Maximum amount of time that a block timestamp is allowed to exceed the

--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -25,10 +25,10 @@
 #include <fcntl.h>
 #include <sys/mman.h>
 #include <sys/select.h>
-#include <sys/socket.h>
+#include <sys/socket.h> // IWYU pragma: export
 #include <sys/types.h>
 #include <net/if.h>
-#include <netinet/in.h>
+#include <netinet/in.h> // IWYU pragma: export
 #include <netinet/tcp.h>
 #include <arpa/inet.h>
 #include <ifaddrs.h>

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -12,18 +12,21 @@
 #include <span.h>
 #include <streams.h>
 
-#include <cstddef>
-#include <cstdint>
-#include <exception>
 #include <leveldb/db.h>
 #include <leveldb/iterator.h>
 #include <leveldb/options.h>
 #include <leveldb/slice.h>
 #include <leveldb/status.h>
 #include <leveldb/write_batch.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <exception>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <vector>
+
 namespace leveldb {
 class Env;
 }

--- a/src/kernel/chain.cpp
+++ b/src/kernel/chain.cpp
@@ -2,6 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <kernel/chain.h>
+
 #include <chain.h>
 #include <interfaces/chain.h>
 #include <sync.h>

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -14,6 +14,7 @@
 #include <util/strencodings.h>
 #include <version.h>
 
+#include <algorithm>
 #include <cassert>
 #include <stdexcept>
 

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -22,6 +22,9 @@
 #include <tuple>
 #include <utility>
 #include <vector>
+#if __cplusplus >= 202002L
+#include <compare>
+#endif
 
 /**
  * A flag that is ORed into the protocol version to designate that a transaction

--- a/src/rpc/fees.cpp
+++ b/src/rpc/fees.cpp
@@ -19,6 +19,7 @@
 #include <array>
 #include <cmath>
 #include <string>
+#include <variant>
 
 namespace node {
 struct NodeContext;

--- a/src/rpc/signmessage.cpp
+++ b/src/rpc/signmessage.cpp
@@ -13,6 +13,7 @@
 #include <util/message.h>
 
 #include <string>
+#include <variant>
 
 static RPCHelpMan verifymessage()
 {

--- a/src/test/fuzz/txorphan.cpp
+++ b/src/test/fuzz/txorphan.cpp
@@ -9,7 +9,6 @@
 #include <policy/policy.h>
 #include <primitives/transaction.h>
 #include <script/script.h>
-#include <sync.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
@@ -21,7 +20,6 @@
 
 #include <cstdint>
 #include <memory>
-#include <set>
 #include <utility>
 #include <vector>
 

--- a/src/test/fuzz/txorphan.cpp
+++ b/src/test/fuzz/txorphan.cpp
@@ -18,6 +18,7 @@
 #include <util/check.h>
 #include <util/time.h>
 
+#include <algorithm>
 #include <cstdint>
 #include <memory>
 #include <utility>

--- a/src/test/fuzz/util/mempool.cpp
+++ b/src/test/fuzz/util/mempool.cpp
@@ -10,6 +10,7 @@
 #include <test/fuzz/util.h>
 #include <test/fuzz/util/mempool.h>
 
+#include <algorithm>
 #include <cassert>
 #include <cstdint>
 #include <limits>

--- a/src/test/fuzz/util/net.cpp
+++ b/src/test/fuzz/util/net.cpp
@@ -21,6 +21,8 @@
 #include <cstdlib>
 #include <cstring>
 #include <thread>
+#include <type_traits>
+#include <unordered_map>
 #include <vector>
 
 class CNode;

--- a/src/test/fuzz/util/net.cpp
+++ b/src/test/fuzz/util/net.cpp
@@ -14,6 +14,7 @@
 #include <util/time.h>
 #include <version.h>
 
+#include <algorithm>
 #include <array>
 #include <cassert>
 #include <cerrno>

--- a/src/test/fuzz/util/net.h
+++ b/src/test/fuzz/util/net.h
@@ -5,6 +5,7 @@
 #ifndef BITCOIN_TEST_FUZZ_UTIL_NET_H
 #define BITCOIN_TEST_FUZZ_UTIL_NET_H
 
+#include <compat/compat.h>
 #include <net.h>
 #include <net_permissions.h>
 #include <netaddress.h>

--- a/src/test/fuzz/util/net.h
+++ b/src/test/fuzz/util/net.h
@@ -7,7 +7,6 @@
 
 #include <compat/compat.h>
 #include <net.h>
-#include <net_permissions.h>
 #include <netaddress.h>
 #include <node/connection_types.h>
 #include <node/eviction.h>
@@ -24,6 +23,8 @@
 #include <memory>
 #include <optional>
 #include <string>
+
+enum class NetPermissionFlags : uint32_t;
 
 CNetAddr ConsumeNetAddr(FuzzedDataProvider& fuzzed_data_provider) noexcept;
 

--- a/src/util/check.h
+++ b/src/util/check.h
@@ -8,6 +8,7 @@
 #include <attributes.h>
 
 #include <stdexcept>
+#include <string>
 #include <utility>
 
 std::string StrFormatInternalBug(const char* msg, const char* file, int line, const char* func);

--- a/src/util/strencodings.cpp
+++ b/src/util/strencodings.cpp
@@ -3,8 +3,9 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <span.h>
 #include <util/strencodings.h>
+
+#include <span.h>
 
 #include <array>
 #include <cassert>
@@ -14,6 +15,9 @@
 #include <ostream>
 #include <string>
 #include <vector>
+#if __cplusplus >= 202002L
+#include <compare>
+#endif
 
 static const std::string CHARS_ALPHA_NUM = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -4,6 +4,7 @@
 
 #include <util/string.h>
 
+#include <map>
 #include <regex>
 #include <string>
 

--- a/src/versionbits.h
+++ b/src/versionbits.h
@@ -6,6 +6,7 @@
 #define BITCOIN_VERSIONBITS_H
 
 #include <chain.h>
+#include <consensus/params.h>
 #include <sync.h>
 
 #include <map>

--- a/src/zmq/zmqnotificationinterface.cpp
+++ b/src/zmq/zmqnotificationinterface.cpp
@@ -8,7 +8,6 @@
 #include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <util/system.h>
-#include <validationinterface.h>
 #include <zmq/zmqabstractnotifier.h>
 #include <zmq/zmqpublishnotifier.h>
 #include <zmq/zmqutil.h>
@@ -20,6 +19,8 @@
 #include <string>
 #include <utility>
 #include <vector>
+
+enum class MemPoolRemovalReason;
 
 CZMQNotificationInterface::CZMQNotificationInterface() : pcontext(nullptr)
 {

--- a/src/zmq/zmqnotificationinterface.h
+++ b/src/zmq/zmqnotificationinterface.h
@@ -15,6 +15,7 @@
 class CBlock;
 class CBlockIndex;
 class CZMQAbstractNotifier;
+enum class MemPoolRemovalReason;
 
 class CZMQNotificationInterface final : public CValidationInterface
 {

--- a/src/zmq/zmqpublishnotifier.cpp
+++ b/src/zmq/zmqpublishnotifier.cpp
@@ -16,7 +16,6 @@
 #include <rpc/server.h>
 #include <serialize.h>
 #include <streams.h>
-#include <sync.h>
 #include <uint256.h>
 #include <version.h>
 #include <zmq/zmqutil.h>


### PR DESCRIPTION
There was a hope that the new IWYU [v0.19](https://github.com/include-what-you-use/include-what-you-use/releases/tag/0.19) gets rid of the entire `contrib/devtools/iwyu/bitcoin.core.imp`. Alas...

Based on https://github.com/bitcoin/bitcoin/pull/26763.