### PR TITLE
guix: pass `--enable-initfini-array` to release GCC

### DIFF
--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -139,9 +139,11 @@ chain for " target " development."))
 ;; https://gcc.gnu.org/install/configure.html
 (define (hardened-gcc gcc)
   (package-with-extra-configure-variable (
-    package-with-extra-configure-variable gcc
-    "--enable-default-ssp" "yes")
-    "--enable-default-pie" "yes"))
+    package-with-extra-configure-variable (
+      package-with-extra-configure-variable gcc
+      "--enable-initfini-array" "yes")
+      "--enable-default-ssp" "yes")
+      "--enable-default-pie" "yes"))
 
 (define* (make-bitcoin-cross-toolchain target
                                        #:key


### PR DESCRIPTION
This returns us to pre-Guix behaviour, where the compilers we were using to build releases, were configured with this option.

> [--enable-initfini-array](https://gcc.gnu.org/install/configure.html)
> Force the use of sections .init_array and .fini_array (instead of .init and .fini) for constructors and destructors. Option --disable-initfini-array has the opposite effect. If neither option is specified, the configure script will try to guess whether the .init_array and .fini_array sections are supported and, if they are, use them.
