### PR TITLE
ci: Run one task with all tests on credits

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -213,6 +213,8 @@ task:
   << : *GLOBAL_TASK_TEMPLATE
   container:
     image: quay.io/centos/centos:stream8
+  # For faster CI feedback, immediately schedule one task that runs all tests
+  << : *CREDITS_TEMPLATE
   env:
     << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
     PACKAGE_MANAGER_INSTALL: "yum install -y"


### PR DESCRIPTION
This should allow to detect any obvious issues in the tests within 10 minutes of opening a pull request, regardless of the current scheduling load on the Cirrus CI community cluster.