### PR TITLE
test: Use same Python executable for subprocesses as for `all-lint.py`

### DIFF
--- a/test/lint/all-lint.py
+++ b/test/lint/all-lint.py
@@ -10,11 +10,12 @@
 from glob import glob
 from pathlib import Path
 from subprocess import run
+from sys import executable
 
 exit_code = 0
 mod_path = Path(__file__).parent
 for lint in glob(f"{mod_path}/lint-*.py"):
-    result = run([lint])
+    result = run([executable, lint])
     if result.returncode != 0:
         print(f"^---- failure generated from {lint.split('/')[-1]}")
         exit_code |= result.returncode


### PR DESCRIPTION
Before this all linters were ran by `/usr/bin/env python3`, no matter what was used to run `test/lint/all-lint.py`. This change allows to use non-default Python executable for `test/lint/all-lint.py` and then all subprocesses will also use same Python interpreter (for example, `python3.10 ./test/lint/all-lint.py`). See https://github.com/bitcoin/bitcoin/issues/26792#issuecomment-1369558866 as use case.
