### PR TITLE
Introduce a Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,140 @@
+
+# Code of Conduct
+
+## Our Pledge
+
+We as contributors pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Moderators are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Moderators have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all spaces where discussion about code proposals to the
+project occur, including - the bitcoin/bitcoin repository and it's ancillary repositories
+(e.g. bitcoin-core/guix.sigs, bitcoin-core/bitcoincore.org),
+public IRC channels where discussions occur (e.g. `#bitcoin-core-dev` on Libera.chat), and
+in person events where multiple contributors convene to discuss the project (e.g. CoreDev.tech events).
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the moderators responsible for enforcement at
+[conduct@bitcoincore.org](mailto:conduct@bitcoincore.org).
+All complaints will be reviewed and investigated promptly and fairly.
+
+The moderators currently can also be reached individually:
+[TODO: FIll out this list]:
+* A
+* B
+* C
+
+All moderators are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+The Community Impact Guidelines will be used in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from the moderators, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,13 @@ purposes. As such, there are repository maintainers who are responsible for
 merging pull requests, the [release cycle](/doc/release-process.md), and
 moderation.
 
+Code of Conduct
+---------------
+
+This project and everyone participating in it is governed by our [Code of Conduct](CODE_OF_CONDUCT.md).
+By participating, you are expected to uphold this code. Please report unacceptable behavior to
+[conduct@bitcoincore.org](mailto:conduct@bitcoincore.org).
+
 Getting Started
 ---------------
 


### PR DESCRIPTION
Over the past couple of years, I have noticed a pattern of behavior from some who participate in Bitcoin Core's development that is abusive and disruptive. These people have made it increasingly difficult to work on this project and generally produced a more toxic working environment. I have heard complaints about specific individuals in the past, but no action was taken nor were there any guidelines on how to deal with such individuals. By introducing a Code of Conduct, we can set the expectations for behavior (it's surprising that adults need to be told how to behave) as well as guidelines for enforcing and punishing those who violate those guidelines.

This code of conduct comes from version 2.1 of the [Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).

Currently the Code of Conduct has people report to a conduct@bitcoincore.org email address. This will need to be setup to forward emails to those who will deal with conduct violations. However we should also have those people be listed by name and email in the document as well so that they can be reached individually. I suggest that we have all of the current maintainers be able to receive reports of conduct violations as well as laanwj and sipa. Additionally, in order to properly handle violations, I propose that these people have at least the Moderator permissions (note that maintainers have the Write permission, which afaict, does not allow blocking of users) and Operator permissions on the `#bitcoin-core-dev` IRC channel.

As some aspects of dealing with code of conduct violations involves public posts, I would also suggest that we enable and use the Discussions feature for that purpose so we can keep them separate from normal issues.