### PR TITLE
test: Skip copying BDB database directory in wallet backwards compatibility test

### DIFF
--- a/test/functional/wallet_backwards_compatibility.py
+++ b/test/functional/wallet_backwards_compatibility.py
@@ -168,7 +168,9 @@ class BackwardsCompatibilityTest(BitcoinTestFramework):
             for wallet in os.listdir(node_master_wallets_dir):
                 shutil.copytree(
                     os.path.join(node_master_wallets_dir, wallet),
-                    os.path.join(self.nodes_wallet_dir(node), wallet)
+                    os.path.join(self.nodes_wallet_dir(node), wallet),
+                    # Do not copy any BDB transaction log files
+                    ignore = shutil.ignore_patterns("database")
                 )
 
         if not self.options.descriptors:


### PR DESCRIPTION
Fixes [#26869](https://github.com/bitcoin/bitcoin/issues/26869)

Version 5.x BerkeleyDB `wallet.dat` files are [backward compatible with the version of BDB that Bitcoin uses](https://github.com/bitcoin/bitcoin/pull/18844#issuecomment-623004113), but the database transaction log files (eg - `database/log.0000000001`) are not.

The legacy (BDB) backwards compatibility test fails intermittently because those log files aren't always deleted when the wallet gets unloaded. It appears that `DB_LOG_AUTO_REMOVE` is the source of the non-determinism since there aren't [guarantees when it'll run](https://docs.oracle.com/cd/E17076_05/html/programmer_reference/transapp_logfile.html). 

Instead, just skip the logs when copying the wallet files to the older nodes. Alternative solutions include 1) restarting `node_master` instead of unloading so that the logs are [guaranteed](https://github.com/bitcoin/bitcoin/blob/8ae2808a4354e8dcc697f76bacc5e2f2befe9220/src/wallet/bdb.cpp#L565-L571) to be deleted or 2) manually deleting the logs before copying the tree, but those are slightly less time efficient. 
