### PR TITLE
fuzz: extend ConsumeNetAddr() to return I2P and CJDNS addresses

### DIFF
--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -261,6 +261,18 @@ public:
         }
     }
 
+    /**
+     * BIP155 network ids recognized by this software.
+     */
+    enum BIP155Network : uint8_t {
+        IPV4 = 1,
+        IPV6 = 2,
+        TORV2 = 3,
+        TORV3 = 4,
+        I2P = 5,
+        CJDNS = 6,
+    };
+
     friend class CSubNet;
 
 private:
@@ -281,18 +293,6 @@ private:
      * @see CNetAddr::IsI2P()
      */
     bool SetI2P(const std::string& addr);
-
-    /**
-     * BIP155 network ids recognized by this software.
-     */
-    enum BIP155Network : uint8_t {
-        IPV4 = 1,
-        IPV6 = 2,
-        TORV2 = 3,
-        TORV3 = 4,
-        I2P = 5,
-        CJDNS = 6,
-    };
 
     /**
      * Size of CNetAddr when serialized as ADDRv1 (pre-BIP155) (in bytes).

--- a/src/test/fuzz/banman.cpp
+++ b/src/test/fuzz/banman.cpp
@@ -70,11 +70,13 @@ FUZZ_TARGET(banman, .init = initialize_banman)
                 fuzzed_data_provider,
                 [&] {
                     CNetAddr net_addr{ConsumeNetAddr(fuzzed_data_provider)};
-                    const std::optional<CNetAddr>& addr{LookupHost(net_addr.ToStringAddr(), /*fAllowLookup=*/false)};
-                    if (addr.has_value() && addr->IsValid()) {
-                        net_addr = *addr;
-                    } else {
-                        contains_invalid = true;
+                    if (!net_addr.IsCJDNS() || !net_addr.IsValid()) {
+                        const std::optional<CNetAddr>& addr{LookupHost(net_addr.ToStringAddr(), /*fAllowLookup=*/false)};
+                        if (addr.has_value() && addr->IsValid()) {
+                            net_addr = *addr;
+                        } else {
+                            contains_invalid = true;
+                        }
                     }
                     ban_man.Ban(net_addr, ConsumeBanTimeOffset(fuzzed_data_provider), fuzzed_data_provider.ConsumeBool());
                 },

--- a/src/test/fuzz/netaddress.cpp
+++ b/src/test/fuzz/netaddress.cpp
@@ -26,6 +26,12 @@ FUZZ_TARGET(netaddress)
     if (net_addr.GetNetwork() == Network::NET_ONION) {
         assert(net_addr.IsTor());
     }
+    if (net_addr.GetNetwork() == Network::NET_I2P) {
+        assert(net_addr.IsI2P());
+    }
+    if (net_addr.GetNetwork() == Network::NET_CJDNS) {
+        assert(net_addr.IsCJDNS());
+    }
     if (net_addr.GetNetwork() == Network::NET_INTERNAL) {
         assert(net_addr.IsInternal());
     }
@@ -68,6 +74,12 @@ FUZZ_TARGET(netaddress)
     }
     if (net_addr.IsTor()) {
         assert(net_addr.GetNetwork() == Network::NET_ONION);
+    }
+    if (net_addr.IsI2P()) {
+        assert(net_addr.GetNetwork() == Network::NET_I2P);
+    }
+    if (net_addr.IsCJDNS()) {
+        assert(net_addr.GetNetwork() == Network::NET_CJDNS);
     }
     (void)net_addr.IsValid();
     (void)net_addr.ToStringAddr();

--- a/src/test/fuzz/util/net.h
+++ b/src/test/fuzz/util/net.h
@@ -24,7 +24,15 @@
 #include <optional>
 #include <string>
 
-CNetAddr ConsumeNetAddr(FuzzedDataProvider& fuzzed_data_provider) noexcept;
+/**
+ * Create a CNetAddr. It may have `addr.IsValid() == false`.
+ * @param[in,out] fuzzed_data_provider Take data for the address from this, if `rand` is `nullptr`.
+ * @param[in,out] rand If not nullptr, take data from it instead of from `fuzzed_data_provider`.
+ * Prefer generating addresses using `fuzzed_data_provider` because it is not uniform. Only use
+ * `rand` if `fuzzed_data_provider` is exhausted or its data is needed for other things.
+ * @return a "random" network address.
+ */
+CNetAddr ConsumeNetAddr(FuzzedDataProvider& fuzzed_data_provider, FastRandomContext* rand = nullptr) noexcept;
 
 class FuzzedSock : public Sock
 {


### PR DESCRIPTION
In the process of doing so, refactor `ConsumeNetAddr()` to generate the addresses from IPv4, IPv6, Tor, I2P and CJDNS networks in the same way - by preparing some random stream and deserializing from it. Similar code was already found in `RandAddr()`.

