### PR TITLE
kernel: add missing include

### DIFF
--- a/src/kernel/cs_main.cpp
+++ b/src/kernel/cs_main.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <kernel/cs_main.h>
 #include <sync.h>
 
 RecursiveMutex cs_main;


### PR DESCRIPTION
This syncs the cs_main definition/declaration.

Noticed when experimenting with the external visibility of `cs_main`.

Specifically, this is needed for the following to work as intended:
```c++
__attribute__ ((visibility ("default"))) extern RecursiveMutex cs_main;
```