### PR TITLE
ci: Use clang-15 in tsan task

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -228,10 +228,10 @@ task:
     FILE_ENV: "./ci/test/00_setup_env_native_qt5.sh"
 
 task:
-  name: '[TSan, depends, gui] [jammy]'
+  name: '[TSan, depends] [bookworm]'
   << : *GLOBAL_TASK_TEMPLATE
   container:
-    image: ubuntu:jammy
+    image: debian:bookworm
     cpu: 6  # Increase CPU and Memory to avoid timeout
     memory: 24G
   env:

--- a/ci/test/00_setup_env_native_tsan.sh
+++ b/ci/test/00_setup_env_native_tsan.sh
@@ -7,8 +7,8 @@
 export LC_ALL=C.UTF-8
 
 export CONTAINER_NAME=ci_native_tsan
-export DOCKER_NAME_TAG=ubuntu:22.04
-export PACKAGES="clang-13 llvm-13 libc++abi-13-dev libc++-13-dev python3-zmq"
-export DEP_OPTS="CC=clang-13 CXX='clang++-13 -stdlib=libc++'"
+export DOCKER_NAME_TAG=debian:bookworm  # For clang-15
+export PACKAGES="clang-15 llvm-15 libc++abi-15-dev libc++-15-dev python3-zmq"
+export DEP_OPTS="CC=clang-15 CXX='clang++-15 -stdlib=libc++' NO_QR=1"  # qr disabled due to libqrencode 3.4.4 compile failure, https://github.com/bitcoin/bitcoin/pull/26768#issuecomment-1367403430
 export GOAL="install"
-export BITCOIN_CONFIG="--enable-zmq CPPFLAGS='-DARENA_DEBUG -DDEBUG_LOCKORDER -DDEBUG_LOCKCONTENTION' CXXFLAGS='-g' --with-sanitizers=thread CC=clang-13 CXX='clang++-13 -stdlib=libc++'"
+export BITCOIN_CONFIG="--enable-zmq CPPFLAGS='-DARENA_DEBUG -DDEBUG_LOCKORDER -DDEBUG_LOCKCONTENTION' CXXFLAGS='-g' --with-sanitizers=thread"


### PR DESCRIPTION
Generally it is best to use the latest clang version for sanitizers, because it comes with the most features and bugfixes.

So bump to clang-15, the latest release, for the tsan task.

The task was using clang-13 (instead of 14) due to a bug, see https://github.com/bitcoin/bitcoin/pull/24572#issue-1169970859. Bumping to 15 will hopefully fix this bug, as well as https://github.com/bitcoin/bitcoin/pull/26759#issuecomment-1367360491