### PR TITLE
test: fix immediate tx relay in wallet_groups.py

### DIFF
--- a/test/functional/wallet_groups.py
+++ b/test/functional/wallet_groups.py
@@ -41,6 +41,11 @@ class WalletGroupTest(BitcoinTestFramework):
 
     def run_test(self):
         self.log.info("Setting up")
+        # To take full use of immediate tx relay, all nodes need to be reachable
+        # via inbound peers, i.e. connect first to last to close the circle
+        # (the default test network topology looks like this:
+        #  node0 <-- node1 <-- node2 <-- node3 <-- node4 <-- node5)
+        self.connect_nodes(0, self.num_nodes - 1)
         # Mine some coins
         self.generate(self.nodes[0], COINBASE_MATURITY + 1)
 


### PR DESCRIPTION
In the functional test wallet_groups.py we whitelist peers on all nodes (`-whitelist=noban@127.0.0.1`) to enable immediate tx relay for fast mempool synchronization. However, considering that this setting only applies to inbound peers and the default test topology looks like this:
```
    node0 <--- node1 <---- node2 <--- ... <-- nodeN
```

txs propagate fast only from lower- to higher-numbered nodes (i.e. "left to right" in the above diagram) and take long from higher- to lower-numbered nodes ("right to left") since in the latter direction we only have outbound peers, where the trickle relay is still active. As a consequence, if a tx is submitted from any node other than node0, the mempool synchronization can take quite long.

This PR fixes this by simply adding another connection from node0 to the last node, leading to a ~2-3x speedup (5 runs measured via `time ./test/functional/wallet_groups.py` are shown):

```
master:
    0m53.31s real     0m08.22s user     0m05.60s system
    0m32.85s real     0m07.44s user     0m04.08s system
    0m46.40s real     0m09.18s user     0m04.23s system
    0m46.96s real     0m11.10s user     0m05.74s system
    0m57.23s real     0m10.53s user     0m05.59s system

PR:
    0m19.64s real     0m09.58s user     0m05.50s system
    0m18.05s real     0m07.77s user     0m04.03s system
    0m18.99s real     0m07.90s user     0m04.25s system
    0m17.49s real     0m07.56s user     0m03.92s system
    0m18.11s real     0m07.74s user     0m03.88s system
```
Note that in most tests this is not a problem since txs very often originate from node0.
