### PR TITLE
[PoC] Structure aware fuzzing with libprotobuf-mutator

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -207,6 +207,12 @@ AC_ARG_ENABLE([fuzz],
     [enable_fuzz=$enableval],
     [enable_fuzz=no])
 
+AC_ARG_ENABLE([proto-fuzz],
+    AS_HELP_STRING([--enable-proto-fuzz],
+    [build for proto fuzzing (default no). enabling this will disable all other targets and override --{enable,disable}-fuzz-binary]),
+    [enable_proto_fuzz=$enableval],
+    [enable_proto_fuzz=no])
+
 AC_ARG_ENABLE([fuzz-binary],
     AS_HELP_STRING([--enable-fuzz-binary],
     [enable building of fuzz binary (default yes).]),
@@ -396,6 +402,20 @@ fi
 if test "$enable_lto" = "yes"; then
   AX_CHECK_COMPILE_FLAG([-flto], [LTO_CXXFLAGS="$LTO_CXXFLAGS -flto"], [AC_MSG_ERROR([compile failed with -flto])], [$CXXFLAG_WERROR])
   AX_CHECK_LINK_FLAG([-flto], [LTO_LDFLAGS="$LTO_LDFLAGS -flto"], [AC_MSG_ERROR([link failed with -flto])], [$CXXFLAG_WERROR])
+fi
+
+if test "$enable_proto_fuzz" = "yes"; then
+  dnl Check that required libraries for proto fuzzing can be found.
+  dnl libprotobuf, libprotobuf-mutator-libfuzzer and libprotobuf-mutator are required.
+  AX_CHECK_LINK_FLAG(
+    [-lprotobuf], [PROTO_FUZZ_LDFLAGS="$PROTO_FUZZ_LDFLAGS -lprotobuf"],
+    [AC_MSG_ERROR([linker did not accept requested flags])], [])
+  AX_CHECK_LINK_FLAG(
+    [-lprotobuf-mutator-libfuzzer], [PROTO_FUZZ_LDFLAGS="$PROTO_FUZZ_LDFLAGS -lprotobuf-mutator-libfuzzer"],
+    [AC_MSG_ERROR([linker did not accept requested flags])], [])
+  AX_CHECK_LINK_FLAG(
+    [-lprotobuf-mutator], [PROTO_FUZZ_LDFLAGS="$PROTO_FUZZ_LDFLAGS -lprotobuf-mutator"],
+    [AC_MSG_ERROR([linker did not accept requested flags])], [])
 fi
 
 if test "$use_sanitizers" != ""; then
@@ -1883,6 +1903,7 @@ AM_CONDITIONAL([USE_SQLITE], [test "$use_sqlite" = "yes"])
 AM_CONDITIONAL([USE_BDB], [test "$use_bdb" = "yes"])
 AM_CONDITIONAL([ENABLE_TESTS], [test "$BUILD_TEST" = "yes"])
 AM_CONDITIONAL([ENABLE_FUZZ], [test "$enable_fuzz" = "yes"])
+AM_CONDITIONAL([ENABLE_PROTO_FUZZ], [test "$enable_proto_fuzz" = "yes"])
 AM_CONDITIONAL([ENABLE_FUZZ_BINARY], [test "$enable_fuzz_binary" = "yes"])
 AM_CONDITIONAL([ENABLE_QT], [test "$bitcoin_enable_qt" = "yes"])
 AM_CONDITIONAL([ENABLE_QT_TESTS], [test "$BUILD_TEST_QT" = "yes"])
@@ -1934,6 +1955,7 @@ AC_SUBST(BITCOIN_WALLET_TOOL_NAME)
 AC_SUBST(BITCOIN_MP_NODE_NAME)
 AC_SUBST(BITCOIN_MP_GUI_NAME)
 
+AC_SUBST(PROTO_FUZZ_LDFLAGS)
 AC_SUBST(RELDFLAGS)
 AC_SUBST(CORE_LDFLAGS)
 AC_SUBST(CORE_CPPFLAGS)

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -6,6 +6,7 @@ if ENABLE_FUZZ_BINARY
 noinst_PROGRAMS += test/fuzz/fuzz
 if ENABLE_PROTO_FUZZ
 noinst_PROGRAMS += test/fuzz/proto/atmp
+noinst_PROGRAMS += test/fuzz/proto/version
 endif
 endif
 
@@ -18,6 +19,7 @@ TEST_BINARY=test/test_bitcoin$(EXEEXT)
 FUZZ_BINARY=test/fuzz/fuzz$(EXEEXT)
 if ENABLE_PROTO_FUZZ
 PROTO_FUZZ_ATMP_BINARY=test/fuzz/proto/atmp$(EXEEXT)
+PROTO_FUZZ_VERSION_BINARY=test/fuzz/proto/version$(EXEEXT)
 endif
 
 JSON_TEST_FILES = \
@@ -251,9 +253,11 @@ PROTO_FUZZ_SUITE_LD_COMMON = \
  $(EVENT_PTHREADS_LIBS)
 
 COMMON_FUZZ_SRC = \
+  test/fuzz/util/net.cpp \
   test/fuzz/proto/convert.cpp \
   test/fuzz/proto/transaction.pb.cc \
-  test/fuzz/proto/mempool_options.pb.cc
+  test/fuzz/proto/mempool_options.pb.cc \
+  test/fuzz/proto/p2p.pb.cc
 
 test_fuzz_proto_atmp_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(BOOST_CPPFLAGS)
 test_fuzz_proto_atmp_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
@@ -263,6 +267,15 @@ test_fuzz_proto_atmp_SOURCES = \
  $(COMMON_FUZZ_SRC) \
  test/fuzz/proto/atmp.cpp \
  test/fuzz/proto/atmp.pb.cc 
+
+test_fuzz_proto_version_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(BOOST_CPPFLAGS)
+test_fuzz_proto_version_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_proto_version_LDADD = $(PROTO_FUZZ_SUITE_LD_COMMON)
+test_fuzz_proto_version_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS) $(PTHREAD_FLAGS) $(RUNTIME_LDFLAGS) $(PROTO_FUZZ_LDFLAGS)
+test_fuzz_proto_version_SOURCES = \
+ $(COMMON_FUZZ_SRC) \
+ test/fuzz/proto/version.cpp \
+ test/fuzz/proto/version.pb.cc
 endif 
 
 test_fuzz_fuzz_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(BOOST_CPPFLAGS)

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -4,6 +4,9 @@
 
 if ENABLE_FUZZ_BINARY
 noinst_PROGRAMS += test/fuzz/fuzz
+if ENABLE_PROTO_FUZZ
+noinst_PROGRAMS += test/fuzz/proto/atmp
+endif
 endif
 
 if ENABLE_TESTS
@@ -13,6 +16,9 @@ endif
 TEST_SRCDIR = test
 TEST_BINARY=test/test_bitcoin$(EXEEXT)
 FUZZ_BINARY=test/fuzz/fuzz$(EXEEXT)
