### PR TITLE
doc: remove nonexistent files from copyright

### DIFF
--- a/contrib/debian/copyright
+++ b/contrib/debian/copyright
@@ -15,14 +15,6 @@ Copyright: 2010-2011, Jonas Smedegaard <dr@jones.dk>
            2011, Matt Corallo <matt@bluematt.me>
 License: GPL-2+
 
-Files: src/secp256k1/build-aux/m4/ax_jni_include_dir.m4
-Copyright: 2008 Don Anderson <dda@sleepycat.com>
-License: GNU-All-permissive-License
-
-Files: src/secp256k1/build-aux/m4/ax_prog_cc_for_build.m4
-Copyright: 2008 Paolo Bonzini <bonzini@gnu.org>
-License: GNU-All-permissive-License
-
 Files: src/qt/res/icons/add.png
        src/qt/res/icons/address-book.png
        src/qt/res/icons/chevron.png
@@ -111,12 +103,6 @@ License: Expat
  CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
  TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-License: GNU-All-permissive-License
- Copying and distribution of this file, with or without modification, are
- permitted in any medium without royalty provided the copyright notice
- and this notice are preserved. This file is offered as-is, without any
- warranty.
 
 License: GPL-2+
  This program is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
The removed files were dropped during a secp256k1 subtree update.