### PR TITLE
doc: Clarify debian copyright comment

### DIFF
--- a/contrib/debian/copyright
+++ b/contrib/debian/copyright
@@ -7,8 +7,8 @@ Source: https://github.com/bitcoin/bitcoin
 Files: *
 Copyright: 2009-2023, Bitcoin Core Developers
 License: Expat
-Comment: The Bitcoin Core Developers encompasses the current developers listed on bitcoin.org,
-         as well as the numerous contributors to the project.
+Comment: The Bitcoin Core Developers encompasses all contributors to the
+         project, listed in the release notes or the git log.
 
 Files: debian/*
 Copyright: 2010-2011, Jonas Smedegaard <dr@jones.dk>


### PR DESCRIPTION
Seems fragile to link to an external site for a list of "current" devs. Also, current devs shouldn't matter in this context. It might be better to explain where *all* contributors are found, so do that instead.