### PR TITLE
ci: remove ccache version pin in MSVC CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -153,7 +153,7 @@ task:
   ccache_cache:
     folder: '%CCACHE_DIR%'
   install_tools_script:
-    - choco install --yes --no-progress ccache --version=4.6.1
+    - choco install --yes --no-progress ccache
     - choco install --yes --no-progress python3 --version=3.9.6
     - pip install zmq
     - ccache --version


### PR DESCRIPTION
The pinning should no-longer be needed; 4.6.2 was broken, latest is 4.7.4, and that includes the necessary fixes.