### PR TITLE
contrib: fix sha256 check in install_db4.sh for FreeBSD

### DIFF
--- a/contrib/install_db4.sh
+++ b/contrib/install_db4.sh
@@ -32,16 +32,15 @@ check_exists() {
 sha256_check() {
   # Args: <sha256_hash> <filename>
   #
-  if check_exists sha256sum; then
-    echo "${1}  ${2}" | sha256sum -c
+  if [ "$(uname)" = "FreeBSD" ]; then
+    # sha256sum exists on FreeBSD, but takes different arguments than the GNU version
+    sha256 -c "${1}" "${2}"
+  elif check_exists sha256sum; then
+    echo "${1} ${2}" | sha256sum -c
   elif check_exists sha256; then
-    if [ "$(uname)" = "FreeBSD" ]; then
-      sha256 -c "${1}" "${2}"
-    else
-      echo "${1}  ${2}" | sha256 -c
-    fi
+    echo "${1} ${2}" | sha256 -c
   else
-    echo "${1}  ${2}" | shasum -a 256 -c
+    echo "${1} ${2}" | shasum -a 256 -c
   fi
 }
 


### PR DESCRIPTION
The FreeBSD version of `sha256sum` takes different arguments than the GNU version.

The `sha256_check` function in `contrib/install_db4.sh` has code specific to FreeBSD, however it doesn't get reached because while the `sha256sum` command does exist on FreeBSD, it is incompatible and results in an error:

```
sha256sum: option requires an argument -- c
usage: sha256sum [-pqrtx] [-c file] [-s string] [files ...]
```

This change moves the FreeBSD-specific code before the check for the `sha256sum` command.

Fixes: #26774
