### PR TITLE
util: Remove duplicate include

### DIFF
--- a/src/support/lockedpool.cpp
+++ b/src/support/lockedpool.cpp
@@ -26,7 +26,6 @@
 #include <iomanip>
 #include <iostream>
 #endif
-#include <utility>
 
 LockedPoolManager* LockedPoolManager::_instance = nullptr;
 


### PR DESCRIPTION
Duplicate `#include <utility>` is upsetting the linter.