### PR TITLE
test: create random and coins utils, add amount helper, dedupe add_coin

### DIFF
--- a/ci/test/06_script_b.sh
+++ b/ci/test/06_script_b.sh
@@ -60,6 +60,7 @@ if [ "${RUN_TIDY}" = "true" ]; then
           " src/rpc/signmessage.cpp"\
           " src/test/fuzz/txorphan.cpp"\
           " src/test/fuzz/util/"\
+          " src/test/util/coins.cpp"\
           " src/uint256.cpp"\
           " src/util/bip32.cpp"\
           " src/util/bytevectorhash.cpp"\

--- a/src/Makefile.test_util.include
+++ b/src/Makefile.test_util.include
@@ -10,6 +10,7 @@ EXTRA_LIBRARIES += \
 TEST_UTIL_H = \
   test/util/blockfilter.h \
   test/util/chainstate.h \
+  test/util/coins.h \
   test/util/json.h \
   test/util/logging.h \
   test/util/mining.h \
@@ -30,6 +31,7 @@ libtest_util_a_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(BOOST_CPPFLAGS)
 libtest_util_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libtest_util_a_SOURCES = \
   test/util/blockfilter.cpp \
+  test/util/coins.cpp \
   test/util/json.cpp \
   test/util/logging.cpp \
   test/util/mining.cpp \

--- a/src/Makefile.test_util.include
+++ b/src/Makefile.test_util.include
@@ -14,6 +14,7 @@ TEST_UTIL_H = \
   test/util/logging.h \
   test/util/mining.h \
   test/util/net.h \
+  test/util/random.h \
   test/util/script.h \
   test/util/setup_common.h \
   test/util/str.h \

--- a/src/test/base58_tests.cpp
+++ b/src/test/base58_tests.cpp
@@ -6,6 +6,7 @@
 
 #include <base58.h>
 #include <test/util/json.h>
+#include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <util/strencodings.h>
 #include <util/vector.h>

--- a/src/test/blockencodings_tests.cpp
+++ b/src/test/blockencodings_tests.cpp
@@ -7,6 +7,7 @@
 #include <consensus/merkle.h>
 #include <pow.h>
 #include <streams.h>
+#include <test/util/random.h>
 #include <test/util/txmempool.h>
 
 #include <test/util/setup_common.h>

--- a/src/test/bloom_tests.cpp
+++ b/src/test/bloom_tests.cpp
@@ -12,6 +12,7 @@
 #include <random.h>
 #include <serialize.h>
 #include <streams.h>
+#include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <uint256.h>
 #include <util/strencodings.h>

--- a/src/test/checkqueue_tests.cpp
+++ b/src/test/checkqueue_tests.cpp
@@ -4,6 +4,7 @@
 
 #include <checkqueue.h>
 #include <sync.h>
