### PR TITLE
bench: update logging benchmarks

### DIFF
--- a/src/bench/logging.cpp
+++ b/src/bench/logging.cpp
@@ -20,23 +20,23 @@ static void Logging(benchmark::Bench& bench, const std::vector<const char*>& ext
     bench.run([&] { log(); });
 }
 
-static void LoggingYoThreadNames(benchmark::Bench& bench)
+static void LogPrintfWithThreadNames(benchmark::Bench& bench)
 {
     Logging(bench, {"-logthreadnames=1"}, [] { LogPrintf("%s\n", "test"); });
 }
-static void LoggingNoThreadNames(benchmark::Bench& bench)
+static void LogPrintfWithoutThreadNames(benchmark::Bench& bench)
 {
     Logging(bench, {"-logthreadnames=0"}, [] { LogPrintf("%s\n", "test"); });
 }
-static void LoggingYoCategory(benchmark::Bench& bench)
+static void LogPrintWithCategory(benchmark::Bench& bench)
 {
     Logging(bench, {"-logthreadnames=0", "-debug=net"}, [] { LogPrint(BCLog::NET, "%s\n", "test"); });
 }
-static void LoggingNoCategory(benchmark::Bench& bench)
+static void LogPrintWithoutCategory(benchmark::Bench& bench)
 {
     Logging(bench, {"-logthreadnames=0", "-debug=0"}, [] { LogPrint(BCLog::NET, "%s\n", "test"); });
 }
-static void LoggingNoFile(benchmark::Bench& bench)
+static void LogWithoutWriteToFile(benchmark::Bench& bench)
 {
     Logging(bench, {"-nodebuglogfile", "-debug=1"}, [] {
         LogPrintf("%s\n", "test");
@@ -44,8 +44,8 @@ static void LoggingNoFile(benchmark::Bench& bench)
     });
 }
 
-BENCHMARK(LoggingYoThreadNames, benchmark::PriorityLevel::HIGH);
-BENCHMARK(LoggingNoThreadNames, benchmark::PriorityLevel::HIGH);
-BENCHMARK(LoggingYoCategory, benchmark::PriorityLevel::HIGH);
-BENCHMARK(LoggingNoCategory, benchmark::PriorityLevel::HIGH);
-BENCHMARK(LoggingNoFile, benchmark::PriorityLevel::HIGH);
+BENCHMARK(LogPrintfWithThreadNames, benchmark::PriorityLevel::HIGH);
+BENCHMARK(LogPrintfWithoutThreadNames, benchmark::PriorityLevel::HIGH);
+BENCHMARK(LogPrintWithCategory, benchmark::PriorityLevel::HIGH);
+BENCHMARK(LogPrintWithoutCategory, benchmark::PriorityLevel::HIGH);
+BENCHMARK(LogWithoutWriteToFile, benchmark::PriorityLevel::HIGH);

--- a/src/bench/logging.cpp
+++ b/src/bench/logging.cpp
@@ -6,6 +6,11 @@
 #include <logging.h>
 #include <test/util/setup_common.h>
 
