### PR TITLE
ci: Make `ccache` hashing content of compiler binary

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,6 +7,7 @@ env:  # Global defaults
   CCACHE_SIZE: "200M"
   CCACHE_DIR: "/tmp/ccache_dir"
   CCACHE_NOHASHDIR: "1"  # Debug info might contain a stale path if the build dir changes, but this is fine
+  CCACHE_COMPILERCHECK: "content"  # Hash the content of the compiler binary rather than its mtime and size
 
 cirrus_ephemeral_worker_template_env: &CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
   DANGER_RUN_CI_ON_HOST: "1"  # Containers will be discarded after the run, so there is no risk that the ci scripts modify the system

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -37,6 +37,8 @@ main_template: &MAIN_TEMPLATE
   timeout_in: 120m  # https://cirrus-ci.org/faq/#instance-timed-out
   ccache_cache:
     folder: "/tmp/ccache_dir"
+    fingerprint_key: 2023-02-11
+    reupload_on_changes: true
   ci_script:
     - ./ci/test_run_all.sh
 


### PR DESCRIPTION
By default, `ccache` includes the modification time (`mtime`) and size of the compiler in the hash to ensure that results retrieved from the cache are accurate. But in CI environment compiler's `mtime` can be unique each run.

Effectively, this PR fixes https://github.com/bitcoin/bitcoin/pull/27063#issuecomment-1423901418:
> Looks like ccache isn't working here
>
> https://cirrus-ci.com/task/4571293245243392?logs=ci#L4178