+#include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <util/system.h>
 #include <util/time.h>

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -173,7 +173,7 @@ void SimulationTest(CCoinsView* base, bool fake_best_block)
 
             if (InsecureRandRange(5) == 0 || coin.IsSpent()) {
                 Coin newcoin;
-                newcoin.out.nValue = InsecureRand32();
+                newcoin.out.nValue = InsecureRandMoneyAmount();
                 newcoin.nHeight = 1;
 
                 // Infrequently test adding unspendable coins.

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -6,6 +6,7 @@
 #include <coins.h>
 #include <script/standard.h>
 #include <streams.h>
+#include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <txdb.h>
 #include <uint256.h>

--- a/src/test/crypto_tests.cpp
+++ b/src/test/crypto_tests.cpp
@@ -17,6 +17,7 @@
 #include <crypto/muhash.h>
 #include <random.h>
 #include <streams.h>
+#include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <util/strencodings.h>
 

--- a/src/test/cuckoocache_tests.cpp
+++ b/src/test/cuckoocache_tests.cpp
@@ -1,9 +1,11 @@
 // Copyright (c) 2012-2021 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include <cuckoocache.h>
 #include <random.h>
 #include <script/sigcache.h>
+#include <test/util/random.h>
 #include <test/util/setup_common.h>
 
 #include <boost/test/unit_test.hpp>

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <dbwrapper.h>
+#include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <uint256.h>
 #include <util/string.h>

--- a/src/test/hash_tests.cpp
+++ b/src/test/hash_tests.cpp
@@ -5,6 +5,7 @@
 #include <clientversion.h>
 #include <crypto/siphash.h>
 #include <hash.h>
+#include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <util/strencodings.h>
 

--- a/src/test/key_tests.cpp
+++ b/src/test/key_tests.cpp
@@ -6,6 +6,7 @@
 
 #include <key_io.h>
 #include <streams.h>
+#include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <uint256.h>
 #include <util/strencodings.h>

--- a/src/test/merkle_tests.cpp
+++ b/src/test/merkle_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <consensus/merkle.h>
+#include <test/util/random.h>
 #include <test/util/setup_common.h>
 
 #include <boost/test/unit_test.hpp>

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -9,6 +9,7 @@
 #include <node/miner.h>
 #include <policy/policy.h>
 #include <script/standard.h>
+#include <test/util/random.h>
 #include <test/util/txmempool.h>
 #include <timedata.h>
 #include <txmempool.h>

--- a/src/test/minisketch_tests.cpp
+++ b/src/test/minisketch_tests.cpp
@@ -5,6 +5,7 @@
 #include <minisketch.h>
 #include <node/minisketchwrapper.h>
 #include <random.h>
+#include <test/util/random.h>
 #include <test/util/setup_common.h>
 
 #include <boost/test/unit_test.hpp>

--- a/src/test/orphanage_tests.cpp
+++ b/src/test/orphanage_tests.cpp
@@ -7,6 +7,7 @@
 #include <script/sign.h>
 #include <script/signingprovider.h>
 #include <script/standard.h>
+#include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <txorphanage.h>
 

--- a/src/test/pmt_tests.cpp
+++ b/src/test/pmt_tests.cpp
@@ -6,6 +6,7 @@
 #include <merkleblock.h>
 #include <serialize.h>
 #include <streams.h>
+#include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <uint256.h>
 #include <version.h>

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -5,6 +5,7 @@
 #include <chain.h>
 #include <chainparams.h>
 #include <pow.h>
+#include <test/util/random.h>
 #include <test/util/setup_common.h>
 
 #include <boost/test/unit_test.hpp>

--- a/src/test/prevector_tests.cpp
+++ b/src/test/prevector_tests.cpp
@@ -9,6 +9,7 @@
 #include <serialize.h>
 #include <streams.h>
 
+#include <test/util/random.h>
 #include <test/util/setup_common.h>
 
 #include <boost/test/unit_test.hpp>

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -16,6 +16,7 @@
 #include <script/signingprovider.h>
 #include <streams.h>
 #include <test/util/json.h>
+#include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <test/util/transaction_utils.h>
 #include <util/strencodings.h>

--- a/src/test/serfloat_tests.cpp
+++ b/src/test/serfloat_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <hash.h>
+#include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <util/serfloat.h>
 #include <serialize.h>

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -110,7 +110,7 @@ void static RandomTransaction(CMutableTransaction& tx, bool fSingle)
     for (int out = 0; out < outs; out++) {
         tx.vout.push_back(CTxOut());
         CTxOut &txout = tx.vout.back();
-        txout.nValue = InsecureRandRange(100000000);
+        txout.nValue = InsecureRandMoneyAmount();
         RandomScript(txout.scriptPubKey);
     }
 }

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -11,6 +11,7 @@
 #include <streams.h>
 #include <test/data/sighash.json.h>
 #include <test/util/json.h>
+#include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <util/strencodings.h>
 #include <util/system.h>

--- a/src/test/skiplist_tests.cpp
+++ b/src/test/skiplist_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chain.h>
+#include <test/util/random.h>
 #include <test/util/setup_common.h>
 
 #include <vector>

--- a/src/test/streams_tests.cpp
+++ b/src/test/streams_tests.cpp
@@ -4,6 +4,7 @@
 
 #include <fs.h>
 #include <streams.h>
+#include <test/util/random.h>
 #include <test/util/setup_common.h>
 
 #include <boost/test/unit_test.hpp>

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -22,6 +22,7 @@
 #include <script/standard.h>
 #include <streams.h>
 #include <test/util/json.h>
+#include <test/util/random.h>
 #include <test/util/script.h>
 #include <test/util/transaction_utils.h>
 #include <util/strencodings.h>

--- a/src/test/txpackage_tests.cpp
+++ b/src/test/txpackage_tests.cpp
@@ -9,6 +9,7 @@
 #include <primitives/transaction.h>
 #include <script/script.h>
 #include <script/standard.h>
+#include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <validation.h>
 

--- a/src/test/txrequest_tests.cpp
+++ b/src/test/txrequest_tests.cpp
@@ -6,6 +6,7 @@
 #include <txrequest.h>
 #include <uint256.h>
 
+#include <test/util/random.h>
 #include <test/util/setup_common.h>
 
 #include <algorithm>

