### PR TITLE
doc: clarify that LOCK() internally checks whether the mutex is held

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -941,7 +941,9 @@ Threads and synchronization
     internal to a class (private or protected) rather than public.
 
   - Combine annotations in function declarations with run-time asserts in
-    function definitions:
+    function definitions (`AssertLockNotHeld()` can be omitted if `LOCK()` is
+    called unconditionally after it because `LOCK()` does the same check as
+    `AssertLockNotHeld()` internally, for non-recursive mutexes):
 
 ```C++
 // txmempool.h

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -246,7 +246,7 @@ void LeaveCritical()
     pop_lock();
 }
 
-std::string LocksHeld()
+static std::string LocksHeld()
 {
     LockData& lockdata = GetLockData();
     std::lock_guard<std::mutex> lock(lockdata.dd_mutex);

--- a/src/sync.h
+++ b/src/sync.h
@@ -57,7 +57,6 @@ template <typename MutexType>
 void EnterCritical(const char* pszName, const char* pszFile, int nLine, MutexType* cs, bool fTry = false);
 void LeaveCritical();
 void CheckLastCritical(void* cs, std::string& lockname, const char* guardname, const char* file, int line);
-std::string LocksHeld();
 template <typename MutexType>
 void AssertLockHeldInternal(const char* pszName, const char* pszFile, int nLine, MutexType* cs) EXCLUSIVE_LOCKS_REQUIRED(cs);
 template <typename MutexType>


### PR DESCRIPTION
Constructs like

```cpp
AssertLockNotHeld(m);
LOCK(m);
```

are equivalent to (almost, modulo some logging differences, see below)

```cpp
LOCK(m);
```

for non-recursive mutexes, so it is ok to omit `AssertLockNotHeld()` in such cases. Requests to do the former keep coming during review process. `developer-notes.md` explicitly states "Combine annotations in function declarations with run-time asserts in function definitions", but that seems to be too strong or unclear. `LOCK()` is also a run-time assert in this case.

Also remove `LocksHeld()` from the public interface in `sync.h` since it is only used in `sync.cpp`.