### PR TITLE
test: Remove boost test msg

### DIFF
--- a/src/test/README.md
+++ b/src/test/README.md
@@ -37,16 +37,7 @@ the `src/qt/test/test_main.cpp` file.
 For example, to run just the `getarg_tests` suite of tests:
 
 ```bash
-test_bitcoin --log_level=all --run_test=getarg_tests
-```
-
-`log_level` controls the verbosity of the test framework, which logs when a
-test case is entered, for example. `test_bitcoin` also accepts the command
-line arguments accepted by `bitcoind`. Use `--` to separate both types of
-arguments:
-
-```bash
-test_bitcoin --log_level=all --run_test=getarg_tests -- -printtoconsole=1
+test_bitcoin --run_test=getarg_tests
 ```
 
 The `-printtoconsole=1` after the two dashes redirects the debug log, which

--- a/src/test/net_peer_eviction_tests.cpp
+++ b/src/test/net_peer_eviction_tests.cpp
@@ -42,7 +42,7 @@ bool IsProtected(int num_peers,
     for (const NodeEvictionCandidate& candidate : candidates) {
         if (protected_peer_ids.count(candidate.id)) {
             // this peer should have been removed from the eviction candidates
-            BOOST_TEST_MESSAGE(strprintf("expected candidate to be protected: %d", candidate.id));
+            std::cout << strprintf("expected candidate to be protected: %d", candidate.id) << std::endl;
             return false;
         }
         if (unprotected_peer_ids.count(candidate.id)) {
@@ -53,8 +53,8 @@ bool IsProtected(int num_peers,
 
     const bool is_protected{unprotected_count == unprotected_peer_ids.size()};
     if (!is_protected) {
-        BOOST_TEST_MESSAGE(strprintf("unprotected: expected %d, actual %d",
-                                     unprotected_peer_ids.size(), unprotected_count));
+        std::cout << strprintf("unprotected: expected %d, actual %d",
+                unprotected_peer_ids.size(), unprotected_count) << std::endl;
     }
     return is_protected;
 }

--- a/src/test/raii_event_tests.cpp
+++ b/src/test/raii_event_tests.cpp
@@ -91,7 +91,7 @@ BOOST_AUTO_TEST_CASE(raii_event_order)
 BOOST_AUTO_TEST_CASE(raii_event_tests_SKIPPED)
 {
     // It would probably be ideal to report skipped, but boost::test doesn't seem to make that practical (at least not in versions available with common distros)
-    BOOST_TEST_MESSAGE("Skipping raii_event_tess: libevent doesn't support event_set_mem_functions");
+    std::cout << "Skipping raii_event_tess: libevent doesn't support event_set_mem_functions" << std::endl;
 }
 
 #endif  // EVENT_SET_MEM_FUNCTIONS_IMPLEMENTED

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -294,7 +294,7 @@ struct SnapshotTestSetup : TestChain100Setup {
             int chains_tested{0};
 
             for (Chainstate* chainstate : chainman.GetAll()) {
-                BOOST_TEST_MESSAGE("Checking coins in " << chainstate->ToString());
+                std::cout << "Checking coins in " << chainstate->ToString() << std::endl;
                 CCoinsViewCache& coinscache = chainstate->CoinsTip();
 
                 // Both caches will be empty initially.
@@ -327,7 +327,7 @@ struct SnapshotTestSetup : TestChain100Setup {
             size_t coins_missing_from_background{0};
 
             for (Chainstate* chainstate : chainman.GetAll()) {
-                BOOST_TEST_MESSAGE("Checking coins in " << chainstate->ToString());
+                std::cout << "Checking coins in " << chainstate->ToString() << std::endl;
                 CCoinsViewCache& coinscache = chainstate->CoinsTip();
                 bool is_background = chainstate != &chainman.ActiveChainstate();
 
@@ -364,7 +364,7 @@ struct SnapshotTestSetup : TestChain100Setup {
     {
         ChainstateManager& chainman = *Assert(m_node.chainman);
 
-        BOOST_TEST_MESSAGE("Simulating node restart");
+        std::cout << "Simulating node restart" << std::endl;
         {
             LOCK(::cs_main);
             for (Chainstate* cs : chainman.GetAll()) {
@@ -492,7 +492,7 @@ BOOST_FIXTURE_TEST_CASE(chainstatemanager_snapshot_init, SnapshotTestSetup)
     // chainstate data, and we end up with a single chainstate that is at tip.
     ChainstateManager& chainman_restarted = this->SimulateNodeRestart();
 
-    BOOST_TEST_MESSAGE("Performing Load/Verify/Activate of chainstate");
+    std::cout << "Performing Load/Verify/Activate of chainstate" << std::endl;
 
     // This call reinitializes the chainstates.
     this->LoadVerifyActivateChainstate();
@@ -507,8 +507,7 @@ BOOST_FIXTURE_TEST_CASE(chainstatemanager_snapshot_init, SnapshotTestSetup)
         BOOST_CHECK_EQUAL(chainman_restarted.ActiveHeight(), 210);
     }
 
-    BOOST_TEST_MESSAGE(
-        "Ensure we can mine blocks on top of the initialized snapshot chainstate");
+    std::cout << "Ensure we can mine blocks on top of the initialized snapshot chainstate" << std::endl;
     mineBlocks(10);
     {
         LOCK(chainman_restarted.GetMutex());

--- a/src/test/validation_flush_tests.cpp
+++ b/src/test/validation_flush_tests.cpp
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_CASE(getcoinscachesizestate)
     constexpr unsigned int COIN_SIZE = is_64_bit ? 80 : 64;
 
     auto print_view_mem_usage = [](CCoinsViewCache& view) {
-        BOOST_TEST_MESSAGE("CCoinsViewCache memory usage: " << view.DynamicMemoryUsage());
+        std::cout << "CCoinsViewCache memory usage: " << view.DynamicMemoryUsage() << std::endl;
     };
 
     constexpr size_t MAX_COINS_CACHE_BYTES = 1024;
@@ -69,7 +69,7 @@ BOOST_AUTO_TEST_CASE(getcoinscachesizestate)
             chainstate.GetCoinsCacheSizeState(MAX_COINS_CACHE_BYTES, /*max_mempool_size_bytes=*/0),
             CoinsCacheSizeState::CRITICAL);
 
-        BOOST_TEST_MESSAGE("Exiting cache flush tests early due to unsupported arch");
+        std::cout << "Exiting cache flush tests early due to unsupported arch" << std::endl;
         return;
     }
 
@@ -126,7 +126,7 @@ BOOST_AUTO_TEST_CASE(getcoinscachesizestate)
     // Only perform these checks on 64 bit hosts; I haven't done the math for 32.
     if (is_64_bit) {
         float usage_percentage = (float)view.DynamicMemoryUsage() / (MAX_COINS_CACHE_BYTES + (1 << 10));
-        BOOST_TEST_MESSAGE("CoinsTip usage percentage: " << usage_percentage);
+        std::cout << "CoinsTip usage percentage: " << usage_percentage << std::endl;
         BOOST_CHECK(usage_percentage >= 0.9);
         BOOST_CHECK(usage_percentage < 1);
         BOOST_CHECK_EQUAL(


### PR DESCRIPTION
`BOOST_TEST_MESSAGE` no longer works. see: https://github.com/bitcoin/bitcoin/pull/18472

Since it doesn't seem like `BOOST_TEST_MESSAGE` was missed, instead of replacing with `cout` maybe it's preferable to just remove the test messages.  For now I just put `cout` in the place of `BOOST_TEST_MESSAGE`.

Also as a consequence of https://github.com/bitcoin/bitcoin/pull/18472, `log_level` option can no longer be passed via the cli so this PR removes it from the docs.