### PR TITLE
[PoC] Integrate SonarCloud

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -339,3 +339,31 @@ task:
   env:
     << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
     FILE_ENV: "./ci/test/00_setup_env_android.sh"
+
+task:
+  name: 'SonarCloud'
+  << : *BASE_TEMPLATE
+  container:
+    image: ubuntu:focal
+  env:
+    DEBIAN_FRONTEND: noninteractive
+  install_script:
+    - apt update && apt install -y build-essential libtool autotools-dev automake pkg-config bsdmainutils python3 libevent-dev libboost-dev libsqlite3-dev ccache git curl wget unzip
+  sonar_cache:
+    folder: "/tmp/sonar_cache"
+  ccache_cache:
+    folder: "/tmp/ccache_dir"
+  sonarcloud_script:
+    - wget https://sonarcloud.io/static/cpp/build-wrapper-linux-x86.zip && unzip build-wrapper-linux-x86.zip
+    - wget https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-4.7.0.2747-linux.zip && unzip sonar-scanner-cli-4.7.0.2747-linux.zip
+    - ./autogen.sh
+    - ./configure --disable-fuzz --disable-zmq
+    - ./build-wrapper-linux-x86/build-wrapper-linux-x86-64 --out-dir bw-output make -j4
+    - ./sonar-scanner-4.7.0.2747-linux/bin/sonar-scanner \
+      -Dsonar.projectKey=bitcoin_bitcoin \
+      -Dsonar.organization=bitcoin \
+      -Dsonar.sources=. \
+      -Dsonar.cfamily.build-wrapper-output=bw-output \
+      -Dsonar.host.url=https://sonarcloud.io \
+      -Dsonar.cfamily.cache.enabled=true \
+      -Dsonar.cfamily.cache.path=/tmp/sonar_cache


### PR DESCRIPTION
This is a proof of concept that integrates SonarCloud in the CI.
SonarCloud is a static code analyzer that could help us catch bugs and improve code quality, so I think this would be a great addition to the CI. It can provide PR diff analysis.
The code in this PR doesn't currently work because it requires a Sonarcloud account along with a token.

I've tested it on master and some pull requests if you want to take a look: https://sonarcloud.io/summary/overall?id=aureleoules_bitcoin.

Let me know your thoughts!
