### PR TITLE
p2p, validation: Don't download witnesses for assumed-valid blocks when running in prune mode

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -140,6 +140,12 @@ enum BlockStatus : uint32_t {
      * on a background chainstate. See `doc/design/assumeutxo.md`.
      */
     BLOCK_ASSUMED_VALID      =   256,
+
+    /**
+     * If set, this indicates that the block is serialized on disk without its
+     * witnesses. Only set for blocks with valid or assumed-valid witnesses.
+     */
+    BLOCK_PRUNED_WITNESSES   =   512,
 };
 
 /** The block chain is a tree shaped structure starting with the
@@ -321,6 +327,12 @@ public:
     {
         AssertLockHeld(::cs_main);
         return nStatus & BLOCK_ASSUMED_VALID;
+    }
+
+    bool HasPrunedWitnesses() const EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
+    {
+        AssertLockHeld(::cs_main);
+        return nStatus & BLOCK_PRUNED_WITNESSES;
     }
 
     //! Raise the validity level of this block index entry.

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -5832,8 +5832,8 @@ bool PeerManagerImpl::SendMessages(CNode* pto)
                 uint32_t nFetchFlags = GetFetchFlags(*peer);
                 vGetData.push_back(CInv(MSG_BLOCK | nFetchFlags, pindex->GetBlockHash()));
                 BlockRequested(pto->GetId(), *pindex);
-                LogPrint(BCLog::NET, "Requesting block %s (%d) peer=%d\n", pindex->GetBlockHash().ToString(),
-                    pindex->nHeight, pto->GetId());
+                LogPrint(BCLog::NET, "Requesting block %s (%d, %s) peer=%d\n", pindex->GetBlockHash().ToString(),
+                    pindex->nHeight, vGetData.back().GetCommand(), pto->GetId());
             }
             if (state.nBlocksInFlight == 0 && staller != -1) {
                 if (State(staller)->m_stalling_since == 0us) {

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -364,6 +364,12 @@ bool BlockManager::LoadBlockIndexDB(const Consensus::Params& consensus_params)
         LogPrintf("LoadBlockIndexDB(): Block files have previously been pruned\n");
     }
 
+    // Check whether we have ever pruned block & undo files
+    m_block_tree_db->ReadPrunedWitnesses(m_pruned_witnesses);
+    if (m_pruned_witnesses) {
+        LogPrintf("LoadBlockIndexDB(): blocks might have previously been stored without witnesses\n");
+    }
+
     // Check whether we need to continue reindexing
     bool fReindexing = false;
     m_block_tree_db->ReadReindexing(fReindexing);

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -138,6 +138,9 @@ private:
      */
     std::unordered_map<std::string, PruneLockInfo> m_prune_locks GUARDED_BY(::cs_main);
 
+    /** True if we have ever stored a block without witnesses. */
+    bool m_pruned_witnesses{false};
+
 public:
     BlockMap m_block_index GUARDED_BY(cs_main);
 
@@ -208,6 +211,9 @@ public:
 
     //! Create or update a prune lock identified by its name
     void UpdatePruneLock(const std::string& name, const PruneLockInfo& lock_info) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+    bool HasPrunedWitnesses() const { return m_pruned_witnesses; }
+    void SetPrunedWitnesses() { m_pruned_witnesses = true; }
 };
 
 void CleanupBlockRevFiles();

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -72,9 +72,10 @@ static ChainstateLoadResult CompleteChainstateInitialization(
         return {ChainstateLoadStatus::FAILURE_INCOMPATIBLE_DB, _("Incorrect or no genesis block found. Wrong datadir for network?")};
     }
 
