### PR TITLE
build: Add CMake-based build system (1 of N)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,12 @@ project("Bitcoin Core"
   LANGUAGES CXX C ASM
 )
 
+set(CLIENT_VERSION_IS_RELEASE "false")
+set(COPYRIGHT_YEAR "2023")
+set(COPYRIGHT_HOLDERS "The %s developers")
+set(COPYRIGHT_HOLDERS_FINAL "The ${PROJECT_NAME} developers")
+set(PACKAGE_BUGREPORT "https://github.com/bitcoin/bitcoin/issues")
+
 # Configurable options.
 # When adding a new option, end the <help_text> with a full stop for consistency.
 include(CMakeDependentOption)
@@ -51,6 +57,8 @@ else()
   list(APPEND configure_warnings "No PIE options will be passed to a linker for executable targets.")
 endif()
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+add_subdirectory(src)
 
 message("\n")
 message("Configure summary")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,99 @@
+# Copyright (c) 2023 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+# IMPORTANT: Changes which affect binary results may not be quietly gated
+#            by CMake version.
+#
+# Debian 10 Buster, https://wiki.debian.org/LTS, EOL 2024:
+#  - CMake 3.13.4, https://packages.debian.org/buster/cmake
+#
+# Ubuntu 22.04 Jammy, https://wiki.ubuntu.com/Releases, EOL 2032:
+#  - CMake 3.22.1, https://packages.ubuntu.com/jammy/cmake
+#
+# Visual Studio 17 2022, https://visualstudio.microsoft.com:
+#  - CMake 3.24
+#
+# All policies known to the running version of CMake and introduced
+# in the 3.24 version or earlier will be set to use NEW behavior.
+# All policies introduced in later versions will be unset.
+# See: https://cmake.org/cmake/help/latest/manual/cmake-policies.7.html
+cmake_minimum_required(VERSION 3.13...3.24)
+
+project("Bitcoin Core"
+  VERSION 24.99.0
+  DESCRIPTION "Bitcoin client software"
+  HOMEPAGE_URL "https://bitcoincore.org/"
+  LANGUAGES CXX C ASM
+)
+
+# Configurable options.
+# When adding a new option, end the <help_text> with a full stop for consistency.
+include(CMakeDependentOption)
+cmake_dependent_option(CXX20 "Enable compilation in C++20 mode." OFF "NOT MSVC" ON)
+
+if(CXX20)
+  set(CMAKE_CXX_STANDARD 20)
+else()
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+set(configure_warnings)
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.14)
+  include(CheckPIESupported)
+  check_pie_supported(OUTPUT_VARIABLE check_pie_output LANGUAGES CXX)
+  if(NOT CMAKE_CXX_LINK_PIE_SUPPORTED)
+    list(APPEND configure_warnings "PIE link options are not supported for executable targets: ${check_pie_output}.")
+  endif()
+else()
+  list(APPEND configure_warnings "No PIE options will be passed to a linker for executable targets.")
+endif()
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+message("\n")
+message("Configure summary")
+message("=================")
+get_directory_property(definitions COMPILE_DEFINITIONS)
+string(REPLACE ";" " " definitions "${definitions}")
+message("Preprocessor defined macros ........... ${definitions}")
+message("C compiler ............................ ${CMAKE_C_COMPILER}")
+message("CFLAGS ................................ ${CMAKE_C_FLAGS}")
+message("C++ compiler .......................... ${CMAKE_CXX_COMPILER}")
+message("CXXFLAGS .............................. ${CMAKE_CXX_FLAGS}")
+get_directory_property(common_compile_options COMPILE_OPTIONS)
+string(REPLACE ";" " " common_compile_options "${common_compile_options}")
+message("Common compile options ................ ${common_compile_options}")
+get_directory_property(common_link_options LINK_OPTIONS)
+string(REPLACE ";" " " common_link_options "${common_link_options}")
+message("Common link options ................... ${common_link_options}")
+if(DEFINED CMAKE_BUILD_TYPE)
+  message("Build type:")
+  message(" - CMAKE_BUILD_TYPE ................... ${CMAKE_BUILD_TYPE}")
+  string(TOUPPER "${CMAKE_BUILD_TYPE}" build_type)
+  message(" - CFLAGS ............................. ${CMAKE_C_FLAGS_${build_type}}")
+  message(" - CXXFLAGS ........................... ${CMAKE_CXX_FLAGS_${build_type}}")
+  message(" - LDFLAGS for executables ............ ${CMAKE_EXE_LINKER_FLAGS_${build_type}}")
+  message(" - LDFLAGS for shared libraries ....... ${CMAKE_SHARED_LINKER_FLAGS_${build_type}}")
+else()
+  message("Available configurations .............. ${CMAKE_CONFIGURATION_TYPES}")
+  message("Debug configuration:")
+  message(" - CFLAGS ............................. ${CMAKE_C_FLAGS_DEBUG}")
+  message(" - CXXFLAGS ........................... ${CMAKE_CXX_FLAGS_DEBUG}")
+  message(" - LDFLAGS for executables ............ ${CMAKE_EXE_LINKER_FLAGS_DEBUG}")
+  message(" - LDFLAGS for shared libraries ....... ${CMAKE_SHARED_LINKER_FLAGS_DEBUG}")
+  message("Release configuration:")
+  message(" - CFLAGS ............................. ${CMAKE_C_FLAGS_RELEASE}")
+  message(" - CXXFLAGS ........................... ${CMAKE_CXX_FLAGS_RELEASE}")
+  message(" - LDFLAGS for executables ............ ${CMAKE_EXE_LINKER_FLAGS_RELEASE}")
+  message(" - LDFLAGS for shared libraries ....... ${CMAKE_SHARED_LINKER_FLAGS_RELEASE}")
+endif()
+message("\n")
+if(configure_warnings)
+    message("  ******\n")
+    foreach(warning IN LISTS configure_warnings)
+      message(WARNING "${warning}")
+    endforeach()
+    message("  ******\n")
+endif()

