### PR TITLE
ci: Update "Win64 native" task

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -153,7 +153,7 @@ task:
   ccache_cache:
     folder: '%CCACHE_DIR%'
   install_tools_script:
-    - choco install --yes --no-progress ccache --version=4.6.1
+    - choco install --yes --no-progress ccache --version=4.7.4
     - choco install --yes --no-progress python3 --version=3.9.6
     - pip install zmq
     - ccache --version

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -102,7 +102,7 @@ task:
   env:
     PATH: 'C:\jom;C:\Python39;C:\Python39\Scripts;C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin;%PATH%'
     PYTHONUTF8: 1
-    CI_VCPKG_TAG: '2022.09.27'
+    CI_VCPKG_TAG: '2023.01.09'
     VCPKG_DOWNLOADS: 'C:\Users\ContainerAdministrator\AppData\Local\vcpkg\downloads'
     VCPKG_DEFAULT_BINARY_CACHE: 'C:\Users\ContainerAdministrator\AppData\Local\vcpkg\archives'
     CCACHE_DIR: 'C:\Users\ContainerAdministrator\AppData\Local\ccache'


### PR DESCRIPTION
This PR bumps `vcpkg` and `ccache` versions.

Dependency changes in `vcpkg` ([2022.09.27](https://github.com/microsoft/vcpkg/releases/tag/2022.09.27) - [2023.01.09](https://github.com/microsoft/vcpkg/releases/tag/2023.01.09)):
 - boost 1.80.0#0 -> 1.81.0#0
 - libevent 2.1.12#6 -> libevent 2.1.12#7
 - sqlite3 3.39.2#0 -> 3.40.0#1

Also see https://github.com/bitcoin/bitcoin/pull/26866#issuecomment-1378591258.