### PR TITLE
ci: Add missing lint dependency (gpg)

### DIFF
--- a/ci/lint/04_install.sh
+++ b/ci/lint/04_install.sh
@@ -7,7 +7,11 @@
 export LC_ALL=C
 
 ${CI_RETRY_EXE} apt-get update
-${CI_RETRY_EXE} apt-get install -y curl git gawk jq xz-utils
+# Lint dependencies:
+# - curl/xz-utils (to install shellcheck)
+# - git (used in many lint scripts)
+# - gpg (used by verify-commits)
+${CI_RETRY_EXE} apt-get install -y curl xz-utils git gpg
 
 PYTHON_PATH=/tmp/python
 if [ ! -d "${PYTHON_PATH}/bin" ]; then


### PR DESCRIPTION
Also, document each dependency.

Adding `gpg` avoids errors when running a release or dev branch in the CI:

https://github.com/bitcoin/bitcoin/blob/01ec5308bf616740c804247043046b23b483df5c/ci/lint/06_script.sh#L30-L42

```
bash: line 1: gpg: command not found
```

https://cirrus-ci.com/task/4582854860996608?logs=lint#L185