+if ENABLE_PROTO_FUZZ
+PROTO_FUZZ_ATMP_BINARY=test/fuzz/proto/atmp$(EXEEXT)
+endif
 
 JSON_TEST_FILES = \
   test/data/script_tests.json \
@@ -225,6 +231,40 @@ FUZZ_SUITE_LD_COMMON += $(LIBBITCOIN_ZMQ) $(ZMQ_LIBS)
 endif
 
 if ENABLE_FUZZ_BINARY
+
+if ENABLE_PROTO_FUZZ
+PROTO_FUZZ_SUITE_LD_COMMON = \
+ $(LIBTEST_UTIL) \
+ $(LIBBITCOIN_NODE) \
+ $(LIBBITCOIN_WALLET) \
+ $(LIBBITCOIN_COMMON) \
+ $(LIBBITCOIN_UTIL) \
+ $(LIBBITCOIN_CONSENSUS) \
+ $(LIBBITCOIN_CRYPTO) \
+ $(LIBBITCOIN_CLI) \
+ $(LIBUNIVALUE) \
+ $(LIBLEVELDB) \
+ $(LIBMEMENV) \
+ $(LIBSECP256K1) \
+ $(MINISKETCH_LIBS) \
+ $(EVENT_LIBS) \
+ $(EVENT_PTHREADS_LIBS)
+
+COMMON_FUZZ_SRC = \
+  test/fuzz/proto/convert.cpp \
+  test/fuzz/proto/transaction.pb.cc \
+  test/fuzz/proto/mempool_options.pb.cc
+
+test_fuzz_proto_atmp_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(BOOST_CPPFLAGS)
+test_fuzz_proto_atmp_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_proto_atmp_LDADD = $(PROTO_FUZZ_SUITE_LD_COMMON)
+test_fuzz_proto_atmp_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS) $(PTHREAD_FLAGS) $(RUNTIME_LDFLAGS) $(PROTO_FUZZ_LDFLAGS)
+test_fuzz_proto_atmp_SOURCES = \
+ $(COMMON_FUZZ_SRC) \
+ test/fuzz/proto/atmp.cpp \
+ test/fuzz/proto/atmp.pb.cc 
+endif 
+
 test_fuzz_fuzz_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(BOOST_CPPFLAGS)
 test_fuzz_fuzz_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_fuzz_LDADD = $(FUZZ_SUITE_LD_COMMON)

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -7,6 +7,7 @@ noinst_PROGRAMS += test/fuzz/fuzz
 if ENABLE_PROTO_FUZZ
 noinst_PROGRAMS += test/fuzz/proto/atmp
 noinst_PROGRAMS += test/fuzz/proto/version
+noinst_PROGRAMS += test/fuzz/proto/validation
 endif
 endif
 
@@ -20,6 +21,7 @@ FUZZ_BINARY=test/fuzz/fuzz$(EXEEXT)
 if ENABLE_PROTO_FUZZ
 PROTO_FUZZ_ATMP_BINARY=test/fuzz/proto/atmp$(EXEEXT)
 PROTO_FUZZ_VERSION_BINARY=test/fuzz/proto/version$(EXEEXT)
+PROTO_FUZZ_VALIDATION_BINARY=test/fuzz/proto/validation$(EXEEXT)
 endif
 
 JSON_TEST_FILES = \
@@ -257,7 +259,8 @@ COMMON_FUZZ_SRC = \
   test/fuzz/proto/convert.cpp \
   test/fuzz/proto/transaction.pb.cc \
   test/fuzz/proto/mempool_options.pb.cc \
-  test/fuzz/proto/p2p.pb.cc
+  test/fuzz/proto/p2p.pb.cc \
+  test/fuzz/proto/block.pb.cc
 
 test_fuzz_proto_atmp_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(BOOST_CPPFLAGS)
 test_fuzz_proto_atmp_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
@@ -276,6 +279,15 @@ test_fuzz_proto_version_SOURCES = \
  $(COMMON_FUZZ_SRC) \
  test/fuzz/proto/version.cpp \
  test/fuzz/proto/version.pb.cc
+
+test_fuzz_proto_validation_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(BOOST_CPPFLAGS)
+test_fuzz_proto_validation_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_proto_validation_LDADD = $(PROTO_FUZZ_SUITE_LD_COMMON)
+test_fuzz_proto_validation_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS) $(PTHREAD_FLAGS) $(RUNTIME_LDFLAGS) $(PROTO_FUZZ_LDFLAGS) 
+test_fuzz_proto_validation_SOURCES = \
+ $(COMMON_FUZZ_SRC) \
+ test/fuzz/proto/validation.cpp \
+ test/fuzz/proto/validation.pb.cc
 endif 
 
 test_fuzz_fuzz_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(BOOST_CPPFLAGS)

