### PR TITLE
ci: Use dedicated root path for ci

### DIFF
--- a/ci/test/00_setup_env.sh
+++ b/ci/test/00_setup_env.sh
@@ -10,12 +10,20 @@ export LC_ALL=C.UTF-8
 # The ci system copies this folder.
 BASE_ROOT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../../ >/dev/null 2>&1 && pwd )
 export BASE_ROOT_DIR
+# The destination root dir.
+if [ -z "${DANGER_RUN_CI_ON_HOST}" ] ; then
+  # This folder only exists on the ci host and will be a copy of BASE_ROOT_DIR
+  export CI_ROOT_DIR="/ci_root"
+else
+  # This folder is equal to BASE_ROOT_DIR and is read-write
+  export CI_ROOT_DIR="${BASE_ROOT_DIR}"
+fi
 # The depends dir.
 # This folder exists only on the ci guest, and on the ci host as a volume.
-export DEPENDS_DIR=${DEPENDS_DIR:-$BASE_ROOT_DIR/depends}
+export DEPENDS_DIR="${CI_ROOT_DIR}/depends"
 # A folder for the ci system to put temporary files (ccache, datadirs for tests, ...)
 # This folder only exists on the ci host.
-export BASE_SCRATCH_DIR=${BASE_SCRATCH_DIR:-$BASE_ROOT_DIR/ci/scratch}
+export BASE_SCRATCH_DIR="${CI_ROOT_DIR}/ci/scratch"
 
 echo "Setting specific values in env"
 if [ -n "${FILE_ENV}" ]; then
@@ -65,7 +73,7 @@ export BASE_OUTDIR=${BASE_OUTDIR:-$BASE_SCRATCH_DIR/out/$HOST}
 export BASE_BUILD_DIR=${BASE_BUILD_DIR:-$BASE_SCRATCH_DIR/build}
 # The folder for previous release binaries.
 # This folder exists only on the ci guest, and on the ci host as a volume.
