### PR TITLE
test: refactor: simplify p2p_{tx_download,eviction}.py by using MiniWallet

### DIFF
--- a/test/functional/p2p_eviction.py
+++ b/test/functional/p2p_eviction.py
@@ -12,22 +12,23 @@ address/netgroup since in the current framework, all peers are connecting from
 the same local address. See Issue #14210 for more info.
 Therefore, this test is limited to the remaining protection criteria.
 """
-
 import time
 
 from test_framework.blocktools import (
-    COINBASE_MATURITY,
     create_block,
     create_coinbase,
 )
 from test_framework.messages import (
     msg_pong,
     msg_tx,
-    tx_from_hex,
 )
-from test_framework.p2p import P2PDataStore, P2PInterface
+from test_framework.p2p import (
+    P2PDataStore,
+    P2PInterface,
+)
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
+from test_framework.wallet import MiniWallet
 
 
 class SlowP2PDataStore(P2PDataStore):
@@ -35,14 +36,15 @@ class SlowP2PDataStore(P2PDataStore):
         time.sleep(0.1)
         self.send_message(msg_pong(message.nonce))
 
+
 class SlowP2PInterface(P2PInterface):
     def on_ping(self, message):
         time.sleep(0.1)
         self.send_message(msg_pong(message.nonce))
 
+
 class P2PEvict(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
         self.num_nodes = 1
         # The choice of maxconnections=32 results in a maximum of 21 inbound connections
         # (32 - 10 outbound - 1 feeler). 20 inbound peers are protected from eviction:
@@ -53,7 +55,7 @@ class P2PEvict(BitcoinTestFramework):
         protected_peers = set()  # peers that we expect to be protected from eviction
         current_peer = -1
         node = self.nodes[0]
-        self.generatetoaddress(node, COINBASE_MATURITY + 1, node.get_deterministic_priv_key().address)
+        self.wallet = MiniWallet(node)
 
         self.log.info("Create 4 peers and protect them from eviction by sending us a block")
         for _ in range(4):
@@ -79,21 +81,8 @@ class P2PEvict(BitcoinTestFramework):
             current_peer += 1
             txpeer.sync_with_ping()
 
-            prevtx = node.getblock(node.getblockhash(i + 1), 2)['tx'][0]
-            rawtx = node.createrawtransaction(
-                inputs=[{'txid': prevtx['txid'], 'vout': 0}],
-                outputs=[{node.get_deterministic_priv_key().address: 50 - 0.00125}],
-            )
-            sigtx = node.signrawtransactionwithkey(
-                hexstring=rawtx,
-                privkeys=[node.get_deterministic_priv_key().key],
-                prevtxs=[{
-                    'txid': prevtx['txid'],
-                    'vout': 0,
-                    'scriptPubKey': prevtx['vout'][0]['scriptPubKey']['hex'],
-                }],
-            )['hex']
-            txpeer.send_message(msg_tx(tx_from_hex(sigtx)))
+            tx = self.wallet.create_self_transfer()['tx']
+            txpeer.send_message(msg_tx(tx))
             protected_peers.add(current_peer)
 
         self.log.info("Create 8 peers and protect them from eviction by having faster pings")
@@ -132,6 +121,7 @@ class P2PEvict(BitcoinTestFramework):
         self.log.info("Test that no peer expected to be protected was evicted")
         self.log.debug("{} protected peers: {}".format(len(protected_peers), protected_peers))
         assert evicted_peers[0] not in protected_peers
+
 
 if __name__ == '__main__':
     P2PEvict().main()

--- a/test/functional/p2p_tx_download.py
+++ b/test/functional/p2p_tx_download.py
@@ -5,6 +5,7 @@
 """
 Test transaction download behavior
 """
+import time
 
 from test_framework.messages import (
     CInv,
@@ -13,7 +14,6 @@ from test_framework.messages import (
     MSG_WTX,
     msg_inv,
     msg_notfound,
-    tx_from_hex,
 )
 from test_framework.p2p import (
     P2PInterface,
@@ -23,9 +23,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
 )
-from test_framework.address import ADDRESS_BCRT1_UNSPENDABLE
-
-import time
+from test_framework.wallet import MiniWallet
 
 
 class TestP2PConn(P2PInterface):
@@ -88,19 +86,8 @@ class TxDownloadTest(BitcoinTestFramework):
 
     def test_inv_block(self):
         self.log.info("Generate a transaction on node 0")
-        tx = self.nodes[0].createrawtransaction(
-            inputs=[{  # coinbase
-                "txid": self.nodes[0].getblock(self.nodes[0].getblockhash(1))['tx'][0],
-                "vout": 0
-            }],
-            outputs={ADDRESS_BCRT1_UNSPENDABLE: 50 - 0.00025},
-        )
-        tx = self.nodes[0].signrawtransactionwithkey(
-            hexstring=tx,
-            privkeys=[self.nodes[0].get_deterministic_priv_key().key],
-        )['hex']
-        ctx = tx_from_hex(tx)
-        txid = int(ctx.rehash(), 16)
+        tx = self.wallet.create_self_transfer()
+        txid = int(tx['txid'], 16)
 
         self.log.info(
             "Announce the transaction to all nodes from all {} incoming peers, but never send it".format(NUM_INBOUND))
@@ -109,7 +96,7 @@ class TxDownloadTest(BitcoinTestFramework):
             p.send_and_ping(msg)
 
         self.log.info("Put the tx in node 0's mempool")
-        self.nodes[0].sendrawtransaction(tx)
+        self.nodes[0].sendrawtransaction(tx['hex'])
 
         # Since node 1 is connected outbound to an honest peer (node 0), it
         # should get the tx within a timeout. (Assuming that node 0
@@ -255,6 +242,8 @@ class TxDownloadTest(BitcoinTestFramework):
         self.nodes[0].p2ps[0].send_message(msg_notfound(vec=[CInv(MSG_TX, 1)]))
 
     def run_test(self):
+        self.wallet = MiniWallet(self.nodes[0])
+
         # Run tests without mocktime that only need one peer-connection first, to avoid restarting the nodes
         self.test_expiry_fallback()
         self.test_disconnect_fallback()


### PR DESCRIPTION
Similar to #26892, this PR simplies the functional tests p2p_tx_download.py and p2p_eviction.py by using MiniWallet in order to avoid manual low-level tx creation. For the latter, rather than mining 100 blocks manually, the pre-mined chain of the test framework is used.

These instances were found via `$ git grep signrawtransactionwithkey ./test/functional`. AFAICT, there are no other instances where MiniWallet could replace tx creation trivially.