### PR TITLE
refactor: Work around Werror=free-nonheap-object in AssumeCalculateMemPoolAncestors

### DIFF
--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -260,8 +260,8 @@ CTxMemPool::setEntries CTxMemPool::AssumeCalculateMemPoolAncestors(
     const Limits& limits,
     bool fSearchForParents /* = true */) const
 {
-    auto result{Assume(CalculateMemPoolAncestors(entry, limits, fSearchForParents))};
-    if (!result) {
+    auto result{CalculateMemPoolAncestors(entry, limits, fSearchForParents)};
+    if (!Assume(result)) {
         LogPrintLevel(BCLog::MEMPOOL, BCLog::Level::Error, "%s: CalculateMemPoolAncestors failed unexpectedly, continuing with empty ancestor set (%s)\n",
                       calling_fn_name, util::ErrorString(result).original);
     }


### PR DESCRIPTION
This works around the s390x gcc bug mentioned in https://github.com/bitcoin/bitcoin/issues/26820