### PR TITLE
ci: Remove unused busybox workaround

### DIFF
--- a/ci/test/04_install.sh
+++ b/ci/test/04_install.sh
@@ -24,6 +24,7 @@ if [[ $BITCOIN_CONFIG = *--with-sanitizers=*address* ]]; then # If ran with (ASa
 fi
 
 export P_CI_DIR="$PWD"
+export BINS_SCRATCH_DIR="${BASE_SCRATCH_DIR}/bins/"
 
 if [ -z "$DANGER_RUN_CI_ON_HOST" ]; then
   echo "Creating $DOCKER_NAME_TAG container to run in"
@@ -64,13 +65,15 @@ else
 fi
 
 CI_EXEC () {
-  $DOCKER_CI_CMD_PREFIX bash -c "export PATH=$BASE_SCRATCH_DIR/bins/:\$PATH && cd \"$P_CI_DIR\" && $*"
+  $DOCKER_CI_CMD_PREFIX bash -c "export PATH=${BINS_SCRATCH_DIR}:\$PATH && cd \"$P_CI_DIR\" && $*"
 }
 CI_EXEC_ROOT () {
-  $DOCKER_CI_CMD_PREFIX_ROOT bash -c "export PATH=$BASE_SCRATCH_DIR/bins/:\$PATH && cd \"$P_CI_DIR\" && $*"
+  $DOCKER_CI_CMD_PREFIX_ROOT bash -c "export PATH=${BINS_SCRATCH_DIR}:\$PATH && cd \"$P_CI_DIR\" && $*"
 }
 export -f CI_EXEC
 export -f CI_EXEC_ROOT
+
+CI_EXEC mkdir -p "${BINS_SCRATCH_DIR}"
 
 if [ -n "$DPKG_ADD_ARCH" ]; then
   CI_EXEC_ROOT dpkg --add-architecture "$DPKG_ADD_ARCH"
@@ -155,12 +158,11 @@ fi
 
 if [ "$USE_BUSY_BOX" = "true" ]; then
   echo "Setup to use BusyBox utils"
-  CI_EXEC mkdir -p "${BASE_SCRATCH_DIR}/bins/"
   # tar excluded for now because it requires passing in the exact archive type in ./depends (fixed in later BusyBox version)
   # find excluded for now because it does not recognize the -delete option in ./depends (fixed in later BusyBox version)
   # ar excluded for now because it does not recognize the -q option in ./depends (unknown if fixed)
   # shellcheck disable=SC1010
-  CI_EXEC for util in \$\(busybox --list \| grep -v "^ar$" \| grep -v "^tar$" \| grep -v "^find$"\)\; do ln -s \$\(command -v busybox\) "${BASE_SCRATCH_DIR}/bins/\$util"\; done
+  CI_EXEC for util in \$\(busybox --list \| grep -v "^ar$" \| grep -v "^tar$" \| grep -v "^find$"\)\; do ln -s \$\(command -v busybox\) "${BINS_SCRATCH_DIR}/\$util"\; done
   # Print BusyBox version
   CI_EXEC patch --help
 fi

--- a/ci/test/04_install.sh
+++ b/ci/test/04_install.sh
@@ -159,10 +159,9 @@ fi
 if [ "$USE_BUSY_BOX" = "true" ]; then
   echo "Setup to use BusyBox utils"
   # tar excluded for now because it requires passing in the exact archive type in ./depends (fixed in later BusyBox version)
-  # find excluded for now because it does not recognize the -delete option in ./depends (fixed in later BusyBox version)
   # ar excluded for now because it does not recognize the -q option in ./depends (unknown if fixed)
   # shellcheck disable=SC1010
-  CI_EXEC for util in \$\(busybox --list \| grep -v "^ar$" \| grep -v "^tar$" \| grep -v "^find$"\)\; do ln -s \$\(command -v busybox\) "${BINS_SCRATCH_DIR}/\$util"\; done
+  CI_EXEC for util in \$\(busybox --list \| grep -v "^ar$" \| grep -v "^tar$" \)\; do ln -s \$\(command -v busybox\) "${BINS_SCRATCH_DIR}/\$util"\; done
   # Print BusyBox version
   CI_EXEC patch --help
 fi


### PR DESCRIPTION
It can be re-added when it is needed again. But it may be more likely that the other workarounds can be removed as well, in a follow-up.