### PR TITLE
build: move rpc/request from util lib to common

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -655,8 +655,9 @@ libbitcoin_common_a_SOURCES = \
   policy/policy.cpp \
   protocol.cpp \
   psbt.cpp \
-  rpc/rawtransaction_util.cpp \
   rpc/external_signer.cpp \
+  rpc/rawtransaction_util.cpp \
+  rpc/request.cpp \
   rpc/util.cpp \
   scheduler.cpp \
   script/descriptor.cpp \
@@ -684,7 +685,6 @@ libbitcoin_util_a_SOURCES = \
   logging.cpp \
   random.cpp \
   randomenv.cpp \
-  rpc/request.cpp \
   support/cleanse.cpp \
   sync.cpp \
   util/asmap.cpp \


### PR DESCRIPTION
This is JSON RPC related code that doesn't need to be in util, and should not be required by the kernel.