### PR TITLE
wallet: improve rescan performance 640%

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -159,6 +159,7 @@ BITCOIN_CORE_H = \
   i2p.h \
   index/base.h \
   index/blockfilterindex.h \
+  index/walletfilterindex.h \
   index/coinstatsindex.h \
   index/disktxpos.h \
   index/txindex.h \
@@ -369,6 +370,7 @@ libbitcoin_node_a_SOURCES = \
   i2p.cpp \
   index/base.cpp \
   index/blockfilterindex.cpp \
+  index/walletfilterindex.cpp \
   index/coinstatsindex.cpp \
   index/txindex.cpp \
   init.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -463,6 +463,7 @@ endif
 libbitcoin_wallet_a_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(BOOST_CPPFLAGS) $(BDB_CPPFLAGS) $(SQLITE_CFLAGS)
 libbitcoin_wallet_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libbitcoin_wallet_a_SOURCES = \
+  blockfilter.cpp \
   wallet/coincontrol.cpp \
   wallet/context.cpp \
   wallet/crypter.cpp \

--- a/src/blockfilter.cpp
+++ b/src/blockfilter.cpp
@@ -53,6 +53,7 @@ std::vector<uint64_t> GCSFilter::QuerySet::sorted_and_ranged(const uint64_t& F) 
     return ranged_elements;
 }
 
+
 uint64_t GCSFilter::HashElement(const Element& element) const
 {
     return HashElement(element, m_params.m_siphash_k0, m_params.m_siphash_k1);
@@ -75,17 +76,6 @@ uint64_t GCSFilter::RangeHashedElement(const uint64_t& hashed_element, const uin
     return FastRange64(hashed_element, F);
 }
 
-std::vector<uint64_t> GCSFilter::BuildHashedSet(const ElementSet& elements) const
-{
-    std::vector<uint64_t> hashed_elements;
-    hashed_elements.reserve(elements.size());
-    for (const Element& element : elements) {
-        uint64_t hashed_element = HashElement(element);
-        hashed_elements.push_back(RangeHashedElement(hashed_element));
-    }
-    std::sort(hashed_elements.begin(), hashed_elements.end());
-    return hashed_elements;
-}
 
 GCSFilter::GCSFilter(const Params& params)
     : m_params(params), m_N(0), m_F(0), m_encoded{0}
@@ -134,10 +124,17 @@ GCSFilter::GCSFilter(const Params& params, const ElementSet& elements)
         return;
     }
 
-    BitStreamWriter<CVectorWriter> bitwriter(stream);
+    std::vector<uint64_t> hashed_elements;
+    hashed_elements.reserve(elements.size());
+    for (const Element& element: elements) {
+        hashed_elements.push_back(RangeHashedElement(HashElement(element)));
+    }
 
+    std::sort(hashed_elements.begin(), hashed_elements.end());
+
+    BitStreamWriter<CVectorWriter> bitwriter(stream);
     uint64_t last_value = 0;