--- a/cmake/bitcoin-config.h.in
+++ b/cmake/bitcoin-config.h.in
@@ -1,0 +1,45 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_CONFIG_H
+
+#define BITCOIN_CONFIG_H
+
+/* Version Build */
+#define CLIENT_VERSION_BUILD @PROJECT_VERSION_PATCH@
+
+/* Version is release */
+#define CLIENT_VERSION_IS_RELEASE @CLIENT_VERSION_IS_RELEASE@
+
+/* Major version */
+#define CLIENT_VERSION_MAJOR @PROJECT_VERSION_MAJOR@
+
+/* Minor version */
+#define CLIENT_VERSION_MINOR @PROJECT_VERSION_MINOR@
+
+/* Copyright holder(s) before %s replacement */
+#define COPYRIGHT_HOLDERS "@COPYRIGHT_HOLDERS@"
+
+/* Copyright holder(s) */
+#define COPYRIGHT_HOLDERS_FINAL "@COPYRIGHT_HOLDERS_FINAL@"
+
+/* Replacement for %s in copyright holders string */
+#define COPYRIGHT_HOLDERS_SUBSTITUTION "@PROJECT_NAME@"
+
+/* Copyright year */
+#define COPYRIGHT_YEAR @COPYRIGHT_YEAR@
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT "@PACKAGE_BUGREPORT@"
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "@PROJECT_NAME@"
+
+/* Define to the home page for this package. */
+#define PACKAGE_URL "@PROJECT_HOMEPAGE_URL@"
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "@PROJECT_VERSION@"
+
+#endif //BITCOIN_CONFIG_H

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,7 @@
+# Copyright (c) 2023 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+configure_file(${CMAKE_SOURCE_DIR}/cmake/bitcoin-config.h.in config/bitcoin-config.h @ONLY)
+add_compile_definitions(HAVE_CONFIG_H)
+include_directories(${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
This is split from https://github.com/bitcoin/bitcoin/pull/25797 which is a full implementation with an Autotools feature parity and has more than 80 commits.

A bit [rehashed](https://github.com/bitcoin/bitcoin/pull/25797#issue-1330985812) list of benefits of a CMake-based build system over an Autotools-based one:

## General benefits

1. [Integration](https://www.kitware.com/static-checks-with-cmake-cdash-iwyu-clang-tidy-lwyu-cpplint-and-cppcheck/) with developer tools like clang-tidy, IWYU etc.

2. CTest tool with a bunch of useful features, including coverage analysis, integration with sanitizers and memory check tools like valgrind.

3. [CPack](https://cmake.org/cmake/help/book/mastering-cmake/chapter/Packaging%20With%20CPack.html), a powerful packaging tool.

4. Integration with IDEs.

5. The concept of a "target with assosiated properties" is better than Autotools' global variables in many ways (robustness, readability, maintanability).

6. _[social]_ A great community. CMake is actively developed.


## The Bitcoin Core specific benefits

A preliminary note. Two arguments (a) "nobody cares about X platform" and (b) "nobody cares about Y binary" are out of this PR scope, as long as the X platform is promised to be supported by the Bitcoin Core project, and the Y binary is a part of the Bitcoin Core project.

7. Native Windows support. No longer need to maintain `build_msvc` subdirectory.

8. Correctness with Windows DLLs out-of-the-box. In comparison, the current build system has 3 ([three!](https://github.com/bitcoin/bitcoin/issues/25008#issuecomment-1113964111)) hacks of libtool. And it is still broken:
- https://github.com/bitcoin/bitcoin/issues/19772
- https://github.com/bitcoin/bitcoin/issues/25008

9. CMake is a native build system of [Qt 6](https://doc.qt.io/qt-6/cmake-manual.html).

10. _[social]_ It is [expected](https://github.com/bitcoin/bitcoin/pull/25797#issuecomment-1408772481) that more current and new developers are/will be able/willing to review/contribute/maintain CMake code rather Autotools stuff.

## Roadmap

There are two goals:
- merge all CMake code by v25.0 and test it
- switch to the CMake-based build system by v26.0

## Implementation details

In particular, this PR establishes the minimum required CMake [version](https://gitlab.kitware.com/cmake/community/-/wikis/CMake-Versions-on-Linux-Distros). As it looks non-productive to support Ubuntu Bionic as a build platform, version [3.13](https://cmake.org/cmake/help/latest/release/3.13.html) has been chosen. Benefits of v3.13 over v3.10 which affect our CMake code directly are as [follow](https://github.com/hebasto/bitcoin/blob/220807-cmake/CMakeLists.txt):
```CMake
#  - 3.11: add_library() and add_executable() commands can now be called without any sources
#          and will not complain as long as sources are added later via the target_sources()
#          command.
#  - 3.11: The target_*() commands learned to set the INTERFACE properties on Imported Targets.
#  - 3.12: The add_compile_definitions() command was added to set preprocessor definitions
#          at directory level. This supersedes add_definitions().
#  - 3.12: If the CONFIGURE_DEPENDS flag is specified, CMake will add logic to the main
#          build system check target to rerun the flagged GLOB commands at build time.
#  - 3.12: The target_link_libraries() command now supports Object Libraries.
#  - 3.12: A new $<TARGET_EXISTS:...> generator expression has been added.
#  - 3.12: A new FindPython3 module has been added to provide a new way to locate python
#          environments.
#  - 3.13: The install(TARGETS) command learned to install targets created outside the current
#          directory.
#  - 3.13: The target_link_options() command was created to specify link options for targets
#          and their dependents.
#  - 3.13: The target_link_libraries() command may now be called to modify targets created
#          outside the current directory.
```

## Notes for reviewers

To configure a build system, one can run in their local repo root:
- on Linux / *BSD / macOS:
```sh
cmake -S . -B  build
```
- on Windows:
```cmd
cmake -G "Visual Studio 17 2022" -A x64 -S . -B build
```

To re-configure, it is recommended to use the clean build tree, for example:
```sh
rm -rf build
```

For now, the only artifact we explicitly create in the build tree is a `bitcoin-config.h` header:
```sh
cat build/src/config/bitcoin-config.h
```