### PR TITLE
test: Fix intermittent sync issue in wallet_pruning

### DIFF
--- a/test/functional/wallet_pruning.py
+++ b/test/functional/wallet_pruning.py
@@ -123,7 +123,7 @@ class WalletPruningTest(BitcoinTestFramework):
 
         # A blk*.dat file is 128MB
         # Generate 250 light blocks
-        self.generate(self.nodes[0], 250, sync_fun=self.no_op)
+        self.generate(self.nodes[0], 250)
         # Generate 50MB worth of large blocks in the blk00000.dat file
         self.mine_large_blocks(self.nodes[0], 50)
 


### PR DESCRIPTION
The `sync_fun=self.no_op` has no motivation or rationale, and seems to be causing issues.

Fix that by removing it.

Actually fixes https://github.com/bitcoin/bitcoin/issues/27065, see https://github.com/bitcoin/bitcoin/pull/27066#issuecomment-1428249997