### PR TITLE
refactor: don't avoid sys/types.h when building for Windows

### DIFF
--- a/src/randomenv.cpp
+++ b/src/randomenv.cpp
@@ -24,11 +24,12 @@
 #include <thread>
 #include <vector>
 
+#include <sys/types.h> // must go before a number of other headers
+
 #ifdef WIN32
 #include <windows.h>
 #include <winreg.h>
 #else
-#include <sys/types.h> // must go before a number of other headers
 #include <fcntl.h>
 #include <netinet/in.h>
 #include <sys/resource.h>

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -35,9 +35,11 @@
 #include <univalue.h>
 #include <utility>
 #include <vector>
+
+#include <sys/types.h>
+
 #ifndef WIN32
 #include <signal.h>
-#include <sys/types.h>
 #include <sys/wait.h>
 #endif
 


### PR DESCRIPTION
We've already used it unguarded in `httpserver.cpp` for years, with no build issues.

Doesn't touch the usage in wallet/bdb.cpp. See #26832.