-export PREVIOUS_RELEASES_DIR=${PREVIOUS_RELEASES_DIR:-$BASE_ROOT_DIR/releases/$HOST}
+export PREVIOUS_RELEASES_DIR="${CI_ROOT_DIR}/ci_prev_releases"
 export SDK_URL=${SDK_URL:-https://bitcoincore.org/depends-sources/sdks}
 export CI_BASE_PACKAGES=${CI_BASE_PACKAGES:-build-essential libtool autotools-dev automake pkg-config bsdmainutils curl ca-certificates ccache python3 rsync git procps bison}
 export GOAL=${GOAL:-install}

--- a/ci/test/06_script_a.sh
+++ b/ci/test/06_script_a.sh
@@ -37,7 +37,7 @@ fi
 CI_EXEC mkdir -p "${BASE_BUILD_DIR}"
 export P_CI_DIR="${BASE_BUILD_DIR}"
 
-CI_EXEC "${BASE_ROOT_DIR}/configure" --cache-file=config.cache "$BITCOIN_CONFIG_ALL" "$BITCOIN_CONFIG" || ( (CI_EXEC cat config.log) && false)
+CI_EXEC "${CI_ROOT_DIR}/configure" --cache-file=config.cache "$BITCOIN_CONFIG_ALL" "$BITCOIN_CONFIG" || ( (CI_EXEC cat config.log) && false)
 
 CI_EXEC make distdir VERSION="$HOST"
 

--- a/ci/test/06_script_b.sh
+++ b/ci/test/06_script_b.sh
@@ -10,18 +10,18 @@ if [[ $HOST = *-mingw32 ]]; then
   # Generate all binaries, so that they can be wrapped
   CI_EXEC make "$MAKEJOBS" -C src/secp256k1 VERBOSE=1
   CI_EXEC make "$MAKEJOBS" -C src minisketch/test.exe VERBOSE=1
-  CI_EXEC "${BASE_ROOT_DIR}/ci/test/wrap-wine.sh"
+  CI_EXEC "${CI_ROOT_DIR}/ci/test/wrap-wine.sh"
 fi
 
 if [ -n "$QEMU_USER_CMD" ]; then
   # Generate all binaries, so that they can be wrapped
   CI_EXEC make "$MAKEJOBS" -C src/secp256k1 VERBOSE=1
   CI_EXEC make "$MAKEJOBS" -C src minisketch/test VERBOSE=1
-  CI_EXEC "${BASE_ROOT_DIR}/ci/test/wrap-qemu.sh"
+  CI_EXEC "${CI_ROOT_DIR}/ci/test/wrap-qemu.sh"
 fi
 
 if [ -n "$USE_VALGRIND" ]; then
-  CI_EXEC "${BASE_ROOT_DIR}/ci/test/wrap-valgrind.sh"
+  CI_EXEC "${CI_ROOT_DIR}/ci/test/wrap-valgrind.sh"
 fi
 
 if [ "$RUN_UNIT_TESTS" = "true" ]; then
@@ -79,7 +79,7 @@ if [ "${RUN_TIDY}" = "true" ]; then
           " -p . ${MAKEJOBS}"\
           " -- -Xiwyu --cxx17ns -Xiwyu --mapping_file=${BASE_BUILD_DIR}/bitcoin-$HOST/contrib/devtools/iwyu/bitcoin.core.imp"\
           " |& tee /tmp/iwyu_ci.out"
-  export P_CI_DIR="${BASE_ROOT_DIR}/src"
+  export P_CI_DIR="${CI_ROOT_DIR}/src"
   CI_EXEC "python3 ${DIR_IWYU}/include-what-you-use/fix_includes.py --nosafe_headers < /tmp/iwyu_ci.out"
   CI_EXEC "git --no-pager diff"
 fi

--- a/ci/test/wrap-qemu.sh
+++ b/ci/test/wrap-qemu.sh
@@ -8,7 +8,7 @@ export LC_ALL=C.UTF-8
 
 for b_name in {"${BASE_OUTDIR}/bin"/*,src/secp256k1/*tests,src/minisketch/test{,-verify},src/univalue/{test_json,unitester,object}}; do
     # shellcheck disable=SC2044
-    for b in $(find "${BASE_ROOT_DIR}" -executable -type f -name "$(basename "$b_name")"); do
+    for b in $(find "${CI_ROOT_DIR}" -executable -type f -name "$(basename "$b_name")"); do
       echo "Wrap $b ..."
       mv "$b" "${b}_orig"
       echo '#!/usr/bin/env bash' > "$b"

--- a/ci/test/wrap-valgrind.sh
+++ b/ci/test/wrap-valgrind.sh
@@ -8,11 +8,11 @@ export LC_ALL=C.UTF-8
 
 for b_name in "${BASE_OUTDIR}/bin"/*; do
     # shellcheck disable=SC2044
-    for b in $(find "${BASE_ROOT_DIR}" -executable -type f -name "$(basename "$b_name")"); do
+    for b in $(find "${CI_ROOT_DIR}" -executable -type f -name "$(basename "$b_name")"); do
       echo "Wrap $b ..."
       mv "$b" "${b}_orig"
       echo '#!/usr/bin/env bash' > "$b"
-      echo "valgrind --gen-suppressions=all --quiet --error-exitcode=1 --suppressions=${BASE_ROOT_DIR}/contrib/valgrind.supp \"${b}_orig\" \"\$@\"" >> "$b"
+      echo "valgrind --gen-suppressions=all --quiet --error-exitcode=1 --suppressions=${CI_ROOT_DIR}/contrib/valgrind.supp \"${b}_orig\" \"\$@\"" >> "$b"
       chmod +x "$b"
     done
 done

--- a/ci/test/wrap-wine.sh
+++ b/ci/test/wrap-wine.sh
@@ -8,7 +8,7 @@ export LC_ALL=C.UTF-8
 
 for b_name in {"${BASE_OUTDIR}/bin"/*,src/secp256k1/*tests,src/minisketch/test{,-verify},src/univalue/{test_json,unitester,object}}.exe; do
     # shellcheck disable=SC2044
-    for b in $(find "${BASE_ROOT_DIR}" -executable -type f -name "$(basename "$b_name")"); do
+    for b in $(find "${CI_ROOT_DIR}" -executable -type f -name "$(basename "$b_name")"); do
       if (file "$b" | grep "Windows"); then
         echo "Wrap $b ..."
         mv "$b" "${b}_orig"


### PR DESCRIPTION
Now that stuff (like depends) is no longer propagated back to the host
folder after commit 141115a0604001b8cce848804798dc174770a994, commit
85892f77c98c7a08834a06d52af3eb474275afd8 can be reverted and
`LOCAL_USER` removed.

So do that. Also for clarity, in the same commit, use a dedicated path
for the ci root folder `CI_ROOT_DIR`.