### PR TITLE
doc: Mention restoring wallet via GUI

### DIFF
--- a/doc/managing-wallets.md
+++ b/doc/managing-wallets.md
@@ -108,7 +108,7 @@ Wallets created before version 0.13 are not HD and must be backed up every 100 k
 
 ### 1.6 Restoring the Wallet From a Backup
 
-To restore a wallet, the `restorewallet` RPC must be used.
+To restore a wallet, the `restorewallet` RPC or the `Restore Wallet` GUI menu item (`File` -> `Restore Wallet…`) must be used.
 
 ```
 $ bitcoin-cli restorewallet "restored-wallet" /home/node01/Backups/backup-01.dat
@@ -144,5 +144,5 @@ unforeseen configurations which result in some scripts being excluded. If a migr
 unexpectedly or otherwise misses any scripts, please create an issue on GitHub. A backup of the
 original wallet can be found in the wallet directory with the name `<name>-<timestamp>.legacy.bak`.
 
-The backup can be restored using the `restorewallet` command as discussed in the
-[Restoring the Wallet From a Backup](#16-restoring-the-wallet-from-a-backup) section
+The backup can be restored using the methods discussed in the
+[Restoring the Wallet From a Backup](#16-restoring-the-wallet-from-a-backup) section.

--- a/doc/managing-wallets.md
+++ b/doc/managing-wallets.md
@@ -88,7 +88,7 @@ In the RPC, the destination parameter must include the name of the file. Otherwi
 $ bitcoin-cli -rpcwallet="wallet-01" backupwallet /home/node01/Backups/backup-01.dat
 ```
 
-In the GUI, the wallet is selected in the `Wallet` drop-down list in the upper right corner. If this list is not present, the wallet can be loaded in `File` ->`Open wallet` if necessary. Then, the backup can be done in `File` -> `Backup Wallet...`.
+In the GUI, the wallet is selected in the `Wallet` drop-down list in the upper right corner. If this list is not present, the wallet can be loaded in `File` ->`Open Wallet` if necessary. Then, the backup can be done in `File` -> `Backup Wallet…`.
 
 This backup file can be stored on one or multiple offline devices, which must be reliable enough to work in an emergency and be malware free. Backup files can be regularly tested to avoid problems in the future.
 


### PR DESCRIPTION
https://github.com/bitcoin/bitcoin/commit/f9783b0f07c0c9a5dd55e1779ece5ab66519c2f2 Recently added the ability to restore wallets via the GUI, but the current wallet guide says backups must be restored via RPC.