### PR TITLE
fuzz: avoid redundant dup key checks when creating Miniscript nodes

### DIFF
--- a/src/test/fuzz/miniscript.cpp
+++ b/src/test/fuzz/miniscript.cpp
@@ -253,7 +253,9 @@ using Type = miniscript::Type;
 using miniscript::operator"" _mst;
 
 //! Construct a miniscript node as a shared_ptr.
-template<typename... Args> NodeRef MakeNodeRef(Args&&... args) { return miniscript::MakeNodeRef<CPubKey>(KEY_COMP, std::forward<Args>(args)...); }
+template<typename... Args> NodeRef MakeNodeRef(Args&&... args) {
+    return miniscript::MakeNodeRef<CPubKey>(miniscript::internal::NoDupCheck{}, std::forward<Args>(args)...);
+}
 
 /** Information about a yet to be constructed Miniscript node. */
 struct NodeInfo {
@@ -762,6 +764,7 @@ NodeRef GenNode(F ConsumeNode, Type root_type = ""_mst, bool strict_valid = fals
         }
     }
     assert(stack.size() == 1);
+    stack[0]->DuplicateKeyCheck(KEY_COMP);
     return std::move(stack[0]);
 }
 


### PR DESCRIPTION
I thought i had done that already in #24149, but it must have slipped through the rebase. It's a 2x speed improvement against the existing corpora and will probably be much more as we extend them with larger nodes.