### PR TITLE
Tests: Fill out dust limit unit test for known types except bare multisig

### DIFF
--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -937,23 +937,58 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     CheckIsNotStandard(t, "bare-multisig");
     g_bare_multi = DEFAULT_PERMIT_BAREMULTISIG;
 
+    // Check compressed P2PK outputs dust threshold (must have leading 02 or 03)
+    t.vout[0].scriptPubKey = CScript() << std::vector<unsigned char>(33, 0x02) << OP_CHECKSIG;
+    t.vout[0].nValue = 576;
+    CheckIsStandard(t);
+    t.vout[0].nValue = 575;
+    CheckIsNotStandard(t, "dust");
+
+    // Check uncompressed P2PK outputs dust threshold (must have leading 04/06/07)
+    t.vout[0].scriptPubKey = CScript() << std::vector<unsigned char>(65, 0x04) << OP_CHECKSIG;
+    t.vout[0].nValue = 672;
+    CheckIsStandard(t);
+    t.vout[0].nValue = 671;
+    CheckIsNotStandard(t, "dust");
+
+    // Check P2PKH outputs dust threshold
+    t.vout[0].scriptPubKey = CScript() << OP_DUP << OP_HASH160 << std::vector<unsigned char>(20, 0) << OP_EQUALVERIFY << OP_CHECKSIG;
+    t.vout[0].nValue = 546;
+    CheckIsStandard(t);
+    t.vout[0].nValue = 545;
+    CheckIsNotStandard(t, "dust");
+
+    // Check P2SH outputs dust threshold
+    t.vout[0].scriptPubKey = CScript() << OP_HASH160 << std::vector<unsigned char>(20, 0) << OP_EQUAL;
+    t.vout[0].nValue = 540;
+    CheckIsStandard(t);
+    t.vout[0].nValue = 539;
+    CheckIsNotStandard(t, "dust");
+
     // Check P2WPKH outputs dust threshold
-    t.vout[0].scriptPubKey = CScript() << OP_0 << ParseHex("ffffffffffffffffffffffffffffffffffffffff");
+    t.vout[0].scriptPubKey = CScript() << OP_0 << std::vector<unsigned char>(20, 0);
     t.vout[0].nValue = 294;
     CheckIsStandard(t);
     t.vout[0].nValue = 293;
     CheckIsNotStandard(t, "dust");
 
     // Check P2WSH outputs dust threshold
-    t.vout[0].scriptPubKey = CScript() << OP_0 << ParseHex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    t.vout[0].scriptPubKey = CScript() << OP_0 << std::vector<unsigned char>(32, 0);
     t.vout[0].nValue = 330;
     CheckIsStandard(t);
     t.vout[0].nValue = 329;
     CheckIsNotStandard(t, "dust");
 
-    // Check future Witness Program versions dust threshold
-    for (int op = OP_2; op <= OP_16; op += 1) {
-        t.vout[0].scriptPubKey = CScript() << (opcodetype)op << ParseHex("ffff");
+    // Check P2TR outputs dust threshold (Invalid xonly key ok!)
+    t.vout[0].scriptPubKey = CScript() << OP_1 << std::vector<unsigned char>(32, 0);
+    t.vout[0].nValue = 330;
+    CheckIsStandard(t);
+    t.vout[0].nValue = 329;
+    CheckIsNotStandard(t, "dust");
+
+    // Check future Witness Program versions dust threshold (non-32-byte pushes are undefined for version 1)
+    for (int op = OP_1; op <= OP_16; op += 1) {
+        t.vout[0].scriptPubKey = CScript() << (opcodetype)op << std::vector<unsigned char>(2, 0);
         t.vout[0].nValue = 240;
         CheckIsStandard(t);
 


### PR DESCRIPTION
Having the constants checked explicitly in a single spot helps with possible regressions and also useful for documentation.

In addition, add a check for undefined v1 witness programs.