### PR TITLE
Customize onion port & disable bind if service not started

### DIFF
--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -701,6 +701,6 @@ CService DefaultOnionServiceTarget()
     struct in_addr onion_service_target;
     onion_service_target.s_addr = htonl(INADDR_LOOPBACK);
     int64_t defaultOnionPort = BaseParams().OnionServiceTargetPort();
-    int64_t targetOnionPort = gArgs.GetArg("-onionport", defaultOnionPort);
+    int64_t targetOnionPort = gArgs.GetIntArg("-onionport", defaultOnionPort);
     return {onion_service_target, (uint16_t)targetOnionPort};
 }

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -700,5 +700,5 @@ CService DefaultOnionServiceTarget()
 {
     struct in_addr onion_service_target;
     onion_service_target.s_addr = htonl(INADDR_LOOPBACK);
-    return {onion_service_target, (uint16_t)gArgs.GetArg("-onionport", BaseParams().OnionServiceTargetPort())};
+    return {onion_service_target, (uint16_t)gArgs.GetArg("-onionport", (int64_t)BaseParams().OnionServiceTargetPort())};
 }

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -700,5 +700,5 @@ CService DefaultOnionServiceTarget()
 {
     struct in_addr onion_service_target;
     onion_service_target.s_addr = htonl(INADDR_LOOPBACK);
-    return {onion_service_target, BaseParams().OnionServiceTargetPort()};
+    return {onion_service_target, (uint16_t)gArgs.GetArg("-onionport", BaseParams().OnionServiceTargetPort())};
 }

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -700,5 +700,7 @@ CService DefaultOnionServiceTarget()
 {
     struct in_addr onion_service_target;
     onion_service_target.s_addr = htonl(INADDR_LOOPBACK);
-    return {onion_service_target, (uint16_t)gArgs.GetArg("-onionport", (int64_t)BaseParams().OnionServiceTargetPort())};
+    int64_t defaultOnionPort = BaseParams().OnionServiceTargetPort();
+    int64_t targetOnionPort = gArgs.GetArg("-onionport", defaultOnionPort);
+    return {onion_service_target, (uint16_t)targetOnionPort};
 }


### PR DESCRIPTION
The problem is caused by the inability to run multiple nodes on the same PC due to a conflict in the listening port for Tor connections.

Here also people faced a similar problem:
https://github.com/bitcoin/bitcoin/issues/22668

My idea is to prevent the array of ports for the onion process from filling up before running ConnMan - thus, the listenonion=0 option will not only prevent the Tor service from starting, but will also not occupy the port.

Additionally, I added port initialization for onion to keep the ability to run multiple nodes with Tor functionality.