### PR TITLE
ci: Use the latest Ubuntu LTS for "ARM64 Android APK" task

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -333,7 +333,7 @@ task:
     FILE_ENV: "./ci/test/00_setup_env_mac_native_arm64.sh"
 
 task:
-  name: 'ARM64 Android APK [focal]'
+  name: 'ARM64 Android APK [jammy]'
   << : *BASE_TEMPLATE
   android_sdk_cache:
     folder: "depends/SDKs/android"
@@ -343,7 +343,7 @@ task:
     fingerprint_script: git rev-list -1 HEAD ./depends
   << : *MAIN_TEMPLATE
   container:
-    image: ubuntu:focal
+    image: ubuntu:jammy
   env:
     << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
     FILE_ENV: "./ci/test/00_setup_env_android.sh"

--- a/ci/test/00_setup_env_android.sh
+++ b/ci/test/00_setup_env_android.sh
@@ -9,7 +9,7 @@ export LC_ALL=C.UTF-8
 export HOST=aarch64-linux-android
 export PACKAGES="unzip openjdk-8-jdk gradle"
 export CONTAINER_NAME=ci_android
-export CI_IMAGE_NAME_TAG="ubuntu:focal"
+export CI_IMAGE_NAME_TAG="ubuntu:jammy"
 
 export RUN_UNIT_TESTS=false
 export RUN_FUNCTIONAL_TESTS=false


### PR DESCRIPTION
Suggested in https://github.com/bitcoin/bitcoin/pull/25797#discussion_r1100172227:

>  I don't expect that anyone is building for android, and if they did, it should be fine to just require the latest Ubuntu LTS, which is Jammy