### PR TITLE
[24.x] ci: add missing xz-utils package

### DIFF
--- a/ci/lint/04_install.sh
+++ b/ci/lint/04_install.sh
@@ -7,7 +7,7 @@
 export LC_ALL=C
 
 ${CI_RETRY_EXE} apt-get update
-${CI_RETRY_EXE} apt-get install -y clang-format-9 python3-pip curl git gawk jq
+${CI_RETRY_EXE} apt-get install -y clang-format-9 python3-pip curl git gawk jq xz-utils
 update-alternatives --install /usr/bin/clang-format      clang-format      "$(which clang-format-9     )" 100
 update-alternatives --install /usr/bin/clang-format-diff clang-format-diff "$(which clang-format-diff-9)" 100
 


### PR DESCRIPTION
Lint job currently fails with:
```bash
Successfully installed toml-0.10.2 vulture-2.3
xz: (stdin): File format not recognized
tar: Child returned status 1
tar: Error is not recoverable: exiting now
```

See https://github.com/bitcoin/bitcoin/pull/26878/checks?check_run_id=10755733033.