### PR TITLE
doc: add databases/py-sqlite3 to FreeBSD test suite deps

### DIFF
--- a/doc/build-freebsd.md
+++ b/doc/build-freebsd.md
@@ -72,7 +72,7 @@ There is an included test suite that is useful for testing code changes when dev
 To run the test suite (recommended), you will need to have Python 3 installed:
 
 ```bash
-pkg install python3
+pkg install python3 databases/py-sqlite3
 ```
 ---
 


### PR DESCRIPTION
Adds missing documentation. See also https://cirrus-ci.com/task/5639240319500288.