### PR TITLE
Make miniscript_{stable,smart} fuzzers avoid too large scripts

### DIFF
--- a/src/script/miniscript.h
+++ b/src/script/miniscript.h
@@ -1136,6 +1136,9 @@ public:
     //! Return the maximum number of ops needed to satisfy this script non-malleably.
     uint32_t GetOps() const { return ops.count + ops.sat.value; }
 
+    //! Return the number of ops in the script (not counting the dynamic ones that depend on execution).
+    uint32_t GetStaticOps() const { return ops.count; }
+
     //! Check the ops limit of this script against the consensus limit.
     bool CheckOpsLimit() const { return GetOps() <= MAX_OPS_PER_SCRIPT; }
 

--- a/src/test/fuzz/miniscript.cpp
+++ b/src/test/fuzz/miniscript.cpp
@@ -806,9 +806,12 @@ NodeRef GenNode(F ConsumeNode, Type root_type, bool strict_valid = false) {
                 node = MakeNodeRef(info.fragment, std::move(info.keys), info.k);
             }
             // Verify acceptability.
-            if (!node || !(node->GetType() << type_needed)) {
+            if (!node || (node->GetType() & "KVWB"_mst) == ""_mst) {
                 assert(!strict_valid);
                 return {};
+            }
+            if (!(type_needed == ""_mst)) {
+                assert(node->GetType() << type_needed);
             }
             if (!node->IsValid()) return {};
             // Move it to the stack.


### PR DESCRIPTION
This adds a number of improvements to the miniscript fuzzers that all amount to rejecting invalid or overly big miniscripts early on:
* Base type propagation in the miniscript_stable fuzzers prevents constructing a large portion of miniscripts that would be illegal, with just a little bit of type logic in the fuzzer. The fuzzer input format is unchanged.
* Ops and script size tracking in GenNode means that too-large scripts (either due to script size limit or ops limit) will be detected on the fly during fuzz input processing, before actually constructing the scripts.

Closes #27147.