### PR TITLE
rpc: simplify scan blocks

### DIFF
--- a/test/functional/rpc_scanblocks.py
+++ b/test/functional/rpc_scanblocks.py
@@ -48,6 +48,7 @@ class ScanblocksTest(BitcoinTestFramework):
         assert blockhash in out['relevant_blocks']
         assert_equal(height, out['to_height'])
         assert_equal(0, out['from_height'])
+        assert_equal(True, out['completed'])
 
         # mine another block
         blockhash_new = self.generate(node, 1)[0]


### PR DESCRIPTION
Coming from https://github.com/bitcoin/bitcoin/pull/23549#pullrequestreview-1105712566

The current `scanblocks` flow walks-through every block in the active chain
until hits the chain tip or processes 10k blocks, then calls `lookupFilterRange`
function to obtain all filters from that particular range.

This is only done to obtain the heights range to look up the block
filters. Which is unneeded.

As `scanblocks` only lookup block filters in the active chain, we can
directly calculate the lookup range heights, by using the chain tip,
without requiring to traverse the chain block by block.