-    for (const uint64_t& value : BuildHashedSet(elements)) {
+    for (const uint64_t& value : hashed_elements) {
         uint64_t delta = value - last_value;
         GolombRiceEncode(bitwriter, m_params.m_P, delta);
         last_value = value;
@@ -186,8 +183,13 @@ bool GCSFilter::Match(const Element& element) const
 
 bool GCSFilter::MatchAny(const ElementSet& elements) const
 {
-    const std::vector<uint64_t> queries = BuildHashedSet(elements);
-    return MatchInternal(queries.data(), queries.size());
+    std::vector<uint64_t> hashed_elements;
+    hashed_elements.reserve(elements.size());
+    for (const Element& element : elements) {
+        hashed_elements.push_back(RangeHashedElement(HashElement(element)));
+    }
+    std::sort(hashed_elements.begin(), hashed_elements.end());
+    return MatchInternal(hashed_elements.data(), hashed_elements.size());
 }
 
 bool GCSFilter::MatchAny(const QuerySet& query_set) const

--- a/src/blockfilter.cpp
+++ b/src/blockfilter.cpp
@@ -190,6 +190,15 @@ bool GCSFilter::MatchAny(const ElementSet& elements) const
     return MatchInternal(queries.data(), queries.size());
 }
 
+bool GCSFilter::MatchAny(const QuerySet& query_set) const
+{
+    assert(query_set.m_params.m_siphash_k0 == m_params.m_siphash_k0);
+    assert(query_set.m_params.m_siphash_k1 == m_params.m_siphash_k1);
+
+    const std::vector<uint64_t> queries = query_set.sorted_and_ranged(m_F);
+    return MatchInternal(queries.data(), queries.size());
+}
+
 const std::string& BlockFilterTypeName(BlockFilterType filter_type)
 {
     static std::string unknown_retval;

--- a/src/blockfilter.cpp
+++ b/src/blockfilter.cpp
@@ -24,6 +24,35 @@ static const std::map<BlockFilterType, std::string> g_filter_types = {
     {BlockFilterType::BASIC, "basic"},
 };
 
+GCSFilter::QuerySet::QuerySet(const Params& params, const ElementSet& elements)
+    : m_params(params)
+{
+    for (const Element& element : elements)
+        insert(element);
+    sort();
+}
+
+void GCSFilter::QuerySet::insert(const Element& element)
+{
+    uint64_t hashed_element = HashElement(element, m_params.m_siphash_k0, m_params.m_siphash_k1);
+    m_hashed_elements.push_back(hashed_element);
+}
+
+void GCSFilter::QuerySet::sort()
+{
+    std::sort(m_hashed_elements.begin(), m_hashed_elements.end());
+}
+
+std::vector<uint64_t> GCSFilter::QuerySet::sorted_and_ranged(const uint64_t& F) const
+{
+    std::vector<uint64_t> ranged_elements;
+    ranged_elements.reserve(m_hashed_elements.size());
+    for (const uint64_t& hashed_element : m_hashed_elements) {
+        ranged_elements.push_back(RangeHashedElement(hashed_element, F));
+    }
+    return ranged_elements;
+}
+
 uint64_t GCSFilter::HashElement(const Element& element) const
 {
     return HashElement(element, m_params.m_siphash_k0, m_params.m_siphash_k1);

--- a/src/blockfilter.h
+++ b/src/blockfilter.h
@@ -46,8 +46,12 @@ private:
     uint64_t m_F;  //!< Range of element hashes, F = N * M
     std::vector<unsigned char> m_encoded;
 
-    /** Hash a data element to an integer in the range [0, N * M). */
-    uint64_t HashToRange(const Element& element) const;
+    /** Hash a data element using stored siphash keys. */
+    uint64_t HashElement(const Element& element) const;
+    static uint64_t HashElement(const Element& element, const uint64_t& siphash_k0, const uint64_t& siphash_k1);
+    /** Return an integer in the range [0, N * M) */
+    uint64_t RangeHashedElement(const uint64_t& hashed_element) const;
+    static uint64_t RangeHashedElement(const uint64_t& hashed_element, const uint64_t& F);
 
     std::vector<uint64_t> BuildHashedSet(const ElementSet& elements) const;
 

--- a/src/blockfilter.h
+++ b/src/blockfilter.h
@@ -66,8 +66,6 @@ private:
     uint64_t RangeHashedElement(const uint64_t& hashed_element) const;
     static uint64_t RangeHashedElement(const uint64_t& hashed_element, const uint64_t& F);
 
-    std::vector<uint64_t> BuildHashedSet(const ElementSet& elements) const;
-
     /** Helper method used to implement Match and MatchAny */
     bool MatchInternal(const uint64_t* sorted_element_hashes, size_t size) const;
 

--- a/src/blockfilter.h
+++ b/src/blockfilter.h
@@ -40,6 +40,19 @@ public:
         {}
     };
 
+    class QuerySet
+    {
+    private:
+        std::vector<uint64_t> m_hashed_elements;
+    public:
+        Params m_params;
+        QuerySet(const Params& params) : m_params(params) {};
+        QuerySet(const Params& params, const ElementSet& elements);
+        void insert(const Element& element);
+        void sort();
+        std::vector<uint64_t> sorted_and_ranged(const uint64_t& F) const;
+    };
+
 private:
     Params m_params;
     uint32_t m_N;  //!< Number of elements in the filter

--- a/src/blockfilter.h
+++ b/src/blockfilter.h
@@ -50,7 +50,7 @@ public:
         QuerySet(const Params& params, const ElementSet& elements);
         void insert(const Element& element);
         void sort();
-        std::vector<uint64_t> sorted_and_ranged(const uint64_t& F) const;
+        const std::vector<uint64_t>& sorted_elements() const;
     };
 
 private:

--- a/src/blockfilter.h
+++ b/src/blockfilter.h
@@ -98,6 +98,7 @@ public:
      * efficient that checking Match on multiple elements separately.
      */
     bool MatchAny(const ElementSet& elements) const;
+    bool MatchAny(const QuerySet& query_set) const;
 };
 
 constexpr uint8_t BASIC_FILTER_P = 19;