--- a/src/test/fuzz/proto/atmp.cpp
+++ b/src/test/fuzz/proto/atmp.cpp
@@ -1,0 +1,175 @@
+#include <libprotobuf-mutator/src/libfuzzer/libfuzzer_macro.h>
+#include <test/fuzz/proto/atmp.pb.h>
+#include <test/fuzz/proto/convert.h>
+#include <test/fuzz/proto/mempool_options.pb.h>
+#include <test/fuzz/proto/transaction.pb.h>
+
+#include <primitives/transaction.h>
+#include <test/util/mining.h>
+#include <test/util/script.h>
+#include <test/util/setup_common.h>
+#include <test/util/txmempool.h>
+#include <validation.h>
+#include <validationinterface.h>
+
+#include <chrono>
+#include <random>
+
+// WHYYYYY
+// const std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;
+const std::function<void(const std::string&)> G_TEST_LOG_FUN;
+const std::function<std::vector<const char*>()> G_TEST_COMMAND_LINE_ARGUMENTS;
+
+const TestingSetup* g_setup;
+std::vector<COutPoint> g_outpoints_coinbase_init_mature;
+std::vector<COutPoint> g_outpoints_coinbase_init_immature;
+
+struct MockedTxPool : public CTxMemPool {
+    void RollingFeeUpdate() EXCLUSIVE_LOCKS_REQUIRED(!cs)
+    {
+        LOCK(cs);
+        lastRollingFeeUpdate = GetTime();
+        blockSinceLastRollingFeeBump = true;
+    }
+};
+
+class MockedChainstate final : public Chainstate
+{
+public:
+    void SetMempool(CTxMemPool* mempool)
+    {
+        m_mempool = mempool;
+    }
+};
+
+extern "C" int LLVMFuzzerInitialize(int* argc, char*** argv)
+{
+    static const auto testing_setup = MakeNoLogFileContext<const TestingSetup>();
+    g_setup = testing_setup.get();
+
+    for (int i = 0; i < 2 * COINBASE_MATURITY; ++i) {
+        CTxIn in = MineBlock(g_setup->m_node, P2WSH_OP_TRUE);
+        // Remember the txids to avoid expensive disk access later on
+        auto& outpoints = i < COINBASE_MATURITY ?
+                              g_outpoints_coinbase_init_mature :
+                              g_outpoints_coinbase_init_immature;
+        outpoints.push_back(in.prevout);
+    }
+    SyncWithValidationInterfaceQueue();
+    return 0;
+}
+
+template <class Proto>
+using PostProcessor =
+    protobuf_mutator::libfuzzer::PostProcessorRegistration<Proto>;
+
+static PostProcessor<common_fuzz::Transaction> post_proc_txid = {
+    [](common_fuzz::Transaction* message, unsigned int seed) {
+        // This is not its own post processor because changing the prevouts affects the txid.
+        // TODO can this be its own post proc?
+        auto post_proc_prev_out = [](common_fuzz::PrevOut* message, unsigned int seed) {
+            std::minstd_rand rnd;
+            rnd.seed(seed);
+
+            if (!std::uniform_int_distribution<uint16_t>(0, 20)(rnd) || message->txid().empty()) {
+                // TODO 5% chance is kinda random
+                COutPoint& outpoint = rnd() % 2 == 0 ?
+                                          g_outpoints_coinbase_init_mature[rnd() % g_outpoints_coinbase_init_mature.size()] :
+                                          g_outpoints_coinbase_init_immature[rnd() % g_outpoints_coinbase_init_immature.size()];
+                message->set_txid(outpoint.hash.ToString());
+                message->set_n(outpoint.n);
+            }
+        };
+
+        auto* inputs = message->mutable_inputs();
+        for (auto& input : *inputs) {
+            post_proc_prev_out(input.mutable_prev_out(), seed);
+            auto* witnesses = input.mutable_witness_stack();
+            witnesses->erase(witnesses->begin(), witnesses->end());
+            *witnesses->Add() = {WITNESS_STACK_ELEM_OP_TRUE.begin(), WITNESS_STACK_ELEM_OP_TRUE.end()};
+        }
+
+        auto post_proc_tx_output = [](common_fuzz::TxOutput* message, unsigned int seed) {
+            std::minstd_rand rnd;
+            rnd.seed(seed);
+            message->mutable_script_pub_key()->set_raw(
+                {P2WSH_OP_TRUE.begin(), P2WSH_OP_TRUE.end()});
+        };
+        auto* outputs = message->mutable_outputs();
+        for (auto& output : *outputs) {
+            post_proc_tx_output(&output, seed);
+        }
+
+        CTransactionRef tx = ConvertTransaction(*message);
+        uint256 txid{tx->GetHash()};
+        message->set_txid(txid.ToString());
+    }};
+
+int64_t ClampTime(int64_t time)
+{
+    const auto* active_tip = WITH_LOCK(
+        cs_main, return g_setup->m_node.chainman->ActiveChain().Tip());
+    return std::min((int64_t)std::numeric_limits<decltype(active_tip->nTime)>::max(),
+                    std::max(time, active_tip->GetMedianTimePast() + 1));
+}
+static PostProcessor<atmp_fuzz::AcceptToMemoryPool> post_proc_atmp_mock_time = {
+    [](atmp_fuzz::AcceptToMemoryPool* message, unsigned int seed) {
+        // Make sure the atmp mock time lies between a sensible minimum and maximum.
+        if (message->has_mock_time()) {
+            message->set_mock_time(ClampTime(message->mock_time()));
+        }
+    }};
+
+DEFINE_PROTO_FUZZER(const atmp_fuzz::Mempool& mempool)
+{
+    const auto& node = g_setup->m_node;
+    auto& chainstate{static_cast<MockedChainstate&>(node.chainman->ActiveChainstate())};
+
+    SetMockTime(ClampTime(0));
+
+    CTxMemPool tx_pool_{ConvertMempoolOptions(mempool.options())};
+    MockedTxPool& tx_pool = *static_cast<MockedTxPool*>(&tx_pool_);
+
+    chainstate.SetMempool(&tx_pool);
+
+    for (const auto& atmp_event : mempool.atmp_events()) {
+        if (atmp_event.has_mock_time()) {
+            SetMockTime(atmp_event.mock_time());
+        }
+
+        if (atmp_event.rolling_fee_update()) {
+            tx_pool.RollingFeeUpdate();
+        }
+
+        if (atmp_event.has_prioritise_delta()) {
+            // TODO does this only make sense when also assembling a block?
+        }
+
+        if (atmp_event.has_transaction()) {
+            auto tx = ConvertTransaction(atmp_event.transaction());
+            WITH_LOCK(::cs_main,
+                      return AcceptToMemoryPool(chainstate, tx, GetTime(),
+                                                atmp_event.bypass_limits(),
+                                                /*test_accept=*/false));
+        }
+
+        if (atmp_event.has_pkg()) {
+            Package pkg;
+            for (const auto& tx : atmp_event.pkg().transactions()) {
+                pkg.push_back(ConvertTransaction(tx));
+            }
+
+            if (!pkg.empty()) {
+                WITH_LOCK(::cs_main,
+                          return ProcessNewPackage(chainstate, tx_pool, pkg,
+                                                   /*test_accept=*/false));
+            }
+        }
+    }
+
+    if (GetMainSignals().CallbacksPending() > 0) {
+        SyncWithValidationInterfaceQueue();
+    }
+
+    WITH_LOCK(::cs_main, tx_pool.check(chainstate.CoinsTip(), chainstate.m_chain.Height() + 1));
+}

--- a/src/test/fuzz/proto/atmp.proto
+++ b/src/test/fuzz/proto/atmp.proto
@@ -1,0 +1,23 @@
+syntax = "proto2";
+
+import "transaction.proto";
+import "mempool_options.proto";
+
+package atmp_fuzz;
+
+// Describes a ATMP event.
+message AcceptToMemoryPool {
+  oneof tx_or_pkg {
+    common_fuzz.Transaction transaction = 1;
+    common_fuzz.Package pkg = 2;
+  }
+  optional int64 mock_time = 3;
+  required bool rolling_fee_update = 4;
+  optional int64 prioritise_delta = 5;
+  required bool bypass_limits = 6;
+}
+
+message Mempool {
+  repeated AcceptToMemoryPool atmp_events = 1;
+  required common_fuzz.MempoolOptions options = 2;
+}

--- a/src/test/fuzz/proto/block.proto
+++ b/src/test/fuzz/proto/block.proto
@@ -1,0 +1,23 @@
+syntax = "proto2";
+
+import "transaction.proto";
+
+package common_fuzz;
+
+message BlockHeader {
+  required int32 version = 1; 
+  required string hash_prev_block = 2;
+  // Filled in by post processing
+  required string merkle_root = 3;
+  required uint32 time = 4;
+  required uint32 bits = 5;
+  required uint32 nonce = 6;
+
+  // Filled in by post processing
+  required string hash = 7;
+}
+
+message Block {
+  required BlockHeader header = 1;
+  repeated common_fuzz.Transaction transactions = 2;
+}