-    // Check for changed -prune state.  What we are concerned about is a user who has pruned blocks
-    // in the past, but is now trying to run unpruned.
-    if (chainman.m_blockman.m_have_pruned && !options.prune) {
+    // Check for changed -prune state.  What we are concerned about is a user
+    // who has pruned blocks or stored blocks without witnesses in the past,
+    // but is now trying to run unpruned.
+    if ((chainman.m_blockman.m_have_pruned || chainman.m_blockman.HasPrunedWitnesses()) && !options.prune) {
         return {ChainstateLoadStatus::FAILURE, _("You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain")};
     }
 

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -25,6 +25,7 @@ static constexpr uint8_t DB_HEAD_BLOCKS{'H'};
 static constexpr uint8_t DB_FLAG{'F'};
 static constexpr uint8_t DB_REINDEX_FLAG{'R'};
 static constexpr uint8_t DB_LAST_BLOCK{'l'};
+static constexpr uint8_t DB_PRUNED_WITNESSES{'W'};
 
 // Keys used in previous version that might still be found in the DB:
 static constexpr uint8_t DB_COINS{'c'};
@@ -177,6 +178,19 @@ size_t CCoinsViewDB::EstimateSize() const
 
 bool CBlockTreeDB::ReadBlockFileInfo(int nFile, CBlockFileInfo &info) {
     return Read(std::make_pair(DB_BLOCK_FILES, nFile), info);
+}
+
+bool CBlockTreeDB::WritePrunedWitnesses(bool pruned_witnesses)
+{
+    if (pruned_witnesses) {
+        return Write(DB_PRUNED_WITNESSES, uint8_t{'1'});
+    }
+    return Erase(DB_PRUNED_WITNESSES);
+}
+
+void CBlockTreeDB::ReadPrunedWitnesses(bool& pruned_witnesses)
+{
+    pruned_witnesses = Exists(DB_PRUNED_WITNESSES);
 }
 
 bool CBlockTreeDB::WriteReindexing(bool fReindexing) {

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -90,6 +90,8 @@ public:
     bool WriteBatchSync(const std::vector<std::pair<int, const CBlockFileInfo*> >& fileInfo, int nLastFile, const std::vector<const CBlockIndex*>& blockinfo);
     bool ReadBlockFileInfo(int nFile, CBlockFileInfo &info);
     bool ReadLastBlockFile(int &nFile);
+    bool WritePrunedWitnesses(bool pruned_witnesses);
+    void ReadPrunedWitnesses(bool& pruned_witnesses);
     bool WriteReindexing(bool fReindexing);
     void ReadReindexing(bool &fReindexing);
     bool WriteFlag(const std::string &name, bool fValue);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2099,36 +2099,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
         return true;
     }
 
-    bool fScriptChecks = true;
-    if (!m_chainman.AssumedValidBlock().IsNull()) {
-        // We've been configured with the hash of a block which has been externally verified to have a valid history.
-        // A suitable default value is included with the software and updated from time to time.  Because validity
-        //  relative to a piece of software is an objective fact these defaults can be easily reviewed.
-        // This setting doesn't force the selection of any particular chain but makes validating some faster by
-        //  effectively caching the result of part of the verification.
-        BlockMap::const_iterator it{m_blockman.m_block_index.find(m_chainman.AssumedValidBlock())};
-        if (it != m_blockman.m_block_index.end()) {
-            if (it->second.GetAncestor(pindex->nHeight) == pindex &&
-                m_chainman.m_best_header->GetAncestor(pindex->nHeight) == pindex &&
-                m_chainman.m_best_header->nChainWork >= m_chainman.MinimumChainWork()) {
-                // This block is a member of the assumed verified chain and an ancestor of the best header.
-                // Script verification is skipped when connecting blocks under the
-                // assumevalid block. Assuming the assumevalid block is valid this
-                // is safe because block merkle hashes are still computed and checked,
-                // Of course, if an assumed valid block is invalid due to false scriptSigs
-                // this optimization would allow an invalid chain to be accepted.
-                // The equivalent time check discourages hash power from extorting the network via DOS attack
-                //  into accepting an invalid block through telling users they must manually set assumevalid.
-                //  Requiring a software change or burying the invalid block, regardless of the setting, makes
-                //  it hard to hide the implication of the demand.  This also avoids having release candidates
-                //  that are hardly doing any signature verification at all in testing without having to
-                //  artificially set the default assumed verified block further back.
-                // The test against the minimum chain work prevents the skipping when denied access to any chain at
-                //  least as good as the expected chain.
-                fScriptChecks = (GetBlockProofEquivalentTime(*m_chainman.m_best_header, *pindex, *m_chainman.m_best_header, params.GetConsensus()) <= 60 * 60 * 24 * 7 * 2);
-            }
-        }
-    }
+    bool fScriptChecks = !m_chainman.IsAssumedValid(*pindex);
 
     const auto time_1{SteadyClock::now()};
     time_check += time_1 - time_start;
@@ -3833,6 +3804,41 @@ bool ChainstateManager::AcceptBlockHeader(const CBlockHeader& block, BlockValida
         *ppindex = pindex;
 
     return true;
+}
+
+bool ChainstateManager::IsAssumedValid(const CBlockIndex& index) const
+{
+    if (!AssumedValidBlock().IsNull()) {
+        // We've been configured with the hash of a block which has been externally verified to have a valid history.
+        // A suitable default value is included with the software and updated from time to time.  Because validity
+        //  relative to a piece of software is an objective fact these defaults can be easily reviewed.
+        // This setting doesn't force the selection of any particular chain but makes validating some faster by
+        //  effectively caching the result of part of the verification.
+        BlockMap::const_iterator it{m_blockman.m_block_index.find(AssumedValidBlock())};
+        if (it != m_blockman.m_block_index.end()) {
+            if (it->second.GetAncestor(index.nHeight) == &index &&
+                m_best_header->GetAncestor(index.nHeight) == &index &&
+                m_best_header->nChainWork >= MinimumChainWork()) {
+                // This block is a member of the assumed verified chain and an ancestor of the best header.
+                // Script verification is skipped when connecting blocks under the
+                // assumevalid block. Assuming the assumevalid block is valid this
+                // is safe because block merkle hashes are still computed and checked,
+                // Of course, if an assumed valid block is invalid due to false scriptSigs
+                // this optimization would allow an invalid chain to be accepted.
+                // The equivalent time check discourages hash power from extorting the network via DOS attack
+                //  into accepting an invalid block through telling users they must manually set assumevalid.
+                //  Requiring a software change or burying the invalid block, regardless of the setting, makes
+                //  it hard to hide the implication of the demand.  This also avoids having release candidates
+                //  that are hardly doing any signature verification at all in testing without having to
+                //  artificially set the default assumed verified block further back.
+                // The test against the minimum chain work prevents the skipping when denied access to any chain at
+                //  least as good as the expected chain.
+                return (GetBlockProofEquivalentTime(*m_best_header, index, *m_best_header, GetConsensus()) > 60 * 60 * 24 * 7 * 2);
+            }
+        }
+    }
+
+    return false;
 }
 
 // Exposed wrapper for AcceptBlockHeader

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3402,6 +3402,10 @@ void Chainstate::ReceivedBlockTransactions(const CBlock& block, CBlockIndex* pin
     pindexNew->nStatus |= BLOCK_HAVE_DATA;
     if (DeploymentActiveAt(*pindexNew, m_chainman, Consensus::DEPLOYMENT_SEGWIT)) {
         pindexNew->nStatus |= BLOCK_OPT_WITNESS;
+
+        if (m_chainman.IsAssumedValid(*pindexNew) && m_chainman.m_blockman.IsPruneMode()) {
+            pindexNew->nStatus |= BLOCK_PRUNED_WITNESSES;
+        }
     }
     pindexNew->RaiseValidity(BLOCK_VALID_TRANSACTIONS);
     m_blockman.m_dirty_blockindex.insert(pindexNew);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3679,8 +3679,15 @@ static bool ContextualCheckBlock(const CBlock& block, BlockValidationState& stat
     // * There must be at least one output whose scriptPubKey is a single 36-byte push, the first 4 bytes of which are
     //   {0xaa, 0x21, 0xa9, 0xed}, and the following 32 bytes are SHA256^2(witness root, witness reserved value). In case there are
     //   multiple, the last one is used.
+    bool check_witness_commitment{DeploymentActiveAfter(pindexPrev, chainman, Consensus::DEPLOYMENT_SEGWIT)};
+    if (check_witness_commitment && chainman.m_blockman.IsPruneMode()) {
+        LOCK(chainman.GetMutex());
+        if (chainman.IsAssumedValid(block.GetHash())) {
+            check_witness_commitment = false;
+        }
+    }
     bool fHaveWitness = false;
-    if (DeploymentActiveAfter(pindexPrev, chainman, Consensus::DEPLOYMENT_SEGWIT)) {
+    if (check_witness_commitment) {
         int commitpos = GetWitnessCommitmentIndex(block);
         if (commitpos != NO_WITNESS_COMMITMENT) {
             bool malleated = false;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3405,6 +3405,10 @@ void Chainstate::ReceivedBlockTransactions(const CBlock& block, CBlockIndex* pin
 
         if (m_chainman.IsAssumedValid(*pindexNew) && m_chainman.m_blockman.IsPruneMode()) {
             pindexNew->nStatus |= BLOCK_PRUNED_WITNESSES;
+            if (!m_chainman.m_blockman.HasPrunedWitnesses() &&
+                m_chainman.m_blockman.m_block_tree_db->WritePrunedWitnesses(true)) {
+                m_chainman.m_blockman.SetPrunedWitnesses();
+            }
         }
     }
     pindexNew->RaiseValidity(BLOCK_VALID_TRANSACTIONS);

--- a/src/validation.h
+++ b/src/validation.h
@@ -963,6 +963,14 @@ public:
     const arith_uint256& MinimumChainWork() const { return *Assert(m_options.minimum_chain_work); }
     const uint256& AssumedValidBlock() const { return *Assert(m_options.assumed_valid_block); }
 
+    bool IsAssumedValid(const CBlockIndex& index) const EXCLUSIVE_LOCKS_REQUIRED(GetMutex());
+    bool IsAssumedValid(const uint256& hash) const EXCLUSIVE_LOCKS_REQUIRED(GetMutex())
+    {
+        const auto* index = m_blockman.LookupBlockIndex(hash);
+        if (!index) return false;
+        return IsAssumedValid(*index);
+    }
+
     /**
      * Alias for ::cs_main.
      * Should be used in new code to make it easier to make ::cs_main a member

--- a/test/functional/feature_assumevalid_pruning.py
+++ b/test/functional/feature_assumevalid_pruning.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+# Copyright (c) The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from test_framework.blocktools import (
+    create_block,
+    create_coinbase,
+    add_witness_commitment,
+)
+from test_framework.p2p import P2PInterface, msg_block
+from test_framework.test_framework import BitcoinTestFramework
+
+class AssumeValidPruningTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 3
+        self.rpc_timeout = 120
+        self.blocks = []
+
+    def setup_network(self):
+        self.add_nodes(3)
+        self.start_node(0)
+
+    def create_blocks(self, num):
+        # Build the blockchain
+        tip = int(self.nodes[0].getbestblockhash(), 16)
+        block_time = self.nodes[0].getblock(
+            self.nodes[0].getbestblockhash())['time'] + 1
+
+        for i in range(num):
+            # TODO create "large" blocks that contain txs with witness data
+            block = create_block(tip, create_coinbase(height=i+1), block_time)
+            add_witness_commitment(block, 0)
+            block.solve()
+            self.blocks.append(block)
+            tip = block.sha256
+            block_time += 1
+
+    def run_test(self):
+        self.create_blocks(num=2500)
+
+        node0 = self.nodes[0].add_p2p_connection(P2PInterface())
+        for block in self.blocks:
+            node0.send_message(msg_block(block))
+        node0.sync_with_ping(960)
+
+        assume_valid_height = 100
+        minimum_work_height = len(self.blocks) - 1
+        # Start node 1 assume-valid and manual pruning
+        self.start_node(1, extra_args=[
+            "-assumevalid=" + hex(self.blocks[assume_valid_height-1].sha256),
+            # TODO if we don't set the min. work, we might end up failing to
+            # validate a block because we request it with witnesses but when
+            # the block arrives and our best header advanced the block would be
+            # considered assumed-valid (leading to unexpected witnesses).
+            "-minimumchainwork=" + self.nodes[0].getblock(self.blocks[minimum_work_height].hash, 1)['chainwork'],
+            "-prune=1",
+        ])
+
+        # Trigger IBD for node 1 and wait for it to finish.
+        self.connect_nodes(0, 1)
+        self.sync_blocks(
+            nodes=[self.nodes[0], self.nodes[1]],
+            timeout=960
+        )
+
+        # Request all blocks from node 1 and check that only the blocks below the
+        # assume-valid point do not have witnesses.
+        for i in range(len(self.blocks)):
+            block = self.nodes[1].getblock(blockhash=self.blocks[i].hash, verbosity=3)
+            for tx in block['tx']:
+                if i < assume_valid_height:
+                    assert ('txinwitness' not in tx_input for tx_input in tx['vin'])
+                else:
+                    assert ('txinwitness' in tx_input for tx_input in tx['vin'])
+
+        # Check that restarting node 1 raises an init error for having pruned
+        # witnesses.
+        self.stop_node(1)
+        self.nodes[1].assert_start_raises_init_error(extra_args=['-prune=0'])
+
+        # Start node 2 assume-valid and manual pruning
+        self.start_node(2, extra_args=[
+            "-assumevalid=" + hex(self.blocks[assume_valid_height-1].sha256),
+            "-minimumchainwork=" + self.nodes[0].getblock(self.blocks[minimum_work_height].hash, 1)['chainwork'],
+            "-prune=1",
+            # We will be changing the assume-valid hash at this height
+            "-stopatheight=" + str(assume_valid_height + 10),
+        ])
+
+        self.connect_nodes(0, 2)
+        self.nodes[2].wait_until_stopped(timeout=960)
+
+        # Restart node 2 with a different assume-valid hash
+        self.start_node(2, extra_args=[
+            "-assumevalid=" + hex(self.blocks[assume_valid_height + 100 - 1].sha256),
+            "-minimumchainwork=" + self.nodes[0].getblock(self.blocks[minimum_work_height].hash, 1)['chainwork'],
+            "-prune=1",
+            # We will be changing the assume-valid hash at this height
+            "-stopatheight=200",
+        ])
+
+        self.connect_nodes(0, 2)
+        self.nodes[2].wait_until_stopped(timeout=960)
+
+        # Restart node 2 with a different assume-valid hash
+        self.start_node(2, extra_args=[
+            "-assumevalid=0",
+            "-minimumchainwork=" + self.nodes[0].getblock(self.blocks[minimum_work_height].hash, 1)['chainwork'],
+            "-prune=1",
+        ])
+
+        self.connect_nodes(0, 2)
+        self.sync_blocks(nodes=[self.nodes[0], self.nodes[2]], timeout=960)
+
+        for i in range(len(self.blocks)):
+            block = self.nodes[2].getblock(blockhash=self.blocks[i].hash, verbosity=3)
+            for tx in block['tx']:
+                if i < assume_valid_height or (i >= assume_valid_height + 10 and i < assume_valid_height + 100):
+                    assert ('txinwitness' not in tx_input for tx_input in tx['vin'])
+                else:
+                    assert ('txinwitness' in tx_input for tx_input in tx['vin'])
+
+if __name__ == '__main__':
+    AssumeValidPruningTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -130,6 +130,7 @@ BASE_SCRIPTS = [
     'wallet_groups.py --descriptors',
     'p2p_blockfilters.py',
     'feature_assumevalid.py',
+    'feature_assumevalid_pruning.py',
     'wallet_taproot.py --descriptors',
     'feature_bip68_sequence.py',
     'rpc_packages.py',


### PR DESCRIPTION
I got a little nerd sniped by this idea, so I created this draft. I have done very little testing so far (syncing signet worked, currently syncing mainnet).

This PR does two things when running in prune mode: (a) assume witness merkle roots to be valid for assumed-valid blocks and (b) request assumed-valid blocks without `MSG_WITNESS_FLAG`.

In theory this is a good idea, because witnesses are not validated (i.e. they are assumed valid up to a certain block `-assumevalid`) and get pruned anyway when running in prune mode, so not downloading them (for assumed-valid blocks) reduces the bandwidth that is needed for IBD (don't have any numbers on this yet).

One downside is that nodes serving blocks without witnesses can't serve them directly from disk. They have to un-serialize and re-serialize without the witnesses before sending them.

Even though this is a draft, conceptual and approach review is very welcome.

---

TODO:

- [ ] a bunch of tests
- [ ] edge cases around manually pruned nodes (https://github.com/bitcoin/bitcoin/pull/27050#issuecomment-1419751142)
- [ ] make sure we are not advertising blocks with witnesses when we in fact do not have the witnesses (https://github.com/bitcoin/bitcoin/pull/27050#issuecomment-1419443888, https://github.com/bitcoin/bitcoin/pull/27050#issuecomment-1419751142)
- [ ] edge case when restarting with different assume valid settings (https://github.com/bitcoin/bitcoin/pull/27050#issuecomment-1419751142)
- [ ] document that it's a change in what constitutes assumevalid (https://github.com/bitcoin/bitcoin/pull/27050#issuecomment-1419611954)
- [ ] always serve pre-segwit blocks straight from disk (https://github.com/bitcoin/bitcoin/pull/27050#discussion_r1097532417)