### PR TITLE
rpc, test: remove newline escape sequence from wallet warning fields

### DIFF
--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -1926,7 +1926,7 @@ RPCHelpMan restorewallet()
 
     UniValue obj(UniValue::VOBJ);
     obj.pushKV("name", wallet->GetName());
-    obj.pushKV("warning", Join(warnings, Untranslated("\n")).original);
+    obj.pushKV("warning", Join(/*container=*/warnings, /*separator=*/Untranslated(" ")).original);
 
     return obj;
 

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -240,7 +240,7 @@ static RPCHelpMan loadwallet()
 
     UniValue obj(UniValue::VOBJ);
     obj.pushKV("name", wallet->GetName());
-    obj.pushKV("warning", Join(warnings, Untranslated("\n")).original);
+    obj.pushKV("warning", Join(/*container=*/warnings, /*separator=*/Untranslated(" ")).original);
 
     return obj;
 },
@@ -405,7 +405,7 @@ static RPCHelpMan createwallet()
 
     UniValue obj(UniValue::VOBJ);
     obj.pushKV("name", wallet->GetName());
-    obj.pushKV("warning", Join(warnings, Untranslated("\n")).original);
+    obj.pushKV("warning", Join(/*container=*/warnings, /*separator=*/Untranslated(" ")).original);
 
     return obj;
 },
@@ -464,7 +464,7 @@ static RPCHelpMan unloadwallet()
     UnloadWallet(std::move(wallet));
 
     UniValue result(UniValue::VOBJ);
-    result.pushKV("warning", Join(warnings, Untranslated("\n")).original);
+    result.pushKV("warning", Join(/*container=*/warnings, /*separator=*/Untranslated(" ")).original);
     return result;
 },
     };

--- a/test/functional/wallet_createwallet.py
+++ b/test/functional/wallet_createwallet.py
@@ -17,7 +17,7 @@ from test_framework.wallet_util import bytes_to_wif, generate_wif_key
 
 LEGACY_WALLET_MSG = "Wallet created successfully. The legacy wallet type is being deprecated and support for creating and opening legacy wallets will be removed in the future."
 EMPTY_PASSPHRASE_MSG = "Empty string given as passphrase, wallet will not be encrypted."
-EMPTY_PASSPHRASE_LEGACY_WALLET_MSG = f"{EMPTY_PASSPHRASE_MSG}\n{LEGACY_WALLET_MSG}"
+EMPTY_PASSPHRASE_LEGACY_WALLET_MSG = f"{EMPTY_PASSPHRASE_MSG} {LEGACY_WALLET_MSG}"
 
 
 class CreateWalletTest(BitcoinTestFramework):


### PR DESCRIPTION
This PR extends our test coverage to demonstrate the issue, then removes newline escape sequences printed in the wallet `warning` field in RPCs `createwallet`, `loadwallet`, `unloadwallet`, and `restorewallet`.

before

```
$ ./src/bitcoin-cli -signet createwallet w1 false false "" false false
{
  "name": "w1",
  "warning": "Empty string given as passphrase, wallet will not be encrypted.\nWallet created successfully. The legacy wallet type is being deprecated and support for creating and opening legacy wallets will be removed in the future."
}
```

after

```
$ ./src/bitcoin-cli -signet createwallet w2 false false "" false false
{
  "name": "w2",
  "warning": "Empty string given as passphrase, wallet will not be encrypted. Wallet created successfully. The legacy wallet type is being deprecated and support for creating and opening legacy wallets will be removed in the future."
}
```

Rationale:  Our RPC is returning newline presentation elements embedded in JSON string field responses. These are a client-side concern, not a server-side one.  If it is important for the RPC client to know how many warnings have been returned in order to display them on separate lines, then it may be a good idea after this to gradually replace the `warning` string field with a `warnings` JSON array of strings, as we do in several other RPCs.  I'm happy to do that in a follow-up, as it would be orthogonal to this change: first the `warnings` field would be added and the `warning` field deprecated, then after a release or so the latter could possibly be removed. In the meantime, this is a simple and focused fix.