### PR TITLE
refactor: use `Hash` helpers for double-SHA256 calculations

### DIFF
--- a/src/blockfilter.cpp
+++ b/src/blockfilter.cpp
@@ -247,21 +247,10 @@ bool BlockFilter::BuildParams(GCSFilter::Params& params) const
 
 uint256 BlockFilter::GetHash() const
 {
-    const std::vector<unsigned char>& data = GetEncodedFilter();
-
-    uint256 result;
-    CHash256().Write(data).Finalize(result);
-    return result;
+    return Hash(GetEncodedFilter());
 }
 
 uint256 BlockFilter::ComputeHeader(const uint256& prev_header) const
 {
-    const uint256& filter_hash = GetHash();
-
-    uint256 result;
-    CHash256()
-        .Write(filter_hash)
-        .Write(prev_header)
-        .Finalize(result);
-    return result;
+    return Hash(GetHash(), prev_header);
 }

--- a/src/index/blockfilterindex.cpp
+++ b/src/index/blockfilterindex.cpp
@@ -157,9 +157,7 @@ bool BlockFilterIndex::ReadFilterFromDisk(const FlatFilePos& pos, const uint256&
     std::vector<uint8_t> encoded_filter;
     try {
         filein >> block_hash >> encoded_filter;
-        uint256 result;
-        CHash256().Write(encoded_filter).Finalize(result);
-        if (result != hash) return error("Checksum mismatch in filter decode.");
+        if (Hash(encoded_filter) != hash) return error("Checksum mismatch in filter decode.");
         filter = BlockFilter(GetFilterType(), block_hash, std::move(encoded_filter), /*skip_decode_check=*/true);
     }
     catch (const std::exception& e) {

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -245,8 +245,7 @@ bool CKey::VerifyPubKey(const CPubKey& pubkey) const {
     unsigned char rnd[8];
     std::string str = "Bitcoin key verification\n";
     GetRandBytes(rnd);
-    uint256 hash;
-    CHash256().Write(MakeUCharSpan(str)).Write(rnd).Finalize(hash);
+    uint256 hash{Hash(str, rnd)};
     std::vector<unsigned char> vchSig;
     Sign(hash, vchSig);
     return pubkey.Verify(hash, vchSig);

--- a/src/test/key_tests.cpp
+++ b/src/test/key_tests.cpp
@@ -205,8 +205,7 @@ BOOST_AUTO_TEST_CASE(key_key_negation)
     unsigned char rnd[8];
     std::string str = "Bitcoin key verification\n";
     GetRandBytes(rnd);
-    uint256 hash;
-    CHash256().Write(MakeUCharSpan(str)).Write(rnd).Finalize(hash);
+    uint256 hash{Hash(str, rnd)};
 
     // import the static test key
     CKey key = DecodeSecret(strSecret1C);

--- a/src/test/merkle_tests.cpp
+++ b/src/test/merkle_tests.cpp
@@ -60,7 +60,7 @@ static void MerkleComputation(const std::vector<uint256>& leaves, uint256* proot
                 }
             }
             mutated |= (inner[level] == h);
-            CHash256().Write(inner[level]).Write(h).Finalize(h);
+            h = Hash(inner[level], h);
         }
         // Store the resulting hash at inner position level.
         inner[level] = h;
@@ -86,7 +86,7 @@ static void MerkleComputation(const std::vector<uint256>& leaves, uint256* proot
         if (pbranch && matchh) {
             pbranch->push_back(h);
         }
-        CHash256().Write(h).Write(h).Finalize(h);
+        h = Hash(h, h);
         // Increment count to the value it would have if two entries at this
         // level had existed.
         count += ((uint32_t{1}) << level);
@@ -101,7 +101,7 @@ static void MerkleComputation(const std::vector<uint256>& leaves, uint256* proot
                     matchh = true;
                 }
             }
-            CHash256().Write(inner[level]).Write(h).Finalize(h);
+            h = Hash(inner[level], h);
             level++;
         }
     }


### PR DESCRIPTION
We have two helper templates `Hash(const T& in1)` and `Hash(const T& in1, const T& in2)` available for calculating the double-SHA256 hash of one object or two concatenated objects, respectively:

https://github.com/bitcoin/bitcoin/blob/b5868f4b1f884e8d6612f34ca4005fe3a992053d/src/hash.h#L74-L89

This PR uses them in order to increase readability and simplify the code. As in #15294 (which inspired this PR, doing the same for RIPEMD160), the helper is not utilized in validation.cpp and  script/interpreter.cpp to avoid touching consensus-relevant code.