--- a/src/index/walletfilterindex.cpp
+++ b/src/index/walletfilterindex.cpp
@@ -1,0 +1,265 @@
+// Copyright (c) 2018-2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <map>
+#include <cmath>
+
+#include <dbwrapper.h>
+#include <hash.h>
+#include <index/walletfilterindex.h>
+#include <node/blockstorage.h>
+#include <util/system.h>
+#include <validation.h>
+
+std::unique_ptr<WalletFilterIndex> g_wallet_filter_index;
+
+using node::UndoReadFromDisk;
+
+constexpr uint8_t DB_BLOCK_HASH{'s'};
+constexpr uint8_t DB_FILTER_POS{'P'};
+constexpr uint8_t DB_SIPHASH_K0{'k'};
+constexpr uint8_t DB_SIPHASH_K1{'K'};
+
+constexpr unsigned int MAX_FLTR_FILE_SIZE = 0x1000000; // 16 MiB
+/** The pre-allocation chunk size for fltr?????.dat files */
+constexpr unsigned int FLTR_FILE_CHUNK_SIZE = 0x100000; // 1 MiB
+
+// value for M explained https://github.com/sipa/writeups/tree/main/minimizing-golomb-filters
+constexpr uint8_t WALLET_FILTER_P = 19;
+constexpr uint32_t WALLET_FILTER_M = 784931; // 1.497137 * pow(2,WALLET_FILTER_P);
+
+namespace {
+
+struct DBVal {
+    FlatFilePos pos;
+    uint64_t filter_sip_hash;
+
+    SERIALIZE_METHODS(DBVal, obj) { READWRITE(obj.pos, obj.filter_sip_hash); }
+};
+
+struct DBHashKey {
+    uint256 hash;
+
+    explicit DBHashKey(const uint256& hash_in) : hash(hash_in) {}
+
+    SERIALIZE_METHODS(DBHashKey, obj) {
+        uint8_t prefix{DB_BLOCK_HASH};
+        READWRITE(prefix);
+        if (prefix != DB_BLOCK_HASH) {
+            throw std::ios_base::failure("Invalid format for wallet filter index DB hash key");
+        }
+
+        READWRITE(obj.hash);
+    }
+};
+
+};
+
+WalletFilterIndex::WalletFilterIndex(std::unique_ptr<interfaces::Chain> chain,
+                                     size_t n_cache_size, bool f_memory, bool f_wipe)
+    : BaseIndex(std::move(chain), "wallet filter index")
+{
+    fs::path path = gArgs.GetDataDirNet() / "indexes" / "walletfilter";
+    fs::create_directories(path);
+
+    m_db = std::make_unique<BaseIndex::DB>(path / "db", n_cache_size, f_memory, f_wipe);
+    m_filter_fileseq = std::make_unique<FlatFileSeq>(std::move(path), "fltr", FLTR_FILE_CHUNK_SIZE);
+}
+
+bool WalletFilterIndex::CustomInit(const std::optional<interfaces::BlockKey>& block)
+{
+    m_params.m_P = WALLET_FILTER_P;
+    m_params.m_M = WALLET_FILTER_M;
+
+    if (m_db->Exists(DB_FILTER_POS) || m_db->Exists(DB_SIPHASH_K0) || m_db->Exists(DB_SIPHASH_K1)) {
+        if (!m_db->Read(DB_FILTER_POS, m_next_filter_pos))
+            return error("%s: Cannot read current %s state; index may be corrupted",
+                         __func__, GetName());
+        if (!m_db->Read(DB_SIPHASH_K0, m_params.m_siphash_k0))
+            return error("%s: Cannot read current %s state; index may be corrupted",
+                         __func__, GetName());
+        if (!m_db->Read(DB_SIPHASH_K1, m_params.m_siphash_k1))
+            return error("%s: Cannot read current %s state; index may be corrupted",
+                         __func__, GetName());
+    } else {
+        m_next_filter_pos.nFile = 0;
+        m_next_filter_pos.nPos = 0;
+
+        m_params.m_siphash_k0 = GetRand(std::numeric_limits<uint64_t>::max());
+        m_params.m_siphash_k1 = GetRand(std::numeric_limits<uint64_t>::max());
+
+        CDBBatch batch(*m_db);
+        batch.Write(DB_SIPHASH_K0, m_params.m_siphash_k0);
+        batch.Write(DB_SIPHASH_K1, m_params.m_siphash_k1);
+        batch.Write(DB_FILTER_POS, m_next_filter_pos);
+        if (!m_db->WriteBatch(batch)) return false;
+    }
+
+    return true;
+}
+
+bool WalletFilterIndex::CustomCommit(CDBBatch& batch)
+{
+    const FlatFilePos& pos = m_next_filter_pos;
+
+    // Flush current filter file to disk.
+    AutoFile file{m_filter_fileseq->Open(pos)};
+    if (file.IsNull()) {
+        return error("%s: Failed to open filter file %d", __func__, pos.nFile);
+    }
+    if (!FileCommit(file.Get())) {
+        return error("%s: Failed to commit filter file %d", __func__, pos.nFile);
+    }
+
+    batch.Write(DB_FILTER_POS, pos);
+    return true;
+}
+
+
+size_t WalletFilterIndex::WriteFilterToDisk(FlatFilePos& pos, const GCSFilter& filter)
+{
+    size_t data_size = GetSerializeSize(filter.GetEncoded(), CLIENT_VERSION);
+
+    // If writing the filter would overflow the file, flush and move to the next one.
+    if (pos.nPos + data_size > MAX_FLTR_FILE_SIZE) {
+        AutoFile last_file{m_filter_fileseq->Open(pos)};
+        if (last_file.IsNull()) {
+            LogPrintf("%s: Failed to open filter file %d\n", __func__, pos.nFile);
+            return 0;
+        }
+        if (!TruncateFile(last_file.Get(), pos.nPos)) {
+            LogPrintf("%s: Failed to truncate filter file %d\n", __func__, pos.nFile);
+            return 0;
+        }
+        if (!FileCommit(last_file.Get())) {
+            LogPrintf("%s: Failed to commit filter file %d\n", __func__, pos.nFile);
+            return 0;
+        }
+
+        pos.nFile++;
+        pos.nPos = 0;
+    }
+
+    // Pre-allocate sufficient space for filter data.
+    bool out_of_space;
+    m_filter_fileseq->Allocate(pos, data_size, out_of_space);
+    if (out_of_space) {
+        LogPrintf("%s: out of disk space\n", __func__);
+        return 0;
+    }
+
+    AutoFile fileout{m_filter_fileseq->Open(pos)};
+    if (fileout.IsNull()) {
+        LogPrintf("%s: Failed to open filter file %d\n", __func__, pos.nFile);
+        return 0;
+    }
+
+    fileout << filter.GetEncoded();
+    return data_size;
+}
+
+bool WalletFilterIndex::ReadFilterFromDisk(const FlatFilePos& pos, GCSFilter& filter) const
+{
+    AutoFile filein{m_filter_fileseq->Open(pos, true)};
+    if (filein.IsNull()) {
+        return false;
+    }
+
+    // Check that the hash of the encoded_filter matches the one stored in the db.
+    std::vector<uint8_t> encoded_filter;
+    try {
+        filein >> encoded_filter;
+        filter = GCSFilter(m_params, std::move(encoded_filter), /*skip_decode_check=*/true);
+    }
+    catch (const std::exception& e) {
+        return error("%s: Failed to deserialize block filter from disk: %s", __func__, e.what());
+    }
+
+    return true;
+}
+
+static GCSFilter::ElementSet WalletFilterElements(const CBlock& block,
+                                                 const CBlockUndo& block_undo)
+{
+    GCSFilter::ElementSet elements;
+
+    for (const CTransactionRef& tx : block.vtx) {
+        for (const CTxOut& txout : tx->vout) {
+            const CScript& script = txout.scriptPubKey;
+            if (script.empty() || script[0] == OP_RETURN) continue;
+            elements.emplace(script.begin(), script.end());
+        }
+    }
+
+    for (const CTxUndo& tx_undo : block_undo.vtxundo) {
+        for (const Coin& prevout : tx_undo.vprevout) {
+            const CScript& script = prevout.out.scriptPubKey;
+            if (script.empty()) continue;
+            elements.emplace(script.begin(), script.end());
+        }
+    }
+
+    return elements;
+}
+
+bool WalletFilterIndex::CustomAppend(const interfaces::BlockInfo& block)
+{
+    CBlockUndo block_undo;
+
+    if (block.height > 0) {
+        // pindex variable gives indexing code access to node internals. It
+        // will be removed in upcoming commit
+        const CBlockIndex* pindex = WITH_LOCK(cs_main, return m_chainstate->m_blockman.LookupBlockIndex(block.hash));
+        if (!UndoReadFromDisk(block_undo, pindex)) {
+            return false;
+        }
+    }
+
+    GCSFilter::ElementSet elements = WalletFilterElements(*Assert(block.data), block_undo);
+    GCSFilter filter(m_params, elements);
+
+    size_t bytes_written = WriteFilterToDisk(m_next_filter_pos, filter);
+    if (bytes_written == 0) return false;
+
+    // filter hash uses the siphash parameters and includes the block hash
+    // this implicitly prevents mixups between indexes and blocks
+    uint64_t filter_sip_hash = CSipHasher(m_params.m_siphash_k0, m_params.m_siphash_k1)
+        .Write(block.hash.GetUint64(0))
+        .Write(block.hash.GetUint64(1))
+        .Write(block.hash.GetUint64(2))
+        .Write(block.hash.GetUint64(3))
+        .Write(filter.GetEncoded().data(), filter.GetEncoded().size())
+        .Finalize();
+
+    DBVal entry;
+    entry.pos = m_next_filter_pos;
+    entry.filter_sip_hash = filter_sip_hash;
+
+    if (!m_db->Write(DBHashKey(block.hash), entry)) {
+        return false;
+    }
+
+    m_next_filter_pos.nPos += bytes_written;
+    return true;
+}
+
+bool WalletFilterIndex::LookupFilter(const CBlockIndex* block_index, GCSFilter& filter_out) const
+{
+    DBVal entry;
+    if (!m_db->Read(DBHashKey(block_index->GetBlockHash()), entry))
+        return false;
+
+    if (!ReadFilterFromDisk(entry.pos, filter_out))
+        return false;
+
+    uint64_t filter_sip_hash = CSipHasher(m_params.m_siphash_k0, m_params.m_siphash_k1)
+        .Write(block_index->GetBlockHash().GetUint64(0))
+        .Write(block_index->GetBlockHash().GetUint64(1))
+        .Write(block_index->GetBlockHash().GetUint64(2))
+        .Write(block_index->GetBlockHash().GetUint64(3))
+        .Write(filter_out.GetEncoded().data(), filter_out.GetEncoded().size())
+        .Finalize();
+
+    return filter_sip_hash == entry.filter_sip_hash;
+}

