### PR TITLE
scripted-diff: Use python 3.7 syntax capture_output=True

### DIFF
--- a/contrib/macdeploy/macdeployqtplus
+++ b/contrib/macdeploy/macdeployqtplus
@@ -187,7 +187,7 @@ def getFrameworks(binaryPath: str, verbose: int) -> List[FrameworkInfo]:
     if verbose:
         print(f"Inspecting with otool: {binaryPath}")
     otoolbin=os.getenv("OTOOL", "otool")
-    otool = run([otoolbin, "-L", binaryPath], stdout=PIPE, stderr=PIPE, text=True)
+    otool = run([otoolbin, "-L", binaryPath], capture_output=True, text=True)
     if otool.returncode != 0:
         sys.stderr.write(otool.stderr)
         sys.stderr.flush()

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -520,7 +520,7 @@ class TestNode():
             '-p', str(self.process.pid),
             '-o', output_path,
         ]
-        subp = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        subp = subprocess.Popen(cmd, capture_output=True)
         self.perf_subprocesses[profile_name] = subp
 
         return subp
@@ -730,7 +730,7 @@ class TestNodeCLI():
             p_args += [command]
         p_args += pos_args + named_args
         self.log.debug("Running bitcoin-cli {}".format(p_args[2:]))
-        process = subprocess.Popen(p_args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        process = subprocess.Popen(p_args, stdin=subprocess.PIPE, capture_output=True, text=True)
         cli_stdout, cli_stderr = process.communicate(input=self.input)
         returncode = process.poll()
         if returncode:

--- a/test/functional/tool_wallet.py
+++ b/test/functional/tool_wallet.py
@@ -37,7 +37,7 @@ class ToolWalletTest(BitcoinTestFramework):
         if not self.options.descriptors and 'create' in args:
             default_args.append('-legacy')
 
-        return subprocess.Popen([binary] + default_args + list(args), stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        return subprocess.Popen([binary] + default_args + list(args), stdin=subprocess.PIPE, capture_output=True, text=True)
 
     def assert_raises_tool_error(self, error, *args):
         p = self.bitcoin_wallet_process(*args)

--- a/test/util/test_runner.py
+++ b/test/util/test_runner.py
@@ -107,7 +107,7 @@ def bctest(testDir, testObj, buildenv):
             raise Exception
 
     # Run the test
-    proc = subprocess.Popen(execrun, stdin=stdinCfg, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    proc = subprocess.Popen(execrun, stdin=stdinCfg, capture_output=True, text=True)
     try:
         outs = proc.communicate(input=inputData)
     except OSError:


### PR DESCRIPTION
Now that we use python 3.7, it makes the code less verbose and clearer to directly use `capture_output` when possible, see https://docs.python.org/3/library/subprocess.html#using-the-subprocess-module