### PR TITLE
test: rpc: add last block announcement time to getpeerinfo result

### DIFF
--- a/doc/release-notes-27052.md
+++ b/doc/release-notes-27052.md
@@ -1,0 +1,8 @@
+JSON-RPC
+--------
+
+The `getpeerinfo` RPC now returns an additional result field,
+`last_block_announcement`, which indicates the most recent time
+this peer was the first to announce a new block to the local node.
+This timestamp, previously internal only, is used by the stale-tip
+eviction logic.

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -495,7 +495,7 @@ struct CNodeState {
     ChainSyncTimeoutState m_chain_sync;
 
     //! Time of last new block announcement
-    int64_t m_last_block_announcement{0};
+    NodeClock::time_point m_last_block_announcement{NodeClock::epoch};
 };
 
 class PeerManagerImpl final : public PeerManager
@@ -547,7 +547,7 @@ public:
         m_best_block_time = time;
     };
     void UnitTestMisbehaving(NodeId peer_id) override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex) { Misbehaving(*Assert(GetPeerRef(peer_id)), ""); };
-    void UpdateLastBlockAnnounceTime(NodeId node, int64_t time_in_seconds) override;
+    void UpdateLastBlockAnnounceTime(NodeId node, NodeClock::time_point time) override;
     ServiceFlags GetDesirableServiceFlags(ServiceFlags services) const override;
 
 private:
@@ -1620,11 +1620,11 @@ void PeerManagerImpl::PushNodeVersion(CNode& pnode, const Peer& peer)
         my_tx_relay, pnode.GetId());
 }
 
-void PeerManagerImpl::UpdateLastBlockAnnounceTime(NodeId node, int64_t time_in_seconds)
+void PeerManagerImpl::UpdateLastBlockAnnounceTime(NodeId node, NodeClock::time_point time)
 {
     LOCK(cs_main);
     CNodeState *state = State(node);
-    if (state) state->m_last_block_announcement = time_in_seconds;
+    if (state) state->m_last_block_announcement = time;
 }
 
 void PeerManagerImpl::InitializeNode(const CNode& node, ServiceFlags our_services)