--- a/src/test/util/blockfilter.cpp
+++ b/src/test/util/blockfilter.cpp
@@ -28,4 +28,3 @@ bool ComputeFilter(BlockFilterType filter_type, const CBlockIndex* block_index, 
     filter = BlockFilter(filter_type, block, block_undo);
     return true;
 }
-

--- a/src/test/util/coins.cpp
+++ b/src/test/util/coins.cpp
@@ -1,0 +1,27 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test/util/coins.h>
+
+#include <coins.h>
+#include <primitives/transaction.h>
+#include <script/script.h>
+#include <test/util/random.h>
+#include <uint256.h>
+
+#include <stdint.h>
+#include <utility>
+
+COutPoint AddTestCoin(CCoinsViewCache& coins_view)
+{
+    Coin new_coin;
+    const uint256 txid{InsecureRand256()};
+    COutPoint outpoint{txid, /*nIn=*/0};
+    new_coin.nHeight = 1;
+    new_coin.out.nValue = InsecureRandMoneyAmount();
+    new_coin.out.scriptPubKey.assign(uint32_t{56}, 1);
+    coins_view.AddCoin(outpoint, std::move(new_coin), /*possible_overwrite=*/false);
+
+    return outpoint;
+};

--- a/src/test/util/coins.h
+++ b/src/test/util/coins.h
@@ -1,0 +1,19 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_TEST_UTIL_COINS_H
+#define BITCOIN_TEST_UTIL_COINS_H
+
+#include <primitives/transaction.h>
+
+class CCoinsViewCache;
+
+/**
+ * Create a Coin with DynamicMemoryUsage of 80 bytes and add it to the given view.
+ * @param[in,out] coins_view  The coins view cache to add the new coin to.
+ * @returns the COutPoint of the created coin.
+ */
+COutPoint AddTestCoin(CCoinsViewCache& coins_view);
+
+#endif // BITCOIN_TEST_UTIL_COINS_H

--- a/src/test/util/random.h
+++ b/src/test/util/random.h
@@ -1,0 +1,39 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_TEST_UTIL_RANDOM_H
+#define BITCOIN_TEST_UTIL_RANDOM_H
+
+#include <random.h>
+#include <test/util/setup_common.h>
+#include <uint256.h>
+
+#include <cstdint>
+
+static inline uint32_t InsecureRand32()
+{
+    return g_insecure_rand_ctx.rand32();
+}
+
+static inline uint256 InsecureRand256()
+{
+    return g_insecure_rand_ctx.rand256();
+}
+
+static inline uint64_t InsecureRandBits(int bits)
+{
+    return g_insecure_rand_ctx.randbits(bits);
+}
+
+static inline uint64_t InsecureRandRange(uint64_t range)
+{
+    return g_insecure_rand_ctx.randrange(range);
+}
+
+static inline bool InsecureRandBool()
+{
+    return g_insecure_rand_ctx.randbool();
+}
+
+#endif // BITCOIN_TEST_UTIL_RANDOM_H

--- a/src/test/util/random.h
+++ b/src/test/util/random.h
@@ -5,6 +5,7 @@
 #ifndef BITCOIN_TEST_UTIL_RANDOM_H
 #define BITCOIN_TEST_UTIL_RANDOM_H
 
+#include <consensus/amount.h>
 #include <random.h>
 #include <test/util/setup_common.h>
 #include <uint256.h>
@@ -34,6 +35,11 @@ static inline uint64_t InsecureRandRange(uint64_t range)
 static inline bool InsecureRandBool()
 {
     return g_insecure_rand_ctx.randbool();
+}
+
+static inline CAmount InsecureRandMoneyAmount()
+{
+    return static_cast<CAmount>(InsecureRandRange(MAX_MONEY + 1));
 }
 
 #endif // BITCOIN_TEST_UTIL_RANDOM_H

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -71,12 +71,6 @@ static inline void SeedInsecureRand(SeedRand seed = SeedRand::SEED)
     }
 }
 