--- a/src/index/walletfilterindex.cpp
+++ b/src/index/walletfilterindex.cpp
@@ -244,20 +244,20 @@ bool WalletFilterIndex::CustomAppend(const interfaces::BlockInfo& block)
     return true;
 }
 
-bool WalletFilterIndex::LookupFilter(const CBlockIndex* block_index, GCSFilter& filter_out) const
+bool WalletFilterIndex::LookupFilter(const uint256& block_hash, GCSFilter& filter_out) const
 {
     DBVal entry;
-    if (!m_db->Read(DBHashKey(block_index->GetBlockHash()), entry))
+    if (!m_db->Read(DBHashKey(block_hash), entry))
         return false;
 
     if (!ReadFilterFromDisk(entry.pos, filter_out))
         return false;
 
     uint64_t filter_sip_hash = CSipHasher(m_params.m_siphash_k0, m_params.m_siphash_k1)
-        .Write(block_index->GetBlockHash().GetUint64(0))
-        .Write(block_index->GetBlockHash().GetUint64(1))
-        .Write(block_index->GetBlockHash().GetUint64(2))
-        .Write(block_index->GetBlockHash().GetUint64(3))
+        .Write(block_hash.GetUint64(0))
+        .Write(block_hash.GetUint64(1))
+        .Write(block_hash.GetUint64(2))
+        .Write(block_hash.GetUint64(3))
         .Write(filter_out.GetEncoded().data(), filter_out.GetEncoded().size())
         .Finalize();
 

--- a/src/index/walletfilterindex.h
+++ b/src/index/walletfilterindex.h
@@ -45,7 +45,7 @@ public:
                               bool f_wipe = false);
 
     /** Get a single filter by block. */
