### PR TITLE
net: simplify the call to vProcessMsg.splice()

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1305,15 +1305,14 @@ void CConnman::SocketHandlerConnected(const std::vector<CNode*>& nodes,
                 RecordBytesRecv(nBytes);
                 if (notify) {
                     size_t nSizeAdded = 0;
-                    auto it(pnode->vRecvMsg.begin());
-                    for (; it != pnode->vRecvMsg.end(); ++it) {
+                    for (const auto& msg : pnode->vRecvMsg) {
                         // vRecvMsg contains only completed CNetMessage
                         // the single possible partially deserialized message are held by TransportDeserializer
-                        nSizeAdded += it->m_raw_message_size;
+                        nSizeAdded += msg.m_raw_message_size;
                     }
                     {
                         LOCK(pnode->cs_vProcessMsg);
-                        pnode->vProcessMsg.splice(pnode->vProcessMsg.end(), pnode->vRecvMsg, pnode->vRecvMsg.begin(), it);
+                        pnode->vProcessMsg.splice(pnode->vProcessMsg.end(), pnode->vRecvMsg);
                         pnode->nProcessQueueSize += nSizeAdded;
                         pnode->fPauseRecv = pnode->nProcessQueueSize > nReceiveFloodSize;
                     }

--- a/src/test/util/net.cpp
+++ b/src/test/util/net.cpp
@@ -67,15 +67,14 @@ void ConnmanTestMsg::NodeReceiveMsgBytes(CNode& node, Span<const uint8_t> msg_by
     assert(node.ReceiveMsgBytes(msg_bytes, complete));
     if (complete) {
         size_t nSizeAdded = 0;
-        auto it(node.vRecvMsg.begin());
-        for (; it != node.vRecvMsg.end(); ++it) {
+        for (const auto& msg : node.vRecvMsg) {
             // vRecvMsg contains only completed CNetMessage
             // the single possible partially deserialized message are held by TransportDeserializer
-            nSizeAdded += it->m_raw_message_size;
+            nSizeAdded += msg.m_raw_message_size;
         }
         {
             LOCK(node.cs_vProcessMsg);
-            node.vProcessMsg.splice(node.vProcessMsg.end(), node.vRecvMsg, node.vRecvMsg.begin(), it);
+            node.vProcessMsg.splice(node.vProcessMsg.end(), node.vRecvMsg);
             node.nProcessQueueSize += nSizeAdded;
             node.fPauseRecv = node.nProcessQueueSize > nReceiveFloodSize;
         }


### PR DESCRIPTION
At the time when

```cpp
pnode->vProcessMsg.splice(pnode->vProcessMsg.end(), pnode->vRecvMsg, pnode->vRecvMsg.begin(), it);
```

is called, `it` is certainly `pnode->vRecvMsg.end()` which makes the call equivalent to:

```cpp
pnode->vProcessMsg.splice(pnode->vProcessMsg.end(), pnode->vRecvMsg, pnode->vRecvMsg.begin(), pnode->vRecvMsg.end());
```

which is equivalent to:

```cpp
pnode->vProcessMsg.splice(pnode->vProcessMsg.end(), pnode->vRecvMsg);
```

Thus, use the latter. Further, maybe irrelevant, but the latter has constant complexity while the original code is `O(length of vRecvMsg)`.