### PR TITLE
depends: systemtap 4.8

### DIFF
--- a/depends/packages/systemtap.mk
+++ b/depends/packages/systemtap.mk
@@ -3,10 +3,11 @@ $(package)_version=4.8
 $(package)_download_path=https://sourceware.org/ftp/systemtap/releases/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=cbd50a4eba5b261394dc454c12448ddec73e55e6742fda7f508f9fbc1331c223
-$(package)_patches=remove_SDT_ASM_SECTION_AUTOGROUP_SUPPORT_check.patch
+$(package)_patches=remove_SDT_ASM_SECTION_AUTOGROUP_SUPPORT_check.patch fix_variadic_warning.patch
 
 define $(package)_preprocess_cmds
   patch -p1 < $($(package)_patch_dir)/remove_SDT_ASM_SECTION_AUTOGROUP_SUPPORT_check.patch && \
+  patch -p1 < $($(package)_patch_dir)/fix_variadic_warning.patch && \
   mkdir -p $($(package)_staging_prefix_dir)/include/sys && \
   cp includes/sys/sdt.h $($(package)_staging_prefix_dir)/include/sys/sdt.h
 endef

--- a/depends/packages/systemtap.mk
+++ b/depends/packages/systemtap.mk
@@ -1,8 +1,8 @@
 package=systemtap
-$(package)_version=4.7
+$(package)_version=4.8
 $(package)_download_path=https://sourceware.org/ftp/systemtap/releases/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=43a0a3db91aa4d41e28015b39a65e62059551f3cc7377ebf3a3a5ca7339e7b1f
+$(package)_sha256_hash=cbd50a4eba5b261394dc454c12448ddec73e55e6742fda7f508f9fbc1331c223
 $(package)_patches=remove_SDT_ASM_SECTION_AUTOGROUP_SUPPORT_check.patch
 
 define $(package)_preprocess_cmds

--- a/depends/patches/systemtap/fix_variadic_warning.patch
+++ b/depends/patches/systemtap/fix_variadic_warning.patch
@@ -1,0 +1,16 @@
+Could be dropped after a migration to C++20.
+See: https://github.com/bitcoin/bitcoin/issues/26916.
+
+diff --git a/includes/sys/sdt.h b/includes/sys/sdt.h
+index 4075a5f..7c6138c 100644
+--- a/includes/sys/sdt.h
++++ b/includes/sys/sdt.h
+@@ -276,7 +276,7 @@ __extension__ extern unsigned long long __sdt_unsp;
+   _SDT_ASM_1(.purgem _SDT_TYPE_)					      \
+   _SDT_ASM_1(.purgem _SDT_TYPE)
+ 
+-#define _SDT_ASM_BODY(provider, name, pack_args, args, ...)		      \
++#define _SDT_ASM_BODY(provider, name, pack_args, args)		            \
+   _SDT_DEF_MACROS							      \
+   _SDT_ASM_1(990:	_SDT_NOP)					      \
+   _SDT_ASM_3(		.pushsection .note.stapsdt,_SDT_ASM_AUTOGROUP,"note") \


### PR DESCRIPTION
Updates systemtap to 4.8.
Includes acc2895a66a4b654e9a0a05ed0927f67f48c75b2 from #25972.
Will half (depends) fix #26916.

Release notes etc: https://lwn.net/Articles/913908/.