### PR TITLE
ci: Improve `ccache` cache hit rates

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,7 +5,7 @@ env:  # Global defaults
   TEST_RUNNER_PORT_MIN: "14000"  # Must be larger than 12321, which is used for the http cache. See https://cirrus-ci.org/guide/writing-tasks/#http-cache
   CI_FAILFAST_TEST_LEAVE_DANGLING: "1"  # Cirrus CI does not care about dangling process and setting this variable avoids killing the CI script itself on error
   CCACHE_SIZE: "200M"
-  CCACHE_DIR: "/tmp/ccache_dir"
+  CCACHE_DIR: '${CIRRUS_WORKING_DIR}/ccache_dir'
   CCACHE_NOHASHDIR: "1"  # Debug info might contain a stale path if the build dir changes, but this is fine
 
 cirrus_ephemeral_worker_template_env: &CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
@@ -35,7 +35,7 @@ base_template: &BASE_TEMPLATE
 main_template: &MAIN_TEMPLATE
   timeout_in: 120m  # https://cirrus-ci.org/faq/#instance-timed-out
   ccache_cache:
-    folder: "/tmp/ccache_dir"
+    folder: '${CCACHE_DIR}'
   ci_script:
     - ./ci/test_run_all.sh
 

--- a/ci/test/00_setup_env_i686_multiprocess.sh
+++ b/ci/test/00_setup_env_i686_multiprocess.sh
@@ -15,3 +15,4 @@ export GOAL="install"
 export BITCOIN_CONFIG="--enable-debug CC='clang -m32' CXX='clang++ -m32' LDFLAGS='--rtlib=compiler-rt -lgcc_s'"
 export TEST_RUNNER_ENV="BITCOIND=bitcoin-node"
 export TEST_RUNNER_EXTRA="--nosandbox"
+export CCACHE_SIZE=400M

--- a/ci/test/00_setup_env_mac_native_arm64.sh
+++ b/ci/test/00_setup_env_mac_native_arm64.sh
@@ -13,4 +13,4 @@ export BITCOIN_CONFIG="--with-gui --with-miniupnpc --with-natpmp --enable-reduce
 export CI_OS_NAME="macos"
 export NO_DEPENDS=1
 export OSX_SDK=""
-export CCACHE_SIZE=300M
+export CCACHE_SIZE=400M

--- a/ci/test/00_setup_env_native_asan.sh
+++ b/ci/test/00_setup_env_native_asan.sh
@@ -24,3 +24,4 @@ export CI_IMAGE_NAME_TAG=ubuntu:22.04
 export NO_DEPENDS=1
 export GOAL="install"
 export BITCOIN_CONFIG="--enable-c++20 --enable-usdt --enable-zmq --with-incompatible-bdb --with-gui=qt5 CPPFLAGS='-DARENA_DEBUG -DDEBUG_LOCKORDER' --with-sanitizers=address,integer,undefined CC=clang CXX=clang++"
+export CCACHE_SIZE=300M

--- a/ci/test/00_setup_env_native_msan.sh
+++ b/ci/test/00_setup_env_native_msan.sh
@@ -20,4 +20,4 @@ export GOAL="install"
 export BITCOIN_CONFIG="--with-sanitizers=memory --disable-hardening --with-asm=no CC=clang CXX=clang++ CFLAGS='${MSAN_FLAGS}' CXXFLAGS='${MSAN_AND_LIBCXX_FLAGS}'"
 export USE_MEMORY_SANITIZER="true"
 export RUN_FUNCTIONAL_TESTS="false"
-export CCACHE_SIZE=250M
+export CCACHE_SIZE=400M


### PR DESCRIPTION
Changes that are not affecting binaries, e.g., #27070 or #27072, are expected to show up to 100% `ccache` hit rate. But that is not the case:
- https://cirrus-ci.com/build/4720733276864512
- https://cirrus-ci.com/build/5915469295648768

Zero hit rate in the "macOS 10.15" is well [known](https://github.com/bitcoin/bitcoin/issues/21552). But a [fix](https://github.com/bitcoin/bitcoin/pull/24620) was [considered](https://github.com/bitcoin/bitcoin/pull/24620#issuecomment-1100850691) not "a good change" and closed.

For another task with nearly-zero hit rate--"ARM64 Android APK"--a fix suggested in https://github.com/bitcoin/bitcoin/pull/27077.

Here are cache hit rates for other problematic tasks:
- "previous releases": 33.47 % and 40.68 %
- "TSan": 77.94 % and 81.07 %
- "MSan": 47.24 % and 49.29 %
- "ASan + LSan + UBSan + integer": 54.96 % and 59.79 %
- "multiprocess": 12.05 % and 15.16 %
- "macOS 13 native": 65.87 % and 67.86 %

In my experiments, making a `ccache_cache` folder task-specific did not help.

Apparently, the problem is related to https://github.com/cirruslabs/cirrus-ci-docs/pull/896.

This PR fixes the issue. Also `CCACHE_SIZE` values have been adjusted for some tasks to avoid cache misses due to "cleanups performed".