### PR TITLE
test: Assert RPC Server binds before creating cookie

### DIFF
--- a/test/functional/rpc_users.py
+++ b/test/functional/rpc_users.py
@@ -86,9 +86,19 @@ class HTTPBasicsTest(BitcoinTestFramework):
         assert_equal(401, call_with_auth(node, user + 'wrong', password + 'wrong').status)
 
     def run_test(self):
-        self.log.info('Check correctness of the rpcauth config option')
         url = urllib.parse.urlparse(self.nodes[0].url)
+        self.log.info('Check that we bind before issuing cookie')
+        with self.nodes[0].assert_debug_log(
+            expected_msgs=[
+                f"Binding RPC on address 127.0.0.1 port {url.port}",
+                "Using random cookie authentication.",
+            ],
+            ordered=True
+        ):
+            self.restart_node(0)
 
+        url = urllib.parse.urlparse(self.nodes[0].url)
+        self.log.info('Check correctness of the rpcauth config option')
         self.test_auth(self.nodes[0], url.username, url.password)
         self.test_auth(self.nodes[0], 'rt', self.rtpassword)
         self.test_auth(self.nodes[0], 'rt2', self.rt2password)

--- a/test/functional/rpc_users.py
+++ b/test/functional/rpc_users.py
@@ -105,8 +105,6 @@ class HTTPBasicsTest(BitcoinTestFramework):
         self.test_auth(self.nodes[0], self.user, self.password)
 
         self.log.info('Check correctness of the rpcuser/rpcpassword config options')
-        url = urllib.parse.urlparse(self.nodes[1].url)
-
         self.test_auth(self.nodes[1], self.rpcuser, self.rpcpassword)
 
         init_error = 'Error: Unable to start HTTP server. See debug log for details.'


### PR DESCRIPTION
If the RPC server does not bind first there exists a race condition between malware and bitcoind to bind to the port and recieve a cookie request from external application.

This test relies on the order of log messages, which may (I don't know) be slightly brittle. However because both `InitHTTPServer()` and `StartHTTPRPC()` are called in single-threaded series from within `AppInitServers()` it should work well enough.

https://github.com/bitcoin/bitcoin/blob/50ac8f57748edd0bf4d42031710a59ebb8068a63/src/init.cpp#L667-L672