-    bool LookupFilter(const CBlockIndex* block_index, GCSFilter& filter_out) const;
+    bool LookupFilter(const uint256& block_hash, GCSFilter& filter_out) const;
 
     const GCSFilter::Params& GetParams() const { return m_params; };
 };

--- a/src/index/walletfilterindex.h
+++ b/src/index/walletfilterindex.h
@@ -1,0 +1,54 @@
+// Copyright (c) 2018-2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_INDEX_WALLETFILTERINDEX_H
+#define BITCOIN_INDEX_WALLETFILTERINDEX_H
+
+#include <attributes.h>
+#include <blockfilter.h>
+#include <chain.h>
+#include <flatfile.h>
+#include <index/base.h>
+#include <util/hasher.h>
+
+static constexpr bool DEFAULT_WALLETFILTERINDEX{false};
+
+class WalletFilterIndex final : public BaseIndex
+{
+private:
+    std::unique_ptr<BaseIndex::DB> m_db;
+
+    FlatFilePos m_next_filter_pos;
+    std::unique_ptr<FlatFileSeq> m_filter_fileseq;
+
+    GCSFilter::Params m_params;
+
+    bool ReadFilterFromDisk(const FlatFilePos& pos, GCSFilter& filter) const;
+    size_t WriteFilterToDisk(FlatFilePos& pos, const GCSFilter& filter);
+
+    bool AllowPrune() const override { return true; }
+
+protected:
+    bool CustomInit(const std::optional<interfaces::BlockKey>& block) override;
+
+    bool CustomCommit(CDBBatch& batch) override;
+
+    bool CustomAppend(const interfaces::BlockInfo& block) override;
+
+    BaseIndex::DB& GetDB() const LIFETIMEBOUND override { return *m_db; }
+
+public:
+    /** Constructs the index, which becomes available to be queried. */
+    explicit WalletFilterIndex(std::unique_ptr<interfaces::Chain> chain,
+                              size_t n_cache_size, bool f_memory = false,
+                              bool f_wipe = false);
+
+    /** Get a single filter by block. */
+    bool LookupFilter(const CBlockIndex* block_index, GCSFilter& filter_out) const;
+};
+
+/// The global wallet filter index. May be null.
+extern std::unique_ptr<WalletFilterIndex> g_wallet_filter_index;
+
+#endif // BITCOIN_INDEX_WALLETFILTERINDEX_H

