### PR TITLE
refactor: Remove duplication of `clang-tidy`'s check names

### DIFF
--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -12,19 +12,7 @@ performance-unnecessary-copy-initialization,
 readability-redundant-declaration,
 readability-redundant-string-init,
 '
-WarningsAsErrors: '
-bugprone-argument-comment,
-bugprone-use-after-move,
-misc-unused-using-decls,
-modernize-use-default-member-init,
-modernize-use-nullptr,
-performance-for-range-copy,
-performance-move-const-arg,
-performance-no-automatic-move,
-performance-unnecessary-copy-initialization,
-readability-redundant-declaration,
-readability-redundant-string-init,
-'
+WarningsAsErrors: '*'
 CheckOptions:
  - key: performance-move-const-arg.CheckTriviallyCopyableMove
    value: false


### PR DESCRIPTION
This PR removes duplication of `clang-tidy`'s check names.

No behavior change.

Split up from https://github.com/bitcoin/bitcoin/pull/26642 as [requested](https://github.com/bitcoin/bitcoin/pull/26642#issuecomment-1385351923).

