### PR TITLE
script: remove unused bitwise `CScriptNum` operators

### DIFF
--- a/src/script/script.h
+++ b/src/script/script.h
@@ -288,9 +288,6 @@ public:
     inline CScriptNum& operator-=( const CScriptNum& rhs)       { return operator-=(rhs.m_value);  }
 
     inline CScriptNum operator&(   const int64_t& rhs)    const { return CScriptNum(m_value & rhs);}
-    inline CScriptNum operator&(   const CScriptNum& rhs) const { return operator&(rhs.m_value);   }
-
-    inline CScriptNum& operator&=( const CScriptNum& rhs)       { return operator&=(rhs.m_value);  }
 
     inline CScriptNum operator-()                         const
     {
@@ -317,12 +314,6 @@ public:
         assert(rhs == 0 || (rhs > 0 && m_value >= std::numeric_limits<int64_t>::min() + rhs) ||
                            (rhs < 0 && m_value <= std::numeric_limits<int64_t>::max() + rhs));
         m_value -= rhs;
-        return *this;
-    }
-
-    inline CScriptNum& operator&=( const int64_t& rhs)
-    {
-        m_value &= rhs;
         return *this;
     }
 

--- a/src/test/fuzz/scriptnum_ops.cpp
+++ b/src/test/fuzz/scriptnum_ops.cpp
@@ -85,12 +85,6 @@ FUZZ_TARGET(scriptnum_ops)
                 script_num = script_num & fuzzed_data_provider.ConsumeIntegral<int64_t>();
             },
             [&] {
-                script_num = script_num & ConsumeScriptNum(fuzzed_data_provider);
-            },
-            [&] {
-                script_num &= ConsumeScriptNum(fuzzed_data_provider);
-            },
-            [&] {
                 if (script_num == CScriptNum{std::numeric_limits<int64_t>::min()}) {
                     // Avoid assertion failure:
                     // ./script/script.h:279: CScriptNum CScriptNum::operator-() const: Assertion `m_value != std::numeric_limits<int64_t>::min()' failed.
@@ -118,9 +112,6 @@ FUZZ_TARGET(scriptnum_ops)
                     return;
                 }
                 script_num -= random_integer;
-            },
-            [&] {
-                script_num &= fuzzed_data_provider.ConsumeIntegral<int64_t>();
             });
         (void)script_num.getint();
         (void)script_num.getvch();


### PR DESCRIPTION
These overloaded operators were introduced almost seven years ago in the implementation of OP_CHECKSEQUENCEVERIFY (BIP112, PR #7524, commit 53e53a33c939949665f60d5eeb82abbb21f97128), but have never been used since outside of fuzzing. One could argue to keep those around solely for consistency reasons, but I think its preferable to get rid of methods that are likely never used. Even the so-far only use of the & operator (checking the OP_CSV argument for the SEQUENCE_LOCKTIME_DISABLE_FLAG), could be removed by simply doing the check on the returned `GetInt64()`, but fiddling in the consensus code is probably not worth it.