### PR TITLE
ci: A few fixes of `ccache` issues

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,6 +7,7 @@ env:  # Global defaults
   CCACHE_SIZE: "200M"
   CCACHE_DIR: "/tmp/ccache_dir"
   CCACHE_NOHASHDIR: "1"  # Debug info might contain a stale path if the build dir changes, but this is fine
+  CCACHE_COMPILERCHECK: "content"  # Hash the content of the compiler binary rather than its mtime and size
 
 cirrus_ephemeral_worker_template_env: &CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
   DANGER_RUN_CI_ON_HOST: "1"  # Containers will be discarded after the run, so there is no risk that the ci scripts modify the system

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -36,6 +36,8 @@ main_template: &MAIN_TEMPLATE
   timeout_in: 120m  # https://cirrus-ci.org/faq/#instance-timed-out
   ccache_cache:
     folder: "/tmp/ccache_dir"
+    fingerprint_script: echo ${CIRRUS_TASK_NAME}
+    reupload_on_changes: true
   ci_script:
     - ./ci/test_run_all.sh
 

--- a/ci/test/00_setup_env_i686_multiprocess.sh
+++ b/ci/test/00_setup_env_i686_multiprocess.sh
@@ -15,3 +15,4 @@ export GOAL="install"
 export BITCOIN_CONFIG="--enable-debug CC='clang -m32' CXX='clang++ -m32' LDFLAGS='--rtlib=compiler-rt -lgcc_s'"
 export TEST_RUNNER_ENV="BITCOIND=bitcoin-node"
 export TEST_RUNNER_EXTRA="--nosandbox"
+export CCACHE_SIZE=400M

--- a/ci/test/00_setup_env_mac_native_arm64.sh
+++ b/ci/test/00_setup_env_mac_native_arm64.sh
@@ -13,4 +13,4 @@ export BITCOIN_CONFIG="--with-gui --with-miniupnpc --with-natpmp --enable-reduce
 export CI_OS_NAME="macos"
 export NO_DEPENDS=1
 export OSX_SDK=""
-export CCACHE_SIZE=300M
+export CCACHE_SIZE=400M

--- a/ci/test/00_setup_env_native_asan.sh
+++ b/ci/test/00_setup_env_native_asan.sh
@@ -24,3 +24,4 @@ export CI_IMAGE_NAME_TAG=ubuntu:22.04
 export NO_DEPENDS=1
 export GOAL="install"
 export BITCOIN_CONFIG="--enable-c++20 --enable-usdt --enable-zmq --with-incompatible-bdb --with-gui=qt5 CPPFLAGS='-DARENA_DEBUG -DDEBUG_LOCKORDER' --with-sanitizers=address,integer,undefined CC=clang CXX=clang++"
+export CCACHE_SIZE=300M

--- a/ci/test/00_setup_env_native_msan.sh
+++ b/ci/test/00_setup_env_native_msan.sh
@@ -20,4 +20,4 @@ export GOAL="install"
 export BITCOIN_CONFIG="--with-sanitizers=memory --disable-hardening --with-asm=no CC=clang CXX=clang++ CFLAGS='${MSAN_FLAGS}' CXXFLAGS='${MSAN_AND_LIBCXX_FLAGS}'"
 export USE_MEMORY_SANITIZER="true"
 export RUN_FUNCTIONAL_TESTS="false"
-export CCACHE_SIZE=250M
+export CCACHE_SIZE=400M


### PR DESCRIPTION
Combined https://github.com/bitcoin/bitcoin/pull/27077 and https://github.com/bitcoin/bitcoin/pull/27083 for the sake of more representative testing.

The [second](https://cirrus-ci.com/build/5852404411793408) run looks promising:
- ["MSan"](https://cirrus-ci.com/task/4583485717872640) task -- 98.74 %
- ["ASan + LSan + UBSan + integer"](https://cirrus-ci.com/task/5146435671293952) task -- 100.0 %
- ["multiprocess"](https://cirrus-ci.com/task/4864960694583296) task -- 99.35 %
- ["macOS 13 native"](https://cirrus-ci.com/task/6342704322314240) task -- 100.0%
- ["Android APK"](https://cirrus-ci.com/task/6272335578136576) task -- 100.0%

Although, the ["previous releases"](https://cirrus-ci.com/task/4935329438760960) task has a 66.10 % cache hit rate. It needs more investigation (not in this PR).