### PR TITLE
fuzz: Mock CMainSignals in process_message(s) targets

### DIFF
--- a/src/test/fuzz/process_message.cpp
+++ b/src/test/fuzz/process_message.cpp
@@ -87,6 +87,12 @@ void fuzz_target(FuzzBufferType buffer, const std::string& LIMIT_TO_MESSAGE_TYPE
     const auto mock_time = ConsumeTime(fuzzed_data_provider);
     SetMockTime(mock_time);
 
+    MockedMainSignals signals(*g_setup->m_node.peerman);
+    auto mock_get_main_signals = [&signals]() -> CMainSignals& {
+        return signals;
+    };
+    MockGetMainSignals = mock_get_main_signals;
+
     // fuzzed_data_provider is fully consumed after this call, don't use it
     CDataStream random_bytes_data_stream{fuzzed_data_provider.ConsumeRemainingBytes<unsigned char>(), SER_NETWORK, PROTOCOL_VERSION};
     try {
@@ -95,7 +101,7 @@ void fuzz_target(FuzzBufferType buffer, const std::string& LIMIT_TO_MESSAGE_TYPE
     } catch (const std::ios_base::failure&) {
     }
     g_setup->m_node.peerman->SendMessages(&p2p_node);
-    SyncWithValidationInterfaceQueue();
+    signals.Sync();
     g_setup->m_node.connman->StopNodes();
 }
 

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -94,6 +94,9 @@ public:
 
 static CMainSignals g_signals;
 
+CMainSignals::CMainSignals() {}
+CMainSignals::~CMainSignals() {}
+
 void CMainSignals::RegisterBackgroundSignalScheduler(CScheduler& scheduler)
 {
     assert(!m_internals);
@@ -118,8 +121,10 @@ size_t CMainSignals::CallbacksPending()
     return m_internals->m_schedulerClient.CallbacksPending();
 }
 
+MainSignalsFunc MockGetMainSignals;
 CMainSignals& GetMainSignals()
 {
+    if (MockGetMainSignals) return MockGetMainSignals();
     return g_signals;
 }
 

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -172,6 +172,7 @@ protected:
      * has been received and connected to the headers tree, though not validated yet */
     virtual void NewPoWValidBlock(const CBlockIndex *pindex, const std::shared_ptr<const CBlock>& block) {};
     friend class CMainSignals;
+    friend class MockedMainSignals;
     friend class ValidationInterfaceTest;
 };
 

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -186,6 +186,9 @@ private:
     friend void ::CallFunctionInValidationInterfaceQueue(std::function<void ()> func);
 
 public:
+    CMainSignals();
+    ~CMainSignals();
+
     /** Register a CScheduler to give callbacks which should run in the background (may only be called once) */
     void RegisterBackgroundSignalScheduler(CScheduler& scheduler);
     /** Unregister a CScheduler to give callbacks which should run in the background - these callbacks will now be dropped! */
@@ -196,16 +199,18 @@ public:
     size_t CallbacksPending();
 
 
-    void UpdatedBlockTip(const CBlockIndex *, const CBlockIndex *, bool fInitialDownload);
-    void TransactionAddedToMempool(const CTransactionRef&, uint64_t mempool_sequence);
-    void TransactionRemovedFromMempool(const CTransactionRef&, MemPoolRemovalReason, uint64_t mempool_sequence);
-    void BlockConnected(const std::shared_ptr<const CBlock> &, const CBlockIndex *pindex);
-    void BlockDisconnected(const std::shared_ptr<const CBlock> &, const CBlockIndex* pindex);
-    void ChainStateFlushed(const CBlockLocator &);
-    void BlockChecked(const CBlock&, const BlockValidationState&);
-    void NewPoWValidBlock(const CBlockIndex *, const std::shared_ptr<const CBlock>&);
+    virtual void UpdatedBlockTip(const CBlockIndex*, const CBlockIndex*, bool fInitialDownload);
+    virtual void TransactionAddedToMempool(const CTransactionRef&, uint64_t mempool_sequence);
+    virtual void TransactionRemovedFromMempool(const CTransactionRef&, MemPoolRemovalReason, uint64_t mempool_sequence);
+    virtual void BlockConnected(const std::shared_ptr<const CBlock>&, const CBlockIndex* pindex);
+    virtual void BlockDisconnected(const std::shared_ptr<const CBlock>&, const CBlockIndex* pindex);
+    virtual void ChainStateFlushed(const CBlockLocator&);
+    virtual void BlockChecked(const CBlock&, const BlockValidationState&);
+    virtual void NewPoWValidBlock(const CBlockIndex*, const std::shared_ptr<const CBlock>&);
 };
 
+using MainSignalsFunc = std::function<CMainSignals&()>;
+extern MainSignalsFunc MockGetMainSignals;
 CMainSignals& GetMainSignals();
 
 #endif // BITCOIN_VALIDATIONINTERFACE_H


### PR DESCRIPTION
Mocking `CMainSignals` gives us the ability to control when the `CValidationInterface` callbacks are called on `PeerManager` in the `process_message(s)` targets. It thereby makes these targets more deterministic/reproducable and slightly faster (per eyeball measurements 5%-10% more execs/s on my machine).

Mostly looking for conceptual review on this because there is an argument to be made about fuzzing with the real `CMainSignals` in combination with TSan, so maybe preserving that behavior in another target could also make sense.