-static inline uint32_t InsecureRand32() { return g_insecure_rand_ctx.rand32(); }
-static inline uint256 InsecureRand256() { return g_insecure_rand_ctx.rand256(); }
-static inline uint64_t InsecureRandBits(int bits) { return g_insecure_rand_ctx.randbits(bits); }
-static inline uint64_t InsecureRandRange(uint64_t range) { return g_insecure_rand_ctx.randrange(range); }
-static inline bool InsecureRandBool() { return g_insecure_rand_ctx.randbool(); }
-
 static constexpr CAmount CENT{1000000};
 
 /** Basic testing setup.

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -9,6 +9,7 @@
 #include <hash.h> // For Hash()
 #include <key.h>  // For CKey
 #include <sync.h>
+#include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <uint256.h>
 #include <util/getuniquepath.h>

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -11,6 +11,7 @@
 #include <pow.h>
 #include <random.h>
 #include <script/standard.h>
+#include <test/util/random.h>
 #include <test/util/script.h>
 #include <test/util/setup_common.h>
 #include <util/time.h>

--- a/src/test/validation_chainstate_tests.cpp
+++ b/src/test/validation_chainstate_tests.cpp
@@ -8,6 +8,7 @@
 #include <rpc/blockchain.h>
 #include <sync.h>
 #include <test/util/chainstate.h>
+#include <test/util/coins.h>
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <uint256.h>
@@ -25,20 +26,6 @@ BOOST_AUTO_TEST_CASE(validation_chainstate_resize_caches)
 {
     ChainstateManager& manager = *Assert(m_node.chainman);
     CTxMemPool& mempool = *Assert(m_node.mempool);
-
-    //! Create and add a Coin with DynamicMemoryUsage of 80 bytes to the given view.
-    auto add_coin = [](CCoinsViewCache& coins_view) -> COutPoint {
-        Coin newcoin;
-        uint256 txid = InsecureRand256();
-        COutPoint outp{txid, 0};
-        newcoin.nHeight = 1;
-        newcoin.out.nValue = InsecureRandMoneyAmount();
-        newcoin.out.scriptPubKey.assign(uint32_t{56}, 1);
-        coins_view.AddCoin(outp, std::move(newcoin), false);
-
-        return outp;
-    };
-
     Chainstate& c1 = WITH_LOCK(cs_main, return manager.InitializeChainstate(&mempool));
     c1.InitCoinsDB(
         /*cache_size_bytes=*/1 << 23, /*in_memory=*/true, /*should_wipe=*/false);
