### PR TITLE
refactor: replace all implicit C-style const/const+reinterpret with explicit casts

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -604,7 +604,7 @@ CService HTTPRequest::GetPeer() const
 #ifdef HAVE_EVHTTP_CONNECTION_GET_PEER_CONST_CHAR
         evhttp_connection_get_peer(con, &address, &port);
 #else
-        evhttp_connection_get_peer(con, (char**)&address, &port);
+        evhttp_connection_get_peer(con, const_cast<char**>(reinterpret_cast<const char**>(&address)), &port);
 #endif // HAVE_EVHTTP_CONNECTION_GET_PEER_CONST_CHAR
 
         peer = LookupNumeric(address, port);

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -191,7 +191,7 @@ CPubKey CKey::GetPubKey() const {
     CPubKey result;
     int ret = secp256k1_ec_pubkey_create(secp256k1_context_sign, &pubkey, begin());
     assert(ret);
-    secp256k1_ec_pubkey_serialize(secp256k1_context_sign, (unsigned char*)result.begin(), &clen, &pubkey, fCompressed ? SECP256K1_EC_COMPRESSED : SECP256K1_EC_UNCOMPRESSED);
+    secp256k1_ec_pubkey_serialize(secp256k1_context_sign, const_cast<unsigned char*>(result.begin()), &clen, &pubkey, fCompressed ? SECP256K1_EC_COMPRESSED : SECP256K1_EC_UNCOMPRESSED);
     assert(result.size() == clen);
     assert(result.IsValid());
     return result;
@@ -300,7 +300,7 @@ bool CKey::SignSchnorr(const uint256& hash, Span<unsigned char> sig, const uint2
 }
 
 bool CKey::Load(const CPrivKey &seckey, const CPubKey &vchPubKey, bool fSkipCheck=false) {
-    if (!ec_seckey_import_der(secp256k1_context_sign, (unsigned char*)begin(), seckey.data(), seckey.size()))
+    if (!ec_seckey_import_der(secp256k1_context_sign, const_cast<unsigned char*>(begin()), seckey.data(), seckey.size()))
         return false;
     fCompressed = vchPubKey.IsCompressed();
     fValid = true;
@@ -324,8 +324,8 @@ bool CKey::Derive(CKey& keyChild, ChainCode &ccChild, unsigned int nChild, const
         BIP32Hash(cc, nChild, 0, begin(), vout.data());
     }
     memcpy(ccChild.begin(), vout.data()+32, 32);
-    memcpy((unsigned char*)keyChild.begin(), begin(), 32);
-    bool ret = secp256k1_ec_seckey_tweak_add(secp256k1_context_sign, (unsigned char*)keyChild.begin(), vout.data());
+    memcpy(const_cast<unsigned char*>(keyChild.begin()), begin(), 32);
+    bool ret = secp256k1_ec_seckey_tweak_add(secp256k1_context_sign, const_cast<unsigned char*>(keyChild.begin()), vout.data());
     keyChild.fCompressed = true;
     keyChild.fValid = ret;
     return ret;

--- a/src/test/argsman_tests.cpp
+++ b/src/test/argsman_tests.cpp
@@ -111,7 +111,7 @@ public:
         test.SetupArgs({{"-value", flags}});
         const char* argv[] = {"ignored", arg};
         std::string error;
-        bool success = test.ParseParameters(arg ? 2 : 1, (char**)argv, error);
+        bool success = test.ParseParameters(arg ? 2 : 1, const_cast<char**>(argv), error);
 
         BOOST_CHECK_EQUAL(test.GetSetting("-value").write(), expect.setting.write());
         auto settings_list = test.GetSettingsList("-value");
@@ -216,13 +216,13 @@ BOOST_AUTO_TEST_CASE(util_ParseParameters)
     std::string error;
     LOCK(testArgs.cs_args);
     testArgs.SetupArgs({a, b, ccc, d});
-    BOOST_CHECK(testArgs.ParseParameters(0, (char**)argv_test, error));
+    BOOST_CHECK(testArgs.ParseParameters(0, const_cast<char**>(argv_test), error));
     BOOST_CHECK(testArgs.m_settings.command_line_options.empty() && testArgs.m_settings.ro_config.empty());
 
-    BOOST_CHECK(testArgs.ParseParameters(1, (char**)argv_test, error));
+    BOOST_CHECK(testArgs.ParseParameters(1, const_cast<char**>(argv_test), error));
     BOOST_CHECK(testArgs.m_settings.command_line_options.empty() && testArgs.m_settings.ro_config.empty());
 
-    BOOST_CHECK(testArgs.ParseParameters(7, (char**)argv_test, error));
+    BOOST_CHECK(testArgs.ParseParameters(7, const_cast<char**>(argv_test), error));
     // expectation: -ignored is ignored (program name argument),
     // -a, -b and -ccc end up in map, -d ignored because it is after
     // a non-option argument (non-GNU option parsing)
@@ -247,17 +247,17 @@ BOOST_AUTO_TEST_CASE(util_ParseInvalidParameters)
 
     const char* argv[] = {"ignored", "-registered"};
     std::string error;
-    BOOST_CHECK(test.ParseParameters(2, (char**)argv, error));
+    BOOST_CHECK(test.ParseParameters(2, const_cast<char**>(argv), error));
     BOOST_CHECK_EQUAL(error, "");
 
     argv[1] = "-unregistered";
-    BOOST_CHECK(!test.ParseParameters(2, (char**)argv, error));
+    BOOST_CHECK(!test.ParseParameters(2, const_cast<char**>(argv), error));
     BOOST_CHECK_EQUAL(error, "Invalid parameter -unregistered");
 
     // Make sure registered parameters prefixed with a chain name trigger errors.
     // (Previously, they were accepted and ignored.)
     argv[1] = "-test.registered";
-    BOOST_CHECK(!test.ParseParameters(2, (char**)argv, error));
+    BOOST_CHECK(!test.ParseParameters(2, const_cast<char**>(argv), error));
     BOOST_CHECK_EQUAL(error, "Invalid parameter -test.registered");
 }
 
@@ -268,7 +268,7 @@ static void TestParse(const std::string& str, bool expected_bool, int64_t expect
     std::string arg = "-value=" + str;
     const char* argv[] = {"ignored", arg.c_str()};
     std::string error;
-    BOOST_CHECK(test.ParseParameters(2, (char**)argv, error));
+    BOOST_CHECK(test.ParseParameters(2, const_cast<char**>(argv), error));
     BOOST_CHECK_EQUAL(test.GetBoolArg("-value", false), expected_bool);
     BOOST_CHECK_EQUAL(test.GetBoolArg("-value", true), expected_bool);
     BOOST_CHECK_EQUAL(test.GetIntArg("-value", 99998), expected_int);
@@ -330,7 +330,7 @@ BOOST_AUTO_TEST_CASE(util_GetBoolArg)
     std::string error;
     LOCK(testArgs.cs_args);
     testArgs.SetupArgs({a, b, c, d, e, f});
-    BOOST_CHECK(testArgs.ParseParameters(7, (char**)argv_test, error));
+    BOOST_CHECK(testArgs.ParseParameters(7, const_cast<char**>(argv_test), error));
 
     // Each letter should be set.
     for (const char opt : "abcdef")
@@ -367,7 +367,7 @@ BOOST_AUTO_TEST_CASE(util_GetBoolArgEdgeCases)
     const char *argv_test[] = {"ignored", "-nofoo", "-foo", "-nobar=0"};
     testArgs.SetupArgs({foo, bar});
     std::string error;
-    BOOST_CHECK(testArgs.ParseParameters(4, (char**)argv_test, error));
+    BOOST_CHECK(testArgs.ParseParameters(4, const_cast<char**>(argv_test), error));
 
     // This was passed twice, second one overrides the negative setting.
     BOOST_CHECK(!testArgs.IsArgNegated("-foo"));
@@ -379,7 +379,7 @@ BOOST_AUTO_TEST_CASE(util_GetBoolArgEdgeCases)
 
     // Config test
     const char *conf_test = "nofoo=1\nfoo=1\nnobar=0\n";
-    BOOST_CHECK(testArgs.ParseParameters(1, (char**)argv_test, error));
+    BOOST_CHECK(testArgs.ParseParameters(1, const_cast<char**>(argv_test), error));
     testArgs.ReadConfigString(conf_test);
 
     // This was passed twice, second one overrides the negative setting,
@@ -394,7 +394,7 @@ BOOST_AUTO_TEST_CASE(util_GetBoolArgEdgeCases)
     // Combined test
     const char *combo_test_args[] = {"ignored", "-nofoo", "-bar"};
     const char *combo_test_conf = "foo=1\nnobar=1\n";
-    BOOST_CHECK(testArgs.ParseParameters(3, (char**)combo_test_args, error));
+    BOOST_CHECK(testArgs.ParseParameters(3, const_cast<char**>(combo_test_args), error));
     testArgs.ReadConfigString(combo_test_conf);
 
     // Command line overrides, but doesn't erase old setting
@@ -654,38 +654,38 @@ BOOST_AUTO_TEST_CASE(util_GetChainName)
     const char* testnetconf = "testnet=1\nregtest=0\n[test]\nregtest=1";
     std::string error;
 
-    BOOST_CHECK(test_args.ParseParameters(0, (char**)argv_testnet, error));
+    BOOST_CHECK(test_args.ParseParameters(0, const_cast<char**>(argv_testnet), error));
     BOOST_CHECK_EQUAL(test_args.GetChainName(), "main");
 
-    BOOST_CHECK(test_args.ParseParameters(2, (char**)argv_testnet, error));
+    BOOST_CHECK(test_args.ParseParameters(2, const_cast<char**>(argv_testnet), error));
     BOOST_CHECK_EQUAL(test_args.GetChainName(), "test");
 
-    BOOST_CHECK(test_args.ParseParameters(2, (char**)argv_regtest, error));
+    BOOST_CHECK(test_args.ParseParameters(2, const_cast<char**>(argv_regtest), error));
     BOOST_CHECK_EQUAL(test_args.GetChainName(), "regtest");
 
-    BOOST_CHECK(test_args.ParseParameters(3, (char**)argv_test_no_reg, error));
+    BOOST_CHECK(test_args.ParseParameters(3, const_cast<char**>(argv_test_no_reg), error));
     BOOST_CHECK_EQUAL(test_args.GetChainName(), "test");
 
-    BOOST_CHECK(test_args.ParseParameters(3, (char**)argv_both, error));
+    BOOST_CHECK(test_args.ParseParameters(3, const_cast<char**>(argv_both), error));
     BOOST_CHECK_THROW(test_args.GetChainName(), std::runtime_error);
 
-    BOOST_CHECK(test_args.ParseParameters(0, (char**)argv_testnet, error));
+    BOOST_CHECK(test_args.ParseParameters(0, const_cast<char**>(argv_testnet), error));
     test_args.ReadConfigString(testnetconf);
     BOOST_CHECK_EQUAL(test_args.GetChainName(), "test");
 
-    BOOST_CHECK(test_args.ParseParameters(2, (char**)argv_testnet, error));
+    BOOST_CHECK(test_args.ParseParameters(2, const_cast<char**>(argv_testnet), error));
     test_args.ReadConfigString(testnetconf);
     BOOST_CHECK_EQUAL(test_args.GetChainName(), "test");
 
-    BOOST_CHECK(test_args.ParseParameters(2, (char**)argv_regtest, error));
+    BOOST_CHECK(test_args.ParseParameters(2, const_cast<char**>(argv_regtest), error));
     test_args.ReadConfigString(testnetconf);
     BOOST_CHECK_THROW(test_args.GetChainName(), std::runtime_error);
 
-    BOOST_CHECK(test_args.ParseParameters(3, (char**)argv_test_no_reg, error));
+    BOOST_CHECK(test_args.ParseParameters(3, const_cast<char**>(argv_test_no_reg), error));
     test_args.ReadConfigString(testnetconf);
     BOOST_CHECK_EQUAL(test_args.GetChainName(), "test");
 
-    BOOST_CHECK(test_args.ParseParameters(3, (char**)argv_both, error));
+    BOOST_CHECK(test_args.ParseParameters(3, const_cast<char**>(argv_both), error));
     test_args.ReadConfigString(testnetconf);
     BOOST_CHECK_THROW(test_args.GetChainName(), std::runtime_error);
 
@@ -693,23 +693,23 @@ BOOST_AUTO_TEST_CASE(util_GetChainName)
     // [test] regtest=1 potentially relevant) doesn't break things
     test_args.SelectConfigNetwork("test");
 
-    BOOST_CHECK(test_args.ParseParameters(0, (char**)argv_testnet, error));
+    BOOST_CHECK(test_args.ParseParameters(0, const_cast<char**>(argv_testnet), error));
     test_args.ReadConfigString(testnetconf);
     BOOST_CHECK_EQUAL(test_args.GetChainName(), "test");
 
-    BOOST_CHECK(test_args.ParseParameters(2, (char**)argv_testnet, error));
+    BOOST_CHECK(test_args.ParseParameters(2, const_cast<char**>(argv_testnet), error));
     test_args.ReadConfigString(testnetconf);
     BOOST_CHECK_EQUAL(test_args.GetChainName(), "test");
 
-    BOOST_CHECK(test_args.ParseParameters(2, (char**)argv_regtest, error));
+    BOOST_CHECK(test_args.ParseParameters(2, const_cast<char**>(argv_regtest), error));
     test_args.ReadConfigString(testnetconf);
     BOOST_CHECK_THROW(test_args.GetChainName(), std::runtime_error);
 
-    BOOST_CHECK(test_args.ParseParameters(2, (char**)argv_test_no_reg, error));
+    BOOST_CHECK(test_args.ParseParameters(2, const_cast<char**>(argv_test_no_reg), error));
     test_args.ReadConfigString(testnetconf);
     BOOST_CHECK_EQUAL(test_args.GetChainName(), "test");
 
-    BOOST_CHECK(test_args.ParseParameters(3, (char**)argv_both, error));
+    BOOST_CHECK(test_args.ParseParameters(3, const_cast<char**>(argv_both), error));
     test_args.ReadConfigString(testnetconf);
     BOOST_CHECK_THROW(test_args.GetChainName(), std::runtime_error);
 }

--- a/src/wallet/crypter.cpp
+++ b/src/wallet/crypter.cpp
@@ -112,7 +112,7 @@ bool EncryptSecret(const CKeyingMaterial& vMasterKey, const CKeyingMaterial &vch
     memcpy(chIV.data(), &nIV, WALLET_CRYPTO_IV_SIZE);
     if(!cKeyCrypter.SetKey(vMasterKey, chIV))
         return false;
-    return cKeyCrypter.Encrypt(*((const CKeyingMaterial*)&vchPlaintext), vchCiphertext);
+    return cKeyCrypter.Encrypt(*(const_cast<CKeyingMaterial*>(&vchPlaintext)), vchCiphertext);
 }
 
 bool DecryptSecret(const CKeyingMaterial& vMasterKey, const std::vector<unsigned char>& vchCiphertext, const uint256& nIV, CKeyingMaterial& vchPlaintext)


### PR DESCRIPTION
This PR aims to replace all implicit C-style const (and const+reinterpret) casts with explicit casts to improve the code's readability and maintainability.

Implicit casts can cause subtle issues and can introduce undefined behavior. Explicit casting improves the code's readability and makes it easier to understand the intent of the code. Additionally, it makes it easier for developers to grep for these casts and do more substantial refactoring that may eliminate the need for casting altogether. By doing this change, it will be easier to maintain this code in the future.

Overall, these changes are straightforward and only involve replacing existing code with explicit casts. The changes improve the readability and maintainability of the codebase and do not introduce any new functionality.

Additionally, as this only replaces const_casts; there should be very few (if any) conflicts with other PRs.