### PR TITLE
update copyright tool to write mit-licenses URL with https rather than http

### DIFF
--- a/contrib/devtools/copyright_header.py
+++ b/contrib/devtools/copyright_header.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # Copyright (c) 2016-2022 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
-# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+# file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
 import re
 import fnmatch
@@ -451,7 +451,7 @@ def get_header_lines(header, start_year, end_year):
 CPP_HEADER = '''
 // Copyright (c) %s The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
 '''
 
 def get_cpp_header_lines_to_insert(start_year, end_year):
@@ -460,7 +460,7 @@ def get_cpp_header_lines_to_insert(start_year, end_year):
 SCRIPT_HEADER = '''
 # Copyright (c) %s The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
-# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+# file COPYING or https://www.opensource.org/licenses/mit-license.php.
 '''
 
 def get_script_header_lines_to_insert(start_year, end_year):


### PR DESCRIPTION
This commit doesn't update the licenses link in the file copyright header on existing files; it only updates `copyright_header.py` (its ` insert` subcommand) so it writes the `https:` link in new files rather than `http:`.
```
https://www.opensource.org/licenses/mit-license.php
```
When running the next `copyright_header.py update` (near the end of the year, @hebasto), perhaps we can run something like this and include in the same PR:
```
git ls-files -- '*.h' '*.cpp' '*.cc' '*.c' '*.mm' '*.py' '*.sh' '*.bash-completion' |
    xargs sed -i s,http://www.opensource.org/licenses,https://www.opensource.org/licenses,
```