### PR TITLE
test: test banlist database recreation

### DIFF
--- a/test/functional/p2p_disconnect_ban.py
+++ b/test/functional/p2p_disconnect_ban.py
@@ -4,6 +4,7 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test node disconnect and ban behavior"""
 import time
+from pathlib import Path
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
@@ -36,6 +37,17 @@ class DisconnectBanTest(BitcoinTestFramework):
         self.log.info("clearbanned: successfully clear ban list")
         self.nodes[1].clearbanned()
         assert_equal(len(self.nodes[1].listbanned()), 0)
+
+        self.log.info('Test banlist database recreation')
+        self.stop_node(1)
+        target_file = self.nodes[1].chain_path / "banlist.json"
+        Path.unlink(target_file)
+        with self.nodes[1].assert_debug_log(["Recreating the banlist database"]):
+            self.start_node(1)
+
+        assert Path.exists(target_file)
+        assert_equal(self.nodes[1].listbanned(), [])
+
         self.nodes[1].setban("127.0.0.0/24", "add")
 
         self.log.info("setban: fail to ban an already banned subnet")


### PR DESCRIPTION
This PR adds test coverage for 'banlist database recreation'. If it wasn't able to read ban db (in `LoadBanlist`), so it should create a new (an empty, ofc) one.
https://github.com/bitcoin/bitcoin/blob/d8bdee0fc889def7c5f5076da13db4fce0a3728a/src/banman.cpp#L28-L45