--- a/src/index/walletfilterindex.h
+++ b/src/index/walletfilterindex.h
@@ -46,6 +46,8 @@ public:
 
     /** Get a single filter by block. */
     bool LookupFilter(const CBlockIndex* block_index, GCSFilter& filter_out) const;
+
+    const GCSFilter::Params& GetParams() const { return m_params; };
 };
 
 /// The global wallet filter index. May be null.

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -151,6 +151,16 @@ public:
     //! or std::nullopt if the block filter for this block couldn't be found.
     virtual std::optional<bool> blockFilterMatchesAny(BlockFilterType filter_type, const uint256& block_hash, const GCSFilter::ElementSet& filter_set) = 0;
 
+    //! Returns whether the wallet filter index is available.
+    virtual bool hasWalletFilterIndex() = 0;
+
+    //! Returns the GCSFilter::Params for the wallet filter index.
+    virtual std::optional<GCSFilter::Params> getWalletFilterParams() = 0;
+
+    //! Returns whether any of the elements match the block via the wallet filter
+    //! or std::nullopt if the wallet filter for this block couldn't be found.
+    virtual std::optional<bool> walletFilterMatchesAny(const uint256& block_hash, const GCSFilter::QuerySet& query_set) = 0;
+
     //! Return whether node has the block and optionally return block metadata
     //! or contents.
     virtual bool findBlock(const uint256& hash, const FoundBlock& block={}) = 0;

--- a/src/node/caches.cpp
+++ b/src/node/caches.cpp
@@ -4,9 +4,12 @@
 
 #include <node/caches.h>
 
+#include <index/walletfilterindex.h>
 #include <index/txindex.h>
 #include <txdb.h>
 #include <util/system.h>
