### PR TITLE
explicit `-d/--delete` argument for verifybinaries/verify.py

### DIFF
--- a/contrib/verifybinaries/README.md
+++ b/contrib/verifybinaries/README.md
@@ -17,7 +17,7 @@ This script attempts to download the signature file `SHA256SUMS.asc` from https:
 
 It first checks if the signature passes, and then downloads the files specified in the file, and checks if the hashes of these files match those that are specified in the signature file.
 
-The script returns 0 if everything passes the checks. It returns 1 if either the signature check or the hash check doesn't pass. If an error occurs the return value is 2.
+The script returns 0 if everything passes the checks. It returns 1 if either the signature check or the hash check doesn't pass. If an error occurs the return value is >= 2.
 
 
 ```sh
@@ -34,8 +34,8 @@ If you only want to download the binaries of certain platform, add the correspon
 ./verify.py bitcoin-core-0.13.0-rc3-win64
 ```
 
-If you do not want to keep the downloaded binaries, specify anything as the second parameter.
+If you do not want to keep the downloaded binaries:
 
 ```sh
-./verify.py bitcoin-core-0.13.0 delete
+./verify.py bitcoin-core-0.13.0 --delete
 ```

--- a/contrib/verifybinaries/verify.py
+++ b/contrib/verifybinaries/verify.py
@@ -13,6 +13,7 @@ The script returns 0 if everything passes the checks. It returns 1 if either
 the signature check or the hash check doesn't pass. If an error occurs the
 return value is >= 2.
 """
+import argparse
 from hashlib import sha256
 import os
 import subprocess
@@ -79,14 +80,18 @@ def remove_files(filenames):
         os.remove(filename)
 
 
-def main(args):
-    # sanity check
-    if len(args) < 1:
-        print("Error: need to specify a version on the command line")
+def main():
+    parser = argparse.ArgumentParser(description="Download and verify bitcoin binaries.")
+    parser.add_argument("version", type=str, metavar="VERSION", help="Target version.")
+    parser.add_argument("-d", "--delete", action="store_true", required=False,
+                        help="Delete the downloaded binaries afterwards.")
+    try:
+        args = parser.parse_args()
+    except SystemExit:
         return 3
 
     # determine remote dir dependent on provided version string
-    version_base, version_rc, os_filter = parse_version_string(args[0])
+    version_base, version_rc, os_filter = parse_version_string(args.version)
     remote_dir = f"/bin/{VERSIONPREFIX}{version_base}/"
     if version_rc:
         remote_dir += f"test.{version_rc}/"
@@ -168,7 +173,7 @@ def main(args):
     verified_binaries = [entry[1] for entry in hashes_to_verify]
 
     # clean up files if desired
-    if len(args) >= 2:
+    if args.delete:
         print("Clean up the binaries")
         remove_files([sigfile1, sigfile2] + verified_binaries)
     else:
@@ -180,4 +185,4 @@ def main(args):
 
 
 if __name__ == '__main__':
-    sys.exit(main(sys.argv[1:]))
+    sys.exit(main())


### PR DESCRIPTION
Use `argparse` (python buil-in) so that delete argument is explicit, instead of 'specify anything as the second parameter' user has to use `-d/--delete` to remove binaries after the check. Explicit is always better than implicit and I myself few times fat-fingered something behind the command and it deleted binaries that I wanted to keep. With this patch you get error for random things:
```
usage: verify.py [-h] [-d] VERSION
verify.py: error: unrecognized arguments: d
```
With argparse `verify.py` now has a nice help message that is handy for scripts:
```
usage: verify.py [-h] [-d] VERSION

Download and verify bitcoin binaries.

positional arguments:
  VERSION       Target version.

optional arguments:
  -h, --help    show this help message and exit
  -d, --delete  Delete the downloaded binaries afterwards.
```

I aslo fixed error in README which previously stated that `If an error occurs the return value is 2.` but correct is that it returns `>= 2`