### PR TITLE
test: Fix intermittent feature_rbf issue

### DIFF
--- a/test/functional/feature_rbf.py
+++ b/test/functional/feature_rbf.py
@@ -392,11 +392,11 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         enough transactions off of each root UTXO to exceed the MAX_REPLACEMENT_LIMIT.
         Then create a conflicting RBF replacement transaction.
         """
-        normal_node = self.nodes[1]
-        wallet = MiniWallet(normal_node)
         # Clear mempools to avoid cross-node sync failure.
         for node in self.nodes:
             self.generate(node, 1)
+        normal_node = self.nodes[1]
+        wallet = MiniWallet(normal_node)
 
         # This has to be chosen so that the total number of transactions can exceed
         # MAX_REPLACEMENT_LIMIT without having any one tx graph run into the descendant


### PR DESCRIPTION
The miniwallet will rescan the chain and mempool on construction. If the mempools are still in sync, it may lead to crashes. Fix that by moving the sync first.

Fixes #26937