### PR TITLE
bench: Expand mempool eviction benchmarking

### DIFF
--- a/src/bench/mempool_eviction.cpp
+++ b/src/bench/mempool_eviction.cpp
@@ -21,116 +21,94 @@ static void AddTx(const CTransactionRef& tx, const CAmount& nFee, CTxMemPool& po
         spendsCoinbase, sigOpCost, lp));
 }
 
-// Right now this is only testing eviction performance in an extremely small
-// mempool. Code needs to be written to generate a much wider variety of
-// unique transactions for a more meaningful performance measurement.
-static void MempoolEviction(benchmark::Bench& bench)
+void add_parents_child(std::vector<CTransactionRef>& txns, size_t package_size, size_t set_num)
+{
+    // N+1 N-input-N-output txns, in a parents-and-child package
+    // Where each tx takes an input from all prior txns
+    const size_t num_puts = std::max(package_size - 1, (size_t)1);
+    const size_t num_txns = package_size;
+    for (size_t txn_index=0; txn_index<num_txns; txn_index++) {
+        CMutableTransaction tx = CMutableTransaction();
+        tx.vin.resize(num_puts);
+        tx.vout.resize(num_puts);
+        for (size_t put_index=0; put_index<num_puts; put_index++) {
+            tx.vin[put_index].scriptSig = CScript() << CScriptNum(txn_index);
+            tx.vin[put_index].scriptWitness.stack.push_back({1});
+            tx.vout[put_index].scriptPubKey = CScript() << CScriptNum(set_num); // Ensures unique txid with set_num
+            tx.vout[put_index].nValue = txn_index;
+
+            if (put_index < txn_index) {
+                // We spend put_index's txn's in the next available slot for each previous transaction
+                assert(put_index + txn_index >= 1);
+                tx.vin[put_index].prevout = COutPoint(txns[put_index]->GetHash(), put_index + txn_index - 1);
+            }
+        }
+        txns.push_back(MakeTransactionRef(tx));
+    }
+}
+
+static void MempoolEvictionInner(benchmark::Bench& bench, size_t num_packages, size_t package_size)
 {
     const auto testing_setup = MakeNoLogFileContext<const TestingSetup>();
 
-    CMutableTransaction tx1 = CMutableTransaction();
-    tx1.vin.resize(1);
-    tx1.vin[0].scriptSig = CScript() << OP_1;
-    tx1.vin[0].scriptWitness.stack.push_back({1});
-    tx1.vout.resize(1);
-    tx1.vout[0].scriptPubKey = CScript() << OP_1 << OP_EQUAL;
-    tx1.vout[0].nValue = 10 * COIN;
+    std::vector<CTransactionRef> txns;
 
-    CMutableTransaction tx2 = CMutableTransaction();
-    tx2.vin.resize(1);
-    tx2.vin[0].scriptSig = CScript() << OP_2;
-    tx2.vin[0].scriptWitness.stack.push_back({2});
-    tx2.vout.resize(1);
-    tx2.vout[0].scriptPubKey = CScript() << OP_2 << OP_EQUAL;
-    tx2.vout[0].nValue = 10 * COIN;
-
-    CMutableTransaction tx3 = CMutableTransaction();
-    tx3.vin.resize(1);
-    tx3.vin[0].prevout = COutPoint(tx2.GetHash(), 0);
-    tx3.vin[0].scriptSig = CScript() << OP_2;
-    tx3.vin[0].scriptWitness.stack.push_back({3});
-    tx3.vout.resize(1);
-    tx3.vout[0].scriptPubKey = CScript() << OP_3 << OP_EQUAL;
-    tx3.vout[0].nValue = 10 * COIN;
-
-    CMutableTransaction tx4 = CMutableTransaction();
-    tx4.vin.resize(2);
-    tx4.vin[0].prevout.SetNull();
-    tx4.vin[0].scriptSig = CScript() << OP_4;
-    tx4.vin[0].scriptWitness.stack.push_back({4});
-    tx4.vin[1].prevout.SetNull();
-    tx4.vin[1].scriptSig = CScript() << OP_4;
-    tx4.vin[1].scriptWitness.stack.push_back({4});
-    tx4.vout.resize(2);
-    tx4.vout[0].scriptPubKey = CScript() << OP_4 << OP_EQUAL;
-    tx4.vout[0].nValue = 10 * COIN;
-    tx4.vout[1].scriptPubKey = CScript() << OP_4 << OP_EQUAL;
-    tx4.vout[1].nValue = 10 * COIN;
-
-    CMutableTransaction tx5 = CMutableTransaction();
-    tx5.vin.resize(2);
-    tx5.vin[0].prevout = COutPoint(tx4.GetHash(), 0);
-    tx5.vin[0].scriptSig = CScript() << OP_4;
-    tx5.vin[0].scriptWitness.stack.push_back({4});
-    tx5.vin[1].prevout.SetNull();
-    tx5.vin[1].scriptSig = CScript() << OP_5;
-    tx5.vin[1].scriptWitness.stack.push_back({5});
-    tx5.vout.resize(2);
-    tx5.vout[0].scriptPubKey = CScript() << OP_5 << OP_EQUAL;
-    tx5.vout[0].nValue = 10 * COIN;
-    tx5.vout[1].scriptPubKey = CScript() << OP_5 << OP_EQUAL;
-    tx5.vout[1].nValue = 10 * COIN;
-
-    CMutableTransaction tx6 = CMutableTransaction();
-    tx6.vin.resize(2);
-    tx6.vin[0].prevout = COutPoint(tx4.GetHash(), 1);
-    tx6.vin[0].scriptSig = CScript() << OP_4;
-    tx6.vin[0].scriptWitness.stack.push_back({4});
-    tx6.vin[1].prevout.SetNull();
-    tx6.vin[1].scriptSig = CScript() << OP_6;
-    tx6.vin[1].scriptWitness.stack.push_back({6});
-    tx6.vout.resize(2);
-    tx6.vout[0].scriptPubKey = CScript() << OP_6 << OP_EQUAL;
-    tx6.vout[0].nValue = 10 * COIN;
-    tx6.vout[1].scriptPubKey = CScript() << OP_6 << OP_EQUAL;
-    tx6.vout[1].nValue = 10 * COIN;
-
-    CMutableTransaction tx7 = CMutableTransaction();
-    tx7.vin.resize(2);
-    tx7.vin[0].prevout = COutPoint(tx5.GetHash(), 0);
-    tx7.vin[0].scriptSig = CScript() << OP_5;
-    tx7.vin[0].scriptWitness.stack.push_back({5});
-    tx7.vin[1].prevout = COutPoint(tx6.GetHash(), 0);
-    tx7.vin[1].scriptSig = CScript() << OP_6;
-    tx7.vin[1].scriptWitness.stack.push_back({6});
-    tx7.vout.resize(2);
-    tx7.vout[0].scriptPubKey = CScript() << OP_7 << OP_EQUAL;
-    tx7.vout[0].nValue = 10 * COIN;
-    tx7.vout[1].scriptPubKey = CScript() << OP_7 << OP_EQUAL;
-    tx7.vout[1].nValue = 10 * COIN;
+    for (size_t i=0; i<num_packages; i++) {
+        add_parents_child(txns, package_size, i);
+    }
 
     CTxMemPool& pool = *Assert(testing_setup->m_node.mempool);
     LOCK2(cs_main, pool.cs);
-    // Create transaction references outside the "hot loop"
-    const CTransactionRef tx1_r{MakeTransactionRef(tx1)};
-    const CTransactionRef tx2_r{MakeTransactionRef(tx2)};
-    const CTransactionRef tx3_r{MakeTransactionRef(tx3)};
-    const CTransactionRef tx4_r{MakeTransactionRef(tx4)};
-    const CTransactionRef tx5_r{MakeTransactionRef(tx5)};
-    const CTransactionRef tx6_r{MakeTransactionRef(tx6)};
-    const CTransactionRef tx7_r{MakeTransactionRef(tx7)};
-
     bench.run([&]() NO_THREAD_SAFETY_ANALYSIS {
-        AddTx(tx1_r, 10000LL, pool);
-        AddTx(tx2_r, 5000LL, pool);
-        AddTx(tx3_r, 20000LL, pool);
-        AddTx(tx4_r, 7000LL, pool);
-        AddTx(tx5_r, 1000LL, pool);
-        AddTx(tx6_r, 1100LL, pool);
-        AddTx(tx7_r, 9000LL, pool);
-        pool.TrimToSize(pool.DynamicMemoryUsage() * 3 / 4);
-        pool.TrimToSize(GetVirtualTransactionSize(*tx1_r));
+        for (size_t i{0}; i < txns.size(); ++i) {
+            // Monotonically decreasing fees
+            AddTx(txns[i], (txns.size() - i)*1000LL, pool);
+        }
+        assert(pool.size() == txns.size());
+        pool.TrimToSize(pool.DynamicMemoryUsage() - 1);
+        assert(pool.size() == txns.size() - 1);
+        pool.TrimToSize(0);
+        assert(pool.size() == 0);
     });
 }
 
