### PR TITLE
Release `LockData::dd_mutex` before calling `*_detected` functions

### DIFF
--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -53,7 +53,7 @@ static int FileWriteStr(std::string_view str, FILE *fp)
 
 bool BCLog::Logger::StartLogging()
 {
-    StdLockGuard scoped_lock(m_cs);
+    LOCK(m_cs);
 
     assert(m_buffering);
     assert(m_fileout == nullptr);
@@ -97,7 +97,7 @@ bool BCLog::Logger::StartLogging()
 
 void BCLog::Logger::DisconnectTestLogger()
 {
-    StdLockGuard scoped_lock(m_cs);
+    LOCK(m_cs);
     m_buffering = true;
     if (m_fileout != nullptr) fclose(m_fileout);
     m_fileout = nullptr;
@@ -111,7 +111,7 @@ void BCLog::Logger::DisconnectTestLogger()
 void BCLog::Logger::DisableLogging()
 {
     {
-        StdLockGuard scoped_lock(m_cs);
+        LOCK(m_cs);
         assert(m_buffering);
         assert(m_print_callbacks.empty());
     }
@@ -159,7 +159,7 @@ bool BCLog::Logger::WillLogCategoryLevel(BCLog::LogFlags category, BCLog::Level 
 
     if (!WillLogCategory(category)) return false;
 
-    StdLockGuard scoped_lock(m_cs);
+    LOCK(m_cs);
     const auto it{m_category_log_levels.find(category)};
     return level >= (it == m_category_log_levels.end() ? LogLevel() : it->second);
 }
@@ -423,7 +423,7 @@ void BCLog::Logger::FormatLogStrInPlace(std::string& str, BCLog::LogFlags catego
 
 void BCLog::Logger::LogPrintStr(std::string_view str, SourceLocation&& source_loc, BCLog::LogFlags category, BCLog::Level level, bool should_ratelimit)
 {
-    StdLockGuard scoped_lock(m_cs);
+    LOCK(m_cs);
     return LogPrintStr_(str, std::move(source_loc), category, level, should_ratelimit);
 }
 
@@ -598,7 +598,7 @@ bool BCLog::Logger::SetCategoryLogLevel(std::string_view category_str, std::stri
     const auto level = GetLogLevel(level_str);
     if (!level.has_value() || level.value() > MAX_USER_SETABLE_SEVERITY_LEVEL) return false;
 
-    StdLockGuard scoped_lock(m_cs);
+    LOCK(m_cs);
     m_category_log_levels[flag] = level.value();
     return true;
 }

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -392,7 +392,7 @@ BCLog::LogRateLimiter::Status BCLog::LogRateLimiter::Consume(
     const SourceLocation& source_loc,
     const std::string& str)
 {
-    StdLockGuard scoped_lock(m_mutex);
+    LOCK(m_mutex);
     auto& stats{m_source_locations.try_emplace(source_loc, m_max_bytes).first->second};
     Status status{stats.m_dropped_bytes > 0 ? Status::STILL_SUPPRESSED : Status::UNSUPPRESSED};
 
@@ -556,7 +556,7 @@ void BCLog::LogRateLimiter::Reset()
 {
     decltype(m_source_locations) source_locations;
     {
-        StdLockGuard scoped_lock(m_mutex);
+        LOCK(m_mutex);
         source_locations.swap(m_source_locations);
         m_suppression_active = false;
     }

--- a/src/logging.h
+++ b/src/logging.h
@@ -150,7 +150,7 @@ namespace BCLog {
         };
 
     private:
-        mutable StdMutex m_mutex;
+        mutable Mutex m_mutex;
 
         //! Stats for each source location that has attempted to log something.
         std::unordered_map<SourceLocation, Stats, SourceLocationHasher, SourceLocationEqual> m_source_locations GUARDED_BY(m_mutex);

--- a/src/threadsafety.h
+++ b/src/threadsafety.h
@@ -6,8 +6,6 @@
 #ifndef BITCOIN_THREADSAFETY_H
 #define BITCOIN_THREADSAFETY_H
 
-#include <mutex>
-
 #ifdef __clang__
 // TL;DR Add GUARDED_BY(mutex) to member variables. The others are
 // rarely necessary. Ex: int nFoo GUARDED_BY(cs_foo);
@@ -53,27 +51,5 @@
 #define NO_THREAD_SAFETY_ANALYSIS
 #define ASSERT_EXCLUSIVE_LOCK(...)
 #endif // __GNUC__
-
-// StdMutex provides an annotated version of std::mutex for us,
-// and should only be used when sync.h Mutex/LOCK/etc are not usable.
-class LOCKABLE StdMutex : public std::mutex
-{
-public:
-#ifdef __clang__
-    //! For negative capabilities in the Clang Thread Safety Analysis.
-    //! A negative requirement uses the EXCLUSIVE_LOCKS_REQUIRED attribute, in conjunction
-    //! with the ! operator, to indicate that a mutex should not be held.
-    const StdMutex& operator!() const { return *this; }
-#endif // __clang__
-};
-
-// StdLockGuard provides an annotated version of std::lock_guard for us,
-// and should only be used when sync.h Mutex/LOCK/etc are not usable.
-class SCOPED_LOCKABLE StdLockGuard : public std::lock_guard<StdMutex>
-{
-public:
-    explicit StdLockGuard(StdMutex& cs) EXCLUSIVE_LOCK_FUNCTION(cs) : std::lock_guard<StdMutex>(cs) {}
-    ~StdLockGuard() UNLOCK_FUNCTION() = default;
-};
 
 #endif // BITCOIN_THREADSAFETY_H


### PR DESCRIPTION
Both `double_lock_detected()` and `potential_deadlock_detected()` functions call `LogPrintf()` which in turn implies locking of the `Logger::m_cs` mutex. To avoid a deadlock, the latter must not have the `Mutex` type (see https://github.com/bitcoin/bitcoin/pull/16112).

With this PR the mentioned restriction has been lifted, and it is possible now to use our regular `Mutex` type for the `Logger::m_cs` mutex instead of a dedicated `StdMutex` type (not introducing that change here, as its diff is much bigger than a few lines, and the currently proposed diff seems valuable by itself).

**Note for reviewers:** Make sure the code is configured and built with `CPPFLAGS=-DDEBUG_LOCKORDER`.