+// All but 2 of the benchmarks should have roughly similar performance:
+//
+// LogPrintWithoutCategory should be ~3 orders of magnitude faster, as nothing is logged.
+//
+// LogWithoutWriteToFile should be ~2 orders of magnitude faster, as it avoids disk writes.
 
 static void Logging(benchmark::Bench& bench, const std::vector<const char*>& extra_args, const std::function<void()>& log)
 {
@@ -68,6 +73,7 @@ static void LogPrintfWithoutThreadNames(benchmark::Bench& bench)
 
 static void LogWithoutWriteToFile(benchmark::Bench& bench)
 {
+    // Disable writing the log to a file, as used for unit tests and fuzzing in `MakeNoLogFileContext`.
     Logging(bench, {"-nodebuglogfile", "-debug=1"}, [] {
         LogPrintf("%s\n", "test");
         LogPrint(BCLog::NET, "%s\n", "test");

--- a/src/bench/logging.cpp
+++ b/src/bench/logging.cpp
@@ -20,6 +20,18 @@ static void Logging(benchmark::Bench& bench, const std::vector<const char*>& ext
     bench.run([&] { log(); });
 }
 
+static void LogPrintLevelWithThreadNames(benchmark::Bench& bench)
+{
+    Logging(bench, {"-logthreadnames=1", "-debug=net"}, [] {
+        LogPrintLevel(BCLog::NET, BCLog::Level::Error, "%s\n", "test"); });
+}
+
+static void LogPrintLevelWithoutThreadNames(benchmark::Bench& bench)
+{
+    Logging(bench, {"-logthreadnames=0", "-debug=net"}, [] {
+        LogPrintLevel(BCLog::NET, BCLog::Level::Error, "%s\n", "test"); });
+}
+
 static void LogPrintWithCategory(benchmark::Bench& bench)
 {
     Logging(bench, {"-logthreadnames=0", "-debug=net"}, [] { LogPrint(BCLog::NET, "%s\n", "test"); });
@@ -28,6 +40,20 @@ static void LogPrintWithCategory(benchmark::Bench& bench)
 static void LogPrintWithoutCategory(benchmark::Bench& bench)
 {
     Logging(bench, {"-logthreadnames=0", "-debug=0"}, [] { LogPrint(BCLog::NET, "%s\n", "test"); });
+}
+
+static void LogPrintfCategoryWithThreadNames(benchmark::Bench& bench)
+{
+    Logging(bench, {"-logthreadnames=1", "-debug=net"}, [] {
+        LogPrintfCategory(BCLog::NET, "%s\n", "test");
+    });
+}
+
+static void LogPrintfCategoryWithoutThreadNames(benchmark::Bench& bench)
+{
+    Logging(bench, {"-logthreadnames=0", "-debug=net"}, [] {
+        LogPrintfCategory(BCLog::NET, "%s\n", "test");
+    });
 }
 
 static void LogPrintfWithThreadNames(benchmark::Bench& bench)
@@ -48,8 +74,12 @@ static void LogWithoutWriteToFile(benchmark::Bench& bench)
     });
 }
 
+BENCHMARK(LogPrintLevelWithThreadNames, benchmark::PriorityLevel::HIGH);
+BENCHMARK(LogPrintLevelWithoutThreadNames, benchmark::PriorityLevel::HIGH);
 BENCHMARK(LogPrintWithCategory, benchmark::PriorityLevel::HIGH);
 BENCHMARK(LogPrintWithoutCategory, benchmark::PriorityLevel::HIGH);
+BENCHMARK(LogPrintfCategoryWithThreadNames, benchmark::PriorityLevel::HIGH);
+BENCHMARK(LogPrintfCategoryWithoutThreadNames, benchmark::PriorityLevel::HIGH);
 BENCHMARK(LogPrintfWithThreadNames, benchmark::PriorityLevel::HIGH);
 BENCHMARK(LogPrintfWithoutThreadNames, benchmark::PriorityLevel::HIGH);
 BENCHMARK(LogWithoutWriteToFile, benchmark::PriorityLevel::HIGH);

--- a/src/bench/logging.cpp
+++ b/src/bench/logging.cpp
@@ -9,6 +9,9 @@
 
 static void Logging(benchmark::Bench& bench, const std::vector<const char*>& extra_args, const std::function<void()>& log)
 {
+    // Reset any enabled logging categories from a previous benchmark run.
+    LogInstance().DisableCategory(BCLog::LogFlags::ALL);
+
     TestingSetup test_setup{
         CBaseChainParams::REGTEST,
         extra_args,

--- a/src/bench/logging.cpp
+++ b/src/bench/logging.cpp
@@ -20,22 +20,26 @@ static void Logging(benchmark::Bench& bench, const std::vector<const char*>& ext
     bench.run([&] { log(); });
 }
 
-static void LogPrintfWithThreadNames(benchmark::Bench& bench)
-{
-    Logging(bench, {"-logthreadnames=1"}, [] { LogPrintf("%s\n", "test"); });
-}
-static void LogPrintfWithoutThreadNames(benchmark::Bench& bench)
-{
-    Logging(bench, {"-logthreadnames=0"}, [] { LogPrintf("%s\n", "test"); });
-}
 static void LogPrintWithCategory(benchmark::Bench& bench)
 {
     Logging(bench, {"-logthreadnames=0", "-debug=net"}, [] { LogPrint(BCLog::NET, "%s\n", "test"); });
 }
+
 static void LogPrintWithoutCategory(benchmark::Bench& bench)
 {
     Logging(bench, {"-logthreadnames=0", "-debug=0"}, [] { LogPrint(BCLog::NET, "%s\n", "test"); });
 }
+
+static void LogPrintfWithThreadNames(benchmark::Bench& bench)
+{
+    Logging(bench, {"-logthreadnames=1"}, [] { LogPrintf("%s\n", "test"); });
+}
+
+static void LogPrintfWithoutThreadNames(benchmark::Bench& bench)
+{
+    Logging(bench, {"-logthreadnames=0"}, [] { LogPrintf("%s\n", "test"); });
+}
+
 static void LogWithoutWriteToFile(benchmark::Bench& bench)
 {
     Logging(bench, {"-nodebuglogfile", "-debug=1"}, [] {
@@ -44,8 +48,8 @@ static void LogWithoutWriteToFile(benchmark::Bench& bench)
     });
 }
 
-BENCHMARK(LogPrintfWithThreadNames, benchmark::PriorityLevel::HIGH);
-BENCHMARK(LogPrintfWithoutThreadNames, benchmark::PriorityLevel::HIGH);
 BENCHMARK(LogPrintWithCategory, benchmark::PriorityLevel::HIGH);
 BENCHMARK(LogPrintWithoutCategory, benchmark::PriorityLevel::HIGH);
+BENCHMARK(LogPrintfWithThreadNames, benchmark::PriorityLevel::HIGH);
+BENCHMARK(LogPrintfWithoutThreadNames, benchmark::PriorityLevel::HIGH);
 BENCHMARK(LogWithoutWriteToFile, benchmark::PriorityLevel::HIGH);

--- a/src/init/common.cpp
+++ b/src/init/common.cpp
@@ -23,7 +23,7 @@
 namespace init {
 void AddLoggingArgs(ArgsManager& argsman)
 {
-    argsman.AddArg("-debuglogfile=<file>", strprintf("Specify location of debug log file. Relative paths will be prefixed by a net-specific datadir location. (-nodebuglogfile to disable; default: %s)", DEFAULT_DEBUGLOGFILE), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    argsman.AddArg("-debuglogfile=<file>", strprintf("Specify location of debug log file (default: %s). Relative paths will be prefixed by a net-specific datadir location. Pass -nodebuglogfile to disable writing the log to a file.", DEFAULT_DEBUGLOGFILE), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-debug=<category>", "Output debug and trace logging (default: -nodebug, supplying <category> is optional). "
         "If <category> is not supplied or if <category> = 1, output all debug and trace logging. <category> can be: " + LogInstance().LogCategoriesString() + ". This option can be specified multiple times to output multiple categories.",
         ArgsManager::ALLOW_ANY, OptionsCategory::DEBUG_TEST);


### PR DESCRIPTION
Update our logging benchmarks for evaluating ongoing work like #25203 and refactoring proposals like #26619 and #26697.

- make the logging benchmarks order-independent (Larry Ruane)
- add missing benchmarks for the `LogPrintLevel` and `LogPrintfCategory` macros that our logging is migrating to; at some later point it should be feasible to drop some of the previous logging benchmarks
- update the logging benchmark naming to be clear which benchmark corresponds to which log macro, and update the ordering to be the same as the output
- add clarifying documentation to the logging benchmarks
- improve the `-debuglogfile` config option help to be clearer; can be tested by running `./src/bitcoind -help | grep -A4 '\-debuglogfile'`

Reviewers can run the logging benchmarks with:
```bash
./src/bench/bench_bitcoin -filter='LogP*.*'
```
