### PR TITLE
[WIP] p2p: asmap, avoid inbound connections from a specific AS

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2469,6 +2469,19 @@ CConnman::~CConnman()
     Stop();
 }
 
+bool CConnman::AvoidPeerByAsn(CAddress addr)
+{
+    auto mapped_as{m_netgroupman.GetMappedAS(addr)};
+    if (mapped_as == 0) return false;
+    for (uint32_t& asn : as_to_avoid) {
+        if (asn == mapped_as) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 std::vector<CAddress> CConnman::GetAddresses(size_t max_addresses, size_t max_pct, std::optional<Network> network) const
 {
     std::vector<CAddress> addresses = addrman.GetAddr(max_addresses, max_pct, network);

--- a/src/net.h
+++ b/src/net.h
@@ -830,6 +830,9 @@ public:
     bool DisconnectNode(const CNetAddr& addr);
     bool DisconnectNode(NodeId id);
 
+    // Check whether we are avoiding peers based on their AS
+    bool AvoidPeerByAsn(CAddress addr);
+
     //! Used to convey which local services we are offering peers during node
     //! connection.
     //!

--- a/src/net.h
+++ b/src/net.h
@@ -685,6 +685,7 @@ public:
         std::vector<NetWhitebindPermissions> vWhiteBinds;
         std::vector<CService> vBinds;
         std::vector<CService> onion_binds;
+        std::vector<uint32_t> as_to_avoid;
         /// True if the user did not specify -bind= or -whitebind= and thus
         /// we should bind on `0.0.0.0` (IPv4) and `::` (IPv6).
         bool bind_on_any;
@@ -705,6 +706,7 @@ public:
         m_use_addrman_outgoing = connOptions.m_use_addrman_outgoing;
         nMaxAddnode = connOptions.nMaxAddnode;
         nMaxFeeler = connOptions.nMaxFeeler;
+        as_to_avoid = connOptions.as_to_avoid;
         m_max_outbound = m_max_outbound_full_relay + m_max_outbound_block_relay + nMaxFeeler;
         m_client_interface = connOptions.uiInterface;
         m_banman = connOptions.m_banman;
@@ -1008,6 +1010,7 @@ private:
     mutable Mutex m_added_nodes_mutex;
     std::vector<CNode*> m_nodes GUARDED_BY(m_nodes_mutex);
     std::list<CNode*> m_nodes_disconnected;
+    std::vector<uint32_t> as_to_avoid;
     mutable RecursiveMutex m_nodes_mutex;
     std::atomic<NodeId> nLastNodeId{0};
     unsigned int nPrevNodeCount{0};

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3163,6 +3163,12 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
             return;
         }
 
+        if (pfrom.IsInboundConn() && m_connman.AvoidPeerByAsn(pfrom.addr)) {
+            LogPrint(BCLog::NET, "peer=%d is from an AS we want to avoid; disconnecting\n", pfrom.GetId());
+            pfrom.fDisconnect = true;
+            return;
+        }
+
         int64_t nTime;
         CService addrMe;
         uint64_t nNonce = 1;


### PR DESCRIPTION
Fixes #26353 

For privacy/security reasons (discussed in #26353 - e.g. malicious nodes on a particular AS), we could avoid connections from particular AS (discussed in #26353). This PR adds a flag `-avoidas`, which can be specified multiple times, where you pass an ASN you want to avoid inbound connections from.

e.g.
```sh
./src/bitcoind --asmap=path/to/file --avoidas=399991
```