### PR TITLE
refactor: Remove stray cs_main redundant declaration

### DIFF
--- a/ci/test/06_script_b.sh
+++ b/ci/test/06_script_b.sh
@@ -48,6 +48,7 @@ if [ "${RUN_TIDY}" = "true" ]; then
           " src/node/chainstate.cpp"\
           " src/node/chainstatemanager_args.cpp"\
           " src/node/mempool_args.cpp"\
+          " src/node/utxo_snapshot.cpp"\
           " src/node/validation_cache_args.cpp"\
           " src/policy/feerate.cpp"\
           " src/policy/packages.cpp"\

--- a/src/node/utxo_snapshot.cpp
+++ b/src/node/utxo_snapshot.cpp
@@ -7,12 +7,17 @@
 #include <fs.h>
 #include <logging.h>
 #include <streams.h>
+#include <sync.h>
+#include <tinyformat.h>
+#include <txdb.h>
 #include <uint256.h>
 #include <util/system.h>
 #include <validation.h>
 
+#include <cassert>
 #include <cstdio>
 #include <optional>
+#include <string>
 
 namespace node {
 

--- a/src/node/utxo_snapshot.h
+++ b/src/node/utxo_snapshot.h
@@ -7,13 +7,16 @@
 #define BITCOIN_NODE_UTXO_SNAPSHOT_H
 
 #include <fs.h>
-#include <uint256.h>
+#include <kernel/cs_main.h>
 #include <serialize.h>
-#include <validation.h>
+#include <sync.h>
+#include <uint256.h>
 
+#include <cstdint>
 #include <optional>
+#include <string_view>
 
-extern RecursiveMutex cs_main;
+class Chainstate;
 
 namespace node {
 //! Metadata describing a serialized version of a UTXO set from which an

--- a/src/sync.h
+++ b/src/sync.h
@@ -11,7 +11,7 @@
 #include <logging/timer.h>
 #endif
 
-#include <threadsafety.h>
+#include <threadsafety.h> // IWYU pragma: export
 #include <util/macros.h>
 
 #include <condition_variable>


### PR DESCRIPTION
Looks like this was forgotten when introducing kernel/cs_main ?

Also, there is a commit to export threadsafety.h from sync.h.