+static void MempoolConstructionInner(benchmark::Bench& bench, size_t num_packages, size_t package_size)
+{
+    const auto testing_setup = MakeNoLogFileContext<const TestingSetup>();
+
+    std::vector<CTransactionRef> txns;
+
+    for (size_t i=0; i<num_packages; i++) {
+        add_parents_child(txns, package_size, i);
+    }
+
+    /* Now we're ready */
+    CTxMemPool& pool = *Assert(testing_setup->m_node.mempool);
+    LOCK2(cs_main, pool.cs);
+    bench.run([&]() NO_THREAD_SAFETY_ANALYSIS {
+        for (size_t i=0; i<txns.size(); i++) {
+            AddTx(txns[i], 1000LL, pool);
+        }
+    });
+}
+
+static void MempoolEviction(benchmark::Bench& bench)
+{
+    size_t package_size = 25;
+    if (bench.complexityN() > 1) {
+        package_size = static_cast<size_t>(bench.complexityN());
+    }
+    MempoolEvictionInner(bench, 2500 / package_size, package_size);
+}
+
+static void MempoolConstruction(benchmark::Bench& bench)
+{
+    size_t package_size = 25;
+    if (bench.complexityN() > 1) {
+        package_size = static_cast<size_t>(bench.complexityN());
+    }
+    MempoolConstructionInner(bench, 2500 / package_size, package_size);
+}
+
 BENCHMARK(MempoolEviction, benchmark::PriorityLevel::HIGH);
+BENCHMARK(MempoolConstruction, benchmark::PriorityLevel::HIGH);


### PR DESCRIPTION
Took the existing benchmark and made is something more exhaustive, targeting eviction of 2500 transactions of different shapes. of dependencies.

Magic number comes from: 100 children being RBF'd, each bumping 24 parents = 2500 transactions

Turns out the benchmark `ComplexMemPool` already does something similar, so if we don't want to expand it, maybe just remove it in favor of the existing better benchmark?