### PR TITLE
refactor: Remove c_str from util/check

### DIFF
--- a/src/util/check.cpp
+++ b/src/util/check.cpp
@@ -14,8 +14,9 @@
 #include <cstdio>
 #include <cstdlib>
 #include <string>
+#include <string_view>
 
-std::string StrFormatInternalBug(const char* msg, const char* file, int line, const char* func)
+std::string StrFormatInternalBug(std::string_view msg, std::string_view file, int line, std::string_view func)
 {
     return strprintf("Internal bug detected: \"%s\"\n%s:%d (%s)\n"
                      "%s %s\n"
@@ -23,12 +24,12 @@ std::string StrFormatInternalBug(const char* msg, const char* file, int line, co
                      msg, file, line, func, PACKAGE_NAME, FormatFullVersion(), PACKAGE_BUGREPORT);
 }
 
-NonFatalCheckError::NonFatalCheckError(const char* msg, const char* file, int line, const char* func)
+NonFatalCheckError::NonFatalCheckError(std::string_view msg, std::string_view file, int line, std::string_view func)
     : std::runtime_error{StrFormatInternalBug(msg, file, line, func)}
 {
 }
 
-void assertion_fail(const char* file, int line, const char* func, const char* assertion)
+void assertion_fail(std::string_view file, int line, std::string_view func, std::string_view assertion)
 {
     auto str = strprintf("%s:%s %s: Assertion `%s' failed.\n", file, line, func, assertion);
     fwrite(str.data(), 1, str.size(), stderr);

--- a/src/util/check.h
+++ b/src/util/check.h
@@ -8,14 +8,16 @@
 #include <attributes.h>
 
 #include <stdexcept>
+#include <string>
+#include <string_view>
 #include <utility>
 
-std::string StrFormatInternalBug(const char* msg, const char* file, int line, const char* func);
+std::string StrFormatInternalBug(std::string_view msg, std::string_view file, int line, std::string_view func);
 
 class NonFatalCheckError : public std::runtime_error
 {
 public:
-    NonFatalCheckError(const char* msg, const char* file, int line, const char* func);
+    NonFatalCheckError(std::string_view msg, std::string_view file, int line, std::string_view func);
 };
 
 #define STR_INTERNAL_BUG(msg) StrFormatInternalBug((msg), __FILE__, __LINE__, __func__)
@@ -49,7 +51,7 @@ T&& inline_check_non_fatal(LIFETIMEBOUND T&& val, const char* file, int line, co
 #endif
 
 /** Helper for Assert() */
-void assertion_fail(const char* file, int line, const char* func, const char* assertion);
+void assertion_fail(std::string_view file, int line, std::string_view func, std::string_view assertion);
 
 /** Helper for Assert()/Assume() */
 template <bool IS_ASSERT, typename T>

--- a/src/wallet/bdb.cpp
+++ b/src/wallet/bdb.cpp
@@ -663,7 +663,7 @@ BerkeleyCursor::BerkeleyCursor(BerkeleyDatabase& database)
     }
     int ret = database.m_db->cursor(nullptr, &m_cursor, 0);
     if (ret != 0) {
-        throw std::runtime_error(STR_INTERNAL_BUG(strprintf("BDB Cursor could not be created. Returned %d", ret).c_str()));
+        throw std::runtime_error(STR_INTERNAL_BUG(strprintf("BDB Cursor could not be created. Returned %d", ret)));
     }
 }
 


### PR DESCRIPTION
Seems confusing and fragile to require calling code to call `c_str()` when passing a read-only view of a std::string.

Fix that by using std::string_view, which can be constructed from string literals and std::string.

Also, remove the now unused `c_str()` from `src/wallet/bdb.cpp`.