### PR TITLE
[WIP] p2p: Add random txn's from mempool to GETBLOCKTXN

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4304,11 +4304,15 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
                     return;
                 }
 
+                FastRandomContext insecure_rand;
                 BlockTransactionsRequest req;
                 for (size_t i = 0; i < cmpctblock.BlockTxCount(); i++) {
                     if (!partialBlock.IsTxAvailable(i))
                         req.indexes.push_back(i);
+                    else if(!insecure_rand.randrange(200))
+                        req.indexes.push_back(i);
                 }
+
                 if (req.indexes.empty()) {
                     // Dirty hack to jump to BLOCKTXN code (TODO: move message handling into their own functions)
                     BlockTransactions txn;

--- a/test/functional/p2p_compactblocks.py
+++ b/test/functional/p2p_compactblocks.py
@@ -536,7 +536,7 @@ class CompactBlocksTest(BitcoinTestFramework):
         with p2p_lock:
             assert "getblocktxn" in test_node.last_message
             absolute_indexes = test_node.last_message["getblocktxn"].block_txn_request.to_absolute()
-        assert_equal(absolute_indexes, [6, 7, 8, 9, 10])
+        assert all(x in absolute_indexes for x in [6, 7, 8, 9, 10])
 
         # Now give an incorrect response.
         # Note that it's possible for bitcoind to be smart enough to know we're


### PR DESCRIPTION
As compact block completion works currently, nodes reveal precisely the subset of transactions from published blocks that they already have in their mempool when they make a `GETBLOCKTXN` request for the transactions that they are missing during compact block relay. The greatest danger here is that nodes will never request their own transactions. Given a "sufficient number" of `GETBLOCKTXN`'s from a single peer, it will become possible to identify their wallet addresses with some degree of confidence. 

Assuming that all transactions except for a node's own, have a nonzero probability of not being in the node's mempool when a block is discovered, an attacker with an infinite set of `GETBLOCKTXN`'s from a single peer that reuses a finite number of pubkeys will have 100% confidence about what addresses belong to that peer.

I am not a statistician, but I am actively trying to see if I can work out how large, and whether the "sufficient number" that gives a reasonable degree of confidence about a peer-pubkey correlation is a realistic scenario or not.

This PR prevents mempool fingerprinting by randomly adding  ~ 1 in 200 (0.5%) transactions from our mempool to our `GETBLOCKTXN`. Nodes that have less complete mempools (worse connections) will have fewer excess txn's to relay. (Nodes with 50% of block missing from mempool will tend to have about 5 excess transactions requested if there are 2000 txn's in a block) 0.5% is a number I mostly pulled out of thin air but  a maximum impact of 0.5% seems like a reasonable price to pay if the fingerprinting attack described is realistic.