+
+constexpr int64_t nMaxWalletFilterIndexCache = 32 << 20;
 
 namespace node {
 CacheSizes CalculateCacheSizes(const ArgsManager& args, size_t n_indexes)
@@ -19,6 +22,8 @@ CacheSizes CalculateCacheSizes(const ArgsManager& args, size_t n_indexes)
     nTotalCache -= sizes.block_tree_db;
     sizes.tx_index = std::min(nTotalCache / 8, args.GetBoolArg("-txindex", DEFAULT_TXINDEX) ? nMaxTxIndexCache << 20 : 0);
     nTotalCache -= sizes.tx_index;
+    sizes.wallet_filter_index = std::min(nTotalCache / 8, args.GetBoolArg("-walletfilterindex", DEFAULT_WALLETFILTERINDEX) ? nMaxWalletFilterIndexCache : 0);
+    nTotalCache -= sizes.wallet_filter_index;
     sizes.filter_index = 0;
     if (n_indexes > 0) {
         int64_t max_cache = std::min(nTotalCache / 8, max_filter_index_cache << 20);

--- a/src/node/caches.h
+++ b/src/node/caches.h
@@ -16,6 +16,7 @@ struct CacheSizes {
     int64_t coins_db;
     int64_t coins;
     int64_t tx_index;
+    int64_t wallet_filter_index;
     int64_t filter_index;
 };
 CacheSizes CalculateCacheSizes(const ArgsManager& args, size_t n_indexes = 0);

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -568,8 +568,7 @@ public:
         if (!g_wallet_filter_index) return std::nullopt;
 
         GCSFilter filter;
-        const CBlockIndex* index{WITH_LOCK(::cs_main, return chainman().m_blockman.LookupBlockIndex(block_hash))};
-        if (index == nullptr || !g_wallet_filter_index->LookupFilter(index, filter)) return std::nullopt;
+        if (!g_wallet_filter_index->LookupFilter(block_hash, filter)) return std::nullopt;
         return filter.MatchAny(query_set);
     }
     bool findBlock(const uint256& hash, const FoundBlock& block) override

--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -1589,7 +1589,8 @@ RPCHelpMan importdescriptors()
                 "\nImport descriptors. This will trigger a rescan of the blockchain based on the earliest timestamp of all descriptors being imported. Requires a new wallet backup.\n"
             "\nNote: This call can take over an hour to complete if using an early timestamp; during that time, other rpc calls\n"
             "may report that the imported keys, addresses or scripts exist but related transactions are still missing.\n"
-            "The rescan is significantly faster if block filters are available (using startup option \"-blockfilterindex=1\").\n",
+            "The rescan is significantly faster if wallers filters are available (using startup option \"-walletfilterindex=1\").\n"
+            "The rescan is faster if block filters are available (using startup option \"-blockfilterindex=1\").\n",
                 {
                     {"requests", RPCArg::Type::ARR, RPCArg::Optional::NO, "Data to be imported",
                         {
@@ -1887,7 +1888,7 @@ RPCHelpMan restorewallet()
         "restorewallet",
         "\nRestore and loads a wallet from backup.\n"
         "\nThe rescan is significantly faster if a descriptor wallet is restored"
-        "\nand block filters are available (using startup option \"-blockfilterindex=1\").\n",
+        "\nand wallet filters are available (using startup option \"-walletfilterindex=1\").\n",
         {
             {"wallet_name", RPCArg::Type::STR, RPCArg::Optional::NO, "The name that will be applied to the restored wallet"},
             {"backup_file", RPCArg::Type::STR, RPCArg::Optional::NO, "The backup file that will be used to restore the wallet."},

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -166,6 +166,7 @@ BASE_SCRIPTS = [
     'wallet_keypool_topup.py --legacy-wallet',
     'wallet_keypool_topup.py --descriptors',
     'wallet_fast_rescan.py --descriptors',
+    'wallet_faster_rescan.py --descriptors',
     'interface_zmq.py',
     'rpc_invalid_address_message.py',
     'interface_bitcoin_cli.py --legacy-wallet',

--- a/test/functional/wallet_faster_rescan.py
+++ b/test/functional/wallet_faster_rescan.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# Copyright (c) 2022 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test that fast rescan using block filters for descriptor wallets detects
+   top-ups correctly and finds the same transactions than the slow variant."""
+import os
+from typing import List
+
+from test_framework.descriptors import descsum_create
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_node import TestNode
+from test_framework.util import assert_equal
+from test_framework.wallet import MiniWallet
+from test_framework.wallet_util import get_generate_key
+
+
+KEYPOOL_SIZE = 100   # smaller than default size to speed-up test
+NUM_DESCRIPTORS = 9  # number of descriptors (8 default ranged ones + 1 fixed non-ranged one)
+NUM_BLOCKS = 6       # number of blocks to mine
+
+
+class WalletFasterRescanTest(BitcoinTestFramework):
+    def add_options(self, parser):
+        self.add_wallet_options(parser, legacy=False)
+
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.extra_args = [[f'-keypool={KEYPOOL_SIZE}', '-walletfilterindex=1']]
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+        self.skip_if_no_sqlite()
+
+    def get_wallet_txids(self, node: TestNode, wallet_name: str) -> List[str]:
+        w = node.get_wallet_rpc(wallet_name)
+        txs = w.listtransactions('*', 1000000)
+        return [tx['txid'] for tx in txs]
+
+    def run_test(self):
+        node = self.nodes[0]
+        wallet = MiniWallet(node)
+
+        self.log.info("Create descriptor wallet with backup")
+        WALLET_BACKUP_FILENAME = os.path.join(node.datadir, 'wallet.bak')
+        node.createwallet(wallet_name='topup_test', descriptors=True)
+        w = node.get_wallet_rpc('topup_test')
+        fixed_key = get_generate_key()
+        print(w.importdescriptors([{"desc": descsum_create(f"wpkh({fixed_key.privkey})"), "timestamp": "now"}]))
+        descriptors = w.listdescriptors()['descriptors']
+        assert_equal(len(descriptors), NUM_DESCRIPTORS)
+        w.backupwallet(WALLET_BACKUP_FILENAME)
+
+        self.log.info(f"Create txs sending to end range address of each descriptor, triggering top-ups")
+        for i in range(NUM_BLOCKS):
+            self.log.info(f"Block {i+1}/{NUM_BLOCKS}")
+            for desc_info in w.listdescriptors()['descriptors']:
+                if 'range' in desc_info:
+                    start_range, end_range = desc_info['range']
+                    addr = w.deriveaddresses(desc_info['desc'], [end_range, end_range])[0]
+                    spk = bytes.fromhex(w.getaddressinfo(addr)['scriptPubKey'])
+                    self.log.info(f"-> range [{start_range},{end_range}], last address {addr}")
+                else:
+                    spk = bytes.fromhex(fixed_key.p2wpkh_script)
+                    self.log.info(f"-> fixed non-range descriptor address {fixed_key.p2wpkh_addr}")
+                wallet.send_to(from_node=node, scriptPubKey=spk, amount=10000)
+            self.generate(node, 1)
+
+        self.log.info("Import wallet backup with block filter index")
+        with node.assert_debug_log(['fast variant using block filters']):
+            node.restorewallet('rescan_fast', WALLET_BACKUP_FILENAME)
+        txids_fast = self.get_wallet_txids(node, 'rescan_fast')
+
+        self.log.info("Import non-active descriptors with block filter index")
+        node.createwallet(wallet_name='rescan_fast_nonactive', descriptors=True, disable_private_keys=True, blank=True)
+        with node.assert_debug_log(['fast variant using block filters']):
+            w = node.get_wallet_rpc('rescan_fast_nonactive')
+            w.importdescriptors([{"desc": descriptor['desc'], "timestamp": 0} for descriptor in descriptors])
+        txids_fast_nonactive = self.get_wallet_txids(node, 'rescan_fast_nonactive')
+
+        self.restart_node(0, [f'-keypool={KEYPOOL_SIZE}', '-walletfilterindex=0'])
+        self.log.info("Import wallet backup w/o block filter index")
+        with node.assert_debug_log(['slow variant inspecting all blocks']):
+            node.restorewallet("rescan_slow", WALLET_BACKUP_FILENAME)
+        txids_slow = self.get_wallet_txids(node, 'rescan_slow')
+
+        self.log.info("Import non-active descriptors w/o block filter index")
+        node.createwallet(wallet_name='rescan_slow_nonactive', descriptors=True, disable_private_keys=True, blank=True)
+        with node.assert_debug_log(['slow variant inspecting all blocks']):
+            w = node.get_wallet_rpc('rescan_slow_nonactive')
+            w.importdescriptors([{"desc": descriptor['desc'], "timestamp": 0} for descriptor in descriptors])
+        txids_slow_nonactive = self.get_wallet_txids(node, 'rescan_slow_nonactive')
+
+        self.log.info("Verify that all rescans found the same txs in slow and fast variants")
+        assert_equal(len(txids_slow), NUM_DESCRIPTORS * NUM_BLOCKS)
+        assert_equal(len(txids_fast), NUM_DESCRIPTORS * NUM_BLOCKS)
+        assert_equal(len(txids_slow_nonactive), NUM_DESCRIPTORS * NUM_BLOCKS)
+        assert_equal(len(txids_fast_nonactive), NUM_DESCRIPTORS * NUM_BLOCKS)
+        assert_equal(sorted(txids_slow), sorted(txids_fast))
+        assert_equal(sorted(txids_slow_nonactive), sorted(txids_fast_nonactive))
+
+
+if __name__ == '__main__':
+    WalletFasterRescanTest().main()


### PR DESCRIPTION
The BIP158 compact block filters make a compromise between performance and security by re-keying the filter for each block.  That means every block requires re-hashing and re-sorting for every script pub key before matching against the filter.

To improve on the performance we can simply generate filters using per index random keys (rather than per filter keys).  We don't share these filters with any attacker so there is no security risk.

I don't use synthetic benchmarks for this as we have only a single data set we're ever processing.

On an arbitrary server:
No filters: 132 minutes
Block filters: 45 minutes
Wallet filters: 7 minutes