@@ -2972,7 +2972,7 @@ void PeerManagerImpl::UpdatePeerStateForReceivedHeaders(CNode& pfrom, Peer& peer
     // are still present, however, as belt-and-suspenders.
 
     if (received_new_header && last_header.nChainWork > m_chainman.ActiveChain().Tip()->nChainWork) {
-        nodestate->m_last_block_announcement = GetTime();
+        nodestate->m_last_block_announcement = NodeClock::now();
     }
 
     // If we're in IBD, we want outbound peers that will serve us a useful
@@ -4654,7 +4654,7 @@ void PeerManagerImpl::ProcessMessage(Peer& peer, CNode& pfrom, const std::string
         // If this was a new header with more work than our tip, update the
         // peer's last block announcement time
         if (received_new_header && pindex->nChainWork > m_chainman.ActiveChain().Tip()->nChainWork) {
-            nodestate->m_last_block_announcement = GetTime();
+            nodestate->m_last_block_announcement = NodeClock::now();
         }
 
         if (pindex->nStatus & BLOCK_HAVE_DATA) // Nothing to do here
@@ -5393,13 +5393,16 @@ void PeerManagerImpl::EvictExtraOutboundPeers(NodeClock::time_point now)
     // Check whether we have too many outbound-full-relay peers
     if (m_connman.GetExtraFullOutboundCount() > 0) {
         // If we have more outbound-full-relay peers than we target, disconnect one.
-        // Pick the outbound-full-relay peer that least recently announced
+        // Pick the outbound-full-relay peer that least-recently announced
         // us a new block, with ties broken by choosing the more recent
-        // connection (higher node id)
+        // connection (higher node id).
         // Protect peers from eviction if we don't have another connection
         // to their network, counting both outbound-full-relay and manual peers.
-        NodeId worst_peer = -1;
-        int64_t oldest_block_announcement = std::numeric_limits<int64_t>::max();
+        struct WorstPeer {
+            NodeId node;
+            NodeClock::time_point oldest_block_announcement;
+        };
+        std::optional<WorstPeer> worst_peer;
 
         m_connman.ForEachNode([&](CNode* pnode) EXCLUSIVE_LOCKS_REQUIRED(::cs_main, m_connman.GetNodesMutex()) {
             AssertLockHeld(::cs_main);
@@ -5414,13 +5417,14 @@ void PeerManagerImpl::EvictExtraOutboundPeers(NodeClock::time_point now)
             // If this is the only connection on a particular network that is
             // OUTBOUND_FULL_RELAY or MANUAL, protect it.
             if (!m_connman.MultipleManualOrFullOutboundConns(pnode->addr.GetNetwork())) return;
-            if (state->m_last_block_announcement < oldest_block_announcement || (state->m_last_block_announcement == oldest_block_announcement && pnode->GetId() > worst_peer)) {
-                worst_peer = pnode->GetId();
-                oldest_block_announcement = state->m_last_block_announcement;
+            if (!worst_peer.has_value() ||
+                (state->m_last_block_announcement < (*worst_peer).oldest_block_announcement) ||
+                ((state->m_last_block_announcement == (*worst_peer).oldest_block_announcement) && pnode->GetId() > (*worst_peer).node)) {
+                worst_peer = WorstPeer{pnode->GetId(), state->m_last_block_announcement};
             }
         });
-        if (worst_peer != -1) {
-            bool disconnected = m_connman.ForNode(worst_peer, [&](CNode* pnode) EXCLUSIVE_LOCKS_REQUIRED(::cs_main) {
+        if (worst_peer.has_value()) {
+            bool disconnected = m_connman.ForNode((*worst_peer).node, [&](CNode* pnode) EXCLUSIVE_LOCKS_REQUIRED(::cs_main) {
                 AssertLockHeld(::cs_main);
 
                 // Only disconnect a peer that has been connected to us for
@@ -5430,7 +5434,8 @@ void PeerManagerImpl::EvictExtraOutboundPeers(NodeClock::time_point now)
                 // block from.
                 CNodeState &state = *State(pnode->GetId());
                 if (now - pnode->m_connected > MINIMUM_CONNECT_TIME && state.vBlocksInFlight.empty()) {
-                    LogDebug(BCLog::NET, "disconnecting extra outbound peer=%d (last block announcement received at time %d)\n", pnode->GetId(), oldest_block_announcement);
+                    LogDebug(BCLog::NET, "disconnecting extra outbound peer=%d (last block announcement received at time %d)\n",
+                             pnode->GetId(), TicksSinceEpoch<std::chrono::seconds>((*worst_peer).oldest_block_announcement));
                     pnode->fDisconnect = true;
                     return true;
                 } else {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1836,6 +1836,7 @@ bool PeerManagerImpl::GetNodeStateStats(NodeId nodeid, CNodeStateStats& stats) c
             if (queue.pindex)
                 stats.vHeightInFlight.push_back(queue.pindex->nHeight);
         }
+        stats.m_last_block_announcement = state->m_last_block_announcement;
     }
 
     PeerRef peer = GetPeerRef(nodeid);

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -67,6 +67,7 @@ struct CNodeStateStats {
     ServiceFlags their_services;
     int64_t presync_height{-1};
     std::chrono::seconds time_offset{0};
+    NodeClock::time_point m_last_block_announcement;
 };
 
 struct PeerManagerInfo {

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -169,7 +169,7 @@ public:
     virtual void CheckForStaleTipAndEvictPeers() = 0;
 
     /** This function is used for testing the stale tip eviction logic, see denialofservice_tests.cpp */
-    virtual void UpdateLastBlockAnnounceTime(NodeId node, int64_t time_in_seconds) = 0;
+    virtual void UpdateLastBlockAnnounceTime(NodeId node, NodeClock::time_point time) = 0;
 
     /**
      * Gets the set of service flags which are "desirable" for a given peer.

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -155,6 +155,7 @@ static RPCMethod getpeerinfo()
                     {RPCResult::Type::NUM_TIME, "lastrecv", "The " + UNIX_EPOCH_TIME + " of the last receive"},
                     {RPCResult::Type::NUM_TIME, "last_transaction", "The " + UNIX_EPOCH_TIME + " of the last valid transaction received from this peer"},
                     {RPCResult::Type::NUM_TIME, "last_block", "The " + UNIX_EPOCH_TIME + " of the last block received from this peer"},
+                    {RPCResult::Type::NUM_TIME, "last_block_announcement", "The " + UNIX_EPOCH_TIME + " this peer was first to announce a block"},
                     {RPCResult::Type::NUM, "bytessent", "The total bytes sent"},
                     {RPCResult::Type::NUM, "bytesrecv", "The total bytes received"},
                     {RPCResult::Type::NUM_TIME, "conntime", "The " + UNIX_EPOCH_TIME + " of the connection"},
@@ -252,6 +253,7 @@ static RPCMethod getpeerinfo()
         obj.pushKV("lastrecv", TicksSinceEpoch<std::chrono::seconds>(stats.m_last_recv));
         obj.pushKV("last_transaction", count_seconds(stats.m_last_tx_time));
         obj.pushKV("last_block", count_seconds(stats.m_last_block_time));
+        obj.pushKV("last_block_announcement", TicksSinceEpoch<std::chrono::seconds>(statestats.m_last_block_announcement));
         obj.pushKV("bytessent", stats.nSendBytes);
         obj.pushKV("bytesrecv", stats.nRecvBytes);
         obj.pushKV("conntime", TicksSinceEpoch<std::chrono::seconds>(stats.m_connected));

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -200,7 +200,7 @@ BOOST_FIXTURE_TEST_CASE(stale_tip_peer_management, OutboundTest)
 
     // Update the last announced block time for the last
     // peer, and check that the next newest node gets evicted.
-    peerLogic->UpdateLastBlockAnnounceTime(vNodes.back()->GetId(), GetTime());
+    peerLogic->UpdateLastBlockAnnounceTime(vNodes.back()->GetId(), NodeClock::now());
 
     peerLogic->CheckForStaleTipAndEvictPeers();
     for (int i = 0; i < max_outbound_full_relay - 1; ++i) {

--- a/test/functional/p2p_block_times.py
+++ b/test/functional/p2p_block_times.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+# Copyright (c) The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""Test block announcement time tracking
+
+The bitcoind client records, for each peer, the most recent time that
+this peer announced a block that the client wasn't already aware of. This
+timestamp, CNodeState::m_last_block_announcement, is available in the
+`last_block_announcement` field of each peer's `getpeerinfo` result. The
+value zero means that this peer has never been the first to announce
+a block to us. Blocks are announced using either the "headers" or
+"cmpctblock" messages.
+
+This timestamp is used when the "potential stale tip" condition occurs:
+When a new block hasn't been seen for a longer-than-expected amount of
+time (currently 30 minutes, see TipMayBeStale()), the client, suspecting
+that there may be new blocks that its peers are not announcing, will
+add an extra outbound peer and disconnect (evict) the peer that has
+least recently been the first to announce a new block to us. (If there
+is a tie, it will disconnect the most recently-added of those peers.)
+
+This test verifies that this timestamp is being set correctly, see
+https://github.com/bitcoin/bitcoin/pull/26172.
+
+The test announces blocks to the node from a test framework peer and
+verifies that the field updates only when the peer is first to announce
+a block extending the tip.
+"""
+
+import time
+from test_framework.blocktools import (
+    create_block,
+    create_coinbase,
+)
+from test_framework.messages import (
+    CBlockHeader,
+    msg_headers,
+)
+from test_framework.p2p import P2PDataStore
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+
+
+class P2PBlockTimes(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+
+    def run_test(self):
+        node = self.nodes[0]
+        cur_time = int(time.time())
+        node.setmocktime(cur_time)
+
+        # Generate one block to exit IBD
+        self.generate(node, 1)
+
+        self.log.info("Create a full-outbound test framework peer")
+        peer = node.add_outbound_p2p_connection(P2PDataStore(), p2p_idx=0)
+
+        self.log.info("Test framework peer generates a new block at height 2")
+        tip = int(node.getbestblockhash(), 16)
+        block = create_block(tip, create_coinbase(2))
+        block.solve()
+
+        self.log.info("Check that last_block_announcement is initially zero")
+        peerinfo = node.getpeerinfo()[0]
+        assert_equal(peerinfo['last_block_announcement'], 0)
+
+        self.log.info("Test framework peer sends node the new block")
+        peer.send_blocks_and_test([block], node, success=True)
+
+        self.log.info("Verify peerinfo block timestamps")
+        peerinfo = node.getpeerinfo()[0]
+        assert_equal(peerinfo['last_block'], cur_time)
+        assert_equal(peerinfo['last_block_announcement'], cur_time)
+
+        self.log.info("Sending a block announcement with no new blocks")
+        node.setmocktime(cur_time + 1)
+        headers_message = msg_headers()
+        headers_message.headers = [CBlockHeader(block)]
+        peer.send_and_ping(headers_message)
+
+        self.log.info("Verify that block announcement time isn't updated")
+        peerinfo = node.getpeerinfo()[0]
+        assert_equal(peerinfo['last_block_announcement'], cur_time)
+
+        # Receiving a second block at height 2 will not be accepted as the tip,
+        # because its chainwork is not greater than that of the earlier height 2 block.
+        self.log.info("Create a second block at height 2 (will be stale)")
+        block2 = create_block(tip, create_coinbase(2), ntime=block.nTime + 1)
+        block2.solve()
+        headers_message2 = msg_headers()
+        headers_message2.headers = [CBlockHeader(block2)]
+        self.log.info("Test framework peer sends node the new (stale) block")
+        peer.send_and_ping(headers_message2)
+
+        self.log.info("Verify that block announcement time isn't updated")
+        peerinfo = node.getpeerinfo()[0]
+        assert_equal(peerinfo['last_block_announcement'], cur_time)
+
+
+if __name__ == '__main__':
+    P2PBlockTimes(__file__).main()

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -107,7 +107,10 @@ class NetTest(BitcoinTestFramework):
         time_now = int(time.time())
         peer_info = [x.getpeerinfo() for x in self.nodes]
         # Verify last_block and last_transaction keys/values.
-        for node, peer, field in product(range(self.num_nodes), range(2), ['last_block', 'last_transaction']):
+        for node, peer, field in product(range(self.num_nodes), range(2),
+                                         ['last_block',
+                                          'last_block_announcement',
+                                          'last_transaction']):
             assert field in peer_info[node][peer].keys()
             if peer_info[node][peer][field] != 0:
                 assert_approx(peer_info[node][peer][field], time_now, vspan=60)
@@ -161,6 +164,7 @@ class NetTest(BitcoinTestFramework):
                 "inbound": True,
                 "inflight": [],
                 "last_block": 0,
+                "last_block_announcement": 0,
                 "last_transaction": 0,
                 "lastrecv": 0 if not self.options.v2transport else no_version_peer_conntime,
                 "lastsend": 0 if not self.options.v2transport else no_version_peer_conntime,

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -198,6 +198,7 @@ BASE_SCRIPTS = [
     'mempool_reorg.py',
     'p2p_block_sync.py --v1transport',
     'p2p_block_sync.py --v2transport',
+    'p2p_block_times.py',
     'wallet_createwallet.py --usecli',
     'wallet_createwallet.py',
     'wallet_reindex.py',


### PR DESCRIPTION
This PR adds `last_block_announcement` to the per-peer `getpeerinfo` RPC result. This is the most recent time that this peer was the first to notify our node of a new block (one that we didn't already know about), or zero if this peer has never been the first to notify us of a new block. This timestamp already exists internally and is used for stale-tip eviction logic; this PR exposes it at the RPC layer.

This PR started out as a suggestion for additional test coverage, see https://github.com/bitcoin/bitcoin/pull/26172#issuecomment-1259678260. It turned out that the easiest way to test (already-merged) #26172 is to add this field to `getpeerinfo` and have a functional test verify its value. But it may also be useful to have this result in its own right, similar to that RPC's existing `last_block` field -- it indicates something about the quality of our peers. It allows one to predict which peer will be evicted when the stale tip logic activates. (I'm not sure if that would be useful, but it may be.)

The functional test added here fails without #26172, which is the main goal.

This PR does not test the actual stale-tip eviction logic; that's difficult to do with a functional test. But it does test the correctness of the timestamp that the eviction logic depends on. #23352 is an attempt to test the eviction logic using a unit test, it's not ready to be merged yet. I think having both kinds of tests would be beneficial.