### PR TITLE
refactor: Add missing includes to fix gcc-13 compile error

### DIFF
--- a/src/support/lockedpool.cpp
+++ b/src/support/lockedpool.cpp
@@ -19,6 +19,9 @@
 #endif
 
 #include <algorithm>
+#include <limits>
+#include <stdexcept>
+#include <utility>
 #ifdef ARENA_DEBUG
 #include <iomanip>
 #include <iostream>

--- a/src/support/lockedpool.h
+++ b/src/support/lockedpool.h
@@ -5,11 +5,11 @@
 #ifndef BITCOIN_SUPPORT_LOCKEDPOOL_H
 #define BITCOIN_SUPPORT_LOCKEDPOOL_H
 
-#include <stdint.h>
+#include <cstddef>
 #include <list>
 #include <map>
-#include <mutex>
 #include <memory>
+#include <mutex>
 #include <unordered_map>
 
 /**


### PR DESCRIPTION
On current master:

```
  CXX      support/libbitcoin_util_a-lockedpool.o
support/lockedpool.cpp: In member function ‘void Arena::free(void*)’:
support/lockedpool.cpp:99:20: error: ‘runtime_error’ is not a member of ‘std’
   99 |         throw std::runtime_error("Arena: invalid or double free");
      |                    ^~~~~~~~~~~~~
support/lockedpool.cpp:22:1: note: ‘std::runtime_error’ is defined in header ‘<stdexcept>’; did you forget to ‘#include <stdexcept>’?
   21 | #include <algorithm>
  +++ |+#include <stdexcept>
   22 | #ifdef ARENA_DEBUG
support/lockedpool.cpp: In member function ‘void LockedPool::free(void*)’:
support/lockedpool.cpp:320:16: error: ‘runtime_error’ is not a member of ‘std’
  320 |     throw std::runtime_error("LockedPool: invalid address not pointing to any arena");
      |                ^~~~~~~~~~~~~
support/lockedpool.cpp:320:16: note: ‘std::runtime_error’ is defined in header ‘<stdexcept>’; did you forget to ‘#include <stdexcept>’?
