### PR TITLE
ci: Fetch no git history, unless lint

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,4 +1,5 @@
 env:  # Global defaults
+  CIRRUS_CLONE_DEPTH: 1
   PACKAGE_MANAGER_INSTALL: "apt-get update && apt-get install -y"
   MAKEJOBS: "-j10"
   TEST_RUNNER_PORT_MIN: "14000"  # Must be larger than 12321, which is used for the http cache. See https://cirrus-ci.org/guide/writing-tasks/#http-cache
@@ -27,7 +28,7 @@ base_template: &BASE_TEMPLATE
     # Unconditionally install git (used in fingerprint_script).
     - bash -c "$PACKAGE_MANAGER_INSTALL git"
     - if [ "$CIRRUS_PR" = "" ]; then exit 0; fi
-    - git fetch $CIRRUS_REPO_CLONE_URL "pull/${CIRRUS_PR}/merge"
+    - git fetch --depth=1 $CIRRUS_REPO_CLONE_URL "pull/${CIRRUS_PR}/merge"
     - git checkout FETCH_HEAD  # Use merged changes to detect silent merge conflicts
                                # Also, the merge commit is used to lint COMMIT_RANGE="HEAD~..HEAD"
 
@@ -76,6 +77,8 @@ task:
   python_cache:
     folder: "/tmp/python"
     fingerprint_script: cat .python-version /etc/os-release
+  unshallow_script:
+    - git fetch --unshallow --no-tags
   lint_script:
     - ./ci/lint_run_all.sh
   env:


### PR DESCRIPTION
Should cut 20s from each build, with no downside?

This is possible since commit fad7281d7842f337932cf44e703fdd631230ddd6