### PR TITLE
p2p: 25880 fixups (stalling timeout)

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1845,7 +1845,7 @@ void PeerManagerImpl::BlockConnected(const std::shared_ptr<const CBlock>& pblock
     if (stalling_timeout != BLOCK_STALLING_TIMEOUT_DEFAULT) {
         const auto new_timeout = std::max(std::chrono::duration_cast<std::chrono::seconds>(stalling_timeout * 0.85), BLOCK_STALLING_TIMEOUT_DEFAULT);
         if (m_block_stalling_timeout.compare_exchange_strong(stalling_timeout, new_timeout)) {
-            LogPrint(BCLog::NET, "Decreased stalling timeout to %d seconds\n", new_timeout.count());
+            LogPrint(BCLog::NET, "Decreased stalling timeout to %d seconds\n", count_seconds(new_timeout));
         }
     }
 }
@@ -5736,7 +5736,7 @@ bool PeerManagerImpl::SendMessages(CNode* pto)
             // bandwidth is insufficient.
             const auto new_timeout = std::min(2 * stalling_timeout, BLOCK_STALLING_TIMEOUT_MAX);
             if (stalling_timeout != new_timeout && m_block_stalling_timeout.compare_exchange_strong(stalling_timeout, new_timeout)) {
-                LogPrint(BCLog::NET, "Increased stalling timeout temporarily to %d seconds\n", m_block_stalling_timeout.load().count());
+                LogPrint(BCLog::NET, "Increased stalling timeout temporarily to %d seconds\n", count_seconds(new_timeout));
             }
             return true;
         }

--- a/test/functional/p2p_ibd_stalling.py
+++ b/test/functional/p2p_ibd_stalling.py
@@ -115,7 +115,7 @@ class P2PIBDStallingTest(BitcoinTestFramework):
 
         self.mocktime += 2
         node.setmocktime(self.mocktime)
-        self.wait_until(lambda: node.num_test_p2p_connections() == NUM_PEERS - 2)
+        self.wait_until(lambda: sum(x.is_connected for x in node.p2ps) == NUM_PEERS - 2)
         self.wait_until(lambda: self.is_block_requested(peers, stall_block))
         self.all_sync_send_with_ping(peers)
 
@@ -128,7 +128,7 @@ class P2PIBDStallingTest(BitcoinTestFramework):
 
         self.mocktime += 2
         node.setmocktime(self.mocktime)
-        self.wait_until(lambda: node.num_test_p2p_connections() == NUM_PEERS - 3)
+        self.wait_until(lambda: sum(x.is_connected for x in node.p2ps) == NUM_PEERS - 3)
         self.wait_until(lambda: self.is_block_requested(peers, stall_block))
         self.all_sync_send_with_ping(peers)
 


### PR DESCRIPTION
Two small fixups to #25880:

- Use `is_connected` instead of `num_test_p2p_connections` to avoid intermittent failures where the p2p MiniNode got disconnected but this info hasn't made it to python yet, so it fails a ping. (https://github.com/bitcoin/bitcoin/pull/25880#discussion_r1089217720)

- Simplify a logging statement (suggested in https://github.com/bitcoin/bitcoin/pull/25880#discussion_r1013738635)