### PR TITLE
ci: Re-introduce `depends_built` cache back in macOS and Android tasks

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -55,14 +55,6 @@ global_task_template: &GLOBAL_TASK_TEMPLATE
   << : *CONTAINER_DEPENDS_TEMPLATE
   << : *MAIN_TEMPLATE
 
-macos_native_task_template: &MACOS_NATIVE_TASK_TEMPLATE
-  << : *BASE_TEMPLATE
-  check_clang_script:
-    - clang --version
-  brew_install_script:
-    - brew install boost libevent qt@5 miniupnpc libnatpmp ccache zeromq qrencode libtool automake gnu-getopt
-  << : *MAIN_TEMPLATE
-
 compute_credits_template: &CREDITS_TEMPLATE
   # https://cirrus-ci.org/pricing/#compute-credits
   # Only use credits for pull requests to the main repo
@@ -328,7 +320,12 @@ task:
   macos_instance:
     # Use latest image, but hardcode version to avoid silent upgrades (and breaks)
     image: ghcr.io/cirruslabs/macos-ventura-xcode:14.1  # https://cirrus-ci.org/guide/macOS
-  << : *MACOS_NATIVE_TASK_TEMPLATE
+  << : *BASE_TEMPLATE
+  check_clang_script:
+    - clang --version
+  brew_install_script:
+    - brew install boost libevent qt@5 miniupnpc libnatpmp ccache zeromq qrencode libtool automake gnu-getopt
+  << : *MAIN_TEMPLATE
   env:
     << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
     CI_USE_APT_INSTALL: "no"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -39,7 +39,7 @@ main_template: &MAIN_TEMPLATE
   ci_script:
     - ./ci/test_run_all.sh
 
-global_task_template: &GLOBAL_TASK_TEMPLATE
+container_depends_template: &CONTAINER_DEPENDS_TEMPLATE
   << : *BASE_TEMPLATE
   container:
     # https://cirrus-ci.org/faq/#are-there-any-limits
@@ -50,6 +50,9 @@ global_task_template: &GLOBAL_TASK_TEMPLATE
   depends_built_cache:
     folder: "depends/built"
     fingerprint_script: echo $CIRRUS_TASK_NAME $(git rev-list -1 HEAD ./depends)
+
+global_task_template: &GLOBAL_TASK_TEMPLATE
+  << : *CONTAINER_DEPENDS_TEMPLATE
   << : *MAIN_TEMPLATE
 
 macos_native_task_template: &MACOS_NATIVE_TASK_TEMPLATE
@@ -308,13 +311,13 @@ task:
 
 task:
   name: 'macOS 10.15 [gui, no tests] [focal]'
-  << : *BASE_TEMPLATE
+  << : *CONTAINER_DEPENDS_TEMPLATE
+  container:
+    image: ubuntu:focal
   macos_sdk_cache:
     folder: "depends/SDKs/$MACOS_SDK"
     fingerprint_key: "$MACOS_SDK"
   << : *MAIN_TEMPLATE
-  container:
-    image: ubuntu:focal
   env:
     MACOS_SDK: "Xcode-12.2-12B45b-extracted-SDK-with-libcxx-headers"
     << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
@@ -334,7 +337,9 @@ task:
 
 task:
   name: 'ARM64 Android APK [jammy]'
-  << : *BASE_TEMPLATE
+  << : *CONTAINER_DEPENDS_TEMPLATE
+  container:
+    image: ubuntu:jammy
   android_sdk_cache:
     folder: "depends/SDKs/android"
     fingerprint_key: "ANDROID_API_LEVEL=28 ANDROID_BUILD_TOOLS_VERSION=28.0.3 ANDROID_NDK_VERSION=23.2.8568313"
@@ -342,8 +347,6 @@ task:
     folder: "depends/sources"
     fingerprint_script: git rev-list -1 HEAD ./depends
   << : *MAIN_TEMPLATE
-  container:
-    image: ubuntu:jammy
   env:
     << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
     FILE_ENV: "./ci/test/00_setup_env_android.sh"


### PR DESCRIPTION
This PR brings a `depends_built` cache back to the "macOS 10.15" and "ARM64 Android APK" CI tasks.

Fixes #27031.