### PR TITLE
p2p: 26847 fixups (AddrMan totals)

### DIFF
--- a/src/addrman.h
+++ b/src/addrman.h
@@ -106,7 +106,7 @@ public:
     * @param[in] in_new           Select addresses only from one table (true = new, false = tried, nullopt = both)
     * @return                     Number of unique addresses that match specified options.
     */
-    size_t Size(std::optional<Network> net = {}, std::optional<bool> in_new = {}) const;
+    size_t Size(std::optional<Network> net = std::nullopt, std::optional<bool> in_new = std::nullopt) const;
 
     /**
      * Attempt to add one or more addresses to addrman's new table.

--- a/src/test/addrman_tests.cpp
+++ b/src/test/addrman_tests.cpp
@@ -947,8 +947,6 @@ BOOST_AUTO_TEST_CASE(load_addrman_corrupted)
     } catch (const std::exception&) {
         exceptionThrown = true;
     }
-    // Even though de-serialization failed addrman is not left in a clean state.
-    BOOST_CHECK(addrman1.Size() == 1);
     BOOST_CHECK(exceptionThrown);
 
     // Test that ReadFromStream fails if peers.dat is corrupt


### PR DESCRIPTION
Two fixups for #26847:
* Now that `AddrMan::Size()` performs internal consistency tests (it didn't before), we can't call it in the `load_addrman_corrupted` unit tests, where we deal with an artificially corrupted `AddrMan`. This would fail the test when using `-checkaddrman=1` (leading to spurious CI fails). Therefore remove the tests assertion, which is not particularly helpful anyway (in production we abort init when peers.dat is corrupted instead of querying AddrMan in its corrupted state).  
 (See https://github.com/bitcoin/bitcoin/pull/26847#issuecomment-1411458339)
* Use `std::nullopt` instead of `{}` for default args (suggested in https://github.com/bitcoin/bitcoin/pull/26847#discussion_r1090643603)