### PR TITLE
mempool / miner: regularly flush <=0-fee entries and mine everything in the mempool

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -591,7 +591,7 @@ void SetupServerArgs(ArgsManager& argsman)
 
 
     argsman.AddArg("-blockmaxweight=<n>", strprintf("Set maximum BIP141 block weight (default: %d)", DEFAULT_BLOCK_MAX_WEIGHT), ArgsManager::ALLOW_ANY, OptionsCategory::BLOCK_CREATION);
-    argsman.AddArg("-blockmintxfee=<amt>", strprintf("Set lowest fee rate (in %s/kvB) for transactions to be included in block creation. (default: %s)", CURRENCY_UNIT, FormatMoney(DEFAULT_BLOCK_MIN_TX_FEE)), ArgsManager::ALLOW_ANY, OptionsCategory::BLOCK_CREATION);
+    argsman.AddArg("-blockmintxfee=<amt>", strprintf("(Deprecated) Set lowest fee rate (in %s/kvB) for transactions to be included in block creation. (default: %s)", CURRENCY_UNIT, FormatMoney(DEFAULT_BLOCK_MIN_TX_FEE)), ArgsManager::ALLOW_ANY, OptionsCategory::BLOCK_CREATION);
     argsman.AddArg("-blockversion=<n>", "Override block version to test forking scenarios", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::BLOCK_CREATION);
 
     argsman.AddArg("-rest", strprintf("Accept public REST requests (default: %u)", DEFAULT_REST_ENABLE), ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
@@ -960,6 +960,7 @@ bool AppInitParameterInteraction(const ArgsManager& args, bool use_syscall_sandb
         if (!ParseMoney(args.GetArg("-blockmintxfee", ""))) {
             return InitError(AmountErrMsg("blockmintxfee", args.GetArg("-blockmintxfee", "")));
         }
+        InitWarning(_("Setting -blockmintxfee higher than zero may result in transactions remaining in your mempool that will never be selected. Use -minrelaytxfee instead."));
     }
 
     nBytesPerSigOp = args.GetIntArg("-bytespersigop", nBytesPerSigOp);

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -370,7 +370,7 @@ void BlockAssembler::addPackageTxs(const CTxMemPool& mempool, int& nPackagesSele
             packageSigOpsCost = modit->nSigOpCostWithAncestors;
         }
 
-        if (packageFees < m_options.blockMinFeeRate.GetFee(packageSize)) {
+        if (packageFees <= 0 || packageFees < m_options.blockMinFeeRate.GetFee(packageSize)) {
             // Everything else we might consider has a lower fee rate
             return;
         }

--- a/src/node/miner.h
+++ b/src/node/miner.h
@@ -150,8 +150,9 @@ private:
 
 public:
     struct Options {
-        // Configuration parameters for the block size
+        // Configuration parameters for the block size (configurable using -blockmaxweight)
         size_t nBlockMaxWeight{DEFAULT_BLOCK_MAX_WEIGHT};
+        // Minimum feerate of packages added to the block (and, by extension, the block overall)
         CFeeRate blockMinFeeRate{DEFAULT_BLOCK_MIN_TX_FEE};
         // Whether to call TestBlockValidity() at the end of CreateNewBlock().
         bool test_block_validity{true};
@@ -200,7 +201,7 @@ int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParam
 /** Update an old GenerateCoinbaseCommitment from CreateNewBlock after the block txs have changed */
 void RegenerateCommitments(CBlock& block, ChainstateManager& chainman);
 
-/** Apply -blockmintxfee and -blockmaxweight options from ArgsManager to BlockAssembler options. */
+/** Apply -blockmaxweight option from ArgsManager to BlockAssembler options. */
 void ApplyArgsManOptions(const ArgsManager& gArgs, BlockAssembler::Options& options);
 } // namespace node
 

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -22,7 +22,7 @@ class CScript;
 /** Default for -blockmaxweight, which controls the range of block weights the mining code will create **/
 static constexpr unsigned int DEFAULT_BLOCK_MAX_WEIGHT{MAX_BLOCK_WEIGHT - 4000};
 /** Default for -blockmintxfee, which sets the minimum feerate for a transaction in blocks created by mining code **/
-static constexpr unsigned int DEFAULT_BLOCK_MIN_TX_FEE{1000};
+static constexpr unsigned int DEFAULT_BLOCK_MIN_TX_FEE{0};
 /** The maximum weight for transactions we're willing to relay/mine */
 static constexpr unsigned int MAX_STANDARD_TX_WEIGHT{400000};
 /** The minimum non-witness size for transactions we're willing to relay/mine: one larger than 64  */

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -56,7 +56,7 @@ struct MinerTestingSetup : public TestingSetup {
 
 BOOST_FIXTURE_TEST_SUITE(miner_tests, MinerTestingSetup)
 
-static CFeeRate blockMinFeeRate = CFeeRate(DEFAULT_BLOCK_MIN_TX_FEE);
+static CFeeRate blockMinFeeRate = CFeeRate(1000);
 
 BlockAssembler MinerTestingSetup::AssemblerForTest(CTxMemPool& tx_mempool)
 {

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1057,17 +1057,23 @@ void CTxMemPool::TrimToSize(size_t sizelimit, std::vector<COutPoint>* pvNoSpends
 
     unsigned nTxnRemoved = 0;
     CFeeRate maxFeeRateRemoved(0);
-    while (!mapTx.empty() && DynamicMemoryUsage() > sizelimit) {
+    while (!mapTx.empty()) {
         indexed_transaction_set::index<descendant_score>::type::iterator it = mapTx.get<descendant_score>().begin();
+
+        CFeeRate removed(it->GetModFeesWithDescendants(), it->GetSizeWithDescendants());
+        // Skim away everything paying literally zero fees, regardless of mempool size.
+        // Above that feerate, just trim until memory is within limits.
+        if (removed > CFeeRate(0) && DynamicMemoryUsage() <= sizelimit) break;
 
         // We set the new mempool min fee to the feerate of the removed set, plus the
         // "minimum reasonable fee rate" (ie some value under which we consider txn
         // to have 0 fee). This way, we don't allow txn to enter mempool with feerate
         // equal to txn which were removed with no block in between.
-        CFeeRate removed(it->GetModFeesWithDescendants(), it->GetSizeWithDescendants());
-        removed += m_incremental_relay_feerate;
-        trackPackageRemoved(removed);
-        maxFeeRateRemoved = std::max(maxFeeRateRemoved, removed);
+        if (removed >= m_min_relay_feerate) {
+            removed += m_incremental_relay_feerate;
+            trackPackageRemoved(removed);
+            maxFeeRateRemoved = std::max(maxFeeRateRemoved, removed);
+        }
 
         setEntries stage;
         CalculateDescendants(mapTx.project<0>(it), stage);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3058,7 +3058,11 @@ bool Chainstate::ActivateBestChainStep(BlockValidationState& state, CBlockIndex*
         // any disconnected transactions back to the mempool.
         MaybeUpdateMempoolForReorg(disconnectpool, true);
     }
-    if (m_mempool) m_mempool->check(this->CoinsTip(), this->m_chain.Height() + 1);
+    if (m_mempool) {
+        // Limit mempool size and evict any transactions below min relay feerate.
+        m_mempool->TrimToSize(m_mempool->m_max_size_bytes);
+        m_mempool->check(this->CoinsTip(), this->m_chain.Height() + 1);
+    }
 
     CheckForkWarningConditions();
 

--- a/test/functional/mempool_minrelayfeerate.py
+++ b/test/functional/mempool_minrelayfeerate.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+# Copyright (c) The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Expected node behaviors from accepting packages with below-minrelayfeerate transactions, evicting
+all 0-fee mempool entries, and mining without a blockmintxfee."""
+
+from decimal import Decimal
+
+from test_framework.blocktools import COINBASE_MATURITY
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_greater_than,
+    assert_greater_than_or_equal,
+)
+from test_framework.wallet import (
+    MiniWallet,
+)
+
+class MempoolMinRelayFeerate(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+
+    def test_low_feerate_mined(self):
+        node = self.nodes[0]
+        self.generate(self.wallet, 100) # blocks generated for inputs
+        # Package with 24 0-fee parents and 1 child.
+        package_hex = []
+        parent_txids = []
+        child_utxos = []
+        confirmed_utxo = self.wallet.get_utxo(mark_as_spent=True)
+        other_parent_utxos = []
+        for _ in range(24):
+            parent = self.wallet.create_self_transfer_multi(num_outputs=3, fee_per_output=0)
+            child_utxos.append(parent["new_utxos"][0])
+            other_parent_utxos.extend(parent["new_utxos"][1:])
+            package_hex.append(parent["hex"])
+            parent_txids.append(parent["tx"].rehash())
+        child = self.wallet.create_self_transfer_multi(utxos_to_spend=child_utxos + [confirmed_utxo], fee_per_output=8000)
+        package_hex.append(child["hex"])
+        child_replacer = self.wallet.create_self_transfer(utxo_to_spend=confirmed_utxo, fee=Decimal("0.0002"))
+
+        self.generate(self.wallet, COINBASE_MATURITY) # mature these utxos
+
+        min_relay_feerate = node.getmempoolinfo()["minrelaytxfee"]
+
+        self.log.info("Submit package with 24 0-fee parents and 1 child bumping them")
+        node.submitpackage(package_hex)
+        mempool0 = node.getrawmempool()
+        assert_equal(len(mempool0), 25)
+        assert all([txid in mempool0 for txid in parent_txids])
+        assert child["tx"].rehash() in mempool0
+
+        self.log.info("Add 2 more children from each 0-fee parent, each with 1.9x the min relay feerate")
+        extra_children_utxos = []
+        for utxo in other_parent_utxos:
+            extra_child = self.wallet.send_self_transfer(from_node=node, utxo_to_spend=utxo, fee_rate=Decimal("0.00001900"))
+            extra_children_utxos.append(extra_child["new_utxo"])
+        mempool1 = node.getrawmempool()
+        assert_equal(len(mempool1), 73)
+        for txid in parent_txids:
+            entry = node.getmempoolentry(txid)
+            assert_equal(entry["descendantcount"], 4)
+            assert_greater_than(entry["vsize"] * min_relay_feerate, entry["fees"]["base"] * 1000)
+            assert_greater_than_or_equal(entry["fees"]["descendant"] * 1000, entry["descendantsize"] * min_relay_feerate)
+
+        self.log.info("Replace child with a tx that does not depend on any of the parents")
+        node.sendrawtransaction(child_replacer["hex"])
+        mempool2 = node.getrawmempool()
+        assert_equal(len(mempool2), len(mempool1))
+        assert child_replacer["tx"].rehash() in mempool2
+        assert not child["tx"].rehash() in mempool2
+        assert all([txid in mempool2 for txid in parent_txids])
+
+        # None of these UTXOs are spent, meaning the parents are no longer adequately bumped.
+        for utxo in child_utxos:
+            utxo_dict = [{ "txid": utxo["txid"], "vout": utxo["vout"] }]
+            assert_equal(node.gettxspendingprevout(utxo_dict), utxo_dict)
+
+        # None of the parents were evicted because their descendant feerates are still above min relay feerate.
+        for txid in parent_txids:
+            entry = node.getmempoolentry(txid)
+            assert_equal(entry["descendantcount"], 3)
+            assert_greater_than_or_equal(entry["fees"]["descendant"] * 1000, entry["descendantsize"] * min_relay_feerate)
+
+        # Each transaction's ancestor feerate is below min relay feerate.
+        for txid in mempool2:
+            if txid == child_replacer["tx"].rehash():
+                break
+            entry = node.getmempoolentry(txid)
+            assert_equal(entry["ancestorcount"], 2)
+            assert_greater_than(entry["ancestorsize"] * min_relay_feerate, entry["fees"]["ancestor"])
+
+        # Further descendants can be added.
+        for utxo in extra_children_utxos:
+            extra_child = self.wallet.send_self_transfer(from_node=node, utxo_to_spend=utxo, fee_rate=Decimal("0.00001"))
+        mempool3 = node.getrawmempool()
+        assert_equal(len(mempool3), 121)
+        for txid in mempool3:
+            if txid == child_replacer["tx"].rehash():
+                break
+            entry = node.getmempoolentry(txid)
+            assert_greater_than(entry["ancestorsize"] * min_relay_feerate, entry["fees"]["ancestor"])
+
+        # The average feerate of these "cheap" transactions is still above min relay feerate.
+        cheap_total_fees = node.getmempoolinfo()["total_fee"] - node.getmempoolentry(child_replacer["txid"])["fees"]["modified"]
+        cheap_total_vsize = node.getmempoolinfo()["bytes"] - node.getmempoolentry(child_replacer["txid"])["vsize"]
+        assert_greater_than_or_equal(cheap_total_fees * 1000, min_relay_feerate * cheap_total_vsize)
+
+        # All transactions are selected for mining, even though their ancestor feerates are below min relay feerate.
+        last_block = self.generate(node, 1)
+        assert_equal(len(self.nodes[0].getblock(blockhash=last_block[0])["tx"]), 122)
+        assert_equal(node.getmempoolinfo()["size"], 0)
+
+    def test_fee_dependency_evictions(self):
+        node = self.nodes[0]
+        self.generate(self.wallet, 120) # blocks generated for inputs
+        self.log.info("Test that 0-fee, no-longer-bumped transactions are removed in RBF")
+        packages = []
+        confirmed_utxos = []
+        for _ in range(5):
+            package_hex = []
+            child_utxos = []
+            confirmed_utxo = self.wallet.get_utxo(mark_as_spent=True)
+            confirmed_utxos.append(confirmed_utxo)
+            for _ in range(24):
+                parent = self.wallet.create_self_transfer(fee=0, fee_rate=0)
+                child_utxos.append(parent["new_utxo"])
+                package_hex.append(parent["hex"])
+            child = self.wallet.create_self_transfer_multi(utxos_to_spend=child_utxos + [confirmed_utxo], fee_per_output=8000)
+            package_hex.append(child["hex"])
+            packages.append(package_hex)
+        child_replacer = self.wallet.create_self_transfer_multi(utxos_to_spend=confirmed_utxos, fee_per_output=9000*5)
+
+        self.generate(node, 100)
+        assert_equal(node.getmempoolinfo()["size"], 0)
+        for package_hex in packages:
+            node.submitpackage(package_hex)
+        prev_size = node.getmempoolinfo()["size"]
+        assert_equal(prev_size, 5 * 25)
+        node.sendrawtransaction(child_replacer["hex"])
+        after_size = node.getmempoolinfo()["size"]
+        assert_equal(after_size, 1)
+        # This replacement evicted more than 100 transactions.
+        assert_greater_than(prev_size - (after_size - 1), 100)
+        self.generate(node, 1)
+
+    def test_deprioritsation(self):
+        node = self.nodes[0]
+        self.log.info("Test that de-prioritisation of a transaction can cause eviction from mempool")
+        tx_deprio = self.wallet.send_self_transfer(from_node=node)
+        assert_equal([tx_deprio["txid"]], node.getrawmempool())
+        node.prioritisetransaction(tx_deprio["txid"], 0, -999999)
+        tx_new = self.wallet.send_self_transfer(from_node=node)
+        assert_equal([tx_new["txid"]], node.getrawmempool())
+
+
+    def run_test(self):
+        node = self.nodes[0]
+        self.wallet = MiniWallet(node)
+        self.test_low_feerate_mined()
+        self.test_fee_dependency_evictions()
+        self.test_deprioritsation()
+
+
+if __name__ == "__main__":
+    MempoolMinRelayFeerate().main()

--- a/test/functional/mempool_reorg.py
+++ b/test/functional/mempool_reorg.py
@@ -10,7 +10,7 @@ that spend (directly or indirectly) coinbase transactions.
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, assert_raises_rpc_error
-from test_framework.wallet import MiniWallet
+from test_framework.wallet import MiniWallet, COIN
 
 class MempoolCoinbaseTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -72,10 +72,16 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
 
         self.log.info("Broadcast and mine spend_3_1")
         spend_3_1_id = self.nodes[0].sendrawtransaction(spend_3_1['hex'])
-        self.log.info("Generate a block")
-        last_block = self.generate(self.nodes[0], 1)
+
+        # A 0-fee transaction in a block should not remain in mempools.
+        free_tx = wallet.create_self_transfer(fee=0, fee_rate=0)
+        self.nodes[0].prioritisetransaction(free_tx["txid"], 0, COIN)
+        self.nodes[0].sendrawtransaction(free_tx["hex"])
         # generate() implicitly syncs blocks, so that peer 1 gets the block before timelock_tx
         # Otherwise, peer 1 would put the timelock_tx in m_recent_rejects
+        self.log.info("Generate a block")
+        last_block = self.generate(self.nodes[0], 1)
+        assert free_tx["txid"] in self.nodes[0].getblock(blockhash=last_block[0])["tx"]
 
         self.log.info("The time-locked transaction can now be spent")
         timelock_tx_id = self.nodes[0].sendrawtransaction(timelock_tx)

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -151,6 +151,7 @@ BASE_SCRIPTS = [
     'wallet_signer.py --descriptors',
     'wallet_importmulti.py --legacy-wallet',
     'mempool_limit.py',
+    'mempool_minrelayfeerate.py',
     'rpc_txoutproof.py',
     'wallet_listreceivedby.py --legacy-wallet',
     'wallet_listreceivedby.py --descriptors',


### PR DESCRIPTION
This was suggested in https://github.com/bitcoin/bitcoin/pull/26933#issuecomment-1412320818.

**The Problem**
Package CPFP (only accessible through regtest-only RPC submitpackage) allows 0-fee (or otherwise below min relay feerate) transactions if they are bumped by a child. We need to know what to do with these transactions if they lose their sponsor, e.g. due to a replacement that removed the input spending this 0-fee transaction.

This is made slightly more complicated by the fact that our "selection scoring" (BlockAssembler) is different from our "eviction scoring." Roughly, we select based on ancestor feerate and evict based on descendant feerate. This may lead to [evicting things we would actually want to mine](https://github.com/bitcoin/bitcoin/pull/27018#issuecomment-1424742766) and [not evicting things that we will never mine](https://github.com/bitcoin/bitcoin/pull/26933#issuecomment-1400143991).

This PR's approach is to remove the 1sat/vB `-blockmintxfee` and have BlockAssembler select anything in the mempool (still based on ancestor packages, but not stopping at 1sat/vB). It also adds logic to `TrimToSize()` to evict anything paying <=0 fees. The idea is, if we're getting to the bottom of our mempool, we scrape up all the sats we can. Anything that pays *some* fee is worth adding to the block template.

A major advantage of this approach is that 0-fee, non-v3 transactions can be bumped in package CPFP.

A few observations which may or may not be problematic:
- This increases the potential work after a reorg, since we add an extra step of removing the below-minrelayfeerate entries.
- This increases the number of transactions that may be evicted in a replacement (from the worst case scenario we discussed before, it's up to 2500 entries).
- This means you can remove a transaction from your own mempool by calling prioritisetransaction with a negative value.
