### PR TITLE
test: drop E275 rule in lint-python.py for flake8 5.0.4, update dependencies

### DIFF
--- a/ci/lint/04_install.sh
+++ b/ci/lint/04_install.sh
@@ -17,10 +17,10 @@ ${CI_RETRY_EXE} apt-get install -y python3-pip curl git gawk jq
 )
 
 ${CI_RETRY_EXE} pip3 install codespell==2.2.1
-${CI_RETRY_EXE} pip3 install flake8==4.0.1
-${CI_RETRY_EXE} pip3 install mypy==0.942
-${CI_RETRY_EXE} pip3 install pyzmq==22.3.0
-${CI_RETRY_EXE} pip3 install vulture==2.3
+${CI_RETRY_EXE} pip3 install flake8==5.0.4
+${CI_RETRY_EXE} pip3 install mypy==0.971
+${CI_RETRY_EXE} pip3 install pyzmq==24.0.1
+${CI_RETRY_EXE} pip3 install vulture==2.6
 
 SHELLCHECK_VERSION=v0.8.0
 curl -sL "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" | tar --xz -xf - --directory /tmp/

--- a/test/lint/lint-python.py
+++ b/test/lint/lint-python.py
@@ -35,7 +35,6 @@ ENABLED = (
     'E272,'  # multiple spaces before keyword
     'E273,'  # tab after keyword
     'E274,'  # tab before keyword
-    'E275,'  # missing whitespace after keyword
     'E304,'  # blank lines found after function decorator
     'E306,'  # expected 1 blank line before a nested definition
     'E401,'  # multiple imports on one line


### PR DESCRIPTION
It is helpful to be able to run the python linter locally to review PRs and check local diffs and work.  Fix the errors raised by `./test/lint/lint-python.py` when run locally with flake8 5.0.4, which enforces rule E275 more strictly than previous versions, by dropping enforcement of that rule from our linter. Also update our python linter CI dependencies. Alternative to #26257.
