### PR TITLE
compat: move (win) S_* defines into bdb

### DIFF
--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -62,15 +62,6 @@ typedef unsigned int SOCKET;
 #endif
 #endif
 
-// Windows doesn't define S_IRUSR or S_IWUSR. We define both
-// here, with the same values as glibc (see stat.h).
-#ifdef WIN32
-#ifndef S_IRUSR
-#define S_IRUSR             0400
-#define S_IWUSR             0200
-#endif
-#endif
-
 // Windows defines MAX_PATH as it's maximum path length.
 // We define MAX_PATH for use on non-Windows systems.
 #ifndef WIN32

--- a/src/randomenv.cpp
+++ b/src/randomenv.cpp
@@ -24,11 +24,12 @@
 #include <thread>
 #include <vector>
 
+#include <sys/types.h> // must go before a number of other headers
+
 #ifdef WIN32
 #include <windows.h>
 #include <winreg.h>
 #else
-#include <sys/types.h> // must go before a number of other headers
 #include <fcntl.h>
 #include <netinet/in.h>
 #include <sys/resource.h>

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -35,9 +35,11 @@
 #include <univalue.h>
 #include <utility>
 #include <vector>
+
+#include <sys/types.h>
+
 #ifndef WIN32
 #include <signal.h>
-#include <sys/types.h>
 #include <sys/wait.h>
 #endif
 

--- a/src/wallet/bdb.cpp
+++ b/src/wallet/bdb.cpp
@@ -15,8 +15,15 @@
 
 #include <stdint.h>
 
-#ifndef WIN32
 #include <sys/stat.h>
+
+// Windows may not define S_IRUSR or S_IWUSR. We define both
+// here, with the same values as glibc (see stat.h).
+#ifdef WIN32
+#ifndef S_IRUSR
+#define S_IRUSR             0400
+#define S_IWUSR             0200
+#endif
 #endif
 
 namespace wallet {


### PR DESCRIPTION
This is the only place these defines are used. They may also be available when building for Windows. `sys/stat.h` is available, and we already use it unguarded in other code. So move the defines into bdb, after the stat.h include, and remove compat from bdb.cpp.