--- a/src/test/fuzz/proto/convert.cpp
+++ b/src/test/fuzz/proto/convert.cpp
@@ -1,10 +1,15 @@
 #include <test/fuzz/proto/convert.h>
 
+#include <net.h>
+#include <node/connection_types.h>
 #include <primitives/transaction.h>
 #include <txmempool.h>
 
+#include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/proto/mempool_options.pb.h>
+#include <test/fuzz/proto/p2p.pb.h>
 #include <test/fuzz/proto/transaction.pb.h>
+#include <test/fuzz/util/net.h>
 
 CTransactionRef ConvertTransaction(const common_fuzz::Transaction& proto_tx)
 {
@@ -53,7 +58,7 @@ CTxMemPool::Options ConvertMempoolOptions(const common_fuzz::MempoolOptions& mem
     mempool_opts.estimator = nullptr;
     mempool_opts.check_ratio = 1;
 
-	// TODO clean up the naming
+    // TODO clean up the naming
     auto& options = mempool_options;
     if (options.has_max_size_bytes())
         mempool_opts.require_standard = options.require_standard();
@@ -86,4 +91,114 @@ CTxMemPool::Options ConvertMempoolOptions(const common_fuzz::MempoolOptions& mem
         mempool_limits.descendant_size_vbytes = limits.descendant_size_limit();
 
     return mempool_opts;
+}
+
+ConnectionType ConvertConnType(const common_fuzz::ConnectionType& type)
+{
+    switch (type) {
+    case common_fuzz::MANUAL:
+        return ConnectionType::MANUAL;
+    case common_fuzz::BLOCK_RELAY:
+        return ConnectionType::BLOCK_RELAY;
+    case common_fuzz::OUTBOUND_FULL_RELAY:
+        return ConnectionType::OUTBOUND_FULL_RELAY;
+    case common_fuzz::INBOUND:
+        return ConnectionType::OUTBOUND_FULL_RELAY;
+    case common_fuzz::INBOUND_ONION:
+        return ConnectionType::INBOUND;
+    case common_fuzz::ADDR_FETCH:
+        return ConnectionType::ADDR_FETCH;
+    case common_fuzz::FEELER:
+        return ConnectionType::FEELER;
+    }
+}
+
+NetPermissionFlags ConvertPermFlags(const common_fuzz::NetPermissionFlags& flags)
+{
+    NetPermissionFlags perms{0};
+    if (flags.addr()) perms = perms | NetPermissionFlags::Addr;
+    if (flags.noban()) perms = perms | NetPermissionFlags::NoBan;
+    if (flags.download()) perms = perms | NetPermissionFlags::Download;
+    if (flags.relay()) perms = perms | NetPermissionFlags::Relay;
+    if (flags.force_relay()) perms = perms | NetPermissionFlags::ForceRelay;
+    if (flags.mempool()) perms = perms | NetPermissionFlags::Mempool;
+    if (flags.implicit()) perms = perms | NetPermissionFlags::Implicit;
+    if (flags.bloom_filter()) perms = perms | NetPermissionFlags::BloomFilter;
+    return perms;
+}
+
+CNode& ConvertConnection(const common_fuzz::Connection& connection, FuzzedDataProvider& sock_data_provider)
+{
+    CNodeOptions options;
+    if (connection.has_perm_flags()) {
+        options.permission_flags = ConvertPermFlags(connection.perm_flags());
+    }
+    if (connection.has_prefer_evict()) {
+        options.prefer_evict = connection.prefer_evict();
+    }
+
+    CNode* node = new CNode{
+        /*id=*/0,
+        /*sock=*/std::make_shared<FuzzedSock>(sock_data_provider),
+        /*addrIn=*/CAddress(),
+        /*nKeyedNetGroupIn=*/connection.keyed_net_group(),
+        /*nLocalHostNonceIn=*/connection.local_host_nonce(),
+        /*addrBindIn=*/CAddress(),
+        /*addrNameIn=*/"",
+        /*conn_type_in=*/ConvertConnType(connection.conn_type()),
+        /*inbound_onion=*/connection.conn_type() == common_fuzz::INBOUND_ONION,
+        std::move(options),
+    };
+
+    return *node;
+}
+
+ServiceFlags ConvertServiceFlags(const common_fuzz::ServiceFlags& flags)
+{
+    uint64_t service_flags{0};
+    if (flags.bloom()) service_flags |= NODE_BLOOM;
+    if (flags.network()) service_flags |= NODE_NETWORK;
+    if (flags.network_limited()) service_flags |= NODE_NETWORK_LIMITED;
+    if (flags.compact_filters()) service_flags |= NODE_COMPACT_FILTERS;
+    if (flags.witness()) service_flags |= NODE_WITNESS;
+
+    return ServiceFlags{service_flags};
+}
+
+std::tuple<std::string, std::vector<uint8_t>> ConvertHandshakeMsg(const common_fuzz::HandshakeMsg& msg)
+{
+    std::string type;
+    CDataStream stream{SER_NETWORK, PROTOCOL_VERSION};
+    if (msg.has_version()) {
+        type = NetMsgType::VERSION;
+        stream << msg.version().version()
+               << (uint64_t)ConvertServiceFlags(msg.version().services())
+               << msg.version().time()
+               << uint64_t{0}
+               << CService()
+               << uint64_t{0} << uint64_t{0} << uint64_t{0} << uint16_t{0}
+               << msg.version().nonce()
+               << msg.version().sub_version()
+               << msg.version().starting_height()
+               << msg.version().tx_relay();
+    } else if (msg.has_send_cmpct()) {
+        type = NetMsgType::SENDCMPCT;
+        stream << msg.send_cmpct().high_bw()
+               << msg.send_cmpct().version();
+    } else if (msg.has_verack()) {
+        type = NetMsgType::VERACK;
+    } else if (msg.has_sendaddrv2()) {
+        type = NetMsgType::SENDADDRV2;
+    } else if (msg.has_sendtxrcncl()) {
+        type = NetMsgType::SENDTXRCNCL;
+        stream << msg.sendtxrcncl().version()
+               << msg.sendtxrcncl().salt();
+    } else if (msg.has_wtxidrelay()) {
+        type = NetMsgType::WTXIDRELAY;
+    }
+
+    std::vector<uint8_t> data(stream.size());
+    if (stream.size() > 0)
+        std::memcpy(data.data(), (uint8_t*)stream.data(), stream.size());
+    return {type, std::move(data)};
 }

--- a/src/test/fuzz/proto/convert.cpp
+++ b/src/test/fuzz/proto/convert.cpp
@@ -1,0 +1,89 @@
+#include <test/fuzz/proto/convert.h>
+
+#include <primitives/transaction.h>
+#include <txmempool.h>
+
+#include <test/fuzz/proto/mempool_options.pb.h>
+#include <test/fuzz/proto/transaction.pb.h>
+
+CTransactionRef ConvertTransaction(const common_fuzz::Transaction& proto_tx)
+{
+    CMutableTransaction mtx;
+    mtx.nLockTime = proto_tx.lock_time();
+    mtx.nVersion = proto_tx.version();
+
+    for (const auto& proto_input : proto_tx.inputs()) {
+        CTxIn input;
+        input.nSequence = proto_input.sequence();
+        // scriptWitness
+        for (const auto& witness : proto_input.witness_stack()) {
+            input.scriptWitness.stack.push_back({witness.begin(), witness.end()});
+        }
+        // scriptSig
+        std::vector<uint8_t> script{proto_input.script_sig().raw().begin(),
+                                    proto_input.script_sig().raw().end()};
+        input.scriptSig = {script.begin(), script.end()};
+        // prevout
+        auto hex = proto_input.prev_out().txid();
+        hex.resize(64);
+        input.prevout.hash = uint256S(hex);
+        input.prevout.n = proto_input.prev_out().n();
+
+        mtx.vin.emplace_back(std::move(input));
+    }
+
+    for (const auto& proto_output : proto_tx.outputs()) {
+        CTxOut output;
+        output.nValue = proto_output.value();
+        std::vector<uint8_t> script{proto_output.script_pub_key().raw().begin(),
+                                    proto_output.script_pub_key().raw().end()};
+        output.scriptPubKey = {script.begin(), script.end()};
+        mtx.vout.emplace_back(std::move(output));
+    }
+
+    return MakeTransactionRef(mtx);
+}
+
+CTxMemPool::Options ConvertMempoolOptions(const common_fuzz::MempoolOptions& mempool_options)
+{
+    // Take the default options for tests...
+    CTxMemPool::Options mempool_opts;
+
+    // ...override specific options for this specific fuzz suite
+    mempool_opts.estimator = nullptr;
+    mempool_opts.check_ratio = 1;
+
+	// TODO clean up the naming
+    auto& options = mempool_options;
+    if (options.has_max_size_bytes())
+        mempool_opts.require_standard = options.require_standard();
+    if (options.has_expiry_hours())
+        mempool_opts.expiry = std::chrono::hours{options.expiry_hours()};
+    if (options.has_incremental_relay_feerate())
+        mempool_opts.incremental_relay_feerate = CFeeRate{options.incremental_relay_feerate()};
+    if (options.has_min_relay_feerate())
+        mempool_opts.min_relay_feerate = CFeeRate{options.min_relay_feerate()};
+    if (options.has_dust_relay_feerate())
+        mempool_opts.dust_relay_feerate = CFeeRate{options.dust_relay_feerate()};
+    if (options.has_max_datacarrier_bytes())
+        mempool_opts.max_datacarrier_bytes = options.max_datacarrier_bytes();
+    if (options.has_permit_bare_multisig())
+        mempool_opts.permit_bare_multisig = options.permit_bare_multisig();
+    if (options.has_require_standard())
+        mempool_opts.require_standard = options.require_standard();
+    if (options.has_full_rbf())
+        mempool_opts.full_rbf = options.full_rbf();
+
+    auto& limits = options.limits();
+    auto& mempool_limits = mempool_opts.limits;
+    if (limits.has_ancestor_count_limit())
+        mempool_limits.ancestor_count = limits.ancestor_count_limit();
+    if (limits.has_ancestor_size_limit())
+        mempool_limits.ancestor_size_vbytes = limits.ancestor_size_limit();
+    if (limits.has_descendant_count_limit())
+        mempool_limits.descendant_count = limits.descendant_count_limit();
+    if (limits.has_ancestor_size_limit())
+        mempool_limits.descendant_size_vbytes = limits.descendant_size_limit();
+
+    return mempool_opts;
+}

--- a/src/test/fuzz/proto/convert.h
+++ b/src/test/fuzz/proto/convert.h
@@ -1,14 +1,25 @@
 #ifndef BITCOIN_TEST_FUZZ_PROTO_CONVERT_H
 #define BITCOIN_TEST_FUZZ_PROTO_CONVERT_H
 
+#include <net.h>
+#include <node/connection_types.h>
 #include <primitives/transaction.h>
 #include <txmempool.h>
 
+#include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/proto/mempool_options.pb.h>
+#include <test/fuzz/proto/p2p.pb.h>
 #include <test/fuzz/proto/transaction.pb.h>
+#include <test/fuzz/util/net.h>
 
 CTransactionRef ConvertTransaction(const common_fuzz::Transaction& proto_tx);
 
 CTxMemPool::Options ConvertMempoolOptions(const common_fuzz::MempoolOptions& mempool_opts);
+
+ConnectionType ConvertConnType(const common_fuzz::ConnectionType& type);
+NetPermissionFlags ConvertPermFlags(const common_fuzz::NetPermissionFlags& flags);
+CNode& ConvertConnection(const common_fuzz::Connection& connection, FuzzedDataProvider& sock_data_provider);
+ServiceFlags ConvertServiceFlags(const common_fuzz::ServiceFlags& flags);
+std::tuple<std::string, std::vector<uint8_t>> ConvertHandshakeMsg(const common_fuzz::HandshakeMsg& msg);
 
 #endif

--- a/src/test/fuzz/proto/convert.h
+++ b/src/test/fuzz/proto/convert.h
@@ -3,10 +3,12 @@
 
 #include <net.h>
 #include <node/connection_types.h>
+#include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <txmempool.h>
 
 #include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/proto/block.pb.h>
 #include <test/fuzz/proto/mempool_options.pb.h>
 #include <test/fuzz/proto/p2p.pb.h>
 #include <test/fuzz/proto/transaction.pb.h>
@@ -21,5 +23,8 @@ NetPermissionFlags ConvertPermFlags(const common_fuzz::NetPermissionFlags& flags
 CNode& ConvertConnection(const common_fuzz::Connection& connection, FuzzedDataProvider& sock_data_provider);
 ServiceFlags ConvertServiceFlags(const common_fuzz::ServiceFlags& flags);
 std::tuple<std::string, std::vector<uint8_t>> ConvertHandshakeMsg(const common_fuzz::HandshakeMsg& msg);
+
+CBlockHeader ConvertHeader(const common_fuzz::BlockHeader& proto_header);
+std::shared_ptr<CBlock> ConvertBlock(const common_fuzz::Block& block);
 
 #endif

--- a/src/test/fuzz/proto/convert.h
+++ b/src/test/fuzz/proto/convert.h
@@ -1,0 +1,14 @@
+#ifndef BITCOIN_TEST_FUZZ_PROTO_CONVERT_H
+#define BITCOIN_TEST_FUZZ_PROTO_CONVERT_H
+
+#include <primitives/transaction.h>
+#include <txmempool.h>
+
+#include <test/fuzz/proto/mempool_options.pb.h>
+#include <test/fuzz/proto/transaction.pb.h>
+
+CTransactionRef ConvertTransaction(const common_fuzz::Transaction& proto_tx);
+
+CTxMemPool::Options ConvertMempoolOptions(const common_fuzz::MempoolOptions& mempool_opts);
+
+#endif

--- a/src/test/fuzz/proto/mempool_options.proto
+++ b/src/test/fuzz/proto/mempool_options.proto
@@ -1,0 +1,23 @@
+syntax = "proto2";
+
+package common_fuzz;
+
+message MempoolLimits {
+  optional uint32 ancestor_count_limit = 1;
+  optional uint32 ancestor_size_limit = 2;
+  optional uint32 descendant_count_limit = 3;
+  optional uint32 descendant_size_limit = 4;
+}
+
+message MempoolOptions {
+  optional int64 max_size_bytes = 1;
+  optional uint32 expiry_hours = 2;
+  optional int64 incremental_relay_feerate = 3;
+  optional int64 min_relay_feerate = 4;
+  optional int64 dust_relay_feerate = 5;
+  optional int32 max_datacarrier_bytes = 6;
+  optional bool permit_bare_multisig = 7;
+  optional bool require_standard = 8;
+  optional bool full_rbf = 9;
+  required MempoolLimits limits = 10;
+}

--- a/src/test/fuzz/proto/p2p.proto
+++ b/src/test/fuzz/proto/p2p.proto
@@ -1,0 +1,93 @@
+syntax = "proto2";
+
+package common_fuzz;
+
+message ServiceFlags {
+  required bool network = 1;
+  required bool network_limited = 2;
+  required bool witness = 3;
+  required bool compact_filters = 4;
+  required bool bloom = 5;
+
+  optional uint64 fuzzed_bits = 6;
+}
+
+enum ConnectionType {
+  INBOUND = 1;
+  OUTBOUND_FULL_RELAY = 2;
+  MANUAL = 3;
+  FEELER = 4;
+  BLOCK_RELAY = 5;
+  ADDR_FETCH = 6;
+  INBOUND_ONION = 7;
+}
+
+message NetPermissionFlags {
+  required bool bloom_filter = 1;
+  required bool relay = 2;
+  required bool force_relay = 3;
+  required bool download = 4;
+  required bool noban = 5;
+  required bool mempool = 6;
+  required bool addr = 7;
+  required bool implicit = 8;
+}
+
+message Address {
+  enum Network {
+    IPv4 = 1;
+    IPv6 = 2;
+    TOR = 3;
+    I2P = 4;
+    CJDNS = 5;
+  }
+
+  required Network network = 1;
+  required bytes addr_bytes = 2;
+}
+
+message Version {
+  required int32 version = 1;
+  required ServiceFlags services = 2;
+  required int64 time = 3;
+  // 8 ignored bytes
+  required Address their_addr = 4;
+  // 26 ignored bytes
+  required uint64 nonce = 5;
+  required string sub_version = 6;
+  required int32 starting_height = 7;
+  required bool tx_relay = 8;
+}
+message SendCmpct {
+  required bool high_bw = 1;
+  required uint64 version = 2;
+}
+message SendTxRcncl {
+  required uint32 version = 1;
+  required uint64 salt = 2;
+}
+message Empty {}
+
+message HandshakeMsg {
+  optional int64 mock_time = 1;
+  oneof msg {
+    SendCmpct send_cmpct = 2;
+    Empty sendaddrv2 = 3;
+    SendTxRcncl sendtxrcncl = 4;
+    Empty wtxidrelay = 5;
+    Empty verack = 6;
+    Version version = 7;
+  }
+}
+
+message Connection {
+  required bytes socket_data_provider = 1;
+  required Address addr = 2;
+  required uint64 keyed_net_group = 3;
+  required uint64 local_host_nonce = 4;
+  required Address addr_bind = 5;
+  required ConnectionType conn_type = 6;
+  // Options
+  optional NetPermissionFlags perm_flags = 7;
+  optional bool prefer_evict = 8;
+}

--- a/src/test/fuzz/proto/transaction.proto
+++ b/src/test/fuzz/proto/transaction.proto
@@ -1,0 +1,37 @@
+syntax = "proto2";
+
+package common_fuzz;
+
+message PrevOut {
+  required string txid = 1;
+  required uint32 n = 2;
+}
+
+message Script {
+  required bytes raw = 1;
+}
+
+message TxInput {
+  required PrevOut prev_out = 1;
+  required Script script_sig = 2;
+  required uint32 sequence = 3;
+  repeated bytes witness_stack = 4;
+}
+
+message TxOutput {
+  required int64 value = 1;
+  required Script script_pub_key = 2;
+}
+
+message Transaction {
+  required string txid = 1;
+
+  repeated TxInput inputs = 2;
+  repeated TxOutput outputs = 3;
+  required int32 version = 4;
+  required uint32 lock_time = 5;
+}
+
+message Package {
+  repeated Transaction transactions = 1;
+}

--- a/src/test/fuzz/proto/validation.cpp
+++ b/src/test/fuzz/proto/validation.cpp
@@ -1,0 +1,148 @@
+#include <libprotobuf-mutator/src/libfuzzer/libfuzzer_macro.h>
+#include <test/fuzz/proto/validation.pb.h>
+#include <test/fuzz/proto/convert.h>
+
+#include <consensus/merkle.h>
+#include <node/caches.h>
+#include <node/chainstate.h>
+#include <pow.h>
+#include <test/util/setup_common.h>
+#include <test/util/validation.h>
+#include <timedata.h>
+#include <validation.h>
+#include <validationinterface.h>
+
+#include <iostream>
+
+namespace {
+const TestingSetup* g_setup;
+} // namespace
+
+// WHYYYYY
+// const std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;
+const std::function<void(const std::string&)> G_TEST_LOG_FUN;
+const std::function<std::vector<const char*>()> G_TEST_COMMAND_LINE_ARGUMENTS;
+
+extern "C" int LLVMFuzzerInitialize(int* argc, char*** argv)
+{
+    static const auto testing_setup = MakeNoLogFileContext<const TestingSetup>();
+    g_setup = testing_setup.get();
+    return 0;
+}
+
+int64_t ClampTime(int64_t time)
+{
+    static const int64_t time_min{946684801};  // 2000-01-01T00:00:01Z
+    static const int64_t time_max{4133980799}; // 2100-12-31T23:59:59Z
+    return std::min(time_max,
+                    std::max(time, time_min));
+}
+
+template <class Proto>
+using PostProcessor =
+    protobuf_mutator::libfuzzer::PostProcessorRegistration<Proto>;
+
+static PostProcessor<validation_fuzz::ValidationAction> clamp_action_mock_time = {
+    [](validation_fuzz::ValidationAction* message, unsigned int seed) {
+        // Make sure the atmp mock time lies between a sensible minimum and maximum.
+        if (message->has_mock_time()) {
+            message->set_mock_time(ClampTime(message->mock_time()));
+        }
+    }};
+
+static PostProcessor<common_fuzz::Transaction> set_txid = {
+    [](common_fuzz::Transaction* message, unsigned int seed) {
+        auto tx = ConvertTransaction(*message);
+        message->set_txid(tx->GetHash().ToString());
+        // TODO sometimes create coinbases, the fuzzer struggles with the commitment
+    }};
+
+static PostProcessor<common_fuzz::Block> block_hash_and_merkle = {
+    [](common_fuzz::Block* message, unsigned int seed) {
+        auto block = ConvertBlock(*message);
+        auto mut_header = message->mutable_header();
+        mut_header->set_hash(block->GetHash().ToString());
+        mut_header->set_merkle_root(BlockMerkleRoot(*block).ToString());
+
+        if (mut_header->hash_prev_block().size() != 64) {
+            auto& genesis{Params().GenesisBlock()};
+            mut_header->set_hash_prev_block(genesis.GetHash().ToString());
+
+            mut_header->set_bits(genesis.nBits);
+            mut_header->set_nonce(genesis.nNonce);
+            mut_header->set_version(genesis.nVersion);
+            mut_header->set_time(genesis.nTime + 1);
+        }
+
+        int max_tries{1000};
+        while (!CheckProofOfWork(block->GetHash(), block->nBits, g_setup->m_node.chainman->GetConsensus()) && max_tries-- > 0) {
+            ++block->nNonce;
+        }
+
+        mut_header->set_nonce(block->nNonce);
+    }};
+
+DEFINE_PROTO_FUZZER(const validation_fuzz::FuzzValidation& fuzz_validation)
+{
+    SetMockTime(ClampTime(0));
+
+    CTxMemPool tx_pool{fuzz_validation.has_mempool_options() ?
+                           ConvertMempoolOptions(fuzz_validation.mempool_options()) :
+                           CTxMemPool::Options{}};
+    const CChainParams& params{Params()};
+    ChainstateManager chainman{ChainstateManager::Options{
+        .chainparams = params,
+        .adjusted_time_callback = GetAdjustedTime,
+    }};
+
+    auto cache_sizes = node::CalculateCacheSizes(g_setup->m_args);
+    chainman.m_blockman.m_block_tree_db = std::make_unique<CBlockTreeDB>(cache_sizes.block_tree_db, true);
+
+    node::ChainstateLoadOptions options;
+    options.mempool = &tx_pool;
+    options.block_tree_db_in_memory = true;
+    options.coins_db_in_memory = true;
+    options.reindex = node::fReindex;
+    options.reindex_chainstate = false;
+    options.prune = node::fPruneMode;
+    options.check_blocks = DEFAULT_CHECKBLOCKS;
+    options.check_level = DEFAULT_CHECKLEVEL;
+    auto [status, error] = LoadChainstate(chainman, cache_sizes, options);
+    assert(status == node::ChainstateLoadStatus::SUCCESS);
+
+    BlockValidationState state;
+    assert(chainman.ActiveChainstate().ActivateBestChain(state));
+
+    for (auto action : fuzz_validation.actions()) {
+        if (action.has_mock_time()) {
+            SetMockTime(action.mock_time());
+        }
+
+        if (action.has_process_new_block()) {
+            bool new_block{false};
+            (void)chainman.ProcessNewBlock(
+                /*block=*/ConvertBlock(action.process_new_block().block()),
+                /*force_processing=*/action.process_new_block().force(),
+                /*min_pow_checked=*/action.process_new_block().min_pow_checked(),
+                /*new_block=*/&new_block);
+        } else if (action.has_process_new_headers()) {
+            std::vector<CBlockHeader> headers;
+            for (auto header : action.process_new_headers().headers()) {
+                headers.push_back(ConvertHeader(header));
+            }
+
+            BlockValidationState state;
+            (void)chainman.ProcessNewBlockHeaders(
+                /*block=*/headers,
+                /*min_pow_checked=*/action.process_new_headers().min_pow_checked(),
+                /*state=*/state);
+        } else if (action.has_process_transaction()) {
+            LOCK(cs_main);
+            (void)chainman.ProcessTransaction(
+                /*tx=*/ConvertTransaction(action.process_transaction()),
+                /*test_accept=*/false);
+        }
+    }
+
+    chainman.ActiveChainstate().CheckBlockIndex();
+}

--- a/src/test/fuzz/proto/validation.proto
+++ b/src/test/fuzz/proto/validation.proto
@@ -1,0 +1,32 @@
+syntax = "proto2";
+
+import "transaction.proto";
+import "block.proto";
+import "mempool_options.proto";
+
+package validation_fuzz;
+
+message ProcessNewBlock {
+  required common_fuzz.Block block = 1;
+  required bool force = 2;
+  required bool min_pow_checked = 3;
+}
+
+message ProcessNewHeaders {
+  repeated common_fuzz.BlockHeader headers = 1;
+  required bool min_pow_checked = 2;
+}
+
+message ValidationAction {
+  optional int64 mock_time = 1;
+  oneof action {
+    ProcessNewBlock process_new_block = 2;
+    ProcessNewHeaders process_new_headers = 3;
+	common_fuzz.Transaction process_transaction = 4;
+  }
+}
+
+message FuzzValidation {
+  optional common_fuzz.MempoolOptions mempool_options = 1;
+  repeated ValidationAction actions = 2;
+}

--- a/src/test/fuzz/proto/version.cpp
+++ b/src/test/fuzz/proto/version.cpp
@@ -1,0 +1,90 @@
+#include <libprotobuf-mutator/src/libfuzzer/libfuzzer_macro.h>
+#include <test/fuzz/proto/convert.h>
+#include <test/fuzz/proto/version.pb.h>
+
+#include <net.h>
+#include <net_processing.h>
+#include <script/script.h>
+#include <test/fuzz/util/net.h>
+#include <test/util/setup_common.h>
+#include <test/util/validation.h>
+#include <validation.h>
+#include <validationinterface.h>
+
+#include <iostream>
+
+namespace {
+const TestingSetup* g_setup;
+} // namespace
+
+// WHYYYYY
+// const std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;
+const std::function<void(const std::string&)> G_TEST_LOG_FUN;
+const std::function<std::vector<const char*>()> G_TEST_COMMAND_LINE_ARGUMENTS;
+
+extern "C" int LLVMFuzzerInitialize(int* argc, char*** argv)
+{
+    static const auto testing_setup = MakeNoLogFileContext<const TestingSetup>();
+    g_setup = testing_setup.get();
+    return 0;
+}
+
+int64_t ClampTime(int64_t time)
+{
+    const auto* active_tip = WITH_LOCK(
+        cs_main, return g_setup->m_node.chainman->ActiveChain().Tip());
+    return std::min((int64_t)std::numeric_limits<decltype(active_tip->nTime)>::max(),
+                    std::max(time, active_tip->GetMedianTimePast() + 1));
+}
+
+template <class Proto>
+using PostProcessor =
+    protobuf_mutator::libfuzzer::PostProcessorRegistration<Proto>;
+
+static PostProcessor<common_fuzz::HandshakeMsg> post_proc_atmp_mock_time = {
+    [](common_fuzz::HandshakeMsg* message, unsigned int seed) {
+        // Make sure the atmp mock time lies between a sensible minimum and maximum.
+        if (message->has_mock_time()) {
+            message->set_mock_time(ClampTime(message->mock_time()));
+        }
+    }};
+
+DEFINE_PROTO_FUZZER(const version_fuzz::VersionHandshake& version_handshake)
+{
+    ConnmanTestMsg& connman = *static_cast<ConnmanTestMsg*>(g_setup->m_node.connman.get());
+    TestChainState& chainstate = *static_cast<TestChainState*>(&g_setup->m_node.chainman->ActiveChainstate());
+    SetMockTime(1610000000); // any time to successfully reset ibd
+    chainstate.ResetIbd();
+
+    LOCK(NetEventsInterface::g_msgproc_mutex);
+
+    FuzzedDataProvider sock_data_provider{
+        (uint8_t*)version_handshake.peer().socket_data_provider().data(),
+        version_handshake.peer().socket_data_provider().size()};
+    auto& node = ConvertConnection(version_handshake.peer(), sock_data_provider);
+    g_setup->m_node.peerman->InitializeNode(node, ConvertServiceFlags(version_handshake.our_flags()));
+    connman.AddTestNode(node);
+
+    for (const auto& msg : version_handshake.msgs()) {
+        auto [type, bytes] = ConvertHandshakeMsg(msg);
+
+        if (msg.has_mock_time()) {
+            SetMockTime(msg.mock_time());
+        }
+
+        CSerializedNetMsg net_msg;
+        net_msg.m_type = type;
+        net_msg.data = std::move(bytes);
+
+        (void)connman.ReceiveMsgFrom(node, net_msg);
+        node.fPauseSend = false;
+
+        try {
+            connman.ProcessMessagesOnce(node);
+        } catch (const std::ios_base::failure&) {
+        }
+        g_setup->m_node.peerman->SendMessages(&node);
+    }
+
+    g_setup->m_node.connman->StopNodes();
+}

--- a/src/test/fuzz/proto/version.proto
+++ b/src/test/fuzz/proto/version.proto
@@ -1,0 +1,11 @@
+syntax = "proto2";
+
+import "p2p.proto";
+
+package version_fuzz;
+
+message VersionHandshake {
+  required common_fuzz.Connection peer = 1;
+  required common_fuzz.ServiceFlags our_flags = 2;
+  repeated common_fuzz.HandshakeMsg msgs = 3;
+}


### PR DESCRIPTION
We currently use `FuzzedDataProvider` and a suite of `Consume*` functions for targets that require input formats other than a byte array. This approach is good for a lot of targets but has issues when it comes to more complex input formats.
* The input corpora consist of custom input serialization formats, which means that the inputs have no meaning outside of the target itself. Seeding or sharing inputs is basically impossible when dealing with custom formats per target, however mutation based fuzzers are particularly effective when provided with an initial seed corpus (coverage guided fuzzers like libFuzzer are able to start from an empty corpus but that is less effective).
* The fuzzer is not able to make useful mutations efficiently, because it only deals with raw bytes and is not aware of the input format. Fuzzers will still be able to create useful mutations, however only after many iterations.
* Changing the target often leads to invalidation of the existing input corpus. For example, if the target is modified to interpret the input data in a more useful way, then the previous input corpus is invalidated, as the serialization format is modified.

libFuzzer provides an interface for dealing with structured input formats: `LLVMFuzzerCustomMutator` and `LLVMFuzzerCustomCrossOver`. Using this interface it is possible to curate input corpora with highly structured input formats (e.g. png files, json, encrypted, compressed, base64 encoded). This is described [here](https://github.com/google/fuzzing/blob/master/docs/structure-aware-fuzzing.md) in detail.

[libprotobuf-mutator](https://github.com/google/libprotobuf-mutator) is a library for mutating protocol buffers, that also provides an interface around libFuzzer's custom mutator API. It allows us to specify input grammars using protobufs and exclusively provides useful mutations (i.e. mutations of the specified input format).

Using `libprofobuf-mutator` can address most of the issues of the  ´FuzzedDataProvider` approach.
* Input corpora exclusively consist of valid protobuf serializations. Meaning that seeding of corpora becomes quite easy, as all you need to do is provide your initial test cases in the protobuf format (i.e. have a script that produces useful initial test cases, similar to `feature_taproot --dumptests` except that it should spit out protobufs instead of json objects). Sharing inputs between targets becomes much easier (e.g. if two targets make use of transactions as inputs, then copying the transactions from one targets corpus to the other can easily be automated).
* By default the protobufs are serialized into a human readable format, which makes debugging of crashes easier and also enables hand-rolling (initial) test cases.
* IMO, writing protobuf definitions to define input grammars is very easy and maintainable. Looking at the protobuf definition gives an immediate overview of the input type a target takes (vs having to understand the combination `FuzzedDataProvider` and `Consume*` calls).
* Modifying the target is possible without invalidating the existing inputs.
* (We could likely get rid of quite a few of our `Consume*` functions meaning that there is less test only code to maintain.)

I have provided three examples in this PR that make use of `libprotobuf-mutator`.
- Fuzzing mempool acceptance
- Fuzzing the version handshake
- Fuzzing validation (ProcessNewBlock, ProcessNewBlockHeaders, ProcessTransaction)

Further reading/watching:
- https://github.com/google/fuzzing/blob/master/docs/structure-aware-fuzzing.md
- https://github.com/google/fuzzing/blob/master/docs/split-inputs.md
-  https://www.youtube.com/watch?v=U60hC16HEDY 
- https://media.ccc.de/v/35c3-9579-attacking_chrome_ipc.

## Building this PR

First clone and build [libprotobuf-mutator](https://github.com/google/libprotobuf-mutator), instruction can be found in their readme.

Then compile the protobuf definitions in this PR to c++:
```sh
cd src/test/fuzz/proto/
protoc *.proto --cpp_out .
```

Next configure and build the proto fuzzer binaries:
```sh
./configure --enable-fuzz --enable-proto-fuzz --with-sanitizers=fuzzer && make
```
If you did not install the libprotobuf-mutator libraries and headers onto your system, then you might have to set `LDFLAGS` and `CPPFLAGS` to point to your local LPM build.

If you manage to build and run the fuzzers, you can inspect the generated inputs with `cat` or any editor of your choosing.

---

*Looking for conceptual review*