### PR TITLE
refactor: remove windows-only compat.h usage in randomenv

### DIFF
--- a/src/randomenv.cpp
+++ b/src/randomenv.cpp
@@ -13,22 +13,21 @@
 #include <compat/cpuid.h>
 #include <crypto/sha512.h>
 #include <support/cleanse.h>
-#include <util/time.h> // for GetTime()
-#ifdef WIN32
-#include <windows.h>
-#include <winreg.h>
-#endif
+#include <util/time.h>
 
 #include <algorithm>
 #include <atomic>
+#include <cstdint>
+#include <cstring>
 #include <chrono>
 #include <climits>
 #include <thread>
 #include <vector>
 
-#include <stdint.h>
-#include <string.h>
-#ifndef WIN32
+#ifdef WIN32
+#include <windows.h>
+#include <winreg.h>
+#else
 #include <sys/types.h> // must go before a number of other headers
 #include <fcntl.h>
 #include <netinet/in.h>

--- a/src/randomenv.cpp
+++ b/src/randomenv.cpp
@@ -15,7 +15,8 @@
 #include <support/cleanse.h>
 #include <util/time.h> // for GetTime()
 #ifdef WIN32
-#include <compat/compat.h>
+#include <windows.h>
+#include <winreg.h>
 #endif
 
 #include <algorithm>


### PR DESCRIPTION
Similar to #26814.

Having a windows-only include of compat.h is confusing, not-only because it's already included globally via util/time.h, but also because it's unclear why compat.h is included (neither of the required headers are included there).

This change is related to removing the use of compat.h as a miscellaneous catch-all for unclear/platform specific includes. Somewhat prompted by IWYU-related discussion here: https://github.com/bitcoin/bitcoin/pull/26763/files#r1058861693.