### PR TITLE
ci: Properly set COMMIT_RANGE in lint task

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -29,6 +29,7 @@ base_template: &BASE_TEMPLATE
     - if [ "$CIRRUS_PR" = "" ]; then exit 0; fi
     - git fetch $CIRRUS_REPO_CLONE_URL "pull/${CIRRUS_PR}/merge"
     - git checkout FETCH_HEAD  # Use merged changes to detect silent merge conflicts
+                               # Also, the merge commit is used to lint COMMIT_RANGE="HEAD~..HEAD"
 
 main_template: &MAIN_TEMPLATE
   timeout_in: 120m  # https://cirrus-ci.org/faq/#instance-timed-out

--- a/ci/lint/06_script.sh
+++ b/ci/lint/06_script.sh
@@ -6,9 +6,8 @@
 
 export LC_ALL=C
 
-GIT_HEAD=$(git rev-parse HEAD)
 if [ -n "$CIRRUS_PR" ]; then
-  COMMIT_RANGE="${CIRRUS_BASE_SHA}..$GIT_HEAD"
+  COMMIT_RANGE="HEAD~..HEAD"
   echo
   git log --no-merges --oneline "$COMMIT_RANGE"
   echo


### PR DESCRIPTION
Currently the variable holds (apart from the commits in the pull request) all commits to master since the pull was opened.

This is problematic, because already merged commits are linted in unrelated pulls, leading to:

* Wasted resources. For example, currently the lint task may take 9 minutes, when it should take 1. See https://cirrus-ci.com/task/6032782770569216?logs=lint#L1449
* False failures. For example, when a "wrong" commit is in master it can lead to some pulls failing unrelatedly, and others not.

Now that the CI has the `/merge` commit (since commit fad7281d7842f337932cf44e703fdd631230ddd6), `COMMIT_RANGE` can simply be set to `HEAD~..HEAD` to only hold the changes in the pull.