@@ -48,7 +35,7 @@ BOOST_AUTO_TEST_CASE(validation_chainstate_resize_caches)
     // Add a coin to the in-memory cache, upsize once, then downsize.
     {
         LOCK(::cs_main);
-        auto outpoint = add_coin(c1.CoinsTip());
+        const auto outpoint = AddTestCoin(c1.CoinsTip());
 
         // Set a meaningless bestblock value in the coinsview cache - otherwise we won't
         // flush during ResizecoinsCaches() and will subsequently hit an assertion.

--- a/src/test/validation_chainstate_tests.cpp
+++ b/src/test/validation_chainstate_tests.cpp
@@ -8,6 +8,7 @@
 #include <rpc/blockchain.h>
 #include <sync.h>
 #include <test/util/chainstate.h>
+#include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <uint256.h>
 #include <validation.h>

--- a/src/test/validation_chainstate_tests.cpp
+++ b/src/test/validation_chainstate_tests.cpp
@@ -32,7 +32,7 @@ BOOST_AUTO_TEST_CASE(validation_chainstate_resize_caches)
         uint256 txid = InsecureRand256();
         COutPoint outp{txid, 0};
         newcoin.nHeight = 1;
-        newcoin.out.nValue = InsecureRand32();
+        newcoin.out.nValue = InsecureRandMoneyAmount();
         newcoin.out.scriptPubKey.assign(uint32_t{56}, 1);
         coins_view.AddCoin(outp, std::move(newcoin), false);
 

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -9,6 +9,7 @@
 #include <rpc/blockchain.h>
 #include <sync.h>
 #include <test/util/chainstate.h>
+#include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <timedata.h>
 #include <uint256.h>

--- a/src/test/validation_flush_tests.cpp
+++ b/src/test/validation_flush_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 //
 #include <sync.h>
+#include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <validation.h>
 

--- a/src/test/validation_flush_tests.cpp
+++ b/src/test/validation_flush_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 //
 #include <sync.h>
+#include <test/util/coins.h>
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <validation.h>
@@ -24,19 +25,6 @@ BOOST_AUTO_TEST_CASE(getcoinscachesizestate)
 
     LOCK(::cs_main);
     auto& view = chainstate.CoinsTip();
-
-    //! Create and add a Coin with DynamicMemoryUsage of 80 bytes to the given view.
-    auto add_coin = [](CCoinsViewCache& coins_view) -> COutPoint {
-        Coin newcoin;
-        uint256 txid = InsecureRand256();
-        COutPoint outp{txid, 0};
-        newcoin.nHeight = 1;
-        newcoin.out.nValue = InsecureRandMoneyAmount();
-        newcoin.out.scriptPubKey.assign(uint32_t{56}, 1);
-        coins_view.AddCoin(outp, std::move(newcoin), false);
-
-        return outp;
-    };
 
     // The number of bytes consumed by coin's heap data, i.e. CScript
     // (prevector<28, unsigned char>) when assigned 56 bytes of data per above.
@@ -62,7 +50,7 @@ BOOST_AUTO_TEST_CASE(getcoinscachesizestate)
         // Add a bunch of coins to see that we at least flip over to CRITICAL.
 
         for (int i{0}; i < 1000; ++i) {
-            COutPoint res = add_coin(view);
+            const COutPoint res = AddTestCoin(view);
             BOOST_CHECK_EQUAL(view.AccessCoin(res).DynamicMemoryUsage(), COIN_SIZE);
         }
 
@@ -84,7 +72,7 @@ BOOST_AUTO_TEST_CASE(getcoinscachesizestate)
     constexpr int COINS_UNTIL_CRITICAL{3};
 
     for (int i{0}; i < COINS_UNTIL_CRITICAL; ++i) {
-        COutPoint res = add_coin(view);
+        const COutPoint res = AddTestCoin(view);
         print_view_mem_usage(view);
         BOOST_CHECK_EQUAL(view.AccessCoin(res).DynamicMemoryUsage(), COIN_SIZE);
         BOOST_CHECK_EQUAL(
@@ -94,7 +82,7 @@ BOOST_AUTO_TEST_CASE(getcoinscachesizestate)
 
     // Adding some additional coins will push us over the edge to CRITICAL.
     for (int i{0}; i < 4; ++i) {
-        add_coin(view);
+        AddTestCoin(view);
         print_view_mem_usage(view);
         if (chainstate.GetCoinsCacheSizeState(MAX_COINS_CACHE_BYTES, /*max_mempool_size_bytes=*/0) ==
             CoinsCacheSizeState::CRITICAL) {
@@ -112,7 +100,7 @@ BOOST_AUTO_TEST_CASE(getcoinscachesizestate)
         CoinsCacheSizeState::OK);
 
     for (int i{0}; i < 3; ++i) {
-        add_coin(view);
+        AddTestCoin(view);
         print_view_mem_usage(view);
         BOOST_CHECK_EQUAL(
             chainstate.GetCoinsCacheSizeState(MAX_COINS_CACHE_BYTES, /*max_mempool_size_bytes=*/1 << 10),
@@ -121,7 +109,7 @@ BOOST_AUTO_TEST_CASE(getcoinscachesizestate)
 
     // Adding another coin with the additional mempool room will put us >90%
     // but not yet critical.
-    add_coin(view);
+    AddTestCoin(view);
     print_view_mem_usage(view);
 
     // Only perform these checks on 64 bit hosts; I haven't done the math for 32.
@@ -137,7 +125,7 @@ BOOST_AUTO_TEST_CASE(getcoinscachesizestate)
 
     // Using the default max_* values permits way more coins to be added.
     for (int i{0}; i < 1000; ++i) {
-        add_coin(view);
+        AddTestCoin(view);
         BOOST_CHECK_EQUAL(
             chainstate.GetCoinsCacheSizeState(),
             CoinsCacheSizeState::OK);

--- a/src/test/validation_flush_tests.cpp
+++ b/src/test/validation_flush_tests.cpp
@@ -31,7 +31,7 @@ BOOST_AUTO_TEST_CASE(getcoinscachesizestate)
         uint256 txid = InsecureRand256();
         COutPoint outp{txid, 0};
         newcoin.nHeight = 1;
-        newcoin.out.nValue = InsecureRand32();
+        newcoin.out.nValue = InsecureRandMoneyAmount();
         newcoin.out.scriptPubKey.assign(uint32_t{56}, 1);
         coins_view.AddCoin(outp, std::move(newcoin), false);
 

--- a/src/test/versionbits_tests.cpp
+++ b/src/test/versionbits_tests.cpp
@@ -5,6 +5,7 @@
 #include <chain.h>
 #include <chainparams.h>
 #include <consensus/params.h>
+#include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <versionbits.h>
 

--- a/src/wallet/test/wallet_crypto_tests.cpp
+++ b/src/wallet/test/wallet_crypto_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <util/strencodings.h>
 #include <wallet/crypter.h>


### PR DESCRIPTION
- Move random test utilities from `setup_common` to a new `random` file, as many tests don't use this code.

- Create a helper to generate semi-random CAmounts up to `MONEY_RANGE` rather than only uint32, and use the helper in the unit tests.

- De-duplicate a shared `add_coin` method by extracting it to a `coins` test utility.
