### PR TITLE
build: set boost cppflags with --enable-fuzz

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1451,7 +1451,7 @@ if test "$use_natpmp" != "no"; then
   CPPFLAGS="$TEMP_CPPFLAGS"
 fi
 
-if test "$build_bitcoin_wallet$build_bitcoin_cli$build_bitcoin_tx$build_bitcoin_util$build_bitcoind$bitcoin_enable_qt$use_tests$use_bench" = "nononononononono"; then
+if test "$build_bitcoin_wallet$build_bitcoin_cli$build_bitcoin_tx$build_bitcoin_util$build_bitcoind$bitcoin_enable_qt$use_tests$use_bench$enable_fuzz_binary" = "nonononononononono"; then
   use_boost=no
 else
   use_boost=yes


### PR DESCRIPTION
Even though all other targets are disabled, we still need Boost CPPFLAGS (`use_boost`) to compile. This currently works everywhere, except on arm macOS (where the include path is non-standard), because generally, the Boost include path is generic, i.e `/usr/include`.