### PR TITLE
net: remove orphaned CSubNet::SanityCheck()

### DIFF
--- a/src/blockencodings.h
+++ b/src/blockencodings.h
@@ -135,7 +135,7 @@ protected:
 public:
     CBlockHeader header;
 
-    // Can be overriden for testing
+    // Can be overridden for testing
     using CheckBlockFn = std::function<bool(const CBlock&, BlockValidationState&, const Consensus::Params&, bool, bool)>;
     CheckBlockFn m_check_block_mock{nullptr};
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1671,7 +1671,7 @@ void CConnman::ThreadOpenConnections(const std::vector<std::string> connect)
                 // Therefore, we do not add them to addrman in the first place.
                 // In case previously unreachable networks become reachable
                 // (e.g. in case of -onlynet changes by the user), fixed seeds will
-                // be loaded only for networks for which we have no addressses.
+                // be loaded only for networks for which we have no addresses.
                 seed_addrs.erase(std::remove_if(seed_addrs.begin(), seed_addrs.end(),
                                                 [&fixed_seed_networks](const CAddress& addr) { return fixed_seed_networks.count(addr.GetNetwork()) == 0; }),
                                  seed_addrs.end());

--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -1106,29 +1106,6 @@ bool CSubNet::IsValid() const
     return valid;
 }
 
-bool CSubNet::SanityCheck() const
-{
-    switch (network.m_net) {
-    case NET_IPV4:
-    case NET_IPV6:
-        break;
-    case NET_ONION:
-    case NET_I2P:
-    case NET_CJDNS:
-        return true;
-    case NET_INTERNAL:
-    case NET_UNROUTABLE:
-    case NET_MAX:
-        return false;
-    }
-
-    for (size_t x = 0; x < network.m_addr.size(); ++x) {
-        if (network.m_addr[x] & ~netmask[x]) return false;
-    }
-
-    return true;
-}
-
 bool operator==(const CSubNet& a, const CSubNet& b)
 {
     return a.valid == b.valid && a.network == b.network && !memcmp(a.netmask, b.netmask, 16);

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -476,8 +476,6 @@ protected:
     /// Is this value valid? (only used to signal parse errors)
     bool valid;
 
-    bool SanityCheck() const;
-
 public:
     /**
      * Construct an invalid subnet (empty, `Match()` always returns false).

--- a/test/lint/lint-locale-dependence.py
+++ b/test/lint/lint-locale-dependence.py
@@ -34,8 +34,6 @@
 #
 # See https://doc.qt.io/qt-5/qcoreapplication.html#locale-settings and
 # https://stackoverflow.com/a/34878283 for more details.
-#
-# TODO: Reduce KNOWN_VIOLATIONS by replacing uses of locale dependent snprintf with strprintf.
 
 import re
 import sys


### PR DESCRIPTION
`CSubNet::SanityCheck()` was added in #20140, and not removed in #22570 when it became orphaned code.

Also, remove an out-of-date `snprintf` TODO that was resolved in #27036, and fix up 2 words to make the spelling linter green again.
