### PR TITLE
test: wallet: add coverage for `-spendzeroconfchange` setting

### DIFF
--- a/test/functional/mempool_limit.py
+++ b/test/functional/mempool_limit.py
@@ -25,7 +25,6 @@ class MempoolLimitTest(BitcoinTestFramework):
         self.extra_args = [[
             "-datacarriersize=100000",
             "-maxmempool=5",
-            "-spendzeroconfchange=0",
         ]]
         self.supports_cli = False
 


### PR DESCRIPTION
This PR adds missing test coverage for the `-spendzeroconfchange` setting (in particular the non-default case `=0`). Note that in contrast to the name, the setting does not only apply to change outputs, but in fact to _all_ unconfirmed outputs that we sent to ourselves, i.e. we can trigger the testing path simply with a single recipient address. The first commit removes the setting from the functional test mempool_limit.py, where it doesn't have any effect, since the test was changed to use MiniWallet in commit dddca3899c4738e512313a85aeb006310e34e31f.