### PR TITLE
test: add end-to-end tests for CConnman and PeerManager

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -118,8 +118,6 @@ static constexpr int STALE_RELAY_AGE_LIMIT = 30 * 24 * 60 * 60;
 /// Age after which a block is considered historical for purposes of rate
 /// limiting block relay. Set to one week, denominated in seconds.
 static constexpr int HISTORICAL_BLOCK_AGE = 7 * 24 * 60 * 60;
-/** Time between pings automatically sent out for latency probing and keepalive */
-static constexpr auto PING_INTERVAL{2min};
 /** The maximum number of entries in a locator */
 static const unsigned int MAX_LOCATOR_SZ = 101;
 /** The maximum number of entries in an 'inv' protocol message */

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -47,6 +47,8 @@ static const unsigned int MAX_CMPCTBLOCKS_INFLIGHT_PER_BLOCK = 3;
 /** Number of headers sent in one getheaders result. We rely on the assumption that if a peer sends
  *  less than this number, we reached its tip. Changing this value is a protocol upgrade. */
 static const unsigned int MAX_HEADERS_RESULTS = 2000;
+/** Time between pings automatically sent out for latency probing and keepalive */
+static constexpr auto PING_INTERVAL{2min};
 
 struct CNodeStateStats {
     int nSyncHeight = -1;

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -63,6 +63,7 @@ add_executable(test_bitcoin
   minisketch_tests.cpp
   multisig_tests.cpp
   bip328_tests.cpp
+  net_msg_tests.cpp
   net_peer_connection_tests.cpp
   net_peer_eviction_tests.cpp
   net_tests.cpp

--- a/src/test/net_msg_tests.cpp
+++ b/src/test/net_msg_tests.cpp
@@ -1,0 +1,197 @@
+// Copyright (c) 2022-2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <net.h>
+#include <net_processing.h>
+#include <netbase.h>
+#include <primitives/block.h>
+#include <protocol.h>
+#include <streams.h>
+#include <test/util/logging.h>
+#include <test/util/net.h>
+#include <test/util/setup_common.h>
+#include <tinyformat.h>
+#include <uint256.h>
+#include <util/time.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <atomic>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <ratio>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+BOOST_FIXTURE_TEST_SUITE(net_msg_tests, NetTestingSetup)
+
+BOOST_AUTO_TEST_CASE(initial_messages_exchange)
+{
+    std::unordered_map<std::string, size_t> count_sent_messages;
+    const auto pipes{m_sockets_pipes.PopFront()};
+
+    // Wait for all messages due to the initial handshake to be Send() to the socket.
+    // The FEEFILTER is the last one, so quit when we get that.
+    for (;;) {
+        auto msg = pipes->send.GetNetMsg();
+        if (!msg.has_value()) {
+            break;
+        }
+        ++count_sent_messages[msg->m_type];
+        if (msg->m_type == NetMsgType::FEEFILTER) {
+            break;
+        }
+    }
+
+    BOOST_CHECK_EQUAL(count_sent_messages[NetMsgType::VERSION], 1);
+    BOOST_CHECK_EQUAL(count_sent_messages[NetMsgType::WTXIDRELAY], 1);
+    BOOST_CHECK_EQUAL(count_sent_messages[NetMsgType::SENDADDRV2], 1);
+    BOOST_CHECK_EQUAL(count_sent_messages[NetMsgType::VERACK], 1);
+    BOOST_CHECK_EQUAL(count_sent_messages[NetMsgType::GETADDR], 1);
+    BOOST_CHECK_EQUAL(count_sent_messages[NetMsgType::SENDCMPCT], 1);
+    BOOST_CHECK_EQUAL(count_sent_messages[NetMsgType::PING], 1);
+    BOOST_CHECK_EQUAL(count_sent_messages[NetMsgType::GETHEADERS], 1);
+    BOOST_CHECK_EQUAL(count_sent_messages[NetMsgType::FEEFILTER], 1);
+}
+
+BOOST_AUTO_TEST_CASE(addr)
+{
+    const auto pipes{m_sockets_pipes.PopFront()};
+    std::vector<CAddress> addresses{5};
+
+    ASSERT_DEBUG_LOG_WAIT(strprintf("Received addr: %u addresses", addresses.size()), 30s);
+    pipes->recv.PushNetMsg(NetMsgType::ADDRV2, CAddress::V2_NETWORK(addresses));
+}
+
+BOOST_AUTO_TEST_CASE(getblocks)
+{
+    const auto pipes{m_sockets_pipes.PopFront()};
+    std::vector<uint256> hashes{5};
+    CBlockLocator block_locator{std::move(hashes)};
+    uint256 hash_stop;
+
+    ASSERT_DEBUG_LOG_WAIT("getblocks -1 to end", 30s);
+    pipes->recv.PushNetMsg(NetMsgType::GETBLOCKS, block_locator, hash_stop);
+}
+
+BOOST_AUTO_TEST_CASE(ping)
+{
+    const auto pipes{m_sockets_pipes.PopFront()};
+
+    auto WaitForPingStats = [this](std::chrono::microseconds min,
+                                   std::chrono::microseconds last,
+                                   std::chrono::microseconds wait) {
+        BOOST_REQUIRE_EQUAL(m_node.connman->GetNodeCount(ConnectionDirection::Both), 1);
+
+        const auto deadline = std::chrono::steady_clock::now() + 30s;
+        bool end{false};
+
+        // Collect the ping stats and check if they are as expected. Retry if not as expected.
+        for (;;) {
+            m_node.connman->ForEachNode([&](CNode* node) {
+                CNodeStateStats stats;
+                BOOST_REQUIRE(m_node.peerman->GetNodeStateStats(node->GetId(), stats));
+                const auto min_actual{node->m_min_ping_time.load().count()};
+                const auto last_actual{node->m_last_ping_time.load().count()};
+                const auto wait_actual{stats.m_ping_wait.count()};
+                const bool ok{min_actual == min.count() &&
+                              last_actual == last.count() &&
+                              wait_actual == wait.count()};
+
+                if (ok) {
+                    end = true;
+                } else if (std::chrono::steady_clock::now() > deadline) {
+                    BOOST_CHECK_EQUAL(min_actual, min.count());
+                    BOOST_CHECK_EQUAL(last_actual, last.count());
+                    BOOST_CHECK_EQUAL(wait_actual, wait.count());
+                    end = true;
+                }
+            });
+            if (end) {
+                break;
+            }
+            std::this_thread::sleep_for(100ms);
+        }
+    };
+
+    auto GetPingNonceSent = [&]() {
+        for (;;) {
+            auto msg = pipes->send.GetNetMsg();
+            assert(msg.has_value());
+            if (msg->m_type == NetMsgType::PING) {
+                uint64_t nonce;
+                msg->m_recv >> nonce;
+                return nonce;
+            }
+        }
+    };
+
+    auto SendPing = [&]() {
+        {
+            ASSERT_DEBUG_LOG_WAIT("sending ping", 30s);
+            SetMockTime(GetMockTime() + PING_INTERVAL + 1s);
+        }
+        return GetPingNonceSent();
+    };
+
+    BOOST_TEST_MESSAGE("Ensure initial messages exchange has completed with the sending of a ping "
+                       "with nonce != 0 and the ping stats indicate a pending ping.");
+    BOOST_REQUIRE_NE(GetPingNonceSent(), 0);
+    auto time_elapsed = 1s;
+    SetMockTime(GetMockTime() + time_elapsed);
+    WaitForPingStats(/*min=*/std::chrono::microseconds::max(), /*last=*/0us, /*wait=*/time_elapsed);
+
+    BOOST_TEST_MESSAGE("Check that receiving a PONG without nonce cancels our PING");
+    {
+        ASSERT_DEBUG_LOG_WAIT("Short payload", 30s);
+        pipes->recv.PushNetMsg(NetMsgType::PONG);
+    }
+    WaitForPingStats(/*min=*/std::chrono::microseconds::max(), /*last=*/0us, /*wait=*/0us);
+
+    BOOST_TEST_MESSAGE("Check that receiving an unrequested PONG is logged and ignored");
+    {
+        ASSERT_DEBUG_LOG_WAIT("Unsolicited pong without ping", 30s);
+        pipes->recv.PushNetMsg(NetMsgType::PONG, /*nonce=*/uint64_t{0});
+    }
+
+    BOOST_TEST_MESSAGE("Check that receiving a PONG with the wrong nonce does not cancel our PING");
+    uint64_t nonce{SendPing()};
+    {
+        ASSERT_DEBUG_LOG_WAIT("Nonce mismatch", 30s);
+        pipes->recv.PushNetMsg(NetMsgType::PONG, nonce + 1);
+    }
+    time_elapsed = 5s;
+    SetMockTime(GetMockTime() + time_elapsed);
+    WaitForPingStats(/*min=*/std::chrono::microseconds::max(), /*last=*/0us, /*wait=*/time_elapsed);
+
+    BOOST_TEST_MESSAGE("Check that receiving a PONG with nonce=0 cancels our PING");
+    {
+        ASSERT_DEBUG_LOG_WAIT("Nonce zero", 30s);
+        pipes->recv.PushNetMsg(NetMsgType::PONG, /*nonce=*/uint64_t{0});
+    }
+    WaitForPingStats(/*min=*/std::chrono::microseconds::max(), /*last=*/0us, /*wait=*/0us);
+
+    BOOST_TEST_MESSAGE("Check that receiving a PONG with the correct nonce cancels our PING");
+    nonce = SendPing();
+    time_elapsed = 5s;
+    SetMockTime(GetMockTime() + time_elapsed);
+    pipes->recv.PushNetMsg(NetMsgType::PONG, nonce);
+    WaitForPingStats(time_elapsed, time_elapsed, 0us);
+}
+
+BOOST_AUTO_TEST_CASE(redundant_verack)
+{
+    const auto pipes{m_sockets_pipes.PopFront()};
+
+    ASSERT_DEBUG_LOG_WAIT("ignoring redundant verack message", 30s);
+    pipes->recv.PushNetMsg(NetMsgType::VERACK);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/util/logging.cpp
+++ b/src/test/util/logging.cpp
@@ -11,19 +11,30 @@
 #include <cstdlib>
 #include <iostream>
 
-DebugLogHelper::DebugLogHelper(std::string message, MatchFn match)
-    : m_message{std::move(message)}, m_match(std::move(match))
+DebugLogHelper::DebugLogHelper(std::string message, MatchFn match, std::optional<std::chrono::milliseconds> timeout)
+    : m_message{std::move(message)}, m_timeout{timeout}, m_match(std::move(match))
 {
     m_print_connection = LogInstance().PushBackCallback(
         [this](const std::string& s) {
-            if (m_found) return;
-            m_found = s.find(m_message) != std::string::npos && m_match(&s);
+            StdLockGuard lock{m_mutex};
+            if (!m_found) {
+                if (s.find(m_message) != std::string::npos && m_match(&s)) {
+                    m_found = true;
+                    m_cv.notify_all();
+                }
+            }
         });
     noui_test_redirect();
 }
 
 DebugLogHelper::~DebugLogHelper()
 {
+    {
+        StdUniqueLock lock{m_mutex};
+        if (m_timeout.has_value()) {
+            m_cv.wait_for(lock, m_timeout.value(), [this]() EXCLUSIVE_LOCKS_REQUIRED(m_mutex) { return m_found; });
+        }
+    }
     noui_reconnect();
     LogInstance().DeleteCallback(m_print_connection);
     if (!m_found && m_match(nullptr)) {

--- a/src/test/util/logging.h
+++ b/src/test/util/logging.h
@@ -5,10 +5,14 @@
 #ifndef BITCOIN_TEST_UTIL_LOGGING_H
 #define BITCOIN_TEST_UTIL_LOGGING_H
 
+#include <sync.h>
 #include <util/macros.h>
 
+#include <chrono>
+#include <condition_variable>
 #include <functional>
 #include <list>
+#include <optional>
 #include <string>
 
 class DebugLogHelper
@@ -25,7 +29,15 @@ public:
     //! Can return false to do the opposite in either case.
     using MatchFn = std::function<bool(const std::string* line)>;
 
-    explicit DebugLogHelper(std::string message, MatchFn match = [](const std::string*){ return true; });
+    static bool MatchFnDefault(const std::string*)
+    {
+        return true;
+    }
+
+    explicit DebugLogHelper(
+        std::string message,
+        MatchFn match = MatchFnDefault,
+        std::optional<std::chrono::milliseconds> timeout = std::nullopt);
 
     DebugLogHelper(const DebugLogHelper&) = delete;
     DebugLogHelper& operator=(const DebugLogHelper&) = delete;
@@ -34,11 +46,20 @@ public:
 
 private:
     const std::string m_message;
-    bool m_found{false};
+    const std::optional<std::chrono::milliseconds> m_timeout;
+    // Mutex + LOCK() is not usable here because LOCK() may print to the log
+    // itself (see DEBUG_LOCKCONTENTION) causing a deadlock between this mutex
+    // and BCLog::Logger::m_cs which is acquired when logging a message.
+    StdMutex m_mutex;
+    std::condition_variable_any m_cv;
+    bool m_found GUARDED_BY(m_mutex){false};
     std::list<std::function<void(const std::string&)>>::iterator m_print_connection;
     MatchFn m_match;
 };
 
 #define ASSERT_DEBUG_LOG(message) DebugLogHelper UNIQUE_NAME(debugloghelper)(message)
+
+#define ASSERT_DEBUG_LOG_WAIT(message, timeout) \
+    DebugLogHelper UNIQUE_NAME(debugloghelper)(message, DebugLogHelper::MatchFnDefault, timeout)
 
 #endif // BITCOIN_TEST_UTIL_LOGGING_H

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -597,6 +597,106 @@ std::vector<CTransactionRef> TestChain100Setup::PopulateMempool(FastRandomContex
     return mempool_transactions;
 }
 
+NetTestingSetup::NetTestingSetup(ChainType chain_type, const TestOpts& test_opts)
+    : TestingSetup{chain_type, test_opts}
+{
+    CreateSock = [this](int, int, int) {
+        auto pipes = std::make_shared<DynSock::Pipes>();
+
+        // Schedule VERSION, VERACK and PING to be returned by Recv() from the socket (initial handshake).
+        pipes->recv.PushNetMsg(NetMsgType::VERSION,
+                               /*version=*/PROTOCOL_VERSION,
+                               /*services=*/uint64_t{NODE_NETWORK | NODE_WITNESS},
+                               /*timestamp=*/count_seconds(GetTime<std::chrono::seconds>()),
+                               /*addr_recv services=*/uint64_t{NODE_NETWORK | NODE_WITNESS},
+                               /*addr_recv=*/CAddress::V2_NETWORK(CService{}),
+                               /*addr_trans services=*/uint64_t{NODE_NETWORK | NODE_WITNESS},
+                               /*addr_trans=*/CAddress::V2_NETWORK(CService{}),
+                               /*nonce=*/uint64_t{0},
+                               /*user_agent=*/std::string{},
+                               /*start_height=*/1,
+                               /*relay=*/false);
+        pipes->recv.PushNetMsg(NetMsgType::VERACK);
+        pipes->recv.PushNetMsg(NetMsgType::PING, /*nonce=*/uint64_t{123});
+
+        m_sockets_pipes.PushBack(pipes);
+
+        // An empty queue means that the Accept() method on the sockets created
+        // here will always return nullptr (mimicking an error).
+        auto accept_sockets{std::make_shared<DynSock::Queue>()};
+
+        return std::make_unique<DynSock>(pipes, accept_sockets);
+    };
+
+    fListen = false;
+    fNameLookup = false;
+    m_node.args->ForceSetArg("-dnsseed", "0");
+    m_node.args->ForceSetArg("-fixedseeds", "0");
+
+    // Add 1.2.3.4:8333 to addrman, sent to us by 5.6.7.8.
+    in_addr service_in_addr;
+    service_in_addr.s_addr = htonl(0x01020304);
+    const CService service{service_in_addr, 8333};
+    const CAddress addr{service, ServiceFlags{NODE_NETWORK | NODE_WITNESS}};
+    in_addr source_in_addr;
+    source_in_addr.s_addr = htonl(0x05060708);
+    m_node.addrman->Add(std::vector<CAddress>{addr}, CNetAddr{source_in_addr});
+
+    CConnman::Options opts;
+    opts.m_max_automatic_connections = 1;
+    opts.nSendBufferMaxSize = 1000 * m_node.args->GetIntArg("-maxsendbuffer", DEFAULT_MAXSENDBUFFER);
+    opts.nReceiveFloodSize = 1000 * m_node.args->GetIntArg("-maxreceivebuffer", DEFAULT_MAXRECEIVEBUFFER);
+    opts.m_banman = m_node.banman.get();
+    opts.m_msgproc = m_node.peerman.get();
+    opts.m_use_addrman_outgoing = true;
+
+    SetMockTime(GetTime());
+
+    if (!m_node.connman->Start(*m_node.scheduler, opts)) {
+        throw std::runtime_error{"Cannot start connman"};
+    }
+}
+
+NetTestingSetup::~NetTestingSetup()
+{
+    std::shared_ptr<DynSock::Pipes> pipes;
+    while ((pipes = m_sockets_pipes.PopFront(false)).get() != nullptr) {
+        pipes->recv.Eof();
+    }
+    m_node.connman->Interrupt();
+
+    SetMockTime(0s);
+
+    m_node.args->ForceSetArg("-fixedseeds", DEFAULT_FIXEDSEEDS ? "1" : "0");
+    m_node.args->ForceSetArg("-dnsseed", DEFAULT_DNSSEED ? "1" : "0");
+    fNameLookup = DEFAULT_NAME_LOOKUP;
+    fListen = true;
+    CreateSock = CreateSockOS;
+}
+
+void NetTestingSetup::PipesFifo::PushBack(std::shared_ptr<DynSock::Pipes> pipes)
+{
+    LOCK(m_mutex);
+    m_list.push_back(pipes);
+    m_cond.notify_one();
+}
+
+std::shared_ptr<DynSock::Pipes> NetTestingSetup::PipesFifo::PopFront(bool wait)
+{
+    WAIT_LOCK(m_mutex, lock);
+    if (wait) {
+        m_cond.wait(lock, [this]() EXCLUSIVE_LOCKS_REQUIRED(m_mutex) {
+            AssertLockHeld(m_mutex);
+            return !m_list.empty();
+        });
+    } else if (m_list.empty()) {
+        return nullptr;
+    }
+    std::shared_ptr<DynSock::Pipes> ret{m_list.front()};
+    m_list.pop_front();
+    return ret;
+}
+
 /**
  * @returns a real block (0000000000013b8ab2cd513b0261a14096412195a72a0c4827d229dcc7e0f7af)
  *      with 9 txs.

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -16,6 +16,7 @@
 #include <primitives/transaction.h>
 #include <pubkey.h>
 #include <stdexcept>
+#include <test/util/net.h>
 #include <test/util/random.h>
 #include <util/chaintype.h> // IWYU pragma: export
 #include <util/check.h>
@@ -134,6 +135,42 @@ struct RegTestingSetup : public TestingSetup {
 struct Testnet4Setup : public TestingSetup {
     Testnet4Setup()
         : TestingSetup{ChainType::TESTNET4} {}
+};
+
+/**
+ * TestingSetup + start connman at the beginning of each test and stop it when it ends.
+ * Changes `CreateSock()` to create `DynSock` sockets, so that the connman functions do not create
+ * a real socket and do not open real network connections. The mocked sockets' data can be
+ * controlled via the `m_sockets_pipes` member, available in each unit test.
+ * The connman is configured in such a way that it would try to open one p2p connection.
+ */
+struct NetTestingSetup : public TestingSetup {
+    explicit NetTestingSetup(ChainType chain_type = ChainType::REGTEST, const TestOpts& test_opts = {});
+
+    ~NetTestingSetup();
+
+    /**
+     * Thread safe FIFO of std::shared_ptr<DynSock::Pipes>.
+     * Used for pushing the pipes of newly created sockets (by CConnman threads) and
+     * getting and controlling them from tests.
+     */
+    class PipesFifo {
+    public:
+        /**
+         * Append a new pair of pipes to the list.
+         */
+        void PushBack(std::shared_ptr<DynSock::Pipes> pipes) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
+        /**
+         * Remove the front of the list and return it.
+         */
+        std::shared_ptr<DynSock::Pipes> PopFront(bool wait = true) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
+    private:
+        Mutex m_mutex;
+        std::condition_variable m_cond;
+        std::list<std::shared_ptr<DynSock::Pipes>> m_list GUARDED_BY(m_mutex);
+    } m_sockets_pipes;
 };
 
 class CBlock;

--- a/src/threadsafety.h
+++ b/src/threadsafety.h
@@ -76,4 +76,13 @@ public:
     ~StdLockGuard() UNLOCK_FUNCTION() = default;
 };
 
+// StdUniqueLock provides an annotated version of std::unique_lock for us,
+// and should only be used when sync.h Mutex/LOCK/etc are not usable.
+class SCOPED_LOCKABLE StdUniqueLock : public std::unique_lock<StdMutex>
+{
+public:
+    explicit StdUniqueLock(StdMutex& cs) EXCLUSIVE_LOCK_FUNCTION(cs) : std::unique_lock<StdMutex>(cs) {}
+    ~StdUniqueLock() UNLOCK_FUNCTION() = default;
+};
+
 #endif // BITCOIN_THREADSAFETY_H


### PR DESCRIPTION
Add unit tests that write data to a mocked socket and inspect what CConnman/PeerManager have written back to the socket, or check the internal state to verify that the behavior is as expected.

This is now possible, after most of https://github.com/bitcoin/bitcoin/pull/21878 has been merged - we don't do any syscalls (e.g. `connect()`, `recv()`) from the high level code and using a mocked socket allows testing the entire networking stack without opening actual network connections.