### PR TITLE
Update translations for 25.0 soft translation string freeze

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,7 +1,7 @@
 [main]
 host = https://www.transifex.com
 
-[o:bitcoin:p:bitcoin:r:qt-translation-024x]
+[o:bitcoin:p:bitcoin:r:qt-translation-025x]
 file_filter = src/qt/locale/bitcoin_<lang>.xlf
 source_file = src/qt/locale/bitcoin_en.xlf
 source_lang = en

--- a/src/Makefile.qt_locale.include
+++ b/src/Makefile.qt_locale.include
@@ -31,6 +31,7 @@ QT_TS = \
   qt/locale/bitcoin_gl.ts \
   qt/locale/bitcoin_gl_ES.ts \
   qt/locale/bitcoin_gu.ts \
+  qt/locale/bitcoin_ha.ts \
   qt/locale/bitcoin_he.ts \
   qt/locale/bitcoin_hr.ts \
   qt/locale/bitcoin_hu.ts \
@@ -43,6 +44,7 @@ QT_TS = \
   qt/locale/bitcoin_kl.ts \
   qt/locale/bitcoin_km.ts \
   qt/locale/bitcoin_ko.ts \
+  qt/locale/bitcoin_ku.ts \
   qt/locale/bitcoin_ku_IQ.ts \
   qt/locale/bitcoin_ky.ts \
   qt/locale/bitcoin_la.ts \
@@ -58,6 +60,7 @@ QT_TS = \
   qt/locale/bitcoin_ne.ts \
   qt/locale/bitcoin_nl.ts \
   qt/locale/bitcoin_no.ts \
+  qt/locale/bitcoin_pa.ts \
   qt/locale/bitcoin_pam.ts \
   qt/locale/bitcoin_pl.ts \
   qt/locale/bitcoin_pt.ts \
@@ -78,10 +81,13 @@ QT_TS = \
   qt/locale/bitcoin_ta.ts \
   qt/locale/bitcoin_te.ts \
   qt/locale/bitcoin_th.ts \
+  qt/locale/bitcoin_tk.ts \
+  qt/locale/bitcoin_tl.ts \
   qt/locale/bitcoin_tr.ts \
   qt/locale/bitcoin_ug.ts \
   qt/locale/bitcoin_uk.ts \
   qt/locale/bitcoin_ur.ts \
+  qt/locale/bitcoin_uz.ts \
   qt/locale/bitcoin_uz@Cyrl.ts \
   qt/locale/bitcoin_uz@Latn.ts \
   qt/locale/bitcoin_vi.ts \

--- a/src/qt/bitcoin_locale.qrc
+++ b/src/qt/bitcoin_locale.qrc
@@ -32,6 +32,7 @@
         <file alias="gl">locale/bitcoin_gl.qm</file>
         <file alias="gl_ES">locale/bitcoin_gl_ES.qm</file>
         <file alias="gu">locale/bitcoin_gu.qm</file>
+        <file alias="ha">locale/bitcoin_ha.qm</file>
         <file alias="he">locale/bitcoin_he.qm</file>
         <file alias="hr">locale/bitcoin_hr.qm</file>
         <file alias="hu">locale/bitcoin_hu.qm</file>
@@ -44,6 +45,7 @@
         <file alias="kl">locale/bitcoin_kl.qm</file>
         <file alias="km">locale/bitcoin_km.qm</file>
         <file alias="ko">locale/bitcoin_ko.qm</file>
+        <file alias="ku">locale/bitcoin_ku.qm</file>
         <file alias="ku_IQ">locale/bitcoin_ku_IQ.qm</file>
         <file alias="ky">locale/bitcoin_ky.qm</file>
         <file alias="la">locale/bitcoin_la.qm</file>
@@ -59,6 +61,7 @@
         <file alias="ne">locale/bitcoin_ne.qm</file>
         <file alias="nl">locale/bitcoin_nl.qm</file>
         <file alias="no">locale/bitcoin_no.qm</file>
+        <file alias="pa">locale/bitcoin_pa.qm</file>
         <file alias="pam">locale/bitcoin_pam.qm</file>
         <file alias="pl">locale/bitcoin_pl.qm</file>
         <file alias="pt">locale/bitcoin_pt.qm</file>
@@ -79,10 +82,13 @@
         <file alias="ta">locale/bitcoin_ta.qm</file>
         <file alias="te">locale/bitcoin_te.qm</file>
         <file alias="th">locale/bitcoin_th.qm</file>
+        <file alias="tk">locale/bitcoin_tk.qm</file>
+        <file alias="tl">locale/bitcoin_tl.qm</file>
         <file alias="tr">locale/bitcoin_tr.qm</file>
         <file alias="ug">locale/bitcoin_ug.qm</file>
         <file alias="uk">locale/bitcoin_uk.qm</file>
         <file alias="ur">locale/bitcoin_ur.qm</file>
+        <file alias="uz">locale/bitcoin_uz.qm</file>
         <file alias="uz@Cyrl">locale/bitcoin_uz@Cyrl.qm</file>
         <file alias="uz@Latn">locale/bitcoin_uz@Latn.qm</file>
         <file alias="vi">locale/bitcoin_vi.qm</file>

--- a/src/qt/bitcoinstrings.cpp
+++ b/src/qt/bitcoinstrings.cpp
@@ -15,8 +15,8 @@ QT_TRANSLATE_NOOP("bitcoin-core", ""
 "a backup."),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "%s request to listen on port %u. This port is considered \"bad\" and thus it "
-"is unlikely that any Bitcoin Core peers connect to it. See doc/p2p-bad-ports."
-"md for details and a full list."),
+"is unlikely that any peer will connect to it. See doc/p2p-bad-ports.md for "
+"details and a full list."),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "-maxtxfee is set very high! Fees this large could be paid on a single "
 "transaction."),
@@ -33,9 +33,6 @@ QT_TRANSLATE_NOOP("bitcoin-core", ""
 "temporarily disable txindex while using -reindex-chainstate, or replace -"
 "reindex-chainstate with -reindex to fully rebuild all indexes."),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
-"Assumed-valid: last wallet synchronisation goes beyond available block data. "
-"You need to wait for the background validation chain to download more blocks."),
-QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Cannot downgrade wallet from version %i to version %i. Wallet version "
 "unchanged."),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
@@ -48,11 +45,19 @@ QT_TRANSLATE_NOOP("bitcoin-core", ""
 "upgrading to support pre-split keypool. Please use version %i or no version "
 "specified."),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
+"Disk space for %s may not accommodate the block files. Approximately %u GB "
+"of data will be stored in this directory."),
+QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Distributed under the MIT software license, see the accompanying file %s or "
 "%s"),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Error loading %s: External signer wallet being loaded without external "
 "signer support compiled"),
+QT_TRANSLATE_NOOP("bitcoin-core", ""
+"Error loading wallet. Wallet requires blocks to be downloaded, and software "
+"does not currently support loading wallets while blocks are being downloaded "
+"out of order when using assumeutxo snapshots. Wallet should be able to load "
+"successfully after node sync reaches height %s"),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Error reading %s! All keys read correctly, but transaction data or address "
 "book entries might be missing or incorrect."),
@@ -79,8 +84,8 @@ QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Error: Transaction %s in wallet cannot be identified to belong to migrated "
 "wallets"),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
-"Error: Unable to produce descriptors for this legacy wallet. Make sure the "
-"wallet is unlocked first"),
+"Error: Unable to produce descriptors for this legacy wallet. Make sure to "
+"provide the wallet's passphrase if it is encrypted."),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Failed to rename invalid peers.dat file. Please move or delete it and try "
 "again."),
@@ -112,12 +117,18 @@ QT_TRANSLATE_NOOP("bitcoin-core", ""
 "No wallet file format provided. To use createfromdump, -format=<format> must "
 "be provided."),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
+"Outbound connections restricted to CJDNS (-onlynet=cjdns) but -"
+"cjdnsreachable is not provided"),
+QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Outbound connections restricted to Tor (-onlynet=onion) but the proxy for "
 "reaching the Tor network is explicitly forbidden: -onion=0"),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Outbound connections restricted to Tor (-onlynet=onion) but the proxy for "
 "reaching the Tor network is not provided: none of -proxy, -onion or -"
 "listenonion is given"),
+QT_TRANSLATE_NOOP("bitcoin-core", ""
+"Outbound connections restricted to i2p (-onlynet=i2p) but -i2psam is not "
+"provided"),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Please check that your computer's date and time are correct! If your clock "
 "is wrong, %s will not work properly."),
@@ -148,6 +159,13 @@ QT_TRANSLATE_NOOP("bitcoin-core", ""
 "space, run a full -reindex, otherwise ignore this error. This error message "
 "will not be displayed again."),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
+"The inputs size exceeds the maximum weight. Please try sending a smaller "
+"amount or manually consolidating your wallet's UTXOs"),
+QT_TRANSLATE_NOOP("bitcoin-core", ""
+"The preselected coins total amount does not cover the transaction target. "
+"Please allow other inputs to be automatically selected or include more coins "
+"manually"),
+QT_TRANSLATE_NOOP("bitcoin-core", ""
 "The transaction amount is too small to send after the fee has been deducted"),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "This error could occur if this wallet was not shutdown cleanly and was last "
@@ -170,6 +188,10 @@ QT_TRANSLATE_NOOP("bitcoin-core", ""
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Unable to replay blocks. You will need to rebuild the database using -"
 "reindex-chainstate."),
+QT_TRANSLATE_NOOP("bitcoin-core", ""
+"Unexpected legacy entry in descriptor wallet found. Loading wallet %s\n"
+"\n"
+"The wallet might have been tampered with or created with malicious intent.\n"),
 QT_TRANSLATE_NOOP("bitcoin-core", ""
 "Unknown wallet file format \"%s\" provided. Please provide one of \"bdb\" or "
 "\"sqlite\"."),
@@ -235,6 +257,7 @@ QT_TRANSLATE_NOOP("bitcoin-core", "Error loading block database"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Error opening block database"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Error reading from database, shutting down."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Error reading next record from wallet database"),
+QT_TRANSLATE_NOOP("bitcoin-core", "Error: Cannot extract destination from the generated scriptpubkey"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Error: Could not add watchonly tx to watchonly wallet"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Error: Could not delete watchonly transactions"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Error: Couldn't create cursor into database"),
@@ -264,6 +287,7 @@ QT_TRANSLATE_NOOP("bitcoin-core", "Importing…"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Incorrect or no genesis block found. Wrong datadir for network?"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Initialization sanity check failed. %s is shutting down."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Input not found or already spent"),
+QT_TRANSLATE_NOOP("bitcoin-core", "Insufficient dbcache for block verification"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Insufficient funds"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Invalid -i2psam address or hostname: '%s'"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Invalid -onion address or hostname: '%s'"),
@@ -274,6 +298,8 @@ QT_TRANSLATE_NOOP("bitcoin-core", "Invalid amount for -discardfee=<amount>: '%s'
 QT_TRANSLATE_NOOP("bitcoin-core", "Invalid amount for -fallbackfee=<amount>: '%s'"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Invalid amount for -paytxfee=<amount>: '%s' (must be at least %s)"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Invalid netmask specified in -whitelist: '%s'"),
+QT_TRANSLATE_NOOP("bitcoin-core", "Invalid port specified in %s: '%s'"),
+QT_TRANSLATE_NOOP("bitcoin-core", "Invalid pre-selected input %s"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Listening for incoming connections failed (listen returned error %s)"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Loading P2P addresses…"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Loading banlist…"),
@@ -284,6 +310,8 @@ QT_TRANSLATE_NOOP("bitcoin-core", "Missing solving data for estimating transacti
 QT_TRANSLATE_NOOP("bitcoin-core", "Need to specify a port with -whitebind: '%s'"),
 QT_TRANSLATE_NOOP("bitcoin-core", "No addresses available"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Not enough file descriptors available."),
+QT_TRANSLATE_NOOP("bitcoin-core", "Not found pre-selected input %s"),
+QT_TRANSLATE_NOOP("bitcoin-core", "Not solvable pre-selected input %s"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Prune cannot be configured with a negative value."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Prune mode is incompatible with -txindex."),
 QT_TRANSLATE_NOOP("bitcoin-core", "Pruning blockstore…"),

--- a/src/qt/locale/bitcoin_am.ts
+++ b/src/qt/locale/bitcoin_am.ts
@@ -359,6 +359,11 @@
         <translation type="unfinished">መደበኛ ዋሌት</translation>
     </message>
     <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">ዋሌት ስም</translation>
+    </message>
+    <message>
         <source>Zoom</source>
         <translation type="unfinished">እሳድግ</translation>
     </message>
@@ -482,6 +487,27 @@
     <message>
         <source>Bitcoin</source>
         <translation type="unfinished">ቢትኮይን</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
     </message>
     <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>

--- a/src/qt/locale/bitcoin_ar.ts
+++ b/src/qt/locale/bitcoin_ar.ts
@@ -3,140 +3,145 @@
     <name>AddressBookPage</name>
     <message>
         <source>Right-click to edit address or label</source>
-        <translation type="unfinished">أنقر بزر الماوس الأيمن لتحرير العنوان أو التصنيف</translation>
+        <translation type="unfinished">انقر بزر الفأرة الأيمن لتحرير العنوان أو المذكرة</translation>
     </message>
     <message>
         <source>Create a new address</source>
-        <translation type="unfinished">إنشاء عنوان جديد</translation>
+        <translation type="unfinished">أنشئ عنوان جديد</translation>
     </message>
     <message>
         <source>&amp;New</source>
-        <translation type="unfinished">جديد</translation>
+        <translation type="unfinished">&amp;جديد</translation>
     </message>
     <message>
         <source>Copy the currently selected address to the system clipboard</source>
-        <translation type="unfinished">نسخ العنوان المحدد حاليًا إلى حافظة النظام</translation>
+        <translation type="unfinished">‫انسخ العنوان المحدد للحافظة‬</translation>
     </message>
     <message>
         <source>&amp;Copy</source>
-        <translation type="unfinished">نسخ</translation>
+        <translation type="unfinished">&amp;نسخ</translation>
     </message>
     <message>
         <source>C&amp;lose</source>
-        <translation type="unfinished">غلق</translation>
+        <translation type="unfinished">ا&amp;غلاق</translation>
     </message>
     <message>
         <source>Delete the currently selected address from the list</source>
-        <translation type="unfinished">احذف العنوان المحدد حاليًا من القائمة</translation>
+        <translation type="unfinished">احذف العنوان المحدد من القائمة</translation>
     </message>
     <message>
         <source>Enter address or label to search</source>
-        <translation type="unfinished">أدخل العنوان أو التصنيف للبحث</translation>
+        <translation type="unfinished">أدخل عنوانا أو مذكرة للبحث</translation>
     </message>
     <message>
         <source>Export the data in the current tab to a file</source>
-        <translation type="unfinished">استخراج البيانات في علامة التبويب الحالية إلى ملف</translation>
+        <translation type="unfinished">صدّر البيانات في التبويب الحالي الى ملف</translation>
     </message>
     <message>
         <source>&amp;Export</source>
-        <translation type="unfinished">استخراج</translation>
+        <translation type="unfinished">&amp;تصدير</translation>
     </message>
     <message>
         <source>&amp;Delete</source>
-        <translation type="unfinished">حذف</translation>
+        <translation type="unfinished">&amp;حذف</translation>
     </message>
     <message>
         <source>Choose the address to send coins to</source>
-        <translation type="unfinished">إختر العنوان الرقمي اللذي تريد الإرسال له</translation>
+        <translation type="unfinished">اختر العنوان الذي ترغب بارسال بتكوين اليه</translation>
     </message>
     <message>
         <source>Choose the address to receive coins with</source>
-        <translation type="unfinished">إختر العنوان الرقمي اللذي سيحصل على العملات</translation>
+        <translation type="unfinished">اختر العنوان الذي ترغب باستلام بتكوين اليه</translation>
     </message>
     <message>
         <source>C&amp;hoose</source>
-        <translation type="unfinished">اختر</translation>
+        <translation type="unfinished">ا&amp;ختر</translation>
     </message>
     <message>
         <source>Sending addresses</source>
-        <translation type="unfinished">العنوان الرقمي المُرسِل</translation>
+        <translation type="unfinished">‫العناوين المرسِلة‬</translation>
     </message>
     <message>
         <source>Receiving addresses</source>
-        <translation type="unfinished">العنوان الرقمي المُرسَل إليه</translation>
+        <translation type="unfinished">العناوين المستلمة</translation>
     </message>
     <message>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
-        <translation type="unfinished">هذه هي عناوين البيتكوين لإرسال المدفوعات. دائما تحقق من المبلغ وعنوان المستلم قبل الإرسال.</translation>
+        <translation type="unfinished">‫هذه عناوين البتكوين الخاصة بك لإرسال المدفوعات. تأكد دائما من القيم المدخلة ومن العنوان المستلم قبل الارسال.‬</translation>
     </message>
     <message>
         <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
 Signing is only possible with addresses of the type 'legacy'.</source>
-        <translation type="unfinished">هذه هي عناوين بتكوين الخاصة بك لتلقي المدفوعات. استخدم الزر "إنشاء عنوان استلام جديد" في علامة تبويب الاستلام لإنشاء عناوين جديدة.
-التوقيع ممكن فقط مع عناوين من النوع "قديم".</translation>
+        <translation type="unfinished">هذه عناوين البتكوين الخاصة بك لاستلام المدفوعات. قم بالنقر على زر انشاء عنوان استلام جديد لإنشاء عناوين جديدة.
+التوقيع ممكن باستخدام العناوين القديمة "Legacy" فقط.</translation>
     </message>
     <message>
         <source>&amp;Copy Address</source>
-        <translation type="unfinished">نسخ العنوان</translation>
+        <translation type="unfinished">&amp;نسخ العنوان</translation>
     </message>
     <message>
         <source>Copy &amp;Label</source>
-        <translation type="unfinished">نسخ&amp;تسمية</translation>
+        <translation type="unfinished">نسخ &amp;المذكرة</translation>
     </message>
     <message>
         <source>&amp;Edit</source>
-        <translation type="unfinished">تحرير</translation>
+        <translation type="unfinished">&amp;تحرير</translation>
     </message>
     <message>
         <source>Export Address List</source>
-        <translation type="unfinished">صدّر قائمة العناوين</translation>
+        <translation type="unfinished">تصدير قائمة العناوين</translation>
     </message>
     <message>
         <source>Comma separated file</source>
         <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
-        <translation type="unfinished">ملف مفصَّل بالفواصل</translation>
+        <translation type="unfinished">ملف القيم المفصولة بفاصلة</translation>
+    </message>
+    <message>
+        <source>There was an error trying to save the address list to %1. Please try again.</source>
+        <extracomment>An error message. %1 is a stand-in argument for the name of the file we attempted to save to.</extracomment>
+        <translation type="unfinished">حدث خطأ أثناء محاولة حفظ قائمة العناوين في %1. يرجى معاودة المحاولة. </translation>
     </message>
     <message>
         <source>Exporting Failed</source>
-        <translation type="unfinished">لقد فشل التصدير</translation>
+        <translation type="unfinished">فشل التصدير</translation>
     </message>
 </context>
 <context>
     <name>AddressTableModel</name>
     <message>
         <source>Label</source>
-        <translation type="unfinished">وسم</translation>
+        <translation type="unfinished">المذكرة</translation>
     </message>
     <message>
         <source>Address</source>
-        <translation type="unfinished">عنوان</translation>
+        <translation type="unfinished">العنوان</translation>
     </message>
     <message>
         <source>(no label)</source>
-        <translation type="unfinished">(بدون وسم)</translation>
+        <translation type="unfinished">( لا وجود لمذكرة)</translation>
     </message>
 </context>
 <context>
     <name>AskPassphraseDialog</name>
     <message>
         <source>Passphrase Dialog</source>
-        <translation type="unfinished">مربع كلمة المرور</translation>
+        <translation type="unfinished">‫حوار عبارة المرور‬</translation>
     </message>
     <message>
         <source>Enter passphrase</source>
-        <translation type="unfinished">ادخل كلمة المرور</translation>
+        <translation type="unfinished">‫ادخل عبارة المرور‬</translation>
     </message>
     <message>
         <source>New passphrase</source>
-        <translation type="unfinished">كلمة مرور جديد</translation>
+        <translation type="unfinished">‫أنشئ عبارة مرور‬</translation>
     </message>
     <message>
         <source>Repeat new passphrase</source>
-        <translation type="unfinished">إعادة إدخال كلمة المرور</translation>
+        <translation type="unfinished">‫أعد عبارة المرور‬</translation>
     </message>
     <message>
         <source>Show passphrase</source>
-        <translation type="unfinished">أظهر كلمة المرور</translation>
+        <translation type="unfinished">‫عرض عبارة المرور‬</translation>
     </message>
     <message>
         <source>Encrypt wallet</source>
@@ -144,15 +149,15 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
-        <translation type="unfinished">العملية تحتاج كملة المرور المحفظة لتستطيع فتحها.</translation>
+        <translation type="unfinished">‫هذه العملية تتطلب عبارة المرور لفك تشفير المحفظة.‬</translation>
     </message>
     <message>
         <source>Unlock wallet</source>
-        <translation type="unfinished">فتح المحفظة</translation>
+        <translation type="unfinished">فتح قفل المحفظة</translation>
     </message>
     <message>
         <source>Change passphrase</source>
-        <translation type="unfinished">تغيير كلمة المرور</translation>
+        <translation type="unfinished">‫تغيير عبارة المرور‬</translation>
     </message>
     <message>
         <source>Confirm wallet encryption</source>
@@ -160,47 +165,47 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
-        <translation type="unfinished">إذا شفرت محفظتك وفقدت كلمة المرور، ستفقد كل ما تملك من البيتكوين.</translation>
+        <translation type="unfinished">تحذير: إذا قمت بتشفير المحفظة وأضعت الكلمة السرية؛ &lt;b&gt;ستفقد كل البتكوين&lt;/b&gt;!</translation>
     </message>
     <message>
         <source>Are you sure you wish to encrypt your wallet?</source>
-        <translation type="unfinished">هل انت متأكد بأنك تريد تشفير محفظتك؟</translation>
+        <translation type="unfinished">هل أنت متأكد من رغبتك في تشفير المحفظة؟</translation>
     </message>
     <message>
         <source>Wallet encrypted</source>
-        <translation type="unfinished">تم تشفير المحفظة</translation>
+        <translation type="unfinished">المحفظة مشفرة</translation>
     </message>
     <message>
         <source>Enter the new passphrase for the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
-        <translation type="unfinished">أدخل كلمة المرور الجديدة للمحفظة. &lt;br/&gt; الرجاء استخدام  كلمة مرور تتكون من &lt;b&gt; عشرة أحرف عشوائية أو أكثر &lt;/b&gt; ، أو &lt;b&gt; ثماني كلمات أو أكثر&lt;/b&gt; .</translation>
+        <translation type="unfinished">أدخل عبارة المرور للمحفظة. &lt;br/&gt;الرجاء استخدام عبارة مرور تتكون من &lt;b&gt;عشر خانات عشوائية أو أكثر&lt;/b&gt;، أو &lt;b&gt;ثمان كلمات أو أكثر&lt;/b&gt;.</translation>
     </message>
     <message>
         <source>Enter the old passphrase and new passphrase for the wallet.</source>
-        <translation type="unfinished">ادخل كملة المرور القديمة وكلمة المرور الجديدة للمحفظة.</translation>
+        <translation type="unfinished">أدخل ‫عبارة المرور‬ السابقة و‫عبارة المرور‬ الجديدة للمحفظة</translation>
     </message>
     <message>
         <source>Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
-        <translation type="unfinished">تذكر أن تشفير محفظتك لا يحمي البيتكوين الخاصة بك بشكل كامل من السرقة من قبل البرامج الخبيثةالتي تصيب حاسوبك</translation>
+        <translation type="unfinished">تذكر أن تشفير محفظتك قد لا يحميك بشكل كامل من البرمجيات الخبيثة التي تصيب جهازك.</translation>
     </message>
     <message>
         <source>Wallet to be encrypted</source>
-        <translation type="unfinished">سوف يتم تشفير محفظتك</translation>
+        <translation type="unfinished">‫المحفظة سيتم تشفيرها‬</translation>
     </message>
     <message>
         <source>Your wallet is about to be encrypted. </source>
-        <translation type="unfinished">سوف يتم تشفير محفظتك.</translation>
+        <translation type="unfinished">سوف تشفر محفظتك.</translation>
     </message>
     <message>
         <source>Your wallet is now encrypted. </source>
-        <translation type="unfinished">محفظتك ألان مشفرة</translation>
+        <translation type="unfinished">محفظتك الان مشفرة.</translation>
     </message>
     <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <translation type="unfinished">هام: أي نسخة إحتياطية سابقة  قمت بها لمحفظتك يجب استبدالها  بأخرى حديثة، مشفرة. لأسباب أمنية، النسخ الاحتياطية السابقة لملفات المحفظة الغير مشفرة تصبح عديمة الفائدة مع بداية استخدام المحفظة المشفرة الجديدة.</translation>
+        <translation type="unfinished">مهم!!!: يجب استبدال أي نسخة احتياطية سابقة بملف المحفظة المشفر الجديد. لأسباب أمنية، لن تستطيع استخدام النسخ الاحتياطية السابقة الغير مشفرة عندما تبدأ في استخدام المحفظة المشفرة الجديدة.</translation>
     </message>
     <message>
         <source>Wallet encryption failed</source>
-        <translation type="unfinished">خطأ في تشفير المحفظة</translation>
+        <translation type="unfinished">فشل تشفير المحفظة</translation>
     </message>
     <message>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
@@ -208,7 +213,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>The supplied passphrases do not match.</source>
-        <translation type="unfinished">كلمتي المرور ليستا متطابقتان</translation>
+        <translation type="unfinished">عبارتي مرور غير متطابقتين.</translation>
     </message>
     <message>
         <source>Wallet unlock failed</source>
@@ -216,22 +221,22 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
-        <translation type="unfinished">كلمة المرور التي تم إدخالها لفك تشفير المحفظة غير صحيحة.</translation>
+        <translation type="unfinished">‫عبارة المرور التي تم إدخالها لفك تشفير المحفظة غير صحيحة.‬</translation>
     </message>
     <message>
         <source>Wallet passphrase was successfully changed.</source>
-        <translation type="unfinished">لقد تم تغير عبارة مرور المحفظة بنجاح</translation>
+        <translation type="unfinished">‫لقد تم تغيير عبارة المرور بنجاح.‬</translation>
     </message>
     <message>
         <source>Warning: The Caps Lock key is on!</source>
-        <translation type="unfinished">تحذير: مفتاح الحروف الكبيرة مفعل</translation>
+        <translation type="unfinished">‫تحذير: مفتاح الحروف الكبيرة مفعل!‬</translation>
     </message>
 </context>
 <context>
     <name>BanTableModel</name>
     <message>
         <source>IP/Netmask</source>
-        <translation type="unfinished">عنوان البروتوكول/قناع</translation>
+        <translation type="unfinished">‫بروتوكول الانترنت/قناع الشبكة‬</translation>
     </message>
     <message>
         <source>Banned Until</source>
@@ -241,8 +246,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>BitcoinApplication</name>
     <message>
+        <source>Settings file %1 might be corrupt or invalid.</source>
+        <translation type="unfinished">ملف الاعدادات %1 قد يكون تالف او غير صالح</translation>
+    </message>
+    <message>
         <source>Runaway exception</source>
-        <translation type="unfinished">استثناء هارب</translation>
+        <translation type="unfinished">‫‫Runaway exception‬</translation>
     </message>
     <message>
         <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
@@ -252,12 +261,30 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Internal error</source>
         <translation type="unfinished">خطأ داخلي</translation>
     </message>
-    </context>
+    <message>
+        <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
+        <translation type="unfinished">حدث خطأ داخلي. سيحاول %1 المتابعة بأمان. هذا خطأ غير متوقع يمكن الإبلاغ عنه كما هو موضح أدناه.</translation>
+    </message>
+</context>
 <context>
     <name>QObject</name>
     <message>
+        <source>Do you want to reset settings to default values, or to abort without making changes?</source>
+        <extracomment>Explanatory text shown on startup when the settings file cannot be read. Prompts user to make a choice between resetting or aborting.</extracomment>
+        <translation type="unfinished">‫هل تريد اعادة ضبط الاعدادات للقيم الافتراضية؟ أو الالغاء دون اجراء تغييرات؟‬</translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. Check that settings file is writable, or try running with -nosettings.</source>
+        <extracomment>Explanatory text shown on startup when the settings file could not be written. Prompts user to check that we have the ability to write to the file. Explains that the user has the option of running without a settings file.</extracomment>
+        <translation type="unfinished">‫حدث خطأ فادح. تأكد أن أذونات ملف الاعدادات تسمح بالكتابة، جرب الاستمرار بتفعيل خيار -دون اعدادات.‬</translation>
+    </message>
+    <message>
         <source>Error: Specified data directory "%1" does not exist.</source>
-        <translation type="unfinished">خطأ: دليل البيانات المحدد "%1" غير موجود.</translation>
+        <translation type="unfinished">‫خطأ: المجلد المحدد "%1" غير موجود.‬</translation>
+    </message>
+    <message>
+        <source>Error: Cannot parse configuration file: %1.</source>
+        <translation type="unfinished">‫خطأ: لا يمكن تحليل ملف الإعداد: %1.‬</translation>
     </message>
     <message>
         <source>Error: %1</source>
@@ -265,7 +292,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>%1 didn't yet exit safely…</source>
-        <translation type="unfinished">%1 لم يخرج بامان بعد</translation>
+        <translation type="unfinished">‫%1 لم يغلق بامان بعد…‬</translation>
     </message>
     <message>
         <source>unknown</source>
@@ -273,7 +300,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Amount</source>
-        <translation type="unfinished">مبلغ</translation>
+        <translation type="unfinished">‫القيمة‬</translation>
     </message>
     <message>
         <source>Enter a Bitcoin address (e.g. %1)</source>
@@ -281,7 +308,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Unroutable</source>
-        <translation type="unfinished">غير قابل للطرق</translation>
+        <translation type="unfinished">‫غير قابل للتوجيه‬</translation>
     </message>
     <message>
         <source>Internal</source>
@@ -290,22 +317,22 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Inbound</source>
         <extracomment>An inbound connection from a peer. An inbound connection is a connection initiated by a peer.</extracomment>
-        <translation type="unfinished">داخل</translation>
+        <translation type="unfinished">‫وارد‬</translation>
     </message>
     <message>
         <source>Outbound</source>
         <extracomment>An outbound connection to a peer. An outbound connection is a connection initiated by us.</extracomment>
-        <translation type="unfinished">خارجي</translation>
+        <translation type="unfinished">‫صادر‬</translation>
     </message>
     <message>
         <source>Full Relay</source>
         <extracomment>Peer connection type that relays all network information.</extracomment>
-        <translation type="unfinished">تتابع كامل</translation>
+        <translation type="unfinished">‫موصل كامل‬</translation>
     </message>
     <message>
         <source>Block Relay</source>
         <extracomment>Peer connection type that relays network information about blocks and not transactions or addresses.</extracomment>
-        <translation type="unfinished">بلوك ريلاي</translation>
+        <translation type="unfinished">‫موصل طابق‬</translation>
     </message>
     <message>
         <source>Manual</source>
@@ -315,12 +342,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Feeler</source>
         <extracomment>Short-lived peer connection type that tests the aliveness of known addresses.</extracomment>
-        <translation type="unfinished">المحسس</translation>
+        <translation type="unfinished">‫تفقدي‬</translation>
     </message>
     <message>
         <source>Address Fetch</source>
         <extracomment>Short-lived peer connection type that solicits known addresses from a peer.</extracomment>
-        <translation type="unfinished">إحضار العنوان</translation>
+        <translation type="unfinished">‫جلب العنوان‬</translation>
     </message>
     <message>
         <source>%1 d</source>
@@ -353,56 +380,56 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n second(s)</numerusform>
+            <numerusform>%n second(s)</numerusform>
+            <numerusform>%n second(s)</numerusform>
+            <numerusform>%n second(s)</numerusform>
+            <numerusform>%n second(s)</numerusform>
+            <numerusform>%n‫‫ ثواني‬</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n minute(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n minute(s)</numerusform>
+            <numerusform>%n minute(s)</numerusform>
+            <numerusform>%n minute(s)</numerusform>
+            <numerusform>%n minute(s)</numerusform>
+            <numerusform>%n minute(s)</numerusform>
+            <numerusform>%n ‫دقائق‬</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n hour(s)</numerusform>
+            <numerusform>%n hour(s)</numerusform>
+            <numerusform>%n hour(s)</numerusform>
+            <numerusform>%n hour(s)</numerusform>
+            <numerusform>%n hour(s)</numerusform>
+            <numerusform>%n‫ساعات‬</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n day(s)</numerusform>
+            <numerusform>%n day(s)</numerusform>
+            <numerusform>%n day(s)</numerusform>
+            <numerusform>%n day(s)</numerusform>
+            <numerusform>%n day(s)</numerusform>
+            <numerusform>%n ‫أيام‬</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n week(s)</numerusform>
+            <numerusform>%n week(s)</numerusform>
+            <numerusform>%n week(s)</numerusform>
+            <numerusform>%n week(s)</numerusform>
+            <numerusform>%n week(s)</numerusform>
+            <numerusform>%n ‫أسابيع‬</numerusform>
         </translation>
     </message>
     <message>
@@ -412,12 +439,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n year(s)</numerusform>
+            <numerusform>%n year(s)</numerusform>
+            <numerusform>%n year(s)</numerusform>
+            <numerusform>%n year(s)</numerusform>
+            <numerusform>%n year(s)</numerusform>
+            <numerusform>%n ‫سنوات‬</numerusform>
         </translation>
     </message>
     <message>
@@ -430,38 +457,62 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>%1 MB</source>
-        <translation type="unfinished">%1 ميقا بايت</translation>
+        <translation type="unfinished">%1 ‫ميجابايت‬</translation>
     </message>
     <message>
         <source>%1 GB</source>
-        <translation type="unfinished">%1 قيقا بايت</translation>
+        <translation type="unfinished">%1 ‫جيجابايت‬</translation>
     </message>
 </context>
 <context>
     <name>bitcoin-core</name>
     <message>
+        <source>Settings file could not be read</source>
+        <translation type="unfinished">‫ملف الاعدادات لا يمكن قراءته‬</translation>
+    </message>
+    <message>
+        <source>Settings file could not be written</source>
+        <translation type="unfinished">‫لم نتمكن من كتابة ملف الاعدادات‬</translation>
+    </message>
+    <message>
         <source>The %s developers</source>
         <translation type="unfinished">%s المبرمجون</translation>
     </message>
     <message>
+        <source>%s corrupt. Try using the wallet tool bitcoin-wallet to salvage or restoring a backup.</source>
+        <translation type="unfinished">‫‫%s مشكل. حاول استخدام أداة محفظة البتكوين للاصلاح أو استعادة نسخة احتياطية.‬</translation>
+    </message>
+    <message>
         <source>-maxtxfee is set very high! Fees this large could be paid on a single transaction.</source>
-        <translation type="unfinished">-maxtxfee الموضوع عالي جدا! رسوم بهذا الحجم من الممكن أن تدفع على معاملة.</translation>
+        <translation type="unfinished">‫الحد الأعلى للرسوم عال جدا! رسوم بهذه الكمية تكفي لإرسال عملية كاملة.‬</translation>
+    </message>
+    <message>
+        <source>Cannot downgrade wallet from version %i to version %i. Wallet version unchanged.</source>
+        <translation type="unfinished">‫لا يمكن استرجاع إصدار المحفظة من %i الى %i. لم يتغير إصدار المحفظة.‬</translation>
     </message>
     <message>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running.</source>
-        <translation type="unfinished">لا يمكن الحصول على قفل على دليل البيانات %s. من المحتمل أن %s يعمل بالفعل.</translation>
+        <translation type="unfinished">‫لا يمكن اقفال المجلد %s. من المحتمل أن %s يعمل بالفعل.‬</translation>
+    </message>
+    <message>
+        <source>Distributed under the MIT software license, see the accompanying file %s or %s</source>
+        <translation type="unfinished">موزع بموجب ترخيص برامج MIT ، راجع الملف المصاحب %s أو %s</translation>
     </message>
     <message>
         <source>Error reading %s! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation type="unfinished">خطأ في قراءة %s! جميع المفاتيح قرأت بشكل صحيح، لكن بيانات المعاملة أو إدخالات سجل العناوين قد تكون مفقودة أو غير صحيحة.</translation>
     </message>
     <message>
+        <source>Error reading %s! Transaction data may be missing or incorrect. Rescanning wallet.</source>
+        <translation type="unfinished">‫خطأ في قراءة %s بيانات العملية قد تكون مفقودة أو غير صحيحة. اعادة فحص المحفظة.‬</translation>
+    </message>
+    <message>
         <source>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.</source>
-        <translation type="unfinished">عملية حساب الرسوم فشلت. الرسوم الاحتياطية غير مفعلة. انتظر عدة كتل أو مكن خيار الرسوم الاحتياطية. </translation>
+        <translation type="unfinished">‫عملية حساب الرسوم فشلت. خيار الرسوم الاحتياطية غير مفعل. انتظر عدة طوابق أو فعل خيار الرسوم الاحتياطية.‬</translation>
     </message>
     <message>
         <source>File %s already exists. If you are sure this is what you want, move it out of the way first.</source>
-        <translation type="unfinished">الملف %s موجود مسبقا , اذا كنت متأكدا من المتابعة يرجى ارساله بعيدا للاستمرار </translation>
+        <translation type="unfinished">الملف %s موجود مسبقا , اذا كنت متأكدا من المتابعة يرجى ابعاده للاستمرار.</translation>
     </message>
     <message>
         <source>Invalid amount for -maxtxfee=&lt;amount&gt;: '%s' (must be at least the minrelay fee of %s to prevent stuck transactions)</source>
@@ -469,7 +520,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Please check that your computer's date and time are correct! If your clock is wrong, %s will not work properly.</source>
-        <translation type="unfinished">رجاء تأكد من أن التاريخ والوقت في حاسوبك صحيحان! اذا كانت ساعتك خاطئة، %s لن يعمل كما بصورة صحيحة.</translation>
+        <translation type="unfinished">رجاء تأكد من أن التاريخ والوقت في حاسوبك صحيحان! اذا كانت ساعتك خاطئة، %s لن يعمل بصورة صحيحة.</translation>
     </message>
     <message>
         <source>Please contribute if you find %s useful. Visit %s for further information about the software.</source>
@@ -477,11 +528,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Prune configured below the minimum of %d MiB.  Please use a higher number.</source>
-        <translation type="unfinished">تم تكوين تقليم أقل من الحد الأدنى %d ميجابايت. من فضلك استعمل رقم أعلى.</translation>
+        <translation type="unfinished">‫الاختصار أقل من الحد الأدنى %d ميجابايت. من فضلك ارفع الحد.‬</translation>
     </message>
     <message>
         <source>Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of pruned node)</source>
-        <translation type="unfinished">تقليم: اخر مزامنة للمحفظة كانت قبل البيانات الملقمة. تحتاج الى - اعادة فهرسة (قم بتنزيل سلسلة الكتل بأكملها مرة أخرى في حال تم تقليم عقدة)</translation>
+        <translation type="unfinished">‫الاختصار: اخر مزامنة للمحفظة كانت قبل البيانات المختصرة. تحتاج الى - اعادة فهرسة (قم بتنزيل الطوابق المتتالية بأكملها مرة أخرى في حال تم اختصار النود)‬</translation>
     </message>
     <message>
         <source>SQLiteDatabase: Unknown sqlite wallet schema version %d. Only version %d is supported</source>
@@ -489,7 +540,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>The block database contains a block which appears to be from the future. This may be due to your computer's date and time being set incorrectly. Only rebuild the block database if you are sure that your computer's date and time are correct</source>
-        <translation type="unfinished">قاعدة بيانات الكتل تحتوي على كتلة يبدو أنها من المستقبل. قد يكون هذا بسبب أن التاريخ والوقت في حاسوبك قم ضبط بشكل غير صحيح. قم بإعادة بناء قاعدة بيانات الكتل في حال كنت متأكد من أن التاريخ والوقت قد تم ضبطهما بشكل صحيح.</translation>
+        <translation type="unfinished">‫قاعدة بيانات الطوابق تحتوي على طابق مستقبلي كما يبدو. قد يكون هذا بسبب أن التاريخ والوقت في جهازك لم يضبطا بشكل صحيح. قم بإعادة بناء قاعدة بيانات الطوابق في حال كنت متأكدا من أن التاريخ والوقت قد تم ضبطهما بشكل صحيح‬</translation>
     </message>
     <message>
         <source>The transaction amount is too small to send after the fee has been deducted</source>
@@ -497,7 +548,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
-        <translation type="unfinished">هذه بنية للتجربة ما قبل-الاصدار - استخدمها على مسؤوليتك الخاصة - لا تستخدمها للتعدين أو لتطبيقات التجارة.</translation>
+        <translation type="unfinished">‫هذه بناء برمجي تجريبي - استخدمه على مسؤوليتك الخاصة - لا تستخدمه للتعدين أو التجارة‬</translation>
+    </message>
+    <message>
+        <source>This is the maximum transaction fee you pay (in addition to the normal fee) to prioritize partial spend avoidance over regular coin selection.</source>
+        <translation type="unfinished">‫هذا هو الحد الاعلى للرسوم التي تدفعها (بالاضافة للرسوم العادية) لتفادي الدفع الجزئي واعطاء أولوية لاختيار الوحدات.‬</translation>
     </message>
     <message>
         <source>This is the transaction fee you may discard if change is smaller than dust at this level</source>
@@ -508,28 +563,36 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">هذه هي رسوم المعاملة التي قد تدفعها عندما تكون عملية حساب الرسوم غير متوفرة.</translation>
     </message>
     <message>
-        <source>Unable to replay blocks. You will need to rebuild the database using -reindex-chainstate.</source>
-        <translation type="unfinished">غير قادر على اعادة الكتل. سوف تحتاج الى اعادة بناء قاعدة البيانات باستخدام - reindex-chainstate</translation>
+        <source>Unknown wallet file format "%s" provided. Please provide one of "bdb" or "sqlite".</source>
+        <translation type="unfinished">‫صيغة ملف المحفظة غير معروفة “%s”. الرجاء تقديم اما “bdb” أو “sqlite”.‬</translation>
+    </message>
+    <message>
+        <source>Wallet created successfully. The legacy wallet type is being deprecated and support for creating and opening legacy wallets will be removed in the future.</source>
+        <translation type="unfinished">‫تم انشاء المحفظة بنجاح. سيتم الغاء العمل بنوعية المحافظ القديمة ولن يتم دعم انشاءها أو فتحها مستقبلا.‬</translation>
     </message>
     <message>
         <source>Warning: Private keys detected in wallet {%s} with disabled private keys</source>
-        <translation type="unfinished">تحذير: تم اكتشاف مفاتيح خاصة في المحفظة {%s} مع مفاتيح خاصة موقفة. </translation>
+        <translation type="unfinished">‫تحذير: تم اكتشاف مفاتيح خاصة في المحفظة {%s} رغم أن خيار التعامل مع المفاتيح الخاصة معطل‬} مع مفاتيح خاصة موقفة. </translation>
     </message>
     <message>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
-        <translation type="unfinished">تحذير: لا يبدو أننا نتفق تمامًا مع أقراننا! قد تحتاج إلى الترقية ، أو قد تحتاج العقد الأخرى إلى الترقية.</translation>
+        <translation type="unfinished">‫تحذير: لا يبدو أننا نتفق تمامًا مع أقراننا! قد تحتاج إلى الترقية ، أو قد تحتاج الأنواد الأخرى إلى الترقية.‬</translation>
     </message>
     <message>
         <source>You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain</source>
-        <translation type="unfinished">تحتاج إلى إعادة إنشاء قاعدة البيانات باستخدام -reindex للعودة إلى الوضعية الغير مجردة. هذا سوف يعيد تحميل سلسلة الكتل بأكملها</translation>
+        <translation type="unfinished">‫تحتاج إلى إعادة إنشاء قاعدة البيانات باستخدام -reindex للعودة إلى الوضعية النود الكامل. هذا سوف يعيد تحميل الطوابق المتتالية بأكملها‬</translation>
     </message>
     <message>
         <source>%s is set very high!</source>
-        <translation type="unfinished">%s عالٍ جداً</translation>
+        <translation type="unfinished">ضبط %s مرتفع جدا!‬</translation>
     </message>
     <message>
         <source>-maxmempool must be at least %d MB</source>
-        <translation type="unfinished">-الحد الأقصى للذاكرة على الأقل %d ميغابايت</translation>
+        <translation type="unfinished">‫-الحد الأقصى لتجمع الذاكرة  %d ميجابايت‬ على الأقل</translation>
+    </message>
+    <message>
+        <source>A fatal internal error occurred, see debug.log for details</source>
+        <translation type="unfinished">‫حدث خطأ داخلي شديد، راجع ملف تصحيح الأخطاء للتفاصيل‬</translation>
     </message>
     <message>
         <source>Cannot resolve -%s address: '%s'</source>
@@ -537,7 +600,19 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Cannot write to data directory '%s'; check permissions.</source>
-        <translation type="unfinished">لايمكن الكتابة على دليل البيانات '%s'؛ تحقق من السماحيات. </translation>
+        <translation type="unfinished">‫لايمكن الكتابة في المجلد '%s'؛ تحقق من الصلاحيات.‬</translation>
+    </message>
+    <message>
+        <source>%s request to listen on port %u. This port is considered "bad" and thus it is unlikely that any Bitcoin Core peers connect to it. See doc/p2p-bad-ports.md for details and a full list.</source>
+        <translation type="unfinished">%s طلب الاستماع على منفذ %u. يعتبر منفذه "سيئًا" وبالتالي فمن غير المحتمل أن يتصل به أي من أقران Bitcoin Core. انظر الى doc / p2p-bad-ports.md للحصول على التفاصيل والقائمة الكاملة.</translation>
+    </message>
+    <message>
+        <source>Failed to rename invalid peers.dat file. Please move or delete it and try again.</source>
+        <translation type="unfinished">‫فشل في إعادة تسمية ملف invalid peers.dat. يرجى نقله أو حذفه وحاول مرة أخرى.‬</translation>
+    </message>
+    <message>
+        <source>Config setting for %s only applied on %s network when in [%s] section.</source>
+        <translation type="unfinished">يتم تطبيق إعداد التكوين لـ%s فقط على شبكة %s في قسم [%s].</translation>
     </message>
     <message>
         <source>Copyright (C) %i-%i</source>
@@ -545,15 +620,23 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Corrupted block database detected</source>
-        <translation type="unfinished">تم الكشف عن قاعدة بيانات كتل تالفة</translation>
+        <translation type="unfinished">‫تم الكشف عن قاعدة بيانات طوابق تالفة‬</translation>
+    </message>
+    <message>
+        <source>Could not find asmap file %s</source>
+        <translation type="unfinished">تعذر العثور على ملف asmap %s</translation>
+    </message>
+    <message>
+        <source>Could not parse asmap file %s</source>
+        <translation type="unfinished">تعذر تحليل ملف asmap %s</translation>
     </message>
     <message>
         <source>Disk space is too low!</source>
-        <translation type="unfinished">تحذير: مساحة القرص منخفضة</translation>
+        <translation type="unfinished">‫تحذير: مساحة التخزين منخفضة!‬</translation>
     </message>
     <message>
         <source>Do you want to rebuild the block database now?</source>
-        <translation type="unfinished">هل تريد إعادة بناء قاعدة بيانات الكتل الآن؟</translation>
+        <translation type="unfinished">‫هل تريد إعادة بناء قاعدة بيانات الطوابق الآن؟‬</translation>
     </message>
     <message>
         <source>Done loading</source>
@@ -561,7 +644,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Dump file %s does not exist.</source>
-        <translation type="unfinished">ملف مهمل %s غير موجود</translation>
+        <translation type="unfinished">‫ملف الاسقاط %s غير موجود.‬</translation>
     </message>
     <message>
         <source>Error creating %s</source>
@@ -573,7 +656,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Error loading %s: Private keys can only be disabled during creation</source>
-        <translation type="unfinished">خطأ في تحميل %s:  لا يمكن تعطيل المفاتيح الخاصة إلا أثناء الإنشاء.</translation>
+        <translation type="unfinished">‫خطأ في تحميل %s: يمكن تعطيل المفاتيح الخاصة أثناء الانشاء فقط‬</translation>
     </message>
     <message>
         <source>Error loading %s: Wallet corrupted</source>
@@ -581,35 +664,51 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Error loading %s: Wallet requires newer version of %s</source>
-        <translation type="unfinished">خطا تحميل %s: المحفظة تتطلب النسخة الجديدة من %s.</translation>
+        <translation type="unfinished">‫خطأ في تحميل %s: المحفظة تتطلب الاصدار الجديد من %s‬</translation>
     </message>
     <message>
         <source>Error loading block database</source>
-        <translation type="unfinished">خطأ في تحميل قاعدة بيانات الكتل</translation>
+        <translation type="unfinished">‫خطأ في تحميل قاعدة بيانات الطوابق‬</translation>
     </message>
     <message>
         <source>Error opening block database</source>
-        <translation type="unfinished">خطأ في فتح قاعدة بيانات الكتل</translation>
+        <translation type="unfinished">‫خطأ في فتح قاعدة بيانات الطوابق‬</translation>
     </message>
     <message>
         <source>Error reading from database, shutting down.</source>
-        <translation type="unfinished">خطأ في القراءة من قاعدة البيانات ، والتوقف.</translation>
+        <translation type="unfinished">‫خطأ في القراءة من قاعدة البيانات ، يجري التوقف.‬</translation>
     </message>
     <message>
         <source>Error reading next record from wallet database</source>
         <translation type="unfinished">خطأ قراءة السجل التالي من قاعدة بيانات المحفظة</translation>
     </message>
     <message>
-        <source>Error upgrading chainstate database</source>
-        <translation type="unfinished">خطأ في ترقية قاعدة بيانات chainstate</translation>
+        <source>Error: Could not add watchonly tx to watchonly wallet</source>
+        <translation type="unfinished">‫خطأ: لا يمكن اضافة عملية المراقبة فقط لمحفظة المراقبة‬</translation>
+    </message>
+    <message>
+        <source>Error: Could not delete watchonly transactions</source>
+        <translation type="unfinished">‫خطأ: لا يمكن حذف عمليات المراقبة فقط‬</translation>
     </message>
     <message>
         <source>Error: Couldn't create cursor into database</source>
-        <translation type="unfinished">خطأ : لا يمكن انشاء مؤشر ضمن قاعدة البيانات </translation>
+        <translation type="unfinished">‫خطأ : لم نتمكن من انشاء علامة فارقة (cursor) في قاعدة البيانات‬</translation>
     </message>
     <message>
         <source>Error: Disk space is low for %s</source>
-        <translation type="unfinished">خطأ : مساحة القرص منخفضة ل %s</translation>
+        <translation type="unfinished">‫خطأ : مساحة التخزين منخفضة ل %s</translation>
+    </message>
+    <message>
+        <source>Error: Failed to create new watchonly wallet</source>
+        <translation type="unfinished">‫خطأ: فشل انشاء محفظة المراقبة فقط الجديدة‬</translation>
+    </message>
+    <message>
+        <source>Error: Got key that was not hex: %s</source>
+        <translation type="unfinished">‫خطأ: المفتاح ليس في صيغة ست عشرية: %s</translation>
+    </message>
+    <message>
+        <source>Error: Got value that was not hex: %s</source>
+        <translation type="unfinished">‫خطأ: القيمة ليست في صيغة ست عشرية: %s</translation>
     </message>
     <message>
         <source>Error: Missing checksum</source>
@@ -617,7 +716,23 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Error: No %s addresses available.</source>
-        <translation type="unfinished">خطأ : لا عناوين%s متوفرة </translation>
+        <translation type="unfinished">‫خطأ : لا يتوفر %s عناوين.‬</translation>
+    </message>
+    <message>
+        <source>Error: Unable to begin reading all records in the database</source>
+        <translation type="unfinished">‫خطأ: غير قادر على قراءة السجلات في قاعدة البيانات‬</translation>
+    </message>
+    <message>
+        <source>Error: Unable to make a backup of your wallet</source>
+        <translation type="unfinished">‫خطأ: غير قادر النسخ الاحتياطي للمحفظة‬</translation>
+    </message>
+    <message>
+        <source>Error: Unable to read all records in the database</source>
+        <translation type="unfinished">‫خطأ: غير قادر على قراءة السجلات في قاعدة البيانات‬</translation>
+    </message>
+    <message>
+        <source>Error: Unable to remove watchonly address book data</source>
+        <translation type="unfinished">‫خطأ: غير قادر على ازالة عناوين المراقبة فقط من السجل‬</translation>
     </message>
     <message>
         <source>Error: Unable to write record to new wallet</source>
@@ -629,27 +744,35 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Failed to rescan the wallet during initialization</source>
-        <translation type="unfinished">فشل في اعادة مسح المحفظة خلال عملية التهيئة.</translation>
+        <translation type="unfinished">‫فشلت عملية اعادة تفحص وتدقيق المحفظة أثناء التهيئة‬</translation>
     </message>
     <message>
         <source>Failed to verify database</source>
         <translation type="unfinished">فشل في التحقق من قاعدة البيانات</translation>
     </message>
     <message>
+        <source>Fee rate (%s) is lower than the minimum fee rate setting (%s)</source>
+        <translation type="unfinished">‫معدل الرسوم (%s) أقل من الحد الادنى لاعدادات معدل الرسوم (%s)‬</translation>
+    </message>
+    <message>
         <source>Ignoring duplicate -wallet %s.</source>
-        <translation type="unfinished"> تم تجاهل تعريف مكرر -wallet %s</translation>
+        <translation type="unfinished">‫تجاهل المحفظة المكررة %s.‬</translation>
     </message>
     <message>
         <source>Importing…</source>
-        <translation type="unfinished">استيراد </translation>
+        <translation type="unfinished">‫الاستيراد…‬</translation>
     </message>
     <message>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
-        <translation type="unfinished">لم يتم العثور على كتلة تكوين أو لم تكون صحيحة. datadir خاطئة للشبكة؟</translation>
+        <translation type="unfinished">‫لم يتم العثور على طابق الأساس أو المعلومات غير صحيحة. مجلد بيانات خاطئ للشبكة؟‬</translation>
     </message>
     <message>
         <source>Initialization sanity check failed. %s is shutting down.</source>
-        <translation type="unfinished">فشل بالتحقق في اختبار التعقل. تم إيقاف %s.</translation>
+        <translation type="unfinished">‫فشل التحقق من اختبار التعقل. تم إيقاف %s.</translation>
+    </message>
+    <message>
+        <source>Input not found or already spent</source>
+        <translation type="unfinished">‫المدخلات غير موجودة أو تم صرفها‬</translation>
     </message>
     <message>
         <source>Insufficient funds</source>
@@ -661,19 +784,19 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Invalid P2P permission: '%s'</source>
-        <translation type="unfinished"> إذن غير صالح لالند للند: '%s' </translation>
+        <translation type="unfinished">‫إذن القرين للقرين غير صالح: ‘%s’‬</translation>
     </message>
     <message>
         <source>Invalid amount for -%s=&lt;amount&gt;: '%s'</source>
-        <translation type="unfinished">مبلغ غير صحيح -%s=: '%s'</translation>
+        <translation type="unfinished">‫قيمة غير صحيحة‬ ل - %s=&lt;amount&gt;:"%s"</translation>
     </message>
     <message>
         <source>Invalid amount for -discardfee=&lt;amount&gt;: '%s'</source>
-        <translation type="unfinished">مبلغ غير صحيح  -discardfee=: '%s'</translation>
+        <translation type="unfinished">‫قيمة غير صحيحة‬  -discardfee=&lt;amount&gt;:"%s"</translation>
     </message>
     <message>
         <source>Invalid amount for -fallbackfee=&lt;amount&gt;: '%s'</source>
-        <translation type="unfinished">مبلغ غير صحيح -fallbackfee=: '%s'</translation>
+        <translation type="unfinished">مبلغ غير صحيح ل -fallbackfee=&lt;amount&gt;: '%s'</translation>
     </message>
     <message>
         <source>Loading P2P addresses…</source>
@@ -685,11 +808,15 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Loading block index…</source>
-        <translation type="unfinished">تحميل مؤشر الكتلة</translation>
+        <translation type="unfinished">‫تحميل فهرس الطابق…‬</translation>
     </message>
     <message>
         <source>Loading wallet…</source>
-        <translation type="unfinished">تحميل المحفظة</translation>
+        <translation type="unfinished">‫تحميل المحفظة…‬</translation>
+    </message>
+    <message>
+        <source>Missing amount</source>
+        <translation type="unfinished">‫يفتقد القيمة‬</translation>
     </message>
     <message>
         <source>Not enough file descriptors available.</source>
@@ -697,27 +824,27 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Prune cannot be configured with a negative value.</source>
-        <translation type="unfinished">لا يمكن تهيئة التجريد بقيمة سالبة.</translation>
+        <translation type="unfinished">‫لا يمكن ضبط الاختصار بقيمة سالبة.‬</translation>
     </message>
     <message>
         <source>Prune mode is incompatible with -txindex.</source>
-        <translation type="unfinished">وضع التجريد غير متوافق مع -txindex.</translation>
+        <translation type="unfinished">‫وضع الاختصار غير متوافق مع -txindex.‬</translation>
     </message>
     <message>
         <source>Replaying blocks…</source>
-        <translation type="unfinished">كتل الإعادة</translation>
+        <translation type="unfinished">‫إستعادة الطوابق…‬</translation>
     </message>
     <message>
         <source>Rescanning…</source>
-        <translation type="unfinished">إعادة المسح </translation>
+        <translation type="unfinished">‫إعادة التفحص والتدقيق…‬</translation>
     </message>
     <message>
         <source>SQLiteDatabase: Failed to execute statement to verify database: %s</source>
-        <translation type="unfinished">SQLiteDatabase: فشل في تحضير التصريح لجلب التطبيق id: %s</translation>
+        <translation type="unfinished">‫‫SQLiteDatabase: فشل في تنفيذ الامر لتوثيق قاعدة البيانات: %s</translation>
     </message>
     <message>
         <source>Section [%s] is not recognized.</source>
-        <translation type="unfinished">لم يتم التعرف على القسم  [%s]</translation>
+        <translation type="unfinished">لم يتم التعرف على القسم [%s]</translation>
     </message>
     <message>
         <source>Signing transaction failed</source>
@@ -725,13 +852,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Specified -walletdir "%s" does not exist</source>
-        <translation type="unfinished">ملف المحفظة المحدد "%s" غير موجود
-</translation>
+        <translation type="unfinished">‫مجلد المحفظة المحددة "%s" غير موجود</translation>
     </message>
     <message>
         <source>Specified -walletdir "%s" is a relative path</source>
-        <translation type="unfinished">ملف المحفظة المحدد "%s" غير موجود
-</translation>
+        <translation type="unfinished">‫مسار مجلد المحفظة المحدد "%s" مختصر ومتغير‬</translation>
     </message>
     <message>
         <source>The source code is available from %s.</source>
@@ -739,11 +864,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>The transaction amount is too small to pay the fee</source>
-        <translation type="unfinished">قيمة المعاملة صغيرة جدا لدفع الأجر</translation>
+        <translation type="unfinished">‫قيمة المعاملة صغيرة جدا ولا تكفي لدفع الرسوم‬</translation>
     </message>
     <message>
         <source>The wallet will avoid paying less than the minimum relay fee.</source>
-        <translation type="unfinished">سوف تتجنب المحفظة دفع أقل من الحد الأدنى لرسوم التتابع.</translation>
+        <translation type="unfinished">‫سوف تتجنب المحفظة دفع رسوم أقل من الحد الأدنى للتوصيل.‬</translation>
     </message>
     <message>
         <source>This is experimental software.</source>
@@ -755,7 +880,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>This is the transaction fee you will pay if you send a transaction.</source>
-        <translation type="unfinished">هذه هي رسوم تحويل الأموال التي ستدفعها إذا قمت بتحويل الأموال.</translation>
+        <translation type="unfinished">‫هذه هي رسوم ارسال العملية التي ستدفعها إذا قمت بارسال العمليات.‬</translation>
     </message>
     <message>
         <source>Transaction amount too small</source>
@@ -763,15 +888,15 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Transaction amounts must not be negative</source>
-        <translation type="unfinished">يجب ألا تكون قيمة المعاملة سلبية</translation>
-    </message>
-    <message>
-        <source>Transaction has too long of a mempool chain</source>
-        <translation type="unfinished">المعاملات طويلة جداً على حجم سلسلة الذاكرة </translation>
+        <translation type="unfinished">‫يجب ألا تكون قيمة العملية بالسالب‬</translation>
     </message>
     <message>
         <source>Transaction must have at least one recipient</source>
         <translation type="unfinished">يجب أن تحتوي المعاملة على مستلم واحد على الأقل</translation>
+    </message>
+    <message>
+        <source>Transaction needs a change address, but we can't generate it.</source>
+        <translation type="unfinished">‫العملية تتطلب عنوان فكة ولكن لم نتمكن من توليد العنوان.‬</translation>
     </message>
     <message>
         <source>Transaction too large</source>
@@ -791,7 +916,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Unable to generate keys</source>
-        <translation type="unfinished"> غير قادر على توليد مفاتيح.</translation>
+        <translation type="unfinished"> غير قادر على توليد مفاتيح</translation>
     </message>
     <message>
         <source>Unable to open %s for writing</source>
@@ -803,7 +928,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Unknown -blockfilterindex value %s.</source>
-        <translation type="unfinished">قيمة -blockfilterindex  مجهولة %s.</translation>
+        <translation type="unfinished">‫قيمة -blockfilterindex  مجهولة %s.‬</translation>
     </message>
     <message>
         <source>Unknown address type '%s'</source>
@@ -814,12 +939,8 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">شبكة مجهولة عرفت حددت في -onlynet: '%s'</translation>
     </message>
     <message>
-        <source>Upgrading UTXO database</source>
-        <translation type="unfinished">ترقية قاعدة بيانات UTXO</translation>
-    </message>
-    <message>
         <source>Verifying blocks…</source>
-        <translation type="unfinished">جار التحقق من الكتل...</translation>
+        <translation type="unfinished">جار التحقق من الطوابق...</translation>
     </message>
     <message>
         <source>Verifying wallet(s)…</source>
@@ -827,7 +948,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Wallet needed to be rewritten: restart %s to complete</source>
-        <translation type="unfinished">يلزم إعادة كتابة المحفظة: إعادة تشغيل %s لإكمال العملية</translation>
+        <translation type="unfinished">يجب إعادة كتابة المحفظة: يلزم إعادة تشغيل %s لإكمال العملية</translation>
     </message>
 </context>
 <context>
@@ -850,7 +971,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>E&amp;xit</source>
-        <translation type="unfinished">خروج</translation>
+        <translation type="unfinished">‫خ&amp;روج‬</translation>
     </message>
     <message>
         <source>Quit application</source>
@@ -858,11 +979,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>&amp;About %1</source>
-        <translation type="unfinished">حوالي %1</translation>
+        <translation type="unfinished">&amp;حوالي %1</translation>
     </message>
     <message>
         <source>Show information about %1</source>
-        <translation type="unfinished">أظهر المعلومات حولة %1</translation>
+        <translation type="unfinished">‫أظهر المعلومات حول %1‬</translation>
     </message>
     <message>
         <source>About &amp;Qt</source>
@@ -870,15 +991,19 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Show information about Qt</source>
-        <translation type="unfinished">اظهر المعلومات</translation>
+        <translation type="unfinished">‫اظهر المعلومات عن Qt‬</translation>
     </message>
     <message>
         <source>Modify configuration options for %1</source>
-        <translation type="unfinished">تغيير خيارات الإعداد لأساس ل%1</translation>
+        <translation type="unfinished">تغيير خيارات الإعداد ل%1</translation>
     </message>
     <message>
         <source>Create a new wallet</source>
         <translation type="unfinished">إنشاء محفظة جديدة</translation>
+    </message>
+    <message>
+        <source>&amp;Minimize</source>
+        <translation type="unfinished">‫&amp;تصغير‬</translation>
     </message>
     <message>
         <source>Wallet:</source>
@@ -887,15 +1012,15 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Network activity disabled.</source>
         <extracomment>A substring of the tooltip.</extracomment>
-        <translation type="unfinished">تم إلغاء تفعيل الشبكه</translation>
+        <translation type="unfinished">‫نشاط الشبكة معطل.‬</translation>
     </message>
     <message>
         <source>Proxy is &lt;b&gt;enabled&lt;/b&gt;: %1</source>
-        <translation type="unfinished">%1 اتصال نشط بشبكة البيتكوين</translation>
+        <translation type="unfinished">البروكسي &lt;b&gt;يعمل &lt;/b&gt;:%1</translation>
     </message>
     <message>
         <source>Send coins to a Bitcoin address</source>
-        <translation type="unfinished">ارسل عملات الى عنوان بيتكوين</translation>
+        <translation type="unfinished">‫ارسل بتكوين الى عنوان‬</translation>
     </message>
     <message>
         <source>Backup wallet to another location</source>
@@ -903,7 +1028,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Change the passphrase used for wallet encryption</source>
-        <translation type="unfinished">تغيير كلمة المرور المستخدمة لتشفير المحفظة</translation>
+        <translation type="unfinished">‫تغيير عبارة المرور المستخدمة لتشفير المحفظة‬</translation>
     </message>
     <message>
         <source>&amp;Send</source>
@@ -911,15 +1036,15 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>&amp;Receive</source>
-        <translation type="unfinished">&amp;استقبل</translation>
+        <translation type="unfinished">‫&amp;استلم‬</translation>
     </message>
     <message>
         <source>&amp;Options…</source>
-        <translation type="unfinished">&amp; خيارات</translation>
+        <translation type="unfinished">‫&amp;خيارات…‬</translation>
     </message>
     <message>
         <source>&amp;Encrypt Wallet…</source>
-        <translation type="unfinished">&amp; تشفير المحفظة</translation>
+        <translation type="unfinished">‫&amp;تشفير المحفظة…‬</translation>
     </message>
     <message>
         <source>Encrypt the private keys that belong to your wallet</source>
@@ -927,39 +1052,39 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>&amp;Backup Wallet…</source>
-        <translation type="unfinished">&amp; محفظة احتياطية</translation>
+        <translation type="unfinished">‫&amp;انسخ المحفظة احتياطيا…‬</translation>
     </message>
     <message>
         <source>&amp;Change Passphrase…</source>
-        <translation type="unfinished">وتغيير العبارات...</translation>
+        <translation type="unfinished">‫&amp;تغيير عبارة المرور…‬</translation>
     </message>
     <message>
         <source>Sign &amp;message…</source>
-        <translation type="unfinished">علامة ورسالة...</translation>
+        <translation type="unfinished">‫توقيع &amp;رسالة…‬</translation>
     </message>
     <message>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
-        <translation type="unfinished">وقَع الرسائل بواسطة ال: Bitcoin الخاص بك لإثبات امتلاكك لهم</translation>
+        <translation type="unfinished">‫وقَع الرسائل باستخدام عناوين البتكوين لإثبات امتلاكك لهذه العناوين‬</translation>
     </message>
     <message>
         <source>&amp;Verify message…</source>
-        <translation type="unfinished">&amp; تحقق من الرسالة</translation>
+        <translation type="unfinished">‫&amp;تحقق من الرسالة…‬</translation>
     </message>
     <message>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
-        <translation type="unfinished">تحقق من الرسائل للتأكد من أنَها وُقعت برسائل Bitcoin محدَدة</translation>
+        <translation type="unfinished">‫تحقق من الرسائل للتأكد من أنَها وُقّعت بعناوين بتكوين محددة‬</translation>
     </message>
     <message>
         <source>&amp;Load PSBT from file…</source>
-        <translation type="unfinished">وتحميل PSBT من ملف...</translation>
+        <translation type="unfinished">‫&amp;تحميل معاملة PSBT من ملف…‬</translation>
     </message>
     <message>
         <source>Open &amp;URI…</source>
-        <translation type="unfinished">فتح ورابط...</translation>
+        <translation type="unfinished">‫فتح &amp;رابط…‬</translation>
     </message>
     <message>
         <source>Close Wallet…</source>
-        <translation type="unfinished">اغلاق المحفظة</translation>
+        <translation type="unfinished">‫اغلاق المحفظة…‬</translation>
     </message>
     <message>
         <source>Create Wallet…</source>
@@ -967,7 +1092,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Close All Wallets…</source>
-        <translation type="unfinished">اغلاق جميع المحافظ</translation>
+        <translation type="unfinished">‫اغلاق جميع المحافظ…‬</translation>
     </message>
     <message>
         <source>&amp;File</source>
@@ -986,36 +1111,40 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">شريط أدوات علامات التبويب</translation>
     </message>
     <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation type="unfinished">مزامنة الرؤوس (%1%)...</translation>
+    </message>
+    <message>
         <source>Synchronizing with network…</source>
-        <translation type="unfinished">مزامنة مع الشبكة ...</translation>
+        <translation type="unfinished">‫تزامن مع الشبكة…‬</translation>
     </message>
     <message>
         <source>Indexing blocks on disk…</source>
-        <translation type="unfinished">كتل الفهرسة على القرص ...</translation>
+        <translation type="unfinished">‫فهرسة الطوابق على وحدة التخزين المحلي…‬</translation>
     </message>
     <message>
         <source>Processing blocks on disk…</source>
-        <translation type="unfinished">كتل المعالجة على القرص ...</translation>
+        <translation type="unfinished">‫معالجة الطوابق على وحدة التخزين المحلي…‬</translation>
     </message>
     <message>
         <source>Reindexing blocks on disk…</source>
-        <translation type="unfinished">جارٍ إعادة فهرسة الكتل الموجودة على القرص ...</translation>
+        <translation type="unfinished">‫إعادة فهرسة الطوابق في وحدة التخزين المحلي…‬</translation>
     </message>
     <message>
         <source>Connecting to peers…</source>
-        <translation type="unfinished">الاتصال بالأقران ...</translation>
+        <translation type="unfinished">‫الاتصال بالأقران…‬</translation>
     </message>
     <message>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
-        <translation type="unfinished">أطلب دفعات (يولد كودات الرمز المربع وبيت كوين: العناوين المعطاة)</translation>
+        <translation type="unfinished">‫أطلب مدفوعات (أنشئ رموز استجابة (QR Codes) وعناوين بتكوين)‬</translation>
     </message>
     <message>
         <source>Show the list of used sending addresses and labels</source>
-        <translation type="unfinished">عرض قائمة عناوين الإرسال المستخدمة والملصقات</translation>
+        <translation type="unfinished">‫عرض قائمة العناوين المرسِلة والمذكرات (المستخدمة سابقا)‬</translation>
     </message>
     <message>
         <source>Show the list of used receiving addresses and labels</source>
-        <translation type="unfinished">عرض قائمة عناوين الإستقبال المستخدمة والملصقات</translation>
+        <translation type="unfinished">‫عرض قائمة العناوين المستلمة والمذكرات (المستخدمة سابقا)‬</translation>
     </message>
     <message>
         <source>&amp;Command-line options</source>
@@ -1024,29 +1153,29 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>Processed %n block(s) of transaction history.</numerusform>
+            <numerusform>Processed %n block(s) of transaction history.</numerusform>
+            <numerusform>Processed %n block(s) of transaction history.</numerusform>
+            <numerusform>Processed %n block(s) of transaction history.</numerusform>
+            <numerusform>Processed %n block(s) of transaction history.</numerusform>
+            <numerusform>‫تمت معالجة %n طوابق من العمليات التاريخية.‬</numerusform>
         </translation>
     </message>
     <message>
         <source>%1 behind</source>
-        <translation type="unfinished">خلف %1</translation>
+        <translation type="unfinished">‫متأخر‬ %1</translation>
     </message>
     <message>
         <source>Catching up…</source>
-        <translation type="unfinished">يمسك…</translation>
+        <translation type="unfinished">‫يجري التدارك…‬</translation>
     </message>
     <message>
         <source>Last received block was generated %1 ago.</source>
-        <translation type="unfinished">تم توليد الكتلة المستقبلة الأخيرة منذ %1.</translation>
+        <translation type="unfinished">‫آخر طابق مستلم تم بناءه قبل %1.</translation>
     </message>
     <message>
         <source>Transactions after this will not yet be visible.</source>
-        <translation type="unfinished">المعاملات بعد ذلك لن تكون مريئة بعد.</translation>
+        <translation type="unfinished">‫المعاملات بعد هذه لن تكون ظاهرة فورا.‬</translation>
     </message>
     <message>
         <source>Error</source>
@@ -1062,35 +1191,39 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Up to date</source>
-        <translation type="unfinished">محدث</translation>
+        <translation type="unfinished">‫حديث‬</translation>
     </message>
     <message>
         <source>Load Partially Signed Bitcoin Transaction</source>
-        <translation type="unfinished">تحميل معاملة بتكوين الموقعة جزئيًا</translation>
+        <translation type="unfinished">‫تحميل معاملة بتكوين موقعة جزئيًا (PSBT)‬</translation>
+    </message>
+    <message>
+        <source>Load PSBT from &amp;clipboard…</source>
+        <translation type="unfinished">‫تحميل معاملة بتكوين موقعة جزئيا (‫PSBT) من &amp;الحافظة…‬</translation>
     </message>
     <message>
         <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
-        <translation type="unfinished">تحميل معاملة بتكوين الموقعة جزئيًا من الحافظة</translation>
+        <translation type="unfinished">‫تحميل معاملة بتكوين موقعة جزئيًا ‫(‫PSBT) من الحافظة‬</translation>
     </message>
     <message>
         <source>Node window</source>
-        <translation type="unfinished">نافذة Node </translation>
+        <translation type="unfinished">‫نافذة النود‬</translation>
     </message>
     <message>
         <source>Open node debugging and diagnostic console</source>
-        <translation type="unfinished">افتح وحدة التحكم في تصحيح أخطاء node والتشخيص</translation>
+        <translation type="unfinished">‫افتح وحدة التحكم في تصحيح الأخطاء والتشخيص للنود‬</translation>
     </message>
     <message>
         <source>&amp;Sending addresses</source>
-        <translation type="unfinished">&amp;عناوين الإرسال</translation>
+        <translation type="unfinished">‫&amp;عناوين الإرسال‬</translation>
     </message>
     <message>
         <source>&amp;Receiving addresses</source>
-        <translation type="unfinished">&amp;عناوين الإستقبال</translation>
+        <translation type="unfinished">‫&amp;عناوين الإستلام‬</translation>
     </message>
     <message>
         <source>Open a bitcoin: URI</source>
-        <translation type="unfinished">افتح عملة بيتكوين: URI</translation>
+        <translation type="unfinished">‫افتح رابط بتكوين: URI‬</translation>
     </message>
     <message>
         <source>Open Wallet</source>
@@ -1098,39 +1231,69 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Open a wallet</source>
-        <translation type="unfinished">افتح المحفظة</translation>
+        <translation type="unfinished">‫افتح محفظة‬</translation>
     </message>
     <message>
         <source>Close wallet</source>
         <translation type="unfinished">اغلق المحفظة</translation>
     </message>
     <message>
+        <source>Restore Wallet…</source>
+        <extracomment>Name of the menu item that restores wallet from a backup file.</extracomment>
+        <translation type="unfinished">‫استعادة محفظة…‬</translation>
+    </message>
+    <message>
+        <source>Restore a wallet from a backup file</source>
+        <extracomment>Status tip for Restore Wallet menu item</extracomment>
+        <translation type="unfinished">‫استعادة محفظة من ملف النسخ الاحتياطي‬</translation>
+    </message>
+    <message>
         <source>Close all wallets</source>
-        <translation type="unfinished">إغلاق جميع المحافظ ...</translation>
+        <translation type="unfinished">‫إغلاق جميع المحافظ‬</translation>
     </message>
     <message>
         <source>Show the %1 help message to get a list with possible Bitcoin command-line options</source>
-        <translation type="unfinished">بين اشارة المساعدة %1 للحصول على قائمة من خيارات اوامر البت كوين المحتملة </translation>
+        <translation type="unfinished">‫اعرض %1 رسالة المساعدة للحصول على قائمة من خيارات سطر أوامر البتكوين المحتملة‬</translation>
     </message>
     <message>
         <source>&amp;Mask values</source>
-        <translation type="unfinished">&amp; إخفاء القيم</translation>
+        <translation type="unfinished">&amp;إخفاء القيم</translation>
     </message>
     <message>
         <source>Mask the values in the Overview tab</source>
-        <translation type="unfinished">إخفاء القيم في علامة التبويب نظرة عامة</translation>
+        <translation type="unfinished">‫إخفاء القيم في علامة التبويب: نظرة عامة‬</translation>
     </message>
     <message>
         <source>default wallet</source>
-        <translation type="unfinished">المحفظة الإفتراضية</translation>
+        <translation type="unfinished">‫محفظة افتراضية‬</translation>
     </message>
     <message>
         <source>No wallets available</source>
-        <translation type="unfinished">المحفظة الرقمية غير متوفرة</translation>
+        <translation type="unfinished">‫لا يوجد محفظة متاحة‬</translation>
+    </message>
+    <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">بيانات المحفظة</translation>
+    </message>
+    <message>
+        <source>Load Wallet Backup</source>
+        <extracomment>The title for Restore Wallet File Windows</extracomment>
+        <translation type="unfinished">‫تحميل النسخة الاحتياطية لمحفظة‬</translation>
+    </message>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of pop-up window shown when the user is attempting to restore a wallet.</extracomment>
+        <translation type="unfinished">استعادة المحفظة</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">إسم المحفظة</translation>
     </message>
     <message>
         <source>&amp;Window</source>
-        <translation type="unfinished">نافذه</translation>
+        <translation type="unfinished">‫&amp;نافذة‬</translation>
     </message>
     <message>
         <source>Zoom</source>
@@ -1142,18 +1305,26 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>%1 client</source>
-        <translation type="unfinished">الزبون %1</translation>
+        <translation type="unfinished">‫العميل %1</translation>
+    </message>
+    <message>
+        <source>&amp;Hide</source>
+        <translation type="unfinished">‫&amp;اخفاء‬</translation>
+    </message>
+    <message>
+        <source>S&amp;how</source>
+        <translation type="unfinished">‫ع&amp;رض‬</translation>
     </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n active connection(s) to Bitcoin network.</numerusform>
+            <numerusform>%n active connection(s) to Bitcoin network.</numerusform>
+            <numerusform>%n active connection(s) to Bitcoin network.</numerusform>
+            <numerusform>%n active connection(s) to Bitcoin network.</numerusform>
+            <numerusform>%n active connection(s) to Bitcoin network.</numerusform>
+            <numerusform>%n اتصال نشط بشبكة البتكوين.</numerusform>
         </translation>
     </message>
     <message>
@@ -1164,7 +1335,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Show Peers tab</source>
         <extracomment>A context menu item. The "Peers tab" is an element of the "Node window".</extracomment>
-        <translation type="unfinished">إظهار علامة التبويب النظراء</translation>
+        <translation type="unfinished">‫إظهار تبويب الأقران‬</translation>
     </message>
     <message>
         <source>Disable network activity</source>
@@ -1175,6 +1346,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Enable network activity</source>
         <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
         <translation type="unfinished">تمكين نشاط الشبكة</translation>
+    </message>
+    <message>
+        <source>Pre-syncing Headers (%1%)…</source>
+        <translation type="unfinished">ما قبل مزامنة الرؤوس (%1%)…</translation>
     </message>
     <message>
         <source>Error: %1</source>
@@ -1188,46 +1363,45 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Date: %1
 </source>
         <translation type="unfinished">التاريخ %1
-
-
 </translation>
     </message>
     <message>
         <source>Amount: %1
 </source>
-        <translation type="unfinished">الكمية %1
+        <translation type="unfinished">القيمة %1
 </translation>
     </message>
     <message>
         <source>Wallet: %1
 </source>
-        <translation type="unfinished">المحفظة:  %1</translation>
+        <translation type="unfinished">المحفظة:  %1
+</translation>
     </message>
     <message>
         <source>Type: %1
 </source>
-        <translation type="unfinished">نوع %1
+        <translation type="unfinished">النوع %1
 </translation>
     </message>
     <message>
         <source>Label: %1
 </source>
-        <translation type="unfinished">علامه: %1
+        <translation type="unfinished">‫المذكرة‬: %1
 </translation>
     </message>
     <message>
         <source>Address: %1
 </source>
-        <translation type="unfinished">عنوان %1
+        <translation type="unfinished">العنوان %1
 </translation>
     </message>
     <message>
         <source>Sent transaction</source>
-        <translation type="unfinished">إرسال المعاملة</translation>
+        <translation type="unfinished">‫العمليات المرسلة‬</translation>
     </message>
     <message>
         <source>Incoming transaction</source>
-        <translation type="unfinished">المعاملات الواردة</translation>
+        <translation type="unfinished">‫العمليات الواردة‬</translation>
     </message>
     <message>
         <source>HD key generation is &lt;b&gt;enabled&lt;/b&gt;</source>
@@ -1239,7 +1413,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Private key &lt;b&gt;disabled&lt;/b&gt;</source>
-        <translation type="unfinished">المفتاح السري &lt;b&gt;معطل&lt;/b&gt;</translation>
+        <translation type="unfinished">المفتاح الخاص &lt;b&gt;معطل&lt;/b&gt;</translation>
     </message>
     <message>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
@@ -1258,14 +1432,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <name>UnitDisplayStatusBarControl</name>
     <message>
         <source>Unit to show amounts in. Click to select another unit.</source>
-        <translation type="unfinished">الوحدة لإظهار المبالغ فيها. انقر لتحديد وحدة أخرى.</translation>
+        <translation type="unfinished">‫وحدة عرض القيمة. انقر لتغيير وحدة العرض.‬</translation>
     </message>
 </context>
 <context>
     <name>CoinControlDialog</name>
     <message>
         <source>Coin Selection</source>
-        <translation type="unfinished">اختيار العمله</translation>
+        <translation type="unfinished">اختيار وحدات البتكوين</translation>
     </message>
     <message>
         <source>Quantity:</source>
@@ -1273,11 +1447,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Bytes:</source>
-        <translation type="unfinished">بايت</translation>
+        <translation type="unfinished">بايت:</translation>
     </message>
     <message>
         <source>Amount:</source>
-        <translation type="unfinished">القيمة :</translation>
+        <translation type="unfinished">القيمة:</translation>
     </message>
     <message>
         <source>Fee:</source>
@@ -1289,15 +1463,15 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>After Fee:</source>
-        <translation type="unfinished">بعد الرسوم :</translation>
+        <translation type="unfinished">بعد الرسوم:</translation>
     </message>
     <message>
         <source>Change:</source>
-        <translation type="unfinished">تعديل :</translation>
+        <translation type="unfinished">تعديل:</translation>
     </message>
     <message>
         <source>(un)select all</source>
-        <translation type="unfinished">عدم اختيار الجميع</translation>
+        <translation type="unfinished">‫الغاء تحديد الكل‬</translation>
     </message>
     <message>
         <source>Tree mode</source>
@@ -1309,15 +1483,15 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Amount</source>
-        <translation type="unfinished">مبلغ</translation>
+        <translation type="unfinished">‫القيمة‬</translation>
     </message>
     <message>
         <source>Received with label</source>
-        <translation type="unfinished">مستقبل مع ملصق</translation>
+        <translation type="unfinished">‫استُلم وله مذكرة‬</translation>
     </message>
     <message>
         <source>Received with address</source>
-        <translation type="unfinished">مستقبل مع عنوان</translation>
+        <translation type="unfinished">‫مستلم مع عنوان‬</translation>
     </message>
     <message>
         <source>Date</source>
@@ -1329,23 +1503,27 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Confirmed</source>
-        <translation type="unfinished">تأكيد</translation>
+        <translation type="unfinished">‫نافذ‬</translation>
     </message>
     <message>
         <source>Copy amount</source>
-        <translation type="unfinished">نسخ الكمية</translation>
+        <translation type="unfinished">‫نسخ القيمة‬</translation>
     </message>
     <message>
         <source>&amp;Copy address</source>
-        <translation type="unfinished">انسخ العنوان</translation>
+        <translation type="unfinished">‫&amp;نسخ العنوان‬</translation>
     </message>
     <message>
         <source>Copy &amp;label</source>
-        <translation type="unfinished">نسخ و تصنيف</translation>
+        <translation type="unfinished">‫نسخ &amp;اضافة مذكرة‬</translation>
     </message>
     <message>
         <source>Copy &amp;amount</source>
-        <translation type="unfinished">نسخ &amp;مبلغ</translation>
+        <translation type="unfinished">‫نسخ &amp;القيمة‬</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID and output index</source>
+        <translation type="unfinished">‫نسخ &amp;معرف العملية وفهرس المخرجات‬</translation>
     </message>
     <message>
         <source>L&amp;ock unspent</source>
@@ -1377,7 +1555,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Copy change</source>
-        <translation type="unfinished">نسخ التعديل</translation>
+        <translation type="unfinished">‫نسخ الفكة‬</translation>
     </message>
     <message>
         <source>(%1 locked)</source>
@@ -1393,23 +1571,23 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>This label turns red if any recipient receives an amount smaller than the current dust threshold.</source>
-        <translation type="unfinished">يتحول هذا الملصق إلى اللون الأحمر إذا تلقى أي مستلم كمية أصغر من عتبة الغبار الحالية.</translation>
+        <translation type="unfinished">‫تتحول هذه المذكرة إلى اللون الأحمر إذا تلقى مستلم كمية أقل من الحد الأعلى الحالي للغبار .‬</translation>
     </message>
     <message>
         <source>Can vary +/- %1 satoshi(s) per input.</source>
-        <translation type="unfinished">يمكن أن يختلف +/- %1 من ساتوشي(s) لكل إدخال.</translation>
+        <translation type="unfinished">‫يمكن يزيد أو ينقص %1 ساتوشي لكل مدخل.‬</translation>
     </message>
     <message>
         <source>(no label)</source>
-        <translation type="unfinished">(بدون وسم)</translation>
+        <translation type="unfinished">( لا وجود لمذكرة)</translation>
     </message>
     <message>
         <source>change from %1 (%2)</source>
-        <translation type="unfinished">تغير من %1 (%2)</translation>
+        <translation type="unfinished">تغيير من %1 (%2)</translation>
     </message>
     <message>
         <source>(change)</source>
-        <translation type="unfinished">(تغير)</translation>
+        <translation type="unfinished">‫(غيّر)‬</translation>
     </message>
 </context>
 <context>
@@ -1422,11 +1600,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
         <extracomment>Descriptive text of the create wallet progress window which indicates to the user which wallet is currently being created.</extracomment>
-        <translation type="unfinished">جاري انشاء المحفظة &lt;b&gt;%1&lt;/b&gt;... </translation>
+        <translation type="unfinished">جار انشاء المحفظة &lt;b&gt;%1&lt;/b&gt;...</translation>
     </message>
     <message>
         <source>Create wallet failed</source>
-        <translation type="unfinished">فشل إنشاء المحفظة</translation>
+        <translation type="unfinished">‫تعذر إنشاء المحفظة‬</translation>
     </message>
     <message>
         <source>Create wallet warning</source>
@@ -1436,12 +1614,29 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Can't list signers</source>
         <translation type="unfinished">لا يمكن سرد الموقعين</translation>
     </message>
+    <message>
+        <source>Too many external signers found</source>
+        <translation type="unfinished">‫تم العثور على موقّعين خارجيين كُثر (Too Many)‬</translation>
+    </message>
+</context>
+<context>
+    <name>LoadWalletsActivity</name>
+    <message>
+        <source>Load Wallets</source>
+        <extracomment>Title of progress window which is displayed when wallets are being loaded.</extracomment>
+        <translation type="unfinished">‫تحميل المحفظة‬</translation>
+    </message>
+    <message>
+        <source>Loading wallets…</source>
+        <extracomment>Descriptive text of the load wallets progress window which indicates to the user that wallets are currently being loaded.</extracomment>
+        <translation type="unfinished">‫تحميل المحافظ…‬</translation>
+    </message>
 </context>
 <context>
     <name>OpenWalletActivity</name>
     <message>
         <source>Open wallet failed</source>
-        <translation type="unfinished">فشل فتح محفظة</translation>
+        <translation type="unfinished">‫تعذر فتح محفظة‬</translation>
     </message>
     <message>
         <source>Open wallet warning</source>
@@ -1449,17 +1644,45 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>default wallet</source>
-        <translation type="unfinished">المحفظة الإفتراضية</translation>
+        <translation type="unfinished">‫محفظة افتراضية‬</translation>
     </message>
     <message>
         <source>Open Wallet</source>
         <extracomment>Title of window indicating the progress of opening of a wallet.</extracomment>
-        <translation type="unfinished">افتح المحفظة</translation>
+        <translation type="unfinished">‫افتح محفظة‬</translation>
     </message>
     <message>
         <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
         <extracomment>Descriptive text of the open wallet progress window which indicates to the user which wallet is currently being opened.</extracomment>
-        <translation type="unfinished">جاري فتح المحفظة&lt;b&gt;%1&lt;/b&gt;...</translation>
+        <translation type="unfinished">جار فتح المحفظة&lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+</context>
+<context>
+    <name>RestoreWalletActivity</name>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of progress window which is displayed when wallets are being restored.</extracomment>
+        <translation type="unfinished">استعادة المحفظة</translation>
+    </message>
+    <message>
+        <source>Restoring Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the restore wallets progress window which indicates to the user that wallets are currently being restored.</extracomment>
+        <translation type="unfinished">استعادة المحفظة &lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+    <message>
+        <source>Restore wallet failed</source>
+        <extracomment>Title of message box which is displayed when the wallet could not be restored.</extracomment>
+        <translation type="unfinished">‫تعذر استعادة المحفظة‬</translation>
+    </message>
+    <message>
+        <source>Restore wallet warning</source>
+        <extracomment>Title of message box which is displayed when the wallet is restored with some warning.</extracomment>
+        <translation type="unfinished">‫تحذير استعادة المحفظة‬</translation>
+    </message>
+    <message>
+        <source>Restore wallet message</source>
+        <extracomment>Title of message box which is displayed when the wallet is successfully restored.</extracomment>
+        <translation type="unfinished">‫رسالة استعادة محفظة‬</translation>
     </message>
 </context>
 <context>
@@ -1469,12 +1692,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">اغلق المحفظة</translation>
     </message>
     <message>
+        <source>Are you sure you wish to close the wallet &lt;i&gt;%1&lt;/i&gt;?</source>
+        <translation type="unfinished">هل أنت متأكد من رغبتك في إغلاق المحفظة &lt;i&gt;%1&lt;/i&gt;؟ </translation>
+    </message>
+    <message>
         <source>Closing the wallet for too long can result in having to resync the entire chain if pruning is enabled.</source>
-        <translation type="unfinished">اغلاق المحفظة لفترة طويلة قد يؤدي الى الاضطرار الى اعادة مزامنة السلسلة بأكملها اذا تم تمكين التلقيم.</translation>
+        <translation type="unfinished">‫اغلاق المحفظة لفترة طويلة قد يتطلب اعادة مزامنة المتتالية بأكملها إذا كانت النود مختصرة.‬</translation>
     </message>
     <message>
         <source>Close all wallets</source>
-        <translation type="unfinished">إغلاق جميع المحافظ ...</translation>
+        <translation type="unfinished">إغلاق جميع المحافظ</translation>
     </message>
     <message>
         <source>Are you sure you wish to close all wallets?</source>
@@ -1497,7 +1724,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Encrypt the wallet. The wallet will be encrypted with a passphrase of your choice.</source>
-        <translation type="unfinished">شفر المحفظة. المحفظة سيتم تشفيرها بإستخدام كلمة مرور من إختيارك.</translation>
+        <translation type="unfinished">‫شفر المحفظة. المحفظة سيتم تشفيرها بإستخدام عبارة مرور من اختيارك.‬</translation>
     </message>
     <message>
         <source>Encrypt Wallet</source>
@@ -1509,7 +1736,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Disable private keys for this wallet. Wallets with private keys disabled will have no private keys and cannot have an HD seed or imported private keys. This is ideal for watch-only wallets.</source>
-        <translation type="unfinished">تعطيل المفاتيح الخاصة لهذه المحفظة. لن تحتوي المحافظ ذات المفاتيح الخاصة المعطلة على مفاتيح خاصة ولا يمكن أن تحتوي على مفتاح HD أو مفاتيح خاصة مستوردة. هذا مثالي لمحافظ مشاهدة فقط فقط.</translation>
+        <translation type="unfinished">‫تعطيل المفاتيح الخاصة لهذه المحفظة. لن تحتوي المحافظ ذات المفاتيح الخاصة المعطلة على مفاتيح خاصة ولا يمكن أن تحتوي على مفتاح HD أو مفاتيح خاصة مستوردة. هذا مثالي لمحافظ المراقبة فقط.‬</translation>
     </message>
     <message>
         <source>Disable Private Keys</source>
@@ -1533,7 +1760,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Use an external signing device such as a hardware wallet. Configure the external signer script in wallet preferences first.</source>
-        <translation type="unfinished">استخدم جهاز توقيع خارجي مثل محفظة الأجهزة.  قم بتكوين البرنامج النصي للموقِّع الخارجي في تفضيلات المحفظة أولاً.</translation>
+        <translation type="unfinished">‫استخدم جهاز توقيع خارجي مثل محفظة خارجية. أعد مسار المحفظة الخارجية في اعدادات المحفظة أولاً.‬</translation>
     </message>
     <message>
         <source>External signer</source>
@@ -1561,15 +1788,15 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>&amp;Label</source>
-        <translation type="unfinished">&amp;وصف</translation>
+        <translation type="unfinished">‫&amp;مذكرة‬</translation>
     </message>
     <message>
         <source>The label associated with this address list entry</source>
-        <translation type="unfinished">الملصق المرتبط بقائمة العناوين المدخلة</translation>
+        <translation type="unfinished">‫المذكرة المرتبطة بقائمة العناوين هذه‬</translation>
     </message>
     <message>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
-        <translation type="unfinished">العنوان المرتبط بقائمة العناوين المدخلة. و التي يمكن تعديلها فقط بواسطة ارسال العناوين</translation>
+        <translation type="unfinished">‫العنوان مرتبط بقائمة العناوين المدخلة. يمكن التعديل لعناوين الارسال فقط.‬</translation>
     </message>
     <message>
         <source>&amp;Address</source>
@@ -1589,11 +1816,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>The entered address "%1" is not a valid Bitcoin address.</source>
-        <translation type="unfinished">العنوان المدخل "%1" ليس عنوان بيت كوين صحيح.</translation>
+        <translation type="unfinished">‫العنوان المدخل "%1" ليس عنوان بتكوين صحيح.‬</translation>
     </message>
     <message>
         <source>Address "%1" already exists as a receiving address with label "%2" and so cannot be added as a sending address.</source>
-        <translation type="unfinished">العنوان "%1" موجود بالفعل كعنوان إستقبال تحت مسمى "%2" ولذلك لا يمكن إضافته كعنوان إرسال.</translation>
+        <translation type="unfinished">‫العنوان "%1" موجود بالفعل كعنوان استلام مع المذكرة "%2" لذلك لا يمكن إضافته كعنوان إرسال.‬</translation>
     </message>
     <message>
         <source>The entered address "%1" is already in the address book with label "%2".</source>
@@ -1601,18 +1828,18 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Could not unlock wallet.</source>
-        <translation type="unfinished"> يمكن فتح المحفظة.</translation>
+        <translation type="unfinished">‫تعذر فتح المحفظة.‬</translation>
     </message>
     <message>
         <source>New key generation failed.</source>
-        <translation type="unfinished">فشل توليد مفتاح جديد.</translation>
+        <translation type="unfinished">‫تعذر توليد مفتاح جديد.‬</translation>
     </message>
 </context>
 <context>
     <name>FreespaceChecker</name>
     <message>
         <source>A new data directory will be created.</source>
-        <translation type="unfinished">سيتم انشاء دليل بيانات جديد.</translation>
+        <translation type="unfinished">‫سيتم انشاء مجلد بيانات جديد.‬</translation>
     </message>
     <message>
         <source>name</source>
@@ -1620,15 +1847,15 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
-        <translation type="unfinished">الدليل موجوج بالفعل. أضف %1 اذا نويت إنشاء دليل جديد هنا.</translation>
+        <translation type="unfinished">‫المجلد موجود بالفعل. أضف %1 اذا أردت إنشاء مجلد جديد هنا.‬</translation>
     </message>
     <message>
         <source>Path already exists, and is not a directory.</source>
-        <translation type="unfinished">المسار موجود بالفعل، وهو ليس دليلاً.</translation>
+        <translation type="unfinished">‫المسار موجود بالفعل، وهو ليس مجلدا.‬</translation>
     </message>
     <message>
         <source>Cannot create data directory here.</source>
-        <translation type="unfinished">لا يمكن انشاء دليل بيانات هنا .</translation>
+        <translation type="unfinished">‫لا يمكن انشاء مجلد بيانات هنا.‬</translation>
     </message>
 </context>
 <context>
@@ -1637,45 +1864,70 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Bitcoin</source>
         <translation type="unfinished">بتكوين</translation>
     </message>
-    <message>
-        <source>(of %1 GB needed)</source>
-        <translation type="unfinished">(من %1 الجيجابايت المطلوبة)</translation>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform>%n GB of space available</numerusform>
+            <numerusform>%n GB of space available</numerusform>
+            <numerusform>%n GB of space available</numerusform>
+            <numerusform>%n GB of space available</numerusform>
+            <numerusform>%n GB of space available</numerusform>
+            <numerusform>‫‫%n جيجابايت من المساحة متوفرة</numerusform>
+        </translation>
     </message>
-    <message>
-        <source>(%1 GB needed for full chain)</source>
-        <translation type="unfinished">(%1 مطلوب غيغابايت للسلسلة الكاملة)</translation>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform>(of %n GB needed)</numerusform>
+            <numerusform>(of %n GB needed)</numerusform>
+            <numerusform>(of %n GB needed)</numerusform>
+            <numerusform>(of %n GB needed)</numerusform>
+            <numerusform>(of %n GB needed)</numerusform>
+            <numerusform>‫(مطلوب %n جيجابايت)‬</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform>(%n GB needed for full chain)</numerusform>
+            <numerusform>(%n GB needed for full chain)</numerusform>
+            <numerusform>(%n GB needed for full chain)</numerusform>
+            <numerusform>(%n GB needed for full chain)</numerusform>
+            <numerusform>(%n GB needed for full chain)</numerusform>
+            <numerusform>‫( مطلوب %n جيجابايت لكامل المتتالية)‬</numerusform>
+        </translation>
     </message>
     <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
-        <translation type="unfinished">سيتم تخزين %1 جيجابايت على الأقل من البيانات في هذا الدليل، وستنمو مع الوقت.</translation>
+        <translation type="unfinished">‫سيتم تخزين %1 جيجابايت على الأقل من المجلد في هذا الدليل، وستنمو مع الوقت.‬</translation>
     </message>
     <message>
         <source>Approximately %1 GB of data will be stored in this directory.</source>
-        <translation type="unfinished">سيتم تخزين %1 جيجابايت تقريباً من البيانات في هذا الدليل.</translation>
+        <translation type="unfinished">‫سيتم تخزين %1 جيجابايت تقريباً من البيانات في هذا المجلد.‬</translation>
     </message>
     <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>(sufficient to restore backups %n day(s) old)</numerusform>
+            <numerusform>(sufficient to restore backups %n day(s) old)</numerusform>
+            <numerusform>(sufficient to restore backups %n day(s) old)</numerusform>
+            <numerusform>(sufficient to restore backups %n day(s) old)</numerusform>
+            <numerusform>(sufficient to restore backups %n day(s) old)</numerusform>
+            <numerusform>(sufficient to restore backups %n day(s) old)</numerusform>
         </translation>
     </message>
     <message>
         <source>%1 will download and store a copy of the Bitcoin block chain.</source>
-        <translation type="unfinished">سيقوم %1 بتنزيل نسخة من سلسلة كتل بتكوين وتخزينها.</translation>
+        <translation type="unfinished">‫سيقوم %1 بتنزيل نسخة من الطوابق المتتالية للبتكوين وتخزينها.‬</translation>
     </message>
     <message>
         <source>The wallet will also be stored in this directory.</source>
-        <translation type="unfinished">سوف يتم تخزين المحفظة في هذا الدليل.</translation>
+        <translation type="unfinished">‫سوف يتم تخزين المحفظة في هذا المجلد.‬</translation>
     </message>
     <message>
         <source>Error: Specified data directory "%1" cannot be created.</source>
-        <translation type="unfinished">خطأ: لا يمكن تكوين دليل بيانات مخصص ل %1</translation>
+        <translation type="unfinished">‫خطأ: مجلد البيانات المحدد “%1” لا يمكن انشاءه.‬</translation>
     </message>
     <message>
         <source>Error</source>
@@ -1683,54 +1935,54 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Welcome</source>
-        <translation type="unfinished">أهلا</translation>
+        <translation type="unfinished">‫مرحبا‬</translation>
     </message>
     <message>
         <source>Welcome to %1.</source>
-        <translation type="unfinished"> اهلا بكم في %1</translation>
+        <translation type="unfinished">‫مرحبا بكم في %1.‬</translation>
     </message>
     <message>
         <source>As this is the first time the program is launched, you can choose where %1 will store its data.</source>
-        <translation type="unfinished">بما انه هذه اول مرة لانطلاق هذا البرنامج, فيمكنك ان تختار اين سيخزن %1 بياناته</translation>
-    </message>
-    <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation type="unfinished">عند النقر على "موافق" ، سيبدأ %1 في تنزيل ومعالجة سلسلة الكتل %4 الكاملة (%2 جيجابايت) بدءًا من المعاملات الأقدم في %3 عند تشغيل %4 في البداية.</translation>
+        <translation type="unfinished">‫بما ان هذه المرة الأولى لتشغيل هذا البرنامج، يمكنك اختيار موقع تخزين %1 البيانات.‬</translation>
     </message>
     <message>
         <source>Limit block chain storage to</source>
-        <translation type="unfinished">تقييد تخزين سلسلة الكتل إلى</translation>
+        <translation type="unfinished">‫تقييد تخزين الطوابق المتتالية حتى‬</translation>
     </message>
     <message>
         <source>Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</source>
-        <translation type="unfinished">تتطلب العودة إلى هذا الإعداد إعادة تنزيل سلسلة الكتل بالكامل. من الأسرع تنزيل السلسلة الكاملة أولاً وتقليمها لاحقًا. تعطيل بعض الميزات المتقدمة.</translation>
+        <translation type="unfinished">‫تتطلب العودة إلى هذا الإعداد إعادة تنزيل الطوابق المتتالية بالكامل. من الأسرع تنزيل المتتالية الكاملة أولاً ثم اختصارها لاحقًا. تتعطل بعض الميزات المتقدمة.‬</translation>
     </message>
     <message>
         <source> GB</source>
-        <translation type="unfinished">غيغابايت</translation>
+        <translation type="unfinished">‫ ‫جيجابايت‬</translation>
     </message>
     <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
-        <translation type="unfinished">تُعد هذه المزامنة الأولية أمرًا شاقًا للغاية، وقد تعرض جهاز الكمبيوتر الخاص بك للمشاكل الذي لم يلاحظها أحد سابقًا. في كل مرة تقوم فيها بتشغيل %1، سيتابع التحميل من حيث تم التوقف.</translation>
+        <translation type="unfinished">‫تُعد المزامنة الأولية عملية مجهدة للأجهزة، و قد تكتشف بعض المشاكل المتعلقة بعتاد جهازك والتي لم تلاحظها مسبقًا. في كل مرة تقوم فيها بتشغيل %1، سيتابع البرنامج التحميل من حيث توقف سابقا.‬</translation>
+    </message>
+    <message>
+        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2 GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
+        <translation type="unfinished">‫عندما تنقر موافق. %1 سنبدأ التحميل ومعالجة كامل %4 الطوابق المتتالية (%2 GB) بدأً من أوائل العمليات في %3 عندما %4 تم الاطلاق لأول مرة.‬</translation>
     </message>
     <message>
         <source>If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</source>
-        <translation type="unfinished">إذا كنت قد اخترت تقييد تخزين سلسلة الكتل (التجريد)، فيجب تحميل البيانات القديمة ومعالجتها، ولكن سيتم حذفها بعد ذلك للحفاظ على انخفاض استخدام القرص.</translation>
+        <translation type="unfinished">‫إذا اخترت تقييد تخزين الطوابق المتتالية (الاختصار)، فيجب تحميل البيانات القديمة ومعالجتها، وسيتم حذفها بعد ذلك لابقاء مساحة التخزين في النطاق المحدد.‬</translation>
     </message>
     <message>
         <source>Use the default data directory</source>
-        <translation type="unfinished">استخدام دليل البانات الافتراضي</translation>
+        <translation type="unfinished">‫استخدام مجلد البيانات الافتراضي‬</translation>
     </message>
     <message>
         <source>Use a custom data directory:</source>
-        <translation type="unfinished">استخدام دليل بيانات مخصص:</translation>
+        <translation type="unfinished">‫استخدام مجلد بيانات آخر:‬</translation>
     </message>
 </context>
 <context>
     <name>HelpMessageDialog</name>
     <message>
         <source>version</source>
-        <translation type="unfinished">النسخة</translation>
+        <translation type="unfinished">‫الاصدار‬</translation>
     </message>
     <message>
         <source>About %1</source>
@@ -1745,42 +1997,42 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <name>ShutdownWindow</name>
     <message>
         <source>%1 is shutting down…</source>
-        <translation type="unfinished">%1 يتم الإغلاق ...</translation>
+        <translation type="unfinished">‫%1 يتم الإغلاق…‬</translation>
     </message>
     <message>
         <source>Do not shut down the computer until this window disappears.</source>
-        <translation type="unfinished">لا توقف عمل الكمبيوتر حتى تختفي هذه النافذة</translation>
+        <translation type="unfinished">‫لا تغلق الكمبيوتر حتى تختفي هذه النافذة.‬</translation>
     </message>
 </context>
 <context>
     <name>ModalOverlay</name>
     <message>
         <source>Form</source>
-        <translation type="unfinished">نمودج</translation>
+        <translation type="unfinished">‫نموذج‬</translation>
     </message>
     <message>
         <source>Recent transactions may not yet be visible, and therefore your wallet's balance might be incorrect. This information will be correct once your wallet has finished synchronizing with the bitcoin network, as detailed below.</source>
-        <translation type="unfinished">قد لا تكون المعاملات الأخيرة مرئية بعد، وبالتالي قد يكون رصيد محفظتك غير صحيح. ستكون هذه المعلومات صحيحة بمجرد الانتهاء من محفظتك مع شبكة البيتكوين، كما هو مفصل أدناه.</translation>
+        <translation type="unfinished">‫قد لا تكون العمليات الأخيرة مرئية بعد، وبالتالي قد يكون رصيد محفظتك غير دقيق. ستكون هذه المعلومات دقيقة بمجرد انتهاء مزامنة محفظتك مع شبكة البيتكوين، كما هو موضح أدناه.‬</translation>
     </message>
     <message>
         <source>Attempting to spend bitcoins that are affected by not-yet-displayed transactions will not be accepted by the network.</source>
-        <translation type="unfinished">لن تقبل الشبكة محاولة إنفاق البتكوين المتأثرة بالمعاملات التي لم يتم عرضها بعد.</translation>
+        <translation type="unfinished">‫لن تقبل الشبكة محاولة انفاق وحدات البتكوين في الطوابق لم يتم مزامنتها بعد.‬</translation>
     </message>
     <message>
         <source>Number of blocks left</source>
-        <translation type="unfinished">عدد الكتل الفاضلة</translation>
+        <translation type="unfinished">‫عدد الطوابق المتبقية‬</translation>
     </message>
     <message>
         <source>Unknown…</source>
-        <translation type="unfinished">غير معروف</translation>
+        <translation type="unfinished">‫غير معروف…‬</translation>
     </message>
     <message>
         <source>calculating…</source>
-        <translation type="unfinished">جاري الحساب</translation>
+        <translation type="unfinished">‫جار الحساب…‬</translation>
     </message>
     <message>
         <source>Last block time</source>
-        <translation type="unfinished">اخر وقت الكتلة</translation>
+        <translation type="unfinished">‫وقت الطابق الأخير‬</translation>
     </message>
     <message>
         <source>Progress</source>
@@ -1788,11 +2040,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Progress increase per hour</source>
-        <translation type="unfinished">تقدم يزيد بلساعة</translation>
+        <translation type="unfinished">‫التقدم لكل ساعة‬</translation>
     </message>
     <message>
         <source>Estimated time left until synced</source>
-        <translation type="unfinished">الوقت المتبقي للمزامنة</translation>
+        <translation type="unfinished">‫الوقت المتبقي حتى التزامن‬</translation>
     </message>
     <message>
         <source>Hide</source>
@@ -1800,18 +2052,22 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Esc</source>
-        <translation type="unfinished">خروج</translation>
+        <translation type="unfinished">‫‫Esc‬</translation>
     </message>
     <message>
         <source>Unknown. Syncing Headers (%1, %2%)…</source>
-        <translation type="unfinished">مجهول.  مزامنة الرؤوس (%1،%2٪) ...</translation>
+        <translation type="unfinished">‫غير معروف. مزامنة الرؤوس (%1, %2%)…‬</translation>
+    </message>
+    <message>
+        <source>Unknown. Pre-syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">‫غير معروف. ما قبل مزامنة الرؤوس (%1, %2%)…‬</translation>
     </message>
 </context>
 <context>
     <name>OpenURIDialog</name>
     <message>
         <source>Open bitcoin URI</source>
-        <translation type="unfinished">افتح بتكوين URI</translation>
+        <translation type="unfinished">‫افتح رابط بتكوين (URI)‬</translation>
     </message>
     <message>
         <source>URI:</source>
@@ -1820,22 +2076,22 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Paste address from clipboard</source>
         <extracomment>Tooltip text for button that allows you to paste an address that is in your clipboard.</extracomment>
-        <translation type="unfinished">انسخ العنوان من لوحة المفاتيح</translation>
+        <translation type="unfinished">‫ألصق العنوان من الحافظة‬</translation>
     </message>
 </context>
 <context>
     <name>OptionsDialog</name>
     <message>
         <source>Options</source>
-        <translation type="unfinished">خيارات ...</translation>
+        <translation type="unfinished">خيارات</translation>
     </message>
     <message>
         <source>&amp;Main</source>
-        <translation type="unfinished">&amp;الرئيسي</translation>
+        <translation type="unfinished">‫&amp;الرئيسية‬</translation>
     </message>
     <message>
         <source>Automatically start %1 after logging in to the system.</source>
-        <translation type="unfinished">ابدأ تلقائيًا %1 بعد تسجيل الدخول إلى النظام.</translation>
+        <translation type="unfinished">‫تشغيل البرنامج تلقائيا %1 بعد تسجيل الدخول إلى النظام.‬</translation>
     </message>
     <message>
         <source>&amp;Start %1 on system login</source>
@@ -1843,11 +2099,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Enabling pruning significantly reduces the disk space required to store transactions. All blocks are still fully validated. Reverting this setting requires re-downloading the entire blockchain.</source>
-        <translation type="unfinished">يؤدي تمكين التقليم إلى تقليل مساحة القرص المطلوبة بشكل كبير لتخزين المعاملات. لا تزال جميع الكتل مصدق عليها بشكل كامل. تتطلب العودة إلى هذا الإعداد إعادة تنزيل blockchain بالكامل.</translation>
+        <translation type="unfinished">‫يؤدي تمكين خيار اختصار النود إلى تقليل مساحة التخزين المطلوبة بشكل كبير. يتم المصادقة على جميع الطوابق رغم تفعيل هذا الخيار،. إلغاء هذا الاعداد يتطلب اعادة تحميل الطوابق المتتالية من جديد بشكل كامل.‬</translation>
     </message>
     <message>
         <source>Size of &amp;database cache</source>
-        <translation type="unfinished">حجم ذاكرة التخزين المؤقت لقاعدة البيانات</translation>
+        <translation type="unfinished">‫حجم ذاكرة التخزين المؤقت ل&amp;قاعدة البيانات‬</translation>
     </message>
     <message>
         <source>Number of script &amp;verification threads</source>
@@ -1855,23 +2111,27 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
-        <translation type="unfinished">عنوان IP للوكيل (مثل IPv4: 127.0.0.1 / IPv6: ::1)</translation>
+        <translation type="unfinished">‫عنوان IP للوكيل (مثل IPv4: 127.0.0.1 / IPv6: ::1)‬</translation>
     </message>
     <message>
         <source>Shows if the supplied default SOCKS5 proxy is used to reach peers via this network type.</source>
-        <translation type="unfinished">إظهار ما إذا كان وكيل SOCKS5 الافتراضي الموفر تم استخدامه للوصول إلى النظراء عبر نوع الشبكة هذا.</translation>
+        <translation type="unfinished">إظهار ما إذا كان وكيل SOCKS5 الافتراضي الموفر تم استخدامه للوصول إلى الأقران عبر نوع الشبكة هذا.</translation>
     </message>
     <message>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
-        <translation type="unfinished">التصغير بدلاً من الخروج من التطبيق عند إغلاق النافذة. عند تفعيل هذا الخيار، سيتم إغلاق التطبيق فقط بعد اختيار الخروج من القائمة.</translation>
+        <translation type="unfinished">‫التصغير بدلاً من الخروج من التطبيق عند إغلاق النافذة. عند تفعيل هذا الخيار، سيتم إغلاق التطبيق فقط بعد النقر على خروج من القائمة المنسدلة.‬</translation>
+    </message>
+    <message>
+        <source>Options set in this dialog are overridden by the command line:</source>
+        <translation type="unfinished">‫التفضيلات المعينة عن طريق سطر الأوامر لها أولوية أكبر وتتجاوز التفضيلات المختارة هنا:‬</translation>
     </message>
     <message>
         <source>Open the %1 configuration file from the working directory.</source>
-        <translation type="unfinished">فتح ملف الإعدادات %1 من الدليل العامل.</translation>
+        <translation type="unfinished">‫فتح ملف %1 الإعداد من مجلد العمل.‬</translation>
     </message>
     <message>
         <source>Open Configuration File</source>
-        <translation type="unfinished">فتح ملف الإعدادات</translation>
+        <translation type="unfinished">‫فتح ملف الإعداد‬</translation>
     </message>
     <message>
         <source>Reset all client options to default.</source>
@@ -1879,7 +2139,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>&amp;Reset Options</source>
-        <translation type="unfinished">&amp;استعادة الخيارات</translation>
+        <translation type="unfinished">‫&amp;اعادة تهيئة الخيارات‬</translation>
     </message>
     <message>
         <source>&amp;Network</source>
@@ -1887,47 +2147,77 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Prune &amp;block storage to</source>
-        <translation type="unfinished">تقليم وحظر التخزين لـ</translation>
+        <translation type="unfinished">‫اختصار &amp;تخزين الطابق</translation>
     </message>
     <message>
         <source>GB</source>
-        <translation type="unfinished">جب</translation>
+        <translation type="unfinished">‫جيجابايت‬</translation>
     </message>
     <message>
         <source>Reverting this setting requires re-downloading the entire blockchain.</source>
-        <translation type="unfinished">تتطلب العودة إلى هذا الإعداد إعادة تنزيل سلسلة الكتل بالكامل.</translation>
+        <translation type="unfinished">‫العودة الى هذا الاعداد تتطلب إعادة تنزيل الطوابق المتتالية بالكامل.‬</translation>
+    </message>
+    <message>
+        <source>Maximum database cache size. A larger cache can contribute to faster sync, after which the benefit is less pronounced for most use cases. Lowering the cache size will reduce memory usage. Unused mempool memory is shared for this cache.</source>
+        <extracomment>Tooltip text for Options window setting that sets the size of the database cache. Explains the corresponding effects of increasing/decreasing this value.</extracomment>
+        <translation type="unfinished">‫الحد الأعلى لحجم قاعدة البيانات المؤقتة (الكاش). رفع حد الكاش يزيد من سرعة المزامنة. هذا الخيار مفيد أثناء المزامنة وقد لا يفيد بعد اكتمال المزامنة في معظم الحالات. تخفيض حجم الكاش يقلل من استهلاك الذاكرة. ذاكرة تجمع الذاكرة (mempool) الغير مستخدمة مضمنة في هذا الكاش.‬</translation>
     </message>
     <message>
         <source>MiB</source>
-        <translation type="unfinished">ميجا بايت</translation>
+        <translation type="unfinished">‫ميجابايت‬</translation>
     </message>
     <message>
         <source>(0 = auto, &lt;0 = leave that many cores free)</source>
-        <translation type="unfinished">(0 = تلقائي, &lt;0 = اترك هذا العدد من الأنوية حر)</translation>
+        <translation type="unfinished">‫(0 = تلقائي, &lt;0 = لترك أنوية حرة بقدر الرقم السالب)‬</translation>
+    </message>
+    <message>
+        <source>Enable R&amp;PC server</source>
+        <extracomment>An Options window setting to enable the RPC server.</extracomment>
+        <translation type="unfinished">‫تفعيل خادم نداء &amp;الاجراء البعيد (RPC)‬</translation>
     </message>
     <message>
         <source>W&amp;allet</source>
-        <translation type="unfinished">&amp;محفظة</translation>
+        <translation type="unfinished">‫م&amp;حفظة‬</translation>
+    </message>
+    <message>
+        <source>Whether to set subtract fee from amount as default or not.</source>
+        <extracomment>Tooltip text for Options window setting that sets subtracting the fee from a sending amount as default.</extracomment>
+        <translation type="unfinished">‫تعيين خيار خصم الرسوم من القيمة كخيار افتراضي أم لا.‬</translation>
+    </message>
+    <message>
+        <source>Subtract &amp;fee from amount by default</source>
+        <extracomment>An Options window setting to set subtracting the fee from a sending amount as default.</extracomment>
+        <translation type="unfinished">‫اخصم &amp;الرسوم من القيمة بشكل افتراضي‬</translation>
     </message>
     <message>
         <source>Expert</source>
-        <translation type="unfinished">تصدير</translation>
+        <translation type="unfinished">‫خبير‬</translation>
     </message>
     <message>
         <source>Enable coin &amp;control features</source>
-        <translation type="unfinished">تفعيل ميزات التحكم في العملة</translation>
+        <translation type="unfinished">‫تفعيل ميزة &amp;التحكم بوحدات البتكوين‬</translation>
     </message>
     <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
-        <translation type="unfinished">اذا قمت بتعطيل الانفاق من النقود الغير مؤكدة، النقود من معاملة غير مؤكدة لن تكون قابلة للاستعمال حتى تحتوي تلك المعاملة على الأقل على تأكيد واحد. هذا أيضا يؤثر على كيفية حساب رصيدك.</translation>
+        <translation type="unfinished">‫اذا قمت بتعطيل خيار الانفاق من الفكة الغير مؤكدة، لن يكون بمقدورك التحكم بتلك الفكة حتى تنْفُذ العملية وتحصل على تأكيد واحد على الأقل. هذا أيضا يؤثر على كيفية حساب رصيدك.‬</translation>
     </message>
     <message>
         <source>&amp;Spend unconfirmed change</source>
-        <translation type="unfinished">دفع الفكة غير المؤكدة</translation>
+        <translation type="unfinished">‫&amp;دفع الفكة غير المؤكدة‬</translation>
+    </message>
+    <message>
+        <source>Enable &amp;PSBT controls</source>
+        <extracomment>An options window setting to enable PSBT controls.</extracomment>
+        <translation type="unfinished">‫تفعيل التحكم ب &amp;المعاملات الموقعة جزئيا‬</translation>
+    </message>
+    <message>
+        <source>Whether to show PSBT controls.</source>
+        <extracomment>Tooltip text for options window setting that enables PSBT controls.</extracomment>
+        <translation type="unfinished">‫خيار عرض التحكم بالمعاملات الموقعة جزئيا.‬</translation>
     </message>
     <message>
         <source>External Signer (e.g. hardware wallet)</source>
-        <translation type="unfinished">الموقّع الخارجي (مثل محفظة الأجهزة)</translation>
+        <translation type="unfinished">‫جهاز التوقيع الخارجي (مثل المحفظة الخارجية)‬</translation>
     </message>
     <message>
         <source>&amp;External signer script path</source>
@@ -1935,19 +2225,19 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Full path to a Bitcoin Core compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</source>
-        <translation type="unfinished">المسار الكامل إلى برنامج نصي متوافق مع Bitcoin Core (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). احذر: يمكن أن تسرق البرامج الضارة عملاتك!</translation>
+        <translation type="unfinished">‫مثال لمسار كامل متوافق مع البتكوين الأساسي Bitcoin Core (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). احذر: يمكن أن تسرق البرمجيات الضارة عملاتك!‬</translation>
     </message>
     <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
-        <translation type="unfinished">فتح منفذ خادم البتكوين تلقائيا على الموجه. هذا فقط يعمل عندما يكون الموجه الخاص بك يدعم UPnP ومفعل ايضا.</translation>
+        <translation type="unfinished">‫فتح منفذ عميل البتكوين تلقائيا على الموجه. يعمل فقط عندما يكون الموجه الخاص بك يدعم UPnP ومفعل ايضا.‬</translation>
     </message>
     <message>
         <source>Map port using &amp;UPnP</source>
-        <translation type="unfinished">ربط المنفذ باستخدام UPnP</translation>
+        <translation type="unfinished">‫ربط المنفذ باستخدام &amp;UPnP‬</translation>
     </message>
     <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports NAT-PMP and it is enabled. The external port could be random.</source>
-        <translation type="unfinished">افتح منفذ عميل Bitcoin تلقائيًا على جهاز التوجيه. يعمل هذا فقط عندما يدعم جهاز التوجيه الخاص بك NAT-PMP ويتم تمكينه. يمكن أن يكون المنفذ الخارجي عشوائيًا.</translation>
+        <translation type="unfinished">‫افتح منفذ عميل بتكوين تلقائيًا على جهاز التوجيه. يعمل هذا فقط عندما يدعم جهاز التوجيه الخاص بك NAT-PMP ويتم تمكينه. يمكن أن يكون المنفذ الخارجي عشوائيًا.‬</translation>
     </message>
     <message>
         <source>Map port using NA&amp;T-PMP</source>
@@ -1959,7 +2249,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Allow incomin&amp;g connections</source>
-        <translation type="unfinished">السماح بالاتصالات الواردة.</translation>
+        <translation type="unfinished">‫السماح بالاتصالات الوارد&amp;ة‬</translation>
     </message>
     <message>
         <source>Connect to the Bitcoin network through a SOCKS5 proxy.</source>
@@ -1983,7 +2273,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Used for reaching peers via:</source>
-        <translation type="unfinished">مستخدم للاتصال بالاصدقاء من خلال:</translation>
+        <translation type="unfinished">مستخدم للاتصال بالاقران من خلال:</translation>
     </message>
     <message>
         <source>Tor</source>
@@ -1991,27 +2281,27 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>&amp;Window</source>
-        <translation type="unfinished">نافذه</translation>
+        <translation type="unfinished">&amp;نافذة</translation>
     </message>
     <message>
         <source>Show the icon in the system tray.</source>
-        <translation type="unfinished">أظهر الرمز في لوحة النظام.</translation>
+        <translation type="unfinished">عرض الأيقونة في زاوية الأيقونات.</translation>
     </message>
     <message>
         <source>&amp;Show tray icon</source>
-        <translation type="unfinished">&amp; اعرض لوحة الأيقونة </translation>
+        <translation type="unfinished">‫&amp;اعرض الأيقونة في الزاوية‬</translation>
     </message>
     <message>
         <source>Show only a tray icon after minimizing the window.</source>
-        <translation type="unfinished">إظهار آيقونة الصينية فقط بعد تصغير النافذة.</translation>
+        <translation type="unfinished">‫عرض الأيقونة في زاوية الأيقونات فقط بعد تصغير النافذة.‬</translation>
     </message>
     <message>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
-        <translation type="unfinished">التصغير إلى صينية النظام بدلاً من شريط المهام</translation>
+        <translation type="unfinished">‫التصغير إلى زاوية الأيقونات بدلاً من شريط المهام‬</translation>
     </message>
     <message>
         <source>M&amp;inimize on close</source>
-        <translation type="unfinished">تصغير عند الإغلاق</translation>
+        <translation type="unfinished">‫ت&amp;صغير عند الإغلاق‬</translation>
     </message>
     <message>
         <source>&amp;Display</source>
@@ -2023,19 +2313,27 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>The user interface language can be set here. This setting will take effect after restarting %1.</source>
-        <translation type="unfinished">سيسري هذا الإعداد بعد إعادة تشغيل %1.</translation>
+        <translation type="unfinished">‫يمكن ضبط الواجهة اللغوية للمستخدم من هنا. هذا الإعداد يتطلب إعادة تشغيل %1.‬</translation>
     </message>
     <message>
         <source>&amp;Unit to show amounts in:</source>
-        <translation type="unfinished">الوحدة لإظهار المبالغ فيها:</translation>
+        <translation type="unfinished">‫وحدة لعرض القيم:‬</translation>
     </message>
     <message>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
-        <translation type="unfinished">اختر وحدة التقسيم الفرعية الافتراضية للعرض في الواجهة وعند إرسال العملات.</translation>
+        <translation type="unfinished">‫اختر وحدة التقسيم الفرعية الافتراضية للعرض في الواجهة وعند إرسال البتكوين.‬</translation>
+    </message>
+    <message>
+        <source>Third-party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</source>
+        <translation type="unfinished">‫عناوين أطراف أخرى (مثل: مستكشف الطوابق) تظهر في النافذة المبوبة للعمليات كخيار في القائمة المنبثقة. %s في الرابط تُستبدل بمعرف التجزئة. سيتم فصل العناوين بخط أفقي |.‬</translation>
+    </message>
+    <message>
+        <source>&amp;Third-party transaction URLs</source>
+        <translation type="unfinished">‫&amp;عناوين عمليات أطراف أخرى‬</translation>
     </message>
     <message>
         <source>Whether to show coin control features or not.</source>
-        <translation type="unfinished">ما اذا أردت إظهار ميزات التحكم في العملة أم لا.</translation>
+        <translation type="unfinished">‫ما اذا أردت إظهار ميزات التحكم في وحدات البتكوين أم لا.‬</translation>
     </message>
     <message>
         <source>Connect to the Bitcoin network through a separate SOCKS5 proxy for Tor onion services.</source>
@@ -2051,15 +2349,15 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>embedded "%1"</source>
-        <translation type="unfinished">المضمنة "%1"</translation>
+        <translation type="unfinished">‫مضمنة "%1"‬</translation>
     </message>
     <message>
-        <source>Options set in this dialog are overridden by the command line or in the configuration file:</source>
-        <translation type="unfinished">يتم تجاوز الخيارات المعينة في مربع الحوار هذا بواسطة سطر الأوامر أو في ملف التكوين:</translation>
+        <source>closest matching "%1"</source>
+        <translation type="unfinished">‫أقرب تطابق "%1"</translation>
     </message>
     <message>
         <source>&amp;OK</source>
-        <translation type="unfinished">تم</translation>
+        <translation type="unfinished">&amp;تم</translation>
     </message>
     <message>
         <source>&amp;Cancel</source>
@@ -2068,7 +2366,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Compiled without external signing support (required for external signing)</source>
         <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
-        <translation type="unfinished">مجمعة بدون دعم توقيع خارجي (مطلوب للتوقيع الخارجي)</translation>
+        <translation type="unfinished">‫مجمعة بدون دعم التوقيع الخارجي (مطلوب للتوقيع الخارجي)‬</translation>
     </message>
     <message>
         <source>default</source>
@@ -2080,25 +2378,37 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Confirm options reset</source>
+        <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
         <translation type="unfinished">تأكيد استعادة الخيارات</translation>
     </message>
     <message>
         <source>Client restart required to activate changes.</source>
-        <translation type="unfinished">يتطلب إعادة تشغيل العميل لتفعيل التغييرات.</translation>
+        <extracomment>Text explaining that the settings changed will not come into effect until the client is restarted.</extracomment>
+        <translation type="unfinished">‫يجب إعادة تشغيل العميل لتفعيل التغييرات.‬</translation>
+    </message>
+    <message>
+        <source>Current settings will be backed up at "%1".</source>
+        <extracomment>Text explaining to the user that the client's current settings will be backed up at a specific location. %1 is a stand-in argument for the backup location's path.</extracomment>
+        <translation type="unfinished">‫سيتم النسخ الاحتياطي للاعدادات على “%1”.‬".</translation>
     </message>
     <message>
         <source>Client will be shut down. Do you want to proceed?</source>
-        <translation type="unfinished">سوف يتم إيقاف العميل تماماً. هل تريد الإستمرار؟</translation>
+        <extracomment>Text asking the user to confirm if they would like to proceed with a client shutdown.</extracomment>
+        <translation type="unfinished">‫سوف يتم إيقاف العميل تماماً. هل تريد الإستمرار؟‬</translation>
     </message>
     <message>
         <source>Configuration options</source>
         <extracomment>Window title text of pop-up box that allows opening up of configuration file.</extracomment>
-        <translation type="unfinished">إعداد الخيارات</translation>
+        <translation type="unfinished">‫خيارات الإعداد‬</translation>
     </message>
     <message>
         <source>The configuration file is used to specify advanced user options which override GUI settings. Additionally, any command-line options will override this configuration file.</source>
         <extracomment>Explanatory text about the priority order of instructions considered by client. The order from high to low being: command-line, configuration file, GUI settings.</extracomment>
-        <translation type="unfinished">يتم استخدام ملف التكوين لتحديد خيارات المستخدم المتقدمة التي تتجاوز إعدادات واجهة المستخدم الرسومية. بالإضافة إلى ذلك ، ستتجاوز أي خيارات سطر أوامر ملف التكوين هذا.</translation>
+        <translation type="unfinished">‫يتم استخدام ملف الإعداد لتحديد خيارات المستخدم المتقدمة التي تتجاوز إعدادات واجهة المستخدم الرسومية. بالإضافة إلى ذلك ، ستتجاوز خيارات سطر الأوامر ملف الإعداد هذا.‬</translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation type="unfinished">‫استمرار‬</translation>
     </message>
     <message>
         <source>Cancel</source>
@@ -2110,7 +2420,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>The configuration file could not be opened.</source>
-        <translation type="unfinished">لم تتمكن من فتح ملف الإعدادات.</translation>
+        <translation type="unfinished">‫لم تتمكن من فتح ملف الإعداد.‬</translation>
     </message>
     <message>
         <source>This change would require a client restart.</source>
@@ -2118,14 +2428,21 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>The supplied proxy address is invalid.</source>
-        <translation type="unfinished">عنوان الوكيل توفيره غير صالح.</translation>
+        <translation type="unfinished">‫عنوان الوكيل الذي تم ادخاله غير صالح.‬</translation>
+    </message>
+</context>
+<context>
+    <name>OptionsModel</name>
+    <message>
+        <source>Could not read setting "%1", %2.</source>
+        <translation type="unfinished">‫لا يمكن قراءة الاعدادات “%1”, %2.‬</translation>
     </message>
 </context>
 <context>
     <name>OverviewPage</name>
     <message>
         <source>Form</source>
-        <translation type="unfinished">نمودج</translation>
+        <translation type="unfinished">‫نموذج‬</translation>
     </message>
     <message>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
@@ -2133,15 +2450,15 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Watch-only:</source>
-        <translation type="unfinished">مشاهدة فقط:</translation>
+        <translation type="unfinished">‫مراقبة فقط:‬</translation>
     </message>
     <message>
         <source>Available:</source>
-        <translation type="unfinished">متوفر</translation>
+        <translation type="unfinished">‫متاح:‬</translation>
     </message>
     <message>
         <source>Your current spendable balance</source>
-        <translation type="unfinished">رصيدك القابل للصرف</translation>
+        <translation type="unfinished">‫الرصيد المتاح للصرف‬</translation>
     </message>
     <message>
         <source>Pending:</source>
@@ -2153,7 +2470,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Immature:</source>
-        <translation type="unfinished">غير ناضجة</translation>
+        <translation type="unfinished">‫غير ناضج:‬</translation>
     </message>
     <message>
         <source>Mined balance that has not yet matured</source>
@@ -2173,7 +2490,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Your current balance in watch-only addresses</source>
-        <translation type="unfinished">رصيدك الحالي في العناوين المشاهدة فقط</translation>
+        <translation type="unfinished">‫رصيد عناوين المراقبة‬</translation>
     </message>
     <message>
         <source>Spendable:</source>
@@ -2181,19 +2498,19 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Recent transactions</source>
-        <translation type="unfinished">أحدث المعاملات</translation>
+        <translation type="unfinished">العمليات الأخيرة</translation>
     </message>
     <message>
         <source>Unconfirmed transactions to watch-only addresses</source>
-        <translation type="unfinished">معاملات غير مؤكدة للعناوين المشاهدة فقط</translation>
+        <translation type="unfinished">‫عمليات غير مؤكدة لعناوين المراقبة‬</translation>
     </message>
     <message>
         <source>Mined balance in watch-only addresses that has not yet matured</source>
-        <translation type="unfinished">الرصيد المعدّن في العناوين المشاهدة فقط التي لم تنضج بعد</translation>
+        <translation type="unfinished">‫الرصيد المعدّن في عناوين المراقبة الذي لم ينضج بعد‬</translation>
     </message>
     <message>
         <source>Current total balance in watch-only addresses</source>
-        <translation type="unfinished">الرصيد الإجمالي الحالي في العناوين المشاهدة فقط</translation>
+        <translation type="unfinished">‫الرصيد الإجمالي الحالي في عناوين المراقبة‬</translation>
     </message>
     <message>
         <source>Privacy mode activated for the Overview tab. To unmask the values, uncheck Settings-&gt;Mask values.</source>
@@ -2208,11 +2525,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Sign Tx</source>
-        <translation type="unfinished">تسجيل Tx</translation>
+        <translation type="unfinished">‫توقيع العملية‬</translation>
     </message>
     <message>
         <source>Broadcast Tx</source>
-        <translation type="unfinished">بث TX</translation>
+        <translation type="unfinished">‫بث العملية‬</translation>
     </message>
     <message>
         <source>Copy to Clipboard</source>
@@ -2220,7 +2537,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Save…</source>
-        <translation type="unfinished">حفظ ...</translation>
+        <translation type="unfinished">‫حفظ…‬</translation>
     </message>
     <message>
         <source>Close</source>
@@ -2228,11 +2545,15 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Failed to load transaction: %1</source>
-        <translation type="unfinished">فشل تحميل المعاملة: %1</translation>
+        <translation type="unfinished">‫فشل تحميل العملية: %1‬</translation>
     </message>
     <message>
         <source>Failed to sign transaction: %1</source>
         <translation type="unfinished">فشل توقيع المعاملة: %1</translation>
+    </message>
+    <message>
+        <source>Cannot sign inputs while wallet is locked.</source>
+        <translation type="unfinished">‫لا يمكن توقيع المدخلات والمحفظة مقفلة.‬</translation>
     </message>
     <message>
         <source>Could not sign any more inputs.</source>
@@ -2240,31 +2561,31 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Signed %1 inputs, but more signatures are still required.</source>
-        <translation type="unfinished">تم توقيع %1 إدخالات، ولكن لا تزال هناك حاجة إلى المزيد من التوقيعات.</translation>
+        <translation type="unfinished">‫تم توقيع %1 مدخلات، مطلوب توقيعات اضافية.‬</translation>
     </message>
     <message>
         <source>Signed transaction successfully. Transaction is ready to broadcast.</source>
-        <translation type="unfinished">تم توقيع المعاملة بنجاح. المعاملة جاهزة للبث.</translation>
+        <translation type="unfinished">‫تم توقيع المعاملة بنجاح. العملية جاهزة للبث.‬</translation>
     </message>
     <message>
         <source>Unknown error processing transaction.</source>
-        <translation type="unfinished">خطأ غير معروف في معالجة المعاملة.</translation>
+        <translation type="unfinished">‫خطأ غير معروف في معالجة العملية.‬</translation>
     </message>
     <message>
         <source>Transaction broadcast successfully! Transaction ID: %1</source>
-        <translation type="unfinished">تم بث المعاملة بنجاح! معرّف المعاملة: %1</translation>
+        <translation type="unfinished">‫تم بث العملية بنجاح! معرّف العملية: %1‬</translation>
     </message>
     <message>
         <source>Transaction broadcast failed: %1</source>
-        <translation type="unfinished">فشل بث المعاملة: %1</translation>
+        <translation type="unfinished">‫فشل بث العملية: %1‬</translation>
     </message>
     <message>
         <source>PSBT copied to clipboard.</source>
-        <translation type="unfinished">نسخ PSBT إلى الحافظة.</translation>
+        <translation type="unfinished">‫نسخ المعاملة الموقعة جزئيا إلى الحافظة.‬</translation>
     </message>
     <message>
         <source>Save Transaction Data</source>
-        <translation type="unfinished">حفظ بيانات المعاملات</translation>
+        <translation type="unfinished">‫حفظ بيانات العملية‬</translation>
     </message>
     <message>
         <source>Partially Signed Transaction (Binary)</source>
@@ -2273,7 +2594,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>PSBT saved to disk.</source>
-        <translation type="unfinished">تم حفظ PSBT على القرص.</translation>
+        <translation type="unfinished">‫تم حفظ المعاملة الموقعة جزئيا على وحدة التخزين.‬</translation>
     </message>
     <message>
         <source> * Sends %1 to %2</source>
@@ -2281,11 +2602,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Unable to calculate transaction fee or total transaction amount.</source>
-        <translation type="unfinished">غير قادر على حساب رسوم المعاملة أو إجمالي مبلغ المعاملة.</translation>
+        <translation type="unfinished">‫غير قادر على حساب رسوم العملية أو إجمالي قيمة العملية.‬</translation>
     </message>
     <message>
         <source>Pays transaction fee: </source>
-        <translation type="unfinished">دفع رسوم المعاملة:</translation>
+        <translation type="unfinished">‫دفع رسوم العملية: ‬</translation>
     </message>
     <message>
         <source>Total Amount</source>
@@ -2296,6 +2617,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">أو</translation>
     </message>
     <message>
+        <source>Transaction has %1 unsigned inputs.</source>
+        <translation type="unfinished">‫المعاملة تحتوي على %1 من المدخلات غير موقعة.‬</translation>
+    </message>
+    <message>
         <source>Transaction is missing some information about inputs.</source>
         <translation type="unfinished">تفتقد المعاملة إلى بعض المعلومات حول المدخلات </translation>
     </message>
@@ -2304,20 +2629,24 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">المعاملة ما زالت تحتاج التوقيع.</translation>
     </message>
     <message>
+        <source>(But no wallet is loaded.)</source>
+        <translation type="unfinished">‫(لكن لم يتم تحميل محفظة.)‬</translation>
+    </message>
+    <message>
         <source>(But this wallet cannot sign transactions.)</source>
-        <translation type="unfinished">.لكن هذه المخفضة لا يمكنها توقيع للمعاملات</translation>
+        <translation type="unfinished">‫(لكن لا يمكن توقيع العمليات بهذه المحفظة.)‬</translation>
     </message>
     <message>
         <source>(But this wallet does not have the right keys.)</source>
-        <translation type="unfinished">لكن هذه المحفظة لا تحتوي على المفاتيح الصحيحة.</translation>
+        <translation type="unfinished">‫(لكن هذه المحفظة لا تحتوي على المفاتيح الصحيحة.)‬</translation>
     </message>
     <message>
         <source>Transaction is fully signed and ready for broadcast.</source>
-        <translation type="unfinished"> الصفقة موقعة بالكامل وجاهزة للبث</translation>
+        <translation type="unfinished">‫المعاملة موقعة بالكامل وجاهزة للبث.‬</translation>
     </message>
     <message>
         <source>Transaction status is unknown.</source>
-        <translation type="unfinished">حالة المعاملة غير معروفة.</translation>
+        <translation type="unfinished">‫حالة العملية غير معروفة.‬</translation>
     </message>
 </context>
 <context>
@@ -2342,11 +2671,13 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Cannot process payment request because BIP70 is not supported.
 Due to widespread security flaws in BIP70 it's strongly recommended that any merchant instructions to switch wallets be ignored.
 If you are receiving this error you should request the merchant provide a BIP21 compatible URI.</source>
-        <translation type="unfinished">لا يمكن معالجة طلب الدفع لأن BIP70 غير مدعوم. نظرًا لوجود عيوب أمنية واسعة النطاق في BIP70 ، يوصى بشدة بتجاهل أي تعليمات تاجر لتبديل المحافظ. إذا كنت تتلقى هذا الخطأ ، يجب أن تطلب من التاجر تقديم عنوان URI متوافق مع BIP21.</translation>
+        <translation type="unfinished">‫لا يمكن معالجة طلب الدفع لأن BIP70 غير مدعوم.
+‬‫‫‫نظرًا لوجود عيوب أمنية كبيرة في ‫BIP70 يوصى بشدة بتجاهل أي تعليمات من المستلمين لتبديل المحافظ.
+‬‫‫‫إذا كنت تتلقى هذا الخطأ ، يجب أن تطلب من المستلم تقديم عنوان URI متوافق مع BIP21.‬</translation>
     </message>
     <message>
         <source>URI cannot be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
-        <translation type="unfinished">لا يمكن تحليل العنوان (URI)! يمكن أن يحدث هذا بسبب عنوان بتكوين غير صالح أو معلمات عنوان (URI) غير صحيحة.</translation>
+        <translation type="unfinished">‫لا يمكن تحليل العنوان (URI)! يمكن أن يحدث هذا بسبب عنوان بتكوين غير صالح أو محددات عنوان غير صحيحة.‬</translation>
     </message>
     <message>
         <source>Payment request file handling</source>
@@ -2371,6 +2702,11 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <translation type="unfinished">الأقران</translation>
     </message>
     <message>
+        <source>Age</source>
+        <extracomment>Title of Peers Table column which indicates the duration (length of time) since the peer connection started.</extracomment>
+        <translation type="unfinished">العمر</translation>
+    </message>
+    <message>
         <source>Direction</source>
         <extracomment>Title of Peers Table column which indicates the direction the peer connection was initiated from.</extracomment>
         <translation type="unfinished">جهة</translation>
@@ -2383,12 +2719,12 @@ If you are receiving this error you should request the merchant provide a BIP21 
     <message>
         <source>Received</source>
         <extracomment>Title of Peers Table column which indicates the total amount of network information we have received from the peer.</extracomment>
-        <translation type="unfinished">إستقبل</translation>
+        <translation type="unfinished">‫استُلم‬</translation>
     </message>
     <message>
         <source>Address</source>
         <extracomment>Title of Peers Table column which contains the IP/Onion/I2P address of the connected peer.</extracomment>
-        <translation type="unfinished">عنوان</translation>
+        <translation type="unfinished">العنوان</translation>
     </message>
     <message>
         <source>Type</source>
@@ -2398,24 +2734,24 @@ If you are receiving this error you should request the merchant provide a BIP21 
     <message>
         <source>Network</source>
         <extracomment>Title of Peers Table column which states the network the peer connected through.</extracomment>
-        <translation type="unfinished">الشبكه</translation>
+        <translation type="unfinished">الشبكة</translation>
     </message>
     <message>
         <source>Inbound</source>
         <extracomment>An Inbound Connection from a Peer.</extracomment>
-        <translation type="unfinished">داخل</translation>
+        <translation type="unfinished">‫وارد‬</translation>
     </message>
     <message>
         <source>Outbound</source>
         <extracomment>An Outbound Connection to a Peer.</extracomment>
-        <translation type="unfinished">خارجي</translation>
+        <translation type="unfinished">‫صادر‬</translation>
     </message>
 </context>
 <context>
     <name>QRImageWidget</name>
     <message>
         <source>&amp;Save Image…</source>
-        <translation type="unfinished">&amp;احفظ الصورة…</translation>
+        <translation type="unfinished">&amp;احفظ الصورة...</translation>
     </message>
     <message>
         <source>&amp;Copy Image</source>
@@ -2423,19 +2759,19 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
-        <translation type="unfinished">العنوان المستخدم طويل جدًا، حاول أن تقوم بتقليل نص التسمية / الرسالة.</translation>
+        <translation type="unfinished">‫العنوان الناتج طويل جدًا، حاول أن تقلص النص للمذكرة / الرسالة.‬</translation>
     </message>
     <message>
         <source>Error encoding URI into QR Code.</source>
-        <translation type="unfinished">خطأ في ترميز العنوان إلى الرمز المربع.</translation>
+        <translation type="unfinished">‫خطأ في ترميز العنوان إلى رمز الاستجابة السريع QR.‬</translation>
     </message>
     <message>
         <source>QR code support not available.</source>
-        <translation type="unfinished">دعم كود الـQR غير متوفر.</translation>
+        <translation type="unfinished">‫دعم رمز الاستجابة السريع QR غير متوفر.‬</translation>
     </message>
     <message>
         <source>Save QR Code</source>
-        <translation type="unfinished">حفظ رمز الاستجابة السريعة QR</translation>
+        <translation type="unfinished">حفظ رمز الاستجابة السريع QR</translation>
     </message>
     <message>
         <source>PNG Image</source>
@@ -2451,11 +2787,11 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Client version</source>
-        <translation type="unfinished">نسخه العميل</translation>
+        <translation type="unfinished">‫اصدار العميل‬</translation>
     </message>
     <message>
         <source>&amp;Information</source>
-        <translation type="unfinished">المعلومات</translation>
+        <translation type="unfinished">‫&amp;المعلومات‬</translation>
     </message>
     <message>
         <source>General</source>
@@ -2463,11 +2799,19 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Datadir</source>
-        <translation type="unfinished">دليل البيانات</translation>
+        <translation type="unfinished">‫مجلد البيانات‬</translation>
+    </message>
+    <message>
+        <source>To specify a non-default location of the data directory use the '%1' option.</source>
+        <translation type="unfinished">‫لتحديد مكان غير-إفتراضي لمجلد البيانات استخدم خيار الـ'%1'.‬</translation>
     </message>
     <message>
         <source>Blocksdir</source>
-        <translation type="unfinished">ملف الكتل blocksdir</translation>
+        <translation type="unfinished">‫مجلد الطوابق‬</translation>
+    </message>
+    <message>
+        <source>To specify a non-default location of the blocks directory use the '%1' option.</source>
+        <translation type="unfinished">‫لتحديد مكان غير-إفتراضي لمجلد البيانات استخدم خيار الـ'"%1'.‬</translation>
     </message>
     <message>
         <source>Startup time</source>
@@ -2475,7 +2819,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Network</source>
-        <translation type="unfinished">الشبكه</translation>
+        <translation type="unfinished">الشبكة</translation>
     </message>
     <message>
         <source>Name</source>
@@ -2495,7 +2839,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Current number of transactions</source>
-        <translation type="unfinished">عدد المعاملات الحالي</translation>
+        <translation type="unfinished">عدد العمليات الحالي</translation>
     </message>
     <message>
         <source>Memory usage</source>
@@ -2507,15 +2851,15 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>(none)</source>
-        <translation type="unfinished">(لايوجد)</translation>
+        <translation type="unfinished">‫(لا شيء)‬</translation>
     </message>
     <message>
         <source>&amp;Reset</source>
-        <translation type="unfinished">إعادة تعيين</translation>
+        <translation type="unfinished">‫&amp;إعادة تعيين‬</translation>
     </message>
     <message>
         <source>Received</source>
-        <translation type="unfinished">إستقبل</translation>
+        <translation type="unfinished">‫مستلم‬</translation>
     </message>
     <message>
         <source>Sent</source>
@@ -2523,15 +2867,15 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>&amp;Peers</source>
-        <translation type="unfinished">&amp;اصدقاء</translation>
+        <translation type="unfinished">‫&amp;أقران‬</translation>
     </message>
     <message>
         <source>Banned peers</source>
-        <translation type="unfinished">الأقران الممنوعين</translation>
+        <translation type="unfinished">‫الأقران المحظورون‬</translation>
     </message>
     <message>
         <source>Select a peer to view detailed information.</source>
-        <translation type="unfinished">حدد نظير لعرض معلومات مفصلة.</translation>
+        <translation type="unfinished">‫اختر قرينا لعرض معلومات مفصلة.‬</translation>
     </message>
     <message>
         <source>Version</source>
@@ -2539,23 +2883,57 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Starting Block</source>
-        <translation type="unfinished">كتلة البداية</translation>
+        <translation type="unfinished">‫طابق البداية‬</translation>
     </message>
     <message>
         <source>Synced Headers</source>
-        <translation type="unfinished">رؤوس متزامنة</translation>
+        <translation type="unfinished">‫رؤوس مزامنة‬</translation>
     </message>
     <message>
         <source>Synced Blocks</source>
-        <translation type="unfinished">كتل متزامنة</translation>
+        <translation type="unfinished">‫طوابق مزامنة‬</translation>
+    </message>
+    <message>
+        <source>Last Transaction</source>
+        <translation type="unfinished">‫آخر عملية‬</translation>
     </message>
     <message>
         <source>The mapped Autonomous System used for diversifying peer selection.</source>
-        <translation type="unfinished">يستخدم النظام المستقل المعين لتنويع اختيار الأقران.</translation>
+        <translation type="unfinished">‫النظام التفصيلي المستقل المستخدم لتنويع اختيار الأقران.‬</translation>
     </message>
     <message>
         <source>Mapped AS</source>
-        <translation type="unfinished">تعيين AS</translation>
+        <translation type="unfinished">‫‫Mapped AS‬</translation>
+    </message>
+    <message>
+        <source>Whether we relay addresses to this peer.</source>
+        <extracomment>Tooltip text for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
+        <translation type="unfinished">‫توصيل العناوين لهذا القرين أم لا.‬</translation>
+    </message>
+    <message>
+        <source>Address Relay</source>
+        <extracomment>Text title for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
+        <translation type="unfinished">‫توصيل العنوان‬</translation>
+    </message>
+    <message>
+        <source>The total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</source>
+        <extracomment>Tooltip text for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
+        <translation type="unfinished">‫مجموع العناوين المستلمة والمعالجة من هذا القرين (تستثنى العناوين المسقطة بسبب التقييد الحدي)‬</translation>
+    </message>
+    <message>
+        <source>The total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</source>
+        <extracomment>Tooltip text for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
+        <translation type="unfinished">‫مجموع العناوين المستلمة والمسقطة من هذا القرين (غير معالجة) بسبب التقييد الحدي.‬</translation>
+    </message>
+    <message>
+        <source>Addresses Processed</source>
+        <extracomment>Text title for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
+        <translation type="unfinished">‫العناوين المعالجة‬</translation>
+    </message>
+    <message>
+        <source>Addresses Rate-Limited</source>
+        <extracomment>Text title for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
+        <translation type="unfinished">‫عناوين مقيدة حديا‬</translation>
     </message>
     <message>
         <source>User Agent</source>
@@ -2563,11 +2941,15 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Node window</source>
-        <translation type="unfinished">نافذة Node </translation>
+        <translation type="unfinished">‫نافذة نود‬</translation>
     </message>
     <message>
         <source>Current block height</source>
-        <translation type="unfinished">ارتفاع الكتلة الحالي</translation>
+        <translation type="unfinished">‫ارتفاع الطابق الحالي‬</translation>
+    </message>
+    <message>
+        <source>Open the %1 debug log file from the current data directory. This can take a few seconds for large log files.</source>
+        <translation type="unfinished">‫افتح %1 ملف سجل المعالجة والتصحيح من مجلد البيانات الحالي. قد يستغرق عدة ثواني للسجلات الكبيرة.‬</translation>
     </message>
     <message>
         <source>Decrease font size</source>
@@ -2591,7 +2973,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>The network protocol this peer is connected through: IPv4, IPv6, Onion, I2P, or CJDNS.</source>
-        <translation type="unfinished">بروتوكول الشبكة الذي يتصل به هذا النظير من خلال: IPv4 أو IPv6 أو Onion أو I2P أو CJDNS.</translation>
+        <translation type="unfinished">‫بروتوكول الشبكة الذي يتصل به هذا القرين من خلال: IPv4 أو IPv6 أو Onion أو I2P أو CJDNS.‬</translation>
     </message>
     <message>
         <source>Services</source>
@@ -2599,19 +2981,15 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Whether the peer requested us to relay transactions.</source>
-        <translation type="unfinished">ما إذا كان الزميل قد طلب منا ترحيل المعاملات.</translation>
+        <translation type="unfinished">‫ما إذا كان القرين قد طلب توصيل العمليات.‬</translation>
     </message>
     <message>
         <source>Wants Tx Relay</source>
-        <translation type="unfinished">يريد Tx Relay</translation>
-    </message>
-    <message>
-        <source>High bandwidth BIP152 compact block relay: %1</source>
-        <translation type="unfinished">عرض النطاق الترددي العالي BIP152 كتلة التتابع المدمجة: %1</translation>
+        <translation type="unfinished">‫يريد موصل عمليات‬</translation>
     </message>
     <message>
         <source>High Bandwidth</source>
-        <translation type="unfinished">عرض النطاق الترددي العالي</translation>
+        <translation type="unfinished">‫نطاق بيانات عالي‬</translation>
     </message>
     <message>
         <source>Connection Time</source>
@@ -2619,24 +2997,24 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Elapsed time since a novel block passing initial validity checks was received from this peer.</source>
-        <translation type="unfinished">الوقت المنقضي منذ استلام كتلة جديدة اجتياز اختبارات الصلاحية الأولية من هذا النظير.</translation>
+        <translation type="unfinished">‫الوقت المنقضي منذ استلام طابق جديد مجتاز لاختبارات الصلاحية الأولية من هذا القرين.‬</translation>
     </message>
     <message>
         <source>Last Block</source>
-        <translation type="unfinished">الكتلة الأخيرة </translation>
+        <translation type="unfinished">‫الطابق الأخير‬</translation>
     </message>
     <message>
         <source>Elapsed time since a novel transaction accepted into our mempool was received from this peer.</source>
         <extracomment>Tooltip text for the Last Transaction field in the peer details area.</extracomment>
-        <translation type="unfinished">الوقت المنقضي منذ استلام معاملة جديدة تم قبولها في مجموعة المذكرات الخاصة بنا من هذا النظير.</translation>
+        <translation type="unfinished">‫الوقت المنقضي منذ استلام عملية مقبولة في تجمع الذاكرة من هذا النظير.‬</translation>
     </message>
     <message>
         <source>Last Send</source>
-        <translation type="unfinished">آخر استقبال</translation>
+        <translation type="unfinished">‫آخر ارسال‬</translation>
     </message>
     <message>
         <source>Last Receive</source>
-        <translation type="unfinished">آخر إرسال</translation>
+        <translation type="unfinished">‫آخر إستلام‬</translation>
     </message>
     <message>
         <source>Ping Time</source>
@@ -2660,19 +3038,19 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Last block time</source>
-        <translation type="unfinished">اخر وقت الكتلة</translation>
+        <translation type="unfinished">‫وقت اخر طابق‬</translation>
     </message>
     <message>
         <source>&amp;Open</source>
-        <translation type="unfinished">الفتح</translation>
+        <translation type="unfinished">‫&amp;فتح‬</translation>
     </message>
     <message>
         <source>&amp;Console</source>
-        <translation type="unfinished">وحدة التحكم</translation>
+        <translation type="unfinished">‫&amp;سطر الأوامر‬</translation>
     </message>
     <message>
         <source>&amp;Network Traffic</source>
-        <translation type="unfinished">&amp;حركة مرور الشبكة</translation>
+        <translation type="unfinished">&amp;حركة الشبكة</translation>
     </message>
     <message>
         <source>Totals</source>
@@ -2680,11 +3058,11 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Debug log file</source>
-        <translation type="unfinished">تصحيح ملف السجل</translation>
+        <translation type="unfinished">‫ملف سجل تصحيح الأخطاء‬</translation>
     </message>
     <message>
         <source>Clear console</source>
-        <translation type="unfinished">مسح وحدة التحكم</translation>
+        <translation type="unfinished">‫مسح الأوامر‬</translation>
     </message>
     <message>
         <source>In:</source>
@@ -2697,27 +3075,27 @@ If you are receiving this error you should request the merchant provide a BIP21 
     <message>
         <source>Inbound: initiated by peer</source>
         <extracomment>Explanatory text for an inbound peer connection.</extracomment>
-        <translation type="unfinished">الواردة: بدأها النظير</translation>
+        <translation type="unfinished">‫الواردة: بدأها القرين‬</translation>
     </message>
     <message>
         <source>Outbound Full Relay: default</source>
         <extracomment>Explanatory text for an outbound peer connection that relays all network information. This is the default behavior for outbound connections.</extracomment>
-        <translation type="unfinished">ترحيل كامل صادر: افتراضي</translation>
+        <translation type="unfinished">‫الموصل الكامل الصادر: افتراضي‬</translation>
     </message>
     <message>
         <source>Outbound Block Relay: does not relay transactions or addresses</source>
         <extracomment>Explanatory text for an outbound peer connection that relays network information about blocks and not transactions or addresses.</extracomment>
-        <translation type="unfinished">ترحيل الكتلة الصادرة: لا يقوم بترحيل المعاملات أو العناوين</translation>
+        <translation type="unfinished">‫موصل الطابق الصادر: لا يقوم بتوصيل العمليات أو العناوين‬</translation>
     </message>
     <message>
         <source>Outbound Manual: added using RPC %1 or %2/%3 configuration options</source>
         <extracomment>Explanatory text for an outbound peer connection that was established manually through one of several methods. The numbered arguments are stand-ins for the methods available to establish manual connections.</extracomment>
-        <translation type="unfinished">دليل الصادر: تمت إضافته باستخدام خيارات RPC %1 أو %2/%3 التكوين</translation>
+        <translation type="unfinished">‫دليل الصادر: مضاف باستخدام نداء الاجراء البعيد RPC %1 أو %2/%3 خيارات الاعداد‬</translation>
     </message>
     <message>
         <source>Outbound Feeler: short-lived, for testing addresses</source>
         <extracomment>Explanatory text for a short-lived outbound peer connection that is used to test the aliveness of known addresses.</extracomment>
-        <translation type="unfinished">أداة التجسس الصادرة: قصيرة الأجل ، لاختبار العناوين</translation>
+        <translation type="unfinished">‫أداة التفقد الصادر: قصير الأجل ، لاختبار العناوين‬</translation>
     </message>
     <message>
         <source>Outbound Address Fetch: short-lived, for soliciting addresses</source>
@@ -2726,15 +3104,15 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>we selected the peer for high bandwidth relay</source>
-        <translation type="unfinished">اخترنا النظير لترحيل النطاق الترددي العالي</translation>
+        <translation type="unfinished">‫اخترنا القرين لتوصيل نطاق البيانات العالي‬</translation>
     </message>
     <message>
         <source>the peer selected us for high bandwidth relay</source>
-        <translation type="unfinished">اختارنا النظير لترحيل النطاق الترددي العالي</translation>
+        <translation type="unfinished">‫القرين اختارنا لتوصيل بيانات ذات نطاق عالي‬</translation>
     </message>
     <message>
         <source>no high bandwidth relay selected</source>
-        <translation type="unfinished">لم يتم تحديد ترحيل النطاق الترددي العالي</translation>
+        <translation type="unfinished">‫لم يتم تحديد موصل للبيانات عالية النطاق‬</translation>
     </message>
     <message>
         <source>Ctrl++</source>
@@ -2747,19 +3125,13 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <translation type="unfinished">Ctrl + -</translation>
     </message>
     <message>
-        <source>Ctrl+_</source>
-        <extracomment>Secondary shortcut to decrease the RPC console font size.</extracomment>
-        <translation type="unfinished">Ctrl+_
- </translation>
-    </message>
-    <message>
         <source>&amp;Copy address</source>
         <extracomment>Context menu action to copy the address of a peer.</extracomment>
-        <translation type="unfinished">انسخ العنوان</translation>
+        <translation type="unfinished">&amp;انسخ العنوان</translation>
     </message>
     <message>
         <source>&amp;Disconnect</source>
-        <translation type="unfinished">قطع الاتصال</translation>
+        <translation type="unfinished">&amp;قطع الاتصال</translation>
     </message>
     <message>
         <source>1 &amp;hour</source>
@@ -2779,7 +3151,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>&amp;Unban</source>
-        <translation type="unfinished">رفع الحظر</translation>
+        <translation type="unfinished">&amp;رفع الحظر</translation>
     </message>
     <message>
         <source>Network activity disabled</source>
@@ -2787,12 +3159,20 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Executing command without any wallet</source>
-        <translation type="unfinished">تنفيذ الأوامر بدون محفظة </translation>
+        <translation type="unfinished">‫تنفيذ الأوامر بدون أي محفظة‬</translation>
+    </message>
+    <message>
+        <source>Executing command using "%1" wallet</source>
+        <translation type="unfinished">‫تنفيذ الأوامر باستخدام "%1" من المحفظة‬</translation>
     </message>
     <message>
         <source>Executing…</source>
         <extracomment>A console message indicating an entered command is currently being executed.</extracomment>
         <translation type="unfinished">جار التنفيذ...</translation>
+    </message>
+    <message>
+        <source>(peer: %1)</source>
+        <translation type="unfinished">(قرين: %1)</translation>
     </message>
     <message>
         <source>via %1</source>
@@ -2824,7 +3204,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Unknown</source>
-        <translation type="unfinished">غير معرف</translation>
+        <translation type="unfinished">غير معروف</translation>
     </message>
 </context>
 <context>
@@ -2835,7 +3215,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>&amp;Label:</source>
-        <translation type="unfinished">&amp;وصف :</translation>
+        <translation type="unfinished">&amp;المذكرة :</translation>
     </message>
     <message>
         <source>&amp;Message:</source>
@@ -2843,7 +3223,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
-        <translation type="unfinished">رسالة اختيارية لإرفاقها بطلب الدفع، والتي سيتم عرضها عند فتح الطلب. ملاحظة: لن يتم إرسال الرسالة مع الدفعة عبر شبكة البتكوين.</translation>
+        <translation type="unfinished">‫رسالة اختيارية لإرفاقها بطلب الدفع، والتي سيتم عرضها عند فتح الطلب. ملاحظة: لن يتم إرسال الرسالة مع العملية عبر شبكة البتكوين.‬</translation>
     </message>
     <message>
         <source>An optional label to associate with the new receiving address.</source>
@@ -2859,7 +3239,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>An optional label to associate with the new receiving address (used by you to identify an invoice).  It is also attached to the payment request.</source>
-        <translation type="unfinished">وُسم اختياري للربط مع عنوان الاستقبال (يستعمل من قبلك لتحديد فاتورة). هو أيضا مرفق بطلب الدفع.</translation>
+        <translation type="unfinished">‫مذكرة اختيارية للربط مع عنوان الاستلام (يستعمل من قبلك لتعريف فاتورة). هو أيضا مرفق بطلب الدفع.‬</translation>
     </message>
     <message>
         <source>An optional message that is attached to the payment request and may be displayed to the sender.</source>
@@ -2867,11 +3247,11 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>&amp;Create new receiving address</source>
-        <translation type="unfinished">و إنشاء عناوين استقبال جديدة</translation>
+        <translation type="unfinished">&amp;إنشاء عناوين استلام جديدة</translation>
     </message>
     <message>
         <source>Clear all fields of the form.</source>
-        <translation type="unfinished">مسح كل حقول النموذج المطلوبة</translation>
+        <translation type="unfinished">‫مسح كل الحقول من النموذج.‬</translation>
     </message>
     <message>
         <source>Clear</source>
@@ -2899,38 +3279,42 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Copy &amp;URI</source>
-        <translation type="unfinished">نسخ  &amp;URI</translation>
+        <translation type="unfinished">‫نسخ &amp;الرابط (URI)‬</translation>
     </message>
     <message>
         <source>&amp;Copy address</source>
-        <translation type="unfinished">انسخ العنوان</translation>
+        <translation type="unfinished">‫&amp;نسخ العنوان‬</translation>
     </message>
     <message>
         <source>Copy &amp;label</source>
-        <translation type="unfinished">نسخ و تصنيف</translation>
+        <translation type="unfinished">‫نسخ &amp;مذكرة‬</translation>
     </message>
     <message>
         <source>Copy &amp;message</source>
-        <translation type="unfinished">نسخ و ارسال </translation>
+        <translation type="unfinished">‫نسخ &amp;رسالة‬</translation>
     </message>
     <message>
         <source>Copy &amp;amount</source>
-        <translation type="unfinished">نسخ &amp;مبلغ</translation>
+        <translation type="unfinished">‫نسخ &amp;القيمة‬</translation>
     </message>
     <message>
         <source>Could not unlock wallet.</source>
-        <translation type="unfinished"> يمكن فتح المحفظة.</translation>
+        <translation type="unfinished">‫تعذر فتح المحفظة.‬</translation>
     </message>
-    </context>
+    <message>
+        <source>Could not generate new %1 address</source>
+        <translation type="unfinished">تعذر توليد عنوان %1 جديد.</translation>
+    </message>
+</context>
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
         <source>Request payment to …</source>
-        <translation type="unfinished"> طلب الدفع لـ....</translation>
+        <translation type="unfinished"> طلب الدفع لـ ...</translation>
     </message>
     <message>
         <source>Address:</source>
-        <translation type="unfinished">العناوين:</translation>
+        <translation type="unfinished">العنوان:</translation>
     </message>
     <message>
         <source>Amount:</source>
@@ -2938,11 +3322,11 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Label:</source>
-        <translation type="unfinished">وسم:</translation>
+        <translation type="unfinished">مذكرة:</translation>
     </message>
     <message>
         <source>Message:</source>
-        <translation type="unfinished">الرسائل</translation>
+        <translation type="unfinished">رسالة:</translation>
     </message>
     <message>
         <source>Wallet:</source>
@@ -2950,7 +3334,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Copy &amp;URI</source>
-        <translation type="unfinished">نسخ  &amp;URI</translation>
+        <translation type="unfinished">‫نسخ &amp;الرابط (URI)‬</translation>
     </message>
     <message>
         <source>Copy &amp;Address</source>
@@ -2958,7 +3342,11 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>&amp;Verify</source>
-        <translation type="unfinished">تأكيد</translation>
+        <translation type="unfinished">&amp;تحقق</translation>
+    </message>
+    <message>
+        <source>Verify this address on e.g. a hardware wallet screen</source>
+        <translation type="unfinished">تحقق من العنوان على شاشة المحفظة الخارجية</translation>
     </message>
     <message>
         <source>&amp;Save Image…</source>
@@ -2981,7 +3369,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Label</source>
-        <translation type="unfinished">وسم</translation>
+        <translation type="unfinished">المذكرة</translation>
     </message>
     <message>
         <source>Message</source>
@@ -2989,7 +3377,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>(no label)</source>
-        <translation type="unfinished">(بدون وسم)</translation>
+        <translation type="unfinished">( لا وجود لمذكرة)</translation>
     </message>
     <message>
         <source>(no message)</source>
@@ -2997,7 +3385,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>(no amount requested)</source>
-        <translation type="unfinished">(لا يوجد مبلغ مطلوب)</translation>
+        <translation type="unfinished">(لا يوجد قيمة مطلوبة)</translation>
     </message>
     <message>
         <source>Requested</source>
@@ -3008,11 +3396,11 @@ If you are receiving this error you should request the merchant provide a BIP21 
     <name>SendCoinsDialog</name>
     <message>
         <source>Send Coins</source>
-        <translation type="unfinished">إرسال العملات</translation>
+        <translation type="unfinished">إرسال البتكوين</translation>
     </message>
     <message>
         <source>Coin Control Features</source>
-        <translation type="unfinished">ميزات التحكم بالعملة</translation>
+        <translation type="unfinished">‫ميزات التحكم بوحدات البتكوين‬</translation>
     </message>
     <message>
         <source>automatically selected</source>
@@ -3032,7 +3420,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Amount:</source>
-        <translation type="unfinished">القيمة :</translation>
+        <translation type="unfinished">القيمة:</translation>
     </message>
     <message>
         <source>Fee:</source>
@@ -3040,15 +3428,15 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>After Fee:</source>
-        <translation type="unfinished">بعد الرسوم :</translation>
+        <translation type="unfinished">بعد الرسوم:</translation>
     </message>
     <message>
         <source>Change:</source>
-        <translation type="unfinished">تعديل :</translation>
+        <translation type="unfinished">تعديل:</translation>
     </message>
     <message>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
-        <translation type="unfinished">إذا تم تنشيط هذا، ولكن عنوان الفكة فارغ أو غير صالح، فسيتم إرسال الفكة إلى عنوان تم إنشاؤه حديثًا.</translation>
+        <translation type="unfinished">‫إذا تم تنشيط هذا، ولكن عنوان الفكة فارغ أو غير صالح، فسيتم إرسال الفكة إلى عنوان مولّد حديثًا.‬</translation>
     </message>
     <message>
         <source>Custom change address</source>
@@ -3060,7 +3448,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until you have validated the complete chain.</source>
-        <translation type="unfinished">يمكن أن يؤدي استخدام الرسوم الاحتياطية إلى إرسال معاملة تستغرق عدة ساعات أو أيام (أو أبدًا) للتأكيد. ضع في اعتبارك اختيار الرسوم يدويًا أو انتظر حتى تتحقق من صحة السلسلة الكاملة.</translation>
+        <translation type="unfinished">‫يمكن أن يؤدي استخدام الرسوم الاحتياطية إلى إرسال معاملة تستغرق عدة ساعات أو أيام (أو أبدًا) للتأكيد. ضع في اعتبارك اختيار الرسوم يدويًا أو انتظر حتى تتحقق من صحة المتتالية الكاملة.‬</translation>
     </message>
     <message>
         <source>Warning: Fee estimation is currently not possible.</source>
@@ -3092,11 +3480,11 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Clear all fields of the form.</source>
-        <translation type="unfinished">مسح كل حقول النموذج المطلوبة</translation>
+        <translation type="unfinished">‫مسح كل الحقول من النموذج.‬</translation>
     </message>
     <message>
         <source>Inputs…</source>
-        <translation type="unfinished">المدخلات </translation>
+        <translation type="unfinished">المدخلات...</translation>
     </message>
     <message>
         <source>Dust:</source>
@@ -3104,19 +3492,31 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Choose…</source>
-        <translation type="unfinished">اختيار </translation>
+        <translation type="unfinished">اختيار...</translation>
     </message>
     <message>
         <source>Hide transaction fee settings</source>
         <translation type="unfinished">اخفاء اعدادات رسوم المعاملة</translation>
     </message>
     <message>
+        <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
+
+Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satoshis per kvB" for a transaction size of 500 virtual bytes (half of 1 kvB) would ultimately yield a fee of only 50 satoshis.</source>
+        <translation type="unfinished">‫حدد الرسوم المخصصة لكل كيلوبايت (١٠٠٠ بايت) من حجم العملية الافتراضي.
+
+ملاحظة: بما أن الرسوم تحتسب لكل بايت، معدل الرسوم ل “ ١٠٠ ساتوشي لكل كيلوبايت افتراضي” لعملية بحجم ٥٠٠ بايت افتراضي (نصف كيلوبايت افتراضي) ستكون ٥٠ ساتوشي فقط.‬</translation>
+    </message>
+    <message>
         <source>When there is less transaction volume than space in the blocks, miners as well as relaying nodes may enforce a minimum fee. Paying only this minimum fee is just fine, but be aware that this can result in a never confirming transaction once there is more demand for bitcoin transactions than the network can process.</source>
-        <translation type="unfinished">عندما يكون هناك حجم معاملات أقل من الفراغ في الكتل، المعدنون وعقد الترحيل أيضا من الممكن أن يفرضوا الحد الأدنى للرسوم. دفع الحد الأدنى للرسوم قد يكون على ما يرام، لكن كن حذرا بأنه هذا الشيء قد يؤدي الى معاملة لن تتأكد أبدا بمجرد أن الطلب على معاملات البتكوين قد أصبح أكثر مما تتحمله الشبكة.</translation>
+        <translation type="unfinished">‫قد يفرض المعدنون والأنواد الموصلة حدا أدنى للرسوم عندما يكون عدد العمليات قليل نسبة لسعة الطوابق. يمكنك دفع الحد الأدنى ولكن كن على دراية بأن العملية قد لا تنفذ في حالة أن الطلب على عمليات البتكوين فاق قدرة الشبكة على المعالجة.‬</translation>
     </message>
     <message>
         <source>A too low fee might result in a never confirming transaction (read the tooltip)</source>
-        <translation type="unfinished">رسوم قليلة جدا من الممكن أن تؤدي الى معاملة لن تتأكد أبدا (اقرأ التلميح).</translation>
+        <translation type="unfinished">‫الرسوم القليلة جدا قد تؤدي الى عملية لا تتأكد أبدا (اقرأ التلميح).‬</translation>
+    </message>
+    <message>
+        <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
+        <translation type="unfinished">‫(الرسوم الذكية غير مهيأة بعد. عادة يتطلب عدة طوابق…)‬</translation>
     </message>
     <message>
         <source>Confirmation time target:</source>
@@ -3128,7 +3528,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>With Replace-By-Fee (BIP-125) you can increase a transaction's fee after it is sent. Without this, a higher fee may be recommended to compensate for increased transaction delay risk.</source>
-        <translation type="unfinished">مع الإستبدال بواسطة الرسوم (BIP-125) يمكنك زيادة رسوم المعاملة بعد إرسالها. وبدون ذلك، قد نوصي برسوم أعلى للتعويض عن مخاطر تأخير المعاملة المتزايدة.</translation>
+        <translation type="unfinished">‫يمكنك زيادة رسوم المعاملة بعد إرسالها عند تفعيل الاستبدال بواسطة الرسوم (BIP-125). نوصي بوضع رسوم أعلى اذا لم يتم التفعيل لتفادي مخاطر تأخير العملية.‬</translation>
     </message>
     <message>
         <source>Clear &amp;All</source>
@@ -3144,7 +3544,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>S&amp;end</source>
-        <translation type="unfinished">&amp;ارسال</translation>
+        <translation type="unfinished">‫ا&amp;رسال‬</translation>
     </message>
     <message>
         <source>Copy quantity</source>
@@ -3172,47 +3572,63 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Copy change</source>
-        <translation type="unfinished">نسخ التعديل</translation>
+        <translation type="unfinished">‫نسخ الفكة‬</translation>
     </message>
     <message>
         <source>%1 (%2 blocks)</source>
-        <translation type="unfinished">%1 (%2 كثلة)</translation>
+        <translation type="unfinished">%1 (%2 طوابق)</translation>
     </message>
     <message>
         <source>Sign on device</source>
         <extracomment>"device" usually means a hardware wallet.</extracomment>
-        <translation type="unfinished">ولوج الى المحفظة </translation>
+        <translation type="unfinished">‫جهاز التوقيع‬</translation>
     </message>
     <message>
         <source>Connect your hardware wallet first.</source>
-        <translation type="unfinished">قم بتوصيل جهاز المحفظة أولا </translation>
+        <translation type="unfinished">‫قم بتوصيل المحفظة الخارجية أولا.‬</translation>
+    </message>
+    <message>
+        <source>Set external signer script path in Options -&gt; Wallet</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">‫أعد المسار البرمجي للموقع الخارجي من خيارات -&gt; محفظة‬</translation>
     </message>
     <message>
         <source>Cr&amp;eate Unsigned</source>
-        <translation type="unfinished">إنشاء غير موقع
- </translation>
+        <translation type="unfinished">‫إن&amp;شاء من غير توقيع‬</translation>
+    </message>
+    <message>
+        <source> from wallet '%1'</source>
+        <translation type="unfinished">من المحفظة '%1'</translation>
+    </message>
+    <message>
+        <source>%1 to '%2'</source>
+        <translation type="unfinished">%1 الى "%2"</translation>
     </message>
     <message>
         <source>%1 to %2</source>
         <translation type="unfinished">%1 الى %2</translation>
     </message>
     <message>
+        <source>To review recipient list click "Show Details…"</source>
+        <translation type="unfinished">‫لمراجعة قائمة المستلمين انقر على “عرض التفاصيل…”‬</translation>
+    </message>
+    <message>
         <source>Sign failed</source>
-        <translation type="unfinished">فشل التسجيل</translation>
+        <translation type="unfinished">‫فشل التوقيع‬</translation>
     </message>
     <message>
         <source>External signer not found</source>
         <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
-        <translation type="unfinished">لم يتم العثور على تسجيل خارجي</translation>
+        <translation type="unfinished">‫لم يتم العثور على موقّع خارجي‬</translation>
     </message>
     <message>
         <source>External signer failure</source>
         <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
-        <translation type="unfinished">فشل التسجيل الخارجي</translation>
+        <translation type="unfinished">‫فشل الموقّع الخارجي‬</translation>
     </message>
     <message>
         <source>Save Transaction Data</source>
-        <translation type="unfinished">حفظ بيانات المعاملات</translation>
+        <translation type="unfinished">حفظ بيانات العملية</translation>
     </message>
     <message>
         <source>Partially Signed Transaction (Binary)</source>
@@ -3233,7 +3649,22 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>You can increase the fee later (signals Replace-By-Fee, BIP-125).</source>
-        <translation type="unfinished">يمكنك زيادة الرسوم لاحقًا (بإشارة الإستبدال بواسطة الرسوم، BIP-125).</translation>
+        <translation type="unfinished">‫يمكنك زيادة الرسوم لاحقًا (الاستبدال بواسطة الرسوم، BIP-125 مفعل).‬</translation>
+    </message>
+    <message>
+        <source>Please, review your transaction proposal. This will produce a Partially Signed Bitcoin Transaction (PSBT) which you can save or copy and then sign with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
+        <extracomment>Text to inform a user attempting to create a transaction of their current options. At this stage, a user can only create a PSBT. This string is displayed when private keys are disabled and an external signer is not available.</extracomment>
+        <translation type="unfinished">‫رجاء، راجع معاملتك. هذا ينشئ معاملة بتكوين موقعة جزئيا (PSBT) ويمكنك حفظها أو نسخها و التوقيع مع محفظة %1 غير متصلة بالشبكة، أو محفظة خارجية متوافقة مع الـPSBT.‬</translation>
+    </message>
+    <message>
+        <source>Do you want to create this transaction?</source>
+        <extracomment>Message displayed when attempting to create a transaction. Cautionary text to prompt the user to verify that the displayed transaction details represent the transaction the user intends to create.</extracomment>
+        <translation type="unfinished">‫هل تريد انشاء هذه المعاملة؟‬</translation>
+    </message>
+    <message>
+        <source>Please, review your transaction. You can create and send this transaction or create a Partially Signed Bitcoin Transaction (PSBT), which you can save or copy and then sign with, e.g., an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
+        <extracomment>Text to inform a user attempting to create a transaction of their current options. At this stage, a user can send their transaction or create a PSBT. This string is displayed when both private keys and PSBT controls are enabled.</extracomment>
+        <translation type="unfinished">‫رجاء، راجع معاملتك.تستطيع انشاء وارسال هذه العملية أو انشاء معاملة بتكوين موقعة جزئيا (PSBT) ويمكنك حفظها أو نسخها و التوقيع مع محفظة %1 غير متصلة بالشبكة، أو محفظة خارجية متوافقة مع الـPSBT.‬</translation>
     </message>
     <message>
         <source>Please, review your transaction.</source>
@@ -3246,7 +3677,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Not signalling Replace-By-Fee, BIP-125.</source>
-        <translation type="unfinished">لا يشير إلى الإستبدال بواسطة الرسوم، BIP-125.</translation>
+        <translation type="unfinished">‫الاستبدال بواسطة الرسوم، BIP-125 غير مفعلة.‬</translation>
     </message>
     <message>
         <source>Total Amount</source>
@@ -3254,23 +3685,23 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Confirm send coins</source>
-        <translation type="unfinished">تأكيد الإرسال Coins</translation>
+        <translation type="unfinished">‫تأكيد ارسال وحدات البتكوين‬</translation>
     </message>
     <message>
         <source>Watch-only balance:</source>
-        <translation type="unfinished">رصيد للاستعراض فقط:</translation>
+        <translation type="unfinished">‫رصيد المراقبة:‬</translation>
     </message>
     <message>
         <source>The recipient address is not valid. Please recheck.</source>
-        <translation type="unfinished">عنوان المستلم غير صالح. يرجى إعادة الفحص.</translation>
+        <translation type="unfinished">‫عنوان المستلم غير صالح. يرجى مراجعة العنوان.‬</translation>
     </message>
     <message>
         <source>The amount to pay must be larger than 0.</source>
-        <translation type="unfinished">المبلغ المدفوع يجب ان يكون اكبر من 0</translation>
+        <translation type="unfinished">‫القيمة المدفوعة يجب ان تكون اكبر من 0.‬</translation>
     </message>
     <message>
         <source>The amount exceeds your balance.</source>
-        <translation type="unfinished">القيمة تتجاوز رصيدك</translation>
+        <translation type="unfinished">القيمة تتجاوز رصيدك.</translation>
     </message>
     <message>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
@@ -3278,29 +3709,25 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Duplicate address found: addresses should only be used once each.</source>
-        <translation type="unfinished">تم العثور على عنوان مكرر: يجب استخدام العناوين مرة واحدة فقط.</translation>
+        <translation type="unfinished">‫تم العثور على عنوان مكرر: من الأفضل استخدام العناوين مرة واحدة فقط.‬</translation>
     </message>
     <message>
         <source>Transaction creation failed!</source>
-        <translation type="unfinished">فشل في إنشاء المعاملة!</translation>
+        <translation type="unfinished">‫تعذر إنشاء المعاملة!‬</translation>
     </message>
     <message>
         <source>A fee higher than %1 is considered an absurdly high fee.</source>
         <translation type="unfinished">تعتبر الرسوم الأعلى من %1 رسوماً باهظة.</translation>
     </message>
-    <message>
-        <source>Payment request expired.</source>
-        <translation type="unfinished">انتهاء صلاحية طلب الدفع.</translation>
-    </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>Estimated to begin confirmation within %n block(s).</numerusform>
+            <numerusform>Estimated to begin confirmation within %n block(s).</numerusform>
+            <numerusform>Estimated to begin confirmation within %n block(s).</numerusform>
+            <numerusform>Estimated to begin confirmation within %n block(s).</numerusform>
+            <numerusform>Estimated to begin confirmation within %n block(s).</numerusform>
+            <numerusform>‫الوقت التقديري للنفاذ خلال %n طوابق.‬</numerusform>
         </translation>
     </message>
     <message>
@@ -3317,11 +3744,11 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>The address you selected for change is not part of this wallet. Any or all funds in your wallet may be sent to this address. Are you sure?</source>
-        <translation type="unfinished">العنوان الذي قمت بتحديده للتغيير ليس جزءا من هذه المحفظة. أي أو جميع الأموال في محفظتك قد يتم إرسالها لهذا العنوان. هل أنت متأكد؟</translation>
+        <translation type="unfinished">‫العنوان الذي قمت بتحديده للفكة ليس جزءا من هذه المحفظة. بعض أو جميع الأموال في محفظتك قد يتم إرسالها لهذا العنوان. هل أنت متأكد؟‬</translation>
     </message>
     <message>
         <source>(no label)</source>
-        <translation type="unfinished">(بدون وسم)</translation>
+        <translation type="unfinished">( لا وجود لمذكرة)</translation>
     </message>
 </context>
 <context>
@@ -3336,35 +3763,35 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>&amp;Label:</source>
-        <translation type="unfinished">&amp;وصف :</translation>
+        <translation type="unfinished">&amp;مذكرة :</translation>
     </message>
     <message>
         <source>Choose previously used address</source>
-        <translation type="unfinished">اختر عنوانا مستخدم سابقا</translation>
+        <translation type="unfinished">‫اختر عنوانا تم استخدامه سابقا‬</translation>
     </message>
     <message>
         <source>The Bitcoin address to send the payment to</source>
-        <translation type="unfinished">عنوان البت كوين المرسل اليه الدفع</translation>
+        <translation type="unfinished">‫عنوان البتكوين لارسال الدفعة له‬</translation>
     </message>
     <message>
         <source>Paste address from clipboard</source>
-        <translation type="unfinished">انسخ العنوان من لوحة المفاتيح</translation>
+        <translation type="unfinished">‫الصق العنوان من الحافظة‬</translation>
     </message>
     <message>
         <source>Remove this entry</source>
-        <translation type="unfinished">ازل هذه المداخله</translation>
+        <translation type="unfinished">‫ازل هذا المدخل‬</translation>
     </message>
     <message>
         <source>The amount to send in the selected unit</source>
-        <translation type="unfinished">المبلغ للإرسال في الوحدة المحددة</translation>
+        <translation type="unfinished">‫القيمة للإرسال في الوحدة المحددة‬</translation>
     </message>
     <message>
         <source>The fee will be deducted from the amount being sent. The recipient will receive less bitcoins than you enter in the amount field. If multiple recipients are selected, the fee is split equally.</source>
-        <translation type="unfinished">سيتم خصم الرسوم من المبلغ الذي يتم إرساله. لذا سوف يتلقى المستلم مبلغ أقل من البتكوين المدخل في حقل المبلغ. في حالة تحديد عدة مستلمين، يتم تقسيم الرسوم بالتساوي.</translation>
+        <translation type="unfinished">‫سيتم خصم الرسوم من المبلغ الذي يتم إرساله. لذا سوف يتلقى المستلم قيمة أقل من البتكوين المدخل في حقل القيمة. في حالة تحديد عدة مستلمين، يتم تقسيم الرسوم بالتساوي.‬</translation>
     </message>
     <message>
         <source>S&amp;ubtract fee from amount</source>
-        <translation type="unfinished">طرح الرسوم من المبلغ</translation>
+        <translation type="unfinished">‫ط&amp;رح الرسوم من القيمة‬</translation>
     </message>
     <message>
         <source>Use available balance</source>
@@ -3372,31 +3799,15 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Message:</source>
-        <translation type="unfinished">الرسائل</translation>
-    </message>
-    <message>
-        <source>This is an unauthenticated payment request.</source>
-        <translation type="unfinished">هذا طلب دفع لم يتم مصادقته.</translation>
-    </message>
-    <message>
-        <source>This is an authenticated payment request.</source>
-        <translation type="unfinished">هذا طلب دفع تمت مصادقته.</translation>
+        <translation type="unfinished">‫رسالة:‬</translation>
     </message>
     <message>
         <source>Enter a label for this address to add it to the list of used addresses</source>
-        <translation type="unfinished">أدخل تسمية لهذا العنوان لإضافته إلى قائمة العناوين المستخدمة</translation>
+        <translation type="unfinished">‫أدخل مذكرة لهذا العنوان لإضافته إلى قائمة العناوين المستخدمة‬</translation>
     </message>
     <message>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
-        <translation type="unfinished">الرسالة التي تم إرفاقها مع البتكوين: العنوان الذي سيتم تخزينه مع المعاملة للرجوع إليه. ملاحظة: لن يتم إرسال هذه الرسالة عبر شبكة البتكوين.</translation>
-    </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">ادفع &amp;الى :</translation>
-    </message>
-    <message>
-        <source>Memo:</source>
-        <translation type="unfinished">مذكرة:</translation>
+        <translation type="unfinished">‫الرسالة يتم إرفاقها مع البتكوين: الرابط سيتم تخزينه مع العملية لك للرجوع إليه. ملاحظة: لن يتم إرسال هذه الرسالة عبر شبكة البتكوين.‬</translation>
     </message>
 </context>
 <context>
@@ -3414,7 +3825,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     <name>SignVerifyMessageDialog</name>
     <message>
         <source>Signatures - Sign / Verify a Message</source>
-        <translation type="unfinished">التواقيع - التوقيع / التحقق من الرسالة</translation>
+        <translation type="unfinished">التواقيع - التوقيع / تحقق من الرسالة</translation>
     </message>
     <message>
         <source>&amp;Sign Message</source>
@@ -3422,11 +3833,11 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>You can sign messages/agreements with your addresses to prove you can receive bitcoins sent to them. Be careful not to sign anything vague or random, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
-        <translation type="unfinished">تستطيع توقيع رسائل/اتفاقات مع عناوينك لإثبات أنه بإمكانك استقبال بتكوين مرسل إليهم. كن حذرا من عدم توقيع أي شيء غامض أو عشوائي، كهجمات التصيد التي قد تحاول خداعك لتوقيع هويتك لديهم. وقع البيانات المفصلة بالكامل والتي أنت توافق عليها فقط.</translation>
+        <translation type="unfinished">‫تستطيع توقيع رسائل/اتفاقيات من عناوينك لإثبات أنه بإمكانك استلام بتكوين مرسل لهذه العناوين. كن حذرا من توقيع أي شيء غامض أو عشوائي، هجمات التصيد قد تحاول خداعك وانتحال هويتك. وقع البيانات الواضحة بالكامل والتي توافق عليها فقط.‬</translation>
     </message>
     <message>
         <source>The Bitcoin address to sign the message with</source>
-        <translation type="unfinished">عنوان البتكوين لتوقيع الرسالة به</translation>
+        <translation type="unfinished">عنوان البتكوين لتوقيع الرسالة منه</translation>
     </message>
     <message>
         <source>Choose previously used address</source>
@@ -3434,7 +3845,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Paste address from clipboard</source>
-        <translation type="unfinished">انسخ العنوان من لوحة المفاتيح</translation>
+        <translation type="unfinished">‫ألصق العنوان من الحافظة‬</translation>
     </message>
     <message>
         <source>Enter the message you want to sign here</source>
@@ -3450,15 +3861,15 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Sign the message to prove you own this Bitcoin address</source>
-        <translation type="unfinished">وقع الرسالة لتثبت انك تمتلك عنوان البت كوين هذا</translation>
+        <translation type="unfinished">‫وقع الرسالة لتثبت انك تملك عنوان البتكوين هذا‬</translation>
     </message>
     <message>
         <source>Sign &amp;Message</source>
-        <translation type="unfinished">توقيع $الرسالة</translation>
+        <translation type="unfinished">توقيع &amp;الرسالة</translation>
     </message>
     <message>
         <source>Reset all sign message fields</source>
-        <translation type="unfinished">إعادة تعيين كافة حقول رسالة التوقيع</translation>
+        <translation type="unfinished">‫إعادة تعيين كافة حقول توقيع الرسالة‬</translation>
     </message>
     <message>
         <source>Clear &amp;All</source>
@@ -3466,7 +3877,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>&amp;Verify Message</source>
-        <translation type="unfinished">&amp;تحقق رسالة</translation>
+        <translation type="unfinished">‫&amp;تحقق من الرسالة‬</translation>
     </message>
     <message>
         <source>Enter the receiver's address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack. Note that this only proves the signing party receives with the address, it cannot prove sendership of any transaction!</source>
@@ -3474,7 +3885,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>The Bitcoin address the message was signed with</source>
-        <translation type="unfinished">عنوان البتكوين الذي تم توقيع الرسالة به</translation>
+        <translation type="unfinished">عنوان البتكوين الذي تم توقيع الرسالة منه</translation>
     </message>
     <message>
         <source>The signed message to verify</source>
@@ -3482,15 +3893,15 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>The signature given when the message was signed</source>
-        <translation type="unfinished">التوقيع يعطى عندما تكون الرسالة موقعة.</translation>
+        <translation type="unfinished">‫التوقيع المعطى عند توقيع الرسالة‬</translation>
     </message>
     <message>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
-        <translation type="unfinished">تحقق من الرسالة للتأكد من توقيعها مع عنوان البتكوين المحدد</translation>
+        <translation type="unfinished">‫تحقق من الرسالة للتأكد أنه تم توقيعها من عنوان البتكوين المحدد‬</translation>
     </message>
     <message>
         <source>Verify &amp;Message</source>
-        <translation type="unfinished">تحقق &amp;الرسالة</translation>
+        <translation type="unfinished">تحقق من &amp;الرسالة</translation>
     </message>
     <message>
         <source>Reset all verify message fields</source>
@@ -3498,7 +3909,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Click "Sign Message" to generate signature</source>
-        <translation type="unfinished">اضغط  "توقيع الرسالة" لتوليد التوقيع</translation>
+        <translation type="unfinished">‫انقر "توقيع الرسالة" لانشاء التوقيع‬</translation>
     </message>
     <message>
         <source>The entered address is invalid.</source>
@@ -3506,15 +3917,15 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Please check the address and try again.</source>
-        <translation type="unfinished">الرجاء التأكد من العنوان والمحاولة مرة اخرى</translation>
+        <translation type="unfinished">الرجاء التأكد من العنوان والمحاولة مرة اخرى.</translation>
     </message>
     <message>
         <source>The entered address does not refer to a key.</source>
-        <translation type="unfinished">العنوان المدخل لا يشير الى مفتاح</translation>
+        <translation type="unfinished">العنوان المدخل لا يشير الى مفتاح.</translation>
     </message>
     <message>
         <source>Wallet unlock was cancelled.</source>
-        <translation type="unfinished">تم الغاء عملية فتح المحفظة</translation>
+        <translation type="unfinished">تم الغاء عملية فتح المحفظة.</translation>
     </message>
     <message>
         <source>No error</source>
@@ -3522,7 +3933,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Private key for the entered address is not available.</source>
-        <translation type="unfinished">المفتاح الخاص للعنوان المدخل غير موجود.</translation>
+        <translation type="unfinished">‫المفتاح الخاص للعنوان المدخل غير متاح.‬</translation>
     </message>
     <message>
         <source>Message signing failed.</source>
@@ -3554,6 +3965,17 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
 </context>
 <context>
+    <name>SplashScreen</name>
+    <message>
+        <source>(press q to shutdown and continue later)</source>
+        <translation type="unfinished">‫(انقر q للاغلاق والمواصلة لاحقا)‬</translation>
+    </message>
+    <message>
+        <source>press q to shutdown</source>
+        <translation type="unfinished">‫انقر q للاغلاق‬</translation>
+    </message>
+</context>
+<context>
     <name>TrafficGraphWidget</name>
     <message>
         <source>kB/s</source>
@@ -3564,26 +3986,32 @@ If you are receiving this error you should request the merchant provide a BIP21 
     <name>TransactionDesc</name>
     <message>
         <source>conflicted with a transaction with %1 confirmations</source>
-        <translation type="unfinished">تعارضت مع معاملة لديها %1 تأكيدات</translation>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that conflicts with a confirmed transaction.</extracomment>
+        <translation type="unfinished">‫تعارضت مع عملية أخرى تم تأكيدها %1</translation>
     </message>
     <message>
-        <source>in memory pool</source>
-        <translation type="unfinished">في تجمع الذاكرة</translation>
+        <source>0/unconfirmed, in memory pool</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is in the memory pool.</extracomment>
+        <translation type="unfinished">‫0/غير مؤكدة، في تجمع الذاكرة‬</translation>
     </message>
     <message>
-        <source>not in memory pool</source>
-        <translation type="unfinished">ليس في تجمع الذاكرة</translation>
+        <source>0/unconfirmed, not in memory pool</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is not in the memory pool.</extracomment>
+        <translation type="unfinished">‫0/غير مؤكدة، ليست في تجمع الذاكرة‬</translation>
     </message>
     <message>
         <source>abandoned</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an abandoned transaction.</extracomment>
         <translation type="unfinished">مهجور</translation>
     </message>
     <message>
         <source>%1/unconfirmed</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
         <translation type="unfinished">غير مؤكدة/%1</translation>
     </message>
     <message>
         <source>%1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
         <translation type="unfinished">تأكيد %1</translation>
     </message>
     <message>
@@ -3600,7 +4028,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Generated</source>
-        <translation type="unfinished">تم اصداره.</translation>
+        <translation type="unfinished">‫مُصدر‬</translation>
     </message>
     <message>
         <source>From</source>
@@ -3620,25 +4048,21 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>watch-only</source>
-        <translation type="unfinished">مشاهدة فقط</translation>
+        <translation type="unfinished">‫مراقبة فقط‬</translation>
     </message>
     <message>
         <source>label</source>
-        <translation type="unfinished">علامة</translation>
-    </message>
-    <message>
-        <source>Credit</source>
-        <translation type="unfinished">رصيد</translation>
+        <translation type="unfinished">‫مذكرة‬</translation>
     </message>
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>matures in %n more block(s)</numerusform>
+            <numerusform>matures in %n more block(s)</numerusform>
+            <numerusform>matures in %n more block(s)</numerusform>
+            <numerusform>matures in %n more block(s)</numerusform>
+            <numerusform>matures in %n more block(s)</numerusform>
+            <numerusform>matures in %n more block(s)</numerusform>
         </translation>
     </message>
     <message>
@@ -3646,24 +4070,12 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <translation type="unfinished">غير مقبولة</translation>
     </message>
     <message>
-        <source>Debit</source>
-        <translation type="unfinished">دين</translation>
-    </message>
-    <message>
-        <source>Total debit</source>
-        <translation type="unfinished">إجمالي الخصم</translation>
-    </message>
-    <message>
-        <source>Total credit</source>
-        <translation type="unfinished">إجمالي الرصيد</translation>
-    </message>
-    <message>
         <source>Transaction fee</source>
-        <translation type="unfinished">رسوم المعاملة</translation>
+        <translation type="unfinished">رسوم العملية</translation>
     </message>
     <message>
         <source>Net amount</source>
-        <translation type="unfinished">صافي المبلغ</translation>
+        <translation type="unfinished">‫صافي القيمة‬</translation>
     </message>
     <message>
         <source>Message</source>
@@ -3675,11 +4087,11 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Transaction ID</source>
-        <translation type="unfinished">رقم المعاملة</translation>
+        <translation type="unfinished">‫رقم العملية‬</translation>
     </message>
     <message>
         <source>Transaction total size</source>
-        <translation type="unfinished">الحجم الكلي للمعاملات</translation>
+        <translation type="unfinished">الحجم الكلي ‫للعملية‬</translation>
     </message>
     <message>
         <source>Transaction virtual size</source>
@@ -3703,7 +4115,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Transaction</source>
-        <translation type="unfinished">معاملة</translation>
+        <translation type="unfinished">‫عملية‬</translation>
     </message>
     <message>
         <source>Inputs</source>
@@ -3711,7 +4123,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Amount</source>
-        <translation type="unfinished">مبلغ</translation>
+        <translation type="unfinished">‫القيمة‬</translation>
     </message>
     <message>
         <source>true</source>
@@ -3745,7 +4157,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Label</source>
-        <translation type="unfinished">وسم</translation>
+        <translation type="unfinished">المذكرة</translation>
     </message>
     <message>
         <source>Unconfirmed</source>
@@ -3761,7 +4173,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Confirmed (%1 confirmations)</source>
-        <translation type="unfinished">مؤكد (%1 تأكيدات)</translation>
+        <translation type="unfinished">‫نافذ (%1 تأكيدات)‬</translation>
     </message>
     <message>
         <source>Conflicted</source>
@@ -3773,15 +4185,15 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Generated but not accepted</source>
-        <translation type="unfinished">ولدت ولكن لم تقبل</translation>
+        <translation type="unfinished">ولّدت ولكن لم تقبل</translation>
     </message>
     <message>
         <source>Received with</source>
-        <translation type="unfinished">استقبل مع</translation>
+        <translation type="unfinished">‫استلم في‬</translation>
     </message>
     <message>
         <source>Received from</source>
-        <translation type="unfinished">استقبل من</translation>
+        <translation type="unfinished">‫استلم من</translation>
     </message>
     <message>
         <source>Sent to</source>
@@ -3792,8 +4204,12 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <translation type="unfinished">دفع لنفسك</translation>
     </message>
     <message>
+        <source>Mined</source>
+        <translation type="unfinished">‫معدّن‬</translation>
+    </message>
+    <message>
         <source>watch-only</source>
-        <translation type="unfinished">مشاهدة فقط</translation>
+        <translation type="unfinished">‫مراقبة فقط‬</translation>
     </message>
     <message>
         <source>(n/a)</source>
@@ -3801,7 +4217,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>(no label)</source>
-        <translation type="unfinished">(بدون وسم)</translation>
+        <translation type="unfinished">( لا وجود لمذكرة)</translation>
     </message>
     <message>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
@@ -3809,23 +4225,23 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Date and time that the transaction was received.</source>
-        <translation type="unfinished">التاريخ والوقت الذي تم فيه تلقي المعاملة.</translation>
+        <translation type="unfinished">‫التاريخ والوقت الذي تم فيه استلام العملية.‬</translation>
     </message>
     <message>
         <source>Type of transaction.</source>
-        <translation type="unfinished">نوع المعاملات</translation>
+        <translation type="unfinished">‫نوع العملية.‬</translation>
     </message>
     <message>
         <source>Whether or not a watch-only address is involved in this transaction.</source>
-        <translation type="unfinished">ما إذا كان العنوان المشاهدة فقط متضمنًا في هذه المعاملة أم لا.</translation>
+        <translation type="unfinished">‫إذا كان عنوان المراقبة له علاقة بهذه العملية أم لا.‬</translation>
     </message>
     <message>
         <source>User-defined intent/purpose of the transaction.</source>
-        <translation type="unfinished">تحديد سبب المعاملة من المستخدم</translation>
+        <translation type="unfinished">‫سبب تنفيذ العملية للمستخدم.‬</translation>
     </message>
     <message>
         <source>Amount removed from or added to balance.</source>
-        <translation type="unfinished">المبلغ الذي أزيل أو أضيف الى الرصيد</translation>
+        <translation type="unfinished">‫القيمة المضافة أو المزالة من الرصيد.‬</translation>
     </message>
 </context>
 <context>
@@ -3840,11 +4256,11 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>This week</source>
-        <translation type="unfinished">هدا الاسبوع</translation>
+        <translation type="unfinished">هذا الاسبوع</translation>
     </message>
     <message>
         <source>This month</source>
-        <translation type="unfinished">هدا الشهر</translation>
+        <translation type="unfinished">هذا الشهر</translation>
     </message>
     <message>
         <source>Last month</source>
@@ -3852,11 +4268,11 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>This year</source>
-        <translation type="unfinished">هدا العام</translation>
+        <translation type="unfinished">هذا العام</translation>
     </message>
     <message>
         <source>Received with</source>
-        <translation type="unfinished">استقبل مع</translation>
+        <translation type="unfinished">‫استلم في‬</translation>
     </message>
     <message>
         <source>Sent to</source>
@@ -3867,12 +4283,16 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <translation type="unfinished">إليك</translation>
     </message>
     <message>
+        <source>Mined</source>
+        <translation type="unfinished">‫معدّن‬</translation>
+    </message>
+    <message>
         <source>Other</source>
         <translation type="unfinished">أخرى</translation>
     </message>
     <message>
         <source>Enter address, transaction id, or label to search</source>
-        <translation type="unfinished">أدخل العنوان أو معرف المعاملة أو التصنيف للبحث</translation>
+        <translation type="unfinished">‫أدخل العنوان أو معرف المعاملة أو المذكرة للبحث‬</translation>
     </message>
     <message>
         <source>Min amount</source>
@@ -3880,52 +4300,61 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Range…</source>
-        <translation type="unfinished">نطاق</translation>
+        <translation type="unfinished">نطاق...</translation>
     </message>
     <message>
         <source>&amp;Copy address</source>
-        <translation type="unfinished">انسخ العنوان</translation>
+        <translation type="unfinished">‫&amp;انسخ العنوان‬</translation>
     </message>
     <message>
         <source>Copy &amp;label</source>
-        <translation type="unfinished">نسخ و تصنيف</translation>
+        <translation type="unfinished">‫نسخ &amp;مذكرة‬</translation>
     </message>
     <message>
         <source>Copy &amp;amount</source>
-        <translation type="unfinished">نسخ &amp;مبلغ</translation>
+        <translation type="unfinished">‫نسخ &amp;القيمة‬</translation>
     </message>
     <message>
         <source>Copy transaction &amp;ID</source>
-        <translation type="unfinished">نسخ المعاملة &amp;المعرف</translation>
+        <translation type="unfinished">‫نسخ &amp;معرف العملية‬</translation>
+    </message>
+    <message>
+        <source>Copy &amp;raw transaction</source>
+        <translation type="unfinished">‫نسخ &amp;النص الأصلي للعملية‬</translation>
     </message>
     <message>
         <source>Copy full transaction &amp;details</source>
-        <translation type="unfinished">نسخ كامل تفاصيل المعاملة</translation>
+        <translation type="unfinished">‫نسخ كامل &amp;تفاصيل العملية‬</translation>
     </message>
     <message>
         <source>&amp;Show transaction details</source>
-        <translation type="unfinished">و اظهر تفاصيل الصفقة</translation>
+        <translation type="unfinished">‫&amp; اظهر تفاصيل العملية‬</translation>
     </message>
     <message>
         <source>Increase transaction &amp;fee</source>
-        <translation type="unfinished">زيادة الصفقات و الرسوم</translation>
+        <translation type="unfinished">‫زيادة العملية و الرسوم‬</translation>
     </message>
     <message>
         <source>A&amp;bandon transaction</source>
-        <translation type="unfinished">التخلي عن المعاملة</translation>
+        <translation type="unfinished">‫ال&amp;تخلي عن العملية</translation>
     </message>
     <message>
         <source>&amp;Edit address label</source>
         <translation type="unfinished">و تحرير تسمية العنوان </translation>
     </message>
     <message>
+        <source>Show in %1</source>
+        <extracomment>Transactions table context menu action to show the selected transaction in a third-party block explorer. %1 is a stand-in argument for the URL of the explorer.</extracomment>
+        <translation type="unfinished">‫عرض في %1</translation>
+    </message>
+    <message>
         <source>Export Transaction History</source>
-        <translation type="unfinished">تصدير تفاصيل المعاملات</translation>
+        <translation type="unfinished">‫تصدير سجل العمليات التاريخي‬</translation>
     </message>
     <message>
         <source>Comma separated file</source>
         <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
-        <translation type="unfinished">ملف مفصَّل بالفواصل</translation>
+        <translation type="unfinished">ملف القيم المفصولة بفاصلة</translation>
     </message>
     <message>
         <source>Confirmed</source>
@@ -3933,7 +4362,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Watch-only</source>
-        <translation type="unfinished">مشاهدة فقط</translation>
+        <translation type="unfinished">‫مراقبة فقط‬</translation>
     </message>
     <message>
         <source>Date</source>
@@ -3945,23 +4374,23 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Label</source>
-        <translation type="unfinished">وسم</translation>
+        <translation type="unfinished">المذكرة</translation>
     </message>
     <message>
         <source>Address</source>
-        <translation type="unfinished">عنوان</translation>
-    </message>
-    <message>
-        <source>ID</source>
         <translation type="unfinished">العنوان</translation>
     </message>
     <message>
+        <source>ID</source>
+        <translation type="unfinished">‫المعرف‬</translation>
+    </message>
+    <message>
         <source>Exporting Failed</source>
-        <translation type="unfinished">لقد فشل التصدير</translation>
+        <translation type="unfinished">فشل التصدير</translation>
     </message>
     <message>
         <source>There was an error trying to save the transaction history to %1.</source>
-        <translation type="unfinished">حدث خطأ أثناء محاولة حفظ محفوظات المعاملة إلى %1.</translation>
+        <translation type="unfinished">‫حدث خطأ أثناء محاولة حفظ سجل العملية التاريخي في %1.‬</translation>
     </message>
     <message>
         <source>Exporting Successful</source>
@@ -3969,7 +4398,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>The transaction history was successfully saved to %1.</source>
-        <translation type="unfinished">تم حفظ محفوظات المعاملة بنجاح إلى %1.</translation>
+        <translation type="unfinished">‫تم حفظ سجل العملية التاريخي بنجاح في %1.‬</translation>
     </message>
     <message>
         <source>Range:</source>
@@ -3986,8 +4415,8 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <source>No wallet has been loaded.
 Go to File &gt; Open Wallet to load a wallet.
 - OR -</source>
-        <translation type="unfinished">لم يتم تحميل أية محافظ.
-اذهب الى ملف &gt; افتح محفظة لتحميل محفظة.
+        <translation type="unfinished">لم يتم تحميل أي محافظ.
+اذهب الى ملف &gt; فتح محفظة لتحميل محفظة.
 - أو -</translation>
     </message>
     <message>
@@ -4000,11 +4429,11 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <source>Unable to decode PSBT from clipboard (invalid base64)</source>
-        <translation type="unfinished">تعذر فك تشفير PSBT من الحافظة (base64 غير صالح)</translation>
+        <translation type="unfinished">‫تعذر قراءة وتحليل ترميز PSBT من الحافظة (base64 غير صالح)‬</translation>
     </message>
     <message>
         <source>Load Transaction Data</source>
-        <translation type="unfinished">تحميل بيانات المعاملة</translation>
+        <translation type="unfinished">‫تحميل بيانات العملية‬</translation>
     </message>
     <message>
         <source>Partially Signed Transaction (*.psbt)</source>
@@ -4016,14 +4445,14 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <source>Unable to decode PSBT</source>
-        <translation type="unfinished">غير قادر على فك تشفير PSBT</translation>
+        <translation type="unfinished">‫غير قادر على قراءة وتحليل ترميز PSBT‬</translation>
     </message>
 </context>
 <context>
     <name>WalletModel</name>
     <message>
         <source>Send Coins</source>
-        <translation type="unfinished">إرسال العملات</translation>
+        <translation type="unfinished">‫إرسال وحدات البتكوين‬</translation>
     </message>
     <message>
         <source>Fee bump error</source>
@@ -4031,7 +4460,7 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <source>Increasing transaction fee failed</source>
-        <translation type="unfinished">فشل في زيادة رسوم المعاملة</translation>
+        <translation type="unfinished">فشل في زيادة رسوم العملية</translation>
     </message>
     <message>
         <source>Do you want to increase the fee?</source>
@@ -4040,7 +4469,7 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <source>Current fee:</source>
-        <translation type="unfinished">الأجر الحالي:</translation>
+        <translation type="unfinished">‫الرسوم الان:‬</translation>
     </message>
     <message>
         <source>Increase:</source>
@@ -4048,7 +4477,7 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <source>New fee:</source>
-        <translation type="unfinished">أجر جديد:</translation>
+        <translation type="unfinished">‫رسم جديد:‬</translation>
     </message>
     <message>
         <source>Confirm fee bump</source>
@@ -4083,15 +4512,15 @@ Go to File &gt; Open Wallet to load a wallet.
     <name>WalletView</name>
     <message>
         <source>&amp;Export</source>
-        <translation type="unfinished">استخراج</translation>
+        <translation type="unfinished">&amp;تصدير</translation>
     </message>
     <message>
         <source>Export the data in the current tab to a file</source>
-        <translation type="unfinished">استخراج البيانات في علامة التبويب الحالية إلى ملف</translation>
+        <translation type="unfinished">صدّر البيانات في التبويب الحالي الى ملف</translation>
     </message>
     <message>
         <source>Backup Wallet</source>
-        <translation type="unfinished">نسخ احتياط للمحفظة</translation>
+        <translation type="unfinished">‫انسخ المحفظة احتياطيا‬</translation>
     </message>
     <message>
         <source>Wallet Data</source>
@@ -4100,11 +4529,15 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <source>Backup Failed</source>
-        <translation type="unfinished">فشل النسخ الاحتياطي</translation>
+        <translation type="unfinished">‫تعذر النسخ الاحتياطي‬</translation>
+    </message>
+    <message>
+        <source>There was an error trying to save the wallet data to %1.</source>
+        <translation type="unfinished">لقد حدث خطأ أثناء محاولة حفظ بيانات المحفظة الى %1.</translation>
     </message>
     <message>
         <source>Backup Successful</source>
-        <translation type="unfinished">نجاح  النسخ الاحتياطي</translation>
+        <translation type="unfinished">‫نجح النسخ الاحتياطي‬</translation>
     </message>
     <message>
         <source>The wallet data was successfully saved to %1.</source>

--- a/src/qt/locale/bitcoin_az.ts
+++ b/src/qt/locale/bitcoin_az.ts
@@ -92,6 +92,11 @@ Daxil olma, yalnız 'qanuni' tipli ünvanlar ilə mümkündür.</translation>
         <translation type="unfinished">Ünvan siyahısını ixrac et</translation>
     </message>
     <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">Vergüllə ayrılmış fayl</translation>
+    </message>
+    <message>
         <source>There was an error trying to save the address list to %1. Please try again.</source>
         <extracomment>An error message. %1 is a stand-in argument for the name of the file we attempted to save to.</extracomment>
         <translation type="unfinished">Ünvan siyahısını %1 daxilində saxlamağı sınayarkən xəta baş verdi. Zəhmət olmasa yenidən sınayın.</translation>
@@ -159,20 +164,68 @@ Daxil olma, yalnız 'qanuni' tipli ünvanlar ilə mümkündür.</translation>
         <translation type="unfinished">Pulqabı şifrələməsini təsdiqlə</translation>
     </message>
     <message>
+        <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
+        <translation type="unfinished">Xəbərdarlıq: Əgər siz pulqabınızı şifrədən çıxarsanız və şifrəli sözü itirmiş olsanız &lt;b&gt;BÜTÜN BİTCOİNLƏRİNİZİ İTİRƏCƏKSİNİZ&lt;/b&gt;!</translation>
+    </message>
+    <message>
+        <source>Are you sure you wish to encrypt your wallet?</source>
+        <translation type="unfinished">Pulqabınızı şifrədən çıxarmaq istədiyinizə əminsiniz?</translation>
+    </message>
+    <message>
+        <source>Wallet encrypted</source>
+        <translation type="unfinished">Pulqabı şifrələndi.</translation>
+    </message>
+    <message>
+        <source>Enter the new passphrase for the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
+        <translation type="unfinished">Pulqabı üçün yeni şifrəli sözü daxil edin.&lt;br/&gt;Lütfən &lt;b&gt;on və daha çox qarışıq simvollardan&lt;/b&gt; və ya &lt;b&gt;səkkiz və daha çox sayda sözdən&lt;/b&gt; ibarət şifrəli söz istifadə edin.</translation>
+    </message>
+    <message>
+        <source>Enter the old passphrase and new passphrase for the wallet.</source>
+        <translation type="unfinished">Pulqabı üçün köhnə şifrəli sözü və yeni şifrəli sözü daxil edin</translation>
+    </message>
+    <message>
         <source>Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
-        <translation type="unfinished">Unutmayın ki, cüzdanınızın şifrələməsi bitcoinlərinizi kompüterinizə zərərli proqram tərəfindən oğurlanmaqdan tamamilə qoruya bilməz.</translation>
+        <translation type="unfinished">Unutmayın ki, pulqabınızın şifrələməsi bitcoinlərinizi kompüterinizə zərərli proqram tərəfindən oğurlanmaqdan tamamilə qoruya bilməz.</translation>
     </message>
     <message>
         <source>Wallet to be encrypted</source>
-        <translation type="unfinished">Cüzdan şifrələnəcək</translation>
+        <translation type="unfinished">Pulqabı şifrələnəcək</translation>
     </message>
     <message>
         <source>Your wallet is about to be encrypted. </source>
-        <translation type="unfinished">Cüzdanınız şifrələnmək üzrədir.</translation>
+        <translation type="unfinished">Pulqabınız şifrələnmək üzrədir.</translation>
     </message>
     <message>
         <source>Your wallet is now encrypted. </source>
-        <translation type="unfinished">Cüzdanınız artıq şifrələnib.</translation>
+        <translation type="unfinished">Pulqabınız artıq şifrələnib.</translation>
+    </message>
+    <message>
+        <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
+        <translation type="unfinished">VACİBDİR: Pulqabınızın əvvəlki ehtiyyat nüsxələri yenicə yaradılan şifrələnmiş cüzdan ilə əvəz olunmalıdır. Təhlükəsizlik baxımından yeni şifrələnmiş pulqabını işə salan kimi əvvəlki şifrəsi açılmış pulqabının ehtiyyat nüsxələri qeyri-işlək olacaqdır.</translation>
+    </message>
+    <message>
+        <source>Wallet encryption failed</source>
+        <translation type="unfinished">Cüzdanın şifrələnməsi baş tutmadı</translation>
+    </message>
+    <message>
+        <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
+        <translation type="unfinished">Daxili xəta səbəbindən cüzdanın şifrələnməsi baş tutmadı. Cüzdanınız şifrələnmədi.</translation>
+    </message>
+    <message>
+        <source>The supplied passphrases do not match.</source>
+        <translation type="unfinished">Təqdim etdiyiniz şifrəli söz uyğun deyil.</translation>
+    </message>
+    <message>
+        <source>Wallet unlock failed</source>
+        <translation type="unfinished">Cüzdanın şifrədən çıxarılması baş tutmadı</translation>
+    </message>
+    <message>
+        <source>The passphrase entered for the wallet decryption was incorrect.</source>
+        <translation type="unfinished">Cüzdanı şifrədən çıxarmaq üçün daxil etdiyiniz şifrəli söz səhvdir.</translation>
+    </message>
+    <message>
+        <source>Wallet passphrase was successfully changed.</source>
+        <translation type="unfinished">Cüzdanın şifrəli sözü uğurla dəyişdirildi.</translation>
     </message>
     <message>
         <source>Warning: The Caps Lock key is on!</source>
@@ -180,7 +233,67 @@ Daxil olma, yalnız 'qanuni' tipli ünvanlar ilə mümkündür.</translation>
     </message>
 </context>
 <context>
+    <name>BanTableModel</name>
+    <message>
+        <source>Banned Until</source>
+        <translation type="unfinished">Qadağan edildi</translation>
+    </message>
+</context>
+<context>
+    <name>BitcoinApplication</name>
+    <message>
+        <source>Settings file %1 might be corrupt or invalid.</source>
+        <translation type="unfinished">Ola bilsin ki, %1 faylı zədələnib və ya yararsızdır.</translation>
+    </message>
+    <message>
+        <source>Runaway exception</source>
+        <translation type="unfinished">İdarə edilə bilməyən istisna</translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
+        <translation type="unfinished">Ciddi xəta baş verdi. %1 təhlükəsiz davam etdirilə bilməz və bağlanacaqdır.</translation>
+    </message>
+    <message>
+        <source>Internal error</source>
+        <translation type="unfinished">Daxili xəta</translation>
+    </message>
+    <message>
+        <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
+        <translation type="unfinished">Daxili xəta baş verdi. %1 təhlükəsiz davam etməyə cəhd edəcək. Bu gözlənilməz bir xətadır və onun haqqında aşağıdakı şəkildə bildirmək olar.</translation>
+    </message>
+</context>
+<context>
     <name>QObject</name>
+    <message>
+        <source>Do you want to reset settings to default values, or to abort without making changes?</source>
+        <extracomment>Explanatory text shown on startup when the settings file cannot be read. Prompts user to make a choice between resetting or aborting.</extracomment>
+        <translation type="unfinished">Siz ayarları dəyərləri ilkin dəyərlərinə sıfırlamaq istəyirsiniz, yoxsa dəyişiklik etmədən bu əməliyyatı ləğv etmək istəyirsiniz?</translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. Check that settings file is writable, or try running with -nosettings.</source>
+        <extracomment>Explanatory text shown on startup when the settings file could not be written. Prompts user to check that we have the ability to write to the file. Explains that the user has the option of running without a settings file.</extracomment>
+        <translation type="unfinished">Ciddi xəta baş verdi. Ayarlar faylının yazılabilən olduğunu yoxlayın və ya -nonsettings (ayarlarsız) parametri ilə işə salın.</translation>
+    </message>
+    <message>
+        <source>Error: Specified data directory "%1" does not exist.</source>
+        <translation type="unfinished">Xəta: Göstərilmiş verilənlər qovluğu "%1" mövcud deyil</translation>
+    </message>
+    <message>
+        <source>Error: Cannot parse configuration file: %1.</source>
+        <translation type="unfinished">Xəta: Tənzimləmə faylını təhlil etmək mümkün deyil: %1</translation>
+    </message>
+    <message>
+        <source>Error: %1</source>
+        <translation type="unfinished">XƏta: %1</translation>
+    </message>
+    <message>
+        <source>%1 didn't yet exit safely…</source>
+        <translation type="unfinished">%1 hələ də təhlükəsiz bağlanmayıb...</translation>
+    </message>
+    <message>
+        <source>Amount</source>
+        <translation type="unfinished">Məbləğ</translation>
+    </message>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation type="unfinished">
@@ -227,6 +340,14 @@ Daxil olma, yalnız 'qanuni' tipli ünvanlar ilə mümkündür.</translation>
 <context>
     <name>bitcoin-core</name>
     <message>
+        <source>Settings file could not be read</source>
+        <translation type="unfinished">Ayarlar faylı oxuna bilmədi</translation>
+    </message>
+    <message>
+        <source>Settings file could not be written</source>
+        <translation type="unfinished">Ayarlar faylı yazıla bilmədi</translation>
+    </message>
+    <message>
         <source>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.</source>
         <translation type="unfinished">Ödəniş təxmin edilmədi. Fallbackfee sıradan çıxarıldı. Bir neçə blok gözləyin və ya Fallbackfee-ni fəallaşdırın.</translation>
     </message>
@@ -254,15 +375,224 @@ Daxil olma, yalnız 'qanuni' tipli ünvanlar ilə mümkündür.</translation>
 <context>
     <name>BitcoinGUI</name>
     <message>
+        <source>&amp;Overview</source>
+        <translation type="unfinished">&amp;İcmal</translation>
+    </message>
+    <message>
+        <source>Show general overview of wallet</source>
+        <translation type="unfinished">Cüzdanın əsas icmalı göstərilsin</translation>
+    </message>
+    <message>
+        <source>&amp;Transactions</source>
+        <translation type="unfinished">&amp;Köçürmələr</translation>
+    </message>
+    <message>
+        <source>Browse transaction history</source>
+        <translation type="unfinished">Köçürmə tarixçəsinə baxış</translation>
+    </message>
+    <message>
+        <source>E&amp;xit</source>
+        <translation type="unfinished">Çı&amp;xış</translation>
+    </message>
+    <message>
+        <source>Quit application</source>
+        <translation type="unfinished">Tətbiqdən çıxış</translation>
+    </message>
+    <message>
+        <source>&amp;About %1</source>
+        <translation type="unfinished">%1 h&amp;aqqında</translation>
+    </message>
+    <message>
+        <source>Show information about %1</source>
+        <translation type="unfinished">%1 haqqında məlumatlar göstərilsin</translation>
+    </message>
+    <message>
+        <source>About &amp;Qt</source>
+        <translation type="unfinished">&amp;Qt haqqında</translation>
+    </message>
+    <message>
+        <source>Show information about Qt</source>
+        <translation type="unfinished">Qt haqqında məlumatlar göstərilsin</translation>
+    </message>
+    <message>
+        <source>Modify configuration options for %1</source>
+        <translation type="unfinished">%1 üçün tənzimləmə seçimlərini dəyişin</translation>
+    </message>
+    <message>
+        <source>Create a new wallet</source>
+        <translation type="unfinished">Yeni cüzdan yaradın</translation>
+    </message>
+    <message>
+        <source>&amp;Minimize</source>
+        <translation type="unfinished">&amp;Yığın</translation>
+    </message>
+    <message>
+        <source>Wallet:</source>
+        <translation type="unfinished">Cüzdan:</translation>
+    </message>
+    <message>
+        <source>Network activity disabled.</source>
+        <extracomment>A substring of the tooltip.</extracomment>
+        <translation type="unfinished">İnternet bağlantısı söndürülüb.</translation>
+    </message>
+    <message>
+        <source>Proxy is &lt;b&gt;enabled&lt;/b&gt;: %1</source>
+        <translation type="unfinished">Proksi &lt;b&gt;işə salınıb&lt;/b&gt;: %1</translation>
+    </message>
+    <message>
+        <source>Send coins to a Bitcoin address</source>
+        <translation type="unfinished">Pulları Bitcoin ünvanına göndərin</translation>
+    </message>
+    <message>
+        <source>Backup wallet to another location</source>
+        <translation type="unfinished">Cüzdanın ehtiyyat nüsxəsini başqa yerdə saxlayın</translation>
+    </message>
+    <message>
+        <source>Change the passphrase used for wallet encryption</source>
+        <translation type="unfinished">Cüzdanın şifrələnməsi üçün istifadə olunan şifrəli sözü dəyişin</translation>
+    </message>
+    <message>
+        <source>&amp;Send</source>
+        <translation type="unfinished">&amp;Göndərin</translation>
+    </message>
+    <message>
+        <source>&amp;Receive</source>
+        <translation type="unfinished">&amp;Qəbul edin</translation>
+    </message>
+    <message>
+        <source>&amp;Options…</source>
+        <translation type="unfinished">&amp;Parametrlər</translation>
+    </message>
+    <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation type="unfinished">&amp;Cüzdanı şifrələyin...</translation>
+    </message>
+    <message>
+        <source>Encrypt the private keys that belong to your wallet</source>
+        <translation type="unfinished">Cüzdanınıza aid məxfi açarları şifrələyin</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation type="unfinished">&amp;Cüzdanın ehtiyyat nüsxəsini saxlayın...</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation type="unfinished">&amp;Şifrəli sözü dəyişin...</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation type="unfinished">İs&amp;marıcı imzalayın...</translation>
+    </message>
+    <message>
+        <source>Sign messages with your Bitcoin addresses to prove you own them</source>
+        <translation type="unfinished">Bitcoin ünvanlarınızın sahibi olduğunuzu sübut etmək üçün ismarıcları imzalayın</translation>
+    </message>
+    <message>
+        <source>&amp;Verify message…</source>
+        <translation type="unfinished">&amp;İsmarıcı doğrulayın...</translation>
+    </message>
+    <message>
+        <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
+        <translation type="unfinished">Göstərilmiş Bitcoin ünvanları ilə imzalandıqlarına əmin olmaq üçün ismarıcları doğrulayın</translation>
+    </message>
+    <message>
+        <source>&amp;Load PSBT from file…</source>
+        <translation type="unfinished">PSBT-i fayldan yük&amp;ləyin...</translation>
+    </message>
+    <message>
+        <source>Open &amp;URI…</source>
+        <translation type="unfinished">&amp;URI-ni açın...</translation>
+    </message>
+    <message>
+        <source>Close Wallet…</source>
+        <translation type="unfinished">Cüzdanı bağlayın...</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation type="unfinished">Cüzdan yaradın...</translation>
+    </message>
+    <message>
+        <source>Close All Wallets…</source>
+        <translation type="unfinished">Bütün cüzdanları bağlayın...</translation>
+    </message>
+    <message>
+        <source>&amp;File</source>
+        <translation type="unfinished">&amp;Fayl</translation>
+    </message>
+    <message>
         <source>&amp;Settings</source>
         <translation type="unfinished">&amp;Tənzimləmələr</translation>
+    </message>
+    <message>
+        <source>&amp;Help</source>
+        <translation type="unfinished">&amp;Kömək</translation>
+    </message>
+    <message>
+        <source>Tabs toolbar</source>
+        <translation type="unfinished">Vərəq alətlər zolağı</translation>
+    </message>
+    <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation type="unfinished">Başlıqlar eyniləşdirilir (%1%)...</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation type="unfinished">İnternet şəbəkəsi ilə eyniləşdirmə...</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation type="unfinished">Bloklar diskdə indekslənir...</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation type="unfinished">Bloklar diskdə icra olunur...</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation type="unfinished">Bloklar diskdə təkrar indekslənir...</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation type="unfinished">İştirakçılara qoşulur...</translation>
+    </message>
+    <message>
+        <source>Request payments (generates QR codes and bitcoin: URIs)</source>
+        <translation type="unfinished">Ödəmə tələbi (QR-kodlar və Bitcoin URI-ləri yaradılır):</translation>
+    </message>
+    <message>
+        <source>Show the list of used sending addresses and labels</source>
+        <translation type="unfinished">İstifadə olunmuş göndərmə ünvanlarının və etiketlərin siyahısını göstərmək </translation>
+    </message>
+    <message>
+        <source>Show the list of used receiving addresses and labels</source>
+        <translation type="unfinished">İstifadə edilmiş qəbuletmə ünvanlarının və etiketlərin siyahısını göstərmək</translation>
+    </message>
+    <message>
+        <source>&amp;Command-line options</source>
+        <translation type="unfinished">Əmr &amp;sətri parametrləri</translation>
     </message>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>Köçürmə tarixçəsinin %n bloku işləndi.</numerusform>
+            <numerusform>Köçürmə tarixçəsinin %n bloku işləndi.</numerusform>
         </translation>
+    </message>
+    <message>
+        <source>%1 behind</source>
+        <translation type="unfinished">%1 geridə qalır</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation type="unfinished">Eyniləşir...</translation>
+    </message>
+    <message>
+        <source>Last received block was generated %1 ago.</source>
+        <translation type="unfinished">Sonuncu qəbul edilmiş blok %1 əvvəl yaradılıb.</translation>
+    </message>
+    <message>
+        <source>Transactions after this will not yet be visible.</source>
+        <translation type="unfinished">Bundan sonrakı köçürmələr hələlik görünməyəcək.</translation>
     </message>
     <message>
         <source>Error</source>
@@ -277,35 +607,636 @@ Daxil olma, yalnız 'qanuni' tipli ünvanlar ilə mümkündür.</translation>
         <translation type="unfinished">Məlumat</translation>
     </message>
     <message>
+        <source>Up to date</source>
+        <translation type="unfinished">Eyniləşdirildi</translation>
+    </message>
+    <message>
+        <source>Load Partially Signed Bitcoin Transaction</source>
+        <translation type="unfinished">Qismən imzalanmış Bitcoin köçürmələrini yükləyin</translation>
+    </message>
+    <message>
+        <source>Load PSBT from &amp;clipboard…</source>
+        <translation type="unfinished">PSBT-i &amp;mübadilə yaddaşından yükləyin...</translation>
+    </message>
+    <message>
+        <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
+        <translation type="unfinished">Qismən İmzalanmış Bitcoin Köçürməsini (PSBT) mübadilə yaddaşından yükləmək</translation>
+    </message>
+    <message>
+        <source>Node window</source>
+        <translation type="unfinished">Qovşaq pəncərəsi</translation>
+    </message>
+    <message>
+        <source>Open node debugging and diagnostic console</source>
+        <translation type="unfinished">Qovşaq sazlaması və diaqnostika konsolunu açın</translation>
+    </message>
+    <message>
+        <source>&amp;Sending addresses</source>
+        <translation type="unfinished">&amp;Göndərmək üçün ünvanlar</translation>
+    </message>
+    <message>
+        <source>&amp;Receiving addresses</source>
+        <translation type="unfinished">&amp;Qəbul etmək üçün ünvanlar</translation>
+    </message>
+    <message>
+        <source>Open a bitcoin: URI</source>
+        <translation type="unfinished">Bitcoin açın: URI</translation>
+    </message>
+    <message>
+        <source>Open Wallet</source>
+        <translation type="unfinished">Cüzdanı açın</translation>
+    </message>
+    <message>
         <source>Open a wallet</source>
         <translation type="unfinished">Bir pulqabı aç</translation>
+    </message>
+    <message>
+        <source>Close wallet</source>
+        <translation type="unfinished">Cüzdanı bağlayın</translation>
+    </message>
+    <message>
+        <source>Restore Wallet…</source>
+        <extracomment>Name of the menu item that restores wallet from a backup file.</extracomment>
+        <translation type="unfinished">Cüzdanı bərpa edin...</translation>
+    </message>
+    <message>
+        <source>Restore a wallet from a backup file</source>
+        <extracomment>Status tip for Restore Wallet menu item</extracomment>
+        <translation type="unfinished">Cüzdanı ehtiyyat nüsxə faylından bərpa edin</translation>
+    </message>
+    <message>
+        <source>Close all wallets</source>
+        <translation type="unfinished">Bütün cüzdanları bağlayın</translation>
+    </message>
+    <message>
+        <source>Show the %1 help message to get a list with possible Bitcoin command-line options</source>
+        <translation type="unfinished">Mümkün Bitcoin əmr sətri əməliyyatları siyahısını almaq üçün %1 kömək ismarıcı göstərilsin</translation>
+    </message>
+    <message>
+        <source>&amp;Mask values</source>
+        <translation type="unfinished">&amp;Dəyərləri gizlədin</translation>
+    </message>
+    <message>
+        <source>Mask the values in the Overview tab</source>
+        <translation type="unfinished">İcmal vərəqində dəyərləri gizlədin</translation>
+    </message>
+    <message>
+        <source>default wallet</source>
+        <translation type="unfinished">standart cüzdan</translation>
+    </message>
+    <message>
+        <source>No wallets available</source>
+        <translation type="unfinished">Heç bir cüzdan yoxdur</translation>
+    </message>
+    <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">Cüzdanı verilənləri</translation>
+    </message>
+    <message>
+        <source>Load Wallet Backup</source>
+        <extracomment>The title for Restore Wallet File Windows</extracomment>
+        <translation type="unfinished">Cüzdan ehtiyyat nesxəsini yüklə</translation>
+    </message>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of pop-up window shown when the user is attempting to restore a wallet.</extracomment>
+        <translation type="unfinished">Cüzdanı bərpa et</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">Pulqabının adı</translation>
+    </message>
+    <message>
+        <source>&amp;Window</source>
+        <translation type="unfinished">&amp;Pəncərə</translation>
+    </message>
+    <message>
+        <source>Zoom</source>
+        <translation type="unfinished">Miqyas</translation>
+    </message>
+    <message>
+        <source>Main Window</source>
+        <translation type="unfinished">Əsas pəncərə</translation>
+    </message>
+    <message>
+        <source>%1 client</source>
+        <translation type="unfinished">%1 müştəri</translation>
+    </message>
+    <message>
+        <source>&amp;Hide</source>
+        <translation type="unfinished">&amp;Gizlədin</translation>
+    </message>
+    <message>
+        <source>S&amp;how</source>
+        <translation type="unfinished">&amp;Göstərin</translation>
     </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>Bitcoin şəbəkəsinə %n aktiv bağlantı.</numerusform>
+            <numerusform>Bitcoin şəbəkəsinə %n aktiv bağlantı.</numerusform>
         </translation>
     </message>
-    </context>
+    <message>
+        <source>Click for more actions.</source>
+        <extracomment>A substring of the tooltip. "More actions" are available via the context menu.</extracomment>
+        <translation type="unfinished">Daha çıx əməllər üçün vurun.</translation>
+    </message>
+    <message>
+        <source>Show Peers tab</source>
+        <extracomment>A context menu item. The "Peers tab" is an element of the "Node window".</extracomment>
+        <translation type="unfinished">İştirakşılar vərəqini göstərmək</translation>
+    </message>
+    <message>
+        <source>Disable network activity</source>
+        <extracomment>A context menu item.</extracomment>
+        <translation type="unfinished">Şəbəkə bağlantısını söndürün</translation>
+    </message>
+    <message>
+        <source>Enable network activity</source>
+        <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
+        <translation type="unfinished">Şəbəkə bağlantısını açın</translation>
+    </message>
+    <message>
+        <source>Error: %1</source>
+        <translation type="unfinished">XƏta: %1</translation>
+    </message>
+    <message>
+        <source>Warning: %1</source>
+        <translation type="unfinished">Xəbərdarlıq: %1</translation>
+    </message>
+    <message>
+        <source>Date: %1
+</source>
+        <translation type="unfinished">Tarix: %1
+</translation>
+    </message>
+    <message>
+        <source>Amount: %1
+</source>
+        <translation type="unfinished">Məbləğ: %1
+</translation>
+    </message>
+    <message>
+        <source>Wallet: %1
+</source>
+        <translation type="unfinished">Cüzdan: %1
+</translation>
+    </message>
+    <message>
+        <source>Type: %1
+</source>
+        <translation type="unfinished">Növ: %1
+</translation>
+    </message>
+    <message>
+        <source>Label: %1
+</source>
+        <translation type="unfinished">Etiket: %1
+</translation>
+    </message>
+    <message>
+        <source>Address: %1
+</source>
+        <translation type="unfinished">Ünvan: %1
+</translation>
+    </message>
+    <message>
+        <source>Sent transaction</source>
+        <translation type="unfinished">Göndərilmiş köçürmə</translation>
+    </message>
+    <message>
+        <source>Incoming transaction</source>
+        <translation type="unfinished">Daxil olan köçürmə</translation>
+    </message>
+    <message>
+        <source>HD key generation is &lt;b&gt;enabled&lt;/b&gt;</source>
+        <translation type="unfinished">HD açar yaradılması &lt;b&gt;aktivdir&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>HD key generation is &lt;b&gt;disabled&lt;/b&gt;</source>
+        <translation type="unfinished">HD açar yaradılması &lt;b&gt;söndürülüb&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Private key &lt;b&gt;disabled&lt;/b&gt;</source>
+        <translation type="unfinished">Məxfi açar &lt;b&gt;söndürülüb&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
+        <translation type="unfinished">Cüzdan &lt;b&gt;şifrələnib&lt;/b&gt; və hal-hazırda &lt;b&gt;kiliddən çıxarılıb&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
+        <translation type="unfinished">Cüzdan &lt;b&gt;şifrələnib&lt;/b&gt; və hal-hazırda &lt;b&gt;kiliddlənib&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Original message:</source>
+        <translation type="unfinished">Orijinal ismarıc:</translation>
+    </message>
+</context>
+<context>
+    <name>UnitDisplayStatusBarControl</name>
+    <message>
+        <source>Unit to show amounts in. Click to select another unit.</source>
+        <translation type="unfinished">Məbləğin vahidi. Başqa vahidi seçmək üçün vurun.</translation>
+    </message>
+</context>
 <context>
     <name>CoinControlDialog</name>
     <message>
+        <source>Coin Selection</source>
+        <translation type="unfinished">Pul seçimi</translation>
+    </message>
+    <message>
+        <source>Quantity:</source>
+        <translation type="unfinished">Miqdar:</translation>
+    </message>
+    <message>
+        <source>Bytes:</source>
+        <translation type="unfinished">Baytlar:</translation>
+    </message>
+    <message>
+        <source>Amount:</source>
+        <translation type="unfinished">Məbləğ:</translation>
+    </message>
+    <message>
+        <source>Fee:</source>
+        <translation type="unfinished">Komissiya:</translation>
+    </message>
+    <message>
+        <source>Dust:</source>
+        <translation type="unfinished">Toz:</translation>
+    </message>
+    <message>
+        <source>After Fee:</source>
+        <translation type="unfinished">Komissiydan sonra:</translation>
+    </message>
+    <message>
+        <source>Change:</source>
+        <translation type="unfinished">Qalıq:</translation>
+    </message>
+    <message>
+        <source>(un)select all</source>
+        <translation type="unfinished">seçim</translation>
+    </message>
+    <message>
+        <source>Tree mode</source>
+        <translation type="unfinished">Ağac rejimi</translation>
+    </message>
+    <message>
+        <source>List mode</source>
+        <translation type="unfinished">Siyahı rejim</translation>
+    </message>
+    <message>
+        <source>Amount</source>
+        <translation type="unfinished">Məbləğ</translation>
+    </message>
+    <message>
+        <source>Received with label</source>
+        <translation type="unfinished">Etiket ilə alındı</translation>
+    </message>
+    <message>
+        <source>Received with address</source>
+        <translation type="unfinished">Ünvan ilə alındı</translation>
+    </message>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">Tarix</translation>
+    </message>
+    <message>
+        <source>Confirmations</source>
+        <translation type="unfinished">Təsdiqləmələr</translation>
+    </message>
+    <message>
+        <source>Confirmed</source>
+        <translation type="unfinished">Təsdiqləndi</translation>
+    </message>
+    <message>
+        <source>Copy amount</source>
+        <translation type="unfinished">Məbləği kopyalayın</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Ünvanı kopyalayın</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">&amp;Etiketi kopyalayın</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">&amp;Məbləği kopyalayın</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID and output index</source>
+        <translation type="unfinished">Köçürmə &amp;İD-sini və çıxış indeksini kopyalayın</translation>
+    </message>
+    <message>
+        <source>L&amp;ock unspent</source>
+        <translation type="unfinished">Xərclənməmiş qalığı &amp;kilidləyin</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock unspent</source>
+        <translation type="unfinished">Xərclənməmiş qalığı kilidd'n &amp;çıxarın</translation>
+    </message>
+    <message>
         <source>Copy quantity</source>
         <translation type="unfinished">Miqdarı kopyalayın</translation>
+    </message>
+    <message>
+        <source>Copy fee</source>
+        <translation type="unfinished">Komissiyanı kopyalayın</translation>
+    </message>
+    <message>
+        <source>Copy after fee</source>
+        <translation type="unfinished">Komissyadan sonra kopyalayın</translation>
+    </message>
+    <message>
+        <source>Copy bytes</source>
+        <translation type="unfinished">Baytları koyalayın</translation>
+    </message>
+    <message>
+        <source>Copy dust</source>
+        <translation type="unfinished">Tozu kopyalayın</translation>
     </message>
     <message>
         <source>Copy change</source>
         <translation type="unfinished">Dəyişikliyi kopyalayın</translation>
     </message>
     <message>
+        <source>(%1 locked)</source>
+        <translation type="unfinished">(%1 kilidləndi)</translation>
+    </message>
+    <message>
+        <source>yes</source>
+        <translation type="unfinished">bəli</translation>
+    </message>
+    <message>
+        <source>no</source>
+        <translation type="unfinished">xeyr</translation>
+    </message>
+    <message>
+        <source>This label turns red if any recipient receives an amount smaller than the current dust threshold.</source>
+        <translation type="unfinished">Əgər alıcı məbləği cari toz həddindən az alarsa bu etiket qırmızı olur.</translation>
+    </message>
+    <message>
+        <source>Can vary +/- %1 satoshi(s) per input.</source>
+        <translation type="unfinished">Hər daxilolmada +/- %1 satoşi dəyişə bilər.</translation>
+    </message>
+    <message>
         <source>(no label)</source>
         <translation type="unfinished">(etiket yoxdur)</translation>
+    </message>
+    <message>
+        <source>change from %1 (%2)</source>
+        <translation type="unfinished">bunlardan qalıq: %1 (%2)</translation>
+    </message>
+    <message>
+        <source>(change)</source>
+        <translation type="unfinished">(qalıq)</translation>
+    </message>
+</context>
+<context>
+    <name>CreateWalletActivity</name>
+    <message>
+        <source>Create Wallet</source>
+        <extracomment>Title of window indicating the progress of creation of a new wallet.</extracomment>
+        <translation type="unfinished">Cüzdan yaradın</translation>
+    </message>
+    <message>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the create wallet progress window which indicates to the user which wallet is currently being created.</extracomment>
+        <translation type="unfinished">&lt;b&gt;%1&lt;/b&gt; cüzdanı yaradılır...</translation>
+    </message>
+    <message>
+        <source>Create wallet failed</source>
+        <translation type="unfinished">Cüzdan yaradıla bilmədi</translation>
+    </message>
+    <message>
+        <source>Create wallet warning</source>
+        <translation type="unfinished">Cüzdan yaradılma xəbərdarlığı</translation>
+    </message>
+    <message>
+        <source>Can't list signers</source>
+        <translation type="unfinished">İmzalaynları göstərmək mümkün deyil</translation>
+    </message>
+    </context>
+<context>
+    <name>LoadWalletsActivity</name>
+    <message>
+        <source>Load Wallets</source>
+        <extracomment>Title of progress window which is displayed when wallets are being loaded.</extracomment>
+        <translation type="unfinished">Cüzdanları yükləyin</translation>
+    </message>
+    <message>
+        <source>Loading wallets…</source>
+        <extracomment>Descriptive text of the load wallets progress window which indicates to the user that wallets are currently being loaded.</extracomment>
+        <translation type="unfinished">Pulqabılar yüklənir...</translation>
+    </message>
+</context>
+<context>
+    <name>OpenWalletActivity</name>
+    <message>
+        <source>Open wallet failed</source>
+        <translation type="unfinished">Pulqabı açıla bilmədi</translation>
+    </message>
+    <message>
+        <source>Open wallet warning</source>
+        <translation type="unfinished">Pulqabının açılması xəbərdarlığı</translation>
+    </message>
+    <message>
+        <source>default wallet</source>
+        <translation type="unfinished">standart cüzdan</translation>
+    </message>
+    <message>
+        <source>Open Wallet</source>
+        <extracomment>Title of window indicating the progress of opening of a wallet.</extracomment>
+        <translation type="unfinished">Cüzdanı açın</translation>
+    </message>
+    <message>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the open wallet progress window which indicates to the user which wallet is currently being opened.</extracomment>
+        <translation type="unfinished">&lt;b&gt;%1&lt;/b&gt; pulqabı açılır...</translation>
+    </message>
+</context>
+<context>
+    <name>RestoreWalletActivity</name>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of progress window which is displayed when wallets are being restored.</extracomment>
+        <translation type="unfinished">Cüzdanı bərpa et</translation>
+    </message>
+    <message>
+        <source>Restoring Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the restore wallets progress window which indicates to the user that wallets are currently being restored.</extracomment>
+        <translation type="unfinished">&lt;b&gt;%1&lt;/b&gt; cüzdanı bərpa olunur...</translation>
+    </message>
+    <message>
+        <source>Restore wallet failed</source>
+        <extracomment>Title of message box which is displayed when the wallet could not be restored.</extracomment>
+        <translation type="unfinished">Cüzdan bərpa oluna bilmədi</translation>
+    </message>
+    <message>
+        <source>Restore wallet warning</source>
+        <extracomment>Title of message box which is displayed when the wallet is restored with some warning.</extracomment>
+        <translation type="unfinished">Cüzdanın bərpa olunması xəbərdarlığı</translation>
+    </message>
+    <message>
+        <source>Restore wallet message</source>
+        <extracomment>Title of message box which is displayed when the wallet is successfully restored.</extracomment>
+        <translation type="unfinished">Cüzdanın bərpası ismarıcı</translation>
+    </message>
+</context>
+<context>
+    <name>WalletController</name>
+    <message>
+        <source>Close wallet</source>
+        <translation type="unfinished">Cüzdanı bağlayın</translation>
+    </message>
+    <message>
+        <source>Are you sure you wish to close the wallet &lt;i&gt;%1&lt;/i&gt;?</source>
+        <translation type="unfinished">&lt;i&gt;%1&lt;/i&gt; pulqabını bağlamaq istədiyinizə əminsiniz?</translation>
+    </message>
+    <message>
+        <source>Closing the wallet for too long can result in having to resync the entire chain if pruning is enabled.</source>
+        <translation type="unfinished">Pulqabının uzun müddət bağlı qaldıqda əgər budama (azalma) aktiv olarsa bu, bütün zəncirin təkrar eyniləşditrilməsi ilə nəticələnə bilər.</translation>
+    </message>
+    <message>
+        <source>Close all wallets</source>
+        <translation type="unfinished">Bütün cüzdanları bağlayın</translation>
+    </message>
+    <message>
+        <source>Are you sure you wish to close all wallets?</source>
+        <translation type="unfinished">Bütün pulqabılarını bağlamaq istədiyinizə əminsiniz?</translation>
+    </message>
+</context>
+<context>
+    <name>CreateWalletDialog</name>
+    <message>
+        <source>Create Wallet</source>
+        <translation type="unfinished">Cüzdan yaradın</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <translation type="unfinished">Pulqabının adı</translation>
+    </message>
+    <message>
+        <source>Wallet</source>
+        <translation type="unfinished">Pulqabı</translation>
+    </message>
+    <message>
+        <source>Encrypt the wallet. The wallet will be encrypted with a passphrase of your choice.</source>
+        <translation type="unfinished">Pulqabının şifrələnməsi. Pulqabı sizin seçdiyiniz şifrəli söz ilə şifrələnəcək.</translation>
+    </message>
+    <message>
+        <source>Encrypt Wallet</source>
+        <translation type="unfinished">Pulqabını şifrələyin</translation>
+    </message>
+    <message>
+        <source>Advanced Options</source>
+        <translation type="unfinished">Əlavə parametrlər</translation>
+    </message>
+    <message>
+        <source>Disable private keys for this wallet. Wallets with private keys disabled will have no private keys and cannot have an HD seed or imported private keys. This is ideal for watch-only wallets.</source>
+        <translation type="unfinished">Bu pulqabının məxfi açarını söndürün. Məxfi açarı söndürülmüş pulqabılarında məxfi açarlar saxlanılmır, onlarda HD məxfi açarlar yaradıla bilıməz və məxfi açarlar idxal edilə bilməz. Bu sadəcə müşahidə edən pulqabıları üçün ideal variantdır.</translation>
+    </message>
+    <message>
+        <source>Disable Private Keys</source>
+        <translation type="unfinished">Məxfi açarları söndürün</translation>
+    </message>
+    <message>
+        <source>Make a blank wallet. Blank wallets do not initially have private keys or scripts. Private keys and addresses can be imported, or an HD seed can be set, at a later time.</source>
+        <translation type="unfinished">Boş pulqabı yaradın. Boş pulqabında ilkin olaraq açarlar və skriptlər yoxdur. Sonra məxfi açarlar və ünvanlar idxal edilə bilər və ya HD məxfi açarlar təyin edilə bilər.</translation>
+    </message>
+    <message>
+        <source>Make Blank Wallet</source>
+        <translation type="unfinished">Boş pulqabı yaradın</translation>
+    </message>
+    <message>
+        <source>Use descriptors for scriptPubKey management</source>
+        <translation type="unfinished">Publik açar skripti (scriptPubKey) idarəetməsi üçün deskreptorlardan itifadə edin</translation>
+    </message>
+    <message>
+        <source>Descriptor Wallet</source>
+        <translation type="unfinished">Deskriptor pulqabı</translation>
+    </message>
+    <message>
+        <source>Use an external signing device such as a hardware wallet. Configure the external signer script in wallet preferences first.</source>
+        <translation type="unfinished">Aparat cüzdanı kimi xarici imzalama cihazından istifadə edin. Əvvəlcə cüzdan seçimlərində xarici imzalayan skriptini konfiqurasiya edin.</translation>
+    </message>
+    <message>
+        <source>External signer</source>
+        <translation type="unfinished">Xarici imzalayıcı</translation>
+    </message>
+    <message>
+        <source>Create</source>
+        <translation type="unfinished">Yarat</translation>
+    </message>
+    </context>
+<context>
+    <name>EditAddressDialog</name>
+    <message>
+        <source>Edit Address</source>
+        <translation type="unfinished">Ünvanda düzəliş et</translation>
+    </message>
+    <message>
+        <source>&amp;Label</source>
+        <translation type="unfinished">&amp;Etiket</translation>
+    </message>
+    <message>
+        <source>&amp;Address</source>
+        <translation type="unfinished">&amp;Ünvan</translation>
+    </message>
+    <message>
+        <source>New sending address</source>
+        <translation type="unfinished">Yeni göndərilmə ünvanı</translation>
+    </message>
+    <message>
+        <source>Edit receiving address</source>
+        <translation type="unfinished">Qəbul ünvanını düzəliş et</translation>
+    </message>
+    <message>
+        <source>Edit sending address</source>
+        <translation type="unfinished">Göndərilmə ünvanını düzəliş et</translation>
+    </message>
+    <message>
+        <source>New key generation failed.</source>
+        <translation type="unfinished">Yeni açar yaradılma uğursuz oldu.</translation>
+    </message>
+</context>
+<context>
+    <name>FreespaceChecker</name>
+    <message>
+        <source>name</source>
+        <translation type="unfinished">ad</translation>
     </message>
     </context>
 <context>
     <name>Intro</name>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
     <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
@@ -319,12 +1250,70 @@ Daxil olma, yalnız 'qanuni' tipli ünvanlar ilə mümkündür.</translation>
         <translation type="unfinished">Xəta</translation>
     </message>
     <message>
+        <source>Welcome</source>
+        <translation type="unfinished">Xoş gəlmisiniz</translation>
+    </message>
+    <message>
         <source>Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</source>
         <translation type="unfinished">Bu tənzimləməni geri almaq bütün blok zəncirinin yenidən endirilməsini tələb edəcək. Əvvəlcə tam zənciri endirmək və sonra budamaq daha sürətlidir. Bəzi qabaqcıl özəllikləri sıradan çıxarar.</translation>
+    </message>
+    <message>
+        <source> GB</source>
+        <translation type="unfinished">QB</translation>
+    </message>
+    </context>
+<context>
+    <name>HelpMessageDialog</name>
+    <message>
+        <source>version</source>
+        <translation type="unfinished">versiya</translation>
+    </message>
+    </context>
+<context>
+    <name>ModalOverlay</name>
+    <message>
+        <source>Number of blocks left</source>
+        <translation type="unfinished">Qalan blokların sayı</translation>
+    </message>
+    <message>
+        <source>Unknown…</source>
+        <translation type="unfinished">Bilinməyən...</translation>
+    </message>
+    <message>
+        <source>calculating…</source>
+        <translation type="unfinished">hesablanır...</translation>
+    </message>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished">Gizlə</translation>
     </message>
     </context>
 <context>
     <name>OptionsDialog</name>
+    <message>
+        <source>Options</source>
+        <translation type="unfinished">Seçimlər</translation>
+    </message>
+    <message>
+        <source>&amp;Main</source>
+        <translation type="unfinished">&amp;Əsas</translation>
+    </message>
+    <message>
+        <source>Open Configuration File</source>
+        <translation type="unfinished">Konfiqurasiya Faylını Aç</translation>
+    </message>
+    <message>
+        <source>&amp;Reset Options</source>
+        <translation type="unfinished">&amp;Seçimləri Sıfırla</translation>
+    </message>
+    <message>
+        <source>&amp;Network</source>
+        <translation type="unfinished">&amp;Şəbəkə</translation>
+    </message>
+    <message>
+        <source>GB</source>
+        <translation type="unfinished">QB</translation>
+    </message>
     <message>
         <source>Reverting this setting requires re-downloading the entire blockchain.</source>
         <translation type="unfinished">Bu tənzimləməni geri almaq bütün blok zəncirinin yenidən endirilməsini tələb edəcək. </translation>
@@ -334,12 +1323,78 @@ Daxil olma, yalnız 'qanuni' tipli ünvanlar ilə mümkündür.</translation>
         <translation type="unfinished">&amp;UPnP istifadə edən xəritə portu</translation>
     </message>
     <message>
+        <source>&amp;Window</source>
+        <translation type="unfinished">&amp;Pəncərə</translation>
+    </message>
+    <message>
         <source>The user interface language can be set here. This setting will take effect after restarting %1.</source>
         <translation type="unfinished">İstifadəçi interfeys dili burada tənzimlənə bilər. Bu tənzimləmə %1 yenidən başladıldıqdan sonra təsirli olacaq.</translation>
     </message>
     <message>
+        <source>&amp;Cancel</source>
+        <translation type="unfinished">&amp;Ləğv et</translation>
+    </message>
+    <message>
+        <source>Configuration options</source>
+        <extracomment>Window title text of pop-up box that allows opening up of configuration file.</extracomment>
+        <translation type="unfinished">Konfiqurasiya seçimləri</translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation type="unfinished">Davam et</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Ləğv et</translation>
+    </message>
+    <message>
         <source>Error</source>
         <translation type="unfinished">Xəta</translation>
+    </message>
+    </context>
+<context>
+    <name>OverviewPage</name>
+    <message>
+        <source>Total:</source>
+        <translation type="unfinished">Ümumi:</translation>
+    </message>
+    <message>
+        <source>Recent transactions</source>
+        <translation type="unfinished">Son əməliyyatlar</translation>
+    </message>
+    </context>
+<context>
+    <name>PSBTOperationsDialog</name>
+    <message>
+        <source>Copy to Clipboard</source>
+        <translation type="unfinished">Buferə kopyala</translation>
+    </message>
+    <message>
+        <source>Save…</source>
+        <translation type="unfinished">Yadda saxla...</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation type="unfinished">Bağla</translation>
+    </message>
+    <message>
+        <source>Failed to load transaction: %1</source>
+        <translation type="unfinished">Əməliyyatı yükləmək alınmadı:%1</translation>
+    </message>
+    <message>
+        <source>Total Amount</source>
+        <translation type="unfinished">Ümumi Miqdar</translation>
+    </message>
+    <message>
+        <source>or</source>
+        <translation type="unfinished">və ya</translation>
+    </message>
+    </context>
+<context>
+    <name>PaymentServer</name>
+    <message>
+        <source>Payment request error</source>
+        <translation type="unfinished">Ödəmə tələbinin xətası</translation>
     </message>
     </context>
 <context>
@@ -349,16 +1404,64 @@ Daxil olma, yalnız 'qanuni' tipli ünvanlar ilə mümkündür.</translation>
         <extracomment>Title of Peers Table column which contains the IP/Onion/I2P address of the connected peer.</extracomment>
         <translation type="unfinished">Ünvan</translation>
     </message>
+    <message>
+        <source>Network</source>
+        <extracomment>Title of Peers Table column which states the network the peer connected through.</extracomment>
+        <translation type="unfinished">Şəbəkə</translation>
+    </message>
     </context>
 <context>
     <name>RPCConsole</name>
     <message>
+        <source>Network</source>
+        <translation type="unfinished">Şəbəkə</translation>
+    </message>
+    <message>
         <source>&amp;Reset</source>
         <translation type="unfinished">&amp;Sıfırla</translation>
+    </message>
+    <message>
+        <source>Node window</source>
+        <translation type="unfinished">Qovşaq pəncərəsi</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <extracomment>Context menu action to copy the address of a peer.</extracomment>
+        <translation type="unfinished">&amp;Ünvanı kopyalayın</translation>
+    </message>
+    </context>
+<context>
+    <name>ReceiveCoinsDialog</name>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Ünvanı kopyalayın</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">&amp;Etiketi kopyalayın</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">&amp;Məbləği kopyalayın</translation>
+    </message>
+    </context>
+<context>
+    <name>ReceiveRequestDialog</name>
+    <message>
+        <source>Amount:</source>
+        <translation type="unfinished">Məbləğ:</translation>
+    </message>
+    <message>
+        <source>Wallet:</source>
+        <translation type="unfinished">Cüzdan:</translation>
     </message>
     </context>
 <context>
     <name>RecentRequestsTableModel</name>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">Tarix</translation>
+    </message>
     <message>
         <source>Label</source>
         <translation type="unfinished">Etiket</translation>
@@ -371,12 +1474,72 @@ Daxil olma, yalnız 'qanuni' tipli ünvanlar ilə mümkündür.</translation>
 <context>
     <name>SendCoinsDialog</name>
     <message>
+        <source>Quantity:</source>
+        <translation type="unfinished">Miqdar:</translation>
+    </message>
+    <message>
+        <source>Bytes:</source>
+        <translation type="unfinished">Baytlar:</translation>
+    </message>
+    <message>
+        <source>Amount:</source>
+        <translation type="unfinished">Məbləğ:</translation>
+    </message>
+    <message>
+        <source>Fee:</source>
+        <translation type="unfinished">Komissiya:</translation>
+    </message>
+    <message>
+        <source>After Fee:</source>
+        <translation type="unfinished">Komissiydan sonra:</translation>
+    </message>
+    <message>
+        <source>Change:</source>
+        <translation type="unfinished">Qalıq:</translation>
+    </message>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished">Gizlə</translation>
+    </message>
+    <message>
+        <source>Dust:</source>
+        <translation type="unfinished">Toz:</translation>
+    </message>
+    <message>
         <source>Copy quantity</source>
         <translation type="unfinished">Miqdarı kopyalayın</translation>
     </message>
     <message>
+        <source>Copy amount</source>
+        <translation type="unfinished">Məbləği kopyalayın</translation>
+    </message>
+    <message>
+        <source>Copy fee</source>
+        <translation type="unfinished">Komissiyanı kopyalayın</translation>
+    </message>
+    <message>
+        <source>Copy after fee</source>
+        <translation type="unfinished">Komissyadan sonra kopyalayın</translation>
+    </message>
+    <message>
+        <source>Copy bytes</source>
+        <translation type="unfinished">Baytları koyalayın</translation>
+    </message>
+    <message>
+        <source>Copy dust</source>
+        <translation type="unfinished">Tozu kopyalayın</translation>
+    </message>
+    <message>
         <source>Copy change</source>
         <translation type="unfinished">Dəyişikliyi kopyalayın</translation>
+    </message>
+    <message>
+        <source>or</source>
+        <translation type="unfinished">və ya</translation>
+    </message>
+    <message>
+        <source>Total Amount</source>
+        <translation type="unfinished">Ümumi Miqdar</translation>
     </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
@@ -392,6 +1555,10 @@ Daxil olma, yalnız 'qanuni' tipli ünvanlar ilə mümkündür.</translation>
 </context>
 <context>
     <name>TransactionDesc</name>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">Tarix</translation>
+    </message>
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
@@ -399,9 +1566,17 @@ Daxil olma, yalnız 'qanuni' tipli ünvanlar ilə mümkündür.</translation>
             <numerusform />
         </translation>
     </message>
+    <message>
+        <source>Amount</source>
+        <translation type="unfinished">Məbləğ</translation>
+    </message>
     </context>
 <context>
     <name>TransactionTableModel</name>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">Tarix</translation>
+    </message>
     <message>
         <source>Label</source>
         <translation type="unfinished">Etiket</translation>
@@ -416,6 +1591,31 @@ Daxil olma, yalnız 'qanuni' tipli ünvanlar ilə mümkündür.</translation>
     <message>
         <source>Other</source>
         <translation type="unfinished">Başqa</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Ünvanı kopyalayın</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">&amp;Etiketi kopyalayın</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">&amp;Məbləği kopyalayın</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">Vergüllə ayrılmış fayl</translation>
+    </message>
+    <message>
+        <source>Confirmed</source>
+        <translation type="unfinished">Təsdiqləndi</translation>
+    </message>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">Tarix</translation>
     </message>
     <message>
         <source>Label</source>
@@ -433,10 +1633,21 @@ Daxil olma, yalnız 'qanuni' tipli ünvanlar ilə mümkündür.</translation>
 <context>
     <name>WalletFrame</name>
     <message>
+        <source>Create a new wallet</source>
+        <translation type="unfinished">Yeni cüzdan yaradın</translation>
+    </message>
+    <message>
         <source>Error</source>
         <translation type="unfinished">Xəta</translation>
     </message>
     </context>
+<context>
+    <name>WalletModel</name>
+    <message>
+        <source>default wallet</source>
+        <translation type="unfinished">standart cüzdan</translation>
+    </message>
+</context>
 <context>
     <name>WalletView</name>
     <message>
@@ -447,5 +1658,14 @@ Daxil olma, yalnız 'qanuni' tipli ünvanlar ilə mümkündür.</translation>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished">Hazırki vərəqdəki verilənləri fayla ixrac edin</translation>
     </message>
-    </context>
+    <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">Cüzdanı verilənləri</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Ləğv et</translation>
+    </message>
+</context>
 </TS>

--- a/src/qt/locale/bitcoin_be.ts
+++ b/src/qt/locale/bitcoin_be.ts
@@ -660,6 +660,30 @@
         <translation type="unfinished">Біткойн</translation>
     </message>
     <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
@@ -903,15 +927,7 @@
         <source>Message:</source>
         <translation type="unfinished">Паведамленне:</translation>
     </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">Заплаціць да:</translation>
-    </message>
-    <message>
-        <source>Memo:</source>
-        <translation type="unfinished">Памятка:</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
@@ -923,10 +939,12 @@
     <name>TransactionDesc</name>
     <message>
         <source>%1/unconfirmed</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
         <translation type="unfinished">%1/непацверджана</translation>
     </message>
     <message>
         <source>%1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
         <translation type="unfinished">%1 пацверджанняў</translation>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_bg.ts
+++ b/src/qt/locale/bitcoin_bg.ts
@@ -87,6 +87,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Изнеси лист с адреси</translation>
     </message>
     <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">Файл, разделен със запетая</translation>
+    </message>
+    <message>
         <source>There was an error trying to save the address list to %1. Please try again.</source>
         <extracomment>An error message. %1 is a stand-in argument for the name of the file we attempted to save to.</extracomment>
         <translation type="unfinished">Получи се грешка при запазването на листа с адреси към %1. Моля опитайте пак.</translation>
@@ -174,6 +179,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Въведете старата и новата паролна фраза за портфейла.</translation>
     </message>
     <message>
+        <source>Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
+        <translation type="unfinished">Не забравяйте, че криптирането на вашия портфейл не може напълно да защити вашите биткойни от кражба от зловреден софтуер, заразяващ компютъра ви.</translation>
+    </message>
+    <message>
         <source>Wallet to be encrypted</source>
         <translation type="unfinished">Портфейл за криптиране</translation>
     </message>
@@ -232,6 +241,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>BitcoinApplication</name>
     <message>
+        <source>Settings file %1 might be corrupt or invalid.</source>
+        <translation type="unfinished">Файлът с настройки %1 може да е повреден или невалиден.</translation>
+    </message>
+    <message>
+        <source>Runaway exception</source>
+        <translation type="unfinished">Изключи бягащите</translation>
+    </message>
+    <message>
         <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
         <translation type="unfinished">Фатална грешка се появи. %1 не може да продължи безопастно и ще се затвори.</translation>
     </message>
@@ -239,7 +256,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Internal error</source>
         <translation type="unfinished">Вътрешна грешка.</translation>
     </message>
-    </context>
+    <message>
+        <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
+        <translation type="unfinished">Възникна вътрешна грешка. %1 ще се опита да продължи безопасно. Това е неочакван бъг, който може да бъде докладван, както е описано по-долу.</translation>
+    </message>
+</context>
 <context>
     <name>QObject</name>
     <message>
@@ -255,6 +276,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Error: Specified data directory "%1" does not exist.</source>
         <translation type="unfinished">Грешка:Избраната "%1" директория не съществува.</translation>
+    </message>
+    <message>
+        <source>Error: Cannot parse configuration file: %1.</source>
+        <translation type="unfinished">Грешка: Не може да се анализира конфигурационния файл: %1.</translation>
     </message>
     <message>
         <source>Error: %1</source>
@@ -439,7 +464,31 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Transaction too large</source>
         <translation type="unfinished">Транзакцията е твърде голяма</translation>
     </message>
-    </context>
+    <message>
+        <source>Unknown new rules activated (versionbit %i)</source>
+        <translation type="unfinished">Активирани са неизвестни нови правила (versionbit %i)</translation>
+    </message>
+    <message>
+        <source>Unsupported logging category %s=%s.</source>
+        <translation type="unfinished">Неподдържана logging категория%s=%s.</translation>
+    </message>
+    <message>
+        <source>User Agent comment (%s) contains unsafe characters.</source>
+        <translation type="unfinished">Коментар потребителски агент (%s) съдържа не безопасни знаци. </translation>
+    </message>
+    <message>
+        <source>Verifying blocks…</source>
+        <translation type="unfinished">Секторите се проверяват...</translation>
+    </message>
+    <message>
+        <source>Verifying wallet(s)…</source>
+        <translation type="unfinished">Потвърждаване на портфейл(и)...</translation>
+    </message>
+    <message>
+        <source>Wallet needed to be rewritten: restart %s to complete</source>
+        <translation type="unfinished">Портфейлът трябва да бъде презаписан : рестартирай %s , за да завърши</translation>
+    </message>
+</context>
 <context>
     <name>BitcoinGUI</name>
     <message>
@@ -568,6 +617,18 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">&amp;Зареди PSBT от файл…</translation>
     </message>
     <message>
+        <source>Open &amp;URI…</source>
+        <translation type="unfinished">Отвори &amp;URI...</translation>
+    </message>
+    <message>
+        <source>Close Wallet…</source>
+        <translation type="unfinished">Затвори Портфейл...</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation type="unfinished">Създай Портфейл...</translation>
+    </message>
+    <message>
         <source>Close All Wallets…</source>
         <translation type="unfinished">Затвори всички уолети</translation>
     </message>
@@ -588,8 +649,28 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Лентата с инструменти</translation>
     </message>
     <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation type="unfinished">Синхронизиране на хедъри (%1%)</translation>
+    </message>
+    <message>
         <source>Synchronizing with network…</source>
         <translation type="unfinished">Синхронизиране с мрежа</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation type="unfinished">Индексиране на блокове от диска...</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation type="unfinished">Обработват се блокове на диска...</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation type="unfinished">Преиндексиране на блоково от диска...</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation type="unfinished">Свързване с рояк...</translation>
     </message>
     <message>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
@@ -610,13 +691,17 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>Обработени %n сектори от историята с трансакции.</numerusform>
+            <numerusform>Обработени %n сектори от историята с трансакции.</numerusform>
         </translation>
     </message>
     <message>
         <source>%1 behind</source>
         <translation type="unfinished">%1 зад</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation type="unfinished">Наваксвам...</translation>
     </message>
     <message>
         <source>Last received block was generated %1 ago.</source>
@@ -643,8 +728,40 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Актуално</translation>
     </message>
     <message>
+        <source>Ctrl+Q</source>
+        <translation type="unfinished">Ctrl+Q </translation>
+    </message>
+    <message>
+        <source>Load Partially Signed Bitcoin Transaction</source>
+        <translation type="unfinished">Заредете частично подписана Bitcoin трансакция</translation>
+    </message>
+    <message>
+        <source>Load PSBT from &amp;clipboard…</source>
+        <translation type="unfinished">Заредете PSBT (частично подписана Bitcoin трансакция) от &amp;клипборд...</translation>
+    </message>
+    <message>
+        <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
+        <translation type="unfinished">Заредете частично подписана Bitcoin трансакция от клипборд</translation>
+    </message>
+    <message>
         <source>Node window</source>
         <translation type="unfinished">Прозорец на възела</translation>
+    </message>
+    <message>
+        <source>Open node debugging and diagnostic console</source>
+        <translation type="unfinished">Отвори конзола за отстраняване на грешки и диагностика на възела</translation>
+    </message>
+    <message>
+        <source>&amp;Sending addresses</source>
+        <translation type="unfinished">&amp;Изпращане на адреси</translation>
+    </message>
+    <message>
+        <source>&amp;Receiving addresses</source>
+        <translation type="unfinished">&amp;Получаване на адреси</translation>
+    </message>
+    <message>
+        <source>Open a bitcoin: URI</source>
+        <translation type="unfinished">Отвори bitcoin: URI</translation>
     </message>
     <message>
         <source>Open Wallet</source>
@@ -659,12 +776,30 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Затвори портфейла</translation>
     </message>
     <message>
+        <source>Restore Wallet…</source>
+        <extracomment>Name of the menu item that restores wallet from a backup file.</extracomment>
+        <translation type="unfinished">Възстановяване на Портфейл...</translation>
+    </message>
+    <message>
+        <source>Restore a wallet from a backup file</source>
+        <extracomment>Status tip for Restore Wallet menu item</extracomment>
+        <translation type="unfinished">Възстанови портфейла от резервен файл</translation>
+    </message>
+    <message>
         <source>Close all wallets</source>
         <translation type="unfinished">Затвори всички портфейли</translation>
     </message>
     <message>
         <source>Show the %1 help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished">Покажи %1 помощно съобщение за да получиш лист с възможни Биткойн команди</translation>
+    </message>
+    <message>
+        <source>&amp;Mask values</source>
+        <translation type="unfinished">§Маскирай стойностите</translation>
+    </message>
+    <message>
+        <source>Mask the values in the Overview tab</source>
+        <translation type="unfinished">Маскирай стойностите в раздела Преглед</translation>
     </message>
     <message>
         <source>default wallet</source>
@@ -675,8 +810,32 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Няма достъпни портфейли</translation>
     </message>
     <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">Данни от портфейла</translation>
+    </message>
+    <message>
+        <source>Load Wallet Backup</source>
+        <extracomment>The title for Restore Wallet File Windows</extracomment>
+        <translation type="unfinished">Зареди резервно копие на портфейл</translation>
+    </message>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of pop-up window shown when the user is attempting to restore a wallet.</extracomment>
+        <translation type="unfinished">Възстановяване на Портфейл</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">Име на портфейл</translation>
+    </message>
+    <message>
         <source>&amp;Window</source>
         <translation type="unfinished">&amp;Прозорец</translation>
+    </message>
+    <message>
+        <source>Ctrl+M</source>
+        <translation type="unfinished">Ctrl+M </translation>
     </message>
     <message>
         <source>Zoom</source>
@@ -690,18 +849,31 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>%1 client</source>
         <translation type="unfinished">%1 клиент</translation>
     </message>
+    <message>
+        <source>&amp;Hide</source>
+        <translation type="unfinished">&amp;Скрий</translation>
+    </message>
+    <message>
+        <source>S&amp;how</source>
+        <translation type="unfinished">&amp;Покажи</translation>
+    </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n свързани активно към Bitcoin мрежата.</numerusform>
+            <numerusform>%n активно свързани към Биткойн мрежата. </numerusform>
         </translation>
     </message>
     <message>
         <source>Click for more actions.</source>
         <extracomment>A substring of the tooltip. "More actions" are available via the context menu.</extracomment>
         <translation type="unfinished">Клик за повече действия</translation>
+    </message>
+    <message>
+        <source>Show Peers tab</source>
+        <extracomment>A context menu item. The "Peers tab" is an element of the "Node window".</extracomment>
+        <translation type="unfinished">Показване на раздела с Пиъри</translation>
     </message>
     <message>
         <source>Disable network activity</source>
@@ -791,6 +963,13 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
 </context>
 <context>
+    <name>UnitDisplayStatusBarControl</name>
+    <message>
+        <source>Unit to show amounts in. Click to select another unit.</source>
+        <translation type="unfinished">Елемент за показване на суми. Щракнете, за да изберете друга единица.</translation>
+    </message>
+</context>
+<context>
     <name>CoinControlDialog</name>
     <message>
         <source>Coin Selection</source>
@@ -869,8 +1048,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">&amp;Копирай адрес</translation>
     </message>
     <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Копиране на етикет</translation>
+    </message>
+    <message>
         <source>Copy &amp;amount</source>
         <translation type="unfinished">Копирай сума</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID and output index</source>
+        <translation type="unfinished">Копирайте идентификатора &amp;ID на трансакцията и изходния индекс</translation>
     </message>
     <message>
         <source>L&amp;ock unspent</source>
@@ -953,7 +1140,19 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Create wallet failed</source>
         <translation type="unfinished">Създаването на портфейл не бе успешен</translation>
     </message>
-    </context>
+    <message>
+        <source>Create wallet warning</source>
+        <translation type="unfinished">Създайте предупредителен портфейл </translation>
+    </message>
+    <message>
+        <source>Can't list signers</source>
+        <translation type="unfinished">Не мога да изброя подписите</translation>
+    </message>
+    <message>
+        <source>Too many external signers found</source>
+        <translation type="unfinished">Намерени са твърде много външни подписващи</translation>
+    </message>
+</context>
 <context>
     <name>LoadWalletsActivity</name>
     <message>
@@ -974,6 +1173,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Отварянето на уолет неупсешно</translation>
     </message>
     <message>
+        <source>Open wallet warning</source>
+        <translation type="unfinished">Внимание, отворен портфейл</translation>
+    </message>
+    <message>
         <source>default wallet</source>
         <translation type="unfinished">Портфейл по подразбиране</translation>
     </message>
@@ -982,7 +1185,30 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <extracomment>Title of window indicating the progress of opening of a wallet.</extracomment>
         <translation type="unfinished">Отворете портфейл</translation>
     </message>
-    </context>
+    <message>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the open wallet progress window which indicates to the user which wallet is currently being opened.</extracomment>
+        <translation type="unfinished">Отваряне на портфейл &lt;b&gt;%1&lt;/b&gt;…</translation>
+    </message>
+</context>
+<context>
+    <name>RestoreWalletActivity</name>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of progress window which is displayed when wallets are being restored.</extracomment>
+        <translation type="unfinished">Възстановяване на Портфейл</translation>
+    </message>
+    <message>
+        <source>Restore wallet failed</source>
+        <extracomment>Title of message box which is displayed when the wallet could not be restored.</extracomment>
+        <translation type="unfinished">Възстановяването на портфейла не бе успешно</translation>
+    </message>
+    <message>
+        <source>Restore wallet message</source>
+        <extracomment>Title of message box which is displayed when the wallet is successfully restored.</extracomment>
+        <translation type="unfinished">Съобщение портфейлът е възстановен</translation>
+    </message>
+</context>
 <context>
     <name>WalletController</name>
     <message>
@@ -990,10 +1216,22 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Затвори портфейла</translation>
     </message>
     <message>
+        <source>Are you sure you wish to close the wallet &lt;i&gt;%1&lt;/i&gt;?</source>
+        <translation type="unfinished">Сигурни ли сте, че искате да затворите портфейла&lt;i&gt;%1&lt;/i&gt;?</translation>
+    </message>
+    <message>
+        <source>Closing the wallet for too long can result in having to resync the entire chain if pruning is enabled.</source>
+        <translation type="unfinished">Затварянето на портфейла за твърде дълго може да доведе до необходимост от повторно синхронизиране на цялата верига, ако съкращаването е активирано.</translation>
+    </message>
+    <message>
         <source>Close all wallets</source>
         <translation type="unfinished">Затвори всички портфейли</translation>
     </message>
-    </context>
+    <message>
+        <source>Are you sure you wish to close all wallets?</source>
+        <translation type="unfinished">Сигурни ли сте, че искате да затворите всички портфейли?</translation>
+    </message>
+</context>
 <context>
     <name>CreateWalletDialog</name>
     <message>
@@ -1009,14 +1247,63 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">портфейл</translation>
     </message>
     <message>
+        <source>Encrypt the wallet. The wallet will be encrypted with a passphrase of your choice.</source>
+        <translation type="unfinished">Кодиране на портфейла. Портфейлът ще бъде криптиран с парола по ваш избор.</translation>
+    </message>
+    <message>
         <source>Encrypt Wallet</source>
         <translation type="unfinished">Криптирай портфейла</translation>
+    </message>
+    <message>
+        <source>Advanced Options</source>
+        <translation type="unfinished">Разширени настройки</translation>
+    </message>
+    <message>
+        <source>Disable private keys for this wallet. Wallets with private keys disabled will have no private keys and cannot have an HD seed or imported private keys. This is ideal for watch-only wallets.</source>
+        <translation type="unfinished">Деактивирайте частните ключове за този портфейл. Портфейлите с деактивирани частни ключове няма да имат частни ключове и не могат да имат HD seed или импортирани частни ключове. Това е идеално за портфейли, които служат само за наблюдение на баланса.</translation>
+    </message>
+    <message>
+        <source>Disable Private Keys</source>
+        <translation type="unfinished">Изключете частните (тайните) ключове</translation>
+    </message>
+    <message>
+        <source>Make a blank wallet. Blank wallets do not initially have private keys or scripts. Private keys and addresses can be imported, or an HD seed can be set, at a later time.</source>
+        <translation type="unfinished">Създайте празен портфейл.  Празните портфейли първоначално нямат частни ключове или скриптове. Частните ключове и адреси могат да бъдат импортирани или може да се зададе HD seed по-късно. </translation>
+    </message>
+    <message>
+        <source>Make Blank Wallet</source>
+        <translation type="unfinished">Създайте празен портфейл</translation>
+    </message>
+    <message>
+        <source>Use descriptors for scriptPubKey management</source>
+        <translation type="unfinished">Използвайте декодери за управление на scriptPubKey</translation>
+    </message>
+    <message>
+        <source>Descriptor Wallet</source>
+        <translation type="unfinished">Декодер за портфейл</translation>
+    </message>
+    <message>
+        <source>Use an external signing device such as a hardware wallet. Configure the external signer script in wallet preferences first.</source>
+        <translation type="unfinished">Използвайте външно устройство за подписване, като хардуерен портфейл. Конфигурирайте първо външния скрипт на подписа в предпочитания портфейл.</translation>
+    </message>
+    <message>
+        <source>External signer</source>
+        <translation type="unfinished">Външен подпис</translation>
     </message>
     <message>
         <source>Create</source>
         <translation type="unfinished">Създай</translation>
     </message>
-    </context>
+    <message>
+        <source>Compiled without sqlite support (required for descriptor wallets)</source>
+        <translation type="unfinished">Компилиран без поддръжка на sqlite (изисква се за декодер на портфейли)</translation>
+    </message>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Компилиран без поддръжка на външни подписи (изисква се за външно подписване)</translation>
+    </message>
+</context>
 <context>
     <name>EditAddressDialog</name>
     <message>
@@ -1056,6 +1343,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">"%1" не е валиден Биткоин адрес.</translation>
     </message>
     <message>
+        <source>Address "%1" already exists as a receiving address with label "%2" and so cannot be added as a sending address.</source>
+        <translation type="unfinished">Адресът "%1" вече съществува като адрес за получаване с етикет "%2" и затова не може да бъде добавен като адрес за изпращане.</translation>
+    </message>
+    <message>
+        <source>The entered address "%1" is already in the address book with label "%2".</source>
+        <translation type="unfinished">Въведеният адрес "%1" вече е в адресната книга с етикет "%2".</translation>
+    </message>
+    <message>
         <source>Could not unlock wallet.</source>
         <translation type="unfinished">Не може да отключите портфейла.</translation>
     </message>
@@ -1093,6 +1388,27 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Bitcoin</source>
         <translation type="unfinished">Биткоин</translation>
     </message>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform>фе</numerusform>
+            <numerusform>(от %n гигабайта са нужни)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
     <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
         <translation type="unfinished">Най малко %1 GB данни ще бъдат запаметени в тази директория, и ще нарастват през времето.</translation>
@@ -1105,13 +1421,21 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>(достатъчно за възстановяване на резервните копия %n от преди дни)</numerusform>
+            <numerusform>(достатъчно за възстановяване на резервните копия %n от преди дни)</numerusform>
         </translation>
     </message>
     <message>
         <source>%1 will download and store a copy of the Bitcoin block chain.</source>
         <translation type="unfinished">%1 ще свали и съхрани копие на биткойн блокчейна.</translation>
+    </message>
+    <message>
+        <source>The wallet will also be stored in this directory.</source>
+        <translation type="unfinished">Портфейлът ще се съхранява и в тази директория.</translation>
+    </message>
+    <message>
+        <source>Error: Specified data directory "%1" cannot be created.</source>
+        <translation type="unfinished">Грешка: Не може да се създаде посочената директория за данни "%1"</translation>
     </message>
     <message>
         <source>Error</source>
@@ -1130,8 +1454,24 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Програмата се стартира за първи път вие може да изберете къде %1 ще се запаметят данните.</translation>
     </message>
     <message>
+        <source>Limit block chain storage to</source>
+        <translation type="unfinished">Ограничете блокчейнното съхранение</translation>
+    </message>
+    <message>
+        <source>Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</source>
+        <translation type="unfinished">Връщането на тази настройка изисква повторно изтегляне на цялата секторна верига. По-бързо е първо да изтеглите пълната верига и да я подрязвате по-късно. Деактивира някои разширени функции.</translation>
+    </message>
+    <message>
+        <source> GB</source>
+        <translation type="unfinished">ГБ</translation>
+    </message>
+    <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
         <translation type="unfinished">Първоначалната синхронизация е изключително взискателна, и може да разкрие хардуерни проблеми с вашия компютър, които до сега са били незабелязани. Всеки път, когато включите %1,  свалянето ще започне от където е приключило.</translation>
+    </message>
+    <message>
+        <source>If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</source>
+        <translation type="unfinished">Ако сте избрали да ограничите съхранението на блокови вериги (подрязване), историческите данни все още трябва да бъдат изтеглени и обработени, но ще бъдат изтрити след това, за да поддържате използването на вашия диск.</translation>
     </message>
     <message>
         <source>Use the default data directory</source>
@@ -1160,6 +1500,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>ShutdownWindow</name>
     <message>
+        <source>%1 is shutting down…</source>
+        <translation type="unfinished">%1 изключва се...</translation>
+    </message>
+    <message>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished">Не изключвайте компютъра докато този прозорец не изчезне.</translation>
     </message>
@@ -1171,6 +1515,26 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">форма</translation>
     </message>
     <message>
+        <source>Recent transactions may not yet be visible, and therefore your wallet's balance might be incorrect. This information will be correct once your wallet has finished synchronizing with the bitcoin network, as detailed below.</source>
+        <translation type="unfinished">Последните трансакции все още не могат да се виждат и следователно балансът на портфейла ви може да бъде неправилен. Тази информация ще бъде правилна, след като портфейлът ви приключи синхронизирането с Bitcoin мрежата, както е подробно описано по-долу.</translation>
+    </message>
+    <message>
+        <source>Attempting to spend bitcoins that are affected by not-yet-displayed transactions will not be accepted by the network.</source>
+        <translation type="unfinished">Опитът да се изразходват биткойни, които са засегнати от все още показаните трансакции, няма да бъдат приети от мрежата.</translation>
+    </message>
+    <message>
+        <source>Number of blocks left</source>
+        <translation type="unfinished">Брой останали блокове</translation>
+    </message>
+    <message>
+        <source>Unknown…</source>
+        <translation type="unfinished">Неизвестно...</translation>
+    </message>
+    <message>
+        <source>calculating…</source>
+        <translation type="unfinished">изчисляване...</translation>
+    </message>
+    <message>
         <source>Last block time</source>
         <translation type="unfinished">Време на последния блок</translation>
     </message>
@@ -1179,12 +1543,36 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">прогрес</translation>
     </message>
     <message>
+        <source>Progress increase per hour</source>
+        <translation type="unfinished">Увеличаване на напредъка на час</translation>
+    </message>
+    <message>
+        <source>Estimated time left until synced</source>
+        <translation type="unfinished">Прогнозираното време остава до синхронизиране</translation>
+    </message>
+    <message>
         <source>Hide</source>
         <translation type="unfinished">Скрий</translation>
+    </message>
+    <message>
+        <source>Esc</source>
+        <translation type="unfinished">избягай</translation>
+    </message>
+    <message>
+        <source>%1 is currently syncing.  It will download headers and blocks from peers and validate them until reaching the tip of the block chain.</source>
+        <translation type="unfinished">%1 в момента синхронизира. Той ще изтегля заглавия и блокове от рояка и ще ги утвърди, докато достигне върха на секторната верига.</translation>
+    </message>
+    <message>
+        <source>Unknown. Syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">Неизвестно. Синхронизиране на Глави (%1, %2%)...</translation>
     </message>
     </context>
 <context>
     <name>OpenURIDialog</name>
+    <message>
+        <source>Open bitcoin URI</source>
+        <translation type="unfinished">Отвори bitcoin URI </translation>
+    </message>
     <message>
         <source>Paste address from clipboard</source>
         <extracomment>Tooltip text for button that allows you to paste an address that is in your clipboard.</extracomment>
@@ -1202,6 +1590,18 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">&amp;Основни</translation>
     </message>
     <message>
+        <source>Automatically start %1 after logging in to the system.</source>
+        <translation type="unfinished">Автоматично стартиране %1 след влизане в системата.</translation>
+    </message>
+    <message>
+        <source>&amp;Start %1 on system login</source>
+        <translation type="unfinished">&amp;Стартиране %1 при влизане в системата</translation>
+    </message>
+    <message>
+        <source>Enabling pruning significantly reduces the disk space required to store transactions. All blocks are still fully validated. Reverting this setting requires re-downloading the entire blockchain.</source>
+        <translation type="unfinished">Активирането на подрязването значително намалява дисковото пространство, необходимо за съхраняване на трансакции. Всички блокове все още са напълно валидирани. Връщането на тази настройка изисква повторно изтегляне на целия блокчейн.</translation>
+    </message>
+    <message>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished">Размер на кеша в &amp;базата данни</translation>
     </message>
@@ -1212,6 +1612,18 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished">IP адрес на прокси (напр. за IPv4: 127.0.0.1 / за IPv6: ::1)</translation>
+    </message>
+    <message>
+        <source>Shows if the supplied default SOCKS5 proxy is used to reach peers via this network type.</source>
+        <translation type="unfinished">Показва дали предоставеният proxy по подразбиране Socks5 се използва за достигане до рояк чрез този тип мрежа.</translation>
+    </message>
+    <message>
+        <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
+        <translation type="unfinished">Минимизиране вместо излизане от приложението, когато прозорецът е затворен. Когато тази опция е активирана, приложението ще се затвори само след избиране на Изход от менюто.</translation>
+    </message>
+    <message>
+        <source>Options set in this dialog are overridden by the command line:</source>
+        <translation type="unfinished">Опциите, зададени в този диалогов прозорец, се заменят от командния ред:</translation>
     </message>
     <message>
         <source>Open Configuration File</source>
@@ -1230,12 +1642,54 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">&amp;Мрежа</translation>
     </message>
     <message>
+        <source>Prune &amp;block storage to</source>
+        <translation type="unfinished">Съкратете &amp;блоковото хранилище до</translation>
+    </message>
+    <message>
         <source>GB</source>
         <translation type="unfinished">ГБ</translation>
     </message>
     <message>
+        <source>Reverting this setting requires re-downloading the entire blockchain.</source>
+        <translation type="unfinished">Връщането на тази настройка изисква повторно изтегляне на цялата блокова верига.</translation>
+    </message>
+    <message>
+        <source>Maximum database cache size. A larger cache can contribute to faster sync, after which the benefit is less pronounced for most use cases. Lowering the cache size will reduce memory usage. Unused mempool memory is shared for this cache.</source>
+        <extracomment>Tooltip text for Options window setting that sets the size of the database cache. Explains the corresponding effects of increasing/decreasing this value.</extracomment>
+        <translation type="unfinished">Максимален размер кеш за базата данни.  По-големият кеш може да допринесе за по-бърза синхронизация, след което ползата е по-малко изразена за повечето случаи на употреба. Намаляването на размера на кеша ще намали използването на паметта. Неизползваната mempool памет се споделя за този кеш.</translation>
+    </message>
+    <message>
+        <source>Set the number of script verification threads. Negative values correspond to the number of cores you want to leave free to the system.</source>
+        <extracomment>Tooltip text for Options window setting that sets the number of script verification threads. Explains that negative values mean to leave these many cores free to the system.</extracomment>
+        <translation type="unfinished">Задайте броя на нишките за проверка на скрипта. Отрицателните стойности съответстват на броя ядра, които искате да оставите свободни за системата.</translation>
+    </message>
+    <message>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation type="unfinished">(0 = авто, &lt;0 = оставете толкова свободни ядра) </translation>
+    </message>
+    <message>
+        <source>This allows you or a third party tool to communicate with the node through command-line and JSON-RPC commands.</source>
+        <extracomment>Tooltip text for Options window setting that enables the RPC server.</extracomment>
+        <translation type="unfinished">Това позволява на вас или на инструмент на трета страна да комуникирате с възела чрез команден ред и JSON-RPC команди.</translation>
+    </message>
+    <message>
+        <source>Enable R&amp;PC server</source>
+        <extracomment>An Options window setting to enable the RPC server.</extracomment>
+        <translation type="unfinished">Активиране на R&amp;PC сървър</translation>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished">По&amp;ртфейл</translation>
+    </message>
+    <message>
+        <source>Whether to set subtract fee from amount as default or not.</source>
+        <extracomment>Tooltip text for Options window setting that sets subtracting the fee from a sending amount as default.</extracomment>
+        <translation type="unfinished">Дали да зададете изваждане на такса от сумата по подразбиране или не.</translation>
+    </message>
+    <message>
+        <source>Subtract &amp;fee from amount by default</source>
+        <extracomment>An Options window setting to set subtracting the fee from a sending amount as default.</extracomment>
+        <translation type="unfinished">Изваждане &amp;такса от сума по подразбиране</translation>
     </message>
     <message>
         <source>Expert</source>
@@ -1246,8 +1700,34 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Позволяване на монетите и &amp;техните възможности</translation>
     </message>
     <message>
+        <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
+        <translation type="unfinished">Ако деактивирате разходите за непотвърдена промяна, промяната от трансакция не може да се използва, докато тази транзакция няма поне едно потвърждение. Това се отразява и на това как се изчислява вашият баланс.</translation>
+    </message>
+    <message>
         <source>&amp;Spend unconfirmed change</source>
         <translation type="unfinished">&amp;Похарчете непотвърденото ресто</translation>
+    </message>
+    <message>
+        <source>Enable &amp;PSBT controls</source>
+        <extracomment>An options window setting to enable PSBT controls.</extracomment>
+        <translation type="unfinished">Активиране &amp;PSBT контроли</translation>
+    </message>
+    <message>
+        <source>Whether to show PSBT controls.</source>
+        <extracomment>Tooltip text for options window setting that enables PSBT controls.</extracomment>
+        <translation type="unfinished">Дали да покажа PSBT контроли.</translation>
+    </message>
+    <message>
+        <source>External Signer (e.g. hardware wallet)</source>
+        <translation type="unfinished">Външен подпис (например хардуерен портфейл)</translation>
+    </message>
+    <message>
+        <source>&amp;External signer script path</source>
+        <translation type="unfinished">&amp;Външен път на скрипта на подписващия</translation>
+    </message>
+    <message>
+        <source>Full path to a Bitcoin Core compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</source>
+        <translation type="unfinished">Пълен път към съвместим с биткойн основен скрипт (например C: \ Downloads \ hwi.exe или /users/you/downloads/hwi.py). Внимавайте: злонамерен софтуер може да открадне вашите монети!</translation>
     </message>
     <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
@@ -1326,12 +1806,21 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Дали да покаже възможностите за контрол на монетите или не.</translation>
     </message>
     <message>
+        <source>Monospaced font in the Overview tab:</source>
+        <translation type="unfinished">Моноширинен шрифт в раздела Общ преглед:</translation>
+    </message>
+    <message>
         <source>&amp;OK</source>
         <translation type="unfinished">ОК</translation>
     </message>
     <message>
         <source>&amp;Cancel</source>
         <translation type="unfinished">Отказ</translation>
+    </message>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Компилиран без поддръжка на външни подписи (изисква се за външно подписване)</translation>
     </message>
     <message>
         <source>default</source>
@@ -1343,14 +1832,17 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Confirm options reset</source>
+        <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
         <translation type="unfinished">Потвърдете опциите за нулиране</translation>
     </message>
     <message>
         <source>Client restart required to activate changes.</source>
+        <extracomment>Text explaining that the settings changed will not come into effect until the client is restarted.</extracomment>
         <translation type="unfinished">Изисква се рестартиране на клиента за активиране на извършените промени.</translation>
     </message>
     <message>
         <source>Client will be shut down. Do you want to proceed?</source>
+        <extracomment>Text asking the user to confirm if they would like to proceed with a client shutdown.</extracomment>
         <translation type="unfinished">Клиентът ще бъде изключен. Искате ли да продължите?</translation>
     </message>
     <message>
@@ -1428,6 +1920,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </context>
 <context>
     <name>PSBTOperationsDialog</name>
+    <message>
+        <source>Save…</source>
+        <translation type="unfinished">Запази...</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation type="unfinished">Затвори</translation>
+    </message>
     <message>
         <source>or</source>
         <translation type="unfinished">или</translation>
@@ -1751,6 +2251,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">&amp;Копирай адрес</translation>
     </message>
     <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Копиране на етикет</translation>
+    </message>
+    <message>
         <source>Copy &amp;amount</source>
         <translation type="unfinished">Копирай сума</translation>
     </message>
@@ -1971,10 +2475,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Transaction creation failed!</source>
         <translation type="unfinished">Грешка при създаването на транзакция!</translation>
     </message>
-    <message>
-        <source>Payment request expired.</source>
-        <translation type="unfinished">Заявката за плащане е изтекла.</translation>
-    </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
@@ -2029,15 +2529,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Message:</source>
         <translation type="unfinished">Съобщение:</translation>
     </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">Плащане на:</translation>
-    </message>
-    <message>
-        <source>Memo:</source>
-        <translation type="unfinished">Бележка:</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
@@ -2148,15 +2640,13 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>TransactionDesc</name>
     <message>
-        <source>0/unconfirmed, %1</source>
-        <translation type="unfinished">0/непотвърдено, %1</translation>
-    </message>
-    <message>
         <source>%1/unconfirmed</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
         <translation type="unfinished">%1/непотвърдени</translation>
     </message>
     <message>
         <source>%1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
         <translation type="unfinished">включена в %1 блока</translation>
     </message>
     <message>
@@ -2412,12 +2902,21 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">&amp;Копирай адрес</translation>
     </message>
     <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Копиране на етикет</translation>
+    </message>
+    <message>
         <source>Copy &amp;amount</source>
         <translation type="unfinished">Копирай сума</translation>
     </message>
     <message>
         <source>Export Transaction History</source>
         <translation type="unfinished">Изнасяне историята на транзакциите</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">Файл, разделен със запетая</translation>
     </message>
     <message>
         <source>Confirmed</source>
@@ -2507,6 +3006,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Backup Wallet</source>
         <translation type="unfinished">Запазване на портфейла</translation>
+    </message>
+    <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">Данни от портфейла</translation>
     </message>
     <message>
         <source>Backup Failed</source>

--- a/src/qt/locale/bitcoin_bn.ts
+++ b/src/qt/locale/bitcoin_bn.ts
@@ -55,6 +55,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>BitcoinApplication</name>
     <message>
+        <source>Settings file %1 might be corrupt or invalid.</source>
+        <translation type="unfinished">1%1 সেটিংস ফাইল টি সম্ভবত নষ্ট বা করাপ্ট</translation>
+    </message>
+    <message>
         <source>Runaway exception</source>
         <translation type="unfinished">পলাতক ব্যতিক্রম</translation>
     </message>
@@ -73,6 +77,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 </context>
 <context>
     <name>QObject</name>
+    <message>
+        <source>Do you want to reset settings to default values, or to abort without making changes?</source>
+        <extracomment>Explanatory text shown on startup when the settings file cannot be read. Prompts user to make a choice between resetting or aborting.</extracomment>
+        <translation type="unfinished">আপনি কি সেটিংস পুনরায় ডিফল্ট করতে,অথবা কোনো পরিবর্তন ছাড়াই ফিরে যেতে চান? </translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. Check that settings file is writable, or try running with -nosettings.</source>
+        <extracomment>Explanatory text shown on startup when the settings file could not be written. Prompts user to check that we have the ability to write to the file. Explains that the user has the option of running without a settings file.</extracomment>
+        <translation type="unfinished">একটি জটিল ত্রুটি হয়েছে। সেটিং ফাইল টি রাইটেবল কিনা চেক করুন, অথবা -nosettings দিয়ে রান করার চেষ্টা করুন</translation>
+    </message>
     <message>
         <source>%1 didn't yet exit safely…</source>
         <translation type="unfinished">%1 এখনো নিরাপদে বের হয়নি</translation>
@@ -168,6 +182,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">একটি নতুন ওয়ালেট তৈরি করুন</translation>
     </message>
     <message>
+        <source>&amp;Minimize</source>
+        <translation type="unfinished">ছোট করুন</translation>
+    </message>
+    <message>
         <source>&amp;Options…</source>
         <translation type="unfinished">&amp;বিকল্প...</translation>
     </message>
@@ -246,7 +264,34 @@ Signing is only possible with addresses of the type 'legacy'.</source>
             <numerusform />
         </translation>
     </message>
-    </context>
+    <message>
+        <source>Click for more actions.</source>
+        <extracomment>A substring of the tooltip. "More actions" are available via the context menu.</extracomment>
+        <translation type="unfinished">আরো কর্মের জন্য চাপ দিন</translation>
+    </message>
+    <message>
+        <source>Disable network activity</source>
+        <extracomment>A context menu item.</extracomment>
+        <translation type="unfinished">নেটওয়ার্ক কার্যকলাপ বন্ধ করুন</translation>
+    </message>
+    <message>
+        <source>Enable network activity</source>
+        <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
+        <translation type="unfinished">নেটওয়ার্ক কার্যকলাপ চালু করুন</translation>
+    </message>
+    <message>
+        <source>Sent transaction</source>
+        <translation type="unfinished">লেনদেন পাঠানো হয়েছে</translation>
+    </message>
+    <message>
+        <source>Incoming transaction</source>
+        <translation type="unfinished">লেনদেন আসছে</translation>
+    </message>
+    <message>
+        <source>Original message:</source>
+        <translation type="unfinished">আসল বার্তা:</translation>
+    </message>
+</context>
 <context>
     <name>UnitDisplayStatusBarControl</name>
     <message>
@@ -257,6 +302,22 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>CoinControlDialog</name>
     <message>
+        <source>Coin Selection</source>
+        <translation type="unfinished">মুদ্রা নির্বাচন</translation>
+    </message>
+    <message>
+        <source>Quantity:</source>
+        <translation type="unfinished">পরিমাণ</translation>
+    </message>
+    <message>
+        <source>Fee:</source>
+        <translation type="unfinished">পারিশ্রমিক</translation>
+    </message>
+    <message>
+        <source>Change:</source>
+        <translation type="unfinished">পরিবর্তন</translation>
+    </message>
+    <message>
         <source>Date</source>
         <translation type="unfinished">তারিখ</translation>
     </message>
@@ -264,13 +325,25 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Confirmed</source>
         <translation type="unfinished">নিশ্চিত করা হয়েছে</translation>
     </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">ঠিকানা কপি করুন</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">কপি লেবেল</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">কপি পরিমাণ</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID and output index</source>
+        <translation type="unfinished">লেনদেন আইডি এবং আউটপুট সূচক কপি করুন</translation>
+    </message>
     </context>
 <context>
     <name>WalletController</name>
-    <message>
-        <source>Close wallet</source>
-        <translation type="unfinished">ওয়ালেট বন্ধ করুন</translation>
-    </message>
     <message>
         <source>Are you sure you wish to close the wallet &lt;i&gt;%1&lt;/i&gt;?</source>
         <translation type="unfinished">আপনি কি নিশ্চিত যে আপনি ওয়ালেট বন্ধ করতে চান&lt;i&gt;%1&lt;/i&gt;?</translation>
@@ -311,6 +384,27 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>Intro</name>
     <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform>(of %n GB needed)</numerusform>
+            <numerusform>(of %n GB needed)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform>(%n GB needed for full chain)</numerusform>
+            <numerusform>(%n GB needed for full chain)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
@@ -321,11 +415,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </context>
 <context>
     <name>PeerTableModel</name>
-    <message>
-        <source>Address</source>
-        <extracomment>Title of Peers Table column which contains the IP/Onion/I2P address of the connected peer.</extracomment>
-        <translation type="unfinished">ঠিকানা</translation>
-    </message>
     <message>
         <source>Type</source>
         <extracomment>Title of Peers Table column which describes the type of peer connection. The "type" describes why the connection exists.</extracomment>
@@ -345,6 +434,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>RPCConsole</name>
     <message>
+        <source>&amp;Copy address</source>
+        <extracomment>Context menu action to copy the address of a peer.</extracomment>
+        <translation type="unfinished">ঠিকানা কপি করুন</translation>
+    </message>
+    <message>
         <source>Unknown</source>
         <translation type="unfinished">অজানা</translation>
     </message>
@@ -363,16 +457,24 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>&amp;Message:</source>
         <translation type="unfinished">&amp;বার্তাঃ</translation>
     </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">ঠিকানা কপি করুন</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">কপি লেবেল</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">কপি পরিমাণ</translation>
+    </message>
     </context>
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
         <source>Date</source>
         <translation type="unfinished">তারিখ</translation>
-    </message>
-    <message>
-        <source>Label</source>
-        <translation type="unfinished">লেবেল</translation>
     </message>
     </context>
 <context>
@@ -416,13 +518,21 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Type</source>
         <translation type="unfinished">টাইপ</translation>
     </message>
-    <message>
-        <source>Label</source>
-        <translation type="unfinished">লেবেল</translation>
-    </message>
     </context>
 <context>
     <name>TransactionView</name>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">ঠিকানা কপি করুন</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">কপি লেবেল</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">কপি পরিমাণ</translation>
+    </message>
     <message>
         <source>Comma separated file</source>
         <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
@@ -443,14 +553,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Type</source>
         <translation type="unfinished">টাইপ</translation>
-    </message>
-    <message>
-        <source>Label</source>
-        <translation type="unfinished">লেবেল</translation>
-    </message>
-    <message>
-        <source>Address</source>
-        <translation type="unfinished">ঠিকানা</translation>
     </message>
     <message>
         <source>ID</source>

--- a/src/qt/locale/bitcoin_bs.ts
+++ b/src/qt/locale/bitcoin_bs.ts
@@ -260,6 +260,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>QObject</name>
     <message>
+        <source>Do you want to reset settings to default values, or to abort without making changes?</source>
+        <extracomment>Explanatory text shown on startup when the settings file cannot be read. Prompts user to make a choice between resetting or aborting.</extracomment>
+        <translation type="unfinished">Želite li resetirati postavke na zadane vrijednosti ili prekinuti bez unošenja promjena?</translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. Check that settings file is writable, or try running with -nosettings.</source>
+        <extracomment>Explanatory text shown on startup when the settings file could not be written. Prompts user to check that we have the ability to write to the file. Explains that the user has the option of running without a settings file.</extracomment>
+        <translation type="unfinished">Došlo je do fatalne greške. Provjerite da li se u datoteku postavki može pisati ili pokušajte pokrenuti s -nosettings.</translation>
+    </message>
+    <message>
         <source>Error: Specified data directory "%1" does not exist.</source>
         <translation type="unfinished">Greška: Navedeni direktorij podataka "%1" ne postoji.</translation>
     </message>
@@ -334,6 +344,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </context>
 <context>
     <name>bitcoin-core</name>
+    <message>
+        <source>Settings file could not be read</source>
+        <translation type="unfinished">Nije moguće pročitati fajl postavki</translation>
+    </message>
+    <message>
+        <source>Settings file could not be written</source>
+        <translation type="unfinished">Nije moguće upisati datoteku postavki</translation>
+    </message>
     <message>
         <source>Replaying blocks…</source>
         <translation type="unfinished">Reprodukcija blokova…</translation>
@@ -487,10 +505,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Nepodržana kategorija logivanja %s=%s.</translation>
     </message>
     <message>
-        <source>Upgrading UTXO database</source>
-        <translation type="unfinished">Nadogradnja UTXO baze podataka</translation>
-    </message>
-    <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
         <translation type="unfinished">Komentar korisničkog agenta (%s) sadrži nesigurne znakove.</translation>
     </message>
@@ -558,6 +572,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Kreirajte novi novčanik</translation>
     </message>
     <message>
+        <source>&amp;Minimize</source>
+        <translation type="unfinished">&amp;Minimiziraj</translation>
+    </message>
+    <message>
         <source>Wallet:</source>
         <translation type="unfinished">Novčanik:</translation>
     </message>
@@ -599,12 +617,20 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Šifrirajte privatne ključeve koji pripadaju vašem novčaniku</translation>
     </message>
     <message>
+        <source>Sign &amp;message…</source>
+        <translation type="unfinished">Potpiši &amp;poruku…</translation>
+    </message>
+    <message>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation type="unfinished">Potpišite poruke sa svojim Bitcoin adresama da biste dokazali da ste njihov vlasnik</translation>
     </message>
     <message>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation type="unfinished">Potvrdite poruke kako biste bili sigurni da su potpisane navedenim Bitcoin adresama</translation>
+    </message>
+    <message>
+        <source>Open &amp;URI…</source>
+        <translation type="unfinished">Otvori &amp;URI…</translation>
     </message>
     <message>
         <source>Close Wallet…</source>
@@ -765,6 +791,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>No wallets available</source>
         <translation type="unfinished">Nema dostupnih novčanika</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">Ime Novčanika</translation>
     </message>
     <message>
         <source>&amp;Window</source>
@@ -1182,6 +1213,30 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 </context>
 <context>
     <name>Intro</name>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
     <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
         <translation type="unfinished">Najmanje %1 GB podataka bit će pohranjeno u ovom direktoriju i vremenom će rasti.</translation>
@@ -1226,10 +1281,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>As this is the first time the program is launched, you can choose where %1 will store its data.</source>
         <translation type="unfinished">Zato što je ovo prvi put da se program pokreće, možete odabrati gdje će %1 čuvati svoje podatke.</translation>
-    </message>
-    <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation type="unfinished">Kada kliknete OK, %1 će početi preuzimati i obrađivati ​​puni lanac blokova %4 (%2GB), počevši od najranijih transakcija u %3 kada je %4 prvi put pokrenut.</translation>
     </message>
     <message>
         <source>Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</source>

--- a/src/qt/locale/bitcoin_ca.ts
+++ b/src/qt/locale/bitcoin_ca.ts
@@ -257,13 +257,19 @@ Només és possible firmar amb adreces del tipus "legacy".</translation>
         <source>Internal error</source>
         <translation type="unfinished">Error intern</translation>
     </message>
-    <message>
-        <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
-        <translation type="unfinished">S'ha produït un error intern. %1 intentarà continuar amb seguretat. Es pot informar sobre aquest error inesperat com es descriu a continuació.</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>QObject</name>
+    <message>
+        <source>Do you want to reset settings to default values, or to abort without making changes?</source>
+        <extracomment>Explanatory text shown on startup when the settings file cannot be read. Prompts user to make a choice between resetting or aborting.</extracomment>
+        <translation type="unfinished">Voleu restablir la configuració als valors predeterminats o sortir sense desar els canvis?</translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. Check that settings file is writable, or try running with -nosettings.</source>
+        <extracomment>Explanatory text shown on startup when the settings file could not be written. Prompts user to check that we have the ability to write to the file. Explains that the user has the option of running without a settings file.</extracomment>
+        <translation type="unfinished">Un error fatal s'ha produit. Revisa que l'arxiu de preferències sigui d'escriptura, o torna-ho a intentar amb -nosettings</translation>
+    </message>
     <message>
         <source>Error: Specified data directory "%1" does not exist.</source>
         <translation type="unfinished">Error: El directori de dades especificat «%1» no existeix.</translation>
@@ -384,6 +390,14 @@ Només és possible firmar amb adreces del tipus "legacy".</translation>
 <context>
     <name>bitcoin-core</name>
     <message>
+        <source>Settings file could not be read</source>
+        <translation type="unfinished">El fitxer de configuració no es pot llegir</translation>
+    </message>
+    <message>
+        <source>Settings file could not be written</source>
+        <translation type="unfinished">El fitxer de configuració no pot ser escrit</translation>
+    </message>
+    <message>
         <source>The %s developers</source>
         <translation type="unfinished">Els desenvolupadors %s</translation>
     </message>
@@ -430,10 +444,6 @@ Només és possible firmar amb adreces del tipus "legacy".</translation>
     <message>
         <source>Error: Legacy wallets only support the "legacy", "p2sh-segwit", and "bech32" address types</source>
         <translation type="unfinished">Error: les carteres heretades només admeten els tipus d'adreces «legacy», «p2sh-segwit» i «bech32»</translation>
-    </message>
-    <message>
-        <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
-        <translation type="unfinished">Error: ha fallat escoltar les connexions entrants (l'escoltament ha retornat l'error %s)</translation>
     </message>
     <message>
         <source>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.</source>
@@ -644,10 +654,6 @@ Només és possible firmar amb adreces del tipus "legacy".</translation>
         <translation type="unfinished">S'ha produït un error en llegir el següent registre de la base de dades de la cartera</translation>
     </message>
     <message>
-        <source>Error upgrading chainstate database</source>
-        <translation type="unfinished">S'ha produït un error en actualitzar la base de dades de chainstate</translation>
-    </message>
-    <message>
         <source>Error: Couldn't create cursor into database</source>
         <translation type="unfinished">Error: No s'ha pogut crear el cursor a la base de dades</translation>
     </message>
@@ -781,20 +787,12 @@ Només és possible firmar amb adreces del tipus "legacy".</translation>
         <translation type="unfinished">Cal especificar un port amb -whitebind: «%s»</translation>
     </message>
     <message>
-        <source>No proxy server specified. Use -proxy=&lt;ip&gt; or -proxy=&lt;ip:port&gt;.</source>
-        <translation type="unfinished">No s'ha especificat cap servidor intermediari. Utilitzeu -proxy =&lt;ip&gt; o -proxy =&lt;ip:port&gt;.</translation>
-    </message>
-    <message>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished">No hi ha suficient descriptors de fitxers disponibles.</translation>
     </message>
     <message>
         <source>Prune cannot be configured with a negative value.</source>
         <translation type="unfinished">La poda no es pot configurar amb un valor negatiu.</translation>
-    </message>
-    <message>
-        <source>Prune mode is incompatible with -coinstatsindex.</source>
-        <translation type="unfinished">El mode de poda és incompatible amb -coinstatsindex.</translation>
     </message>
     <message>
         <source>Prune mode is incompatible with -txindex.</source>
@@ -961,10 +959,6 @@ Només és possible firmar amb adreces del tipus "legacy".</translation>
         <translation type="unfinished">Categoria de registre no admesa %s=%s.</translation>
     </message>
     <message>
-        <source>Upgrading UTXO database</source>
-        <translation type="unfinished">Actualització de la base de dades UTXO</translation>
-    </message>
-    <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
         <translation type="unfinished">El comentari de l'agent d'usuari (%s) conté caràcters insegurs.</translation>
     </message>
@@ -1032,6 +1026,10 @@ Només és possible firmar amb adreces del tipus "legacy".</translation>
         <translation type="unfinished">Crear una nova cartera</translation>
     </message>
     <message>
+        <source>&amp;Minimize</source>
+        <translation type="unfinished">&amp;Minimitza</translation>
+    </message>
+    <message>
         <source>Wallet:</source>
         <translation type="unfinished">Moneder:</translation>
     </message>
@@ -1090,7 +1088,7 @@ Només és possible firmar amb adreces del tipus "legacy".</translation>
     </message>
     <message>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
-        <translation type="unfinished">Signa els missatges amb la seva adreça de Bitcoin per a provar que les posseeixes</translation>
+        <translation type="unfinished">Signa el missatges amb la seva adreça de Bitcoin per provar que les poseeixes</translation>
     </message>
     <message>
         <source>&amp;Verify message…</source>
@@ -1098,7 +1096,7 @@ Només és possible firmar amb adreces del tipus "legacy".</translation>
     </message>
     <message>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
-        <translation type="unfinished">Verifiqueu els missatges per a assegurar-vos que han estat signats amb una adreça Bitcoin específica.</translation>
+        <translation type="unfinished">Verifiqueu els missatges per assegurar-vos que han estat signats amb una adreça Bitcoin específica.</translation>
     </message>
     <message>
         <source>&amp;Load PSBT from file…</source>
@@ -1179,8 +1177,8 @@ Només és possible firmar amb adreces del tipus "legacy".</translation>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>Processat(s) %n bloc(s) de l'historial de transaccions.</numerusform>
+            <numerusform>Processat(s) %n bloc(s) de l'historial de transaccions.</numerusform>
         </translation>
     </message>
     <message>
@@ -1214,6 +1212,10 @@ Només és possible firmar amb adreces del tipus "legacy".</translation>
     <message>
         <source>Load Partially Signed Bitcoin Transaction</source>
         <translation type="unfinished">Carrega la transacció Bitcoin signada parcialment</translation>
+    </message>
+    <message>
+        <source>Load PSBT from &amp;clipboard…</source>
+        <translation type="unfinished">Carrega la PSBT des del porta-retalls.</translation>
     </message>
     <message>
         <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
@@ -1276,6 +1278,16 @@ Només és possible firmar amb adreces del tipus "legacy".</translation>
         <translation type="unfinished">No hi ha cap cartera disponible</translation>
     </message>
     <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">Dades de la cartera</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">Nom de la cartera</translation>
+    </message>
+    <message>
         <source>&amp;Window</source>
         <translation type="unfinished">&amp;Finestra</translation>
     </message>
@@ -1291,12 +1303,16 @@ Només és possible firmar amb adreces del tipus "legacy".</translation>
         <source>%1 client</source>
         <translation type="unfinished">Client de %1</translation>
     </message>
+    <message>
+        <source>&amp;Hide</source>
+        <translation type="unfinished">&amp;Amaga</translation>
+    </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n connexió activa a la xarxa Bitcoin</numerusform>
+            <numerusform>%n connexions actives a la xarxa Bitcoin</numerusform>
         </translation>
     </message>
     <message>
@@ -1570,7 +1586,7 @@ Només és possible firmar amb adreces del tipus "legacy".</translation>
         <source>Can't list signers</source>
         <translation type="unfinished">No es poden enumerar signants</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>OpenWalletActivity</name>
     <message>
@@ -1772,13 +1788,26 @@ Això és ideal per a carteres de mode només lectura.</translation>
 </context>
 <context>
     <name>Intro</name>
-    <message>
-        <source>(of %1 GB needed)</source>
-        <translation type="unfinished">(of %1 GB necessaris)</translation>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
     </message>
-    <message>
-        <source>(%1 GB needed for full chain)</source>
-        <translation type="unfinished">(%1 GB necessaris per a la cadena completa)</translation>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform>(Un GB necessari)</numerusform>
+            <numerusform>(de %n GB necessàris)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform>(Un GB necessari per a la cadena completa)</numerusform>
+            <numerusform>(Un GB necessari per a la cadena completa)</numerusform>
+        </translation>
     </message>
     <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
@@ -1792,8 +1821,8 @@ Això és ideal per a carteres de mode només lectura.</translation>
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>(suficient per restaurar les còpies de seguretat de%n dia (s))</numerusform>
+            <numerusform>(suficient per a restaurar les còpies de seguretat de %n die(s))</numerusform>
         </translation>
     </message>
     <message>
@@ -1819,10 +1848,6 @@ Això és ideal per a carteres de mode només lectura.</translation>
     <message>
         <source>As this is the first time the program is launched, you can choose where %1 will store its data.</source>
         <translation type="unfinished">Com és la primera vegada que s'executa el programa, podeu triar on %1 emmagatzemaran les dades.</translation>
-    </message>
-    <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation type="unfinished">Quan feu clic a D'acord, %1 començarà a descarregar i processar la cadena de blocs %4 completa (%2 GB) començant per les primeres transaccions de %3, any de llençament inicial de %4.</translation>
     </message>
     <message>
         <source>Limit block chain storage to</source>
@@ -1929,7 +1954,7 @@ Això és ideal per a carteres de mode només lectura.</translation>
         <source>Unknown. Syncing Headers (%1, %2%)…</source>
         <translation type="unfinished">Desconegut. Sincronització de les capçaleres (%1, %2%)...</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>OpenURIDialog</name>
     <message>
@@ -2157,10 +2182,6 @@ Això és ideal per a carteres de mode només lectura.</translation>
         <translation type="unfinished">coincidència més propera "%1"</translation>
     </message>
     <message>
-        <source>Options set in this dialog are overridden by the command line or in the configuration file:</source>
-        <translation type="unfinished">Opcions configurades en aquest diàleg són sobreescrites per la línia de comandes o el fitxer de configuració:</translation>
-    </message>
-    <message>
         <source>&amp;OK</source>
         <translation type="unfinished">&amp;D'acord</translation>
     </message>
@@ -2183,14 +2204,17 @@ Això és ideal per a carteres de mode només lectura.</translation>
     </message>
     <message>
         <source>Confirm options reset</source>
+        <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
         <translation type="unfinished">Confirmeu el reestabliment de les opcions</translation>
     </message>
     <message>
         <source>Client restart required to activate changes.</source>
+        <extracomment>Text explaining that the settings changed will not come into effect until the client is restarted.</extracomment>
         <translation type="unfinished">Cal reiniciar el client per a activar els canvis.</translation>
     </message>
     <message>
         <source>Client will be shut down. Do you want to proceed?</source>
+        <extracomment>Text asking the user to confirm if they would like to proceed with a client shutdown.</extracomment>
         <translation type="unfinished">S'aturarà el client. Voleu procedir?</translation>
     </message>
     <message>
@@ -3410,10 +3434,6 @@ Nota: atès que la tarifa es calcula per byte, una tarifa de "100 satoshis per k
         <source>A fee higher than %1 is considered an absurdly high fee.</source>
         <translation type="unfinished">Una tarifa superior a %1 es considera una tarifa absurdament alta.</translation>
     </message>
-    <message>
-        <source>Payment request expired.</source>
-        <translation type="unfinished">La sol·licitud de pagament ha vençut.</translation>
-    </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
@@ -3497,14 +3517,6 @@ Nota: atès que la tarifa es calcula per byte, una tarifa de "100 satoshis per k
         <translation type="unfinished">Missatge:</translation>
     </message>
     <message>
-        <source>This is an unauthenticated payment request.</source>
-        <translation type="unfinished">Aquesta és una sol·licitud de pagament no autenticada.</translation>
-    </message>
-    <message>
-        <source>This is an authenticated payment request.</source>
-        <translation type="unfinished">Aquesta és una sol·licitud de pagament autenticada.</translation>
-    </message>
-    <message>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished">Introduïu una etiqueta per a aquesta adreça per afegir-la a la llista d'adreces utilitzades</translation>
     </message>
@@ -3512,11 +3524,7 @@ Nota: atès que la tarifa es calcula per byte, una tarifa de "100 satoshis per k
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished">Un missatge que s'ha adjuntat al bitcoin: URI que s'emmagatzemarà amb la transacció per a la vostra referència. Nota: el missatge no s'enviarà a través de la xarxa Bitcoin.</translation>
     </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">Paga a:</translation>
-    </message>
-    </context>
+</context>
 <context>
     <name>SendConfirmationDialog</name>
     <message>
@@ -3686,30 +3694,22 @@ Nota: atès que la tarifa es calcula per byte, una tarifa de "100 satoshis per k
     <name>TransactionDesc</name>
     <message>
         <source>conflicted with a transaction with %1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that conflicts with a confirmed transaction.</extracomment>
         <translation type="unfinished">produït un conflicte amb una transacció amb %1 confirmacions</translation>
     </message>
     <message>
-        <source>0/unconfirmed, %1</source>
-        <translation type="unfinished">0/no confirmades, %1</translation>
-    </message>
-    <message>
-        <source>in memory pool</source>
-        <translation type="unfinished">a la reserva de memòria</translation>
-    </message>
-    <message>
-        <source>not in memory pool</source>
-        <translation type="unfinished">no a la reserva de memòria</translation>
-    </message>
-    <message>
         <source>abandoned</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an abandoned transaction.</extracomment>
         <translation type="unfinished">abandonada</translation>
     </message>
     <message>
         <source>%1/unconfirmed</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
         <translation type="unfinished">%1/sense confirmar</translation>
     </message>
     <message>
         <source>%1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
         <translation type="unfinished">%1 confirmacions</translation>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_cs.ts
+++ b/src/qt/locale/bitcoin_cs.ts
@@ -241,6 +241,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>BitcoinApplication</name>
     <message>
+        <source>Settings file %1 might be corrupt or invalid.</source>
+        <translation type="unfinished">Soubor s nastavením %1 může být poškozený nebo neplatný.</translation>
+    </message>
+    <message>
         <source>Runaway exception</source>
         <translation type="unfinished">Uprchlá výjimka</translation>
     </message>
@@ -259,6 +263,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 </context>
 <context>
     <name>QObject</name>
+    <message>
+        <source>Do you want to reset settings to default values, or to abort without making changes?</source>
+        <extracomment>Explanatory text shown on startup when the settings file cannot be read. Prompts user to make a choice between resetting or aborting.</extracomment>
+        <translation type="unfinished">Přeješ si obnovit výchozí nastavení, nebo odejít bez ukládání změn?</translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. Check that settings file is writable, or try running with -nosettings.</source>
+        <extracomment>Explanatory text shown on startup when the settings file could not be written. Prompts user to check that we have the ability to write to the file. Explains that the user has the option of running without a settings file.</extracomment>
+        <translation type="unfinished">Nastala závažná chyba. Ověř zda-li je možné do souboru s nastavením zapisovat a nebo vyzkoušej aplikaci spustit s parametrem -nosettings.</translation>
+    </message>
     <message>
         <source>Error: Specified data directory "%1" does not exist.</source>
         <translation type="unfinished">Chyba: Zadaný adresář pro data „%1“ neexistuje.</translation>
@@ -341,41 +355,41 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n sekunda</numerusform>
+            <numerusform>%n sekundy</numerusform>
+            <numerusform>%n sekund</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n minute(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n minuta</numerusform>
+            <numerusform>%n minuty</numerusform>
+            <numerusform>%n minut</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n hodina</numerusform>
+            <numerusform>%n hodiny</numerusform>
+            <numerusform>%n hodin</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n den</numerusform>
+            <numerusform>%n dny</numerusform>
+            <numerusform>%n dní</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n týden</numerusform>
+            <numerusform>%n týdny</numerusform>
+            <numerusform>%n týdnů</numerusform>
         </translation>
     </message>
     <message>
@@ -385,14 +399,22 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n rok</numerusform>
+            <numerusform>%n roky</numerusform>
+            <numerusform>%n let</numerusform>
         </translation>
     </message>
     </context>
 <context>
     <name>bitcoin-core</name>
+    <message>
+        <source>Settings file could not be read</source>
+        <translation type="unfinished">Soubor s nastavením není možné přečíst</translation>
+    </message>
+    <message>
+        <source>Settings file could not be written</source>
+        <translation type="unfinished">Do souboru s nastavením není možné zapisovat</translation>
+    </message>
     <message>
         <source>The %s developers</source>
         <translation type="unfinished">Vývojáři %s</translation>
@@ -426,6 +448,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Nastala chyba při čtení souboru %s! Všechny klíče se přečetly správně, ale data o transakcích nebo záznamy v adresáři mohou chybět či být nesprávné.</translation>
     </message>
     <message>
+        <source>Error reading %s! Transaction data may be missing or incorrect. Rescanning wallet.</source>
+        <translation type="unfinished">Chyba při čtení %s! Data o transakci mohou chybět a nebo být chybná.
+Ověřuji peněženku.</translation>
+    </message>
+    <message>
         <source>Error: Dumpfile format record is incorrect. Got "%s", expected "format".</source>
         <translation type="unfinished">Chyba: záznam formátu souboru výpisu je nesprávný. Získáno "%s", očekáváno "format".</translation>
     </message>
@@ -442,10 +469,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Chyba: Starší peněženky podporují pouze typy adres "legacy", "p2sh-segwit" a "bech32".</translation>
     </message>
     <message>
-        <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
-        <translation type="unfinished">Chyba: Nelze naslouchat příchozí spojení (listen vrátil chybu %s)</translation>
-    </message>
-    <message>
         <source>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.</source>
         <translation type="unfinished">Odhad poplatku se nepodařil. Fallbackfee je zakázaný. Počkejte několik bloků nebo povolte -fallbackfee.</translation>
     </message>
@@ -456,6 +479,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Invalid amount for -maxtxfee=&lt;amount&gt;: '%s' (must be at least the minrelay fee of %s to prevent stuck transactions)</source>
         <translation type="unfinished">Neplatná částka pro -maxtxfee=&lt;amount&gt;: '%s' (musí být alespoň jako poplatek minrelay %s, aby transakce nezůstávaly trčet)</translation>
+    </message>
+    <message>
+        <source>Invalid or corrupt peers.dat (%s). If you believe this is a bug, please report it to %s. As a workaround, you can move the file (%s) out of the way (rename, move, or delete) to have a new one created on the next start.</source>
+        <translation type="unfinished">Neplatný nebo poškozený soubor peers.dat (%s). Pokud věříš, že se jedná o chybu, prosím nahlas ji na %s. Jako řešení lze přesunout soubor (%s) z cesty (přejmenovat, přesunout nebo odstranit), aby se při dalším spuštění vytvořil nový.</translation>
     </message>
     <message>
         <source>More than one onion bind address is provided. Using %s for the automatically created Tor onion service.</source>
@@ -486,6 +513,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Prořezávání je nastaveno pod minimum %d MiB.  Použij, prosím, nějaké vyšší číslo.</translation>
     </message>
     <message>
+        <source>Prune mode is incompatible with -reindex-chainstate. Use full -reindex instead.</source>
+        <translation type="unfinished">Režim pročištění je nekompatibilní s parametrem -reindex-chainstate. Místo toho použij plný -reindex.</translation>
+    </message>
+    <message>
         <source>Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of pruned node)</source>
         <translation type="unfinished">Prořezávání: poslední synchronizace peněženky proběhla před už prořezanými daty. Je třeba provést -reindex (tedy v případě prořezávacího režimu stáhnout znovu celý blockchain)</translation>
     </message>
@@ -496,6 +527,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>The block database contains a block which appears to be from the future. This may be due to your computer's date and time being set incorrectly. Only rebuild the block database if you are sure that your computer's date and time are correct</source>
         <translation type="unfinished">Databáze bloků obsahuje blok, který vypadá jako z budoucnosti, což může být kvůli špatně nastavenému datu a času na tvém počítači. Nech databázi bloků přestavět pouze v případě, že si jsi jistý, že máš na počítači správný datum a čas</translation>
+    </message>
+    <message>
+        <source>The block index db contains a legacy 'txindex'. To clear the occupied disk space, run a full -reindex, otherwise ignore this error. This error message will not be displayed again.</source>
+        <translation type="unfinished">Databáze indexu bloků obsahuje starší 'txindex'. Pro vyčištění obsazeného místa na disku, spusťte úplný -reindex, v opačném případě tuto chybu ignorujte. Tato chybová zpráva nebude znovu zobrazena.</translation>
     </message>
     <message>
         <source>The transaction amount is too small to send after the fee has been deducted</source>
@@ -534,6 +569,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Byl poskytnut neznámý formát souboru peněženky "%s". Poskytněte prosím "bdb" nebo "sqlite".</translation>
     </message>
     <message>
+        <source>Unsupported chainstate database format found. Please restart with -reindex-chainstate. This will rebuild the chainstate database.</source>
+        <translation type="unfinished">Nalezen nepodporovaný formát databáze řetězců. Restartujte prosím aplikaci s parametrem -reindex-chainstate. Tím dojde k opětovného sestavení databáze řetězců.</translation>
+    </message>
+    <message>
+        <source>Wallet created successfully. The legacy wallet type is being deprecated and support for creating and opening legacy wallets will be removed in the future.</source>
+        <translation type="unfinished">Peněženka úspěšně vytvořena. Starší typ peněženek je označen za zastaralý a podpora pro vytváření a otevření starých peněženek bude v budoucnu odebrána.</translation>
+    </message>
+    <message>
         <source>Warning: Dumpfile wallet format "%s" does not match command line specified format "%s".</source>
         <translation type="unfinished">Varování: formát výpisu peněženky "%s" se neshoduje s formátem "%s", který byl určen příkazem.</translation>
     </message>
@@ -570,12 +613,108 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Nemohu přeložit -%s adresu: '%s'</translation>
     </message>
     <message>
+        <source>Cannot set -forcednsseed to true when setting -dnsseed to false.</source>
+        <translation type="unfinished">Nelze nastavit -forcednsseed na hodnotu true, když je nastaveno -dnsseed na hodnotu false.</translation>
+    </message>
+    <message>
         <source>Cannot set -peerblockfilters without -blockfilterindex.</source>
         <translation type="unfinished">Nelze nastavit -peerblockfilters bez -blockfilterindex.</translation>
     </message>
     <message>
         <source>Cannot write to data directory '%s'; check permissions.</source>
         <translation type="unfinished">Není možné zapisovat do adresáře ' %s'; zkontrolujte oprávnění.</translation>
+    </message>
+    <message>
+        <source>The -txindex upgrade started by a previous version cannot be completed. Restart with the previous version or run a full -reindex.</source>
+        <translation type="unfinished">Aktualizaci -txindex zahájenou předchozí verzí není možné dokončit. Restartujte s předchozí verzí a nebo spusťte úplný -reindex.</translation>
+    </message>
+    <message>
+        <source>%s request to listen on port %u. This port is considered "bad" and thus it is unlikely that any Bitcoin Core peers connect to it. See doc/p2p-bad-ports.md for details and a full list.</source>
+        <translation type="unfinished">%s požadavek pro naslouchání na portu %u. Tento port je považován za "špatný" a z tohoto důvodu je nepravděpodobné, že by se k němu připojovali některé uzly Bitcoin Core. Podrobnosti a úplný seznam špatných portů nalezneš v dokumentu doc/p2p-bad-ports.md.</translation>
+    </message>
+    <message>
+        <source>-reindex-chainstate option is not compatible with -blockfilterindex. Please temporarily disable blockfilterindex while using -reindex-chainstate, or replace -reindex-chainstate with -reindex to fully rebuild all indexes.</source>
+        <translation type="unfinished">Parametr -reindex-chainstate není kompatibilní s parametrem -blockfilterindex. Při použití -reindex-chainstate dočasně zakažte parametr -blockfilterindex nebo nahraďte parametr -reindex-chainstate parametrem -reindex pro úplné opětovné sestavení všech indexů.</translation>
+    </message>
+    <message>
+        <source>-reindex-chainstate option is not compatible with -coinstatsindex. Please temporarily disable coinstatsindex while using -reindex-chainstate, or replace -reindex-chainstate with -reindex to fully rebuild all indexes.</source>
+        <translation type="unfinished">Parametr -reindex-chainstate není kompatibilní s parametrem -coinstatsindex. Při použití -reindex-chainstate dočasně zakažte parametr -coinstatsindex nebo nahraďte parametr -reindex-chainstate parametrem -reindex pro úplné opětovné sestavení všech indexů.</translation>
+    </message>
+    <message>
+        <source>-reindex-chainstate option is not compatible with -txindex. Please temporarily disable txindex while using -reindex-chainstate, or replace -reindex-chainstate with -reindex to fully rebuild all indexes.</source>
+        <translation type="unfinished">Parametr -reindex-chainstate není kompatibilní s parametrem -txindex. Při použití -reindex-chainstate dočasně zakažte parametr -txindex nebo nahraďte parametr -reindex-chainstate parametrem -reindex pro úplné opětovné sestavení všech indexů.</translation>
+    </message>
+    <message>
+        <source>Assumed-valid: last wallet synchronisation goes beyond available block data. You need to wait for the background validation chain to download more blocks.</source>
+        <translation type="unfinished">Předpokládaná platnost: poslední synchronizace peněženky přesahuje dostupná data bloků. Je potřeba počkat až ověření řetězců v pozadí stáhne další bloky.</translation>
+    </message>
+    <message>
+        <source>Cannot provide specific connections and have addrman find outgoing connections at the same time.</source>
+        <translation type="unfinished">Nelze poskytovat konkrétní spojení a zároveň mít vyhledávání addrman odchozích spojení ve stejný čas.</translation>
+    </message>
+    <message>
+        <source>Error loading %s: External signer wallet being loaded without external signer support compiled</source>
+        <translation type="unfinished">Chyba při načtení %s: Externí podepisovací peněženka se načítá bez zkompilované podpory externího podpisovatele.</translation>
+    </message>
+    <message>
+        <source>Error: Address book data in wallet cannot be identified to belong to migrated wallets</source>
+        <translation type="unfinished">Chyba: Data adres v peněžence není možné identifikovat jako data patřící k migrovaným peněženkám.</translation>
+    </message>
+    <message>
+        <source>Error: Duplicate descriptors created during migration. Your wallet may be corrupted.</source>
+        <translation type="unfinished">Chyba: Duplicitní popisovače vytvořené během migrace. Vaše peněženka může být poškozena.</translation>
+    </message>
+    <message>
+        <source>Error: Transaction %s in wallet cannot be identified to belong to migrated wallets</source>
+        <translation type="unfinished">Chyba: Transakce %s v peněžence nemůže být identifikována jako transakce patřící k migrovaným peněženkám.</translation>
+    </message>
+    <message>
+        <source>Error: Unable to produce descriptors for this legacy wallet. Make sure the wallet is unlocked first</source>
+        <translation type="unfinished">Chyba: Nelze vytvořit popisovače pro tuto starší peněženku. Nejprve se ujistěte, že je peněženka odemčená.</translation>
+    </message>
+    <message>
+        <source>Failed to rename invalid peers.dat file. Please move or delete it and try again.</source>
+        <translation type="unfinished">Nelze přejmenovat neplatný peers.dat soubor. Prosím přesuňte jej, nebo odstraňte a zkuste znovu.</translation>
+    </message>
+    <message>
+        <source>Incompatible options: -dnsseed=1 was explicitly specified, but -onlynet forbids connections to IPv4/IPv6</source>
+        <translation type="unfinished">Nekompatibilní možnost: -dnsseed=1 byla explicitně zadána, ale -onlynet zakazuje připojení k IPv4/IPv6</translation>
+    </message>
+    <message>
+        <source>Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is explicitly forbidden: -onion=0</source>
+        <translation type="unfinished">Odchozí spojení omezená do sítě Tor (-onlynet=onion), ale proxy pro dosažení sítě Tor je výslovně zakázána: -onion=0</translation>
+    </message>
+    <message>
+        <source>Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is not provided: none of -proxy, -onion or -listenonion is given</source>
+        <translation type="unfinished">Odchozí spojení omezená do sítě Tor (-onlynet=onion), ale není zadán žádný proxy server pro přístup do sítě Tor: není zadán žádný z parametrů: -proxy, -onion, nebo -listenonion</translation>
+    </message>
+    <message>
+        <source>Unrecognized descriptor found. Loading wallet %s
+
+The wallet might had been created on a newer version.
+Please try running the latest software version.
+</source>
+        <translation type="unfinished">Nalezen nerozpoznatelný popisovač. Načítaní peněženky %s
+
+Peněženka mohla být vytvořena v novější verzi.
+Zkuste prosím spustit nejnovější verzi softwaru.
+</translation>
+    </message>
+    <message>
+        <source>Unsupported category-specific logging level -loglevel=%s. Expected -loglevel=&lt;category&gt;:&lt;loglevel&gt;. Valid categories: %s. Valid loglevels: %s.</source>
+        <translation type="unfinished">Nepodporovaná úroveň pro logování úrovně -loglevel=%s. Očekávaný parametr -loglevel=&lt;category&gt;:&lt;loglevel&gt;. Platné kategorie: %s. Platné úrovně logování: %s.</translation>
+    </message>
+    <message>
+        <source>
+Unable to cleanup failed migration</source>
+        <translation type="unfinished">
+Nepodařilo se vyčistit nepovedenou migraci</translation>
+    </message>
+    <message>
+        <source>
+Unable to restore backup of wallet.</source>
+        <translation type="unfinished">
+Nelze obnovit zálohu peněženky.</translation>
     </message>
     <message>
         <source>Config setting for %s only applied on %s network when in [%s] section.</source>
@@ -658,8 +797,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Chyba při čtení následujícího záznamu z databáze peněženky</translation>
     </message>
     <message>
-        <source>Error upgrading chainstate database</source>
-        <translation type="unfinished">Chyba při aktualizaci stavové databáze blockchainu</translation>
+        <source>Error: Could not add watchonly tx to watchonly wallet</source>
+        <translation type="unfinished">Chyba: Nelze přidat pouze-sledovací tx do peněženky pro čtení</translation>
+    </message>
+    <message>
+        <source>Error: Could not delete watchonly transactions</source>
+        <translation type="unfinished">Chyba: Nelze odstranit transakce které jsou pouze pro čtení</translation>
     </message>
     <message>
         <source>Error: Couldn't create cursor into database</source>
@@ -672,6 +815,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Error: Dumpfile checksum does not match. Computed %s, expected %s</source>
         <translation type="unfinished">Chyba: kontrolní součet souboru výpisu se neshoduje. Vypočteno %s, očekáváno %s</translation>
+    </message>
+    <message>
+        <source>Error: Failed to create new watchonly wallet</source>
+        <translation type="unfinished">Chyba: Nelze vytvořit novou peněženku pouze pro čtení</translation>
     </message>
     <message>
         <source>Error: Got key that was not hex: %s</source>
@@ -694,8 +841,36 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Chyba: Žádné %s adresy nejsou dostupné.</translation>
     </message>
     <message>
+        <source>Error: Not all watchonly txs could be deleted</source>
+        <translation type="unfinished">Chyba: Ne všechny pouze-sledovací tx bylo možné smazat</translation>
+    </message>
+    <message>
+        <source>Error: This wallet already uses SQLite</source>
+        <translation type="unfinished">Chyba: Tato peněženka již používá SQLite</translation>
+    </message>
+    <message>
+        <source>Error: This wallet is already a descriptor wallet</source>
+        <translation type="unfinished">Chyba: Tato peněženka je již popisovačná peněženka</translation>
+    </message>
+    <message>
+        <source>Error: Unable to begin reading all records in the database</source>
+        <translation type="unfinished">Chyba: Nelze zahájit čtení všech záznamů v databázi</translation>
+    </message>
+    <message>
+        <source>Error: Unable to make a backup of your wallet</source>
+        <translation type="unfinished">Chyba: Nelze vytvořit zálohu tvojí peněženky</translation>
+    </message>
+    <message>
         <source>Error: Unable to parse version %u as a uint32_t</source>
         <translation type="unfinished">Chyba: nelze zpracovat verzi %u jako uint32_t</translation>
+    </message>
+    <message>
+        <source>Error: Unable to read all records in the database</source>
+        <translation type="unfinished">Chyba: Nelze přečíst všechny záznamy v databázi</translation>
+    </message>
+    <message>
+        <source>Error: Unable to remove watchonly address book data</source>
+        <translation type="unfinished">Chyba: Nelze odstranit data z adresáře pouze pro sledování</translation>
     </message>
     <message>
         <source>Error: Unable to write record to new wallet</source>
@@ -732,6 +907,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Initialization sanity check failed. %s is shutting down.</source>
         <translation type="unfinished">Selhala úvodní zevrubná prověrka. %s se ukončuje.</translation>
+    </message>
+    <message>
+        <source>Input not found or already spent</source>
+        <translation type="unfinished">Vstup nenalezen a nebo je již utracen</translation>
     </message>
     <message>
         <source>Insufficient funds</source>
@@ -774,6 +953,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Ve -whitelist byla zadána neplatná podsíť: '%s'</translation>
     </message>
     <message>
+        <source>Listening for incoming connections failed (listen returned error %s)</source>
+        <translation type="unfinished">Chyba: Nelze naslouchat příchozí spojení (naslouchač vrátil chybu %s)</translation>
+    </message>
+    <message>
         <source>Loading P2P addresses…</source>
         <translation type="unfinished">Načítám P2P adresy…</translation>
     </message>
@@ -790,12 +973,20 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Načítám peněženku...</translation>
     </message>
     <message>
+        <source>Missing amount</source>
+        <translation type="unfinished">Chybějící částka</translation>
+    </message>
+    <message>
+        <source>Missing solving data for estimating transaction size</source>
+        <translation type="unfinished">Chybí data pro vyřešení odhadnutí velikosti transakce</translation>
+    </message>
+    <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
         <translation type="unfinished">V rámci -whitebind je třeba specifikovat i port: '%s'</translation>
     </message>
     <message>
-        <source>No proxy server specified. Use -proxy=&lt;ip&gt; or -proxy=&lt;ip:port&gt;.</source>
-        <translation type="unfinished">Není specifikován proxy server. Použijte -proxy=&lt;ip&gt; nebo -proxy=&lt;ip:port&gt;.</translation>
+        <source>No addresses available</source>
+        <translation type="unfinished">Není k dispozici žádná adresa</translation>
     </message>
     <message>
         <source>Not enough file descriptors available.</source>
@@ -804,10 +995,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Prune cannot be configured with a negative value.</source>
         <translation type="unfinished">Prořezávání nemůže být zkonfigurováno s negativní hodnotou.</translation>
-    </message>
-    <message>
-        <source>Prune mode is incompatible with -coinstatsindex.</source>
-        <translation type="unfinished">Prořezávací režim je nekompatibilní s -coinstatsindex.</translation>
     </message>
     <message>
         <source>Prune mode is incompatible with -txindex.</source>
@@ -910,6 +1097,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Částky v transakci nemohou být záporné</translation>
     </message>
     <message>
+        <source>Transaction change output index out of range</source>
+        <translation type="unfinished">Výstupní index změny transakce mimo rozsah</translation>
+    </message>
+    <message>
         <source>Transaction has too long of a mempool chain</source>
         <translation type="unfinished">Transakce má v transakčním zásobníku příliš dlouhý řetězec</translation>
     </message>
@@ -918,8 +1109,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Transakce musí mít alespoň jednoho příjemce</translation>
     </message>
     <message>
+        <source>Transaction needs a change address, but we can't generate it.</source>
+        <translation type="unfinished">Transakce potřebuje změnu adresy, ale ta se nepodařila vygenerovat.</translation>
+    </message>
+    <message>
         <source>Transaction too large</source>
         <translation type="unfinished">Transakce je příliš velká</translation>
+    </message>
+    <message>
+        <source>Unable to allocate memory for -maxsigcachesize: '%s' MiB</source>
+        <translation type="unfinished">Není možné alokovat paměť pro -maxsigcachesize '%s' MiB</translation>
     </message>
     <message>
         <source>Unable to bind to %s on this computer (bind returned error %s)</source>
@@ -934,6 +1133,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Nebylo možné vytvořit soubor PID '%s': %s</translation>
     </message>
     <message>
+        <source>Unable to find UTXO for external input</source>
+        <translation type="unfinished">Nelze najít UTXO pro externí vstup</translation>
+    </message>
+    <message>
         <source>Unable to generate initial keys</source>
         <translation type="unfinished">Nepodařilo se mi vygenerovat počáteční klíče</translation>
     </message>
@@ -946,8 +1149,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Nelze otevřít %s pro zápis</translation>
     </message>
     <message>
+        <source>Unable to parse -maxuploadtarget: '%s'</source>
+        <translation type="unfinished">Nelze rozebrat -maxuploadtarget: '%s'</translation>
+    </message>
+    <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
         <translation type="unfinished">Nemohu spustit HTTP server. Detaily viz v debug.log.</translation>
+    </message>
+    <message>
+        <source>Unable to unload the wallet before migrating</source>
+        <translation type="unfinished">Před migrací není možné peněženku odnačíst</translation>
     </message>
     <message>
         <source>Unknown -blockfilterindex value %s.</source>
@@ -970,12 +1181,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Neznámá nová pravidla aktivována (verzový bit %i)</translation>
     </message>
     <message>
-        <source>Unsupported logging category %s=%s.</source>
-        <translation type="unfinished">Nepodporovaná logovací kategorie %s=%s.</translation>
+        <source>Unsupported global logging level -loglevel=%s. Valid values: %s.</source>
+        <translation type="unfinished">Nepodporovaný globální logovací úroveň -loglevel=%s. Možné hodnoty: %s.</translation>
     </message>
     <message>
-        <source>Upgrading UTXO database</source>
-        <translation type="unfinished">Aktualizuji databázi neutracených výstupů (UTXO)</translation>
+        <source>Unsupported logging category %s=%s.</source>
+        <translation type="unfinished">Nepodporovaná logovací kategorie %s=%s.</translation>
     </message>
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
@@ -1043,6 +1254,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Create a new wallet</source>
         <translation type="unfinished">Vytvoř novou peněženku</translation>
+    </message>
+    <message>
+        <source>&amp;Minimize</source>
+        <translation type="unfinished">&amp;Minimalizovat</translation>
     </message>
     <message>
         <source>Wallet:</source>
@@ -1192,9 +1407,9 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>Zpracován %n blok transakční historie.</numerusform>
+            <numerusform>Zpracovány %n bloky transakční historie.</numerusform>
+            <numerusform>Zpracováno %n bloků transakční historie</numerusform>
         </translation>
     </message>
     <message>
@@ -1234,6 +1449,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Načíst částečně podepsanou Bitcoinovou transakci</translation>
     </message>
     <message>
+        <source>Load PSBT from &amp;clipboard…</source>
+        <translation type="unfinished">Načíst PSBT ze &amp;schránky</translation>
+    </message>
+    <message>
         <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
         <translation type="unfinished">Načíst částečně podepsanou Bitcoinovou transakci ze schránky</translation>
     </message>
@@ -1270,6 +1489,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Zavřít peněženku</translation>
     </message>
     <message>
+        <source>Restore Wallet…</source>
+        <extracomment>Name of the menu item that restores wallet from a backup file.</extracomment>
+        <translation type="unfinished">Obnovit peněženku...</translation>
+    </message>
+    <message>
+        <source>Restore a wallet from a backup file</source>
+        <extracomment>Status tip for Restore Wallet menu item</extracomment>
+        <translation type="unfinished">Obnovit peněženku ze záložního souboru</translation>
+    </message>
+    <message>
         <source>Close all wallets</source>
         <translation type="unfinished">Zavřít všechny peněženky</translation>
     </message>
@@ -1294,6 +1523,26 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Nejsou dostupné žádné peněženky</translation>
     </message>
     <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">Data peněženky</translation>
+    </message>
+    <message>
+        <source>Load Wallet Backup</source>
+        <extracomment>The title for Restore Wallet File Windows</extracomment>
+        <translation type="unfinished">Nahrát zálohu peněženky</translation>
+    </message>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of pop-up window shown when the user is attempting to restore a wallet.</extracomment>
+        <translation type="unfinished">Obnovit peněženku</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">Název peněženky</translation>
+    </message>
+    <message>
         <source>&amp;Window</source>
         <translation type="unfinished">O&amp;kno</translation>
     </message>
@@ -1309,13 +1558,21 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>%1 client</source>
         <translation type="unfinished">%1 klient</translation>
     </message>
+    <message>
+        <source>&amp;Hide</source>
+        <translation type="unfinished">Skryj</translation>
+    </message>
+    <message>
+        <source>S&amp;how</source>
+        <translation type="unfinished">Zobraz</translation>
+    </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n aktivní spojení s Bitcoinovou sítí.</numerusform>
+            <numerusform>%n aktivní spojení s Bitcoinovou sítí.</numerusform>
+            <numerusform>%n aktivních spojení s Bitcoinovou sítí.</numerusform>
         </translation>
     </message>
     <message>
@@ -1337,6 +1594,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Enable network activity</source>
         <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
         <translation type="unfinished">Zapnout síťovou aktivitu</translation>
+    </message>
+    <message>
+        <source>Pre-syncing Headers (%1%)…</source>
+        <translation type="unfinished">Předběžná synchronizace hlavičky bloků (%1 %)...</translation>
     </message>
     <message>
         <source>Error: %1</source>
@@ -1509,6 +1770,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Zkopírovat &amp;částku</translation>
     </message>
     <message>
+        <source>Copy transaction &amp;ID and output index</source>
+        <translation type="unfinished">Zkopíruj &amp;ID transakce a výstupní index</translation>
+    </message>
+    <message>
         <source>L&amp;ock unspent</source>
         <translation type="unfinished">&amp;zamknout neutracené</translation>
     </message>
@@ -1597,6 +1862,23 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Can't list signers</source>
         <translation type="unfinished">Nelze vypsat podepisovatele</translation>
     </message>
+    <message>
+        <source>Too many external signers found</source>
+        <translation type="unfinished">Nalezeno mnoho externích podpisovatelů</translation>
+    </message>
+</context>
+<context>
+    <name>LoadWalletsActivity</name>
+    <message>
+        <source>Load Wallets</source>
+        <extracomment>Title of progress window which is displayed when wallets are being loaded.</extracomment>
+        <translation type="unfinished">Načíst peněženky</translation>
+    </message>
+    <message>
+        <source>Loading wallets…</source>
+        <extracomment>Descriptive text of the load wallets progress window which indicates to the user that wallets are currently being loaded.</extracomment>
+        <translation type="unfinished">Načítám peněženky...</translation>
+    </message>
 </context>
 <context>
     <name>OpenWalletActivity</name>
@@ -1621,6 +1903,34 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
         <extracomment>Descriptive text of the open wallet progress window which indicates to the user which wallet is currently being opened.</extracomment>
         <translation type="unfinished">Otevírám peněženku &lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+</context>
+<context>
+    <name>RestoreWalletActivity</name>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of progress window which is displayed when wallets are being restored.</extracomment>
+        <translation type="unfinished">Obnovit peněženku</translation>
+    </message>
+    <message>
+        <source>Restoring Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the restore wallets progress window which indicates to the user that wallets are currently being restored.</extracomment>
+        <translation type="unfinished">Obnovuji peněženku &lt;b&gt;%1&lt;/b&gt; ...</translation>
+    </message>
+    <message>
+        <source>Restore wallet failed</source>
+        <extracomment>Title of message box which is displayed when the wallet could not be restored.</extracomment>
+        <translation type="unfinished">Obnovení peněženky selhalo</translation>
+    </message>
+    <message>
+        <source>Restore wallet warning</source>
+        <extracomment>Title of message box which is displayed when the wallet is restored with some warning.</extracomment>
+        <translation type="unfinished">Varování při obnovení peněženky</translation>
+    </message>
+    <message>
+        <source>Restore wallet message</source>
+        <extracomment>Title of message box which is displayed when the wallet is successfully restored.</extracomment>
+        <translation type="unfinished">Obnovení peněženky</translation>
     </message>
 </context>
 <context>
@@ -1798,9 +2108,29 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 </context>
 <context>
     <name>Intro</name>
-    <message>
-        <source>(of %1 GB needed)</source>
-        <translation type="unfinished">(z požadovaných %1 GB )</translation>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform>%n GB místa k dispozici</numerusform>
+            <numerusform>%n GB místa k dispozici</numerusform>
+            <numerusform>%n GB místa k dispozici</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform>(z %n GB požadovaných)</numerusform>
+            <numerusform>(z %n GB požadovaných)</numerusform>
+            <numerusform>(z %n GB požadovaných)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform>(%n GB požadovaných pro plný řetězec)</numerusform>
+            <numerusform>(%n GB požadovaných pro plný řetězec)</numerusform>
+            <numerusform>(%n GB požadovaných pro plný řetězec)</numerusform>
+        </translation>
     </message>
     <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
@@ -1814,9 +2144,9 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>(Dostačující k obnovení zálohy %n dne staré)</numerusform>
+            <numerusform>(Dostačující k obnovení záloh %n dnů staré)</numerusform>
+            <numerusform>(Dostačující k obnovení záloh %n dnů staré)</numerusform>
         </translation>
     </message>
     <message>
@@ -1848,10 +2178,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Tohle je poprvé, co spouštíš %1, takže si můžeš zvolit, kam bude ukládat svá data.</translation>
     </message>
     <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation type="unfinished">Jakmile stiskneš OK, %1 začne stahovat a zpracovávat celý %4ový blockchain (%2 GB), počínaje nejstaršími transakcemi z roku %3, kdy byl %4 spuštěn.</translation>
-    </message>
-    <message>
         <source>Limit block chain storage to</source>
         <translation type="unfinished">Omezit uložiště blokového řetězce na</translation>
     </message>
@@ -1866,6 +2192,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
         <translation type="unfinished">Prvotní synchronizace je velice náročná, a mohou se tak díky ní začít na tvém počítači projevovat dosud skryté hardwarové problémy. Pokaždé, když spustíš %1, bude stahování pokračovat tam, kde skončilo.</translation>
+    </message>
+    <message>
+        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2 GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
+        <translation type="unfinished">Jakmile stiskneš OK, %1 začne stahovat a zpracovávat celý %4ový blockchain (%2 GB), počínaje nejstaršími transakcemi z roku %3, kdy byl %4 spuštěn.</translation>
     </message>
     <message>
         <source>If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</source>
@@ -1964,6 +2294,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Unknown. Syncing Headers (%1, %2%)…</source>
         <translation type="unfinished">Neznámé. Synchronizace hlaviček bloků (%1, %2%)...</translation>
     </message>
+    <message>
+        <source>Unknown. Pre-syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">Neznámé. Předběžná synchronizace hlavičky bloků (%1, %2%)...</translation>
+    </message>
 </context>
 <context>
     <name>OpenURIDialog</name>
@@ -2020,6 +2354,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Zavřením se aplikace minimalizuje. Pokud je tato volba zaškrtnuta, tak se aplikace ukončí pouze zvolením Konec v menu.</translation>
     </message>
     <message>
+        <source>Options set in this dialog are overridden by the command line:</source>
+        <translation type="unfinished">Nastavení v tomto dialogu jsou přepsány příkazovým řádkem:</translation>
+    </message>
+    <message>
         <source>Open the %1 configuration file from the working directory.</source>
         <translation type="unfinished">Otevře konfigurační soubor %1 z pracovního adresáře.</translation>
     </message>
@@ -2048,12 +2386,42 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Obnovení tohoto nastavení vyžaduje opětovné stažení celého blockchainu.</translation>
     </message>
     <message>
+        <source>Maximum database cache size. A larger cache can contribute to faster sync, after which the benefit is less pronounced for most use cases. Lowering the cache size will reduce memory usage. Unused mempool memory is shared for this cache.</source>
+        <extracomment>Tooltip text for Options window setting that sets the size of the database cache. Explains the corresponding effects of increasing/decreasing this value.</extracomment>
+        <translation type="unfinished">Maximální velikost vyrovnávací paměti databáze. Větší vyrovnávací paměť může přispět k rychlejší synchronizaci, avšak přínos pro většinu případů použití je méně výrazný. Snížení velikosti vyrovnávací paměti sníží využití paměti. Nevyužívaná paměť mempoolu je pro tuto vyrovnávací paměť sdílená.</translation>
+    </message>
+    <message>
+        <source>Set the number of script verification threads. Negative values correspond to the number of cores you want to leave free to the system.</source>
+        <extracomment>Tooltip text for Options window setting that sets the number of script verification threads. Explains that negative values mean to leave these many cores free to the system.</extracomment>
+        <translation type="unfinished">Nastaví počet vláken pro ověřování skriptů. Negativní hodnota odpovídá počtu jader procesoru, které chcete ponechat volné pro systém. </translation>
+    </message>
+    <message>
         <source>(0 = auto, &lt;0 = leave that many cores free)</source>
         <translation type="unfinished">(0 = automaticky, &lt;0 = nechat daný počet jader volný, výchozí: 0)</translation>
     </message>
     <message>
+        <source>This allows you or a third party tool to communicate with the node through command-line and JSON-RPC commands.</source>
+        <extracomment>Tooltip text for Options window setting that enables the RPC server.</extracomment>
+        <translation type="unfinished">Toto povolí tobě nebo nástrojům třetích stran komunikovat pomocí uzlu skrz příkazový řádek a JSON-RPC příkazy.</translation>
+    </message>
+    <message>
+        <source>Enable R&amp;PC server</source>
+        <extracomment>An Options window setting to enable the RPC server.</extracomment>
+        <translation type="unfinished">Povolit R&amp;PC server</translation>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished">P&amp;eněženka</translation>
+    </message>
+    <message>
+        <source>Whether to set subtract fee from amount as default or not.</source>
+        <extracomment>Tooltip text for Options window setting that sets subtracting the fee from a sending amount as default.</extracomment>
+        <translation type="unfinished">Zda nastavit odečtení poplatku od částky jako výchozí či nikoliv.</translation>
+    </message>
+    <message>
+        <source>Subtract &amp;fee from amount by default</source>
+        <extracomment>An Options window setting to set subtracting the fee from a sending amount as default.</extracomment>
+        <translation type="unfinished">Odečíst &amp;poplatek od výchozí částky</translation>
     </message>
     <message>
         <source>Expert</source>
@@ -2070,6 +2438,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>&amp;Spend unconfirmed change</source>
         <translation type="unfinished">&amp;Utrácet i ještě nepotvrzené drobné</translation>
+    </message>
+    <message>
+        <source>Enable &amp;PSBT controls</source>
+        <extracomment>An options window setting to enable PSBT controls.</extracomment>
+        <translation type="unfinished">Povolit &amp;PSBT kontrolu</translation>
+    </message>
+    <message>
+        <source>Whether to show PSBT controls.</source>
+        <extracomment>Tooltip text for options window setting that enables PSBT controls.</extracomment>
+        <translation type="unfinished">Zobrazit ovládací prvky PSBT.</translation>
     </message>
     <message>
         <source>External Signer (e.g. hardware wallet)</source>
@@ -2176,6 +2554,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Zvol výchozí podjednotku, která se bude zobrazovat v programu a při posílání mincí.</translation>
     </message>
     <message>
+        <source>Third-party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</source>
+        <translation type="unfinished">URL třetích stran (např. block exploreru), která se zobrazí v kontextovém menu v záložce Transakce. %s v URL se nahradí hashem transakce. Více URL odděl svislítkem |.</translation>
+    </message>
+    <message>
+        <source>&amp;Third-party transaction URLs</source>
+        <translation type="unfinished">&amp;URL třetích stran pro transakce</translation>
+    </message>
+    <message>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished">Zda ukazovat možnosti pro ruční správu mincí nebo ne.</translation>
     </message>
@@ -2200,10 +2586,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">nejbližší shoda "%1"</translation>
     </message>
     <message>
-        <source>Options set in this dialog are overridden by the command line or in the configuration file:</source>
-        <translation type="unfinished">Nastavení v tomto dialogu jsou přepsány konzolí nebo konfiguračním souborem:</translation>
-    </message>
-    <message>
         <source>&amp;OK</source>
         <translation type="unfinished">&amp;Budiž</translation>
     </message>
@@ -2226,14 +2608,22 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Confirm options reset</source>
+        <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
         <translation type="unfinished">Potvrzení obnovení nastavení</translation>
     </message>
     <message>
         <source>Client restart required to activate changes.</source>
+        <extracomment>Text explaining that the settings changed will not come into effect until the client is restarted.</extracomment>
         <translation type="unfinished">K aktivaci změn je potřeba restartovat klienta.</translation>
     </message>
     <message>
+        <source>Current settings will be backed up at "%1".</source>
+        <extracomment>Text explaining to the user that the client's current settings will be backed up at a specific location. %1 is a stand-in argument for the backup location's path.</extracomment>
+        <translation type="unfinished">Aktuální nastavení bude uloženo v "%1".</translation>
+    </message>
+    <message>
         <source>Client will be shut down. Do you want to proceed?</source>
+        <extracomment>Text asking the user to confirm if they would like to proceed with a client shutdown.</extracomment>
         <translation type="unfinished">Klient se vypne, chceš pokračovat?</translation>
     </message>
     <message>
@@ -2245,6 +2635,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>The configuration file is used to specify advanced user options which override GUI settings. Additionally, any command-line options will override this configuration file.</source>
         <extracomment>Explanatory text about the priority order of instructions considered by client. The order from high to low being: command-line, configuration file, GUI settings.</extracomment>
         <translation type="unfinished">Konfigurační soubor slouží k nastavování uživatelsky pokročilých možností, které mají přednost před konfigurací z GUI. Parametry z příkazové řádky však mají před konfiguračním souborem přednost.</translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation type="unfinished">Pokračovat</translation>
     </message>
     <message>
         <source>Cancel</source>
@@ -2265,6 +2659,13 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>The supplied proxy address is invalid.</source>
         <translation type="unfinished">Zadaná adresa proxy je neplatná.</translation>
+    </message>
+</context>
+<context>
+    <name>OptionsModel</name>
+    <message>
+        <source>Could not read setting "%1", %2.</source>
+        <translation type="unfinished">Nelze přečíst nastavení "%1", %2.</translation>
     </message>
 </context>
 <context>
@@ -2377,6 +2778,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Nepodařilo se podepsat transakci: %1</translation>
     </message>
     <message>
+        <source>Cannot sign inputs while wallet is locked.</source>
+        <translation type="unfinished">Nelze podepsat vstup, když je peněženka uzamčena.</translation>
+    </message>
+    <message>
         <source>Could not sign any more inputs.</source>
         <translation type="unfinished">Nelze podepsat další vstupy.</translation>
     </message>
@@ -2450,6 +2855,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Transakce stále potřebuje podpis(y).</translation>
     </message>
     <message>
+        <source>(But no wallet is loaded.)</source>
+        <translation type="unfinished">(Ale žádná peněženka není načtená.)</translation>
+    </message>
+    <message>
         <source>(But this wallet cannot sign transactions.)</source>
         <translation type="unfinished">(Ale tato peněženka nemůže podepisovat transakce.)</translation>
     </message>
@@ -2517,6 +2926,11 @@ Pokud vidíte tuto chybu, měli byste požádat, aby obchodník poskytl adresu k
         <source>Peer</source>
         <extracomment>Title of Peers Table column which contains a unique number used to identify a connection.</extracomment>
         <translation type="unfinished">Protějšek</translation>
+    </message>
+    <message>
+        <source>Age</source>
+        <extracomment>Title of Peers Table column which indicates the duration (length of time) since the peer connection started.</extracomment>
+        <translation type="unfinished">Trvání</translation>
     </message>
     <message>
         <source>Direction</source>
@@ -2702,12 +3116,46 @@ Pokud vidíte tuto chybu, měli byste požádat, aby obchodník poskytl adresu k
         <translation type="unfinished">Aktuálně bloků</translation>
     </message>
     <message>
+        <source>Last Transaction</source>
+        <translation type="unfinished">Poslední transakce</translation>
+    </message>
+    <message>
         <source>The mapped Autonomous System used for diversifying peer selection.</source>
         <translation type="unfinished">Mapovaný nezávislý - Autonomní Systém používaný pro rozšírení vzájemného výběru protějsků.</translation>
     </message>
     <message>
         <source>Mapped AS</source>
         <translation type="unfinished">Mapovaný AS</translation>
+    </message>
+    <message>
+        <source>Whether we relay addresses to this peer.</source>
+        <extracomment>Tooltip text for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
+        <translation type="unfinished">Zda předáváme adresy tomuto uzlu.</translation>
+    </message>
+    <message>
+        <source>Address Relay</source>
+        <extracomment>Text title for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
+        <translation type="unfinished">Přenášení adres</translation>
+    </message>
+    <message>
+        <source>The total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</source>
+        <extracomment>Tooltip text for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
+        <translation type="unfinished">Celkový počet adres obdržených od tohoto uzlu, které byly zpracovány (nezahrnuje adresy, které byly zahozeny díky omezení ovládání toku provozu)</translation>
+    </message>
+    <message>
+        <source>The total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</source>
+        <extracomment>Tooltip text for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
+        <translation type="unfinished">Celkový počet adres obdržených od tohoto uzlu, který byly zahozeny (nebyly zpracovány) díky omezení ovládání toku provozu.</translation>
+    </message>
+    <message>
+        <source>Addresses Processed</source>
+        <extracomment>Text title for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
+        <translation type="unfinished">Zpracováno adres</translation>
+    </message>
+    <message>
+        <source>Addresses Rate-Limited</source>
+        <extracomment>Text title for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
+        <translation type="unfinished">Adresy s omezením počtu přijatých adres</translation>
     </message>
     <message>
         <source>User Agent</source>
@@ -2916,6 +3364,11 @@ Pokud vidíte tuto chybu, měli byste požádat, aby obchodník poskytl adresu k
     <message>
         <source>1 &amp;year</source>
         <translation type="unfinished">1 &amp;rok</translation>
+    </message>
+    <message>
+        <source>&amp;Copy IP/Netmask</source>
+        <extracomment>Context menu action to copy the IP/Netmask of a banned peer. IP/Netmask is the combination of a peer's IP address and its Netmask. For IP address, see: https://en.wikipedia.org/wiki/IP_address.</extracomment>
+        <translation type="unfinished">&amp;Zkopíruj IP/Masku</translation>
     </message>
     <message>
         <source>&amp;Unban</source>
@@ -3425,6 +3878,16 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
         <translation type="unfinished">Zkontrolujte prosím svůj návrh transakce. Výsledkem bude částečně podepsaná bitcoinová transakce (PSBT), kterou můžete uložit nebo kopírovat a poté podepsat např. pomocí offline %1 peněženky nebo hardwarové peněženky kompatibilní s PSBT.</translation>
     </message>
     <message>
+        <source>Do you want to create this transaction?</source>
+        <extracomment>Message displayed when attempting to create a transaction. Cautionary text to prompt the user to verify that the displayed transaction details represent the transaction the user intends to create.</extracomment>
+        <translation type="unfinished">Přejete si vytvořit tuto transakci?</translation>
+    </message>
+    <message>
+        <source>Please, review your transaction. You can create and send this transaction or create a Partially Signed Bitcoin Transaction (PSBT), which you can save or copy and then sign with, e.g., an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
+        <extracomment>Text to inform a user attempting to create a transaction of their current options. At this stage, a user can send their transaction or create a PSBT. This string is displayed when both private keys and PSBT controls are enabled.</extracomment>
+        <translation type="unfinished">Prosím ověř svojí transakci. Můžeš vytvořit a odeslat tuto transakci nebo vytvořit Částečně Podepsanou Bitcoinovou Transakci (PSBT), kterou můžeš uložit nebo zkopírovat a poté podepsat např. v offline %1 peněžence, nebo hardwarové peněžence kompatibilní s PSBT.</translation>
+    </message>
+    <message>
         <source>Please, review your transaction.</source>
         <extracomment>Text to prompt a user to review the details of the transaction they are attempting to send.</extracomment>
         <translation type="unfinished">Prosím, zkontrolujte vaši transakci.</translation>
@@ -3477,16 +3940,12 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
         <source>A fee higher than %1 is considered an absurdly high fee.</source>
         <translation type="unfinished">Poplatek vyšší než %1 je považován za absurdně vysoký.</translation>
     </message>
-    <message>
-        <source>Payment request expired.</source>
-        <translation type="unfinished">Platební požadavek vypršel.</translation>
-    </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>Potvrzování by podle odhadu mělo začít během %n bloku.</numerusform>
+            <numerusform>Potvrzování by podle odhadu mělo začít během %n bloků.</numerusform>
+            <numerusform>Potvrzování by podle odhadu mělo začít během %n bloků.</numerusform>
         </translation>
     </message>
     <message>
@@ -3561,28 +4020,12 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
         <translation type="unfinished">Zpráva:</translation>
     </message>
     <message>
-        <source>This is an unauthenticated payment request.</source>
-        <translation type="unfinished">Tohle je neověřený platební požadavek.</translation>
-    </message>
-    <message>
-        <source>This is an authenticated payment request.</source>
-        <translation type="unfinished">Tohle je ověřený platební požadavek.</translation>
-    </message>
-    <message>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished">Zadej označení této adresy; obojí se ti pak uloží do adresáře</translation>
     </message>
     <message>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished">Zpráva, která byla připojena k bitcoin: URI a která se ti pro přehled uloží k transakci. Poznámka: Tahle zpráva se neposílá s platbou po bitcoinové síti.</translation>
-    </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">Komu:</translation>
-    </message>
-    <message>
-        <source>Memo:</source>
-        <translation type="unfinished">Poznámka:</translation>
     </message>
 </context>
 <context>
@@ -3745,35 +4188,41 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
         <source>(press q to shutdown and continue later)</source>
         <translation type="unfinished">(stiskni q pro ukončení a pokračování později)</translation>
     </message>
-    </context>
+    <message>
+        <source>press q to shutdown</source>
+        <translation type="unfinished">stiskněte q pro vypnutí</translation>
+    </message>
+</context>
 <context>
     <name>TransactionDesc</name>
     <message>
         <source>conflicted with a transaction with %1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that conflicts with a confirmed transaction.</extracomment>
         <translation type="unfinished">koliduje s transakcí o %1 konfirmacích</translation>
     </message>
     <message>
-        <source>0/unconfirmed, %1</source>
-        <translation type="unfinished">0/nepotvrzeno, %1</translation>
+        <source>0/unconfirmed, in memory pool</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is in the memory pool.</extracomment>
+        <translation type="unfinished">0/nepotvrzené, je v transakčním zásobníku</translation>
     </message>
     <message>
-        <source>in memory pool</source>
-        <translation type="unfinished">v transakčním zásobníku</translation>
-    </message>
-    <message>
-        <source>not in memory pool</source>
-        <translation type="unfinished">není ani v transakčním zásobníku</translation>
+        <source>0/unconfirmed, not in memory pool</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is not in the memory pool.</extracomment>
+        <translation type="unfinished">0/nepotvrzené, není v transakčním zásobníku</translation>
     </message>
     <message>
         <source>abandoned</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an abandoned transaction.</extracomment>
         <translation type="unfinished">zanechaná</translation>
     </message>
     <message>
         <source>%1/unconfirmed</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
         <translation type="unfinished">%1/nepotvrzeno</translation>
     </message>
     <message>
         <source>%1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
         <translation type="unfinished">%1 potvrzení</translation>
     </message>
     <message>
@@ -3823,9 +4272,9 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>dozraje za %n další blok</numerusform>
+            <numerusform>dozraje za %n další bloky</numerusform>
+            <numerusform>dozraje za %n dalších bloků</numerusform>
         </translation>
     </message>
     <message>
@@ -4108,6 +4557,11 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     <message>
         <source>&amp;Edit address label</source>
         <translation type="unfinished">&amp;Upravit označení adresy</translation>
+    </message>
+    <message>
+        <source>Show in %1</source>
+        <extracomment>Transactions table context menu action to show the selected transaction in a third-party block explorer. %1 is a stand-in argument for the URL of the explorer.</extracomment>
+        <translation type="unfinished">Zobraz v %1</translation>
     </message>
     <message>
         <source>Export Transaction History</source>

--- a/src/qt/locale/bitcoin_cy.ts
+++ b/src/qt/locale/bitcoin_cy.ts
@@ -660,6 +660,36 @@
 <context>
     <name>Intro</name>
     <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+            <numerusform />
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+            <numerusform />
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+            <numerusform />
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">

--- a/src/qt/locale/bitcoin_da.ts
+++ b/src/qt/locale/bitcoin_da.ts
@@ -245,6 +245,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>BitcoinApplication</name>
     <message>
+        <source>Settings file %1 might be corrupt or invalid.</source>
+        <translation type="unfinished">Indstillings filen 1%1 kan være korrupt eller invalid.</translation>
+    </message>
+    <message>
+        <source>Runaway exception</source>
+        <translation type="unfinished">Runaway undtagelse</translation>
+    </message>
+    <message>
         <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
         <translation type="unfinished">Der skete en fatal fejl. %1 kan ikke længere fortsætte sikkert og vil afslutte.</translation>
     </message>
@@ -252,9 +260,23 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Internal error</source>
         <translation type="unfinished">Intern fejl</translation>
     </message>
-    </context>
+    <message>
+        <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
+        <translation type="unfinished">Der skete en intern fejl. %1 vil prøve at forsætte på sikker vis. Dette er en uventet fejl som kan reporteres som beskrevet under. </translation>
+    </message>
+</context>
 <context>
     <name>QObject</name>
+    <message>
+        <source>Do you want to reset settings to default values, or to abort without making changes?</source>
+        <extracomment>Explanatory text shown on startup when the settings file cannot be read. Prompts user to make a choice between resetting or aborting.</extracomment>
+        <translation type="unfinished">Vil du nulstille indstillinger til standardværdier eller afbryde uden at foretage ændringer?</translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. Check that settings file is writable, or try running with -nosettings.</source>
+        <extracomment>Explanatory text shown on startup when the settings file could not be written. Prompts user to check that we have the ability to write to the file. Explains that the user has the option of running without a settings file.</extracomment>
+        <translation type="unfinished">Der opstod en fatal fejl. Tjek at indstillingsfilen er skrivbar, eller prøv at anvend -nosettings.</translation>
+    </message>
     <message>
         <source>Error: Specified data directory "%1" does not exist.</source>
         <translation type="unfinished">Fejl: Angivet datamappe “%1” eksisterer ikke.</translation>
@@ -268,6 +290,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Fejl: %1</translation>
     </message>
     <message>
+        <source>%1 didn't yet exit safely…</source>
+        <translation type="unfinished">%1 har endnu ikke afsluttet på sikker vis…</translation>
+    </message>
+    <message>
         <source>unknown</source>
         <translation type="unfinished">ukendt</translation>
     </message>
@@ -278,6 +304,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Enter a Bitcoin address (e.g. %1)</source>
         <translation type="unfinished">Indtast en Bitcoin-adresse (fx %1)</translation>
+    </message>
+    <message>
+        <source>Unroutable</source>
+        <translation type="unfinished">Urutebar</translation>
     </message>
     <message>
         <source>Internal</source>
@@ -294,9 +324,24 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Udgående</translation>
     </message>
     <message>
+        <source>Full Relay</source>
+        <extracomment>Peer connection type that relays all network information.</extracomment>
+        <translation type="unfinished">Fuld Videresend</translation>
+    </message>
+    <message>
+        <source>Block Relay</source>
+        <extracomment>Peer connection type that relays network information about blocks and not transactions or addresses.</extracomment>
+        <translation type="unfinished">Blok Vidersend</translation>
+    </message>
+    <message>
         <source>Manual</source>
         <extracomment>Peer connection type established manually through one of several methods.</extracomment>
         <translation type="unfinished">Brugervejledning</translation>
+    </message>
+    <message>
+        <source>Feeler</source>
+        <extracomment>Short-lived peer connection type that tests the aliveness of known addresses.</extracomment>
+        <translation type="unfinished">Føler</translation>
     </message>
     <message>
         <source>Address Fetch</source>
@@ -314,36 +359,36 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n sekund(er)</numerusform>
+            <numerusform>%n sekund(er)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n minute(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n minut(er)</numerusform>
+            <numerusform>%n minut(er)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n time(r)</numerusform>
+            <numerusform>%n time(r)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n dag(e)</numerusform>
+            <numerusform>%n dag(e)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n uge(r)</numerusform>
+            <numerusform>%n uge(r)</numerusform>
         </translation>
     </message>
     <message>
@@ -353,13 +398,21 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n år</numerusform>
+            <numerusform>%n år</numerusform>
         </translation>
     </message>
     </context>
 <context>
     <name>bitcoin-core</name>
+    <message>
+        <source>Settings file could not be read</source>
+        <translation type="unfinished">Indstillingsfilen kunne ikke læses</translation>
+    </message>
+    <message>
+        <source>Settings file could not be written</source>
+        <translation type="unfinished">Indstillingsfilen kunne ikke skrives</translation>
+    </message>
     <message>
         <source>The %s developers</source>
         <translation type="unfinished">Udviklerne af %s</translation>
@@ -373,8 +426,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">-maxtxfee er sat meget højt! Gebyrer så store risikeres betalt på en enkelt transaktion.</translation>
     </message>
     <message>
+        <source>Cannot downgrade wallet from version %i to version %i. Wallet version unchanged.</source>
+        <translation type="unfinished">Kan ikke nedgradere tegnebogen fra version %i til version %i. Wallet-versionen uændret.</translation>
+    </message>
+    <message>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running.</source>
         <translation type="unfinished">Kan ikke opnå en lås på datamappe %s. %s kører sansynligvis allerede.</translation>
+    </message>
+    <message>
+        <source>Cannot upgrade a non HD split wallet from version %i to version %i without upgrading to support pre-split keypool. Please use version %i or no version specified.</source>
+        <translation type="unfinished">Kan ikke opgradere en ikke-HD split wallet fra version %i til version %i uden at opgradere til at understøtte pre-split keypool. Brug venligst version %i eller ingen version angivet.</translation>
     </message>
     <message>
         <source>Distributed under the MIT software license, see the accompanying file %s or %s</source>
@@ -385,20 +446,56 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Fejl under læsning af %s! Alle nøgler blev læst korrekt, men transaktionsdata eller indgange i adressebogen kan mangle eller være ukorrekte.</translation>
     </message>
     <message>
-        <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
-        <translation type="unfinished">Fejl: Lytning efter indkommende forbindelser mislykkedes (lytning resultarede i fejl %s)</translation>
+        <source>Error reading %s! Transaction data may be missing or incorrect. Rescanning wallet.</source>
+        <translation type="unfinished">Fejl ved læsning %s! Transaktionsdata kan mangle eller være forkerte. Genscanner tegnebogen.</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile format record is incorrect. Got "%s", expected "format".</source>
+        <translation type="unfinished">Fejl: Dumpfilformat dokument er forkert. Fik "%s", forventet "format".</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile identifier record is incorrect. Got "%s", expected "%s".</source>
+        <translation type="unfinished">Fejl: Dumpfilformat dokument er forkert. Fik "%s", forventet "%s".</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile version is not supported. This version of bitcoin-wallet only supports version 1 dumpfiles. Got dumpfile with version %s</source>
+        <translation type="unfinished">Fejl: Dumpfil-versionen understøttes ikke. Denne version af bitcoin-tegnebog understøtter kun version 1 dumpfiler. Fik dumpfil med version %s</translation>
+    </message>
+    <message>
+        <source>Error: Legacy wallets only support the "legacy", "p2sh-segwit", and "bech32" address types</source>
+        <translation type="unfinished">Fejl: Ældre tegnebøger understøtter kun adressetyperne "legacy", "p2sh-segwit" og "bech32"</translation>
     </message>
     <message>
         <source>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.</source>
         <translation type="unfinished">Estimering af gebyr mislykkedes. Tilbagefaldsgebyr er deaktiveret. Vent et par blokke eller aktiver -fallbackfee.</translation>
     </message>
     <message>
+        <source>File %s already exists. If you are sure this is what you want, move it out of the way first.</source>
+        <translation type="unfinished">Fil %s eksisterer allerede. Hvis du er sikker på, at det er det, du vil have, så flyt det af vejen først.</translation>
+    </message>
+    <message>
         <source>Invalid amount for -maxtxfee=&lt;amount&gt;: '%s' (must be at least the minrelay fee of %s to prevent stuck transactions)</source>
         <translation type="unfinished">Ugyldigt beløb for -maxtxfee=&lt;beløb&gt;: “%s” (skal være på mindst minrelay-gebyret på %s for at undgå hængende transaktioner)</translation>
     </message>
     <message>
+        <source>Invalid or corrupt peers.dat (%s). If you believe this is a bug, please report it to %s. As a workaround, you can move the file (%s) out of the way (rename, move, or delete) to have a new one created on the next start.</source>
+        <translation type="unfinished">Ugyldige eller korrupte peers.dat (%s). Hvis du mener, at dette er en fejl, bedes du rapportere det til %s. Som en løsning kan du flytte filen (%s) ud af vejen (omdøbe, flytte eller slette) for at få oprettet en ny ved næste start.</translation>
+    </message>
+    <message>
         <source>More than one onion bind address is provided. Using %s for the automatically created Tor onion service.</source>
         <translation type="unfinished">Mere end én onion-bindingsadresse er opgivet. Bruger %s til den automatiske oprettelse af Tor-onion-tjeneste.</translation>
+    </message>
+    <message>
+        <source>No dump file provided. To use createfromdump, -dumpfile=&lt;filename&gt; must be provided.</source>
+        <translation type="unfinished">Der er ikke angivet nogen dumpfil. For at bruge createfromdump skal -dumpfile= &lt;filename&gt; angives.</translation>
+    </message>
+    <message>
+        <source>No dump file provided. To use dump, -dumpfile=&lt;filename&gt; must be provided.</source>
+        <translation type="unfinished">Der er ikke angivet nogen dumpfil. For at bruge dump skal -dumpfile=&lt;filename&gt; angives.</translation>
+    </message>
+    <message>
+        <source>No wallet file format provided. To use createfromdump, -format=&lt;format&gt; must be provided.</source>
+        <translation type="unfinished">Der er ikke angivet noget tegnebogsfilformat. For at bruge createfromdump skal -format=&lt;format&gt; angives.</translation>
     </message>
     <message>
         <source>Please check that your computer's date and time are correct! If your clock is wrong, %s will not work properly.</source>
@@ -423,6 +520,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>The block database contains a block which appears to be from the future. This may be due to your computer's date and time being set incorrectly. Only rebuild the block database if you are sure that your computer's date and time are correct</source>
         <translation type="unfinished">Blokdatabasen indeholder en blok, som ser ud til at være fra fremtiden. Dette kan skyldes, at din computers dato og tid ikke er sat korrekt. Genopbyg kun blokdatabasen, hvis du er sikker på, at din computers dato og tid er korrekt</translation>
+    </message>
+    <message>
+        <source>The block index db contains a legacy 'txindex'. To clear the occupied disk space, run a full -reindex, otherwise ignore this error. This error message will not be displayed again.</source>
+        <translation type="unfinished">Blokindekset db indeholder et ældre 'txindex'. For at rydde den optagede diskplads skal du køre en fuld -reindex, ellers ignorere denne fejl. Denne fejlmeddelelse vil ikke blive vist igen.</translation>
     </message>
     <message>
         <source>The transaction amount is too small to send after the fee has been deducted</source>
@@ -457,12 +558,24 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Kan ikke genafspille blokke. Du er nødt til at genopbytte databasen ved hjælp af -reindex-chainstate.</translation>
     </message>
     <message>
+        <source>Unknown wallet file format "%s" provided. Please provide one of "bdb" or "sqlite".</source>
+        <translation type="unfinished">Ukendt tegnebogsfilformat "%s" angivet. Angiv en af "bdb" eller "sqlite".</translation>
+    </message>
+    <message>
+        <source>Warning: Dumpfile wallet format "%s" does not match command line specified format "%s".</source>
+        <translation type="unfinished">Advarsel: Dumpfile tegnebogsformatet "%s" matcher ikke kommandolinjens specificerede format "%s".</translation>
+    </message>
+    <message>
         <source>Warning: Private keys detected in wallet {%s} with disabled private keys</source>
         <translation type="unfinished">Advarsel: Private nøgler opdaget i tegnebog {%s} med deaktiverede private nøgler</translation>
     </message>
     <message>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished">Advarsel: Vi ser ikke ud til at være fuldt ud enige med andre knuder! Du kan være nødt til at opgradere, eller andre knuder kan være nødt til at opgradere.</translation>
+    </message>
+    <message>
+        <source>Witness data for blocks after height %d requires validation. Please restart with -reindex.</source>
+        <translation type="unfinished">Vidnedata for blokke efter højde %d kræver validering. Genstart venligst med -reindex.</translation>
     </message>
     <message>
         <source>You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain</source>
@@ -485,12 +598,36 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Kan ikke finde -%s-adressen: “%s”</translation>
     </message>
     <message>
+        <source>Cannot set -forcednsseed to true when setting -dnsseed to false.</source>
+        <translation type="unfinished">Kan ikke indstille -forcednsseed til true, når -dnsseed indstilles til false.</translation>
+    </message>
+    <message>
         <source>Cannot set -peerblockfilters without -blockfilterindex.</source>
         <translation type="unfinished">Kan ikke indstille -peerblockfilters uden -blockfilterindex.</translation>
     </message>
     <message>
         <source>Cannot write to data directory '%s'; check permissions.</source>
         <translation type="unfinished">Kan ikke skrive til datamappe '%s'; tjek tilladelser.</translation>
+    </message>
+    <message>
+        <source>The -txindex upgrade started by a previous version cannot be completed. Restart with the previous version or run a full -reindex.</source>
+        <translation type="unfinished">Opgraderingen af -txindex som er startet af en tidligere version kan ikke fuldføres. Genstart med den tidligere version eller kør en fuld -reindex.</translation>
+    </message>
+    <message>
+        <source>%s request to listen on port %u. This port is considered "bad" and thus it is unlikely that any Bitcoin Core peers connect to it. See doc/p2p-bad-ports.md for details and a full list.</source>
+        <translation type="unfinished">%sanmodning om st lytte på havn%uDenne port betragtes som „dårlig“, og det er derfor usandsynligt, at nogen Bitcoin Core-jævnaldrende opretter forbindelse til den. Se doc/p2p-bad-ports.md for detaljer og en komplet liste.</translation>
+    </message>
+    <message>
+        <source>Cannot provide specific connections and have addrman find outgoing connections at the same time.</source>
+        <translation type="unfinished">Kan ikke levere specifikke forbindelser og få adrman til at finde udgående forbindelser på samme tid.</translation>
+    </message>
+    <message>
+        <source>Error loading %s: External signer wallet being loaded without external signer support compiled</source>
+        <translation type="unfinished">Fejlindlæsning %s: Ekstern underskriver-tegnebog indlæses uden ekstern underskriverunderstøttelse kompileret</translation>
+    </message>
+    <message>
+        <source>Failed to rename invalid peers.dat file. Please move or delete it and try again.</source>
+        <translation type="unfinished">Kunne ikke omdøbe ugyldig peers.dat fil. Flyt eller slet den venligst og prøv igen.</translation>
     </message>
     <message>
         <source>Config setting for %s only applied on %s network when in [%s] section.</source>
@@ -523,6 +660,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Done loading</source>
         <translation type="unfinished">Indlæsning gennemført</translation>
+    </message>
+    <message>
+        <source>Dump file %s does not exist.</source>
+        <translation type="unfinished">Dumpfil %s findes ikke.</translation>
+    </message>
+    <message>
+        <source>Error creating %s</source>
+        <translation type="unfinished">Fejl skaber %s</translation>
     </message>
     <message>
         <source>Error initializing block database</source>
@@ -561,16 +706,48 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Fejl under læsning fra database; lukker ned.</translation>
     </message>
     <message>
-        <source>Error upgrading chainstate database</source>
-        <translation type="unfinished">Fejl under opgradering af kædetilstandsdatabase</translation>
+        <source>Error reading next record from wallet database</source>
+        <translation type="unfinished">Fejl ved læsning af næste post fra tegnebogsdatabase</translation>
+    </message>
+    <message>
+        <source>Error: Couldn't create cursor into database</source>
+        <translation type="unfinished">Fejl: Kunne ikke oprette markøren i databasen</translation>
     </message>
     <message>
         <source>Error: Disk space is low for %s</source>
         <translation type="unfinished">Fejl: Disk plads er lavt for %s</translation>
     </message>
     <message>
+        <source>Error: Dumpfile checksum does not match. Computed %s, expected %s</source>
+        <translation type="unfinished">Fejl: Dumpfil kontrolsum stemmer ikke overens. Beregnet %s, forventet %s</translation>
+    </message>
+    <message>
+        <source>Error: Got key that was not hex: %s</source>
+        <translation type="unfinished">Fejl: Fik nøgle, der ikke var hex: %s</translation>
+    </message>
+    <message>
+        <source>Error: Got value that was not hex: %s</source>
+        <translation type="unfinished">Fejl: Fik værdi, der ikke var hex: %s</translation>
+    </message>
+    <message>
         <source>Error: Keypool ran out, please call keypoolrefill first</source>
         <translation type="unfinished">Fejl: Nøglepøl løb tør, tilkald venligst keypoolrefill først</translation>
+    </message>
+    <message>
+        <source>Error: Missing checksum</source>
+        <translation type="unfinished">Fejl: Manglende kontrolsum</translation>
+    </message>
+    <message>
+        <source>Error: No %s addresses available.</source>
+        <translation type="unfinished">Fejl: Ingen tilgængelige %s adresser.</translation>
+    </message>
+    <message>
+        <source>Error: Unable to parse version %u as a uint32_t</source>
+        <translation type="unfinished">Fejl: Kan ikke parse version %u som en uint32_t</translation>
+    </message>
+    <message>
+        <source>Error: Unable to write record to new wallet</source>
+        <translation type="unfinished">Fejl: Kan ikke skrive post til ny tegnebog</translation>
     </message>
     <message>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
@@ -605,8 +782,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Sundhedstjek under initialisering mislykkedes. %s lukker ned.</translation>
     </message>
     <message>
+        <source>Input not found or already spent</source>
+        <translation type="unfinished">Input ikke fundet eller allerede brugt</translation>
+    </message>
+    <message>
         <source>Insufficient funds</source>
         <translation type="unfinished">Manglende dækning</translation>
+    </message>
+    <message>
+        <source>Invalid -i2psam address or hostname: '%s'</source>
+        <translation type="unfinished">Ugyldig -i2psam-adresse eller værtsnavn: '%s'</translation>
     </message>
     <message>
         <source>Invalid -onion address or hostname: '%s'</source>
@@ -657,12 +842,20 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Indlæser tegnebog...</translation>
     </message>
     <message>
+        <source>Missing amount</source>
+        <translation type="unfinished">Manglende beløb</translation>
+    </message>
+    <message>
+        <source>Missing solving data for estimating transaction size</source>
+        <translation type="unfinished">Manglende løsningsdata til estimering af transaktionsstørrelse</translation>
+    </message>
+    <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
         <translation type="unfinished">Nødt til at angive en port med -whitebinde: “%s”</translation>
     </message>
     <message>
-        <source>No proxy server specified. Use -proxy=&lt;ip&gt; or -proxy=&lt;ip:port&gt;.</source>
-        <translation type="unfinished">Ingen proxyserver specificeret. Brug -proxy=&lt;ip&gt; eller -proxy=&lt;ip:port&gt;.</translation>
+        <source>No addresses available</source>
+        <translation type="unfinished">Ingen adresser tilgængelige</translation>
     </message>
     <message>
         <source>Not enough file descriptors available.</source>
@@ -683,6 +876,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
         <translation type="unfinished">Reducerer -maxconnections fra %d til %d på grund af systembegrænsninger.</translation>
+    </message>
+    <message>
+        <source>Replaying blocks…</source>
+        <translation type="unfinished">Genafspiller blokke...</translation>
     </message>
     <message>
         <source>Rescanning…</source>
@@ -729,8 +926,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Angivet blokmappe “%s” eksisterer ikke.</translation>
     </message>
     <message>
+        <source>Starting network threads…</source>
+        <translation type="unfinished">Starter netværkstråde...</translation>
+    </message>
+    <message>
         <source>The source code is available from %s.</source>
         <translation type="unfinished">Kildekoden er tilgængelig fra %s.</translation>
+    </message>
+    <message>
+        <source>The specified config file %s does not exist</source>
+        <translation type="unfinished">Den angivne konfigurationsfil %s findes ikke</translation>
     </message>
     <message>
         <source>The transaction amount is too small to pay the fee</source>
@@ -761,12 +966,20 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Transaktionsbeløb må ikke være negative</translation>
     </message>
     <message>
+        <source>Transaction change output index out of range</source>
+        <translation type="unfinished">Transaktions byttepenge outputindeks uden for intervallet</translation>
+    </message>
+    <message>
         <source>Transaction has too long of a mempool chain</source>
         <translation type="unfinished">Transaktionen har en for lang hukommelsespuljekæde</translation>
     </message>
     <message>
         <source>Transaction must have at least one recipient</source>
         <translation type="unfinished">Transaktionen skal have mindst én modtager</translation>
+    </message>
+    <message>
+        <source>Transaction needs a change address, but we can't generate it.</source>
+        <translation type="unfinished">Transaktionen behøver en byttepenge adresse, men vi kan ikke generere den.</translation>
     </message>
     <message>
         <source>Transaction too large</source>
@@ -793,6 +1006,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">U-istand til at generere nøgler</translation>
     </message>
     <message>
+        <source>Unable to open %s for writing</source>
+        <translation type="unfinished">Kan ikke åbne %s til skrivning</translation>
+    </message>
+    <message>
+        <source>Unable to parse -maxuploadtarget: '%s'</source>
+        <translation type="unfinished">Kan ikke parse -maxuploadtarget: '%s'</translation>
+    </message>
+    <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
         <translation type="unfinished">Kunne ikke starte HTTP-server. Se fejlretningslog for detaljer.</translation>
     </message>
@@ -813,16 +1034,20 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Ukendt netværk anført i -onlynet: “%s”</translation>
     </message>
     <message>
+        <source>Unknown new rules activated (versionbit %i)</source>
+        <translation type="unfinished">Ukendte nye regler aktiveret (versionsbit %i)</translation>
+    </message>
+    <message>
         <source>Unsupported logging category %s=%s.</source>
         <translation type="unfinished">Ikke understøttet logningskategori %s=%s.</translation>
     </message>
     <message>
-        <source>Upgrading UTXO database</source>
-        <translation type="unfinished">Opgraderer UTXO-database</translation>
-    </message>
-    <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
         <translation type="unfinished">Brugeragent-kommentar (%s) indeholder usikre tegn.</translation>
+    </message>
+    <message>
+        <source>Verifying blocks…</source>
+        <translation type="unfinished">Verificerer blokke…</translation>
     </message>
     <message>
         <source>Verifying wallet(s)…</source>
@@ -884,6 +1109,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Opret en ny tegnebog</translation>
     </message>
     <message>
+        <source>&amp;Minimize</source>
+        <translation type="unfinished">&amp;Minimér</translation>
+    </message>
+    <message>
         <source>Wallet:</source>
         <translation type="unfinished">Tegnebog:</translation>
     </message>
@@ -929,6 +1158,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">&amp;Sikkerhedskopiér Tegnebog</translation>
     </message>
     <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation type="unfinished">&amp;Skift adgangskode</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation type="unfinished">Signér &amp;besked</translation>
+    </message>
+    <message>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation type="unfinished">Signér beskeder med dine Bitcoin-adresser for at bevise, at de tilhører dig</translation>
     </message>
@@ -939,6 +1176,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation type="unfinished">Verificér beskeder for at sikre, at de er signeret med de angivne Bitcoin-adresser</translation>
+    </message>
+    <message>
+        <source>&amp;Load PSBT from file…</source>
+        <translation type="unfinished">&amp;Indlæs PSBT fra fil...</translation>
+    </message>
+    <message>
+        <source>Open &amp;URI…</source>
+        <translation type="unfinished">Åben &amp;URI...</translation>
     </message>
     <message>
         <source>Close Wallet…</source>
@@ -969,8 +1214,24 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Faneværktøjslinje</translation>
     </message>
     <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation type="unfinished">Synkroniserer hoveder (%1%)…</translation>
+    </message>
+    <message>
         <source>Synchronizing with network…</source>
         <translation type="unfinished">Synkroniserer med netværk …</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation type="unfinished">Indekserer blokke på disken…</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation type="unfinished">Bearbejder blokke på disken…</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation type="unfinished">Genindekserer blokke på disken…</translation>
     </message>
     <message>
         <source>Connecting to peers…</source>
@@ -995,8 +1256,8 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>Behandlede %n blok(e) af transaktionshistorik.</numerusform>
+            <numerusform>Behandlede %n blok(e) af transaktionshistorik.</numerusform>
         </translation>
     </message>
     <message>
@@ -1030,6 +1291,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Load Partially Signed Bitcoin Transaction</source>
         <translation type="unfinished">Indlæs Partvist Signeret Bitcoin-Transaktion</translation>
+    </message>
+    <message>
+        <source>Load PSBT from &amp;clipboard…</source>
+        <translation type="unfinished">Indlæs PSBT fra &amp;clipboard</translation>
     </message>
     <message>
         <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
@@ -1068,6 +1333,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Luk tegnebog</translation>
     </message>
     <message>
+        <source>Restore Wallet…</source>
+        <extracomment>Name of the menu item that restores wallet from a backup file.</extracomment>
+        <translation type="unfinished">Gendan pung</translation>
+    </message>
+    <message>
+        <source>Restore a wallet from a backup file</source>
+        <extracomment>Status tip for Restore Wallet menu item</extracomment>
+        <translation type="unfinished">Gendan en pung, fra en backup fil. </translation>
+    </message>
+    <message>
         <source>Close all wallets</source>
         <translation type="unfinished">Luk alle tegnebøgerne </translation>
     </message>
@@ -1092,6 +1367,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Ingen tegnebøger tilgængelige</translation>
     </message>
     <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">Tegnebogsdata</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">Navn på tegnebog</translation>
+    </message>
+    <message>
         <source>&amp;Window</source>
         <translation type="unfinished">&amp;Vindue</translation>
     </message>
@@ -1103,13 +1388,26 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>%1 client</source>
         <translation type="unfinished">%1-klient</translation>
     </message>
+    <message>
+        <source>&amp;Hide</source>
+        <translation type="unfinished">&amp;Skjul</translation>
+    </message>
+    <message>
+        <source>S&amp;how</source>
+        <translation type="unfinished">&amp;Vis</translation>
+    </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n aktiv(e) forbindelse(r) til Bitcoin-netværket.</numerusform>
+            <numerusform>%n aktiv(e) forbindelse(r) til Bitcoin-netværket.</numerusform>
         </translation>
+    </message>
+    <message>
+        <source>Click for more actions.</source>
+        <extracomment>A substring of the tooltip. "More actions" are available via the context menu.</extracomment>
+        <translation type="unfinished">Click for flere aktioner.</translation>
     </message>
     <message>
         <source>Show Peers tab</source>
@@ -1279,6 +1577,30 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Kopiér beløb</translation>
     </message>
     <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Kopiér adresse</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Kopiér &amp;mærkat</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Kopiér &amp;beløb</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID and output index</source>
+        <translation type="unfinished">Kopiér transaktion &amp;ID og outputindeks</translation>
+    </message>
+    <message>
+        <source>L&amp;ock unspent</source>
+        <translation type="unfinished">&amp;Fastlås ubrugte</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock unspent</source>
+        <translation type="unfinished">&amp;Lås ubrugte op</translation>
+    </message>
+    <message>
         <source>Copy quantity</source>
         <translation type="unfinished">Kopiér mængde</translation>
     </message>
@@ -1355,7 +1677,24 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Create wallet warning</source>
         <translation type="unfinished">Advarsel for oprettelse af tegnebog</translation>
     </message>
+    <message>
+        <source>Can't list signers</source>
+        <translation type="unfinished">Kan ikke liste underskrivere</translation>
+    </message>
     </context>
+<context>
+    <name>LoadWalletsActivity</name>
+    <message>
+        <source>Load Wallets</source>
+        <extracomment>Title of progress window which is displayed when wallets are being loaded.</extracomment>
+        <translation type="unfinished">Indlæs Tegnebøger</translation>
+    </message>
+    <message>
+        <source>Loading wallets…</source>
+        <extracomment>Descriptive text of the load wallets progress window which indicates to the user that wallets are currently being loaded.</extracomment>
+        <translation type="unfinished">Indlæser tegnebøger...</translation>
+    </message>
+</context>
 <context>
     <name>OpenWalletActivity</name>
     <message>
@@ -1375,7 +1714,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <extracomment>Title of window indicating the progress of opening of a wallet.</extracomment>
         <translation type="unfinished">Åben Tegnebog</translation>
     </message>
-    </context>
+    <message>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the open wallet progress window which indicates to the user which wallet is currently being opened.</extracomment>
+        <translation type="unfinished">Åbner Tegnebog &lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+</context>
 <context>
     <name>WalletController</name>
     <message>
@@ -1450,6 +1794,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Beskriver-Pung</translation>
     </message>
     <message>
+        <source>Use an external signing device such as a hardware wallet. Configure the external signer script in wallet preferences first.</source>
+        <translation type="unfinished">Brug en ekstern signeringsenhed som en hardwaretegnebog. Konfigurer den eksterne underskriver skript i tegnebogspræferencerne først.</translation>
+    </message>
+    <message>
+        <source>External signer</source>
+        <translation type="unfinished">Ekstern underskriver</translation>
+    </message>
+    <message>
         <source>Create</source>
         <translation type="unfinished">Opret</translation>
     </message>
@@ -1457,7 +1809,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Compiled without sqlite support (required for descriptor wallets)</source>
         <translation type="unfinished">Kompileret uden sqlite-understøttelse (krævet til beskriver-punge)</translation>
     </message>
-    </context>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Kompileret uden ekstern underskriver understøttelse (nødvendig for ekstern underskriver)</translation>
+    </message>
+</context>
 <context>
     <name>EditAddressDialog</name>
     <message>
@@ -1538,6 +1895,27 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 </context>
 <context>
     <name>Intro</name>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform>(ud af %n GB nødvendig)</numerusform>
+            <numerusform>(ud af %n GB nødvendig)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform>(%n GB nødvendig for komplet kæde)</numerusform>
+            <numerusform>(%n GB nødvendig for komplet kæde)</numerusform>
+        </translation>
+    </message>
     <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
         <translation type="unfinished">Mindst %1 GB data vil blive gemt i denne mappe, og det vil vokse over tid.</translation>
@@ -1550,8 +1928,8 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>(tilstrækkelig for at gendanne backups %n dag(e) gammel)</numerusform>
+            <numerusform>(tilstrækkelig for at gendanne backups %n dag(e) gammel)</numerusform>
         </translation>
     </message>
     <message>
@@ -1583,12 +1961,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Siden dette er første gang, programmet startes, kan du vælge, hvor %1 skal gemme sin data.</translation>
     </message>
     <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation type="unfinished">Når du klikker OK, vil %1 begynde at downloade og bearbejde den fulde %4-blokkæde (%2 GB), startende med de tidligste transaktioner i %3, da %4 først startede.</translation>
+        <source>Limit block chain storage to</source>
+        <translation type="unfinished">Begræns blokkæde opbevaring til</translation>
     </message>
     <message>
         <source>Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</source>
         <translation type="unfinished">Ændring af denne indstilling senere kræver gendownload af hele blokkæden. Det er hurtigere at downloade den komplette kæde først og beskære den senere. Slår nogle avancerede funktioner fra.</translation>
+    </message>
+    <message>
+        <source> GB</source>
+        <translation type="unfinished">GB</translation>
     </message>
     <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
@@ -1620,6 +2002,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 </context>
 <context>
     <name>ShutdownWindow</name>
+    <message>
+        <source>%1 is shutting down…</source>
+        <translation type="unfinished">%1 lukker ned…</translation>
+    </message>
     <message>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished">Luk ikke computeren ned, før dette vindue forsvinder.</translation>
@@ -1675,6 +2061,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>%1 is currently syncing.  It will download headers and blocks from peers and validate them until reaching the tip of the block chain.</source>
         <translation type="unfinished">%1 synkroniserer lige nu. Hoveder og blokke bliver downloadet og valideret fra andre knuder. Processen fortsætter indtil den seneste blok nås.</translation>
     </message>
+    <message>
+        <source>Unknown. Syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">Ukendt. Synkroniserer Hoveder (%1, %2%)...</translation>
+    </message>
     </context>
 <context>
     <name>OpenURIDialog</name>
@@ -1705,6 +2095,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>&amp;Start %1 on system login</source>
         <translation type="unfinished">&amp;Start %1 ved systemlogin</translation>
+    </message>
+    <message>
+        <source>Enabling pruning significantly reduces the disk space required to store transactions. All blocks are still fully validated. Reverting this setting requires re-downloading the entire blockchain.</source>
+        <translation type="unfinished">Aktivering af beskæring reducerer betydeligt den diskplads, der kræves til at gemme transaktioner. Alle blokke er stadig fuldt validerede. Gendannelse af denne indstilling kræver gendownload af hele blokkæden.</translation>
     </message>
     <message>
         <source>Size of &amp;database cache</source>
@@ -1755,12 +2149,42 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Ændring af denne indstilling senere kræver download af hele blokkæden igen.</translation>
     </message>
     <message>
+        <source>Maximum database cache size. A larger cache can contribute to faster sync, after which the benefit is less pronounced for most use cases. Lowering the cache size will reduce memory usage. Unused mempool memory is shared for this cache.</source>
+        <extracomment>Tooltip text for Options window setting that sets the size of the database cache. Explains the corresponding effects of increasing/decreasing this value.</extracomment>
+        <translation type="unfinished">Maksimal størrelse på databasecache. En større cache kan bidrage til hurtigere synkronisering, hvorefter fordelen er mindre synlig i de fleste tilfælde. Sænkning af cachestørrelsen vil reducere hukommelsesforbruget. Ubrugt mempool-hukommelse deles for denne cache.</translation>
+    </message>
+    <message>
+        <source>Set the number of script verification threads. Negative values correspond to the number of cores you want to leave free to the system.</source>
+        <extracomment>Tooltip text for Options window setting that sets the number of script verification threads. Explains that negative values mean to leave these many cores free to the system.</extracomment>
+        <translation type="unfinished">Indstil antallet af scriptbekræftelsestråde. Negative værdier svarer til antallet af kerner, du ønsker at lade være frie til systemet.</translation>
+    </message>
+    <message>
         <source>(0 = auto, &lt;0 = leave that many cores free)</source>
         <translation type="unfinished">(0 = auto, &lt;0 = efterlad så mange kerner fri)</translation>
     </message>
     <message>
+        <source>This allows you or a third party tool to communicate with the node through command-line and JSON-RPC commands.</source>
+        <extracomment>Tooltip text for Options window setting that enables the RPC server.</extracomment>
+        <translation type="unfinished">Dette giver dig eller et tredjepartsværktøj mulighed for at kommunikere med knuden gennem kommandolinje- og JSON-RPC-kommandoer.</translation>
+    </message>
+    <message>
+        <source>Enable R&amp;PC server</source>
+        <extracomment>An Options window setting to enable the RPC server.</extracomment>
+        <translation type="unfinished">Aktiver &amp;RPC-server</translation>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished">&amp;Tegnebog</translation>
+    </message>
+    <message>
+        <source>Whether to set subtract fee from amount as default or not.</source>
+        <extracomment>Tooltip text for Options window setting that sets subtracting the fee from a sending amount as default.</extracomment>
+        <translation type="unfinished">Hvorvidt der skal trækkes gebyr fra beløb som standard eller ej.</translation>
+    </message>
+    <message>
+        <source>Subtract &amp;fee from amount by default</source>
+        <extracomment>An Options window setting to set subtracting the fee from a sending amount as default.</extracomment>
+        <translation type="unfinished">Træk &amp;gebyr fra beløbet som standard</translation>
     </message>
     <message>
         <source>Expert</source>
@@ -1779,12 +2203,42 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">&amp;Brug ubekræftede byttepenge</translation>
     </message>
     <message>
+        <source>Enable &amp;PSBT controls</source>
+        <extracomment>An options window setting to enable PSBT controls.</extracomment>
+        <translation type="unfinished">Aktiver &amp;PSBT styring</translation>
+    </message>
+    <message>
+        <source>Whether to show PSBT controls.</source>
+        <extracomment>Tooltip text for options window setting that enables PSBT controls.</extracomment>
+        <translation type="unfinished">Om PSBT styring skal vises.</translation>
+    </message>
+    <message>
+        <source>External Signer (e.g. hardware wallet)</source>
+        <translation type="unfinished">Ekstern underskriver (f.eks. hardwaretegnebog)</translation>
+    </message>
+    <message>
+        <source>&amp;External signer script path</source>
+        <translation type="unfinished">&amp;Ekstern underskrivers scriptsti</translation>
+    </message>
+    <message>
+        <source>Full path to a Bitcoin Core compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</source>
+        <translation type="unfinished">Fuld sti til et Bitcoin Core-kompatibelt script (f.eks. C:\Downloads\hwi.exe eller /Users/you/Downloads/hwi.py). Pas på: malware kan stjæle dine mønter!</translation>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation type="unfinished">Åbn automatisk Bitcoin-klientens port på routeren. Dette virker kun, når din router understøtter UPnP, og UPnP er aktiveret.</translation>
     </message>
     <message>
         <source>Map port using &amp;UPnP</source>
         <translation type="unfinished">Konfigurér port vha. &amp;UPnP</translation>
+    </message>
+    <message>
+        <source>Automatically open the Bitcoin client port on the router. This only works when your router supports NAT-PMP and it is enabled. The external port could be random.</source>
+        <translation type="unfinished">Åbn automatisk Bitcoin-klientporten på routeren. Dette virker kun, når din router understøtter NAT-PMP, og den er aktiveret. Den eksterne port kan være tilfældig.</translation>
+    </message>
+    <message>
+        <source>Map port using NA&amp;T-PMP</source>
+        <translation type="unfinished">Kortport ved hjælp af NA&amp;T-PMP</translation>
     </message>
     <message>
         <source>Accept connections from outside.</source>
@@ -1819,6 +2273,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">&amp;Vindue</translation>
     </message>
     <message>
+        <source>Show the icon in the system tray.</source>
+        <translation type="unfinished">Vis ikonet i proceslinjen.</translation>
+    </message>
+    <message>
+        <source>&amp;Show tray icon</source>
+        <translation type="unfinished">&amp;Vis bakkeikon</translation>
+    </message>
+    <message>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation type="unfinished">Vis kun et statusikon efter minimering af vinduet.</translation>
     </message>
@@ -1851,6 +2313,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Vælg standard for underopdeling af enhed, som skal vises i brugergrænsefladen og ved afsendelse af bitcoins.</translation>
     </message>
     <message>
+        <source>Third-party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</source>
+        <translation type="unfinished">Tredjeparts-URL'er (f.eks. en blokudforsker), der vises på fanen Transaktioner som genvejsmenupunkter. %s i URL'en erstattes af transaktions-hash. Flere URL'er er adskilt af lodret streg |.</translation>
+    </message>
+    <message>
+        <source>&amp;Third-party transaction URLs</source>
+        <translation type="unfinished">&amp;Tredjeparts transaktions-URL'er</translation>
+    </message>
+    <message>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished">Hvorvidt egenskaber for coin-styring skal vises eller ej.</translation>
     </message>
@@ -1863,8 +2333,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Brug separate SOCKS&amp;5 proxy, for at nå fælle via Tor-onion-tjenester:</translation>
     </message>
     <message>
-        <source>Options set in this dialog are overridden by the command line or in the configuration file:</source>
-        <translation type="unfinished">Valgmuligheder sat i denne dialog er overskrevet af kommandolinjen eller i konfigurationsfilen:</translation>
+        <source>Monospaced font in the Overview tab:</source>
+        <translation type="unfinished">Monospaced skrifttype på fanen Oversigt:</translation>
+    </message>
+    <message>
+        <source>embedded "%1"</source>
+        <translation type="unfinished">indlejret "%1"</translation>
+    </message>
+    <message>
+        <source>closest matching "%1"</source>
+        <translation type="unfinished">tættest matchende "%1"</translation>
     </message>
     <message>
         <source>&amp;OK</source>
@@ -1873,6 +2351,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>&amp;Cancel</source>
         <translation type="unfinished">&amp;Annullér</translation>
+    </message>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Kompileret uden ekstern underskriver understøttelse (nødvendig for ekstern underskriver)</translation>
     </message>
     <message>
         <source>default</source>
@@ -1884,14 +2367,17 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Confirm options reset</source>
+        <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
         <translation type="unfinished">Bekræft nulstilling af indstillinger</translation>
     </message>
     <message>
         <source>Client restart required to activate changes.</source>
+        <extracomment>Text explaining that the settings changed will not come into effect until the client is restarted.</extracomment>
         <translation type="unfinished">Genstart af klienten er nødvendig for at aktivere ændringer.</translation>
     </message>
     <message>
         <source>Client will be shut down. Do you want to proceed?</source>
+        <extracomment>Text asking the user to confirm if they would like to proceed with a client shutdown.</extracomment>
         <translation type="unfinished">Klienten vil lukke ned. Vil du fortsætte?</translation>
     </message>
     <message>
@@ -1903,6 +2389,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>The configuration file is used to specify advanced user options which override GUI settings. Additionally, any command-line options will override this configuration file.</source>
         <extracomment>Explanatory text about the priority order of instructions considered by client. The order from high to low being: command-line, configuration file, GUI settings.</extracomment>
         <translation type="unfinished">Konfigurationsfilen bruges til at opsætte avancerede brugerindstillinger, som tilsidesætter indstillingerne i den grafiske brugerflade. Derudover vil eventuelle kommandolinjetilvalg tilsidesætte denne konfigurationsfil.</translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation type="unfinished">Forsæt</translation>
     </message>
     <message>
         <source>Cancel</source>
@@ -2031,6 +2521,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Kunne ikke signere transaktion: %1</translation>
     </message>
     <message>
+        <source>Cannot sign inputs while wallet is locked.</source>
+        <translation type="unfinished">Kan ikke signere inputs, mens tegnebogen er låst.</translation>
+    </message>
+    <message>
         <source>Could not sign any more inputs.</source>
         <translation type="unfinished">Kunne ikke signere flere input.</translation>
     </message>
@@ -2061,6 +2555,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Save Transaction Data</source>
         <translation type="unfinished">Gem Transaktionsdata</translation>
+    </message>
+    <message>
+        <source>Partially Signed Transaction (Binary)</source>
+        <extracomment>Expanded name of the binary PSBT file format. See: BIP 174.</extracomment>
+        <translation type="unfinished">Delvist underskrevet transaktion (Binær)</translation>
     </message>
     <message>
         <source>PSBT saved to disk.</source>
@@ -2099,6 +2598,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Transaktion mangler stadig signatur(er).</translation>
     </message>
     <message>
+        <source>(But no wallet is loaded.)</source>
+        <translation type="unfinished">(Men ingen tegnebog er indlæst.)</translation>
+    </message>
+    <message>
         <source>(But this wallet cannot sign transactions.)</source>
         <translation type="unfinished">(Men denne tegnebog kan ikke signere transaktioner.)</translation>
     </message>
@@ -2132,6 +2635,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>'bitcoin://' is not a valid URI. Use 'bitcoin:' instead.</source>
         <translation type="unfinished">'bitcoin://' er ikke et gyldigt URI. Brug 'bitcoin:' istedet.</translation>
+    </message>
+    <message>
+        <source>Cannot process payment request because BIP70 is not supported.
+Due to widespread security flaws in BIP70 it's strongly recommended that any merchant instructions to switch wallets be ignored.
+If you are receiving this error you should request the merchant provide a BIP21 compatible URI.</source>
+        <translation type="unfinished">Kan ikke behandle betalingsanmodning, fordi BIP70 ikke understøttes.
+På grund af udbredte sikkerhedsfejl i BIP70 anbefales det på det kraftigste, at enhver købmands instruktioner om at skifte tegnebog ignoreres.
+Hvis du modtager denne fejl, skal du anmode forhandleren om en BIP21-kompatibel URI.</translation>
     </message>
     <message>
         <source>URI cannot be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
@@ -2325,12 +2836,36 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Synkroniserede blokke</translation>
     </message>
     <message>
+        <source>Last Transaction</source>
+        <translation type="unfinished">Sidste transaktion</translation>
+    </message>
+    <message>
         <source>The mapped Autonomous System used for diversifying peer selection.</source>
         <translation type="unfinished">Afbildning fra Autonome Systemer (et Internet-Protocol-rutefindingsprefiks) til IP-adresser som bruges til at diversificere knudeforbindelser. Den engelske betegnelse er "asmap".</translation>
     </message>
     <message>
         <source>Mapped AS</source>
         <translation type="unfinished">Autonomt-System-afbildning</translation>
+    </message>
+    <message>
+        <source>Whether we relay addresses to this peer.</source>
+        <extracomment>Tooltip text for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
+        <translation type="unfinished">Om vi videresender adresser til denne peer.</translation>
+    </message>
+    <message>
+        <source>Address Relay</source>
+        <extracomment>Text title for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
+        <translation type="unfinished">Adresserelæ</translation>
+    </message>
+    <message>
+        <source>Addresses Processed</source>
+        <extracomment>Text title for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
+        <translation type="unfinished">Adresser Behandlet</translation>
+    </message>
+    <message>
+        <source>Addresses Rate-Limited</source>
+        <extracomment>Text title for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
+        <translation type="unfinished">Adresser Hastighedsbegrænset</translation>
     </message>
     <message>
         <source>User Agent</source>
@@ -2361,16 +2896,53 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Tilladelser</translation>
     </message>
     <message>
+        <source>The direction and type of peer connection: %1</source>
+        <translation type="unfinished">Retningen og typen af peer-forbindelse: %1</translation>
+    </message>
+    <message>
+        <source>Direction/Type</source>
+        <translation type="unfinished">Retning/Type</translation>
+    </message>
+    <message>
+        <source>The network protocol this peer is connected through: IPv4, IPv6, Onion, I2P, or CJDNS.</source>
+        <translation type="unfinished">Netværksprotokollen, som denne peer er forbundet via: IPv4, IPv6, Onion, I2P eller CJDNS.</translation>
+    </message>
+    <message>
         <source>Services</source>
         <translation type="unfinished">Tjenester</translation>
+    </message>
+    <message>
+        <source>Whether the peer requested us to relay transactions.</source>
+        <translation type="unfinished">Om peeren anmodede os om at videresende transaktioner.</translation>
+    </message>
+    <message>
+        <source>Wants Tx Relay</source>
+        <translation type="unfinished">Vil have transaktion videresend</translation>
+    </message>
+    <message>
+        <source>High bandwidth BIP152 compact block relay: %1</source>
+        <translation type="unfinished">BIP152 kompakt blokrelæ med høj bredbånd: %1</translation>
+    </message>
+    <message>
+        <source>High Bandwidth</source>
+        <translation type="unfinished">Højt Bredbånd</translation>
     </message>
     <message>
         <source>Connection Time</source>
         <translation type="unfinished">Forbindelsestid</translation>
     </message>
     <message>
+        <source>Elapsed time since a novel block passing initial validity checks was received from this peer.</source>
+        <translation type="unfinished">Forløbet tid siden en ny blok, der bestod indledende gyldighedstjek, blev modtaget fra denne peer.</translation>
+    </message>
+    <message>
         <source>Last Block</source>
         <translation type="unfinished">Sidste Blok</translation>
+    </message>
+    <message>
+        <source>Elapsed time since a novel transaction accepted into our mempool was received from this peer.</source>
+        <extracomment>Tooltip text for the Last Transaction field in the peer details area.</extracomment>
+        <translation type="unfinished">Forløbet tid siden en ny transaktion, der blev accepteret i vores mempool, blev modtaget fra denne peer.</translation>
     </message>
     <message>
         <source>Last Send</source>
@@ -2437,6 +3009,53 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Udgående:</translation>
     </message>
     <message>
+        <source>Inbound: initiated by peer</source>
+        <extracomment>Explanatory text for an inbound peer connection.</extracomment>
+        <translation type="unfinished">Indgående: initieret af peer</translation>
+    </message>
+    <message>
+        <source>Outbound Full Relay: default</source>
+        <extracomment>Explanatory text for an outbound peer connection that relays all network information. This is the default behavior for outbound connections.</extracomment>
+        <translation type="unfinished">Udgående fuld relæ: standard</translation>
+    </message>
+    <message>
+        <source>Outbound Block Relay: does not relay transactions or addresses</source>
+        <extracomment>Explanatory text for an outbound peer connection that relays network information about blocks and not transactions or addresses.</extracomment>
+        <translation type="unfinished">Udgående blokrelæ: videresender ikke transaktioner eller adresser</translation>
+    </message>
+    <message>
+        <source>Outbound Manual: added using RPC %1 or %2/%3 configuration options</source>
+        <extracomment>Explanatory text for an outbound peer connection that was established manually through one of several methods. The numbered arguments are stand-ins for the methods available to establish manual connections.</extracomment>
+        <translation type="unfinished">Udgående manual: tilføjet ved hjælp af RPC %1 eller %2/%3 konfigurationsmuligheder</translation>
+    </message>
+    <message>
+        <source>Outbound Feeler: short-lived, for testing addresses</source>
+        <extracomment>Explanatory text for a short-lived outbound peer connection that is used to test the aliveness of known addresses.</extracomment>
+        <translation type="unfinished">Udgående fejl: kortvarig, til test af adresser</translation>
+    </message>
+    <message>
+        <source>Outbound Address Fetch: short-lived, for soliciting addresses</source>
+        <extracomment>Explanatory text for a short-lived outbound peer connection that is used to request addresses from a peer.</extracomment>
+        <translation type="unfinished">Udgående adressehentning: kortvarig, til at anmode om adresser</translation>
+    </message>
+    <message>
+        <source>we selected the peer for high bandwidth relay</source>
+        <translation type="unfinished">vi valgte denne peer for høj bredbånd relæ</translation>
+    </message>
+    <message>
+        <source>the peer selected us for high bandwidth relay</source>
+        <translation type="unfinished">peeren valgte os til høj bredbånd relæ</translation>
+    </message>
+    <message>
+        <source>no high bandwidth relay selected</source>
+        <translation type="unfinished">ingen høj bredbånd relæ valgt</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <extracomment>Context menu action to copy the address of a peer.</extracomment>
+        <translation type="unfinished">&amp;Kopiér adresse</translation>
+    </message>
+    <message>
         <source>&amp;Disconnect</source>
         <translation type="unfinished">&amp;Afbryd forbindelse</translation>
     </message>
@@ -2445,12 +3064,21 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">1 &amp;time</translation>
     </message>
     <message>
+        <source>1 d&amp;ay</source>
+        <translation type="unfinished">1 &amp;dag</translation>
+    </message>
+    <message>
         <source>1 &amp;week</source>
         <translation type="unfinished">1 &amp;uge</translation>
     </message>
     <message>
         <source>1 &amp;year</source>
         <translation type="unfinished">1 &amp;år</translation>
+    </message>
+    <message>
+        <source>&amp;Copy IP/Netmask</source>
+        <extracomment>Context menu action to copy the IP/Netmask of a banned peer. IP/Netmask is the combination of a peer's IP address and its Netmask. For IP address, see: https://en.wikipedia.org/wiki/IP_address.</extracomment>
+        <translation type="unfinished">&amp;Kopiér IP/Netmask</translation>
     </message>
     <message>
         <source>&amp;Unban</source>
@@ -2467,6 +3095,28 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Executing command using "%1" wallet</source>
         <translation type="unfinished">Eksekverer kommando ved brug af "%1" tegnebog</translation>
+    </message>
+    <message>
+        <source>Welcome to the %1 RPC console.
+Use up and down arrows to navigate history, and %2 to clear screen.
+Use %3 and %4 to increase or decrease the font size.
+Type %5 for an overview of available commands.
+For more information on using this console, type %6.
+
+%7WARNING: Scammers have been active, telling users to type commands here, stealing their wallet contents. Do not use this console without fully understanding the ramifications of a command.%8</source>
+        <extracomment>RPC console welcome message. Placeholders %7 and %8 are style tags for the warning content, and they are not space separated from the rest of the text intentionally.</extracomment>
+        <translation type="unfinished">Velkommen til %1 RPC-konsollen.
+Brug op- og nedpilene til at navigere i historikken og %2 til at rydde skærmen.
+Brug %3 og %4 til at øge eller formindske skriftstørrelsen.
+Skriv %5 for at få en oversigt over tilgængelige kommandoer.
+For mere information om brug af denne konsol, skriv %6.
+
+%7 ADVARSEL: Svindlere har været aktive og bedt brugerne om at skrive kommandoer her og stjæle deres tegnebogsindhold. Brug ikke denne konsol uden fuldt ud at forstå konsekvenserne af en kommando.%8</translation>
+    </message>
+    <message>
+        <source>Executing…</source>
+        <extracomment>A console message indicating an entered command is currently being executed.</extracomment>
+        <translation type="unfinished">Udfører...</translation>
     </message>
     <message>
         <source>Yes</source>
@@ -2572,6 +3222,22 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Kopiér &amp;URI</translation>
     </message>
     <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Kopiér adresse</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Kopiér &amp;mærkat</translation>
+    </message>
+    <message>
+        <source>Copy &amp;message</source>
+        <translation type="unfinished">Kopiér &amp;besked</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Kopiér &amp;beløb</translation>
+    </message>
+    <message>
         <source>Could not unlock wallet.</source>
         <translation type="unfinished">Kunne ikke låse tegnebog op.</translation>
     </message>
@@ -2613,6 +3279,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Copy &amp;Address</source>
         <translation type="unfinished">Kopiér &amp;adresse</translation>
+    </message>
+    <message>
+        <source>&amp;Verify</source>
+        <translation type="unfinished">&amp;Bekræft</translation>
+    </message>
+    <message>
+        <source>Verify this address on e.g. a hardware wallet screen</source>
+        <translation type="unfinished">Bekræft denne adresse på f.eks. en hardwaretegnebogs skærm</translation>
     </message>
     <message>
         <source>&amp;Save Image…</source>
@@ -2765,12 +3439,24 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Skjul indstillinger for transaktionsgebyr</translation>
     </message>
     <message>
+        <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
+
+Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satoshis per kvB" for a transaction size of 500 virtual bytes (half of 1 kvB) would ultimately yield a fee of only 50 satoshis.</source>
+        <translation type="unfinished">Angiv et brugerdefineret gebyr pr. kB (1.000 bytes) af transaktionens virtuelle størrelse.
+
+Bemærk: Da gebyret beregnes på per-byte-basis, ville en gebyrsats på "100 satoshis pr. kvB" for en transaktionsstørrelse på 500 virtuelle bytes (halvdelen af 1 kvB) i sidste ende kun give et gebyr på 50 satoshis.</translation>
+    </message>
+    <message>
         <source>When there is less transaction volume than space in the blocks, miners as well as relaying nodes may enforce a minimum fee. Paying only this minimum fee is just fine, but be aware that this can result in a never confirming transaction once there is more demand for bitcoin transactions than the network can process.</source>
         <translation type="unfinished">På tidspunkter, hvor der er færre transaktioner, end der er plads til i nye blokke, kan minere og videresendende knuder gennemtvinge et minimumsgebyr. Du kan vælge kun at betale dette minimumsgebyr, men vær opmærksom på, at det kan resultere i en transaktion, der aldrig bliver bekræftet, hvis mængden af nye bitcoin-transaktioner stiger til mere, end hvad netværket kan behandle ad gangen.</translation>
     </message>
     <message>
         <source>A too low fee might result in a never confirming transaction (read the tooltip)</source>
         <translation type="unfinished">Et for lavt gebyr kan resultere i en transaktion, der aldrig bekræftes (læs værktøjstippet)</translation>
+    </message>
+    <message>
+        <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
+        <translation type="unfinished">(Smart gebyr er ikke initialiseret endnu. Dette tager normalt et par blokke...)</translation>
     </message>
     <message>
         <source>Confirmation time target:</source>
@@ -2833,6 +3519,20 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">%1 (%2 blokke)</translation>
     </message>
     <message>
+        <source>Sign on device</source>
+        <extracomment>"device" usually means a hardware wallet.</extracomment>
+        <translation type="unfinished">Underskriv på enhed</translation>
+    </message>
+    <message>
+        <source>Connect your hardware wallet first.</source>
+        <translation type="unfinished">Tilslut din hardwaretegnebog først.</translation>
+    </message>
+    <message>
+        <source>Set external signer script path in Options -&gt; Wallet</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Indstil ekstern underskriver scriptsti i Indstillinger -&gt; Tegnebog</translation>
+    </message>
+    <message>
         <source>Cr&amp;eate Unsigned</source>
         <translation type="unfinished">L&amp;av usigneret</translation>
     </message>
@@ -2849,12 +3549,39 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">%1 til %2</translation>
     </message>
     <message>
+        <source>To review recipient list click "Show Details…"</source>
+        <translation type="unfinished">For at vurdere modtager listen tryk "Vis Detaljer..."</translation>
+    </message>
+    <message>
+        <source>Sign failed</source>
+        <translation type="unfinished">Underskrivningen fejlede</translation>
+    </message>
+    <message>
+        <source>External signer not found</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Ekstern underskriver ikke fundet</translation>
+    </message>
+    <message>
+        <source>External signer failure</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Ekstern underskriver fejl</translation>
+    </message>
+    <message>
         <source>Save Transaction Data</source>
         <translation type="unfinished">Gem Transaktionsdata</translation>
     </message>
     <message>
+        <source>Partially Signed Transaction (Binary)</source>
+        <extracomment>Expanded name of the binary PSBT file format. See: BIP 174.</extracomment>
+        <translation type="unfinished">Delvist underskrevet transaktion (Binær)</translation>
+    </message>
+    <message>
         <source>PSBT saved</source>
         <translation type="unfinished">PSBT gemt</translation>
+    </message>
+    <message>
+        <source>External balance:</source>
+        <translation type="unfinished">Ekstern balance:</translation>
     </message>
     <message>
         <source>or</source>
@@ -2868,6 +3595,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Please, review your transaction proposal. This will produce a Partially Signed Bitcoin Transaction (PSBT) which you can save or copy and then sign with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
         <extracomment>Text to inform a user attempting to create a transaction of their current options. At this stage, a user can only create a PSBT. This string is displayed when private keys are disabled and an external signer is not available.</extracomment>
         <translation type="unfinished">Gennemse venligst dit transaktionsforslag. Dette vil producere en Partvist Signeret Bitcoin Transaktion (PSBT), som du kan gemme eller kopiere, og så signere med f.eks. en offline %1 pung, eller en PSBT-kompatibel maskinelpung.</translation>
+    </message>
+    <message>
+        <source>Do you want to create this transaction?</source>
+        <extracomment>Message displayed when attempting to create a transaction. Cautionary text to prompt the user to verify that the displayed transaction details represent the transaction the user intends to create.</extracomment>
+        <translation type="unfinished">Vil du oprette denne transaktion?</translation>
+    </message>
+    <message>
+        <source>Please, review your transaction. You can create and send this transaction or create a Partially Signed Bitcoin Transaction (PSBT), which you can save or copy and then sign with, e.g., an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
+        <extracomment>Text to inform a user attempting to create a transaction of their current options. At this stage, a user can send their transaction or create a PSBT. This string is displayed when both private keys and PSBT controls are enabled.</extracomment>
+        <translation type="unfinished">Gennemgå venligst din transaktion. Du kan oprette og sende denne transaktion eller oprette en delvist underskrevet Bitcoin-transaktion (PSBT), som du kan gemme eller kopiere og derefter underskrive med, f.eks. en offline %1 tegnebog eller en PSBT-kompatibel hardwaretegnebog.</translation>
     </message>
     <message>
         <source>Please, review your transaction.</source>
@@ -2922,15 +3659,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>A fee higher than %1 is considered an absurdly high fee.</source>
         <translation type="unfinished">Et gebyr højere end %1 opfattes som et absurd højt gebyr.</translation>
     </message>
-    <message>
-        <source>Payment request expired.</source>
-        <translation type="unfinished">Betalingsanmodning er udløbet.</translation>
-    </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>Anslået at begynde bekræftelse inden for %n blok(e).</numerusform>
+            <numerusform>Anslået at begynde bekræftelse inden for %n blok(e).</numerusform>
         </translation>
     </message>
     <message>
@@ -3005,14 +3738,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Besked:</translation>
     </message>
     <message>
-        <source>This is an unauthenticated payment request.</source>
-        <translation type="unfinished">Dette er en uautentificeret betalingsanmodning.</translation>
-    </message>
-    <message>
-        <source>This is an authenticated payment request.</source>
-        <translation type="unfinished">Dette er en autentificeret betalingsanmodning.</translation>
-    </message>
-    <message>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished">Indtast et mærkat for denne adresse for at føje den til listen over brugte adresser</translation>
     </message>
@@ -3020,11 +3745,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished">En besked, som blev føjet til “bitcoin:”-URI'en, som vil gemmes med transaktionen til din reference. Bemærk: Denne besked vil ikke blive sendt over Bitcoin-netværket.</translation>
     </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">Betal til:</translation>
-    </message>
-    </context>
+</context>
 <context>
     <name>SendConfirmationDialog</name>
     <message>
@@ -3185,35 +3906,31 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>(press q to shutdown and continue later)</source>
         <translation type="unfinished">(tast q for at lukke ned og fortsætte senere)</translation>
     </message>
-    </context>
+    <message>
+        <source>press q to shutdown</source>
+        <translation type="unfinished">tryk på q for at lukke</translation>
+    </message>
+</context>
 <context>
     <name>TransactionDesc</name>
     <message>
         <source>conflicted with a transaction with %1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that conflicts with a confirmed transaction.</extracomment>
         <translation type="unfinished">i konflikt med en transaktion, der har %1 bekræftelser</translation>
     </message>
     <message>
-        <source>0/unconfirmed, %1</source>
-        <translation type="unfinished">0/ubekræftet, %1</translation>
-    </message>
-    <message>
-        <source>in memory pool</source>
-        <translation type="unfinished">i hukommelsespulje</translation>
-    </message>
-    <message>
-        <source>not in memory pool</source>
-        <translation type="unfinished">ikke i hukommelsespulje</translation>
-    </message>
-    <message>
         <source>abandoned</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an abandoned transaction.</extracomment>
         <translation type="unfinished">opgivet</translation>
     </message>
     <message>
         <source>%1/unconfirmed</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
         <translation type="unfinished">%1/ubekræftet</translation>
     </message>
     <message>
         <source>%1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
         <translation type="unfinished">%1 bekræftelser</translation>
     </message>
     <message>
@@ -3259,8 +3976,8 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>modnes i yderligere %n blok(e)</numerusform>
+            <numerusform>modnes i yderligere %n blok(e)</numerusform>
         </translation>
     </message>
     <message>
@@ -3509,6 +4226,51 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Interval...</translation>
     </message>
     <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Kopiér adresse</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Kopiér &amp;mærkat</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Kopiér &amp;beløb</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">Kopiér transaktion &amp;ID</translation>
+    </message>
+    <message>
+        <source>Copy &amp;raw transaction</source>
+        <translation type="unfinished">Kopiér &amp;rå transaktion</translation>
+    </message>
+    <message>
+        <source>Copy full transaction &amp;details</source>
+        <translation type="unfinished">Kopiér alle transaktion &amp;oplysninger </translation>
+    </message>
+    <message>
+        <source>&amp;Show transaction details</source>
+        <translation type="unfinished">&amp;Vis transaktionsoplysninger</translation>
+    </message>
+    <message>
+        <source>Increase transaction &amp;fee</source>
+        <translation type="unfinished">Hæv transaktions &amp;gebyr</translation>
+    </message>
+    <message>
+        <source>A&amp;bandon transaction</source>
+        <translation type="unfinished">&amp;Opgiv transaction</translation>
+    </message>
+    <message>
+        <source>&amp;Edit address label</source>
+        <translation type="unfinished">&amp;Rediger adresseetiket</translation>
+    </message>
+    <message>
+        <source>Show in %1</source>
+        <extracomment>Transactions table context menu action to show the selected transaction in a third-party block explorer. %1 is a stand-in argument for the URL of the explorer.</extracomment>
+        <translation type="unfinished">Vis på %1</translation>
+    </message>
+    <message>
         <source>Export Transaction History</source>
         <translation type="unfinished">Eksportér transaktionshistorik</translation>
     </message>
@@ -3633,6 +4395,10 @@ Gå til Fil &gt; Åbn Pung for, at indlæse en pung.
         <translation type="unfinished">Nyt gebyr:</translation>
     </message>
     <message>
+        <source>Warning: This may pay the additional fee by reducing change outputs or adding inputs, when necessary. It may add a new change output if one does not already exist. These changes may potentially leak privacy.</source>
+        <translation type="unfinished">Advarsel: Dette kan betale det ekstra gebyr ved at reducere byttepengesoutputs eller tilføje inputs, når det er nødvendigt. Det kan tilføje et nyt byttepengesoutput, hvis et ikke allerede eksisterer. Disse ændringer kan potentielt lække privatlivets fred.</translation>
+    </message>
+    <message>
         <source>Confirm fee bump</source>
         <translation type="unfinished">Bekræft gebyrforøgelse</translation>
     </message>
@@ -3651,6 +4417,10 @@ Gå til Fil &gt; Åbn Pung for, at indlæse en pung.
     <message>
         <source>Could not commit transaction</source>
         <translation type="unfinished">Kunne ikke gennemføre transaktionen</translation>
+    </message>
+    <message>
+        <source>Can't display address</source>
+        <translation type="unfinished">Adressen kan ikke vises</translation>
     </message>
     <message>
         <source>default wallet</source>

--- a/src/qt/locale/bitcoin_el.ts
+++ b/src/qt/locale/bitcoin_el.ts
@@ -242,6 +242,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>BitcoinApplication</name>
     <message>
+        <source>Settings file %1 might be corrupt or invalid.</source>
+        <translation type="unfinished">Το αρχείο Ρυθμίσεων %1 ενδέχεται να είναι κατεστραμμένο ή μη έγκυρο.</translation>
+    </message>
+    <message>
         <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
         <translation type="unfinished">Συνέβη ενα μοιραίο σφάλμα. %1 δε μπορεί να συνεχιστεί με ασφάλεια και θα σταματήσει</translation>
     </message>
@@ -326,6 +330,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Manual</source>
         <extracomment>Peer connection type established manually through one of several methods.</extracomment>
         <translation type="unfinished">Χειροκίνητα</translation>
+    </message>
+    <message>
+        <source>Address Fetch</source>
+        <extracomment>Short-lived peer connection type that solicits known addresses from a peer.</extracomment>
+        <translation type="unfinished">Λήψη Διεύθυνσης</translation>
     </message>
     <message>
         <source>None</source>
@@ -429,10 +438,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Σφάλμα: Η έκδοση του αρχείου dump δεν υποστηρίζεται. Αυτή η έκδοση του bitcoin-wallet υποστηρίζει αρχεία dump μόνο της έκδοσης 1. Δόθηκε αρχείο dump έκδοσης %s.</translation>
     </message>
     <message>
-        <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
-        <translation type="unfinished">Σφάλμα: Η ακρόαση για εισερχόμενες συνδέσεις απέτυχε (ακούστε επιστραμμένο σφάλμα %s)</translation>
-    </message>
-    <message>
         <source>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.</source>
         <translation type="unfinished">Η αποτίμηση του τέλους απέτυχε. Το Fallbackfee είναι απενεργοποιημένο. Περιμένετε λίγα τετράγωνα ή ενεργοποιήστε το -fallbackfee.</translation>
     </message>
@@ -471,6 +476,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of pruned node)</source>
         <translation type="unfinished">Κλάδεμα: ο τελευταίος συγχρονισμός πορτοφολιού ξεπερνά τα κλαδεμένα δεδομένα. Πρέπει να κάνετε -reindex (κατεβάστε ολόκληρο το blockchain και πάλι σε περίπτωση κλαδέματος κόμβου)</translation>
+    </message>
+    <message>
+        <source>SQLiteDatabase: Unknown sqlite wallet schema version %d. Only version %d is supported</source>
+        <translation type="unfinished">SQLiteDatabase: Άγνωστη sqlite έκδοση %d του schema πορτοφολιού . Υποστηρίζεται μόνο η έκδοση %d.</translation>
     </message>
     <message>
         <source>The block database contains a block which appears to be from the future. This may be due to your computer's date and time being set incorrectly. Only rebuild the block database if you are sure that your computer's date and time are correct</source>
@@ -601,10 +610,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Σφάλμα ανάγνωσης από τη βάση δεδομένων, εκτελείται τερματισμός.</translation>
     </message>
     <message>
-        <source>Error upgrading chainstate database</source>
-        <translation type="unfinished">Σφάλμα κατά την αναβάθμιση της βάσης δεδομένων chainstate</translation>
-    </message>
-    <message>
         <source>Error: Disk space is low for %s</source>
         <translation type="unfinished">Σφάλμα: Ο χώρος στο δίσκο είναι χαμηλός για %s</translation>
     </message>
@@ -705,8 +710,8 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Πρέπει να καθορίσετε μια θύρα με -whitebind: '%s'</translation>
     </message>
     <message>
-        <source>No proxy server specified. Use -proxy=&lt;ip&gt; or -proxy=&lt;ip:port&gt;.</source>
-        <translation type="unfinished">Δεν ορίστηκε διακομιστής μεσολάβησης. Χρησιμοποιήστε -proxy=&lt;ip&gt; ή -proxy=&lt;ip:port&gt;.</translation>
+        <source>No addresses available</source>
+        <translation type="unfinished">Καμμία διαθέσιμη διεύθυνση</translation>
     </message>
     <message>
         <source>Not enough file descriptors available.</source>
@@ -727,6 +732,18 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Rescanning…</source>
         <translation type="unfinished">Σάρωση εκ νέου...</translation>
+    </message>
+    <message>
+        <source>SQLiteDatabase: Failed to execute statement to verify database: %s</source>
+        <translation type="unfinished">SQLite βάση δεδομένων: Απέτυχε η εκτέλεση της δήλωσης για την επαλήθευση της βάσης δεδομένων: %s</translation>
+    </message>
+    <message>
+        <source>SQLiteDatabase: Failed to prepare statement to verify database: %s</source>
+        <translation type="unfinished">SQLite βάση δεδομένων: Απέτυχε η προετοιμασία της δήλωσης για την επαλήθευση της βάσης δεδομένων: %s</translation>
+    </message>
+    <message>
+        <source>SQLiteDatabase: Failed to read database verification error: %s</source>
+        <translation type="unfinished">SQLite βάση δεδομένων: Απέτυχε η ανάγνωση της επαλήθευσης του σφάλματος της βάσης δεδομένων: %s</translation>
     </message>
     <message>
         <source>SQLiteDatabase: Unexpected application id. Expected %u, got %u</source>
@@ -755,6 +772,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Specified blocks directory "%s" does not exist.</source>
         <translation type="unfinished">Δεν υπάρχει κατάλογος καθορισμένων μπλοκ "%s".</translation>
+    </message>
+    <message>
+        <source>Starting network threads…</source>
+        <translation type="unfinished">Εκκίνηση των threads δικτύου...</translation>
     </message>
     <message>
         <source>The source code is available from %s.</source>
@@ -845,16 +866,20 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Έχει οριστεί άγνωστo δίκτυο στο -onlynet: '%s'</translation>
     </message>
     <message>
+        <source>Unknown new rules activated (versionbit %i)</source>
+        <translation type="unfinished">Ενεργοποιήθηκαν άγνωστοι νέοι κανόνες (bit έκδοσης %i)</translation>
+    </message>
+    <message>
         <source>Unsupported logging category %s=%s.</source>
         <translation type="unfinished">Μη υποστηριζόμενη κατηγορία καταγραφής %s=%s.</translation>
     </message>
     <message>
-        <source>Upgrading UTXO database</source>
-        <translation type="unfinished">Αναβάθμιση της βάσης δεδομένων UTXO</translation>
-    </message>
-    <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
         <translation type="unfinished">Το σχόλιο του παράγοντα χρήστη (%s) περιέχει μη ασφαλείς χαρακτήρες.</translation>
+    </message>
+    <message>
+        <source>Verifying blocks…</source>
+        <translation type="unfinished">Επαλήθευση των blocks…</translation>
     </message>
     <message>
         <source>Verifying wallet(s)…</source>
@@ -986,7 +1011,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
-        <translation type="unfinished">Ελέγξτε τα μηνύματα για να βεβαιωθείτε ότι υπογράφηκαν με τις καθορισμένες διευθύνσεις Bitcoin</translation>
+        <translation type="unfinished">Υπογράψτε ένα μήνυμα για ν' αποδείξετε πως ανήκει μια συγκεκριμένη διεύθυνση Bitcoin</translation>
     </message>
     <message>
         <source>&amp;Load PSBT from file…</source>
@@ -1067,8 +1092,8 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>Επεξεργάστηκε %n των μπλοκ του ιστορικού συναλλαγών.</numerusform>
+            <numerusform>Επεξεργάσθηκαν %n μπλοκ του ιστορικού συναλλαγών.</numerusform>
         </translation>
     </message>
     <message>
@@ -1148,6 +1173,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Κλείσιμο πορτοφολιού</translation>
     </message>
     <message>
+        <source>Restore Wallet…</source>
+        <extracomment>Name of the menu item that restores wallet from a backup file.</extracomment>
+        <translation type="unfinished">Επαναφορά Πορτοφολιού...</translation>
+    </message>
+    <message>
+        <source>Restore a wallet from a backup file</source>
+        <extracomment>Status tip for Restore Wallet menu item</extracomment>
+        <translation type="unfinished">Επαναφορά ενός πορτοφολιού από ένα αρχείο αντίγραφου ασφαλείας</translation>
+    </message>
+    <message>
         <source>Close all wallets</source>
         <translation type="unfinished">Κλείσιμο όλων των πορτοφολιών</translation>
     </message>
@@ -1172,6 +1207,26 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Κανένα πορτοφόλι διαθέσιμο</translation>
     </message>
     <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">Δεδομένα πορτοφολιού</translation>
+    </message>
+    <message>
+        <source>Load Wallet Backup</source>
+        <extracomment>The title for Restore Wallet File Windows</extracomment>
+        <translation type="unfinished">Φόρτωση Αντίγραφου Ασφαλείας Πορτοφολιού</translation>
+    </message>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of pop-up window shown when the user is attempting to restore a wallet.</extracomment>
+        <translation type="unfinished">Επαναφορά Πορτοφολιού</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">Όνομα Πορτοφολιού</translation>
+    </message>
+    <message>
         <source>&amp;Window</source>
         <translation type="unfinished">&amp;Παράθυρο</translation>
     </message>
@@ -1187,12 +1242,20 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>%1 client</source>
         <translation type="unfinished">%1 πελάτης</translation>
     </message>
+    <message>
+        <source>&amp;Hide</source>
+        <translation type="unfinished">$Απόκρυψη</translation>
+    </message>
+    <message>
+        <source>S&amp;how</source>
+        <translation type="unfinished">Ε&amp;μφάνιση</translation>
+    </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>1%n  ενεργές συνδέσεις στο δίκτυο Bitcoin.</numerusform>
+            <numerusform>%n ενεργές συνδέσεις στο δίκτυο Bitcoin.</numerusform>
         </translation>
     </message>
     <message>
@@ -1390,6 +1453,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">L&amp;ock διαθέσιμο</translation>
     </message>
     <message>
+        <source>&amp;Unlock unspent</source>
+        <translation type="unfinished">&amp;Ξεκλείδωμα διαθέσιμου υπολοίπου</translation>
+    </message>
+    <message>
         <source>Copy quantity</source>
         <translation type="unfinished">Αντιγραφή ποσότητας</translation>
     </message>
@@ -1470,7 +1537,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Can't list signers</source>
         <translation type="unfinished">Αδυναμία απαρίθμησης εγγεγραμμένων </translation>
     </message>
-</context>
+    </context>
 <context>
     <name>LoadWalletsActivity</name>
     <message>
@@ -1507,6 +1574,34 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
         <extracomment>Descriptive text of the open wallet progress window which indicates to the user which wallet is currently being opened.</extracomment>
         <translation type="unfinished">Άνοιγμα πορτοφολιού &lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+</context>
+<context>
+    <name>RestoreWalletActivity</name>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of progress window which is displayed when wallets are being restored.</extracomment>
+        <translation type="unfinished">Επαναφορά Πορτοφολιού</translation>
+    </message>
+    <message>
+        <source>Restoring Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the restore wallets progress window which indicates to the user that wallets are currently being restored.</extracomment>
+        <translation type="unfinished">Επαναφορά Πορτοφολιού &lt;b&gt; %1 &lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Restore wallet failed</source>
+        <extracomment>Title of message box which is displayed when the wallet could not be restored.</extracomment>
+        <translation type="unfinished">Αποτυχία επαναφοράς πορτοφολιού</translation>
+    </message>
+    <message>
+        <source>Restore wallet warning</source>
+        <extracomment>Title of message box which is displayed when the wallet is restored with some warning.</extracomment>
+        <translation type="unfinished">Προειδοποίηση επαναφοράς πορτοφολιού</translation>
+    </message>
+    <message>
+        <source>Restore wallet message</source>
+        <extracomment>Title of message box which is displayed when the wallet is successfully restored.</extracomment>
+        <translation type="unfinished">Μύνημα επαναφοράς πορτοφολιού</translation>
     </message>
 </context>
 <context>
@@ -1583,6 +1678,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Πορτοφόλι Περιγραφέα </translation>
     </message>
     <message>
+        <source>Use an external signing device such as a hardware wallet. Configure the external signer script in wallet preferences first.</source>
+        <translation type="unfinished">Χρησιμοποιήστε μια εξωτερική συσκευή υπογραφής, όπως ένα πορτοφόλι υλικού. Ρυθμίστε πρώτα στις προτιμήσεις του πορτοφολιού το εξωτερικό script υπογραφής.</translation>
+    </message>
+    <message>
         <source>External signer</source>
         <translation type="unfinished">Εξωτερικός υπογράφων</translation>
     </message>
@@ -1594,7 +1693,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Compiled without sqlite support (required for descriptor wallets)</source>
         <translation type="unfinished">Μεταγλωτίστηκε χωρίς την υποστήριξη sqlite (απαραίτητη για περιγραφικά πορτοφόλια )</translation>
     </message>
-    </context>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Συντάχθηκε χωρίς την υποστήριξη εξωτερικής υπογραφής (απαιτείται για εξωτερική υπογραφή)</translation>
+    </message>
+</context>
 <context>
     <name>EditAddressDialog</name>
     <message>
@@ -1675,13 +1779,26 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 </context>
 <context>
     <name>Intro</name>
-    <message>
-        <source>(of %1 GB needed)</source>
-        <translation type="unfinished">(από τα %1 GB που απαιτούνται)</translation>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
     </message>
-    <message>
-        <source>(%1 GB needed for full chain)</source>
-        <translation type="unfinished">(%1 GB απαιτούνται για την πλήρη αλυσίδα)</translation>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform>(από το %n GB που απαιτείται)</numerusform>
+            <numerusform>(από τα %n GB που απαιτούνται)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform>(%n GB απαιτούνται για την πλήρη αλυσίδα)</numerusform>
+            <numerusform>(%n GB απαιτούνται για την πλήρη αλυσίδα)</numerusform>
+        </translation>
     </message>
     <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
@@ -1722,10 +1839,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Welcome to %1.</source>
         <translation type="unfinished">Καλωσήρθες στο %1.</translation>
-    </message>
-    <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation type="unfinished">Όταν κάνετε κλικ στο OK, το %1 θα ξεκινήσει τη λήψη και την επεξεργασία της πλήρους αλυσίδας μπλοκ% 4 (%2GB) αρχίζοντας από τις πρώτες συναλλαγές στο %3 όταν αρχικά ξεκίνησε το %4.</translation>
     </message>
     <message>
         <source>Limit block chain storage to</source>
@@ -1836,7 +1949,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Unknown. Syncing Headers (%1, %2%)…</source>
         <translation type="unfinished">Άγνωστο. Συγχρονισμός επικεφαλίδων (%1, %2%)...</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>OpenURIDialog</name>
     <message>
@@ -1868,6 +1981,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">&amp;Έναρξη %1 στο σύστημα σύνδεσης</translation>
     </message>
     <message>
+        <source>Enabling pruning significantly reduces the disk space required to store transactions. All blocks are still fully validated. Reverting this setting requires re-downloading the entire blockchain.</source>
+        <translation type="unfinished">Η ενεργοποίηση του κλαδέματος μειώνει τον απαιτούμενο χώρο για την αποθήκευση συναλλαγών. Όλα τα μπλόκ είναι πλήρως επαληθευμένα. Η επαναφορά αυτής της ρύθμισης απαιτεί επανεγκατάσταση ολόκληρου του blockchain.</translation>
+    </message>
+    <message>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished">Μέγεθος κρυφής μνήμης βάσης δεδομένων.</translation>
     </message>
@@ -1886,6 +2003,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
         <translation type="unfinished">Ελαχιστοποίηση αντί για έξοδο κατά το κλείσιμο του παραθύρου. Όταν αυτή η επιλογή είναι ενεργοποιημένη, η εφαρμογή θα κλείνει μόνο αν επιλεχθεί η Έξοδος στο μενού.</translation>
+    </message>
+    <message>
+        <source>Options set in this dialog are overridden by the command line:</source>
+        <translation type="unfinished">Οι επιλογές που έχουν οριστεί σε αυτό το παράθυρο διαλόγου παραβλέπονται από τη γραμμή εντολών</translation>
     </message>
     <message>
         <source>Open the %1 configuration file from the working directory.</source>
@@ -1924,8 +2045,18 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">(0 = αυτόματο, &lt;0 = ελεύθεροι πυρήνες)</translation>
     </message>
     <message>
+        <source>Enable R&amp;PC server</source>
+        <extracomment>An Options window setting to enable the RPC server.</extracomment>
+        <translation type="unfinished">Ενεργοποίηση R&amp;PC σέρβερ</translation>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished">Π&amp;ορτοφόλι</translation>
+    </message>
+    <message>
+        <source>Whether to set subtract fee from amount as default or not.</source>
+        <extracomment>Tooltip text for Options window setting that sets subtracting the fee from a sending amount as default.</extracomment>
+        <translation type="unfinished">Να τεθεί ο φόρος αφαίρεσης από το ποσό στην προκαθορισμένη τιμή ή οχι. </translation>
     </message>
     <message>
         <source>Expert</source>
@@ -1944,6 +2075,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">&amp;Ξόδεμα μη επικυρωμένων ρέστων</translation>
     </message>
     <message>
+        <source>External Signer (e.g. hardware wallet)</source>
+        <translation type="unfinished">Εξωτερική συσκευή υπογραφής (π.χ. πορτοφόλι υλικού)</translation>
+    </message>
+    <message>
         <source>Full path to a Bitcoin Core compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</source>
         <translation type="unfinished">Πλήρης διαδρομή ενός script συμβατού με το Bitcoin Core (π.χ.: C:\Downloads\hwi.exe ή /Users/you/Downloads/hwi.py). Προσοχή: το κακόβουλο λογισμικό μπορεί να κλέψει τα νομίσματά σας!</translation>
     </message>
@@ -1954,6 +2089,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Map port using &amp;UPnP</source>
         <translation type="unfinished">Απόδοση θυρών με χρήση &amp;UPnP</translation>
+    </message>
+    <message>
+        <source>Automatically open the Bitcoin client port on the router. This only works when your router supports NAT-PMP and it is enabled. The external port could be random.</source>
+        <translation type="unfinished">Ανοίξτε αυτόματα τη πόρτα του Bitcoin client στο router. Αυτό λειτουργεί μόνο όταν το router σας υποστηρίζει NAT-PMP και είναι ενεργοποιημένο. Η εξωτερική πόρτα μπορεί να είναι τυχαία.</translation>
     </message>
     <message>
         <source>Map port using NA&amp;T-PMP</source>
@@ -2052,8 +2191,8 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">ενσωματωμένο "%1"</translation>
     </message>
     <message>
-        <source>Options set in this dialog are overridden by the command line or in the configuration file:</source>
-        <translation type="unfinished">Οι επιλογές που έχουν οριστεί σε αυτό το παράθυρο διαλόγου παραβλέπονται από τη γραμμή εντολών ή από το αρχείο διαμόρφωσης:</translation>
+        <source>closest matching "%1"</source>
+        <translation type="unfinished">πλησιέστερη αντιστοίχιση "%1"</translation>
     </message>
     <message>
         <source>&amp;OK</source>
@@ -2062,6 +2201,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>&amp;Cancel</source>
         <translation type="unfinished">&amp;Ακύρωση</translation>
+    </message>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Συντάχθηκε χωρίς την υποστήριξη εξωτερικής υπογραφής (απαιτείται για εξωτερική υπογραφή)</translation>
     </message>
     <message>
         <source>default</source>
@@ -2073,14 +2217,17 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Confirm options reset</source>
+        <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
         <translation type="unfinished">Επιβεβαίωση επαναφοράς επιλογών</translation>
     </message>
     <message>
         <source>Client restart required to activate changes.</source>
+        <extracomment>Text explaining that the settings changed will not come into effect until the client is restarted.</extracomment>
         <translation type="unfinished">Χρειάζεται επανεκκίνηση του προγράμματος για να ενεργοποιηθούν οι αλλαγές.</translation>
     </message>
     <message>
         <source>Client will be shut down. Do you want to proceed?</source>
+        <extracomment>Text asking the user to confirm if they would like to proceed with a client shutdown.</extracomment>
         <translation type="unfinished">Ο πελάτης θα τερματιστεί. Θέλετε να συνεχίσετε?</translation>
     </message>
     <message>
@@ -2093,6 +2240,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>The configuration file is used to specify advanced user options which override GUI settings. Additionally, any command-line options will override this configuration file.</source>
         <extracomment>Explanatory text about the priority order of instructions considered by client. The order from high to low being: command-line, configuration file, GUI settings.</extracomment>
         <translation type="unfinished">Το αρχείο ρυθμίσεων χρησιμοποιείται για τον προσδιορισμό των προχωρημένων επιλογών χρηστών που παρακάμπτουν τις ρυθμίσεις GUI. Επιπλέον, όλες οι επιλογές γραμμής εντολών θα αντικαταστήσουν αυτό το αρχείο ρυθμίσεων.</translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation type="unfinished">Συνεχίστε</translation>
     </message>
     <message>
         <source>Cancel</source>
@@ -2113,6 +2264,13 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>The supplied proxy address is invalid.</source>
         <translation type="unfinished">Δεν είναι έγκυρη η διεύθυνση διαμεσολαβητή</translation>
+    </message>
+</context>
+<context>
+    <name>OptionsModel</name>
+    <message>
+        <source>Could not read setting "%1", %2.</source>
+        <translation type="unfinished">Δεν μπορεί να διαβαστεί η ρύθμιση "%1", %2.</translation>
     </message>
 </context>
 <context>
@@ -2229,6 +2387,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Αποτυχία εκπλήρωσης συναλλαγής: %1</translation>
     </message>
     <message>
+        <source>Cannot sign inputs while wallet is locked.</source>
+        <translation type="unfinished">Αδύνατη η υπογραφή εισδοχών ενώ το πορτοφόλι είναι κλειδωμένο</translation>
+    </message>
+    <message>
         <source>Could not sign any more inputs.</source>
         <translation type="unfinished">Δεν είναι δυνατή η υπογραφή περισσότερων καταχωρήσεων.</translation>
     </message>
@@ -2303,6 +2465,10 @@ ID Συναλλαγής: %1</translation>
         <translation type="unfinished">Η συναλλαγή απαιτεί υπογραφή/ές</translation>
     </message>
     <message>
+        <source>(But no wallet is loaded.)</source>
+        <translation type="unfinished">(Δεν έχει γίνει φόρτωση πορτοφολιού)</translation>
+    </message>
+    <message>
         <source>(But this wallet cannot sign transactions.)</source>
         <translation type="unfinished">(Αλλά αυτό το πορτοφόλι δεν μπορεί να υπογράψει συναλλαγές.)</translation>
     </message>
@@ -2357,6 +2523,11 @@ ID Συναλλαγής: %1</translation>
         <source>Peer</source>
         <extracomment>Title of Peers Table column which contains a unique number used to identify a connection.</extracomment>
         <translation type="unfinished">Χρήστης</translation>
+    </message>
+    <message>
+        <source>Age</source>
+        <extracomment>Title of Peers Table column which indicates the duration (length of time) since the peer connection started.</extracomment>
+        <translation type="unfinished">Ηλικία</translation>
     </message>
     <message>
         <source>Direction</source>
@@ -2542,6 +2713,10 @@ ID Συναλλαγής: %1</translation>
         <translation type="unfinished">Συγχρονισμένα Μπλοκς</translation>
     </message>
     <message>
+        <source>Last Transaction</source>
+        <translation type="unfinished">Τελευταία Συναλλαγή</translation>
+    </message>
+    <message>
         <source>The mapped Autonomous System used for diversifying peer selection.</source>
         <translation type="unfinished">Το χαρτογραφημένο Αυτόνομο Σύστημα που χρησιμοποιείται για τη διαφοροποίηση της επιλογής ομοτίμων.</translation>
     </message>
@@ -2596,6 +2771,10 @@ ID Συναλλαγής: %1</translation>
     <message>
         <source>Connection Time</source>
         <translation type="unfinished">Χρόνος σύνδεσης</translation>
+    </message>
+    <message>
+        <source>Last Block</source>
+        <translation type="unfinished">Τελευταίο Block</translation>
     </message>
     <message>
         <source>Last Send</source>
@@ -2662,6 +2841,11 @@ ID Συναλλαγής: %1</translation>
         <translation type="unfinished">Εξερχόμενα:</translation>
     </message>
     <message>
+        <source>Inbound: initiated by peer</source>
+        <extracomment>Explanatory text for an inbound peer connection.</extracomment>
+        <translation type="unfinished">Εισερχόμενo: Ξεκίνησε από peer</translation>
+    </message>
+    <message>
         <source>the peer selected us for high bandwidth relay</source>
         <translation type="unfinished">ο ομότιμος μας επέλεξε για υψηλής ταχύτητας αναμετάδοση </translation>
     </message>
@@ -2687,6 +2871,11 @@ ID Συναλλαγής: %1</translation>
         <translation type="unfinished">1 &amp;χρόνος</translation>
     </message>
     <message>
+        <source>&amp;Copy IP/Netmask</source>
+        <extracomment>Context menu action to copy the IP/Netmask of a banned peer. IP/Netmask is the combination of a peer's IP address and its Netmask. For IP address, see: https://en.wikipedia.org/wiki/IP_address.</extracomment>
+        <translation type="unfinished">&amp;Αντιγραφή IP/Netmask</translation>
+    </message>
+    <message>
         <source>&amp;Unban</source>
         <translation type="unfinished">&amp;Ακύρωση Απαγόρευσης</translation>
     </message>
@@ -2697,6 +2886,10 @@ ID Συναλλαγής: %1</translation>
     <message>
         <source>Executing command without any wallet</source>
         <translation type="unfinished">Εκτέλεση εντολής χωρίς πορτοφόλι</translation>
+    </message>
+    <message>
+        <source>Ctrl+I</source>
+        <translation type="unfinished">Ctrl+Ι </translation>
     </message>
     <message>
         <source>Executing command using "%1" wallet</source>
@@ -3139,6 +3332,10 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
         <translation type="unfinished">%1 προς το %2</translation>
     </message>
     <message>
+        <source>To review recipient list click "Show Details…"</source>
+        <translation type="unfinished">Για να αναθεωρήσετε τη λίστα παραληπτών, κάντε κλικ στην επιλογή "Εμφάνιση λεπτομερειών..."</translation>
+    </message>
+    <message>
         <source>Sign failed</source>
         <translation type="unfinished">H εγγραφή απέτυχε</translation>
     </message>
@@ -3161,6 +3358,10 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
         <translation type="unfinished">Το PSBT αποθηκεύτηκε</translation>
     </message>
     <message>
+        <source>External balance:</source>
+        <translation type="unfinished">Εξωτερικό υπόλοιπο:</translation>
+    </message>
+    <message>
         <source>or</source>
         <translation type="unfinished">ή</translation>
     </message>
@@ -3172,6 +3373,11 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
         <source>Please, review your transaction proposal. This will produce a Partially Signed Bitcoin Transaction (PSBT) which you can save or copy and then sign with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
         <extracomment>Text to inform a user attempting to create a transaction of their current options. At this stage, a user can only create a PSBT. This string is displayed when private keys are disabled and an external signer is not available.</extracomment>
         <translation type="unfinished">Παρακαλούμε, ελέγξτε την πρόταση συναλλαγής. Θα παραχθεί μια συναλλαγή Bitcoin με μερική υπογραφή (PSBT), την οποία μπορείτε να αντιγράψετε και στη συνέχεια να υπογράψετε με π.χ. ένα πορτοφόλι %1 εκτός σύνδεσης ή ένα πορτοφόλι υλικού συμβατό με το PSBT.</translation>
+    </message>
+    <message>
+        <source>Do you want to create this transaction?</source>
+        <extracomment>Message displayed when attempting to create a transaction. Cautionary text to prompt the user to verify that the displayed transaction details represent the transaction the user intends to create.</extracomment>
+        <translation type="unfinished">Θέλετε να δημιουργήσετε αυτήν τη συναλλαγή;</translation>
     </message>
     <message>
         <source>Please, review your transaction.</source>
@@ -3226,10 +3432,6 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     <message>
         <source>A fee higher than %1 is considered an absurdly high fee.</source>
         <translation type="unfinished">Ένα τέλος υψηλότερο από το %1 θεωρείται ένα παράλογο υψηλό έξοδο.</translation>
-    </message>
-    <message>
-        <source>Payment request expired.</source>
-        <translation type="unfinished">Η αίτηση πληρωμής έληξε.</translation>
     </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
@@ -3306,28 +3508,12 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
         <translation type="unfinished">Μήνυμα:</translation>
     </message>
     <message>
-        <source>This is an unauthenticated payment request.</source>
-        <translation type="unfinished">Πρόκειται για αίτημα πληρωμής χωρίς έλεγχο ταυτότητας.</translation>
-    </message>
-    <message>
-        <source>This is an authenticated payment request.</source>
-        <translation type="unfinished">Πρόκειται για ένα πιστοποιημένο αίτημα πληρωμής.</translation>
-    </message>
-    <message>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished">Εισάγετε μία ετικέτα για αυτή την διεύθυνση για να προστεθεί στη λίστα με τις χρησιμοποιημένες διευθύνσεις</translation>
     </message>
     <message>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished">Ένα μήνυμα που επισυνάφθηκε στο bitcoin: URI το οποίο θα αποθηκευτεί με τη συναλλαγή για αναφορά. Σημείωση: Αυτό το μήνυμα δεν θα σταλεί μέσω του δικτύου Bitcoin.</translation>
-    </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">Πληρωμή σε:</translation>
-    </message>
-    <message>
-        <source>Memo:</source>
-        <translation type="unfinished">Σημείωση:</translation>
     </message>
 </context>
 <context>
@@ -3485,33 +3671,36 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     </message>
 </context>
 <context>
+    <name>SplashScreen</name>
+    <message>
+        <source>(press q to shutdown and continue later)</source>
+        <translation type="unfinished">(πατήστε q για κλείσιμο και συνεχίστε αργότερα)</translation>
+    </message>
+    <message>
+        <source>press q to shutdown</source>
+        <translation type="unfinished">πατήστε q για κλείσιμο</translation>
+    </message>
+</context>
+<context>
     <name>TransactionDesc</name>
     <message>
         <source>conflicted with a transaction with %1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that conflicts with a confirmed transaction.</extracomment>
         <translation type="unfinished">σε σύγκρουση με μια συναλλαγή με %1 επιβεβαιώσεις</translation>
     </message>
     <message>
-        <source>0/unconfirmed, %1</source>
-        <translation type="unfinished">0/ανεπιβεβαίωτο, %1</translation>
-    </message>
-    <message>
-        <source>in memory pool</source>
-        <translation type="unfinished">στην πισίνα μνήμης</translation>
-    </message>
-    <message>
-        <source>not in memory pool</source>
-        <translation type="unfinished">όχι στην πισίνα μνήμης</translation>
-    </message>
-    <message>
         <source>abandoned</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an abandoned transaction.</extracomment>
         <translation type="unfinished">εγκαταλελειμμένος</translation>
     </message>
     <message>
         <source>%1/unconfirmed</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
         <translation type="unfinished">%1/μη επιβεβαιωμένο</translation>
     </message>
     <message>
         <source>%1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
         <translation type="unfinished">%1 επιβεβαιώσεις</translation>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_en.ts
+++ b/src/qt/locale/bitcoin_en.ts
@@ -55,7 +55,7 @@
     </message>
     <message>
         <location line="-30"/>
-        <location filename="../addressbookpage.cpp" line="+128"/>
+        <location filename="../addressbookpage.cpp" line="+127"/>
         <source>&amp;Delete</source>
         <translation>&amp;Delete</translation>
     </message>
@@ -179,7 +179,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+51"/>
+        <location filename="../askpassphrasedialog.cpp" line="+49"/>
         <source>Encrypt wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -199,7 +199,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
+        <location line="+47"/>
         <source>Confirm wallet encryption</source>
         <translation type="unfinished"></translation>
     </message>
@@ -215,12 +215,12 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
     </message>
     <message>
         <location line="+18"/>
-        <location line="+44"/>
+        <location line="+55"/>
         <source>Wallet encrypted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-125"/>
+        <location line="-135"/>
         <source>Enter the new passphrase for the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -230,7 +230,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+55"/>
+        <location line="+54"/>
         <source>Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -257,41 +257,57 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
     <message>
         <location line="+6"/>
         <location line="+8"/>
-        <location line="+32"/>
-        <location line="+6"/>
+        <location line="+59"/>
         <source>Wallet encryption failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-45"/>
+        <location line="-66"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+8"/>
-        <location line="+38"/>
+        <location line="+59"/>
         <source>The supplied passphrases do not match.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-27"/>
-        <location line="+6"/>
+        <location line="-46"/>
+        <location line="+3"/>
+        <location line="+12"/>
         <source>Wallet unlock failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
-        <location line="+20"/>
+        <location line="-14"/>
+        <location line="+31"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-6"/>
+        <location line="-28"/>
+        <source>The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 25.0, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
+        <location line="+7"/>
+        <location line="+3"/>
+        <source>Passphrase change failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The old passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 25.0, please try again with only the characters up to — but not including — the first null character.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+45"/>
         <location line="+33"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation type="unfinished"></translation>
@@ -313,7 +329,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
 <context>
     <name>BitcoinApplication</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+288"/>
+        <location filename="../bitcoin.cpp" line="+283"/>
         <source>Settings file %1 might be corrupt or invalid.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -411,18 +427,18 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+393"/>
+        <location line="+395"/>
         <source>Network activity disabled.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+439"/>
+        <location line="+436"/>
         <source>Proxy is &lt;b&gt;enabled&lt;/b&gt;: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1160"/>
+        <location line="-1159"/>
         <source>Send coins to a Bitcoin address</source>
         <translation>Send coins to a Bitcoin address</translation>
     </message>
@@ -537,7 +553,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation>Tabs toolbar</translation>
     </message>
     <message>
-        <location line="+457"/>
+        <location line="+459"/>
         <source>Syncing Headers (%1%)…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -557,17 +573,12 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <source>Reindexing blocks on disk…</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+6"/>
+        <location line="+7"/>
         <source>Connecting to peers…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-833"/>
+        <location line="-832"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -587,7 +598,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location line="+749"/>
+        <location line="+748"/>
         <source>Processed %n block(s) of transaction history.</source>
         <translation>
             <numerusform>Processed %n block of transaction history.</numerusform>
@@ -635,7 +646,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation>Up to date</translation>
     </message>
     <message>
-        <location line="-818"/>
+        <location line="-817"/>
         <source>Ctrl+Q</source>
         <translation type="unfinished"></translation>
     </message>
@@ -781,7 +792,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+258"/>
+        <location line="+260"/>
         <source>%1 client</source>
         <translation type="unfinished"></translation>
     </message>
@@ -834,7 +845,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+152"/>
+        <location line="+149"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1266,7 +1277,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation>&amp;Address</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+29"/>
+        <location filename="../editaddressdialog.cpp" line="+27"/>
         <source>New sending address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1410,7 +1421,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation>Use a custom data directory:</translation>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+32"/>
+        <location filename="../intro.cpp" line="+30"/>
         <source>Bitcoin</source>
         <translation type="unfinished">Bitcoin</translation>
     </message>
@@ -1518,7 +1529,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
     <message>
         <location line="+7"/>
         <location line="+26"/>
-        <location filename="../modaloverlay.cpp" line="+155"/>
+        <location filename="../modaloverlay.cpp" line="+152"/>
         <source>Unknown…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1661,7 +1672,12 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+231"/>
+        <location line="+132"/>
+        <source>Full path to a %1 compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+99"/>
         <location line="+187"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished"></translation>
@@ -1817,12 +1833,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
-        <source>Full path to a Bitcoin Core compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+32"/>
+        <location line="+42"/>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</translation>
     </message>
@@ -2092,7 +2103,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
 <context>
     <name>OptionsModel</name>
     <message>
-        <location filename="../optionsmodel.cpp" line="+204"/>
+        <location filename="../optionsmodel.cpp" line="+198"/>
         <source>Could not read setting &quot;%1&quot;, %2.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2191,7 +2202,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+185"/>
+        <location filename="../overviewpage.cpp" line="+184"/>
         <source>Privacy mode activated for the Overview tab. To unmask the values, uncheck Settings-&gt;Mask values.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2363,7 +2374,7 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+152"/>
+        <location filename="../paymentserver.cpp" line="+149"/>
         <source>Payment request error</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2467,7 +2478,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <translation type="unfinished">Network</translation>
     </message>
     <message>
-        <location filename="../peertablemodel.cpp" line="+78"/>
+        <location filename="../peertablemodel.cpp" line="+77"/>
         <source>Inbound</source>
         <extracomment>An Inbound Connection from a Peer.</extracomment>
         <translation type="unfinished"></translation>
@@ -2497,7 +2508,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+256"/>
+        <location line="+257"/>
         <source>Unroutable</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2663,7 +2674,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="-294"/>
+        <location filename="../bitcoin.cpp" line="-288"/>
         <source>Do you want to reset settings to default values, or to abort without making changes?</source>
         <extracomment>Explanatory text shown on startup when the settings file cannot be read. Prompts user to make a choice between resetting or aborting.</extracomment>
         <translation type="unfinished"></translation>
@@ -2675,17 +2686,17 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+393"/>
+        <location line="+386"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+9"/>
         <source>Error: Cannot parse configuration file: %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
+        <location line="+14"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2908,7 +2919,17 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+124"/>
+        <location line="+72"/>
+        <source>Whether we relay transactions to this peer.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Transaction Relay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+49"/>
         <source>Starting Block</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3030,17 +3051,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <source>Whether the peer requested us to relay transactions.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Wants Tx Relay</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+23"/>
+        <location line="+52"/>
         <source>High bandwidth BIP152 compact block relay: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3308,7 +3319,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+316"/>
+        <location line="+320"/>
         <source>Ctrl+I</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3328,7 +3339,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-321"/>
+        <location line="-325"/>
         <source>Executing command using &quot;%1&quot; wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3455,7 +3466,7 @@ For more information on using this console, type %6.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+47"/>
+        <location filename="../receivecoinsdialog.cpp" line="+46"/>
         <source>Copy &amp;URI</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3548,7 +3559,7 @@ For more information on using this console, type %6.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+49"/>
+        <location filename="../receiverequestdialog.cpp" line="+48"/>
         <source>Request payment to %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3633,7 +3644,7 @@ For more information on using this console, type %6.
     <name>SendCoinsDialog</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+757"/>
+        <location filename="../sendcoinsdialog.cpp" line="+755"/>
         <source>Send Coins</source>
         <translation>Send Coins</translation>
     </message>
@@ -3820,7 +3831,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
         <translation>S&amp;end</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-658"/>
+        <location filename="../sendcoinsdialog.cpp" line="-660"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3887,7 +3898,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+92"/>
         <source> from wallet &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4311,7 +4322,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+120"/>
+        <location filename="../signverifymessagedialog.cpp" line="+119"/>
         <location line="+99"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"></translation>
@@ -4385,7 +4396,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+187"/>
+        <location filename="../splashscreen.cpp" line="+177"/>
         <source>(press q to shutdown and continue later)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4398,7 +4409,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
+        <location filename="../trafficgraphwidget.cpp" line="+74"/>
         <source>kB/s</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4640,7 +4651,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+261"/>
+        <location filename="../transactiontablemodel.cpp" line="+257"/>
         <source>Date</source>
         <translation type="unfinished">Date</translation>
     </message>
@@ -4956,7 +4967,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+172"/>
+        <location line="+169"/>
         <source>Range:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4969,7 +4980,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
 <context>
     <name>UnitDisplayStatusBarControl</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+41"/>
+        <location filename="../bitcoingui.cpp" line="+39"/>
         <source>Unit to show amounts in. Click to select another unit.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5052,20 +5063,21 @@ Go to File &gt; Open Wallet to load a wallet.
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+232"/>
+        <location filename="../walletmodel.cpp" line="+228"/>
+        <location line="+13"/>
         <source>Send Coins</source>
         <translation type="unfinished">Send Coins</translation>
     </message>
     <message>
-        <location line="+263"/>
-        <location line="+52"/>
+        <location line="+248"/>
+        <location line="+55"/>
         <location line="+15"/>
         <location line="+5"/>
         <source>Fee bump error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-72"/>
+        <location line="-75"/>
         <source>Increasing transaction fee failed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5096,12 +5108,12 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+5"/>
         <source>Confirm fee bump</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+23"/>
         <source>Can&apos;t draft transaction.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5134,7 +5146,7 @@ Go to File &gt; Open Wallet to load a wallet.
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+51"/>
+        <location filename="../walletview.cpp" line="+50"/>
         <source>&amp;Export</source>
         <translation type="unfinished">&amp;Export</translation>
     </message>
@@ -5193,12 +5205,17 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
+        <location line="+3"/>
+        <source>%s request to listen on port %u. This port is considered &quot;bad&quot; and thus it is unlikely that any peer will connect to it. See doc/p2p-bad-ports.md for details and a full list.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>-maxtxfee is set very high! Fees this large could be paid on a single transaction.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
+        <location line="+15"/>
         <source>Cannot downgrade wallet from version %i to version %i. Wallet version unchanged.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5214,11 +5231,21 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <location line="+4"/>
+        <source>Disk space for %s may not accommodate the block files. Approximately %u GB of data will be stored in this directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
         <source>Distributed under the MIT software license, see the accompanying file %s or %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+6"/>
+        <source>Error loading wallet. Wallet requires blocks to be downloaded, and software does not currently support loading wallets while blocks are being downloaded out of order when using assumeutxo snapshots. Wallet should be able to load successfully after node sync reaches height %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <source>Error reading %s! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5248,7 +5275,12 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="+6"/>
+        <source>Error: Unable to produce descriptors for this legacy wallet. Make sure to provide the wallet&apos;s passphrase if it is encrypted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
         <source>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5288,7 +5320,7 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+16"/>
         <source>Please check that your computer&apos;s date and time are correct! If your clock is wrong, %s will not work properly.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5328,7 +5360,7 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+11"/>
         <source>The transaction amount is too small to send after the fee has been deducted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5368,7 +5400,7 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+7"/>
         <source>Unknown wallet file format &quot;%s&quot; provided. Please provide one of &quot;bdb&quot; or &quot;sqlite&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5443,17 +5475,12 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-79"/>
+        <location line="-90"/>
         <source>The -txindex upgrade started by a previous version cannot be completed. Restart with the previous version or run a full -reindex.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-122"/>
-        <source>%s request to listen on port %u. This port is considered &quot;bad&quot; and thus it is unlikely that any Bitcoin Core peers connect to it. See doc/p2p-bad-ports.md for details and a full list.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="-126"/>
         <source>-reindex-chainstate option is not compatible with -blockfilterindex. Please temporarily disable blockfilterindex while using -reindex-chainstate, or replace -reindex-chainstate with -reindex to fully rebuild all indexes.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5468,22 +5495,17 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <source>Assumed-valid: last wallet synchronisation goes beyond available block data. You need to wait for the background validation chain to download more blocks.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+8"/>
+        <location line="+9"/>
         <source>Cannot provide specific connections and have addrman find outgoing connections at the same time.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+13"/>
         <source>Error loading %s: External signer wallet being loaded without external signer support compiled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
+        <location line="+14"/>
         <source>Error: Address book data in wallet cannot be identified to belong to migrated wallets</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5498,12 +5520,7 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Error: Unable to produce descriptors for this legacy wallet. Make sure the wallet is unlocked first</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
+        <location line="+6"/>
         <source>Failed to rename invalid peers.dat file. Please move or delete it and try again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5514,6 +5531,11 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <location line="+21"/>
+        <source>Outbound connections restricted to CJDNS (-onlynet=cjdns) but -cjdnsreachable is not provided</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
         <source>Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is explicitly forbidden: -onion=0</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5523,7 +5545,30 @@ Go to File &gt; Open Wallet to load a wallet.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+59"/>
+        <location line="+4"/>
+        <source>Outbound connections restricted to i2p (-onlynet=i2p) but -i2psam is not provided</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+32"/>
+        <source>The inputs size exceeds the maximum weight. Please try sending a smaller amount or manually consolidating your wallet&apos;s UTXOs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>The preselected coins total amount does not cover the transaction target. Please allow other inputs to be automatically selected or include more coins manually</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+27"/>
+        <source>Unexpected legacy entry in descriptor wallet found. Loading wallet %s
+
+The wallet might have been tampered with or created with malicious intent.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
         <source>Unrecognized descriptor found. Loading wallet %s
 
 The wallet might had been created on a newer version.
@@ -5646,6 +5691,11 @@ Unable to restore backup of wallet.</source>
     <message>
         <location line="+1"/>
         <source>Error reading next record from wallet database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Error: Cannot extract destination from the generated scriptpubkey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5795,6 +5845,11 @@ Unable to restore backup of wallet.</source>
     </message>
     <message>
         <location line="+1"/>
+        <source>Insufficient dbcache for block verification</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>Insufficient funds</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5845,6 +5900,16 @@ Unable to restore backup of wallet.</source>
     </message>
     <message>
         <location line="+1"/>
+        <source>Invalid port specified in %s: &apos;%s&apos;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Invalid pre-selected input %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>Listening for incoming connections failed (listen returned error %s)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5891,6 +5956,16 @@ Unable to restore backup of wallet.</source>
     <message>
         <location line="+1"/>
         <source>Not enough file descriptors available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Not found pre-selected input %s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Not solvable pre-selected input %s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6159,7 +6234,7 @@ Unable to restore backup of wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="-519"/>
+        <location filename="../bitcoin.cpp" line="-514"/>
         <source>Settings file could not be read</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/qt/locale/bitcoin_en.xlf
+++ b/src/qt/locale/bitcoin_en.xlf
@@ -45,7 +45,7 @@
       <trans-unit id="_msg11">
         <source xml:space="preserve">&amp;Delete</source>
         <context-group purpose="location"><context context-type="linenumber">101</context></context-group>
-        <context-group purpose="location"><context context-type="sourcefile">../addressbookpage.cpp</context><context context-type="linenumber">128</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../addressbookpage.cpp</context><context context-type="linenumber">127</context></context-group>
       </trans-unit>
     </group>
   </body></file>
@@ -53,62 +53,62 @@
     <group restype="x-trolltech-linguist-context" resname="AddressBookPage">
       <trans-unit id="_msg12">
         <source xml:space="preserve">Choose the address to send coins to</source>
-        <context-group purpose="location"><context context-type="linenumber">90</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">89</context></context-group>
       </trans-unit>
       <trans-unit id="_msg13">
         <source xml:space="preserve">Choose the address to receive coins with</source>
-        <context-group purpose="location"><context context-type="linenumber">91</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">90</context></context-group>
       </trans-unit>
       <trans-unit id="_msg14">
         <source xml:space="preserve">C&amp;hoose</source>
-        <context-group purpose="location"><context context-type="linenumber">96</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">95</context></context-group>
       </trans-unit>
       <trans-unit id="_msg15">
         <source xml:space="preserve">Sending addresses</source>
-        <context-group purpose="location"><context context-type="linenumber">102</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">101</context></context-group>
       </trans-unit>
       <trans-unit id="_msg16">
         <source xml:space="preserve">Receiving addresses</source>
-        <context-group purpose="location"><context context-type="linenumber">103</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">102</context></context-group>
       </trans-unit>
       <trans-unit id="_msg17">
         <source xml:space="preserve">These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
-        <context-group purpose="location"><context context-type="linenumber">110</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">109</context></context-group>
       </trans-unit>
       <trans-unit id="_msg18">
         <source xml:space="preserve">These are your Bitcoin addresses for receiving payments. Use the &apos;Create new receiving address&apos; button in the receive tab to create new addresses.
 Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
-        <context-group purpose="location"><context context-type="linenumber">115</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">114</context></context-group>
       </trans-unit>
       <trans-unit id="_msg19">
         <source xml:space="preserve">&amp;Copy Address</source>
-        <context-group purpose="location"><context context-type="linenumber">123</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">122</context></context-group>
       </trans-unit>
       <trans-unit id="_msg20">
         <source xml:space="preserve">Copy &amp;Label</source>
-        <context-group purpose="location"><context context-type="linenumber">124</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">123</context></context-group>
       </trans-unit>
       <trans-unit id="_msg21">
         <source xml:space="preserve">&amp;Edit</source>
-        <context-group purpose="location"><context context-type="linenumber">125</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">124</context></context-group>
       </trans-unit>
       <trans-unit id="_msg22">
         <source xml:space="preserve">Export Address List</source>
-        <context-group purpose="location"><context context-type="linenumber">289</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">288</context></context-group>
       </trans-unit>
       <trans-unit id="_msg23">
         <source xml:space="preserve">Comma separated file</source>
-        <context-group purpose="location"><context context-type="linenumber">292</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">291</context></context-group>
         <note annotates="source" from="developer">Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</note>
       </trans-unit>
       <trans-unit id="_msg24">
         <source xml:space="preserve">There was an error trying to save the address list to %1. Please try again.</source>
-        <context-group purpose="location"><context context-type="linenumber">308</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">307</context></context-group>
         <note annotates="source" from="developer">An error message. %1 is a stand-in argument for the name of the file we attempted to save to.</note>
       </trans-unit>
       <trans-unit id="_msg25">
         <source xml:space="preserve">Exporting Failed</source>
-        <context-group purpose="location"><context context-type="linenumber">305</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">304</context></context-group>
       </trans-unit>
     </group>
   </body></file>
@@ -156,109 +156,122 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
     <group restype="x-trolltech-linguist-context" resname="AskPassphraseDialog">
       <trans-unit id="_msg34">
         <source xml:space="preserve">Encrypt wallet</source>
-        <context-group purpose="location"><context context-type="linenumber">51</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">49</context></context-group>
       </trans-unit>
       <trans-unit id="_msg35">
         <source xml:space="preserve">This operation needs your wallet passphrase to unlock the wallet.</source>
-        <context-group purpose="location"><context context-type="linenumber">54</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">52</context></context-group>
       </trans-unit>
       <trans-unit id="_msg36">
         <source xml:space="preserve">Unlock wallet</source>
-        <context-group purpose="location"><context context-type="linenumber">59</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">57</context></context-group>
       </trans-unit>
       <trans-unit id="_msg37">
         <source xml:space="preserve">Change passphrase</source>
-        <context-group purpose="location"><context context-type="linenumber">62</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">60</context></context-group>
       </trans-unit>
       <trans-unit id="_msg38">
         <source xml:space="preserve">Confirm wallet encryption</source>
-        <context-group purpose="location"><context context-type="linenumber">110</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">107</context></context-group>
       </trans-unit>
       <trans-unit id="_msg39">
         <source xml:space="preserve">Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
-        <context-group purpose="location"><context context-type="linenumber">111</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">108</context></context-group>
       </trans-unit>
       <trans-unit id="_msg40">
         <source xml:space="preserve">Are you sure you wish to encrypt your wallet?</source>
-        <context-group purpose="location"><context context-type="linenumber">111</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">108</context></context-group>
       </trans-unit>
       <trans-unit id="_msg41">
         <source xml:space="preserve">Wallet encrypted</source>
-        <context-group purpose="location"><context context-type="linenumber">129</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">173</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">126</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">181</context></context-group>
       </trans-unit>
       <trans-unit id="_msg42">
         <source xml:space="preserve">Enter the new passphrase for the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
-        <context-group purpose="location"><context context-type="linenumber">48</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">46</context></context-group>
       </trans-unit>
       <trans-unit id="_msg43">
         <source xml:space="preserve">Enter the old passphrase and new passphrase for the wallet.</source>
-        <context-group purpose="location"><context context-type="linenumber">63</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">61</context></context-group>
       </trans-unit>
       <trans-unit id="_msg44">
         <source xml:space="preserve">Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
-        <context-group purpose="location"><context context-type="linenumber">118</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">115</context></context-group>
       </trans-unit>
       <trans-unit id="_msg45">
         <source xml:space="preserve">Wallet to be encrypted</source>
-        <context-group purpose="location"><context context-type="linenumber">122</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">119</context></context-group>
       </trans-unit>
       <trans-unit id="_msg46">
         <source xml:space="preserve">Your wallet is about to be encrypted. </source>
-        <context-group purpose="location"><context context-type="linenumber">124</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">121</context></context-group>
       </trans-unit>
       <trans-unit id="_msg47">
         <source xml:space="preserve">Your wallet is now encrypted. </source>
-        <context-group purpose="location"><context context-type="linenumber">131</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">128</context></context-group>
       </trans-unit>
       <trans-unit id="_msg48">
         <source xml:space="preserve">IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <context-group purpose="location"><context context-type="linenumber">133</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">130</context></context-group>
       </trans-unit>
       <trans-unit id="_msg49">
         <source xml:space="preserve">Wallet encryption failed</source>
-        <context-group purpose="location"><context context-type="linenumber">139</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">147</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">179</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">185</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">136</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">144</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">203</context></context-group>
       </trans-unit>
       <trans-unit id="_msg50">
         <source xml:space="preserve">Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
-        <context-group purpose="location"><context context-type="linenumber">140</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">137</context></context-group>
       </trans-unit>
       <trans-unit id="_msg51">
         <source xml:space="preserve">The supplied passphrases do not match.</source>
-        <context-group purpose="location"><context context-type="linenumber">148</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">186</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">145</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">204</context></context-group>
       </trans-unit>
       <trans-unit id="_msg52">
         <source xml:space="preserve">Wallet unlock failed</source>
-        <context-group purpose="location"><context context-type="linenumber">159</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">165</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">158</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">161</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">173</context></context-group>
       </trans-unit>
       <trans-unit id="_msg53">
         <source xml:space="preserve">The passphrase entered for the wallet decryption was incorrect.</source>
-        <context-group purpose="location"><context context-type="linenumber">160</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">180</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">159</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">190</context></context-group>
       </trans-unit>
       <trans-unit id="_msg54">
-        <source xml:space="preserve">Wallet passphrase was successfully changed.</source>
-        <context-group purpose="location"><context context-type="linenumber">174</context></context-group>
+        <source xml:space="preserve">The passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 25.0, please try again with only the characters up to — but not including — the first null character. If this is successful, please set a new passphrase to avoid this issue in the future.</source>
+        <context-group purpose="location"><context context-type="linenumber">162</context></context-group>
       </trans-unit>
       <trans-unit id="_msg55">
+        <source xml:space="preserve">Wallet passphrase was successfully changed.</source>
+        <context-group purpose="location"><context context-type="linenumber">182</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg56">
+        <source xml:space="preserve">Passphrase change failed</source>
+        <context-group purpose="location"><context context-type="linenumber">189</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">192</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg57">
+        <source xml:space="preserve">The old passphrase entered for the wallet decryption is incorrect. It contains a null character (ie - a zero byte). If the passphrase was set with a version of this software prior to 25.0, please try again with only the characters up to — but not including — the first null character.</source>
+        <context-group purpose="location"><context context-type="linenumber">193</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg58">
         <source xml:space="preserve">Warning: The Caps Lock key is on!</source>
-        <context-group purpose="location"><context context-type="linenumber">220</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">253</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">238</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">271</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../bantablemodel.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="BanTableModel">
-      <trans-unit id="_msg56">
+      <trans-unit id="_msg59">
         <source xml:space="preserve">IP/Netmask</source>
         <context-group purpose="location"><context context-type="linenumber">85</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg57">
+      <trans-unit id="_msg60">
         <source xml:space="preserve">Banned Until</source>
         <context-group purpose="location"><context context-type="linenumber">85</context></context-group>
       </trans-unit>
@@ -266,615 +279,611 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
   </body></file>
   <file original="../bitcoin.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="BitcoinApplication">
-      <trans-unit id="_msg58">
-        <source xml:space="preserve">Settings file %1 might be corrupt or invalid.</source>
-        <context-group purpose="location"><context context-type="linenumber">288</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg59">
-        <source xml:space="preserve">Runaway exception</source>
-        <context-group purpose="location"><context context-type="linenumber">466</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg60">
-        <source xml:space="preserve">A fatal error occurred. %1 can no longer continue safely and will quit.</source>
-        <context-group purpose="location"><context context-type="linenumber">467</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg61">
-        <source xml:space="preserve">Internal error</source>
-        <context-group purpose="location"><context context-type="linenumber">476</context></context-group>
+        <source xml:space="preserve">Settings file %1 might be corrupt or invalid.</source>
+        <context-group purpose="location"><context context-type="linenumber">283</context></context-group>
       </trans-unit>
       <trans-unit id="_msg62">
+        <source xml:space="preserve">Runaway exception</source>
+        <context-group purpose="location"><context context-type="linenumber">461</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg63">
+        <source xml:space="preserve">A fatal error occurred. %1 can no longer continue safely and will quit.</source>
+        <context-group purpose="location"><context context-type="linenumber">462</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg64">
+        <source xml:space="preserve">Internal error</source>
+        <context-group purpose="location"><context context-type="linenumber">471</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg65">
         <source xml:space="preserve">An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
-        <context-group purpose="location"><context context-type="linenumber">477</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">472</context></context-group>
       </trans-unit>
     </group>
     <group restype="x-trolltech-linguist-context" resname="QObject">
-      <trans-unit id="_msg63">
+      <trans-unit id="_msg66">
         <source xml:space="preserve">Do you want to reset settings to default values, or to abort without making changes?</source>
-        <context-group purpose="location"><context context-type="linenumber">183</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">184</context></context-group>
         <note annotates="source" from="developer">Explanatory text shown on startup when the settings file cannot be read. Prompts user to make a choice between resetting or aborting.</note>
       </trans-unit>
-      <trans-unit id="_msg64">
+      <trans-unit id="_msg67">
         <source xml:space="preserve">A fatal error occurred. Check that settings file is writable, or try running with -nosettings.</source>
-        <context-group purpose="location"><context context-type="linenumber">207</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">208</context></context-group>
         <note annotates="source" from="developer">Explanatory text shown on startup when the settings file could not be written. Prompts user to check that we have the ability to write to the file. Explains that the user has the option of running without a settings file.</note>
       </trans-unit>
-      <trans-unit id="_msg65">
-        <source xml:space="preserve">Error: Specified data directory &quot;%1&quot; does not exist.</source>
-        <context-group purpose="location"><context context-type="linenumber">600</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg66">
-        <source xml:space="preserve">Error: Cannot parse configuration file: %1.</source>
-        <context-group purpose="location"><context context-type="linenumber">606</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg67">
-        <source xml:space="preserve">Error: %1</source>
-        <context-group purpose="location"><context context-type="linenumber">621</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg68">
+        <source xml:space="preserve">Error: Specified data directory &quot;%1&quot; does not exist.</source>
+        <context-group purpose="location"><context context-type="linenumber">594</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg69">
+        <source xml:space="preserve">Error: Cannot parse configuration file: %1.</source>
+        <context-group purpose="location"><context context-type="linenumber">603</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg70">
+        <source xml:space="preserve">Error: %1</source>
+        <context-group purpose="location"><context context-type="linenumber">617</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg71">
         <source xml:space="preserve">%1 didn&apos;t yet exit safely…</source>
-        <context-group purpose="location"><context context-type="linenumber">695</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">691</context></context-group>
       </trans-unit>
     </group>
     <group restype="x-trolltech-linguist-context" resname="bitcoin-core">
-      <trans-unit id="_msg69">
+      <trans-unit id="_msg72">
         <source xml:space="preserve">Settings file could not be read</source>
-        <context-group purpose="location"><context context-type="linenumber">176</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">177</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg70">
+      <trans-unit id="_msg73">
         <source xml:space="preserve">Settings file could not be written</source>
-        <context-group purpose="location"><context context-type="linenumber">199</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">200</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../bitcoingui.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="BitcoinGUI">
-      <trans-unit id="_msg71">
+      <trans-unit id="_msg74">
         <source xml:space="preserve">&amp;Overview</source>
         <context-group purpose="location"><context context-type="linenumber">253</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg72">
+      <trans-unit id="_msg75">
         <source xml:space="preserve">Show general overview of wallet</source>
         <context-group purpose="location"><context context-type="linenumber">254</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg73">
+      <trans-unit id="_msg76">
         <source xml:space="preserve">&amp;Transactions</source>
         <context-group purpose="location"><context context-type="linenumber">274</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg74">
+      <trans-unit id="_msg77">
         <source xml:space="preserve">Browse transaction history</source>
         <context-group purpose="location"><context context-type="linenumber">275</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg75">
+      <trans-unit id="_msg78">
         <source xml:space="preserve">E&amp;xit</source>
         <context-group purpose="location"><context context-type="linenumber">294</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg76">
+      <trans-unit id="_msg79">
         <source xml:space="preserve">Quit application</source>
         <context-group purpose="location"><context context-type="linenumber">295</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg77">
+      <trans-unit id="_msg80">
         <source xml:space="preserve">&amp;About %1</source>
         <context-group purpose="location"><context context-type="linenumber">298</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg78">
+      <trans-unit id="_msg81">
         <source xml:space="preserve">Show information about %1</source>
         <context-group purpose="location"><context context-type="linenumber">299</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg79">
+      <trans-unit id="_msg82">
         <source xml:space="preserve">About &amp;Qt</source>
         <context-group purpose="location"><context context-type="linenumber">302</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg80">
+      <trans-unit id="_msg83">
         <source xml:space="preserve">Show information about Qt</source>
         <context-group purpose="location"><context context-type="linenumber">303</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg81">
+      <trans-unit id="_msg84">
         <source xml:space="preserve">Modify configuration options for %1</source>
         <context-group purpose="location"><context context-type="linenumber">306</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg82">
+      <trans-unit id="_msg85">
         <source xml:space="preserve">Create a new wallet</source>
         <context-group purpose="location"><context context-type="linenumber">350</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg83">
+      <trans-unit id="_msg86">
         <source xml:space="preserve">&amp;Minimize</source>
         <context-group purpose="location"><context context-type="linenumber">510</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg84">
+      <trans-unit id="_msg87">
         <source xml:space="preserve">Wallet:</source>
         <context-group purpose="location"><context context-type="linenumber">589</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg85">
+      <trans-unit id="_msg88">
         <source xml:space="preserve">Network activity disabled.</source>
-        <context-group purpose="location"><context context-type="linenumber">982</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">984</context></context-group>
         <note annotates="source" from="developer">A substring of the tooltip.</note>
       </trans-unit>
-      <trans-unit id="_msg86">
+      <trans-unit id="_msg89">
         <source xml:space="preserve">Proxy is &lt;b&gt;enabled&lt;/b&gt;: %1</source>
-        <context-group purpose="location"><context context-type="linenumber">1421</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1420</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg87">
+      <trans-unit id="_msg90">
         <source xml:space="preserve">Send coins to a Bitcoin address</source>
         <context-group purpose="location"><context context-type="linenumber">261</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg88">
+      <trans-unit id="_msg91">
         <source xml:space="preserve">Backup wallet to another location</source>
         <context-group purpose="location"><context context-type="linenumber">314</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg89">
+      <trans-unit id="_msg92">
         <source xml:space="preserve">Change the passphrase used for wallet encryption</source>
         <context-group purpose="location"><context context-type="linenumber">316</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg90">
+      <trans-unit id="_msg93">
         <source xml:space="preserve">&amp;Send</source>
         <context-group purpose="location"><context context-type="linenumber">260</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg91">
+      <trans-unit id="_msg94">
         <source xml:space="preserve">&amp;Receive</source>
         <context-group purpose="location"><context context-type="linenumber">267</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg92">
+      <trans-unit id="_msg95">
         <source xml:space="preserve">&amp;Options…</source>
         <context-group purpose="location"><context context-type="linenumber">305</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg93">
+      <trans-unit id="_msg96">
         <source xml:space="preserve">&amp;Encrypt Wallet…</source>
         <context-group purpose="location"><context context-type="linenumber">310</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg94">
+      <trans-unit id="_msg97">
         <source xml:space="preserve">Encrypt the private keys that belong to your wallet</source>
         <context-group purpose="location"><context context-type="linenumber">311</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg95">
+      <trans-unit id="_msg98">
         <source xml:space="preserve">&amp;Backup Wallet…</source>
         <context-group purpose="location"><context context-type="linenumber">313</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg96">
+      <trans-unit id="_msg99">
         <source xml:space="preserve">&amp;Change Passphrase…</source>
         <context-group purpose="location"><context context-type="linenumber">315</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg97">
+      <trans-unit id="_msg100">
         <source xml:space="preserve">Sign &amp;message…</source>
         <context-group purpose="location"><context context-type="linenumber">317</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg98">
+      <trans-unit id="_msg101">
         <source xml:space="preserve">Sign messages with your Bitcoin addresses to prove you own them</source>
         <context-group purpose="location"><context context-type="linenumber">318</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg99">
+      <trans-unit id="_msg102">
         <source xml:space="preserve">&amp;Verify message…</source>
         <context-group purpose="location"><context context-type="linenumber">319</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg100">
+      <trans-unit id="_msg103">
         <source xml:space="preserve">Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <context-group purpose="location"><context context-type="linenumber">320</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg101">
+      <trans-unit id="_msg104">
         <source xml:space="preserve">&amp;Load PSBT from file…</source>
         <context-group purpose="location"><context context-type="linenumber">321</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg102">
+      <trans-unit id="_msg105">
         <source xml:space="preserve">Open &amp;URI…</source>
         <context-group purpose="location"><context context-type="linenumber">337</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg103">
+      <trans-unit id="_msg106">
         <source xml:space="preserve">Close Wallet…</source>
         <context-group purpose="location"><context context-type="linenumber">345</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg104">
+      <trans-unit id="_msg107">
         <source xml:space="preserve">Create Wallet…</source>
         <context-group purpose="location"><context context-type="linenumber">348</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg105">
+      <trans-unit id="_msg108">
         <source xml:space="preserve">Close All Wallets…</source>
         <context-group purpose="location"><context context-type="linenumber">358</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg106">
+      <trans-unit id="_msg109">
         <source xml:space="preserve">&amp;File</source>
         <context-group purpose="location"><context context-type="linenumber">477</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg107">
+      <trans-unit id="_msg110">
         <source xml:space="preserve">&amp;Settings</source>
         <context-group purpose="location"><context context-type="linenumber">497</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg108">
+      <trans-unit id="_msg111">
         <source xml:space="preserve">&amp;Help</source>
         <context-group purpose="location"><context context-type="linenumber">558</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg109">
+      <trans-unit id="_msg112">
         <source xml:space="preserve">Tabs toolbar</source>
         <context-group purpose="location"><context context-type="linenumber">569</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg110">
-        <source xml:space="preserve">Syncing Headers (%1%)…</source>
-        <context-group purpose="location"><context context-type="linenumber">1026</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg111">
-        <source xml:space="preserve">Synchronizing with network…</source>
-        <context-group purpose="location"><context context-type="linenumber">1084</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg112">
-        <source xml:space="preserve">Indexing blocks on disk…</source>
-        <context-group purpose="location"><context context-type="linenumber">1089</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg113">
-        <source xml:space="preserve">Processing blocks on disk…</source>
-        <context-group purpose="location"><context context-type="linenumber">1091</context></context-group>
+        <source xml:space="preserve">Syncing Headers (%1%)…</source>
+        <context-group purpose="location"><context context-type="linenumber">1028</context></context-group>
       </trans-unit>
       <trans-unit id="_msg114">
-        <source xml:space="preserve">Reindexing blocks on disk…</source>
-        <context-group purpose="location"><context context-type="linenumber">1095</context></context-group>
+        <source xml:space="preserve">Synchronizing with network…</source>
+        <context-group purpose="location"><context context-type="linenumber">1086</context></context-group>
       </trans-unit>
       <trans-unit id="_msg115">
-        <source xml:space="preserve">Connecting to peers…</source>
-        <context-group purpose="location"><context context-type="linenumber">1101</context></context-group>
+        <source xml:space="preserve">Indexing blocks on disk…</source>
+        <context-group purpose="location"><context context-type="linenumber">1091</context></context-group>
       </trans-unit>
       <trans-unit id="_msg116">
+        <source xml:space="preserve">Processing blocks on disk…</source>
+        <context-group purpose="location"><context context-type="linenumber">1093</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg117">
+        <source xml:space="preserve">Connecting to peers…</source>
+        <context-group purpose="location"><context context-type="linenumber">1100</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg118">
         <source xml:space="preserve">Request payments (generates QR codes and bitcoin: URIs)</source>
         <context-group purpose="location"><context context-type="linenumber">268</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg117">
+      <trans-unit id="_msg119">
         <source xml:space="preserve">Show the list of used sending addresses and labels</source>
         <context-group purpose="location"><context context-type="linenumber">333</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg118">
+      <trans-unit id="_msg120">
         <source xml:space="preserve">Show the list of used receiving addresses and labels</source>
         <context-group purpose="location"><context context-type="linenumber">335</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg119">
+      <trans-unit id="_msg121">
         <source xml:space="preserve">&amp;Command-line options</source>
         <context-group purpose="location"><context context-type="linenumber">361</context></context-group>
       </trans-unit>
       <group restype="x-gettext-plurals">
-        <context-group purpose="location"><context context-type="linenumber">1110</context></context-group>
-        <trans-unit id="_msg120[0]">
+        <context-group purpose="location"><context context-type="linenumber">1109</context></context-group>
+        <trans-unit id="_msg122[0]">
           <source xml:space="preserve">Processed %n block(s) of transaction history.</source>
         </trans-unit>
-        <trans-unit id="_msg120[1]">
+        <trans-unit id="_msg122[1]">
           <source xml:space="preserve">Processed %n block(s) of transaction history.</source>
         </trans-unit>
       </group>
-      <trans-unit id="_msg121">
-        <source xml:space="preserve">%1 behind</source>
-        <context-group purpose="location"><context context-type="linenumber">1133</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg122">
-        <source xml:space="preserve">Catching up…</source>
-        <context-group purpose="location"><context context-type="linenumber">1138</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg123">
-        <source xml:space="preserve">Last received block was generated %1 ago.</source>
-        <context-group purpose="location"><context context-type="linenumber">1157</context></context-group>
+        <source xml:space="preserve">%1 behind</source>
+        <context-group purpose="location"><context context-type="linenumber">1132</context></context-group>
       </trans-unit>
       <trans-unit id="_msg124">
-        <source xml:space="preserve">Transactions after this will not yet be visible.</source>
-        <context-group purpose="location"><context context-type="linenumber">1159</context></context-group>
+        <source xml:space="preserve">Catching up…</source>
+        <context-group purpose="location"><context context-type="linenumber">1137</context></context-group>
       </trans-unit>
       <trans-unit id="_msg125">
-        <source xml:space="preserve">Error</source>
-        <context-group purpose="location"><context context-type="linenumber">1184</context></context-group>
+        <source xml:space="preserve">Last received block was generated %1 ago.</source>
+        <context-group purpose="location"><context context-type="linenumber">1156</context></context-group>
       </trans-unit>
       <trans-unit id="_msg126">
-        <source xml:space="preserve">Warning</source>
-        <context-group purpose="location"><context context-type="linenumber">1188</context></context-group>
+        <source xml:space="preserve">Transactions after this will not yet be visible.</source>
+        <context-group purpose="location"><context context-type="linenumber">1158</context></context-group>
       </trans-unit>
       <trans-unit id="_msg127">
-        <source xml:space="preserve">Information</source>
-        <context-group purpose="location"><context context-type="linenumber">1192</context></context-group>
+        <source xml:space="preserve">Error</source>
+        <context-group purpose="location"><context context-type="linenumber">1183</context></context-group>
       </trans-unit>
       <trans-unit id="_msg128">
-        <source xml:space="preserve">Up to date</source>
-        <context-group purpose="location"><context context-type="linenumber">1114</context></context-group>
+        <source xml:space="preserve">Warning</source>
+        <context-group purpose="location"><context context-type="linenumber">1187</context></context-group>
       </trans-unit>
       <trans-unit id="_msg129">
+        <source xml:space="preserve">Information</source>
+        <context-group purpose="location"><context context-type="linenumber">1191</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg130">
+        <source xml:space="preserve">Up to date</source>
+        <context-group purpose="location"><context context-type="linenumber">1113</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg131">
         <source xml:space="preserve">Ctrl+Q</source>
         <context-group purpose="location"><context context-type="linenumber">296</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg130">
+      <trans-unit id="_msg132">
         <source xml:space="preserve">Load Partially Signed Bitcoin Transaction</source>
         <context-group purpose="location"><context context-type="linenumber">322</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg131">
+      <trans-unit id="_msg133">
         <source xml:space="preserve">Load PSBT from &amp;clipboard…</source>
         <context-group purpose="location"><context context-type="linenumber">323</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg132">
+      <trans-unit id="_msg134">
         <source xml:space="preserve">Load Partially Signed Bitcoin Transaction from clipboard</source>
         <context-group purpose="location"><context context-type="linenumber">324</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg133">
+      <trans-unit id="_msg135">
         <source xml:space="preserve">Node window</source>
         <context-group purpose="location"><context context-type="linenumber">326</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg134">
+      <trans-unit id="_msg136">
         <source xml:space="preserve">Open node debugging and diagnostic console</source>
         <context-group purpose="location"><context context-type="linenumber">327</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg135">
+      <trans-unit id="_msg137">
         <source xml:space="preserve">&amp;Sending addresses</source>
         <context-group purpose="location"><context context-type="linenumber">332</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg136">
+      <trans-unit id="_msg138">
         <source xml:space="preserve">&amp;Receiving addresses</source>
         <context-group purpose="location"><context context-type="linenumber">334</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg137">
+      <trans-unit id="_msg139">
         <source xml:space="preserve">Open a bitcoin: URI</source>
         <context-group purpose="location"><context context-type="linenumber">338</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg138">
+      <trans-unit id="_msg140">
         <source xml:space="preserve">Open Wallet</source>
         <context-group purpose="location"><context context-type="linenumber">340</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg139">
+      <trans-unit id="_msg141">
         <source xml:space="preserve">Open a wallet</source>
         <context-group purpose="location"><context context-type="linenumber">342</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg140">
+      <trans-unit id="_msg142">
         <source xml:space="preserve">Close wallet</source>
         <context-group purpose="location"><context context-type="linenumber">346</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg141">
+      <trans-unit id="_msg143">
         <source xml:space="preserve">Restore Wallet…</source>
         <context-group purpose="location"><context context-type="linenumber">353</context></context-group>
         <note annotates="source" from="developer">Name of the menu item that restores wallet from a backup file.</note>
       </trans-unit>
-      <trans-unit id="_msg142">
+      <trans-unit id="_msg144">
         <source xml:space="preserve">Restore a wallet from a backup file</source>
         <context-group purpose="location"><context context-type="linenumber">356</context></context-group>
         <note annotates="source" from="developer">Status tip for Restore Wallet menu item</note>
       </trans-unit>
-      <trans-unit id="_msg143">
+      <trans-unit id="_msg145">
         <source xml:space="preserve">Close all wallets</source>
         <context-group purpose="location"><context context-type="linenumber">359</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg144">
+      <trans-unit id="_msg146">
         <source xml:space="preserve">Show the %1 help message to get a list with possible Bitcoin command-line options</source>
         <context-group purpose="location"><context context-type="linenumber">363</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg145">
+      <trans-unit id="_msg147">
         <source xml:space="preserve">&amp;Mask values</source>
         <context-group purpose="location"><context context-type="linenumber">365</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg146">
+      <trans-unit id="_msg148">
         <source xml:space="preserve">Mask the values in the Overview tab</source>
         <context-group purpose="location"><context context-type="linenumber">367</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg147">
+      <trans-unit id="_msg149">
         <source xml:space="preserve">default wallet</source>
         <context-group purpose="location"><context context-type="linenumber">398</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg148">
+      <trans-unit id="_msg150">
         <source xml:space="preserve">No wallets available</source>
         <context-group purpose="location"><context context-type="linenumber">418</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg149">
+      <trans-unit id="_msg151">
         <source xml:space="preserve">Wallet Data</source>
         <context-group purpose="location"><context context-type="linenumber">424</context></context-group>
         <note annotates="source" from="developer">Name of the wallet data file format.</note>
       </trans-unit>
-      <trans-unit id="_msg150">
+      <trans-unit id="_msg152">
         <source xml:space="preserve">Load Wallet Backup</source>
         <context-group purpose="location"><context context-type="linenumber">427</context></context-group>
         <note annotates="source" from="developer">The title for Restore Wallet File Windows</note>
       </trans-unit>
-      <trans-unit id="_msg151">
+      <trans-unit id="_msg153">
         <source xml:space="preserve">Restore Wallet</source>
         <context-group purpose="location"><context context-type="linenumber">435</context></context-group>
         <note annotates="source" from="developer">Title of pop-up window shown when the user is attempting to restore a wallet.</note>
       </trans-unit>
-      <trans-unit id="_msg152">
+      <trans-unit id="_msg154">
         <source xml:space="preserve">Wallet Name</source>
         <context-group purpose="location"><context context-type="linenumber">437</context></context-group>
         <note annotates="source" from="developer">Label of the input field where the name of the wallet is entered.</note>
       </trans-unit>
-      <trans-unit id="_msg153">
+      <trans-unit id="_msg155">
         <source xml:space="preserve">&amp;Window</source>
         <context-group purpose="location"><context context-type="linenumber">508</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg154">
+      <trans-unit id="_msg156">
         <source xml:space="preserve">Ctrl+M</source>
         <context-group purpose="location"><context context-type="linenumber">511</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg155">
+      <trans-unit id="_msg157">
         <source xml:space="preserve">Zoom</source>
         <context-group purpose="location"><context context-type="linenumber">520</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg156">
+      <trans-unit id="_msg158">
         <source xml:space="preserve">Main Window</source>
         <context-group purpose="location"><context context-type="linenumber">538</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg157">
-        <source xml:space="preserve">%1 client</source>
-        <context-group purpose="location"><context context-type="linenumber">796</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg158">
-        <source xml:space="preserve">&amp;Hide</source>
-        <context-group purpose="location"><context context-type="linenumber">861</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg159">
+        <source xml:space="preserve">%1 client</source>
+        <context-group purpose="location"><context context-type="linenumber">798</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg160">
+        <source xml:space="preserve">&amp;Hide</source>
+        <context-group purpose="location"><context context-type="linenumber">863</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg161">
         <source xml:space="preserve">S&amp;how</source>
-        <context-group purpose="location"><context context-type="linenumber">862</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">864</context></context-group>
       </trans-unit>
       <group restype="x-gettext-plurals">
-        <context-group purpose="location"><context context-type="linenumber">979</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">981</context></context-group>
         <note annotates="source" from="developer">A substring of the tooltip.</note>
-        <trans-unit id="_msg160[0]">
+        <trans-unit id="_msg162[0]">
           <source xml:space="preserve">%n active connection(s) to Bitcoin network.</source>
         </trans-unit>
-        <trans-unit id="_msg160[1]">
+        <trans-unit id="_msg162[1]">
           <source xml:space="preserve">%n active connection(s) to Bitcoin network.</source>
         </trans-unit>
       </group>
-      <trans-unit id="_msg161">
+      <trans-unit id="_msg163">
         <source xml:space="preserve">Click for more actions.</source>
-        <context-group purpose="location"><context context-type="linenumber">989</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">991</context></context-group>
         <note annotates="source" from="developer">A substring of the tooltip. &quot;More actions&quot; are available via the context menu.</note>
       </trans-unit>
-      <trans-unit id="_msg162">
+      <trans-unit id="_msg164">
         <source xml:space="preserve">Show Peers tab</source>
-        <context-group purpose="location"><context context-type="linenumber">1006</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1008</context></context-group>
         <note annotates="source" from="developer">A context menu item. The &quot;Peers tab&quot; is an element of the &quot;Node window&quot;.</note>
       </trans-unit>
-      <trans-unit id="_msg163">
+      <trans-unit id="_msg165">
         <source xml:space="preserve">Disable network activity</source>
-        <context-group purpose="location"><context context-type="linenumber">1014</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1016</context></context-group>
         <note annotates="source" from="developer">A context menu item.</note>
       </trans-unit>
-      <trans-unit id="_msg164">
+      <trans-unit id="_msg166">
         <source xml:space="preserve">Enable network activity</source>
-        <context-group purpose="location"><context context-type="linenumber">1016</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1018</context></context-group>
         <note annotates="source" from="developer">A context menu item. The network activity was disabled previously.</note>
       </trans-unit>
-      <trans-unit id="_msg165">
-        <source xml:space="preserve">Pre-syncing Headers (%1%)…</source>
-        <context-group purpose="location"><context context-type="linenumber">1033</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg166">
-        <source xml:space="preserve">Error: %1</source>
-        <context-group purpose="location"><context context-type="linenumber">1185</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg167">
-        <source xml:space="preserve">Warning: %1</source>
-        <context-group purpose="location"><context context-type="linenumber">1189</context></context-group>
+        <source xml:space="preserve">Pre-syncing Headers (%1%)…</source>
+        <context-group purpose="location"><context context-type="linenumber">1035</context></context-group>
       </trans-unit>
       <trans-unit id="_msg168">
+        <source xml:space="preserve">Error: %1</source>
+        <context-group purpose="location"><context context-type="linenumber">1184</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg169">
+        <source xml:space="preserve">Warning: %1</source>
+        <context-group purpose="location"><context context-type="linenumber">1188</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg170">
         <source xml:space="preserve">Date: %1
+</source>
+        <context-group purpose="location"><context context-type="linenumber">1296</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg171">
+        <source xml:space="preserve">Amount: %1
 </source>
         <context-group purpose="location"><context context-type="linenumber">1297</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg169">
-        <source xml:space="preserve">Amount: %1
-</source>
-        <context-group purpose="location"><context context-type="linenumber">1298</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg170">
+      <trans-unit id="_msg172">
         <source xml:space="preserve">Wallet: %1
 </source>
-        <context-group purpose="location"><context context-type="linenumber">1300</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg171">
-        <source xml:space="preserve">Type: %1
-</source>
-        <context-group purpose="location"><context context-type="linenumber">1302</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg172">
-        <source xml:space="preserve">Label: %1
-</source>
-        <context-group purpose="location"><context context-type="linenumber">1304</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1299</context></context-group>
       </trans-unit>
       <trans-unit id="_msg173">
-        <source xml:space="preserve">Address: %1
+        <source xml:space="preserve">Type: %1
 </source>
-        <context-group purpose="location"><context context-type="linenumber">1306</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1301</context></context-group>
       </trans-unit>
       <trans-unit id="_msg174">
-        <source xml:space="preserve">Sent transaction</source>
-        <context-group purpose="location"><context context-type="linenumber">1307</context></context-group>
+        <source xml:space="preserve">Label: %1
+</source>
+        <context-group purpose="location"><context context-type="linenumber">1303</context></context-group>
       </trans-unit>
       <trans-unit id="_msg175">
-        <source xml:space="preserve">Incoming transaction</source>
-        <context-group purpose="location"><context context-type="linenumber">1307</context></context-group>
+        <source xml:space="preserve">Address: %1
+</source>
+        <context-group purpose="location"><context context-type="linenumber">1305</context></context-group>
       </trans-unit>
       <trans-unit id="_msg176">
-        <source xml:space="preserve">HD key generation is &lt;b&gt;enabled&lt;/b&gt;</source>
-        <context-group purpose="location"><context context-type="linenumber">1359</context></context-group>
+        <source xml:space="preserve">Sent transaction</source>
+        <context-group purpose="location"><context context-type="linenumber">1306</context></context-group>
       </trans-unit>
       <trans-unit id="_msg177">
-        <source xml:space="preserve">HD key generation is &lt;b&gt;disabled&lt;/b&gt;</source>
-        <context-group purpose="location"><context context-type="linenumber">1359</context></context-group>
+        <source xml:space="preserve">Incoming transaction</source>
+        <context-group purpose="location"><context context-type="linenumber">1306</context></context-group>
       </trans-unit>
       <trans-unit id="_msg178">
-        <source xml:space="preserve">Private key &lt;b&gt;disabled&lt;/b&gt;</source>
-        <context-group purpose="location"><context context-type="linenumber">1359</context></context-group>
+        <source xml:space="preserve">HD key generation is &lt;b&gt;enabled&lt;/b&gt;</source>
+        <context-group purpose="location"><context context-type="linenumber">1358</context></context-group>
       </trans-unit>
       <trans-unit id="_msg179">
-        <source xml:space="preserve">Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
-        <context-group purpose="location"><context context-type="linenumber">1382</context></context-group>
+        <source xml:space="preserve">HD key generation is &lt;b&gt;disabled&lt;/b&gt;</source>
+        <context-group purpose="location"><context context-type="linenumber">1358</context></context-group>
       </trans-unit>
       <trans-unit id="_msg180">
-        <source xml:space="preserve">Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
-        <context-group purpose="location"><context context-type="linenumber">1390</context></context-group>
+        <source xml:space="preserve">Private key &lt;b&gt;disabled&lt;/b&gt;</source>
+        <context-group purpose="location"><context context-type="linenumber">1358</context></context-group>
       </trans-unit>
       <trans-unit id="_msg181">
+        <source xml:space="preserve">Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
+        <context-group purpose="location"><context context-type="linenumber">1381</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg182">
+        <source xml:space="preserve">Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
+        <context-group purpose="location"><context context-type="linenumber">1389</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg183">
         <source xml:space="preserve">Original message:</source>
-        <context-group purpose="location"><context context-type="linenumber">1509</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1508</context></context-group>
       </trans-unit>
     </group>
     <group restype="x-trolltech-linguist-context" resname="UnitDisplayStatusBarControl">
-      <trans-unit id="_msg182">
+      <trans-unit id="_msg184">
         <source xml:space="preserve">Unit to show amounts in. Click to select another unit.</source>
-        <context-group purpose="location"><context context-type="linenumber">1550</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1547</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../forms/coincontroldialog.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="CoinControlDialog">
-      <trans-unit id="_msg183">
+      <trans-unit id="_msg185">
         <source xml:space="preserve">Coin Selection</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg184">
+      <trans-unit id="_msg186">
         <source xml:space="preserve">Quantity:</source>
         <context-group purpose="location"><context context-type="linenumber">48</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg185">
+      <trans-unit id="_msg187">
         <source xml:space="preserve">Bytes:</source>
         <context-group purpose="location"><context context-type="linenumber">77</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg186">
+      <trans-unit id="_msg188">
         <source xml:space="preserve">Amount:</source>
         <context-group purpose="location"><context context-type="linenumber">122</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg187">
+      <trans-unit id="_msg189">
         <source xml:space="preserve">Fee:</source>
         <context-group purpose="location"><context context-type="linenumber">202</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg188">
+      <trans-unit id="_msg190">
         <source xml:space="preserve">Dust:</source>
         <context-group purpose="location"><context context-type="linenumber">154</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg189">
+      <trans-unit id="_msg191">
         <source xml:space="preserve">After Fee:</source>
         <context-group purpose="location"><context context-type="linenumber">247</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg190">
+      <trans-unit id="_msg192">
         <source xml:space="preserve">Change:</source>
         <context-group purpose="location"><context context-type="linenumber">279</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg191">
+      <trans-unit id="_msg193">
         <source xml:space="preserve">(un)select all</source>
         <context-group purpose="location"><context context-type="linenumber">335</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg192">
+      <trans-unit id="_msg194">
         <source xml:space="preserve">Tree mode</source>
         <context-group purpose="location"><context context-type="linenumber">351</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg193">
+      <trans-unit id="_msg195">
         <source xml:space="preserve">List mode</source>
         <context-group purpose="location"><context context-type="linenumber">364</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg194">
+      <trans-unit id="_msg196">
         <source xml:space="preserve">Amount</source>
         <context-group purpose="location"><context context-type="linenumber">420</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg195">
+      <trans-unit id="_msg197">
         <source xml:space="preserve">Received with label</source>
         <context-group purpose="location"><context context-type="linenumber">425</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg196">
+      <trans-unit id="_msg198">
         <source xml:space="preserve">Received with address</source>
         <context-group purpose="location"><context context-type="linenumber">430</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg197">
+      <trans-unit id="_msg199">
         <source xml:space="preserve">Date</source>
         <context-group purpose="location"><context context-type="linenumber">435</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg198">
+      <trans-unit id="_msg200">
         <source xml:space="preserve">Confirmations</source>
         <context-group purpose="location"><context context-type="linenumber">440</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg199">
+      <trans-unit id="_msg201">
         <source xml:space="preserve">Confirmed</source>
         <context-group purpose="location"><context context-type="linenumber">443</context></context-group>
       </trans-unit>
@@ -882,88 +891,88 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
   </body></file>
   <file original="../coincontroldialog.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="CoinControlDialog">
-      <trans-unit id="_msg200">
+      <trans-unit id="_msg202">
         <source xml:space="preserve">Copy amount</source>
         <context-group purpose="location"><context context-type="linenumber">69</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg201">
+      <trans-unit id="_msg203">
         <source xml:space="preserve">&amp;Copy address</source>
         <context-group purpose="location"><context context-type="linenumber">58</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg202">
+      <trans-unit id="_msg204">
         <source xml:space="preserve">Copy &amp;label</source>
         <context-group purpose="location"><context context-type="linenumber">59</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg203">
+      <trans-unit id="_msg205">
         <source xml:space="preserve">Copy &amp;amount</source>
         <context-group purpose="location"><context context-type="linenumber">60</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg204">
+      <trans-unit id="_msg206">
         <source xml:space="preserve">Copy transaction &amp;ID and output index</source>
         <context-group purpose="location"><context context-type="linenumber">61</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg205">
+      <trans-unit id="_msg207">
         <source xml:space="preserve">L&amp;ock unspent</source>
         <context-group purpose="location"><context context-type="linenumber">63</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg206">
+      <trans-unit id="_msg208">
         <source xml:space="preserve">&amp;Unlock unspent</source>
         <context-group purpose="location"><context context-type="linenumber">64</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg207">
+      <trans-unit id="_msg209">
         <source xml:space="preserve">Copy quantity</source>
         <context-group purpose="location"><context context-type="linenumber">68</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg208">
+      <trans-unit id="_msg210">
         <source xml:space="preserve">Copy fee</source>
         <context-group purpose="location"><context context-type="linenumber">70</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg209">
+      <trans-unit id="_msg211">
         <source xml:space="preserve">Copy after fee</source>
         <context-group purpose="location"><context context-type="linenumber">71</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg210">
+      <trans-unit id="_msg212">
         <source xml:space="preserve">Copy bytes</source>
         <context-group purpose="location"><context context-type="linenumber">72</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg211">
+      <trans-unit id="_msg213">
         <source xml:space="preserve">Copy dust</source>
         <context-group purpose="location"><context context-type="linenumber">73</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg212">
+      <trans-unit id="_msg214">
         <source xml:space="preserve">Copy change</source>
         <context-group purpose="location"><context context-type="linenumber">74</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg213">
+      <trans-unit id="_msg215">
         <source xml:space="preserve">(%1 locked)</source>
         <context-group purpose="location"><context context-type="linenumber">380</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg214">
+      <trans-unit id="_msg216">
         <source xml:space="preserve">yes</source>
         <context-group purpose="location"><context context-type="linenumber">534</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg215">
+      <trans-unit id="_msg217">
         <source xml:space="preserve">no</source>
         <context-group purpose="location"><context context-type="linenumber">534</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg216">
+      <trans-unit id="_msg218">
         <source xml:space="preserve">This label turns red if any recipient receives an amount smaller than the current dust threshold.</source>
         <context-group purpose="location"><context context-type="linenumber">548</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg217">
+      <trans-unit id="_msg219">
         <source xml:space="preserve">Can vary +/- %1 satoshi(s) per input.</source>
         <context-group purpose="location"><context context-type="linenumber">553</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg218">
+      <trans-unit id="_msg220">
         <source xml:space="preserve">(no label)</source>
         <context-group purpose="location"><context context-type="linenumber">600</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">654</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg219">
+      <trans-unit id="_msg221">
         <source xml:space="preserve">change from %1 (%2)</source>
         <context-group purpose="location"><context context-type="linenumber">647</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg220">
+      <trans-unit id="_msg222">
         <source xml:space="preserve">(change)</source>
         <context-group purpose="location"><context context-type="linenumber">648</context></context-group>
       </trans-unit>
@@ -971,114 +980,114 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
   </body></file>
   <file original="../walletcontroller.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="CreateWalletActivity">
-      <trans-unit id="_msg221">
+      <trans-unit id="_msg223">
         <source xml:space="preserve">Create Wallet</source>
         <context-group purpose="location"><context context-type="linenumber">244</context></context-group>
         <note annotates="source" from="developer">Title of window indicating the progress of creation of a new wallet.</note>
       </trans-unit>
-      <trans-unit id="_msg222">
+      <trans-unit id="_msg224">
         <source xml:space="preserve">Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
         <context-group purpose="location"><context context-type="linenumber">247</context></context-group>
         <note annotates="source" from="developer">Descriptive text of the create wallet progress window which indicates to the user which wallet is currently being created.</note>
       </trans-unit>
-      <trans-unit id="_msg223">
+      <trans-unit id="_msg225">
         <source xml:space="preserve">Create wallet failed</source>
         <context-group purpose="location"><context context-type="linenumber">280</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg224">
+      <trans-unit id="_msg226">
         <source xml:space="preserve">Create wallet warning</source>
         <context-group purpose="location"><context context-type="linenumber">282</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg225">
+      <trans-unit id="_msg227">
         <source xml:space="preserve">Can&apos;t list signers</source>
         <context-group purpose="location"><context context-type="linenumber">298</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg226">
+      <trans-unit id="_msg228">
         <source xml:space="preserve">Too many external signers found</source>
         <context-group purpose="location"><context context-type="linenumber">301</context></context-group>
       </trans-unit>
     </group>
     <group restype="x-trolltech-linguist-context" resname="LoadWalletsActivity">
-      <trans-unit id="_msg227">
+      <trans-unit id="_msg229">
         <source xml:space="preserve">Load Wallets</source>
         <context-group purpose="location"><context context-type="linenumber">375</context></context-group>
         <note annotates="source" from="developer">Title of progress window which is displayed when wallets are being loaded.</note>
       </trans-unit>
-      <trans-unit id="_msg228">
+      <trans-unit id="_msg230">
         <source xml:space="preserve">Loading wallets…</source>
         <context-group purpose="location"><context context-type="linenumber">378</context></context-group>
         <note annotates="source" from="developer">Descriptive text of the load wallets progress window which indicates to the user that wallets are currently being loaded.</note>
       </trans-unit>
     </group>
     <group restype="x-trolltech-linguist-context" resname="OpenWalletActivity">
-      <trans-unit id="_msg229">
+      <trans-unit id="_msg231">
         <source xml:space="preserve">Open wallet failed</source>
         <context-group purpose="location"><context context-type="linenumber">332</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg230">
+      <trans-unit id="_msg232">
         <source xml:space="preserve">Open wallet warning</source>
         <context-group purpose="location"><context context-type="linenumber">334</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg231">
+      <trans-unit id="_msg233">
         <source xml:space="preserve">default wallet</source>
         <context-group purpose="location"><context context-type="linenumber">344</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg232">
+      <trans-unit id="_msg234">
         <source xml:space="preserve">Open Wallet</source>
         <context-group purpose="location"><context context-type="linenumber">348</context></context-group>
         <note annotates="source" from="developer">Title of window indicating the progress of opening of a wallet.</note>
       </trans-unit>
-      <trans-unit id="_msg233">
+      <trans-unit id="_msg235">
         <source xml:space="preserve">Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
         <context-group purpose="location"><context context-type="linenumber">351</context></context-group>
         <note annotates="source" from="developer">Descriptive text of the open wallet progress window which indicates to the user which wallet is currently being opened.</note>
       </trans-unit>
     </group>
     <group restype="x-trolltech-linguist-context" resname="RestoreWalletActivity">
-      <trans-unit id="_msg234">
+      <trans-unit id="_msg236">
         <source xml:space="preserve">Restore Wallet</source>
         <context-group purpose="location"><context context-type="linenumber">400</context></context-group>
         <note annotates="source" from="developer">Title of progress window which is displayed when wallets are being restored.</note>
       </trans-unit>
-      <trans-unit id="_msg235">
+      <trans-unit id="_msg237">
         <source xml:space="preserve">Restoring Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
         <context-group purpose="location"><context context-type="linenumber">403</context></context-group>
         <note annotates="source" from="developer">Descriptive text of the restore wallets progress window which indicates to the user that wallets are currently being restored.</note>
       </trans-unit>
-      <trans-unit id="_msg236">
+      <trans-unit id="_msg238">
         <source xml:space="preserve">Restore wallet failed</source>
         <context-group purpose="location"><context context-type="linenumber">422</context></context-group>
         <note annotates="source" from="developer">Title of message box which is displayed when the wallet could not be restored.</note>
       </trans-unit>
-      <trans-unit id="_msg237">
+      <trans-unit id="_msg239">
         <source xml:space="preserve">Restore wallet warning</source>
         <context-group purpose="location"><context context-type="linenumber">425</context></context-group>
         <note annotates="source" from="developer">Title of message box which is displayed when the wallet is restored with some warning.</note>
       </trans-unit>
-      <trans-unit id="_msg238">
+      <trans-unit id="_msg240">
         <source xml:space="preserve">Restore wallet message</source>
         <context-group purpose="location"><context context-type="linenumber">428</context></context-group>
         <note annotates="source" from="developer">Title of message box which is displayed when the wallet is successfully restored.</note>
       </trans-unit>
     </group>
     <group restype="x-trolltech-linguist-context" resname="WalletController">
-      <trans-unit id="_msg239">
+      <trans-unit id="_msg241">
         <source xml:space="preserve">Close wallet</source>
         <context-group purpose="location"><context context-type="linenumber">84</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg240">
+      <trans-unit id="_msg242">
         <source xml:space="preserve">Are you sure you wish to close the wallet &lt;i&gt;%1&lt;/i&gt;?</source>
         <context-group purpose="location"><context context-type="linenumber">85</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg241">
+      <trans-unit id="_msg243">
         <source xml:space="preserve">Closing the wallet for too long can result in having to resync the entire chain if pruning is enabled.</source>
         <context-group purpose="location"><context context-type="linenumber">86</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg242">
+      <trans-unit id="_msg244">
         <source xml:space="preserve">Close all wallets</source>
         <context-group purpose="location"><context context-type="linenumber">99</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg243">
+      <trans-unit id="_msg245">
         <source xml:space="preserve">Are you sure you wish to close all wallets?</source>
         <context-group purpose="location"><context context-type="linenumber">100</context></context-group>
       </trans-unit>
@@ -1086,59 +1095,59 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
   </body></file>
   <file original="../forms/createwalletdialog.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="CreateWalletDialog">
-      <trans-unit id="_msg244">
+      <trans-unit id="_msg246">
         <source xml:space="preserve">Create Wallet</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg245">
+      <trans-unit id="_msg247">
         <source xml:space="preserve">Wallet Name</source>
         <context-group purpose="location"><context context-type="linenumber">25</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg246">
+      <trans-unit id="_msg248">
         <source xml:space="preserve">Wallet</source>
         <context-group purpose="location"><context context-type="linenumber">38</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg247">
+      <trans-unit id="_msg249">
         <source xml:space="preserve">Encrypt the wallet. The wallet will be encrypted with a passphrase of your choice.</source>
         <context-group purpose="location"><context context-type="linenumber">47</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg248">
+      <trans-unit id="_msg250">
         <source xml:space="preserve">Encrypt Wallet</source>
         <context-group purpose="location"><context context-type="linenumber">50</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg249">
+      <trans-unit id="_msg251">
         <source xml:space="preserve">Advanced Options</source>
         <context-group purpose="location"><context context-type="linenumber">76</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg250">
+      <trans-unit id="_msg252">
         <source xml:space="preserve">Disable private keys for this wallet. Wallets with private keys disabled will have no private keys and cannot have an HD seed or imported private keys. This is ideal for watch-only wallets.</source>
         <context-group purpose="location"><context context-type="linenumber">85</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg251">
+      <trans-unit id="_msg253">
         <source xml:space="preserve">Disable Private Keys</source>
         <context-group purpose="location"><context context-type="linenumber">88</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg252">
+      <trans-unit id="_msg254">
         <source xml:space="preserve">Make a blank wallet. Blank wallets do not initially have private keys or scripts. Private keys and addresses can be imported, or an HD seed can be set, at a later time.</source>
         <context-group purpose="location"><context context-type="linenumber">95</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg253">
+      <trans-unit id="_msg255">
         <source xml:space="preserve">Make Blank Wallet</source>
         <context-group purpose="location"><context context-type="linenumber">98</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg254">
+      <trans-unit id="_msg256">
         <source xml:space="preserve">Use descriptors for scriptPubKey management</source>
         <context-group purpose="location"><context context-type="linenumber">105</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg255">
+      <trans-unit id="_msg257">
         <source xml:space="preserve">Descriptor Wallet</source>
         <context-group purpose="location"><context context-type="linenumber">108</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg256">
+      <trans-unit id="_msg258">
         <source xml:space="preserve">Use an external signing device such as a hardware wallet. Configure the external signer script in wallet preferences first.</source>
         <context-group purpose="location"><context context-type="linenumber">118</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg257">
+      <trans-unit id="_msg259">
         <source xml:space="preserve">External signer</source>
         <context-group purpose="location"><context context-type="linenumber">121</context></context-group>
       </trans-unit>
@@ -1146,15 +1155,15 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
   </body></file>
   <file original="../createwalletdialog.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="CreateWalletDialog">
-      <trans-unit id="_msg258">
+      <trans-unit id="_msg260">
         <source xml:space="preserve">Create</source>
         <context-group purpose="location"><context context-type="linenumber">22</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg259">
+      <trans-unit id="_msg261">
         <source xml:space="preserve">Compiled without sqlite support (required for descriptor wallets)</source>
         <context-group purpose="location"><context context-type="linenumber">90</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg260">
+      <trans-unit id="_msg262">
         <source xml:space="preserve">Compiled without external signing support (required for external signing)</source>
         <context-group purpose="location"><context context-type="linenumber">104</context></context-group>
         <note annotates="source" from="developer">&quot;External signing&quot; means using devices such as hardware wallets.</note>
@@ -1163,23 +1172,23 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
   </body></file>
   <file original="../forms/editaddressdialog.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="EditAddressDialog">
-      <trans-unit id="_msg261">
+      <trans-unit id="_msg263">
         <source xml:space="preserve">Edit Address</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg262">
+      <trans-unit id="_msg264">
         <source xml:space="preserve">&amp;Label</source>
         <context-group purpose="location"><context context-type="linenumber">25</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg263">
+      <trans-unit id="_msg265">
         <source xml:space="preserve">The label associated with this address list entry</source>
         <context-group purpose="location"><context context-type="linenumber">35</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg264">
+      <trans-unit id="_msg266">
         <source xml:space="preserve">The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <context-group purpose="location"><context context-type="linenumber">52</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg265">
+      <trans-unit id="_msg267">
         <source xml:space="preserve">&amp;Address</source>
         <context-group purpose="location"><context context-type="linenumber">42</context></context-group>
       </trans-unit>
@@ -1187,152 +1196,152 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
   </body></file>
   <file original="../editaddressdialog.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="EditAddressDialog">
-      <trans-unit id="_msg266">
-        <source xml:space="preserve">New sending address</source>
-        <context-group purpose="location"><context context-type="linenumber">29</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg267">
-        <source xml:space="preserve">Edit receiving address</source>
-        <context-group purpose="location"><context context-type="linenumber">32</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg268">
-        <source xml:space="preserve">Edit sending address</source>
-        <context-group purpose="location"><context context-type="linenumber">36</context></context-group>
+        <source xml:space="preserve">New sending address</source>
+        <context-group purpose="location"><context context-type="linenumber">27</context></context-group>
       </trans-unit>
       <trans-unit id="_msg269">
-        <source xml:space="preserve">The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
-        <context-group purpose="location"><context context-type="linenumber">113</context></context-group>
+        <source xml:space="preserve">Edit receiving address</source>
+        <context-group purpose="location"><context context-type="linenumber">30</context></context-group>
       </trans-unit>
       <trans-unit id="_msg270">
-        <source xml:space="preserve">Address &quot;%1&quot; already exists as a receiving address with label &quot;%2&quot; and so cannot be added as a sending address.</source>
-        <context-group purpose="location"><context context-type="linenumber">146</context></context-group>
+        <source xml:space="preserve">Edit sending address</source>
+        <context-group purpose="location"><context context-type="linenumber">34</context></context-group>
       </trans-unit>
       <trans-unit id="_msg271">
-        <source xml:space="preserve">The entered address &quot;%1&quot; is already in the address book with label &quot;%2&quot;.</source>
-        <context-group purpose="location"><context context-type="linenumber">151</context></context-group>
+        <source xml:space="preserve">The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
+        <context-group purpose="location"><context context-type="linenumber">111</context></context-group>
       </trans-unit>
       <trans-unit id="_msg272">
-        <source xml:space="preserve">Could not unlock wallet.</source>
-        <context-group purpose="location"><context context-type="linenumber">123</context></context-group>
+        <source xml:space="preserve">Address &quot;%1&quot; already exists as a receiving address with label &quot;%2&quot; and so cannot be added as a sending address.</source>
+        <context-group purpose="location"><context context-type="linenumber">144</context></context-group>
       </trans-unit>
       <trans-unit id="_msg273">
+        <source xml:space="preserve">The entered address &quot;%1&quot; is already in the address book with label &quot;%2&quot;.</source>
+        <context-group purpose="location"><context context-type="linenumber">149</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg274">
+        <source xml:space="preserve">Could not unlock wallet.</source>
+        <context-group purpose="location"><context context-type="linenumber">121</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg275">
         <source xml:space="preserve">New key generation failed.</source>
-        <context-group purpose="location"><context context-type="linenumber">128</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">126</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../intro.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="FreespaceChecker">
-      <trans-unit id="_msg274">
+      <trans-unit id="_msg276">
         <source xml:space="preserve">A new data directory will be created.</source>
         <context-group purpose="location"><context context-type="linenumber">73</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg275">
+      <trans-unit id="_msg277">
         <source xml:space="preserve">name</source>
         <context-group purpose="location"><context context-type="linenumber">95</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg276">
+      <trans-unit id="_msg278">
         <source xml:space="preserve">Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <context-group purpose="location"><context context-type="linenumber">97</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg277">
+      <trans-unit id="_msg279">
         <source xml:space="preserve">Path already exists, and is not a directory.</source>
         <context-group purpose="location"><context context-type="linenumber">100</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg278">
+      <trans-unit id="_msg280">
         <source xml:space="preserve">Cannot create data directory here.</source>
         <context-group purpose="location"><context context-type="linenumber">107</context></context-group>
       </trans-unit>
     </group>
     <group restype="x-trolltech-linguist-context" resname="Intro">
-      <trans-unit id="_msg279">
+      <trans-unit id="_msg281">
         <source xml:space="preserve">Bitcoin</source>
-        <context-group purpose="location"><context context-type="linenumber">139</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">137</context></context-group>
       </trans-unit>
       <group restype="x-gettext-plurals">
-        <context-group purpose="location"><context context-type="linenumber">301</context></context-group>
-        <trans-unit id="_msg280[0]">
-          <source xml:space="preserve">%n GB of space available</source>
-        </trans-unit>
-        <trans-unit id="_msg280[1]">
-          <source xml:space="preserve">%n GB of space available</source>
-        </trans-unit>
-      </group>
-      <group restype="x-gettext-plurals">
-        <context-group purpose="location"><context context-type="linenumber">303</context></context-group>
-        <trans-unit id="_msg281[0]">
-          <source xml:space="preserve">(of %n GB needed)</source>
-        </trans-unit>
-        <trans-unit id="_msg281[1]">
-          <source xml:space="preserve">(of %n GB needed)</source>
-        </trans-unit>
-      </group>
-      <group restype="x-gettext-plurals">
-        <context-group purpose="location"><context context-type="linenumber">306</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">299</context></context-group>
         <trans-unit id="_msg282[0]">
-          <source xml:space="preserve">(%n GB needed for full chain)</source>
+          <source xml:space="preserve">%n GB of space available</source>
         </trans-unit>
         <trans-unit id="_msg282[1]">
+          <source xml:space="preserve">%n GB of space available</source>
+        </trans-unit>
+      </group>
+      <group restype="x-gettext-plurals">
+        <context-group purpose="location"><context context-type="linenumber">301</context></context-group>
+        <trans-unit id="_msg283[0]">
+          <source xml:space="preserve">(of %n GB needed)</source>
+        </trans-unit>
+        <trans-unit id="_msg283[1]">
+          <source xml:space="preserve">(of %n GB needed)</source>
+        </trans-unit>
+      </group>
+      <group restype="x-gettext-plurals">
+        <context-group purpose="location"><context context-type="linenumber">304</context></context-group>
+        <trans-unit id="_msg284[0]">
+          <source xml:space="preserve">(%n GB needed for full chain)</source>
+        </trans-unit>
+        <trans-unit id="_msg284[1]">
           <source xml:space="preserve">(%n GB needed for full chain)</source>
         </trans-unit>
       </group>
-      <trans-unit id="_msg283">
+      <trans-unit id="_msg285">
         <source xml:space="preserve">At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
-        <context-group purpose="location"><context context-type="linenumber">378</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">376</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg284">
+      <trans-unit id="_msg286">
         <source xml:space="preserve">Approximately %1 GB of data will be stored in this directory.</source>
-        <context-group purpose="location"><context context-type="linenumber">381</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">379</context></context-group>
       </trans-unit>
       <group restype="x-gettext-plurals">
-        <context-group purpose="location"><context context-type="linenumber">390</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">388</context></context-group>
         <note annotates="source" from="developer">Explanatory text on the capability of the current prune target.</note>
-        <trans-unit id="_msg285[0]">
+        <trans-unit id="_msg287[0]">
           <source xml:space="preserve">(sufficient to restore backups %n day(s) old)</source>
         </trans-unit>
-        <trans-unit id="_msg285[1]">
+        <trans-unit id="_msg287[1]">
           <source xml:space="preserve">(sufficient to restore backups %n day(s) old)</source>
         </trans-unit>
       </group>
-      <trans-unit id="_msg286">
-        <source xml:space="preserve">%1 will download and store a copy of the Bitcoin block chain.</source>
-        <context-group purpose="location"><context context-type="linenumber">392</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg287">
-        <source xml:space="preserve">The wallet will also be stored in this directory.</source>
-        <context-group purpose="location"><context context-type="linenumber">394</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg288">
-        <source xml:space="preserve">Error: Specified data directory &quot;%1&quot; cannot be created.</source>
-        <context-group purpose="location"><context context-type="linenumber">250</context></context-group>
+        <source xml:space="preserve">%1 will download and store a copy of the Bitcoin block chain.</source>
+        <context-group purpose="location"><context context-type="linenumber">390</context></context-group>
       </trans-unit>
       <trans-unit id="_msg289">
+        <source xml:space="preserve">The wallet will also be stored in this directory.</source>
+        <context-group purpose="location"><context context-type="linenumber">392</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg290">
+        <source xml:space="preserve">Error: Specified data directory &quot;%1&quot; cannot be created.</source>
+        <context-group purpose="location"><context context-type="linenumber">248</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg291">
         <source xml:space="preserve">Error</source>
-        <context-group purpose="location"><context context-type="linenumber">280</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">278</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../utilitydialog.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="HelpMessageDialog">
-      <trans-unit id="_msg290">
+      <trans-unit id="_msg292">
         <source xml:space="preserve">version</source>
         <context-group purpose="location"><context context-type="linenumber">38</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg291">
+      <trans-unit id="_msg293">
         <source xml:space="preserve">About %1</source>
         <context-group purpose="location"><context context-type="linenumber">42</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg292">
+      <trans-unit id="_msg294">
         <source xml:space="preserve">Command-line options</source>
         <context-group purpose="location"><context context-type="linenumber">60</context></context-group>
       </trans-unit>
     </group>
     <group restype="x-trolltech-linguist-context" resname="ShutdownWindow">
-      <trans-unit id="_msg293">
+      <trans-unit id="_msg295">
         <source xml:space="preserve">%1 is shutting down…</source>
         <context-group purpose="location"><context context-type="linenumber">145</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg294">
+      <trans-unit id="_msg296">
         <source xml:space="preserve">Do not shut down the computer until this window disappears.</source>
         <context-group purpose="location"><context context-type="linenumber">146</context></context-group>
       </trans-unit>
@@ -1340,47 +1349,47 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
   </body></file>
   <file original="../forms/intro.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="Intro">
-      <trans-unit id="_msg295">
+      <trans-unit id="_msg297">
         <source xml:space="preserve">Welcome</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg296">
+      <trans-unit id="_msg298">
         <source xml:space="preserve">Welcome to %1.</source>
         <context-group purpose="location"><context context-type="linenumber">23</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg297">
+      <trans-unit id="_msg299">
         <source xml:space="preserve">As this is the first time the program is launched, you can choose where %1 will store its data.</source>
         <context-group purpose="location"><context context-type="linenumber">49</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg298">
+      <trans-unit id="_msg300">
         <source xml:space="preserve">Limit block chain storage to</source>
         <context-group purpose="location"><context context-type="linenumber">238</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg299">
+      <trans-unit id="_msg301">
         <source xml:space="preserve">Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</source>
         <context-group purpose="location"><context context-type="linenumber">241</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg300">
+      <trans-unit id="_msg302">
         <source xml:space="preserve"> GB</source>
         <context-group purpose="location"><context context-type="linenumber">248</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg301">
+      <trans-unit id="_msg303">
         <source xml:space="preserve">This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
         <context-group purpose="location"><context context-type="linenumber">216</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg302">
+      <trans-unit id="_msg304">
         <source xml:space="preserve">When you click OK, %1 will begin to download and process the full %4 block chain (%2 GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
         <context-group purpose="location"><context context-type="linenumber">206</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg303">
+      <trans-unit id="_msg305">
         <source xml:space="preserve">If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</source>
         <context-group purpose="location"><context context-type="linenumber">226</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg304">
+      <trans-unit id="_msg306">
         <source xml:space="preserve">Use the default data directory</source>
         <context-group purpose="location"><context context-type="linenumber">66</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg305">
+      <trans-unit id="_msg307">
         <source xml:space="preserve">Use a custom data directory:</source>
         <context-group purpose="location"><context context-type="linenumber">73</context></context-group>
       </trans-unit>
@@ -1388,54 +1397,54 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
   </body></file>
   <file original="../forms/modaloverlay.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="ModalOverlay">
-      <trans-unit id="_msg306">
+      <trans-unit id="_msg308">
         <source xml:space="preserve">Form</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg307">
+      <trans-unit id="_msg309">
         <source xml:space="preserve">Recent transactions may not yet be visible, and therefore your wallet&apos;s balance might be incorrect. This information will be correct once your wallet has finished synchronizing with the bitcoin network, as detailed below.</source>
         <context-group purpose="location"><context context-type="linenumber">133</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg308">
+      <trans-unit id="_msg310">
         <source xml:space="preserve">Attempting to spend bitcoins that are affected by not-yet-displayed transactions will not be accepted by the network.</source>
         <context-group purpose="location"><context context-type="linenumber">152</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg309">
+      <trans-unit id="_msg311">
         <source xml:space="preserve">Number of blocks left</source>
         <context-group purpose="location"><context context-type="linenumber">215</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg310">
+      <trans-unit id="_msg312">
         <source xml:space="preserve">Unknown…</source>
         <context-group purpose="location"><context context-type="linenumber">222</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">248</context></context-group>
-        <context-group purpose="location"><context context-type="sourcefile">../modaloverlay.cpp</context><context context-type="linenumber">155</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../modaloverlay.cpp</context><context context-type="linenumber">152</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg311">
+      <trans-unit id="_msg313">
         <source xml:space="preserve">calculating…</source>
         <context-group purpose="location"><context context-type="linenumber">292</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">312</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg312">
+      <trans-unit id="_msg314">
         <source xml:space="preserve">Last block time</source>
         <context-group purpose="location"><context context-type="linenumber">235</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg313">
+      <trans-unit id="_msg315">
         <source xml:space="preserve">Progress</source>
         <context-group purpose="location"><context context-type="linenumber">261</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg314">
+      <trans-unit id="_msg316">
         <source xml:space="preserve">Progress increase per hour</source>
         <context-group purpose="location"><context context-type="linenumber">285</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg315">
+      <trans-unit id="_msg317">
         <source xml:space="preserve">Estimated time left until synced</source>
         <context-group purpose="location"><context context-type="linenumber">305</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg316">
+      <trans-unit id="_msg318">
         <source xml:space="preserve">Hide</source>
         <context-group purpose="location"><context context-type="linenumber">342</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg317">
+      <trans-unit id="_msg319">
         <source xml:space="preserve">Esc</source>
         <context-group purpose="location"><context context-type="linenumber">345</context></context-group>
       </trans-unit>
@@ -1443,37 +1452,37 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
   </body></file>
   <file original="../modaloverlay.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="ModalOverlay">
-      <trans-unit id="_msg318">
-        <source xml:space="preserve">%1 is currently syncing.  It will download headers and blocks from peers and validate them until reaching the tip of the block chain.</source>
-        <context-group purpose="location"><context context-type="linenumber">34</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg319">
-        <source xml:space="preserve">Unknown. Syncing Headers (%1, %2%)…</source>
-        <context-group purpose="location"><context context-type="linenumber">161</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg320">
+        <source xml:space="preserve">%1 is currently syncing.  It will download headers and blocks from peers and validate them until reaching the tip of the block chain.</source>
+        <context-group purpose="location"><context context-type="linenumber">31</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg321">
+        <source xml:space="preserve">Unknown. Syncing Headers (%1, %2%)…</source>
+        <context-group purpose="location"><context context-type="linenumber">158</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg322">
         <source xml:space="preserve">Unknown. Pre-syncing Headers (%1, %2%)…</source>
-        <context-group purpose="location"><context context-type="linenumber">166</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">163</context></context-group>
       </trans-unit>
     </group>
     <group restype="x-trolltech-linguist-context" resname="QObject">
-      <trans-unit id="_msg321">
+      <trans-unit id="_msg323">
         <source xml:space="preserve">unknown</source>
-        <context-group purpose="location"><context context-type="linenumber">126</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">123</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../forms/openuridialog.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="OpenURIDialog">
-      <trans-unit id="_msg322">
+      <trans-unit id="_msg324">
         <source xml:space="preserve">Open bitcoin URI</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg323">
+      <trans-unit id="_msg325">
         <source xml:space="preserve">URI:</source>
         <context-group purpose="location"><context context-type="linenumber">22</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg324">
+      <trans-unit id="_msg326">
         <source xml:space="preserve">Paste address from clipboard</source>
         <context-group purpose="location"><context context-type="linenumber">36</context></context-group>
         <note annotates="source" from="developer">Tooltip text for button that allows you to paste an address that is in your clipboard.</note>
@@ -1482,310 +1491,310 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
   </body></file>
   <file original="../forms/optionsdialog.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="OptionsDialog">
-      <trans-unit id="_msg325">
+      <trans-unit id="_msg327">
         <source xml:space="preserve">Options</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg326">
+      <trans-unit id="_msg328">
         <source xml:space="preserve">&amp;Main</source>
         <context-group purpose="location"><context context-type="linenumber">27</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg327">
+      <trans-unit id="_msg329">
         <source xml:space="preserve">Automatically start %1 after logging in to the system.</source>
         <context-group purpose="location"><context context-type="linenumber">33</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg328">
+      <trans-unit id="_msg330">
         <source xml:space="preserve">&amp;Start %1 on system login</source>
         <context-group purpose="location"><context context-type="linenumber">36</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg329">
+      <trans-unit id="_msg331">
         <source xml:space="preserve">Enabling pruning significantly reduces the disk space required to store transactions. All blocks are still fully validated. Reverting this setting requires re-downloading the entire blockchain.</source>
         <context-group purpose="location"><context context-type="linenumber">58</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg330">
+      <trans-unit id="_msg332">
         <source xml:space="preserve">Size of &amp;database cache</source>
         <context-group purpose="location"><context context-type="linenumber">111</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg331">
+      <trans-unit id="_msg333">
         <source xml:space="preserve">Number of script &amp;verification threads</source>
         <context-group purpose="location"><context context-type="linenumber">157</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg332">
+      <trans-unit id="_msg334">
+        <source xml:space="preserve">Full path to a %1 compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</source>
+        <context-group purpose="location"><context context-type="linenumber">289</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg335">
         <source xml:space="preserve">IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <context-group purpose="location"><context context-type="linenumber">388</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">575</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg333">
+      <trans-unit id="_msg336">
         <source xml:space="preserve">Shows if the supplied default SOCKS5 proxy is used to reach peers via this network type.</source>
         <context-group purpose="location"><context context-type="linenumber">457</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">480</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">503</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg334">
+      <trans-unit id="_msg337">
         <source xml:space="preserve">Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
         <context-group purpose="location"><context context-type="linenumber">672</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg335">
+      <trans-unit id="_msg338">
         <source xml:space="preserve">Options set in this dialog are overridden by the command line:</source>
         <context-group purpose="location"><context context-type="linenumber">899</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg336">
+      <trans-unit id="_msg339">
         <source xml:space="preserve">Open the %1 configuration file from the working directory.</source>
         <context-group purpose="location"><context context-type="linenumber">944</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg337">
+      <trans-unit id="_msg340">
         <source xml:space="preserve">Open Configuration File</source>
         <context-group purpose="location"><context context-type="linenumber">947</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg338">
+      <trans-unit id="_msg341">
         <source xml:space="preserve">Reset all client options to default.</source>
         <context-group purpose="location"><context context-type="linenumber">957</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg339">
+      <trans-unit id="_msg342">
         <source xml:space="preserve">&amp;Reset Options</source>
         <context-group purpose="location"><context context-type="linenumber">960</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg340">
+      <trans-unit id="_msg343">
         <source xml:space="preserve">&amp;Network</source>
         <context-group purpose="location"><context context-type="linenumber">315</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg341">
+      <trans-unit id="_msg344">
         <source xml:space="preserve">Prune &amp;block storage to</source>
         <context-group purpose="location"><context context-type="linenumber">61</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg342">
+      <trans-unit id="_msg345">
         <source xml:space="preserve">GB</source>
         <context-group purpose="location"><context context-type="linenumber">71</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg343">
+      <trans-unit id="_msg346">
         <source xml:space="preserve">Reverting this setting requires re-downloading the entire blockchain.</source>
         <context-group purpose="location"><context context-type="linenumber">96</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg344">
+      <trans-unit id="_msg347">
         <source xml:space="preserve">Maximum database cache size. A larger cache can contribute to faster sync, after which the benefit is less pronounced for most use cases. Lowering the cache size will reduce memory usage. Unused mempool memory is shared for this cache.</source>
         <context-group purpose="location"><context context-type="linenumber">108</context></context-group>
         <note annotates="source" from="developer">Tooltip text for Options window setting that sets the size of the database cache. Explains the corresponding effects of increasing/decreasing this value.</note>
       </trans-unit>
-      <trans-unit id="_msg345">
+      <trans-unit id="_msg348">
         <source xml:space="preserve">MiB</source>
         <context-group purpose="location"><context context-type="linenumber">127</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg346">
+      <trans-unit id="_msg349">
         <source xml:space="preserve">Set the number of script verification threads. Negative values correspond to the number of cores you want to leave free to the system.</source>
         <context-group purpose="location"><context context-type="linenumber">154</context></context-group>
         <note annotates="source" from="developer">Tooltip text for Options window setting that sets the number of script verification threads. Explains that negative values mean to leave these many cores free to the system.</note>
       </trans-unit>
-      <trans-unit id="_msg347">
+      <trans-unit id="_msg350">
         <source xml:space="preserve">(0 = auto, &lt;0 = leave that many cores free)</source>
         <context-group purpose="location"><context context-type="linenumber">170</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg348">
+      <trans-unit id="_msg351">
         <source xml:space="preserve">This allows you or a third party tool to communicate with the node through command-line and JSON-RPC commands.</source>
         <context-group purpose="location"><context context-type="linenumber">192</context></context-group>
         <note annotates="source" from="developer">Tooltip text for Options window setting that enables the RPC server.</note>
       </trans-unit>
-      <trans-unit id="_msg349">
+      <trans-unit id="_msg352">
         <source xml:space="preserve">Enable R&amp;PC server</source>
         <context-group purpose="location"><context context-type="linenumber">195</context></context-group>
         <note annotates="source" from="developer">An Options window setting to enable the RPC server.</note>
       </trans-unit>
-      <trans-unit id="_msg350">
+      <trans-unit id="_msg353">
         <source xml:space="preserve">W&amp;allet</source>
         <context-group purpose="location"><context context-type="linenumber">216</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg351">
+      <trans-unit id="_msg354">
         <source xml:space="preserve">Whether to set subtract fee from amount as default or not.</source>
         <context-group purpose="location"><context context-type="linenumber">222</context></context-group>
         <note annotates="source" from="developer">Tooltip text for Options window setting that sets subtracting the fee from a sending amount as default.</note>
       </trans-unit>
-      <trans-unit id="_msg352">
+      <trans-unit id="_msg355">
         <source xml:space="preserve">Subtract &amp;fee from amount by default</source>
         <context-group purpose="location"><context context-type="linenumber">225</context></context-group>
         <note annotates="source" from="developer">An Options window setting to set subtracting the fee from a sending amount as default.</note>
       </trans-unit>
-      <trans-unit id="_msg353">
+      <trans-unit id="_msg356">
         <source xml:space="preserve">Expert</source>
         <context-group purpose="location"><context context-type="linenumber">232</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg354">
+      <trans-unit id="_msg357">
         <source xml:space="preserve">Enable coin &amp;control features</source>
         <context-group purpose="location"><context context-type="linenumber">241</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg355">
+      <trans-unit id="_msg358">
         <source xml:space="preserve">If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <context-group purpose="location"><context context-type="linenumber">248</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg356">
+      <trans-unit id="_msg359">
         <source xml:space="preserve">&amp;Spend unconfirmed change</source>
         <context-group purpose="location"><context context-type="linenumber">251</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg357">
+      <trans-unit id="_msg360">
         <source xml:space="preserve">Enable &amp;PSBT controls</source>
         <context-group purpose="location"><context context-type="linenumber">258</context></context-group>
         <note annotates="source" from="developer">An options window setting to enable PSBT controls.</note>
       </trans-unit>
-      <trans-unit id="_msg358">
+      <trans-unit id="_msg361">
         <source xml:space="preserve">Whether to show PSBT controls.</source>
         <context-group purpose="location"><context context-type="linenumber">261</context></context-group>
         <note annotates="source" from="developer">Tooltip text for options window setting that enables PSBT controls.</note>
       </trans-unit>
-      <trans-unit id="_msg359">
+      <trans-unit id="_msg362">
         <source xml:space="preserve">External Signer (e.g. hardware wallet)</source>
         <context-group purpose="location"><context context-type="linenumber">271</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg360">
+      <trans-unit id="_msg363">
         <source xml:space="preserve">&amp;External signer script path</source>
         <context-group purpose="location"><context context-type="linenumber">279</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg361">
-        <source xml:space="preserve">Full path to a Bitcoin Core compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</source>
-        <context-group purpose="location"><context context-type="linenumber">289</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg362">
+      <trans-unit id="_msg364">
         <source xml:space="preserve">Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <context-group purpose="location"><context context-type="linenumber">321</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg363">
+      <trans-unit id="_msg365">
         <source xml:space="preserve">Map port using &amp;UPnP</source>
         <context-group purpose="location"><context context-type="linenumber">324</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg364">
+      <trans-unit id="_msg366">
         <source xml:space="preserve">Automatically open the Bitcoin client port on the router. This only works when your router supports NAT-PMP and it is enabled. The external port could be random.</source>
         <context-group purpose="location"><context context-type="linenumber">331</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg365">
+      <trans-unit id="_msg367">
         <source xml:space="preserve">Map port using NA&amp;T-PMP</source>
         <context-group purpose="location"><context context-type="linenumber">334</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg366">
+      <trans-unit id="_msg368">
         <source xml:space="preserve">Accept connections from outside.</source>
         <context-group purpose="location"><context context-type="linenumber">341</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg367">
+      <trans-unit id="_msg369">
         <source xml:space="preserve">Allow incomin&amp;g connections</source>
         <context-group purpose="location"><context context-type="linenumber">344</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg368">
+      <trans-unit id="_msg370">
         <source xml:space="preserve">Connect to the Bitcoin network through a SOCKS5 proxy.</source>
         <context-group purpose="location"><context context-type="linenumber">351</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg369">
+      <trans-unit id="_msg371">
         <source xml:space="preserve">&amp;Connect through SOCKS5 proxy (default proxy):</source>
         <context-group purpose="location"><context context-type="linenumber">354</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg370">
+      <trans-unit id="_msg372">
         <source xml:space="preserve">Proxy &amp;IP:</source>
         <context-group purpose="location"><context context-type="linenumber">363</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">550</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg371">
+      <trans-unit id="_msg373">
         <source xml:space="preserve">&amp;Port:</source>
         <context-group purpose="location"><context context-type="linenumber">395</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">582</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg372">
+      <trans-unit id="_msg374">
         <source xml:space="preserve">Port of the proxy (e.g. 9050)</source>
         <context-group purpose="location"><context context-type="linenumber">420</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">607</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg373">
+      <trans-unit id="_msg375">
         <source xml:space="preserve">Used for reaching peers via:</source>
         <context-group purpose="location"><context context-type="linenumber">444</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg374">
+      <trans-unit id="_msg376">
         <source xml:space="preserve">IPv4</source>
         <context-group purpose="location"><context context-type="linenumber">467</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg375">
+      <trans-unit id="_msg377">
         <source xml:space="preserve">IPv6</source>
         <context-group purpose="location"><context context-type="linenumber">490</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg376">
+      <trans-unit id="_msg378">
         <source xml:space="preserve">Tor</source>
         <context-group purpose="location"><context context-type="linenumber">513</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg377">
+      <trans-unit id="_msg379">
         <source xml:space="preserve">&amp;Window</source>
         <context-group purpose="location"><context context-type="linenumber">643</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg378">
+      <trans-unit id="_msg380">
         <source xml:space="preserve">Show the icon in the system tray.</source>
         <context-group purpose="location"><context context-type="linenumber">649</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg379">
+      <trans-unit id="_msg381">
         <source xml:space="preserve">&amp;Show tray icon</source>
         <context-group purpose="location"><context context-type="linenumber">652</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg380">
+      <trans-unit id="_msg382">
         <source xml:space="preserve">Show only a tray icon after minimizing the window.</source>
         <context-group purpose="location"><context context-type="linenumber">662</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg381">
+      <trans-unit id="_msg383">
         <source xml:space="preserve">&amp;Minimize to the tray instead of the taskbar</source>
         <context-group purpose="location"><context context-type="linenumber">665</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg382">
+      <trans-unit id="_msg384">
         <source xml:space="preserve">M&amp;inimize on close</source>
         <context-group purpose="location"><context context-type="linenumber">675</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg383">
+      <trans-unit id="_msg385">
         <source xml:space="preserve">&amp;Display</source>
         <context-group purpose="location"><context context-type="linenumber">696</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg384">
+      <trans-unit id="_msg386">
         <source xml:space="preserve">User Interface &amp;language:</source>
         <context-group purpose="location"><context context-type="linenumber">704</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg385">
+      <trans-unit id="_msg387">
         <source xml:space="preserve">The user interface language can be set here. This setting will take effect after restarting %1.</source>
         <context-group purpose="location"><context context-type="linenumber">717</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg386">
+      <trans-unit id="_msg388">
         <source xml:space="preserve">&amp;Unit to show amounts in:</source>
         <context-group purpose="location"><context context-type="linenumber">728</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg387">
+      <trans-unit id="_msg389">
         <source xml:space="preserve">Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <context-group purpose="location"><context context-type="linenumber">741</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg388">
+      <trans-unit id="_msg390">
         <source xml:space="preserve">Third-party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</source>
         <context-group purpose="location"><context context-type="linenumber">752</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">765</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg389">
+      <trans-unit id="_msg391">
         <source xml:space="preserve">&amp;Third-party transaction URLs</source>
         <context-group purpose="location"><context context-type="linenumber">755</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg390">
+      <trans-unit id="_msg392">
         <source xml:space="preserve">Whether to show coin control features or not.</source>
         <context-group purpose="location"><context context-type="linenumber">238</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg391">
+      <trans-unit id="_msg393">
         <source xml:space="preserve">Connect to the Bitcoin network through a separate SOCKS5 proxy for Tor onion services.</source>
         <context-group purpose="location"><context context-type="linenumber">538</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg392">
+      <trans-unit id="_msg394">
         <source xml:space="preserve">Use separate SOCKS&amp;5 proxy to reach peers via Tor onion services:</source>
         <context-group purpose="location"><context context-type="linenumber">541</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg393">
+      <trans-unit id="_msg395">
         <source xml:space="preserve">Monospaced font in the Overview tab:</source>
         <context-group purpose="location"><context context-type="linenumber">777</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg394">
+      <trans-unit id="_msg396">
         <source xml:space="preserve">embedded &quot;%1&quot;</source>
         <context-group purpose="location"><context context-type="linenumber">785</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg395">
+      <trans-unit id="_msg397">
         <source xml:space="preserve">closest matching &quot;%1&quot;</source>
         <context-group purpose="location"><context context-type="linenumber">834</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg396">
+      <trans-unit id="_msg398">
         <source xml:space="preserve">&amp;OK</source>
         <context-group purpose="location"><context context-type="linenumber">1040</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg397">
+      <trans-unit id="_msg399">
         <source xml:space="preserve">&amp;Cancel</source>
         <context-group purpose="location"><context context-type="linenumber">1053</context></context-group>
       </trans-unit>
@@ -1793,71 +1802,71 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
   </body></file>
   <file original="../optionsdialog.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="OptionsDialog">
-      <trans-unit id="_msg398">
+      <trans-unit id="_msg400">
         <source xml:space="preserve">Compiled without external signing support (required for external signing)</source>
         <context-group purpose="location"><context context-type="linenumber">96</context></context-group>
         <note annotates="source" from="developer">&quot;External signing&quot; means using devices such as hardware wallets.</note>
       </trans-unit>
-      <trans-unit id="_msg399">
+      <trans-unit id="_msg401">
         <source xml:space="preserve">default</source>
         <context-group purpose="location"><context context-type="linenumber">108</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg400">
+      <trans-unit id="_msg402">
         <source xml:space="preserve">none</source>
         <context-group purpose="location"><context context-type="linenumber">194</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg401">
+      <trans-unit id="_msg403">
         <source xml:space="preserve">Confirm options reset</source>
         <context-group purpose="location"><context context-type="linenumber">301</context></context-group>
         <note annotates="source" from="developer">Window title text of pop-up window shown when the user has chosen to reset options.</note>
       </trans-unit>
-      <trans-unit id="_msg402">
+      <trans-unit id="_msg404">
         <source xml:space="preserve">Client restart required to activate changes.</source>
         <context-group purpose="location"><context context-type="linenumber">292</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">371</context></context-group>
         <note annotates="source" from="developer">Text explaining that the settings changed will not come into effect until the client is restarted.</note>
       </trans-unit>
-      <trans-unit id="_msg403">
+      <trans-unit id="_msg405">
         <source xml:space="preserve">Current settings will be backed up at &quot;%1&quot;.</source>
         <context-group purpose="location"><context context-type="linenumber">296</context></context-group>
         <note annotates="source" from="developer">Text explaining to the user that the client&apos;s current settings will be backed up at a specific location. %1 is a stand-in argument for the backup location&apos;s path.</note>
       </trans-unit>
-      <trans-unit id="_msg404">
+      <trans-unit id="_msg406">
         <source xml:space="preserve">Client will be shut down. Do you want to proceed?</source>
         <context-group purpose="location"><context context-type="linenumber">299</context></context-group>
         <note annotates="source" from="developer">Text asking the user to confirm if they would like to proceed with a client shutdown.</note>
       </trans-unit>
-      <trans-unit id="_msg405">
+      <trans-unit id="_msg407">
         <source xml:space="preserve">Configuration options</source>
         <context-group purpose="location"><context context-type="linenumber">319</context></context-group>
         <note annotates="source" from="developer">Window title text of pop-up box that allows opening up of configuration file.</note>
       </trans-unit>
-      <trans-unit id="_msg406">
+      <trans-unit id="_msg408">
         <source xml:space="preserve">The configuration file is used to specify advanced user options which override GUI settings. Additionally, any command-line options will override this configuration file.</source>
         <context-group purpose="location"><context context-type="linenumber">322</context></context-group>
         <note annotates="source" from="developer">Explanatory text about the priority order of instructions considered by client. The order from high to low being: command-line, configuration file, GUI settings.</note>
       </trans-unit>
-      <trans-unit id="_msg407">
+      <trans-unit id="_msg409">
         <source xml:space="preserve">Continue</source>
         <context-group purpose="location"><context context-type="linenumber">325</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg408">
+      <trans-unit id="_msg410">
         <source xml:space="preserve">Cancel</source>
         <context-group purpose="location"><context context-type="linenumber">326</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg409">
+      <trans-unit id="_msg411">
         <source xml:space="preserve">Error</source>
         <context-group purpose="location"><context context-type="linenumber">335</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg410">
+      <trans-unit id="_msg412">
         <source xml:space="preserve">The configuration file could not be opened.</source>
         <context-group purpose="location"><context context-type="linenumber">335</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg411">
+      <trans-unit id="_msg413">
         <source xml:space="preserve">This change would require a client restart.</source>
         <context-group purpose="location"><context context-type="linenumber">375</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg412">
+      <trans-unit id="_msg414">
         <source xml:space="preserve">The supplied proxy address is invalid.</source>
         <context-group purpose="location"><context context-type="linenumber">403</context></context-group>
       </trans-unit>
@@ -1865,84 +1874,84 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
   </body></file>
   <file original="../optionsmodel.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="OptionsModel">
-      <trans-unit id="_msg413">
+      <trans-unit id="_msg415">
         <source xml:space="preserve">Could not read setting &quot;%1&quot;, %2.</source>
-        <context-group purpose="location"><context context-type="linenumber">204</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">198</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../forms/overviewpage.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="OverviewPage">
-      <trans-unit id="_msg414">
+      <trans-unit id="_msg416">
         <source xml:space="preserve">Form</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg415">
+      <trans-unit id="_msg417">
         <source xml:space="preserve">The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <context-group purpose="location"><context context-type="linenumber">76</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">411</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg416">
+      <trans-unit id="_msg418">
         <source xml:space="preserve">Watch-only:</source>
         <context-group purpose="location"><context context-type="linenumber">284</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg417">
+      <trans-unit id="_msg419">
         <source xml:space="preserve">Available:</source>
         <context-group purpose="location"><context context-type="linenumber">294</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg418">
+      <trans-unit id="_msg420">
         <source xml:space="preserve">Your current spendable balance</source>
         <context-group purpose="location"><context context-type="linenumber">304</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg419">
+      <trans-unit id="_msg421">
         <source xml:space="preserve">Pending:</source>
         <context-group purpose="location"><context context-type="linenumber">339</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg420">
+      <trans-unit id="_msg422">
         <source xml:space="preserve">Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <context-group purpose="location"><context context-type="linenumber">139</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg421">
+      <trans-unit id="_msg423">
         <source xml:space="preserve">Immature:</source>
         <context-group purpose="location"><context context-type="linenumber">239</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg422">
+      <trans-unit id="_msg424">
         <source xml:space="preserve">Mined balance that has not yet matured</source>
         <context-group purpose="location"><context context-type="linenumber">210</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg423">
+      <trans-unit id="_msg425">
         <source xml:space="preserve">Balances</source>
         <context-group purpose="location"><context context-type="linenumber">60</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg424">
+      <trans-unit id="_msg426">
         <source xml:space="preserve">Total:</source>
         <context-group purpose="location"><context context-type="linenumber">200</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg425">
+      <trans-unit id="_msg427">
         <source xml:space="preserve">Your current total balance</source>
         <context-group purpose="location"><context context-type="linenumber">249</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg426">
+      <trans-unit id="_msg428">
         <source xml:space="preserve">Your current balance in watch-only addresses</source>
         <context-group purpose="location"><context context-type="linenumber">323</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg427">
+      <trans-unit id="_msg429">
         <source xml:space="preserve">Spendable:</source>
         <context-group purpose="location"><context context-type="linenumber">346</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg428">
+      <trans-unit id="_msg430">
         <source xml:space="preserve">Recent transactions</source>
         <context-group purpose="location"><context context-type="linenumber">395</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg429">
+      <trans-unit id="_msg431">
         <source xml:space="preserve">Unconfirmed transactions to watch-only addresses</source>
         <context-group purpose="location"><context context-type="linenumber">120</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg430">
+      <trans-unit id="_msg432">
         <source xml:space="preserve">Mined balance in watch-only addresses that has not yet matured</source>
         <context-group purpose="location"><context context-type="linenumber">158</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg431">
+      <trans-unit id="_msg433">
         <source xml:space="preserve">Current total balance in watch-only addresses</source>
         <context-group purpose="location"><context context-type="linenumber">268</context></context-group>
       </trans-unit>
@@ -1950,35 +1959,35 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
   </body></file>
   <file original="../overviewpage.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="OverviewPage">
-      <trans-unit id="_msg432">
+      <trans-unit id="_msg434">
         <source xml:space="preserve">Privacy mode activated for the Overview tab. To unmask the values, uncheck Settings-&gt;Mask values.</source>
-        <context-group purpose="location"><context context-type="linenumber">185</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">184</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../forms/psbtoperationsdialog.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="PSBTOperationsDialog">
-      <trans-unit id="_msg433">
+      <trans-unit id="_msg435">
         <source xml:space="preserve">Dialog</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg434">
+      <trans-unit id="_msg436">
         <source xml:space="preserve">Sign Tx</source>
         <context-group purpose="location"><context context-type="linenumber">86</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg435">
+      <trans-unit id="_msg437">
         <source xml:space="preserve">Broadcast Tx</source>
         <context-group purpose="location"><context context-type="linenumber">102</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg436">
+      <trans-unit id="_msg438">
         <source xml:space="preserve">Copy to Clipboard</source>
         <context-group purpose="location"><context context-type="linenumber">122</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg437">
+      <trans-unit id="_msg439">
         <source xml:space="preserve">Save…</source>
         <context-group purpose="location"><context context-type="linenumber">129</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg438">
+      <trans-unit id="_msg440">
         <source xml:space="preserve">Close</source>
         <context-group purpose="location"><context context-type="linenumber">136</context></context-group>
       </trans-unit>
@@ -1986,108 +1995,108 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
   </body></file>
   <file original="../psbtoperationsdialog.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="PSBTOperationsDialog">
-      <trans-unit id="_msg439">
+      <trans-unit id="_msg441">
         <source xml:space="preserve">Failed to load transaction: %1</source>
         <context-group purpose="location"><context context-type="linenumber">61</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg440">
+      <trans-unit id="_msg442">
         <source xml:space="preserve">Failed to sign transaction: %1</source>
         <context-group purpose="location"><context context-type="linenumber">86</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg441">
+      <trans-unit id="_msg443">
         <source xml:space="preserve">Cannot sign inputs while wallet is locked.</source>
         <context-group purpose="location"><context context-type="linenumber">94</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg442">
+      <trans-unit id="_msg444">
         <source xml:space="preserve">Could not sign any more inputs.</source>
         <context-group purpose="location"><context context-type="linenumber">96</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg443">
+      <trans-unit id="_msg445">
         <source xml:space="preserve">Signed %1 inputs, but more signatures are still required.</source>
         <context-group purpose="location"><context context-type="linenumber">98</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg444">
+      <trans-unit id="_msg446">
         <source xml:space="preserve">Signed transaction successfully. Transaction is ready to broadcast.</source>
         <context-group purpose="location"><context context-type="linenumber">101</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg445">
+      <trans-unit id="_msg447">
         <source xml:space="preserve">Unknown error processing transaction.</source>
         <context-group purpose="location"><context context-type="linenumber">113</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg446">
+      <trans-unit id="_msg448">
         <source xml:space="preserve">Transaction broadcast successfully! Transaction ID: %1</source>
         <context-group purpose="location"><context context-type="linenumber">123</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg447">
+      <trans-unit id="_msg449">
         <source xml:space="preserve">Transaction broadcast failed: %1</source>
         <context-group purpose="location"><context context-type="linenumber">126</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg448">
+      <trans-unit id="_msg450">
         <source xml:space="preserve">PSBT copied to clipboard.</source>
         <context-group purpose="location"><context context-type="linenumber">135</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg449">
+      <trans-unit id="_msg451">
         <source xml:space="preserve">Save Transaction Data</source>
         <context-group purpose="location"><context context-type="linenumber">158</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg450">
+      <trans-unit id="_msg452">
         <source xml:space="preserve">Partially Signed Transaction (Binary)</source>
         <context-group purpose="location"><context context-type="linenumber">160</context></context-group>
         <note annotates="source" from="developer">Expanded name of the binary PSBT file format. See: BIP 174.</note>
       </trans-unit>
-      <trans-unit id="_msg451">
+      <trans-unit id="_msg453">
         <source xml:space="preserve">PSBT saved to disk.</source>
         <context-group purpose="location"><context context-type="linenumber">167</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg452">
+      <trans-unit id="_msg454">
         <source xml:space="preserve"> * Sends %1 to %2</source>
         <context-group purpose="location"><context context-type="linenumber">183</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg453">
+      <trans-unit id="_msg455">
         <source xml:space="preserve">Unable to calculate transaction fee or total transaction amount.</source>
         <context-group purpose="location"><context context-type="linenumber">193</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg454">
+      <trans-unit id="_msg456">
         <source xml:space="preserve">Pays transaction fee: </source>
         <context-group purpose="location"><context context-type="linenumber">195</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg455">
+      <trans-unit id="_msg457">
         <source xml:space="preserve">Total Amount</source>
         <context-group purpose="location"><context context-type="linenumber">207</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg456">
+      <trans-unit id="_msg458">
         <source xml:space="preserve">or</source>
         <context-group purpose="location"><context context-type="linenumber">210</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg457">
+      <trans-unit id="_msg459">
         <source xml:space="preserve">Transaction has %1 unsigned inputs.</source>
         <context-group purpose="location"><context context-type="linenumber">216</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg458">
+      <trans-unit id="_msg460">
         <source xml:space="preserve">Transaction is missing some information about inputs.</source>
         <context-group purpose="location"><context context-type="linenumber">262</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg459">
+      <trans-unit id="_msg461">
         <source xml:space="preserve">Transaction still needs signature(s).</source>
         <context-group purpose="location"><context context-type="linenumber">266</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg460">
+      <trans-unit id="_msg462">
         <source xml:space="preserve">(But no wallet is loaded.)</source>
         <context-group purpose="location"><context context-type="linenumber">269</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg461">
+      <trans-unit id="_msg463">
         <source xml:space="preserve">(But this wallet cannot sign transactions.)</source>
         <context-group purpose="location"><context context-type="linenumber">272</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg462">
+      <trans-unit id="_msg464">
         <source xml:space="preserve">(But this wallet does not have the right keys.)</source>
         <context-group purpose="location"><context context-type="linenumber">275</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg463">
+      <trans-unit id="_msg465">
         <source xml:space="preserve">Transaction is fully signed and ready for broadcast.</source>
         <context-group purpose="location"><context context-type="linenumber">283</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg464">
+      <trans-unit id="_msg466">
         <source xml:space="preserve">Transaction status is unknown.</source>
         <context-group purpose="location"><context context-type="linenumber">287</context></context-group>
       </trans-unit>
@@ -2095,90 +2104,90 @@ Signing is only possible with addresses of the type &apos;legacy&apos;.</source>
   </body></file>
   <file original="../paymentserver.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="PaymentServer">
-      <trans-unit id="_msg465">
-        <source xml:space="preserve">Payment request error</source>
-        <context-group purpose="location"><context context-type="linenumber">152</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg466">
-        <source xml:space="preserve">Cannot start bitcoin: click-to-pay handler</source>
-        <context-group purpose="location"><context context-type="linenumber">153</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg467">
-        <source xml:space="preserve">URI handling</source>
-        <context-group purpose="location"><context context-type="linenumber">201</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">217</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">223</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">230</context></context-group>
+        <source xml:space="preserve">Payment request error</source>
+        <context-group purpose="location"><context context-type="linenumber">149</context></context-group>
       </trans-unit>
       <trans-unit id="_msg468">
-        <source xml:space="preserve">&apos;bitcoin://&apos; is not a valid URI. Use &apos;bitcoin:&apos; instead.</source>
-        <context-group purpose="location"><context context-type="linenumber">201</context></context-group>
+        <source xml:space="preserve">Cannot start bitcoin: click-to-pay handler</source>
+        <context-group purpose="location"><context context-type="linenumber">150</context></context-group>
       </trans-unit>
       <trans-unit id="_msg469">
+        <source xml:space="preserve">URI handling</source>
+        <context-group purpose="location"><context context-type="linenumber">198</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">214</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">220</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">227</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg470">
+        <source xml:space="preserve">&apos;bitcoin://&apos; is not a valid URI. Use &apos;bitcoin:&apos; instead.</source>
+        <context-group purpose="location"><context context-type="linenumber">198</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg471">
         <source xml:space="preserve">Cannot process payment request because BIP70 is not supported.
 Due to widespread security flaws in BIP70 it&apos;s strongly recommended that any merchant instructions to switch wallets be ignored.
 If you are receiving this error you should request the merchant provide a BIP21 compatible URI.</source>
-        <context-group purpose="location"><context context-type="linenumber">218</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">241</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">215</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">238</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg470">
+      <trans-unit id="_msg472">
         <source xml:space="preserve">URI cannot be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
-        <context-group purpose="location"><context context-type="linenumber">231</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">228</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg471">
+      <trans-unit id="_msg473">
         <source xml:space="preserve">Payment request file handling</source>
-        <context-group purpose="location"><context context-type="linenumber">240</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">237</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../peertablemodel.h" datatype="c" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="PeerTableModel">
-      <trans-unit id="_msg472">
+      <trans-unit id="_msg474">
         <source xml:space="preserve">User Agent</source>
         <context-group purpose="location"><context context-type="linenumber">112</context></context-group>
         <note annotates="source" from="developer">Title of Peers Table column which contains the peer&apos;s User Agent string.</note>
       </trans-unit>
-      <trans-unit id="_msg473">
+      <trans-unit id="_msg475">
         <source xml:space="preserve">Ping</source>
         <context-group purpose="location"><context context-type="linenumber">103</context></context-group>
         <note annotates="source" from="developer">Title of Peers Table column which indicates the current latency of the connection with the peer.</note>
       </trans-unit>
-      <trans-unit id="_msg474">
+      <trans-unit id="_msg476">
         <source xml:space="preserve">Peer</source>
         <context-group purpose="location"><context context-type="linenumber">85</context></context-group>
         <note annotates="source" from="developer">Title of Peers Table column which contains a unique number used to identify a connection.</note>
       </trans-unit>
-      <trans-unit id="_msg475">
+      <trans-unit id="_msg477">
         <source xml:space="preserve">Age</source>
         <context-group purpose="location"><context context-type="linenumber">88</context></context-group>
         <note annotates="source" from="developer">Title of Peers Table column which indicates the duration (length of time) since the peer connection started.</note>
       </trans-unit>
-      <trans-unit id="_msg476">
+      <trans-unit id="_msg478">
         <source xml:space="preserve">Direction</source>
         <context-group purpose="location"><context context-type="linenumber">94</context></context-group>
         <note annotates="source" from="developer">Title of Peers Table column which indicates the direction the peer connection was initiated from.</note>
       </trans-unit>
-      <trans-unit id="_msg477">
+      <trans-unit id="_msg479">
         <source xml:space="preserve">Sent</source>
         <context-group purpose="location"><context context-type="linenumber">106</context></context-group>
         <note annotates="source" from="developer">Title of Peers Table column which indicates the total amount of network information we have sent to the peer.</note>
       </trans-unit>
-      <trans-unit id="_msg478">
+      <trans-unit id="_msg480">
         <source xml:space="preserve">Received</source>
         <context-group purpose="location"><context context-type="linenumber">109</context></context-group>
         <note annotates="source" from="developer">Title of Peers Table column which indicates the total amount of network information we have received from the peer.</note>
       </trans-unit>
-      <trans-unit id="_msg479">
+      <trans-unit id="_msg481">
         <source xml:space="preserve">Address</source>
         <context-group purpose="location"><context context-type="linenumber">91</context></context-group>
         <note annotates="source" from="developer">Title of Peers Table column which contains the IP/Onion/I2P address of the connected peer.</note>
       </trans-unit>
-      <trans-unit id="_msg480">
+      <trans-unit id="_msg482">
         <source xml:space="preserve">Type</source>
         <context-group purpose="location"><context context-type="linenumber">97</context></context-group>
         <note annotates="source" from="developer">Title of Peers Table column which describes the type of peer connection. The &quot;type&quot; describes why the connection exists.</note>
       </trans-unit>
-      <trans-unit id="_msg481">
+      <trans-unit id="_msg483">
         <source xml:space="preserve">Network</source>
         <context-group purpose="location"><context context-type="linenumber">100</context></context-group>
         <note annotates="source" from="developer">Title of Peers Table column which states the network the peer connected through.</note>
@@ -2187,21 +2196,21 @@ If you are receiving this error you should request the merchant provide a BIP21 
   </body></file>
   <file original="../peertablemodel.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="PeerTableModel">
-      <trans-unit id="_msg482">
+      <trans-unit id="_msg484">
         <source xml:space="preserve">Inbound</source>
-        <context-group purpose="location"><context context-type="linenumber">78</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">77</context></context-group>
         <note annotates="source" from="developer">An Inbound Connection from a Peer.</note>
       </trans-unit>
-      <trans-unit id="_msg483">
+      <trans-unit id="_msg485">
         <source xml:space="preserve">Outbound</source>
-        <context-group purpose="location"><context context-type="linenumber">80</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">79</context></context-group>
         <note annotates="source" from="developer">An Outbound Connection to a Peer.</note>
       </trans-unit>
     </group>
   </body></file>
   <file original="../bitcoinunits.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="QObject">
-      <trans-unit id="_msg484">
+      <trans-unit id="_msg486">
         <source xml:space="preserve">Amount</source>
         <context-group purpose="location"><context context-type="linenumber">197</context></context-group>
       </trans-unit>
@@ -2209,194 +2218,194 @@ If you are receiving this error you should request the merchant provide a BIP21 
   </body></file>
   <file original="../guiutil.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="QObject">
-      <trans-unit id="_msg485">
+      <trans-unit id="_msg487">
         <source xml:space="preserve">Enter a Bitcoin address (e.g. %1)</source>
         <context-group purpose="location"><context context-type="linenumber">129</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg486">
+      <trans-unit id="_msg488">
         <source xml:space="preserve">Ctrl+W</source>
         <context-group purpose="location"><context context-type="linenumber">417</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg487">
-        <source xml:space="preserve">Unroutable</source>
-        <context-group purpose="location"><context context-type="linenumber">673</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg488">
-        <source xml:space="preserve">Internal</source>
-        <context-group purpose="location"><context context-type="linenumber">679</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg489">
-        <source xml:space="preserve">Inbound</source>
-        <context-group purpose="location"><context context-type="linenumber">692</context></context-group>
-        <note annotates="source" from="developer">An inbound connection from a peer. An inbound connection is a connection initiated by a peer.</note>
+        <source xml:space="preserve">Unroutable</source>
+        <context-group purpose="location"><context context-type="linenumber">674</context></context-group>
       </trans-unit>
       <trans-unit id="_msg490">
-        <source xml:space="preserve">Outbound</source>
-        <context-group purpose="location"><context context-type="linenumber">695</context></context-group>
-        <note annotates="source" from="developer">An outbound connection to a peer. An outbound connection is a connection initiated by us.</note>
+        <source xml:space="preserve">Internal</source>
+        <context-group purpose="location"><context context-type="linenumber">680</context></context-group>
       </trans-unit>
       <trans-unit id="_msg491">
-        <source xml:space="preserve">Full Relay</source>
-        <context-group purpose="location"><context context-type="linenumber">700</context></context-group>
-        <note annotates="source" from="developer">Peer connection type that relays all network information.</note>
+        <source xml:space="preserve">Inbound</source>
+        <context-group purpose="location"><context context-type="linenumber">693</context></context-group>
+        <note annotates="source" from="developer">An inbound connection from a peer. An inbound connection is a connection initiated by a peer.</note>
       </trans-unit>
       <trans-unit id="_msg492">
-        <source xml:space="preserve">Block Relay</source>
-        <context-group purpose="location"><context context-type="linenumber">703</context></context-group>
-        <note annotates="source" from="developer">Peer connection type that relays network information about blocks and not transactions or addresses.</note>
+        <source xml:space="preserve">Outbound</source>
+        <context-group purpose="location"><context context-type="linenumber">696</context></context-group>
+        <note annotates="source" from="developer">An outbound connection to a peer. An outbound connection is a connection initiated by us.</note>
       </trans-unit>
       <trans-unit id="_msg493">
-        <source xml:space="preserve">Manual</source>
-        <context-group purpose="location"><context context-type="linenumber">705</context></context-group>
-        <note annotates="source" from="developer">Peer connection type established manually through one of several methods.</note>
+        <source xml:space="preserve">Full Relay</source>
+        <context-group purpose="location"><context context-type="linenumber">701</context></context-group>
+        <note annotates="source" from="developer">Peer connection type that relays all network information.</note>
       </trans-unit>
       <trans-unit id="_msg494">
-        <source xml:space="preserve">Feeler</source>
-        <context-group purpose="location"><context context-type="linenumber">707</context></context-group>
-        <note annotates="source" from="developer">Short-lived peer connection type that tests the aliveness of known addresses.</note>
+        <source xml:space="preserve">Block Relay</source>
+        <context-group purpose="location"><context context-type="linenumber">704</context></context-group>
+        <note annotates="source" from="developer">Peer connection type that relays network information about blocks and not transactions or addresses.</note>
       </trans-unit>
       <trans-unit id="_msg495">
-        <source xml:space="preserve">Address Fetch</source>
-        <context-group purpose="location"><context context-type="linenumber">709</context></context-group>
-        <note annotates="source" from="developer">Short-lived peer connection type that solicits known addresses from a peer.</note>
+        <source xml:space="preserve">Manual</source>
+        <context-group purpose="location"><context context-type="linenumber">706</context></context-group>
+        <note annotates="source" from="developer">Peer connection type established manually through one of several methods.</note>
       </trans-unit>
       <trans-unit id="_msg496">
-        <source xml:space="preserve">%1 d</source>
-        <context-group purpose="location"><context context-type="linenumber">722</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">734</context></context-group>
+        <source xml:space="preserve">Feeler</source>
+        <context-group purpose="location"><context context-type="linenumber">708</context></context-group>
+        <note annotates="source" from="developer">Short-lived peer connection type that tests the aliveness of known addresses.</note>
       </trans-unit>
       <trans-unit id="_msg497">
-        <source xml:space="preserve">%1 h</source>
+        <source xml:space="preserve">Address Fetch</source>
+        <context-group purpose="location"><context context-type="linenumber">710</context></context-group>
+        <note annotates="source" from="developer">Short-lived peer connection type that solicits known addresses from a peer.</note>
+      </trans-unit>
+      <trans-unit id="_msg498">
+        <source xml:space="preserve">%1 d</source>
         <context-group purpose="location"><context context-type="linenumber">723</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">735</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg498">
-        <source xml:space="preserve">%1 m</source>
+      <trans-unit id="_msg499">
+        <source xml:space="preserve">%1 h</source>
         <context-group purpose="location"><context context-type="linenumber">724</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">736</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg499">
-        <source xml:space="preserve">%1 s</source>
-        <context-group purpose="location"><context context-type="linenumber">726</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">737</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">763</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg500">
-        <source xml:space="preserve">None</source>
-        <context-group purpose="location"><context context-type="linenumber">751</context></context-group>
+        <source xml:space="preserve">%1 m</source>
+        <context-group purpose="location"><context context-type="linenumber">725</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">737</context></context-group>
       </trans-unit>
       <trans-unit id="_msg501">
-        <source xml:space="preserve">N/A</source>
-        <context-group purpose="location"><context context-type="linenumber">757</context></context-group>
+        <source xml:space="preserve">%1 s</source>
+        <context-group purpose="location"><context context-type="linenumber">727</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">738</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">764</context></context-group>
       </trans-unit>
       <trans-unit id="_msg502">
-        <source xml:space="preserve">%1 ms</source>
+        <source xml:space="preserve">None</source>
+        <context-group purpose="location"><context context-type="linenumber">752</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg503">
+        <source xml:space="preserve">N/A</source>
         <context-group purpose="location"><context context-type="linenumber">758</context></context-group>
       </trans-unit>
-      <group restype="x-gettext-plurals">
-        <context-group purpose="location"><context context-type="linenumber">776</context></context-group>
-        <trans-unit id="_msg503[0]">
-          <source xml:space="preserve">%n second(s)</source>
-        </trans-unit>
-        <trans-unit id="_msg503[1]">
-          <source xml:space="preserve">%n second(s)</source>
-        </trans-unit>
-      </group>
-      <group restype="x-gettext-plurals">
-        <context-group purpose="location"><context context-type="linenumber">780</context></context-group>
-        <trans-unit id="_msg504[0]">
-          <source xml:space="preserve">%n minute(s)</source>
-        </trans-unit>
-        <trans-unit id="_msg504[1]">
-          <source xml:space="preserve">%n minute(s)</source>
-        </trans-unit>
-      </group>
-      <group restype="x-gettext-plurals">
-        <context-group purpose="location"><context context-type="linenumber">784</context></context-group>
-        <trans-unit id="_msg505[0]">
-          <source xml:space="preserve">%n hour(s)</source>
-        </trans-unit>
-        <trans-unit id="_msg505[1]">
-          <source xml:space="preserve">%n hour(s)</source>
-        </trans-unit>
-      </group>
-      <group restype="x-gettext-plurals">
-        <context-group purpose="location"><context context-type="linenumber">788</context></context-group>
-        <trans-unit id="_msg506[0]">
-          <source xml:space="preserve">%n day(s)</source>
-        </trans-unit>
-        <trans-unit id="_msg506[1]">
-          <source xml:space="preserve">%n day(s)</source>
-        </trans-unit>
-      </group>
-      <group restype="x-gettext-plurals">
-        <context-group purpose="location"><context context-type="linenumber">792</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">798</context></context-group>
-        <trans-unit id="_msg507[0]">
-          <source xml:space="preserve">%n week(s)</source>
-        </trans-unit>
-        <trans-unit id="_msg507[1]">
-          <source xml:space="preserve">%n week(s)</source>
-        </trans-unit>
-      </group>
-      <trans-unit id="_msg508">
-        <source xml:space="preserve">%1 and %2</source>
-        <context-group purpose="location"><context context-type="linenumber">798</context></context-group>
+      <trans-unit id="_msg504">
+        <source xml:space="preserve">%1 ms</source>
+        <context-group purpose="location"><context context-type="linenumber">759</context></context-group>
       </trans-unit>
       <group restype="x-gettext-plurals">
-        <context-group purpose="location"><context context-type="linenumber">798</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">777</context></context-group>
+        <trans-unit id="_msg505[0]">
+          <source xml:space="preserve">%n second(s)</source>
+        </trans-unit>
+        <trans-unit id="_msg505[1]">
+          <source xml:space="preserve">%n second(s)</source>
+        </trans-unit>
+      </group>
+      <group restype="x-gettext-plurals">
+        <context-group purpose="location"><context context-type="linenumber">781</context></context-group>
+        <trans-unit id="_msg506[0]">
+          <source xml:space="preserve">%n minute(s)</source>
+        </trans-unit>
+        <trans-unit id="_msg506[1]">
+          <source xml:space="preserve">%n minute(s)</source>
+        </trans-unit>
+      </group>
+      <group restype="x-gettext-plurals">
+        <context-group purpose="location"><context context-type="linenumber">785</context></context-group>
+        <trans-unit id="_msg507[0]">
+          <source xml:space="preserve">%n hour(s)</source>
+        </trans-unit>
+        <trans-unit id="_msg507[1]">
+          <source xml:space="preserve">%n hour(s)</source>
+        </trans-unit>
+      </group>
+      <group restype="x-gettext-plurals">
+        <context-group purpose="location"><context context-type="linenumber">789</context></context-group>
+        <trans-unit id="_msg508[0]">
+          <source xml:space="preserve">%n day(s)</source>
+        </trans-unit>
+        <trans-unit id="_msg508[1]">
+          <source xml:space="preserve">%n day(s)</source>
+        </trans-unit>
+      </group>
+      <group restype="x-gettext-plurals">
+        <context-group purpose="location"><context context-type="linenumber">793</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">799</context></context-group>
         <trans-unit id="_msg509[0]">
-          <source xml:space="preserve">%n year(s)</source>
+          <source xml:space="preserve">%n week(s)</source>
         </trans-unit>
         <trans-unit id="_msg509[1]">
-          <source xml:space="preserve">%n year(s)</source>
+          <source xml:space="preserve">%n week(s)</source>
         </trans-unit>
       </group>
       <trans-unit id="_msg510">
-        <source xml:space="preserve">%1 B</source>
-        <context-group purpose="location"><context context-type="linenumber">806</context></context-group>
+        <source xml:space="preserve">%1 and %2</source>
+        <context-group purpose="location"><context context-type="linenumber">799</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg511">
-        <source xml:space="preserve">%1 kB</source>
-        <context-group purpose="location"><context context-type="linenumber">808</context></context-group>
-      </trans-unit>
+      <group restype="x-gettext-plurals">
+        <context-group purpose="location"><context context-type="linenumber">799</context></context-group>
+        <trans-unit id="_msg511[0]">
+          <source xml:space="preserve">%n year(s)</source>
+        </trans-unit>
+        <trans-unit id="_msg511[1]">
+          <source xml:space="preserve">%n year(s)</source>
+        </trans-unit>
+      </group>
       <trans-unit id="_msg512">
-        <source xml:space="preserve">%1 MB</source>
-        <context-group purpose="location"><context context-type="linenumber">810</context></context-group>
+        <source xml:space="preserve">%1 B</source>
+        <context-group purpose="location"><context context-type="linenumber">807</context></context-group>
       </trans-unit>
       <trans-unit id="_msg513">
+        <source xml:space="preserve">%1 kB</source>
+        <context-group purpose="location"><context context-type="linenumber">809</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg514">
+        <source xml:space="preserve">%1 MB</source>
+        <context-group purpose="location"><context context-type="linenumber">811</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg515">
         <source xml:space="preserve">%1 GB</source>
-        <context-group purpose="location"><context context-type="linenumber">812</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">813</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../qrimagewidget.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="QRImageWidget">
-      <trans-unit id="_msg514">
+      <trans-unit id="_msg516">
         <source xml:space="preserve">&amp;Save Image…</source>
         <context-group purpose="location"><context context-type="linenumber">30</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg515">
+      <trans-unit id="_msg517">
         <source xml:space="preserve">&amp;Copy Image</source>
         <context-group purpose="location"><context context-type="linenumber">31</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg516">
+      <trans-unit id="_msg518">
         <source xml:space="preserve">Resulting URI too long, try to reduce the text for label / message.</source>
         <context-group purpose="location"><context context-type="linenumber">42</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg517">
+      <trans-unit id="_msg519">
         <source xml:space="preserve">Error encoding URI into QR Code.</source>
         <context-group purpose="location"><context context-type="linenumber">49</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg518">
+      <trans-unit id="_msg520">
         <source xml:space="preserve">QR code support not available.</source>
         <context-group purpose="location"><context context-type="linenumber">90</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg519">
+      <trans-unit id="_msg521">
         <source xml:space="preserve">Save QR Code</source>
         <context-group purpose="location"><context context-type="linenumber">120</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg520">
+      <trans-unit id="_msg522">
         <source xml:space="preserve">PNG Image</source>
         <context-group purpose="location"><context context-type="linenumber">123</context></context-group>
         <note annotates="source" from="developer">Expanded name of the PNG file format. See: https://en.wikipedia.org/wiki/Portable_Network_Graphics.</note>
@@ -2405,7 +2414,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
   </body></file>
   <file original="../forms/debugwindow.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="RPCConsole">
-      <trans-unit id="_msg521">
+      <trans-unit id="_msg523">
         <source xml:space="preserve">N/A</source>
         <context-group purpose="location"><context context-type="linenumber">75</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">101</context></context-group>
@@ -2446,291 +2455,291 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <context-group purpose="location"><context context-type="linenumber">1662</context></context-group>
         <context-group purpose="location"><context context-type="sourcefile">../rpcconsole.h</context><context context-type="linenumber">143</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg522">
+      <trans-unit id="_msg524">
         <source xml:space="preserve">Client version</source>
         <context-group purpose="location"><context context-type="linenumber">65</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg523">
+      <trans-unit id="_msg525">
         <source xml:space="preserve">&amp;Information</source>
         <context-group purpose="location"><context context-type="linenumber">43</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg524">
+      <trans-unit id="_msg526">
         <source xml:space="preserve">General</source>
         <context-group purpose="location"><context context-type="linenumber">58</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg525">
+      <trans-unit id="_msg527">
         <source xml:space="preserve">Datadir</source>
         <context-group purpose="location"><context context-type="linenumber">114</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg526">
+      <trans-unit id="_msg528">
         <source xml:space="preserve">To specify a non-default location of the data directory use the &apos;%1&apos; option.</source>
         <context-group purpose="location"><context context-type="linenumber">124</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg527">
+      <trans-unit id="_msg529">
         <source xml:space="preserve">Blocksdir</source>
         <context-group purpose="location"><context context-type="linenumber">143</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg528">
+      <trans-unit id="_msg530">
         <source xml:space="preserve">To specify a non-default location of the blocks directory use the &apos;%1&apos; option.</source>
         <context-group purpose="location"><context context-type="linenumber">153</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg529">
+      <trans-unit id="_msg531">
         <source xml:space="preserve">Startup time</source>
         <context-group purpose="location"><context context-type="linenumber">172</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg530">
+      <trans-unit id="_msg532">
         <source xml:space="preserve">Network</source>
         <context-group purpose="location"><context context-type="linenumber">201</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">1093</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg531">
+      <trans-unit id="_msg533">
         <source xml:space="preserve">Name</source>
         <context-group purpose="location"><context context-type="linenumber">208</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg532">
+      <trans-unit id="_msg534">
         <source xml:space="preserve">Number of connections</source>
         <context-group purpose="location"><context context-type="linenumber">231</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg533">
+      <trans-unit id="_msg535">
         <source xml:space="preserve">Block chain</source>
         <context-group purpose="location"><context context-type="linenumber">260</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg534">
+      <trans-unit id="_msg536">
         <source xml:space="preserve">Memory Pool</source>
         <context-group purpose="location"><context context-type="linenumber">319</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg535">
+      <trans-unit id="_msg537">
         <source xml:space="preserve">Current number of transactions</source>
         <context-group purpose="location"><context context-type="linenumber">326</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg536">
+      <trans-unit id="_msg538">
         <source xml:space="preserve">Memory usage</source>
         <context-group purpose="location"><context context-type="linenumber">349</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg537">
+      <trans-unit id="_msg539">
         <source xml:space="preserve">Wallet: </source>
         <context-group purpose="location"><context context-type="linenumber">443</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg538">
+      <trans-unit id="_msg540">
         <source xml:space="preserve">(none)</source>
         <context-group purpose="location"><context context-type="linenumber">454</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg539">
+      <trans-unit id="_msg541">
         <source xml:space="preserve">&amp;Reset</source>
         <context-group purpose="location"><context context-type="linenumber">665</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg540">
+      <trans-unit id="_msg542">
         <source xml:space="preserve">Received</source>
         <context-group purpose="location"><context context-type="linenumber">745</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">1453</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg541">
+      <trans-unit id="_msg543">
         <source xml:space="preserve">Sent</source>
         <context-group purpose="location"><context context-type="linenumber">825</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">1430</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg542">
+      <trans-unit id="_msg544">
         <source xml:space="preserve">&amp;Peers</source>
         <context-group purpose="location"><context context-type="linenumber">866</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg543">
+      <trans-unit id="_msg545">
         <source xml:space="preserve">Banned peers</source>
         <context-group purpose="location"><context context-type="linenumber">942</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg544">
+      <trans-unit id="_msg546">
         <source xml:space="preserve">Select a peer to view detailed information.</source>
         <context-group purpose="location"><context context-type="linenumber">1010</context></context-group>
         <context-group purpose="location"><context context-type="sourcefile">../rpcconsole.cpp</context><context context-type="linenumber">1155</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg545">
+      <trans-unit id="_msg547">
         <source xml:space="preserve">Version</source>
         <context-group purpose="location"><context context-type="linenumber">1116</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg546">
+      <trans-unit id="_msg548">
+        <source xml:space="preserve">Whether we relay transactions to this peer.</source>
+        <context-group purpose="location"><context context-type="linenumber">1188</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg549">
+        <source xml:space="preserve">Transaction Relay</source>
+        <context-group purpose="location"><context context-type="linenumber">1191</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg550">
         <source xml:space="preserve">Starting Block</source>
         <context-group purpose="location"><context context-type="linenumber">1240</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg547">
+      <trans-unit id="_msg551">
         <source xml:space="preserve">Synced Headers</source>
         <context-group purpose="location"><context context-type="linenumber">1263</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg548">
+      <trans-unit id="_msg552">
         <source xml:space="preserve">Synced Blocks</source>
         <context-group purpose="location"><context context-type="linenumber">1286</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg549">
+      <trans-unit id="_msg553">
         <source xml:space="preserve">Last Transaction</source>
         <context-group purpose="location"><context context-type="linenumber">1361</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg550">
+      <trans-unit id="_msg554">
         <source xml:space="preserve">The mapped Autonomous System used for diversifying peer selection.</source>
         <context-group purpose="location"><context context-type="linenumber">1571</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg551">
+      <trans-unit id="_msg555">
         <source xml:space="preserve">Mapped AS</source>
         <context-group purpose="location"><context context-type="linenumber">1574</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg552">
+      <trans-unit id="_msg556">
         <source xml:space="preserve">Whether we relay addresses to this peer.</source>
         <context-group purpose="location"><context context-type="linenumber">1597</context></context-group>
         <note annotates="source" from="developer">Tooltip text for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</note>
       </trans-unit>
-      <trans-unit id="_msg553">
+      <trans-unit id="_msg557">
         <source xml:space="preserve">Address Relay</source>
         <context-group purpose="location"><context context-type="linenumber">1600</context></context-group>
         <note annotates="source" from="developer">Text title for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</note>
       </trans-unit>
-      <trans-unit id="_msg554">
+      <trans-unit id="_msg558">
         <source xml:space="preserve">The total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</source>
         <context-group purpose="location"><context context-type="linenumber">1623</context></context-group>
         <note annotates="source" from="developer">Tooltip text for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</note>
       </trans-unit>
-      <trans-unit id="_msg555">
+      <trans-unit id="_msg559">
         <source xml:space="preserve">The total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</source>
         <context-group purpose="location"><context context-type="linenumber">1649</context></context-group>
         <note annotates="source" from="developer">Tooltip text for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</note>
       </trans-unit>
-      <trans-unit id="_msg556">
+      <trans-unit id="_msg560">
         <source xml:space="preserve">Addresses Processed</source>
         <context-group purpose="location"><context context-type="linenumber">1626</context></context-group>
         <note annotates="source" from="developer">Text title for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</note>
       </trans-unit>
-      <trans-unit id="_msg557">
+      <trans-unit id="_msg561">
         <source xml:space="preserve">Addresses Rate-Limited</source>
         <context-group purpose="location"><context context-type="linenumber">1652</context></context-group>
         <note annotates="source" from="developer">Text title for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</note>
       </trans-unit>
-      <trans-unit id="_msg558">
+      <trans-unit id="_msg562">
         <source xml:space="preserve">User Agent</source>
         <context-group purpose="location"><context context-type="linenumber">88</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">1139</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg559">
+      <trans-unit id="_msg563">
         <source xml:space="preserve">Node window</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg560">
+      <trans-unit id="_msg564">
         <source xml:space="preserve">Current block height</source>
         <context-group purpose="location"><context context-type="linenumber">267</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg561">
+      <trans-unit id="_msg565">
         <source xml:space="preserve">Open the %1 debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <context-group purpose="location"><context context-type="linenumber">397</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg562">
+      <trans-unit id="_msg566">
         <source xml:space="preserve">Decrease font size</source>
         <context-group purpose="location"><context context-type="linenumber">475</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg563">
+      <trans-unit id="_msg567">
         <source xml:space="preserve">Increase font size</source>
         <context-group purpose="location"><context context-type="linenumber">495</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg564">
+      <trans-unit id="_msg568">
         <source xml:space="preserve">Permissions</source>
         <context-group purpose="location"><context context-type="linenumber">1041</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg565">
+      <trans-unit id="_msg569">
         <source xml:space="preserve">The direction and type of peer connection: %1</source>
         <context-group purpose="location"><context context-type="linenumber">1064</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg566">
+      <trans-unit id="_msg570">
         <source xml:space="preserve">Direction/Type</source>
         <context-group purpose="location"><context context-type="linenumber">1067</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg567">
+      <trans-unit id="_msg571">
         <source xml:space="preserve">The network protocol this peer is connected through: IPv4, IPv6, Onion, I2P, or CJDNS.</source>
         <context-group purpose="location"><context context-type="linenumber">1090</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg568">
+      <trans-unit id="_msg572">
         <source xml:space="preserve">Services</source>
         <context-group purpose="location"><context context-type="linenumber">1162</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg569">
-        <source xml:space="preserve">Whether the peer requested us to relay transactions.</source>
-        <context-group purpose="location"><context context-type="linenumber">1188</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg570">
-        <source xml:space="preserve">Wants Tx Relay</source>
-        <context-group purpose="location"><context context-type="linenumber">1191</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg571">
+      <trans-unit id="_msg573">
         <source xml:space="preserve">High bandwidth BIP152 compact block relay: %1</source>
         <context-group purpose="location"><context context-type="linenumber">1214</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg572">
+      <trans-unit id="_msg574">
         <source xml:space="preserve">High Bandwidth</source>
         <context-group purpose="location"><context context-type="linenumber">1217</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg573">
+      <trans-unit id="_msg575">
         <source xml:space="preserve">Connection Time</source>
         <context-group purpose="location"><context context-type="linenumber">1309</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg574">
+      <trans-unit id="_msg576">
         <source xml:space="preserve">Elapsed time since a novel block passing initial validity checks was received from this peer.</source>
         <context-group purpose="location"><context context-type="linenumber">1332</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg575">
+      <trans-unit id="_msg577">
         <source xml:space="preserve">Last Block</source>
         <context-group purpose="location"><context context-type="linenumber">1335</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg576">
+      <trans-unit id="_msg578">
         <source xml:space="preserve">Elapsed time since a novel transaction accepted into our mempool was received from this peer.</source>
         <context-group purpose="location"><context context-type="linenumber">1358</context></context-group>
         <note annotates="source" from="developer">Tooltip text for the Last Transaction field in the peer details area.</note>
       </trans-unit>
-      <trans-unit id="_msg577">
+      <trans-unit id="_msg579">
         <source xml:space="preserve">Last Send</source>
         <context-group purpose="location"><context context-type="linenumber">1384</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg578">
+      <trans-unit id="_msg580">
         <source xml:space="preserve">Last Receive</source>
         <context-group purpose="location"><context context-type="linenumber">1407</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg579">
+      <trans-unit id="_msg581">
         <source xml:space="preserve">Ping Time</source>
         <context-group purpose="location"><context context-type="linenumber">1476</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg580">
+      <trans-unit id="_msg582">
         <source xml:space="preserve">The duration of a currently outstanding ping.</source>
         <context-group purpose="location"><context context-type="linenumber">1499</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg581">
+      <trans-unit id="_msg583">
         <source xml:space="preserve">Ping Wait</source>
         <context-group purpose="location"><context context-type="linenumber">1502</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg582">
+      <trans-unit id="_msg584">
         <source xml:space="preserve">Min Ping</source>
         <context-group purpose="location"><context context-type="linenumber">1525</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg583">
+      <trans-unit id="_msg585">
         <source xml:space="preserve">Time Offset</source>
         <context-group purpose="location"><context context-type="linenumber">1548</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg584">
+      <trans-unit id="_msg586">
         <source xml:space="preserve">Last block time</source>
         <context-group purpose="location"><context context-type="linenumber">290</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg585">
+      <trans-unit id="_msg587">
         <source xml:space="preserve">&amp;Open</source>
         <context-group purpose="location"><context context-type="linenumber">400</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg586">
+      <trans-unit id="_msg588">
         <source xml:space="preserve">&amp;Console</source>
         <context-group purpose="location"><context context-type="linenumber">426</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg587">
+      <trans-unit id="_msg589">
         <source xml:space="preserve">&amp;Network Traffic</source>
         <context-group purpose="location"><context context-type="linenumber">613</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg588">
+      <trans-unit id="_msg590">
         <source xml:space="preserve">Totals</source>
         <context-group purpose="location"><context context-type="linenumber">681</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg589">
+      <trans-unit id="_msg591">
         <source xml:space="preserve">Debug log file</source>
         <context-group purpose="location"><context context-type="linenumber">390</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg590">
+      <trans-unit id="_msg592">
         <source xml:space="preserve">Clear console</source>
         <context-group purpose="location"><context context-type="linenumber">515</context></context-group>
       </trans-unit>
@@ -2738,139 +2747,139 @@ If you are receiving this error you should request the merchant provide a BIP21 
   </body></file>
   <file original="../rpcconsole.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="RPCConsole">
-      <trans-unit id="_msg591">
+      <trans-unit id="_msg593">
         <source xml:space="preserve">In:</source>
         <context-group purpose="location"><context context-type="linenumber">953</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg592">
+      <trans-unit id="_msg594">
         <source xml:space="preserve">Out:</source>
         <context-group purpose="location"><context context-type="linenumber">954</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg593">
+      <trans-unit id="_msg595">
         <source xml:space="preserve">Inbound: initiated by peer</source>
         <context-group purpose="location"><context context-type="linenumber">496</context></context-group>
         <note annotates="source" from="developer">Explanatory text for an inbound peer connection.</note>
       </trans-unit>
-      <trans-unit id="_msg594">
+      <trans-unit id="_msg596">
         <source xml:space="preserve">Outbound Full Relay: default</source>
         <context-group purpose="location"><context context-type="linenumber">500</context></context-group>
         <note annotates="source" from="developer">Explanatory text for an outbound peer connection that relays all network information. This is the default behavior for outbound connections.</note>
       </trans-unit>
-      <trans-unit id="_msg595">
+      <trans-unit id="_msg597">
         <source xml:space="preserve">Outbound Block Relay: does not relay transactions or addresses</source>
         <context-group purpose="location"><context context-type="linenumber">503</context></context-group>
         <note annotates="source" from="developer">Explanatory text for an outbound peer connection that relays network information about blocks and not transactions or addresses.</note>
       </trans-unit>
-      <trans-unit id="_msg596">
+      <trans-unit id="_msg598">
         <source xml:space="preserve">Outbound Manual: added using RPC %1 or %2/%3 configuration options</source>
         <context-group purpose="location"><context context-type="linenumber">508</context></context-group>
         <note annotates="source" from="developer">Explanatory text for an outbound peer connection that was established manually through one of several methods. The numbered arguments are stand-ins for the methods available to establish manual connections.</note>
       </trans-unit>
-      <trans-unit id="_msg597">
+      <trans-unit id="_msg599">
         <source xml:space="preserve">Outbound Feeler: short-lived, for testing addresses</source>
         <context-group purpose="location"><context context-type="linenumber">514</context></context-group>
         <note annotates="source" from="developer">Explanatory text for a short-lived outbound peer connection that is used to test the aliveness of known addresses.</note>
       </trans-unit>
-      <trans-unit id="_msg598">
+      <trans-unit id="_msg600">
         <source xml:space="preserve">Outbound Address Fetch: short-lived, for soliciting addresses</source>
         <context-group purpose="location"><context context-type="linenumber">517</context></context-group>
         <note annotates="source" from="developer">Explanatory text for a short-lived outbound peer connection that is used to request addresses from a peer.</note>
       </trans-unit>
-      <trans-unit id="_msg599">
+      <trans-unit id="_msg601">
         <source xml:space="preserve">we selected the peer for high bandwidth relay</source>
         <context-group purpose="location"><context context-type="linenumber">521</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg600">
+      <trans-unit id="_msg602">
         <source xml:space="preserve">the peer selected us for high bandwidth relay</source>
         <context-group purpose="location"><context context-type="linenumber">522</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg601">
+      <trans-unit id="_msg603">
         <source xml:space="preserve">no high bandwidth relay selected</source>
         <context-group purpose="location"><context context-type="linenumber">523</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg602">
+      <trans-unit id="_msg604">
         <source xml:space="preserve">Ctrl++</source>
         <context-group purpose="location"><context context-type="linenumber">536</context></context-group>
         <note annotates="source" from="developer">Main shortcut to increase the RPC console font size.</note>
       </trans-unit>
-      <trans-unit id="_msg603">
+      <trans-unit id="_msg605">
         <source xml:space="preserve">Ctrl+=</source>
         <context-group purpose="location"><context context-type="linenumber">538</context></context-group>
         <note annotates="source" from="developer">Secondary shortcut to increase the RPC console font size.</note>
       </trans-unit>
-      <trans-unit id="_msg604">
+      <trans-unit id="_msg606">
         <source xml:space="preserve">Ctrl+-</source>
         <context-group purpose="location"><context context-type="linenumber">542</context></context-group>
         <note annotates="source" from="developer">Main shortcut to decrease the RPC console font size.</note>
       </trans-unit>
-      <trans-unit id="_msg605">
+      <trans-unit id="_msg607">
         <source xml:space="preserve">Ctrl+_</source>
         <context-group purpose="location"><context context-type="linenumber">544</context></context-group>
         <note annotates="source" from="developer">Secondary shortcut to decrease the RPC console font size.</note>
       </trans-unit>
-      <trans-unit id="_msg606">
+      <trans-unit id="_msg608">
         <source xml:space="preserve">&amp;Copy address</source>
         <context-group purpose="location"><context context-type="linenumber">695</context></context-group>
         <note annotates="source" from="developer">Context menu action to copy the address of a peer.</note>
       </trans-unit>
-      <trans-unit id="_msg607">
+      <trans-unit id="_msg609">
         <source xml:space="preserve">&amp;Disconnect</source>
         <context-group purpose="location"><context context-type="linenumber">699</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg608">
+      <trans-unit id="_msg610">
         <source xml:space="preserve">1 &amp;hour</source>
         <context-group purpose="location"><context context-type="linenumber">700</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg609">
+      <trans-unit id="_msg611">
         <source xml:space="preserve">1 d&amp;ay</source>
         <context-group purpose="location"><context context-type="linenumber">701</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg610">
+      <trans-unit id="_msg612">
         <source xml:space="preserve">1 &amp;week</source>
         <context-group purpose="location"><context context-type="linenumber">702</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg611">
+      <trans-unit id="_msg613">
         <source xml:space="preserve">1 &amp;year</source>
         <context-group purpose="location"><context context-type="linenumber">703</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg612">
+      <trans-unit id="_msg614">
         <source xml:space="preserve">&amp;Copy IP/Netmask</source>
         <context-group purpose="location"><context context-type="linenumber">729</context></context-group>
         <note annotates="source" from="developer">Context menu action to copy the IP/Netmask of a banned peer. IP/Netmask is the combination of a peer&apos;s IP address and its Netmask. For IP address, see: https://en.wikipedia.org/wiki/IP_address.</note>
       </trans-unit>
-      <trans-unit id="_msg613">
+      <trans-unit id="_msg615">
         <source xml:space="preserve">&amp;Unban</source>
         <context-group purpose="location"><context context-type="linenumber">733</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg614">
+      <trans-unit id="_msg616">
         <source xml:space="preserve">Network activity disabled</source>
         <context-group purpose="location"><context context-type="linenumber">957</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg615">
+      <trans-unit id="_msg617">
         <source xml:space="preserve">Executing command without any wallet</source>
         <context-group purpose="location"><context context-type="linenumber">1035</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg616">
-        <source xml:space="preserve">Ctrl+I</source>
-        <context-group purpose="location"><context context-type="linenumber">1351</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg617">
-        <source xml:space="preserve">Ctrl+T</source>
-        <context-group purpose="location"><context context-type="linenumber">1352</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg618">
-        <source xml:space="preserve">Ctrl+N</source>
-        <context-group purpose="location"><context context-type="linenumber">1353</context></context-group>
+        <source xml:space="preserve">Ctrl+I</source>
+        <context-group purpose="location"><context context-type="linenumber">1355</context></context-group>
       </trans-unit>
       <trans-unit id="_msg619">
-        <source xml:space="preserve">Ctrl+P</source>
-        <context-group purpose="location"><context context-type="linenumber">1354</context></context-group>
+        <source xml:space="preserve">Ctrl+T</source>
+        <context-group purpose="location"><context context-type="linenumber">1356</context></context-group>
       </trans-unit>
       <trans-unit id="_msg620">
+        <source xml:space="preserve">Ctrl+N</source>
+        <context-group purpose="location"><context context-type="linenumber">1357</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg621">
+        <source xml:space="preserve">Ctrl+P</source>
+        <context-group purpose="location"><context context-type="linenumber">1358</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg622">
         <source xml:space="preserve">Executing command using &quot;%1&quot; wallet</source>
         <context-group purpose="location"><context context-type="linenumber">1033</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg621">
+      <trans-unit id="_msg623">
         <source xml:space="preserve">Welcome to the %1 RPC console.
 Use up and down arrows to navigate history, and %2 to clear screen.
 Use %3 and %4 to increase or decrease the font size.
@@ -2881,16 +2890,16 @@ For more information on using this console, type %6.
         <context-group purpose="location"><context context-type="linenumber">887</context></context-group>
         <note annotates="source" from="developer">RPC console welcome message. Placeholders %7 and %8 are style tags for the warning content, and they are not space separated from the rest of the text intentionally.</note>
       </trans-unit>
-      <trans-unit id="_msg622">
+      <trans-unit id="_msg624">
         <source xml:space="preserve">Executing…</source>
         <context-group purpose="location"><context context-type="linenumber">1043</context></context-group>
         <note annotates="source" from="developer">A console message indicating an entered command is currently being executed.</note>
       </trans-unit>
-      <trans-unit id="_msg623">
+      <trans-unit id="_msg625">
         <source xml:space="preserve">(peer: %1)</source>
         <context-group purpose="location"><context context-type="linenumber">1161</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg624">
+      <trans-unit id="_msg626">
         <source xml:space="preserve">via %1</source>
         <context-group purpose="location"><context context-type="linenumber">1163</context></context-group>
       </trans-unit>
@@ -2898,31 +2907,31 @@ For more information on using this console, type %6.
   </body></file>
   <file original="../rpcconsole.h" datatype="c" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="RPCConsole">
-      <trans-unit id="_msg625">
+      <trans-unit id="_msg627">
         <source xml:space="preserve">Yes</source>
         <context-group purpose="location"><context context-type="linenumber">142</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg626">
+      <trans-unit id="_msg628">
         <source xml:space="preserve">No</source>
         <context-group purpose="location"><context context-type="linenumber">142</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg627">
+      <trans-unit id="_msg629">
         <source xml:space="preserve">To</source>
         <context-group purpose="location"><context context-type="linenumber">142</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg628">
+      <trans-unit id="_msg630">
         <source xml:space="preserve">From</source>
         <context-group purpose="location"><context context-type="linenumber">142</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg629">
+      <trans-unit id="_msg631">
         <source xml:space="preserve">Ban for</source>
         <context-group purpose="location"><context context-type="linenumber">143</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg630">
+      <trans-unit id="_msg632">
         <source xml:space="preserve">Never</source>
         <context-group purpose="location"><context context-type="linenumber">185</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg631">
+      <trans-unit id="_msg633">
         <source xml:space="preserve">Unknown</source>
         <context-group purpose="location"><context context-type="linenumber">143</context></context-group>
       </trans-unit>
@@ -2930,72 +2939,72 @@ For more information on using this console, type %6.
   </body></file>
   <file original="../forms/receivecoinsdialog.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="ReceiveCoinsDialog">
-      <trans-unit id="_msg632">
+      <trans-unit id="_msg634">
         <source xml:space="preserve">&amp;Amount:</source>
         <context-group purpose="location"><context context-type="linenumber">37</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg633">
+      <trans-unit id="_msg635">
         <source xml:space="preserve">&amp;Label:</source>
         <context-group purpose="location"><context context-type="linenumber">83</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg634">
+      <trans-unit id="_msg636">
         <source xml:space="preserve">&amp;Message:</source>
         <context-group purpose="location"><context context-type="linenumber">53</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg635">
+      <trans-unit id="_msg637">
         <source xml:space="preserve">An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <context-group purpose="location"><context context-type="linenumber">50</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg636">
+      <trans-unit id="_msg638">
         <source xml:space="preserve">An optional label to associate with the new receiving address.</source>
         <context-group purpose="location"><context context-type="linenumber">80</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg637">
+      <trans-unit id="_msg639">
         <source xml:space="preserve">Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <context-group purpose="location"><context context-type="linenumber">73</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg638">
+      <trans-unit id="_msg640">
         <source xml:space="preserve">An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <context-group purpose="location"><context context-type="linenumber">34</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">193</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg639">
+      <trans-unit id="_msg641">
         <source xml:space="preserve">An optional label to associate with the new receiving address (used by you to identify an invoice).  It is also attached to the payment request.</source>
         <context-group purpose="location"><context context-type="linenumber">66</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg640">
+      <trans-unit id="_msg642">
         <source xml:space="preserve">An optional message that is attached to the payment request and may be displayed to the sender.</source>
         <context-group purpose="location"><context context-type="linenumber">96</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg641">
+      <trans-unit id="_msg643">
         <source xml:space="preserve">&amp;Create new receiving address</source>
         <context-group purpose="location"><context context-type="linenumber">111</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg642">
+      <trans-unit id="_msg644">
         <source xml:space="preserve">Clear all fields of the form.</source>
         <context-group purpose="location"><context context-type="linenumber">134</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg643">
+      <trans-unit id="_msg645">
         <source xml:space="preserve">Clear</source>
         <context-group purpose="location"><context context-type="linenumber">137</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg644">
+      <trans-unit id="_msg646">
         <source xml:space="preserve">Requested payments history</source>
         <context-group purpose="location"><context context-type="linenumber">273</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg645">
+      <trans-unit id="_msg647">
         <source xml:space="preserve">Show the selected request (does the same as double clicking an entry)</source>
         <context-group purpose="location"><context context-type="linenumber">298</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg646">
+      <trans-unit id="_msg648">
         <source xml:space="preserve">Show</source>
         <context-group purpose="location"><context context-type="linenumber">301</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg647">
+      <trans-unit id="_msg649">
         <source xml:space="preserve">Remove the selected entries from the list</source>
         <context-group purpose="location"><context context-type="linenumber">318</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg648">
+      <trans-unit id="_msg650">
         <source xml:space="preserve">Remove</source>
         <context-group purpose="location"><context context-type="linenumber">321</context></context-group>
       </trans-unit>
@@ -3003,83 +3012,83 @@ For more information on using this console, type %6.
   </body></file>
   <file original="../receivecoinsdialog.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="ReceiveCoinsDialog">
-      <trans-unit id="_msg649">
-        <source xml:space="preserve">Copy &amp;URI</source>
-        <context-group purpose="location"><context context-type="linenumber">47</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg650">
-        <source xml:space="preserve">&amp;Copy address</source>
-        <context-group purpose="location"><context context-type="linenumber">48</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg651">
-        <source xml:space="preserve">Copy &amp;label</source>
-        <context-group purpose="location"><context context-type="linenumber">49</context></context-group>
+        <source xml:space="preserve">Copy &amp;URI</source>
+        <context-group purpose="location"><context context-type="linenumber">46</context></context-group>
       </trans-unit>
       <trans-unit id="_msg652">
-        <source xml:space="preserve">Copy &amp;message</source>
-        <context-group purpose="location"><context context-type="linenumber">50</context></context-group>
+        <source xml:space="preserve">&amp;Copy address</source>
+        <context-group purpose="location"><context context-type="linenumber">47</context></context-group>
       </trans-unit>
       <trans-unit id="_msg653">
-        <source xml:space="preserve">Copy &amp;amount</source>
-        <context-group purpose="location"><context context-type="linenumber">51</context></context-group>
+        <source xml:space="preserve">Copy &amp;label</source>
+        <context-group purpose="location"><context context-type="linenumber">48</context></context-group>
       </trans-unit>
       <trans-unit id="_msg654">
-        <source xml:space="preserve">Could not unlock wallet.</source>
-        <context-group purpose="location"><context context-type="linenumber">176</context></context-group>
+        <source xml:space="preserve">Copy &amp;message</source>
+        <context-group purpose="location"><context context-type="linenumber">49</context></context-group>
       </trans-unit>
       <trans-unit id="_msg655">
+        <source xml:space="preserve">Copy &amp;amount</source>
+        <context-group purpose="location"><context context-type="linenumber">50</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg656">
+        <source xml:space="preserve">Could not unlock wallet.</source>
+        <context-group purpose="location"><context context-type="linenumber">175</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg657">
         <source xml:space="preserve">Could not generate new %1 address</source>
-        <context-group purpose="location"><context context-type="linenumber">181</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">180</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../forms/receiverequestdialog.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="ReceiveRequestDialog">
-      <trans-unit id="_msg656">
+      <trans-unit id="_msg658">
         <source xml:space="preserve">Request payment to …</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg657">
+      <trans-unit id="_msg659">
         <source xml:space="preserve">Address:</source>
         <context-group purpose="location"><context context-type="linenumber">90</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg658">
+      <trans-unit id="_msg660">
         <source xml:space="preserve">Amount:</source>
         <context-group purpose="location"><context context-type="linenumber">119</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg659">
+      <trans-unit id="_msg661">
         <source xml:space="preserve">Label:</source>
         <context-group purpose="location"><context context-type="linenumber">148</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg660">
+      <trans-unit id="_msg662">
         <source xml:space="preserve">Message:</source>
         <context-group purpose="location"><context context-type="linenumber">180</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg661">
+      <trans-unit id="_msg663">
         <source xml:space="preserve">Wallet:</source>
         <context-group purpose="location"><context context-type="linenumber">212</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg662">
+      <trans-unit id="_msg664">
         <source xml:space="preserve">Copy &amp;URI</source>
         <context-group purpose="location"><context context-type="linenumber">240</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg663">
+      <trans-unit id="_msg665">
         <source xml:space="preserve">Copy &amp;Address</source>
         <context-group purpose="location"><context context-type="linenumber">250</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg664">
+      <trans-unit id="_msg666">
         <source xml:space="preserve">&amp;Verify</source>
         <context-group purpose="location"><context context-type="linenumber">260</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg665">
+      <trans-unit id="_msg667">
         <source xml:space="preserve">Verify this address on e.g. a hardware wallet screen</source>
         <context-group purpose="location"><context context-type="linenumber">263</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg666">
+      <trans-unit id="_msg668">
         <source xml:space="preserve">&amp;Save Image…</source>
         <context-group purpose="location"><context context-type="linenumber">273</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg667">
+      <trans-unit id="_msg669">
         <source xml:space="preserve">Payment information</source>
         <context-group purpose="location"><context context-type="linenumber">39</context></context-group>
       </trans-unit>
@@ -3087,39 +3096,39 @@ For more information on using this console, type %6.
   </body></file>
   <file original="../receiverequestdialog.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="ReceiveRequestDialog">
-      <trans-unit id="_msg668">
+      <trans-unit id="_msg670">
         <source xml:space="preserve">Request payment to %1</source>
-        <context-group purpose="location"><context context-type="linenumber">49</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">48</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../recentrequeststablemodel.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="RecentRequestsTableModel">
-      <trans-unit id="_msg669">
+      <trans-unit id="_msg671">
         <source xml:space="preserve">Date</source>
         <context-group purpose="location"><context context-type="linenumber">32</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg670">
+      <trans-unit id="_msg672">
         <source xml:space="preserve">Label</source>
         <context-group purpose="location"><context context-type="linenumber">32</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg671">
+      <trans-unit id="_msg673">
         <source xml:space="preserve">Message</source>
         <context-group purpose="location"><context context-type="linenumber">32</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg672">
+      <trans-unit id="_msg674">
         <source xml:space="preserve">(no label)</source>
         <context-group purpose="location"><context context-type="linenumber">70</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg673">
+      <trans-unit id="_msg675">
         <source xml:space="preserve">(no message)</source>
         <context-group purpose="location"><context context-type="linenumber">79</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg674">
+      <trans-unit id="_msg676">
         <source xml:space="preserve">(no amount requested)</source>
         <context-group purpose="location"><context context-type="linenumber">87</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg675">
+      <trans-unit id="_msg677">
         <source xml:space="preserve">Requested</source>
         <context-group purpose="location"><context context-type="linenumber">130</context></context-group>
       </trans-unit>
@@ -3127,154 +3136,154 @@ For more information on using this console, type %6.
   </body></file>
   <file original="../forms/sendcoinsdialog.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="SendCoinsDialog">
-      <trans-unit id="_msg676">
+      <trans-unit id="_msg678">
         <source xml:space="preserve">Send Coins</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
-        <context-group purpose="location"><context context-type="sourcefile">../sendcoinsdialog.cpp</context><context context-type="linenumber">757</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../sendcoinsdialog.cpp</context><context context-type="linenumber">755</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg677">
+      <trans-unit id="_msg679">
         <source xml:space="preserve">Coin Control Features</source>
         <context-group purpose="location"><context context-type="linenumber">90</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg678">
+      <trans-unit id="_msg680">
         <source xml:space="preserve">automatically selected</source>
         <context-group purpose="location"><context context-type="linenumber">120</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg679">
+      <trans-unit id="_msg681">
         <source xml:space="preserve">Insufficient funds!</source>
         <context-group purpose="location"><context context-type="linenumber">139</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg680">
+      <trans-unit id="_msg682">
         <source xml:space="preserve">Quantity:</source>
         <context-group purpose="location"><context context-type="linenumber">228</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg681">
+      <trans-unit id="_msg683">
         <source xml:space="preserve">Bytes:</source>
         <context-group purpose="location"><context context-type="linenumber">263</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg682">
+      <trans-unit id="_msg684">
         <source xml:space="preserve">Amount:</source>
         <context-group purpose="location"><context context-type="linenumber">311</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg683">
+      <trans-unit id="_msg685">
         <source xml:space="preserve">Fee:</source>
         <context-group purpose="location"><context context-type="linenumber">391</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg684">
+      <trans-unit id="_msg686">
         <source xml:space="preserve">After Fee:</source>
         <context-group purpose="location"><context context-type="linenumber">442</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg685">
+      <trans-unit id="_msg687">
         <source xml:space="preserve">Change:</source>
         <context-group purpose="location"><context context-type="linenumber">474</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg686">
+      <trans-unit id="_msg688">
         <source xml:space="preserve">If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <context-group purpose="location"><context context-type="linenumber">518</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg687">
+      <trans-unit id="_msg689">
         <source xml:space="preserve">Custom change address</source>
         <context-group purpose="location"><context context-type="linenumber">521</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg688">
+      <trans-unit id="_msg690">
         <source xml:space="preserve">Transaction Fee:</source>
         <context-group purpose="location"><context context-type="linenumber">727</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg689">
+      <trans-unit id="_msg691">
         <source xml:space="preserve">Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until you have validated the complete chain.</source>
         <context-group purpose="location"><context context-type="linenumber">765</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg690">
+      <trans-unit id="_msg692">
         <source xml:space="preserve">Warning: Fee estimation is currently not possible.</source>
         <context-group purpose="location"><context context-type="linenumber">774</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg691">
+      <trans-unit id="_msg693">
         <source xml:space="preserve">per kilobyte</source>
         <context-group purpose="location"><context context-type="linenumber">856</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg692">
+      <trans-unit id="_msg694">
         <source xml:space="preserve">Hide</source>
         <context-group purpose="location"><context context-type="linenumber">803</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg693">
+      <trans-unit id="_msg695">
         <source xml:space="preserve">Recommended:</source>
         <context-group purpose="location"><context context-type="linenumber">915</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg694">
+      <trans-unit id="_msg696">
         <source xml:space="preserve">Custom:</source>
         <context-group purpose="location"><context context-type="linenumber">945</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg695">
+      <trans-unit id="_msg697">
         <source xml:space="preserve">Send to multiple recipients at once</source>
         <context-group purpose="location"><context context-type="linenumber">1160</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg696">
+      <trans-unit id="_msg698">
         <source xml:space="preserve">Add &amp;Recipient</source>
         <context-group purpose="location"><context context-type="linenumber">1163</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg697">
+      <trans-unit id="_msg699">
         <source xml:space="preserve">Clear all fields of the form.</source>
         <context-group purpose="location"><context context-type="linenumber">1143</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg698">
+      <trans-unit id="_msg700">
         <source xml:space="preserve">Inputs…</source>
         <context-group purpose="location"><context context-type="linenumber">110</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg699">
+      <trans-unit id="_msg701">
         <source xml:space="preserve">Dust:</source>
         <context-group purpose="location"><context context-type="linenumber">343</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg700">
+      <trans-unit id="_msg702">
         <source xml:space="preserve">Choose…</source>
         <context-group purpose="location"><context context-type="linenumber">741</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg701">
+      <trans-unit id="_msg703">
         <source xml:space="preserve">Hide transaction fee settings</source>
         <context-group purpose="location"><context context-type="linenumber">800</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg702">
+      <trans-unit id="_msg704">
         <source xml:space="preserve">Specify a custom fee per kB (1,000 bytes) of the transaction&apos;s virtual size.
 
 Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 satoshis per kvB&quot; for a transaction size of 500 virtual bytes (half of 1 kvB) would ultimately yield a fee of only 50 satoshis.</source>
         <context-group purpose="location"><context context-type="linenumber">851</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg703">
+      <trans-unit id="_msg705">
         <source xml:space="preserve">When there is less transaction volume than space in the blocks, miners as well as relaying nodes may enforce a minimum fee. Paying only this minimum fee is just fine, but be aware that this can result in a never confirming transaction once there is more demand for bitcoin transactions than the network can process.</source>
         <context-group purpose="location"><context context-type="linenumber">886</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg704">
+      <trans-unit id="_msg706">
         <source xml:space="preserve">A too low fee might result in a never confirming transaction (read the tooltip)</source>
         <context-group purpose="location"><context context-type="linenumber">889</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg705">
+      <trans-unit id="_msg707">
         <source xml:space="preserve">(Smart fee not initialized yet. This usually takes a few blocks…)</source>
         <context-group purpose="location"><context context-type="linenumber">994</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg706">
+      <trans-unit id="_msg708">
         <source xml:space="preserve">Confirmation time target:</source>
         <context-group purpose="location"><context context-type="linenumber">1020</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg707">
+      <trans-unit id="_msg709">
         <source xml:space="preserve">Enable Replace-By-Fee</source>
         <context-group purpose="location"><context context-type="linenumber">1078</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg708">
+      <trans-unit id="_msg710">
         <source xml:space="preserve">With Replace-By-Fee (BIP-125) you can increase a transaction&apos;s fee after it is sent. Without this, a higher fee may be recommended to compensate for increased transaction delay risk.</source>
         <context-group purpose="location"><context context-type="linenumber">1081</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg709">
+      <trans-unit id="_msg711">
         <source xml:space="preserve">Clear &amp;All</source>
         <context-group purpose="location"><context context-type="linenumber">1146</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg710">
+      <trans-unit id="_msg712">
         <source xml:space="preserve">Balance:</source>
         <context-group purpose="location"><context context-type="linenumber">1201</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg711">
+      <trans-unit id="_msg713">
         <source xml:space="preserve">Confirm the send action</source>
         <context-group purpose="location"><context context-type="linenumber">1117</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg712">
+      <trans-unit id="_msg714">
         <source xml:space="preserve">S&amp;end</source>
         <context-group purpose="location"><context context-type="linenumber">1120</context></context-group>
       </trans-unit>
@@ -3282,278 +3291,278 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
   </body></file>
   <file original="../sendcoinsdialog.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="SendCoinsDialog">
-      <trans-unit id="_msg713">
-        <source xml:space="preserve">Copy quantity</source>
-        <context-group purpose="location"><context context-type="linenumber">99</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg714">
-        <source xml:space="preserve">Copy amount</source>
-        <context-group purpose="location"><context context-type="linenumber">100</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg715">
-        <source xml:space="preserve">Copy fee</source>
-        <context-group purpose="location"><context context-type="linenumber">101</context></context-group>
+        <source xml:space="preserve">Copy quantity</source>
+        <context-group purpose="location"><context context-type="linenumber">95</context></context-group>
       </trans-unit>
       <trans-unit id="_msg716">
-        <source xml:space="preserve">Copy after fee</source>
-        <context-group purpose="location"><context context-type="linenumber">102</context></context-group>
+        <source xml:space="preserve">Copy amount</source>
+        <context-group purpose="location"><context context-type="linenumber">96</context></context-group>
       </trans-unit>
       <trans-unit id="_msg717">
-        <source xml:space="preserve">Copy bytes</source>
-        <context-group purpose="location"><context context-type="linenumber">103</context></context-group>
+        <source xml:space="preserve">Copy fee</source>
+        <context-group purpose="location"><context context-type="linenumber">97</context></context-group>
       </trans-unit>
       <trans-unit id="_msg718">
-        <source xml:space="preserve">Copy dust</source>
-        <context-group purpose="location"><context context-type="linenumber">104</context></context-group>
+        <source xml:space="preserve">Copy after fee</source>
+        <context-group purpose="location"><context context-type="linenumber">98</context></context-group>
       </trans-unit>
       <trans-unit id="_msg719">
-        <source xml:space="preserve">Copy change</source>
-        <context-group purpose="location"><context context-type="linenumber">105</context></context-group>
+        <source xml:space="preserve">Copy bytes</source>
+        <context-group purpose="location"><context context-type="linenumber">99</context></context-group>
       </trans-unit>
       <trans-unit id="_msg720">
-        <source xml:space="preserve">%1 (%2 blocks)</source>
-        <context-group purpose="location"><context context-type="linenumber">179</context></context-group>
+        <source xml:space="preserve">Copy dust</source>
+        <context-group purpose="location"><context context-type="linenumber">100</context></context-group>
       </trans-unit>
       <trans-unit id="_msg721">
-        <source xml:space="preserve">Sign on device</source>
-        <context-group purpose="location"><context context-type="linenumber">209</context></context-group>
-        <note annotates="source" from="developer">&quot;device&quot; usually means a hardware wallet.</note>
+        <source xml:space="preserve">Copy change</source>
+        <context-group purpose="location"><context context-type="linenumber">101</context></context-group>
       </trans-unit>
       <trans-unit id="_msg722">
-        <source xml:space="preserve">Connect your hardware wallet first.</source>
-        <context-group purpose="location"><context context-type="linenumber">212</context></context-group>
+        <source xml:space="preserve">%1 (%2 blocks)</source>
+        <context-group purpose="location"><context context-type="linenumber">175</context></context-group>
       </trans-unit>
       <trans-unit id="_msg723">
-        <source xml:space="preserve">Set external signer script path in Options -&gt; Wallet</source>
-        <context-group purpose="location"><context context-type="linenumber">216</context></context-group>
-        <note annotates="source" from="developer">&quot;External signer&quot; means using devices such as hardware wallets.</note>
+        <source xml:space="preserve">Sign on device</source>
+        <context-group purpose="location"><context context-type="linenumber">205</context></context-group>
+        <note annotates="source" from="developer">&quot;device&quot; usually means a hardware wallet.</note>
       </trans-unit>
       <trans-unit id="_msg724">
-        <source xml:space="preserve">Cr&amp;eate Unsigned</source>
-        <context-group purpose="location"><context context-type="linenumber">219</context></context-group>
+        <source xml:space="preserve">Connect your hardware wallet first.</source>
+        <context-group purpose="location"><context context-type="linenumber">208</context></context-group>
       </trans-unit>
       <trans-unit id="_msg725">
-        <source xml:space="preserve">Creates a Partially Signed Bitcoin Transaction (PSBT) for use with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
-        <context-group purpose="location"><context context-type="linenumber">220</context></context-group>
+        <source xml:space="preserve">Set external signer script path in Options -&gt; Wallet</source>
+        <context-group purpose="location"><context context-type="linenumber">212</context></context-group>
+        <note annotates="source" from="developer">&quot;External signer&quot; means using devices such as hardware wallets.</note>
       </trans-unit>
       <trans-unit id="_msg726">
-        <source xml:space="preserve"> from wallet &apos;%1&apos;</source>
-        <context-group purpose="location"><context context-type="linenumber">310</context></context-group>
+        <source xml:space="preserve">Cr&amp;eate Unsigned</source>
+        <context-group purpose="location"><context context-type="linenumber">215</context></context-group>
       </trans-unit>
       <trans-unit id="_msg727">
-        <source xml:space="preserve">%1 to &apos;%2&apos;</source>
-        <context-group purpose="location"><context context-type="linenumber">321</context></context-group>
+        <source xml:space="preserve">Creates a Partially Signed Bitcoin Transaction (PSBT) for use with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
+        <context-group purpose="location"><context context-type="linenumber">216</context></context-group>
       </trans-unit>
       <trans-unit id="_msg728">
-        <source xml:space="preserve">%1 to %2</source>
-        <context-group purpose="location"><context context-type="linenumber">326</context></context-group>
+        <source xml:space="preserve"> from wallet &apos;%1&apos;</source>
+        <context-group purpose="location"><context context-type="linenumber">308</context></context-group>
       </trans-unit>
       <trans-unit id="_msg729">
-        <source xml:space="preserve">To review recipient list click &quot;Show Details…&quot;</source>
-        <context-group purpose="location"><context context-type="linenumber">392</context></context-group>
+        <source xml:space="preserve">%1 to &apos;%2&apos;</source>
+        <context-group purpose="location"><context context-type="linenumber">319</context></context-group>
       </trans-unit>
       <trans-unit id="_msg730">
-        <source xml:space="preserve">Sign failed</source>
-        <context-group purpose="location"><context context-type="linenumber">452</context></context-group>
+        <source xml:space="preserve">%1 to %2</source>
+        <context-group purpose="location"><context context-type="linenumber">324</context></context-group>
       </trans-unit>
       <trans-unit id="_msg731">
-        <source xml:space="preserve">External signer not found</source>
-        <context-group purpose="location"><context context-type="linenumber">457</context></context-group>
-        <note annotates="source" from="developer">&quot;External signer&quot; means using devices such as hardware wallets.</note>
+        <source xml:space="preserve">To review recipient list click &quot;Show Details…&quot;</source>
+        <context-group purpose="location"><context context-type="linenumber">390</context></context-group>
       </trans-unit>
       <trans-unit id="_msg732">
-        <source xml:space="preserve">External signer failure</source>
-        <context-group purpose="location"><context context-type="linenumber">462</context></context-group>
-        <note annotates="source" from="developer">&quot;External signer&quot; means using devices such as hardware wallets.</note>
+        <source xml:space="preserve">Sign failed</source>
+        <context-group purpose="location"><context context-type="linenumber">450</context></context-group>
       </trans-unit>
       <trans-unit id="_msg733">
-        <source xml:space="preserve">Save Transaction Data</source>
-        <context-group purpose="location"><context context-type="linenumber">428</context></context-group>
+        <source xml:space="preserve">External signer not found</source>
+        <context-group purpose="location"><context context-type="linenumber">455</context></context-group>
+        <note annotates="source" from="developer">&quot;External signer&quot; means using devices such as hardware wallets.</note>
       </trans-unit>
       <trans-unit id="_msg734">
-        <source xml:space="preserve">Partially Signed Transaction (Binary)</source>
-        <context-group purpose="location"><context context-type="linenumber">430</context></context-group>
-        <note annotates="source" from="developer">Expanded name of the binary PSBT file format. See: BIP 174.</note>
+        <source xml:space="preserve">External signer failure</source>
+        <context-group purpose="location"><context context-type="linenumber">460</context></context-group>
+        <note annotates="source" from="developer">&quot;External signer&quot; means using devices such as hardware wallets.</note>
       </trans-unit>
       <trans-unit id="_msg735">
-        <source xml:space="preserve">PSBT saved</source>
-        <context-group purpose="location"><context context-type="linenumber">437</context></context-group>
+        <source xml:space="preserve">Save Transaction Data</source>
+        <context-group purpose="location"><context context-type="linenumber">426</context></context-group>
       </trans-unit>
       <trans-unit id="_msg736">
-        <source xml:space="preserve">External balance:</source>
-        <context-group purpose="location"><context context-type="linenumber">703</context></context-group>
+        <source xml:space="preserve">Partially Signed Transaction (Binary)</source>
+        <context-group purpose="location"><context context-type="linenumber">428</context></context-group>
+        <note annotates="source" from="developer">Expanded name of the binary PSBT file format. See: BIP 174.</note>
       </trans-unit>
       <trans-unit id="_msg737">
-        <source xml:space="preserve">or</source>
-        <context-group purpose="location"><context context-type="linenumber">388</context></context-group>
+        <source xml:space="preserve">PSBT saved</source>
+        <context-group purpose="location"><context context-type="linenumber">435</context></context-group>
       </trans-unit>
       <trans-unit id="_msg738">
-        <source xml:space="preserve">You can increase the fee later (signals Replace-By-Fee, BIP-125).</source>
-        <context-group purpose="location"><context context-type="linenumber">370</context></context-group>
+        <source xml:space="preserve">External balance:</source>
+        <context-group purpose="location"><context context-type="linenumber">701</context></context-group>
       </trans-unit>
       <trans-unit id="_msg739">
-        <source xml:space="preserve">Please, review your transaction proposal. This will produce a Partially Signed Bitcoin Transaction (PSBT) which you can save or copy and then sign with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
-        <context-group purpose="location"><context context-type="linenumber">340</context></context-group>
-        <note annotates="source" from="developer">Text to inform a user attempting to create a transaction of their current options. At this stage, a user can only create a PSBT. This string is displayed when private keys are disabled and an external signer is not available.</note>
+        <source xml:space="preserve">or</source>
+        <context-group purpose="location"><context context-type="linenumber">386</context></context-group>
       </trans-unit>
       <trans-unit id="_msg740">
-        <source xml:space="preserve">Do you want to create this transaction?</source>
-        <context-group purpose="location"><context context-type="linenumber">334</context></context-group>
-        <note annotates="source" from="developer">Message displayed when attempting to create a transaction. Cautionary text to prompt the user to verify that the displayed transaction details represent the transaction the user intends to create.</note>
+        <source xml:space="preserve">You can increase the fee later (signals Replace-By-Fee, BIP-125).</source>
+        <context-group purpose="location"><context context-type="linenumber">368</context></context-group>
       </trans-unit>
       <trans-unit id="_msg741">
-        <source xml:space="preserve">Please, review your transaction. You can create and send this transaction or create a Partially Signed Bitcoin Transaction (PSBT), which you can save or copy and then sign with, e.g., an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
-        <context-group purpose="location"><context context-type="linenumber">345</context></context-group>
-        <note annotates="source" from="developer">Text to inform a user attempting to create a transaction of their current options. At this stage, a user can send their transaction or create a PSBT. This string is displayed when both private keys and PSBT controls are enabled.</note>
+        <source xml:space="preserve">Please, review your transaction proposal. This will produce a Partially Signed Bitcoin Transaction (PSBT) which you can save or copy and then sign with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
+        <context-group purpose="location"><context context-type="linenumber">338</context></context-group>
+        <note annotates="source" from="developer">Text to inform a user attempting to create a transaction of their current options. At this stage, a user can only create a PSBT. This string is displayed when private keys are disabled and an external signer is not available.</note>
       </trans-unit>
       <trans-unit id="_msg742">
-        <source xml:space="preserve">Please, review your transaction.</source>
-        <context-group purpose="location"><context context-type="linenumber">348</context></context-group>
-        <note annotates="source" from="developer">Text to prompt a user to review the details of the transaction they are attempting to send.</note>
+        <source xml:space="preserve">Do you want to create this transaction?</source>
+        <context-group purpose="location"><context context-type="linenumber">332</context></context-group>
+        <note annotates="source" from="developer">Message displayed when attempting to create a transaction. Cautionary text to prompt the user to verify that the displayed transaction details represent the transaction the user intends to create.</note>
       </trans-unit>
       <trans-unit id="_msg743">
-        <source xml:space="preserve">Transaction fee</source>
-        <context-group purpose="location"><context context-type="linenumber">356</context></context-group>
+        <source xml:space="preserve">Please, review your transaction. You can create and send this transaction or create a Partially Signed Bitcoin Transaction (PSBT), which you can save or copy and then sign with, e.g., an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
+        <context-group purpose="location"><context context-type="linenumber">343</context></context-group>
+        <note annotates="source" from="developer">Text to inform a user attempting to create a transaction of their current options. At this stage, a user can send their transaction or create a PSBT. This string is displayed when both private keys and PSBT controls are enabled.</note>
       </trans-unit>
       <trans-unit id="_msg744">
-        <source xml:space="preserve">Not signalling Replace-By-Fee, BIP-125.</source>
-        <context-group purpose="location"><context context-type="linenumber">372</context></context-group>
+        <source xml:space="preserve">Please, review your transaction.</source>
+        <context-group purpose="location"><context context-type="linenumber">346</context></context-group>
+        <note annotates="source" from="developer">Text to prompt a user to review the details of the transaction they are attempting to send.</note>
       </trans-unit>
       <trans-unit id="_msg745">
-        <source xml:space="preserve">Total Amount</source>
-        <context-group purpose="location"><context context-type="linenumber">385</context></context-group>
+        <source xml:space="preserve">Transaction fee</source>
+        <context-group purpose="location"><context context-type="linenumber">354</context></context-group>
       </trans-unit>
       <trans-unit id="_msg746">
-        <source xml:space="preserve">Confirm send coins</source>
-        <context-group purpose="location"><context context-type="linenumber">484</context></context-group>
+        <source xml:space="preserve">Not signalling Replace-By-Fee, BIP-125.</source>
+        <context-group purpose="location"><context context-type="linenumber">370</context></context-group>
       </trans-unit>
       <trans-unit id="_msg747">
-        <source xml:space="preserve">Watch-only balance:</source>
-        <context-group purpose="location"><context context-type="linenumber">706</context></context-group>
+        <source xml:space="preserve">Total Amount</source>
+        <context-group purpose="location"><context context-type="linenumber">383</context></context-group>
       </trans-unit>
       <trans-unit id="_msg748">
-        <source xml:space="preserve">The recipient address is not valid. Please recheck.</source>
-        <context-group purpose="location"><context context-type="linenumber">730</context></context-group>
+        <source xml:space="preserve">Confirm send coins</source>
+        <context-group purpose="location"><context context-type="linenumber">482</context></context-group>
       </trans-unit>
       <trans-unit id="_msg749">
-        <source xml:space="preserve">The amount to pay must be larger than 0.</source>
-        <context-group purpose="location"><context context-type="linenumber">733</context></context-group>
+        <source xml:space="preserve">Watch-only balance:</source>
+        <context-group purpose="location"><context context-type="linenumber">704</context></context-group>
       </trans-unit>
       <trans-unit id="_msg750">
-        <source xml:space="preserve">The amount exceeds your balance.</source>
-        <context-group purpose="location"><context context-type="linenumber">736</context></context-group>
+        <source xml:space="preserve">The recipient address is not valid. Please recheck.</source>
+        <context-group purpose="location"><context context-type="linenumber">728</context></context-group>
       </trans-unit>
       <trans-unit id="_msg751">
-        <source xml:space="preserve">The total exceeds your balance when the %1 transaction fee is included.</source>
-        <context-group purpose="location"><context context-type="linenumber">739</context></context-group>
+        <source xml:space="preserve">The amount to pay must be larger than 0.</source>
+        <context-group purpose="location"><context context-type="linenumber">731</context></context-group>
       </trans-unit>
       <trans-unit id="_msg752">
-        <source xml:space="preserve">Duplicate address found: addresses should only be used once each.</source>
-        <context-group purpose="location"><context context-type="linenumber">742</context></context-group>
+        <source xml:space="preserve">The amount exceeds your balance.</source>
+        <context-group purpose="location"><context context-type="linenumber">734</context></context-group>
       </trans-unit>
       <trans-unit id="_msg753">
-        <source xml:space="preserve">Transaction creation failed!</source>
-        <context-group purpose="location"><context context-type="linenumber">745</context></context-group>
+        <source xml:space="preserve">The total exceeds your balance when the %1 transaction fee is included.</source>
+        <context-group purpose="location"><context context-type="linenumber">737</context></context-group>
       </trans-unit>
       <trans-unit id="_msg754">
+        <source xml:space="preserve">Duplicate address found: addresses should only be used once each.</source>
+        <context-group purpose="location"><context context-type="linenumber">740</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg755">
+        <source xml:space="preserve">Transaction creation failed!</source>
+        <context-group purpose="location"><context context-type="linenumber">743</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg756">
         <source xml:space="preserve">A fee higher than %1 is considered an absurdly high fee.</source>
-        <context-group purpose="location"><context context-type="linenumber">749</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">747</context></context-group>
       </trans-unit>
       <group restype="x-gettext-plurals">
-        <context-group purpose="location"><context context-type="linenumber">872</context></context-group>
-        <trans-unit id="_msg755[0]">
+        <context-group purpose="location"><context context-type="linenumber">870</context></context-group>
+        <trans-unit id="_msg757[0]">
           <source xml:space="preserve">Estimated to begin confirmation within %n block(s).</source>
         </trans-unit>
-        <trans-unit id="_msg755[1]">
+        <trans-unit id="_msg757[1]">
           <source xml:space="preserve">Estimated to begin confirmation within %n block(s).</source>
         </trans-unit>
       </group>
-      <trans-unit id="_msg756">
-        <source xml:space="preserve">Warning: Invalid Bitcoin address</source>
-        <context-group purpose="location"><context context-type="linenumber">973</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg757">
-        <source xml:space="preserve">Warning: Unknown change address</source>
-        <context-group purpose="location"><context context-type="linenumber">978</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg758">
-        <source xml:space="preserve">Confirm custom change address</source>
-        <context-group purpose="location"><context context-type="linenumber">981</context></context-group>
+        <source xml:space="preserve">Warning: Invalid Bitcoin address</source>
+        <context-group purpose="location"><context context-type="linenumber">971</context></context-group>
       </trans-unit>
       <trans-unit id="_msg759">
-        <source xml:space="preserve">The address you selected for change is not part of this wallet. Any or all funds in your wallet may be sent to this address. Are you sure?</source>
-        <context-group purpose="location"><context context-type="linenumber">981</context></context-group>
+        <source xml:space="preserve">Warning: Unknown change address</source>
+        <context-group purpose="location"><context context-type="linenumber">976</context></context-group>
       </trans-unit>
       <trans-unit id="_msg760">
+        <source xml:space="preserve">Confirm custom change address</source>
+        <context-group purpose="location"><context context-type="linenumber">979</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg761">
+        <source xml:space="preserve">The address you selected for change is not part of this wallet. Any or all funds in your wallet may be sent to this address. Are you sure?</source>
+        <context-group purpose="location"><context context-type="linenumber">979</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg762">
         <source xml:space="preserve">(no label)</source>
-        <context-group purpose="location"><context context-type="linenumber">1002</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1000</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../forms/sendcoinsentry.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="SendCoinsEntry">
-      <trans-unit id="_msg761">
+      <trans-unit id="_msg763">
         <source xml:space="preserve">A&amp;mount:</source>
         <context-group purpose="location"><context context-type="linenumber">151</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg762">
+      <trans-unit id="_msg764">
         <source xml:space="preserve">Pay &amp;To:</source>
         <context-group purpose="location"><context context-type="linenumber">35</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg763">
+      <trans-unit id="_msg765">
         <source xml:space="preserve">&amp;Label:</source>
         <context-group purpose="location"><context context-type="linenumber">128</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg764">
+      <trans-unit id="_msg766">
         <source xml:space="preserve">Choose previously used address</source>
         <context-group purpose="location"><context context-type="linenumber">60</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg765">
+      <trans-unit id="_msg767">
         <source xml:space="preserve">The Bitcoin address to send the payment to</source>
         <context-group purpose="location"><context context-type="linenumber">53</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg766">
+      <trans-unit id="_msg768">
         <source xml:space="preserve">Alt+A</source>
         <context-group purpose="location"><context context-type="linenumber">76</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg767">
+      <trans-unit id="_msg769">
         <source xml:space="preserve">Paste address from clipboard</source>
         <context-group purpose="location"><context context-type="linenumber">83</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg768">
+      <trans-unit id="_msg770">
         <source xml:space="preserve">Alt+P</source>
         <context-group purpose="location"><context context-type="linenumber">99</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg769">
+      <trans-unit id="_msg771">
         <source xml:space="preserve">Remove this entry</source>
         <context-group purpose="location"><context context-type="linenumber">106</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg770">
+      <trans-unit id="_msg772">
         <source xml:space="preserve">The amount to send in the selected unit</source>
         <context-group purpose="location"><context context-type="linenumber">166</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg771">
+      <trans-unit id="_msg773">
         <source xml:space="preserve">The fee will be deducted from the amount being sent. The recipient will receive less bitcoins than you enter in the amount field. If multiple recipients are selected, the fee is split equally.</source>
         <context-group purpose="location"><context context-type="linenumber">173</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg772">
+      <trans-unit id="_msg774">
         <source xml:space="preserve">S&amp;ubtract fee from amount</source>
         <context-group purpose="location"><context context-type="linenumber">176</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg773">
+      <trans-unit id="_msg775">
         <source xml:space="preserve">Use available balance</source>
         <context-group purpose="location"><context context-type="linenumber">183</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg774">
+      <trans-unit id="_msg776">
         <source xml:space="preserve">Message:</source>
         <context-group purpose="location"><context context-type="linenumber">192</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg775">
+      <trans-unit id="_msg777">
         <source xml:space="preserve">Enter a label for this address to add it to the list of used addresses</source>
         <context-group purpose="location"><context context-type="linenumber">141</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">144</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg776">
+      <trans-unit id="_msg778">
         <source xml:space="preserve">A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <context-group purpose="location"><context context-type="linenumber">202</context></context-group>
       </trans-unit>
@@ -3561,11 +3570,11 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
   </body></file>
   <file original="../sendcoinsdialog.h" datatype="c" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="SendConfirmationDialog">
-      <trans-unit id="_msg777">
+      <trans-unit id="_msg779">
         <source xml:space="preserve">Send</source>
         <context-group purpose="location"><context context-type="linenumber">144</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg778">
+      <trans-unit id="_msg780">
         <source xml:space="preserve">Create Unsigned</source>
         <context-group purpose="location"><context context-type="linenumber">146</context></context-group>
       </trans-unit>
@@ -3573,105 +3582,105 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
   </body></file>
   <file original="../forms/signverifymessagedialog.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="SignVerifyMessageDialog">
-      <trans-unit id="_msg779">
+      <trans-unit id="_msg781">
         <source xml:space="preserve">Signatures - Sign / Verify a Message</source>
         <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg780">
+      <trans-unit id="_msg782">
         <source xml:space="preserve">&amp;Sign Message</source>
         <context-group purpose="location"><context context-type="linenumber">27</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg781">
+      <trans-unit id="_msg783">
         <source xml:space="preserve">You can sign messages/agreements with your addresses to prove you can receive bitcoins sent to them. Be careful not to sign anything vague or random, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <context-group purpose="location"><context context-type="linenumber">33</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg782">
+      <trans-unit id="_msg784">
         <source xml:space="preserve">The Bitcoin address to sign the message with</source>
         <context-group purpose="location"><context context-type="linenumber">51</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg783">
+      <trans-unit id="_msg785">
         <source xml:space="preserve">Choose previously used address</source>
         <context-group purpose="location"><context context-type="linenumber">58</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">274</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg784">
+      <trans-unit id="_msg786">
         <source xml:space="preserve">Alt+A</source>
         <context-group purpose="location"><context context-type="linenumber">68</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">284</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg785">
+      <trans-unit id="_msg787">
         <source xml:space="preserve">Paste address from clipboard</source>
         <context-group purpose="location"><context context-type="linenumber">78</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg786">
+      <trans-unit id="_msg788">
         <source xml:space="preserve">Alt+P</source>
         <context-group purpose="location"><context context-type="linenumber">88</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg787">
+      <trans-unit id="_msg789">
         <source xml:space="preserve">Enter the message you want to sign here</source>
         <context-group purpose="location"><context context-type="linenumber">100</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">103</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg788">
+      <trans-unit id="_msg790">
         <source xml:space="preserve">Signature</source>
         <context-group purpose="location"><context context-type="linenumber">110</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg789">
+      <trans-unit id="_msg791">
         <source xml:space="preserve">Copy the current signature to the system clipboard</source>
         <context-group purpose="location"><context context-type="linenumber">140</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg790">
+      <trans-unit id="_msg792">
         <source xml:space="preserve">Sign the message to prove you own this Bitcoin address</source>
         <context-group purpose="location"><context context-type="linenumber">161</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg791">
+      <trans-unit id="_msg793">
         <source xml:space="preserve">Sign &amp;Message</source>
         <context-group purpose="location"><context context-type="linenumber">164</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg792">
+      <trans-unit id="_msg794">
         <source xml:space="preserve">Reset all sign message fields</source>
         <context-group purpose="location"><context context-type="linenumber">178</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg793">
+      <trans-unit id="_msg795">
         <source xml:space="preserve">Clear &amp;All</source>
         <context-group purpose="location"><context context-type="linenumber">181</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">338</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg794">
+      <trans-unit id="_msg796">
         <source xml:space="preserve">&amp;Verify Message</source>
         <context-group purpose="location"><context context-type="linenumber">240</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg795">
+      <trans-unit id="_msg797">
         <source xml:space="preserve">Enter the receiver&apos;s address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack. Note that this only proves the signing party receives with the address, it cannot prove sendership of any transaction!</source>
         <context-group purpose="location"><context context-type="linenumber">246</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg796">
+      <trans-unit id="_msg798">
         <source xml:space="preserve">The Bitcoin address the message was signed with</source>
         <context-group purpose="location"><context context-type="linenumber">267</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg797">
+      <trans-unit id="_msg799">
         <source xml:space="preserve">The signed message to verify</source>
         <context-group purpose="location"><context context-type="linenumber">296</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">299</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg798">
+      <trans-unit id="_msg800">
         <source xml:space="preserve">The signature given when the message was signed</source>
         <context-group purpose="location"><context context-type="linenumber">306</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">309</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg799">
+      <trans-unit id="_msg801">
         <source xml:space="preserve">Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <context-group purpose="location"><context context-type="linenumber">318</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg800">
+      <trans-unit id="_msg802">
         <source xml:space="preserve">Verify &amp;Message</source>
         <context-group purpose="location"><context context-type="linenumber">321</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg801">
+      <trans-unit id="_msg803">
         <source xml:space="preserve">Reset all verify message fields</source>
         <context-group purpose="location"><context context-type="linenumber">335</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg802">
+      <trans-unit id="_msg804">
         <source xml:space="preserve">Click &quot;Sign Message&quot; to generate signature</source>
         <context-group purpose="location"><context context-type="linenumber">125</context></context-group>
       </trans-unit>
@@ -3679,164 +3688,164 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
   </body></file>
   <file original="../signverifymessagedialog.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="SignVerifyMessageDialog">
-      <trans-unit id="_msg803">
-        <source xml:space="preserve">The entered address is invalid.</source>
-        <context-group purpose="location"><context context-type="linenumber">120</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">219</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg804">
-        <source xml:space="preserve">Please check the address and try again.</source>
-        <context-group purpose="location"><context context-type="linenumber">120</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">127</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">220</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">227</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg805">
-        <source xml:space="preserve">The entered address does not refer to a key.</source>
-        <context-group purpose="location"><context context-type="linenumber">127</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">226</context></context-group>
+        <source xml:space="preserve">The entered address is invalid.</source>
+        <context-group purpose="location"><context context-type="linenumber">119</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">218</context></context-group>
       </trans-unit>
       <trans-unit id="_msg806">
-        <source xml:space="preserve">Wallet unlock was cancelled.</source>
-        <context-group purpose="location"><context context-type="linenumber">135</context></context-group>
+        <source xml:space="preserve">Please check the address and try again.</source>
+        <context-group purpose="location"><context context-type="linenumber">119</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">126</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">219</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">226</context></context-group>
       </trans-unit>
       <trans-unit id="_msg807">
-        <source xml:space="preserve">No error</source>
-        <context-group purpose="location"><context context-type="linenumber">146</context></context-group>
+        <source xml:space="preserve">The entered address does not refer to a key.</source>
+        <context-group purpose="location"><context context-type="linenumber">126</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">225</context></context-group>
       </trans-unit>
       <trans-unit id="_msg808">
-        <source xml:space="preserve">Private key for the entered address is not available.</source>
-        <context-group purpose="location"><context context-type="linenumber">149</context></context-group>
+        <source xml:space="preserve">Wallet unlock was cancelled.</source>
+        <context-group purpose="location"><context context-type="linenumber">134</context></context-group>
       </trans-unit>
       <trans-unit id="_msg809">
-        <source xml:space="preserve">Message signing failed.</source>
-        <context-group purpose="location"><context context-type="linenumber">152</context></context-group>
+        <source xml:space="preserve">No error</source>
+        <context-group purpose="location"><context context-type="linenumber">145</context></context-group>
       </trans-unit>
       <trans-unit id="_msg810">
-        <source xml:space="preserve">Message signed.</source>
-        <context-group purpose="location"><context context-type="linenumber">164</context></context-group>
+        <source xml:space="preserve">Private key for the entered address is not available.</source>
+        <context-group purpose="location"><context context-type="linenumber">148</context></context-group>
       </trans-unit>
       <trans-unit id="_msg811">
-        <source xml:space="preserve">The signature could not be decoded.</source>
-        <context-group purpose="location"><context context-type="linenumber">233</context></context-group>
+        <source xml:space="preserve">Message signing failed.</source>
+        <context-group purpose="location"><context context-type="linenumber">151</context></context-group>
       </trans-unit>
       <trans-unit id="_msg812">
-        <source xml:space="preserve">Please check the signature and try again.</source>
-        <context-group purpose="location"><context context-type="linenumber">234</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">241</context></context-group>
+        <source xml:space="preserve">Message signed.</source>
+        <context-group purpose="location"><context context-type="linenumber">163</context></context-group>
       </trans-unit>
       <trans-unit id="_msg813">
-        <source xml:space="preserve">The signature did not match the message digest.</source>
-        <context-group purpose="location"><context context-type="linenumber">240</context></context-group>
+        <source xml:space="preserve">The signature could not be decoded.</source>
+        <context-group purpose="location"><context context-type="linenumber">232</context></context-group>
       </trans-unit>
       <trans-unit id="_msg814">
-        <source xml:space="preserve">Message verification failed.</source>
-        <context-group purpose="location"><context context-type="linenumber">246</context></context-group>
+        <source xml:space="preserve">Please check the signature and try again.</source>
+        <context-group purpose="location"><context context-type="linenumber">233</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">240</context></context-group>
       </trans-unit>
       <trans-unit id="_msg815">
+        <source xml:space="preserve">The signature did not match the message digest.</source>
+        <context-group purpose="location"><context context-type="linenumber">239</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg816">
+        <source xml:space="preserve">Message verification failed.</source>
+        <context-group purpose="location"><context context-type="linenumber">245</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg817">
         <source xml:space="preserve">Message verified.</source>
-        <context-group purpose="location"><context context-type="linenumber">214</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">213</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../splashscreen.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="SplashScreen">
-      <trans-unit id="_msg816">
+      <trans-unit id="_msg818">
         <source xml:space="preserve">(press q to shutdown and continue later)</source>
-        <context-group purpose="location"><context context-type="linenumber">187</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">177</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg817">
+      <trans-unit id="_msg819">
         <source xml:space="preserve">press q to shutdown</source>
-        <context-group purpose="location"><context context-type="linenumber">188</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">178</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../trafficgraphwidget.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="TrafficGraphWidget">
-      <trans-unit id="_msg818">
+      <trans-unit id="_msg820">
         <source xml:space="preserve">kB/s</source>
-        <context-group purpose="location"><context context-type="linenumber">79</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">74</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../transactiondesc.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="TransactionDesc">
-      <trans-unit id="_msg819">
+      <trans-unit id="_msg821">
         <source xml:space="preserve">conflicted with a transaction with %1 confirmations</source>
         <context-group purpose="location"><context context-type="linenumber">43</context></context-group>
         <note annotates="source" from="developer">Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that conflicts with a confirmed transaction.</note>
       </trans-unit>
-      <trans-unit id="_msg820">
+      <trans-unit id="_msg822">
         <source xml:space="preserve">0/unconfirmed, in memory pool</source>
         <context-group purpose="location"><context context-type="linenumber">50</context></context-group>
         <note annotates="source" from="developer">Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is in the memory pool.</note>
       </trans-unit>
-      <trans-unit id="_msg821">
+      <trans-unit id="_msg823">
         <source xml:space="preserve">0/unconfirmed, not in memory pool</source>
         <context-group purpose="location"><context context-type="linenumber">55</context></context-group>
         <note annotates="source" from="developer">Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is not in the memory pool.</note>
       </trans-unit>
-      <trans-unit id="_msg822">
+      <trans-unit id="_msg824">
         <source xml:space="preserve">abandoned</source>
         <context-group purpose="location"><context context-type="linenumber">61</context></context-group>
         <note annotates="source" from="developer">Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an abandoned transaction.</note>
       </trans-unit>
-      <trans-unit id="_msg823">
+      <trans-unit id="_msg825">
         <source xml:space="preserve">%1/unconfirmed</source>
         <context-group purpose="location"><context context-type="linenumber">69</context></context-group>
         <note annotates="source" from="developer">Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</note>
       </trans-unit>
-      <trans-unit id="_msg824">
+      <trans-unit id="_msg826">
         <source xml:space="preserve">%1 confirmations</source>
         <context-group purpose="location"><context context-type="linenumber">74</context></context-group>
         <note annotates="source" from="developer">Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</note>
       </trans-unit>
-      <trans-unit id="_msg825">
+      <trans-unit id="_msg827">
         <source xml:space="preserve">Status</source>
         <context-group purpose="location"><context context-type="linenumber">124</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg826">
+      <trans-unit id="_msg828">
         <source xml:space="preserve">Date</source>
         <context-group purpose="location"><context context-type="linenumber">127</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg827">
+      <trans-unit id="_msg829">
         <source xml:space="preserve">Source</source>
         <context-group purpose="location"><context context-type="linenumber">134</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg828">
+      <trans-unit id="_msg830">
         <source xml:space="preserve">Generated</source>
         <context-group purpose="location"><context context-type="linenumber">134</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg829">
+      <trans-unit id="_msg831">
         <source xml:space="preserve">From</source>
         <context-group purpose="location"><context context-type="linenumber">139</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">153</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">225</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg830">
+      <trans-unit id="_msg832">
         <source xml:space="preserve">unknown</source>
         <context-group purpose="location"><context context-type="linenumber">153</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg831">
+      <trans-unit id="_msg833">
         <source xml:space="preserve">To</source>
         <context-group purpose="location"><context context-type="linenumber">154</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">174</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">244</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg832">
+      <trans-unit id="_msg834">
         <source xml:space="preserve">own address</source>
         <context-group purpose="location"><context context-type="linenumber">156</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg833">
+      <trans-unit id="_msg835">
         <source xml:space="preserve">watch-only</source>
         <context-group purpose="location"><context context-type="linenumber">156</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">225</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg834">
+      <trans-unit id="_msg836">
         <source xml:space="preserve">label</source>
         <context-group purpose="location"><context context-type="linenumber">158</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg835">
+      <trans-unit id="_msg837">
         <source xml:space="preserve">Credit</source>
         <context-group purpose="location"><context context-type="linenumber">194</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">206</context></context-group>
@@ -3846,98 +3855,98 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
       </trans-unit>
       <group restype="x-gettext-plurals">
         <context-group purpose="location"><context context-type="linenumber">196</context></context-group>
-        <trans-unit id="_msg836[0]">
+        <trans-unit id="_msg838[0]">
           <source xml:space="preserve">matures in %n more block(s)</source>
         </trans-unit>
-        <trans-unit id="_msg836[1]">
+        <trans-unit id="_msg838[1]">
           <source xml:space="preserve">matures in %n more block(s)</source>
         </trans-unit>
       </group>
-      <trans-unit id="_msg837">
+      <trans-unit id="_msg839">
         <source xml:space="preserve">not accepted</source>
         <context-group purpose="location"><context context-type="linenumber">198</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg838">
+      <trans-unit id="_msg840">
         <source xml:space="preserve">Debit</source>
         <context-group purpose="location"><context context-type="linenumber">258</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">284</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">347</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg839">
+      <trans-unit id="_msg841">
         <source xml:space="preserve">Total debit</source>
         <context-group purpose="location"><context context-type="linenumber">268</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg840">
+      <trans-unit id="_msg842">
         <source xml:space="preserve">Total credit</source>
         <context-group purpose="location"><context context-type="linenumber">269</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg841">
+      <trans-unit id="_msg843">
         <source xml:space="preserve">Transaction fee</source>
         <context-group purpose="location"><context context-type="linenumber">274</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg842">
+      <trans-unit id="_msg844">
         <source xml:space="preserve">Net amount</source>
         <context-group purpose="location"><context context-type="linenumber">296</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg843">
+      <trans-unit id="_msg845">
         <source xml:space="preserve">Message</source>
         <context-group purpose="location"><context context-type="linenumber">302</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">314</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg844">
+      <trans-unit id="_msg846">
         <source xml:space="preserve">Comment</source>
         <context-group purpose="location"><context context-type="linenumber">304</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg845">
+      <trans-unit id="_msg847">
         <source xml:space="preserve">Transaction ID</source>
         <context-group purpose="location"><context context-type="linenumber">306</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg846">
+      <trans-unit id="_msg848">
         <source xml:space="preserve">Transaction total size</source>
         <context-group purpose="location"><context context-type="linenumber">307</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg847">
+      <trans-unit id="_msg849">
         <source xml:space="preserve">Transaction virtual size</source>
         <context-group purpose="location"><context context-type="linenumber">308</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg848">
+      <trans-unit id="_msg850">
         <source xml:space="preserve">Output index</source>
         <context-group purpose="location"><context context-type="linenumber">309</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg849">
+      <trans-unit id="_msg851">
         <source xml:space="preserve"> (Certificate was not verified)</source>
         <context-group purpose="location"><context context-type="linenumber">325</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg850">
+      <trans-unit id="_msg852">
         <source xml:space="preserve">Merchant</source>
         <context-group purpose="location"><context context-type="linenumber">328</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg851">
+      <trans-unit id="_msg853">
         <source xml:space="preserve">Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <context-group purpose="location"><context context-type="linenumber">336</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg852">
+      <trans-unit id="_msg854">
         <source xml:space="preserve">Debug information</source>
         <context-group purpose="location"><context context-type="linenumber">344</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg853">
+      <trans-unit id="_msg855">
         <source xml:space="preserve">Transaction</source>
         <context-group purpose="location"><context context-type="linenumber">352</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg854">
+      <trans-unit id="_msg856">
         <source xml:space="preserve">Inputs</source>
         <context-group purpose="location"><context context-type="linenumber">355</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg855">
+      <trans-unit id="_msg857">
         <source xml:space="preserve">Amount</source>
         <context-group purpose="location"><context context-type="linenumber">376</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg856">
+      <trans-unit id="_msg858">
         <source xml:space="preserve">true</source>
         <context-group purpose="location"><context context-type="linenumber">377</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">378</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg857">
+      <trans-unit id="_msg859">
         <source xml:space="preserve">false</source>
         <context-group purpose="location"><context context-type="linenumber">377</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">378</context></context-group>
@@ -3946,7 +3955,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
   </body></file>
   <file original="../forms/transactiondescdialog.ui" datatype="x-trolltech-designer-ui" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="TransactionDescDialog">
-      <trans-unit id="_msg858">
+      <trans-unit id="_msg860">
         <source xml:space="preserve">This pane shows a detailed description of the transaction</source>
         <context-group purpose="location"><context context-type="linenumber">20</context></context-group>
       </trans-unit>
@@ -3954,7 +3963,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
   </body></file>
   <file original="../transactiondescdialog.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="TransactionDescDialog">
-      <trans-unit id="_msg859">
+      <trans-unit id="_msg861">
         <source xml:space="preserve">Details for %1</source>
         <context-group purpose="location"><context context-type="linenumber">18</context></context-group>
       </trans-unit>
@@ -3962,306 +3971,306 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 
   </body></file>
   <file original="../transactiontablemodel.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="TransactionTableModel">
-      <trans-unit id="_msg860">
-        <source xml:space="preserve">Date</source>
-        <context-group purpose="location"><context context-type="linenumber">261</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg861">
-        <source xml:space="preserve">Type</source>
-        <context-group purpose="location"><context context-type="linenumber">261</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg862">
-        <source xml:space="preserve">Label</source>
-        <context-group purpose="location"><context context-type="linenumber">261</context></context-group>
+        <source xml:space="preserve">Date</source>
+        <context-group purpose="location"><context context-type="linenumber">257</context></context-group>
       </trans-unit>
       <trans-unit id="_msg863">
-        <source xml:space="preserve">Unconfirmed</source>
-        <context-group purpose="location"><context context-type="linenumber">321</context></context-group>
+        <source xml:space="preserve">Type</source>
+        <context-group purpose="location"><context context-type="linenumber">257</context></context-group>
       </trans-unit>
       <trans-unit id="_msg864">
-        <source xml:space="preserve">Abandoned</source>
-        <context-group purpose="location"><context context-type="linenumber">324</context></context-group>
+        <source xml:space="preserve">Label</source>
+        <context-group purpose="location"><context context-type="linenumber">257</context></context-group>
       </trans-unit>
       <trans-unit id="_msg865">
-        <source xml:space="preserve">Confirming (%1 of %2 recommended confirmations)</source>
-        <context-group purpose="location"><context context-type="linenumber">327</context></context-group>
+        <source xml:space="preserve">Unconfirmed</source>
+        <context-group purpose="location"><context context-type="linenumber">317</context></context-group>
       </trans-unit>
       <trans-unit id="_msg866">
-        <source xml:space="preserve">Confirmed (%1 confirmations)</source>
-        <context-group purpose="location"><context context-type="linenumber">330</context></context-group>
+        <source xml:space="preserve">Abandoned</source>
+        <context-group purpose="location"><context context-type="linenumber">320</context></context-group>
       </trans-unit>
       <trans-unit id="_msg867">
-        <source xml:space="preserve">Conflicted</source>
-        <context-group purpose="location"><context context-type="linenumber">333</context></context-group>
+        <source xml:space="preserve">Confirming (%1 of %2 recommended confirmations)</source>
+        <context-group purpose="location"><context context-type="linenumber">323</context></context-group>
       </trans-unit>
       <trans-unit id="_msg868">
-        <source xml:space="preserve">Immature (%1 confirmations, will be available after %2)</source>
-        <context-group purpose="location"><context context-type="linenumber">336</context></context-group>
+        <source xml:space="preserve">Confirmed (%1 confirmations)</source>
+        <context-group purpose="location"><context context-type="linenumber">326</context></context-group>
       </trans-unit>
       <trans-unit id="_msg869">
-        <source xml:space="preserve">Generated but not accepted</source>
-        <context-group purpose="location"><context context-type="linenumber">339</context></context-group>
+        <source xml:space="preserve">Conflicted</source>
+        <context-group purpose="location"><context context-type="linenumber">329</context></context-group>
       </trans-unit>
       <trans-unit id="_msg870">
-        <source xml:space="preserve">Received with</source>
-        <context-group purpose="location"><context context-type="linenumber">378</context></context-group>
+        <source xml:space="preserve">Immature (%1 confirmations, will be available after %2)</source>
+        <context-group purpose="location"><context context-type="linenumber">332</context></context-group>
       </trans-unit>
       <trans-unit id="_msg871">
-        <source xml:space="preserve">Received from</source>
-        <context-group purpose="location"><context context-type="linenumber">380</context></context-group>
+        <source xml:space="preserve">Generated but not accepted</source>
+        <context-group purpose="location"><context context-type="linenumber">335</context></context-group>
       </trans-unit>
       <trans-unit id="_msg872">
-        <source xml:space="preserve">Sent to</source>
-        <context-group purpose="location"><context context-type="linenumber">383</context></context-group>
+        <source xml:space="preserve">Received with</source>
+        <context-group purpose="location"><context context-type="linenumber">374</context></context-group>
       </trans-unit>
       <trans-unit id="_msg873">
-        <source xml:space="preserve">Payment to yourself</source>
-        <context-group purpose="location"><context context-type="linenumber">385</context></context-group>
+        <source xml:space="preserve">Received from</source>
+        <context-group purpose="location"><context context-type="linenumber">376</context></context-group>
       </trans-unit>
       <trans-unit id="_msg874">
-        <source xml:space="preserve">Mined</source>
-        <context-group purpose="location"><context context-type="linenumber">387</context></context-group>
+        <source xml:space="preserve">Sent to</source>
+        <context-group purpose="location"><context context-type="linenumber">379</context></context-group>
       </trans-unit>
       <trans-unit id="_msg875">
-        <source xml:space="preserve">watch-only</source>
-        <context-group purpose="location"><context context-type="linenumber">415</context></context-group>
+        <source xml:space="preserve">Payment to yourself</source>
+        <context-group purpose="location"><context context-type="linenumber">381</context></context-group>
       </trans-unit>
       <trans-unit id="_msg876">
-        <source xml:space="preserve">(n/a)</source>
-        <context-group purpose="location"><context context-type="linenumber">431</context></context-group>
+        <source xml:space="preserve">Mined</source>
+        <context-group purpose="location"><context context-type="linenumber">383</context></context-group>
       </trans-unit>
       <trans-unit id="_msg877">
-        <source xml:space="preserve">(no label)</source>
-        <context-group purpose="location"><context context-type="linenumber">638</context></context-group>
+        <source xml:space="preserve">watch-only</source>
+        <context-group purpose="location"><context context-type="linenumber">411</context></context-group>
       </trans-unit>
       <trans-unit id="_msg878">
-        <source xml:space="preserve">Transaction status. Hover over this field to show number of confirmations.</source>
-        <context-group purpose="location"><context context-type="linenumber">677</context></context-group>
+        <source xml:space="preserve">(n/a)</source>
+        <context-group purpose="location"><context context-type="linenumber">427</context></context-group>
       </trans-unit>
       <trans-unit id="_msg879">
-        <source xml:space="preserve">Date and time that the transaction was received.</source>
-        <context-group purpose="location"><context context-type="linenumber">679</context></context-group>
+        <source xml:space="preserve">(no label)</source>
+        <context-group purpose="location"><context context-type="linenumber">634</context></context-group>
       </trans-unit>
       <trans-unit id="_msg880">
-        <source xml:space="preserve">Type of transaction.</source>
-        <context-group purpose="location"><context context-type="linenumber">681</context></context-group>
+        <source xml:space="preserve">Transaction status. Hover over this field to show number of confirmations.</source>
+        <context-group purpose="location"><context context-type="linenumber">673</context></context-group>
       </trans-unit>
       <trans-unit id="_msg881">
-        <source xml:space="preserve">Whether or not a watch-only address is involved in this transaction.</source>
-        <context-group purpose="location"><context context-type="linenumber">683</context></context-group>
+        <source xml:space="preserve">Date and time that the transaction was received.</source>
+        <context-group purpose="location"><context context-type="linenumber">675</context></context-group>
       </trans-unit>
       <trans-unit id="_msg882">
-        <source xml:space="preserve">User-defined intent/purpose of the transaction.</source>
-        <context-group purpose="location"><context context-type="linenumber">685</context></context-group>
+        <source xml:space="preserve">Type of transaction.</source>
+        <context-group purpose="location"><context context-type="linenumber">677</context></context-group>
       </trans-unit>
       <trans-unit id="_msg883">
+        <source xml:space="preserve">Whether or not a watch-only address is involved in this transaction.</source>
+        <context-group purpose="location"><context context-type="linenumber">679</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg884">
+        <source xml:space="preserve">User-defined intent/purpose of the transaction.</source>
+        <context-group purpose="location"><context context-type="linenumber">681</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg885">
         <source xml:space="preserve">Amount removed from or added to balance.</source>
-        <context-group purpose="location"><context context-type="linenumber">687</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">683</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../transactionview.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="TransactionView">
-      <trans-unit id="_msg884">
+      <trans-unit id="_msg886">
         <source xml:space="preserve">All</source>
         <context-group purpose="location"><context context-type="linenumber">73</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">89</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg885">
+      <trans-unit id="_msg887">
         <source xml:space="preserve">Today</source>
         <context-group purpose="location"><context context-type="linenumber">74</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg886">
+      <trans-unit id="_msg888">
         <source xml:space="preserve">This week</source>
         <context-group purpose="location"><context context-type="linenumber">75</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg887">
+      <trans-unit id="_msg889">
         <source xml:space="preserve">This month</source>
         <context-group purpose="location"><context context-type="linenumber">76</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg888">
+      <trans-unit id="_msg890">
         <source xml:space="preserve">Last month</source>
         <context-group purpose="location"><context context-type="linenumber">77</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg889">
+      <trans-unit id="_msg891">
         <source xml:space="preserve">This year</source>
         <context-group purpose="location"><context context-type="linenumber">78</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg890">
+      <trans-unit id="_msg892">
         <source xml:space="preserve">Received with</source>
         <context-group purpose="location"><context context-type="linenumber">90</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg891">
+      <trans-unit id="_msg893">
         <source xml:space="preserve">Sent to</source>
         <context-group purpose="location"><context context-type="linenumber">92</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg892">
+      <trans-unit id="_msg894">
         <source xml:space="preserve">To yourself</source>
         <context-group purpose="location"><context context-type="linenumber">94</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg893">
+      <trans-unit id="_msg895">
         <source xml:space="preserve">Mined</source>
         <context-group purpose="location"><context context-type="linenumber">95</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg894">
+      <trans-unit id="_msg896">
         <source xml:space="preserve">Other</source>
         <context-group purpose="location"><context context-type="linenumber">96</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg895">
+      <trans-unit id="_msg897">
         <source xml:space="preserve">Enter address, transaction id, or label to search</source>
         <context-group purpose="location"><context context-type="linenumber">101</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg896">
+      <trans-unit id="_msg898">
         <source xml:space="preserve">Min amount</source>
         <context-group purpose="location"><context context-type="linenumber">105</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg897">
+      <trans-unit id="_msg899">
         <source xml:space="preserve">Range…</source>
         <context-group purpose="location"><context context-type="linenumber">79</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg898">
+      <trans-unit id="_msg900">
         <source xml:space="preserve">&amp;Copy address</source>
         <context-group purpose="location"><context context-type="linenumber">169</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg899">
+      <trans-unit id="_msg901">
         <source xml:space="preserve">Copy &amp;label</source>
         <context-group purpose="location"><context context-type="linenumber">170</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg900">
+      <trans-unit id="_msg902">
         <source xml:space="preserve">Copy &amp;amount</source>
         <context-group purpose="location"><context context-type="linenumber">171</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg901">
+      <trans-unit id="_msg903">
         <source xml:space="preserve">Copy transaction &amp;ID</source>
         <context-group purpose="location"><context context-type="linenumber">172</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg902">
+      <trans-unit id="_msg904">
         <source xml:space="preserve">Copy &amp;raw transaction</source>
         <context-group purpose="location"><context context-type="linenumber">173</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg903">
+      <trans-unit id="_msg905">
         <source xml:space="preserve">Copy full transaction &amp;details</source>
         <context-group purpose="location"><context context-type="linenumber">174</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg904">
+      <trans-unit id="_msg906">
         <source xml:space="preserve">&amp;Show transaction details</source>
         <context-group purpose="location"><context context-type="linenumber">175</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg905">
+      <trans-unit id="_msg907">
         <source xml:space="preserve">Increase transaction &amp;fee</source>
         <context-group purpose="location"><context context-type="linenumber">177</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg906">
+      <trans-unit id="_msg908">
         <source xml:space="preserve">A&amp;bandon transaction</source>
         <context-group purpose="location"><context context-type="linenumber">180</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg907">
+      <trans-unit id="_msg909">
         <source xml:space="preserve">&amp;Edit address label</source>
         <context-group purpose="location"><context context-type="linenumber">181</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg908">
+      <trans-unit id="_msg910">
         <source xml:space="preserve">Show in %1</source>
         <context-group purpose="location"><context context-type="linenumber">240</context></context-group>
         <note annotates="source" from="developer">Transactions table context menu action to show the selected transaction in a third-party block explorer. %1 is a stand-in argument for the URL of the explorer.</note>
       </trans-unit>
-      <trans-unit id="_msg909">
+      <trans-unit id="_msg911">
         <source xml:space="preserve">Export Transaction History</source>
         <context-group purpose="location"><context context-type="linenumber">359</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg910">
+      <trans-unit id="_msg912">
         <source xml:space="preserve">Comma separated file</source>
         <context-group purpose="location"><context context-type="linenumber">362</context></context-group>
         <note annotates="source" from="developer">Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</note>
       </trans-unit>
-      <trans-unit id="_msg911">
+      <trans-unit id="_msg913">
         <source xml:space="preserve">Confirmed</source>
         <context-group purpose="location"><context context-type="linenumber">371</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg912">
+      <trans-unit id="_msg914">
         <source xml:space="preserve">Watch-only</source>
         <context-group purpose="location"><context context-type="linenumber">373</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg913">
+      <trans-unit id="_msg915">
         <source xml:space="preserve">Date</source>
         <context-group purpose="location"><context context-type="linenumber">374</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg914">
+      <trans-unit id="_msg916">
         <source xml:space="preserve">Type</source>
         <context-group purpose="location"><context context-type="linenumber">375</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg915">
+      <trans-unit id="_msg917">
         <source xml:space="preserve">Label</source>
         <context-group purpose="location"><context context-type="linenumber">376</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg916">
+      <trans-unit id="_msg918">
         <source xml:space="preserve">Address</source>
         <context-group purpose="location"><context context-type="linenumber">377</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg917">
+      <trans-unit id="_msg919">
         <source xml:space="preserve">ID</source>
         <context-group purpose="location"><context context-type="linenumber">379</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg918">
+      <trans-unit id="_msg920">
         <source xml:space="preserve">Exporting Failed</source>
         <context-group purpose="location"><context context-type="linenumber">382</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg919">
+      <trans-unit id="_msg921">
         <source xml:space="preserve">There was an error trying to save the transaction history to %1.</source>
         <context-group purpose="location"><context context-type="linenumber">382</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg920">
+      <trans-unit id="_msg922">
         <source xml:space="preserve">Exporting Successful</source>
         <context-group purpose="location"><context context-type="linenumber">386</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg921">
+      <trans-unit id="_msg923">
         <source xml:space="preserve">The transaction history was successfully saved to %1.</source>
         <context-group purpose="location"><context context-type="linenumber">386</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg922">
+      <trans-unit id="_msg924">
         <source xml:space="preserve">Range:</source>
-        <context-group purpose="location"><context context-type="linenumber">558</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">555</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg923">
+      <trans-unit id="_msg925">
         <source xml:space="preserve">to</source>
-        <context-group purpose="location"><context context-type="linenumber">566</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">563</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../walletframe.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="WalletFrame">
-      <trans-unit id="_msg924">
+      <trans-unit id="_msg926">
         <source xml:space="preserve">No wallet has been loaded.
 Go to File &gt; Open Wallet to load a wallet.
 - OR -</source>
         <context-group purpose="location"><context context-type="linenumber">45</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg925">
+      <trans-unit id="_msg927">
         <source xml:space="preserve">Create a new wallet</source>
         <context-group purpose="location"><context context-type="linenumber">50</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg926">
+      <trans-unit id="_msg928">
         <source xml:space="preserve">Error</source>
         <context-group purpose="location"><context context-type="linenumber">201</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">211</context></context-group>
         <context-group purpose="location"><context context-type="linenumber">229</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg927">
+      <trans-unit id="_msg929">
         <source xml:space="preserve">Unable to decode PSBT from clipboard (invalid base64)</source>
         <context-group purpose="location"><context context-type="linenumber">201</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg928">
+      <trans-unit id="_msg930">
         <source xml:space="preserve">Load Transaction Data</source>
         <context-group purpose="location"><context context-type="linenumber">207</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg929">
+      <trans-unit id="_msg931">
         <source xml:space="preserve">Partially Signed Transaction (*.psbt)</source>
         <context-group purpose="location"><context context-type="linenumber">208</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg930">
+      <trans-unit id="_msg932">
         <source xml:space="preserve">PSBT file must be smaller than 100 MiB</source>
         <context-group purpose="location"><context context-type="linenumber">211</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg931">
+      <trans-unit id="_msg933">
         <source xml:space="preserve">Unable to decode PSBT</source>
         <context-group purpose="location"><context context-type="linenumber">229</context></context-group>
       </trans-unit>
@@ -4269,896 +4278,948 @@ Go to File &gt; Open Wallet to load a wallet.
   </body></file>
   <file original="../walletmodel.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="WalletModel">
-      <trans-unit id="_msg932">
-        <source xml:space="preserve">Send Coins</source>
-        <context-group purpose="location"><context context-type="linenumber">232</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg933">
-        <source xml:space="preserve">Fee bump error</source>
-        <context-group purpose="location"><context context-type="linenumber">495</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">547</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">562</context></context-group>
-        <context-group purpose="location"><context context-type="linenumber">567</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg934">
-        <source xml:space="preserve">Increasing transaction fee failed</source>
-        <context-group purpose="location"><context context-type="linenumber">495</context></context-group>
+        <source xml:space="preserve">Send Coins</source>
+        <context-group purpose="location"><context context-type="linenumber">228</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">241</context></context-group>
       </trans-unit>
       <trans-unit id="_msg935">
-        <source xml:space="preserve">Do you want to increase the fee?</source>
-        <context-group purpose="location"><context context-type="linenumber">502</context></context-group>
-        <note annotates="source" from="developer">Asks a user if they would like to manually increase the fee of a transaction that has already been created.</note>
+        <source xml:space="preserve">Fee bump error</source>
+        <context-group purpose="location"><context context-type="linenumber">489</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">544</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">559</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">564</context></context-group>
       </trans-unit>
       <trans-unit id="_msg936">
-        <source xml:space="preserve">Current fee:</source>
-        <context-group purpose="location"><context context-type="linenumber">506</context></context-group>
+        <source xml:space="preserve">Increasing transaction fee failed</source>
+        <context-group purpose="location"><context context-type="linenumber">489</context></context-group>
       </trans-unit>
       <trans-unit id="_msg937">
-        <source xml:space="preserve">Increase:</source>
-        <context-group purpose="location"><context context-type="linenumber">510</context></context-group>
+        <source xml:space="preserve">Do you want to increase the fee?</source>
+        <context-group purpose="location"><context context-type="linenumber">496</context></context-group>
+        <note annotates="source" from="developer">Asks a user if they would like to manually increase the fee of a transaction that has already been created.</note>
       </trans-unit>
       <trans-unit id="_msg938">
-        <source xml:space="preserve">New fee:</source>
-        <context-group purpose="location"><context context-type="linenumber">514</context></context-group>
+        <source xml:space="preserve">Current fee:</source>
+        <context-group purpose="location"><context context-type="linenumber">500</context></context-group>
       </trans-unit>
       <trans-unit id="_msg939">
-        <source xml:space="preserve">Warning: This may pay the additional fee by reducing change outputs or adding inputs, when necessary. It may add a new change output if one does not already exist. These changes may potentially leak privacy.</source>
-        <context-group purpose="location"><context context-type="linenumber">522</context></context-group>
+        <source xml:space="preserve">Increase:</source>
+        <context-group purpose="location"><context context-type="linenumber">504</context></context-group>
       </trans-unit>
       <trans-unit id="_msg940">
-        <source xml:space="preserve">Confirm fee bump</source>
-        <context-group purpose="location"><context context-type="linenumber">525</context></context-group>
+        <source xml:space="preserve">New fee:</source>
+        <context-group purpose="location"><context context-type="linenumber">508</context></context-group>
       </trans-unit>
       <trans-unit id="_msg941">
-        <source xml:space="preserve">Can&apos;t draft transaction.</source>
-        <context-group purpose="location"><context context-type="linenumber">547</context></context-group>
+        <source xml:space="preserve">Warning: This may pay the additional fee by reducing change outputs or adding inputs, when necessary. It may add a new change output if one does not already exist. These changes may potentially leak privacy.</source>
+        <context-group purpose="location"><context context-type="linenumber">516</context></context-group>
       </trans-unit>
       <trans-unit id="_msg942">
-        <source xml:space="preserve">PSBT copied</source>
-        <context-group purpose="location"><context context-type="linenumber">554</context></context-group>
+        <source xml:space="preserve">Confirm fee bump</source>
+        <context-group purpose="location"><context context-type="linenumber">521</context></context-group>
       </trans-unit>
       <trans-unit id="_msg943">
-        <source xml:space="preserve">Can&apos;t sign transaction.</source>
-        <context-group purpose="location"><context context-type="linenumber">562</context></context-group>
+        <source xml:space="preserve">Can&apos;t draft transaction.</source>
+        <context-group purpose="location"><context context-type="linenumber">544</context></context-group>
       </trans-unit>
       <trans-unit id="_msg944">
-        <source xml:space="preserve">Could not commit transaction</source>
-        <context-group purpose="location"><context context-type="linenumber">567</context></context-group>
+        <source xml:space="preserve">PSBT copied</source>
+        <context-group purpose="location"><context context-type="linenumber">551</context></context-group>
       </trans-unit>
       <trans-unit id="_msg945">
-        <source xml:space="preserve">Can&apos;t display address</source>
-        <context-group purpose="location"><context context-type="linenumber">581</context></context-group>
+        <source xml:space="preserve">Can&apos;t sign transaction.</source>
+        <context-group purpose="location"><context context-type="linenumber">559</context></context-group>
       </trans-unit>
       <trans-unit id="_msg946">
+        <source xml:space="preserve">Could not commit transaction</source>
+        <context-group purpose="location"><context context-type="linenumber">564</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg947">
+        <source xml:space="preserve">Can&apos;t display address</source>
+        <context-group purpose="location"><context context-type="linenumber">578</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg948">
         <source xml:space="preserve">default wallet</source>
-        <context-group purpose="location"><context context-type="linenumber">599</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">596</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../walletview.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="WalletView">
-      <trans-unit id="_msg947">
-        <source xml:space="preserve">&amp;Export</source>
-        <context-group purpose="location"><context context-type="linenumber">51</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg948">
-        <source xml:space="preserve">Export the data in the current tab to a file</source>
-        <context-group purpose="location"><context context-type="linenumber">52</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg949">
-        <source xml:space="preserve">Backup Wallet</source>
-        <context-group purpose="location"><context context-type="linenumber">214</context></context-group>
+        <source xml:space="preserve">&amp;Export</source>
+        <context-group purpose="location"><context context-type="linenumber">50</context></context-group>
       </trans-unit>
       <trans-unit id="_msg950">
-        <source xml:space="preserve">Wallet Data</source>
-        <context-group purpose="location"><context context-type="linenumber">216</context></context-group>
-        <note annotates="source" from="developer">Name of the wallet data file format.</note>
+        <source xml:space="preserve">Export the data in the current tab to a file</source>
+        <context-group purpose="location"><context context-type="linenumber">51</context></context-group>
       </trans-unit>
       <trans-unit id="_msg951">
-        <source xml:space="preserve">Backup Failed</source>
-        <context-group purpose="location"><context context-type="linenumber">222</context></context-group>
+        <source xml:space="preserve">Backup Wallet</source>
+        <context-group purpose="location"><context context-type="linenumber">213</context></context-group>
       </trans-unit>
       <trans-unit id="_msg952">
-        <source xml:space="preserve">There was an error trying to save the wallet data to %1.</source>
-        <context-group purpose="location"><context context-type="linenumber">222</context></context-group>
+        <source xml:space="preserve">Wallet Data</source>
+        <context-group purpose="location"><context context-type="linenumber">215</context></context-group>
+        <note annotates="source" from="developer">Name of the wallet data file format.</note>
       </trans-unit>
       <trans-unit id="_msg953">
-        <source xml:space="preserve">Backup Successful</source>
-        <context-group purpose="location"><context context-type="linenumber">226</context></context-group>
+        <source xml:space="preserve">Backup Failed</source>
+        <context-group purpose="location"><context context-type="linenumber">221</context></context-group>
       </trans-unit>
       <trans-unit id="_msg954">
-        <source xml:space="preserve">The wallet data was successfully saved to %1.</source>
-        <context-group purpose="location"><context context-type="linenumber">226</context></context-group>
+        <source xml:space="preserve">There was an error trying to save the wallet data to %1.</source>
+        <context-group purpose="location"><context context-type="linenumber">221</context></context-group>
       </trans-unit>
       <trans-unit id="_msg955">
+        <source xml:space="preserve">Backup Successful</source>
+        <context-group purpose="location"><context context-type="linenumber">225</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg956">
+        <source xml:space="preserve">The wallet data was successfully saved to %1.</source>
+        <context-group purpose="location"><context context-type="linenumber">225</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg957">
         <source xml:space="preserve">Cancel</source>
-        <context-group purpose="location"><context context-type="linenumber">263</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">262</context></context-group>
       </trans-unit>
     </group>
   </body></file>
   <file original="../bitcoinstrings.cpp" datatype="cpp" source-language="en"><body>
     <group restype="x-trolltech-linguist-context" resname="bitcoin-core">
-      <trans-unit id="_msg956">
+      <trans-unit id="_msg958">
         <source xml:space="preserve">The %s developers</source>
         <context-group purpose="location"><context context-type="linenumber">12</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg957">
+      <trans-unit id="_msg959">
         <source xml:space="preserve">%s corrupt. Try using the wallet tool bitcoin-wallet to salvage or restoring a backup.</source>
         <context-group purpose="location"><context context-type="linenumber">13</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg958">
+      <trans-unit id="_msg960">
+        <source xml:space="preserve">%s request to listen on port %u. This port is considered &quot;bad&quot; and thus it is unlikely that any peer will connect to it. See doc/p2p-bad-ports.md for details and a full list.</source>
+        <context-group purpose="location"><context context-type="linenumber">16</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg961">
         <source xml:space="preserve">-maxtxfee is set very high! Fees this large could be paid on a single transaction.</source>
         <context-group purpose="location"><context context-type="linenumber">20</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg959">
+      <trans-unit id="_msg962">
         <source xml:space="preserve">Cannot downgrade wallet from version %i to version %i. Wallet version unchanged.</source>
+        <context-group purpose="location"><context context-type="linenumber">35</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg963">
+        <source xml:space="preserve">Cannot obtain a lock on data directory %s. %s is probably already running.</source>
         <context-group purpose="location"><context context-type="linenumber">38</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg960">
-        <source xml:space="preserve">Cannot obtain a lock on data directory %s. %s is probably already running.</source>
-        <context-group purpose="location"><context context-type="linenumber">41</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg961">
+      <trans-unit id="_msg964">
         <source xml:space="preserve">Cannot upgrade a non HD split wallet from version %i to version %i without upgrading to support pre-split keypool. Please use version %i or no version specified.</source>
-        <context-group purpose="location"><context context-type="linenumber">46</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">43</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg962">
+      <trans-unit id="_msg965">
+        <source xml:space="preserve">Disk space for %s may not accommodate the block files. Approximately %u GB of data will be stored in this directory.</source>
+        <context-group purpose="location"><context context-type="linenumber">47</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg966">
         <source xml:space="preserve">Distributed under the MIT software license, see the accompanying file %s or %s</source>
         <context-group purpose="location"><context context-type="linenumber">50</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg963">
-        <source xml:space="preserve">Error reading %s! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
+      <trans-unit id="_msg967">
+        <source xml:space="preserve">Error loading wallet. Wallet requires blocks to be downloaded, and software does not currently support loading wallets while blocks are being downloaded out of order when using assumeutxo snapshots. Wallet should be able to load successfully after node sync reaches height %s</source>
         <context-group purpose="location"><context context-type="linenumber">56</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg964">
-        <source xml:space="preserve">Error reading %s! Transaction data may be missing or incorrect. Rescanning wallet.</source>
-        <context-group purpose="location"><context context-type="linenumber">59</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg965">
-        <source xml:space="preserve">Error: Dumpfile format record is incorrect. Got &quot;%s&quot;, expected &quot;format&quot;.</source>
-        <context-group purpose="location"><context context-type="linenumber">65</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg966">
-        <source xml:space="preserve">Error: Dumpfile identifier record is incorrect. Got &quot;%s&quot;, expected &quot;%s&quot;.</source>
-        <context-group purpose="location"><context context-type="linenumber">67</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg967">
-        <source xml:space="preserve">Error: Dumpfile version is not supported. This version of bitcoin-wallet only supports version 1 dumpfiles. Got dumpfile with version %s</source>
-        <context-group purpose="location"><context context-type="linenumber">69</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg968">
-        <source xml:space="preserve">Error: Legacy wallets only support the &quot;legacy&quot;, &quot;p2sh-segwit&quot;, and &quot;bech32&quot; address types</source>
-        <context-group purpose="location"><context context-type="linenumber">75</context></context-group>
+        <source xml:space="preserve">Error reading %s! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
+        <context-group purpose="location"><context context-type="linenumber">61</context></context-group>
       </trans-unit>
       <trans-unit id="_msg969">
-        <source xml:space="preserve">Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.</source>
-        <context-group purpose="location"><context context-type="linenumber">87</context></context-group>
+        <source xml:space="preserve">Error reading %s! Transaction data may be missing or incorrect. Rescanning wallet.</source>
+        <context-group purpose="location"><context context-type="linenumber">64</context></context-group>
       </trans-unit>
       <trans-unit id="_msg970">
-        <source xml:space="preserve">File %s already exists. If you are sure this is what you want, move it out of the way first.</source>
-        <context-group purpose="location"><context context-type="linenumber">90</context></context-group>
+        <source xml:space="preserve">Error: Dumpfile format record is incorrect. Got &quot;%s&quot;, expected &quot;format&quot;.</source>
+        <context-group purpose="location"><context context-type="linenumber">70</context></context-group>
       </trans-unit>
       <trans-unit id="_msg971">
-        <source xml:space="preserve">Invalid amount for -maxtxfee=&lt;amount&gt;: &apos;%s&apos; (must be at least the minrelay fee of %s to prevent stuck transactions)</source>
-        <context-group purpose="location"><context context-type="linenumber">96</context></context-group>
+        <source xml:space="preserve">Error: Dumpfile identifier record is incorrect. Got &quot;%s&quot;, expected &quot;%s&quot;.</source>
+        <context-group purpose="location"><context context-type="linenumber">72</context></context-group>
       </trans-unit>
       <trans-unit id="_msg972">
-        <source xml:space="preserve">Invalid or corrupt peers.dat (%s). If you believe this is a bug, please report it to %s. As a workaround, you can move the file (%s) out of the way (rename, move, or delete) to have a new one created on the next start.</source>
-        <context-group purpose="location"><context context-type="linenumber">99</context></context-group>
+        <source xml:space="preserve">Error: Dumpfile version is not supported. This version of bitcoin-wallet only supports version 1 dumpfiles. Got dumpfile with version %s</source>
+        <context-group purpose="location"><context context-type="linenumber">74</context></context-group>
       </trans-unit>
       <trans-unit id="_msg973">
-        <source xml:space="preserve">More than one onion bind address is provided. Using %s for the automatically created Tor onion service.</source>
-        <context-group purpose="location"><context context-type="linenumber">103</context></context-group>
+        <source xml:space="preserve">Error: Legacy wallets only support the &quot;legacy&quot;, &quot;p2sh-segwit&quot;, and &quot;bech32&quot; address types</source>
+        <context-group purpose="location"><context context-type="linenumber">80</context></context-group>
       </trans-unit>
       <trans-unit id="_msg974">
-        <source xml:space="preserve">No dump file provided. To use createfromdump, -dumpfile=&lt;filename&gt; must be provided.</source>
-        <context-group purpose="location"><context context-type="linenumber">106</context></context-group>
+        <source xml:space="preserve">Error: Unable to produce descriptors for this legacy wallet. Make sure to provide the wallet&apos;s passphrase if it is encrypted.</source>
+        <context-group purpose="location"><context context-type="linenumber">86</context></context-group>
       </trans-unit>
       <trans-unit id="_msg975">
-        <source xml:space="preserve">No dump file provided. To use dump, -dumpfile=&lt;filename&gt; must be provided.</source>
-        <context-group purpose="location"><context context-type="linenumber">109</context></context-group>
+        <source xml:space="preserve">Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.</source>
+        <context-group purpose="location"><context context-type="linenumber">92</context></context-group>
       </trans-unit>
       <trans-unit id="_msg976">
-        <source xml:space="preserve">No wallet file format provided. To use createfromdump, -format=&lt;format&gt; must be provided.</source>
-        <context-group purpose="location"><context context-type="linenumber">111</context></context-group>
+        <source xml:space="preserve">File %s already exists. If you are sure this is what you want, move it out of the way first.</source>
+        <context-group purpose="location"><context context-type="linenumber">95</context></context-group>
       </trans-unit>
       <trans-unit id="_msg977">
-        <source xml:space="preserve">Please check that your computer&apos;s date and time are correct! If your clock is wrong, %s will not work properly.</source>
-        <context-group purpose="location"><context context-type="linenumber">121</context></context-group>
+        <source xml:space="preserve">Invalid amount for -maxtxfee=&lt;amount&gt;: &apos;%s&apos; (must be at least the minrelay fee of %s to prevent stuck transactions)</source>
+        <context-group purpose="location"><context context-type="linenumber">101</context></context-group>
       </trans-unit>
       <trans-unit id="_msg978">
-        <source xml:space="preserve">Please contribute if you find %s useful. Visit %s for further information about the software.</source>
-        <context-group purpose="location"><context context-type="linenumber">124</context></context-group>
+        <source xml:space="preserve">Invalid or corrupt peers.dat (%s). If you believe this is a bug, please report it to %s. As a workaround, you can move the file (%s) out of the way (rename, move, or delete) to have a new one created on the next start.</source>
+        <context-group purpose="location"><context context-type="linenumber">104</context></context-group>
       </trans-unit>
       <trans-unit id="_msg979">
-        <source xml:space="preserve">Prune configured below the minimum of %d MiB.  Please use a higher number.</source>
-        <context-group purpose="location"><context context-type="linenumber">127</context></context-group>
+        <source xml:space="preserve">More than one onion bind address is provided. Using %s for the automatically created Tor onion service.</source>
+        <context-group purpose="location"><context context-type="linenumber">108</context></context-group>
       </trans-unit>
       <trans-unit id="_msg980">
-        <source xml:space="preserve">Prune mode is incompatible with -reindex-chainstate. Use full -reindex instead.</source>
-        <context-group purpose="location"><context context-type="linenumber">129</context></context-group>
+        <source xml:space="preserve">No dump file provided. To use createfromdump, -dumpfile=&lt;filename&gt; must be provided.</source>
+        <context-group purpose="location"><context context-type="linenumber">111</context></context-group>
       </trans-unit>
       <trans-unit id="_msg981">
-        <source xml:space="preserve">Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of pruned node)</source>
-        <context-group purpose="location"><context context-type="linenumber">132</context></context-group>
+        <source xml:space="preserve">No dump file provided. To use dump, -dumpfile=&lt;filename&gt; must be provided.</source>
+        <context-group purpose="location"><context context-type="linenumber">114</context></context-group>
       </trans-unit>
       <trans-unit id="_msg982">
-        <source xml:space="preserve">SQLiteDatabase: Unknown sqlite wallet schema version %d. Only version %d is supported</source>
-        <context-group purpose="location"><context context-type="linenumber">135</context></context-group>
+        <source xml:space="preserve">No wallet file format provided. To use createfromdump, -format=&lt;format&gt; must be provided.</source>
+        <context-group purpose="location"><context context-type="linenumber">116</context></context-group>
       </trans-unit>
       <trans-unit id="_msg983">
-        <source xml:space="preserve">The block database contains a block which appears to be from the future. This may be due to your computer&apos;s date and time being set incorrectly. Only rebuild the block database if you are sure that your computer&apos;s date and time are correct</source>
-        <context-group purpose="location"><context context-type="linenumber">141</context></context-group>
+        <source xml:space="preserve">Please check that your computer&apos;s date and time are correct! If your clock is wrong, %s will not work properly.</source>
+        <context-group purpose="location"><context context-type="linenumber">132</context></context-group>
       </trans-unit>
       <trans-unit id="_msg984">
-        <source xml:space="preserve">The block index db contains a legacy &apos;txindex&apos;. To clear the occupied disk space, run a full -reindex, otherwise ignore this error. This error message will not be displayed again.</source>
-        <context-group purpose="location"><context context-type="linenumber">146</context></context-group>
+        <source xml:space="preserve">Please contribute if you find %s useful. Visit %s for further information about the software.</source>
+        <context-group purpose="location"><context context-type="linenumber">135</context></context-group>
       </trans-unit>
       <trans-unit id="_msg985">
-        <source xml:space="preserve">The transaction amount is too small to send after the fee has been deducted</source>
-        <context-group purpose="location"><context context-type="linenumber">150</context></context-group>
+        <source xml:space="preserve">Prune configured below the minimum of %d MiB.  Please use a higher number.</source>
+        <context-group purpose="location"><context context-type="linenumber">138</context></context-group>
       </trans-unit>
       <trans-unit id="_msg986">
-        <source xml:space="preserve">This error could occur if this wallet was not shutdown cleanly and was last loaded using a build with a newer version of Berkeley DB. If so, please use the software that last loaded this wallet</source>
-        <context-group purpose="location"><context context-type="linenumber">152</context></context-group>
+        <source xml:space="preserve">Prune mode is incompatible with -reindex-chainstate. Use full -reindex instead.</source>
+        <context-group purpose="location"><context context-type="linenumber">140</context></context-group>
       </trans-unit>
       <trans-unit id="_msg987">
-        <source xml:space="preserve">This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
-        <context-group purpose="location"><context context-type="linenumber">156</context></context-group>
+        <source xml:space="preserve">Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of pruned node)</source>
+        <context-group purpose="location"><context context-type="linenumber">143</context></context-group>
       </trans-unit>
       <trans-unit id="_msg988">
-        <source xml:space="preserve">This is the maximum transaction fee you pay (in addition to the normal fee) to prioritize partial spend avoidance over regular coin selection.</source>
-        <context-group purpose="location"><context context-type="linenumber">159</context></context-group>
+        <source xml:space="preserve">SQLiteDatabase: Unknown sqlite wallet schema version %d. Only version %d is supported</source>
+        <context-group purpose="location"><context context-type="linenumber">146</context></context-group>
       </trans-unit>
       <trans-unit id="_msg989">
-        <source xml:space="preserve">This is the transaction fee you may discard if change is smaller than dust at this level</source>
-        <context-group purpose="location"><context context-type="linenumber">162</context></context-group>
+        <source xml:space="preserve">The block database contains a block which appears to be from the future. This may be due to your computer&apos;s date and time being set incorrectly. Only rebuild the block database if you are sure that your computer&apos;s date and time are correct</source>
+        <context-group purpose="location"><context context-type="linenumber">152</context></context-group>
       </trans-unit>
       <trans-unit id="_msg990">
-        <source xml:space="preserve">This is the transaction fee you may pay when fee estimates are not available.</source>
-        <context-group purpose="location"><context context-type="linenumber">165</context></context-group>
+        <source xml:space="preserve">The block index db contains a legacy &apos;txindex&apos;. To clear the occupied disk space, run a full -reindex, otherwise ignore this error. This error message will not be displayed again.</source>
+        <context-group purpose="location"><context context-type="linenumber">157</context></context-group>
       </trans-unit>
       <trans-unit id="_msg991">
-        <source xml:space="preserve">Total length of network version string (%i) exceeds maximum length (%i). Reduce the number or size of uacomments.</source>
-        <context-group purpose="location"><context context-type="linenumber">167</context></context-group>
+        <source xml:space="preserve">The transaction amount is too small to send after the fee has been deducted</source>
+        <context-group purpose="location"><context context-type="linenumber">168</context></context-group>
       </trans-unit>
       <trans-unit id="_msg992">
-        <source xml:space="preserve">Unable to replay blocks. You will need to rebuild the database using -reindex-chainstate.</source>
+        <source xml:space="preserve">This error could occur if this wallet was not shutdown cleanly and was last loaded using a build with a newer version of Berkeley DB. If so, please use the software that last loaded this wallet</source>
         <context-group purpose="location"><context context-type="linenumber">170</context></context-group>
       </trans-unit>
       <trans-unit id="_msg993">
-        <source xml:space="preserve">Unknown wallet file format &quot;%s&quot; provided. Please provide one of &quot;bdb&quot; or &quot;sqlite&quot;.</source>
-        <context-group purpose="location"><context context-type="linenumber">173</context></context-group>
+        <source xml:space="preserve">This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
+        <context-group purpose="location"><context context-type="linenumber">174</context></context-group>
       </trans-unit>
       <trans-unit id="_msg994">
-        <source xml:space="preserve">Unsupported chainstate database format found. Please restart with -reindex-chainstate. This will rebuild the chainstate database.</source>
-        <context-group purpose="location"><context context-type="linenumber">184</context></context-group>
+        <source xml:space="preserve">This is the maximum transaction fee you pay (in addition to the normal fee) to prioritize partial spend avoidance over regular coin selection.</source>
+        <context-group purpose="location"><context context-type="linenumber">177</context></context-group>
       </trans-unit>
       <trans-unit id="_msg995">
-        <source xml:space="preserve">Wallet created successfully. The legacy wallet type is being deprecated and support for creating and opening legacy wallets will be removed in the future.</source>
-        <context-group purpose="location"><context context-type="linenumber">187</context></context-group>
+        <source xml:space="preserve">This is the transaction fee you may discard if change is smaller than dust at this level</source>
+        <context-group purpose="location"><context context-type="linenumber">180</context></context-group>
       </trans-unit>
       <trans-unit id="_msg996">
-        <source xml:space="preserve">Warning: Dumpfile wallet format &quot;%s&quot; does not match command line specified format &quot;%s&quot;.</source>
-        <context-group purpose="location"><context context-type="linenumber">191</context></context-group>
+        <source xml:space="preserve">This is the transaction fee you may pay when fee estimates are not available.</source>
+        <context-group purpose="location"><context context-type="linenumber">183</context></context-group>
       </trans-unit>
       <trans-unit id="_msg997">
-        <source xml:space="preserve">Warning: Private keys detected in wallet {%s} with disabled private keys</source>
-        <context-group purpose="location"><context context-type="linenumber">194</context></context-group>
+        <source xml:space="preserve">Total length of network version string (%i) exceeds maximum length (%i). Reduce the number or size of uacomments.</source>
+        <context-group purpose="location"><context context-type="linenumber">185</context></context-group>
       </trans-unit>
       <trans-unit id="_msg998">
-        <source xml:space="preserve">Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
-        <context-group purpose="location"><context context-type="linenumber">196</context></context-group>
+        <source xml:space="preserve">Unable to replay blocks. You will need to rebuild the database using -reindex-chainstate.</source>
+        <context-group purpose="location"><context context-type="linenumber">188</context></context-group>
       </trans-unit>
       <trans-unit id="_msg999">
-        <source xml:space="preserve">Witness data for blocks after height %d requires validation. Please restart with -reindex.</source>
-        <context-group purpose="location"><context context-type="linenumber">199</context></context-group>
+        <source xml:space="preserve">Unknown wallet file format &quot;%s&quot; provided. Please provide one of &quot;bdb&quot; or &quot;sqlite&quot;.</source>
+        <context-group purpose="location"><context context-type="linenumber">195</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1000">
-        <source xml:space="preserve">You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain</source>
-        <context-group purpose="location"><context context-type="linenumber">202</context></context-group>
+        <source xml:space="preserve">Unsupported chainstate database format found. Please restart with -reindex-chainstate. This will rebuild the chainstate database.</source>
+        <context-group purpose="location"><context context-type="linenumber">206</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1001">
-        <source xml:space="preserve">%s is set very high!</source>
-        <context-group purpose="location"><context context-type="linenumber">211</context></context-group>
+        <source xml:space="preserve">Wallet created successfully. The legacy wallet type is being deprecated and support for creating and opening legacy wallets will be removed in the future.</source>
+        <context-group purpose="location"><context context-type="linenumber">209</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1002">
-        <source xml:space="preserve">-maxmempool must be at least %d MB</source>
-        <context-group purpose="location"><context context-type="linenumber">212</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1003">
-        <source xml:space="preserve">A fatal internal error occurred, see debug.log for details</source>
+        <source xml:space="preserve">Warning: Dumpfile wallet format &quot;%s&quot; does not match command line specified format &quot;%s&quot;.</source>
         <context-group purpose="location"><context context-type="linenumber">213</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1004">
-        <source xml:space="preserve">Cannot resolve -%s address: &apos;%s&apos;</source>
-        <context-group purpose="location"><context context-type="linenumber">214</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1005">
-        <source xml:space="preserve">Cannot set -forcednsseed to true when setting -dnsseed to false.</source>
-        <context-group purpose="location"><context context-type="linenumber">215</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1006">
-        <source xml:space="preserve">Cannot set -peerblockfilters without -blockfilterindex.</source>
+      <trans-unit id="_msg1003">
+        <source xml:space="preserve">Warning: Private keys detected in wallet {%s} with disabled private keys</source>
         <context-group purpose="location"><context context-type="linenumber">216</context></context-group>
       </trans-unit>
+      <trans-unit id="_msg1004">
+        <source xml:space="preserve">Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
+        <context-group purpose="location"><context context-type="linenumber">218</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1005">
+        <source xml:space="preserve">Witness data for blocks after height %d requires validation. Please restart with -reindex.</source>
+        <context-group purpose="location"><context context-type="linenumber">221</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1006">
+        <source xml:space="preserve">You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain</source>
+        <context-group purpose="location"><context context-type="linenumber">224</context></context-group>
+      </trans-unit>
       <trans-unit id="_msg1007">
-        <source xml:space="preserve">Cannot write to data directory &apos;%s&apos;; check permissions.</source>
-        <context-group purpose="location"><context context-type="linenumber">217</context></context-group>
+        <source xml:space="preserve">%s is set very high!</source>
+        <context-group purpose="location"><context context-type="linenumber">233</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1008">
-        <source xml:space="preserve">The -txindex upgrade started by a previous version cannot be completed. Restart with the previous version or run a full -reindex.</source>
-        <context-group purpose="location"><context context-type="linenumber">138</context></context-group>
+        <source xml:space="preserve">-maxmempool must be at least %d MB</source>
+        <context-group purpose="location"><context context-type="linenumber">234</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1009">
-        <source xml:space="preserve">%s request to listen on port %u. This port is considered &quot;bad&quot; and thus it is unlikely that any Bitcoin Core peers connect to it. See doc/p2p-bad-ports.md for details and a full list.</source>
-        <context-group purpose="location"><context context-type="linenumber">16</context></context-group>
+        <source xml:space="preserve">A fatal internal error occurred, see debug.log for details</source>
+        <context-group purpose="location"><context context-type="linenumber">235</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1010">
+        <source xml:space="preserve">Cannot resolve -%s address: &apos;%s&apos;</source>
+        <context-group purpose="location"><context context-type="linenumber">236</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1011">
+        <source xml:space="preserve">Cannot set -forcednsseed to true when setting -dnsseed to false.</source>
+        <context-group purpose="location"><context context-type="linenumber">237</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1012">
+        <source xml:space="preserve">Cannot set -peerblockfilters without -blockfilterindex.</source>
+        <context-group purpose="location"><context context-type="linenumber">238</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1013">
+        <source xml:space="preserve">Cannot write to data directory &apos;%s&apos;; check permissions.</source>
+        <context-group purpose="location"><context context-type="linenumber">239</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1014">
+        <source xml:space="preserve">The -txindex upgrade started by a previous version cannot be completed. Restart with the previous version or run a full -reindex.</source>
+        <context-group purpose="location"><context context-type="linenumber">149</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1015">
         <source xml:space="preserve">-reindex-chainstate option is not compatible with -blockfilterindex. Please temporarily disable blockfilterindex while using -reindex-chainstate, or replace -reindex-chainstate with -reindex to fully rebuild all indexes.</source>
         <context-group purpose="location"><context context-type="linenumber">23</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1011">
+      <trans-unit id="_msg1016">
         <source xml:space="preserve">-reindex-chainstate option is not compatible with -coinstatsindex. Please temporarily disable coinstatsindex while using -reindex-chainstate, or replace -reindex-chainstate with -reindex to fully rebuild all indexes.</source>
         <context-group purpose="location"><context context-type="linenumber">27</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1012">
+      <trans-unit id="_msg1017">
         <source xml:space="preserve">-reindex-chainstate option is not compatible with -txindex. Please temporarily disable txindex while using -reindex-chainstate, or replace -reindex-chainstate with -reindex to fully rebuild all indexes.</source>
         <context-group purpose="location"><context context-type="linenumber">31</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1013">
-        <source xml:space="preserve">Assumed-valid: last wallet synchronisation goes beyond available block data. You need to wait for the background validation chain to download more blocks.</source>
-        <context-group purpose="location"><context context-type="linenumber">35</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1014">
+      <trans-unit id="_msg1018">
         <source xml:space="preserve">Cannot provide specific connections and have addrman find outgoing connections at the same time.</source>
-        <context-group purpose="location"><context context-type="linenumber">43</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">40</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1015">
+      <trans-unit id="_msg1019">
         <source xml:space="preserve">Error loading %s: External signer wallet being loaded without external signer support compiled</source>
         <context-group purpose="location"><context context-type="linenumber">53</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1016">
-        <source xml:space="preserve">Error: Address book data in wallet cannot be identified to belong to migrated wallets</source>
-        <context-group purpose="location"><context context-type="linenumber">62</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1017">
-        <source xml:space="preserve">Error: Duplicate descriptors created during migration. Your wallet may be corrupted.</source>
-        <context-group purpose="location"><context context-type="linenumber">72</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1018">
-        <source xml:space="preserve">Error: Transaction %s in wallet cannot be identified to belong to migrated wallets</source>
-        <context-group purpose="location"><context context-type="linenumber">78</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1019">
-        <source xml:space="preserve">Error: Unable to produce descriptors for this legacy wallet. Make sure the wallet is unlocked first</source>
-        <context-group purpose="location"><context context-type="linenumber">81</context></context-group>
-      </trans-unit>
       <trans-unit id="_msg1020">
-        <source xml:space="preserve">Failed to rename invalid peers.dat file. Please move or delete it and try again.</source>
-        <context-group purpose="location"><context context-type="linenumber">84</context></context-group>
+        <source xml:space="preserve">Error: Address book data in wallet cannot be identified to belong to migrated wallets</source>
+        <context-group purpose="location"><context context-type="linenumber">67</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1021">
-        <source xml:space="preserve">Incompatible options: -dnsseed=1 was explicitly specified, but -onlynet forbids connections to IPv4/IPv6</source>
-        <context-group purpose="location"><context context-type="linenumber">93</context></context-group>
+        <source xml:space="preserve">Error: Duplicate descriptors created during migration. Your wallet may be corrupted.</source>
+        <context-group purpose="location"><context context-type="linenumber">77</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1022">
-        <source xml:space="preserve">Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is explicitly forbidden: -onion=0</source>
-        <context-group purpose="location"><context context-type="linenumber">114</context></context-group>
+        <source xml:space="preserve">Error: Transaction %s in wallet cannot be identified to belong to migrated wallets</source>
+        <context-group purpose="location"><context context-type="linenumber">83</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1023">
-        <source xml:space="preserve">Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is not provided: none of -proxy, -onion or -listenonion is given</source>
-        <context-group purpose="location"><context context-type="linenumber">117</context></context-group>
+        <source xml:space="preserve">Failed to rename invalid peers.dat file. Please move or delete it and try again.</source>
+        <context-group purpose="location"><context context-type="linenumber">89</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1024">
+        <source xml:space="preserve">Incompatible options: -dnsseed=1 was explicitly specified, but -onlynet forbids connections to IPv4/IPv6</source>
+        <context-group purpose="location"><context context-type="linenumber">98</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1025">
+        <source xml:space="preserve">Outbound connections restricted to CJDNS (-onlynet=cjdns) but -cjdnsreachable is not provided</source>
+        <context-group purpose="location"><context context-type="linenumber">119</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1026">
+        <source xml:space="preserve">Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is explicitly forbidden: -onion=0</source>
+        <context-group purpose="location"><context context-type="linenumber">122</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1027">
+        <source xml:space="preserve">Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is not provided: none of -proxy, -onion or -listenonion is given</source>
+        <context-group purpose="location"><context context-type="linenumber">125</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1028">
+        <source xml:space="preserve">Outbound connections restricted to i2p (-onlynet=i2p) but -i2psam is not provided</source>
+        <context-group purpose="location"><context context-type="linenumber">129</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1029">
+        <source xml:space="preserve">The inputs size exceeds the maximum weight. Please try sending a smaller amount or manually consolidating your wallet&apos;s UTXOs</source>
+        <context-group purpose="location"><context context-type="linenumber">161</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1030">
+        <source xml:space="preserve">The preselected coins total amount does not cover the transaction target. Please allow other inputs to be automatically selected or include more coins manually</source>
+        <context-group purpose="location"><context context-type="linenumber">164</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1031">
+        <source xml:space="preserve">Unexpected legacy entry in descriptor wallet found. Loading wallet %s
+
+The wallet might have been tampered with or created with malicious intent.
+</source>
+        <context-group purpose="location"><context context-type="linenumber">191</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1032">
         <source xml:space="preserve">Unrecognized descriptor found. Loading wallet %s
 
 The wallet might had been created on a newer version.
 Please try running the latest software version.
 </source>
-        <context-group purpose="location"><context context-type="linenumber">176</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1025">
-        <source xml:space="preserve">Unsupported category-specific logging level -loglevel=%s. Expected -loglevel=&lt;category&gt;:&lt;loglevel&gt;. Valid categories: %s. Valid loglevels: %s.</source>
-        <context-group purpose="location"><context context-type="linenumber">181</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1026">
-        <source xml:space="preserve">
-Unable to cleanup failed migration</source>
-        <context-group purpose="location"><context context-type="linenumber">205</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1027">
-        <source xml:space="preserve">
-Unable to restore backup of wallet.</source>
-        <context-group purpose="location"><context context-type="linenumber">208</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1028">
-        <source xml:space="preserve">Config setting for %s only applied on %s network when in [%s] section.</source>
-        <context-group purpose="location"><context context-type="linenumber">218</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1029">
-        <source xml:space="preserve">Copyright (C) %i-%i</source>
-        <context-group purpose="location"><context context-type="linenumber">219</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1030">
-        <source xml:space="preserve">Corrupted block database detected</source>
-        <context-group purpose="location"><context context-type="linenumber">220</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1031">
-        <source xml:space="preserve">Could not find asmap file %s</source>
-        <context-group purpose="location"><context context-type="linenumber">221</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1032">
-        <source xml:space="preserve">Could not parse asmap file %s</source>
-        <context-group purpose="location"><context context-type="linenumber">222</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">198</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1033">
-        <source xml:space="preserve">Disk space is too low!</source>
-        <context-group purpose="location"><context context-type="linenumber">223</context></context-group>
+        <source xml:space="preserve">Unsupported category-specific logging level -loglevel=%s. Expected -loglevel=&lt;category&gt;:&lt;loglevel&gt;. Valid categories: %s. Valid loglevels: %s.</source>
+        <context-group purpose="location"><context context-type="linenumber">203</context></context-group>
       </trans-unit>
       <trans-unit id="_msg1034">
-        <source xml:space="preserve">Do you want to rebuild the block database now?</source>
-        <context-group purpose="location"><context context-type="linenumber">224</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1035">
-        <source xml:space="preserve">Done loading</source>
-        <context-group purpose="location"><context context-type="linenumber">225</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1036">
-        <source xml:space="preserve">Dump file %s does not exist.</source>
-        <context-group purpose="location"><context context-type="linenumber">226</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1037">
-        <source xml:space="preserve">Error creating %s</source>
+        <source xml:space="preserve">
+Unable to cleanup failed migration</source>
         <context-group purpose="location"><context context-type="linenumber">227</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1038">
-        <source xml:space="preserve">Error initializing block database</source>
-        <context-group purpose="location"><context context-type="linenumber">228</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1039">
-        <source xml:space="preserve">Error initializing wallet database environment %s!</source>
-        <context-group purpose="location"><context context-type="linenumber">229</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1040">
-        <source xml:space="preserve">Error loading %s</source>
+      <trans-unit id="_msg1035">
+        <source xml:space="preserve">
+Unable to restore backup of wallet.</source>
         <context-group purpose="location"><context context-type="linenumber">230</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1041">
-        <source xml:space="preserve">Error loading %s: Private keys can only be disabled during creation</source>
-        <context-group purpose="location"><context context-type="linenumber">231</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1042">
-        <source xml:space="preserve">Error loading %s: Wallet corrupted</source>
-        <context-group purpose="location"><context context-type="linenumber">232</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1043">
-        <source xml:space="preserve">Error loading %s: Wallet requires newer version of %s</source>
-        <context-group purpose="location"><context context-type="linenumber">233</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1044">
-        <source xml:space="preserve">Error loading block database</source>
-        <context-group purpose="location"><context context-type="linenumber">234</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1045">
-        <source xml:space="preserve">Error opening block database</source>
-        <context-group purpose="location"><context context-type="linenumber">235</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1046">
-        <source xml:space="preserve">Error reading from database, shutting down.</source>
-        <context-group purpose="location"><context context-type="linenumber">236</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1047">
-        <source xml:space="preserve">Error reading next record from wallet database</source>
-        <context-group purpose="location"><context context-type="linenumber">237</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1048">
-        <source xml:space="preserve">Error: Could not add watchonly tx to watchonly wallet</source>
-        <context-group purpose="location"><context context-type="linenumber">238</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1049">
-        <source xml:space="preserve">Error: Could not delete watchonly transactions</source>
-        <context-group purpose="location"><context context-type="linenumber">239</context></context-group>
-      </trans-unit>
-      <trans-unit id="_msg1050">
-        <source xml:space="preserve">Error: Couldn&apos;t create cursor into database</source>
+      <trans-unit id="_msg1036">
+        <source xml:space="preserve">Config setting for %s only applied on %s network when in [%s] section.</source>
         <context-group purpose="location"><context context-type="linenumber">240</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1051">
-        <source xml:space="preserve">Error: Disk space is low for %s</source>
+      <trans-unit id="_msg1037">
+        <source xml:space="preserve">Copyright (C) %i-%i</source>
         <context-group purpose="location"><context context-type="linenumber">241</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1052">
-        <source xml:space="preserve">Error: Dumpfile checksum does not match. Computed %s, expected %s</source>
+      <trans-unit id="_msg1038">
+        <source xml:space="preserve">Corrupted block database detected</source>
         <context-group purpose="location"><context context-type="linenumber">242</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1053">
-        <source xml:space="preserve">Error: Failed to create new watchonly wallet</source>
+      <trans-unit id="_msg1039">
+        <source xml:space="preserve">Could not find asmap file %s</source>
         <context-group purpose="location"><context context-type="linenumber">243</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1054">
-        <source xml:space="preserve">Error: Got key that was not hex: %s</source>
+      <trans-unit id="_msg1040">
+        <source xml:space="preserve">Could not parse asmap file %s</source>
         <context-group purpose="location"><context context-type="linenumber">244</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1055">
-        <source xml:space="preserve">Error: Got value that was not hex: %s</source>
+      <trans-unit id="_msg1041">
+        <source xml:space="preserve">Disk space is too low!</source>
         <context-group purpose="location"><context context-type="linenumber">245</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1056">
-        <source xml:space="preserve">Error: Keypool ran out, please call keypoolrefill first</source>
+      <trans-unit id="_msg1042">
+        <source xml:space="preserve">Do you want to rebuild the block database now?</source>
         <context-group purpose="location"><context context-type="linenumber">246</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1057">
-        <source xml:space="preserve">Error: Missing checksum</source>
+      <trans-unit id="_msg1043">
+        <source xml:space="preserve">Done loading</source>
         <context-group purpose="location"><context context-type="linenumber">247</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1058">
-        <source xml:space="preserve">Error: No %s addresses available.</source>
+      <trans-unit id="_msg1044">
+        <source xml:space="preserve">Dump file %s does not exist.</source>
         <context-group purpose="location"><context context-type="linenumber">248</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1059">
-        <source xml:space="preserve">Error: Not all watchonly txs could be deleted</source>
+      <trans-unit id="_msg1045">
+        <source xml:space="preserve">Error creating %s</source>
         <context-group purpose="location"><context context-type="linenumber">249</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1060">
-        <source xml:space="preserve">Error: This wallet already uses SQLite</source>
+      <trans-unit id="_msg1046">
+        <source xml:space="preserve">Error initializing block database</source>
         <context-group purpose="location"><context context-type="linenumber">250</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1061">
-        <source xml:space="preserve">Error: This wallet is already a descriptor wallet</source>
+      <trans-unit id="_msg1047">
+        <source xml:space="preserve">Error initializing wallet database environment %s!</source>
         <context-group purpose="location"><context context-type="linenumber">251</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1062">
-        <source xml:space="preserve">Error: Unable to begin reading all records in the database</source>
+      <trans-unit id="_msg1048">
+        <source xml:space="preserve">Error loading %s</source>
         <context-group purpose="location"><context context-type="linenumber">252</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1063">
-        <source xml:space="preserve">Error: Unable to make a backup of your wallet</source>
+      <trans-unit id="_msg1049">
+        <source xml:space="preserve">Error loading %s: Private keys can only be disabled during creation</source>
         <context-group purpose="location"><context context-type="linenumber">253</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1064">
-        <source xml:space="preserve">Error: Unable to parse version %u as a uint32_t</source>
+      <trans-unit id="_msg1050">
+        <source xml:space="preserve">Error loading %s: Wallet corrupted</source>
         <context-group purpose="location"><context context-type="linenumber">254</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1065">
-        <source xml:space="preserve">Error: Unable to read all records in the database</source>
+      <trans-unit id="_msg1051">
+        <source xml:space="preserve">Error loading %s: Wallet requires newer version of %s</source>
         <context-group purpose="location"><context context-type="linenumber">255</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1066">
-        <source xml:space="preserve">Error: Unable to remove watchonly address book data</source>
+      <trans-unit id="_msg1052">
+        <source xml:space="preserve">Error loading block database</source>
         <context-group purpose="location"><context context-type="linenumber">256</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1067">
-        <source xml:space="preserve">Error: Unable to write record to new wallet</source>
+      <trans-unit id="_msg1053">
+        <source xml:space="preserve">Error opening block database</source>
         <context-group purpose="location"><context context-type="linenumber">257</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1068">
-        <source xml:space="preserve">Failed to listen on any port. Use -listen=0 if you want this.</source>
+      <trans-unit id="_msg1054">
+        <source xml:space="preserve">Error reading from database, shutting down.</source>
         <context-group purpose="location"><context context-type="linenumber">258</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1069">
-        <source xml:space="preserve">Failed to rescan the wallet during initialization</source>
+      <trans-unit id="_msg1055">
+        <source xml:space="preserve">Error reading next record from wallet database</source>
         <context-group purpose="location"><context context-type="linenumber">259</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1070">
-        <source xml:space="preserve">Failed to verify database</source>
+      <trans-unit id="_msg1056">
+        <source xml:space="preserve">Error: Cannot extract destination from the generated scriptpubkey</source>
         <context-group purpose="location"><context context-type="linenumber">260</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1071">
-        <source xml:space="preserve">Fee rate (%s) is lower than the minimum fee rate setting (%s)</source>
+      <trans-unit id="_msg1057">
+        <source xml:space="preserve">Error: Could not add watchonly tx to watchonly wallet</source>
         <context-group purpose="location"><context context-type="linenumber">261</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1072">
-        <source xml:space="preserve">Ignoring duplicate -wallet %s.</source>
+      <trans-unit id="_msg1058">
+        <source xml:space="preserve">Error: Could not delete watchonly transactions</source>
         <context-group purpose="location"><context context-type="linenumber">262</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1073">
-        <source xml:space="preserve">Importing…</source>
+      <trans-unit id="_msg1059">
+        <source xml:space="preserve">Error: Couldn&apos;t create cursor into database</source>
         <context-group purpose="location"><context context-type="linenumber">263</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1074">
-        <source xml:space="preserve">Incorrect or no genesis block found. Wrong datadir for network?</source>
+      <trans-unit id="_msg1060">
+        <source xml:space="preserve">Error: Disk space is low for %s</source>
         <context-group purpose="location"><context context-type="linenumber">264</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1075">
-        <source xml:space="preserve">Initialization sanity check failed. %s is shutting down.</source>
+      <trans-unit id="_msg1061">
+        <source xml:space="preserve">Error: Dumpfile checksum does not match. Computed %s, expected %s</source>
         <context-group purpose="location"><context context-type="linenumber">265</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1076">
-        <source xml:space="preserve">Input not found or already spent</source>
+      <trans-unit id="_msg1062">
+        <source xml:space="preserve">Error: Failed to create new watchonly wallet</source>
         <context-group purpose="location"><context context-type="linenumber">266</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1077">
-        <source xml:space="preserve">Insufficient funds</source>
+      <trans-unit id="_msg1063">
+        <source xml:space="preserve">Error: Got key that was not hex: %s</source>
         <context-group purpose="location"><context context-type="linenumber">267</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1078">
-        <source xml:space="preserve">Invalid -i2psam address or hostname: &apos;%s&apos;</source>
+      <trans-unit id="_msg1064">
+        <source xml:space="preserve">Error: Got value that was not hex: %s</source>
         <context-group purpose="location"><context context-type="linenumber">268</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1079">
-        <source xml:space="preserve">Invalid -onion address or hostname: &apos;%s&apos;</source>
+      <trans-unit id="_msg1065">
+        <source xml:space="preserve">Error: Keypool ran out, please call keypoolrefill first</source>
         <context-group purpose="location"><context context-type="linenumber">269</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1080">
-        <source xml:space="preserve">Invalid -proxy address or hostname: &apos;%s&apos;</source>
+      <trans-unit id="_msg1066">
+        <source xml:space="preserve">Error: Missing checksum</source>
         <context-group purpose="location"><context context-type="linenumber">270</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1081">
-        <source xml:space="preserve">Invalid P2P permission: &apos;%s&apos;</source>
+      <trans-unit id="_msg1067">
+        <source xml:space="preserve">Error: No %s addresses available.</source>
         <context-group purpose="location"><context context-type="linenumber">271</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1082">
-        <source xml:space="preserve">Invalid amount for -%s=&lt;amount&gt;: &apos;%s&apos;</source>
+      <trans-unit id="_msg1068">
+        <source xml:space="preserve">Error: Not all watchonly txs could be deleted</source>
         <context-group purpose="location"><context context-type="linenumber">272</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1083">
-        <source xml:space="preserve">Invalid amount for -discardfee=&lt;amount&gt;: &apos;%s&apos;</source>
+      <trans-unit id="_msg1069">
+        <source xml:space="preserve">Error: This wallet already uses SQLite</source>
         <context-group purpose="location"><context context-type="linenumber">273</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1084">
-        <source xml:space="preserve">Invalid amount for -fallbackfee=&lt;amount&gt;: &apos;%s&apos;</source>
+      <trans-unit id="_msg1070">
+        <source xml:space="preserve">Error: This wallet is already a descriptor wallet</source>
         <context-group purpose="location"><context context-type="linenumber">274</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1085">
-        <source xml:space="preserve">Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos; (must be at least %s)</source>
+      <trans-unit id="_msg1071">
+        <source xml:space="preserve">Error: Unable to begin reading all records in the database</source>
         <context-group purpose="location"><context context-type="linenumber">275</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1086">
-        <source xml:space="preserve">Invalid netmask specified in -whitelist: &apos;%s&apos;</source>
+      <trans-unit id="_msg1072">
+        <source xml:space="preserve">Error: Unable to make a backup of your wallet</source>
         <context-group purpose="location"><context context-type="linenumber">276</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1087">
-        <source xml:space="preserve">Listening for incoming connections failed (listen returned error %s)</source>
+      <trans-unit id="_msg1073">
+        <source xml:space="preserve">Error: Unable to parse version %u as a uint32_t</source>
         <context-group purpose="location"><context context-type="linenumber">277</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1088">
-        <source xml:space="preserve">Loading P2P addresses…</source>
+      <trans-unit id="_msg1074">
+        <source xml:space="preserve">Error: Unable to read all records in the database</source>
         <context-group purpose="location"><context context-type="linenumber">278</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1089">
-        <source xml:space="preserve">Loading banlist…</source>
+      <trans-unit id="_msg1075">
+        <source xml:space="preserve">Error: Unable to remove watchonly address book data</source>
         <context-group purpose="location"><context context-type="linenumber">279</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1090">
-        <source xml:space="preserve">Loading block index…</source>
+      <trans-unit id="_msg1076">
+        <source xml:space="preserve">Error: Unable to write record to new wallet</source>
         <context-group purpose="location"><context context-type="linenumber">280</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1091">
-        <source xml:space="preserve">Loading wallet…</source>
+      <trans-unit id="_msg1077">
+        <source xml:space="preserve">Failed to listen on any port. Use -listen=0 if you want this.</source>
         <context-group purpose="location"><context context-type="linenumber">281</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1092">
-        <source xml:space="preserve">Missing amount</source>
+      <trans-unit id="_msg1078">
+        <source xml:space="preserve">Failed to rescan the wallet during initialization</source>
         <context-group purpose="location"><context context-type="linenumber">282</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1093">
-        <source xml:space="preserve">Missing solving data for estimating transaction size</source>
+      <trans-unit id="_msg1079">
+        <source xml:space="preserve">Failed to verify database</source>
         <context-group purpose="location"><context context-type="linenumber">283</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1094">
-        <source xml:space="preserve">Need to specify a port with -whitebind: &apos;%s&apos;</source>
+      <trans-unit id="_msg1080">
+        <source xml:space="preserve">Fee rate (%s) is lower than the minimum fee rate setting (%s)</source>
         <context-group purpose="location"><context context-type="linenumber">284</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1095">
-        <source xml:space="preserve">No addresses available</source>
+      <trans-unit id="_msg1081">
+        <source xml:space="preserve">Ignoring duplicate -wallet %s.</source>
         <context-group purpose="location"><context context-type="linenumber">285</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1096">
-        <source xml:space="preserve">Not enough file descriptors available.</source>
+      <trans-unit id="_msg1082">
+        <source xml:space="preserve">Importing…</source>
         <context-group purpose="location"><context context-type="linenumber">286</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1097">
-        <source xml:space="preserve">Prune cannot be configured with a negative value.</source>
+      <trans-unit id="_msg1083">
+        <source xml:space="preserve">Incorrect or no genesis block found. Wrong datadir for network?</source>
         <context-group purpose="location"><context context-type="linenumber">287</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1098">
-        <source xml:space="preserve">Prune mode is incompatible with -txindex.</source>
+      <trans-unit id="_msg1084">
+        <source xml:space="preserve">Initialization sanity check failed. %s is shutting down.</source>
         <context-group purpose="location"><context context-type="linenumber">288</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1099">
-        <source xml:space="preserve">Pruning blockstore…</source>
+      <trans-unit id="_msg1085">
+        <source xml:space="preserve">Input not found or already spent</source>
         <context-group purpose="location"><context context-type="linenumber">289</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1100">
-        <source xml:space="preserve">Reducing -maxconnections from %d to %d, because of system limitations.</source>
+      <trans-unit id="_msg1086">
+        <source xml:space="preserve">Insufficient dbcache for block verification</source>
         <context-group purpose="location"><context context-type="linenumber">290</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1101">
-        <source xml:space="preserve">Replaying blocks…</source>
+      <trans-unit id="_msg1087">
+        <source xml:space="preserve">Insufficient funds</source>
         <context-group purpose="location"><context context-type="linenumber">291</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1102">
-        <source xml:space="preserve">Rescanning…</source>
+      <trans-unit id="_msg1088">
+        <source xml:space="preserve">Invalid -i2psam address or hostname: &apos;%s&apos;</source>
         <context-group purpose="location"><context context-type="linenumber">292</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1103">
-        <source xml:space="preserve">SQLiteDatabase: Failed to execute statement to verify database: %s</source>
+      <trans-unit id="_msg1089">
+        <source xml:space="preserve">Invalid -onion address or hostname: &apos;%s&apos;</source>
         <context-group purpose="location"><context context-type="linenumber">293</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1104">
-        <source xml:space="preserve">SQLiteDatabase: Failed to prepare statement to verify database: %s</source>
+      <trans-unit id="_msg1090">
+        <source xml:space="preserve">Invalid -proxy address or hostname: &apos;%s&apos;</source>
         <context-group purpose="location"><context context-type="linenumber">294</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1105">
-        <source xml:space="preserve">SQLiteDatabase: Failed to read database verification error: %s</source>
+      <trans-unit id="_msg1091">
+        <source xml:space="preserve">Invalid P2P permission: &apos;%s&apos;</source>
         <context-group purpose="location"><context context-type="linenumber">295</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1106">
-        <source xml:space="preserve">SQLiteDatabase: Unexpected application id. Expected %u, got %u</source>
+      <trans-unit id="_msg1092">
+        <source xml:space="preserve">Invalid amount for -%s=&lt;amount&gt;: &apos;%s&apos;</source>
         <context-group purpose="location"><context context-type="linenumber">296</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1107">
-        <source xml:space="preserve">Section [%s] is not recognized.</source>
+      <trans-unit id="_msg1093">
+        <source xml:space="preserve">Invalid amount for -discardfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <context-group purpose="location"><context context-type="linenumber">297</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1108">
-        <source xml:space="preserve">Signing transaction failed</source>
+      <trans-unit id="_msg1094">
+        <source xml:space="preserve">Invalid amount for -fallbackfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <context-group purpose="location"><context context-type="linenumber">298</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1109">
-        <source xml:space="preserve">Specified -walletdir &quot;%s&quot; does not exist</source>
+      <trans-unit id="_msg1095">
+        <source xml:space="preserve">Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos; (must be at least %s)</source>
         <context-group purpose="location"><context context-type="linenumber">299</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1110">
-        <source xml:space="preserve">Specified -walletdir &quot;%s&quot; is a relative path</source>
+      <trans-unit id="_msg1096">
+        <source xml:space="preserve">Invalid netmask specified in -whitelist: &apos;%s&apos;</source>
         <context-group purpose="location"><context context-type="linenumber">300</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1111">
-        <source xml:space="preserve">Specified -walletdir &quot;%s&quot; is not a directory</source>
+      <trans-unit id="_msg1097">
+        <source xml:space="preserve">Invalid port specified in %s: &apos;%s&apos;</source>
         <context-group purpose="location"><context context-type="linenumber">301</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1112">
-        <source xml:space="preserve">Specified blocks directory &quot;%s&quot; does not exist.</source>
+      <trans-unit id="_msg1098">
+        <source xml:space="preserve">Invalid pre-selected input %s</source>
         <context-group purpose="location"><context context-type="linenumber">302</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1113">
-        <source xml:space="preserve">Starting network threads…</source>
+      <trans-unit id="_msg1099">
+        <source xml:space="preserve">Listening for incoming connections failed (listen returned error %s)</source>
         <context-group purpose="location"><context context-type="linenumber">303</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1114">
-        <source xml:space="preserve">The source code is available from %s.</source>
+      <trans-unit id="_msg1100">
+        <source xml:space="preserve">Loading P2P addresses…</source>
         <context-group purpose="location"><context context-type="linenumber">304</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1115">
-        <source xml:space="preserve">The specified config file %s does not exist</source>
+      <trans-unit id="_msg1101">
+        <source xml:space="preserve">Loading banlist…</source>
         <context-group purpose="location"><context context-type="linenumber">305</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1116">
-        <source xml:space="preserve">The transaction amount is too small to pay the fee</source>
+      <trans-unit id="_msg1102">
+        <source xml:space="preserve">Loading block index…</source>
         <context-group purpose="location"><context context-type="linenumber">306</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1117">
-        <source xml:space="preserve">The wallet will avoid paying less than the minimum relay fee.</source>
+      <trans-unit id="_msg1103">
+        <source xml:space="preserve">Loading wallet…</source>
         <context-group purpose="location"><context context-type="linenumber">307</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1118">
-        <source xml:space="preserve">This is experimental software.</source>
+      <trans-unit id="_msg1104">
+        <source xml:space="preserve">Missing amount</source>
         <context-group purpose="location"><context context-type="linenumber">308</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1119">
-        <source xml:space="preserve">This is the minimum transaction fee you pay on every transaction.</source>
+      <trans-unit id="_msg1105">
+        <source xml:space="preserve">Missing solving data for estimating transaction size</source>
         <context-group purpose="location"><context context-type="linenumber">309</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1120">
-        <source xml:space="preserve">This is the transaction fee you will pay if you send a transaction.</source>
+      <trans-unit id="_msg1106">
+        <source xml:space="preserve">Need to specify a port with -whitebind: &apos;%s&apos;</source>
         <context-group purpose="location"><context context-type="linenumber">310</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1121">
-        <source xml:space="preserve">Transaction amount too small</source>
+      <trans-unit id="_msg1107">
+        <source xml:space="preserve">No addresses available</source>
         <context-group purpose="location"><context context-type="linenumber">311</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1122">
-        <source xml:space="preserve">Transaction amounts must not be negative</source>
+      <trans-unit id="_msg1108">
+        <source xml:space="preserve">Not enough file descriptors available.</source>
         <context-group purpose="location"><context context-type="linenumber">312</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1123">
-        <source xml:space="preserve">Transaction change output index out of range</source>
+      <trans-unit id="_msg1109">
+        <source xml:space="preserve">Not found pre-selected input %s</source>
         <context-group purpose="location"><context context-type="linenumber">313</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1124">
-        <source xml:space="preserve">Transaction has too long of a mempool chain</source>
+      <trans-unit id="_msg1110">
+        <source xml:space="preserve">Not solvable pre-selected input %s</source>
         <context-group purpose="location"><context context-type="linenumber">314</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1125">
-        <source xml:space="preserve">Transaction must have at least one recipient</source>
+      <trans-unit id="_msg1111">
+        <source xml:space="preserve">Prune cannot be configured with a negative value.</source>
         <context-group purpose="location"><context context-type="linenumber">315</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1126">
-        <source xml:space="preserve">Transaction needs a change address, but we can&apos;t generate it.</source>
+      <trans-unit id="_msg1112">
+        <source xml:space="preserve">Prune mode is incompatible with -txindex.</source>
         <context-group purpose="location"><context context-type="linenumber">316</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1127">
-        <source xml:space="preserve">Transaction too large</source>
+      <trans-unit id="_msg1113">
+        <source xml:space="preserve">Pruning blockstore…</source>
         <context-group purpose="location"><context context-type="linenumber">317</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1128">
-        <source xml:space="preserve">Unable to allocate memory for -maxsigcachesize: &apos;%s&apos; MiB</source>
+      <trans-unit id="_msg1114">
+        <source xml:space="preserve">Reducing -maxconnections from %d to %d, because of system limitations.</source>
         <context-group purpose="location"><context context-type="linenumber">318</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1129">
-        <source xml:space="preserve">Unable to bind to %s on this computer (bind returned error %s)</source>
+      <trans-unit id="_msg1115">
+        <source xml:space="preserve">Replaying blocks…</source>
         <context-group purpose="location"><context context-type="linenumber">319</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1130">
-        <source xml:space="preserve">Unable to bind to %s on this computer. %s is probably already running.</source>
+      <trans-unit id="_msg1116">
+        <source xml:space="preserve">Rescanning…</source>
         <context-group purpose="location"><context context-type="linenumber">320</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1131">
-        <source xml:space="preserve">Unable to create the PID file &apos;%s&apos;: %s</source>
+      <trans-unit id="_msg1117">
+        <source xml:space="preserve">SQLiteDatabase: Failed to execute statement to verify database: %s</source>
         <context-group purpose="location"><context context-type="linenumber">321</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1132">
-        <source xml:space="preserve">Unable to find UTXO for external input</source>
+      <trans-unit id="_msg1118">
+        <source xml:space="preserve">SQLiteDatabase: Failed to prepare statement to verify database: %s</source>
         <context-group purpose="location"><context context-type="linenumber">322</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1133">
-        <source xml:space="preserve">Unable to generate initial keys</source>
+      <trans-unit id="_msg1119">
+        <source xml:space="preserve">SQLiteDatabase: Failed to read database verification error: %s</source>
         <context-group purpose="location"><context context-type="linenumber">323</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1134">
-        <source xml:space="preserve">Unable to generate keys</source>
+      <trans-unit id="_msg1120">
+        <source xml:space="preserve">SQLiteDatabase: Unexpected application id. Expected %u, got %u</source>
         <context-group purpose="location"><context context-type="linenumber">324</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1135">
-        <source xml:space="preserve">Unable to open %s for writing</source>
+      <trans-unit id="_msg1121">
+        <source xml:space="preserve">Section [%s] is not recognized.</source>
         <context-group purpose="location"><context context-type="linenumber">325</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1136">
-        <source xml:space="preserve">Unable to parse -maxuploadtarget: &apos;%s&apos;</source>
+      <trans-unit id="_msg1122">
+        <source xml:space="preserve">Signing transaction failed</source>
         <context-group purpose="location"><context context-type="linenumber">326</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1137">
-        <source xml:space="preserve">Unable to start HTTP server. See debug log for details.</source>
+      <trans-unit id="_msg1123">
+        <source xml:space="preserve">Specified -walletdir &quot;%s&quot; does not exist</source>
         <context-group purpose="location"><context context-type="linenumber">327</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1138">
-        <source xml:space="preserve">Unable to unload the wallet before migrating</source>
+      <trans-unit id="_msg1124">
+        <source xml:space="preserve">Specified -walletdir &quot;%s&quot; is a relative path</source>
         <context-group purpose="location"><context context-type="linenumber">328</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1139">
-        <source xml:space="preserve">Unknown -blockfilterindex value %s.</source>
+      <trans-unit id="_msg1125">
+        <source xml:space="preserve">Specified -walletdir &quot;%s&quot; is not a directory</source>
         <context-group purpose="location"><context context-type="linenumber">329</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1140">
-        <source xml:space="preserve">Unknown address type &apos;%s&apos;</source>
+      <trans-unit id="_msg1126">
+        <source xml:space="preserve">Specified blocks directory &quot;%s&quot; does not exist.</source>
         <context-group purpose="location"><context context-type="linenumber">330</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1141">
-        <source xml:space="preserve">Unknown change type &apos;%s&apos;</source>
+      <trans-unit id="_msg1127">
+        <source xml:space="preserve">Starting network threads…</source>
         <context-group purpose="location"><context context-type="linenumber">331</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1142">
-        <source xml:space="preserve">Unknown network specified in -onlynet: &apos;%s&apos;</source>
+      <trans-unit id="_msg1128">
+        <source xml:space="preserve">The source code is available from %s.</source>
         <context-group purpose="location"><context context-type="linenumber">332</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1143">
-        <source xml:space="preserve">Unknown new rules activated (versionbit %i)</source>
+      <trans-unit id="_msg1129">
+        <source xml:space="preserve">The specified config file %s does not exist</source>
         <context-group purpose="location"><context context-type="linenumber">333</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1144">
-        <source xml:space="preserve">Unsupported global logging level -loglevel=%s. Valid values: %s.</source>
+      <trans-unit id="_msg1130">
+        <source xml:space="preserve">The transaction amount is too small to pay the fee</source>
         <context-group purpose="location"><context context-type="linenumber">334</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1145">
-        <source xml:space="preserve">Unsupported logging category %s=%s.</source>
+      <trans-unit id="_msg1131">
+        <source xml:space="preserve">The wallet will avoid paying less than the minimum relay fee.</source>
         <context-group purpose="location"><context context-type="linenumber">335</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1146">
-        <source xml:space="preserve">User Agent comment (%s) contains unsafe characters.</source>
+      <trans-unit id="_msg1132">
+        <source xml:space="preserve">This is experimental software.</source>
         <context-group purpose="location"><context context-type="linenumber">336</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1147">
-        <source xml:space="preserve">Verifying blocks…</source>
+      <trans-unit id="_msg1133">
+        <source xml:space="preserve">This is the minimum transaction fee you pay on every transaction.</source>
         <context-group purpose="location"><context context-type="linenumber">337</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1148">
-        <source xml:space="preserve">Verifying wallet(s)…</source>
+      <trans-unit id="_msg1134">
+        <source xml:space="preserve">This is the transaction fee you will pay if you send a transaction.</source>
         <context-group purpose="location"><context context-type="linenumber">338</context></context-group>
       </trans-unit>
-      <trans-unit id="_msg1149">
-        <source xml:space="preserve">Wallet needed to be rewritten: restart %s to complete</source>
+      <trans-unit id="_msg1135">
+        <source xml:space="preserve">Transaction amount too small</source>
         <context-group purpose="location"><context context-type="linenumber">339</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1136">
+        <source xml:space="preserve">Transaction amounts must not be negative</source>
+        <context-group purpose="location"><context context-type="linenumber">340</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1137">
+        <source xml:space="preserve">Transaction change output index out of range</source>
+        <context-group purpose="location"><context context-type="linenumber">341</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1138">
+        <source xml:space="preserve">Transaction has too long of a mempool chain</source>
+        <context-group purpose="location"><context context-type="linenumber">342</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1139">
+        <source xml:space="preserve">Transaction must have at least one recipient</source>
+        <context-group purpose="location"><context context-type="linenumber">343</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1140">
+        <source xml:space="preserve">Transaction needs a change address, but we can&apos;t generate it.</source>
+        <context-group purpose="location"><context context-type="linenumber">344</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1141">
+        <source xml:space="preserve">Transaction too large</source>
+        <context-group purpose="location"><context context-type="linenumber">345</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1142">
+        <source xml:space="preserve">Unable to allocate memory for -maxsigcachesize: &apos;%s&apos; MiB</source>
+        <context-group purpose="location"><context context-type="linenumber">346</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1143">
+        <source xml:space="preserve">Unable to bind to %s on this computer (bind returned error %s)</source>
+        <context-group purpose="location"><context context-type="linenumber">347</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1144">
+        <source xml:space="preserve">Unable to bind to %s on this computer. %s is probably already running.</source>
+        <context-group purpose="location"><context context-type="linenumber">348</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1145">
+        <source xml:space="preserve">Unable to create the PID file &apos;%s&apos;: %s</source>
+        <context-group purpose="location"><context context-type="linenumber">349</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1146">
+        <source xml:space="preserve">Unable to find UTXO for external input</source>
+        <context-group purpose="location"><context context-type="linenumber">350</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1147">
+        <source xml:space="preserve">Unable to generate initial keys</source>
+        <context-group purpose="location"><context context-type="linenumber">351</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1148">
+        <source xml:space="preserve">Unable to generate keys</source>
+        <context-group purpose="location"><context context-type="linenumber">352</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1149">
+        <source xml:space="preserve">Unable to open %s for writing</source>
+        <context-group purpose="location"><context context-type="linenumber">353</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1150">
+        <source xml:space="preserve">Unable to parse -maxuploadtarget: &apos;%s&apos;</source>
+        <context-group purpose="location"><context context-type="linenumber">354</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1151">
+        <source xml:space="preserve">Unable to start HTTP server. See debug log for details.</source>
+        <context-group purpose="location"><context context-type="linenumber">355</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1152">
+        <source xml:space="preserve">Unable to unload the wallet before migrating</source>
+        <context-group purpose="location"><context context-type="linenumber">356</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1153">
+        <source xml:space="preserve">Unknown -blockfilterindex value %s.</source>
+        <context-group purpose="location"><context context-type="linenumber">357</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1154">
+        <source xml:space="preserve">Unknown address type &apos;%s&apos;</source>
+        <context-group purpose="location"><context context-type="linenumber">358</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1155">
+        <source xml:space="preserve">Unknown change type &apos;%s&apos;</source>
+        <context-group purpose="location"><context context-type="linenumber">359</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1156">
+        <source xml:space="preserve">Unknown network specified in -onlynet: &apos;%s&apos;</source>
+        <context-group purpose="location"><context context-type="linenumber">360</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1157">
+        <source xml:space="preserve">Unknown new rules activated (versionbit %i)</source>
+        <context-group purpose="location"><context context-type="linenumber">361</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1158">
+        <source xml:space="preserve">Unsupported global logging level -loglevel=%s. Valid values: %s.</source>
+        <context-group purpose="location"><context context-type="linenumber">362</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1159">
+        <source xml:space="preserve">Unsupported logging category %s=%s.</source>
+        <context-group purpose="location"><context context-type="linenumber">363</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1160">
+        <source xml:space="preserve">User Agent comment (%s) contains unsafe characters.</source>
+        <context-group purpose="location"><context context-type="linenumber">364</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1161">
+        <source xml:space="preserve">Verifying blocks…</source>
+        <context-group purpose="location"><context context-type="linenumber">365</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1162">
+        <source xml:space="preserve">Verifying wallet(s)…</source>
+        <context-group purpose="location"><context context-type="linenumber">366</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1163">
+        <source xml:space="preserve">Wallet needed to be rewritten: restart %s to complete</source>
+        <context-group purpose="location"><context context-type="linenumber">367</context></context-group>
       </trans-unit>
     </group>
   </body></file>

--- a/src/qt/locale/bitcoin_eo.ts
+++ b/src/qt/locale/bitcoin_eo.ts
@@ -568,6 +568,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">defaŭlta monujo</translation>
     </message>
     <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">Monujo-Nomo</translation>
+    </message>
+    <message>
         <source>&amp;Window</source>
         <translation type="unfinished">&amp;Fenestro</translation>
     </message>
@@ -930,6 +935,27 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Bitmono</translation>
     </message>
     <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
@@ -1147,6 +1173,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Confirm options reset</source>
+        <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
         <translation type="unfinished">Konfirmi reŝargo de agordoj</translation>
     </message>
     <message>
@@ -1719,15 +1746,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished">Tajpu etikedon por tiu ĉi adreso por aldoni ĝin al la listo de uzitaj adresoj</translation>
     </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">Pagi Al:</translation>
-    </message>
-    <message>
-        <source>Memo:</source>
-        <translation type="unfinished">Memorando:</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>SendConfirmationDialog</name>
     <message>
@@ -1854,10 +1873,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <name>TransactionDesc</name>
     <message>
         <source>%1/unconfirmed</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
         <translation type="unfinished">%1/nekonfirmite</translation>
     </message>
     <message>
         <source>%1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
         <translation type="unfinished">%1 konfirmoj</translation>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_es.ts
+++ b/src/qt/locale/bitcoin_es.ts
@@ -3,7 +3,7 @@
     <name>AddressBookPage</name>
     <message>
         <source>Right-click to edit address or label</source>
-        <translation type="unfinished">Haz clic derecho para editar la dirección o etiqueta </translation>
+        <translation type="unfinished">Haz clic con el botón derecho del ratón para editar la dirección o la etiqueta</translation>
     </message>
     <message>
         <source>Create a new address</source>
@@ -23,11 +23,11 @@
     </message>
     <message>
         <source>C&amp;lose</source>
-        <translation type="unfinished">Cerrar</translation>
+        <translation type="unfinished">C&amp;errar</translation>
     </message>
     <message>
         <source>Delete the currently selected address from the list</source>
-        <translation type="unfinished">Borrar de la lista la dirección seleccionada</translation>
+        <translation type="unfinished">Eliminar de la lista la dirección actualmente seleccionada</translation>
     </message>
     <message>
         <source>Enter address or label to search</source>
@@ -43,7 +43,7 @@
     </message>
     <message>
         <source>&amp;Delete</source>
-        <translation type="unfinished">&amp;Borrar</translation>
+        <translation type="unfinished">E&amp;liminar</translation>
     </message>
     <message>
         <source>Choose the address to send coins to</source>
@@ -55,7 +55,7 @@
     </message>
     <message>
         <source>C&amp;hoose</source>
-        <translation type="unfinished">Escoger</translation>
+        <translation type="unfinished">E&amp;scoger</translation>
     </message>
     <message>
         <source>Sending addresses</source>
@@ -67,13 +67,13 @@
     </message>
     <message>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
-        <translation type="unfinished">Estas son tus direcciones Bitcoin para enviar pagos. Comprueba siempre la cantidad y la dirección de recibo antes de transferir monedas.</translation>
+        <translation type="unfinished">Estas son tus direcciones Bitcoin para enviar pagos. Comprueba siempre el importe y la dirección de recepción antes de transferir monedas.</translation>
     </message>
     <message>
         <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
 Signing is only possible with addresses of the type 'legacy'.</source>
-        <translation type="unfinished">Estas son tus direcciones Bitcoin para la recepción de pagos. Usa el botón 'Crear una nueva dirección para recepción' en la pestaña Recibir para crear nuevas direcciones.
-Firmar solo es posible con direcciones del tipo Legacy.</translation>
+        <translation type="unfinished">Estas son tus direcciones Bitcoin para la recepción de pagos. Usa el botón «Crear una nueva dirección para recepción» en la pestaña Recibir para crear nuevas direcciones.
+Firmar solo es posible con direcciones del tipo «Legacy».</translation>
     </message>
     <message>
         <source>&amp;Copy Address</source>
@@ -81,7 +81,7 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     </message>
     <message>
         <source>Copy &amp;Label</source>
-        <translation type="unfinished">Copiar &amp;Etiqueta</translation>
+        <translation type="unfinished">Copiar &amp;etiqueta</translation>
     </message>
     <message>
         <source>&amp;Edit</source>
@@ -89,7 +89,12 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     </message>
     <message>
         <source>Export Address List</source>
-        <translation type="unfinished">Exportar la Lista de Direcciones</translation>
+        <translation type="unfinished">Exportar la lista de direcciones</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">Archivo separado por comas</translation>
     </message>
     <message>
         <source>There was an error trying to save the address list to %1. Please try again.</source>
@@ -160,7 +165,7 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     </message>
     <message>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
-        <translation type="unfinished">Atención: Si cifras tu monedero y pierdes la contraseña, perderás ¡&lt;b&gt;TODOS TUS BITCOINS&lt;/b&gt;!</translation>
+        <translation type="unfinished">Atención: Si cifras tu monedero y pierdes la contraseña, &lt;b&gt;¡PERDERÁS TODOS TUS BITCOINS!&lt;/b&gt;</translation>
     </message>
     <message>
         <source>Are you sure you wish to encrypt your wallet?</source>
@@ -196,7 +201,7 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     </message>
     <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <translation type="unfinished">IMPORTANTE: Cualquier copia de seguridad que hayas hecho del archivo de tu monedero debe ser reemplazada por el archivo cifrado del monedero recién generado. Por razones de seguridad, las copias de seguridad anteriores del archivo de la billetera sin cifrar serán inútiles cuando empieces a usar el nuevo monedero cifrado.</translation>
+        <translation type="unfinished">IMPORTANTE: Cualquier copia de seguridad que hayas hecho del archivo de tu monedero debe ser reemplazada por el archivo cifrado del monedero recién generado. Por razones de seguridad, las copias de seguridad anteriores del archivo del monedero sin cifrar serán inútiles cuando empieces a usar el nuevo monedero cifrado.</translation>
     </message>
     <message>
         <source>Wallet encryption failed</source>
@@ -208,7 +213,7 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     </message>
     <message>
         <source>The supplied passphrases do not match.</source>
-        <translation type="unfinished">Las contraseñas dadas no coinciden.</translation>
+        <translation type="unfinished">Las contraseñas proporcionadas no coinciden.</translation>
     </message>
     <message>
         <source>Wallet unlock failed</source>
@@ -235,11 +240,15 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     </message>
     <message>
         <source>Banned Until</source>
-        <translation type="unfinished">Prohibido hasta</translation>
+        <translation type="unfinished">Bloqueado hasta</translation>
     </message>
 </context>
 <context>
     <name>BitcoinApplication</name>
+    <message>
+        <source>Settings file %1 might be corrupt or invalid.</source>
+        <translation type="unfinished">El archivo de configuración %1 puede estar corrupto o no ser válido.</translation>
+    </message>
     <message>
         <source>Runaway exception</source>
         <translation type="unfinished">Excepción fuera de control</translation>
@@ -267,11 +276,15 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     <message>
         <source>A fatal error occurred. Check that settings file is writable, or try running with -nosettings.</source>
         <extracomment>Explanatory text shown on startup when the settings file could not be written. Prompts user to check that we have the ability to write to the file. Explains that the user has the option of running without a settings file.</extracomment>
-        <translation type="unfinished">Un error fatal ha ocurrido. Comprueba que el archivo de configuración soporta escritura, o intenta correr de nuevo el programa con -nosettings</translation>
+        <translation type="unfinished">Un error fatal ha ocurrido. Comprueba que el archivo de configuración soporta escritura, o intenta ejecutar de nuevo el programa con -nosettings</translation>
     </message>
     <message>
         <source>Error: Specified data directory "%1" does not exist.</source>
-        <translation type="unfinished">Error: El directorio de datos especificado "%1" no existe.</translation>
+        <translation type="unfinished">Error: El directorio de datos especificado «%1» no existe.</translation>
+    </message>
+    <message>
+        <source>Error: Cannot parse configuration file: %1.</source>
+        <translation type="unfinished">Error: No se puede analizar/parsear el archivo de configuración: %1.</translation>
     </message>
     <message>
         <source>%1 didn't yet exit safely…</source>
@@ -283,7 +296,7 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     </message>
     <message>
         <source>Amount</source>
-        <translation type="unfinished">Cantidad</translation>
+        <translation type="unfinished">Importe</translation>
     </message>
     <message>
         <source>Enter a Bitcoin address (e.g. %1)</source>
@@ -296,6 +309,16 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     <message>
         <source>Internal</source>
         <translation type="unfinished">Interno</translation>
+    </message>
+    <message>
+        <source>Inbound</source>
+        <extracomment>An inbound connection from a peer. An inbound connection is a connection initiated by a peer.</extracomment>
+        <translation type="unfinished">Entrante</translation>
+    </message>
+    <message>
+        <source>Outbound</source>
+        <extracomment>An outbound connection to a peer. An outbound connection is a connection initiated by us.</extracomment>
+        <translation type="unfinished">Saliente</translation>
     </message>
     <message>
         <source>Full Relay</source>
@@ -328,43 +351,47 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n segundo</numerusform>
+            <numerusform>%n segundos</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n minute(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n minuto</numerusform>
+            <numerusform>%n minutos</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n hora</numerusform>
+            <numerusform>%n horas</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n día</numerusform>
+            <numerusform>%n días</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n semana</numerusform>
+            <numerusform>%n semanas</numerusform>
         </translation>
+    </message>
+    <message>
+        <source>%1 and %2</source>
+        <translation type="unfinished">%1 y %2</translation>
     </message>
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n años</numerusform>
+            <numerusform>%n años</numerusform>
         </translation>
     </message>
     </context>
@@ -379,44 +406,76 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
         <translation type="unfinished">El archivo de configuración no puede escribirse</translation>
     </message>
     <message>
+        <source>The %s developers</source>
+        <translation type="unfinished">Los desarrolladores de %s</translation>
+    </message>
+    <message>
         <source>%s corrupt. Try using the wallet tool bitcoin-wallet to salvage or restoring a backup.</source>
         <translation type="unfinished">%s corrupto. Intenta utilizar la herramienta del monedero bitcoin-monedero para salvar o restaurar una copia de seguridad.</translation>
+    </message>
+    <message>
+        <source>-maxtxfee is set very high! Fees this large could be paid on a single transaction.</source>
+        <translation type="unfinished">-maxtxfee tiene un valor muy elevado! Comisiones muy grandes podrían ser pagadas en una única transacción.</translation>
     </message>
     <message>
         <source>Cannot downgrade wallet from version %i to version %i. Wallet version unchanged.</source>
         <translation type="unfinished">No se pudo cambiar la versión %i a la versión anterior %i.  Versión del monedero sin cambios.</translation>
     </message>
     <message>
+        <source>Cannot obtain a lock on data directory %s. %s is probably already running.</source>
+        <translation type="unfinished">No se puede bloquear el directorio %s. %s probablemente ya se está ejecutando.</translation>
+    </message>
+    <message>
         <source>Cannot upgrade a non HD split wallet from version %i to version %i without upgrading to support pre-split keypool. Please use version %i or no version specified.</source>
-        <translation type="unfinished">No se puede actualizar un monedero no dividido en HD de la versión  1%i a la versión 1%i sin actualizar para admitir el grupo de claves pre-dividido. Por favor, use la versión  1%i o ninguna versión especificada.</translation>
+        <translation type="unfinished">No se puede actualizar un monedero no dividido en HD de la versión %i a la versión %i sin actualizar para admitir el grupo de claves pre-dividido. Por favor, use la versión %i o ninguna versión especificada.</translation>
+    </message>
+    <message>
+        <source>Distributed under the MIT software license, see the accompanying file %s or %s</source>
+        <translation type="unfinished">Distribuido bajo la licencia de software MIT, vea el archivo adjunto %s o %s</translation>
+    </message>
+    <message>
+        <source>Error reading %s! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
+        <translation type="unfinished">¡Error leyendo %s!. Todas las claves se han leído correctamente, pero los datos de la transacción o el libro de direcciones pueden faltar o ser incorrectos.</translation>
     </message>
     <message>
         <source>Error reading %s! Transaction data may be missing or incorrect. Rescanning wallet.</source>
-        <translation type="unfinished">¡Error de lectura %s! Los datos de la transacción pueden faltar o ser incorrectos. Reescaneo de la billetera.</translation>
+        <translation type="unfinished">¡Error de lectura %s! Los datos de la transacción pueden faltar o ser incorrectos. Reescaneo del monedero.</translation>
     </message>
     <message>
         <source>Error: Dumpfile format record is incorrect. Got "%s", expected "format".</source>
-        <translation type="unfinished">Error: el registro del formato del archivo de volcado es incorrecto. Se obtuvo "%s", del "formato" esperado.</translation>
+        <translation type="unfinished">Error: el registro del formato del archivo de volcado es incorrecto. Se obtuvo «%s», del «formato» esperado.</translation>
     </message>
     <message>
         <source>Error: Dumpfile identifier record is incorrect. Got "%s", expected "%s".</source>
-        <translation type="unfinished">Error: el registro del identificador del archivo de volcado es incorrecto. Se obtuvo   "%s" se esperaba "%s".</translation>
+        <translation type="unfinished">Error: el registro del identificador del archivo de volcado es incorrecto. Se obtuvo «%s» se esperaba «%s».</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile version is not supported. This version of bitcoin-wallet only supports version 1 dumpfiles. Got dumpfile with version %s</source>
+        <translation type="unfinished">Error: la versión del archivo volcado no es compatible. Esta versión de monedero bitcoin solo admite archivos de volcado de la versión 1. Consigue volcado de fichero con la versión %s</translation>
     </message>
     <message>
         <source>Error: Legacy wallets only support the "legacy", "p2sh-segwit", and "bech32" address types</source>
-        <translation type="unfinished">Error: Los monederos heredados solo admiten los tipos de dirección "legacy", "p2sh-segwit" y "bech32"</translation>
+        <translation type="unfinished">Error: Los monederos heredados solo admiten los tipos de dirección «legacy», «p2sh-segwit» y «bech32»</translation>
+    </message>
+    <message>
+        <source>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.</source>
+        <translation type="unfinished">Estimación de la comisión fallida. Fallbackfee está deshabilitado. Espere unos pocos bloques o habilite -fallbackfee.</translation>
     </message>
     <message>
         <source>File %s already exists. If you are sure this is what you want, move it out of the way first.</source>
         <translation type="unfinished">El archivo  %s  ya existe. Si está seguro de que esto es lo que quiere, muévalo de lugar primero.</translation>
     </message>
     <message>
+        <source>Invalid amount for -maxtxfee=&lt;amount&gt;: '%s' (must be at least the minrelay fee of %s to prevent stuck transactions)</source>
+        <translation type="unfinished">Importe inválido para -maxtxfee=&lt;amount&gt;: «%s» (debe ser al menos la comisión mímina de %s para prevenir transacciones atascadas)</translation>
+    </message>
+    <message>
         <source>Invalid or corrupt peers.dat (%s). If you believe this is a bug, please report it to %s. As a workaround, you can move the file (%s) out of the way (rename, move, or delete) to have a new one created on the next start.</source>
-        <translation type="unfinished">Peers.dat inválido o corrupto (%s). Si cree que se trata de un error, infórmelo a %s. Como alternativa, puedes mover el archivo (%s) (renombrarlo, moverlo o eliminarlo) para que se cree uno nuevo en el siguiente inicio.</translation>
+        <translation type="unfinished">Archivo peers.dat inválido o corrupto (%s). Si cree que se trata de un error, infórmelo a %s. Como alternativa, puedes mover el archivo (%s) (renombrarlo, moverlo o eliminarlo) para que se cree uno nuevo en el siguiente inicio.</translation>
     </message>
     <message>
         <source>More than one onion bind address is provided. Using %s for the automatically created Tor onion service.</source>
-        <translation type="unfinished">Se proporciona más de una dirección de ligar de cebolla. Utilizando %s para el servicio Tor cebolla creado automático.</translation>
+        <translation type="unfinished">Se proporciona más de una dirección de enlace onion. Utilizando %s para el servicio onion de Tor creado automáticamente.</translation>
     </message>
     <message>
         <source>No dump file provided. To use createfromdump, -dumpfile=&lt;filename&gt; must be provided.</source>
@@ -428,39 +487,119 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     </message>
     <message>
         <source>No wallet file format provided. To use createfromdump, -format=&lt;format&gt; must be provided.</source>
-        <translation type="unfinished">Ningún archivo de billetera proveído. Para usar createfromdump, -format=&lt;format&gt;debe ser proveído.</translation>
+        <translation type="unfinished">Ningún archivo de formato monedero facilitado. Para usar createfromdump, -format=&lt;format&gt;debe ser facilitado.</translation>
+    </message>
+    <message>
+        <source>Please check that your computer's date and time are correct! If your clock is wrong, %s will not work properly.</source>
+        <translation type="unfinished">¡Por favor, compruebe si la fecha y hora en su computadora son correctas! Si su reloj está mal, %s no trabajará correctamente.</translation>
+    </message>
+    <message>
+        <source>Please contribute if you find %s useful. Visit %s for further information about the software.</source>
+        <translation type="unfinished">Contribuya si encuentra %s de utilidad. Visite %s para más información acerca del programa.</translation>
+    </message>
+    <message>
+        <source>Prune configured below the minimum of %d MiB.  Please use a higher number.</source>
+        <translation type="unfinished">La poda se ha configurado por debajo del mínimo de %d MiB. Por favor utiliza un valor mas alto.</translation>
+    </message>
+    <message>
+        <source>Prune mode is incompatible with -reindex-chainstate. Use full -reindex instead.</source>
+        <translation type="unfinished">El modo poda no es compatible con -reindex-chainstate. Haz uso de un -reindex completo en su lugar.</translation>
+    </message>
+    <message>
+        <source>Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of pruned node)</source>
+        <translation type="unfinished">Poda: la última sincronización del monedero sobrepasa los datos podados. Necesita reindexar con -reindex (o descargar la cadena de bloques de nuevo en el caso de un nodo podado)</translation>
     </message>
     <message>
         <source>SQLiteDatabase: Unknown sqlite wallet schema version %d. Only version %d is supported</source>
         <translation type="unfinished">SQLiteDatabase: versión del esquema de la monedero sqlite desconocido %d. Sólo version %d se admite</translation>
     </message>
     <message>
+        <source>The block database contains a block which appears to be from the future. This may be due to your computer's date and time being set incorrectly. Only rebuild the block database if you are sure that your computer's date and time are correct</source>
+        <translation type="unfinished">La base de datos de bloques contiene un bloque que parece ser del futuro. Esto puede ser porque la fecha y hora de su ordenador están mal ajustados. Reconstruya la base de datos de bloques solo si está seguro de que la fecha y hora de su ordenador están ajustadas correctamente.</translation>
+    </message>
+    <message>
         <source>The block index db contains a legacy 'txindex'. To clear the occupied disk space, run a full -reindex, otherwise ignore this error. This error message will not be displayed again.</source>
-        <translation type="unfinished">El índice de bloque db contiene un 'txindex' heredado. Para borrar el espacio de disco ocupado, ejecute un -reindex completo, de lo contrario ignore este error. Este mensaje de error no se volverá a mostrar.</translation>
+        <translation type="unfinished">El índice de bloque db contiene un «txindex» heredado. Para borrar el espacio de disco ocupado, ejecute un -reindex completo, de lo contrario ignore este error. Este mensaje de error no se volverá a mostrar.</translation>
+    </message>
+    <message>
+        <source>The transaction amount is too small to send after the fee has been deducted</source>
+        <translation type="unfinished">Importe de transacción muy pequeño después de la deducción de la comisión</translation>
     </message>
     <message>
         <source>This error could occur if this wallet was not shutdown cleanly and was last loaded using a build with a newer version of Berkeley DB. If so, please use the software that last loaded this wallet</source>
-        <translation type="unfinished">Este error podría ocurrir si la billetera no fuese apagada correctamente y fuese cargada usando una compilación con una versión más nueva de Berkeley DB. Si es así, utilice el software que cargó por última vez en esta billetera.</translation>
+        <translation type="unfinished">Este error podría ocurrir si el monedero no fuese apagado correctamente y fuese cargado usando una compilación con una versión más nueva de Berkeley DB. Si es así, utilice el software que cargó por última vez este monedero.</translation>
+    </message>
+    <message>
+        <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
+        <translation type="unfinished">Esta es una versión de pre-prueba - utilícela bajo su propio riesgo. No la utilice para usos comerciales o de minería.</translation>
     </message>
     <message>
         <source>This is the maximum transaction fee you pay (in addition to the normal fee) to prioritize partial spend avoidance over regular coin selection.</source>
-        <translation type="unfinished">Esta es la tarifa máxima que pagas (además de la tarifa normal) para priorizar la evasión del gasto parcial sobre la selección regular de monedas.</translation>
+        <translation type="unfinished">Esta es la comisión máxima que pagas (además de la comisión normal) para priorizar la evasión del gasto parcial sobre la selección regular de monedas.</translation>
+    </message>
+    <message>
+        <source>This is the transaction fee you may discard if change is smaller than dust at this level</source>
+        <translation type="unfinished">Esta es la comisión de transacción que puede descartar si el cambio es más pequeño que el polvo a este nivel.</translation>
+    </message>
+    <message>
+        <source>This is the transaction fee you may pay when fee estimates are not available.</source>
+        <translation type="unfinished">Esta es la comisión por transacción que deberá pagar cuando la estimación de comisión no esté disponible.</translation>
+    </message>
+    <message>
+        <source>Total length of network version string (%i) exceeds maximum length (%i). Reduce the number or size of uacomments.</source>
+        <translation type="unfinished">La longitud total de la cadena de versión de red ( %i ) supera la longitud máxima ( %i ) . Reducir el número o tamaño de uacomments .</translation>
+    </message>
+    <message>
+        <source>Unable to replay blocks. You will need to rebuild the database using -reindex-chainstate.</source>
+        <translation type="unfinished">No se ha podido reproducir los bloques. Deberá reconstruir la base de datos utilizando -reindex-chainstate.</translation>
     </message>
     <message>
         <source>Unknown wallet file format "%s" provided. Please provide one of "bdb" or "sqlite".</source>
-        <translation type="unfinished">Formato de monedero desconocido "%s" proporcionado. Por favor, proporcione uno de "bdb" o "sqlite".</translation>
+        <translation type="unfinished">Formato de monedero desconocido «%s» proporcionado. Por favor, proporcione uno de «bdb» o «sqlite».</translation>
+    </message>
+    <message>
+        <source>Unsupported chainstate database format found. Please restart with -reindex-chainstate. This will rebuild the chainstate database.</source>
+        <translation type="unfinished">Formato de la base de datos chainstate encontrado. Por favor reinicia con -reindex-chainstate. Esto reconstruirá la base de datos chainstate.</translation>
+    </message>
+    <message>
+        <source>Wallet created successfully. The legacy wallet type is being deprecated and support for creating and opening legacy wallets will be removed in the future.</source>
+        <translation type="unfinished">Monedero creado satisfactoriamente. El tipo de monedero «Legacy» está descontinuado y la asistencia para crear y abrir monederos «legacy» será eliminada en el futuro.</translation>
     </message>
     <message>
         <source>Warning: Dumpfile wallet format "%s" does not match command line specified format "%s".</source>
-        <translation type="unfinished">Aviso: el formato del monedero del archivo de volcado "%s" no coincide con el formato especificado en la línea de comandos "%s".</translation>
+        <translation type="unfinished">Aviso: el formato del monedero del archivo de volcado «%s» no coincide con el formato especificado en la línea de comandos «%s».</translation>
+    </message>
+    <message>
+        <source>Warning: Private keys detected in wallet {%s} with disabled private keys</source>
+        <translation type="unfinished">Advertencia: Claves privadas detectadas en el monedero {%s} con clave privada deshabilitada</translation>
+    </message>
+    <message>
+        <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
+        <translation type="unfinished">Advertencia: ¡No parecemos concordar del todo con nuestros pares! Puede que necesite actualizarse, o puede que otros nodos necesiten actualizarse.</translation>
     </message>
     <message>
         <source>Witness data for blocks after height %d requires validation. Please restart with -reindex.</source>
         <translation type="unfinished">Hay que validar los datos de los testigos de los bloques después de la altura%d. Por favor, reinicie con -reindex.</translation>
     </message>
     <message>
+        <source>You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain</source>
+        <translation type="unfinished">Necesita reconstruir la base de datos utilizando -reindex para volver al modo sin poda. Esto volverá a descargar toda la cadena de bloques</translation>
+    </message>
+    <message>
+        <source>%s is set very high!</source>
+        <translation type="unfinished">¡%s esta configurado muy alto!</translation>
+    </message>
+    <message>
+        <source>-maxmempool must be at least %d MB</source>
+        <translation type="unfinished">-maxmempool debe ser por lo menos de %d MB</translation>
+    </message>
+    <message>
         <source>A fatal internal error occurred, see debug.log for details</source>
         <translation type="unfinished">Ha ocurrido un error interno grave. Consulta debug.log para más detalles.</translation>
+    </message>
+    <message>
+        <source>Cannot resolve -%s address: '%s'</source>
+        <translation type="unfinished">No se puede resolver -%s dirección: «%s»</translation>
     </message>
     <message>
         <source>Cannot set -forcednsseed to true when setting -dnsseed to false.</source>
@@ -471,8 +610,128 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
         <translation type="unfinished">No se puede establecer -peerblockfilters sin -blockfilterindex.</translation>
     </message>
     <message>
+        <source>Cannot write to data directory '%s'; check permissions.</source>
+        <translation type="unfinished">No es posible escribir en el directorio «%s»; comprueba permisos.</translation>
+    </message>
+    <message>
+        <source>The -txindex upgrade started by a previous version cannot be completed. Restart with the previous version or run a full -reindex.</source>
+        <translation type="unfinished">La actualización -txindex iniciada por una versión anterior no puede completarse. Reinicie con la versión anterior o ejecute un -reindex completo.</translation>
+    </message>
+    <message>
+        <source>%s request to listen on port %u. This port is considered "bad" and thus it is unlikely that any Bitcoin Core peers connect to it. See doc/p2p-bad-ports.md for details and a full list.</source>
+        <translation type="unfinished">solicitud %s de escucha en el puerto %u . Este puerto se considera "malo" y por lo tanto es poco probable que ningún par de Bitcoin Core se conecte a él. Ver doc/p2p-bad-ports.md para más detalles y una lista completa.</translation>
+    </message>
+    <message>
+        <source>-reindex-chainstate option is not compatible with -blockfilterindex. Please temporarily disable blockfilterindex while using -reindex-chainstate, or replace -reindex-chainstate with -reindex to fully rebuild all indexes.</source>
+        <translation type="unfinished">La opción -reindex-chainstate no es compatible con -blockfilterindex. Por favor, desactiva temporalmente blockfilterindex cuando uses -reindex-chainstate, o sustituye -reindex-chainstate por -reindex para reconstruir completamente todos los índices.</translation>
+    </message>
+    <message>
+        <source>-reindex-chainstate option is not compatible with -coinstatsindex. Please temporarily disable coinstatsindex while using -reindex-chainstate, or replace -reindex-chainstate with -reindex to fully rebuild all indexes.</source>
+        <translation type="unfinished">La opción -reindex-chainstate no es compatible con -coinstatsindex. Por favor, desactiva temporalmente coinstatsindex cuando uses -reindex-chainstate, o sustituye -reindex-chainstate por -reindex para reconstruir completamente todos los índices.</translation>
+    </message>
+    <message>
+        <source>-reindex-chainstate option is not compatible with -txindex. Please temporarily disable txindex while using -reindex-chainstate, or replace -reindex-chainstate with -reindex to fully rebuild all indexes.</source>
+        <translation type="unfinished">La opción -reindex-chainstate no es compatible con -txindex. Por favor, desactiva temporalmente txindex cuando uses -reindex-chainstate, o sustituye -reindex-chainstate por -reindex para reconstruir completamente todos los índices.</translation>
+    </message>
+    <message>
+        <source>Assumed-valid: last wallet synchronisation goes beyond available block data. You need to wait for the background validation chain to download more blocks.</source>
+        <translation type="unfinished">Asumido-válido: la última sincronización del monedero va más allá de los datos de bloques disponibles. Debes esperar a que se descarguen en segundo plano más bloques de la cadena de validación.</translation>
+    </message>
+    <message>
+        <source>Cannot provide specific connections and have addrman find outgoing connections at the same time.</source>
+        <translation type="unfinished">No se puede proporcionar conexiones específicas y hacer que addrman encuentre conexiones salientes al mismo tiempo.</translation>
+    </message>
+    <message>
+        <source>Error loading %s: External signer wallet being loaded without external signer support compiled</source>
+        <translation type="unfinished">Error de carga %s : Se está cargando el monedero del firmante externo sin que se haya compilado el soporte del firmante externo</translation>
+    </message>
+    <message>
+        <source>Error: Address book data in wallet cannot be identified to belong to migrated wallets</source>
+        <translation type="unfinished">Error: los datos de la libreta de direcciones en el monedero no se identifican como pertenecientes a monederos migrados</translation>
+    </message>
+    <message>
+        <source>Error: Duplicate descriptors created during migration. Your wallet may be corrupted.</source>
+        <translation type="unfinished">Error: Se han creado descriptores duplicados durante la migración. Tu monedero puede estar dañado.</translation>
+    </message>
+    <message>
+        <source>Error: Transaction %s in wallet cannot be identified to belong to migrated wallets</source>
+        <translation type="unfinished">Error: La transacción %s del monedero no se puede identificar como perteneciente a monederos migrados</translation>
+    </message>
+    <message>
+        <source>Error: Unable to produce descriptors for this legacy wallet. Make sure the wallet is unlocked first</source>
+        <translation type="unfinished">Error: No se pueden producir descriptores para este monedero legacy. Asegúrate primero que el monedero está desbloqueado.</translation>
+    </message>
+    <message>
+        <source>Failed to rename invalid peers.dat file. Please move or delete it and try again.</source>
+        <translation type="unfinished">No se ha podido cambiar el nombre del archivo peers.dat . Por favor, muévalo o elimínelo e inténtelo de nuevo.</translation>
+    </message>
+    <message>
+        <source>Incompatible options: -dnsseed=1 was explicitly specified, but -onlynet forbids connections to IPv4/IPv6</source>
+        <translation type="unfinished">Opciones incompatibles: -dnsseed=1 se especificó explicitamente, pero  -onlynet impide conexiones a IPv4/IPv6</translation>
+    </message>
+    <message>
+        <source>Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is explicitly forbidden: -onion=0</source>
+        <translation type="unfinished">Conexiones salientes restringidas a Tor (-onlynet=onion) pero el proxy para alcanzar la red Tor está explícitamente prohibido: -onion=0</translation>
+    </message>
+    <message>
+        <source>Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is not provided: none of -proxy, -onion or -listenonion is given</source>
+        <translation type="unfinished">Conexiones salientes restringidas a Tor (-onlynet=onion) pero no se proporciona el proxy para alcanzar la red Tor: no se indica ninguna de las opciones -proxy, -onion, o -listenonion </translation>
+    </message>
+    <message>
+        <source>Unrecognized descriptor found. Loading wallet %s
+
+The wallet might had been created on a newer version.
+Please try running the latest software version.
+</source>
+        <translation type="unfinished">Se encontró un descriptor desconocido. Cargando monedero %s
+
+El monedero puede haber sido creado con una versión más nueva.
+Por favor intenta ejecutar la ultima versión del software.
+</translation>
+    </message>
+    <message>
+        <source>Unsupported category-specific logging level -loglevel=%s. Expected -loglevel=&lt;category&gt;:&lt;loglevel&gt;. Valid categories: %s. Valid loglevels: %s.</source>
+        <translation type="unfinished">Categoría especifica de nivel de registro no soportada  -loglevel=%s. Se espera -loglevel=&lt;category&gt;:&lt;loglevel&gt;. Categorías válidas: %s. Niveles de registro válidos: %s.</translation>
+    </message>
+    <message>
+        <source>
+Unable to cleanup failed migration</source>
+        <translation type="unfinished">
+No es posible limpiar la migración fallida</translation>
+    </message>
+    <message>
+        <source>
+Unable to restore backup of wallet.</source>
+        <translation type="unfinished">
+No es posible restaurar la copia de seguridad del monedero.</translation>
+    </message>
+    <message>
+        <source>Config setting for %s only applied on %s network when in [%s] section.</source>
+        <translation type="unfinished">Los ajustes de configuración para %s solo aplicados en la red %s  cuando se encuentra en la sección [%s].</translation>
+    </message>
+    <message>
+        <source>Corrupted block database detected</source>
+        <translation type="unfinished">Corrupción de base de datos de bloques detectada.</translation>
+    </message>
+    <message>
+        <source>Could not find asmap file %s</source>
+        <translation type="unfinished">No se pudo encontrar el archivo AS Map %s</translation>
+    </message>
+    <message>
+        <source>Could not parse asmap file %s</source>
+        <translation type="unfinished">No se pudo analizar el archivo AS Map %s</translation>
+    </message>
+    <message>
         <source>Disk space is too low!</source>
         <translation type="unfinished">¡El espacio en el disco es demasiado pequeño!</translation>
+    </message>
+    <message>
+        <source>Do you want to rebuild the block database now?</source>
+        <translation type="unfinished">¿Quieres reconstruir la base de datos de bloques ahora?</translation>
+    </message>
+    <message>
+        <source>Done loading</source>
+        <translation type="unfinished">Carga completa</translation>
     </message>
     <message>
         <source>Dump file %s does not exist.</source>
@@ -483,20 +742,72 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
         <translation type="unfinished">Error creando %s</translation>
     </message>
     <message>
+        <source>Error initializing block database</source>
+        <translation type="unfinished">Error al inicializar la base de datos de bloques</translation>
+    </message>
+    <message>
+        <source>Error initializing wallet database environment %s!</source>
+        <translation type="unfinished">Error al inicializar el entorno de la base de datos del monedero  %s</translation>
+    </message>
+    <message>
+        <source>Error loading %s</source>
+        <translation type="unfinished">Error cargando %s</translation>
+    </message>
+    <message>
+        <source>Error loading %s: Private keys can only be disabled during creation</source>
+        <translation type="unfinished">Error cargando %s: Las claves privadas solo pueden ser deshabilitadas durante la creación.</translation>
+    </message>
+    <message>
+        <source>Error loading %s: Wallet corrupted</source>
+        <translation type="unfinished">Error cargando %s: Monedero corrupto</translation>
+    </message>
+    <message>
+        <source>Error loading %s: Wallet requires newer version of %s</source>
+        <translation type="unfinished">Error cargando %s: Monedero requiere una versión mas reciente de %s</translation>
+    </message>
+    <message>
+        <source>Error loading block database</source>
+        <translation type="unfinished">Error cargando base de datos de bloques</translation>
+    </message>
+    <message>
+        <source>Error opening block database</source>
+        <translation type="unfinished">Error al abrir base de datos de bloques.</translation>
+    </message>
+    <message>
+        <source>Error reading from database, shutting down.</source>
+        <translation type="unfinished">Error al leer la base de datos, cerrando aplicación.</translation>
+    </message>
+    <message>
         <source>Error reading next record from wallet database</source>
-        <translation type="unfinished">Error al leer el seguiente registro de la base de datos de la "wallet"</translation>
+        <translation type="unfinished">Error al leer el siguiente registro de la base de datos del monedero</translation>
+    </message>
+    <message>
+        <source>Error: Could not add watchonly tx to watchonly wallet</source>
+        <translation type="unfinished">Error: No se puede añadir la transacción de observación al monedero de observación</translation>
+    </message>
+    <message>
+        <source>Error: Could not delete watchonly transactions</source>
+        <translation type="unfinished">Error: No se pueden eliminar las transacciones de observación</translation>
     </message>
     <message>
         <source>Error: Couldn't create cursor into database</source>
         <translation type="unfinished">Error: No se pudo crear el cursor en la base de datos</translation>
     </message>
     <message>
+        <source>Error: Disk space is low for %s</source>
+        <translation type="unfinished">Error: Espacio en disco bajo por %s</translation>
+    </message>
+    <message>
         <source>Error: Dumpfile checksum does not match. Computed %s, expected %s</source>
         <translation type="unfinished">Error: La suma de comprobación del archivo de volcado no coincide. Calculada%s, prevista%s</translation>
     </message>
     <message>
+        <source>Error: Failed to create new watchonly wallet</source>
+        <translation type="unfinished">Error: No se puede crear un monedero de observación</translation>
+    </message>
+    <message>
         <source>Error: Got key that was not hex: %s</source>
-        <translation type="unfinished">Error: Se recibió una llave que no es hex: %s</translation>
+        <translation type="unfinished">Error: Se recibió una clave que no es hex: %s</translation>
     </message>
     <message>
         <source>Error: Got value that was not hex: %s</source>
@@ -504,24 +815,59 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     </message>
     <message>
         <source>Error: Keypool ran out, please call keypoolrefill first</source>
-        <translation type="unfinished">Keypool se ha agotado, por favor, llama a keypoolrefill antes</translation>
+        <translation type="unfinished">Error: Keypool se ha agotado, por favor, invoca «keypoolrefill» primero</translation>
     </message>
     <message>
         <source>Error: Missing checksum</source>
-        <translation type="unfinished">Error: No se ha encontrado 'checksum'</translation>
+        <translation type="unfinished">Error: No se ha encontrado suma de comprobación</translation>
     </message>
     <message>
         <source>Error: No %s addresses available.</source>
-        <translation type="unfinished">Error: No hay %sdirecciones disponibles.
-</translation>
+        <translation type="unfinished">Error: No hay direcciones %s disponibles .</translation>
+    </message>
+    <message>
+        <source>Error: Not all watchonly txs could be deleted</source>
+        <translation type="unfinished">Error: No se pueden eliminar todas las transacciones de observación</translation>
+    </message>
+    <message>
+        <source>Error: This wallet already uses SQLite</source>
+        <translation type="unfinished">Error: Este monedero ya usa SQLite</translation>
+    </message>
+    <message>
+        <source>Error: This wallet is already a descriptor wallet</source>
+        <translation type="unfinished">Error: Este monedero ya es un monedero descriptor</translation>
+    </message>
+    <message>
+        <source>Error: Unable to begin reading all records in the database</source>
+        <translation type="unfinished">Error: No es posible comenzar a leer todos los registros en la base de datos</translation>
+    </message>
+    <message>
+        <source>Error: Unable to make a backup of your wallet</source>
+        <translation type="unfinished">Error: No es posible realizar la copia de seguridad de tu monedero</translation>
     </message>
     <message>
         <source>Error: Unable to parse version %u as a uint32_t</source>
         <translation type="unfinished">Error: No se ha podido analizar la versión %ucomo uint32_t</translation>
     </message>
     <message>
+        <source>Error: Unable to read all records in the database</source>
+        <translation type="unfinished">Error: No es posible leer todos los registros en la base de datos</translation>
+    </message>
+    <message>
+        <source>Error: Unable to remove watchonly address book data</source>
+        <translation type="unfinished">Error: No es posible eliminar los datos de la libreta de direcciones de observación</translation>
+    </message>
+    <message>
         <source>Error: Unable to write record to new wallet</source>
-        <translation type="unfinished">Error: No se pudo escribir el registro en la nueva billetera</translation>
+        <translation type="unfinished">Error: No se pudo escribir el registro en el nuevo monedero</translation>
+    </message>
+    <message>
+        <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
+        <translation type="unfinished">Ha fallado la escucha en todos los puertos. Usa -listen=0 si deseas esto.</translation>
+    </message>
+    <message>
+        <source>Failed to rescan the wallet during initialization</source>
+        <translation type="unfinished">Fallo al volver a escanear el monedero durante el inicio</translation>
     </message>
     <message>
         <source>Failed to verify database</source>
@@ -540,6 +886,14 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
         <translation type="unfinished">Importando...</translation>
     </message>
     <message>
+        <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
+        <translation type="unfinished">Bloque de génesis no encontrado o incorrecto. ¿datadir equivocada para la red?</translation>
+    </message>
+    <message>
+        <source>Initialization sanity check failed. %s is shutting down.</source>
+        <translation type="unfinished">La inicialización de la verificación de validez falló. Se está cerrando %s.</translation>
+    </message>
+    <message>
         <source>Input not found or already spent</source>
         <translation type="unfinished">Entrada no encontrada o ya gastada</translation>
     </message>
@@ -549,7 +903,43 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     </message>
     <message>
         <source>Invalid -i2psam address or hostname: '%s'</source>
-        <translation type="unfinished">Dirección de -i2psam o dominio ' %s' inválido</translation>
+        <translation type="unfinished">Dirección de -i2psam o dominio «%s» inválido</translation>
+    </message>
+    <message>
+        <source>Invalid -onion address or hostname: '%s'</source>
+        <translation type="unfinished">Dirección -onion o hostname: «%s» inválido</translation>
+    </message>
+    <message>
+        <source>Invalid -proxy address or hostname: '%s'</source>
+        <translation type="unfinished">Dirección -proxy o hostname: «%s» inválido</translation>
+    </message>
+    <message>
+        <source>Invalid P2P permission: '%s'</source>
+        <translation type="unfinished">Permiso P2P: «%s» inválido</translation>
+    </message>
+    <message>
+        <source>Invalid amount for -%s=&lt;amount&gt;: '%s'</source>
+        <translation type="unfinished">Importe para -%s=&lt;amount&gt;: «%s» inválido</translation>
+    </message>
+    <message>
+        <source>Invalid amount for -discardfee=&lt;amount&gt;: '%s'</source>
+        <translation type="unfinished">Importe para -discardfee=&lt;amount&gt;: «%s» inválido</translation>
+    </message>
+    <message>
+        <source>Invalid amount for -fallbackfee=&lt;amount&gt;: '%s'</source>
+        <translation type="unfinished">Importe para -fallbackfee=&lt;amount&gt;: «%s» inválido</translation>
+    </message>
+    <message>
+        <source>Invalid amount for -paytxfee=&lt;amount&gt;: '%s' (must be at least %s)</source>
+        <translation type="unfinished">Importe para  -paytxfee=&lt;amount&gt;: «%s» inválido (debe ser al menos %s)</translation>
+    </message>
+    <message>
+        <source>Invalid netmask specified in -whitelist: '%s'</source>
+        <translation type="unfinished">Máscara de red especificada en -whitelist: «%s» inválida</translation>
+    </message>
+    <message>
+        <source>Listening for incoming connections failed (listen returned error %s)</source>
+        <translation type="unfinished">La escucha para conexiones entrantes falló (la escucha devolvió el error %s)</translation>
     </message>
     <message>
         <source>Loading P2P addresses…</source>
@@ -557,7 +947,7 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     </message>
     <message>
         <source>Loading banlist…</source>
-        <translation type="unfinished">Cargando banlist...</translation>
+        <translation type="unfinished">Cargando lista de bloqueos...</translation>
     </message>
     <message>
         <source>Loading block index…</source>
@@ -569,27 +959,39 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     </message>
     <message>
         <source>Missing amount</source>
-        <translation type="unfinished">Cantidad faltante</translation>
+        <translation type="unfinished">Importe faltante</translation>
     </message>
     <message>
         <source>Missing solving data for estimating transaction size</source>
         <translation type="unfinished">Faltan datos de resolución para estimar el tamaño de las transacciones</translation>
     </message>
     <message>
+        <source>Need to specify a port with -whitebind: '%s'</source>
+        <translation type="unfinished">Necesita especificar un puerto con -whitebind: «%s»</translation>
+    </message>
+    <message>
         <source>No addresses available</source>
         <translation type="unfinished">Sin direcciones disponibles</translation>
     </message>
     <message>
-        <source>No proxy server specified. Use -proxy=&lt;ip&gt; or -proxy=&lt;ip:port&gt;.</source>
-        <translation type="unfinished">No se ha especificado un servidor de proxy. Use -proxy=&lt;ip&gt;o -proxy=&lt;ip:port&gt;.</translation>
+        <source>Not enough file descriptors available.</source>
+        <translation type="unfinished">No hay suficientes descriptores de archivo disponibles.</translation>
     </message>
     <message>
-        <source>Prune mode is incompatible with -coinstatsindex.</source>
-        <translation type="unfinished">"Prune mode" es incompatible with -txindex.</translation>
+        <source>Prune cannot be configured with a negative value.</source>
+        <translation type="unfinished">La poda no se puede configurar con un valor negativo.</translation>
+    </message>
+    <message>
+        <source>Prune mode is incompatible with -txindex.</source>
+        <translation type="unfinished">El modo de poda es incompatible con -txindex.</translation>
     </message>
     <message>
         <source>Pruning blockstore…</source>
         <translation type="unfinished">Podando almacén de bloques…</translation>
+    </message>
+    <message>
+        <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
+        <translation type="unfinished">Reduciendo -maxconnections de %d a %d, debido a limitaciones del sistema.</translation>
     </message>
     <message>
         <source>Replaying blocks…</source>
@@ -616,16 +1018,76 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
         <translation type="unfinished">SQLiteDatabase: id aplicación inesperada. Esperado %u, tiene %u</translation>
     </message>
     <message>
+        <source>Section [%s] is not recognized.</source>
+        <translation type="unfinished">Sección [%s] no reconocida.</translation>
+    </message>
+    <message>
+        <source>Signing transaction failed</source>
+        <translation type="unfinished">Firma de transacción fallida</translation>
+    </message>
+    <message>
+        <source>Specified -walletdir "%s" does not exist</source>
+        <translation type="unfinished">No existe -walletdir «%s» especificada</translation>
+    </message>
+    <message>
+        <source>Specified -walletdir "%s" is a relative path</source>
+        <translation type="unfinished">Ruta relativa para -walletdir «%s» especificada</translation>
+    </message>
+    <message>
+        <source>Specified -walletdir "%s" is not a directory</source>
+        <translation type="unfinished">No existe directorio para -walletdir «%s» especificada</translation>
+    </message>
+    <message>
+        <source>Specified blocks directory "%s" does not exist.</source>
+        <translation type="unfinished">No existe directorio de bloques «%s» especificado.</translation>
+    </message>
+    <message>
         <source>Starting network threads…</source>
         <translation type="unfinished">Iniciando procesos de red...</translation>
+    </message>
+    <message>
+        <source>The source code is available from %s.</source>
+        <translation type="unfinished">El código fuente esta disponible desde %s.</translation>
     </message>
     <message>
         <source>The specified config file %s does not exist</source>
         <translation type="unfinished">El archivo de configuración especificado %s no existe </translation>
     </message>
     <message>
+        <source>The transaction amount is too small to pay the fee</source>
+        <translation type="unfinished">El importe de la transacción es muy pequeño para pagar la comisión</translation>
+    </message>
+    <message>
+        <source>The wallet will avoid paying less than the minimum relay fee.</source>
+        <translation type="unfinished">El monedero evitará pagar menos de la comisión mínima de retransmisión. </translation>
+    </message>
+    <message>
+        <source>This is experimental software.</source>
+        <translation type="unfinished">Este es un software experimental.</translation>
+    </message>
+    <message>
+        <source>This is the minimum transaction fee you pay on every transaction.</source>
+        <translation type="unfinished">Esta es la comisión mínima que pagarás en cada transacción.</translation>
+    </message>
+    <message>
+        <source>This is the transaction fee you will pay if you send a transaction.</source>
+        <translation type="unfinished">Esta es la comisión por transacción a pagar si realiza una transacción.</translation>
+    </message>
+    <message>
+        <source>Transaction amount too small</source>
+        <translation type="unfinished">Importe de la transacción muy pequeño</translation>
+    </message>
+    <message>
         <source>Transaction amounts must not be negative</source>
-        <translation type="unfinished">Los montos de la transacción no deben ser negativos</translation>
+        <translation type="unfinished">Los importes de la transacción no deben ser negativos</translation>
+    </message>
+    <message>
+        <source>Transaction change output index out of range</source>
+        <translation type="unfinished">Índice de salida de cambio de transacción fuera de rango</translation>
+    </message>
+    <message>
+        <source>Transaction has too long of a mempool chain</source>
+        <translation type="unfinished">La transacción lleva largo tiempo en la piscina de memoria</translation>
     </message>
     <message>
         <source>Transaction must have at least one recipient</source>
@@ -640,16 +1102,80 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
         <translation type="unfinished">Transacción demasiado grande</translation>
     </message>
     <message>
+        <source>Unable to allocate memory for -maxsigcachesize: '%s' MiB</source>
+        <translation type="unfinished">No se ha podido reservar memoria para -maxsigcachesize: «%s» MiB</translation>
+    </message>
+    <message>
+        <source>Unable to bind to %s on this computer (bind returned error %s)</source>
+        <translation type="unfinished">No es posible conectar con %s en este sistema (bind ha devuelto el error %s)</translation>
+    </message>
+    <message>
+        <source>Unable to bind to %s on this computer. %s is probably already running.</source>
+        <translation type="unfinished">No se ha podido conectar con %s en este equipo. %s es posible que esté todavía en ejecución.</translation>
+    </message>
+    <message>
+        <source>Unable to create the PID file '%s': %s</source>
+        <translation type="unfinished">No es posible crear el fichero PID «%s»: %s</translation>
+    </message>
+    <message>
+        <source>Unable to find UTXO for external input</source>
+        <translation type="unfinished">No se encuentra UTXO para entrada externa</translation>
+    </message>
+    <message>
+        <source>Unable to generate initial keys</source>
+        <translation type="unfinished">No es posible generar las claves iniciales</translation>
+    </message>
+    <message>
+        <source>Unable to generate keys</source>
+        <translation type="unfinished">No es posible generar claves</translation>
+    </message>
+    <message>
         <source>Unable to open %s for writing</source>
         <translation type="unfinished">No se ha podido abrir %s para escribir</translation>
     </message>
     <message>
         <source>Unable to parse -maxuploadtarget: '%s'</source>
-        <translation type="unfinished">No se ha podido analizar -maxuploadtarget: '%s'</translation>
+        <translation type="unfinished">No se ha podido analizar -maxuploadtarget: «%s»</translation>
+    </message>
+    <message>
+        <source>Unable to start HTTP server. See debug log for details.</source>
+        <translation type="unfinished">No se ha podido iniciar el servidor HTTP. Ver registro de depuración para detalles.</translation>
+    </message>
+    <message>
+        <source>Unable to unload the wallet before migrating</source>
+        <translation type="unfinished">Fallo al descargar el monedero antes de la migración</translation>
+    </message>
+    <message>
+        <source>Unknown -blockfilterindex value %s.</source>
+        <translation type="unfinished">Valor -blockfilterindex %s desconocido.</translation>
+    </message>
+    <message>
+        <source>Unknown address type '%s'</source>
+        <translation type="unfinished">Tipo de dirección «%s» desconocida</translation>
+    </message>
+    <message>
+        <source>Unknown change type '%s'</source>
+        <translation type="unfinished">Tipo de cambio «%s» desconocido</translation>
+    </message>
+    <message>
+        <source>Unknown network specified in -onlynet: '%s'</source>
+        <translation type="unfinished">Red especificada en -onlynet: «%s» desconocida</translation>
     </message>
     <message>
         <source>Unknown new rules activated (versionbit %i)</source>
         <translation type="unfinished">Nuevas reglas desconocidas activadas (versionbit %i)</translation>
+    </message>
+    <message>
+        <source>Unsupported global logging level -loglevel=%s. Valid values: %s.</source>
+        <translation type="unfinished">Nivel de registro de depuración global -loglevel=%s no soportado. Valores válidos: %s.</translation>
+    </message>
+    <message>
+        <source>Unsupported logging category %s=%s.</source>
+        <translation type="unfinished">Categoría de registro no soportada %s=%s. </translation>
+    </message>
+    <message>
+        <source>User Agent comment (%s) contains unsafe characters.</source>
+        <translation type="unfinished">El comentario del Agente de Usuario (%s) contiene caracteres inseguros.</translation>
     </message>
     <message>
         <source>Verifying blocks…</source>
@@ -659,7 +1185,11 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
         <source>Verifying wallet(s)…</source>
         <translation type="unfinished">Verificando monedero(s)...</translation>
     </message>
-    </context>
+    <message>
+        <source>Wallet needed to be rewritten: restart %s to complete</source>
+        <translation type="unfinished">Es necesario reescribir el monedero: reiniciar %s para completar</translation>
+    </message>
+</context>
 <context>
     <name>BitcoinGUI</name>
     <message>
@@ -732,12 +1262,32 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
         <translation type="unfinished">Enviar monedas a una dirección Bitcoin</translation>
     </message>
     <message>
+        <source>Backup wallet to another location</source>
+        <translation type="unfinished">Respaldar monedero en otra ubicación</translation>
+    </message>
+    <message>
+        <source>Change the passphrase used for wallet encryption</source>
+        <translation type="unfinished">Cambiar la contraseña utilizada para el cifrado del monedero</translation>
+    </message>
+    <message>
+        <source>&amp;Send</source>
+        <translation type="unfinished">&amp;Enviar</translation>
+    </message>
+    <message>
+        <source>&amp;Receive</source>
+        <translation type="unfinished">&amp;Recibir</translation>
+    </message>
+    <message>
         <source>&amp;Options…</source>
         <translation type="unfinished">&amp;Opciones...</translation>
     </message>
     <message>
         <source>&amp;Encrypt Wallet…</source>
-        <translation type="unfinished">&amp;Cifrar monedero</translation>
+        <translation type="unfinished">Cifrar &amp;monedero...</translation>
+    </message>
+    <message>
+        <source>Encrypt the private keys that belong to your wallet</source>
+        <translation type="unfinished">Cifrar las claves privadas de tu monedero</translation>
     </message>
     <message>
         <source>&amp;Backup Wallet…</source>
@@ -752,12 +1302,20 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
         <translation type="unfinished">Firmar &amp;mensaje...</translation>
     </message>
     <message>
+        <source>Sign messages with your Bitcoin addresses to prove you own them</source>
+        <translation type="unfinished">Firmar un mensaje para probar que eres dueño de esta dirección</translation>
+    </message>
+    <message>
         <source>&amp;Verify message…</source>
         <translation type="unfinished">&amp;Verificar mensaje...</translation>
     </message>
     <message>
+        <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
+        <translation type="unfinished">Verificar mensajes comprobando que están firmados con direcciones Bitcoin concretas</translation>
+    </message>
+    <message>
         <source>&amp;Load PSBT from file…</source>
-        <translation type="unfinished">&amp;Cargar PSBT desde archivo...</translation>
+        <translation type="unfinished">&amp;Cargar TBPF desde archivo...</translation>
     </message>
     <message>
         <source>Open &amp;URI…</source>
@@ -765,23 +1323,35 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     </message>
     <message>
         <source>Close Wallet…</source>
-        <translation type="unfinished">Cerrar cartera...</translation>
+        <translation type="unfinished">Cerrar monedero...</translation>
     </message>
     <message>
         <source>Create Wallet…</source>
-        <translation type="unfinished">Crear cartera...</translation>
+        <translation type="unfinished">Crear monedero...</translation>
     </message>
     <message>
         <source>Close All Wallets…</source>
-        <translation type="unfinished">Cerrar todas las carteras...</translation>
+        <translation type="unfinished">Cerrar todos los monederos...</translation>
+    </message>
+    <message>
+        <source>&amp;File</source>
+        <translation type="unfinished">&amp;Archivo</translation>
+    </message>
+    <message>
+        <source>&amp;Settings</source>
+        <translation type="unfinished">&amp;Configuración</translation>
     </message>
     <message>
         <source>&amp;Help</source>
         <translation type="unfinished">&amp;Ayuda</translation>
     </message>
     <message>
+        <source>Tabs toolbar</source>
+        <translation type="unfinished">Barra de pestañas</translation>
+    </message>
+    <message>
         <source>Syncing Headers (%1%)…</source>
-        <translation type="unfinished">Sincronizando cabeceras (1%1%)</translation>
+        <translation type="unfinished">Sincronizando cabeceras (%1%)...</translation>
     </message>
     <message>
         <source>Synchronizing with network…</source>
@@ -797,22 +1367,50 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     </message>
     <message>
         <source>Reindexing blocks on disk…</source>
-        <translation type="unfinished">Reindexando bloques en disco</translation>
+        <translation type="unfinished">Reindexando bloques en disco...</translation>
     </message>
     <message>
         <source>Connecting to peers…</source>
-        <translation type="unfinished">Conectando con compañeros...</translation>
+        <translation type="unfinished">Conectando con pares...</translation>
+    </message>
+    <message>
+        <source>Request payments (generates QR codes and bitcoin: URIs)</source>
+        <translation type="unfinished">Solicitar pagos (genera código QR y URI's de Bitcoin)</translation>
+    </message>
+    <message>
+        <source>Show the list of used sending addresses and labels</source>
+        <translation type="unfinished">Editar la lista de las direcciones y etiquetas almacenadas</translation>
+    </message>
+    <message>
+        <source>Show the list of used receiving addresses and labels</source>
+        <translation type="unfinished">Mostrar la lista de direcciones de envío y etiquetas</translation>
+    </message>
+    <message>
+        <source>&amp;Command-line options</source>
+        <translation type="unfinished">&amp;Opciones de línea de comandos</translation>
     </message>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>Procesado %n bloque del historial de transacciones.</numerusform>
+            <numerusform>Procesado %n bloques del historial de transacciones.</numerusform>
         </translation>
+    </message>
+    <message>
+        <source>%1 behind</source>
+        <translation type="unfinished">%1 detrás</translation>
     </message>
     <message>
         <source>Catching up…</source>
         <translation type="unfinished">Poniéndose al día...</translation>
+    </message>
+    <message>
+        <source>Last received block was generated %1 ago.</source>
+        <translation type="unfinished">El último bloque recibido fue generado hace %1 horas.</translation>
+    </message>
+    <message>
+        <source>Transactions after this will not yet be visible.</source>
+        <translation type="unfinished">Las transacciones posteriores aún no son visibles.</translation>
     </message>
     <message>
         <source>Warning</source>
@@ -823,16 +1421,36 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
         <translation type="unfinished">Información</translation>
     </message>
     <message>
+        <source>Up to date</source>
+        <translation type="unfinished">Actualizado al día </translation>
+    </message>
+    <message>
         <source>Load Partially Signed Bitcoin Transaction</source>
         <translation type="unfinished">Cargar una transacción de Bitcoin parcialmente firmada</translation>
     </message>
     <message>
         <source>Load PSBT from &amp;clipboard…</source>
-        <translation type="unfinished">Cargar PSBT desde &amp;portapapeles</translation>
+        <translation type="unfinished">Cargar TBPF desde &amp;portapapeles...</translation>
     </message>
     <message>
         <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
         <translation type="unfinished">Cargar una transacción de Bitcoin parcialmente firmada desde el Portapapeles</translation>
+    </message>
+    <message>
+        <source>Node window</source>
+        <translation type="unfinished">Ventana del nodo</translation>
+    </message>
+    <message>
+        <source>&amp;Sending addresses</source>
+        <translation type="unfinished">Direcciones de &amp;envío</translation>
+    </message>
+    <message>
+        <source>&amp;Receiving addresses</source>
+        <translation type="unfinished">Direcciones de &amp;recepción</translation>
+    </message>
+    <message>
+        <source>Open a bitcoin: URI</source>
+        <translation type="unfinished">Abrir un bitcoin: URI</translation>
     </message>
     <message>
         <source>Open Wallet</source>
@@ -847,8 +1465,22 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
         <translation type="unfinished">Cerrar monedero</translation>
     </message>
     <message>
+        <source>Restore Wallet…</source>
+        <extracomment>Name of the menu item that restores wallet from a backup file.</extracomment>
+        <translation type="unfinished">Restaurar monedero…</translation>
+    </message>
+    <message>
+        <source>Restore a wallet from a backup file</source>
+        <extracomment>Status tip for Restore Wallet menu item</extracomment>
+        <translation type="unfinished">Restaurar monedero desde un archivo de respaldo</translation>
+    </message>
+    <message>
         <source>Close all wallets</source>
         <translation type="unfinished">Cerrar todos los monederos</translation>
+    </message>
+    <message>
+        <source>Show the %1 help message to get a list with possible Bitcoin command-line options</source>
+        <translation type="unfinished">Muestra el mensaje de ayuda %1 para obtener una lista con posibles opciones de línea de comandos de Bitcoin.</translation>
     </message>
     <message>
         <source>&amp;Mask values</source>
@@ -856,7 +1488,7 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     </message>
     <message>
         <source>Mask the values in the Overview tab</source>
-        <translation type="unfinished">Esconder los valores de la ventana de previsualización</translation>
+        <translation type="unfinished">Ocultar los valores de la ventana de previsualización</translation>
     </message>
     <message>
         <source>default wallet</source>
@@ -867,26 +1499,66 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
         <translation type="unfinished">No hay monederos disponibles</translation>
     </message>
     <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">Datos del monedero </translation>
+    </message>
+    <message>
+        <source>Load Wallet Backup</source>
+        <extracomment>The title for Restore Wallet File Windows</extracomment>
+        <translation type="unfinished">Cargar copia de seguridad del monedero</translation>
+    </message>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of pop-up window shown when the user is attempting to restore a wallet.</extracomment>
+        <translation type="unfinished">Restaurar monedero</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">Nombre del monedero</translation>
+    </message>
+    <message>
         <source>&amp;Window</source>
         <translation type="unfinished">&amp;Ventana</translation>
+    </message>
+    <message>
+        <source>Zoom</source>
+        <translation type="unfinished">Acercar</translation>
+    </message>
+    <message>
+        <source>Main Window</source>
+        <translation type="unfinished">Ventana principal</translation>
+    </message>
+    <message>
+        <source>%1 client</source>
+        <translation type="unfinished">%1 cliente</translation>
+    </message>
+    <message>
+        <source>&amp;Hide</source>
+        <translation type="unfinished">&amp;Ocultar </translation>
+    </message>
+    <message>
+        <source>S&amp;how</source>
+        <translation type="unfinished">&amp;Mostrar</translation>
     </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n conexión activa con la red Bitcoin.</numerusform>
+            <numerusform>%n conexiones activas con la red Bitcoin.</numerusform>
         </translation>
     </message>
     <message>
         <source>Click for more actions.</source>
         <extracomment>A substring of the tooltip. "More actions" are available via the context menu.</extracomment>
-        <translation type="unfinished">Haz click para ver más acciones.</translation>
+        <translation type="unfinished">Haz clic para ver más acciones.</translation>
     </message>
     <message>
         <source>Show Peers tab</source>
         <extracomment>A context menu item. The "Peers tab" is an element of the "Node window".</extracomment>
-        <translation type="unfinished">Mostrar pestaña Pares</translation>
+        <translation type="unfinished">Mostrar pestaña de pares</translation>
     </message>
     <message>
         <source>Disable network activity</source>
@@ -897,6 +1569,10 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
         <source>Enable network activity</source>
         <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
         <translation type="unfinished">Habilitar la actividad de la red</translation>
+    </message>
+    <message>
+        <source>Pre-syncing Headers (%1%)…</source>
+        <translation type="unfinished">Presincronizando cabeceras (%1%)...</translation>
     </message>
     <message>
         <source>Warning: %1</source>
@@ -911,13 +1587,19 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     <message>
         <source>Amount: %1
 </source>
-        <translation type="unfinished">Cantidad: %1
+        <translation type="unfinished">Importe: %1
 </translation>
     </message>
     <message>
         <source>Wallet: %1
 </source>
         <translation type="unfinished">Monedero: %1
+</translation>
+    </message>
+    <message>
+        <source>Type: %1
+</source>
+        <translation type="unfinished">Tipo: %1
 </translation>
     </message>
     <message>
@@ -938,15 +1620,38 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     </message>
     <message>
         <source>Incoming transaction</source>
-        <translation type="unfinished">Transacción entrante</translation>
+        <translation type="unfinished">Transacción recibida</translation>
+    </message>
+    <message>
+        <source>HD key generation is &lt;b&gt;enabled&lt;/b&gt;</source>
+        <translation type="unfinished">La generación de clave HD está &lt;b&gt;habilitada&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>HD key generation is &lt;b&gt;disabled&lt;/b&gt;</source>
+        <translation type="unfinished">La generación de clave HD está &lt;b&gt;deshabilitada&lt;/b&gt;</translation>
     </message>
     <message>
         <source>Private key &lt;b&gt;disabled&lt;/b&gt;</source>
-        <translation type="unfinished">Llave privada &lt;b&gt;deshabilitada&lt;/b&gt;</translation>
+        <translation type="unfinished">Clave privada &lt;b&gt;deshabilitada&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
+        <translation type="unfinished">El monedero está &lt;b&gt;cifrado&lt;/b&gt; y actualmente &lt;b&gt;desbloqueado&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
+        <translation type="unfinished">El monedero está &lt;b&gt;cifrado&lt;/b&gt; y actualmente &lt;b&gt;bloqueado&lt;/b&gt;</translation>
     </message>
     <message>
         <source>Original message:</source>
         <translation type="unfinished">Mensaje original:</translation>
+    </message>
+</context>
+<context>
+    <name>UnitDisplayStatusBarControl</name>
+    <message>
+        <source>Unit to show amounts in. Click to select another unit.</source>
+        <translation type="unfinished">Unidad en la que se muestran los importes. Haga clic para seleccionar otra unidad.</translation>
     </message>
 </context>
 <context>
@@ -961,11 +1666,15 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     </message>
     <message>
         <source>Amount:</source>
-        <translation type="unfinished">Cuantía:</translation>
+        <translation type="unfinished">Importe:</translation>
     </message>
     <message>
         <source>Fee:</source>
         <translation type="unfinished">Comisión:</translation>
+    </message>
+    <message>
+        <source>Dust:</source>
+        <translation type="unfinished">Polvo:</translation>
     </message>
     <message>
         <source>After Fee:</source>
@@ -981,15 +1690,23 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     </message>
     <message>
         <source>Tree mode</source>
-        <translation type="unfinished">Modo Árbol</translation>
+        <translation type="unfinished">Modo árbol</translation>
     </message>
     <message>
         <source>List mode</source>
-        <translation type="unfinished">Modo Lista</translation>
+        <translation type="unfinished">Modo lista</translation>
     </message>
     <message>
         <source>Amount</source>
-        <translation type="unfinished">Cantidad</translation>
+        <translation type="unfinished">Importe</translation>
+    </message>
+    <message>
+        <source>Received with label</source>
+        <translation type="unfinished">Recibido con dirección</translation>
+    </message>
+    <message>
+        <source>Received with address</source>
+        <translation type="unfinished">Recibido con etiqueta</translation>
     </message>
     <message>
         <source>Date</source>
@@ -1004,16 +1721,20 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
         <translation type="unfinished">Confirmado</translation>
     </message>
     <message>
+        <source>Copy amount</source>
+        <translation type="unfinished">Copiar importe</translation>
+    </message>
+    <message>
         <source>&amp;Copy address</source>
-        <translation type="unfinished">copiar dirección </translation>
+        <translation type="unfinished">&amp;Copiar dirección</translation>
     </message>
     <message>
         <source>Copy &amp;label</source>
-        <translation type="unfinished">Copiar &amp;label</translation>
+        <translation type="unfinished">Copiar &amp;etiqueta</translation>
     </message>
     <message>
         <source>Copy &amp;amount</source>
-        <translation type="unfinished">Copiar &amp;amount</translation>
+        <translation type="unfinished">Copiar &amp;importe</translation>
     </message>
     <message>
         <source>Copy transaction &amp;ID and output index</source>
@@ -1021,11 +1742,15 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     </message>
     <message>
         <source>L&amp;ock unspent</source>
-        <translation type="unfinished">Bloquear no gastado</translation>
+        <translation type="unfinished">B&amp;loquear no gastado</translation>
     </message>
     <message>
         <source>&amp;Unlock unspent</source>
         <translation type="unfinished">&amp;Desbloquear lo no gastado</translation>
+    </message>
+    <message>
+        <source>Copy quantity</source>
+        <translation type="unfinished">Copiar cantidad</translation>
     </message>
     <message>
         <source>Copy fee</source>
@@ -1036,12 +1761,32 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
         <translation type="unfinished">Copiar después de la comisión</translation>
     </message>
     <message>
+        <source>Copy bytes</source>
+        <translation type="unfinished">Copiar bytes</translation>
+    </message>
+    <message>
+        <source>Copy dust</source>
+        <translation type="unfinished">Copiar polvo</translation>
+    </message>
+    <message>
         <source>Copy change</source>
         <translation type="unfinished">Copiar cambio</translation>
     </message>
     <message>
+        <source>(%1 locked)</source>
+        <translation type="unfinished">(%1 bloqueado)</translation>
+    </message>
+    <message>
         <source>yes</source>
         <translation type="unfinished">sí</translation>
+    </message>
+    <message>
+        <source>This label turns red if any recipient receives an amount smaller than the current dust threshold.</source>
+        <translation type="unfinished">Esta etiqueta se vuelve roja si algún receptor recibe un importe inferior al umbral actual establecido para el polvo.</translation>
+    </message>
+    <message>
+        <source>Can vary +/- %1 satoshi(s) per input.</source>
+        <translation type="unfinished">Puede variar en +/- %1 satoshi(s) por entrada.</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -1061,24 +1806,28 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     <message>
         <source>Create Wallet</source>
         <extracomment>Title of window indicating the progress of creation of a new wallet.</extracomment>
-        <translation type="unfinished">Crear Monedero</translation>
+        <translation type="unfinished">Crear monedero</translation>
     </message>
     <message>
         <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
         <extracomment>Descriptive text of the create wallet progress window which indicates to the user which wallet is currently being created.</extracomment>
-        <translation type="unfinished">Creando Monedero &lt;b&gt;%1&lt;/b&gt;…</translation>
+        <translation type="unfinished">Creando monedero &lt;b&gt;%1&lt;/b&gt;…</translation>
     </message>
     <message>
         <source>Create wallet failed</source>
-        <translation type="unfinished">Crear monedero ha fallado</translation>
+        <translation type="unfinished">Fallo al crear monedero</translation>
     </message>
     <message>
         <source>Create wallet warning</source>
-        <translation type="unfinished">Advertencia sobre crear monedero</translation>
+        <translation type="unfinished">Advertencia al crear monedero</translation>
     </message>
     <message>
         <source>Can't list signers</source>
         <translation type="unfinished">No se pueden enumerar los firmantes</translation>
+    </message>
+    <message>
+        <source>Too many external signers found</source>
+        <translation type="unfinished">Se han encontrado demasiados firmantes externos</translation>
     </message>
 </context>
 <context>
@@ -1098,25 +1847,53 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     <name>OpenWalletActivity</name>
     <message>
         <source>Open wallet failed</source>
-        <translation type="unfinished">Abrir monedero ha fallado</translation>
+        <translation type="unfinished">Fallo al abrir monedero</translation>
     </message>
     <message>
         <source>Open wallet warning</source>
-        <translation type="unfinished">Advertencia sobre crear monedero</translation>
+        <translation type="unfinished">Advertencia al abrir monedero</translation>
     </message>
     <message>
         <source>default wallet</source>
-        <translation type="unfinished">Monedero predeterminado</translation>
+        <translation type="unfinished">monedero predeterminado</translation>
     </message>
     <message>
         <source>Open Wallet</source>
         <extracomment>Title of window indicating the progress of opening of a wallet.</extracomment>
-        <translation type="unfinished">Abrir Monedero</translation>
+        <translation type="unfinished">Abrir monedero</translation>
     </message>
     <message>
         <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
         <extracomment>Descriptive text of the open wallet progress window which indicates to the user which wallet is currently being opened.</extracomment>
-        <translation type="unfinished">Abriendo Monedero &lt;b&gt;%1&lt;/b&gt;...</translation>
+        <translation type="unfinished">Abriendo monedero &lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+</context>
+<context>
+    <name>RestoreWalletActivity</name>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of progress window which is displayed when wallets are being restored.</extracomment>
+        <translation type="unfinished">Restaurar monedero</translation>
+    </message>
+    <message>
+        <source>Restoring Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the restore wallets progress window which indicates to the user that wallets are currently being restored.</extracomment>
+        <translation type="unfinished">Restaurando monedero &lt;b&gt;%1&lt;/b&gt;…</translation>
+    </message>
+    <message>
+        <source>Restore wallet failed</source>
+        <extracomment>Title of message box which is displayed when the wallet could not be restored.</extracomment>
+        <translation type="unfinished">Fallo al restaurar monedero</translation>
+    </message>
+    <message>
+        <source>Restore wallet warning</source>
+        <extracomment>Title of message box which is displayed when the wallet is restored with some warning.</extracomment>
+        <translation type="unfinished">Advertencia al restaurar monedero</translation>
+    </message>
+    <message>
+        <source>Restore wallet message</source>
+        <extracomment>Title of message box which is displayed when the wallet is successfully restored.</extracomment>
+        <translation type="unfinished">Mensaje al restaurar monedero</translation>
     </message>
 </context>
 <context>
@@ -1128,6 +1905,10 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     <message>
         <source>Are you sure you wish to close the wallet &lt;i&gt;%1&lt;/i&gt;?</source>
         <translation type="unfinished">¿Estás seguro de que deseas cerrar el monedero &lt;i&gt;%1&lt;/i&gt;?</translation>
+    </message>
+    <message>
+        <source>Closing the wallet for too long can result in having to resync the entire chain if pruning is enabled.</source>
+        <translation type="unfinished">Cerrar el monedero durante demasiado tiempo puede causar la resincronización de toda la cadena si la poda es habilitada.</translation>
     </message>
     <message>
         <source>Close all wallets</source>
@@ -1142,11 +1923,11 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     <name>CreateWalletDialog</name>
     <message>
         <source>Create Wallet</source>
-        <translation type="unfinished">Crear Monedero</translation>
+        <translation type="unfinished">Crear monedero</translation>
     </message>
     <message>
         <source>Wallet Name</source>
-        <translation type="unfinished">Nombre del Monedero</translation>
+        <translation type="unfinished">Nombre del monedero</translation>
     </message>
     <message>
         <source>Wallet</source>
@@ -1158,15 +1939,27 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     </message>
     <message>
         <source>Encrypt Wallet</source>
-        <translation type="unfinished">Cifrar Monedero</translation>
+        <translation type="unfinished">Cifrar monedero</translation>
     </message>
     <message>
         <source>Advanced Options</source>
-        <translation type="unfinished">Opciones Avanzadas</translation>
+        <translation type="unfinished">Opciones avanzadas</translation>
+    </message>
+    <message>
+        <source>Disable private keys for this wallet. Wallets with private keys disabled will have no private keys and cannot have an HD seed or imported private keys. This is ideal for watch-only wallets.</source>
+        <translation type="unfinished">Deshabilita las claves privadas para este monedero. Los monederos con claves privadas deshabilitadas no tendrán claves privadas y no podrán tener ni una semilla HD ni claves privadas importadas. Esto es ideal para monederos de solo observación.</translation>
     </message>
     <message>
         <source>Disable Private Keys</source>
-        <translation type="unfinished">Deshabilita las Llaves Privadas</translation>
+        <translation type="unfinished">Deshabilita las claves privadas</translation>
+    </message>
+    <message>
+        <source>Make a blank wallet. Blank wallets do not initially have private keys or scripts. Private keys and addresses can be imported, or an HD seed can be set, at a later time.</source>
+        <translation type="unfinished">Crear un monedero vacío. Los monederos vacíos no tienen claves privadas ni scripts. Las claves privadas y direcciones pueden importarse después o también establecer una semilla HD.</translation>
+    </message>
+    <message>
+        <source>Make Blank Wallet</source>
+        <translation type="unfinished">Crear monedero vacío</translation>
     </message>
     <message>
         <source>Use descriptors for scriptPubKey management</source>
@@ -1202,15 +1995,47 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     <name>EditAddressDialog</name>
     <message>
         <source>Edit Address</source>
-        <translation type="unfinished">Editar Dirección</translation>
+        <translation type="unfinished">Editar dirección</translation>
     </message>
     <message>
         <source>&amp;Label</source>
         <translation type="unfinished">&amp;Etiqueta</translation>
     </message>
     <message>
+        <source>The label associated with this address list entry</source>
+        <translation type="unfinished">La etiqueta asociada con esta entrada en la lista de direcciones</translation>
+    </message>
+    <message>
+        <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
+        <translation type="unfinished">La dirección asociada con esta entrada en la guía. Solo puede ser modificada para direcciones de envío.</translation>
+    </message>
+    <message>
         <source>&amp;Address</source>
         <translation type="unfinished">&amp;Dirección</translation>
+    </message>
+    <message>
+        <source>New sending address</source>
+        <translation type="unfinished">Nueva dirección de envío</translation>
+    </message>
+    <message>
+        <source>Edit receiving address</source>
+        <translation type="unfinished">Editar dirección de recepción</translation>
+    </message>
+    <message>
+        <source>Edit sending address</source>
+        <translation type="unfinished">Editar dirección de envio</translation>
+    </message>
+    <message>
+        <source>The entered address "%1" is not a valid Bitcoin address.</source>
+        <translation type="unfinished">La dirección introducida «%1» no es una dirección Bitcoin válida.</translation>
+    </message>
+    <message>
+        <source>Address "%1" already exists as a receiving address with label "%2" and so cannot be added as a sending address.</source>
+        <translation type="unfinished">La dirección «%1» ya existe como dirección de recepción con la etiqueta «%2» y, por lo tanto, no se puede agregar como dirección de envío.</translation>
+    </message>
+    <message>
+        <source>The entered address "%1" is already in the address book with label "%2".</source>
+        <translation type="unfinished">La dirección introducida «%1» ya se encuentra en la libreta de direcciones con la etiqueta «%2».</translation>
     </message>
     <message>
         <source>Could not unlock wallet.</source>
@@ -1218,7 +2043,7 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     </message>
     <message>
         <source>New key generation failed.</source>
-        <translation type="unfinished">La generación de la nueva clave fallo</translation>
+        <translation type="unfinished">Fallo en la generación de la nueva clave.</translation>
     </message>
 </context>
 <context>
@@ -1231,24 +2056,69 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
         <source>name</source>
         <translation type="unfinished">nombre</translation>
     </message>
-    </context>
-<context>
-    <name>Intro</name>
     <message>
-        <source>(of %1 GB needed)</source>
-        <translation type="unfinished">(de %1 GB necesarios)</translation>
+        <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
+        <translation type="unfinished">El directorio ya existe. Agrega %1 si tiene la intención de crear un nuevo directorio aquí.</translation>
     </message>
     <message>
-        <source>(%1 GB needed for full chain)</source>
-        <translation type="unfinished">(%1 GB necesarios para la cadena completa)</translation>
+        <source>Path already exists, and is not a directory.</source>
+        <translation type="unfinished">La ruta ya existe, y no es un directorio.</translation>
+    </message>
+    <message>
+        <source>Cannot create data directory here.</source>
+        <translation type="unfinished">No puede crear directorio de datos aquí.</translation>
+    </message>
+</context>
+<context>
+    <name>Intro</name>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform>%n GB de espacio disponible</numerusform>
+            <numerusform>%n GB de espacio disponible</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform>(de %n GB necesario)</numerusform>
+            <numerusform>(de %n GB necesarios)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform>(%n GB necesario para completar la cadena de bloques)</numerusform>
+            <numerusform>(%n GB necesarios para completar la cadena de bloques)</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
+        <translation type="unfinished">Al menos %1 GB de información será almacenada en este directorio, y seguirá creciendo a través del tiempo.</translation>
+    </message>
+    <message>
+        <source>Approximately %1 GB of data will be stored in this directory.</source>
+        <translation type="unfinished">Aproximadamente %1 GB de información será almacenada en este directorio.</translation>
     </message>
     <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>(suficiente para restaurar copias de seguridad de %n día de antigüedad)</numerusform>
+            <numerusform>(suficiente para restaurar copias de seguridad de %n días de antigüedad)</numerusform>
         </translation>
+    </message>
+    <message>
+        <source>%1 will download and store a copy of the Bitcoin block chain.</source>
+        <translation type="unfinished">%1 descargará y almacenará una copia de la cadena de bloques de Bitcoin.</translation>
+    </message>
+    <message>
+        <source>The wallet will also be stored in this directory.</source>
+        <translation type="unfinished">El monedero también se almacenará en este directorio.</translation>
+    </message>
+    <message>
+        <source>Error: Specified data directory "%1" cannot be created.</source>
+        <translation type="unfinished">Error: El directorio de datos especificado «%1» no pudo ser creado.</translation>
     </message>
     <message>
         <source>Welcome</source>
@@ -1259,14 +2129,42 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
         <translation type="unfinished">Bienvenido a %1.</translation>
     </message>
     <message>
+        <source>As this is the first time the program is launched, you can choose where %1 will store its data.</source>
+        <translation type="unfinished">Al ser esta la primera vez que se ejecuta el programa, puedes escoger donde %1 almacenará los datos.</translation>
+    </message>
+    <message>
         <source>Limit block chain storage to</source>
         <translation type="unfinished">Limitar el almacenamiento de cadena de bloques a</translation>
+    </message>
+    <message>
+        <source>Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</source>
+        <translation type="unfinished">Al revertir este ajuste se requiere volver a descargar la cadena de bloques completa. Es más rápido descargar primero la cadena completa y después podarla. Desactiva algunas características avanzadas.</translation>
     </message>
     <message>
         <source> GB</source>
         <translation type="unfinished">GB</translation>
     </message>
-    </context>
+    <message>
+        <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
+        <translation type="unfinished">El primer proceso de sincronización consume muchos recursos, y es posible que puedan ocurrir problemas de hardware que anteriormente no hayas notado. Cada vez que ejecutes %1 automáticamente se reiniciará el proceso de sincronización desde el punto que lo dejaste anteriormente.</translation>
+    </message>
+    <message>
+        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2 GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
+        <translation type="unfinished">Cuando hagas clic en OK, %1 se iniciará la descarga y procesamiento de toda la cadena %4 de bloques (%2 GB) empezando con las primeras transacciones en %3 cuando %4 fue inicialmente lanzado.</translation>
+    </message>
+    <message>
+        <source>If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</source>
+        <translation type="unfinished">Si ha elegido limitar el almacenamiento de la cadena de bloques (pruning o poda), los datos históricos todavía se deben descargar y procesar, pero se eliminarán posteriormente para mantener el uso del disco bajo.</translation>
+    </message>
+    <message>
+        <source>Use the default data directory</source>
+        <translation type="unfinished">Usa el directorio de datos predeterminado</translation>
+    </message>
+    <message>
+        <source>Use a custom data directory:</source>
+        <translation type="unfinished">Usa un directorio de datos personalizado:</translation>
+    </message>
+</context>
 <context>
     <name>HelpMessageDialog</name>
     <message>
@@ -1275,9 +2173,13 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     </message>
     <message>
         <source>About %1</source>
-        <translation type="unfinished">Alrededor de %1</translation>
+        <translation type="unfinished">Acerca de %1</translation>
     </message>
-    </context>
+    <message>
+        <source>Command-line options</source>
+        <translation type="unfinished">&amp;Opciones de línea de comandos</translation>
+    </message>
+</context>
 <context>
     <name>ShutdownWindow</name>
     <message>
@@ -1292,12 +2194,32 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
 <context>
     <name>ModalOverlay</name>
     <message>
+        <source>Form</source>
+        <translation type="unfinished">Formulario</translation>
+    </message>
+    <message>
+        <source>Recent transactions may not yet be visible, and therefore your wallet's balance might be incorrect. This information will be correct once your wallet has finished synchronizing with the bitcoin network, as detailed below.</source>
+        <translation type="unfinished">Es posible que las transacciones recientes aún no estén visibles y por lo tanto, el saldo de su monedero podría ser incorrecto. Esta información será correcta una vez que su monedero haya terminado de sincronizarse con la red bitcoin, como se detalla a continuación.</translation>
+    </message>
+    <message>
+        <source>Attempting to spend bitcoins that are affected by not-yet-displayed transactions will not be accepted by the network.</source>
+        <translation type="unfinished">La red no aceptará intentar gastar bitcoins que se vean afectados por transacciones aún no mostradas.</translation>
+    </message>
+    <message>
+        <source>Number of blocks left</source>
+        <translation type="unfinished">Numero de bloques pendientes</translation>
+    </message>
+    <message>
         <source>Unknown…</source>
         <translation type="unfinished">Desconocido...</translation>
     </message>
     <message>
         <source>calculating…</source>
         <translation type="unfinished">calculando...</translation>
+    </message>
+    <message>
+        <source>Last block time</source>
+        <translation type="unfinished">Hora del último bloque</translation>
     </message>
     <message>
         <source>Progress</source>
@@ -1308,12 +2230,36 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
         <translation type="unfinished">Incremento del progreso por hora</translation>
     </message>
     <message>
+        <source>Estimated time left until synced</source>
+        <translation type="unfinished">Tiempo estimado antes de sincronizar</translation>
+    </message>
+    <message>
         <source>Hide</source>
-        <translation type="unfinished">Ocultar </translation>
+        <translation type="unfinished">Ocultar</translation>
+    </message>
+    <message>
+        <source>%1 is currently syncing.  It will download headers and blocks from peers and validate them until reaching the tip of the block chain.</source>
+        <translation type="unfinished">%1 está actualmente sincronizándose. Descargará cabeceras y bloques de nodos semejantes y los validará hasta alcanzar la cabeza de la cadena de bloques.</translation>
     </message>
     <message>
         <source>Unknown. Syncing Headers (%1, %2%)…</source>
-        <translation type="unfinished">Desconocido. Sincronizando Cabeceras (%1, %2%)…</translation>
+        <translation type="unfinished">Desconocido. Sincronizando cabeceras (%1, %2%)…</translation>
+    </message>
+    <message>
+        <source>Unknown. Pre-syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">Desconocido. Presincronizando cabeceras (%1, %2%)…</translation>
+    </message>
+</context>
+<context>
+    <name>OpenURIDialog</name>
+    <message>
+        <source>Open bitcoin URI</source>
+        <translation type="unfinished">Abrir URI de bitcoin</translation>
+    </message>
+    <message>
+        <source>Paste address from clipboard</source>
+        <extracomment>Tooltip text for button that allows you to paste an address that is in your clipboard.</extracomment>
+        <translation type="unfinished">Pegar dirección desde portapapeles</translation>
     </message>
 </context>
 <context>
@@ -1327,22 +2273,82 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
         <translation type="unfinished">&amp;Principal</translation>
     </message>
     <message>
+        <source>Automatically start %1 after logging in to the system.</source>
+        <translation type="unfinished">Iniciar automáticamente %1 después de iniciar sesión en el sistema.</translation>
+    </message>
+    <message>
+        <source>&amp;Start %1 on system login</source>
+        <translation type="unfinished">&amp;Iniciar %1 al iniciar sesión en el sistema</translation>
+    </message>
+    <message>
         <source>Enabling pruning significantly reduces the disk space required to store transactions. All blocks are still fully validated. Reverting this setting requires re-downloading the entire blockchain.</source>
-        <translation type="unfinished">Activar el pruning reduce significativamente el espacio de disco necesario para guardar las transacciones. Todos los bloques son completamente validados de cualquier manera. Revertir esta opción requiere que descarques de nuevo toda la cadena de bloques.</translation>
+        <translation type="unfinished">Activar la poda reduce significativamente el espacio de disco necesario para guardar las transacciones. Todos los bloques son completamente validados de cualquier manera. Revertir esta opción requiere descargar de nuevo toda la cadena de bloques.</translation>
+    </message>
+    <message>
+        <source>Size of &amp;database cache</source>
+        <translation type="unfinished">Tamaño de la caché de la base de &amp;datos</translation>
+    </message>
+    <message>
+        <source>Number of script &amp;verification threads</source>
+        <translation type="unfinished">Número de hilos de &amp;verificación de scripts</translation>
+    </message>
+    <message>
+        <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
+        <translation type="unfinished">Dirección IP del proxy (Ejemplo. IPv4: 127.0.0.1 / IPv6: ::1)</translation>
+    </message>
+    <message>
+        <source>Shows if the supplied default SOCKS5 proxy is used to reach peers via this network type.</source>
+        <translation type="unfinished">Muestra si el proxy SOCKS5 por defecto se utiliza para conectarse a pares a través de este tipo de red.</translation>
+    </message>
+    <message>
+        <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
+        <translation type="unfinished">Minimizar en vez de salir de la aplicación cuando la ventana está cerrada. Cuando se activa esta opción, la aplicación sólo se cerrará después de seleccionar Salir en el menú.</translation>
+    </message>
+    <message>
+        <source>Options set in this dialog are overridden by the command line:</source>
+        <translation type="unfinished">Las opciones establecidas en este diálogo serán invalidadas por la línea de comandos:</translation>
+    </message>
+    <message>
+        <source>Open the %1 configuration file from the working directory.</source>
+        <translation type="unfinished">Abrir el archivo de configuración %1 en el directorio de trabajo.</translation>
+    </message>
+    <message>
+        <source>Open Configuration File</source>
+        <translation type="unfinished">Abrir archivo de configuración</translation>
+    </message>
+    <message>
+        <source>Reset all client options to default.</source>
+        <translation type="unfinished">Restablecer todas las opciones del cliente a los valores predeterminados.</translation>
+    </message>
+    <message>
+        <source>&amp;Reset Options</source>
+        <translation type="unfinished">&amp;Restablecer opciones</translation>
     </message>
     <message>
         <source>&amp;Network</source>
         <translation type="unfinished">&amp;Red</translation>
     </message>
     <message>
+        <source>Prune &amp;block storage to</source>
+        <translation type="unfinished">Podar el almacenamiento de &amp;bloques a</translation>
+    </message>
+    <message>
+        <source>Reverting this setting requires re-downloading the entire blockchain.</source>
+        <translation type="unfinished">Revertir estas configuraciones requiere descargar de nuevo la cadena de bloques completa.</translation>
+    </message>
+    <message>
         <source>Maximum database cache size. A larger cache can contribute to faster sync, after which the benefit is less pronounced for most use cases. Lowering the cache size will reduce memory usage. Unused mempool memory is shared for this cache.</source>
         <extracomment>Tooltip text for Options window setting that sets the size of the database cache. Explains the corresponding effects of increasing/decreasing this value.</extracomment>
-        <translation type="unfinished">Tamaño máximo de la caché de la base de datos. Una caché más grande puede contribuir a una sincronización más rápida, después de lo cual el beneficio es menos pronunciado para la mayoría de los casos de uso. Disminuir el tamaño de la caché reducirá el uso de la memoria. La memoria mempool no utilizada se comparte para esta caché.</translation>
+        <translation type="unfinished">Tamaño máximo de la caché de la base de datos. Una caché más grande puede contribuir a una sincronización más rápida, después de lo cual el beneficio es menos pronunciado para la mayoría de los casos de uso. Disminuir el tamaño de la caché reducirá el uso de la memoria. La memoria de la piscina de memoria no utilizada se comparte para esta caché.</translation>
     </message>
     <message>
         <source>Set the number of script verification threads. Negative values correspond to the number of cores you want to leave free to the system.</source>
         <extracomment>Tooltip text for Options window setting that sets the number of script verification threads. Explains that negative values mean to leave these many cores free to the system.</extracomment>
         <translation type="unfinished">Establezca el número de hilos de verificación de scripts. Los valores negativos corresponden al número de núcleos que se desea dejar libres al sistema.</translation>
+    </message>
+    <message>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation type="unfinished">(0 = auto, &lt;0 = deja esa cantidad de núcleos libres)</translation>
     </message>
     <message>
         <source>This allows you or a third party tool to communicate with the node through command-line and JSON-RPC commands.</source>
@@ -1355,9 +2361,13 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
         <translation type="unfinished">Activar servidor R&amp;PC</translation>
     </message>
     <message>
+        <source>W&amp;allet</source>
+        <translation type="unfinished">M&amp;onedero</translation>
+    </message>
+    <message>
         <source>Whether to set subtract fee from amount as default or not.</source>
         <extracomment>Tooltip text for Options window setting that sets subtracting the fee from a sending amount as default.</extracomment>
-        <translation type="unfinished">Establecer si se resta la tasa del importe por defecto o no.</translation>
+        <translation type="unfinished">Establecer si se resta la comisión del importe por defecto o no.</translation>
     </message>
     <message>
         <source>Subtract &amp;fee from amount by default</source>
@@ -1370,37 +2380,45 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     </message>
     <message>
         <source>Enable coin &amp;control features</source>
-        <translation type="unfinished">Habilitar características de &amp;Control de Moneda.</translation>
+        <translation type="unfinished">Habilitar características de &amp;control de moneda.</translation>
     </message>
     <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished">Si deshabilitas el gasto de un cambio no confirmado, el cambio de una transacción no se puede usar hasta que esa transacción tenga al menos una confirmación. Esto también afecta a cómo se calcula tu saldo.</translation>
     </message>
     <message>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation type="unfinished">&amp;Gastar cambio sin confirmar</translation>
+    </message>
+    <message>
         <source>Enable &amp;PSBT controls</source>
         <extracomment>An options window setting to enable PSBT controls.</extracomment>
-        <translation type="unfinished">Activar controles &amp;PSBT</translation>
+        <translation type="unfinished">Activar controles &amp;TBPF</translation>
     </message>
     <message>
         <source>Whether to show PSBT controls.</source>
         <extracomment>Tooltip text for options window setting that enables PSBT controls.</extracomment>
-        <translation type="unfinished">Establecer si se muestran los controles PSBT</translation>
+        <translation type="unfinished">Establecer si se muestran los controles TBPF</translation>
     </message>
     <message>
         <source>External Signer (e.g. hardware wallet)</source>
-        <translation type="unfinished">Dispositivo Externo de Firma (ej. billetera de hardware)</translation>
+        <translation type="unfinished">Dispositivo externo de firma (ej. billetera de hardware)</translation>
     </message>
     <message>
         <source>&amp;External signer script path</source>
-        <translation type="unfinished">&amp;Ruta de script de firma externo</translation>
+        <translation type="unfinished">Ruta de script de firma &amp;externo</translation>
     </message>
     <message>
         <source>Full path to a Bitcoin Core compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</source>
         <translation type="unfinished">Ruta completa al script compatible con Bitcoin Core (ej. C:\Descargas\hwi.exe o /Usuarios/SuUsuario/Descargas/hwi.py). Cuidado: código malicioso podría robarle sus monedas!</translation>
     </message>
     <message>
+        <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
+        <translation type="unfinished">Abrir automáticamente el puerto del cliente Bitcoin en el router. Esta opción solo funciona cuando el router admite UPnP y está activado.</translation>
+    </message>
+    <message>
         <source>Map port using &amp;UPnP</source>
-        <translation type="unfinished">Mapear el puerto usando &amp;UPnp</translation>
+        <translation type="unfinished">Mapear el puerto usando &amp;UPnP</translation>
     </message>
     <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports NAT-PMP and it is enabled. The external port could be random.</source>
@@ -1416,7 +2434,31 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     </message>
     <message>
         <source>Allow incomin&amp;g connections</source>
-        <translation type="unfinished">Permitir conexiones entrantes</translation>
+        <translation type="unfinished">&amp;Permitir conexiones entrantes</translation>
+    </message>
+    <message>
+        <source>Connect to the Bitcoin network through a SOCKS5 proxy.</source>
+        <translation type="unfinished">Conectar a la red de Bitcoin a través de un proxy SOCKS5.</translation>
+    </message>
+    <message>
+        <source>&amp;Connect through SOCKS5 proxy (default proxy):</source>
+        <translation type="unfinished">&amp;Conectar a través del proxy SOCKS5 (proxy predeterminado):</translation>
+    </message>
+    <message>
+        <source>Proxy &amp;IP:</source>
+        <translation type="unfinished">&amp;IP proxy::</translation>
+    </message>
+    <message>
+        <source>&amp;Port:</source>
+        <translation type="unfinished">&amp;Puerto:</translation>
+    </message>
+    <message>
+        <source>Port of the proxy (e.g. 9050)</source>
+        <translation type="unfinished">Puerto del proxy (ej. 9050)</translation>
+    </message>
+    <message>
+        <source>Used for reaching peers via:</source>
+        <translation type="unfinished">Utilizado para llegar a los pares a través de:</translation>
     </message>
     <message>
         <source>&amp;Window</source>
@@ -1424,19 +2466,43 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     </message>
     <message>
         <source>Show the icon in the system tray.</source>
-        <translation type="unfinished">Mostrar el ícono en la bandeja del sistema.</translation>
+        <translation type="unfinished">Mostrar el icono en la bandeja del sistema.</translation>
     </message>
     <message>
         <source>&amp;Show tray icon</source>
-        <translation type="unfinished">Mostrar la bandeja del sistema.</translation>
+        <translation type="unfinished">Mostrar la &amp;bandeja del sistema.</translation>
     </message>
     <message>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation type="unfinished">Mostrar solo un icono de bandeja después de minimizar la ventana.</translation>
     </message>
     <message>
+        <source>&amp;Minimize to the tray instead of the taskbar</source>
+        <translation type="unfinished">&amp;Minimiza a la bandeja en vez de la barra de tareas</translation>
+    </message>
+    <message>
+        <source>M&amp;inimize on close</source>
+        <translation type="unfinished">M&amp;inimizar al cerrar</translation>
+    </message>
+    <message>
         <source>&amp;Display</source>
         <translation type="unfinished">&amp;Mostrar</translation>
+    </message>
+    <message>
+        <source>User Interface &amp;language:</source>
+        <translation type="unfinished">&amp;Idioma de la interfaz de usuario:</translation>
+    </message>
+    <message>
+        <source>The user interface language can be set here. This setting will take effect after restarting %1.</source>
+        <translation type="unfinished">El idioma de la interfaz de usuario puede establecerse aquí. Esta configuración tendrá efecto después de reiniciar %1.</translation>
+    </message>
+    <message>
+        <source>&amp;Unit to show amounts in:</source>
+        <translation type="unfinished">&amp;Unidad en la que mostrar importes:</translation>
+    </message>
+    <message>
+        <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
+        <translation type="unfinished">Elegir la subdivisión predeterminada para mostrar cantidades en la interfaz y cuando se envían monedas.</translation>
     </message>
     <message>
         <source>Third-party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</source>
@@ -1444,7 +2510,11 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     </message>
     <message>
         <source>&amp;Third-party transaction URLs</source>
-        <translation type="unfinished">URLs de transacciones de &amp;Terceros</translation>
+        <translation type="unfinished">URLs de transacciones de &amp;terceros</translation>
+    </message>
+    <message>
+        <source>Whether to show coin control features or not.</source>
+        <translation type="unfinished">Mostrar o no funcionalidad del control de moneda</translation>
     </message>
     <message>
         <source>Connect to the Bitcoin network through a separate SOCKS5 proxy for Tor onion services.</source>
@@ -1452,19 +2522,23 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     </message>
     <message>
         <source>Use separate SOCKS&amp;5 proxy to reach peers via Tor onion services:</source>
-        <translation type="unfinished">Usar proxy SOCKS&amp;5 para alcanzar nodos via servicios ocultos Tor:</translation>
+        <translation type="unfinished">Usar proxy SOCKS&amp;5 para alcanzar nodos vía servicios anónimos Tor:</translation>
     </message>
     <message>
         <source>Monospaced font in the Overview tab:</source>
-        <translation type="unfinished">letra Monospace en la pestaña Resumen: </translation>
+        <translation type="unfinished">Fuente monoespaciada en la pestaña Resumen:</translation>
     </message>
     <message>
         <source>embedded "%1"</source>
-        <translation type="unfinished">incrustado "%1"</translation>
+        <translation type="unfinished">incrustado «%1»</translation>
     </message>
     <message>
         <source>closest matching "%1"</source>
-        <translation type="unfinished">coincidencia más aproximada "%1"</translation>
+        <translation type="unfinished">coincidencia más aproximada «%1»</translation>
+    </message>
+    <message>
+        <source>&amp;Cancel</source>
+        <translation type="unfinished">&amp;Cancelar</translation>
     </message>
     <message>
         <source>Compiled without external signing support (required for external signing)</source>
@@ -1481,20 +2555,33 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     </message>
     <message>
         <source>Confirm options reset</source>
+        <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
         <translation type="unfinished">Confirmar restablecimiento de opciones</translation>
     </message>
     <message>
         <source>Client restart required to activate changes.</source>
+        <extracomment>Text explaining that the settings changed will not come into effect until the client is restarted.</extracomment>
         <translation type="unfinished">Es necesario reiniciar el cliente para activar los cambios.</translation>
     </message>
     <message>
+        <source>Current settings will be backed up at "%1".</source>
+        <extracomment>Text explaining to the user that the client's current settings will be backed up at a specific location. %1 is a stand-in argument for the backup location's path.</extracomment>
+        <translation type="unfinished">Los ajustes actuales se guardarán en «%1».</translation>
+    </message>
+    <message>
         <source>Client will be shut down. Do you want to proceed?</source>
+        <extracomment>Text asking the user to confirm if they would like to proceed with a client shutdown.</extracomment>
         <translation type="unfinished">El cliente se cerrará. ¿Deseas continuar?</translation>
     </message>
     <message>
         <source>Configuration options</source>
         <extracomment>Window title text of pop-up box that allows opening up of configuration file.</extracomment>
         <translation type="unfinished">Opciones de configuración</translation>
+    </message>
+    <message>
+        <source>The configuration file is used to specify advanced user options which override GUI settings. Additionally, any command-line options will override this configuration file.</source>
+        <extracomment>Explanatory text about the priority order of instructions considered by client. The order from high to low being: command-line, configuration file, GUI settings.</extracomment>
+        <translation type="unfinished">El archivo de configuración se utiliza para especificar opciones de usuario avanzadas que anulan la configuración de la GUI. Además, cualquier opción de línea de comandos anulará este archivo de configuración.</translation>
     </message>
     <message>
         <source>Continue</source>
@@ -1518,14 +2605,25 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     </message>
 </context>
 <context>
+    <name>OptionsModel</name>
+    <message>
+        <source>Could not read setting "%1", %2.</source>
+        <translation type="unfinished">No se puede leer el ajuste «%1», %2.</translation>
+    </message>
+</context>
+<context>
     <name>OverviewPage</name>
     <message>
         <source>Form</source>
         <translation type="unfinished">Formulario</translation>
     </message>
     <message>
+        <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
+        <translation type="unfinished">La información mostrada puede estar desactualizada. Su monedero se sincroniza automáticamente con la red de Bitcoin después de establecer una conexión, pero este proceso aún no se ha completado.</translation>
+    </message>
+    <message>
         <source>Watch-only:</source>
-        <translation type="unfinished">Solo lectura:</translation>
+        <translation type="unfinished">Solo observación:</translation>
     </message>
     <message>
         <source>Available:</source>
@@ -1544,24 +2642,44 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
         <translation type="unfinished">Total de transacciones que aún no se han sido confirmadas, y que no son contabilizadas dentro del saldo disponible para gastar</translation>
     </message>
     <message>
+        <source>Immature:</source>
+        <translation type="unfinished">No disponible:</translation>
+    </message>
+    <message>
+        <source>Mined balance that has not yet matured</source>
+        <translation type="unfinished">Saldo recién minado que aún no está disponible</translation>
+    </message>
+    <message>
         <source>Your current total balance</source>
         <translation type="unfinished">Saldo total actual</translation>
     </message>
     <message>
         <source>Your current balance in watch-only addresses</source>
-        <translation type="unfinished">Su saldo actual en direcciones solo-lectura</translation>
+        <translation type="unfinished">Su saldo actual en direcciones de observación</translation>
     </message>
     <message>
         <source>Spendable:</source>
-        <translation type="unfinished">Gastable:</translation>
+        <translation type="unfinished">Disponible:</translation>
     </message>
     <message>
         <source>Recent transactions</source>
         <translation type="unfinished">Transaciones recientes</translation>
     </message>
     <message>
+        <source>Unconfirmed transactions to watch-only addresses</source>
+        <translation type="unfinished">Transacciones sin confirmar a direcciones de observación</translation>
+    </message>
+    <message>
+        <source>Mined balance in watch-only addresses that has not yet matured</source>
+        <translation type="unfinished">Saldo minado en direcciones de observación que aún no está disponible</translation>
+    </message>
+    <message>
+        <source>Current total balance in watch-only addresses</source>
+        <translation type="unfinished">Saldo total actual en direcciones de observación</translation>
+    </message>
+    <message>
         <source>Privacy mode activated for the Overview tab. To unmask the values, uncheck Settings-&gt;Mask values.</source>
-        <translation type="unfinished">Modo de privacidad activado para la pestaña de visión general. Para desenmascarar los valores, desmarcar los valores de Configuración-&gt;Máscara.</translation>
+        <translation type="unfinished">Modo de privacidad activado para la pestaña de visión general. Para desenmascarar los valores, desmarcar los valores de Configuración-&gt;Enmascarar valores.</translation>
     </message>
 </context>
 <context>
@@ -1600,7 +2718,7 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     </message>
     <message>
         <source>Cannot sign inputs while wallet is locked.</source>
-        <translation type="unfinished">No se pueden firmar las entradas mientras la billetera está bloqueada.</translation>
+        <translation type="unfinished">No se pueden firmar las entradas mientras el monedero está bloqueado.</translation>
     </message>
     <message>
         <source>Could not sign any more inputs.</source>
@@ -1628,7 +2746,7 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     </message>
     <message>
         <source>PSBT copied to clipboard.</source>
-        <translation type="unfinished">PSBT copiado al portapapeles</translation>
+        <translation type="unfinished">TBPF copiado al portapapeles</translation>
     </message>
     <message>
         <source>Save Transaction Data</source>
@@ -1641,7 +2759,7 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     </message>
     <message>
         <source>PSBT saved to disk.</source>
-        <translation type="unfinished">PSBT guardado en la memoria.</translation>
+        <translation type="unfinished">TBPF guardado en disco.</translation>
     </message>
     <message>
         <source> * Sends %1 to %2</source>
@@ -1649,7 +2767,7 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     </message>
     <message>
         <source>Unable to calculate transaction fee or total transaction amount.</source>
-        <translation type="unfinished">No se ha podido calcular la comisión por transacción o la totalidad de la cantidad de la transacción.</translation>
+        <translation type="unfinished">No se ha podido calcular la comisión por transacción o la totalidad del importe de la transacción.</translation>
     </message>
     <message>
         <source>Pays transaction fee: </source>
@@ -1657,7 +2775,7 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     </message>
     <message>
         <source>Total Amount</source>
-        <translation type="unfinished">Cantidad Total</translation>
+        <translation type="unfinished">Importe total</translation>
     </message>
     <message>
         <source>or</source>
@@ -1693,11 +2811,27 @@ Firmar solo es posible con direcciones del tipo Legacy.</translation>
     </message>
     <message>
         <source>Transaction status is unknown.</source>
-        <translation type="unfinished">El estatus de la transacción es desconocido.</translation>
+        <translation type="unfinished">El estado de la transacción es desconocido.</translation>
     </message>
 </context>
 <context>
     <name>PaymentServer</name>
+    <message>
+        <source>Payment request error</source>
+        <translation type="unfinished">Error en la solicitud de pago</translation>
+    </message>
+    <message>
+        <source>Cannot start bitcoin: click-to-pay handler</source>
+        <translation type="unfinished">No se puede iniciar bitcoin: controlador clic-para-pagar</translation>
+    </message>
+    <message>
+        <source>URI handling</source>
+        <translation type="unfinished">Gestión de URI</translation>
+    </message>
+    <message>
+        <source>'bitcoin://' is not a valid URI. Use 'bitcoin:' instead.</source>
+        <translation type="unfinished">«bitcoin: //» no es un URI válido. Use «bitcoin:» en su lugar.</translation>
+    </message>
     <message>
         <source>Cannot process payment request because BIP70 is not supported.
 Due to widespread security flaws in BIP70 it's strongly recommended that any merchant instructions to switch wallets be ignored.
@@ -1706,13 +2840,36 @@ If you are receiving this error you should request the merchant provide a BIP21 
 Debido a los fallos de seguridad generalizados en el BIP70, se recomienda encarecidamente ignorar las instrucciones del comerciante para cambiar de monedero.
 Si recibe este error, debe solicitar al comerciante que le proporcione un URI compatible con BIP21.</translation>
     </message>
-    </context>
+    <message>
+        <source>URI cannot be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
+        <translation type="unfinished">¡No se puede interpretar la URI! Esto puede deberse a una dirección Bitcoin inválida o a parámetros de URI mal formados.</translation>
+    </message>
+    <message>
+        <source>Payment request file handling</source>
+        <translation type="unfinished">Gestión del archivo de solicitud de pago</translation>
+    </message>
+</context>
 <context>
     <name>PeerTableModel</name>
+    <message>
+        <source>User Agent</source>
+        <extracomment>Title of Peers Table column which contains the peer's User Agent string.</extracomment>
+        <translation type="unfinished">Agente del usuario</translation>
+    </message>
     <message>
         <source>Peer</source>
         <extracomment>Title of Peers Table column which contains a unique number used to identify a connection.</extracomment>
         <translation type="unfinished">Pares</translation>
+    </message>
+    <message>
+        <source>Age</source>
+        <extracomment>Title of Peers Table column which indicates the duration (length of time) since the peer connection started.</extracomment>
+        <translation type="unfinished">Duración</translation>
+    </message>
+    <message>
+        <source>Direction</source>
+        <extracomment>Title of Peers Table column which indicates the direction the peer connection was initiated from.</extracomment>
+        <translation type="unfinished">Sentido</translation>
     </message>
     <message>
         <source>Sent</source>
@@ -1730,11 +2887,26 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
         <translation type="unfinished">Dirección</translation>
     </message>
     <message>
+        <source>Type</source>
+        <extracomment>Title of Peers Table column which describes the type of peer connection. The "type" describes why the connection exists.</extracomment>
+        <translation type="unfinished">Tipo</translation>
+    </message>
+    <message>
         <source>Network</source>
         <extracomment>Title of Peers Table column which states the network the peer connected through.</extracomment>
         <translation type="unfinished">Red</translation>
     </message>
-    </context>
+    <message>
+        <source>Inbound</source>
+        <extracomment>An Inbound Connection from a Peer.</extracomment>
+        <translation type="unfinished">Entrante</translation>
+    </message>
+    <message>
+        <source>Outbound</source>
+        <extracomment>An Outbound Connection to a Peer.</extracomment>
+        <translation type="unfinished">Saliente</translation>
+    </message>
+</context>
 <context>
     <name>QRImageWidget</name>
     <message>
@@ -1746,6 +2918,10 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
         <translation type="unfinished">&amp;Copiar Imagen</translation>
     </message>
     <message>
+        <source>Resulting URI too long, try to reduce the text for label / message.</source>
+        <translation type="unfinished">URI resultante demasiado larga. Intente reducir el texto de la etiqueta / mensaje.</translation>
+    </message>
+    <message>
         <source>Error encoding URI into QR Code.</source>
         <translation type="unfinished">Fallo al codificar URI en código QR.</translation>
     </message>
@@ -1755,7 +2931,7 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>Save QR Code</source>
-        <translation type="unfinished">Guardar Código QR</translation>
+        <translation type="unfinished">Guardar código QR</translation>
     </message>
     <message>
         <source>PNG Image</source>
@@ -1771,11 +2947,23 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>Client version</source>
-        <translation type="unfinished">Versión del Cliente</translation>
+        <translation type="unfinished">Versión del cliente</translation>
     </message>
     <message>
         <source>&amp;Information</source>
         <translation type="unfinished">&amp;Información</translation>
+    </message>
+    <message>
+        <source>To specify a non-default location of the data directory use the '%1' option.</source>
+        <translation type="unfinished">Para especificar una localización personalizada del directorio de datos, usa la opción «%1».</translation>
+    </message>
+    <message>
+        <source>To specify a non-default location of the blocks directory use the '%1' option.</source>
+        <translation type="unfinished">Para especificar una localización personalizada del directorio de bloques, usa la opción «%1». </translation>
+    </message>
+    <message>
+        <source>Startup time</source>
+        <translation type="unfinished">Hora de inicio</translation>
     </message>
     <message>
         <source>Network</source>
@@ -1794,6 +2982,10 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
         <translation type="unfinished">Cadena de bloques</translation>
     </message>
     <message>
+        <source>Memory Pool</source>
+        <translation type="unfinished">Piscina de memoria</translation>
+    </message>
+    <message>
         <source>Current number of transactions</source>
         <translation type="unfinished">Número actual de transacciones</translation>
     </message>
@@ -1803,7 +2995,7 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>Wallet: </source>
-        <translation type="unfinished">Monedero</translation>
+        <translation type="unfinished">Monedero:</translation>
     </message>
     <message>
         <source>(none)</source>
@@ -1823,46 +3015,89 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>&amp;Peers</source>
-        <translation type="unfinished">Pares</translation>
+        <translation type="unfinished">&amp;Pares</translation>
+    </message>
+    <message>
+        <source>Banned peers</source>
+        <translation type="unfinished">Pares bloqueados</translation>
+    </message>
+    <message>
+        <source>Select a peer to view detailed information.</source>
+        <translation type="unfinished">Selecciona un par para ver la información detallada.</translation>
     </message>
     <message>
         <source>Version</source>
         <translation type="unfinished">Versión</translation>
     </message>
     <message>
+        <source>Starting Block</source>
+        <translation type="unfinished">Bloque de inicio</translation>
+    </message>
+    <message>
+        <source>Synced Headers</source>
+        <translation type="unfinished">Encabezados sincronizados</translation>
+    </message>
+    <message>
+        <source>Synced Blocks</source>
+        <translation type="unfinished">Bloques sincronizados</translation>
+    </message>
+    <message>
         <source>Last Transaction</source>
         <translation type="unfinished">Última transacción</translation>
     </message>
     <message>
+        <source>The mapped Autonomous System used for diversifying peer selection.</source>
+        <translation type="unfinished">El Sistema Autónomo mapeado utilizado para la selección diversificada de pares.</translation>
+    </message>
+    <message>
+        <source>Mapped AS</source>
+        <translation type="unfinished">SA Mapeado</translation>
+    </message>
+    <message>
         <source>Whether we relay addresses to this peer.</source>
-        <extracomment>Tooltip text for the Address Relay field in the peer details area.</extracomment>
-        <translation type="unfinished">Si retransmitimos las direcciones a este peer.</translation>
+        <extracomment>Tooltip text for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
+        <translation type="unfinished">Si retransmitimos las direcciones a este par.</translation>
     </message>
     <message>
         <source>Address Relay</source>
-        <translation type="unfinished">Transimisión de la dirección</translation>
+        <extracomment>Text title for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
+        <translation type="unfinished">Transmisión de la dirección</translation>
     </message>
     <message>
-        <source>Total number of addresses processed, excluding those dropped due to rate-limiting.</source>
-        <extracomment>Tooltip text for the Addresses Processed field in the peer details area.</extracomment>
-        <translation type="unfinished">Número total de direcciones procesadas, excluyendo las descartadas por limitación de tasa</translation>
+        <source>The total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</source>
+        <extracomment>Tooltip text for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
+        <translation type="unfinished">El número total de direcciones recibidas desde este par que han sido procesadas (excluyendo las direcciones que han sido desestimadas debido a la limitación de velocidad).</translation>
+    </message>
+    <message>
+        <source>The total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</source>
+        <extracomment>Tooltip text for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
+        <translation type="unfinished">El número total de direcciones recibidas desde este par que han sido desestimadas (no procesadas) debido a la limitación de velocidad.</translation>
     </message>
     <message>
         <source>Addresses Processed</source>
+        <extracomment>Text title for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
         <translation type="unfinished">Direcciones procesadas</translation>
     </message>
     <message>
-        <source>Total number of addresses dropped due to rate-limiting.</source>
-        <extracomment>Tooltip text for the Addresses Rate-Limited field in the peer details area.</extracomment>
-        <translation type="unfinished">Número total de direcciones descartadas por límite de tasa</translation>
+        <source>Addresses Rate-Limited</source>
+        <extracomment>Text title for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
+        <translation type="unfinished">Direcciones con límite de ratio</translation>
     </message>
     <message>
-        <source>Addresses Rate-Limited</source>
-        <translation type="unfinished">Direcciones con límite de tasa</translation>
+        <source>User Agent</source>
+        <translation type="unfinished">Agente del usuario</translation>
+    </message>
+    <message>
+        <source>Node window</source>
+        <translation type="unfinished">Ventana del nodo</translation>
     </message>
     <message>
         <source>Current block height</source>
         <translation type="unfinished">Altura del bloque actual</translation>
+    </message>
+    <message>
+        <source>Open the %1 debug log file from the current data directory. This can take a few seconds for large log files.</source>
+        <translation type="unfinished">Abra el archivo de registro de depuración %1 del directorio de datos actual. Esto puede tomar unos segundos para archivos de registro grandes.</translation>
     </message>
     <message>
         <source>Decrease font size</source>
@@ -1886,8 +3121,7 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>The network protocol this peer is connected through: IPv4, IPv6, Onion, I2P, or CJDNS.</source>
-        <translation type="unfinished">El protocolo de red de este par está conectado a través de:
- IPv4, IPv6, Onion, I2P, o CJDNS.</translation>
+        <translation type="unfinished">El protocolo de red de este par está conectado a través de: IPv4, IPv6, Onion, I2P, o CJDNS.</translation>
     </message>
     <message>
         <source>Services</source>
@@ -1895,7 +3129,7 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>Whether the peer requested us to relay transactions.</source>
-        <translation type="unfinished">Si el peer nos solicitó que transmitiéramos las transacciones.</translation>
+        <translation type="unfinished">Si el par nos solicitó que transmitiéramos las transacciones.</translation>
     </message>
     <message>
         <source>Wants Tx Relay</source>
@@ -1907,7 +3141,7 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>High Bandwidth</source>
-        <translation type="unfinished">banda ancha</translation>
+        <translation type="unfinished">Banda ancha</translation>
     </message>
     <message>
         <source>Connection Time</source>
@@ -1919,12 +3153,76 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
     </message>
     <message>
         <source>Last Block</source>
-        <translation type="unfinished">Último Bloque</translation>
+        <translation type="unfinished">Último bloque</translation>
     </message>
     <message>
         <source>Elapsed time since a novel transaction accepted into our mempool was received from this peer.</source>
         <extracomment>Tooltip text for the Last Transaction field in the peer details area.</extracomment>
-        <translation type="unfinished">Tiempo transcurrido desde que se recibió de este par una nueva transacción aceptada en nuestro mempool.</translation>
+        <translation type="unfinished">Tiempo transcurrido desde que se recibió de este par una nueva transacción aceptada en nuestra piscina de memoria.</translation>
+    </message>
+    <message>
+        <source>Last Send</source>
+        <translation type="unfinished">Último envío</translation>
+    </message>
+    <message>
+        <source>Last Receive</source>
+        <translation type="unfinished">Última recepción</translation>
+    </message>
+    <message>
+        <source>Ping Time</source>
+        <translation type="unfinished">Tiempo de ping</translation>
+    </message>
+    <message>
+        <source>The duration of a currently outstanding ping.</source>
+        <translation type="unfinished">La duración de un ping actualmente pendiente.</translation>
+    </message>
+    <message>
+        <source>Ping Wait</source>
+        <translation type="unfinished">Espera de ping</translation>
+    </message>
+    <message>
+        <source>Min Ping</source>
+        <translation type="unfinished">Ping mínimo</translation>
+    </message>
+    <message>
+        <source>Time Offset</source>
+        <translation type="unfinished">Desplazamiento de tiempo</translation>
+    </message>
+    <message>
+        <source>Last block time</source>
+        <translation type="unfinished">Hora del último bloque</translation>
+    </message>
+    <message>
+        <source>&amp;Open</source>
+        <translation type="unfinished">&amp;Abrir</translation>
+    </message>
+    <message>
+        <source>&amp;Console</source>
+        <translation type="unfinished">&amp;Consola</translation>
+    </message>
+    <message>
+        <source>&amp;Network Traffic</source>
+        <translation type="unfinished">&amp;Tráfico de Red</translation>
+    </message>
+    <message>
+        <source>Totals</source>
+        <translation type="unfinished">Totales</translation>
+    </message>
+    <message>
+        <source>Debug log file</source>
+        <translation type="unfinished">Archivo de registro de depuración</translation>
+    </message>
+    <message>
+        <source>Clear console</source>
+        <translation type="unfinished">Limpiar consola</translation>
+    </message>
+    <message>
+        <source>In:</source>
+        <translation type="unfinished">Entrada:</translation>
+    </message>
+    <message>
+        <source>Out:</source>
+        <translation type="unfinished">Salida:</translation>
     </message>
     <message>
         <source>Inbound: initiated by peer</source>
@@ -1978,8 +3276,12 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
         <translation type="unfinished">&amp;Desconectar</translation>
     </message>
     <message>
+        <source>1 &amp;hour</source>
+        <translation type="unfinished">1 &amp;hora</translation>
+    </message>
+    <message>
         <source>1 d&amp;ay</source>
-        <translation type="unfinished">1 día</translation>
+        <translation type="unfinished">1 &amp;día</translation>
     </message>
     <message>
         <source>1 &amp;week</source>
@@ -1995,8 +3297,20 @@ Si recibe este error, debe solicitar al comerciante que le proporcione un URI co
         <translation type="unfinished">&amp;Copiar IP/Mascara de red</translation>
     </message>
     <message>
+        <source>&amp;Unban</source>
+        <translation type="unfinished">&amp;Desbloquear</translation>
+    </message>
+    <message>
         <source>Network activity disabled</source>
         <translation type="unfinished">Actividad de red desactivada</translation>
+    </message>
+    <message>
+        <source>Executing command without any wallet</source>
+        <translation type="unfinished">Ejecutar comando sin monedero</translation>
+    </message>
+    <message>
+        <source>Executing command using "%1" wallet</source>
+        <translation type="unfinished">Ejecutar comando usando monedero «%1»</translation>
     </message>
     <message>
         <source>Welcome to the %1 RPC console.
@@ -2012,7 +3326,7 @@ For more information on using this console, type %6.
 Utiliza %3 y %4 para aumentar o disminuir el tamaño de la fuente. 
 Escribe %5 para ver un resumen de los comandos disponibles. Para más información sobre cómo usar esta consola, escribe %6.
 
-%7AVISO: Los estafadores han estado activos diciendo a los usuarios que escriban comandos aquí, robando el contenido de sus carteras. No uses esta consola sin entender completamente las ramificaciones de un comando.%8</translation>
+%7 AVISO: Los estafadores han estado activos diciendo a los usuarios que escriban comandos aquí, robando el contenido de sus monederos. No uses esta consola sin entender completamente las ramificaciones de un comando.%8</translation>
     </message>
     <message>
         <source>Executing…</source>
@@ -2040,6 +3354,10 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
         <translation type="unfinished">De</translation>
     </message>
     <message>
+        <source>Ban for</source>
+        <translation type="unfinished">Bloqueo para</translation>
+    </message>
+    <message>
         <source>Never</source>
         <translation type="unfinished">Nunca</translation>
     </message>
@@ -2052,7 +3370,7 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
     <name>ReceiveCoinsDialog</name>
     <message>
         <source>&amp;Amount:</source>
-        <translation type="unfinished">&amp;Cantidad</translation>
+        <translation type="unfinished">&amp;Importe</translation>
     </message>
     <message>
         <source>&amp;Label:</source>
@@ -2063,8 +3381,48 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
         <translation type="unfinished">&amp;Mensaje</translation>
     </message>
     <message>
+        <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
+        <translation type="unfinished">Mensaje opcional para agregar a la solicitud de pago, el cual será mostrado cuando la solicitud esté abierta. Nota: El mensaje no se enviará con el pago a través de la red de Bitcoin.</translation>
+    </message>
+    <message>
+        <source>An optional label to associate with the new receiving address.</source>
+        <translation type="unfinished">Etiqueta opcional para asociar con la nueva dirección de recepción.</translation>
+    </message>
+    <message>
+        <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
+        <translation type="unfinished">Usa este formulario para solicitar un pago. Todos los campos son &lt;b&gt;opcionales&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
+        <translation type="unfinished">Un importe opcional para solicitar. Deje esto vacío o en cero para no solicitar una cantidad específica.</translation>
+    </message>
+    <message>
+        <source>An optional label to associate with the new receiving address (used by you to identify an invoice).  It is also attached to the payment request.</source>
+        <translation type="unfinished">Etiqueta opcional para asociar con la nueva dirección de recepción (utilizado por ti para identificar una factura). También esta asociado a la solicitud de pago.</translation>
+    </message>
+    <message>
+        <source>An optional message that is attached to the payment request and may be displayed to the sender.</source>
+        <translation type="unfinished">Mensaje opcional asociado a la solicitud de pago que podría ser presentado al remitente </translation>
+    </message>
+    <message>
+        <source>&amp;Create new receiving address</source>
+        <translation type="unfinished">&amp;Crear una nueva dirección de recepción</translation>
+    </message>
+    <message>
+        <source>Clear all fields of the form.</source>
+        <translation type="unfinished">Limpiar todos los campos del formulario.</translation>
+    </message>
+    <message>
         <source>Clear</source>
         <translation type="unfinished">Limpiar</translation>
+    </message>
+    <message>
+        <source>Requested payments history</source>
+        <translation type="unfinished">Historial de pagos solicitados</translation>
+    </message>
+    <message>
+        <source>Show the selected request (does the same as double clicking an entry)</source>
+        <translation type="unfinished">Mostrar la solicitud seleccionada (hace lo mismo que hacer doble clic en una entrada)</translation>
     </message>
     <message>
         <source>Show</source>
@@ -2096,7 +3454,11 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
     </message>
     <message>
         <source>Copy &amp;amount</source>
-        <translation type="unfinished">Copiar &amp;cantidad</translation>
+        <translation type="unfinished">Copiar &amp;importe</translation>
+    </message>
+    <message>
+        <source>Could not unlock wallet.</source>
+        <translation type="unfinished">No se pudo desbloquear el monedero.</translation>
     </message>
     <message>
         <source>Could not generate new %1 address</source>
@@ -2115,7 +3477,7 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
     </message>
     <message>
         <source>Amount:</source>
-        <translation type="unfinished">Cantidad:</translation>
+        <translation type="unfinished">Importe:</translation>
     </message>
     <message>
         <source>Label:</source>
@@ -2130,8 +3492,12 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
         <translation type="unfinished">Monedero:</translation>
     </message>
     <message>
+        <source>Copy &amp;URI</source>
+        <translation type="unfinished">Copiar &amp;URI</translation>
+    </message>
+    <message>
         <source>Copy &amp;Address</source>
-        <translation type="unfinished">Copiar &amp;Dirección</translation>
+        <translation type="unfinished">Copiar &amp;dirección</translation>
     </message>
     <message>
         <source>&amp;Verify</source>
@@ -2139,7 +3505,7 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
     </message>
     <message>
         <source>Verify this address on e.g. a hardware wallet screen</source>
-        <translation type="unfinished">Verifica esta dirección en la pantalla de tu billetera fría u otro dispositivo</translation>
+        <translation type="unfinished">Verifica esta dirección en la pantalla de tu monedero frío u otro dispositivo</translation>
     </message>
     <message>
         <source>&amp;Save Image…</source>
@@ -2149,9 +3515,17 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
         <source>Payment information</source>
         <translation type="unfinished">Información del pago</translation>
     </message>
-    </context>
+    <message>
+        <source>Request payment to %1</source>
+        <translation type="unfinished">Solicitar pago a %1</translation>
+    </message>
+</context>
 <context>
     <name>RecentRequestsTableModel</name>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">Fecha</translation>
+    </message>
     <message>
         <source>Label</source>
         <translation type="unfinished">Etiqueta</translation>
@@ -2164,7 +3538,19 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
         <source>(no label)</source>
         <translation type="unfinished">(sin etiqueta)</translation>
     </message>
-    </context>
+    <message>
+        <source>(no message)</source>
+        <translation type="unfinished">(sin mensaje)</translation>
+    </message>
+    <message>
+        <source>(no amount requested)</source>
+        <translation type="unfinished">(sin importe solicitado)</translation>
+    </message>
+    <message>
+        <source>Requested</source>
+        <translation type="unfinished">Solicitado</translation>
+    </message>
+</context>
 <context>
     <name>SendCoinsDialog</name>
     <message>
@@ -2173,7 +3559,7 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
     </message>
     <message>
         <source>Coin Control Features</source>
-        <translation type="unfinished">Características de control de la moneda</translation>
+        <translation type="unfinished">Características de control de moneda</translation>
     </message>
     <message>
         <source>automatically selected</source>
@@ -2189,7 +3575,7 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
     </message>
     <message>
         <source>Amount:</source>
-        <translation type="unfinished">Cuantía:</translation>
+        <translation type="unfinished">Importe:</translation>
     </message>
     <message>
         <source>Fee:</source>
@@ -2204,16 +3590,60 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
         <translation type="unfinished">Cambio:</translation>
     </message>
     <message>
+        <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
+        <translation type="unfinished">Al activarse, si la dirección esta vacía o es inválida, las monedas serán enviadas a una nueva dirección generada.</translation>
+    </message>
+    <message>
+        <source>Custom change address</source>
+        <translation type="unfinished">Dirección de cambio personalizada</translation>
+    </message>
+    <message>
+        <source>Transaction Fee:</source>
+        <translation type="unfinished">Comisión de transacción:</translation>
+    </message>
+    <message>
         <source>Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until you have validated the complete chain.</source>
         <translation type="unfinished">Si utilizas la comisión por defecto, la transacción puede tardar varias horas o incluso días (o nunca) en confirmarse. Considera elegir la comisión de forma manual o espera hasta que se haya validado completamente la cadena.</translation>
+    </message>
+    <message>
+        <source>Warning: Fee estimation is currently not possible.</source>
+        <translation type="unfinished">Advertencia: En este momento no se puede estimar la comisión.</translation>
     </message>
     <message>
         <source>per kilobyte</source>
         <translation type="unfinished">por kilobyte</translation>
     </message>
     <message>
+        <source>Hide</source>
+        <translation type="unfinished">Ocultar</translation>
+    </message>
+    <message>
+        <source>Recommended:</source>
+        <translation type="unfinished">Recomendado:</translation>
+    </message>
+    <message>
+        <source>Custom:</source>
+        <translation type="unfinished">Personalizado:</translation>
+    </message>
+    <message>
+        <source>Send to multiple recipients at once</source>
+        <translation type="unfinished">Enviar a múltiples destinatarios a la vez</translation>
+    </message>
+    <message>
+        <source>Add &amp;Recipient</source>
+        <translation type="unfinished">Agrega &amp;destinatario</translation>
+    </message>
+    <message>
+        <source>Clear all fields of the form.</source>
+        <translation type="unfinished">Limpiar todos los campos del formulario.</translation>
+    </message>
+    <message>
         <source>Inputs…</source>
         <translation type="unfinished">Entradas...</translation>
+    </message>
+    <message>
+        <source>Dust:</source>
+        <translation type="unfinished">Polvo:</translation>
     </message>
     <message>
         <source>Choose…</source>
@@ -2221,15 +3651,19 @@ Escribe %5 para ver un resumen de los comandos disponibles. Para más informaci�
     </message>
     <message>
         <source>Hide transaction fee settings</source>
-        <translation type="unfinished">Ocultar ajustes de tarifas de transacción</translation>
+        <translation type="unfinished">Ocultar ajustes de comisión de transacción</translation>
     </message>
     <message>
         <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
 
 Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satoshis per kvB" for a transaction size of 500 virtual bytes (half of 1 kvB) would ultimately yield a fee of only 50 satoshis.</source>
-        <translation type="unfinished">Especifica una tarifa personalizada por kB (1.000 bytes) del tamaño virtual de la transacción.
+        <translation type="unfinished">Especifica una comisión personalizada por kB (1.000 bytes) del tamaño virtual de la transacción.
 
-Nota: Dado que la tasa se calcula por cada byte, una tasa de "100 satoshis por kvB" para una transacción de 500 bytes virtuales (la mitad de 1 kvB), supondría finalmente una tasa de sólo 50 satoshis.</translation>
+Nota: Dado que la comisión se calcula por cada byte, una tasa de «100 satoshis por kvB» para una transacción de 500 bytes virtuales (la mitad de 1 kvB), supondría finalmente una comisión de sólo 50 satoshis.</translation>
+    </message>
+    <message>
+        <source>When there is less transaction volume than space in the blocks, miners as well as relaying nodes may enforce a minimum fee. Paying only this minimum fee is just fine, but be aware that this can result in a never confirming transaction once there is more demand for bitcoin transactions than the network can process.</source>
+        <translation type="unfinished">Cuando hay menos volumen de transacciones que espacio en los bloques, los mineros y los nodos de retransmisión pueden imponer una comisión mínima. Pagar solo esta comisión mínima está bien, pero tenga en cuenta que esto puede resultar en una transacción nunca confirmada una vez que haya más demanda de transacciones de Bitcoin de la que la red puede procesar.</translation>
     </message>
     <message>
         <source>A too low fee might result in a never confirming transaction (read the tooltip)</source>
@@ -2238,6 +3672,66 @@ Nota: Dado que la tasa se calcula por cada byte, una tasa de "100 satoshis por k
     <message>
         <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
         <translation type="unfinished">(Comisión inteligente no inicializada todavía. Esto normalmente tarda unos pocos bloques…)</translation>
+    </message>
+    <message>
+        <source>Confirmation time target:</source>
+        <translation type="unfinished">Objetivo de tiempo de confirmación</translation>
+    </message>
+    <message>
+        <source>Enable Replace-By-Fee</source>
+        <translation type="unfinished">Habilitar Replace-By-Fee</translation>
+    </message>
+    <message>
+        <source>With Replace-By-Fee (BIP-125) you can increase a transaction's fee after it is sent. Without this, a higher fee may be recommended to compensate for increased transaction delay risk.</source>
+        <translation type="unfinished">Con Replace-By-Fee (BIP-125) puede incrementar la comisión después de haber enviado la transacción. Si no utiliza esto, se recomienda que añada una comisión mayor para compensar el riesgo adicional de que la transacción se retrase.</translation>
+    </message>
+    <message>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished">Limpiar &amp;todo</translation>
+    </message>
+    <message>
+        <source>Balance:</source>
+        <translation type="unfinished">Saldo:</translation>
+    </message>
+    <message>
+        <source>Confirm the send action</source>
+        <translation type="unfinished">Confirmar el envío</translation>
+    </message>
+    <message>
+        <source>S&amp;end</source>
+        <translation type="unfinished">&amp;Enviar</translation>
+    </message>
+    <message>
+        <source>Copy quantity</source>
+        <translation type="unfinished">Copiar cantidad</translation>
+    </message>
+    <message>
+        <source>Copy amount</source>
+        <translation type="unfinished">Copiar importe</translation>
+    </message>
+    <message>
+        <source>Copy fee</source>
+        <translation type="unfinished">Copiar comisión</translation>
+    </message>
+    <message>
+        <source>Copy after fee</source>
+        <translation type="unfinished">Copiar después de la comisión</translation>
+    </message>
+    <message>
+        <source>Copy bytes</source>
+        <translation type="unfinished">Copiar bytes</translation>
+    </message>
+    <message>
+        <source>Copy dust</source>
+        <translation type="unfinished">Copiar polvo</translation>
+    </message>
+    <message>
+        <source>Copy change</source>
+        <translation type="unfinished">Copiar cambio</translation>
+    </message>
+    <message>
+        <source>%1 (%2 blocks)</source>
+        <translation type="unfinished">%1 (%2 bloques)</translation>
     </message>
     <message>
         <source>Sign on device</source>
@@ -2254,8 +3748,28 @@ Nota: Dado que la tasa se calcula por cada byte, una tasa de "100 satoshis por k
         <translation type="unfinished">Configura una ruta externa al script en Opciones -&gt; Monedero</translation>
     </message>
     <message>
+        <source>Cr&amp;eate Unsigned</source>
+        <translation type="unfinished">Cr&amp;ear sin firmar</translation>
+    </message>
+    <message>
+        <source>Creates a Partially Signed Bitcoin Transaction (PSBT) for use with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
+        <translation type="unfinished">Crea una Transacción de Bitcoin Parcialmente Firmada (TBPF) para uso con p.ej. un monedero fuera de linea %1, o un monedero de hardware compatible con TBPF</translation>
+    </message>
+    <message>
+        <source> from wallet '%1'</source>
+        <translation type="unfinished">desde monedero «%1»</translation>
+    </message>
+    <message>
+        <source>%1 to '%2'</source>
+        <translation type="unfinished">%1 a «%2»</translation>
+    </message>
+    <message>
+        <source>%1 to %2</source>
+        <translation type="unfinished">%1 a %2</translation>
+    </message>
+    <message>
         <source>To review recipient list click "Show Details…"</source>
-        <translation type="unfinished">Para ver la lista de receptores haga clic en "Mostrar detalles"</translation>
+        <translation type="unfinished">Para ver la lista de receptores haga clic en «Mostrar detalles...»</translation>
     </message>
     <message>
         <source>Sign failed</source>
@@ -2282,7 +3796,7 @@ Nota: Dado que la tasa se calcula por cada byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>PSBT saved</source>
-        <translation type="unfinished">PSBT guardado </translation>
+        <translation type="unfinished">TBPF guardado </translation>
     </message>
     <message>
         <source>External balance:</source>
@@ -2293,6 +3807,10 @@ Nota: Dado que la tasa se calcula por cada byte, una tasa de "100 satoshis por k
         <translation type="unfinished">o</translation>
     </message>
     <message>
+        <source>You can increase the fee later (signals Replace-By-Fee, BIP-125).</source>
+        <translation type="unfinished">Puede incrementar la comisión más tarde (use Replace-By-Fee, BIP-125).</translation>
+    </message>
+    <message>
         <source>Please, review your transaction proposal. This will produce a Partially Signed Bitcoin Transaction (PSBT) which you can save or copy and then sign with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
         <extracomment>Text to inform a user attempting to create a transaction of their current options. At this stage, a user can only create a PSBT. This string is displayed when private keys are disabled and an external signer is not available.</extracomment>
         <translation type="unfinished">Por favor, revisa tu propuesta de transacción. Esto producirá una Transacción de Bitcoin Parcialmente Firmada (TBPF) que puedes guardar o copiar y después firmar p.ej. un monedero fuera de línea %1, o un monedero de hardware compatible con TBPF.</translation>
@@ -2300,12 +3818,12 @@ Nota: Dado que la tasa se calcula por cada byte, una tasa de "100 satoshis por k
     <message>
         <source>Do you want to create this transaction?</source>
         <extracomment>Message displayed when attempting to create a transaction. Cautionary text to prompt the user to verify that the displayed transaction details represent the transaction the user intends to create.</extracomment>
-        <translation type="unfinished">Deseas crear esta transacción?</translation>
+        <translation type="unfinished">¿Deseas crear esta transacción?</translation>
     </message>
     <message>
         <source>Please, review your transaction. You can create and send this transaction or create a Partially Signed Bitcoin Transaction (PSBT), which you can save or copy and then sign with, e.g., an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
         <extracomment>Text to inform a user attempting to create a transaction of their current options. At this stage, a user can send their transaction or create a PSBT. This string is displayed when both private keys and PSBT controls are enabled.</extracomment>
-        <translation type="unfinished">Por favor, revisa tu transacción. Puedes crear y enviar esta transacción o crear una Transacción Bitcoin Parcialmente Firmada (PSBT), que puedes guardar o copiar y luego firmar con, por ejemplo, un monedero %1 offline o un monedero hardware compatible con PSBT.</translation>
+        <translation type="unfinished">Por favor, revisa tu transacción. Puedes crear y enviar esta transacción o crear una Transacción Bitcoin Parcialmente Firmada (TBPF), que puedes guardar o copiar y luego firmar con, por ejemplo, un monedero %1 offline o un monedero hardware compatible con TBPF.</translation>
     </message>
     <message>
         <source>Please, review your transaction.</source>
@@ -2317,15 +3835,71 @@ Nota: Dado que la tasa se calcula por cada byte, una tasa de "100 satoshis por k
         <translation type="unfinished">Comisión por transacción.</translation>
     </message>
     <message>
+        <source>Not signalling Replace-By-Fee, BIP-125.</source>
+        <translation type="unfinished">No usa Replace-By-Fee, BIP-125.</translation>
+    </message>
+    <message>
         <source>Total Amount</source>
-        <translation type="unfinished">Cantidad total</translation>
+        <translation type="unfinished">Importe total</translation>
+    </message>
+    <message>
+        <source>Confirm send coins</source>
+        <translation type="unfinished">Confirmar el envío de monedas</translation>
+    </message>
+    <message>
+        <source>Watch-only balance:</source>
+        <translation type="unfinished">Balance solo observación:</translation>
+    </message>
+    <message>
+        <source>The recipient address is not valid. Please recheck.</source>
+        <translation type="unfinished">La dirección de envío no es válida. Por favor revísela.</translation>
+    </message>
+    <message>
+        <source>The amount to pay must be larger than 0.</source>
+        <translation type="unfinished">El importe a pagar debe ser mayor que 0.</translation>
+    </message>
+    <message>
+        <source>The amount exceeds your balance.</source>
+        <translation type="unfinished">El importe sobrepasa su saldo.</translation>
+    </message>
+    <message>
+        <source>The total exceeds your balance when the %1 transaction fee is included.</source>
+        <translation type="unfinished">El total sobrepasa su saldo cuando se incluye la comisión de envío de %1.</translation>
+    </message>
+    <message>
+        <source>Duplicate address found: addresses should only be used once each.</source>
+        <translation type="unfinished">Dirección duplicada encontrada: las direcciones sólo deben ser utilizadas una vez.</translation>
+    </message>
+    <message>
+        <source>Transaction creation failed!</source>
+        <translation type="unfinished">¡Fallo al crear la transacción!</translation>
+    </message>
+    <message>
+        <source>A fee higher than %1 is considered an absurdly high fee.</source>
+        <translation type="unfinished">Una comisión mayor que %1 se considera como una comisión absurdamente alta.</translation>
     </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>Estimado para comenzar confirmación dentro de %n bloque.</numerusform>
+            <numerusform>Estimado para comenzar confirmación dentro de %n bloques.</numerusform>
         </translation>
+    </message>
+    <message>
+        <source>Warning: Invalid Bitcoin address</source>
+        <translation type="unfinished">Alerta: Dirección de Bitcoin inválida</translation>
+    </message>
+    <message>
+        <source>Warning: Unknown change address</source>
+        <translation type="unfinished">Alerta: Dirección de cambio desconocida</translation>
+    </message>
+    <message>
+        <source>Confirm custom change address</source>
+        <translation type="unfinished">Confirmar dirección de cambio personalizada</translation>
+    </message>
+    <message>
+        <source>The address you selected for change is not part of this wallet. Any or all funds in your wallet may be sent to this address. Are you sure?</source>
+        <translation type="unfinished">La dirección que ha seleccionado para el cambio no es parte de su monedero. Parte o todos sus fondos pueden ser enviados a esta dirección. ¿Está seguro?</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -2335,8 +3909,28 @@ Nota: Dado que la tasa se calcula por cada byte, una tasa de "100 satoshis por k
 <context>
     <name>SendCoinsEntry</name>
     <message>
+        <source>A&amp;mount:</source>
+        <translation type="unfinished">I&amp;mporte:</translation>
+    </message>
+    <message>
+        <source>Pay &amp;To:</source>
+        <translation type="unfinished">Pagar &amp;a:</translation>
+    </message>
+    <message>
+        <source>&amp;Label:</source>
+        <translation type="unfinished">&amp;Etiqueta:</translation>
+    </message>
+    <message>
         <source>Choose previously used address</source>
         <translation type="unfinished">Escoger una dirección previamente usada</translation>
+    </message>
+    <message>
+        <source>The Bitcoin address to send the payment to</source>
+        <translation type="unfinished">Dirección Bitcoin a la que se enviará el pago</translation>
+    </message>
+    <message>
+        <source>Paste address from clipboard</source>
+        <translation type="unfinished">Pegar dirección desde portapapeles</translation>
     </message>
     <message>
         <source>Remove this entry</source>
@@ -2344,11 +3938,15 @@ Nota: Dado que la tasa se calcula por cada byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>The amount to send in the selected unit</source>
-        <translation type="unfinished">El monto a enviar en la unidad seleccionada</translation>
+        <translation type="unfinished">El importe a enviar en la unidad seleccionada</translation>
     </message>
     <message>
         <source>The fee will be deducted from the amount being sent. The recipient will receive less bitcoins than you enter in the amount field. If multiple recipients are selected, the fee is split equally.</source>
-        <translation type="unfinished">La comisión será deducida de la cantidad enviada. El destinatario recibirá menos bitcoins que la cantidad introducida en el campo Cantidad. Si hay varios destinatarios seleccionados, la comisión será distribuida a partes iguales.</translation>
+        <translation type="unfinished">La comisión será deducida de la cantidad enviada. El destinatario recibirá menos bitcoins que la cantidad introducida en el campo Importe. Si hay varios destinatarios seleccionados, la comisión será distribuida a partes iguales.</translation>
+    </message>
+    <message>
+        <source>S&amp;ubtract fee from amount</source>
+        <translation type="unfinished">S&amp;ustraer comisión del importe.</translation>
     </message>
     <message>
         <source>Use available balance</source>
@@ -2359,26 +3957,14 @@ Nota: Dado que la tasa se calcula por cada byte, una tasa de "100 satoshis por k
         <translation type="unfinished">Mensaje:</translation>
     </message>
     <message>
-        <source>This is an unauthenticated payment request.</source>
-        <translation type="unfinished">Esta es una solicitud de pago no autentificada.</translation>
-    </message>
-    <message>
-        <source>This is an authenticated payment request.</source>
-        <translation type="unfinished">Esta es una solicitud de pago autentificada.</translation>
-    </message>
-    <message>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished">Introduce una etiqueta para esta dirección para añadirla a la lista de direcciones utilizadas</translation>
     </message>
     <message>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
-        <translation type="unfinished">Mensaje que se agrgará al URI de Bitcoin, el cuál será almacenado con la transacción para su referencia. Nota: Este mensaje no será mandado a través de la red de Bitcoin.</translation>
+        <translation type="unfinished">Mensaje que se agrgará al URI de Bitcoin, el cuál será almacenado con la transacción para su referencia. Nota: Este mensaje no será enviado a través de la red de Bitcoin.</translation>
     </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">Pagar a:</translation>
-    </message>
-    </context>
+</context>
 <context>
     <name>SendConfirmationDialog</name>
     <message>
@@ -2393,30 +3979,146 @@ Nota: Dado que la tasa se calcula por cada byte, una tasa de "100 satoshis por k
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
+        <source>Signatures - Sign / Verify a Message</source>
+        <translation type="unfinished">Firmas - Firmar / verificar un mensaje</translation>
+    </message>
+    <message>
         <source>&amp;Sign Message</source>
-        <translation type="unfinished">&amp;Firmar Mensaje</translation>
+        <translation type="unfinished">&amp;Firmar mensaje</translation>
     </message>
     <message>
         <source>You can sign messages/agreements with your addresses to prove you can receive bitcoins sent to them. Be careful not to sign anything vague or random, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation type="unfinished">Puedes firmar los mensajes con tus direcciones para demostrar que las posees. Ten cuidado de no firmar cualquier cosa vaga, ya que los ataques de phishing pueden tratar de engañarte firmando tu identidad a través de ellos. Firma solo declaraciones totalmente detalladas con las que estés de acuerdo.</translation>
     </message>
     <message>
+        <source>The Bitcoin address to sign the message with</source>
+        <translation type="unfinished">La dirección Bitcoin con la que se firmó el mensaje</translation>
+    </message>
+    <message>
         <source>Choose previously used address</source>
-        <translation type="unfinished">Escoger dirección previamente usada</translation>
+        <translation type="unfinished">Escoger una dirección previamente usada</translation>
     </message>
     <message>
         <source>Paste address from clipboard</source>
-        <translation type="unfinished">Pega dirección desde portapapeles</translation>
+        <translation type="unfinished">Pegar dirección desde portapapeles</translation>
+    </message>
+    <message>
+        <source>Enter the message you want to sign here</source>
+        <translation type="unfinished">Escribe aquí el mensaje que deseas firmar</translation>
     </message>
     <message>
         <source>Signature</source>
         <translation type="unfinished">Firma</translation>
     </message>
     <message>
+        <source>Copy the current signature to the system clipboard</source>
+        <translation type="unfinished">Copiar la firma actual al portapapeles del sistema</translation>
+    </message>
+    <message>
+        <source>Sign the message to prove you own this Bitcoin address</source>
+        <translation type="unfinished">Firmar un mensaje para demostrar que se posee una dirección Bitcoin</translation>
+    </message>
+    <message>
+        <source>Sign &amp;Message</source>
+        <translation type="unfinished">Firmar &amp;mensaje</translation>
+    </message>
+    <message>
+        <source>Reset all sign message fields</source>
+        <translation type="unfinished">Limpiar todos los campos de la firma de mensaje</translation>
+    </message>
+    <message>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished">Limpiar &amp;todo</translation>
+    </message>
+    <message>
+        <source>&amp;Verify Message</source>
+        <translation type="unfinished">&amp;Verificar mensaje</translation>
+    </message>
+    <message>
+        <source>Enter the receiver's address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack. Note that this only proves the signing party receives with the address, it cannot prove sendership of any transaction!</source>
+        <translation type="unfinished">Introduzca la dirección para la firma, el mensaje (asegurándose de copiar tal cual los saltos de línea, espacios, tabulaciones, etc.) y la firma a continuación para verificar el mensaje. Tenga cuidado de no asumir más información de lo que dice el propio mensaje firmado para evitar fraudes basados en ataques de tipo man-in-the-middle. Tenga en cuenta que esto solo prueba que la parte firmante recibe con esta dirección, ¡no puede probar el envío de ninguna transacción!</translation>
+    </message>
+    <message>
+        <source>The Bitcoin address the message was signed with</source>
+        <translation type="unfinished">Dirección Bitcoin con la que firmar el mensaje</translation>
+    </message>
+    <message>
+        <source>The signed message to verify</source>
+        <translation type="unfinished">El mensaje firmado para verificar</translation>
+    </message>
+    <message>
+        <source>The signature given when the message was signed</source>
+        <translation type="unfinished">La firma proporcionada cuando el mensaje fue firmado</translation>
+    </message>
+    <message>
+        <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
+        <translation type="unfinished">Verifique el mensaje para comprobar que fue firmado con la dirección Bitcoin indicada</translation>
+    </message>
+    <message>
+        <source>Verify &amp;Message</source>
+        <translation type="unfinished">Verificar &amp;mensaje</translation>
+    </message>
+    <message>
+        <source>Reset all verify message fields</source>
+        <translation type="unfinished">Limpiar todos los campos de la verificación de mensaje</translation>
+    </message>
+    <message>
+        <source>Click "Sign Message" to generate signature</source>
+        <translation type="unfinished">Haga clic en «Firmar mensaje» para generar la firma</translation>
+    </message>
+    <message>
+        <source>The entered address is invalid.</source>
+        <translation type="unfinished">La dirección introducida es inválida</translation>
+    </message>
+    <message>
+        <source>Please check the address and try again.</source>
+        <translation type="unfinished">Por favor, revise la dirección e inténtelo nuevamente.</translation>
+    </message>
+    <message>
+        <source>The entered address does not refer to a key.</source>
+        <translation type="unfinished">La dirección introducida no corresponde a una clave.</translation>
+    </message>
+    <message>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished">Se ha cancelado el desbloqueo del monedero. </translation>
+    </message>
+    <message>
+        <source>No error</source>
+        <translation type="unfinished">Sin error </translation>
+    </message>
+    <message>
+        <source>Private key for the entered address is not available.</source>
+        <translation type="unfinished">No se dispone de la clave privada para la dirección introducida.</translation>
+    </message>
+    <message>
+        <source>Message signing failed.</source>
+        <translation type="unfinished">Falló la firma del mensaje.</translation>
+    </message>
+    <message>
         <source>Message signed.</source>
         <translation type="unfinished">Mensaje firmado.</translation>
     </message>
-    </context>
+    <message>
+        <source>The signature could not be decoded.</source>
+        <translation type="unfinished">La firma no pudo decodificarse.</translation>
+    </message>
+    <message>
+        <source>Please check the signature and try again.</source>
+        <translation type="unfinished">Por favor, compruebe la firma e inténtelo de nuevo.</translation>
+    </message>
+    <message>
+        <source>The signature did not match the message digest.</source>
+        <translation type="unfinished">La firma no coincide con el resumen del mensaje.</translation>
+    </message>
+    <message>
+        <source>Message verification failed.</source>
+        <translation type="unfinished">Falló la verificación del mensaje.</translation>
+    </message>
+    <message>
+        <source>Message verified.</source>
+        <translation type="unfinished">Mensaje verificado.</translation>
+    </message>
+</context>
 <context>
     <name>SplashScreen</name>
     <message>
@@ -2431,6 +4133,40 @@ Nota: Dado que la tasa se calcula por cada byte, una tasa de "100 satoshis por k
 <context>
     <name>TransactionDesc</name>
     <message>
+        <source>conflicted with a transaction with %1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that conflicts with a confirmed transaction.</extracomment>
+        <translation type="unfinished">Hay un conflicto con una transacción de %1 confirmaciones.</translation>
+    </message>
+    <message>
+        <source>0/unconfirmed, in memory pool</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is in the memory pool.</extracomment>
+        <translation type="unfinished">0/sin confirmar, en la piscina de memoria</translation>
+    </message>
+    <message>
+        <source>0/unconfirmed, not in memory pool</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is not in the memory pool.</extracomment>
+        <translation type="unfinished">0/sin confirmar, no en la piscina de memoria</translation>
+    </message>
+    <message>
+        <source>abandoned</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an abandoned transaction.</extracomment>
+        <translation type="unfinished">abandonada</translation>
+    </message>
+    <message>
+        <source>%1/unconfirmed</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
+        <translation type="unfinished">%1/sin confirmar</translation>
+    </message>
+    <message>
+        <source>%1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
+        <translation type="unfinished">%1 confirmaciones</translation>
+    </message>
+    <message>
+        <source>Status</source>
+        <translation type="unfinished">Estado</translation>
+    </message>
+    <message>
         <source>Date</source>
         <translation type="unfinished">Fecha</translation>
     </message>
@@ -2443,26 +4179,197 @@ Nota: Dado que la tasa se calcula por cada byte, una tasa de "100 satoshis por k
         <translation type="unfinished">Generado</translation>
     </message>
     <message>
+        <source>From</source>
+        <translation type="unfinished">De</translation>
+    </message>
+    <message>
+        <source>unknown</source>
+        <translation type="unfinished">desconocido</translation>
+    </message>
+    <message>
+        <source>To</source>
+        <translation type="unfinished">Para</translation>
+    </message>
+    <message>
+        <source>own address</source>
+        <translation type="unfinished">dirección propia</translation>
+    </message>
+    <message>
         <source>watch-only</source>
         <translation type="unfinished">Solo observación</translation>
+    </message>
+    <message>
+        <source>label</source>
+        <translation type="unfinished">etiqueta</translation>
+    </message>
+    <message>
+        <source>Credit</source>
+        <translation type="unfinished">Crédito</translation>
     </message>
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>disponible en %n bloque</numerusform>
+            <numerusform>disponible en %n bloques</numerusform>
         </translation>
+    </message>
+    <message>
+        <source>not accepted</source>
+        <translation type="unfinished">no aceptada</translation>
+    </message>
+    <message>
+        <source>Debit</source>
+        <translation type="unfinished">Débito</translation>
+    </message>
+    <message>
+        <source>Total debit</source>
+        <translation type="unfinished">Total débito</translation>
+    </message>
+    <message>
+        <source>Total credit</source>
+        <translation type="unfinished">Total crédito</translation>
     </message>
     <message>
         <source>Transaction fee</source>
         <translation type="unfinished">Comisión por transacción.</translation>
     </message>
-    </context>
+    <message>
+        <source>Net amount</source>
+        <translation type="unfinished">Importe neto</translation>
+    </message>
+    <message>
+        <source>Message</source>
+        <translation type="unfinished">Mensaje</translation>
+    </message>
+    <message>
+        <source>Comment</source>
+        <translation type="unfinished">Comentario</translation>
+    </message>
+    <message>
+        <source>Transaction ID</source>
+        <translation type="unfinished">ID transacción</translation>
+    </message>
+    <message>
+        <source>Transaction total size</source>
+        <translation type="unfinished">Tamaño total transacción</translation>
+    </message>
+    <message>
+        <source>Transaction virtual size</source>
+        <translation type="unfinished">Tamaño virtual transacción</translation>
+    </message>
+    <message>
+        <source>Output index</source>
+        <translation type="unfinished">Índice de salida</translation>
+    </message>
+    <message>
+        <source> (Certificate was not verified)</source>
+        <translation type="unfinished"> (No se ha verificado el certificado)</translation>
+    </message>
+    <message>
+        <source>Merchant</source>
+        <translation type="unfinished">Comerciante</translation>
+    </message>
+    <message>
+        <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to "not accepted" and it won't be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
+        <translation type="unfinished">Las monedas generadas deben madurar %1 bloques antes de que puedan ser gastadas. Una vez que generas este bloque, es propagado por la red para ser añadido a la cadena de bloques. Si falla el intento de añadirse en la cadena, su estado cambiará a «no aceptado» y ya no se puede gastar. Esto puede ocurrir ocasionalmente si otro nodo genera un bloque a los pocos segundos del tuyo.</translation>
+    </message>
+    <message>
+        <source>Debug information</source>
+        <translation type="unfinished">Información de depuración</translation>
+    </message>
+    <message>
+        <source>Transaction</source>
+        <translation type="unfinished">Transacción</translation>
+    </message>
+    <message>
+        <source>Inputs</source>
+        <translation type="unfinished">Entradas</translation>
+    </message>
+    <message>
+        <source>Amount</source>
+        <translation type="unfinished">Importe</translation>
+    </message>
+    <message>
+        <source>true</source>
+        <translation type="unfinished">verdadero</translation>
+    </message>
+    <message>
+        <source>false</source>
+        <translation type="unfinished">falso</translation>
+    </message>
+</context>
+<context>
+    <name>TransactionDescDialog</name>
+    <message>
+        <source>This pane shows a detailed description of the transaction</source>
+        <translation type="unfinished">Esta ventana muestra información detallada sobre la transacción</translation>
+    </message>
+    <message>
+        <source>Details for %1</source>
+        <translation type="unfinished">Detalles para %1</translation>
+    </message>
+</context>
 <context>
     <name>TransactionTableModel</name>
     <message>
+        <source>Date</source>
+        <translation type="unfinished">Fecha</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished">Tipo</translation>
+    </message>
+    <message>
         <source>Label</source>
         <translation type="unfinished">Etiqueta</translation>
+    </message>
+    <message>
+        <source>Unconfirmed</source>
+        <translation type="unfinished">Sin confirmar</translation>
+    </message>
+    <message>
+        <source>Abandoned</source>
+        <translation type="unfinished">Abandonada</translation>
+    </message>
+    <message>
+        <source>Confirming (%1 of %2 recommended confirmations)</source>
+        <translation type="unfinished">Confirmando (%1 de %2 confirmaciones recomendadas)</translation>
+    </message>
+    <message>
+        <source>Confirmed (%1 confirmations)</source>
+        <translation type="unfinished">Confirmada (%1 confirmaciones)</translation>
+    </message>
+    <message>
+        <source>Conflicted</source>
+        <translation type="unfinished">En conflicto</translation>
+    </message>
+    <message>
+        <source>Immature (%1 confirmations, will be available after %2)</source>
+        <translation type="unfinished">No disponible (%1 confirmaciones, disponible después de %2)</translation>
+    </message>
+    <message>
+        <source>Generated but not accepted</source>
+        <translation type="unfinished">Generada pero no aceptada</translation>
+    </message>
+    <message>
+        <source>Received with</source>
+        <translation type="unfinished">Recibido con</translation>
+    </message>
+    <message>
+        <source>Received from</source>
+        <translation type="unfinished">Recibido de</translation>
+    </message>
+    <message>
+        <source>Sent to</source>
+        <translation type="unfinished">Enviado a</translation>
+    </message>
+    <message>
+        <source>Payment to yourself</source>
+        <translation type="unfinished">Pago a mi mismo</translation>
+    </message>
+    <message>
+        <source>Mined</source>
+        <translation type="unfinished">Minado</translation>
     </message>
     <message>
         <source>watch-only</source>
@@ -2472,24 +4379,100 @@ Nota: Dado que la tasa se calcula por cada byte, una tasa de "100 satoshis por k
         <source>(no label)</source>
         <translation type="unfinished">(sin etiqueta)</translation>
     </message>
-    </context>
+    <message>
+        <source>Transaction status. Hover over this field to show number of confirmations.</source>
+        <translation type="unfinished">Estado de transacción. Pasa el ratón sobre este campo para ver el número de confirmaciones.</translation>
+    </message>
+    <message>
+        <source>Date and time that the transaction was received.</source>
+        <translation type="unfinished">Fecha y hora cuando se recibió la transacción.</translation>
+    </message>
+    <message>
+        <source>Type of transaction.</source>
+        <translation type="unfinished">Tipo de transacción.</translation>
+    </message>
+    <message>
+        <source>Whether or not a watch-only address is involved in this transaction.</source>
+        <translation type="unfinished">Si una dirección de solo observación está involucrada en esta transacción o no.</translation>
+    </message>
+    <message>
+        <source>User-defined intent/purpose of the transaction.</source>
+        <translation type="unfinished">Descripción de la transacción definida por el usuario.</translation>
+    </message>
+    <message>
+        <source>Amount removed from or added to balance.</source>
+        <translation type="unfinished">Importe sustraído o añadido al balance.</translation>
+    </message>
+</context>
 <context>
     <name>TransactionView</name>
+    <message>
+        <source>All</source>
+        <translation type="unfinished">Todo</translation>
+    </message>
+    <message>
+        <source>Today</source>
+        <translation type="unfinished">Hoy</translation>
+    </message>
+    <message>
+        <source>This week</source>
+        <translation type="unfinished">Esta semana</translation>
+    </message>
+    <message>
+        <source>This month</source>
+        <translation type="unfinished">Este mes</translation>
+    </message>
+    <message>
+        <source>Last month</source>
+        <translation type="unfinished">El mes pasado </translation>
+    </message>
+    <message>
+        <source>This year</source>
+        <translation type="unfinished">Este año</translation>
+    </message>
+    <message>
+        <source>Received with</source>
+        <translation type="unfinished">Recibido con</translation>
+    </message>
+    <message>
+        <source>Sent to</source>
+        <translation type="unfinished">Enviado a</translation>
+    </message>
+    <message>
+        <source>To yourself</source>
+        <translation type="unfinished">A ti mismo</translation>
+    </message>
+    <message>
+        <source>Mined</source>
+        <translation type="unfinished">Minado</translation>
+    </message>
+    <message>
+        <source>Other</source>
+        <translation type="unfinished">Otra</translation>
+    </message>
+    <message>
+        <source>Enter address, transaction id, or label to search</source>
+        <translation type="unfinished">Introduzca dirección, id de transacción o etiqueta a buscar</translation>
+    </message>
+    <message>
+        <source>Min amount</source>
+        <translation type="unfinished">Importe mínimo</translation>
+    </message>
     <message>
         <source>Range…</source>
         <translation type="unfinished">Rango...</translation>
     </message>
     <message>
         <source>&amp;Copy address</source>
-        <translation type="unfinished">copiar dirección </translation>
+        <translation type="unfinished">&amp;Copiar dirección</translation>
     </message>
     <message>
         <source>Copy &amp;label</source>
-        <translation type="unfinished">copiar y etiquetar </translation>
+        <translation type="unfinished">Copiar &amp;etiqueta</translation>
     </message>
     <message>
         <source>Copy &amp;amount</source>
-        <translation type="unfinished">Copiar cantidad</translation>
+        <translation type="unfinished">Copiar &amp;importe</translation>
     </message>
     <message>
         <source>Copy transaction &amp;ID</source>
@@ -2497,27 +4480,27 @@ Nota: Dado que la tasa se calcula por cada byte, una tasa de "100 satoshis por k
     </message>
     <message>
         <source>Copy &amp;raw transaction</source>
-        <translation type="unfinished">Copiar traducción en crudo</translation>
+        <translation type="unfinished">Copiar transacción en c&amp;rudo</translation>
     </message>
     <message>
         <source>Copy full transaction &amp;details</source>
-        <translation type="unfinished">Copiar la transacción entera &amp; detalles</translation>
+        <translation type="unfinished">Copiar &amp;detalles completos de la transacción</translation>
     </message>
     <message>
         <source>&amp;Show transaction details</source>
-        <translation type="unfinished">Mostrar detalles de la transacción</translation>
+        <translation type="unfinished">&amp;Mostrar detalles de la transacción</translation>
     </message>
     <message>
         <source>Increase transaction &amp;fee</source>
-        <translation type="unfinished">Incrementar la comisión de transacción</translation>
+        <translation type="unfinished">&amp;Incrementar comisión de transacción</translation>
     </message>
     <message>
         <source>A&amp;bandon transaction</source>
-        <translation type="unfinished">Abandonar transacción</translation>
+        <translation type="unfinished">A&amp;bandonar transacción</translation>
     </message>
     <message>
         <source>&amp;Edit address label</source>
-        <translation type="unfinished">Editar etiqueta de dirección</translation>
+        <translation type="unfinished">&amp;Editar etiqueta de dirección</translation>
     </message>
     <message>
         <source>Show in %1</source>
@@ -2525,8 +4508,29 @@ Nota: Dado que la tasa se calcula por cada byte, una tasa de "100 satoshis por k
         <translation type="unfinished">Mostrar en %1</translation>
     </message>
     <message>
+        <source>Export Transaction History</source>
+        <translation type="unfinished">Exportar historial de transacciones</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">Archivo separado por comas</translation>
+    </message>
+    <message>
         <source>Confirmed</source>
         <translation type="unfinished">Confirmado</translation>
+    </message>
+    <message>
+        <source>Watch-only</source>
+        <translation type="unfinished">Solo observación</translation>
+    </message>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">Fecha</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished">Tipo</translation>
     </message>
     <message>
         <source>Label</source>
@@ -2540,7 +4544,27 @@ Nota: Dado que la tasa se calcula por cada byte, una tasa de "100 satoshis por k
         <source>Exporting Failed</source>
         <translation type="unfinished">La exportación falló</translation>
     </message>
-    </context>
+    <message>
+        <source>There was an error trying to save the transaction history to %1.</source>
+        <translation type="unfinished">Ha habido un error al intentar guardar en el histórico la transacción con %1.</translation>
+    </message>
+    <message>
+        <source>Exporting Successful</source>
+        <translation type="unfinished">Exportación satisfactoria</translation>
+    </message>
+    <message>
+        <source>The transaction history was successfully saved to %1.</source>
+        <translation type="unfinished">El historial de transacciones ha sido guardado exitosamente en %1</translation>
+    </message>
+    <message>
+        <source>Range:</source>
+        <translation type="unfinished">Rango:</translation>
+    </message>
+    <message>
+        <source>to</source>
+        <translation type="unfinished">a</translation>
+    </message>
+</context>
 <context>
     <name>WalletFrame</name>
     <message>
@@ -2553,11 +4577,11 @@ Vaya a Archivo&gt; Abrir monedero para cargar un monedero.
     </message>
     <message>
         <source>Create a new wallet</source>
-        <translation type="unfinished">Crear monedero nuevo</translation>
+        <translation type="unfinished">Crea un monedero nuevo</translation>
     </message>
     <message>
         <source>Unable to decode PSBT from clipboard (invalid base64)</source>
-        <translation type="unfinished">No se puede decodificar PSBT desde el portapapeles (inválido base64)</translation>
+        <translation type="unfinished">No se puede decodificar TBPF desde el portapapeles (inválido base64)</translation>
     </message>
     <message>
         <source>Load Transaction Data</source>
@@ -2569,27 +4593,75 @@ Vaya a Archivo&gt; Abrir monedero para cargar un monedero.
     </message>
     <message>
         <source>PSBT file must be smaller than 100 MiB</source>
-        <translation type="unfinished">El archivo PSBT debe ser más pequeño de 100 MiB</translation>
+        <translation type="unfinished">El archivo TBPF debe ser más pequeño de 100 MiB</translation>
     </message>
     <message>
         <source>Unable to decode PSBT</source>
-        <translation type="unfinished">Imposible descodificar PSBT</translation>
+        <translation type="unfinished">No es posible descodificar TBPF</translation>
     </message>
 </context>
 <context>
     <name>WalletModel</name>
     <message>
+        <source>Send Coins</source>
+        <translation type="unfinished">Enviar monedas</translation>
+    </message>
+    <message>
+        <source>Fee bump error</source>
+        <translation type="unfinished">Error de incremento de la comisión</translation>
+    </message>
+    <message>
+        <source>Increasing transaction fee failed</source>
+        <translation type="unfinished">Ha fallado el incremento de la comisión de transacción.</translation>
+    </message>
+    <message>
+        <source>Do you want to increase the fee?</source>
+        <extracomment>Asks a user if they would like to manually increase the fee of a transaction that has already been created.</extracomment>
+        <translation type="unfinished">¿Desea incrementar la comisión?</translation>
+    </message>
+    <message>
+        <source>Current fee:</source>
+        <translation type="unfinished">Comisión actual:</translation>
+    </message>
+    <message>
+        <source>Increase:</source>
+        <translation type="unfinished">Incremento:</translation>
+    </message>
+    <message>
+        <source>New fee:</source>
+        <translation type="unfinished">Nueva comisión:</translation>
+    </message>
+    <message>
         <source>Warning: This may pay the additional fee by reducing change outputs or adding inputs, when necessary. It may add a new change output if one does not already exist. These changes may potentially leak privacy.</source>
-        <translation type="unfinished">Advertencia: Esto puede pagar la tasa adicional al reducir el cambio de salidas o agregar entradas, cuando sea necesario. Puede agregar una nueva salida de cambio si aún no existe. Estos cambios pueden potencialmente filtrar la privacidad.</translation>
+        <translation type="unfinished">Advertencia: Esto puede pagar la comisión adicional al reducir el cambio de salidas o agregar entradas, cuando sea necesario. Puede agregar una nueva salida de cambio si aún no existe. Potencialmente estos cambios pueden comprometer la privacidad.</translation>
+    </message>
+    <message>
+        <source>Confirm fee bump</source>
+        <translation type="unfinished">Confirmar incremento de comisión</translation>
+    </message>
+    <message>
+        <source>Can't draft transaction.</source>
+        <translation type="unfinished">No se pudo preparar la transacción.</translation>
+    </message>
+    <message>
+        <source>PSBT copied</source>
+        <translation type="unfinished">TBPF copiada </translation>
+    </message>
+    <message>
+        <source>Can't sign transaction.</source>
+        <translation type="unfinished">No se ha podido firmar la transacción.</translation>
+    </message>
+    <message>
+        <source>Could not commit transaction</source>
+        <translation type="unfinished">No se pudo confirmar la transacción</translation>
     </message>
     <message>
         <source>Can't display address</source>
-        <translation type="unfinished">No se puede mostrar la dirección
-</translation>
+        <translation type="unfinished">No se puede mostrar la dirección</translation>
     </message>
     <message>
         <source>default wallet</source>
-        <translation type="unfinished">Monedero predeterminado</translation>
+        <translation type="unfinished">monedero predeterminado</translation>
     </message>
 </context>
 <context>
@@ -2603,9 +4675,33 @@ Vaya a Archivo&gt; Abrir monedero para cargar un monedero.
         <translation type="unfinished">Exportar a un archivo los datos de esta pestaña</translation>
     </message>
     <message>
+        <source>Backup Wallet</source>
+        <translation type="unfinished">Respaldar monedero</translation>
+    </message>
+    <message>
         <source>Wallet Data</source>
         <extracomment>Name of the wallet data file format.</extracomment>
-        <translation type="unfinished">Datos de la billetera </translation>
+        <translation type="unfinished">Datos del monedero </translation>
     </message>
-    </context>
+    <message>
+        <source>Backup Failed</source>
+        <translation type="unfinished">Copia de seguridad fallida</translation>
+    </message>
+    <message>
+        <source>There was an error trying to save the wallet data to %1.</source>
+        <translation type="unfinished">Ha habido un error al intentar guardar los datos del monedero a %1.</translation>
+    </message>
+    <message>
+        <source>Backup Successful</source>
+        <translation type="unfinished">Se ha completado con éxito la copia de respaldo</translation>
+    </message>
+    <message>
+        <source>The wallet data was successfully saved to %1.</source>
+        <translation type="unfinished">Los datos del monedero se han guardado con éxito en %1.</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Cancelar</translation>
+    </message>
+</context>
 </TS>

--- a/src/qt/locale/bitcoin_es_CL.ts
+++ b/src/qt/locale/bitcoin_es_CL.ts
@@ -246,7 +246,7 @@ Usa el boton "Crear nueva direccion de recibimiento" en la pestaña de recibir p
     </message>
     <message>
         <source>Internal error</source>
-        <translation type="unfinished">Error interno</translation>
+        <translation type="unfinished">error interno</translation>
     </message>
     <message>
         <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
@@ -427,10 +427,6 @@ Usa el boton "Crear nueva direccion de recibimiento" en la pestaña de recibir p
         <translation type="unfinished">Error al leer la base de datos, cerrando aplicación.</translation>
     </message>
     <message>
-        <source>Error upgrading chainstate database</source>
-        <translation type="unfinished">Error actualizando la base de datos chainstate</translation>
-    </message>
-    <message>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished">Ha fallado la escucha en todos los puertos. Usa -listen=0 si desea esto.</translation>
     </message>
@@ -545,10 +541,6 @@ Usa el boton "Crear nueva direccion de recibimiento" en la pestaña de recibir p
     <message>
         <source>Unknown network specified in -onlynet: '%s'</source>
         <translation type="unfinished">La red especificada en -onlynet: '%s' es desconocida</translation>
-    </message>
-    <message>
-        <source>Upgrading UTXO database</source>
-        <translation type="unfinished">Actualizando la base de datos UTXO</translation>
     </message>
     </context>
 <context>
@@ -1070,6 +1062,27 @@ Usa el boton "Crear nueva direccion de recibimiento" en la pestaña de recibir p
 </context>
 <context>
     <name>Intro</name>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform>(de %n GB requerido)</numerusform>
+            <numerusform>(de %n GB requeridos)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
     <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
         <translation type="unfinished">Al menos %1 GB de información será almacenado en este directorio, y seguirá creciendo a través del tiempo.</translation>
@@ -1109,10 +1122,6 @@ Usa el boton "Crear nueva direccion de recibimiento" en la pestaña de recibir p
     <message>
         <source>As this is the first time the program is launched, you can choose where %1 will store its data.</source>
         <translation type="unfinished">Como esta es la primera vez que se lanza el programa, puede elegir dónde %1 almacenará sus datos.</translation>
-    </message>
-    <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation type="unfinished">Al hacer clic OK, %1 iniciará el proceso de descarga y procesará el blockchain completo de %4 (%2 GB), iniciando desde el la transacción más antigua %3 cuando %4 se ejecutó inicialmente.</translation>
     </message>
     <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
@@ -1372,14 +1381,17 @@ Usa el boton "Crear nueva direccion de recibimiento" en la pestaña de recibir p
     </message>
     <message>
         <source>Confirm options reset</source>
+        <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
         <translation type="unfinished">Confirmar restablecimiento de opciones</translation>
     </message>
     <message>
         <source>Client restart required to activate changes.</source>
+        <extracomment>Text explaining that the settings changed will not come into effect until the client is restarted.</extracomment>
         <translation type="unfinished">Se requiere el reinicio del cliente para activar los cambios.</translation>
     </message>
     <message>
         <source>Client will be shut down. Do you want to proceed?</source>
+        <extracomment>Text asking the user to confirm if they would like to proceed with a client shutdown.</extracomment>
         <translation type="unfinished">El cliente será cluasurado. Quieres proceder?</translation>
     </message>
     <message>
@@ -2115,10 +2127,6 @@ Usa el boton "Crear nueva direccion de recibimiento" en la pestaña de recibir p
         <source>A fee higher than %1 is considered an absurdly high fee.</source>
         <translation type="unfinished">Una comisión mayor que %1 se considera como una comisión absurda-mente alta.</translation>
     </message>
-    <message>
-        <source>Payment request expired.</source>
-        <translation type="unfinished">Solicitud de pago caducada.</translation>
-    </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
@@ -2186,20 +2194,8 @@ Usa el boton "Crear nueva direccion de recibimiento" en la pestaña de recibir p
         <translation type="unfinished">Mensaje:</translation>
     </message>
     <message>
-        <source>This is an unauthenticated payment request.</source>
-        <translation type="unfinished">Esta es una petición de pago no autentificada.</translation>
-    </message>
-    <message>
-        <source>This is an authenticated payment request.</source>
-        <translation type="unfinished">Esta es una petición de pago autentificada.</translation>
-    </message>
-    <message>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished">Introduce una etiqueta para esta dirección para añadirla a la lista de direcciones utilizadas</translation>
-    </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">Pagar a:</translation>
     </message>
     </context>
 <context>
@@ -2336,30 +2332,22 @@ Usa el boton "Crear nueva direccion de recibimiento" en la pestaña de recibir p
     <name>TransactionDesc</name>
     <message>
         <source>conflicted with a transaction with %1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that conflicts with a confirmed transaction.</extracomment>
         <translation type="unfinished">Hay un conflicto con la traducción de las confirmaciones %1</translation>
     </message>
     <message>
-        <source>0/unconfirmed, %1</source>
-        <translation type="unfinished">0/no confirmado, %1</translation>
-    </message>
-    <message>
-        <source>in memory pool</source>
-        <translation type="unfinished">en el equipo de memoria</translation>
-    </message>
-    <message>
-        <source>not in memory pool</source>
-        <translation type="unfinished">no en el equipo de memoria</translation>
-    </message>
-    <message>
         <source>abandoned</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an abandoned transaction.</extracomment>
         <translation type="unfinished">abandonado</translation>
     </message>
     <message>
         <source>%1/unconfirmed</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
         <translation type="unfinished">%1/no confirmado</translation>
     </message>
     <message>
         <source>%1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
         <translation type="unfinished">confirmaciones %1</translation>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_es_CO.ts
+++ b/src/qt/locale/bitcoin_es_CO.ts
@@ -7,7 +7,7 @@
     </message>
     <message>
         <source>Create a new address</source>
-        <translation type="unfinished">Crea una nueva dirección</translation>
+        <translation type="unfinished">Crear una nueva dirección</translation>
     </message>
     <message>
         <source>&amp;New</source>
@@ -15,7 +15,7 @@
     </message>
     <message>
         <source>Copy the currently selected address to the system clipboard</source>
-        <translation type="unfinished">Copia la dirección seleccionada al portapapeles</translation>
+        <translation type="unfinished">Copiar la dirección seleccionada actualmente al portapapeles del sistema</translation>
     </message>
     <message>
         <source>&amp;Copy</source>
@@ -55,7 +55,7 @@
     </message>
     <message>
         <source>C&amp;hoose</source>
-        <translation type="unfinished">Seleccione</translation>
+        <translation type="unfinished">S&amp;eleccionar</translation>
     </message>
     <message>
         <source>Sending addresses</source>
@@ -81,7 +81,7 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
     </message>
     <message>
         <source>Copy &amp;Label</source>
-        <translation type="unfinished">Copiar etiqueta</translation>
+        <translation type="unfinished">Copiar &amp;etiqueta</translation>
     </message>
     <message>
         <source>&amp;Edit</source>
@@ -209,7 +209,7 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
     </message>
     <message>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
-        <translation type="unfinished">El proceso de encriptación de la billetera fallo por culpa de un problema interno. Tu billetera no fue encriptada.</translation>
+        <translation type="unfinished">La encriptación de la billetera falló debido a un error interno. Su billetera no se encriptó.</translation>
     </message>
     <message>
         <source>The supplied passphrases do not match.</source>
@@ -246,15 +246,49 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
 <context>
     <name>BitcoinApplication</name>
     <message>
+        <source>Settings file %1 might be corrupt or invalid.</source>
+        <translation type="unfinished">El archivo de configuración %1 puede estar corrupto o no ser válido.</translation>
+    </message>
+    <message>
+        <source>Runaway exception</source>
+        <translation type="unfinished">Excepción fuera de control</translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
+        <translation type="unfinished">Se produjo un error fatal. %1 ya no puede continuar de manera segura y se cerrará.</translation>
+    </message>
+    <message>
         <source>Internal error</source>
         <translation type="unfinished">Error interno</translation>
     </message>
-    </context>
+    <message>
+        <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
+        <translation type="unfinished">Se produjo un error interno. %1 intentará continuar de manera segura. Este es un error inesperado que se puede reportar como se describe a continuación.</translation>
+    </message>
+</context>
 <context>
     <name>QObject</name>
     <message>
+        <source>Do you want to reset settings to default values, or to abort without making changes?</source>
+        <extracomment>Explanatory text shown on startup when the settings file cannot be read. Prompts user to make a choice between resetting or aborting.</extracomment>
+        <translation type="unfinished">¿Deseas restablecer los valores a la configuración predeterminada o abortar sin realizar los cambios?</translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. Check that settings file is writable, or try running with -nosettings.</source>
+        <extracomment>Explanatory text shown on startup when the settings file could not be written. Prompts user to check that we have the ability to write to the file. Explains that the user has the option of running without a settings file.</extracomment>
+        <translation type="unfinished">Se produjo un error fatal. Comprueba que el archivo de configuración soporte escritura o intenta ejecutar el programa con -nosettings.</translation>
+    </message>
+    <message>
         <source>Error: Specified data directory "%1" does not exist.</source>
         <translation type="unfinished">Error: El directorio de datos "%1" especificado no existe.</translation>
+    </message>
+    <message>
+        <source>Error: Cannot parse configuration file: %1.</source>
+        <translation type="unfinished">Error: No se puede analizar el archivo de configuración: %1.</translation>
+    </message>
+    <message>
+        <source>%1 didn't yet exit safely…</source>
+        <translation type="unfinished">%1 aún no salió de forma segura...</translation>
     </message>
     <message>
         <source>unknown</source>
@@ -269,6 +303,14 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
         <translation type="unfinished">Ingresa una dirección de Bitcoin (Ejemplo: %1)</translation>
     </message>
     <message>
+        <source>Unroutable</source>
+        <translation type="unfinished">No enrutable</translation>
+    </message>
+    <message>
+        <source>Internal</source>
+        <translation type="unfinished">Interno</translation>
+    </message>
+    <message>
         <source>Inbound</source>
         <extracomment>An inbound connection from a peer. An inbound connection is a connection initiated by a peer.</extracomment>
         <translation type="unfinished">Entrante</translation>
@@ -279,42 +321,57 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
         <translation type="unfinished">Saliente</translation>
     </message>
     <message>
+        <source>Full Relay</source>
+        <extracomment>Peer connection type that relays all network information.</extracomment>
+        <translation type="unfinished">Retransmisión completa</translation>
+    </message>
+    <message>
+        <source>Block Relay</source>
+        <extracomment>Peer connection type that relays network information about blocks and not transactions or addresses.</extracomment>
+        <translation type="unfinished">Retransmisión de bloque</translation>
+    </message>
+    <message>
+        <source>Address Fetch</source>
+        <extracomment>Short-lived peer connection type that solicits known addresses from a peer.</extracomment>
+        <translation type="unfinished">Recuperación de dirección</translation>
+    </message>
+    <message>
         <source>None</source>
         <translation type="unfinished">Nada</translation>
     </message>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n segundo</numerusform>
+            <numerusform>%n segundos</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n minute(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n minuto</numerusform>
+            <numerusform>%n minutos</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n hora</numerusform>
+            <numerusform>%n horas</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n día</numerusform>
+            <numerusform>%n días</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n semana</numerusform>
+            <numerusform>%n semanas</numerusform>
         </translation>
     </message>
     <message>
@@ -324,28 +381,100 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n año</numerusform>
+            <numerusform>%n años</numerusform>
         </translation>
     </message>
     </context>
 <context>
     <name>bitcoin-core</name>
     <message>
+        <source>Settings file could not be read</source>
+        <translation type="unfinished">El archivo de configuración no se puede leer</translation>
+    </message>
+    <message>
+        <source>Settings file could not be written</source>
+        <translation type="unfinished">El archivo de configuración no se puede escribir</translation>
+    </message>
+    <message>
         <source>The %s developers</source>
         <translation type="unfinished">Los desarrolladores de %s</translation>
+    </message>
+    <message>
+        <source>%s corrupt. Try using the wallet tool bitcoin-wallet to salvage or restoring a backup.</source>
+        <translation type="unfinished">%s corrupto. Intenta utilizar la herramienta de la billetera de bitcoin para rescatar o restaurar una copia de seguridad.</translation>
     </message>
     <message>
         <source>-maxtxfee is set very high! Fees this large could be paid on a single transaction.</source>
         <translation type="unfinished">-maxtxfee tiene un valor muy elevado! Comisiones muy grandes podrían ser pagadas en una única transacción.</translation>
     </message>
     <message>
+        <source>Cannot downgrade wallet from version %i to version %i. Wallet version unchanged.</source>
+        <translation type="unfinished">No se puede pasar de la versión %i a la versión anterior %i.  La versión de la billetera no tiene cambios.</translation>
+    </message>
+    <message>
+        <source>Cannot obtain a lock on data directory %s. %s is probably already running.</source>
+        <translation type="unfinished">No se puede bloquear el directorio de datos %s. %s probablemente ya se está ejecutando.</translation>
+    </message>
+    <message>
+        <source>Cannot upgrade a non HD split wallet from version %i to version %i without upgrading to support pre-split keypool. Please use version %i or no version specified.</source>
+        <translation type="unfinished">No se puede actualizar una billetera dividida no HD de la versión %i a la versión %i sin actualizar para admitir el pool de claves anterior a la división. Usa la versión %i o no especifiques la versión.</translation>
+    </message>
+    <message>
         <source>Distributed under the MIT software license, see the accompanying file %s or %s</source>
         <translation type="unfinished">Distribuido bajo la licencia de software MIT, vea el archivo adjunto %s o %s</translation>
     </message>
     <message>
+        <source>Error reading %s! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
+        <translation type="unfinished">¡Error al leer %s! Todas las claves se leyeron correctamente, pero es probable que falten los datos de la transacción o la libreta de direcciones, o que sean incorrectos.</translation>
+    </message>
+    <message>
+        <source>Error reading %s! Transaction data may be missing or incorrect. Rescanning wallet.</source>
+        <translation type="unfinished">¡Error al leer %s! Es probable que falten los datos de la transacción o que sean incorrectos. Reescaneando billetera.</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile format record is incorrect. Got "%s", expected "format".</source>
+        <translation type="unfinished">Error: el registro del formato del archivo de volcado es incorrecto. Se obtuvo "%s"; se esperaba "formato".</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile identifier record is incorrect. Got "%s", expected "%s".</source>
+        <translation type="unfinished">Error: el registro del identificador del archivo de volcado es incorrecto. Se obtuvo "%s"; se esperaba "%s".</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile version is not supported. This version of bitcoin-wallet only supports version 1 dumpfiles. Got dumpfile with version %s</source>
+        <translation type="unfinished">Error: la versión del archivo volcado no es compatible. Esta versión de la billetera de bitcoin solo admite archivos de volcado de la versión 1. Se obtuvo un archivo de volcado con la versión %s</translation>
+    </message>
+    <message>
+        <source>Error: Legacy wallets only support the "legacy", "p2sh-segwit", and "bech32" address types</source>
+        <translation type="unfinished">Error: las billeteras heredadas solo admiten los tipos de dirección "legacy", "p2sh-segwit" y "bech32".</translation>
+    </message>
+    <message>
+        <source>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.</source>
+        <translation type="unfinished">Error al calcular la comisión. La opción "fallbackfee" está desactivada. Espera algunos bloques o activa "fallbackfee".</translation>
+    </message>
+    <message>
+        <source>File %s already exists. If you are sure this is what you want, move it out of the way first.</source>
+        <translation type="unfinished">El archivo %s ya existe. Si definitivamente quieres hacerlo, quítalo primero.</translation>
+    </message>
+    <message>
+        <source>Invalid amount for -maxtxfee=&lt;amount&gt;: '%s' (must be at least the minrelay fee of %s to prevent stuck transactions)</source>
+        <translation type="unfinished">Importe inválido para -maxtxfee=&lt;amount&gt;: "%s" (debe ser al menos la comisión mínima de retransmisión de %s para evitar transacciones atascadas)</translation>
+    </message>
+    <message>
+        <source>Invalid or corrupt peers.dat (%s). If you believe this is a bug, please report it to %s. As a workaround, you can move the file (%s) out of the way (rename, move, or delete) to have a new one created on the next start.</source>
+        <translation type="unfinished">Archivo peers.dat inválido o corrupto (%s). Si crees que se trata de un error, infórmalo a %s. Como alternativa, puedes quitar el archivo (%s) (renombrarlo, moverlo o eliminarlo) para que se cree uno nuevo en el siguiente inicio.</translation>
+    </message>
+    <message>
         <source>Prune configured below the minimum of %d MiB.  Please use a higher number.</source>
         <translation type="unfinished">La Poda se ha configurado por debajo del mínimo de %d MiB. Por favor utiliza un valor mas alto.</translation>
+    </message>
+    <message>
+        <source>The block index db contains a legacy 'txindex'. To clear the occupied disk space, run a full -reindex, otherwise ignore this error. This error message will not be displayed again.</source>
+        <translation type="unfinished">La base de datos del índice de bloques contiene un "txindex" heredado. Para borrar el espacio de disco ocupado, ejecute un -reindex completo; de lo contrario, ignore este error. Este mensaje de error no se volverá a mostrar.</translation>
+    </message>
+    <message>
+        <source>The transaction amount is too small to send after the fee has been deducted</source>
+        <translation type="unfinished">El monto de la transacción es demasiado pequeño para enviarlo después de deducir la comisión</translation>
     </message>
     <message>
         <source>This is the transaction fee you may discard if change is smaller than dust at this level</source>
@@ -420,10 +549,6 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
         <translation type="unfinished">Error al leer la base de datos, cerrando aplicación.</translation>
     </message>
     <message>
-        <source>Error upgrading chainstate database</source>
-        <translation type="unfinished">Error actualizando la base de datos chainstate</translation>
-    </message>
-    <message>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished">Ha fallado la escucha en todos los puertos. Usa -listen=0 si desea esto.</translation>
     </message>
@@ -457,7 +582,7 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
     </message>
     <message>
         <source>Invalid amount for -fallbackfee=&lt;amount&gt;: '%s'</source>
-        <translation type="unfinished">Monto invalido para -fallbackfee=&lt;amount&gt;: '%s'</translation>
+        <translation type="unfinished">Monto inválido para -fallbackfee=&lt;amount&gt;: '%s'</translation>
     </message>
     <message>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: '%s' (must be at least %s)</source>
@@ -466,6 +591,10 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
     <message>
         <source>Invalid netmask specified in -whitelist: '%s'</source>
         <translation type="unfinished">Máscara de red inválida especificada en -whitelist: '%s'</translation>
+    </message>
+    <message>
+        <source>Missing amount</source>
+        <translation type="unfinished">Falta la cantidad</translation>
     </message>
     <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
@@ -489,7 +618,7 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
     </message>
     <message>
         <source>The transaction amount is too small to pay the fee</source>
-        <translation type="unfinished">El monto a transferir es muy pequeño para pagar el impuesto</translation>
+        <translation type="unfinished">El monto de la transacción es demasiado pequeño para pagar la comisión</translation>
     </message>
     <message>
         <source>The wallet will avoid paying less than the minimum relay fee.</source>
@@ -539,10 +668,6 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
         <source>Unknown network specified in -onlynet: '%s'</source>
         <translation type="unfinished">La red especificada en -onlynet: '%s' es desconocida</translation>
     </message>
-    <message>
-        <source>Upgrading UTXO database</source>
-        <translation type="unfinished">Actualizando la base de datos UTXO</translation>
-    </message>
     </context>
 <context>
     <name>BitcoinGUI</name>
@@ -564,7 +689,7 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
     </message>
     <message>
         <source>E&amp;xit</source>
-        <translation type="unfinished">&amp;Salir</translation>
+        <translation type="unfinished">S&amp;alir</translation>
     </message>
     <message>
         <source>Quit application</source>
@@ -572,7 +697,7 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
     </message>
     <message>
         <source>&amp;About %1</source>
-        <translation type="unfinished">S&amp;obre %1</translation>
+        <translation type="unfinished">&amp;Acerca de %1</translation>
     </message>
     <message>
         <source>Show information about %1</source>
@@ -580,7 +705,7 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
     </message>
     <message>
         <source>About &amp;Qt</source>
-        <translation type="unfinished">Acerca de</translation>
+        <translation type="unfinished">Acerca de &amp;Qt</translation>
     </message>
     <message>
         <source>Show information about Qt</source>
@@ -593,6 +718,10 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
     <message>
         <source>Create a new wallet</source>
         <translation type="unfinished">Crear una nueva billetera</translation>
+    </message>
+    <message>
+        <source>&amp;Minimize</source>
+        <translation type="unfinished">&amp;Minimizar</translation>
     </message>
     <message>
         <source>Wallet:</source>
@@ -628,16 +757,24 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
         <translation type="unfinished">&amp;Recibir</translation>
     </message>
     <message>
+        <source>&amp;Options…</source>
+        <translation type="unfinished">&amp;Opciones...</translation>
+    </message>
+    <message>
         <source>&amp;Encrypt Wallet…</source>
         <translation type="unfinished">&amp;Encriptar billetera…</translation>
     </message>
     <message>
         <source>Encrypt the private keys that belong to your wallet</source>
-        <translation type="unfinished">Cifrar las claves privadas de su monedero</translation>
+        <translation type="unfinished">Cifrar las claves privadas que pertenecen a su billetera</translation>
     </message>
     <message>
         <source>&amp;Backup Wallet…</source>
         <translation type="unfinished">&amp;Realizar copia de seguridad de la billetera</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation type="unfinished">&amp;Cambiar frase de contraseña...</translation>
     </message>
     <message>
         <source>Sign &amp;message…</source>
@@ -654,6 +791,14 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
     <message>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation type="unfinished">Verificar mensajes comprobando que están firmados con direcciones Bitcoin concretas</translation>
+    </message>
+    <message>
+        <source>&amp;Load PSBT from file…</source>
+        <translation type="unfinished">&amp;Cargar PSBT desde archivo...</translation>
+    </message>
+    <message>
+        <source>Open &amp;URI…</source>
+        <translation type="unfinished">Abrir &amp;URI...</translation>
     </message>
     <message>
         <source>Close Wallet…</source>
@@ -684,6 +829,30 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
         <translation type="unfinished">Barra de pestañas</translation>
     </message>
     <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation type="unfinished">Sincronizando encabezados (%1%)...</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation type="unfinished">Sincronizando con la red...</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation type="unfinished">Indexando bloques en disco...</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation type="unfinished">Procesando bloques en disco...</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation type="unfinished">Reindexando bloques en disco...</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation type="unfinished">Conectando con pares...</translation>
+    </message>
+    <message>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished">Pide pagos (genera codigos QR and bitcoin: URls)</translation>
     </message>
@@ -702,13 +871,17 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n bloque procesado del historial de transacciones.</numerusform>
+            <numerusform>%n bloques procesados del historial de transacciones.</numerusform>
         </translation>
     </message>
     <message>
         <source>%1 behind</source>
         <translation type="unfinished">%1 atrás</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation type="unfinished">Poniéndose al día...</translation>
     </message>
     <message>
         <source>Last received block was generated %1 ago.</source>
@@ -729,6 +902,14 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
     <message>
         <source>Up to date</source>
         <translation type="unfinished">Actualizado</translation>
+    </message>
+    <message>
+        <source>Load Partially Signed Bitcoin Transaction</source>
+        <translation type="unfinished">Cargar transacción de Bitcoin parcialmente firmada</translation>
+    </message>
+    <message>
+        <source>Load PSBT from &amp;clipboard…</source>
+        <translation type="unfinished">Cargar PSBT desde el &amp;portapapeles...</translation>
     </message>
     <message>
         <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
@@ -767,12 +948,30 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
         <translation type="unfinished">Cerrar billetera</translation>
     </message>
     <message>
+        <source>Restore Wallet…</source>
+        <extracomment>Name of the menu item that restores wallet from a backup file.</extracomment>
+        <translation type="unfinished">Restaurar billetera…</translation>
+    </message>
+    <message>
+        <source>Restore a wallet from a backup file</source>
+        <extracomment>Status tip for Restore Wallet menu item</extracomment>
+        <translation type="unfinished">Restaurar una billetera desde un archivo de copia de seguridad</translation>
+    </message>
+    <message>
         <source>Close all wallets</source>
         <translation type="unfinished">Cerrar todas las billeteras</translation>
     </message>
     <message>
         <source>Show the %1 help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished">Mostrar el mensaje de ayuda %1 para obtener una lista de los posibles comandos de Bitcoin</translation>
+    </message>
+    <message>
+        <source>&amp;Mask values</source>
+        <translation type="unfinished">&amp;Ocultar valores</translation>
+    </message>
+    <message>
+        <source>Mask the values in the Overview tab</source>
+        <translation type="unfinished">Ocultar los valores en la pestaña de vista general</translation>
     </message>
     <message>
         <source>default wallet</source>
@@ -783,9 +982,28 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
         <translation type="unfinished">No hay billeteras disponibles</translation>
     </message>
     <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">Datos de la billetera</translation>
+    </message>
+    <message>
+        <source>Load Wallet Backup</source>
+        <extracomment>The title for Restore Wallet File Windows</extracomment>
+        <translation type="unfinished">Cargar copia de seguridad de billetera</translation>
+    </message>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of pop-up window shown when the user is attempting to restore a wallet.</extracomment>
+        <translation type="unfinished">Restaurar billetera</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">Nombre de la billetera </translation>
+    </message>
+    <message>
         <source>&amp;Window</source>
-        <translation type="unfinished">y windows
-</translation>
+        <translation type="unfinished">&amp;Ventana</translation>
     </message>
     <message>
         <source>Zoom</source>
@@ -799,13 +1017,45 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
         <source>%1 client</source>
         <translation type="unfinished">%1 cliente</translation>
     </message>
+    <message>
+        <source>&amp;Hide</source>
+        <translation type="unfinished">&amp;Ocultar </translation>
+    </message>
+    <message>
+        <source>S&amp;how</source>
+        <translation type="unfinished">M&amp;ostrar</translation>
+    </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n conexión activa con la red Bitcoin.</numerusform>
+            <numerusform>%n conexiones activas con la red Bitcoin.</numerusform>
         </translation>
+    </message>
+    <message>
+        <source>Click for more actions.</source>
+        <extracomment>A substring of the tooltip. "More actions" are available via the context menu.</extracomment>
+        <translation type="unfinished">Hacer clic para ver más acciones.</translation>
+    </message>
+    <message>
+        <source>Show Peers tab</source>
+        <extracomment>A context menu item. The "Peers tab" is an element of the "Node window".</extracomment>
+        <translation type="unfinished">Mostrar pestaña de pares</translation>
+    </message>
+    <message>
+        <source>Disable network activity</source>
+        <extracomment>A context menu item.</extracomment>
+        <translation type="unfinished">Deshabilitar actividad de red</translation>
+    </message>
+    <message>
+        <source>Enable network activity</source>
+        <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
+        <translation type="unfinished">Habilitar actividad de red</translation>
+    </message>
+    <message>
+        <source>Pre-syncing Headers (%1%)…</source>
+        <translation type="unfinished">Presincronizando encabezados (%1%)...</translation>
     </message>
     <message>
         <source>Warning: %1</source>
@@ -959,6 +1209,30 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
         <translation type="unfinished">Copiar Cantidad</translation>
     </message>
     <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Copiar dirección</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Copiar &amp;etiqueta</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Copiar &amp;cantidad</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID and output index</source>
+        <translation type="unfinished">Copiar &amp;identificador de transacción e índice de salidas</translation>
+    </message>
+    <message>
+        <source>L&amp;ock unspent</source>
+        <translation type="unfinished">B&amp;loquear importe no gastado</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock unspent</source>
+        <translation type="unfinished">&amp;Desbloquear importe no gastado</translation>
+    </message>
+    <message>
         <source>Copy quantity</source>
         <translation type="unfinished">Copiar cantidad</translation>
     </message>
@@ -1019,6 +1293,11 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
         <translation type="unfinished">Crear Billetera</translation>
     </message>
     <message>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the create wallet progress window which indicates to the user which wallet is currently being created.</extracomment>
+        <translation type="unfinished">Creación de monedero&lt;b&gt;%1&lt;/b&gt;</translation>
+    </message>
+    <message>
         <source>Create wallet failed</source>
         <translation type="unfinished">Fallo al crear la billetera</translation>
     </message>
@@ -1026,9 +1305,38 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
         <source>Create wallet warning</source>
         <translation type="unfinished">Advertencia al crear la billetera</translation>
     </message>
-    </context>
+    <message>
+        <source>Can't list signers</source>
+        <translation type="unfinished">No se puede hacer una lista de firmantes</translation>
+    </message>
+    <message>
+        <source>Too many external signers found</source>
+        <translation type="unfinished">Se encontraron demasiados firmantes externos</translation>
+    </message>
+</context>
+<context>
+    <name>LoadWalletsActivity</name>
+    <message>
+        <source>Load Wallets</source>
+        <extracomment>Title of progress window which is displayed when wallets are being loaded.</extracomment>
+        <translation type="unfinished">Cargar billeteras</translation>
+    </message>
+    <message>
+        <source>Loading wallets…</source>
+        <extracomment>Descriptive text of the load wallets progress window which indicates to the user that wallets are currently being loaded.</extracomment>
+        <translation type="unfinished">Cargando billeteras...</translation>
+    </message>
+</context>
 <context>
     <name>OpenWalletActivity</name>
+    <message>
+        <source>Open wallet failed</source>
+        <translation type="unfinished">Fallo al abrir billetera</translation>
+    </message>
+    <message>
+        <source>Open wallet warning</source>
+        <translation type="unfinished">Advertencia al abrir billetera</translation>
+    </message>
     <message>
         <source>default wallet</source>
         <translation type="unfinished">billetera predeterminada</translation>
@@ -1038,12 +1346,53 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
         <extracomment>Title of window indicating the progress of opening of a wallet.</extracomment>
         <translation type="unfinished">Abrir billetera</translation>
     </message>
-    </context>
+    <message>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the open wallet progress window which indicates to the user which wallet is currently being opened.</extracomment>
+        <translation type="unfinished">Abriendo billetera &lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+</context>
+<context>
+    <name>RestoreWalletActivity</name>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of progress window which is displayed when wallets are being restored.</extracomment>
+        <translation type="unfinished">Restaurar billetera</translation>
+    </message>
+    <message>
+        <source>Restoring Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the restore wallets progress window which indicates to the user that wallets are currently being restored.</extracomment>
+        <translation type="unfinished">Restaurando billetera &lt;b&gt;%1&lt;/b&gt;…</translation>
+    </message>
+    <message>
+        <source>Restore wallet failed</source>
+        <extracomment>Title of message box which is displayed when the wallet could not be restored.</extracomment>
+        <translation type="unfinished">Error al restaurar la billetera</translation>
+    </message>
+    <message>
+        <source>Restore wallet warning</source>
+        <extracomment>Title of message box which is displayed when the wallet is restored with some warning.</extracomment>
+        <translation type="unfinished">Advertencia al restaurar billetera</translation>
+    </message>
+    <message>
+        <source>Restore wallet message</source>
+        <extracomment>Title of message box which is displayed when the wallet is successfully restored.</extracomment>
+        <translation type="unfinished">Mensaje al restaurar billetera</translation>
+    </message>
+</context>
 <context>
     <name>WalletController</name>
     <message>
         <source>Close wallet</source>
         <translation type="unfinished">Cerrar billetera</translation>
+    </message>
+    <message>
+        <source>Are you sure you wish to close the wallet &lt;i&gt;%1&lt;/i&gt;?</source>
+        <translation type="unfinished">¿Está seguro de que desea cerrar la billetera &lt;i&gt;%1&lt;/i&gt;?</translation>
+    </message>
+    <message>
+        <source>Closing the wallet for too long can result in having to resync the entire chain if pruning is enabled.</source>
+        <translation type="unfinished">Cerrar la billetera durante demasiado tiempo puede causar la resincronización de toda la cadena si el modo pruning está habilitado.</translation>
     </message>
     <message>
         <source>Close all wallets</source>
@@ -1066,7 +1415,7 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
     </message>
     <message>
         <source>Wallet</source>
-        <translation type="unfinished">Cartera</translation>
+        <translation type="unfinished">Billetera</translation>
     </message>
     <message>
         <source>Encrypt the wallet. The wallet will be encrypted with a passphrase of your choice.</source>
@@ -1097,14 +1446,35 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
         <translation type="unfinished">Crear billetera vacía</translation>
     </message>
     <message>
+        <source>Use descriptors for scriptPubKey management</source>
+        <translation type="unfinished">Use descriptores para la gestión de scriptPubKey</translation>
+    </message>
+    <message>
         <source>Descriptor Wallet</source>
         <translation type="unfinished">Descriptor de la billetera</translation>
+    </message>
+    <message>
+        <source>Use an external signing device such as a hardware wallet. Configure the external signer script in wallet preferences first.</source>
+        <translation type="unfinished">Use un dispositivo de firma externo, por ejemplo, una billetera de hardware. Configure primero el script del firmante externo en las preferencias de la billetera.</translation>
+    </message>
+    <message>
+        <source>External signer</source>
+        <translation type="unfinished">Firmante externo</translation>
     </message>
     <message>
         <source>Create</source>
         <translation type="unfinished">Crear</translation>
     </message>
-    </context>
+    <message>
+        <source>Compiled without sqlite support (required for descriptor wallets)</source>
+        <translation type="unfinished">Compilado sin soporte de sqlite (requerido para billeteras basadas en descriptores)</translation>
+    </message>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Compilado sin soporte de firma externa (necesario para la firma externa)</translation>
+    </message>
+</context>
 <context>
     <name>EditAddressDialog</name>
     <message>
@@ -1144,6 +1514,14 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
         <translation type="unfinished">La dirección introducida "%1" no es una dirección Bitcoin valida.</translation>
     </message>
     <message>
+        <source>Address "%1" already exists as a receiving address with label "%2" and so cannot be added as a sending address.</source>
+        <translation type="unfinished">La dirección "%1" ya existe como dirección de recepción con la etiqueta "%2" y, por lo tanto, no se puede agregar como dirección de envío.</translation>
+    </message>
+    <message>
+        <source>The entered address "%1" is already in the address book with label "%2".</source>
+        <translation type="unfinished">La dirección ingresada "%1" ya está en la libreta de direcciones con la etiqueta "%2".</translation>
+    </message>
+    <message>
         <source>Could not unlock wallet.</source>
         <translation type="unfinished">No se pudo desbloquear la billetera.</translation>
     </message>
@@ -1177,6 +1555,27 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
 </context>
 <context>
     <name>Intro</name>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform>%n GB de espacio disponible</numerusform>
+            <numerusform>%n GB de espacio disponible</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform>(de %n GB necesario)</numerusform>
+            <numerusform>(de %n GB necesarios)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform>(%n GB necesario para completar la cadena)</numerusform>
+            <numerusform>(%n GB necesarios para completar la cadena)</numerusform>
+        </translation>
+    </message>
     <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
         <translation type="unfinished">Al menos %1 GB de información será almacenado en este directorio, y seguirá creciendo a través del tiempo.</translation>
@@ -1189,8 +1588,8 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>(suficiente para restaurar copias de seguridad de %n día de antigüedad)</numerusform>
+            <numerusform>(suficiente para restaurar copias de seguridad de %n días de antigüedad)</numerusform>
         </translation>
     </message>
     <message>
@@ -1218,8 +1617,8 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
         <translation type="unfinished">Al ser la primera vez que se ejecuta el programa, puede elegir donde %1 almacenará sus datos.</translation>
     </message>
     <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation type="unfinished">Al hacer clic OK, %1 iniciará el proceso de descarga y procesará el blockchain completo de %4 (%2 GB), iniciando desde el la transacción más antigua %3 cuando %4 se ejecutó inicialmente.</translation>
+        <source>Limit block chain storage to</source>
+        <translation type="unfinished">Limitar el almacenamiento de cadena de bloques a</translation>
     </message>
     <message>
         <source>Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</source>
@@ -1228,6 +1627,10 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
     <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
         <translation type="unfinished">El primer proceso de sincronización consume muchos recursos, y es posible que puedan ocurrir problemas de hardware que anteriormente no hayas notado. Cada vez que ejecutes %1 automáticamente se reiniciará el proceso de sincronización desde el punto que lo dejaste anteriormente.</translation>
+    </message>
+    <message>
+        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2 GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
+        <translation type="unfinished">Al hacer clic en OK, %1 iniciará el proceso de descarga y procesará la cadena de bloques %4 completa (%2 GB), empezando con la transacción más antigua en %3 cuando %4 se ejecutó inicialmente.</translation>
     </message>
     <message>
         <source>If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</source>
@@ -1260,6 +1663,10 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
 <context>
     <name>ShutdownWindow</name>
     <message>
+        <source>%1 is shutting down…</source>
+        <translation type="unfinished">%1 se está cerrando...</translation>
+    </message>
+    <message>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished">No apague el equipo hasta que desaparezca esta ventana.</translation>
     </message>
@@ -1283,6 +1690,14 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
         <translation type="unfinished">Número de bloques restantes</translation>
     </message>
     <message>
+        <source>Unknown…</source>
+        <translation type="unfinished">Desconocido...</translation>
+    </message>
+    <message>
+        <source>calculating…</source>
+        <translation type="unfinished">calculando...</translation>
+    </message>
+    <message>
         <source>Last block time</source>
         <translation type="unfinished">Hora del último bloque</translation>
     </message>
@@ -1302,9 +1717,25 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
         <source>Hide</source>
         <translation type="unfinished">Ocultar</translation>
     </message>
-    </context>
+    <message>
+        <source>%1 is currently syncing.  It will download headers and blocks from peers and validate them until reaching the tip of the block chain.</source>
+        <translation type="unfinished">%1 se está sincronizando actualmente. Descargará encabezados y bloques de pares, y los validará hasta alcanzar el extremo de la cadena de bloques.</translation>
+    </message>
+    <message>
+        <source>Unknown. Syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">Desconocido. Sincronizando encabezados (%1, %2%)…</translation>
+    </message>
+    <message>
+        <source>Unknown. Pre-syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">Desconocido. Presincronizando encabezados (%1, %2%)…</translation>
+    </message>
+</context>
 <context>
     <name>OpenURIDialog</name>
+    <message>
+        <source>Open bitcoin URI</source>
+        <translation type="unfinished">Abrir URI de bitcoin</translation>
+    </message>
     <message>
         <source>Paste address from clipboard</source>
         <extracomment>Tooltip text for button that allows you to paste an address that is in your clipboard.</extracomment>
@@ -1330,6 +1761,10 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
         <translation type="unfinished">&amp;Iniciar %1 al iniciar el sistema</translation>
     </message>
     <message>
+        <source>Enabling pruning significantly reduces the disk space required to store transactions. All blocks are still fully validated. Reverting this setting requires re-downloading the entire blockchain.</source>
+        <translation type="unfinished">Al activar el modo pruning, se reduce considerablemente el espacio de disco necesario para almacenar las transacciones. Todos los bloques aún se validan completamente. Para revertir esta opción, se requiere descargar de nuevo toda la cadena de bloques.</translation>
+    </message>
+    <message>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished">Tamaño del caché de la base de &amp;datos</translation>
     </message>
@@ -1348,6 +1783,10 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
     <message>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
         <translation type="unfinished">Minimizar en vez de salir de la aplicación cuando la ventana está cerrada. Cuando se activa esta opción, la aplicación sólo se cerrará después de seleccionar Salir en el menú.</translation>
+    </message>
+    <message>
+        <source>Options set in this dialog are overridden by the command line:</source>
+        <translation type="unfinished">Las opciones establecidas en este diálogo serán anuladas por la línea de comandos:</translation>
     </message>
     <message>
         <source>Open the %1 configuration file from the working directory.</source>
@@ -1370,12 +1809,50 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
         <translation type="unfinished">&amp;Red</translation>
     </message>
     <message>
+        <source>Prune &amp;block storage to</source>
+        <translation type="unfinished">Habilitar el modo prune para el almacenamiento de &amp;bloques a</translation>
+    </message>
+    <message>
+        <source>Reverting this setting requires re-downloading the entire blockchain.</source>
+        <translation type="unfinished">Para revertir esta configuración, se debe descargar de nuevo la cadena de bloques completa.</translation>
+    </message>
+    <message>
+        <source>Maximum database cache size. A larger cache can contribute to faster sync, after which the benefit is less pronounced for most use cases. Lowering the cache size will reduce memory usage. Unused mempool memory is shared for this cache.</source>
+        <extracomment>Tooltip text for Options window setting that sets the size of the database cache. Explains the corresponding effects of increasing/decreasing this value.</extracomment>
+        <translation type="unfinished">Tamaño máximo de la caché de la base de datos. Una caché más grande puede contribuir a una sincronización más rápida, después de lo cual el beneficio es menos pronunciado para la mayoría de los casos de uso. Disminuir el tamaño de la caché reducirá el uso de la memoria. La memoria mempool no utilizada se comparte para esta caché.</translation>
+    </message>
+    <message>
+        <source>Set the number of script verification threads. Negative values correspond to the number of cores you want to leave free to the system.</source>
+        <extracomment>Tooltip text for Options window setting that sets the number of script verification threads. Explains that negative values mean to leave these many cores free to the system.</extracomment>
+        <translation type="unfinished">Establezca el número de hilos de verificación de scripts. Los valores negativos corresponden al número de núcleos que se desea dejar libres al sistema.</translation>
+    </message>
+    <message>
         <source>(0 = auto, &lt;0 = leave that many cores free)</source>
         <translation type="unfinished">(0 = auto, &lt;0 = deja esta cantidad de núcleos libres)</translation>
     </message>
     <message>
+        <source>This allows you or a third party tool to communicate with the node through command-line and JSON-RPC commands.</source>
+        <extracomment>Tooltip text for Options window setting that enables the RPC server.</extracomment>
+        <translation type="unfinished">Esto le permite a usted o a una herramienta de terceros comunicarse con el nodo a través de la línea de comandos y los comandos JSON-RPC.</translation>
+    </message>
+    <message>
+        <source>Enable R&amp;PC server</source>
+        <extracomment>An Options window setting to enable the RPC server.</extracomment>
+        <translation type="unfinished">Activar servidor R&amp;PC</translation>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished">Cartera</translation>
+    </message>
+    <message>
+        <source>Whether to set subtract fee from amount as default or not.</source>
+        <extracomment>Tooltip text for Options window setting that sets subtracting the fee from a sending amount as default.</extracomment>
+        <translation type="unfinished">Si se resta la comisión del importe por defecto o no.</translation>
+    </message>
+    <message>
+        <source>Subtract &amp;fee from amount by default</source>
+        <extracomment>An Options window setting to set subtracting the fee from a sending amount as default.</extracomment>
+        <translation type="unfinished">Restar &amp;comisión del importe por defecto</translation>
     </message>
     <message>
         <source>Expert</source>
@@ -1394,12 +1871,42 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
         <translation type="unfinished">Gastar cambio sin confirmar</translation>
     </message>
     <message>
+        <source>Enable &amp;PSBT controls</source>
+        <extracomment>An options window setting to enable PSBT controls.</extracomment>
+        <translation type="unfinished">Activar controles de &amp;PSBT</translation>
+    </message>
+    <message>
+        <source>Whether to show PSBT controls.</source>
+        <extracomment>Tooltip text for options window setting that enables PSBT controls.</extracomment>
+        <translation type="unfinished">Si se muestran los controles de PSBT.</translation>
+    </message>
+    <message>
+        <source>External Signer (e.g. hardware wallet)</source>
+        <translation type="unfinished">Firmante externo (p. ej., billetera de hardware)</translation>
+    </message>
+    <message>
+        <source>&amp;External signer script path</source>
+        <translation type="unfinished">&amp;Ruta al script del firmante externo</translation>
+    </message>
+    <message>
+        <source>Full path to a Bitcoin Core compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</source>
+        <translation type="unfinished">Ruta completa a un script compatible con Bitcoin Core (p. ej., C:\Descargas\hwi.exe o /Usuarios/SuUsuario/Descargas/hwi.py). Advertencia: ¡El malware podría robarle sus monedas!</translation>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation type="unfinished">Abre automáticamente el puerto del cliente Bitcoin en el router. Esto funciona solo cuando tu router es compatible con UPnP y está habilitado.</translation>
     </message>
     <message>
         <source>Map port using &amp;UPnP</source>
         <translation type="unfinished">Direcciona el puerto usando &amp;UPnP</translation>
+    </message>
+    <message>
+        <source>Automatically open the Bitcoin client port on the router. This only works when your router supports NAT-PMP and it is enabled. The external port could be random.</source>
+        <translation type="unfinished">Abre automáticamente el puerto del cliente de Bitcoin en el router. Esto solo funciona cuando el router es compatible con NAT-PMP y está activo. El puerto externo podría ser aleatorio</translation>
+    </message>
+    <message>
+        <source>Map port using NA&amp;T-PMP</source>
+        <translation type="unfinished">Mapear el puerto usando NA&amp;T-PMP</translation>
     </message>
     <message>
         <source>Accept connections from outside.</source>
@@ -1435,8 +1942,15 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
     </message>
     <message>
         <source>&amp;Window</source>
-        <translation type="unfinished">y windows
-</translation>
+        <translation type="unfinished">&amp;Ventana</translation>
+    </message>
+    <message>
+        <source>Show the icon in the system tray.</source>
+        <translation type="unfinished">Mostrar el ícono en la bandeja del sistema.</translation>
+    </message>
+    <message>
+        <source>&amp;Show tray icon</source>
+        <translation type="unfinished">&amp;Mostrar el ícono de la bandeja</translation>
     </message>
     <message>
         <source>Show only a tray icon after minimizing the window.</source>
@@ -1471,12 +1985,45 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
         <translation type="unfinished">Elige la subdivisión por defecto para mostrar cantidaded en la interfaz cuando se envien monedas</translation>
     </message>
     <message>
+        <source>Third-party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</source>
+        <translation type="unfinished">Las URL de terceros (por ejemplo, un explorador de bloques) que aparecen en la pestaña de transacciones como elementos del menú contextual. El hash de la transacción remplaza el valor %s en la URL. Varias URL se separan con una barra vertical (|).</translation>
+    </message>
+    <message>
+        <source>&amp;Third-party transaction URLs</source>
+        <translation type="unfinished">&amp;URL de transacciones de terceros</translation>
+    </message>
+    <message>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished">Mostrar o no funcionalidad de Coin Control</translation>
     </message>
     <message>
+        <source>Connect to the Bitcoin network through a separate SOCKS5 proxy for Tor onion services.</source>
+        <translation type="unfinished">Conectarse a la red Bitcoin a través de un proxy SOCKS5 independiente para los servicios onion de Tor.</translation>
+    </message>
+    <message>
+        <source>Use separate SOCKS&amp;5 proxy to reach peers via Tor onion services:</source>
+        <translation type="unfinished">Usar un proxy SOCKS&amp;5 independiente para comunicarse con pares a través de los servicios onion de Tor:</translation>
+    </message>
+    <message>
+        <source>Monospaced font in the Overview tab:</source>
+        <translation type="unfinished">Fuente monoespaciada en la pestaña de vista general:</translation>
+    </message>
+    <message>
+        <source>embedded "%1"</source>
+        <translation type="unfinished">"%1" insertado</translation>
+    </message>
+    <message>
+        <source>closest matching "%1"</source>
+        <translation type="unfinished">"%1" con la coincidencia más aproximada</translation>
+    </message>
+    <message>
         <source>&amp;Cancel</source>
         <translation type="unfinished">&amp;Cancela</translation>
+    </message>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Compilado sin soporte de firma externa (necesario para la firma externa)</translation>
     </message>
     <message>
         <source>default</source>
@@ -1488,14 +2035,22 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
     </message>
     <message>
         <source>Confirm options reset</source>
+        <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
         <translation type="unfinished">Confirmar reestablecimiento de las opciones</translation>
     </message>
     <message>
         <source>Client restart required to activate changes.</source>
+        <extracomment>Text explaining that the settings changed will not come into effect until the client is restarted.</extracomment>
         <translation type="unfinished">Es necesario reiniciar el cliente para activar los cambios.</translation>
     </message>
     <message>
+        <source>Current settings will be backed up at "%1".</source>
+        <extracomment>Text explaining to the user that the client's current settings will be backed up at a specific location. %1 is a stand-in argument for the backup location's path.</extracomment>
+        <translation type="unfinished">Se realizará una copia de seguridad de la configuración actual en "%1".</translation>
+    </message>
+    <message>
         <source>Client will be shut down. Do you want to proceed?</source>
+        <extracomment>Text asking the user to confirm if they would like to proceed with a client shutdown.</extracomment>
         <translation type="unfinished">El cliente se cerrará. Desea proceder?</translation>
     </message>
     <message>
@@ -1509,6 +2064,14 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
         <translation type="unfinished">El archivo de configuración es utilizado para especificar opciones avanzadas del usuario, que invalidan los ajustes predeterminados. Adicionalmente, cualquier opción ingresada por la línea de comandos invalidará este archivo de configuración.</translation>
     </message>
     <message>
+        <source>Continue</source>
+        <translation type="unfinished">Continuar</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Cancelar</translation>
+    </message>
+    <message>
         <source>The configuration file could not be opened.</source>
         <translation type="unfinished">El archivo de configuración no pudo ser abierto.</translation>
     </message>
@@ -1519,6 +2082,13 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
     <message>
         <source>The supplied proxy address is invalid.</source>
         <translation type="unfinished">El proxy ingresado es inválido.</translation>
+    </message>
+</context>
+<context>
+    <name>OptionsModel</name>
+    <message>
+        <source>Could not read setting "%1", %2.</source>
+        <translation type="unfinished">No se puede leer la configuración "%1", %2.</translation>
     </message>
 </context>
 <context>
@@ -1589,9 +2159,13 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
     </message>
     <message>
         <source>Current total balance in watch-only addresses</source>
-        <translation type="unfinished">Saldo total actual en direcciones de solo reloj</translation>
+        <translation type="unfinished">Saldo total actual en direcciones de solo observación</translation>
     </message>
-    </context>
+    <message>
+        <source>Privacy mode activated for the Overview tab. To unmask the values, uncheck Settings-&gt;Mask values.</source>
+        <translation type="unfinished">Modo de privacidad activado para la pestaña de vista general. Para mostrar los valores, anule la selección de Configuración-&gt;Ocultar valores.</translation>
+    </message>
+</context>
 <context>
     <name>PSBTOperationsDialog</name>
     <message>
@@ -1599,20 +2173,125 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
         <translation type="unfinished">Dialogo</translation>
     </message>
     <message>
+        <source>Sign Tx</source>
+        <translation type="unfinished">Firmar transacción</translation>
+    </message>
+    <message>
+        <source>Broadcast Tx</source>
+        <translation type="unfinished">Transmitir transacción</translation>
+    </message>
+    <message>
+        <source>Copy to Clipboard</source>
+        <translation type="unfinished">Copiar al portapapeles</translation>
+    </message>
+    <message>
+        <source>Save…</source>
+        <translation type="unfinished">Guardar...</translation>
+    </message>
+    <message>
         <source>Close</source>
         <translation type="unfinished">Cerrar</translation>
+    </message>
+    <message>
+        <source>Failed to load transaction: %1</source>
+        <translation type="unfinished">Error al cargar la transacción: %1</translation>
+    </message>
+    <message>
+        <source>Failed to sign transaction: %1</source>
+        <translation type="unfinished">Error al firmar la transacción: %1</translation>
+    </message>
+    <message>
+        <source>Cannot sign inputs while wallet is locked.</source>
+        <translation type="unfinished">No se pueden firmar entradas mientras la billetera está bloqueada.</translation>
+    </message>
+    <message>
+        <source>Could not sign any more inputs.</source>
+        <translation type="unfinished">No se pudo firmar más entradas.</translation>
+    </message>
+    <message>
+        <source>Signed %1 inputs, but more signatures are still required.</source>
+        <translation type="unfinished">Se firmaron %1 entradas, pero aún se requieren más firmas.</translation>
+    </message>
+    <message>
+        <source>Signed transaction successfully. Transaction is ready to broadcast.</source>
+        <translation type="unfinished">La transacción se firmó correctamente y está lista para transmitirse.</translation>
+    </message>
+    <message>
+        <source>Unknown error processing transaction.</source>
+        <translation type="unfinished">Error desconocido al procesar la transacción.</translation>
+    </message>
+    <message>
+        <source>Transaction broadcast successfully! Transaction ID: %1</source>
+        <translation type="unfinished">¡La transacción se transmitió correctamente! Identificador de transacción: %1</translation>
+    </message>
+    <message>
+        <source>Transaction broadcast failed: %1</source>
+        <translation type="unfinished">Error al transmitir la transacción: %1</translation>
+    </message>
+    <message>
+        <source>PSBT copied to clipboard.</source>
+        <translation type="unfinished">PSBT copiada al portapapeles.</translation>
     </message>
     <message>
         <source>Save Transaction Data</source>
         <translation type="unfinished">Guardar datos de la transacción</translation>
     </message>
     <message>
+        <source>Partially Signed Transaction (Binary)</source>
+        <extracomment>Expanded name of the binary PSBT file format. See: BIP 174.</extracomment>
+        <translation type="unfinished">Transacción parcialmente firmada (binario) </translation>
+    </message>
+    <message>
+        <source>PSBT saved to disk.</source>
+        <translation type="unfinished">PSBT guardada en en el disco.</translation>
+    </message>
+    <message>
+        <source> * Sends %1 to %2</source>
+        <translation type="unfinished">* Envía %1 a %2</translation>
+    </message>
+    <message>
+        <source>Unable to calculate transaction fee or total transaction amount.</source>
+        <translation type="unfinished">No se puede calcular la comisión o el importe total de la transacción.</translation>
+    </message>
+    <message>
+        <source>Pays transaction fee: </source>
+        <translation type="unfinished">Paga comisión de transacción:</translation>
+    </message>
+    <message>
         <source>Total Amount</source>
-        <translation type="unfinished">Monto total</translation>
+        <translation type="unfinished">Cantidad total</translation>
     </message>
     <message>
         <source>or</source>
         <translation type="unfinished">o</translation>
+    </message>
+    <message>
+        <source>Transaction has %1 unsigned inputs.</source>
+        <translation type="unfinished">La transacción tiene %1 entradas sin firmar.</translation>
+    </message>
+    <message>
+        <source>Transaction is missing some information about inputs.</source>
+        <translation type="unfinished">A la transacción le falta información sobre entradas.</translation>
+    </message>
+    <message>
+        <source>Transaction still needs signature(s).</source>
+        <translation type="unfinished">La transacción aún necesita firma(s).</translation>
+    </message>
+    <message>
+        <source>(But no wallet is loaded.)</source>
+        <translation type="unfinished">(Pero no se cargó ninguna billetera).</translation>
+    </message>
+    <message>
+        <source>(But this wallet cannot sign transactions.)</source>
+        <translation type="unfinished">(Pero esta billetera no puede firmar transacciones).</translation>
+    </message>
+    <message>
+        <source>(But this wallet does not have the right keys.)</source>
+        <translation type="unfinished">(Pero esta billetera no tiene las claves adecuadas).</translation>
+    </message>
+    <message>
+        <source>Transaction is fully signed and ready for broadcast.</source>
+        <translation type="unfinished">La transacción se firmó completamente y está lista para transmitirse.</translation>
     </message>
     <message>
         <source>Transaction status is unknown.</source>
@@ -1634,6 +2313,18 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
         <translation type="unfinished">Manejo de URI</translation>
     </message>
     <message>
+        <source>'bitcoin://' is not a valid URI. Use 'bitcoin:' instead.</source>
+        <translation type="unfinished">"bitcoin://" no es un URI válido. Use "bitcoin:" en su lugar.</translation>
+    </message>
+    <message>
+        <source>Cannot process payment request because BIP70 is not supported.
+Due to widespread security flaws in BIP70 it's strongly recommended that any merchant instructions to switch wallets be ignored.
+If you are receiving this error you should request the merchant provide a BIP21 compatible URI.</source>
+        <translation type="unfinished">No se puede procesar la solicitud de pago porque no existe compatibilidad con BIP70.
+Debido a los fallos de seguridad generalizados en BIP70, se recomienda encarecidamente ignorar las instrucciones del comerciante para cambiar de billetera.
+Si recibe este error, debe solicitar al comerciante que le proporcione un URI compatible con BIP21.</translation>
+    </message>
+    <message>
         <source>URI cannot be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation type="unfinished">¡URI no puede ser analizado! Esto puede deberse a una dirección de Bitcoin no válida o a parámetros de URI mal formados.</translation>
     </message>
@@ -1644,6 +2335,16 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
 </context>
 <context>
     <name>PeerTableModel</name>
+    <message>
+        <source>Peer</source>
+        <extracomment>Title of Peers Table column which contains a unique number used to identify a connection.</extracomment>
+        <translation type="unfinished">Par</translation>
+    </message>
+    <message>
+        <source>Age</source>
+        <extracomment>Title of Peers Table column which indicates the duration (length of time) since the peer connection started.</extracomment>
+        <translation type="unfinished">Duración</translation>
+    </message>
     <message>
         <source>Direction</source>
         <extracomment>Title of Peers Table column which indicates the direction the peer connection was initiated from.</extracomment>
@@ -1688,18 +2389,35 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
 <context>
     <name>QRImageWidget</name>
     <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">&amp;Guardar imagen...</translation>
+    </message>
+    <message>
         <source>&amp;Copy Image</source>
         <translation type="unfinished">&amp;Copiar imagen</translation>
+    </message>
+    <message>
+        <source>Resulting URI too long, try to reduce the text for label / message.</source>
+        <translation type="unfinished">El URI resultante es demasiado largo, así que trate de reducir el texto de la etiqueta o el mensaje.</translation>
     </message>
     <message>
         <source>Error encoding URI into QR Code.</source>
         <translation type="unfinished">Fallo al codificar URI en código QR.</translation>
     </message>
     <message>
+        <source>QR code support not available.</source>
+        <translation type="unfinished">La compatibilidad con el código QR no está disponible.</translation>
+    </message>
+    <message>
         <source>Save QR Code</source>
         <translation type="unfinished">Guardar código QR</translation>
     </message>
-    </context>
+    <message>
+        <source>PNG Image</source>
+        <extracomment>Expanded name of the PNG file format. See: https://en.wikipedia.org/wiki/Portable_Network_Graphics.</extracomment>
+        <translation type="unfinished">Imagen PNG</translation>
+    </message>
+</context>
 <context>
     <name>RPCConsole</name>
     <message>
@@ -1711,8 +2429,16 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
         <translation type="unfinished">&amp;Información</translation>
     </message>
     <message>
+        <source>To specify a non-default location of the data directory use the '%1' option.</source>
+        <translation type="unfinished">Para especificar una ubicación no predeterminada del directorio de datos, use la opción "%1".</translation>
+    </message>
+    <message>
         <source>Blocksdir</source>
         <translation type="unfinished">Bloques dir</translation>
+    </message>
+    <message>
+        <source>To specify a non-default location of the blocks directory use the '%1' option.</source>
+        <translation type="unfinished">Para especificar una ubicación no predeterminada del directorio de bloques, use la opción "%1".</translation>
     </message>
     <message>
         <source>Startup time</source>
@@ -1732,7 +2458,7 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
     </message>
     <message>
         <source>Block chain</source>
-        <translation type="unfinished">Bloquea cadena</translation>
+        <translation type="unfinished">Cadena de bloques</translation>
     </message>
     <message>
         <source>Current number of transactions</source>
@@ -1788,6 +2514,48 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
         <translation type="unfinished">Bloques sincronizados</translation>
     </message>
     <message>
+        <source>Last Transaction</source>
+        <translation type="unfinished">Última transacción</translation>
+    </message>
+    <message>
+        <source>The mapped Autonomous System used for diversifying peer selection.</source>
+        <translation type="unfinished">El sistema autónomo asignado que se usó para diversificar la selección de pares.</translation>
+    </message>
+    <message>
+        <source>Mapped AS</source>
+        <translation type="unfinished">SA asignado</translation>
+    </message>
+    <message>
+        <source>Whether we relay addresses to this peer.</source>
+        <extracomment>Tooltip text for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
+        <translation type="unfinished">Si retransmitimos las direcciones a este par.</translation>
+    </message>
+    <message>
+        <source>Address Relay</source>
+        <extracomment>Text title for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
+        <translation type="unfinished">Retransmisión de dirección</translation>
+    </message>
+    <message>
+        <source>The total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</source>
+        <extracomment>Tooltip text for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
+        <translation type="unfinished">El número total de direcciones recibidas desde este par que se procesaron (excluye las direcciones omitidas debido a la limitación de volumen).</translation>
+    </message>
+    <message>
+        <source>The total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</source>
+        <extracomment>Tooltip text for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
+        <translation type="unfinished">El número total de direcciones recibidas desde este par que se omitieron (no se procesaron) debido a la limitación de volumen.</translation>
+    </message>
+    <message>
+        <source>Addresses Processed</source>
+        <extracomment>Text title for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
+        <translation type="unfinished">Direcciones procesadas</translation>
+    </message>
+    <message>
+        <source>Addresses Rate-Limited</source>
+        <extracomment>Text title for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
+        <translation type="unfinished">Direcciones omitidas por limitación de volumen</translation>
+    </message>
+    <message>
         <source>Node window</source>
         <translation type="unfinished">Ventana del nodo</translation>
     </message>
@@ -1808,12 +2576,53 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
         <translation type="unfinished">Permisos</translation>
     </message>
     <message>
+        <source>The direction and type of peer connection: %1</source>
+        <translation type="unfinished">La dirección y el tipo de conexión entre pares: %1</translation>
+    </message>
+    <message>
+        <source>Direction/Type</source>
+        <translation type="unfinished">Dirección/Tipo</translation>
+    </message>
+    <message>
+        <source>The network protocol this peer is connected through: IPv4, IPv6, Onion, I2P, or CJDNS.</source>
+        <translation type="unfinished">El protocolo de red mediante el cual está conectado este par: IPv4, IPv6, Onion, I2P o CJDNS.</translation>
+    </message>
+    <message>
         <source>Services</source>
         <translation type="unfinished">Servicios</translation>
     </message>
     <message>
+        <source>Whether the peer requested us to relay transactions.</source>
+        <translation type="unfinished">Si el par nos solicitó retransmitir transacciones.</translation>
+    </message>
+    <message>
+        <source>Wants Tx Relay</source>
+        <translation type="unfinished">Desea retransmisión de transacciones</translation>
+    </message>
+    <message>
+        <source>High bandwidth BIP152 compact block relay: %1</source>
+        <translation type="unfinished">Retransmisión de bloque compacto BIP152 en modo de banda ancha: %1</translation>
+    </message>
+    <message>
+        <source>High Bandwidth</source>
+        <translation type="unfinished">Banda ancha</translation>
+    </message>
+    <message>
         <source>Connection Time</source>
         <translation type="unfinished">Duración de la conexión</translation>
+    </message>
+    <message>
+        <source>Elapsed time since a novel block passing initial validity checks was received from this peer.</source>
+        <translation type="unfinished">Tiempo transcurrido desde que se recibió de este par un nuevo bloque que superó las comprobaciones de validez iniciales.</translation>
+    </message>
+    <message>
+        <source>Last Block</source>
+        <translation type="unfinished">Último bloque</translation>
+    </message>
+    <message>
+        <source>Elapsed time since a novel transaction accepted into our mempool was received from this peer.</source>
+        <extracomment>Tooltip text for the Last Transaction field in the peer details area.</extracomment>
+        <translation type="unfinished">Tiempo transcurrido desde que se recibió de este par una nueva transacción aceptada en nuestra mempool.</translation>
     </message>
     <message>
         <source>Last Send</source>
@@ -1880,6 +2689,53 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
         <translation type="unfinished">Salida:</translation>
     </message>
     <message>
+        <source>Inbound: initiated by peer</source>
+        <extracomment>Explanatory text for an inbound peer connection.</extracomment>
+        <translation type="unfinished">Entrante: iniciada por el par</translation>
+    </message>
+    <message>
+        <source>Outbound Full Relay: default</source>
+        <extracomment>Explanatory text for an outbound peer connection that relays all network information. This is the default behavior for outbound connections.</extracomment>
+        <translation type="unfinished">Retransmisión completa saliente: predeterminada</translation>
+    </message>
+    <message>
+        <source>Outbound Block Relay: does not relay transactions or addresses</source>
+        <extracomment>Explanatory text for an outbound peer connection that relays network information about blocks and not transactions or addresses.</extracomment>
+        <translation type="unfinished">Retransmisión de bloque saliente: no retransmite transacciones o direcciones</translation>
+    </message>
+    <message>
+        <source>Outbound Manual: added using RPC %1 or %2/%3 configuration options</source>
+        <extracomment>Explanatory text for an outbound peer connection that was established manually through one of several methods. The numbered arguments are stand-ins for the methods available to establish manual connections.</extracomment>
+        <translation type="unfinished">Manual saliente: agregada usando las opciones de configuración %1 o %2/%3 de RPC</translation>
+    </message>
+    <message>
+        <source>Outbound Feeler: short-lived, for testing addresses</source>
+        <extracomment>Explanatory text for a short-lived outbound peer connection that is used to test the aliveness of known addresses.</extracomment>
+        <translation type="unfinished">Feeler saliente: de corta duración, para probar direcciones</translation>
+    </message>
+    <message>
+        <source>Outbound Address Fetch: short-lived, for soliciting addresses</source>
+        <extracomment>Explanatory text for a short-lived outbound peer connection that is used to request addresses from a peer.</extracomment>
+        <translation type="unfinished">Recuperación de dirección Saliente: de corta duración, para solicitar direcciones</translation>
+    </message>
+    <message>
+        <source>we selected the peer for high bandwidth relay</source>
+        <translation type="unfinished">Seleccionamos el par para la retransmisión de banda ancha</translation>
+    </message>
+    <message>
+        <source>the peer selected us for high bandwidth relay</source>
+        <translation type="unfinished">El par nos seleccionó para la retransmisión de banda ancha</translation>
+    </message>
+    <message>
+        <source>no high bandwidth relay selected</source>
+        <translation type="unfinished">No se seleccionó la retransmisión de banda ancha</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <extracomment>Context menu action to copy the address of a peer.</extracomment>
+        <translation type="unfinished">&amp;Copiar dirección</translation>
+    </message>
+    <message>
         <source>&amp;Disconnect</source>
         <translation type="unfinished">&amp;Desconectar</translation>
     </message>
@@ -1888,12 +2744,21 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
         <translation type="unfinished">1 &amp;hora</translation>
     </message>
     <message>
+        <source>1 d&amp;ay</source>
+        <translation type="unfinished">1 &amp;día</translation>
+    </message>
+    <message>
         <source>1 &amp;week</source>
         <translation type="unfinished">1 semana</translation>
     </message>
     <message>
         <source>1 &amp;year</source>
         <translation type="unfinished">1 año</translation>
+    </message>
+    <message>
+        <source>&amp;Copy IP/Netmask</source>
+        <extracomment>Context menu action to copy the IP/Netmask of a banned peer. IP/Netmask is the combination of a peer's IP address and its Netmask. For IP address, see: https://en.wikipedia.org/wiki/IP_address.</extracomment>
+        <translation type="unfinished">&amp;Copiar IP/Máscara de red</translation>
     </message>
     <message>
         <source>&amp;Unban</source>
@@ -1906,6 +2771,36 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
     <message>
         <source>Executing command without any wallet</source>
         <translation type="unfinished">Ejecutando comando con cualquier cartera</translation>
+    </message>
+    <message>
+        <source>Executing command using "%1" wallet</source>
+        <translation type="unfinished">Ejecutar comando usando la billetera "%1"</translation>
+    </message>
+    <message>
+        <source>Welcome to the %1 RPC console.
+Use up and down arrows to navigate history, and %2 to clear screen.
+Use %3 and %4 to increase or decrease the font size.
+Type %5 for an overview of available commands.
+For more information on using this console, type %6.
+
+%7WARNING: Scammers have been active, telling users to type commands here, stealing their wallet contents. Do not use this console without fully understanding the ramifications of a command.%8</source>
+        <extracomment>RPC console welcome message. Placeholders %7 and %8 are style tags for the warning content, and they are not space separated from the rest of the text intentionally.</extracomment>
+        <translation type="unfinished">Te damos la bienvenida a la consola RPC de %1.
+Utiliza las flechas hacia arriba y abajo para navegar por el historial, y %2 para borrar la pantalla.
+Utiliza %3 y %4 para aumentar o disminuir el tamaño de la fuente. 
+Escribe %5 para ver los comandos disponibles.
+Para obtener más información sobre cómo usar esta consola, escribe %6.
+
+%7 ADVERTENCIA: Los estafadores han estado activos diciendo a los usuarios que escriban comandos aquí, robando el contenido de sus monederos. No uses esta consola sin entender completamente las ramificaciones de un comando.%8</translation>
+    </message>
+    <message>
+        <source>Executing…</source>
+        <extracomment>A console message indicating an entered command is currently being executed.</extracomment>
+        <translation type="unfinished">Ejecutando...</translation>
+    </message>
+    <message>
+        <source>(peer: %1)</source>
+        <translation type="unfinished">(par: %1)</translation>
     </message>
     <message>
         <source>Yes</source>
@@ -1922,6 +2817,10 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
     <message>
         <source>Ban for</source>
         <translation type="unfinished">Prohibir para</translation>
+    </message>
+    <message>
+        <source>Never</source>
+        <translation type="unfinished">Nunca</translation>
     </message>
     <message>
         <source>Unknown</source>
@@ -1959,6 +2858,18 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
         <translation type="unfinished">Monto opcional a solicitar. Deja este campo vacío o en cero si no quieres definir un monto específico.</translation>
     </message>
     <message>
+        <source>An optional label to associate with the new receiving address (used by you to identify an invoice).  It is also attached to the payment request.</source>
+        <translation type="unfinished">Una etiqueta opcional para asociar con la nueva dirección de recepción (utilizada por ti para identificar una factura). También se adjunta a la solicitud de pago.</translation>
+    </message>
+    <message>
+        <source>An optional message that is attached to the payment request and may be displayed to the sender.</source>
+        <translation type="unfinished">Un mensaje opcional que se adjunta a la solicitud de pago y que puede mostrarse al remitente.</translation>
+    </message>
+    <message>
+        <source>&amp;Create new receiving address</source>
+        <translation type="unfinished">&amp;Crear una nueva dirección de recepción</translation>
+    </message>
+    <message>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished">Limpiar todos los campos del formulario.</translation>
     </message>
@@ -1991,12 +2902,36 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
         <translation type="unfinished">Copiar &amp;URI</translation>
     </message>
     <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Copiar dirección</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Copiar &amp;etiqueta</translation>
+    </message>
+    <message>
+        <source>Copy &amp;message</source>
+        <translation type="unfinished">Copiar &amp;mensaje</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Copiar &amp;cantidad</translation>
+    </message>
+    <message>
         <source>Could not unlock wallet.</source>
         <translation type="unfinished">No se pudo desbloquear la billetera.</translation>
     </message>
-    </context>
+    <message>
+        <source>Could not generate new %1 address</source>
+        <translation type="unfinished">No se pudo generar nueva dirección %1</translation>
+    </message>
+</context>
 <context>
     <name>ReceiveRequestDialog</name>
+    <message>
+        <source>Request payment to …</source>
+        <translation type="unfinished">Solicitar pago a...</translation>
+    </message>
     <message>
         <source>Address:</source>
         <translation type="unfinished">Dirección:</translation>
@@ -2024,6 +2959,18 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
     <message>
         <source>Copy &amp;Address</source>
         <translation type="unfinished">&amp;Copia dirección</translation>
+    </message>
+    <message>
+        <source>&amp;Verify</source>
+        <translation type="unfinished">&amp;Verificar</translation>
+    </message>
+    <message>
+        <source>Verify this address on e.g. a hardware wallet screen</source>
+        <translation type="unfinished">Verifica esta dirección, por ejemplo, en la pantalla de una billetera de hardware</translation>
+    </message>
+    <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">&amp;Guardar imagen...</translation>
     </message>
     <message>
         <source>Payment information</source>
@@ -2105,12 +3052,20 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
         <translation type="unfinished">Cambio:</translation>
     </message>
     <message>
+        <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
+        <translation type="unfinished">Si se activa, pero la dirección de cambio está vacía o es inválida, el cambio se enviará a una dirección generada recientemente.</translation>
+    </message>
+    <message>
         <source>Custom change address</source>
         <translation type="unfinished">Dirección de cambio personalizada</translation>
     </message>
     <message>
         <source>Transaction Fee:</source>
-        <translation type="unfinished">Comisión transacción:</translation>
+        <translation type="unfinished">Comisión de transacción:</translation>
+    </message>
+    <message>
+        <source>Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until you have validated the complete chain.</source>
+        <translation type="unfinished">Si usas la opción "fallbackfee", la transacción puede tardar varias horas o días en confirmarse (o nunca hacerlo). Considera elegir la comisión de forma manual o espera hasta que hayas validado la cadena completa.</translation>
     </message>
     <message>
         <source>Warning: Fee estimation is currently not possible.</source>
@@ -2145,20 +3100,60 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
         <translation type="unfinished">Limpiar todos los campos del formulario.</translation>
     </message>
     <message>
+        <source>Inputs…</source>
+        <translation type="unfinished">Entradas...</translation>
+    </message>
+    <message>
         <source>Dust:</source>
         <translation type="unfinished">Polvo:</translation>
     </message>
     <message>
+        <source>Choose…</source>
+        <translation type="unfinished">Elegir...</translation>
+    </message>
+    <message>
         <source>Hide transaction fee settings</source>
-        <translation type="unfinished">Esconder ajustes de la tarifa de transacción</translation>
+        <translation type="unfinished">Ocultar configuración de la comisión de transacción</translation>
+    </message>
+    <message>
+        <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
+
+Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satoshis per kvB" for a transaction size of 500 virtual bytes (half of 1 kvB) would ultimately yield a fee of only 50 satoshis.</source>
+        <translation type="unfinished">Especifica una comisión personalizada por kB (1000 bytes) del tamaño virtual de la transacción.
+
+Nota: Dado que la comisión se calcula por byte, una tasa de "100 satoshis por kvB" para una transacción de 500 bytes virtuales (la mitad de 1 kvB) produciría, en última instancia, una comisión de solo 50 satoshis.</translation>
+    </message>
+    <message>
+        <source>When there is less transaction volume than space in the blocks, miners as well as relaying nodes may enforce a minimum fee. Paying only this minimum fee is just fine, but be aware that this can result in a never confirming transaction once there is more demand for bitcoin transactions than the network can process.</source>
+        <translation type="unfinished">Cuando hay menos volumen de transacciones que espacio en los bloques, los mineros y los nodos de retransmisión pueden aplicar una comisión mínima. Está bien pagar solo esta comisión mínima, pero ten en cuenta que esto puede ocasionar que una transacción nunca se confirme una vez que haya más demanda de transacciones de Bitcoin de la que puede procesar la red.</translation>
+    </message>
+    <message>
+        <source>A too low fee might result in a never confirming transaction (read the tooltip)</source>
+        <translation type="unfinished">Si la comisión es demasiado baja, es posible que la transacción nunca se confirme (leer la información sobre herramientas).</translation>
+    </message>
+    <message>
+        <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
+        <translation type="unfinished">(La comisión inteligente no se ha inicializado todavía. Esto tarda normalmente algunos bloques…)</translation>
     </message>
     <message>
         <source>Confirmation time target:</source>
         <translation type="unfinished">Objetivo de tiempo de confirmación</translation>
     </message>
     <message>
+        <source>Enable Replace-By-Fee</source>
+        <translation type="unfinished">Activar "Reemplazar-por-comisión"</translation>
+    </message>
+    <message>
+        <source>With Replace-By-Fee (BIP-125) you can increase a transaction's fee after it is sent. Without this, a higher fee may be recommended to compensate for increased transaction delay risk.</source>
+        <translation type="unfinished">Con la función "Reemplazar-por-comisión" (BIP-125), puedes aumentar la comisión de una transacción después de enviarla. Sin esta, es posible que se recomiende una comisión más alta para compensar el mayor riesgo de retraso de la transacción.</translation>
+    </message>
+    <message>
         <source>Clear &amp;All</source>
         <translation type="unfinished">&amp;Borra todos</translation>
+    </message>
+    <message>
+        <source>Balance:</source>
+        <translation type="unfinished">Saldo:</translation>
     </message>
     <message>
         <source>Confirm the send action</source>
@@ -2201,20 +3196,96 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
         <translation type="unfinished">%1 (%2 bloques)</translation>
     </message>
     <message>
+        <source>Sign on device</source>
+        <extracomment>"device" usually means a hardware wallet.</extracomment>
+        <translation type="unfinished">Firmar en el dispositivo</translation>
+    </message>
+    <message>
+        <source>Connect your hardware wallet first.</source>
+        <translation type="unfinished">Conecta primero tu billetera de hardware.</translation>
+    </message>
+    <message>
+        <source>Set external signer script path in Options -&gt; Wallet</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Establecer la ruta al script del firmante externo en "Opciones -&gt; Billetera"</translation>
+    </message>
+    <message>
+        <source>Cr&amp;eate Unsigned</source>
+        <translation type="unfinished">Cr&amp;ear transacción sin firmar</translation>
+    </message>
+    <message>
+        <source>Creates a Partially Signed Bitcoin Transaction (PSBT) for use with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
+        <translation type="unfinished">Crea una transacción de Bitcoin parcialmente firmada (PSBT) para usarla, por ejemplo, con una billetera %1 sin conexión o una billetera de hardware compatible con PSBT.</translation>
+    </message>
+    <message>
         <source> from wallet '%1'</source>
         <translation type="unfinished">desde la billetera '%1'</translation>
+    </message>
+    <message>
+        <source>%1 to '%2'</source>
+        <translation type="unfinished">%1 a '%2'</translation>
     </message>
     <message>
         <source>%1 to %2</source>
         <translation type="unfinished">%1 a %2</translation>
     </message>
     <message>
+        <source>To review recipient list click "Show Details…"</source>
+        <translation type="unfinished">Para consultar la lista de destinatarios, haz clic en "Mostrar detalles..."</translation>
+    </message>
+    <message>
+        <source>Sign failed</source>
+        <translation type="unfinished">Error de firma</translation>
+    </message>
+    <message>
+        <source>External signer not found</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">No se encontró el dispositivo firmante externo</translation>
+    </message>
+    <message>
+        <source>External signer failure</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Error de firmante externo</translation>
+    </message>
+    <message>
         <source>Save Transaction Data</source>
         <translation type="unfinished">Guardar datos de la transacción</translation>
     </message>
     <message>
+        <source>Partially Signed Transaction (Binary)</source>
+        <extracomment>Expanded name of the binary PSBT file format. See: BIP 174.</extracomment>
+        <translation type="unfinished">Transacción parcialmente firmada (binario) </translation>
+    </message>
+    <message>
+        <source>PSBT saved</source>
+        <translation type="unfinished">PSBT guardada</translation>
+    </message>
+    <message>
+        <source>External balance:</source>
+        <translation type="unfinished">Saldo externo:</translation>
+    </message>
+    <message>
         <source>or</source>
         <translation type="unfinished">o</translation>
+    </message>
+    <message>
+        <source>You can increase the fee later (signals Replace-By-Fee, BIP-125).</source>
+        <translation type="unfinished">Puedes aumentar la comisión después (indica "Reemplazar-por-comisión", BIP-125).</translation>
+    </message>
+    <message>
+        <source>Please, review your transaction proposal. This will produce a Partially Signed Bitcoin Transaction (PSBT) which you can save or copy and then sign with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
+        <extracomment>Text to inform a user attempting to create a transaction of their current options. At this stage, a user can only create a PSBT. This string is displayed when private keys are disabled and an external signer is not available.</extracomment>
+        <translation type="unfinished">Revisa por favor la propuesta de transacción. Esto producirá una transacción de Bitcoin parcialmente firmada (PSBT) que puedes guardar o copiar y, luego, firmar; por ejemplo, una billetera %1 sin conexión o una billetera de hardware compatible con PSBT.</translation>
+    </message>
+    <message>
+        <source>Do you want to create this transaction?</source>
+        <extracomment>Message displayed when attempting to create a transaction. Cautionary text to prompt the user to verify that the displayed transaction details represent the transaction the user intends to create.</extracomment>
+        <translation type="unfinished">¿Quieres crear esta transacción?</translation>
+    </message>
+    <message>
+        <source>Please, review your transaction. You can create and send this transaction or create a Partially Signed Bitcoin Transaction (PSBT), which you can save or copy and then sign with, e.g., an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
+        <extracomment>Text to inform a user attempting to create a transaction of their current options. At this stage, a user can send their transaction or create a PSBT. This string is displayed when both private keys and PSBT controls are enabled.</extracomment>
+        <translation type="unfinished">Revisa por favor la transacción. Puedes crear y enviar esta transacción de Bitcoin parcialmente firmada (PSBT), que además puedes guardar o copiar y, luego, firmar; por ejemplo, una billetera %1 sin conexión o una billetera de hardware compatible con PSBT.</translation>
     </message>
     <message>
         <source>Please, review your transaction.</source>
@@ -2226,12 +3297,20 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
         <translation type="unfinished">Comisión de transacción</translation>
     </message>
     <message>
+        <source>Not signalling Replace-By-Fee, BIP-125.</source>
+        <translation type="unfinished">No indica remplazar-por-comisión, BIP-125.</translation>
+    </message>
+    <message>
         <source>Total Amount</source>
-        <translation type="unfinished">Monto total</translation>
+        <translation type="unfinished">Cantidad total</translation>
     </message>
     <message>
         <source>Confirm send coins</source>
         <translation type="unfinished">Confirmar el envió de monedas</translation>
+    </message>
+    <message>
+        <source>Watch-only balance:</source>
+        <translation type="unfinished">Saldo solo de observación:</translation>
     </message>
     <message>
         <source>The recipient address is not valid. Please recheck.</source>
@@ -2261,15 +3340,11 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
         <source>A fee higher than %1 is considered an absurdly high fee.</source>
         <translation type="unfinished">Una comisión mayor que %1 se considera como una comisión absurda-mente alta.</translation>
     </message>
-    <message>
-        <source>Payment request expired.</source>
-        <translation type="unfinished">Solicitud de pago expirada</translation>
-    </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>Se estima que empiece a confirmarse dentro de %n bloque.</numerusform>
+            <numerusform>Se estima que empiece a confirmarse dentro de %n bloques.</numerusform>
         </translation>
     </message>
     <message>
@@ -2324,6 +3399,14 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
         <translation type="unfinished">Quitar esta entrada</translation>
     </message>
     <message>
+        <source>The amount to send in the selected unit</source>
+        <translation type="unfinished">El importe que se enviará en la unidad seleccionada</translation>
+    </message>
+    <message>
+        <source>The fee will be deducted from the amount being sent. The recipient will receive less bitcoins than you enter in the amount field. If multiple recipients are selected, the fee is split equally.</source>
+        <translation type="unfinished">La comisión se deducirá del monto del envío. El destinatario recibirá menos bitcoins que los que ingreses en el campo de cantidad. Si se seleccionan varios destinatarios, la comisión se divide por igual.</translation>
+    </message>
+    <message>
         <source>S&amp;ubtract fee from amount</source>
         <translation type="unfinished">Restar comisiones del monto.</translation>
     </message>
@@ -2336,29 +3419,25 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
         <translation type="unfinished">Mensaje:</translation>
     </message>
     <message>
-        <source>This is an unauthenticated payment request.</source>
-        <translation type="unfinished">Esta es una petición de pago no autentificada.</translation>
-    </message>
-    <message>
-        <source>This is an authenticated payment request.</source>
-        <translation type="unfinished">Esta es una petición de pago autentificada.</translation>
-    </message>
-    <message>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished">Introduce una etiqueta para esta dirección para añadirla a la lista de direcciones utilizadas</translation>
     </message>
     <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">Pagar a:</translation>
+        <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
+        <translation type="unfinished">Un mensaje que se adjuntó al Bitcoin: URI que se almacenará con la transacción a modo de referencia. Nota: Este mensaje no se enviará por la red de Bitcoin.</translation>
     </message>
-    </context>
+</context>
 <context>
     <name>SendConfirmationDialog</name>
     <message>
         <source>Send</source>
         <translation type="unfinished">Enviar</translation>
     </message>
-    </context>
+    <message>
+        <source>Create Unsigned</source>
+        <translation type="unfinished">Crear sin firmar</translation>
+    </message>
+</context>
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
@@ -2368,6 +3447,10 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
     <message>
         <source>&amp;Sign Message</source>
         <translation type="unfinished">&amp;Firmar Mensaje</translation>
+    </message>
+    <message>
+        <source>You can sign messages/agreements with your addresses to prove you can receive bitcoins sent to them. Be careful not to sign anything vague or random, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
+        <translation type="unfinished">Puedes firmar mensajes o acuerdos con tus direcciones para demostrar que puedes recibir los bitcoins que se envíen a ellas. Ten cuidado de no firmar cosas confusas o al azar, ya que los ataques de phishing pueden tratar de engañarte para que les envíes la firma con tu identidad. Firma solo declaraciones totalmente detalladas con las que estés de acuerdo.</translation>
     </message>
     <message>
         <source>The Bitcoin address to sign the message with</source>
@@ -2414,8 +3497,20 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
         <translation type="unfinished">&amp;Firmar Mensaje</translation>
     </message>
     <message>
+        <source>Enter the receiver's address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack. Note that this only proves the signing party receives with the address, it cannot prove sendership of any transaction!</source>
+        <translation type="unfinished">Ingresa la dirección del destinatario, el mensaje (recuerda copiar los saltos de línea, espacios, tabulaciones, etc. con exactitud) y la firma a continuación para verificar el mensaje. Ten cuidado de no leer en la firma más de lo que está en el mensaje firmado en sí, para evitar ser víctima de un engaño por ataque de intermediario. Ten en cuenta que esto solo demuestra que el firmante recibe con la dirección; no puede demostrar la condición de remitente de ninguna transacción.</translation>
+    </message>
+    <message>
         <source>The Bitcoin address the message was signed with</source>
         <translation type="unfinished">La dirección Bitcoin con la que se firmó el mensaje</translation>
+    </message>
+    <message>
+        <source>The signed message to verify</source>
+        <translation type="unfinished">El mensaje firmado para verificar</translation>
+    </message>
+    <message>
+        <source>The signature given when the message was signed</source>
+        <translation type="unfinished">La firma que se dio cuando el mensaje se firmó</translation>
     </message>
     <message>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
@@ -2487,33 +3582,46 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
     </message>
 </context>
 <context>
+    <name>SplashScreen</name>
+    <message>
+        <source>(press q to shutdown and continue later)</source>
+        <translation type="unfinished">(presiona q para apagar y seguir luego)</translation>
+    </message>
+    <message>
+        <source>press q to shutdown</source>
+        <translation type="unfinished">presiona q para apagar </translation>
+    </message>
+</context>
+<context>
     <name>TransactionDesc</name>
     <message>
         <source>conflicted with a transaction with %1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that conflicts with a confirmed transaction.</extracomment>
         <translation type="unfinished">Hay un conflicto con la traducción de las confirmaciones %1</translation>
     </message>
     <message>
-        <source>0/unconfirmed, %1</source>
-        <translation type="unfinished">0/no confirmado, %1</translation>
+        <source>0/unconfirmed, in memory pool</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is in the memory pool.</extracomment>
+        <translation type="unfinished">0/sin confirmar, en el pool de memoria</translation>
     </message>
     <message>
-        <source>in memory pool</source>
-        <translation type="unfinished">en el equipo de memoria</translation>
-    </message>
-    <message>
-        <source>not in memory pool</source>
-        <translation type="unfinished">no en el equipo de memoria</translation>
+        <source>0/unconfirmed, not in memory pool</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is not in the memory pool.</extracomment>
+        <translation type="unfinished">0/sin confirmar, no está en el pool de memoria</translation>
     </message>
     <message>
         <source>abandoned</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an abandoned transaction.</extracomment>
         <translation type="unfinished">abandonado</translation>
     </message>
     <message>
         <source>%1/unconfirmed</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
         <translation type="unfinished">%1/no confirmado</translation>
     </message>
     <message>
         <source>%1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
         <translation type="unfinished">confirmaciones %1</translation>
     </message>
     <message>
@@ -2563,8 +3671,8 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>madura en %n bloque más</numerusform>
+            <numerusform>madura en %n bloques más</numerusform>
         </translation>
     </message>
     <message>
@@ -2601,19 +3709,31 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
     </message>
     <message>
         <source>Transaction ID</source>
-        <translation type="unfinished">Identificador de transacción (ID)</translation>
+        <translation type="unfinished">Identificador de transacción</translation>
     </message>
     <message>
         <source>Transaction total size</source>
         <translation type="unfinished">Tamaño total de transacción</translation>
     </message>
     <message>
+        <source>Transaction virtual size</source>
+        <translation type="unfinished">Tamaño virtual de transacción</translation>
+    </message>
+    <message>
         <source>Output index</source>
         <translation type="unfinished">Indice de salida</translation>
     </message>
     <message>
+        <source> (Certificate was not verified)</source>
+        <translation type="unfinished">(No se verificó el certificado)</translation>
+    </message>
+    <message>
         <source>Merchant</source>
         <translation type="unfinished">Vendedor</translation>
+    </message>
+    <message>
+        <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to "not accepted" and it won't be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
+        <translation type="unfinished">Las monedas generadas deben madurar %1 bloques antes de que se puedan gastar. Cuando generaste este bloque, se transmitió a la red para agregarlo a la cadena de bloques. Si no logra entrar a la cadena, su estado cambiará a "no aceptado" y no se podrá gastar. Esto puede ocurrir ocasionalmente si otro nodo genera un bloque a pocos segundos del tuyo.</translation>
     </message>
     <message>
         <source>Debug information</source>
@@ -2734,6 +3854,14 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
         <translation type="unfinished">Tipo de transacción.</translation>
     </message>
     <message>
+        <source>Whether or not a watch-only address is involved in this transaction.</source>
+        <translation type="unfinished">Si una dirección de solo observación está involucrada en esta transacción o no.</translation>
+    </message>
+    <message>
+        <source>User-defined intent/purpose of the transaction.</source>
+        <translation type="unfinished">Intención o propósito de la transacción definidos por el usuario.</translation>
+    </message>
+    <message>
         <source>Amount removed from or added to balance.</source>
         <translation type="unfinished">Cantidad restada o añadida al balance</translation>
     </message>
@@ -2785,8 +3913,61 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
         <translation type="unfinished">Otra</translation>
     </message>
     <message>
+        <source>Enter address, transaction id, or label to search</source>
+        <translation type="unfinished">Ingresa la dirección, el identificador de transacción o la etiqueta para buscar</translation>
+    </message>
+    <message>
         <source>Min amount</source>
         <translation type="unfinished">Cantidad mínima</translation>
+    </message>
+    <message>
+        <source>Range…</source>
+        <translation type="unfinished">Rango...</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Copiar dirección</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Copiar &amp;etiqueta</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Copiar &amp;cantidad</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">Copiar &amp;ID de transacción</translation>
+    </message>
+    <message>
+        <source>Copy &amp;raw transaction</source>
+        <translation type="unfinished">Copiar transacción &amp;raw</translation>
+    </message>
+    <message>
+        <source>Copy full transaction &amp;details</source>
+        <translation type="unfinished">Copiar &amp;detalles completos de la transacción</translation>
+    </message>
+    <message>
+        <source>&amp;Show transaction details</source>
+        <translation type="unfinished">&amp;Mostrar detalles de la transacción</translation>
+    </message>
+    <message>
+        <source>Increase transaction &amp;fee</source>
+        <translation type="unfinished">Aumentar &amp;comisión de transacción</translation>
+    </message>
+    <message>
+        <source>A&amp;bandon transaction</source>
+        <translation type="unfinished">A&amp;bandonar transacción</translation>
+    </message>
+    <message>
+        <source>&amp;Edit address label</source>
+        <translation type="unfinished">&amp;Editar etiqueta de dirección</translation>
+    </message>
+    <message>
+        <source>Show in %1</source>
+        <extracomment>Transactions table context menu action to show the selected transaction in a third-party block explorer. %1 is a stand-in argument for the URL of the explorer.</extracomment>
+        <translation type="unfinished">Mostrar en %1</translation>
     </message>
     <message>
         <source>Export Transaction History</source>
@@ -2826,6 +4007,10 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
         <translation type="unfinished">Exportación fallida</translation>
     </message>
     <message>
+        <source>There was an error trying to save the transaction history to %1.</source>
+        <translation type="unfinished">Ocurrió un error al intentar guardar el historial de transacciones en %1.</translation>
+    </message>
+    <message>
         <source>Exporting Successful</source>
         <translation type="unfinished">Exportación exitosa</translation>
     </message>
@@ -2845,14 +4030,38 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
 <context>
     <name>WalletFrame</name>
     <message>
+        <source>No wallet has been loaded.
+Go to File &gt; Open Wallet to load a wallet.
+- OR -</source>
+        <translation type="unfinished">No se cargó ninguna billetera.
+Ir a Archivo &gt; Abrir billetera para cargar una.
+- OR -</translation>
+    </message>
+    <message>
         <source>Create a new wallet</source>
         <translation type="unfinished">Crear una nueva billetera</translation>
+    </message>
+    <message>
+        <source>Unable to decode PSBT from clipboard (invalid base64)</source>
+        <translation type="unfinished">No se puede decodificar PSBT desde el portapapeles (Base64 inválido)</translation>
     </message>
     <message>
         <source>Load Transaction Data</source>
         <translation type="unfinished">Cargar datos de la transacción</translation>
     </message>
-    </context>
+    <message>
+        <source>Partially Signed Transaction (*.psbt)</source>
+        <translation type="unfinished">Transacción firmada parcialmente (*.psbt)</translation>
+    </message>
+    <message>
+        <source>PSBT file must be smaller than 100 MiB</source>
+        <translation type="unfinished">El archivo PSBT debe ser más pequeño de 100 MiB</translation>
+    </message>
+    <message>
+        <source>Unable to decode PSBT</source>
+        <translation type="unfinished">No es posible decodificar PSBT</translation>
+    </message>
+</context>
 <context>
     <name>WalletModel</name>
     <message>
@@ -2885,8 +4094,20 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
         <translation type="unfinished">Nueva comisión:</translation>
     </message>
     <message>
+        <source>Warning: This may pay the additional fee by reducing change outputs or adding inputs, when necessary. It may add a new change output if one does not already exist. These changes may potentially leak privacy.</source>
+        <translation type="unfinished">Advertencia: Esta acción puede pagar la comisión adicional al reducir las salidas de cambio o agregar entradas, cuando sea necesario. Asimismo, puede agregar una nueva salida de cambio si aún no existe una. Estos cambios pueden filtrar potencialmente información privada.</translation>
+    </message>
+    <message>
         <source>Confirm fee bump</source>
         <translation type="unfinished">Confirmar incremento de comisión</translation>
+    </message>
+    <message>
+        <source>Can't draft transaction.</source>
+        <translation type="unfinished">No se puede crear un borrador de la transacción.</translation>
+    </message>
+    <message>
+        <source>PSBT copied</source>
+        <translation type="unfinished">PSBT copiada</translation>
     </message>
     <message>
         <source>Can't sign transaction.</source>
@@ -2895,6 +4116,10 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
     <message>
         <source>Could not commit transaction</source>
         <translation type="unfinished">No se pudo confirmar la transacción</translation>
+    </message>
+    <message>
+        <source>Can't display address</source>
+        <translation type="unfinished">No se puede mostrar la dirección</translation>
     </message>
     <message>
         <source>default wallet</source>
@@ -2916,6 +4141,11 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
         <translation type="unfinished">Respaldar monedero</translation>
     </message>
     <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">Datos de la billetera</translation>
+    </message>
+    <message>
         <source>Backup Failed</source>
         <translation type="unfinished">Ha fallado el respaldo</translation>
     </message>
@@ -2931,5 +4161,9 @@ Firmar solo es posible con direcciones del tipo 'Legacy'.</translation>
         <source>The wallet data was successfully saved to %1.</source>
         <translation type="unfinished">Los datos del monedero se han guardado con éxito en %1.</translation>
     </message>
-    </context>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">Cancelar</translation>
+    </message>
+</context>
 </TS>

--- a/src/qt/locale/bitcoin_es_DO.ts
+++ b/src/qt/locale/bitcoin_es_DO.ts
@@ -70,6 +70,11 @@
         <translation type="unfinished">Estas son tus direcciones Bitcoin para realizar pagos. Verifica siempre el monto y la dirección de recepción antes de enviar monedas. </translation>
     </message>
     <message>
+        <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
+Signing is only possible with addresses of the type 'legacy'.</source>
+        <translation type="unfinished">Estas son tus direcciones de Bitcoin para recibir pagos. Utilice el botón 'Crear nueva dirección de recepción' en la pestaña Recibir para crear nuevas direcciones. La firma solo es posible con direcciones del tipo 'legacy'</translation>
+    </message>
+    <message>
         <source>&amp;Copy Address</source>
         <translation type="unfinished">Copiar dirección</translation>
     </message>
@@ -84,6 +89,11 @@
     <message>
         <source>Export Address List</source>
         <translation type="unfinished">Exportar lista de direcciones</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">Archivo separado por comas</translation>
     </message>
     <message>
         <source>There was an error trying to save the address list to %1. Please try again.</source>
@@ -129,6 +139,10 @@
         <translation type="unfinished">Repetir nueva frase de contraseña</translation>
     </message>
     <message>
+        <source>Show passphrase</source>
+        <translation type="unfinished">Mostrar frase de contraseña</translation>
+    </message>
+    <message>
         <source>Encrypt wallet</source>
         <translation type="unfinished">Cifrar monedero</translation>
     </message>
@@ -160,6 +174,30 @@
     <message>
         <source>Wallet encrypted</source>
         <translation type="unfinished">Monedero cifrado</translation>
+    </message>
+    <message>
+        <source>Enter the new passphrase for the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
+        <translation type="unfinished">Ingrese la nueva frase de contraseña para la billetera&lt;br/&gt;. Utilice una frase de cont&lt;b&gt;raseñade diez o más caracteres&lt;/b&gt; aleatorios o och&lt;b&gt;o o más palab&lt;/b&gt;ras.</translation>
+    </message>
+    <message>
+        <source>Enter the old passphrase and new passphrase for the wallet.</source>
+        <translation type="unfinished">Ingrese la frase de contraseña antigua y la nueva frase de contraseña para la billetera</translation>
+    </message>
+    <message>
+        <source>Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
+        <translation type="unfinished">Recuerda que cifrar tu billetera no puede proteger completamente tus bitcoins de ser robados por malware que infecte tu computadora.</translation>
+    </message>
+    <message>
+        <source>Wallet to be encrypted</source>
+        <translation type="unfinished">Billetera para ser cifrada</translation>
+    </message>
+    <message>
+        <source>Your wallet is about to be encrypted. </source>
+        <translation type="unfinished">Tu monedero va a ser cifrado</translation>
+    </message>
+    <message>
+        <source>Your wallet is now encrypted. </source>
+        <translation type="unfinished">Tu monedero está ahora cifrado</translation>
     </message>
     <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
@@ -194,6 +232,24 @@
         <translation type="unfinished">Aviso: ¡La tecla de bloqueo de mayúsculas está activada!</translation>
     </message>
 </context>
+<context>
+    <name>BanTableModel</name>
+    <message>
+        <source>IP/Netmask</source>
+        <translation type="unfinished">IP/Máscara de red</translation>
+    </message>
+    <message>
+        <source>Banned Until</source>
+        <translation type="unfinished">Prohibido hasta</translation>
+    </message>
+</context>
+<context>
+    <name>BitcoinApplication</name>
+    <message>
+        <source>Internal error</source>
+        <translation type="unfinished">Error interno</translation>
+    </message>
+    </context>
 <context>
     <name>QObject</name>
     <message>
@@ -385,6 +441,14 @@
         <translation type="unfinished">Mostrar información acerca de Qt</translation>
     </message>
     <message>
+        <source>Create a new wallet</source>
+        <translation type="unfinished">Crear monedero nuevo</translation>
+    </message>
+    <message>
+        <source>&amp;Minimize</source>
+        <translation type="unfinished">Minimizar</translation>
+    </message>
+    <message>
         <source>Send coins to a Bitcoin address</source>
         <translation type="unfinished">Enviar monedas a una dirección Bitcoin</translation>
     </message>
@@ -403,6 +467,10 @@
     <message>
         <source>&amp;Receive</source>
         <translation type="unfinished">&amp;Recibir</translation>
+    </message>
+    <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation type="unfinished">&amp;Cifrar monedero</translation>
     </message>
     <message>
         <source>Encrypt the private keys that belong to your wallet</source>
@@ -699,6 +767,27 @@
 <context>
     <name>Intro</name>
     <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
@@ -861,10 +950,12 @@
     </message>
     <message>
         <source>Confirm options reset</source>
+        <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
         <translation type="unfinished">Confirme el restablecimiento de las opciones</translation>
     </message>
     <message>
         <source>Client restart required to activate changes.</source>
+        <extracomment>Text explaining that the settings changed will not come into effect until the client is restarted.</extracomment>
         <translation type="unfinished">Reinicio del cliente para activar cambios.</translation>
     </message>
     <message>
@@ -1342,10 +1433,6 @@
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished">Introduce una etiqueta para esta dirección para añadirla a la lista de direcciones utilizadas</translation>
     </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">Paga a:</translation>
-    </message>
     </context>
 <context>
     <name>SignVerifyMessageDialog</name>
@@ -1466,10 +1553,12 @@
     <name>TransactionDesc</name>
     <message>
         <source>%1/unconfirmed</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
         <translation type="unfinished">%1/no confirmado</translation>
     </message>
     <message>
         <source>%1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
         <translation type="unfinished">%1 confirmaciones</translation>
     </message>
     <message>
@@ -1709,6 +1798,11 @@
         <translation type="unfinished">Exportar historial de transacciones</translation>
     </message>
     <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">Archivo separado por comas</translation>
+    </message>
+    <message>
         <source>Confirmed</source>
         <translation type="unfinished">Confirmado</translation>
     </message>
@@ -1753,6 +1847,13 @@
         <translation type="unfinished">para</translation>
     </message>
 </context>
+<context>
+    <name>WalletFrame</name>
+    <message>
+        <source>Create a new wallet</source>
+        <translation type="unfinished">Crear monedero nuevo</translation>
+    </message>
+    </context>
 <context>
     <name>WalletModel</name>
     <message>

--- a/src/qt/locale/bitcoin_es_VE.ts
+++ b/src/qt/locale/bitcoin_es_VE.ts
@@ -70,6 +70,12 @@
         <translation type="unfinished">Estas son sus direcciones Bitcoin para enviar pagos. Compruebe siempre la cantidad y la dirección de recibo antes de transferir monedas.</translation>
     </message>
     <message>
+        <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
+Signing is only possible with addresses of the type 'legacy'.</source>
+        <translation type="unfinished">Lista de tus direcciones de Bitcoin para recibir pagos. Para la  creacion de  una nueva direccion seleccione en la pestana "recibir" la opcion "Crear nueva direccion" 
+Registrarse solo es posible utilizando  una direccion tipo "Legal"</translation>
+    </message>
+    <message>
         <source>&amp;Copy Address</source>
         <translation type="unfinished">Copiar dirección</translation>
     </message>
@@ -749,6 +755,27 @@
 <context>
     <name>Intro</name>
     <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
@@ -915,10 +942,12 @@
     </message>
     <message>
         <source>Confirm options reset</source>
+        <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
         <translation type="unfinished">Confirme el restablecimiento de las opciones</translation>
     </message>
     <message>
         <source>Client restart required to activate changes.</source>
+        <extracomment>Text explaining that the settings changed will not come into effect until the client is restarted.</extracomment>
         <translation type="unfinished">Reinicio del cliente para activar cambios.</translation>
     </message>
     <message>
@@ -1293,10 +1322,6 @@
     <message>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished">Introduce una etiqueta para esta dirección para añadirla a la lista de direcciones utilizadas</translation>
-    </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">Paga a:</translation>
     </message>
     </context>
 <context>

--- a/src/qt/locale/bitcoin_et.ts
+++ b/src/qt/locale/bitcoin_et.ts
@@ -70,6 +70,11 @@
         <translation type="unfinished">Need on sinu Bitcoin aadressid maksete saatmiseks. Ennem müntide saatmist kontrolli alati summat ja makse saaja aadressi.</translation>
     </message>
     <message>
+        <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
+Signing is only possible with addresses of the type 'legacy'.</source>
+        <translation type="unfinished">Need on sinu Bitcoin aadressid makse vastuvõtuks.Kasuta ‘Loo uus vastuvõttu aadress’ nuppu vastuvõtmise vahekaardis, et luua uus aadress. Allkirjastamine on võimalik ainult 'pärand' tüüpi aadressidega.</translation>
+    </message>
+    <message>
         <source>&amp;Copy Address</source>
         <translation type="unfinished">&amp;Kopeeri Aadress</translation>
     </message>
@@ -457,8 +462,20 @@
         <translation type="unfinished">&amp;Valikud</translation>
     </message>
     <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation type="unfinished">&amp;Krüpteeri Rahakott...</translation>
+    </message>
+    <message>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation type="unfinished">Krüpteeri oma rahakoti privaatvõtmed</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation type="unfinished">&amp;Tagavara Rahakott...</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation type="unfinished">&amp;Muuda Salasõna...</translation>
     </message>
     <message>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
@@ -467,6 +484,14 @@
     <message>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation type="unfinished">Kinnita sõnumid kindlustamaks et need allkirjastati määratud Bitcoini aadressiga</translation>
+    </message>
+    <message>
+        <source>Close Wallet…</source>
+        <translation type="unfinished">Sulge Rahakott...</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation type="unfinished">Loo Rahakott...</translation>
     </message>
     <message>
         <source>&amp;File</source>
@@ -483,6 +508,10 @@
     <message>
         <source>Tabs toolbar</source>
         <translation type="unfinished">Vahelehe tööriistariba</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation type="unfinished">Sünkroniseerin võrguga...</translation>
     </message>
     <message>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
@@ -526,6 +555,10 @@
     <message>
         <source>Up to date</source>
         <translation type="unfinished">Ajakohane</translation>
+    </message>
+    <message>
+        <source>Open Wallet</source>
+        <translation type="unfinished">Ava Rahakott</translation>
     </message>
     <message>
         <source>&amp;Window</source>
@@ -702,6 +735,14 @@
     </message>
 </context>
 <context>
+    <name>OpenWalletActivity</name>
+    <message>
+        <source>Open Wallet</source>
+        <extracomment>Title of window indicating the progress of opening of a wallet.</extracomment>
+        <translation type="unfinished">Ava Rahakott</translation>
+    </message>
+    </context>
+<context>
     <name>CreateWalletDialog</name>
     <message>
         <source>Wallet</source>
@@ -756,6 +797,27 @@
     </context>
 <context>
     <name>Intro</name>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
     <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
@@ -906,6 +968,7 @@
     </message>
     <message>
         <source>Confirm options reset</source>
+        <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
         <translation type="unfinished">Kinnita valikute algseadistamine</translation>
     </message>
     <message>
@@ -1370,10 +1433,6 @@
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation type="unfinished">Summa koos tehingu tasuga %1 ületab sinu jääki.</translation>
     </message>
-    <message>
-        <source>Payment request expired.</source>
-        <translation type="unfinished">Maksepäring aegunud.</translation>
-    </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
@@ -1419,10 +1478,6 @@
     <message>
         <source>Message:</source>
         <translation type="unfinished">Sõnum:</translation>
-    </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">Maksa :</translation>
     </message>
     </context>
 <context>
@@ -1552,10 +1607,12 @@
     <name>TransactionDesc</name>
     <message>
         <source>%1/unconfirmed</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
         <translation type="unfinished">%1/kinnitamata</translation>
     </message>
     <message>
         <source>%1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
         <translation type="unfinished">%1 kinnitust</translation>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_eu.ts
+++ b/src/qt/locale/bitcoin_eu.ts
@@ -70,6 +70,12 @@
         <translation type="unfinished">Hauek dira zuk dirua jaso dezaketen Bitcoin helbideak. Egiaztatu beti diru-kopurua eta dirua jasoko duen helbidea zuzen egon daitezen, txanponak bidali baino lehen.</translation>
     </message>
     <message>
+        <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
+Signing is only possible with addresses of the type 'legacy'.</source>
+        <translation type="unfinished">Hauek dira ordainketak jasotzeko zure Bitcoin helbideak. Jaso taulako 'Jasotzeko helbide berri bat sortu' botoia erabili helbide berri bat sortzeko.
+Sinatzea 'legacy' motako helbideekin soilik da posible</translation>
+    </message>
+    <message>
         <source>&amp;Copy Address</source>
         <translation type="unfinished">&amp;Helbidea kopiatu</translation>
     </message>
@@ -84,6 +90,11 @@
     <message>
         <source>Export Address List</source>
         <translation type="unfinished">Helbide lista esportatu</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">Komaz bereizitako fitxategia</translation>
     </message>
     <message>
         <source>There was an error trying to save the address list to %1. Please try again.</source>
@@ -233,6 +244,17 @@
     </message>
 </context>
 <context>
+    <name>BitcoinApplication</name>
+    <message>
+        <source>Runaway exception</source>
+        <translation type="unfinished">Ranaway exception</translation>
+    </message>
+    <message>
+        <source>Internal error</source>
+        <translation type="unfinished">Barne errorea</translation>
+    </message>
+    </context>
+<context>
     <name>QObject</name>
     <message>
         <source>Error: %1</source>
@@ -245,6 +267,18 @@
     <message>
         <source>Amount</source>
         <translation type="unfinished">Kopurua</translation>
+    </message>
+    <message>
+        <source>Internal</source>
+        <translation type="unfinished">Barnekoa</translation>
+    </message>
+    <message>
+        <source>%1 d</source>
+        <translation type="unfinished">%1 e</translation>
+    </message>
+    <message>
+        <source>%1 h</source>
+        <translation type="unfinished">%1 o</translation>
     </message>
     <message numerus="yes">
         <source>%n second(s)</source>
@@ -294,6 +328,70 @@
     <message>
         <source>Done loading</source>
         <translation type="unfinished">Zamaketa amaitua</translation>
+    </message>
+    <message>
+        <source>Importing…</source>
+        <translation type="unfinished">Inportatzen...</translation>
+    </message>
+    <message>
+        <source>Loading wallet…</source>
+        <translation type="unfinished">Diruzorroa kargatzen...</translation>
+    </message>
+    <message>
+        <source>Missing amount</source>
+        <translation type="unfinished">Zenbatekoa falta da</translation>
+    </message>
+    <message>
+        <source>No addresses available</source>
+        <translation type="unfinished">Ez dago helbiderik eskuragarri</translation>
+    </message>
+    <message>
+        <source>Replaying blocks…</source>
+        <translation type="unfinished">Blokeak errepikatzen...</translation>
+    </message>
+    <message>
+        <source>Rescanning…</source>
+        <translation type="unfinished">Bereskaneatzen...</translation>
+    </message>
+    <message>
+        <source>Starting network threads…</source>
+        <translation type="unfinished">Sareko hariak abiarazten...</translation>
+    </message>
+    <message>
+        <source>The source code is available from %s.</source>
+        <translation type="unfinished">Iturri kodea %s-tik dago eskuragarri.</translation>
+    </message>
+    <message>
+        <source>The transaction amount is too small to pay the fee</source>
+        <translation type="unfinished">Transakzio kantitatea txikiegia da kuota ordaintzeko.</translation>
+    </message>
+    <message>
+        <source>This is experimental software.</source>
+        <translation type="unfinished">Hau software esperimentala da</translation>
+    </message>
+    <message>
+        <source>Transaction amount too small</source>
+        <translation type="unfinished">transakzio kopurua txikiegia</translation>
+    </message>
+    <message>
+        <source>Transaction too large</source>
+        <translation type="unfinished">Transakzio luzeegia</translation>
+    </message>
+    <message>
+        <source>Unable to generate initial keys</source>
+        <translation type="unfinished">hasierako giltzak sortzeko ezgai</translation>
+    </message>
+    <message>
+        <source>Unable to generate keys</source>
+        <translation type="unfinished">Giltzak sortzeko ezgai</translation>
+    </message>
+    <message>
+        <source>Verifying blocks…</source>
+        <translation type="unfinished">Blokeak egiaztatzen...</translation>
+    </message>
+    <message>
+        <source>Verifying wallet(s)…</source>
+        <translation type="unfinished">Diruzorroak egiaztatzen...</translation>
     </message>
     </context>
 <context>
@@ -347,6 +445,10 @@
         <translation type="unfinished">Diruzorro berri bat sortu</translation>
     </message>
     <message>
+        <source>&amp;Minimize</source>
+        <translation type="unfinished">&amp;Minimizatu</translation>
+    </message>
+    <message>
         <source>Wallet:</source>
         <translation type="unfinished">Diruzorroa:</translation>
     </message>
@@ -380,16 +482,60 @@
         <translation type="unfinished">&amp;Jaso</translation>
     </message>
     <message>
+        <source>&amp;Options…</source>
+        <translation type="unfinished">&amp;Aukerak...</translation>
+    </message>
+    <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation type="unfinished">&amp;Diruzorroa enkriptatu...</translation>
+    </message>
+    <message>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation type="unfinished">Zure diru-zorroari dagozkion giltza pribatuak enkriptatu.</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation type="unfinished">Diruzorroaren &amp;segurtasun kopia egin...</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation type="unfinished">&amp;aldatu pasahitza</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation type="unfinished">sinatu &amp;mezua</translation>
     </message>
     <message>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation type="unfinished">Sinatu mezuak Bitcoinen helbideekin, jabetza frogatzeko.</translation>
     </message>
     <message>
+        <source>&amp;Verify message…</source>
+        <translation type="unfinished">Mezua &amp;balioztatu</translation>
+    </message>
+    <message>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation type="unfinished">Egiaztatu mesua Bitcoin helbide espezifikoarekin erregistratu direla ziurtatzeko</translation>
+    </message>
+    <message>
+        <source>&amp;Load PSBT from file…</source>
+        <translation type="unfinished">&amp;kargatu PSBT fitxategitik...</translation>
+    </message>
+    <message>
+        <source>Open &amp;URI…</source>
+        <translation type="unfinished">Ireki&amp;URI...</translation>
+    </message>
+    <message>
+        <source>Close Wallet…</source>
+        <translation type="unfinished">Diruzorroa itxi...</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation type="unfinished">Diruzorroa sortu...</translation>
+    </message>
+    <message>
+        <source>Close All Wallets…</source>
+        <translation type="unfinished">Diru-zorro guztiak itxi...</translation>
     </message>
     <message>
         <source>&amp;File</source>
@@ -406,6 +552,26 @@
     <message>
         <source>Tabs toolbar</source>
         <translation type="unfinished">Fitxen tresna-barra</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation type="unfinished">Sarearekin sinkronizatzen...</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation type="unfinished">Diskoko blokeak indexatzen...</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation type="unfinished">Diskoko blokeak prozesatzen...</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation type="unfinished">Diskoko blokeak berzerrendatzen</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation type="unfinished">Pareekin konektatzen...</translation>
     </message>
     <message>
         <source>Show the list of used sending addresses and labels</source>
@@ -429,6 +595,10 @@
     <message>
         <source>%1 behind</source>
         <translation type="unfinished">%1 atzetik</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation type="unfinished">Harrapatzen...</translation>
     </message>
     <message>
         <source>Last received block was generated %1 ago.</source>
@@ -457,6 +627,10 @@
     <message>
         <source>Load Partially Signed Bitcoin Transaction</source>
         <translation type="unfinished">Partzialki sinatutako Bitcoin transakzioa kargatu</translation>
+    </message>
+    <message>
+        <source>Load PSBT from &amp;clipboard…</source>
+        <translation type="unfinished">kargatu PSBT arbeletik...</translation>
     </message>
     <message>
         <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
@@ -503,6 +677,11 @@
         <translation type="unfinished">Ez dago diru-zorrorik eskura</translation>
     </message>
     <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">Diruzorroaren izena</translation>
+    </message>
+    <message>
         <source>&amp;Window</source>
         <translation type="unfinished">&amp;Lehioa</translation>
     </message>
@@ -518,6 +697,14 @@
         <source>%1 client</source>
         <translation type="unfinished">%1 bezeroa</translation>
     </message>
+    <message>
+        <source>&amp;Hide</source>
+        <translation type="unfinished">&amp;Ezkutatu</translation>
+    </message>
+    <message>
+        <source>S&amp;how</source>
+        <translation type="unfinished">E&amp;rakutsi</translation>
+    </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
@@ -525,6 +712,11 @@
             <numerusform />
             <numerusform />
         </translation>
+    </message>
+    <message>
+        <source>Show Peers tab</source>
+        <extracomment>A context menu item. The "Peers tab" is an element of the "Node window".</extracomment>
+        <translation type="unfinished">Erakutxi kideen fitxa</translation>
     </message>
     <message>
         <source>Error: %1</source>
@@ -674,8 +866,20 @@
         <translation type="unfinished">zenbatekoaren kopia</translation>
     </message>
     <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Kopiatu &amp;Etiketa</translation>
+    </message>
+    <message>
         <source>Copy quantity</source>
         <translation type="unfinished">Kopia kopurua</translation>
+    </message>
+    <message>
+        <source>Copy fee</source>
+        <translation type="unfinished">Kopiatu kuota</translation>
+    </message>
+    <message>
+        <source>Copy after fee</source>
+        <translation type="unfinished">Kopia kuotaren ondoren</translation>
     </message>
     <message>
         <source>Copy bytes</source>
@@ -718,6 +922,11 @@
         <translation type="unfinished">Diruzorroa sortu</translation>
     </message>
     <message>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the create wallet progress window which indicates to the user which wallet is currently being created.</extracomment>
+        <translation type="unfinished">Diru-zorroa sortzen&lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+    <message>
         <source>Create wallet failed</source>
         <translation type="unfinished">Diruzorroa sortzen hutsegitea</translation>
     </message>
@@ -725,7 +934,24 @@
         <source>Create wallet warning</source>
         <translation type="unfinished">Diru-zorroa sortzearen buruzko oharra</translation>
     </message>
+    <message>
+        <source>Can't list signers</source>
+        <translation type="unfinished">Ezin dira sinatzaileak zerrendatu</translation>
+    </message>
     </context>
+<context>
+    <name>LoadWalletsActivity</name>
+    <message>
+        <source>Load Wallets</source>
+        <extracomment>Title of progress window which is displayed when wallets are being loaded.</extracomment>
+        <translation type="unfinished">Kargatu diruzorroak</translation>
+    </message>
+    <message>
+        <source>Loading wallets…</source>
+        <extracomment>Descriptive text of the load wallets progress window which indicates to the user that wallets are currently being loaded.</extracomment>
+        <translation type="unfinished">Diruzorroak kargatzen...</translation>
+    </message>
+</context>
 <context>
     <name>OpenWalletActivity</name>
     <message>
@@ -745,7 +971,12 @@
         <extracomment>Title of window indicating the progress of opening of a wallet.</extracomment>
         <translation type="unfinished">Diruzorroa zabaldu</translation>
     </message>
-    </context>
+    <message>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the open wallet progress window which indicates to the user which wallet is currently being opened.</extracomment>
+        <translation type="unfinished">&lt;b&gt;%1&lt;/b&gt; diruzorroa irekitzen ...</translation>
+    </message>
+</context>
 <context>
     <name>WalletController</name>
     <message>
@@ -756,7 +987,11 @@
         <source>Close all wallets</source>
         <translation type="unfinished">Diruzorro guztiak itxi</translation>
     </message>
-    </context>
+    <message>
+        <source>Are you sure you wish to close all wallets?</source>
+        <translation type="unfinished">Ziur diruzorro guztiak itxi nahi dituzula?</translation>
+    </message>
+</context>
 <context>
     <name>CreateWalletDialog</name>
     <message>
@@ -784,8 +1019,16 @@
         <translation type="unfinished">Desgaitu gako pribatuak</translation>
     </message>
     <message>
+        <source>Make Blank Wallet</source>
+        <translation type="unfinished">Egin diruzorro hutsa...</translation>
+    </message>
+    <message>
         <source>Descriptor Wallet</source>
         <translation type="unfinished">Deskriptorearen zorroa</translation>
+    </message>
+    <message>
+        <source>External signer</source>
+        <translation type="unfinished">Kanpo sinatzailea</translation>
     </message>
     <message>
         <source>Create</source>
@@ -830,12 +1073,45 @@
 <context>
     <name>FreespaceChecker</name>
     <message>
+        <source>A new data directory will be created.</source>
+        <translation type="unfinished">Datu direktorio berria sortuko da.</translation>
+    </message>
+    <message>
         <source>name</source>
         <translation type="unfinished">izena</translation>
     </message>
-    </context>
+    <message>
+        <source>Path already exists, and is not a directory.</source>
+        <translation type="unfinished">Bidea existitzen da, eta ez da direktorioa.</translation>
+    </message>
+    <message>
+        <source>Cannot create data directory here.</source>
+        <translation type="unfinished">Ezin da datu direktoria hemen sortu.</translation>
+    </message>
+</context>
 <context>
     <name>Intro</name>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
     <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
@@ -856,7 +1132,19 @@
         <source>Welcome to %1.</source>
         <translation type="unfinished">Ongietorri %1-ra</translation>
     </message>
-    </context>
+    <message>
+        <source> GB</source>
+        <translation type="unfinished">GB</translation>
+    </message>
+    <message>
+        <source>Use the default data directory</source>
+        <translation type="unfinished">Erabili datu direktorio lehenetsia</translation>
+    </message>
+    <message>
+        <source>Use a custom data directory:</source>
+        <translation type="unfinished">Erabili datu direktorio pertsonalizatu bat:</translation>
+    </message>
+</context>
 <context>
     <name>HelpMessageDialog</name>
     <message>
@@ -873,6 +1161,13 @@
     </message>
 </context>
 <context>
+    <name>ShutdownWindow</name>
+    <message>
+        <source>%1 is shutting down…</source>
+        <translation type="unfinished">%1Itzaltzen ari da...</translation>
+    </message>
+    </context>
+<context>
     <name>ModalOverlay</name>
     <message>
         <source>Form</source>
@@ -883,12 +1178,24 @@
         <translation type="unfinished">Gainerako blokeen kopurua.</translation>
     </message>
     <message>
+        <source>Unknown…</source>
+        <translation type="unfinished">Ezezaguna...</translation>
+    </message>
+    <message>
+        <source>calculating…</source>
+        <translation type="unfinished">kalkulatzen...</translation>
+    </message>
+    <message>
         <source>Last block time</source>
         <translation type="unfinished">Azken blokearen unea</translation>
     </message>
     <message>
         <source>Progress</source>
         <translation type="unfinished">Aurrerapena</translation>
+    </message>
+    <message>
+        <source>Progress increase per hour</source>
+        <translation type="unfinished">Aurrerapenaren igoera orduko</translation>
     </message>
     <message>
         <source>Hide</source>
@@ -1011,10 +1318,12 @@
     </message>
     <message>
         <source>Confirm options reset</source>
+        <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
         <translation type="unfinished">Berretsi aukeren berrezarpena</translation>
     </message>
     <message>
         <source>Client restart required to activate changes.</source>
+        <extracomment>Text explaining that the settings changed will not come into effect until the client is restarted.</extracomment>
         <translation type="unfinished">Bezeroa berrabiarazi behar da aldaketak aktibatzeko.</translation>
     </message>
     <message>
@@ -1054,21 +1363,69 @@
         <translation type="unfinished">Ez dago eskuragarri:</translation>
     </message>
     <message>
+        <source>Balances</source>
+        <translation type="unfinished">Saldoa</translation>
+    </message>
+    <message>
         <source>Total:</source>
         <translation type="unfinished">Guztira:</translation>
+    </message>
+    <message>
+        <source>Your current total balance</source>
+        <translation type="unfinished">Zure oraingo erabateko saldoa</translation>
+    </message>
+    <message>
+        <source>Spendable:</source>
+        <translation type="unfinished">Gastagarria:</translation>
+    </message>
+    <message>
+        <source>Recent transactions</source>
+        <translation type="unfinished">Transakzio berriak</translation>
     </message>
     </context>
 <context>
     <name>PSBTOperationsDialog</name>
     <message>
+        <source>Dialog</source>
+        <translation type="unfinished">Elkarrizketa</translation>
+    </message>
+    <message>
+        <source>Sign Tx</source>
+        <translation type="unfinished">Sinatu Tx</translation>
+    </message>
+    <message>
         <source>Copy to Clipboard</source>
         <translation type="unfinished">Kopiatu arbelera</translation>
+    </message>
+    <message>
+        <source>Save…</source>
+        <translation type="unfinished">Gorde...</translation>
     </message>
     <message>
         <source>Close</source>
         <translation type="unfinished">Itxi</translation>
     </message>
-    </context>
+    <message>
+        <source>Save Transaction Data</source>
+        <translation type="unfinished">Gorde transakzioko data</translation>
+    </message>
+    <message>
+        <source>PSBT saved to disk.</source>
+        <translation type="unfinished">PSBT diskoan gorde da.</translation>
+    </message>
+    <message>
+        <source>Total Amount</source>
+        <translation type="unfinished">Kopuru osoa</translation>
+    </message>
+    <message>
+        <source>or</source>
+        <translation type="unfinished">edo</translation>
+    </message>
+    <message>
+        <source>Transaction status is unknown.</source>
+        <translation type="unfinished">Transakzioaren egoera ezezaguna da.</translation>
+    </message>
+</context>
 <context>
     <name>PaymentServer</name>
     <message>
@@ -1084,6 +1441,21 @@
         <translation type="unfinished">Erabiltzaile agentea</translation>
     </message>
     <message>
+        <source>Peer</source>
+        <extracomment>Title of Peers Table column which contains a unique number used to identify a connection.</extracomment>
+        <translation type="unfinished">Kidea</translation>
+    </message>
+    <message>
+        <source>Sent</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have sent to the peer.</extracomment>
+        <translation type="unfinished">Bidalia</translation>
+    </message>
+    <message>
+        <source>Received</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have received from the peer.</extracomment>
+        <translation type="unfinished">Jasoa</translation>
+    </message>
+    <message>
         <source>Address</source>
         <extracomment>Title of Peers Table column which contains the IP/Onion/I2P address of the connected peer.</extracomment>
         <translation type="unfinished">Helbidea</translation>
@@ -1093,9 +1465,102 @@
         <extracomment>Title of Peers Table column which describes the type of peer connection. The "type" describes why the connection exists.</extracomment>
         <translation type="unfinished">Mota</translation>
     </message>
+    <message>
+        <source>Network</source>
+        <extracomment>Title of Peers Table column which states the network the peer connected through.</extracomment>
+        <translation type="unfinished">Sarea</translation>
+    </message>
     </context>
 <context>
+    <name>QRImageWidget</name>
+    <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">&amp;Gorde irudia...</translation>
+    </message>
+    <message>
+        <source>&amp;Copy Image</source>
+        <translation type="unfinished">&amp;kopiatu irudia</translation>
+    </message>
+    <message>
+        <source>Save QR Code</source>
+        <translation type="unfinished">Gorde QR kodea</translation>
+    </message>
+    <message>
+        <source>PNG Image</source>
+        <extracomment>Expanded name of the PNG file format. See: https://en.wikipedia.org/wiki/Portable_Network_Graphics.</extracomment>
+        <translation type="unfinished">PNG irudia</translation>
+    </message>
+</context>
+<context>
     <name>RPCConsole</name>
+    <message>
+        <source>Client version</source>
+        <translation type="unfinished">Bezeroaren bertsioa</translation>
+    </message>
+    <message>
+        <source>&amp;Information</source>
+        <translation type="unfinished">&amp;Informazioa</translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation type="unfinished">Orokorra</translation>
+    </message>
+    <message>
+        <source>Datadir</source>
+        <translation type="unfinished">Datu direktorioa</translation>
+    </message>
+    <message>
+        <source>Blocksdir</source>
+        <translation type="unfinished">Blokeen direktorioa</translation>
+    </message>
+    <message>
+        <source>Startup time</source>
+        <translation type="unfinished">Abiatzeko ordua</translation>
+    </message>
+    <message>
+        <source>Network</source>
+        <translation type="unfinished">Sarea</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished">Izena</translation>
+    </message>
+    <message>
+        <source>Number of connections</source>
+        <translation type="unfinished">Konexio kopurua</translation>
+    </message>
+    <message>
+        <source>Wallet: </source>
+        <translation type="unfinished">Diruzorroa:</translation>
+    </message>
+    <message>
+        <source>(none)</source>
+        <translation type="unfinished">(bat ere ez)</translation>
+    </message>
+    <message>
+        <source>&amp;Reset</source>
+        <translation type="unfinished">&amp;Berrezarri</translation>
+    </message>
+    <message>
+        <source>Received</source>
+        <translation type="unfinished">Jasoa</translation>
+    </message>
+    <message>
+        <source>Sent</source>
+        <translation type="unfinished">Bidalia</translation>
+    </message>
+    <message>
+        <source>&amp;Peers</source>
+        <translation type="unfinished">&amp;Kideak</translation>
+    </message>
+    <message>
+        <source>Banned peers</source>
+        <translation type="unfinished">Debekatutako kideak</translation>
+    </message>
+    <message>
+        <source>Version</source>
+        <translation type="unfinished">Bertsioa</translation>
+    </message>
     <message>
         <source>User Agent</source>
         <translation type="unfinished">Erabiltzaile agentea</translation>
@@ -1105,8 +1570,37 @@
         <translation type="unfinished">Adabegiaren leihoa</translation>
     </message>
     <message>
+        <source>Permissions</source>
+        <translation type="unfinished">Baimenak</translation>
+    </message>
+    <message>
+        <source>Services</source>
+        <translation type="unfinished">Zerbitzuak</translation>
+    </message>
+    <message>
         <source>Last block time</source>
         <translation type="unfinished">Azken blokearen unea</translation>
+    </message>
+    <message>
+        <source>Clear console</source>
+        <translation type="unfinished">Garbitu kontsola</translation>
+    </message>
+    <message>
+        <source>&amp;Disconnect</source>
+        <translation type="unfinished">&amp;Deskonektatu</translation>
+    </message>
+    <message>
+        <source>Executing…</source>
+        <extracomment>A console message indicating an entered command is currently being executed.</extracomment>
+        <translation type="unfinished">Exekutatzen...</translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished">Bai</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished">Ez</translation>
     </message>
     <message>
         <source>To</source>
@@ -1116,7 +1610,15 @@
         <source>From</source>
         <translation type="unfinished">Tik</translation>
     </message>
-    </context>
+    <message>
+        <source>Never</source>
+        <translation type="unfinished">Inoiz ez</translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">Ezezaguna</translation>
+    </message>
+</context>
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
@@ -1132,6 +1634,30 @@
         <translation type="unfinished">&amp;Mezua:</translation>
     </message>
     <message>
+        <source>Clear all fields of the form.</source>
+        <translation type="unfinished">Garbitu formularioko eremu guztiak.</translation>
+    </message>
+    <message>
+        <source>Clear</source>
+        <translation type="unfinished">Garbitu</translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished">Erakutsi</translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation type="unfinished">Ezabatu</translation>
+    </message>
+    <message>
+        <source>Copy &amp;URI</source>
+        <translation type="unfinished">Kopiatu &amp;URI</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Kopiatu &amp;Etiketa</translation>
+    </message>
+    <message>
         <source>Could not unlock wallet.</source>
         <translation type="unfinished">Ezin da diruzorroa desblokeatu.</translation>
     </message>
@@ -1139,8 +1665,16 @@
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
+        <source>Address:</source>
+        <translation type="unfinished">Helbidea:</translation>
+    </message>
+    <message>
         <source>Amount:</source>
         <translation type="unfinished">Kopurua:</translation>
+    </message>
+    <message>
+        <source>Label:</source>
+        <translation type="unfinished">Etiketa:</translation>
     </message>
     <message>
         <source>Message:</source>
@@ -1151,8 +1685,24 @@
         <translation type="unfinished">Diruzorroa:</translation>
     </message>
     <message>
+        <source>Copy &amp;URI</source>
+        <translation type="unfinished">Kopiatu &amp;URI</translation>
+    </message>
+    <message>
         <source>Copy &amp;Address</source>
         <translation type="unfinished">&amp;Helbidea kopiatu</translation>
+    </message>
+    <message>
+        <source>&amp;Verify</source>
+        <translation type="unfinished">&amp;Egiaztatu</translation>
+    </message>
+    <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">&amp;Gorde irudia...</translation>
+    </message>
+    <message>
+        <source>Payment information</source>
+        <translation type="unfinished">Ordainketaren informazioa</translation>
     </message>
     </context>
 <context>
@@ -1173,12 +1723,24 @@
         <source>(no label)</source>
         <translation type="unfinished">(izendapenik ez)</translation>
     </message>
-    </context>
+    <message>
+        <source>(no message)</source>
+        <translation type="unfinished">(mezurik ez)</translation>
+    </message>
+    <message>
+        <source>Requested</source>
+        <translation type="unfinished">Eskatua</translation>
+    </message>
+</context>
 <context>
     <name>SendCoinsDialog</name>
     <message>
         <source>Send Coins</source>
         <translation type="unfinished">Txanponak bidali</translation>
+    </message>
+    <message>
+        <source>automatically selected</source>
+        <translation type="unfinished">automatikoki aukeratua</translation>
     </message>
     <message>
         <source>Quantity:</source>
@@ -1205,16 +1767,40 @@
         <translation type="unfinished">Bueltak:</translation>
     </message>
     <message>
+        <source>Transaction Fee:</source>
+        <translation type="unfinished">Transakzio kuota:</translation>
+    </message>
+    <message>
+        <source>per kilobyte</source>
+        <translation type="unfinished">Kilobyteko</translation>
+    </message>
+    <message>
         <source>Hide</source>
         <translation type="unfinished">Izkutatu</translation>
+    </message>
+    <message>
+        <source>Recommended:</source>
+        <translation type="unfinished">Gomendatutakoa:</translation>
+    </message>
+    <message>
+        <source>Custom:</source>
+        <translation type="unfinished">Neurrira:</translation>
     </message>
     <message>
         <source>Send to multiple recipients at once</source>
         <translation type="unfinished">Hainbat jasotzaileri batera bidali</translation>
     </message>
     <message>
+        <source>Clear all fields of the form.</source>
+        <translation type="unfinished">Garbitu formularioko eremu guztiak.</translation>
+    </message>
+    <message>
         <source>Dust:</source>
         <translation type="unfinished">Hautsa:</translation>
+    </message>
+    <message>
+        <source>Choose…</source>
+        <translation type="unfinished">Aukeratu...</translation>
     </message>
     <message>
         <source>Balance:</source>
@@ -1225,12 +1811,24 @@
         <translation type="unfinished">Bidalketa berretsi</translation>
     </message>
     <message>
+        <source>S&amp;end</source>
+        <translation type="unfinished">Bidali</translation>
+    </message>
+    <message>
         <source>Copy quantity</source>
         <translation type="unfinished">Kopia kopurua</translation>
     </message>
     <message>
         <source>Copy amount</source>
         <translation type="unfinished">zenbatekoaren kopia</translation>
+    </message>
+    <message>
+        <source>Copy fee</source>
+        <translation type="unfinished">Kopiatu kuota</translation>
+    </message>
+    <message>
+        <source>Copy after fee</source>
+        <translation type="unfinished">Kopia kuotaren ondoren</translation>
     </message>
     <message>
         <source>Copy bytes</source>
@@ -1243,6 +1841,49 @@
     <message>
         <source>Copy change</source>
         <translation type="unfinished">Kopiatu aldaketa</translation>
+    </message>
+    <message>
+        <source>Sign on device</source>
+        <extracomment>"device" usually means a hardware wallet.</extracomment>
+        <translation type="unfinished">Sinatu gailuan</translation>
+    </message>
+    <message>
+        <source>Connect your hardware wallet first.</source>
+        <translation type="unfinished">Konektatu zure hardware diruzorroa lehenago.</translation>
+    </message>
+    <message>
+        <source>Sign failed</source>
+        <translation type="unfinished">Sinadurak hutsegitea</translation>
+    </message>
+    <message>
+        <source>External signer not found</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Kanpo sinatzailea ez da aurkitu</translation>
+    </message>
+    <message>
+        <source>External signer failure</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Kanpo sinatzailearen hutsegitea</translation>
+    </message>
+    <message>
+        <source>Save Transaction Data</source>
+        <translation type="unfinished">Gorde transakzioko data</translation>
+    </message>
+    <message>
+        <source>PSBT saved</source>
+        <translation type="unfinished">PSBT gordeta</translation>
+    </message>
+    <message>
+        <source>External balance:</source>
+        <translation type="unfinished">Kanpo saldoa:</translation>
+    </message>
+    <message>
+        <source>or</source>
+        <translation type="unfinished">edo</translation>
+    </message>
+    <message>
+        <source>Total Amount</source>
+        <translation type="unfinished">Kopuru osoa</translation>
     </message>
     <message>
         <source>Confirm send coins</source>
@@ -1279,6 +1920,10 @@
         <translation type="unfinished">&amp;Etiketa:</translation>
     </message>
     <message>
+        <source>Choose previously used address</source>
+        <translation type="unfinished">Aukeratu lehenago aukeraturiko helbidea</translation>
+    </message>
+    <message>
         <source>Paste address from clipboard</source>
         <translation type="unfinished">Arbeletik helbidea itsatsi</translation>
     </message>
@@ -1286,16 +1931,36 @@
         <source>Message:</source>
         <translation type="unfinished">Mezua:</translation>
     </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">Honi ordaindu:</translation>
-    </message>
     </context>
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
+        <source>Choose previously used address</source>
+        <translation type="unfinished">Aukeratu lehenago aukeraturiko helbidea</translation>
+    </message>
+    <message>
         <source>Paste address from clipboard</source>
         <translation type="unfinished">Arbeletik helbidea itsatsi</translation>
+    </message>
+    <message>
+        <source>Enter the message you want to sign here</source>
+        <translation type="unfinished">Sartu sinatu nahi duzun mezua hemen</translation>
+    </message>
+    <message>
+        <source>Signature</source>
+        <translation type="unfinished">Sinadura</translation>
+    </message>
+    <message>
+        <source>Copy the current signature to the system clipboard</source>
+        <translation type="unfinished">Kopiatu oraingo sinadura sistemaren arbelera</translation>
+    </message>
+    <message>
+        <source>Sign &amp;Message</source>
+        <translation type="unfinished">Sinatu &amp;Mezua</translation>
+    </message>
+    <message>
+        <source>&amp;Verify Message</source>
+        <translation type="unfinished">&amp;Egiaztatu mezua</translation>
     </message>
     <message>
         <source>No error</source>
@@ -1313,19 +1978,30 @@
         <source>Please check the signature and try again.</source>
         <translation type="unfinished">Mesedez, begiratu sinadura eta saiatu berriro.</translation>
     </message>
-    </context>
+    <message>
+        <source>Message verification failed.</source>
+        <translation type="unfinished">Mezuen egiaztatzeak huts egin du</translation>
+    </message>
+    <message>
+        <source>Message verified.</source>
+        <translation type="unfinished">Mezua egiaztatua.</translation>
+    </message>
+</context>
 <context>
     <name>TransactionDesc</name>
     <message>
         <source>abandoned</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an abandoned transaction.</extracomment>
         <translation type="unfinished">abandonatuta</translation>
     </message>
     <message>
         <source>%1/unconfirmed</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
         <translation type="unfinished">%1/konfirmatu gabe</translation>
     </message>
     <message>
         <source>%1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
         <translation type="unfinished">%1 konfirmazio</translation>
     </message>
     <message>
@@ -1407,7 +2083,15 @@
         <source>Amount</source>
         <translation type="unfinished">Kopurua</translation>
     </message>
-    </context>
+    <message>
+        <source>true</source>
+        <translation type="unfinished">egia</translation>
+    </message>
+    <message>
+        <source>false</source>
+        <translation type="unfinished">faltsua</translation>
+    </message>
+</context>
 <context>
     <name>TransactionDescDialog</name>
     <message>
@@ -1428,6 +2112,10 @@
     <message>
         <source>Label</source>
         <translation type="unfinished">Izendapen</translation>
+    </message>
+    <message>
+        <source>Unconfirmed</source>
+        <translation type="unfinished">Baieztatu gabea</translation>
     </message>
     <message>
         <source>Confirmed (%1 confirmations)</source>
@@ -1529,6 +2217,15 @@
         <translation type="unfinished">Kopuru minimoa</translation>
     </message>
     <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Kopiatu &amp;Etiketa</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">Komaz bereizitako fitxategia</translation>
+    </message>
+    <message>
         <source>Confirmed</source>
         <translation type="unfinished">Berretsia</translation>
     </message>
@@ -1569,6 +2266,18 @@
     <message>
         <source>Send Coins</source>
         <translation type="unfinished">Txanponak bidali</translation>
+    </message>
+    <message>
+        <source>Current fee:</source>
+        <translation type="unfinished">Oraingo kuota:</translation>
+    </message>
+    <message>
+        <source>New fee:</source>
+        <translation type="unfinished">Kuota berria:</translation>
+    </message>
+    <message>
+        <source>PSBT copied</source>
+        <translation type="unfinished">PSBT kopiatua</translation>
     </message>
     <message>
         <source>default wallet</source>

--- a/src/qt/locale/bitcoin_fa.ts
+++ b/src/qt/locale/bitcoin_fa.ts
@@ -3,15 +3,15 @@
     <name>AddressBookPage</name>
     <message>
         <source>Right-click to edit address or label</source>
-        <translation type="unfinished">برای ویرایش نشانی یا برچسب زدن کلیک ‌راست کنید</translation>
+        <translation type="unfinished">برای ویرایش نشانی یا برچسب راست-کلیک کنید</translation>
     </message>
     <message>
         <source>Create a new address</source>
-        <translation type="unfinished">آدرس جدید ایجاد کنید</translation>
+        <translation type="unfinished">یک آدرس جدید ایجاد کنید</translation>
     </message>
     <message>
         <source>&amp;New</source>
-        <translation type="unfinished">و جدید</translation>
+        <translation type="unfinished">&amp;جدید</translation>
     </message>
     <message>
         <source>Copy the currently selected address to the system clipboard</source>
@@ -27,7 +27,7 @@
     </message>
     <message>
         <source>Delete the currently selected address from the list</source>
-        <translation type="unfinished">حذف آدرس ‌انتخاب شده از فهرست</translation>
+        <translation type="unfinished">حذف آدرس ‌انتخاب شده ی جاری از فهرست</translation>
     </message>
     <message>
         <source>Enter address or label to search</source>
@@ -39,11 +39,19 @@
     </message>
     <message>
         <source>&amp;Export</source>
-        <translation type="unfinished">صدور</translation>
+        <translation type="unfinished">&amp;صدور</translation>
     </message>
     <message>
         <source>&amp;Delete</source>
         <translation type="unfinished">حذف</translation>
+    </message>
+    <message>
+        <source>Choose the address to send coins to</source>
+        <translation type="unfinished">آدرس را برای ارسال کوین وارد کنید</translation>
+    </message>
+    <message>
+        <source>Choose the address to receive coins with</source>
+        <translation type="unfinished">آدرس را برای دریافت کوین وارد کنید</translation>
     </message>
     <message>
         <source>C&amp;hoose</source>
@@ -160,7 +168,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
-        <translation type="unfinished">هشدار: اگر کیف پول خود را رمزگذاری کنید و عبارت خود را گام کنید ، این کار را انجام می دهید &lt;b&gt;تمام کویت های خود را از دست &lt;/b&gt;استفاده کنید!
+        <translation type="unfinished">هشدار: اگر کیف پول خود را رمزگذاری کنید و عبارت خود را گم کنید ، &lt;b&gt;تمام کویت های خود را از دست &lt;/b&gt;خواهید داد!
 </translation>
     </message>
     <message>
@@ -251,12 +259,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>BitcoinApplication</name>
     <message>
-        <source>Runaway exception</source>
-        <translation type="unfinished">استثناء فراری (این استثناء نشان دهنده این است که هسته بیتکوین نتوانست چیزی را در کیف(والت) بنویسد.)</translation>
+        <source>Settings file %1 might be corrupt or invalid.</source>
+        <translation type="unfinished">فایل تنظیمات %1 ممکن است خراب یا نامعتبر باشد.</translation>
     </message>
     <message>
-        <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
-        <translation type="unfinished"> خطای تخریب کننده ای روی داده است.%1 نمیتواند بصورت ایمن ادامه پیدا کند و پایان می یابد.</translation>
+        <source>Runaway exception</source>
+        <translation type="unfinished">استثناء فراری (این استثناء نشان دهنده این است که هسته بیتکوین نتوانست چیزی را در کیف(والت) بنویسد.)</translation>
     </message>
     <message>
         <source>Internal error</source>
@@ -367,31 +375,31 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n second(s)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n minute(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n minute(s)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n hour(s)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n day(s)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n week(s)</numerusform>
         </translation>
     </message>
     <message>
@@ -401,7 +409,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n year(s)</numerusform>
         </translation>
     </message>
     <message>
@@ -591,10 +599,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">خطا در خواندن رکورد بعدی از پایگاه داده کیف پول</translation>
     </message>
     <message>
-        <source>Error upgrading chainstate database</source>
-        <translation type="unfinished">خطا در بارگذاری پایگاه داده ها</translation>
-    </message>
-    <message>
         <source>Error: Couldn't create cursor into database</source>
         <translation type="unfinished">خطا: مکان نما در پایگاه داده ایجاد نشد</translation>
     </message>
@@ -692,10 +696,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">توصیفگرهای فایل به اندازه کافی در دسترس نیست</translation>
     </message>
     <message>
-        <source>Prune mode is incompatible with -coinstatsindex.</source>
-        <translation type="unfinished">حالت Prune با -coinstatsindex ناسازگار است.</translation>
-    </message>
-    <message>
         <source>Pruning blockstore…</source>
         <translation type="unfinished">هرس بلوک فروشی…</translation>
     </message>
@@ -773,6 +773,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">حجم تراکنش خیلی زیاد است</translation>
     </message>
     <message>
+        <source>Unable to find UTXO for external input</source>
+        <translation type="unfinished">قادر به پیدا کردن UTXO  برای ورودی جانبی نیست.</translation>
+    </message>
+    <message>
         <source>Unable to generate initial keys</source>
         <translation type="unfinished">نمیتوان کلید های اولیه را تولید کرد.</translation>
     </message>
@@ -800,10 +804,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Unknown new rules activated (versionbit %i)</source>
         <translation type="unfinished">قوانین جدید ناشناخته فعال شد (‌%iversionbit)</translation>
-    </message>
-    <message>
-        <source>Upgrading UTXO database</source>
-        <translation type="unfinished">ارتقا دادن پایگاه داده UTXO</translation>
     </message>
     <message>
         <source>Verifying blocks…</source>
@@ -934,6 +934,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">پیام تایید</translation>
     </message>
     <message>
+        <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
+        <translation type="unfinished">پیام ها را تأیید کنید تا مطمئن شوید با آدرس های مشخص شده بیت کوین امضا شده اند
+ </translation>
+    </message>
+    <message>
         <source>&amp;Load PSBT from file…</source>
         <translation type="unfinished">بارگیری PSBT از پرونده</translation>
     </message>
@@ -1012,7 +1017,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>سابقه تراکنش بلوک(های) %n پردازش شد.</numerusform>
         </translation>
     </message>
     <message>
@@ -1086,6 +1091,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">کیف پول را ببندید</translation>
     </message>
     <message>
+        <source>Restore Wallet…</source>
+        <extracomment>Name of the menu item that restores wallet from a backup file.</extracomment>
+        <translation type="unfinished">بازیابی کیف پول…</translation>
+    </message>
+    <message>
+        <source>Restore a wallet from a backup file</source>
+        <extracomment>Status tip for Restore Wallet menu item</extracomment>
+        <translation type="unfinished">بازیابی یک کیف پول از یک فایل پشتیبان</translation>
+    </message>
+    <message>
         <source>Close all wallets</source>
         <translation type="unfinished">همه‌ی کیف پول‌ها را ببند</translation>
     </message>
@@ -1097,6 +1112,26 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>No wallets available</source>
         <translation type="unfinished">هیچ کیف پولی در دسترس نمی باشد</translation>
+    </message>
+    <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">داده های کیف پول</translation>
+    </message>
+    <message>
+        <source>Load Wallet Backup</source>
+        <extracomment>The title for Restore Wallet File Windows</extracomment>
+        <translation type="unfinished">بارگیری پشتیبان‌گیری کیف پول</translation>
+    </message>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of pop-up window shown when the user is attempting to restore a wallet.</extracomment>
+        <translation type="unfinished">بازیابی کیف پول</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">نام کیف پول</translation>
     </message>
     <message>
         <source>&amp;Window</source>
@@ -1114,11 +1149,15 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>%1 client</source>
         <translation type="unfinished">کلاینت: %1</translation>
     </message>
+    <message>
+        <source>&amp;Hide</source>
+        <translation type="unfinished">مخفی کن</translation>
+    </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n اتصال(های) فعال به شبکه بیت کوین.</numerusform>
         </translation>
     </message>
     <message>
@@ -1140,6 +1179,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Enable network activity</source>
         <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
         <translation type="unfinished">فعال‌سازی فعالیت شبکه</translation>
+    </message>
+    <message>
+        <source>Pre-syncing Headers (%1%)…</source>
+        <translation type="unfinished">پیش‌همگام‌سازی سرصفحه‌ها (%1%)…</translation>
     </message>
     <message>
         <source>Error: %1</source>
@@ -1399,6 +1442,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Can't list signers</source>
         <translation type="unfinished">نمی‌توان امضاکنندگان را فهرست کرد</translation>
     </message>
+    <message>
+        <source>Too many external signers found</source>
+        <translation type="unfinished">تعداد زیادی امضاکننده خارجی پیدا شد</translation>
+    </message>
 </context>
 <context>
     <name>LoadWalletsActivity</name>
@@ -1441,6 +1488,34 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
 </context>
 <context>
+    <name>RestoreWalletActivity</name>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of progress window which is displayed when wallets are being restored.</extracomment>
+        <translation type="unfinished">بازیابی کیف پول</translation>
+    </message>
+    <message>
+        <source>Restoring Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the restore wallets progress window which indicates to the user that wallets are currently being restored.</extracomment>
+        <translation type="unfinished">بازیابی کیف پول &lt;b&gt;%1&lt;/b&gt; ...</translation>
+    </message>
+    <message>
+        <source>Restore wallet failed</source>
+        <extracomment>Title of message box which is displayed when the wallet could not be restored.</extracomment>
+        <translation type="unfinished">بازیابی کیف پول انجام نشد</translation>
+    </message>
+    <message>
+        <source>Restore wallet warning</source>
+        <extracomment>Title of message box which is displayed when the wallet is restored with some warning.</extracomment>
+        <translation type="unfinished">هشدار بازیابی کیف پول</translation>
+    </message>
+    <message>
+        <source>Restore wallet message</source>
+        <extracomment>Title of message box which is displayed when the wallet is successfully restored.</extracomment>
+        <translation type="unfinished">بازیابی پیام کیف پول</translation>
+    </message>
+</context>
+<context>
     <name>WalletController</name>
     <message>
         <source>Close wallet</source>
@@ -1472,7 +1547,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Encrypt the wallet. The wallet will be encrypted with a passphrase of your choice.</source>
-        <translation type="unfinished">کیف پول را رمز نگاری نمائید. کیف پول با کلمات رمز انتخاب خودتان رمز نگاری خواهد شد</translation>
+        <translation type="unfinished">کیف پول را رمز نگاری نمائید. کیف پول با کلمات رمز دلخواه شما رمز نگاری خواهد شد</translation>
     </message>
     <message>
         <source>Encrypt Wallet</source>
@@ -1593,13 +1668,23 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Bitcoin</source>
         <translation type="unfinished">بیت کوین</translation>
     </message>
-    <message>
-        <source>(of %1 GB needed)</source>
-        <translation type="unfinished">(%1 گیگابایت لازم است)</translation>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform>%n گیگابایت فضای موجود</numerusform>
+        </translation>
     </message>
-    <message>
-        <source>(%1 GB needed for full chain)</source>
-        <translation type="unfinished">(%1 برای زنجیر کامل نیاز است)</translation>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform>(از %n گیگابایت مورد نیاز)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform>(%n گیگابایت برای زنجیره کامل مورد نیاز است)</numerusform>
+        </translation>
     </message>
     <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
@@ -1613,7 +1698,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>(برای بازیابی نسخه‌های پشتیبان %n روز (های) قدیمی کافی است)</numerusform>
         </translation>
     </message>
     <message>
@@ -1647,6 +1732,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source> GB</source>
         <translation type="unfinished">گیگابایت</translation>
+    </message>
+    <message>
+        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2 GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
+        <translation type="unfinished">وقتی تأیید را کلیک می‌کنید، %1 شروع به دانلود و پردازش زنجیره بلاک %4 کامل (%2 گیگابایت) می‌کند که با اولین تراکنش‌ها در %3 شروع می‌شود که %4 در ابتدا راه‌اندازی می شود.</translation>
     </message>
     <message>
         <source>If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</source>
@@ -1740,6 +1829,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Unknown. Syncing Headers (%1, %2%)…</source>
         <translation type="unfinished">ناشناخته. هماهنگ‌سازی سربرگ‌ها (%1، %2%) </translation>
     </message>
+    <message>
+        <source>Unknown. Pre-syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">ناشناس.  پیش‌همگام‌سازی سرصفحه‌ها (%1، %2% )…</translation>
+    </message>
 </context>
 <context>
     <name>OpenURIDialog</name>
@@ -1774,6 +1867,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished">اندازه کش پایگاه داده.</translation>
+    </message>
+    <message>
+        <source>Options set in this dialog are overridden by the command line:</source>
+        <translation type="unfinished">گزینه های تنظیم شده در این گفتگو توسط خط فرمان لغو می شوند:</translation>
     </message>
     <message>
         <source>Open Configuration File</source>
@@ -2004,15 +2101,23 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Confirm options reset</source>
+        <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
         <translation type="unfinished">باز نشانی گزینه ها را تأیید کنید
   </translation>
     </message>
     <message>
         <source>Client restart required to activate changes.</source>
+        <extracomment>Text explaining that the settings changed will not come into effect until the client is restarted.</extracomment>
         <translation type="unfinished">کلاینت نیازمند ریست شدن است برای فعال کردن تغییرات</translation>
     </message>
     <message>
+        <source>Current settings will be backed up at "%1".</source>
+        <extracomment>Text explaining to the user that the client's current settings will be backed up at a specific location. %1 is a stand-in argument for the backup location's path.</extracomment>
+        <translation type="unfinished">تنظیمات فعلی در "%1" پشتیبان گیری خواهد شد.</translation>
+    </message>
+    <message>
         <source>Client will be shut down. Do you want to proceed?</source>
+        <extracomment>Text asking the user to confirm if they would like to proceed with a client shutdown.</extracomment>
         <translation type="unfinished">کلاینت خاموش خواهد شد.آیا میخواهید ادامه دهید؟</translation>
     </message>
     <message>
@@ -2050,6 +2155,13 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>The supplied proxy address is invalid.</source>
         <translation type="unfinished">آدرس پراکسی ارائه شده نامعتبر است.</translation>
+    </message>
+</context>
+<context>
+    <name>OptionsModel</name>
+    <message>
+        <source>Could not read setting "%1", %2.</source>
+        <translation type="unfinished">نمی توان تنظیم "%1"، %2 را خواند.</translation>
     </message>
 </context>
 <context>
@@ -2168,6 +2280,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">یا</translation>
     </message>
     <message>
+        <source>Transaction has %1 unsigned inputs.</source>
+        <translation type="unfinished">%1Transaction has  unsigned inputs.</translation>
+    </message>
+    <message>
         <source>Transaction still needs signature(s).</source>
         <translation type="unfinished">عملیات هنوز به امضا(ها) نیاز دارد.</translation>
     </message>
@@ -2227,6 +2343,11 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <source>Peer</source>
         <extracomment>Title of Peers Table column which contains a unique number used to identify a connection.</extracomment>
         <translation type="unfinished">همتا </translation>
+    </message>
+    <message>
+        <source>Age</source>
+        <extracomment>Title of Peers Table column which indicates the duration (length of time) since the peer connection started.</extracomment>
+        <translation type="unfinished">سن</translation>
     </message>
     <message>
         <source>Direction</source>
@@ -2405,29 +2526,22 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Whether we relay addresses to this peer.</source>
-        <extracomment>Tooltip text for the Address Relay field in the peer details area.</extracomment>
+        <extracomment>Tooltip text for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
         <translation type="unfinished"> ما آدرس‌ها را به این همتا ارسال می‌کنیم.</translation>
     </message>
     <message>
         <source>Address Relay</source>
+        <extracomment>Text title for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
         <translation type="unfinished">رله آدرس</translation>
     </message>
     <message>
-        <source>Total number of addresses processed, excluding those dropped due to rate-limiting.</source>
-        <extracomment>Tooltip text for the Addresses Processed field in the peer details area.</extracomment>
-        <translation type="unfinished">تعداد کل آدرس‌های پردازش شده، به استثنای آدرس‌هایی که به دلیل محدودیت نرخ حذف شده‌اند.</translation>
-    </message>
-    <message>
         <source>Addresses Processed</source>
+        <extracomment>Text title for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
         <translation type="unfinished">آدرس ها پردازش شد</translation>
     </message>
     <message>
-        <source>Total number of addresses dropped due to rate-limiting.</source>
-        <extracomment>Tooltip text for the Addresses Rate-Limited field in the peer details area.</extracomment>
-        <translation type="unfinished">تعداد کل آدرس‌ها به دلیل محدودیت نرخ کاهش یافت.</translation>
-    </message>
-    <message>
         <source>Addresses Rate-Limited</source>
+        <extracomment>Text title for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
         <translation type="unfinished">آدرس ها با نرخ محدود</translation>
     </message>
     <message>
@@ -3028,7 +3142,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     </message>
     <message>
         <source>Copy amount</source>
-        <translation type="unfinished">مقدار کپی</translation>
+        <translation type="unfinished">کپی مقدار</translation>
     </message>
     <message>
         <source>Copy fee</source>
@@ -3167,14 +3281,10 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
         <source>A fee higher than %1 is considered an absurdly high fee.</source>
         <translation type="unfinished">کارمزد بیشتر از %1 است,این یعنی کارمزد خیلی زیادی در نظر گرفته شده است.</translation>
     </message>
-    <message>
-        <source>Payment request expired.</source>
-        <translation type="unfinished">درخواست پرداخت منقضی شد یا تاریخ آن گذشت.</translation>
-    </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>Estimated to begin confirmation within %n block(s).</numerusform>
         </translation>
     </message>
     <message>
@@ -3238,25 +3348,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
         <source>Message:</source>
         <translation type="unfinished">پیام:</translation>
     </message>
-    <message>
-        <source>This is an unauthenticated payment request.</source>
-        <translation type="unfinished">این یک درخواست پرداخت غیرمجاز است.
- </translation>
-    </message>
-    <message>
-        <source>This is an authenticated payment request.</source>
-        <translation type="unfinished">این یک درخواست پرداخت معتبر است.
- </translation>
-    </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">پرداخت کردن</translation>
-    </message>
-    <message>
-        <source>Memo:</source>
-        <translation type="unfinished">یادداشت:</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>SendConfirmationDialog</name>
     <message>
@@ -3421,14 +3513,17 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     <name>TransactionDesc</name>
     <message>
         <source>abandoned</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an abandoned transaction.</extracomment>
         <translation type="unfinished">رها شده</translation>
     </message>
     <message>
         <source>%1/unconfirmed</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
         <translation type="unfinished">%1/تأیید نشده</translation>
     </message>
     <message>
         <source>%1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
         <translation type="unfinished">%1 تأییدیه</translation>
     </message>
     <message>
@@ -3478,7 +3573,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>matures in %n more block(s)</numerusform>
         </translation>
     </message>
     <message>
@@ -3859,11 +3954,11 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     <name>WalletView</name>
     <message>
         <source>&amp;Export</source>
-        <translation type="unfinished">صدور</translation>
+        <translation type="unfinished">&amp;صدور</translation>
     </message>
     <message>
         <source>Export the data in the current tab to a file</source>
-        <translation type="unfinished">داده های موجود در برگه فعلی را به یک فایل صادر کنید</translation>
+        <translation type="unfinished">خروجی گرفتن داده‌ها از برگه ی کنونی در یک پوشه</translation>
     </message>
     <message>
         <source>Backup Wallet</source>

--- a/src/qt/locale/bitcoin_fi.ts
+++ b/src/qt/locale/bitcoin_fi.ts
@@ -246,6 +246,10 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
 <context>
     <name>BitcoinApplication</name>
     <message>
+        <source>Settings file %1 might be corrupt or invalid.</source>
+        <translation type="unfinished">Asetustiedosto %1 saattaa olla vioittunut tai virheellinen.</translation>
+    </message>
+    <message>
         <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
         <translation type="unfinished">Peruuttamaton virhe on tapahtunut. %1 ei voi enää jatkaa turvallisesti ja sammutetaan.</translation>
     </message>
@@ -332,36 +336,36 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n sekunti</numerusform>
+            <numerusform>%n sekuntia</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n minute(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n minuutti</numerusform>
+            <numerusform>%n minuuttia</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n tunti</numerusform>
+            <numerusform>%n tuntia</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n päivä</numerusform>
+            <numerusform>%n päivää</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n viikko</numerusform>
+            <numerusform>%n viikkoa</numerusform>
         </translation>
     </message>
     <message>
@@ -371,8 +375,8 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n vuosi</numerusform>
+            <numerusform>%n vuotta</numerusform>
         </translation>
     </message>
     </context>
@@ -417,10 +421,6 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
     <message>
         <source>Error: Dumpfile version is not supported. This version of bitcoin-wallet only supports version 1 dumpfiles. Got dumpfile with version %s</source>
         <translation type="unfinished">Virhe: Dump-tiedoston versio ei ole tuettu. Tämä bitcoin-lompakon versio tukee vain version 1 dump-tiedostoja. Annetun dump-tiedoston versio %s</translation>
-    </message>
-    <message>
-        <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
-        <translation type="unfinished">Virhe: Saapuvien yhteyksien kuuntelu epäonnistui (kuuntelu palautti virheen %s)</translation>
     </message>
     <message>
         <source>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.</source>
@@ -603,10 +603,6 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
         <translation type="unfinished">Virhe seuraavan tietueen lukemisessa lompakon tietokannasta</translation>
     </message>
     <message>
-        <source>Error upgrading chainstate database</source>
-        <translation type="unfinished">Virhe päivittäessä chainstate-tietokantaa</translation>
-    </message>
-    <message>
         <source>Error: Couldn't create cursor into database</source>
         <translation type="unfinished">Virhe: Tietokantaan ei voitu luoda kursoria.</translation>
     </message>
@@ -715,8 +711,8 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
         <translation type="unfinished">Pitää määritellä portti argumentilla -whitebind: '%s'</translation>
     </message>
     <message>
-        <source>No proxy server specified. Use -proxy=&lt;ip&gt; or -proxy=&lt;ip:port&gt;.</source>
-        <translation type="unfinished">Välityspalvelinta ei ole määritetty. Käytä -proxy=&lt;ip&gt; tai -proxy=&lt;ip:port&gt;.</translation>
+        <source>No addresses available</source>
+        <translation type="unfinished">Osoitteita ei ole saatavilla</translation>
     </message>
     <message>
         <source>Not enough file descriptors available.</source>
@@ -725,10 +721,6 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
     <message>
         <source>Prune cannot be configured with a negative value.</source>
         <translation type="unfinished">Karsintaa ei voi toteuttaa negatiivisella arvolla.</translation>
-    </message>
-    <message>
-        <source>Prune mode is incompatible with -coinstatsindex.</source>
-        <translation type="unfinished">Karsintatila ei ole yhteenopiva -coinstatsindex:n kanssa.</translation>
     </message>
     <message>
         <source>Prune mode is incompatible with -txindex.</source>
@@ -885,10 +877,6 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
     <message>
         <source>Unsupported logging category %s=%s.</source>
         <translation type="unfinished">Lokikategoriaa %s=%s ei tueta.</translation>
-    </message>
-    <message>
-        <source>Upgrading UTXO database</source>
-        <translation type="unfinished">Päivitetään UTXO-tietokantaa</translation>
     </message>
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
@@ -1105,8 +1093,8 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>Käsitelty %n lohko rahansiirtohistoriasta.</numerusform>
+            <numerusform>Käsitelty %n lohkoa rahansiirtohistoriasta.</numerusform>
         </translation>
     </message>
     <message>
@@ -1206,6 +1194,16 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
         <translation type="unfinished">Lompakoita ei ole saatavilla</translation>
     </message>
     <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">Lompakkotiedot</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">Lompakon nimi</translation>
+    </message>
+    <message>
         <source>&amp;Window</source>
         <translation type="unfinished">&amp;Ikkuna</translation>
     </message>
@@ -1221,12 +1219,16 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
         <source>%1 client</source>
         <translation type="unfinished">%1-asiakas</translation>
     </message>
+    <message>
+        <source>&amp;Hide</source>
+        <translation type="unfinished">&amp;Piilota</translation>
+    </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n aktiivinen yhteys Bitcoin-verkkoon.</numerusform>
+            <numerusform>%n aktiivista yhteyttä Bitcoin-verkkoon.</numerusform>
         </translation>
     </message>
     <message>
@@ -1420,6 +1422,10 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
         <translation type="unfinished">Kopioi &amp;määrä</translation>
     </message>
     <message>
+        <source>&amp;Unlock unspent</source>
+        <translation type="unfinished">&amp;Avaa käyttämättömien lukitus</translation>
+    </message>
+    <message>
         <source>Copy quantity</source>
         <translation type="unfinished">Kopioi lukumäärä</translation>
     </message>
@@ -1500,7 +1506,7 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
         <source>Can't list signers</source>
         <translation type="unfinished">Allekirjoittajia ei voida listata</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>LoadWalletsActivity</name>
     <message>
@@ -1706,13 +1712,26 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
 </context>
 <context>
     <name>Intro</name>
-    <message>
-        <source>(of %1 GB needed)</source>
-        <translation type="unfinished">(%1 GB tarvitaan)</translation>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
     </message>
-    <message>
-        <source>(%1 GB needed for full chain)</source>
-        <translation type="unfinished">(%1 GB tarvitaan koko ketjuun)</translation>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform>(tarvitaan %n GB)</numerusform>
+            <numerusform>(tarvitaan %n GB)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform>(tarvitaan %n GB koko ketjua varten)</numerusform>
+            <numerusform>(tarvitaan %n GB koko ketjua varten)</numerusform>
+        </translation>
     </message>
     <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
@@ -1757,10 +1776,6 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
     <message>
         <source>As this is the first time the program is launched, you can choose where %1 will store its data.</source>
         <translation type="unfinished">Tämä on ensimmäinen kerta, kun %1 on käynnistetty, joten voit valita data-hakemiston paikan.</translation>
-    </message>
-    <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation type="unfinished">Kun valitset OK, %1 aloittaa lataamaan ja käsittelemään koko %4 lohkoketjua (%2GB) aloittaen ensimmäisestä siirrosta %3 jolloin %4 käynnistettiin ensimmäistä kertaa.</translation>
     </message>
     <message>
         <source>Limit block chain storage to</source>
@@ -1875,7 +1890,7 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
         <source>Unknown. Syncing Headers (%1, %2%)…</source>
         <translation type="unfinished">Tuntematon. Synkronoidaan järjestysnumeroita (%1,%2%)...</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>OpenURIDialog</name>
     <message>
@@ -1972,6 +1987,11 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
         <translation type="unfinished">Näin sinä tai kolmannen osapuolen työkalu voi kommunikoida solmun kanssa komentorivi- ja JSON-RPC-komentojen avulla.</translation>
     </message>
     <message>
+        <source>Enable R&amp;PC server</source>
+        <extracomment>An Options window setting to enable the RPC server.</extracomment>
+        <translation type="unfinished">Aktivoi R&amp;PC serveri</translation>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished">&amp;Lompakko</translation>
     </message>
@@ -1990,6 +2010,11 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
     <message>
         <source>&amp;Spend unconfirmed change</source>
         <translation type="unfinished">&amp;Käytä varmistamattomia vaihtorahoja</translation>
+    </message>
+    <message>
+        <source>Enable &amp;PSBT controls</source>
+        <extracomment>An options window setting to enable PSBT controls.</extracomment>
+        <translation type="unfinished">Aktivoi &amp;PSBT kontrollit</translation>
     </message>
     <message>
         <source>External Signer (e.g. hardware wallet)</source>
@@ -2116,10 +2141,6 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
         <translation type="unfinished">lähin vastaavuus "%1"</translation>
     </message>
     <message>
-        <source>Options set in this dialog are overridden by the command line or in the configuration file:</source>
-        <translation type="unfinished">Seuraavat komentorivillä tai asetustiedostossa annetut määritykset menevät tässä ikkunassa asetettujen asetusten edelle:</translation>
-    </message>
-    <message>
         <source>&amp;Cancel</source>
         <translation type="unfinished">&amp;Peruuta</translation>
     </message>
@@ -2138,14 +2159,17 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
     </message>
     <message>
         <source>Confirm options reset</source>
+        <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
         <translation type="unfinished">Varmista asetusten palautus</translation>
     </message>
     <message>
         <source>Client restart required to activate changes.</source>
+        <extracomment>Text explaining that the settings changed will not come into effect until the client is restarted.</extracomment>
         <translation type="unfinished">Ohjelman uudelleenkäynnistys aktivoi muutokset.</translation>
     </message>
     <message>
         <source>Client will be shut down. Do you want to proceed?</source>
+        <extracomment>Text asking the user to confirm if they would like to proceed with a client shutdown.</extracomment>
         <translation type="unfinished">Asiakasohjelma sammutetaan. Haluatko jatkaa?</translation>
     </message>
     <message>
@@ -2372,6 +2396,10 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
     <message>
         <source>Transaction still needs signature(s).</source>
         <translation type="unfinished">Siirto tarvitsee vielä allekirjoituksia.</translation>
+    </message>
+    <message>
+        <source>(But no wallet is loaded.)</source>
+        <translation type="unfinished">(Mutta lompakkoa ei ole ladattu.)</translation>
     </message>
     <message>
         <source>(But this wallet cannot sign transactions.)</source>
@@ -2624,6 +2652,10 @@ Jos saat tämän virheen, pyydä kauppiasta antamaan BIP21-yhteensopiva URI.</tr
     <message>
         <source>Synced Blocks</source>
         <translation type="unfinished">Synkronoidut lohkot</translation>
+    </message>
+    <message>
+        <source>Last Transaction</source>
+        <translation type="unfinished">Viimeisin transaktio</translation>
     </message>
     <message>
         <source>The mapped Autonomous System used for diversifying peer selection.</source>
@@ -3210,6 +3242,11 @@ Jos saat tämän virheen, pyydä kauppiasta antamaan BIP21-yhteensopiva URI.</tr
         <translation type="unfinished">%1 (%2 lohkoa)</translation>
     </message>
     <message>
+        <source>Sign on device</source>
+        <extracomment>"device" usually means a hardware wallet.</extracomment>
+        <translation type="unfinished">Allekirjoita laitteella</translation>
+    </message>
+    <message>
         <source>Connect your hardware wallet first.</source>
         <translation type="unfinished">Yhdistä lompakkolaitteesi ensin.</translation>
     </message>
@@ -3229,6 +3266,10 @@ Jos saat tämän virheen, pyydä kauppiasta antamaan BIP21-yhteensopiva URI.</tr
     <message>
         <source> from wallet '%1'</source>
         <translation type="unfinished"> lompakosta '%1'</translation>
+    </message>
+    <message>
+        <source>To review recipient list click "Show Details…"</source>
+        <translation type="unfinished">Tarkastellaksesi vastaanottajalistaa klikkaa "Näytä Lisätiedot..."</translation>
     </message>
     <message>
         <source>Sign failed</source>
@@ -3327,10 +3368,6 @@ Jos saat tämän virheen, pyydä kauppiasta antamaan BIP21-yhteensopiva URI.</tr
         <source>A fee higher than %1 is considered an absurdly high fee.</source>
         <translation type="unfinished">%1:tä ja korkeampaa siirtokulua pidetään mielettömän korkeana.</translation>
     </message>
-    <message>
-        <source>Payment request expired.</source>
-        <translation type="unfinished">Maksupyyntö vanhentui.</translation>
-    </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
@@ -3410,28 +3447,12 @@ Jos saat tämän virheen, pyydä kauppiasta antamaan BIP21-yhteensopiva URI.</tr
         <translation type="unfinished">Viesti:</translation>
     </message>
     <message>
-        <source>This is an unauthenticated payment request.</source>
-        <translation type="unfinished">Tämä on todentamaton maksupyyntö.</translation>
-    </message>
-    <message>
-        <source>This is an authenticated payment request.</source>
-        <translation type="unfinished">Tämä on todennettu maksupyyntö.</translation>
-    </message>
-    <message>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished">Aseta nimi tälle osoitteelle lisätäksesi sen käytettyjen osoitteiden listalle.</translation>
     </message>
     <message>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished">Viesti joka liitettiin bitcoin: URI:iin tallennetaan rahansiirtoon viitteeksi. Tätä viestiä ei lähetetä Bitcoin-verkkoon.</translation>
-    </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">Saaja:</translation>
-    </message>
-    <message>
-        <source>Memo:</source>
-        <translation type="unfinished">Muistio:</translation>
     </message>
 </context>
 <context>
@@ -3594,35 +3615,31 @@ Jos saat tämän virheen, pyydä kauppiasta antamaan BIP21-yhteensopiva URI.</tr
         <source>(press q to shutdown and continue later)</source>
         <translation type="unfinished">(paina q lopettaaksesi ja jatkaaksesi myöhemmin)</translation>
     </message>
-    </context>
+    <message>
+        <source>press q to shutdown</source>
+        <translation type="unfinished">paina q sammuttaaksesi</translation>
+    </message>
+</context>
 <context>
     <name>TransactionDesc</name>
     <message>
         <source>conflicted with a transaction with %1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that conflicts with a confirmed transaction.</extracomment>
         <translation type="unfinished">ristiriidassa maksutapahtumalle, jolla on %1 varmistusta</translation>
     </message>
     <message>
-        <source>0/unconfirmed, %1</source>
-        <translation type="unfinished">0/varmistamaton, %1</translation>
-    </message>
-    <message>
-        <source>in memory pool</source>
-        <translation type="unfinished">muistialtaassa</translation>
-    </message>
-    <message>
-        <source>not in memory pool</source>
-        <translation type="unfinished">ei muistialtaassa</translation>
-    </message>
-    <message>
         <source>abandoned</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an abandoned transaction.</extracomment>
         <translation type="unfinished">hylätty</translation>
     </message>
     <message>
         <source>%1/unconfirmed</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
         <translation type="unfinished">%1/vahvistamaton</translation>
     </message>
     <message>
         <source>%1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
         <translation type="unfinished">%1 vahvistusta</translation>
     </message>
     <message>
@@ -3940,6 +3957,10 @@ Jos saat tämän virheen, pyydä kauppiasta antamaan BIP21-yhteensopiva URI.</tr
     <message>
         <source>Copy &amp;amount</source>
         <translation type="unfinished">Kopioi &amp;määrä</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">Kopio transaktio &amp;ID</translation>
     </message>
     <message>
         <source>Export Transaction History</source>

--- a/src/qt/locale/bitcoin_fil.ts
+++ b/src/qt/locale/bitcoin_fil.ts
@@ -324,10 +324,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Error sa pagbabasa %s! Nabasa nang tama ang lahat ng mga key, ngunit ang data ng transaksyon o mga entry sa address book ay maaaring nawawala o hindi tama.</translation>
     </message>
     <message>
-        <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
-        <translation type="unfinished">Kamalian: Nabigo ang pakikinig sa mga papasok na koneksyon (ang listen ay nagbalik ng error %s)</translation>
-    </message>
-    <message>
         <source>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.</source>
         <translation type="unfinished">Nabigo ang pagtatantya ng bayad. Hindi pinagana ang Fallbackfee. Maghintay ng ilang mga block o paganahin -fallbackfee.</translation>
     </message>
@@ -462,10 +458,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Error reading from database, shutting down.</source>
         <translation type="unfinished">Kamalian sa pagbabasa mula sa database, nag-shu-shut down.</translation>
-    </message>
-    <message>
-        <source>Error upgrading chainstate database</source>
-        <translation type="unfinished">Kamalian sa pag-u-upgrade ng chainstate database</translation>
     </message>
     <message>
         <source>Error: Disk space is low for %s</source>
@@ -636,10 +628,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Hindi suportadong logging category %s=%s.</translation>
     </message>
     <message>
-        <source>Upgrading UTXO database</source>
-        <translation type="unfinished">Nag-u-upgrade ng UTXO database</translation>
-    </message>
-    <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
         <translation type="unfinished">Ang komento ng User Agent (%s) ay naglalaman ng hindi ligtas na mga character.</translation>
     </message>
@@ -699,6 +687,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Gumawa ng Bagong Pitaka</translation>
     </message>
     <message>
+        <source>&amp;Minimize</source>
+        <translation type="unfinished">&amp;Pagliitin</translation>
+    </message>
+    <message>
         <source>Wallet:</source>
         <translation type="unfinished">Walet:</translation>
     </message>
@@ -730,6 +722,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>&amp;Receive</source>
         <translation type="unfinished">Tumanggap</translation>
+    </message>
+    <message>
+        <source>&amp;Options…</source>
+        <translation type="unfinished">&amp;Opsyon</translation>
     </message>
     <message>
         <source>Encrypt the private keys that belong to your wallet</source>
@@ -847,6 +843,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Walang magagamit na mga walet</translation>
     </message>
     <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">Pangalan ng Pitaka</translation>
+    </message>
+    <message>
         <source>&amp;Window</source>
         <translation type="unfinished">Window</translation>
     </message>
@@ -866,8 +867,8 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n aktibong konekyson sa network ng Bitcoin</numerusform>
+            <numerusform>%n mga aktibong koneksyon sa network ng Bitcoin</numerusform>
         </translation>
     </message>
     <message>
@@ -995,6 +996,22 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Copy amount</source>
         <translation type="unfinished">Kopyahin ang halaga</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Kopyahin and address</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Kopyahin ang &amp;label</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Kopyahin ang &amp;halaga</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID and output index</source>
+        <translation type="unfinished">Kopyahin ang &amp;ID ng transaksyon at output index</translation>
     </message>
     <message>
         <source>Copy quantity</source>
@@ -1215,6 +1232,27 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 </context>
 <context>
     <name>Intro</name>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform>(of %n GB needed)</numerusform>
+            <numerusform>(of %n GB needed)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform>(%n GB needed for full chain)</numerusform>
+            <numerusform>(%n GB needed for full chain)</numerusform>
+        </translation>
+    </message>
     <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
         <translation type="unfinished">Kahit na %1 GB na datos ay maiimbak sa direktoryong ito, ito ay lalaki sa pagtagal.</translation>
@@ -1258,10 +1296,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>As this is the first time the program is launched, you can choose where %1 will store its data.</source>
         <translation type="unfinished">Dahil ngayon lang nilunsad ang programang ito, maaari mong piliin kung saan maiinbak ng %1 ang data nito.</translation>
-    </message>
-    <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation type="unfinished">Pagkatapos mong mag-click ng OK, %1 ay magsisimulang mag-download at mag-proseso ng buong blockchain (%2GB) magmula sa pinakaunang transaksyon sa %3 nuong ang %4 ay paunang nilunsad.</translation>
     </message>
     <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
@@ -1516,10 +1550,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Kung magpapakita ng mga tampok ng kontrol ng coin o hindi</translation>
     </message>
     <message>
-        <source>Options set in this dialog are overridden by the command line or in the configuration file:</source>
-        <translation type="unfinished">Ang mga nakatakdang opyson sa dialog na ito ay ma-o-override ng command line o sa configuration file:</translation>
-    </message>
-    <message>
         <source>&amp;OK</source>
         <translation type="unfinished">OK</translation>
     </message>
@@ -1533,14 +1563,17 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Confirm options reset</source>
+        <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
         <translation type="unfinished">Kumpirmahin ang pag-reset ng mga opsyon</translation>
     </message>
     <message>
         <source>Client restart required to activate changes.</source>
+        <extracomment>Text explaining that the settings changed will not come into effect until the client is restarted.</extracomment>
         <translation type="unfinished">Kailangan i-restart ang kliyente upang ma-activate ang mga pagbabago.</translation>
     </message>
     <message>
         <source>Client will be shut down. Do you want to proceed?</source>
+        <extracomment>Text asking the user to confirm if they would like to proceed with a client shutdown.</extracomment>
         <translation type="unfinished">Ang kliyente ay papatayin. Nais mo bang magpatuloy?</translation>
     </message>
     <message>
@@ -1972,6 +2005,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Labas:</translation>
     </message>
     <message>
+        <source>&amp;Copy address</source>
+        <extracomment>Context menu action to copy the address of a peer.</extracomment>
+        <translation type="unfinished">&amp;Kopyahin and address</translation>
+    </message>
+    <message>
         <source>&amp;Disconnect</source>
         <translation type="unfinished">Idiskonekta</translation>
     </message>
@@ -2105,6 +2143,18 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Copy &amp;URI</source>
         <translation type="unfinished">Kopyahin ang URI</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Kopyahin and address</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Kopyahin ang &amp;label</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Kopyahin ang &amp;halaga</translation>
     </message>
     <message>
         <source>Could not unlock wallet.</source>
@@ -2392,10 +2442,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>A fee higher than %1 is considered an absurdly high fee.</source>
         <translation type="unfinished">Ang bayad na mas mataas sa %1 ay itinuturing na napakataas na bayad.</translation>
     </message>
-    <message>
-        <source>Payment request expired.</source>
-        <translation type="unfinished">Ang hiling ng bayad ay nag-expire na.</translation>
-    </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
@@ -2471,14 +2517,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Mensahe:</translation>
     </message>
     <message>
-        <source>This is an unauthenticated payment request.</source>
-        <translation type="unfinished">Ito ay isang unauthenticated na hiling ng bayad.</translation>
-    </message>
-    <message>
-        <source>This is an authenticated payment request.</source>
-        <translation type="unfinished">Ito ay isang authenticated na hiling ng bayad.</translation>
-    </message>
-    <message>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished">Mag-enter ng label para sa address na ito upang idagdag ito sa listahan ng mga gamit na address.</translation>
     </message>
@@ -2486,11 +2524,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished">Mensahe na nakalakip sa bitcoin: URI na kung saan maiimbak kasama ang transaksyon para sa iyong sanggunian. Tandaan: Ang mensaheng ito ay hindi ipapadala sa network ng Bitcoin.</translation>
     </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">Magbayad Sa:</translation>
-    </message>
-    </context>
+</context>
 <context>
     <name>SendConfirmationDialog</name>
     <message>
@@ -2637,30 +2671,22 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <name>TransactionDesc</name>
     <message>
         <source>conflicted with a transaction with %1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that conflicts with a confirmed transaction.</extracomment>
         <translation type="unfinished">sumalungat sa isang transaksyon na may %1 pagkumpirma</translation>
     </message>
     <message>
-        <source>0/unconfirmed, %1</source>
-        <translation type="unfinished">0/hindi nakumpirma, %1</translation>
-    </message>
-    <message>
-        <source>in memory pool</source>
-        <translation type="unfinished">nasa memory pool</translation>
-    </message>
-    <message>
-        <source>not in memory pool</source>
-        <translation type="unfinished">wala sa memory pool</translation>
-    </message>
-    <message>
         <source>abandoned</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an abandoned transaction.</extracomment>
         <translation type="unfinished">inabandona</translation>
     </message>
     <message>
         <source>%1/unconfirmed</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
         <translation type="unfinished">%1/hindi nakumpirma</translation>
     </message>
     <message>
         <source>%1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
         <translation type="unfinished">%1 pagkumpirma</translation>
     </message>
     <message>
@@ -2930,6 +2956,18 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Min amount</source>
         <translation type="unfinished">Minimum na halaga</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Kopyahin and address</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Kopyahin ang &amp;label</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Kopyahin ang &amp;halaga</translation>
     </message>
     <message>
         <source>Export Transaction History</source>

--- a/src/qt/locale/bitcoin_fr.ts
+++ b/src/qt/locale/bitcoin_fr.ts
@@ -3,7 +3,7 @@
     <name>AddressBookPage</name>
     <message>
         <source>Right-click to edit address or label</source>
-        <translation type="unfinished">Cliquer à droite pour modifier l’adresse ou l’étiquette</translation>
+        <translation type="unfinished">Clic droit pour modifier l'adresse ou l'étiquette</translation>
     </message>
     <message>
         <source>Create a new address</source>
@@ -72,8 +72,8 @@
     <message>
         <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
 Signing is only possible with addresses of the type 'legacy'.</source>
-        <translation type="unfinished">Ce sont vos adresses Bitcoin pour recevoir des paiements. Utilisez le bouton « Créer une nouvelle adresse de réception » dans l’onglet Recevoir afin de créer de nouvelles adresses.
-Il n’est possible de signer qu’avec les adresses de type « legacy ».</translation>
+        <translation type="unfinished">Il s'agit de vos adresses Bitcoin pour la réception des paiements. Utilisez le bouton "Créer une nouvelle adresse de réception" dans l'onglet "Recevoir" pour créer de nouvelles adresses.
+La signature n'est possible qu'avec les adresses de type "traditionnelles".</translation>
     </message>
     <message>
         <source>&amp;Copy Address</source>
@@ -229,7 +229,7 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
     </message>
     <message>
         <source>Warning: The Caps Lock key is on!</source>
-        <translation type="unfinished">Avertissement : La touche Verr. Maj. est activée !</translation>
+        <translation type="unfinished">Avertissement : La touche Verr. Maj. est activée</translation>
     </message>
 </context>
 <context>
@@ -246,8 +246,12 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
 <context>
     <name>BitcoinApplication</name>
     <message>
+        <source>Settings file %1 might be corrupt or invalid.</source>
+        <translation type="unfinished">Le fichier de configuration %1 est peut-être corrompu ou invalide.</translation>
+    </message>
+    <message>
         <source>Runaway exception</source>
-        <translation type="unfinished">Exception fugitive</translation>
+        <translation type="unfinished">Exception excessive</translation>
     </message>
     <message>
         <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
@@ -255,7 +259,7 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
     </message>
     <message>
         <source>Internal error</source>
-        <translation type="unfinished">Erreur interne</translation>
+        <translation type="unfinished">erreur interne</translation>
     </message>
     <message>
         <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
@@ -301,6 +305,10 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
     <message>
         <source>Enter a Bitcoin address (e.g. %1)</source>
         <translation type="unfinished">Saisir une adresse Bitcoin (p. ex. %1)</translation>
+    </message>
+    <message>
+        <source>Ctrl+W</source>
+        <translation type="unfinished">Ctrl-W</translation>
     </message>
     <message>
         <source>Unroutable</source>
@@ -364,7 +372,7 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation type="unfinished">
-            <numerusform>%n seconde</numerusform>
+            <numerusform>%n second</numerusform>
             <numerusform>%n secondes</numerusform>
         </translation>
     </message>
@@ -403,8 +411,8 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
-            <numerusform>%n an</numerusform>
-            <numerusform>%n ans</numerusform>
+            <numerusform>%n année</numerusform>
+            <numerusform>%n années</numerusform>
         </translation>
     </message>
     <message>
@@ -444,7 +452,7 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
     </message>
     <message>
         <source>-maxtxfee is set very high! Fees this large could be paid on a single transaction.</source>
-        <translation type="unfinished">La valeur -maxtxfee est très élevée ! Des frais aussi élevés pourraient être payés en une seule transaction.</translation>
+        <translation type="unfinished">La valeur -maxtxfee est très élevée. Des frais aussi élevés pourraient être payés en une seule transaction.</translation>
     </message>
     <message>
         <source>Cannot downgrade wallet from version %i to version %i. Wallet version unchanged.</source>
@@ -456,7 +464,7 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
     </message>
     <message>
         <source>Cannot upgrade a non HD split wallet from version %i to version %i without upgrading to support pre-split keypool. Please use version %i or no version specified.</source>
-        <translation type="unfinished">Impossible de mettre à niveau un porte-monnaie divisé non-HD de la version %i vers la version %i sans mettre à niveau pour prendre en charge la réserve de clés antérieure à la division. Veuillez utiliser la version %i ou ne pas indiquer de version.</translation>
+        <translation type="unfinished">Impossible de mettre à niveau un porte-monnaie divisé non-HD de la version %i vers la version %i sans mise à niveau pour prendre en charge la réserve de clés antérieure à la division. Veuillez utiliser la version %i ou ne pas indiquer de version.</translation>
     </message>
     <message>
         <source>Distributed under the MIT software license, see the accompanying file %s or %s</source>
@@ -468,11 +476,15 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
     </message>
     <message>
         <source>Error reading %s! Transaction data may be missing or incorrect. Rescanning wallet.</source>
-        <translation type="unfinished">Erreur de lecture de %s : soit les données de la transaction manquent soit elles sont incorrectes. Réanalysez le porte-monnaie.</translation>
+        <translation type="unfinished">Erreur de lecture de %s : soit les données de la transaction manquent soit elles sont incorrectes. Réanalyse du porte-monnaie.</translation>
     </message>
     <message>
         <source>Error: Dumpfile format record is incorrect. Got "%s", expected "format".</source>
         <translation type="unfinished">Erreur : L’enregistrement du format du fichier de vidage est incorrect. Est « %s », mais « format » est attendu. </translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile identifier record is incorrect. Got "%s", expected "%s".</source>
+        <translation type="unfinished">Erreur : L’enregistrement de l’identificateur du fichier de vidage est incorrect. Est « %s », mais « %s » est attendu. </translation>
     </message>
     <message>
         <source>Error: Dumpfile version is not supported. This version of bitcoin-wallet only supports version 1 dumpfiles. Got dumpfile with version %s</source>
@@ -480,11 +492,7 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
     </message>
     <message>
         <source>Error: Legacy wallets only support the "legacy", "p2sh-segwit", and "bech32" address types</source>
-        <translation type="unfinished">Erreur : les porte-monnaie hérités ne prennent en charge que les types d’adresse « legacy », « p2sh-segwit », et « bech32 ».</translation>
-    </message>
-    <message>
-        <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
-        <translation type="unfinished">Erreur : L’écoute des connexions entrantes a échoué (l’écoute a retourné l’erreur %s)</translation>
+        <translation type="unfinished">Erreur : les porte-monnaie hérités ne prennent en charge que les types d’adresse « legacy », « p2sh-segwit », et « bech32 »</translation>
     </message>
     <message>
         <source>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.</source>
@@ -531,8 +539,12 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
         <translation type="unfinished">L’élagage est configuré au-dessous du minimum de %d Mio. Veuillez utiliser un nombre plus élevé.</translation>
     </message>
     <message>
+        <source>Prune mode is incompatible with -reindex-chainstate. Use full -reindex instead.</source>
+        <translation type="unfinished">Le mode Prune est incompatible avec -reindex-chainstate. Utilisez plutôt full -reindex.</translation>
+    </message>
+    <message>
         <source>Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of pruned node)</source>
-        <translation type="unfinished">Élagage : la dernière synchronisation de porte-monnaie va par-delà les données élaguées.  Vous devez -reindex (réindexer, télécharger de nouveau toute la chaîne de blocs en cas de nœud élagué)</translation>
+        <translation type="unfinished">Élagage : la dernière synchronisation de porte-monnaie va par-delà les données élaguées. Vous devez -reindex (réindexer, télécharger de nouveau toute la chaîne de blocs en cas de nœud élagué)</translation>
     </message>
     <message>
         <source>SQLiteDatabase: Unknown sqlite wallet schema version %d. Only version %d is supported</source>
@@ -544,19 +556,19 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
     </message>
     <message>
         <source>The block index db contains a legacy 'txindex'. To clear the occupied disk space, run a full -reindex, otherwise ignore this error. This error message will not be displayed again.</source>
-        <translation type="unfinished">La base de données d’indexation des blocs comprend un « txindex » hérité. Pour libérer l’espace disque occupé, exécuter un -reindex complet ou ignorez cette erreur. Ce message d’erreur ne sera pas affiché de nouveau.</translation>
+        <translation type="unfinished">La base de données d’indexation des blocs comprend un « txindex » hérité. Pour libérer l’espace disque occupé, exécutez un -reindex complet ou ignorez cette erreur. Ce message d’erreur ne sera pas affiché de nouveau.</translation>
     </message>
     <message>
         <source>The transaction amount is too small to send after the fee has been deducted</source>
-        <translation type="unfinished">Le montant transactionnel est trop bas pour être envoyé une fois que les frais ont été déduits</translation>
+        <translation type="unfinished">Le montant de la transaction est trop bas pour être envoyé une fois que les frais ont été déduits</translation>
     </message>
     <message>
         <source>This error could occur if this wallet was not shutdown cleanly and was last loaded using a build with a newer version of Berkeley DB. If so, please use the software that last loaded this wallet</source>
-        <translation type="unfinished">Cette erreur pourrait survenir si ce porte-monnaie n’avait pas été fermé proprement et s’il avait été chargé en dernier avec une nouvelle version de Berkeley DB. Si c’est le cas, veuillez utiliser le logiciel qui a chargé ce porte-monnaie en dernier.</translation>
+        <translation type="unfinished">Cette erreur pourrait survenir si ce porte-monnaie n’a pas été fermé proprement et s’il a été chargé en dernier avec une nouvelle version de Berkeley DB. Si c’est le cas, veuillez utiliser le logiciel qui a chargé ce porte-monnaie en dernier.</translation>
     </message>
     <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
-        <translation type="unfinished">Ceci est une préversion de test - son utilisation est entièrement à vos risques - ne pas l’utiliser pour miner ou pour des applications marchandes</translation>
+        <translation type="unfinished">Ceci est une préversion de test — son utilisation est entièrement à vos risques — ne l’utilisez pour miner ou pour des applications marchandes</translation>
     </message>
     <message>
         <source>This is the maximum transaction fee you pay (in addition to the normal fee) to prioritize partial spend avoidance over regular coin selection.</source>
@@ -579,12 +591,24 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
         <translation type="unfinished">Impossible de relire les blocs. Vous devrez reconstruire la base de données avec -reindex-chainstate.</translation>
     </message>
     <message>
+        <source>Unknown wallet file format "%s" provided. Please provide one of "bdb" or "sqlite".</source>
+        <translation type="unfinished">Le format de fichier porte-monnaie « %s » indiqué est inconnu. Veuillez soit indiquer « bdb » soit « sqlite ».</translation>
+    </message>
+    <message>
+        <source>Unsupported chainstate database format found. Please restart with -reindex-chainstate. This will rebuild the chainstate database.</source>
+        <translation type="unfinished">Format de base de données chainstate non pris en charge trouvé. Veuillez redémarrer avec -reindex-chainstate. Cela reconstruira la base de données chainstate.</translation>
+    </message>
+    <message>
+        <source>Wallet created successfully. The legacy wallet type is being deprecated and support for creating and opening legacy wallets will be removed in the future.</source>
+        <translation type="unfinished">Portefeuille créé avec succès. Le type de portefeuille hérité est obsolète et la prise en charge de la création et de l'ouverture de portefeuilles hérités sera supprimée à l'avenir.</translation>
+    </message>
+    <message>
         <source>Warning: Dumpfile wallet format "%s" does not match command line specified format "%s".</source>
         <translation type="unfinished">Avertissement : Le format du fichier de vidage de porte-monnaie « %s » ne correspond pas au format « %s » indiqué dans la ligne de commande.</translation>
     </message>
     <message>
         <source>Warning: Private keys detected in wallet {%s} with disabled private keys</source>
-        <translation type="unfinished">Avertissement : Des clés privées ont été détectées dans le porte-monnaie {%s}, dont les clés privées sont désactivées</translation>
+        <translation type="unfinished">Avertissement : Des clés privées ont été détectées dans le porte-monnaie {%s} avec des clés privées désactivées</translation>
     </message>
     <message>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
@@ -600,7 +624,7 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
     </message>
     <message>
         <source>%s is set very high!</source>
-        <translation type="unfinished">La valeur %s est très élevée !</translation>
+        <translation type="unfinished">La valeur %s est très élevée</translation>
     </message>
     <message>
         <source>-maxmempool must be at least %d MB</source>
@@ -631,12 +655,92 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
         <translation type="unfinished">La mise à niveau -txindex lancée par une version précédente ne peut pas être achevée. Redémarrez la version précédente ou exécutez un -reindex complet.</translation>
     </message>
     <message>
+        <source>%s request to listen on port %u. This port is considered "bad" and thus it is unlikely that any Bitcoin Core peers connect to it. See doc/p2p-bad-ports.md for details and a full list.</source>
+        <translation type="unfinished">%s a demandé d’écouter sur le port %u. Ce port est considéré comme « mauvais » et il est par conséquent improbable que des pairs Bitcoin Core y soient connectés. Consulter doc/p2p-bad-ports.md pour plus de précisions et une liste complète.</translation>
+    </message>
+    <message>
+        <source>-reindex-chainstate option is not compatible with -blockfilterindex. Please temporarily disable blockfilterindex while using -reindex-chainstate, or replace -reindex-chainstate with -reindex to fully rebuild all indexes.</source>
+        <translation type="unfinished">L'option -reindex-chainstate n'est pas compatible avec -blockfilterindex. Veuillez désactiver temporairement blockfilterindex lors de l'utilisation de -reindex-chainstate, ou remplacez -reindex-chainstate par -reindex pour reconstruire complètement tous les index.</translation>
+    </message>
+    <message>
+        <source>-reindex-chainstate option is not compatible with -coinstatsindex. Please temporarily disable coinstatsindex while using -reindex-chainstate, or replace -reindex-chainstate with -reindex to fully rebuild all indexes.</source>
+        <translation type="unfinished">L'option -reindex-chainstate n'est pas compatible avec -coinstatsindex. Veuillez désactiver temporairement coinstatsindex lors de l'utilisation de -reindex-chainstate, ou remplacer -reindex-chainstate par -reindex pour reconstruire complètement tous les index.</translation>
+    </message>
+    <message>
+        <source>-reindex-chainstate option is not compatible with -txindex. Please temporarily disable txindex while using -reindex-chainstate, or replace -reindex-chainstate with -reindex to fully rebuild all indexes.</source>
+        <translation type="unfinished">L'option -reindex-chainstate n'est pas compatible avec -txindex. Veuillez désactiver temporairement txindex lors de l'utilisation de -reindex-chainstate, ou remplacez -reindex-chainstate par -reindex pour reconstruire complètement tous les index.</translation>
+    </message>
+    <message>
+        <source>Assumed-valid: last wallet synchronisation goes beyond available block data. You need to wait for the background validation chain to download more blocks.</source>
+        <translation type="unfinished">Supposé valide : la dernière synchronisation du portefeuille va au-delà des données de bloc disponibles. Vous devez attendre la chaîne de validation en arrière-plan pour télécharger plus de blocs.</translation>
+    </message>
+    <message>
         <source>Cannot provide specific connections and have addrman find outgoing connections at the same time.</source>
-        <translation type="unfinished">Il est impossible de fournir des connexions particulières et en même temps demander à addrman de trouver les connexions sortantes.</translation>
+        <translation type="unfinished">Il est impossible d’indiquer des connexions précises et en même temps de demander à addrman de trouver les connexions sortantes.</translation>
     </message>
     <message>
         <source>Error loading %s: External signer wallet being loaded without external signer support compiled</source>
         <translation type="unfinished">Erreur de chargement de %s : le porte-monnaie signataire externe est chargé sans que la prise en charge de signataires externes soit compilée</translation>
+    </message>
+    <message>
+        <source>Error: Address book data in wallet cannot be identified to belong to migrated wallets</source>
+        <translation type="unfinished">Erreur : les données du carnet d'adresses dans le portefeuille ne peuvent pas être identifiées comme appartenant à des portefeuilles migrés</translation>
+    </message>
+    <message>
+        <source>Error: Duplicate descriptors created during migration. Your wallet may be corrupted.</source>
+        <translation type="unfinished">Erreur : Descripteurs en double créés lors de la migration. Votre portefeuille est peut-être corrompu.</translation>
+    </message>
+    <message>
+        <source>Error: Transaction %s in wallet cannot be identified to belong to migrated wallets</source>
+        <translation type="unfinished">Erreur : la transaction %s dans le portefeuille ne peut pas être identifiée comme appartenant aux portefeuilles migrés</translation>
+    </message>
+    <message>
+        <source>Error: Unable to produce descriptors for this legacy wallet. Make sure the wallet is unlocked first</source>
+        <translation type="unfinished">Erreur : Impossible de produire des descripteurs pour cet ancien portefeuille. Assurez-vous d'abord que le portefeuille est déverrouillé</translation>
+    </message>
+    <message>
+        <source>Failed to rename invalid peers.dat file. Please move or delete it and try again.</source>
+        <translation type="unfinished">Échec de renommage du fichier peers.dat invalide. Veuillez le déplacer ou le supprimer, puis réessayer.</translation>
+    </message>
+    <message>
+        <source>Incompatible options: -dnsseed=1 was explicitly specified, but -onlynet forbids connections to IPv4/IPv6</source>
+        <translation type="unfinished">Options incompatibles : -dnsseed=1 a été explicitement spécifié, mais -onlynet interdit les connexions à IPv4/IPv6</translation>
+    </message>
+    <message>
+        <source>Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is explicitly forbidden: -onion=0</source>
+        <translation type="unfinished">Connexions sortantes limitées à Tor (-onlynet=onion) mais le proxy pour atteindre le réseau Tor est explicitement interdit : -onion=0</translation>
+    </message>
+    <message>
+        <source>Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is not provided: none of -proxy, -onion or -listenonion is given</source>
+        <translation type="unfinished">Connexions sortantes limitées à Tor (-onlynet=onion) mais le proxy pour atteindre le réseau Tor n'est pas fourni : aucun des -proxy, -onion ou -listenonion n'est donné</translation>
+    </message>
+    <message>
+        <source>Unrecognized descriptor found. Loading wallet %s
+
+The wallet might had been created on a newer version.
+Please try running the latest software version.
+</source>
+        <translation type="unfinished">Descripteur non reconnu trouvé. Chargement du portefeuille %s
+
+Le portefeuille a peut-être été créé sur une version plus récente.
+Veuillez essayer d'exécuter la dernière version du logiciel.
+</translation>
+    </message>
+    <message>
+        <source>Unsupported category-specific logging level -loglevel=%s. Expected -loglevel=&lt;category&gt;:&lt;loglevel&gt;. Valid categories: %s. Valid loglevels: %s.</source>
+        <translation type="unfinished">Niveau de journalisation spécifique à une catégorie non pris en charge -loglevel=%s. -loglevel=&lt;category&gt;:&lt;loglevel&gt; attendu. Catégories valides : %s. Niveaux de journalisation valides : %s.</translation>
+    </message>
+    <message>
+        <source>
+Unable to cleanup failed migration</source>
+        <translation type="unfinished">
+Impossible de nettoyer la migration en erreur</translation>
+    </message>
+    <message>
+        <source>
+Unable to restore backup of wallet.</source>
+        <translation type="unfinished">
+Impossible de restaurer la sauvegarde du portefeuille.</translation>
     </message>
     <message>
         <source>Config setting for %s only applied on %s network when in [%s] section.</source>
@@ -644,7 +748,7 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
     </message>
     <message>
         <source>Copyright (C) %i-%i</source>
-        <translation type="unfinished">Tous droits réservés (C) %i-%i</translation>
+        <translation type="unfinished">Tous droits réservés © %i à %i</translation>
     </message>
     <message>
         <source>Corrupted block database detected</source>
@@ -660,7 +764,7 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
     </message>
     <message>
         <source>Disk space is too low!</source>
-        <translation type="unfinished">L’espace disque est trop faible !</translation>
+        <translation type="unfinished">L’espace disque est trop faible</translation>
     </message>
     <message>
         <source>Do you want to rebuild the block database now?</source>
@@ -672,7 +776,7 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
     </message>
     <message>
         <source>Dump file %s does not exist.</source>
-        <translation type="unfinished">Le fichier de vidage %s n’existe pas</translation>
+        <translation type="unfinished">Le fichier de vidage %s n’existe pas.</translation>
     </message>
     <message>
         <source>Error creating %s</source>
@@ -684,7 +788,7 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
     </message>
     <message>
         <source>Error initializing wallet database environment %s!</source>
-        <translation type="unfinished">Erreur d’initialisation de l’environnement de la base de données du porte-monnaie %s !</translation>
+        <translation type="unfinished">Erreur d’initialisation de l’environnement de la base de données du porte-monnaie %s </translation>
     </message>
     <message>
         <source>Error loading %s</source>
@@ -712,15 +816,19 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
     </message>
     <message>
         <source>Error reading from database, shutting down.</source>
-        <translation type="unfinished">Erreur de lecture de la base de données, fermeture en cours.</translation>
+        <translation type="unfinished">Erreur de lecture de la base de données, fermeture en cours</translation>
     </message>
     <message>
         <source>Error reading next record from wallet database</source>
         <translation type="unfinished">Erreur de lecture de l’enregistrement suivant de la base de données du porte-monnaie</translation>
     </message>
     <message>
-        <source>Error upgrading chainstate database</source>
-        <translation type="unfinished">Erreur de mise à niveau de la base de données d’état de la chaîne</translation>
+        <source>Error: Could not add watchonly tx to watchonly wallet</source>
+        <translation type="unfinished">Erreur : Impossible d'ajouter watchonly tx au portefeuille watchonly</translation>
+    </message>
+    <message>
+        <source>Error: Could not delete watchonly transactions</source>
+        <translation type="unfinished">Erreur : impossible de supprimer les transactions surveillées uniquement</translation>
     </message>
     <message>
         <source>Error: Couldn't create cursor into database</source>
@@ -733,6 +841,10 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
     <message>
         <source>Error: Dumpfile checksum does not match. Computed %s, expected %s</source>
         <translation type="unfinished">Erreur : La somme de contrôle du fichier de vidage ne correspond pas. Calculée %s, attendue %s</translation>
+    </message>
+    <message>
+        <source>Error: Failed to create new watchonly wallet</source>
+        <translation type="unfinished">Erreur : Échec de la création d'un nouveau portefeuille watchonly</translation>
     </message>
     <message>
         <source>Error: Got key that was not hex: %s</source>
@@ -752,11 +864,39 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
     </message>
     <message>
         <source>Error: No %s addresses available.</source>
-        <translation type="unfinished">Erreur : Aucune adresse %s n’est disponible</translation>
+        <translation type="unfinished">Erreur : Aucune adresse %s n’est disponible.</translation>
+    </message>
+    <message>
+        <source>Error: Not all watchonly txs could be deleted</source>
+        <translation type="unfinished">Erreur : Tous les txs watchonly n'ont pas pu être supprimés</translation>
+    </message>
+    <message>
+        <source>Error: This wallet already uses SQLite</source>
+        <translation type="unfinished">Erreur : ce portefeuille utilise déjà SQLite</translation>
+    </message>
+    <message>
+        <source>Error: This wallet is already a descriptor wallet</source>
+        <translation type="unfinished">Erreur : Ce portefeuille est déjà un portefeuille de descripteur</translation>
+    </message>
+    <message>
+        <source>Error: Unable to begin reading all records in the database</source>
+        <translation type="unfinished">Erreur : Impossible de commencer à lire tous les enregistrements de la base de données</translation>
+    </message>
+    <message>
+        <source>Error: Unable to make a backup of your wallet</source>
+        <translation type="unfinished">Erreur : impossible de faire une sauvegarde de votre portefeuille</translation>
     </message>
     <message>
         <source>Error: Unable to parse version %u as a uint32_t</source>
         <translation type="unfinished">Erreur : Impossible d’analyser la version %u en tant que uint32_t</translation>
+    </message>
+    <message>
+        <source>Error: Unable to read all records in the database</source>
+        <translation type="unfinished">Erreur : impossible de lire tous les enregistrement dans la base de données</translation>
+    </message>
+    <message>
+        <source>Error: Unable to remove watchonly address book data</source>
+        <translation type="unfinished">Erreur : Impossible de supprimer les données du carnet d'adresses watchonly</translation>
     </message>
     <message>
         <source>Error: Unable to write record to new wallet</source>
@@ -764,7 +904,7 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
     </message>
     <message>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
-        <translation type="unfinished">Échec d'écoute sur n’importe quel port. Utiliser -listen=0 si vous voulez le faire.</translation>
+        <translation type="unfinished">Échec d'écoute sur tous les ports. Si cela est voulu, utiliser -listen=0.</translation>
     </message>
     <message>
         <source>Failed to rescan the wallet during initialization</source>
@@ -791,6 +931,10 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
         <translation type="unfinished">Bloc de genèse incorrect ou introuvable. Mauvais datadir pour le réseau ?</translation>
     </message>
     <message>
+        <source>Initialization sanity check failed. %s is shutting down.</source>
+        <translation type="unfinished">Échec d’initialisation du test de cohérence. %s est en cours de fermeture.</translation>
+    </message>
+    <message>
         <source>Input not found or already spent</source>
         <translation type="unfinished">L’entrée est introuvable ou a déjà été dépensée</translation>
     </message>
@@ -800,7 +944,7 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
     </message>
     <message>
         <source>Invalid -i2psam address or hostname: '%s'</source>
-        <translation type="unfinished">L’adresse ou le nom d’hôte -i2psam est invalide :« %s »</translation>
+        <translation type="unfinished">L’adresse ou le nom d’hôte -i2psam est invalide : « %s »</translation>
     </message>
     <message>
         <source>Invalid -onion address or hostname: '%s'</source>
@@ -828,15 +972,19 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
     </message>
     <message>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: '%s' (must be at least %s)</source>
-        <translation type="unfinished">Le montant est invalide pour -paytxfee=&lt;montant&gt; : « %s » (doit être au moins %s)</translation>
+        <translation type="unfinished">Le montant est invalide pour -paytxfee=&lt;amount&gt; : « %s » (doit être au moins %s)</translation>
     </message>
     <message>
         <source>Invalid netmask specified in -whitelist: '%s'</source>
         <translation type="unfinished">Le masque réseau indiqué dans -whitelist est invalide : « %s »</translation>
     </message>
     <message>
+        <source>Listening for incoming connections failed (listen returned error %s)</source>
+        <translation type="unfinished">L'écoute des connexions entrantes a échoué (l'écoute a renvoyé une erreur %s)</translation>
+    </message>
+    <message>
         <source>Loading P2P addresses…</source>
-        <translation type="unfinished">Chargement des adresses P2P…</translation>
+        <translation type="unfinished">Chargement des adresses P2P…</translation>
     </message>
     <message>
         <source>Loading banlist…</source>
@@ -860,15 +1008,11 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
     </message>
     <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
-        <translation type="unfinished">Un port doit être précisé avec -whitebind : « %s »</translation>
+        <translation type="unfinished">Un port doit être indiqué avec -whitebind : « %s »</translation>
     </message>
     <message>
         <source>No addresses available</source>
         <translation type="unfinished">Aucune adresse n’est disponible</translation>
-    </message>
-    <message>
-        <source>No proxy server specified. Use -proxy=&lt;ip&gt; or -proxy=&lt;ip:port&gt;.</source>
-        <translation type="unfinished">Aucun serveur mandataire n’est indiqué. Utilisez -proxy=&lt;ip&gt; ou -proxy=&lt;ip:port&gt;</translation>
     </message>
     <message>
         <source>Not enough file descriptors available.</source>
@@ -876,15 +1020,11 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
     </message>
     <message>
         <source>Prune cannot be configured with a negative value.</source>
-        <translation type="unfinished">L’élagage ne peut pas être configuré avec une valeur négative.</translation>
-    </message>
-    <message>
-        <source>Prune mode is incompatible with -coinstatsindex.</source>
-        <translation type="unfinished">Le mode élagage n’est pas compatible avec -coinstatsindex.</translation>
+        <translation type="unfinished">L’élagage ne peut pas être configuré avec une valeur négative</translation>
     </message>
     <message>
         <source>Prune mode is incompatible with -txindex.</source>
-        <translation type="unfinished">Le mode élagage n’est pas compatible avec -txindex.</translation>
+        <translation type="unfinished">Le mode élagage n’est pas compatible avec -txindex</translation>
     </message>
     <message>
         <source>Pruning blockstore…</source>
@@ -916,11 +1056,11 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
     </message>
     <message>
         <source>SQLiteDatabase: Unexpected application id. Expected %u, got %u</source>
-        <translation type="unfinished">SQLiteDatabase : l’ID de l’application est inattendu. %u était attendu, %u été retourné</translation>
+        <translation type="unfinished">SQLiteDatabase : l’ID de l’application est inattendu. %u attendu, %u retourné</translation>
     </message>
     <message>
         <source>Section [%s] is not recognized.</source>
-        <translation type="unfinished">La section [%s] n’est pas reconnue.</translation>
+        <translation type="unfinished">La section [%s] n’est pas reconnue</translation>
     </message>
     <message>
         <source>Signing transaction failed</source>
@@ -940,7 +1080,7 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
     </message>
     <message>
         <source>Specified blocks directory "%s" does not exist.</source>
-        <translation type="unfinished">Le répertoire des blocs indiqué « %s » n’existe pas.</translation>
+        <translation type="unfinished">Le répertoire des blocs indiqué « %s » n’existe pas</translation>
     </message>
     <message>
         <source>Starting network threads…</source>
@@ -952,7 +1092,7 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
     </message>
     <message>
         <source>The specified config file %s does not exist</source>
-        <translation type="unfinished">Le fichier de configuration %s n’existe pas</translation>
+        <translation type="unfinished">Le fichier de configuration indiqué %s n’existe pas</translation>
     </message>
     <message>
         <source>The transaction amount is too small to pay the fee</source>
@@ -1003,16 +1143,24 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
         <translation type="unfinished">La transaction est trop grosse</translation>
     </message>
     <message>
+        <source>Unable to allocate memory for -maxsigcachesize: '%s' MiB</source>
+        <translation type="unfinished">Impossible d'allouer de la mémoire pour -maxsigcachesize : '%s' MB</translation>
+    </message>
+    <message>
         <source>Unable to bind to %s on this computer (bind returned error %s)</source>
-        <translation type="unfinished">Impossible de se lier à %s sur cet ordinateur (bind a retourné l’erreur %s)</translation>
+        <translation type="unfinished">Impossible de se lier à %s sur cet ordinateur (la liaison a retourné l’erreur %s)</translation>
     </message>
     <message>
         <source>Unable to bind to %s on this computer. %s is probably already running.</source>
-        <translation type="unfinished">Impossible de se lier à %s sur cet ordinateur. %s fonctionne probablement déjà.</translation>
+        <translation type="unfinished">Impossible de se lier à %s sur cet ordinateur. %s fonctionne probablement déjà</translation>
     </message>
     <message>
         <source>Unable to create the PID file '%s': %s</source>
         <translation type="unfinished">Impossible de créer le fichier PID « %s » : %s</translation>
+    </message>
+    <message>
+        <source>Unable to find UTXO for external input</source>
+        <translation type="unfinished">Impossible de trouver UTXO pour l'entrée externe</translation>
     </message>
     <message>
         <source>Unable to generate initial keys</source>
@@ -1035,16 +1183,20 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
         <translation type="unfinished">Impossible de démarrer le serveur HTTP. Consulter le journal de débogage pour plus de précisions.</translation>
     </message>
     <message>
+        <source>Unable to unload the wallet before migrating</source>
+        <translation type="unfinished">Impossible de décharger le portefeuille avant de migrer</translation>
+    </message>
+    <message>
         <source>Unknown -blockfilterindex value %s.</source>
-        <translation type="unfinished">Valeur -blockfilterindex inconnue %s.</translation>
+        <translation type="unfinished">La valeur -blockfilterindex %s est inconnue.</translation>
     </message>
     <message>
         <source>Unknown address type '%s'</source>
-        <translation type="unfinished">Type d’adresse inconnu « %s »</translation>
+        <translation type="unfinished">Le type d’adresse « %s » est inconnu</translation>
     </message>
     <message>
         <source>Unknown change type '%s'</source>
-        <translation type="unfinished">Le type de monnaie est inconnu « %s »</translation>
+        <translation type="unfinished">Le type de monnaie « %s » est inconnu</translation>
     </message>
     <message>
         <source>Unknown network specified in -onlynet: '%s'</source>
@@ -1055,16 +1207,16 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
         <translation type="unfinished">Les nouvelles règles inconnues sont activées (versionbit %i)</translation>
     </message>
     <message>
-        <source>Unsupported logging category %s=%s.</source>
-        <translation type="unfinished">La catégorie de journalisation n’est pas prise en charge %s=%s.</translation>
+        <source>Unsupported global logging level -loglevel=%s. Valid values: %s.</source>
+        <translation type="unfinished">Niveau de journalisation global non pris en charge -loglevel=%s. Valeurs valides : %s.</translation>
     </message>
     <message>
-        <source>Upgrading UTXO database</source>
-        <translation type="unfinished">Mise à niveau de la base de données UTXO</translation>
+        <source>Unsupported logging category %s=%s.</source>
+        <translation type="unfinished">La catégorie de journalisation %s=%s n’est pas prise en charge</translation>
     </message>
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
-        <translation type="unfinished">Le commentaire de l’agent utilisateur (%s) comporte des caractères dangereux.</translation>
+        <translation type="unfinished">Le commentaire de l’agent utilisateur (%s) comporte des caractères dangereux</translation>
     </message>
     <message>
         <source>Verifying blocks…</source>
@@ -1172,7 +1324,7 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
     </message>
     <message>
         <source>&amp;Backup Wallet…</source>
-        <translation type="unfinished">&amp;auvegarder le porte-monnaie…</translation>
+        <translation type="unfinished">&amp;Sauvegarder le porte-monnaie…</translation>
     </message>
     <message>
         <source>&amp;Change Passphrase…</source>
@@ -1184,7 +1336,7 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
     </message>
     <message>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
-        <translation type="unfinished">Signer les messages avec vos adresses Bitcoin pour prouver que vous les détenez</translation>
+        <translation type="unfinished">Signer les messages avec vos adresses Bitcoin pour prouver que vous les détenez</translation>
     </message>
     <message>
         <source>&amp;Verify message…</source>
@@ -1196,7 +1348,7 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
     </message>
     <message>
         <source>&amp;Load PSBT from file…</source>
-        <translation type="unfinished">&amp;Charger une TBSP d’un fichier…</translation>
+        <translation type="unfinished">&amp;Charger la TBSP d’un fichier…</translation>
     </message>
     <message>
         <source>Open &amp;URI…</source>
@@ -1204,15 +1356,15 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
     </message>
     <message>
         <source>Close Wallet…</source>
-        <translation type="unfinished">Fermer le portefeuille...</translation>
+        <translation type="unfinished">Fermer le porte-monnaie…</translation>
     </message>
     <message>
         <source>Create Wallet…</source>
-        <translation type="unfinished">Créer le portefeuille...</translation>
+        <translation type="unfinished">Créer un porte-monnaie…</translation>
     </message>
     <message>
         <source>Close All Wallets…</source>
-        <translation type="unfinished">Fermer tous les portefeuilles...</translation>
+        <translation type="unfinished">Fermer tous les porte-monnaie…</translation>
     </message>
     <message>
         <source>&amp;File</source>
@@ -1232,7 +1384,7 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
     </message>
     <message>
         <source>Syncing Headers (%1%)…</source>
-        <translation type="unfinished">Synchronisation des en-têtes (%1)…</translation>
+        <translation type="unfinished">Synchronisation des en-têtes (%1%)…</translation>
     </message>
     <message>
         <source>Synchronizing with network…</source>
@@ -1273,8 +1425,8 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation type="unfinished">
-            <numerusform>%n bloc d’historique transactionnel a été traité.</numerusform>
-            <numerusform>%n blocs d’historique transactionnel ont été traités.</numerusform>
+            <numerusform>%n bloc traité de l'historique des transactions.</numerusform>
+            <numerusform>%n bloc(s) traité(s) de l'historique des transactions.</numerusform>
         </translation>
     </message>
     <message>
@@ -1283,7 +1435,7 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
     </message>
     <message>
         <source>Catching up…</source>
-        <translation type="unfinished">Rattrapage en cours…</translation>
+        <translation type="unfinished">Rattrapage…</translation>
     </message>
     <message>
         <source>Last received block was generated %1 ago.</source>
@@ -1354,12 +1506,22 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
         <translation type="unfinished">Fermer le porte-monnaie</translation>
     </message>
     <message>
+        <source>Restore Wallet…</source>
+        <extracomment>Name of the menu item that restores wallet from a backup file.</extracomment>
+        <translation type="unfinished">Restaurer un portefeuille...</translation>
+    </message>
+    <message>
+        <source>Restore a wallet from a backup file</source>
+        <extracomment>Status tip for Restore Wallet menu item</extracomment>
+        <translation type="unfinished">Restaurer un portefeuille depuis un fichier de récupération</translation>
+    </message>
+    <message>
         <source>Close all wallets</source>
         <translation type="unfinished">Fermer tous les porte-monnaie</translation>
     </message>
     <message>
         <source>Show the %1 help message to get a list with possible Bitcoin command-line options</source>
-        <translation type="unfinished">Afficher le message d’aide de %1 pour obtenir la liste des options possibles de ligne de commande Bitcoin</translation>
+        <translation type="unfinished">Afficher le message d’aide de %1 pour obtenir la liste des options possibles en ligne de commande Bitcoin</translation>
     </message>
     <message>
         <source>&amp;Mask values</source>
@@ -1376,6 +1538,26 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
     <message>
         <source>No wallets available</source>
         <translation type="unfinished">Aucun porte-monnaie n’est disponible</translation>
+    </message>
+    <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">Données du porte-monnaie</translation>
+    </message>
+    <message>
+        <source>Load Wallet Backup</source>
+        <extracomment>The title for Restore Wallet File Windows</extracomment>
+        <translation type="unfinished">Charger la Sauvegarde du Portefeuille</translation>
+    </message>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of pop-up window shown when the user is attempting to restore a wallet.</extracomment>
+        <translation type="unfinished">Restaurer le portefeuille</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">Nom du porte-monnaie</translation>
     </message>
     <message>
         <source>&amp;Window</source>
@@ -1405,8 +1587,8 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform>%n connexion active avec le réseau Bitcoin.</numerusform>
-            <numerusform>%n connexions actives avec le réseau Bitcoin.</numerusform>
+            <numerusform>%n connexion active au réseau Bitcoin.</numerusform>
+            <numerusform>%n connexion(s) active(s) au réseau Bitcoin.</numerusform>
         </translation>
     </message>
     <message>
@@ -1428,6 +1610,10 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
         <source>Enable network activity</source>
         <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
         <translation type="unfinished">Activer l’activité réseau</translation>
+    </message>
+    <message>
+        <source>Pre-syncing Headers (%1%)…</source>
+        <translation type="unfinished">Pré-synchronisation des en-têtes (%1%)...</translation>
     </message>
     <message>
         <source>Error: %1</source>
@@ -1684,6 +1870,10 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
         <source>Can't list signers</source>
         <translation type="unfinished">Impossible de lister les signataires</translation>
     </message>
+    <message>
+        <source>Too many external signers found</source>
+        <translation type="unfinished">Trop de signataires externes trouvés</translation>
+    </message>
 </context>
 <context>
     <name>LoadWalletsActivity</name>
@@ -1721,6 +1911,34 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
         <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
         <extracomment>Descriptive text of the open wallet progress window which indicates to the user which wallet is currently being opened.</extracomment>
         <translation type="unfinished">Ouverture du porte-monnaie &lt;b&gt;%1&lt;/b&gt;…</translation>
+    </message>
+</context>
+<context>
+    <name>RestoreWalletActivity</name>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of progress window which is displayed when wallets are being restored.</extracomment>
+        <translation type="unfinished">Restaurer le portefeuille</translation>
+    </message>
+    <message>
+        <source>Restoring Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the restore wallets progress window which indicates to the user that wallets are currently being restored.</extracomment>
+        <translation type="unfinished">Restauration du Portefeuille &lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+    <message>
+        <source>Restore wallet failed</source>
+        <extracomment>Title of message box which is displayed when the wallet could not be restored.</extracomment>
+        <translation type="unfinished">Échec de la restauration du portefeuille</translation>
+    </message>
+    <message>
+        <source>Restore wallet warning</source>
+        <extracomment>Title of message box which is displayed when the wallet is restored with some warning.</extracomment>
+        <translation type="unfinished">Avertissement de restauration du portefeuille</translation>
+    </message>
+    <message>
+        <source>Restore wallet message</source>
+        <extracomment>Title of message box which is displayed when the wallet is successfully restored.</extracomment>
+        <translation type="unfinished">Message de restauration du portefeuille</translation>
     </message>
 </context>
 <context>
@@ -1898,13 +2116,26 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
 </context>
 <context>
     <name>Intro</name>
-    <message>
-        <source>%1 GB of space available</source>
-        <translation type="unfinished">%1 Go d’espace disponible</translation>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform>%n Go d’espace disponible</numerusform>
+            <numerusform>%n Go d’espace disponible</numerusform>
+        </translation>
     </message>
-    <message>
-        <source>(of %1 GB needed)</source>
-        <translation type="unfinished">(sur %1 Go nécessaires)</translation>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform>(de %n GB néccesaire)</numerusform>
+            <numerusform>(de %n GB neccesaires)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform> (%n GB nécessaire pour la chaîne complète)</numerusform>
+            <numerusform>(%n GB necessaires pour la chaîne complète)</numerusform>
+        </translation>
     </message>
     <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
@@ -1918,8 +2149,8 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform>(suffisant pour restaurer les sauvegardes âgées de %n jour)</numerusform>
-            <numerusform>(suffisant pour restaurer les sauvegardes âgées de %n jours)</numerusform>
+            <numerusform>(suffisant pour restaurer les sauvegardes %n jour vieux)</numerusform>
+            <numerusform>(suffisant pour restaurer les sauvegardes %n jours vieux)</numerusform>
         </translation>
     </message>
     <message>
@@ -1951,10 +2182,6 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
         <translation type="unfinished">Comme le logiciel est lancé pour la première fois, vous pouvez choisir où %1 stockera ses données.</translation>
     </message>
     <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation type="unfinished">Quand vous cliquerez sur Valider, %1 commencera à télécharger et à traiter l’intégralité de la chaîne de blocs %4 (%2 Go) en débutant avec les transactions les plus anciennes de %3, quand %4 a été lancé initialement.</translation>
-    </message>
-    <message>
         <source>Limit block chain storage to</source>
         <translation type="unfinished">Limiter l’espace de stockage de chaîne de blocs à</translation>
     </message>
@@ -1969,6 +2196,10 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
     <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
         <translation type="unfinished">Cette synchronisation initiale est très exigeante et pourrait exposer des problèmes matériels dans votre ordinateur passés inaperçus auparavant. Chaque fois que vous exécuterez %1, le téléchargement reprendra où il s’était arrêté.</translation>
+    </message>
+    <message>
+        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2 GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
+        <translation type="unfinished">Lorsque vous cliquez sur OK, %1 commencera à télécharger et à traiter la chaîne de blocs %4 complète (%2 GB) en commençant par les premières transactions lors %3 du %4 lancement initial.</translation>
     </message>
     <message>
         <source>If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</source>
@@ -2025,7 +2256,7 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
     </message>
     <message>
         <source>Unknown…</source>
-        <translation type="unfinished">Inconnus…</translation>
+        <translation type="unfinished">Inconnu…</translation>
     </message>
     <message>
         <source>calculating…</source>
@@ -2062,6 +2293,10 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
     <message>
         <source>Unknown. Syncing Headers (%1, %2%)…</source>
         <translation type="unfinished">Inconnu. Synchronisation des en-têtes (%1, %2 %)…</translation>
+    </message>
+    <message>
+        <source>Unknown. Pre-syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">Inconnue. En-têtes de pré-synchronisation (%1, %2%)…</translation>
     </message>
 </context>
 <context>
@@ -2117,6 +2352,10 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
     <message>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
         <translation type="unfinished">Quand la fenêtre est fermée, la réduire au lieu de quitter l’application. Si cette option est activée, l’application ne sera fermée qu’en sélectionnant Quitter dans le menu.</translation>
+    </message>
+    <message>
+        <source>Options set in this dialog are overridden by the command line:</source>
+        <translation type="unfinished">Les options définies dans cette boîte de dialogue sont remplacées par la ligne de commande :</translation>
     </message>
     <message>
         <source>Open the %1 configuration file from the working directory.</source>
@@ -2336,7 +2575,7 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
     </message>
     <message>
         <source>Use separate SOCKS&amp;5 proxy to reach peers via Tor onion services:</source>
-        <translation type="unfinished">Utiliser un mandataire SOCKS&amp;5 séparé pour atteindre les pairs par les services oignon de Tor.</translation>
+        <translation type="unfinished">Utiliser un mandataire SOCKS&amp;5 séparé pour atteindre les pairs par les services oignon de Tor :</translation>
     </message>
     <message>
         <source>Monospaced font in the Overview tab:</source>
@@ -2349,10 +2588,6 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
     <message>
         <source>closest matching "%1"</source>
         <translation type="unfinished">correspondance la plus proche « %1 »</translation>
-    </message>
-    <message>
-        <source>Options set in this dialog are overridden by the command line or in the configuration file:</source>
-        <translation type="unfinished">Les options définies dans cette boîte de dialogue sont remplacées par la ligne de commande ou par le fichier de configuration :</translation>
     </message>
     <message>
         <source>&amp;OK</source>
@@ -2377,14 +2612,22 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
     </message>
     <message>
         <source>Confirm options reset</source>
+        <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
         <translation type="unfinished">Confirmer la réinitialisation des options</translation>
     </message>
     <message>
         <source>Client restart required to activate changes.</source>
+        <extracomment>Text explaining that the settings changed will not come into effect until the client is restarted.</extracomment>
         <translation type="unfinished">Le redémarrage du client est exigé pour activer les changements.</translation>
     </message>
     <message>
+        <source>Current settings will be backed up at "%1".</source>
+        <extracomment>Text explaining to the user that the client's current settings will be backed up at a specific location. %1 is a stand-in argument for the backup location's path.</extracomment>
+        <translation type="unfinished">Les paramètres courants seront sauvegardés à "%1".</translation>
+    </message>
+    <message>
         <source>Client will be shut down. Do you want to proceed?</source>
+        <extracomment>Text asking the user to confirm if they would like to proceed with a client shutdown.</extracomment>
         <translation type="unfinished">Le client sera arrêté. Voulez-vous continuer ?</translation>
     </message>
     <message>
@@ -2420,6 +2663,13 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
     <message>
         <source>The supplied proxy address is invalid.</source>
         <translation type="unfinished">L’adresse de serveur mandataire fournie est invalide.</translation>
+    </message>
+</context>
+<context>
+    <name>OptionsModel</name>
+    <message>
+        <source>Could not read setting "%1", %2.</source>
+        <translation type="unfinished">Impossible de lire le paramètre "%1", %2.</translation>
     </message>
 </context>
 <context>
@@ -2553,7 +2803,7 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
     </message>
     <message>
         <source>Unknown error processing transaction.</source>
-        <translation type="unfinished">Erreur inconnue lors de traitement de la transaction.</translation>
+        <translation type="unfinished">Erreur inconnue lors de traitement de la transaction</translation>
     </message>
     <message>
         <source>Transaction broadcast successfully! Transaction ID: %1</source>
@@ -2659,7 +2909,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>URI cannot be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
-        <translation type="unfinished">L’URI ne peut pas être analysée ! Cela peut être causé par une adresse Bitcoin invalide ou par des paramètres d’URI mal formés.</translation>
+        <translation type="unfinished">L’URI ne peut pas être analysée. Cela peut être causé par une adresse Bitcoin invalide ou par des paramètres d’URI mal formés.</translation>
     </message>
     <message>
         <source>Payment request file handling</source>
@@ -2677,6 +2927,11 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <source>Peer</source>
         <extracomment>Title of Peers Table column which contains a unique number used to identify a connection.</extracomment>
         <translation type="unfinished">Pair</translation>
+    </message>
+    <message>
+        <source>Age</source>
+        <extracomment>Title of Peers Table column which indicates the duration (length of time) since the peer connection started.</extracomment>
+        <translation type="unfinished">Âge</translation>
     </message>
     <message>
         <source>Sent</source>
@@ -2865,29 +3120,32 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Whether we relay addresses to this peer.</source>
-        <extracomment>Tooltip text for the Address Relay field in the peer details area.</extracomment>
+        <extracomment>Tooltip text for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
         <translation type="unfinished">Reliez ou non des adresses à ce pair.</translation>
     </message>
     <message>
         <source>Address Relay</source>
+        <extracomment>Text title for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
         <translation type="unfinished">Relais d’adresses</translation>
     </message>
     <message>
-        <source>Total number of addresses processed, excluding those dropped due to rate-limiting.</source>
-        <extracomment>Tooltip text for the Addresses Processed field in the peer details area.</extracomment>
-        <translation type="unfinished">Nombre total d’adresses traitées, excluant celles abandonnées en raison de la limite de débit.</translation>
+        <source>The total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</source>
+        <extracomment>Tooltip text for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
+        <translation type="unfinished">Le nombre total d'adresses reçues de cet homologue qui ont été traitées (exclut les adresses qui ont été supprimées en raison de la limitation du débit).</translation>
+    </message>
+    <message>
+        <source>The total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</source>
+        <extracomment>Tooltip text for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
+        <translation type="unfinished">Le nombre total d'adresses reçues de cet homologue qui ont été supprimées (non traitées) en raison de la limitation du débit.</translation>
     </message>
     <message>
         <source>Addresses Processed</source>
+        <extracomment>Text title for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
         <translation type="unfinished">Adresses traitées</translation>
     </message>
     <message>
-        <source>Total number of addresses dropped due to rate-limiting.</source>
-        <extracomment>Tooltip text for the Addresses Rate-Limited field in the peer details area.</extracomment>
-        <translation type="unfinished">Nombre total d’adresses abandonnées en raison de la limite de débit.</translation>
-    </message>
-    <message>
         <source>Addresses Rate-Limited</source>
+        <extracomment>Text title for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
         <translation type="unfinished">Adresses ciblées par la limite de débit</translation>
     </message>
     <message>
@@ -2932,7 +3190,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Wants Tx Relay</source>
-        <translation type="unfinished">Veut Tx relai</translation>
+        <translation type="unfinished">Veut relayer les transactions</translation>
     </message>
     <message>
         <source>High bandwidth BIP152 compact block relay: %1</source>
@@ -3358,7 +3616,7 @@ Pour plus de précisions sur cette console, tapez %6.
     </message>
     <message>
         <source>Insufficient funds!</source>
-        <translation type="unfinished">Les fonds sont insuffisants !</translation>
+        <translation type="unfinished">Les fonds sont insuffisants</translation>
     </message>
     <message>
         <source>Quantity:</source>
@@ -3663,15 +3921,18 @@ Note : Les frais étant calculés par octet, un taux de frais de « 100 satoshi
     </message>
     <message>
         <source>Transaction creation failed!</source>
-        <translation type="unfinished">Échec de création de la transaction !</translation>
+        <translation type="unfinished">Échec de création de la transaction</translation>
     </message>
     <message>
         <source>A fee higher than %1 is considered an absurdly high fee.</source>
         <translation type="unfinished">Des frais supérieurs à %1 sont considérés comme ridiculement élevés.</translation>
     </message>
-    <message>
-        <source>Payment request expired.</source>
-        <translation type="unfinished">La demande de paiement a expiré.</translation>
+    <message numerus="yes">
+        <source>Estimated to begin confirmation within %n block(s).</source>
+        <translation type="unfinished">
+            <numerusform>Estimation pour commencer la confirmation dans le %n bloc.</numerusform>
+            <numerusform>Estimation pour commencer la confirmation dans le(s) %n bloc(s).</numerusform>
+        </translation>
     </message>
     <message>
         <source>Warning: Invalid Bitcoin address</source>
@@ -3710,7 +3971,7 @@ Note : Les frais étant calculés par octet, un taux de frais de « 100 satoshi
     </message>
     <message>
         <source>Choose previously used address</source>
-        <translation type="unfinished">Choisir une adresse déjà utilisée</translation>
+        <translation type="unfinished">Choisir une adresse utilisée précédemment</translation>
     </message>
     <message>
         <source>The Bitcoin address to send the payment to</source>
@@ -3718,7 +3979,7 @@ Note : Les frais étant calculés par octet, un taux de frais de « 100 satoshi
     </message>
     <message>
         <source>Paste address from clipboard</source>
-        <translation type="unfinished">Coller l’adresse du presse-papiers</translation>
+        <translation type="unfinished">Collez l’adresse du presse-papiers</translation>
     </message>
     <message>
         <source>Remove this entry</source>
@@ -3745,28 +4006,12 @@ Note : Les frais étant calculés par octet, un taux de frais de « 100 satoshi
         <translation type="unfinished">Message :</translation>
     </message>
     <message>
-        <source>This is an unauthenticated payment request.</source>
-        <translation type="unfinished">Cette demande de paiement n’est pas authentifiée.</translation>
-    </message>
-    <message>
-        <source>This is an authenticated payment request.</source>
-        <translation type="unfinished">Cette demande de paiement est authentifiée.</translation>
-    </message>
-    <message>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished">Saisir une étiquette pour cette adresse afin de l’ajouter à la liste d’adresses utilisées</translation>
     </message>
     <message>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished">Un message qui était joint à l’URI bitcoin: et qui sera stocké avec la transaction pour référence. Note : Ce message ne sera pas envoyé par le réseau Bitcoin.</translation>
-    </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">Payer à :</translation>
-    </message>
-    <message>
-        <source>Memo:</source>
-        <translation type="unfinished">Mémo :</translation>
     </message>
 </context>
 <context>
@@ -3804,7 +4049,7 @@ Note : Les frais étant calculés par octet, un taux de frais de « 100 satoshi
     </message>
     <message>
         <source>Paste address from clipboard</source>
-        <translation type="unfinished">Coller l’adresse du presse-papiers</translation>
+        <translation type="unfinished">Collez l’adresse du presse-papiers</translation>
     </message>
     <message>
         <source>Enter the message you want to sign here</source>
@@ -3927,7 +4172,7 @@ Note : Les frais étant calculés par octet, un taux de frais de « 100 satoshi
     </message>
     <message>
         <source>press q to shutdown</source>
-        <translation type="unfinished">appuyer sur q pour fermer</translation>
+        <translation type="unfinished">Appuyer sur q pour fermer</translation>
     </message>
 </context>
 <context>
@@ -3941,26 +4186,27 @@ Note : Les frais étant calculés par octet, un taux de frais de « 100 satoshi
     <name>TransactionDesc</name>
     <message>
         <source>conflicted with a transaction with %1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that conflicts with a confirmed transaction.</extracomment>
         <translation type="unfinished">est en conflit avec une transaction ayant %1 confirmations</translation>
     </message>
     <message>
-        <source>0/unconfirmed, %1</source>
-        <translation type="unfinished">0/non confirmées, %1</translation>
+        <source>0/unconfirmed, in memory pool</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is in the memory pool.</extracomment>
+        <translation type="unfinished">0/non confirmé, dans le pool de mémoire</translation>
     </message>
     <message>
-        <source>in memory pool</source>
-        <translation type="unfinished">dans la réserve de mémoire</translation>
-    </message>
-    <message>
-        <source>not in memory pool</source>
-        <translation type="unfinished">pas dans la réserve de mémoire</translation>
+        <source>0/unconfirmed, not in memory pool</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is not in the memory pool.</extracomment>
+        <translation type="unfinished">0/non confirmé, pas dans le pool de mémoire</translation>
     </message>
     <message>
         <source>abandoned</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an abandoned transaction.</extracomment>
         <translation type="unfinished">abandonnée</translation>
     </message>
     <message>
         <source>%1/unconfirmed</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
         <translation type="unfinished">%1/non confirmée</translation>
     </message>
     <message>
@@ -4002,8 +4248,8 @@ Note : Les frais étant calculés par octet, un taux de frais de « 100 satoshi
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
-            <numerusform>arrivera à maturité dans %n bloc</numerusform>
-            <numerusform>arrivera à maturité dans %n blocs</numerusform>
+            <numerusform>matures dans %n bloc supplémentaire</numerusform>
+            <numerusform>matures dans %n blocs supplémentaires</numerusform>
         </translation>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_ga.ts
+++ b/src/qt/locale/bitcoin_ga.ts
@@ -381,10 +381,6 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">Earráid ag léamh %s! Léigh gach eochair i gceart, ach d’fhéadfadh sonraí idirbhirt nó iontrálacha leabhar seoltaí a bheidh in easnamh nó mícheart.</translation>
     </message>
     <message>
-        <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
-        <translation type="unfinished">Earráid: Theip ar éisteacht le naisc teacht-isteach (chuir éist earráid %s ar ais)</translation>
-    </message>
-    <message>
         <source>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.</source>
         <translation type="unfinished">Theip ar mheastachán táillí. Tá fallbackfee díchumasaithe. Fan cúpla bloc nó cumasaigh -fallbackfee.</translation>
     </message>
@@ -557,10 +553,6 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">Earráid ag léamh ón mbunachar sonraí, ag múchadh.</translation>
     </message>
     <message>
-        <source>Error upgrading chainstate database</source>
-        <translation type="unfinished">Earráid ag uasghrádú bunachar sonraí chainstate</translation>
-    </message>
-    <message>
         <source>Error: Disk space is low for %s</source>
         <translation type="unfinished">Earráid: Tá spás ar diosca íseal do %s</translation>
     </message>
@@ -635,10 +627,6 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
     <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
         <translation type="unfinished">Is gá port a shainiú le -whitebind: '%s'</translation>
-    </message>
-    <message>
-        <source>No proxy server specified. Use -proxy=&lt;ip&gt; or -proxy=&lt;ip:port&gt;.</source>
-        <translation type="unfinished">Níl seachfhreastalaí sainithe. Úsáid -proxy=&lt;ip&gt; nó -proxy=&lt;ip:port&gt;.</translation>
     </message>
     <message>
         <source>Not enough file descriptors available.</source>
@@ -783,10 +771,6 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
     <message>
         <source>Unsupported logging category %s=%s.</source>
         <translation type="unfinished">Catagóir logáil gan tacaíocht %s=%s.</translation>
-    </message>
-    <message>
-        <source>Upgrading UTXO database</source>
-        <translation type="unfinished">Ag uasghrádú bunachar sonraí UTXO</translation>
     </message>
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
@@ -1015,6 +999,11 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
     <message>
         <source>No wallets available</source>
         <translation type="unfinished">Níl aon sparán ar fáil</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">Ainm Sparán</translation>
     </message>
     <message>
         <source>&amp;Window</source>
@@ -1455,6 +1444,30 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
 </context>
 <context>
     <name>Intro</name>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform>(de %n GB teastáil)</numerusform>
+            <numerusform>(de %n GB teastáil)</numerusform>
+            <numerusform>(de %n GB teastáil)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform>(%n GB teastáil do slabhra iomlán)</numerusform>
+            <numerusform>(%n GB teastáil do slabhra iomlán)</numerusform>
+            <numerusform>(%n GB teastáil do slabhra iomlán)</numerusform>
+        </translation>
+    </message>
     <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
         <translation type="unfinished">Ar a laghad stórálfar %1 GB de shonraí  sa comhadlann seo, agus fásfaidh sé le himeacht ama.</translation>
@@ -1499,10 +1512,6 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
     <message>
         <source>As this is the first time the program is launched, you can choose where %1 will store its data.</source>
         <translation type="unfinished">Mar gurb é seo an chéad uair a lainseáil an clár, is féidir leat a roghnú cá stórálfaidh %1 a chuid sonraí.</translation>
-    </message>
-    <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation type="unfinished">Nuair a chliceálann tú Togha, tosóidh %1 ag íoslódáil agus ag próiseáil an blocshlabhra iomlán %4 (%2GB) ag tosú leis na hidirbhearta is luaithe %3 nuair a lainseáil %4 i dtosach.</translation>
     </message>
     <message>
         <source>Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</source>
@@ -1777,10 +1786,6 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">Úsáid seachfhreastalaí SOCKS5 ar leith chun sroicheadh piaraí trí sheirbhísí Tor oinniún:</translation>
     </message>
     <message>
-        <source>Options set in this dialog are overridden by the command line or in the configuration file:</source>
-        <translation type="unfinished">Tá na roghanna socraithe sa dialóg seo sáraithe ag líne na n-orduithe nó sa chomhad cumraíochta:</translation>
-    </message>
-    <message>
         <source>&amp;OK</source>
         <translation type="unfinished">&amp;Togha</translation>
     </message>
@@ -1798,14 +1803,17 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
     </message>
     <message>
         <source>Confirm options reset</source>
+        <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
         <translation type="unfinished">Deimhnigh athshocrú roghanna</translation>
     </message>
     <message>
         <source>Client restart required to activate changes.</source>
+        <extracomment>Text explaining that the settings changed will not come into effect until the client is restarted.</extracomment>
         <translation type="unfinished">Atosú cliant ag teastáil chun athruithe a ghníomhachtú.</translation>
     </message>
     <message>
         <source>Client will be shut down. Do you want to proceed?</source>
+        <extracomment>Text asking the user to confirm if they would like to proceed with a client shutdown.</extracomment>
         <translation type="unfinished">Múchfar an cliant. Ar mhaith leat dul ar aghaidh?</translation>
     </message>
     <message>
@@ -2827,10 +2835,6 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <source>A fee higher than %1 is considered an absurdly high fee.</source>
         <translation type="unfinished">Meastar gur táille áiféiseach ard í táille níos airde ná %1.</translation>
     </message>
-    <message>
-        <source>Payment request expired.</source>
-        <translation type="unfinished">Iarratas íocaíocht éagtha.</translation>
-    </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
@@ -2911,28 +2915,12 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
         <translation type="unfinished">Teachtaireacht:</translation>
     </message>
     <message>
-        <source>This is an unauthenticated payment request.</source>
-        <translation type="unfinished">Iarratas íocaíocht neamhfíordheimhnithe é seo.</translation>
-    </message>
-    <message>
-        <source>This is an authenticated payment request.</source>
-        <translation type="unfinished">Iarratas íocaíocht fíordheimhnithe é seo.</translation>
-    </message>
-    <message>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished">Iontráil lipéad don seoladh seo chun é a chur le liosta na seoltaí úsáidte</translation>
     </message>
     <message>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished">Teachtaireacht a bhí ceangailte leis an bitcoin: URI a stórálfar leis an idirbheart le haghaidh do thagairt. Nóta: Ní sheolfar an teachtaireacht seo thar líonra Bitcoin.</translation>
-    </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">Íoc chuig:</translation>
-    </message>
-    <message>
-        <source>Memo:</source>
-        <translation type="unfinished">Meamram:</translation>
     </message>
 </context>
 <context>
@@ -3093,30 +3081,22 @@ Ní féidir síniú ach le seoltaí 'oidhreachta'.</translation>
     <name>TransactionDesc</name>
     <message>
         <source>conflicted with a transaction with %1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that conflicts with a confirmed transaction.</extracomment>
         <translation type="unfinished">faoi choimhlint le idirbheart le %1 dearbhuithe</translation>
     </message>
     <message>
-        <source>0/unconfirmed, %1</source>
-        <translation type="unfinished">0/neamhdheimhnithe, %1</translation>
-    </message>
-    <message>
-        <source>in memory pool</source>
-        <translation type="unfinished">i linn cuimhne</translation>
-    </message>
-    <message>
-        <source>not in memory pool</source>
-        <translation type="unfinished">ní i linn cuimhne</translation>
-    </message>
-    <message>
         <source>abandoned</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an abandoned transaction.</extracomment>
         <translation type="unfinished">tréigthe</translation>
     </message>
     <message>
         <source>%1/unconfirmed</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
         <translation type="unfinished">%1/neamhdheimhnithe</translation>
     </message>
     <message>
         <source>%1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
         <translation type="unfinished">%1 dearbhuithe</translation>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_gd.ts
+++ b/src/qt/locale/bitcoin_gd.ts
@@ -113,6 +113,11 @@
         <source>Information</source>
         <translation type="unfinished">Fiosrachadh</translation>
     </message>
+    <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">Ainm Wallet</translation>
+    </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
@@ -140,6 +145,33 @@
     </context>
 <context>
     <name>Intro</name>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
     <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>

--- a/src/qt/locale/bitcoin_gl.ts
+++ b/src/qt/locale/bitcoin_gl.ts
@@ -706,6 +706,27 @@ Firmar é posible unicamente con enderezos de tipo 'legacy'.</translation>
 <context>
     <name>Intro</name>
     <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
@@ -856,6 +877,7 @@ Firmar é posible unicamente con enderezos de tipo 'legacy'.</translation>
     </message>
     <message>
         <source>Confirm options reset</source>
+        <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
         <translation type="unfinished">Confirmar opcións de restaurar</translation>
     </message>
     <message>
@@ -1221,10 +1243,6 @@ Firmar é posible unicamente con enderezos de tipo 'legacy'.</translation>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation type="unfinished">O total sobrepasa o teu balance cando se inclúe a tarifa de transacción %1.</translation>
     </message>
-    <message>
-        <source>Payment request expired.</source>
-        <translation type="unfinished">Solicitude de pagamento expirada.</translation>
-    </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
@@ -1278,10 +1296,6 @@ Firmar é posible unicamente con enderezos de tipo 'legacy'.</translation>
     <message>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished">Introduce unha etiqueta para esta dirección para engadila á listaxe de direccións empregadas</translation>
-    </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">Pagar A:</translation>
     </message>
     </context>
 <context>
@@ -1403,10 +1417,12 @@ Firmar é posible unicamente con enderezos de tipo 'legacy'.</translation>
     <name>TransactionDesc</name>
     <message>
         <source>%1/unconfirmed</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
         <translation type="unfinished">%1/sen confirmar</translation>
     </message>
     <message>
         <source>%1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
         <translation type="unfinished">%1 confirmacións</translation>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_gl_ES.ts
+++ b/src/qt/locale/bitcoin_gl_ES.ts
@@ -233,10 +233,21 @@
     </message>
 </context>
 <context>
+    <name>BitcoinApplication</name>
+    <message>
+        <source>Internal error</source>
+        <translation type="unfinished">Erro interno</translation>
+    </message>
+    </context>
+<context>
     <name>QObject</name>
     <message>
         <source>Amount</source>
         <translation type="unfinished">Cantidade</translation>
+    </message>
+    <message>
+        <source>Internal</source>
+        <translation type="unfinished">Interno</translation>
     </message>
     <message numerus="yes">
         <source>%n second(s)</source>
@@ -332,6 +343,10 @@
         <translation type="unfinished">Crear unha nova carteira</translation>
     </message>
     <message>
+        <source>&amp;Minimize</source>
+        <translation type="unfinished">&amp;Minimizar</translation>
+    </message>
+    <message>
         <source>Wallet:</source>
         <translation type="unfinished">Carteira:</translation>
     </message>
@@ -365,12 +380,20 @@
         <translation type="unfinished">&amp;Recibir</translation>
     </message>
     <message>
+        <source>&amp;Options…</source>
+        <translation type="unfinished">&amp;Opcións...</translation>
+    </message>
+    <message>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation type="unfinished">Encripta as claves privadas que pertencen á túa carteira</translation>
     </message>
     <message>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation type="unfinished">Asina mensaxes cos teus enderezos de Bitcoin para probar que che pertencen</translation>
+    </message>
+    <message>
+        <source>&amp;Verify message…</source>
+        <translation type="unfinished">&amp;Verifica a mensaxe...</translation>
     </message>
     <message>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
@@ -484,6 +507,11 @@
         <translation type="unfinished">Non hai carteiras dispoñibles</translation>
     </message>
     <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">Nome da Carteira</translation>
+    </message>
+    <message>
         <source>&amp;Window</source>
         <translation type="unfinished">&amp;Xanela</translation>
     </message>
@@ -571,7 +599,11 @@
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation type="unfinished">A carteira está &lt;b&gt;encriptada&lt;/b&gt; e actualmente &lt;b&gt;bloqueada&lt;/b&gt;</translation>
     </message>
-    </context>
+    <message>
+        <source>Original message:</source>
+        <translation type="unfinished">Mensaxe orixinal:</translation>
+    </message>
+</context>
 <context>
     <name>CoinControlDialog</name>
     <message>
@@ -641,6 +673,10 @@
     <message>
         <source>Copy amount</source>
         <translation type="unfinished">Copiar cantidade</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Copiar enderezo</translation>
     </message>
     <message>
         <source>Copy quantity</source>
@@ -749,6 +785,10 @@
         <translation type="unfinished">Encriptar Carteira</translation>
     </message>
     <message>
+        <source>Advanced Options</source>
+        <translation type="unfinished">Opcións avanzadas</translation>
+    </message>
+    <message>
         <source>Disable private keys for this wallet. Wallets with private keys disabled will have no private keys and cannot have an HD seed or imported private keys. This is ideal for watch-only wallets.</source>
         <translation type="unfinished">Desactiva as claves privadas para esta carteira. Carteiras con claves privadas desactivadas non terán claves privadas e polo tanto non poderan ter unha semente HD ou claves privadas importadas. Esto é ideal para carteiras de solo visualización.</translation>
     </message>
@@ -823,6 +863,27 @@
 <context>
     <name>Intro</name>
     <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform>(of %n GB needed)</numerusform>
+            <numerusform>(of %n GB needed)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform>(%n GB needed for full chain)</numerusform>
+            <numerusform>(%n GB needed for full chain)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
@@ -832,14 +893,29 @@
     </message>
     </context>
 <context>
+    <name>ModalOverlay</name>
+    <message>
+        <source>Unknown…</source>
+        <translation type="unfinished">Descoñecido...</translation>
+    </message>
+    </context>
+<context>
     <name>OptionsDialog</name>
     <message>
         <source>&amp;Window</source>
         <translation type="unfinished">&amp;Xanela</translation>
     </message>
+    <message>
+        <source>Continue</source>
+        <translation type="unfinished">Continuar</translation>
+    </message>
     </context>
 <context>
     <name>PSBTOperationsDialog</name>
+    <message>
+        <source>Save…</source>
+        <translation type="unfinished">Gardar...</translation>
+    </message>
     <message>
         <source>Close</source>
         <translation type="unfinished">Pechar</translation>
@@ -854,14 +930,30 @@
     </message>
     </context>
 <context>
+    <name>QRImageWidget</name>
+    <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">&amp;Gardar Imaxe...</translation>
+    </message>
+    </context>
+<context>
     <name>RPCConsole</name>
     <message>
         <source>Node window</source>
         <translation type="unfinished">Xanela de Nodo</translation>
     </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <extracomment>Context menu action to copy the address of a peer.</extracomment>
+        <translation type="unfinished">&amp;Copiar enderezo</translation>
+    </message>
     </context>
 <context>
     <name>ReceiveCoinsDialog</name>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Copiar enderezo</translation>
+    </message>
     <message>
         <source>Could not unlock wallet.</source>
         <translation type="unfinished">Non se puido desbloquear a carteira.</translation>
@@ -876,6 +968,10 @@
     <message>
         <source>Wallet:</source>
         <translation type="unfinished">Carteira:</translation>
+    </message>
+    <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">&amp;Gardar Imaxe...</translation>
     </message>
     </context>
 <context>
@@ -994,6 +1090,10 @@
     </context>
 <context>
     <name>TransactionView</name>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Copiar enderezo</translation>
+    </message>
     <message>
         <source>Confirmed</source>
         <translation type="unfinished">Confirmada</translation>

--- a/src/qt/locale/bitcoin_gu.ts
+++ b/src/qt/locale/bitcoin_gu.ts
@@ -92,6 +92,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">સરનામાં ની સૂચિ નો નિકાસ કરો</translation>
     </message>
     <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">અલ્પવિરામથી વિભાજિત ફાઇલ</translation>
+    </message>
+    <message>
         <source>Exporting Failed</source>
         <translation type="unfinished">નિકાસ ની પ્ર્રાક્રિયા નિષ્ફળ ગયેલ છે</translation>
     </message>
@@ -239,6 +244,27 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>Intro</name>
     <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
@@ -303,6 +329,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </context>
 <context>
     <name>TransactionView</name>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">અલ્પવિરામથી વિભાજિત ફાઇલ</translation>
+    </message>
     <message>
         <source>Label</source>
         <translation type="unfinished">ચિઠ્ઠી</translation>

--- a/src/qt/locale/bitcoin_ha.ts
+++ b/src/qt/locale/bitcoin_ha.ts
@@ -1,89 +1,119 @@
-<TS version="2.1" language="no">
+<TS version="2.1" language="ha">
 <context>
     <name>AddressBookPage</name>
     <message>
         <source>Right-click to edit address or label</source>
-        <translation type="unfinished">Høyreklikk for å redigere addressen eller etikketen </translation>
+        <translation type="unfinished">Danna dama don gyara adireshi ko labil</translation>
     </message>
     <message>
         <source>Create a new address</source>
-        <translation type="unfinished">Lag en ny adresse</translation>
+        <translation type="unfinished">Ƙirƙiri sabon adireshi</translation>
     </message>
     <message>
         <source>&amp;New</source>
-        <translation type="unfinished">&amp;Ny
-</translation>
+        <translation type="unfinished">Sabontawa</translation>
     </message>
     <message>
         <source>Copy the currently selected address to the system clipboard</source>
-        <translation type="unfinished">Kopier den valgte adressen til systemutklippstavlen</translation>
+        <translation type="unfinished">Kwafi adireshin da aka zaɓa a halin yanzu domin yin amfani dashi</translation>
     </message>
     <message>
         <source>&amp;Copy</source>
-        <translation type="unfinished">&amp;Kopier</translation>
+        <translation type="unfinished">&amp;Kwafi</translation>
     </message>
     <message>
         <source>C&amp;lose</source>
-        <translation type="unfinished">C&amp;Tap</translation>
+        <translation type="unfinished">C&amp;Rasa</translation>
     </message>
     <message>
         <source>Delete the currently selected address from the list</source>
-        <translation type="unfinished">Slett den valgte adressen fra listen </translation>
+        <translation type="unfinished">Share adireshin da aka zaɓa a halin yanzu daga jerin </translation>
     </message>
     <message>
         <source>Enter address or label to search</source>
-        <translation type="unfinished">Tast inn adressen eller etiketten for å søke</translation>
+        <translation type="unfinished">Shigar da adireshi ko lakabi don bincika</translation>
     </message>
     <message>
         <source>Export the data in the current tab to a file</source>
-        <translation type="unfinished">Eksporter dataen i gjeldende fane til en fil </translation>
+        <translation type="unfinished">Fitar da bayanan da ke cikin shafin na yanzu zuwa fayil</translation>
     </message>
     <message>
         <source>&amp;Export</source>
-        <translation type="unfinished">&amp;Eksporter</translation>
+        <translation type="unfinished">&amp; Fitarwa</translation>
     </message>
     <message>
         <source>&amp;Delete</source>
-        <translation type="unfinished">&amp;Slett</translation>
+        <translation type="unfinished">&amp;Sharewa</translation>
     </message>
     <message>
         <source>Choose the address to send coins to</source>
-        <translation type="unfinished">Velg adressen du vil sende mynter til </translation>
+        <translation type="unfinished">zaɓi adireshin don aika tsabar kudi</translation>
     </message>
     <message>
         <source>Choose the address to receive coins with</source>
-        <translation type="unfinished">Velg adressen du vil motta mynter med </translation>
+        <translation type="unfinished">Zaɓi adireshin don karɓar kuɗi internet da shi</translation>
     </message>
     <message>
         <source>Sending addresses</source>
-        <translation type="unfinished">Sender adresser </translation>
+        <translation type="unfinished">adireshin aikawa</translation>
     </message>
     <message>
         <source>Receiving addresses</source>
-        <translation type="unfinished">Mottar adresser </translation>
+        <translation type="unfinished">Adireshi da za a karba dashi</translation>
     </message>
     <message>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
-        <translation type="unfinished">Dette er dine Bitcoin adresser for å sende betalinger.Alltid sjekk mengden og mottaker adressen før du sender mynter.  </translation>
+        <translation type="unfinished">Waɗannan adiresoshin Bitcoin ne don tura kuɗi bitcoin . ka tabbatar da cewa adreshin daidai ne kamin ka tura abua a ciki</translation>
+    </message>
+    <message>
+        <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
+Signing is only possible with addresses of the type 'legacy'.</source>
+        <translation type="unfinished">Waɗannan adiresoshin Bitcoin ne don karɓar kuɗi. Yi amfani da maɓallin 'Ƙirƙiri sabon adireshin karɓa' a cikin shafin karɓa don ƙirƙirar sababbin adireshi.
+zaka iya shiga ne kawai da adiresoshin 'na musamman' kawai.</translation>
     </message>
     <message>
         <source>&amp;Copy Address</source>
-        <translation type="unfinished">&amp;Koper adresse</translation>
+        <translation type="unfinished">&amp;Kwafi Adireshin</translation>
+    </message>
+    <message>
+        <source>Copy &amp;Label</source>
+        <translation type="unfinished">Kwafi &amp; Lakabi</translation>
+    </message>
+    <message>
+        <source>&amp;Edit</source>
+        <translation type="unfinished">&amp;Gyara</translation>
     </message>
     <message>
         <source>Export Address List</source>
-        <translation type="unfinished">Eksporter adresse liste</translation>
+        <translation type="unfinished">Fitarwar Jerin Adreshi</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">waƙafin rabuwar fayil</translation>
+    </message>
+    <message>
+        <source>There was an error trying to save the address list to %1. Please try again.</source>
+        <extracomment>An error message. %1 is a stand-in argument for the name of the file we attempted to save to.</extracomment>
+        <translation type="unfinished">An sami kuskure wajen ƙoƙarin ajiye jerin adireshi zuwa 1 %1. Da fatan za a sake gwadawa.</translation>
     </message>
     <message>
         <source>Exporting Failed</source>
-        <translation type="unfinished">Eksportering feilet </translation>
+        <translation type="unfinished">Ba a yi nasarar fitarwa ba</translation>
     </message>
 </context>
 <context>
     <name>AddressTableModel</name>
     <message>
         <source>Address</source>
-        <translation type="unfinished">Adresse </translation>
+        <translation type="unfinished">Adireshi</translation>
+    </message>
+    </context>
+<context>
+    <name>AskPassphraseDialog</name>
+    <message>
+        <source>Unlock wallet</source>
+        <translation type="unfinished">Bude Walet</translation>
     </message>
     </context>
 <context>
@@ -151,6 +181,10 @@
     </context>
 <context>
     <name>Intro</name>
+    <message>
+        <source>Bitcoin</source>
+        <translation type="unfinished">Bitkoin</translation>
+    </message>
     <message numerus="yes">
         <source>%n GB of space available</source>
         <translation type="unfinished">
@@ -186,7 +220,7 @@
     <message>
         <source>Address</source>
         <extracomment>Title of Peers Table column which contains the IP/Onion/I2P address of the connected peer.</extracomment>
-        <translation type="unfinished">Adresse </translation>
+        <translation type="unfinished">Adireshi</translation>
     </message>
     </context>
 <context>
@@ -212,23 +246,28 @@
 <context>
     <name>TransactionView</name>
     <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">waƙafin rabuwar fayil</translation>
+    </message>
+    <message>
         <source>Address</source>
-        <translation type="unfinished">Adresse </translation>
+        <translation type="unfinished">Adireshi</translation>
     </message>
     <message>
         <source>Exporting Failed</source>
-        <translation type="unfinished">Eksportering feilet </translation>
+        <translation type="unfinished">Ba a yi nasarar fitarwa ba</translation>
     </message>
     </context>
 <context>
     <name>WalletView</name>
     <message>
         <source>&amp;Export</source>
-        <translation type="unfinished">&amp;Eksporter</translation>
+        <translation type="unfinished">&amp; Fitarwa</translation>
     </message>
     <message>
         <source>Export the data in the current tab to a file</source>
-        <translation type="unfinished">Eksporter dataen i gjeldende fane til en fil </translation>
+        <translation type="unfinished">Fitar da bayanan da ke cikin shafin na yanzu zuwa fayil</translation>
     </message>
     </context>
 </TS>

--- a/src/qt/locale/bitcoin_he.ts
+++ b/src/qt/locale/bitcoin_he.ts
@@ -3,7 +3,7 @@
     <name>AddressBookPage</name>
     <message>
         <source>Right-click to edit address or label</source>
-        <translation type="unfinished">לחיצה על הלחצן הימני בעכבר לעריכת הכתובת או התווית</translation>
+        <translation type="unfinished">לחץ על הלחצן הימני בעכבר לעריכת הכתובת או התווית</translation>
     </message>
     <message>
         <source>Create a new address</source>
@@ -15,7 +15,7 @@
     </message>
     <message>
         <source>Copy the currently selected address to the system clipboard</source>
-        <translation type="unfinished">העתקת את הכתובת המסומנת ללוח</translation>
+        <translation type="unfinished">העתק את הכתובת המסומנת ללוח</translation>
     </message>
     <message>
         <source>&amp;Copy</source>
@@ -430,10 +430,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">שגיאה בנסיון לקרוא את %s! כל המפתחות נקראו נכונה, אך נתוני העסקה או הכתובות יתכן שחסרו או שגויים.</translation>
     </message>
     <message>
-        <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
-        <translation type="unfinished">שגיאה: האזנה לתקשורת נכנ סת נכשלה (ההאזנה מחזירה שגיאה  %s)</translation>
-    </message>
-    <message>
         <source>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.</source>
         <translation type="unfinished">אמדן גובה עמלה נכשל. Fallbackfee  מנוטרל. יש להמתין מספר בלוקים או לשפעל את  -fallbackfee</translation>
     </message>
@@ -590,10 +586,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">שגיאת קריאה ממסד הנתונים. סוגר את התהליך.</translation>
     </message>
     <message>
-        <source>Error upgrading chainstate database</source>
-        <translation type="unfinished">שגיאת שידרוג מסד הנתונים של מצב השרשרת chainstate</translation>
-    </message>
-    <message>
         <source>Error: Disk space is low for %s</source>
         <translation type="unfinished">שגיאה: שטח הדיסק קטן מדי עובר %s</translation>
     </message>
@@ -668,10 +660,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
         <translation type="unfinished">יש לציין פתחה עם ‎-whitebind:‏ '%s'</translation>
-    </message>
-    <message>
-        <source>No proxy server specified. Use -proxy=&lt;ip&gt; or -proxy=&lt;ip:port&gt;.</source>
-        <translation type="unfinished">לא הוגדר פרוקסי. יש להשתמש ב־‎ -proxy=&lt;ip&gt; או ב־‎ -proxy=&lt;ip:port&gt;.</translation>
     </message>
     <message>
         <source>Not enough file descriptors available.</source>
@@ -802,10 +790,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">קטגורית רישום בלוג שאינה נמתמכת %s=%s.</translation>
     </message>
     <message>
-        <source>Upgrading UTXO database</source>
-        <translation type="unfinished">שדרוג מאגר נתוני UTXO </translation>
-    </message>
-    <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
         <translation type="unfinished">הערת צד המשתמש (%s) כוללת תווים שאינם בטוחים.</translation>
     </message>
@@ -930,6 +914,22 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">אמת הודעות כדי להבטיח שהן נחתמו עם כתובת ביטקוין מסוימות</translation>
     </message>
     <message>
+        <source>Open &amp;URI…</source>
+        <translation type="unfinished">פתיחת הקישור</translation>
+    </message>
+    <message>
+        <source>Close Wallet…</source>
+        <translation type="unfinished">סגירת ארנק</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation type="unfinished">יצירת ארנק</translation>
+    </message>
+    <message>
+        <source>Close All Wallets…</source>
+        <translation type="unfinished">סגירת כל הארנקים</translation>
+    </message>
+    <message>
         <source>&amp;File</source>
         <translation type="unfinished">&amp;קובץ</translation>
     </message>
@@ -944,6 +944,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Tabs toolbar</source>
         <translation type="unfinished">סרגל כלים לשוניות</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation type="unfinished">בסנכרון עם הרשת</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation type="unfinished">מתחבר לעמיתים</translation>
     </message>
     <message>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
@@ -971,6 +979,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>%1 behind</source>
         <translation type="unfinished">%1 מאחור</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation type="unfinished">משלים פערים</translation>
     </message>
     <message>
         <source>Last received block was generated %1 ago.</source>
@@ -1037,6 +1049,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">סגירת ארנק</translation>
     </message>
     <message>
+        <source>Restore Wallet…</source>
+        <extracomment>Name of the menu item that restores wallet from a backup file.</extracomment>
+        <translation type="unfinished">שחזור ארנק</translation>
+    </message>
+    <message>
+        <source>Restore a wallet from a backup file</source>
+        <extracomment>Status tip for Restore Wallet menu item</extracomment>
+        <translation type="unfinished">שחזור ארנק מקובץ גיבוי</translation>
+    </message>
+    <message>
         <source>Close all wallets</source>
         <translation type="unfinished">סגירת כל הארנקים</translation>
     </message>
@@ -1060,6 +1082,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>No wallets available</source>
         <translation type="unfinished">אין ארנקים זמינים</translation>
+    </message>
+    <message>
+        <source>Load Wallet Backup</source>
+        <extracomment>The title for Restore Wallet File Windows</extracomment>
+        <translation type="unfinished">טעינת גיבוי הארנק</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">שם הארנק</translation>
     </message>
     <message>
         <source>&amp;Window</source>
@@ -1503,6 +1535,27 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Bitcoin</source>
         <translation type="unfinished">ביטקוין</translation>
     </message>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform>(מתוך %n ג׳יגה-בייט נדרשים)</numerusform>
+            <numerusform>(מתוך %n ג׳יגה-בייט נדרשים)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform>(ג׳יגה-בייט %n נדרש לשרשרת המלאה)</numerusform>
+            <numerusform>(%n ג׳יגה-בייט נדרשים לשרשרת המלאה)</numerusform>
+        </translation>
+    </message>
     <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
         <translation type="unfinished">לפחות %1 ג״ב של נתונים יאוחסנו בתיקייה זו, והם יגדלו עם הזמן.</translation>
@@ -1546,10 +1599,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>As this is the first time the program is launched, you can choose where %1 will store its data.</source>
         <translation type="unfinished">כיוון שזו ההפעלה הראשונה של התכנית, ניתן לבחור היכן יאוחסן המידע של %1.</translation>
-    </message>
-    <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation type="unfinished">בעת לחיצה על אישור, %1 יחל בהורדה ועיבוד מלאים של שרשרת המקטעים %4 (%2 ג״ב) החל מההעברות הראשונות ב־%3 עם ההשקה הראשונית של %4.</translation>
     </message>
     <message>
         <source>Limit block chain storage to</source>
@@ -1848,10 +1897,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">השתמש בפרוקסי נפרד  SOCKS&amp;5 להגעה לעמיתים דרך שרותי השכבות של  Tor :</translation>
     </message>
     <message>
-        <source>Options set in this dialog are overridden by the command line or in the configuration file:</source>
-        <translation type="unfinished">אפשרויות שמוגדרות בדיאלוג הזה נדרסות ע"י שורת הפקודה או קובץ הקונפיגורציה</translation>
-    </message>
-    <message>
         <source>&amp;OK</source>
         <translation type="unfinished">&amp;אישור</translation>
     </message>
@@ -1869,14 +1914,17 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Confirm options reset</source>
+        <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
         <translation type="unfinished">אישור איפוס האפשרויות</translation>
     </message>
     <message>
         <source>Client restart required to activate changes.</source>
+        <extracomment>Text explaining that the settings changed will not come into effect until the client is restarted.</extracomment>
         <translation type="unfinished">נדרשת הפעלה מחדש של הלקוח כדי להפעיל את השינויים.</translation>
     </message>
     <message>
         <source>Client will be shut down. Do you want to proceed?</source>
+        <extracomment>Text asking the user to confirm if they would like to proceed with a client shutdown.</extracomment>
         <translation type="unfinished">הלקוח יכבה. להמשיך?</translation>
     </message>
     <message>
@@ -2903,10 +2951,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>A fee higher than %1 is considered an absurdly high fee.</source>
         <translation type="unfinished">עמלה מעל לסכום של %1 נחשבת לעמלה גבוהה באופן מוגזם.</translation>
     </message>
-    <message>
-        <source>Payment request expired.</source>
-        <translation type="unfinished">בקשת התשלום פגה.</translation>
-    </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
@@ -2986,28 +3030,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">הודעה:</translation>
     </message>
     <message>
-        <source>This is an unauthenticated payment request.</source>
-        <translation type="unfinished">זוהי בקשת תשלום לא מאומתת.</translation>
-    </message>
-    <message>
-        <source>This is an authenticated payment request.</source>
-        <translation type="unfinished">זוהי בקשה מאומתת לתשלום.</translation>
-    </message>
-    <message>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished">יש לתת תווית לכתובת זו כדי להוסיף אותה לרשימת הכתובות בשימוש</translation>
     </message>
     <message>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished">הודעה שצורפה לביטקוין: כתובת שתאוחסן בהעברה לצורך מעקב מצדך. לתשומת לבך: הודעה זו לא תישלח ברשת הביטקוין.</translation>
-    </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">תשלום לטובת:</translation>
-    </message>
-    <message>
-        <source>Memo:</source>
-        <translation type="unfinished">תזכורת:</translation>
     </message>
 </context>
 <context>
@@ -3168,30 +3196,22 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <name>TransactionDesc</name>
     <message>
         <source>conflicted with a transaction with %1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that conflicts with a confirmed transaction.</extracomment>
         <translation type="unfinished">ישנה סתירה עם עסקה שעברה %1 אימותים</translation>
     </message>
     <message>
-        <source>0/unconfirmed, %1</source>
-        <translation type="unfinished">0/לא מאומתים, %1</translation>
-    </message>
-    <message>
-        <source>in memory pool</source>
-        <translation type="unfinished">במאגר הזיכרון</translation>
-    </message>
-    <message>
-        <source>not in memory pool</source>
-        <translation type="unfinished">לא במאגר הזיכרון</translation>
-    </message>
-    <message>
         <source>abandoned</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an abandoned transaction.</extracomment>
         <translation type="unfinished">ננטש</translation>
     </message>
     <message>
         <source>%1/unconfirmed</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
         <translation type="unfinished">%1/לא מאומתים</translation>
     </message>
     <message>
         <source>%1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
         <translation type="unfinished">%1 אימותים</translation>
     </message>
     <message>
@@ -3659,7 +3679,7 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <source>Export the data in the current tab to a file</source>
-        <translation type="unfinished">שמירת הנתונים מהלשונית הנוכחית לקובץ</translation>
+        <translation type="unfinished">יצוא הנתונים בלשונית הנוכחית לקובץ</translation>
     </message>
     <message>
         <source>Backup Wallet</source>

--- a/src/qt/locale/bitcoin_hr.ts
+++ b/src/qt/locale/bitcoin_hr.ts
@@ -70,6 +70,12 @@
         <translation type="unfinished">Ovo su vaše Bitcoin adrese za slanje novca. Uvijek provjerite iznos i adresu primatelja prije slanja novca.</translation>
     </message>
     <message>
+        <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
+Signing is only possible with addresses of the type 'legacy'.</source>
+        <translation type="unfinished">Ovo su vaše Bitcoin adrese za primanje sredstava. Koristite 'Kreiraj novu adresu za primanje' u tabu Primite kako biste kreirali nove adrese.
+Potpisivanje je moguće samo sa 'legacy' adresama. </translation>
+    </message>
+    <message>
         <source>&amp;Copy Address</source>
         <translation type="unfinished">&amp;Kopirajte adresu</translation>
     </message>
@@ -84,6 +90,11 @@
     <message>
         <source>Export Address List</source>
         <translation type="unfinished">Izvezite listu adresa</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">Datoteka podataka odvojenih zarezima (*.csv)</translation>
     </message>
     <message>
         <source>There was an error trying to save the address list to %1. Please try again.</source>
@@ -233,7 +244,36 @@
     </message>
 </context>
 <context>
+    <name>BitcoinApplication</name>
+    <message>
+        <source>Runaway exception</source>
+        <translation type="unfinished">Runaway iznimka</translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
+        <translation type="unfinished">Dogodila se greška. %1 ne može sigurno nastaviti te će se zatvoriti.</translation>
+    </message>
+    <message>
+        <source>Internal error</source>
+        <translation type="unfinished">Interna greška</translation>
+    </message>
+    <message>
+        <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
+        <translation type="unfinished">Dogodila se interna greška. %1 će pokušati sigurno nastaviti. Ovo je neočekivani bug koji se može prijaviti kao što je objašnjeno ispod.</translation>
+    </message>
+</context>
+<context>
     <name>QObject</name>
+    <message>
+        <source>Do you want to reset settings to default values, or to abort without making changes?</source>
+        <extracomment>Explanatory text shown on startup when the settings file cannot be read. Prompts user to make a choice between resetting or aborting.</extracomment>
+        <translation type="unfinished">Želite li resetirati postavke na početne vrijednosti ili izaći bez promjena?</translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. Check that settings file is writable, or try running with -nosettings.</source>
+        <extracomment>Explanatory text shown on startup when the settings file could not be written. Prompts user to check that we have the ability to write to the file. Explains that the user has the option of running without a settings file.</extracomment>
+        <translation type="unfinished">Dogodila se kobna greška. Provjerite je li datoteka za postavke otvorena za promjene ili pokušajte pokrenuti s -nosettings.</translation>
+    </message>
     <message>
         <source>Error: Specified data directory "%1" does not exist.</source>
         <translation type="unfinished">Greška: Zadana podatkovna mapa "%1" ne postoji.</translation>
@@ -245,6 +285,10 @@
     <message>
         <source>Error: %1</source>
         <translation type="unfinished">Greška: %1</translation>
+    </message>
+    <message>
+        <source>%1 didn't yet exit safely…</source>
+        <translation type="unfinished">%1 se nije još zatvorio na siguran način.</translation>
     </message>
     <message>
         <source>unknown</source>
@@ -259,6 +303,14 @@
         <translation type="unfinished">Unesite Bitcoin adresu (npr. %1)</translation>
     </message>
     <message>
+        <source>Unroutable</source>
+        <translation type="unfinished">Neusmjeriv</translation>
+    </message>
+    <message>
+        <source>Internal</source>
+        <translation type="unfinished">Interni</translation>
+    </message>
+    <message>
         <source>Inbound</source>
         <extracomment>An inbound connection from a peer. An inbound connection is a connection initiated by a peer.</extracomment>
         <translation type="unfinished">Dolazni</translation>
@@ -269,47 +321,72 @@
         <translation type="unfinished">Izlazni</translation>
     </message>
     <message>
+        <source>Full Relay</source>
+        <extracomment>Peer connection type that relays all network information.</extracomment>
+        <translation type="unfinished">Potpuni prijenos</translation>
+    </message>
+    <message>
+        <source>Block Relay</source>
+        <extracomment>Peer connection type that relays network information about blocks and not transactions or addresses.</extracomment>
+        <translation type="unfinished">Blok prijenos</translation>
+    </message>
+    <message>
+        <source>Manual</source>
+        <extracomment>Peer connection type established manually through one of several methods.</extracomment>
+        <translation type="unfinished">Priručnik</translation>
+    </message>
+    <message>
+        <source>Feeler</source>
+        <extracomment>Short-lived peer connection type that tests the aliveness of known addresses.</extracomment>
+        <translation type="unfinished">Ispipavač</translation>
+    </message>
+    <message>
+        <source>Address Fetch</source>
+        <extracomment>Short-lived peer connection type that solicits known addresses from a peer.</extracomment>
+        <translation type="unfinished">Dohvaćanje adrese</translation>
+    </message>
+    <message>
         <source>None</source>
         <translation type="unfinished">Ništa</translation>
     </message>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n second(s)</numerusform>
+            <numerusform>%n second(s)</numerusform>
+            <numerusform>%n sekundi</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n minute(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n minute(s)</numerusform>
+            <numerusform>%n minute(s)</numerusform>
+            <numerusform>%n minuta</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n hour(s)</numerusform>
+            <numerusform>%n hour(s)</numerusform>
+            <numerusform>%n sati</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n day(s)</numerusform>
+            <numerusform>%n day(s)</numerusform>
+            <numerusform>%n dana</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n week(s)</numerusform>
+            <numerusform>%n week(s)</numerusform>
+            <numerusform>%n tjedana</numerusform>
         </translation>
     </message>
     <message>
@@ -319,25 +396,45 @@
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n year(s)</numerusform>
+            <numerusform>%n year(s)</numerusform>
+            <numerusform>%n godina</numerusform>
         </translation>
     </message>
     </context>
 <context>
     <name>bitcoin-core</name>
     <message>
+        <source>Settings file could not be read</source>
+        <translation type="unfinished">Datoteka postavke se ne može pročitati</translation>
+    </message>
+    <message>
+        <source>Settings file could not be written</source>
+        <translation type="unfinished">Datoteka postavke se ne može mijenjati</translation>
+    </message>
+    <message>
         <source>The %s developers</source>
         <translation type="unfinished">Ekipa %s</translation>
+    </message>
+    <message>
+        <source>%s corrupt. Try using the wallet tool bitcoin-wallet to salvage or restoring a backup.</source>
+        <translation type="unfinished">%s korumpirano. Pokušajte koristiti bitcoin-wallet alat za novčanike kako biste ga spasili ili pokrenuti sigurnosnu kopiju.</translation>
     </message>
     <message>
         <source>-maxtxfee is set very high! Fees this large could be paid on a single transaction.</source>
         <translation type="unfinished">-maxtxfee je postavljen preveliko. Naknade ove veličine će biti plaćene na individualnoj transakciji.</translation>
     </message>
     <message>
+        <source>Cannot downgrade wallet from version %i to version %i. Wallet version unchanged.</source>
+        <translation type="unfinished">Nije moguće unazaditi novčanik s verzije %i na verziju %i. Verzija novčanika nepromijenjena.</translation>
+    </message>
+    <message>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running.</source>
         <translation type="unfinished">Program ne može pristupiti podatkovnoj mapi %s. %s je vjerojatno već pokrenut.</translation>
+    </message>
+    <message>
+        <source>Cannot upgrade a non HD split wallet from version %i to version %i without upgrading to support pre-split keypool. Please use version %i or no version specified.</source>
+        <translation type="unfinished">Nije moguće unaprijediti podijeljeni novčanik bez HD-a s verzije %i na verziju %i bez unaprijeđenja na potporu pred-podjelnog bazena ključeva. Molimo koristite verziju %i ili neku drugu.</translation>
     </message>
     <message>
         <source>Distributed under the MIT software license, see the accompanying file %s or %s</source>
@@ -348,16 +445,56 @@
         <translation type="unfinished">Greška kod iščitanja %s! Svi ključevi su ispravno učitani, ali transakcijski podaci ili zapisi u adresaru mogu biti nepotpuni ili netočni.</translation>
     </message>
     <message>
-        <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
-        <translation type="unfinished">Greška: Neuspješno slušanje dolažećih veza (listen je izbacio grešku %s)</translation>
+        <source>Error reading %s! Transaction data may be missing or incorrect. Rescanning wallet.</source>
+        <translation type="unfinished">Greška u čitanju %s! Transakcijski podaci nedostaju ili su netočni. Ponovno skeniranje novčanika.</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile format record is incorrect. Got "%s", expected "format".</source>
+        <translation type="unfinished">Greška: Format dumpfile zapisa je netočan. Dobiven "%s" očekivani "format".</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile identifier record is incorrect. Got "%s", expected "%s".</source>
+        <translation type="unfinished">Greška: Identifikator dumpfile zapisa je netočan. Dobiven "%s", očekivan "%s".</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile version is not supported. This version of bitcoin-wallet only supports version 1 dumpfiles. Got dumpfile with version %s</source>
+        <translation type="unfinished">Greška: Dumpfile verzija nije podržana. Ova bitcoin-wallet  verzija podržava  samo dumpfile verziju 1. Dobiven dumpfile s verzijom %s</translation>
+    </message>
+    <message>
+        <source>Error: Legacy wallets only support the "legacy", "p2sh-segwit", and "bech32" address types</source>
+        <translation type="unfinished">Greška: Legacy novčanici podržavaju samo "legacy", "p2sh-segwit", i "bech32" tipove adresa</translation>
     </message>
     <message>
         <source>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.</source>
         <translation type="unfinished">Neuspješno procjenjivanje naknada. Fallbackfee je isključena. Pričekajte nekoliko blokova ili uključite -fallbackfee.</translation>
     </message>
     <message>
+        <source>File %s already exists. If you are sure this is what you want, move it out of the way first.</source>
+        <translation type="unfinished">Datoteka %s već postoji. Ako ste sigurni da ovo želite, prvo ju maknite, </translation>
+    </message>
+    <message>
         <source>Invalid amount for -maxtxfee=&lt;amount&gt;: '%s' (must be at least the minrelay fee of %s to prevent stuck transactions)</source>
         <translation type="unfinished">Neispravan iznos za -maxtxfee=&lt;amount&gt;: '%s' (mora biti barem minimalnu naknadu za proslijeđivanje od %s kako se ne bi zapela transakcija)</translation>
+    </message>
+    <message>
+        <source>Invalid or corrupt peers.dat (%s). If you believe this is a bug, please report it to %s. As a workaround, you can move the file (%s) out of the way (rename, move, or delete) to have a new one created on the next start.</source>
+        <translation type="unfinished">Nevažeći ili korumpirani peers.dat (%s). Ako mislite da je ovo bug, molimo prijavite %s. Kao alternativno rješenje, možete maknuti datoteku (%s) (preimenuj, makni ili obriši) kako bi se kreirala nova na idućem pokretanju.</translation>
+    </message>
+    <message>
+        <source>More than one onion bind address is provided. Using %s for the automatically created Tor onion service.</source>
+        <translation type="unfinished">Pruženo je više od jedne onion bind adrese. Koristim %s za automatski stvorenu Tor onion uslugu.</translation>
+    </message>
+    <message>
+        <source>No dump file provided. To use createfromdump, -dumpfile=&lt;filename&gt; must be provided.</source>
+        <translation type="unfinished">Dump datoteka nije automatski dostupna. Kako biste koristili createfromdump, -dumpfile=&lt;filename&gt; mora biti osiguran. </translation>
+    </message>
+    <message>
+        <source>No dump file provided. To use dump, -dumpfile=&lt;filename&gt; must be provided.</source>
+        <translation type="unfinished">Dump datoteka nije automatski dostupna. Kako biste koristili dump, -dumpfile=&lt;filename&gt; mora biti osiguran. </translation>
+    </message>
+    <message>
+        <source>No wallet file format provided. To use createfromdump, -format=&lt;format&gt; must be provided.</source>
+        <translation type="unfinished">Format datoteke novčanika nije dostupan. Kako biste koristili reatefromdump, -format=&lt;format&gt; mora biti osiguran.</translation>
     </message>
     <message>
         <source>Please check that your computer's date and time are correct! If your clock is wrong, %s will not work properly.</source>
@@ -376,16 +513,32 @@
         <translation type="unfinished">Obrezivanje: zadnja sinkronizacija novčanika ide dalje od obrezivanih podataka. Morate koristiti -reindex (ponovo preuzeti cijeli lanac blokova u slučaju obrezivanog čvora)</translation>
     </message>
     <message>
+        <source>SQLiteDatabase: Unknown sqlite wallet schema version %d. Only version %d is supported</source>
+        <translation type="unfinished">SQLiteDatabase: Nepoznata sqlite shema novčanika verzija %d. Podržana je samo verzija %d.</translation>
+    </message>
+    <message>
         <source>The block database contains a block which appears to be from the future. This may be due to your computer's date and time being set incorrectly. Only rebuild the block database if you are sure that your computer's date and time are correct</source>
         <translation type="unfinished">Baza blokova sadrži blok koji je naizgled iz budućnosti. Može to biti posljedica krivo namještenog datuma i vremena na vašem računalu. Obnovite bazu blokova samo ako ste sigurni da su točni datum i vrijeme na vašem računalu.</translation>
+    </message>
+    <message>
+        <source>The block index db contains a legacy 'txindex'. To clear the occupied disk space, run a full -reindex, otherwise ignore this error. This error message will not be displayed again.</source>
+        <translation type="unfinished">Index bloka db sadrži legacy 'txindex'. Kako biste očistili zauzeti prostor na disku, pokrenite puni -reindex ili ignorirajte ovu grešku. Ova greška neće biti ponovno prikazana.</translation>
     </message>
     <message>
         <source>The transaction amount is too small to send after the fee has been deducted</source>
         <translation type="unfinished">Iznos transakcije je premalen za poslati nakon naknade</translation>
     </message>
     <message>
+        <source>This error could occur if this wallet was not shutdown cleanly and was last loaded using a build with a newer version of Berkeley DB. If so, please use the software that last loaded this wallet</source>
+        <translation type="unfinished">Ova greška bi se mogla dogoditi kada se ovaj novčanik ne ugasi pravilno i ako je posljednji put bio podignut koristeći noviju verziju Berkeley DB. Ako je tako, molimo koristite softver kojim je novčanik podignut zadnji put.</translation>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation type="unfinished">Ovo je eksperimentalna verzija za testiranje - koristite je na vlastitu odgovornost - ne koristite je za rudarenje ili trgovačke primjene</translation>
+    </message>
+    <message>
+        <source>This is the maximum transaction fee you pay (in addition to the normal fee) to prioritize partial spend avoidance over regular coin selection.</source>
+        <translation type="unfinished">Ovo je najveća transakcijska naknada koju plaćate (uz normalnu naknadu) kako biste prioritizirali izbjegavanje djelomične potrošnje nad uobičajenom selekcijom sredstava.</translation>
     </message>
     <message>
         <source>This is the transaction fee you may discard if change is smaller than dust at this level</source>
@@ -404,12 +557,24 @@
         <translation type="unfinished">Ne mogu se ponovo odigrati blokovi. Morat ćete ponovo složiti bazu koristeći -reindex-chainstate.</translation>
     </message>
     <message>
+        <source>Unknown wallet file format "%s" provided. Please provide one of "bdb" or "sqlite".</source>
+        <translation type="unfinished">Nepoznati formant novčanika "%s" pružen. Molimo dostavite "bdb" ili "sqlite".</translation>
+    </message>
+    <message>
+        <source>Warning: Dumpfile wallet format "%s" does not match command line specified format "%s".</source>
+        <translation type="unfinished">Upozorenje: Dumpfile format novčanika "%s" se ne poklapa sa formatom komandne linije "%s".</translation>
+    </message>
+    <message>
         <source>Warning: Private keys detected in wallet {%s} with disabled private keys</source>
         <translation type="unfinished">Upozorenje: Privatni ključevi pronađeni u novčaniku {%s} s isključenim privatnim ključevima</translation>
     </message>
     <message>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished">Upozorenje: Izgleda da se ne slažemo u potpunosti s našim klijentima! Možda ćete se vi ili ostali čvorovi morati ažurirati.</translation>
+    </message>
+    <message>
+        <source>Witness data for blocks after height %d requires validation. Please restart with -reindex.</source>
+        <translation type="unfinished">Podaci svjedoka za blokove poslije visine %d zahtijevaju validaciju. Molimo restartirajte sa -reindex.</translation>
     </message>
     <message>
         <source>You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain</source>
@@ -424,12 +589,44 @@
         <translation type="unfinished">-maxmempool mora biti barem %d MB</translation>
     </message>
     <message>
+        <source>A fatal internal error occurred, see debug.log for details</source>
+        <translation type="unfinished">Dogodila se kobna greška, vidi detalje u debug.log.</translation>
+    </message>
+    <message>
         <source>Cannot resolve -%s address: '%s'</source>
         <translation type="unfinished">Ne može se razriješiti adresa -%s: '%s'</translation>
     </message>
     <message>
+        <source>Cannot set -forcednsseed to true when setting -dnsseed to false.</source>
+        <translation type="unfinished">Nije moguće postaviti -forcednsseed na true kada je postavka za  -dnsseed false.</translation>
+    </message>
+    <message>
+        <source>Cannot set -peerblockfilters without -blockfilterindex.</source>
+        <translation type="unfinished">Nije moguće postaviti -peerblockfilters bez -blockfilterindex.</translation>
+    </message>
+    <message>
         <source>Cannot write to data directory '%s'; check permissions.</source>
         <translation type="unfinished">Nije moguće pisati u podatkovnu mapu '%s'; provjerite dozvole.</translation>
+    </message>
+    <message>
+        <source>The -txindex upgrade started by a previous version cannot be completed. Restart with the previous version or run a full -reindex.</source>
+        <translation type="unfinished">Unaprijeđenje  -txindex koje za započela prijašnja verzija nije moguće završiti. Ponovno pokrenite s prethodnom verzijom ili pokrenite potpuni -reindex.</translation>
+    </message>
+    <message>
+        <source>%s request to listen on port %u. This port is considered "bad" and thus it is unlikely that any Bitcoin Core peers connect to it. See doc/p2p-bad-ports.md for details and a full list.</source>
+        <translation type="unfinished">%s zahtjev za slušanje na portu %u. Ovaj port se smatra "lošim" i time nije vjerojatno da će se drugi Bitcoin Core peerovi spojiti na njega. Pogledajte doc/p2p-bad-ports.md za detalje i cijeli popis.</translation>
+    </message>
+    <message>
+        <source>Cannot provide specific connections and have addrman find outgoing connections at the same time.</source>
+        <translation type="unfinished">Nije moguće ponuditi specifične veze i istovremeno dati addrman da traži izlazne veze.</translation>
+    </message>
+    <message>
+        <source>Error loading %s: External signer wallet being loaded without external signer support compiled</source>
+        <translation type="unfinished">Pogreška pri učitavanju %s: Vanjski potpisni novčanik se učitava bez kompajlirane potpore vanjskog potpisnika</translation>
+    </message>
+    <message>
+        <source>Failed to rename invalid peers.dat file. Please move or delete it and try again.</source>
+        <translation type="unfinished">Preimenovanje nevažeće peers.dat datoteke neuspješno. Molimo premjestite ili obrišite datoteku i pokušajte ponovno.</translation>
     </message>
     <message>
         <source>Config setting for %s only applied on %s network when in [%s] section.</source>
@@ -448,12 +645,24 @@
         <translation type="unfinished">Nije moguće pročitati asmap datoteku %s</translation>
     </message>
     <message>
+        <source>Disk space is too low!</source>
+        <translation type="unfinished">Nema dovoljno prostora na disku!</translation>
+    </message>
+    <message>
         <source>Do you want to rebuild the block database now?</source>
         <translation type="unfinished">Želite li sada obnoviti bazu blokova?</translation>
     </message>
     <message>
         <source>Done loading</source>
         <translation type="unfinished">Učitavanje gotovo</translation>
+    </message>
+    <message>
+        <source>Dump file %s does not exist.</source>
+        <translation type="unfinished">Dump datoteka %s ne postoji.</translation>
+    </message>
+    <message>
+        <source>Error creating %s</source>
+        <translation type="unfinished">Greška pri stvaranju %s</translation>
     </message>
     <message>
         <source>Error initializing block database</source>
@@ -492,12 +701,48 @@
         <translation type="unfinished">Greška kod iščitanja baze. Zatvara se klijent.</translation>
     </message>
     <message>
-        <source>Error upgrading chainstate database</source>
-        <translation type="unfinished">Greška kod ažuriranja baze stanja lanca</translation>
+        <source>Error reading next record from wallet database</source>
+        <translation type="unfinished">Greška pri očitavanju idućeg zapisa iz baza podataka novčanika</translation>
+    </message>
+    <message>
+        <source>Error: Couldn't create cursor into database</source>
+        <translation type="unfinished">Greška: Nije moguće kreirati cursor u batu podataka</translation>
     </message>
     <message>
         <source>Error: Disk space is low for %s</source>
         <translation type="unfinished">Pogreška: Malo diskovnog prostora za %s</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile checksum does not match. Computed %s, expected %s</source>
+        <translation type="unfinished">Greška: Dumpfile checksum se ne poklapa. Izračunao %s, očekivano %s</translation>
+    </message>
+    <message>
+        <source>Error: Got key that was not hex: %s</source>
+        <translation type="unfinished">Greška: Dobiven ključ koji nije hex: %s</translation>
+    </message>
+    <message>
+        <source>Error: Got value that was not hex: %s</source>
+        <translation type="unfinished">Greška: Dobivena vrijednost koja nije hex: %s</translation>
+    </message>
+    <message>
+        <source>Error: Keypool ran out, please call keypoolrefill first</source>
+        <translation type="unfinished">Greška: Ispraznio se bazen ključeva, molimo prvo pozovite keypoolrefill</translation>
+    </message>
+    <message>
+        <source>Error: Missing checksum</source>
+        <translation type="unfinished">Greška: Nedostaje checksum</translation>
+    </message>
+    <message>
+        <source>Error: No %s addresses available.</source>
+        <translation type="unfinished">Greška: Nema %s adresa raspoloživo.</translation>
+    </message>
+    <message>
+        <source>Error: Unable to parse version %u as a uint32_t</source>
+        <translation type="unfinished">Greška: Nije moguće parsirati verziju %u kao uint32_t</translation>
+    </message>
+    <message>
+        <source>Error: Unable to write record to new wallet</source>
+        <translation type="unfinished">Greška: Nije moguće unijeti zapis u novi novčanik</translation>
     </message>
     <message>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
@@ -508,6 +753,22 @@
         <translation type="unfinished">Neuspješno ponovo skeniranje novčanika tijekom inicijalizacije</translation>
     </message>
     <message>
+        <source>Failed to verify database</source>
+        <translation type="unfinished">Verifikacija baze podataka neuspješna</translation>
+    </message>
+    <message>
+        <source>Fee rate (%s) is lower than the minimum fee rate setting (%s)</source>
+        <translation type="unfinished">Naknada (%s) je niža od postavke minimalne visine naknade (%s)</translation>
+    </message>
+    <message>
+        <source>Ignoring duplicate -wallet %s.</source>
+        <translation type="unfinished">Zanemarujem duplicirani -wallet %s.</translation>
+    </message>
+    <message>
+        <source>Importing…</source>
+        <translation type="unfinished">Uvozim...</translation>
+    </message>
+    <message>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation type="unfinished">Neispravan ili nepostojeći blok geneze. Možda je kriva podatkovna mapa za mrežu?</translation>
     </message>
@@ -516,8 +777,16 @@
         <translation type="unfinished">Brzinska provjera inicijalizacije neuspješna. %s se zatvara.</translation>
     </message>
     <message>
+        <source>Input not found or already spent</source>
+        <translation type="unfinished">Input nije pronađen ili je već potrošen</translation>
+    </message>
+    <message>
         <source>Insufficient funds</source>
         <translation type="unfinished">Nedovoljna sredstva</translation>
+    </message>
+    <message>
+        <source>Invalid -i2psam address or hostname: '%s'</source>
+        <translation type="unfinished">Neispravna -i2psam adresa ili ime računala: '%s'</translation>
     </message>
     <message>
         <source>Invalid -onion address or hostname: '%s'</source>
@@ -552,8 +821,36 @@
         <translation type="unfinished">Neispravna mrežna maska zadana u -whitelist: '%s'</translation>
     </message>
     <message>
+        <source>Loading P2P addresses…</source>
+        <translation type="unfinished">Pokreće se popis P2P adresa...</translation>
+    </message>
+    <message>
+        <source>Loading banlist…</source>
+        <translation type="unfinished">Pokreće se popis zabrana...</translation>
+    </message>
+    <message>
+        <source>Loading block index…</source>
+        <translation type="unfinished">Učitavanje indeksa blokova...</translation>
+    </message>
+    <message>
+        <source>Loading wallet…</source>
+        <translation type="unfinished">Učitavanje novčanika...</translation>
+    </message>
+    <message>
+        <source>Missing amount</source>
+        <translation type="unfinished">Iznos nedostaje</translation>
+    </message>
+    <message>
+        <source>Missing solving data for estimating transaction size</source>
+        <translation type="unfinished">Nedostaju podaci za procjenu veličine transakcije</translation>
+    </message>
+    <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
         <translation type="unfinished">Treba zadati port pomoću -whitebind: '%s'</translation>
+    </message>
+    <message>
+        <source>No addresses available</source>
+        <translation type="unfinished">Nema dostupnih adresa</translation>
     </message>
     <message>
         <source>Not enough file descriptors available.</source>
@@ -568,8 +865,36 @@
         <translation type="unfinished">Način obreživanja (pruning) nekompatibilan je s parametrom -txindex.</translation>
     </message>
     <message>
+        <source>Pruning blockstore…</source>
+        <translation type="unfinished">Pruning blockstore-a...</translation>
+    </message>
+    <message>
         <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
         <translation type="unfinished">Smanjuje se -maxconnections sa %d na %d zbog sustavnih ograničenja.</translation>
+    </message>
+    <message>
+        <source>Replaying blocks…</source>
+        <translation type="unfinished">Premotavam blokove...</translation>
+    </message>
+    <message>
+        <source>Rescanning…</source>
+        <translation type="unfinished">Ponovno pretraživanje...</translation>
+    </message>
+    <message>
+        <source>SQLiteDatabase: Failed to execute statement to verify database: %s</source>
+        <translation type="unfinished">SQLiteDatabase: Neuspješno izvršenje izjave za verifikaciju baze podataka: %s</translation>
+    </message>
+    <message>
+        <source>SQLiteDatabase: Failed to prepare statement to verify database: %s</source>
+        <translation type="unfinished">SQLiteDatabase: Neuspješno pripremanje izjave za verifikaciju baze: %s</translation>
+    </message>
+    <message>
+        <source>SQLiteDatabase: Failed to read database verification error: %s</source>
+        <translation type="unfinished">SQLiteDatabase: Neuspješno čitanje greške verifikacije baze podataka %s</translation>
+    </message>
+    <message>
+        <source>SQLiteDatabase: Unexpected application id. Expected %u, got %u</source>
+        <translation type="unfinished">SQLiteDatabase: Neočekivani id aplikacije. Očekvano %u, pronađeno %u</translation>
     </message>
     <message>
         <source>Section [%s] is not recognized.</source>
@@ -596,8 +921,16 @@
         <translation type="unfinished">Zadana mapa blokova "%s" ne postoji.</translation>
     </message>
     <message>
+        <source>Starting network threads…</source>
+        <translation type="unfinished">Pokreću se mrežne niti...</translation>
+    </message>
+    <message>
         <source>The source code is available from %s.</source>
         <translation type="unfinished">Izvorni kod je dostupan na %s.</translation>
+    </message>
+    <message>
+        <source>The specified config file %s does not exist</source>
+        <translation type="unfinished">Navedena konfiguracijska datoteka %s ne postoji</translation>
     </message>
     <message>
         <source>The transaction amount is too small to pay the fee</source>
@@ -628,12 +961,20 @@
         <translation type="unfinished">Iznosi transakcije ne smiju biti negativni</translation>
     </message>
     <message>
+        <source>Transaction change output index out of range</source>
+        <translation type="unfinished">Indeks change outputa transakcije je izvan dometa</translation>
+    </message>
+    <message>
         <source>Transaction has too long of a mempool chain</source>
         <translation type="unfinished">Transakcija ima prevelik lanac memorijskog bazena</translation>
     </message>
     <message>
         <source>Transaction must have at least one recipient</source>
         <translation type="unfinished">Transakcija mora imati barem jednog primatelja</translation>
+    </message>
+    <message>
+        <source>Transaction needs a change address, but we can't generate it.</source>
+        <translation type="unfinished">Transakciji je potrebna change adresa, ali ju ne možemo generirati.</translation>
     </message>
     <message>
         <source>Transaction too large</source>
@@ -660,6 +1001,14 @@
         <translation type="unfinished">Ne mogu se generirati ključevi</translation>
     </message>
     <message>
+        <source>Unable to open %s for writing</source>
+        <translation type="unfinished">Ne mogu otvoriti %s za upisivanje</translation>
+    </message>
+    <message>
+        <source>Unable to parse -maxuploadtarget: '%s'</source>
+        <translation type="unfinished">Nije moguće parsirati -maxuploadtarget: '%s'</translation>
+    </message>
+    <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
         <translation type="unfinished">Ne može se pokrenuti HTTP server. Vidite debug.log za više detalja.</translation>
     </message>
@@ -680,16 +1029,24 @@
         <translation type="unfinished">Nepoznata mreža zadana kod -onlynet: '%s'</translation>
     </message>
     <message>
+        <source>Unknown new rules activated (versionbit %i)</source>
+        <translation type="unfinished"> Nepoznata nova pravila aktivirana (versionbit %i)</translation>
+    </message>
+    <message>
         <source>Unsupported logging category %s=%s.</source>
         <translation type="unfinished">Nepodržana kategorija zapisa %s=%s.</translation>
     </message>
     <message>
-        <source>Upgrading UTXO database</source>
-        <translation type="unfinished">Ažurira se UTXO baza</translation>
-    </message>
-    <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
         <translation type="unfinished">Komentar pod "Korisnički agent" (%s) sadrži nesigurne znakove.</translation>
+    </message>
+    <message>
+        <source>Verifying blocks…</source>
+        <translation type="unfinished">Provjervanje blokova...</translation>
+    </message>
+    <message>
+        <source>Verifying wallet(s)…</source>
+        <translation type="unfinished">Provjeravanje novčanika...</translation>
     </message>
     <message>
         <source>Wallet needed to be rewritten: restart %s to complete</source>
@@ -740,11 +1097,15 @@
     </message>
     <message>
         <source>Modify configuration options for %1</source>
-        <translation type="unfinished">Promijenite postavke za %1</translation>
+        <translation type="unfinished">Promijeni konfiguraciju opcija za %1</translation>
     </message>
     <message>
         <source>Create a new wallet</source>
         <translation type="unfinished">Stvorite novi novčanik</translation>
+    </message>
+    <message>
+        <source>&amp;Minimize</source>
+        <translation type="unfinished">&amp;Minimiziraj</translation>
     </message>
     <message>
         <source>Wallet:</source>
@@ -761,7 +1122,7 @@
     </message>
     <message>
         <source>Send coins to a Bitcoin address</source>
-        <translation type="unfinished">Pošaljite novac na Bitcoin adresu</translation>
+        <translation type="unfinished">Pošaljite sredstva na Bitcoin adresu</translation>
     </message>
     <message>
         <source>Backup wallet to another location</source>
@@ -777,19 +1138,63 @@
     </message>
     <message>
         <source>&amp;Receive</source>
-        <translation type="unfinished">Pri&amp;mite</translation>
+        <translation type="unfinished">&amp;Primite</translation>
+    </message>
+    <message>
+        <source>&amp;Options…</source>
+        <translation type="unfinished">&amp;Opcije</translation>
+    </message>
+    <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation type="unfinished">&amp;Šifriraj novčanik</translation>
     </message>
     <message>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation type="unfinished">Šifrirajte privatne ključeve u novčaniku</translation>
     </message>
     <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation type="unfinished">&amp;Kreiraj sigurnosnu kopiju novčanika</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation type="unfinished">&amp;Promijeni lozinku</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation type="unfinished">Potpiši &amp;poruku</translation>
+    </message>
+    <message>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation type="unfinished">Poruku potpišemo s Bitcoin adresom, kako bi dokazali vlasništvo nad tom adresom</translation>
     </message>
     <message>
+        <source>&amp;Verify message…</source>
+        <translation type="unfinished">&amp;Potvrdi poruku</translation>
+    </message>
+    <message>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation type="unfinished">Provjerite poruku da je potpisana s navedenom Bitcoin adresom</translation>
+    </message>
+    <message>
+        <source>&amp;Load PSBT from file…</source>
+        <translation type="unfinished">&amp;Učitaj PSBT iz datoteke...</translation>
+    </message>
+    <message>
+        <source>Open &amp;URI…</source>
+        <translation type="unfinished">Otvori &amp;URI adresu...</translation>
+    </message>
+    <message>
+        <source>Close Wallet…</source>
+        <translation type="unfinished">Zatvori novčanik...</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation type="unfinished">Kreiraj novčanik...</translation>
+    </message>
+    <message>
+        <source>Close All Wallets…</source>
+        <translation type="unfinished">Zatvori sve novčanike...</translation>
     </message>
     <message>
         <source>&amp;File</source>
@@ -806,6 +1211,30 @@
     <message>
         <source>Tabs toolbar</source>
         <translation type="unfinished">Traka kartica</translation>
+    </message>
+    <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation type="unfinished">Sinkronizacija zaglavlja bloka (%1%)...</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation type="unfinished">Sinkronizacija s mrežom...</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation type="unfinished">Indeksiranje blokova na disku...</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation type="unfinished">Obrađivanje blokova na disku...</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation type="unfinished">Reindeksiranje blokova na disku...</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation type="unfinished">Povezivanje sa peer-ovima...</translation>
     </message>
     <message>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
@@ -826,14 +1255,18 @@
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>Processed %n block(s) of transaction history.</numerusform>
+            <numerusform>Processed %n block(s) of transaction history.</numerusform>
+            <numerusform>Obrađeno %n blokova povijesti transakcije.</numerusform>
         </translation>
     </message>
     <message>
         <source>%1 behind</source>
         <translation type="unfinished">%1 iza</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation type="unfinished">Ažuriranje...</translation>
     </message>
     <message>
         <source>Last received block was generated %1 ago.</source>
@@ -862,6 +1295,10 @@
     <message>
         <source>Load Partially Signed Bitcoin Transaction</source>
         <translation type="unfinished">Učitaj djelomično potpisanu bitcoin transakciju</translation>
+    </message>
+    <message>
+        <source>Load PSBT from &amp;clipboard…</source>
+        <translation type="unfinished">Učitaj PSBT iz &amp;međuspremnika...</translation>
     </message>
     <message>
         <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
@@ -908,12 +1345,30 @@
         <translation type="unfinished">Prikažite pomoć programa %1 kako biste ispisali moguće opcije preko terminala</translation>
     </message>
     <message>
+        <source>&amp;Mask values</source>
+        <translation type="unfinished">&amp;Sakrij vrijednosti</translation>
+    </message>
+    <message>
+        <source>Mask the values in the Overview tab</source>
+        <translation type="unfinished">Sakrij vrijednost u tabu Pregled </translation>
+    </message>
+    <message>
         <source>default wallet</source>
         <translation type="unfinished">uobičajeni novčanik</translation>
     </message>
     <message>
         <source>No wallets available</source>
         <translation type="unfinished">Nema dostupnih novčanika</translation>
+    </message>
+    <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">Podaci novčanika</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">Ime novčanika</translation>
     </message>
     <message>
         <source>&amp;Window</source>
@@ -931,14 +1386,42 @@
         <source>%1 client</source>
         <translation type="unfinished">%1 klijent</translation>
     </message>
+    <message>
+        <source>&amp;Hide</source>
+        <translation type="unfinished">&amp;Sakrij</translation>
+    </message>
+    <message>
+        <source>S&amp;how</source>
+        <translation type="unfinished">&amp;Pokaži</translation>
+    </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n active connection(s) to Bitcoin network.</numerusform>
+            <numerusform>%n active connection(s) to Bitcoin network.</numerusform>
+            <numerusform>%n aktivnih veza s Bitcoin mrežom.</numerusform>
         </translation>
+    </message>
+    <message>
+        <source>Click for more actions.</source>
+        <extracomment>A substring of the tooltip. "More actions" are available via the context menu.</extracomment>
+        <translation type="unfinished">Klikni za više radnji.</translation>
+    </message>
+    <message>
+        <source>Show Peers tab</source>
+        <extracomment>A context menu item. The "Peers tab" is an element of the "Node window".</extracomment>
+        <translation type="unfinished">Pokaži Peers tab </translation>
+    </message>
+    <message>
+        <source>Disable network activity</source>
+        <extracomment>A context menu item.</extracomment>
+        <translation type="unfinished">Onemogući mrežnu aktivnost</translation>
+    </message>
+    <message>
+        <source>Enable network activity</source>
+        <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
+        <translation type="unfinished">Omogući mrežnu aktivnost</translation>
     </message>
     <message>
         <source>Error: %1</source>
@@ -963,7 +1446,8 @@
     <message>
         <source>Wallet: %1
 </source>
-        <translation type="unfinished">Novčanik: %1</translation>
+        <translation type="unfinished">Novčanik: %1
+</translation>
     </message>
     <message>
         <source>Type: %1
@@ -1011,7 +1495,11 @@
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation type="unfinished">Novčanik je &lt;b&gt;šifriran&lt;/b&gt; i trenutno &lt;b&gt;zaključan&lt;/b&gt;</translation>
     </message>
-    </context>
+    <message>
+        <source>Original message:</source>
+        <translation type="unfinished">Originalna poruka:</translation>
+    </message>
+</context>
 <context>
     <name>UnitDisplayStatusBarControl</name>
     <message>
@@ -1094,6 +1582,30 @@
         <translation type="unfinished">Kopirajte iznos</translation>
     </message>
     <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Kopiraj adresu</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Kopiraj &amp;oznaku</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Kopiraj &amp;iznos</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID and output index</source>
+        <translation type="unfinished">Kopiraj &amp;ID transakcije i output index</translation>
+    </message>
+    <message>
+        <source>L&amp;ock unspent</source>
+        <translation type="unfinished">&amp;Zaključaj nepotrošen input</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock unspent</source>
+        <translation type="unfinished">&amp;Otključaj nepotrošen input</translation>
+    </message>
+    <message>
         <source>Copy quantity</source>
         <translation type="unfinished">Kopirajte iznos</translation>
     </message>
@@ -1158,6 +1670,11 @@
         <translation type="unfinished">Stvorite novčanik</translation>
     </message>
     <message>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the create wallet progress window which indicates to the user which wallet is currently being created.</extracomment>
+        <translation type="unfinished">Kreiranje novčanika &lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+    <message>
         <source>Create wallet failed</source>
         <translation type="unfinished">Neuspješno stvaranje novčanika</translation>
     </message>
@@ -1165,7 +1682,24 @@
         <source>Create wallet warning</source>
         <translation type="unfinished">Upozorenje kod stvaranja novčanika</translation>
     </message>
+    <message>
+        <source>Can't list signers</source>
+        <translation type="unfinished">Nije moguće izlistati potpisnike</translation>
+    </message>
     </context>
+<context>
+    <name>LoadWalletsActivity</name>
+    <message>
+        <source>Load Wallets</source>
+        <extracomment>Title of progress window which is displayed when wallets are being loaded.</extracomment>
+        <translation type="unfinished">Učitaj novčanike</translation>
+    </message>
+    <message>
+        <source>Loading wallets…</source>
+        <extracomment>Descriptive text of the load wallets progress window which indicates to the user that wallets are currently being loaded.</extracomment>
+        <translation type="unfinished">Učitavanje novčanika...</translation>
+    </message>
+</context>
 <context>
     <name>OpenWalletActivity</name>
     <message>
@@ -1185,7 +1719,12 @@
         <extracomment>Title of window indicating the progress of opening of a wallet.</extracomment>
         <translation type="unfinished">Otvorite novčanik</translation>
     </message>
-    </context>
+    <message>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the open wallet progress window which indicates to the user which wallet is currently being opened.</extracomment>
+        <translation type="unfinished">Otvaranje novčanika &lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+</context>
 <context>
     <name>WalletController</name>
     <message>
@@ -1198,13 +1737,17 @@
     </message>
     <message>
         <source>Closing the wallet for too long can result in having to resync the entire chain if pruning is enabled.</source>
-        <translation type="unfinished">Držanje novčanik zatvorenim predugo može rezultirati ponovnom sinkronizacijom cijelog lanca ako je obrezivanje uključeno.</translation>
+        <translation type="unfinished">Držanje novčanik zatvorenim predugo može rezultirati ponovnom sinkronizacijom cijelog lanca ako je uključen pruning (odbacivanje dijela podataka).</translation>
     </message>
     <message>
         <source>Close all wallets</source>
         <translation type="unfinished">Zatvori sve novčanike</translation>
     </message>
-    </context>
+    <message>
+        <source>Are you sure you wish to close all wallets?</source>
+        <translation type="unfinished">Jeste li sigurni da želite zatvoriti sve novčanike?</translation>
+    </message>
+</context>
 <context>
     <name>CreateWalletDialog</name>
     <message>
@@ -1228,6 +1771,10 @@
         <translation type="unfinished">Šifrirajte novčanik</translation>
     </message>
     <message>
+        <source>Advanced Options</source>
+        <translation type="unfinished">Napredne opcije</translation>
+    </message>
+    <message>
         <source>Disable private keys for this wallet. Wallets with private keys disabled will have no private keys and cannot have an HD seed or imported private keys. This is ideal for watch-only wallets.</source>
         <translation type="unfinished">Isključite privatne ključeve za ovaj novčanik. Novčanici gdje su privatni ključevi isključeni neće sadržati privatne ključeve te ne mogu imati HD sjeme ili uvezene privatne ključeve. Ova postavka je idealna za novčanike koje su isključivo za promatranje.</translation>
     </message>
@@ -1244,10 +1791,35 @@
         <translation type="unfinished">Stvorite prazni novčanik</translation>
     </message>
     <message>
+        <source>Use descriptors for scriptPubKey management</source>
+        <translation type="unfinished">Koristi deskriptore za upravljanje scriptPubKey-a</translation>
+    </message>
+    <message>
+        <source>Descriptor Wallet</source>
+        <translation type="unfinished">Deskriptor novčanik</translation>
+    </message>
+    <message>
+        <source>Use an external signing device such as a hardware wallet. Configure the external signer script in wallet preferences first.</source>
+        <translation type="unfinished">Koristi vanjski potpisni uređaj kao što je hardverski novčanik.  Prije korištenja konfiguriraj vanjski potpisni skript u postavkama novčanika.</translation>
+    </message>
+    <message>
+        <source>External signer</source>
+        <translation type="unfinished">Vanjski potpisnik</translation>
+    </message>
+    <message>
         <source>Create</source>
         <translation type="unfinished">Stvorite</translation>
     </message>
-    </context>
+    <message>
+        <source>Compiled without sqlite support (required for descriptor wallets)</source>
+        <translation type="unfinished">Kompajlirano bez sqlite mogućnosti (potrebno za deskriptor novčanike)</translation>
+    </message>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Kompajlirano bez mogućnosti vanjskog potpisivanje (potrebno za vanjsko potpisivanje)</translation>
+    </message>
+</context>
 <context>
     <name>EditAddressDialog</name>
     <message>
@@ -1307,7 +1879,7 @@
     <name>FreespaceChecker</name>
     <message>
         <source>A new data directory will be created.</source>
-        <translation type="unfinished">Bit će stvorena nova podatkovna mapa.</translation>
+        <translation type="unfinished">Biti će stvorena nova podatkovna mapa.</translation>
     </message>
     <message>
         <source>name</source>
@@ -1328,6 +1900,30 @@
 </context>
 <context>
     <name>Intro</name>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform>(od potrebnog prostora od %n GB)</numerusform>
+            <numerusform>(od potrebnog prostora od %n GB)</numerusform>
+            <numerusform>(od potrebnog %n GB)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform>(potreban je %n GB za cijeli lanac)</numerusform>
+            <numerusform>(potrebna su %n GB-a za cijeli lanac)</numerusform>
+            <numerusform>(potrebno je %n GB-a za cijeli lanac)</numerusform>
+        </translation>
+    </message>
     <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
         <translation type="unfinished">Bit će spremljeno barem %1 GB podataka u ovoj mapi te će se povećati tijekom vremena.</translation>
@@ -1340,9 +1936,9 @@
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>(sufficient to restore backups %n day(s) old)</numerusform>
+            <numerusform>(sufficient to restore backups %n day(s) old)</numerusform>
+            <numerusform>(dovoljno za vraćanje sigurnosne kopije stare %n dan(a))</numerusform>
         </translation>
     </message>
     <message>
@@ -1374,8 +1970,8 @@
         <translation type="unfinished">Kako je ovo prvi put da je ova aplikacija pokrenuta, možete izabrati gdje će %1 spremati svoje podatke.</translation>
     </message>
     <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation type="unfinished">Kada kliknete OK, %1 počet će preuzimati i procesirati cijeli lanac blokova (%2GB) počevši s najranijim transakcijama u %3 kad je %4 prvi put pokrenut.</translation>
+        <source>Limit block chain storage to</source>
+        <translation type="unfinished">Ograniči pohranu u blockchain na:</translation>
     </message>
     <message>
         <source>Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</source>
@@ -1387,7 +1983,7 @@
     </message>
     <message>
         <source>If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</source>
-        <translation type="unfinished">Ako odlučite ograničiti spremanje lanca blokova pomoću pruninga (obrezivanja), treba preuzeti i procesirati povijesne podatke. Bit će obrisani naknadno kako bi se smanjila količina zauzetog prostora na disku.</translation>
+        <translation type="unfinished">Ako odlučite ograničiti spremanje lanca blokova pomoću pruninga, treba preuzeti i procesirati povijesne podatke. Bit će obrisani naknadno kako bi se smanjila količina zauzetog prostora na disku.</translation>
     </message>
     <message>
         <source>Use the default data directory</source>
@@ -1416,6 +2012,10 @@
 <context>
     <name>ShutdownWindow</name>
     <message>
+        <source>%1 is shutting down…</source>
+        <translation type="unfinished">%1 do zatvaranja...</translation>
+    </message>
+    <message>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished">Ne ugasite računalo dok ovaj prozor ne nestane.</translation>
     </message>
@@ -1439,6 +2039,14 @@
         <translation type="unfinished">Broj preostalih blokova</translation>
     </message>
     <message>
+        <source>Unknown…</source>
+        <translation type="unfinished">Nepoznato...</translation>
+    </message>
+    <message>
+        <source>calculating…</source>
+        <translation type="unfinished">računam...</translation>
+    </message>
+    <message>
         <source>Last block time</source>
         <translation type="unfinished">Posljednje vrijeme bloka</translation>
     </message>
@@ -1458,6 +2066,10 @@
         <source>Hide</source>
         <translation type="unfinished">Sakrijte</translation>
     </message>
+    <message>
+        <source>Unknown. Syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">Nepoznato. Sinkroniziranje zaglavlja blokova (%1, %2%)...</translation>
+    </message>
     </context>
 <context>
     <name>OpenURIDialog</name>
@@ -1475,7 +2087,7 @@
     <name>OptionsDialog</name>
     <message>
         <source>Options</source>
-        <translation type="unfinished">Postavke</translation>
+        <translation type="unfinished">Opcije</translation>
     </message>
     <message>
         <source>&amp;Main</source>
@@ -1488,6 +2100,10 @@
     <message>
         <source>&amp;Start %1 on system login</source>
         <translation type="unfinished">&amp;Pokrenite %1 kod prijave u sustav</translation>
+    </message>
+    <message>
+        <source>Enabling pruning significantly reduces the disk space required to store transactions. All blocks are still fully validated. Reverting this setting requires re-downloading the entire blockchain.</source>
+        <translation type="unfinished">Omogućavanje pruninga smanjuje prostor na disku potreban za pohranu transakcija. Svi blokovi su još uvijek potpuno potvrđeni. Poništavanje ove postavke uzrokuje ponovno skidanje cijelog blockchaina.</translation>
     </message>
     <message>
         <source>Size of &amp;database cache</source>
@@ -1519,11 +2135,11 @@
     </message>
     <message>
         <source>Reset all client options to default.</source>
-        <translation type="unfinished">Nastavi sve postavke programa na početne vrijednosti.</translation>
+        <translation type="unfinished">Resetiraj sve opcije programa na početne vrijednosti.</translation>
     </message>
     <message>
         <source>&amp;Reset Options</source>
-        <translation type="unfinished">Po&amp;nastavi postavke</translation>
+        <translation type="unfinished">&amp;Resetiraj opcije</translation>
     </message>
     <message>
         <source>&amp;Network</source>
@@ -1538,12 +2154,42 @@
         <translation type="unfinished">Vraćanje na prijašnje stanje zahtijeva ponovo preuzimanje cijelog lanca blokova.</translation>
     </message>
     <message>
+        <source>Maximum database cache size. A larger cache can contribute to faster sync, after which the benefit is less pronounced for most use cases. Lowering the cache size will reduce memory usage. Unused mempool memory is shared for this cache.</source>
+        <extracomment>Tooltip text for Options window setting that sets the size of the database cache. Explains the corresponding effects of increasing/decreasing this value.</extracomment>
+        <translation type="unfinished">Maksimalna veličina cachea baza podataka. Veći cache može doprinijeti bržoj sinkronizaciji, nakon koje je korisnost manje izražena za većinu slučajeva. Smanjenje cache veličine će smanjiti korištenje memorije. Nekorištena mempool memorija se dijeli za ovaj cache. </translation>
+    </message>
+    <message>
+        <source>Set the number of script verification threads. Negative values correspond to the number of cores you want to leave free to the system.</source>
+        <extracomment>Tooltip text for Options window setting that sets the number of script verification threads. Explains that negative values mean to leave these many cores free to the system.</extracomment>
+        <translation type="unfinished">Postavi broj skript verifikacijskih niti. Negativne vrijednosti odgovaraju broju jezgri koje trebate ostaviti slobodnima za sustav.</translation>
+    </message>
+    <message>
         <source>(0 = auto, &lt;0 = leave that many cores free)</source>
         <translation type="unfinished">(0 = automatski odredite, &lt;0 = ostavite slobodno upravo toliko jezgri)</translation>
     </message>
     <message>
+        <source>This allows you or a third party tool to communicate with the node through command-line and JSON-RPC commands.</source>
+        <extracomment>Tooltip text for Options window setting that enables the RPC server.</extracomment>
+        <translation type="unfinished">Ovo omogućava vama ili vanjskom alatu komunikaciju s čvorom kroz command-line i JSON-RPC komande.</translation>
+    </message>
+    <message>
+        <source>Enable R&amp;PC server</source>
+        <extracomment>An Options window setting to enable the RPC server.</extracomment>
+        <translation type="unfinished">Uključi &amp;RPC server</translation>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished">&amp;Novčanik</translation>
+    </message>
+    <message>
+        <source>Whether to set subtract fee from amount as default or not.</source>
+        <extracomment>Tooltip text for Options window setting that sets subtracting the fee from a sending amount as default.</extracomment>
+        <translation type="unfinished">Za postavljanje oduzimanja naknade od iznosa kao zadano ili ne.</translation>
+    </message>
+    <message>
+        <source>Subtract &amp;fee from amount by default</source>
+        <extracomment>An Options window setting to set subtracting the fee from a sending amount as default.</extracomment>
+        <translation type="unfinished">Oduzmi &amp;naknadu od iznosa kao zadano</translation>
     </message>
     <message>
         <source>Expert</source>
@@ -1562,11 +2208,41 @@
         <translation type="unfinished">&amp;Trošenje nepotvrđenih vraćenih iznosa</translation>
     </message>
     <message>
+        <source>Enable &amp;PSBT controls</source>
+        <extracomment>An options window setting to enable PSBT controls.</extracomment>
+        <translation type="unfinished">Uključi  &amp;PBST opcije za upravljanje</translation>
+    </message>
+    <message>
+        <source>Whether to show PSBT controls.</source>
+        <extracomment>Tooltip text for options window setting that enables PSBT controls.</extracomment>
+        <translation type="unfinished">Za prikazivanje PSBT opcija za upravaljanje. </translation>
+    </message>
+    <message>
+        <source>External Signer (e.g. hardware wallet)</source>
+        <translation type="unfinished">Vanjski potpisnik (npr. hardverski novčanik)</translation>
+    </message>
+    <message>
+        <source>&amp;External signer script path</source>
+        <translation type="unfinished">&amp;Put za vanjsku skriptu potpisnika</translation>
+    </message>
+    <message>
+        <source>Full path to a Bitcoin Core compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</source>
+        <translation type="unfinished">Cijeli put do Bitcoin Core kompatibilnog skripta (npr. C:\Downloads\hwi.exe ili /Users/you/Downloads/hwi.py). Upozerenje: malware može ukrasti vaša sredstva!</translation>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation type="unfinished">Automatski otvori port Bitcoin klijenta na ruteru. To radi samo ako ruter podržava UPnP i ako je omogućen.</translation>
     </message>
     <message>
         <source>Map port using &amp;UPnP</source>
+        <translation type="unfinished">Mapiraj port koristeći &amp;UPnP</translation>
+    </message>
+    <message>
+        <source>Automatically open the Bitcoin client port on the router. This only works when your router supports NAT-PMP and it is enabled. The external port could be random.</source>
+        <translation type="unfinished">Automatski otvori port Bitcoin klijenta na ruteru. Ovo radi samo ako ruter podržava UPnP i ako je omogućen. Vanjski port može biti nasumičan.</translation>
+    </message>
+    <message>
+        <source>Map port using NA&amp;T-PMP</source>
         <translation type="unfinished">Mapiraj port koristeći &amp;UPnP</translation>
     </message>
     <message>
@@ -1614,6 +2290,14 @@
         <translation type="unfinished">&amp;Prozor</translation>
     </message>
     <message>
+        <source>Show the icon in the system tray.</source>
+        <translation type="unfinished">Pokaži ikonu sa sustavne trake.</translation>
+    </message>
+    <message>
+        <source>&amp;Show tray icon</source>
+        <translation type="unfinished">&amp;Pokaži ikonu</translation>
+    </message>
+    <message>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation type="unfinished">Prikaži samo ikonu u sistemskoj traci nakon minimiziranja prozora</translation>
     </message>
@@ -1646,12 +2330,36 @@
         <translation type="unfinished">Izaberite željeni najmanji dio bitcoina koji će biti prikazan u sučelju i koji će se koristiti za plaćanje.</translation>
     </message>
     <message>
+        <source>Third-party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</source>
+        <translation type="unfinished">Vanjski URL-ovi transakcije (npr. preglednik blokova) koji se javljaju u kartici transakcija kao elementi kontekstnog izbornika. %s u URL-u zamijenjen je hashom transakcije. Višestruki URL-ovi su odvojeni vertikalnom crtom |.</translation>
+    </message>
+    <message>
+        <source>&amp;Third-party transaction URLs</source>
+        <translation type="unfinished">&amp;Vanjski URL-ovi transakcije</translation>
+    </message>
+    <message>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished">Ovisi želite li prikazati mogućnosti kontroliranja inputa ili ne.</translation>
     </message>
     <message>
-        <source>Options set in this dialog are overridden by the command line or in the configuration file:</source>
-        <translation type="unfinished">Opcije postavljene u ovom dijalogu nadglašene su naredbenom linijom ili konfiguracijskom datotekom:</translation>
+        <source>Connect to the Bitcoin network through a separate SOCKS5 proxy for Tor onion services.</source>
+        <translation type="unfinished">Spojite se na Bitcoin mrežu kroz zaseban SOCKS5 proxy za povezivanje na Tor onion usluge.</translation>
+    </message>
+    <message>
+        <source>Use separate SOCKS&amp;5 proxy to reach peers via Tor onion services:</source>
+        <translation type="unfinished">Koristite zaseban SOCKS&amp;5 proxy kako biste dohvatili klijente preko Tora:</translation>
+    </message>
+    <message>
+        <source>Monospaced font in the Overview tab:</source>
+        <translation type="unfinished">Font fiksne širine u tabu Pregled:</translation>
+    </message>
+    <message>
+        <source>embedded "%1"</source>
+        <translation type="unfinished">ugrađen "%1"</translation>
+    </message>
+    <message>
+        <source>closest matching "%1"</source>
+        <translation type="unfinished">najbliže poklapanje "%1"</translation>
     </message>
     <message>
         <source>&amp;OK</source>
@@ -1660,6 +2368,11 @@
     <message>
         <source>&amp;Cancel</source>
         <translation type="unfinished">&amp;Odustani</translation>
+    </message>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Kompajlirano bez mogućnosti vanjskog potpisivanje (potrebno za vanjsko potpisivanje)</translation>
     </message>
     <message>
         <source>default</source>
@@ -1671,25 +2384,32 @@
     </message>
     <message>
         <source>Confirm options reset</source>
+        <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
         <translation type="unfinished">Potvrdite resetiranje opcija</translation>
     </message>
     <message>
         <source>Client restart required to activate changes.</source>
+        <extracomment>Text explaining that the settings changed will not come into effect until the client is restarted.</extracomment>
         <translation type="unfinished">Potrebno je ponovno pokretanje klijenta kako bi se promjene aktivirale.</translation>
     </message>
     <message>
         <source>Client will be shut down. Do you want to proceed?</source>
+        <extracomment>Text asking the user to confirm if they would like to proceed with a client shutdown.</extracomment>
         <translation type="unfinished">Zatvorit će se klijent. Želite li nastaviti?</translation>
     </message>
     <message>
         <source>Configuration options</source>
         <extracomment>Window title text of pop-up box that allows opening up of configuration file.</extracomment>
-        <translation type="unfinished">Konfiguracijske postavke</translation>
+        <translation type="unfinished">Konfiguracijske opcije</translation>
     </message>
     <message>
         <source>The configuration file is used to specify advanced user options which override GUI settings. Additionally, any command-line options will override this configuration file.</source>
         <extracomment>Explanatory text about the priority order of instructions considered by client. The order from high to low being: command-line, configuration file, GUI settings.</extracomment>
         <translation type="unfinished">Ova konfiguracijska datoteka je korištena za specificiranje napredne korisničke opcije koje će poništiti postavke GUI-a. Također će bilo koje opcije navedene preko terminala poništiti ovu konfiguracijsku datoteku.</translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation type="unfinished">Nastavi</translation>
     </message>
     <message>
         <source>Cancel</source>
@@ -1786,12 +2506,101 @@
         <source>Current total balance in watch-only addresses</source>
         <translation type="unfinished">Trenutno ukupno stanje na isključivo promatranim adresama</translation>
     </message>
-    </context>
+    <message>
+        <source>Privacy mode activated for the Overview tab. To unmask the values, uncheck Settings-&gt;Mask values.</source>
+        <translation type="unfinished">Privatni način aktiviran za tab Pregled. Za prikaz vrijednosti, odznači Postavke -&gt; Sakrij vrijednosti.</translation>
+    </message>
+</context>
 <context>
     <name>PSBTOperationsDialog</name>
     <message>
         <source>Dialog</source>
         <translation type="unfinished">Dijalog</translation>
+    </message>
+    <message>
+        <source>Sign Tx</source>
+        <translation type="unfinished">Potpiši Tx</translation>
+    </message>
+    <message>
+        <source>Broadcast Tx</source>
+        <translation type="unfinished">Objavi Tx</translation>
+    </message>
+    <message>
+        <source>Copy to Clipboard</source>
+        <translation type="unfinished">Kopiraj u međuspremnik</translation>
+    </message>
+    <message>
+        <source>Save…</source>
+        <translation type="unfinished">Spremi...</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation type="unfinished">Zatvori</translation>
+    </message>
+    <message>
+        <source>Failed to load transaction: %1</source>
+        <translation type="unfinished">Neuspješno dohvaćanje transakcije: %1</translation>
+    </message>
+    <message>
+        <source>Failed to sign transaction: %1</source>
+        <translation type="unfinished">Neuspješno potpisivanje transakcije: %1</translation>
+    </message>
+    <message>
+        <source>Cannot sign inputs while wallet is locked.</source>
+        <translation type="unfinished">Nije moguće potpisati inpute dok je novčanik zaključan.</translation>
+    </message>
+    <message>
+        <source>Could not sign any more inputs.</source>
+        <translation type="unfinished">Nije bilo moguće potpisati više inputa. </translation>
+    </message>
+    <message>
+        <source>Signed %1 inputs, but more signatures are still required.</source>
+        <translation type="unfinished">Potpisano %1 inputa, ali potrebno je još potpisa. </translation>
+    </message>
+    <message>
+        <source>Signed transaction successfully. Transaction is ready to broadcast.</source>
+        <translation type="unfinished">Transakcija uspješno potpisana. Transakcija je spremna za objavu.</translation>
+    </message>
+    <message>
+        <source>Unknown error processing transaction.</source>
+        <translation type="unfinished">Nepoznata greška pri obradi transakcije.</translation>
+    </message>
+    <message>
+        <source>Transaction broadcast successfully! Transaction ID: %1</source>
+        <translation type="unfinished">Uspješna objava transakcije! ID transakcije: %1</translation>
+    </message>
+    <message>
+        <source>Transaction broadcast failed: %1</source>
+        <translation type="unfinished">Neuspješna objava transakcije: %1</translation>
+    </message>
+    <message>
+        <source>PSBT copied to clipboard.</source>
+        <translation type="unfinished">PBST kopiran u meduspremnik.</translation>
+    </message>
+    <message>
+        <source>Save Transaction Data</source>
+        <translation type="unfinished">Spremi podatke transakcije</translation>
+    </message>
+    <message>
+        <source>Partially Signed Transaction (Binary)</source>
+        <extracomment>Expanded name of the binary PSBT file format. See: BIP 174.</extracomment>
+        <translation type="unfinished">Djelomično potpisana transakcija (binarno)</translation>
+    </message>
+    <message>
+        <source>PSBT saved to disk.</source>
+        <translation type="unfinished">PBST spremljen na disk.</translation>
+    </message>
+    <message>
+        <source> * Sends %1 to %2</source>
+        <translation type="unfinished">* Šalje %1 %2</translation>
+    </message>
+    <message>
+        <source>Unable to calculate transaction fee or total transaction amount.</source>
+        <translation type="unfinished">Ne mogu izračunati naknadu za transakciju niti totalni iznos transakcije.</translation>
+    </message>
+    <message>
+        <source>Pays transaction fee: </source>
+        <translation type="unfinished">Plaća naknadu za transakciju:</translation>
     </message>
     <message>
         <source>Total Amount</source>
@@ -1801,7 +2610,39 @@
         <source>or</source>
         <translation type="unfinished">ili</translation>
     </message>
-    </context>
+    <message>
+        <source>Transaction has %1 unsigned inputs.</source>
+        <translation type="unfinished">Transakcija ima %1 nepotpisanih inputa.</translation>
+    </message>
+    <message>
+        <source>Transaction is missing some information about inputs.</source>
+        <translation type="unfinished">Transakciji nedostaje informacija o inputima.</translation>
+    </message>
+    <message>
+        <source>Transaction still needs signature(s).</source>
+        <translation type="unfinished">Transakcija još uvijek treba potpis(e).</translation>
+    </message>
+    <message>
+        <source>(But no wallet is loaded.)</source>
+        <translation type="unfinished">(Ali nijedan novčanik nije učitan.)</translation>
+    </message>
+    <message>
+        <source>(But this wallet cannot sign transactions.)</source>
+        <translation type="unfinished">(Ali ovaj novčanik ne može potpisati transakcije.)</translation>
+    </message>
+    <message>
+        <source>(But this wallet does not have the right keys.)</source>
+        <translation type="unfinished">(Ali ovaj novčanik nema odgovarajuće ključeve.)</translation>
+    </message>
+    <message>
+        <source>Transaction is fully signed and ready for broadcast.</source>
+        <translation type="unfinished">Transakcija je cjelovito potpisana i spremna za objavu.</translation>
+    </message>
+    <message>
+        <source>Transaction status is unknown.</source>
+        <translation type="unfinished">Status transakcije je nepoznat.</translation>
+    </message>
+</context>
 <context>
     <name>PaymentServer</name>
     <message>
@@ -1819,6 +2660,14 @@
     <message>
         <source>'bitcoin://' is not a valid URI. Use 'bitcoin:' instead.</source>
         <translation type="unfinished">'bitcoin://' nije ispravan URI. Koristite 'bitcoin:' umjesto toga.</translation>
+    </message>
+    <message>
+        <source>Cannot process payment request because BIP70 is not supported.
+Due to widespread security flaws in BIP70 it's strongly recommended that any merchant instructions to switch wallets be ignored.
+If you are receiving this error you should request the merchant provide a BIP21 compatible URI.</source>
+        <translation type="unfinished">Nemoguće obraditi zahtjev za plaćanje zato što BIP70 nije podržan.
+S obzirom na široko rasprostranjene sigurnosne nedostatke u BIP70, preporučljivo je da zanemarite preporuke trgovca u  vezi promjene novčanika.
+Ako imate ovu grešku, od trgovca zatražite URI koji je kompatibilan sa BIP21.</translation>
     </message>
     <message>
         <source>URI cannot be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
@@ -1880,6 +2729,10 @@
 <context>
     <name>QRImageWidget</name>
     <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">&amp;Spremi sliku...</translation>
+    </message>
+    <message>
         <source>&amp;Copy Image</source>
         <translation type="unfinished">&amp;Kopirajte sliku</translation>
     </message>
@@ -1899,7 +2752,12 @@
         <source>Save QR Code</source>
         <translation type="unfinished">Spremi QR kod</translation>
     </message>
-    </context>
+    <message>
+        <source>PNG Image</source>
+        <extracomment>Expanded name of the PNG file format. See: https://en.wikipedia.org/wiki/Portable_Network_Graphics.</extracomment>
+        <translation type="unfinished">PNG slika</translation>
+    </message>
+</context>
 <context>
     <name>RPCConsole</name>
     <message>
@@ -2007,8 +2865,36 @@
         <translation type="unfinished">Broj sinkronizranih blokova</translation>
     </message>
     <message>
+        <source>Last Transaction</source>
+        <translation type="unfinished">Zadnja transakcija</translation>
+    </message>
+    <message>
+        <source>The mapped Autonomous System used for diversifying peer selection.</source>
+        <translation type="unfinished">Mapirani Autonomni sustav koji se koristi za diverzifikaciju odabira peer-ova.</translation>
+    </message>
+    <message>
         <source>Mapped AS</source>
         <translation type="unfinished">Mapirano kao</translation>
+    </message>
+    <message>
+        <source>Whether we relay addresses to this peer.</source>
+        <extracomment>Tooltip text for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
+        <translation type="unfinished">Prenosimo li adrese ovom peer-u.</translation>
+    </message>
+    <message>
+        <source>Address Relay</source>
+        <extracomment>Text title for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
+        <translation type="unfinished">Prijenos adresa</translation>
+    </message>
+    <message>
+        <source>Addresses Processed</source>
+        <extracomment>Text title for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
+        <translation type="unfinished">Obrađene adrese</translation>
+    </message>
+    <message>
+        <source>Addresses Rate-Limited</source>
+        <extracomment>Text title for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
+        <translation type="unfinished">Adrese ograničene brzinom</translation>
     </message>
     <message>
         <source>User Agent</source>
@@ -2017,6 +2903,10 @@
     <message>
         <source>Node window</source>
         <translation type="unfinished">Konzola za čvor</translation>
+    </message>
+    <message>
+        <source>Current block height</source>
+        <translation type="unfinished">Trenutna visina bloka</translation>
     </message>
     <message>
         <source>Open the %1 debug log file from the current data directory. This can take a few seconds for large log files.</source>
@@ -2031,12 +2921,57 @@
         <translation type="unfinished">Povećajte veličinu fonta</translation>
     </message>
     <message>
+        <source>Permissions</source>
+        <translation type="unfinished">Dopuštenja</translation>
+    </message>
+    <message>
+        <source>The direction and type of peer connection: %1</source>
+        <translation type="unfinished">Smjer i tip peer konekcije: %1</translation>
+    </message>
+    <message>
+        <source>Direction/Type</source>
+        <translation type="unfinished">Smjer/tip</translation>
+    </message>
+    <message>
+        <source>The network protocol this peer is connected through: IPv4, IPv6, Onion, I2P, or CJDNS.</source>
+        <translation type="unfinished">Mrežni protokoli kroz koje je spojen ovaj peer: IPv4, IPv6, Onion, I2P, ili CJDNS.</translation>
+    </message>
+    <message>
         <source>Services</source>
         <translation type="unfinished">Usluge</translation>
     </message>
     <message>
+        <source>Whether the peer requested us to relay transactions.</source>
+        <translation type="unfinished">Je li peer od nas zatražio prijenos transakcija.</translation>
+    </message>
+    <message>
+        <source>Wants Tx Relay</source>
+        <translation type="unfinished">Želi Tx prijenos</translation>
+    </message>
+    <message>
+        <source>High bandwidth BIP152 compact block relay: %1</source>
+        <translation type="unfinished">Visoka razina BIP152 kompaktnog blok prijenosa: %1</translation>
+    </message>
+    <message>
+        <source>High Bandwidth</source>
+        <translation type="unfinished">Visoka razina prijenosa podataka</translation>
+    </message>
+    <message>
         <source>Connection Time</source>
         <translation type="unfinished">Trajanje veze</translation>
+    </message>
+    <message>
+        <source>Elapsed time since a novel block passing initial validity checks was received from this peer.</source>
+        <translation type="unfinished">Vrijeme prošlo od kada je ovaj peer primio novi bloka koji je prošao osnovne provjere validnosti.</translation>
+    </message>
+    <message>
+        <source>Last Block</source>
+        <translation type="unfinished">Zadnji blok</translation>
+    </message>
+    <message>
+        <source>Elapsed time since a novel transaction accepted into our mempool was received from this peer.</source>
+        <extracomment>Tooltip text for the Last Transaction field in the peer details area.</extracomment>
+        <translation type="unfinished">Vrijeme prošlo od kada je ovaj peer primio novu transakciju koja je prihvaćena u naš mempool.</translation>
     </message>
     <message>
         <source>Last Send</source>
@@ -2103,6 +3038,53 @@
         <translation type="unfinished">Izlazne:</translation>
     </message>
     <message>
+        <source>Inbound: initiated by peer</source>
+        <extracomment>Explanatory text for an inbound peer connection.</extracomment>
+        <translation type="unfinished">Ulazna: pokrenuo peer</translation>
+    </message>
+    <message>
+        <source>Outbound Full Relay: default</source>
+        <extracomment>Explanatory text for an outbound peer connection that relays all network information. This is the default behavior for outbound connections.</extracomment>
+        <translation type="unfinished">Izlazni potpuni prijenos: zadano</translation>
+    </message>
+    <message>
+        <source>Outbound Block Relay: does not relay transactions or addresses</source>
+        <extracomment>Explanatory text for an outbound peer connection that relays network information about blocks and not transactions or addresses.</extracomment>
+        <translation type="unfinished">Izlazni blok prijenos: ne prenosi transakcije ili adrese</translation>
+    </message>
+    <message>
+        <source>Outbound Manual: added using RPC %1 or %2/%3 configuration options</source>
+        <extracomment>Explanatory text for an outbound peer connection that was established manually through one of several methods. The numbered arguments are stand-ins for the methods available to establish manual connections.</extracomment>
+        <translation type="unfinished">Priručnik za izlazeće (?): dodano koristeći RPC %1 ili %2/%3 konfiguracijske opcije</translation>
+    </message>
+    <message>
+        <source>Outbound Feeler: short-lived, for testing addresses</source>
+        <extracomment>Explanatory text for a short-lived outbound peer connection that is used to test the aliveness of known addresses.</extracomment>
+        <translation type="unfinished">Izlazni ispipavač: kratkotrajan, za testiranje adresa</translation>
+    </message>
+    <message>
+        <source>Outbound Address Fetch: short-lived, for soliciting addresses</source>
+        <extracomment>Explanatory text for a short-lived outbound peer connection that is used to request addresses from a peer.</extracomment>
+        <translation type="unfinished">Dohvaćanje izlaznih adresa: kratkotrajno, za traženje adresa</translation>
+    </message>
+    <message>
+        <source>we selected the peer for high bandwidth relay</source>
+        <translation type="unfinished">odabrali smo peera za brzopodatkovni prijenos</translation>
+    </message>
+    <message>
+        <source>the peer selected us for high bandwidth relay</source>
+        <translation type="unfinished">peer odabran za brzopodatkovni prijenos</translation>
+    </message>
+    <message>
+        <source>no high bandwidth relay selected</source>
+        <translation type="unfinished">brzopodatkovni prijenos nije odabran</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <extracomment>Context menu action to copy the address of a peer.</extracomment>
+        <translation type="unfinished">&amp;Kopiraj adresu</translation>
+    </message>
+    <message>
         <source>&amp;Disconnect</source>
         <translation type="unfinished">&amp;Odspojite</translation>
     </message>
@@ -2111,12 +3093,21 @@
         <translation type="unfinished">1 &amp;sat</translation>
     </message>
     <message>
+        <source>1 d&amp;ay</source>
+        <translation type="unfinished">1 d&amp;an</translation>
+    </message>
+    <message>
         <source>1 &amp;week</source>
         <translation type="unfinished">1 &amp;tjedan</translation>
     </message>
     <message>
         <source>1 &amp;year</source>
         <translation type="unfinished">1 &amp;godinu</translation>
+    </message>
+    <message>
+        <source>&amp;Copy IP/Netmask</source>
+        <extracomment>Context menu action to copy the IP/Netmask of a banned peer. IP/Netmask is the combination of a peer's IP address and its Netmask. For IP address, see: https://en.wikipedia.org/wiki/IP_address.</extracomment>
+        <translation type="unfinished">&amp;Kopiraj IP/Netmask</translation>
     </message>
     <message>
         <source>&amp;Unban</source>
@@ -2133,6 +3124,28 @@
     <message>
         <source>Executing command using "%1" wallet</source>
         <translation type="unfinished">Izvršava se naredba koristeći novčanik "%1"</translation>
+    </message>
+    <message>
+        <source>Welcome to the %1 RPC console.
+Use up and down arrows to navigate history, and %2 to clear screen.
+Use %3 and %4 to increase or decrease the font size.
+Type %5 for an overview of available commands.
+For more information on using this console, type %6.
+
+%7WARNING: Scammers have been active, telling users to type commands here, stealing their wallet contents. Do not use this console without fully understanding the ramifications of a command.%8</source>
+        <extracomment>RPC console welcome message. Placeholders %7 and %8 are style tags for the warning content, and they are not space separated from the rest of the text intentionally.</extracomment>
+        <translation type="unfinished">Dobrodošli u %1 RPC konzolu.
+Koristite strelice za gore i dolje kako biste navigirali kroz povijest, i %2 za micanje svega sa zaslona.
+Koristite %3 i %4 za smanjivanje i povećavanje veličine fonta.
+Utipkajte %5 za pregled svih dosrupnih komandi.
+Za više informacija o korištenju ove konzile, utipkajte %6.
+
+%7UPOZORENJE: Prevaranti su uvijek aktivni te kradu sadržaj novčanika korisnika tako što im daju upute koje komande upisati. Nemojte koristiti ovu konzolu bez potpunog razumijevanja posljedica upisivanja komande.%8</translation>
+    </message>
+    <message>
+        <source>Executing…</source>
+        <extracomment>A console message indicating an entered command is currently being executed.</extracomment>
+        <translation type="unfinished">Izvršavam...</translation>
     </message>
     <message>
         <source>via %1</source>
@@ -2157,6 +3170,10 @@
     <message>
         <source>Ban for</source>
         <translation type="unfinished">Zabranite za</translation>
+    </message>
+    <message>
+        <source>Never</source>
+        <translation type="unfinished">Nikada</translation>
     </message>
     <message>
         <source>Unknown</source>
@@ -2192,6 +3209,10 @@
     <message>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished">Opcionalan iznos koji možete zahtijevati. Ostavite ovo prazno ili unesite nulu ako ne želite zahtijevati specifičan iznos.</translation>
+    </message>
+    <message>
+        <source>An optional label to associate with the new receiving address (used by you to identify an invoice).  It is also attached to the payment request.</source>
+        <translation type="unfinished">Neobvezna oznaka za označavanje nove primateljske adrese (koristi se za identifikaciju računa). Također je pridružena zahtjevu za plaćanje.</translation>
     </message>
     <message>
         <source>An optional message that is attached to the payment request and may be displayed to the sender.</source>
@@ -2234,12 +3255,40 @@
         <translation type="unfinished">Kopiraj &amp;URI</translation>
     </message>
     <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Kopiraj adresu</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Kopiraj &amp;oznaku</translation>
+    </message>
+    <message>
+        <source>Copy &amp;message</source>
+        <translation type="unfinished">Kopiraj &amp;poruku</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Kopiraj &amp;iznos</translation>
+    </message>
+    <message>
         <source>Could not unlock wallet.</source>
         <translation type="unfinished">Ne može se otključati novčanik.</translation>
     </message>
-    </context>
+    <message>
+        <source>Could not generate new %1 address</source>
+        <translation type="unfinished">Ne mogu generirati novu %1 adresu</translation>
+    </message>
+</context>
 <context>
     <name>ReceiveRequestDialog</name>
+    <message>
+        <source>Request payment to …</source>
+        <translation type="unfinished">Zatraži plaćanje na...</translation>
+    </message>
+    <message>
+        <source>Address:</source>
+        <translation type="unfinished">Adresa:</translation>
+    </message>
     <message>
         <source>Amount:</source>
         <translation type="unfinished">Iznos:</translation>
@@ -2263,6 +3312,18 @@
     <message>
         <source>Copy &amp;Address</source>
         <translation type="unfinished">Kopiraj &amp;adresu</translation>
+    </message>
+    <message>
+        <source>&amp;Verify</source>
+        <translation type="unfinished">&amp;Verificiraj</translation>
+    </message>
+    <message>
+        <source>Verify this address on e.g. a hardware wallet screen</source>
+        <translation type="unfinished">Verificiraj ovu adresu na npr. zaslonu hardverskog novčanika</translation>
+    </message>
+    <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">&amp;Spremi sliku...</translation>
     </message>
     <message>
         <source>Payment information</source>
@@ -2395,13 +3456,29 @@
         <translation type="unfinished">Obriši sva polja</translation>
     </message>
     <message>
+        <source>Inputs…</source>
+        <translation type="unfinished">Inputi...</translation>
+    </message>
+    <message>
         <source>Dust:</source>
         <translation type="unfinished">Prah:</translation>
+    </message>
+    <message>
+        <source>Choose…</source>
+        <translation type="unfinished">Odaberi...</translation>
     </message>
     <message>
         <source>Hide transaction fee settings</source>
         <translation type="unfinished">Sakrijte postavke za transakcijske provizije
 </translation>
+    </message>
+    <message>
+        <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
+
+Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satoshis per kvB" for a transaction size of 500 virtual bytes (half of 1 kvB) would ultimately yield a fee of only 50 satoshis.</source>
+        <translation type="unfinished">Zadajte prilagodenu naknadu po kB (1000 bajtova) virtualne veličine transakcije.
+
+Napomena: Budući da se naknada računa po bajtu, naknada od "100 satošija po kB" za transakciju veličine 500 bajtova (polovica od 1 kB) rezultirala bi ultimativno naknadom od samo 50 satošija.</translation>
     </message>
     <message>
         <source>When there is less transaction volume than space in the blocks, miners as well as relaying nodes may enforce a minimum fee. Paying only this minimum fee is just fine, but be aware that this can result in a never confirming transaction once there is more demand for bitcoin transactions than the network can process.</source>
@@ -2410,6 +3487,10 @@
     <message>
         <source>A too low fee might result in a never confirming transaction (read the tooltip)</source>
         <translation type="unfinished">Preniska naknada može rezultirati transakcijom koja se nikad ne potvrđuje (vidite oblačić)</translation>
+    </message>
+    <message>
+        <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
+        <translation type="unfinished">(Pametna procjena naknada još nije inicijalizirana. Inače traje nekoliko blokova...)</translation>
     </message>
     <message>
         <source>Confirmation time target:</source>
@@ -2472,8 +3553,26 @@
         <translation type="unfinished">%1 (%2 blokova)</translation>
     </message>
     <message>
+        <source>Sign on device</source>
+        <extracomment>"device" usually means a hardware wallet.</extracomment>
+        <translation type="unfinished">Potpiši na uređaju</translation>
+    </message>
+    <message>
+        <source>Connect your hardware wallet first.</source>
+        <translation type="unfinished">Prvo poveži svoj hardverski novčanik.</translation>
+    </message>
+    <message>
+        <source>Set external signer script path in Options -&gt; Wallet</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Postavi put za vanjsku skriptu potpisnika u Opcije -&gt; Novčanik</translation>
+    </message>
+    <message>
         <source>Cr&amp;eate Unsigned</source>
         <translation type="unfinished">Cr&amp;eate nije potpisan</translation>
+    </message>
+    <message>
+        <source>Creates a Partially Signed Bitcoin Transaction (PSBT) for use with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
+        <translation type="unfinished">Stvara djelomično potpisanu Bitcoin transakciju (Partially Signed Bitcoin Transaction - PSBT) za upotrebu sa npr. novčanikom %1 koji nije povezan s mrežom ili sa PSBT kompatibilnim hardverskim novčanikom.</translation>
     </message>
     <message>
         <source> from wallet '%1'</source>
@@ -2488,8 +3587,39 @@
         <translation type="unfinished">%1 na %2</translation>
     </message>
     <message>
+        <source>To review recipient list click "Show Details…"</source>
+        <translation type="unfinished">Kliknite "Prikažite detalje..." kako biste pregledali popis primatelja</translation>
+    </message>
+    <message>
         <source>Sign failed</source>
         <translation type="unfinished">Potpis nije uspio</translation>
+    </message>
+    <message>
+        <source>External signer not found</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Vanjski potpisnik nije pronađen</translation>
+    </message>
+    <message>
+        <source>External signer failure</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Neuspješno vanjsko potpisivanje</translation>
+    </message>
+    <message>
+        <source>Save Transaction Data</source>
+        <translation type="unfinished">Spremi podatke transakcije</translation>
+    </message>
+    <message>
+        <source>Partially Signed Transaction (Binary)</source>
+        <extracomment>Expanded name of the binary PSBT file format. See: BIP 174.</extracomment>
+        <translation type="unfinished">Djelomično potpisana transakcija (binarno)</translation>
+    </message>
+    <message>
+        <source>PSBT saved</source>
+        <translation type="unfinished">PSBT spremljen</translation>
+    </message>
+    <message>
+        <source>External balance:</source>
+        <translation type="unfinished">Vanjski balans:</translation>
     </message>
     <message>
         <source>or</source>
@@ -2498,6 +3628,21 @@
     <message>
         <source>You can increase the fee later (signals Replace-By-Fee, BIP-125).</source>
         <translation type="unfinished">Možete kasnije povećati naknadu (javlja Replace-By-Fee, BIP-125).</translation>
+    </message>
+    <message>
+        <source>Please, review your transaction proposal. This will produce a Partially Signed Bitcoin Transaction (PSBT) which you can save or copy and then sign with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
+        <extracomment>Text to inform a user attempting to create a transaction of their current options. At this stage, a user can only create a PSBT. This string is displayed when private keys are disabled and an external signer is not available.</extracomment>
+        <translation type="unfinished">Molimo pregledajte svoj prijedlog transakcije. Ovo će stvoriti djelomično potpisanu Bitcoin transakciju (PBST) koju možete spremiti ili kopirati i zatim potpisati sa npr. novčanikom %1 koji nije povezan s mrežom ili sa PSBT kompatibilnim hardverskim novčanikom.</translation>
+    </message>
+    <message>
+        <source>Do you want to create this transaction?</source>
+        <extracomment>Message displayed when attempting to create a transaction. Cautionary text to prompt the user to verify that the displayed transaction details represent the transaction the user intends to create.</extracomment>
+        <translation type="unfinished">Želite li kreirati ovu transakciju?</translation>
+    </message>
+    <message>
+        <source>Please, review your transaction. You can create and send this transaction or create a Partially Signed Bitcoin Transaction (PSBT), which you can save or copy and then sign with, e.g., an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
+        <extracomment>Text to inform a user attempting to create a transaction of their current options. At this stage, a user can send their transaction or create a PSBT. This string is displayed when both private keys and PSBT controls are enabled.</extracomment>
+        <translation type="unfinished">Molimo pregledajte svoju transakciju. Možete kreirarti i poslati ovu transakciju ili kreirati djelomično potpisanu Bitcoin transakciju (PBST) koju možete spremiti ili kopirati i zatim potpisati sa npr. novčanikom %1 koji nije povezan s mrežom ili sa PSBT kompatibilnim hardverskim novčanikom.</translation>
     </message>
     <message>
         <source>Please, review your transaction.</source>
@@ -2552,16 +3697,12 @@
         <source>A fee higher than %1 is considered an absurdly high fee.</source>
         <translation type="unfinished">Naknada veća od %1 smatra se apsurdno visokim naknadom.</translation>
     </message>
-    <message>
-        <source>Payment request expired.</source>
-        <translation type="unfinished">Zahtjev za plaćanje istekao.</translation>
-    </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>Estimated to begin confirmation within %n block(s).</numerusform>
+            <numerusform>Estimated to begin confirmation within %n block(s).</numerusform>
+            <numerusform>Procijenjeno je da će potvrđivanje početi unutar %n blokova.</numerusform>
         </translation>
     </message>
     <message>
@@ -2636,28 +3777,12 @@
         <translation type="unfinished">Poruka:</translation>
     </message>
     <message>
-        <source>This is an unauthenticated payment request.</source>
-        <translation type="unfinished">Ovo je neautenticiran zahtjev za plaćanje.</translation>
-    </message>
-    <message>
-        <source>This is an authenticated payment request.</source>
-        <translation type="unfinished">Ovo je autenticiran zahtjev za plaćanje.</translation>
-    </message>
-    <message>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished">Unesite oznaku za ovu adresu kako bi ju dodali u vaš adresar</translation>
     </message>
     <message>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished">Poruka koja je dodana uplati: URI koji će biti spremljen s transakcijom za referencu. Napomena: Ova poruka neće biti poslana preko Bitcoin mreže.</translation>
-    </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">Primatelj plaćanja:</translation>
-    </message>
-    <message>
-        <source>Memo:</source>
-        <translation type="unfinished">Zapis:</translation>
     </message>
 </context>
 <context>
@@ -2666,7 +3791,11 @@
         <source>Send</source>
         <translation type="unfinished">Pošalji</translation>
     </message>
-    </context>
+    <message>
+        <source>Create Unsigned</source>
+        <translation type="unfinished">Kreiraj nepotpisano</translation>
+    </message>
+</context>
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
@@ -2811,33 +3940,36 @@
     </message>
 </context>
 <context>
+    <name>SplashScreen</name>
+    <message>
+        <source>(press q to shutdown and continue later)</source>
+        <translation type="unfinished">(pritisnite q kako bi ugasili i nastavili kasnije)</translation>
+    </message>
+    <message>
+        <source>press q to shutdown</source>
+        <translation type="unfinished">pritisnite q za gašenje</translation>
+    </message>
+</context>
+<context>
     <name>TransactionDesc</name>
     <message>
         <source>conflicted with a transaction with %1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that conflicts with a confirmed transaction.</extracomment>
         <translation type="unfinished">subokljen s transakcijom broja potvrde %1</translation>
     </message>
     <message>
-        <source>0/unconfirmed, %1</source>
-        <translation type="unfinished">0/nepotvrđeno, %1</translation>
-    </message>
-    <message>
-        <source>in memory pool</source>
-        <translation type="unfinished">u memorijskom bazenu</translation>
-    </message>
-    <message>
-        <source>not in memory pool</source>
-        <translation type="unfinished">nije u memorijskom bazenu</translation>
-    </message>
-    <message>
         <source>abandoned</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an abandoned transaction.</extracomment>
         <translation type="unfinished">napušteno</translation>
     </message>
     <message>
         <source>%1/unconfirmed</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
         <translation type="unfinished">%1/nepotvrđeno</translation>
     </message>
     <message>
         <source>%1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
         <translation type="unfinished">%1 potvrda</translation>
     </message>
     <message>
@@ -2883,9 +4015,9 @@
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>matures in %n more block(s)</numerusform>
+            <numerusform>matures in %n more block(s)</numerusform>
+            <numerusform>dozrijeva za još %n blokova</numerusform>
         </translation>
     </message>
     <message>
@@ -3138,8 +4270,62 @@
         <translation type="unfinished">Min iznos</translation>
     </message>
     <message>
+        <source>Range…</source>
+        <translation type="unfinished">Raspon...</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Kopiraj adresu</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Kopiraj &amp;oznaku</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Kopiraj &amp;iznos</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">Kopiraj &amp;ID transakcije</translation>
+    </message>
+    <message>
+        <source>Copy &amp;raw transaction</source>
+        <translation type="unfinished">Kopiraj &amp;sirovu transakciju</translation>
+    </message>
+    <message>
+        <source>Copy full transaction &amp;details</source>
+        <translation type="unfinished">Kopiraj sve transakcijske &amp;detalje</translation>
+    </message>
+    <message>
+        <source>&amp;Show transaction details</source>
+        <translation type="unfinished">&amp;Prikaži detalje transakcije</translation>
+    </message>
+    <message>
+        <source>Increase transaction &amp;fee</source>
+        <translation type="unfinished">Povećaj transakcijsku &amp;naknadu</translation>
+    </message>
+    <message>
+        <source>A&amp;bandon transaction</source>
+        <translation type="unfinished">&amp;Napusti transakciju</translation>
+    </message>
+    <message>
+        <source>&amp;Edit address label</source>
+        <translation type="unfinished">&amp;Izmjeni oznaku adrese</translation>
+    </message>
+    <message>
+        <source>Show in %1</source>
+        <extracomment>Transactions table context menu action to show the selected transaction in a third-party block explorer. %1 is a stand-in argument for the URL of the explorer.</extracomment>
+        <translation type="unfinished">Prikazi u %1</translation>
+    </message>
+    <message>
         <source>Export Transaction History</source>
         <translation type="unfinished">Izvozite povijest transakcija</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">Datoteka podataka odvojenih zarezima (*.csv)</translation>
     </message>
     <message>
         <source>Confirmed</source>
@@ -3193,6 +4379,14 @@
 <context>
     <name>WalletFrame</name>
     <message>
+        <source>No wallet has been loaded.
+Go to File &gt; Open Wallet to load a wallet.
+- OR -</source>
+        <translation type="unfinished">Nijedan novčanik nije učitan.
+Idi na Datoteka &gt;  Otvori novčanik za učitanje novčanika.
+- ILI -</translation>
+    </message>
+    <message>
         <source>Create a new wallet</source>
         <translation type="unfinished">Stvorite novi novčanik</translation>
     </message>
@@ -3200,7 +4394,27 @@
         <source>Error</source>
         <translation type="unfinished">Greška</translation>
     </message>
-    </context>
+    <message>
+        <source>Unable to decode PSBT from clipboard (invalid base64)</source>
+        <translation type="unfinished">Nije moguće dekodirati PSBT iz međuspremnika (nevažeći base64)</translation>
+    </message>
+    <message>
+        <source>Load Transaction Data</source>
+        <translation type="unfinished">Učitaj podatke transakcije</translation>
+    </message>
+    <message>
+        <source>Partially Signed Transaction (*.psbt)</source>
+        <translation type="unfinished">Djelomično potpisana transakcija (*.psbt)</translation>
+    </message>
+    <message>
+        <source>PSBT file must be smaller than 100 MiB</source>
+        <translation type="unfinished">PSBT datoteka mora biti manja od 100 MB</translation>
+    </message>
+    <message>
+        <source>Unable to decode PSBT</source>
+        <translation type="unfinished">Nije moguće dekodirati PSBT</translation>
+    </message>
+</context>
 <context>
     <name>WalletModel</name>
     <message>
@@ -3233,6 +4447,10 @@
         <translation type="unfinished">Nova naknada:</translation>
     </message>
     <message>
+        <source>Warning: This may pay the additional fee by reducing change outputs or adding inputs, when necessary. It may add a new change output if one does not already exist. These changes may potentially leak privacy.</source>
+        <translation type="unfinished">Upozorenje: Ovo može platiti dodatnu naknadu smanjenjem change outputa ili dodavanjem inputa, po potrebi. Može dodati novi change output ako jedan već ne postoji. Ove promjene bi mogle smanjiti privatnost.</translation>
+    </message>
+    <message>
         <source>Confirm fee bump</source>
         <translation type="unfinished">Potvrdite povećanje naknade</translation>
     </message>
@@ -3253,6 +4471,10 @@
         <translation type="unfinished">Transakcija ne može biti izvršena.</translation>
     </message>
     <message>
+        <source>Can't display address</source>
+        <translation type="unfinished">Ne mogu prikazati adresu</translation>
+    </message>
+    <message>
         <source>default wallet</source>
         <translation type="unfinished">uobičajeni novčanik</translation>
     </message>
@@ -3270,6 +4492,11 @@
     <message>
         <source>Backup Wallet</source>
         <translation type="unfinished">Arhiviranje novčanika</translation>
+    </message>
+    <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">Podaci novčanika</translation>
     </message>
     <message>
         <source>Backup Failed</source>

--- a/src/qt/locale/bitcoin_hu.ts
+++ b/src/qt/locale/bitcoin_hu.ts
@@ -3,7 +3,7 @@
     <name>AddressBookPage</name>
     <message>
         <source>Right-click to edit address or label</source>
-        <translation type="unfinished">A cím vagy címke szerkeszteséhez kattintson a jobb gombbal</translation>
+        <translation type="unfinished">A cím vagy címke szerkesztéséhez kattintson a jobb gombbal</translation>
     </message>
     <message>
         <source>Create a new address</source>
@@ -47,11 +47,11 @@
     </message>
     <message>
         <source>Choose the address to send coins to</source>
-        <translation type="unfinished">Kedvezményezett címének kiválasztása</translation>
+        <translation type="unfinished">Válassza ki a küldési címet kimenő utalásokhoz</translation>
     </message>
     <message>
         <source>Choose the address to receive coins with</source>
-        <translation type="unfinished">Jóváírási cím kiválasztása</translation>
+        <translation type="unfinished">Válassza ki a fogadó címet beérkező utalásokhoz</translation>
     </message>
     <message>
         <source>C&amp;hoose</source>
@@ -76,11 +76,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>&amp;Copy Address</source>
-        <translation type="unfinished">&amp;Cím másolása</translation>
+        <translation type="unfinished">Cím &amp;másolása</translation>
     </message>
     <message>
         <source>Copy &amp;Label</source>
-        <translation type="unfinished">Másolás és Címkézés</translation>
+        <translation type="unfinished">Másolás és &amp;címkézés</translation>
     </message>
     <message>
         <source>&amp;Edit</source>
@@ -98,7 +98,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>There was an error trying to save the address list to %1. Please try again.</source>
         <extracomment>An error message. %1 is a stand-in argument for the name of the file we attempted to save to.</extracomment>
-        <translation type="unfinished">Hiba történt a címlista %1 mentésekor.  Kérem próbálja újra.</translation>
+        <translation type="unfinished">Hiba történt a címlista %1 mentésekor. Kérem próbálja újra.</translation>
     </message>
     <message>
         <source>Exporting Failed</source>
@@ -176,7 +176,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Enter the new passphrase for the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
-        <translation type="unfinished">Írja be a tárca új jelszavát. &lt;br/&gt;A jelszó összetétele a következő: &lt;b&gt;tíz vagy annál több véletlenszerű karakter&lt;/b&gt;, vagy &lt;b&gt;nyolc vagy annál több szó&lt;/b&gt;. </translation>
+        <translation type="unfinished">Írja be a tárca új jelszavát. &lt;br/&gt;Használjon &lt;b&gt;legalább tíz véletlenszerű karakterből&lt;/b&gt;, vagy &lt;b&gt;legalább nyolc szóból&lt;/b&gt; álló jelszót.</translation>
     </message>
     <message>
         <source>Enter the old passphrase and new passphrase for the wallet.</source>
@@ -244,6 +244,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 </context>
 <context>
     <name>BitcoinApplication</name>
+    <message>
+        <source>Settings file %1 might be corrupt or invalid.</source>
+        <translation type="unfinished">A beállítások fájl %1 sérült vagy érvénytelen.</translation>
+    </message>
+    <message>
+        <source>Runaway exception</source>
+        <translation type="unfinished">Ajajj, nagy baj van: Runaway exception!</translation>
+    </message>
     <message>
         <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
         <translation type="unfinished">Végzetes hiba történt %1 nem tud biztonságban továbblépni így most kilép.</translation>
@@ -367,31 +375,31 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n másodperc</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n minute(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n perc</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n óra</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n nap</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n hét</numerusform>
         </translation>
     </message>
     <message>
@@ -401,7 +409,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n év</numerusform>
         </translation>
     </message>
     </context>
@@ -429,11 +437,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Cannot downgrade wallet from version %i to version %i. Wallet version unchanged.</source>
-        <translation type="unfinished">Nem sikerült a tárcát %iverzióról %iverzióra vissza módosítani. A tárca verzió változatlan maradt.</translation>
+        <translation type="unfinished">Nem sikerült a tárcát %i verzióról %i verzióra módosítani. A tárca verziója változatlan maradt.</translation>
     </message>
     <message>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running.</source>
-        <translation type="unfinished">Az %s adatkönyvtár nem zárható.  A %s valószínűleg fut már.</translation>
+        <translation type="unfinished">Az %s adatkönyvtár nem zárolható. A %s valószínűleg fut már.</translation>
     </message>
     <message>
         <source>Cannot upgrade a non HD split wallet from version %i to version %i without upgrading to support pre-split keypool. Please use version %i or no version specified.</source>
@@ -466,10 +474,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Error: Legacy wallets only support the "legacy", "p2sh-segwit", and "bech32" address types</source>
         <translation type="unfinished">Hiba: Régi típusú tárcák csak "legacy", "p2sh-segwit" és "bech32" címformátumokat támogatják</translation>
-    </message>
-    <message>
-        <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
-        <translation type="unfinished">Hiba: Figyelés a bejövő kapcsolatokra sikertelen (a listen hibaüzenete: %s)</translation>
     </message>
     <message>
         <source>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.</source>
@@ -616,6 +620,26 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Nem lehet írni a '%s' könyvtárba; ellenőrizze a jogosultságokat.</translation>
     </message>
     <message>
+        <source>The -txindex upgrade started by a previous version cannot be completed. Restart with the previous version or run a full -reindex.</source>
+        <translation type="unfinished">A -txindex frissítése nem fejezhető be mivel egy korábbi verzió kezdte el. Indítsa újra az előző verziót vagy futtassa a teljes -reindex parancsot.</translation>
+    </message>
+    <message>
+        <source>%s request to listen on port %u. This port is considered "bad" and thus it is unlikely that any Bitcoin Core peers connect to it. See doc/p2p-bad-ports.md for details and a full list.</source>
+        <translation type="unfinished">%s kérés figyel a(z) %u porton. Ennek a portnak a megítélése "rossz" ezért valószínűtlen, hogy más Bitcoin Core partner ezen keresztül csatlakozna. Részletekért és teljes listáért lásd doc/p2p-bad-ports.md.</translation>
+    </message>
+    <message>
+        <source>Cannot provide specific connections and have addrman find outgoing connections at the same time.</source>
+        <translation type="unfinished">Nem lehetséges a megadott kapcsolatok és az addrman által felderített kapcsolatok egyidejű használata.</translation>
+    </message>
+    <message>
+        <source>Error loading %s: External signer wallet being loaded without external signer support compiled</source>
+        <translation type="unfinished">Hiba %s betöltése közben: Külső aláíró tárca betöltése külső aláírók támogatása nélkül</translation>
+    </message>
+    <message>
+        <source>Failed to rename invalid peers.dat file. Please move or delete it and try again.</source>
+        <translation type="unfinished">Az érvénytelen peers.dat fájl átnevezése sikertelen. Kérjük mozgassa vagy törölje, majd próbálja újra.</translation>
+    </message>
+    <message>
         <source>Config setting for %s only applied on %s network when in [%s] section.</source>
         <translation type="unfinished">A konfigurációs beálltás %s kizárólag az %s hálózatra vonatkozik amikor a [%s] szekcióban van.</translation>
     </message>
@@ -657,11 +681,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Error initializing block database</source>
-        <translation type="unfinished">A blokkadatbázis inicializálása nem sikerült</translation>
+        <translation type="unfinished">A blokkadatbázis előkészítése nem sikerült</translation>
     </message>
     <message>
         <source>Error initializing wallet database environment %s!</source>
-        <translation type="unfinished">A tárca-adatbázis inicializálása nem sikerült: %s!</translation>
+        <translation type="unfinished">A tárca-adatbázis előkészítése nem sikerült: %s!</translation>
     </message>
     <message>
         <source>Error loading %s</source>
@@ -696,12 +720,8 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">A tárca adatbázisból a következő rekord beolvasása sikertelen.</translation>
     </message>
     <message>
-        <source>Error upgrading chainstate database</source>
-        <translation type="unfinished">Hiba a blokk adatbázis betöltése közben</translation>
-    </message>
-    <message>
         <source>Error: Couldn't create cursor into database</source>
-        <translation type="unfinished">Hiba: Nem tudott kurzort az adatbázisba készíteni</translation>
+        <translation type="unfinished">Hiba: Kurzor létrehozása az adatbázisba sikertelen.</translation>
     </message>
     <message>
         <source>Error: Disk space is low for %s</source>
@@ -721,7 +741,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Error: Keypool ran out, please call keypoolrefill first</source>
-        <translation type="unfinished">A címraktár kiürült, kérjük előbb adja ki a keypoolrefill parancsot.</translation>
+        <translation type="unfinished">A címraktár kiürült, előbb adja ki a keypoolrefill parancsot.</translation>
     </message>
     <message>
         <source>Error: Missing checksum</source>
@@ -730,6 +750,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Error: No %s addresses available.</source>
         <translation type="unfinished">Hiba: Nem áll rendelkezésre %s cím.</translation>
+    </message>
+    <message>
+        <source>Error: This wallet already uses SQLite</source>
+        <translation type="unfinished">Hiba: Ez a pénztárca már használja az SQLite-t</translation>
     </message>
     <message>
         <source>Error: Unable to parse version %u as a uint32_t</source>
@@ -757,7 +781,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Ignoring duplicate -wallet %s.</source>
-        <translation type="unfinished">A duplikált -wallet %s figyelmen kívül hagyva.</translation>
+        <translation type="unfinished">Az ismétlődő -wallet %s figyelmen kívül hagyva.</translation>
     </message>
     <message>
         <source>Importing…</source>
@@ -781,15 +805,15 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Invalid -i2psam address or hostname: '%s'</source>
-        <translation type="unfinished">Érvénytelen -i2psam cím vagy hostname: '%s'</translation>
+        <translation type="unfinished">Érvénytelen -i2psam cím vagy kiszolgáló: '%s'</translation>
     </message>
     <message>
         <source>Invalid -onion address or hostname: '%s'</source>
-        <translation type="unfinished">Érvénytelen -onion cím vagy hosztnév: '%s'</translation>
+        <translation type="unfinished">Érvénytelen -onion cím vagy kiszolgáló: '%s'</translation>
     </message>
     <message>
         <source>Invalid -proxy address or hostname: '%s'</source>
-        <translation type="unfinished">Érvénytelen -proxy cím vagy hosztnév: '%s'</translation>
+        <translation type="unfinished">Érvénytelen -proxy cím vagy kiszolgáló: '%s'</translation>
     </message>
     <message>
         <source>Invalid P2P permission: '%s'</source>
@@ -848,20 +872,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Nincsenek rendelkezésre álló címek</translation>
     </message>
     <message>
-        <source>No proxy server specified. Use -proxy=&lt;ip&gt; or -proxy=&lt;ip:port&gt;.</source>
-        <translation type="unfinished">Proxy szerver nincs megadva. A megadás módja:  -proxy=&lt;ip&gt; vagy -proxy=&lt;ip:port&gt;</translation>
-    </message>
-    <message>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished">Nincs elég fájlleíró.</translation>
     </message>
     <message>
         <source>Prune cannot be configured with a negative value.</source>
         <translation type="unfinished">Nyesett üzemmódot nem lehet negatív értékkel konfigurálni.</translation>
-    </message>
-    <message>
-        <source>Prune mode is incompatible with -coinstatsindex.</source>
-        <translation type="unfinished">A Prune mód nem kompatibilis a -coinstatsindex funkcióval.</translation>
     </message>
     <message>
         <source>Prune mode is incompatible with -txindex.</source>
@@ -921,7 +937,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Specified blocks directory "%s" does not exist.</source>
-        <translation type="unfinished">A megadott blokkönyvtár "%s" nem létezik.</translation>
+        <translation type="unfinished">A megadott blokk könyvtár "%s" nem létezik.</translation>
     </message>
     <message>
         <source>Starting network threads…</source>
@@ -962,6 +978,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Transaction amounts must not be negative</source>
         <translation type="unfinished">Tranzakció összege nem lehet negatív</translation>
+    </message>
+    <message>
+        <source>Transaction change output index out of range</source>
+        <translation type="unfinished">Tartományon kivüli tranzakció visszajáró index</translation>
     </message>
     <message>
         <source>Transaction has too long of a mempool chain</source>
@@ -1036,10 +1056,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Nem támogatott naplózási kategória %s=%s</translation>
     </message>
     <message>
-        <source>Upgrading UTXO database</source>
-        <translation type="unfinished">UTXO adatbázis frissítése</translation>
-    </message>
-    <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
         <translation type="unfinished">A felhasználói ügynök megjegyzés (%s) veszélyes karaktert tartalmaz.</translation>
     </message>
@@ -1100,7 +1116,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Modify configuration options for %1</source>
-        <translation type="unfinished">%1 beállítások módosítása</translation>
+        <translation type="unfinished">%1 beállításainak módosítása</translation>
     </message>
     <message>
         <source>Create a new wallet</source>
@@ -1145,7 +1161,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>&amp;Options…</source>
-        <translation type="unfinished">&amp;Opciók…</translation>
+        <translation type="unfinished">&amp;Beállítások…</translation>
     </message>
     <message>
         <source>&amp;Encrypt Wallet…</source>
@@ -1153,7 +1169,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Encrypt the private keys that belong to your wallet</source>
-        <translation type="unfinished">A tárcához tartozó privát kulcsok titkosítása</translation>
+        <translation type="unfinished">A tárcádhoz tartozó privát kulcsok titkosítása</translation>
     </message>
     <message>
         <source>&amp;Backup Wallet…</source>
@@ -1169,7 +1185,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
-        <translation type="unfinished">Üzenetek aláírása a Bitcoin-címeivel, amivel bizonyíthatja hogy a cím az Öné</translation>
+        <translation type="unfinished">Üzenetek aláírása a Bitcoin-címmeiddel, amivel bizonyítod, hogy a cím a sajátod</translation>
     </message>
     <message>
         <source>&amp;Verify message…</source>
@@ -1258,7 +1274,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n blokk feldolgozva a tranzakciótörténetből.</numerusform>
         </translation>
     </message>
     <message>
@@ -1338,6 +1354,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Tárca bezárása</translation>
     </message>
     <message>
+        <source>Restore Wallet…</source>
+        <extracomment>Name of the menu item that restores wallet from a backup file.</extracomment>
+        <translation type="unfinished">Tárca visszaállítása...</translation>
+    </message>
+    <message>
         <source>Close all wallets</source>
         <translation type="unfinished">Összes tárca bezárása</translation>
     </message>
@@ -1362,6 +1383,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Nincs elérhető tárca</translation>
     </message>
     <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">Tárca adat</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">Tárca neve</translation>
+    </message>
+    <message>
         <source>&amp;Window</source>
         <translation type="unfinished">&amp;Ablak</translation>
     </message>
@@ -1377,11 +1408,19 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>%1 client</source>
         <translation type="unfinished">%1 kliens</translation>
     </message>
+    <message>
+        <source>&amp;Hide</source>
+        <translation type="unfinished">&amp;Elrejt</translation>
+    </message>
+    <message>
+        <source>S&amp;how</source>
+        <translation type="unfinished">&amp;Mutat</translation>
+    </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n aktív kapcsolat a Bitcoin hálózathoz.</numerusform>
         </translation>
     </message>
     <message>
@@ -1462,15 +1501,15 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>HD key generation is &lt;b&gt;disabled&lt;/b&gt;</source>
-        <translation type="unfinished">HD kulcs generálás &lt;b&gt;tiltva&lt;/b&gt;</translation>
+        <translation type="unfinished">HD kulcs generálás &lt;b&gt;letiltva&lt;/b&gt;</translation>
     </message>
     <message>
         <source>Private key &lt;b&gt;disabled&lt;/b&gt;</source>
-        <translation type="unfinished">Privát kulcs &lt;b&gt;inaktív&lt;/b&gt;</translation>
+        <translation type="unfinished">Privát kulcs &lt;b&gt;letiltva&lt;/b&gt;</translation>
     </message>
     <message>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
-        <translation type="unfinished">A tárca &lt;b&gt;titkosítva&lt;/b&gt; és jelenleg &lt;b&gt;nyitva&lt;/b&gt;.</translation>
+        <translation type="unfinished">A tárca &lt;b&gt;titkosítva&lt;/b&gt; és jelenleg &lt;b&gt;feloldva&lt;/b&gt;.</translation>
     </message>
     <message>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
@@ -1485,7 +1524,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <name>UnitDisplayStatusBarControl</name>
     <message>
         <source>Unit to show amounts in. Click to select another unit.</source>
-        <translation type="unfinished">Egység, amelyben az összegek meg lesznek jelenítve. Kattintson ide, ha másik egységet szeretne kiválasztani.</translation>
+        <translation type="unfinished">Egység, amelyben az összegek lesznek megjelenítve. Kattintson ide másik egység kiválasztásához.</translation>
     </message>
 </context>
 <context>
@@ -1667,7 +1706,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Can't list signers</source>
         <translation type="unfinished">Nem lehet az aláírókat listázni</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>LoadWalletsActivity</name>
     <message>
@@ -1698,7 +1737,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Open Wallet</source>
         <extracomment>Title of window indicating the progress of opening of a wallet.</extracomment>
-        <translation type="unfinished">Tárca megnyitása</translation>
+        <translation type="unfinished">Tárca Megnyitása</translation>
     </message>
     <message>
         <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
@@ -1706,6 +1745,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">&lt;b&gt;%1&lt;/b&gt; tárca megnyitása…</translation>
     </message>
 </context>
+<context>
+    <name>RestoreWalletActivity</name>
+    <message>
+        <source>Restore wallet failed</source>
+        <extracomment>Title of message box which is displayed when the wallet could not be restored.</extracomment>
+        <translation type="unfinished">A pénztárca helyreállítása nem sikerült</translation>
+    </message>
+    </context>
 <context>
     <name>WalletController</name>
     <message>
@@ -1765,7 +1812,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Make a blank wallet. Blank wallets do not initially have private keys or scripts. Private keys and addresses can be imported, or an HD seed can be set, at a later time.</source>
-        <translation type="unfinished">Üres tárca készítése. Az üres tárcák kezdetben nem tartalmaznak privát kulcsokat vagy szkripteket. Később lehetséges a privát kulcsok vagy címek importálása avagy egy HD mag beállítása.</translation>
+        <translation type="unfinished">Üres tárca készítése. Az üres tárcák kezdetben nem tartalmaznak privát kulcsokat vagy szkripteket. Később lehetséges a privát kulcsok vagy címek importálása illetve egy HD mag beállítása.</translation>
     </message>
     <message>
         <source>Make Blank Wallet</source>
@@ -1849,7 +1896,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Could not unlock wallet.</source>
-        <translation type="unfinished">Nem sikerült a tárca felnyitása</translation>
+        <translation type="unfinished">Nem sikerült a tárca feloldása</translation>
     </message>
     <message>
         <source>New key generation failed.</source>
@@ -1864,7 +1911,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>name</source>
-        <translation type="unfinished">Név</translation>
+        <translation type="unfinished">név</translation>
     </message>
     <message>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
@@ -1881,13 +1928,23 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 </context>
 <context>
     <name>Intro</name>
-    <message>
-        <source>(of %1 GB needed)</source>
-        <translation type="unfinished">(a szükséges %1 GB-ból)</translation>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+        </translation>
     </message>
-    <message>
-        <source>(%1 GB needed for full chain)</source>
-        <translation type="unfinished">(%1 GB szükséges a teljes lánchoz)</translation>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform>(%n GB szükségesnek)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform>(%n GB szükséges a teljes lánchoz)</numerusform>
+        </translation>
     </message>
     <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
@@ -1901,7 +1958,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>(elegendő %n nappal ezelőtti biztonsági mentések visszaállításához)</numerusform>
         </translation>
     </message>
     <message>
@@ -1910,7 +1967,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>The wallet will also be stored in this directory.</source>
-        <translation type="unfinished">A tárcát is ebben a könyvtárban tároljuk.</translation>
+        <translation type="unfinished">A tárca is ebben a könyvtárban tárolódik.</translation>
     </message>
     <message>
         <source>Error: Specified data directory "%1" cannot be created.</source>
@@ -1931,10 +1988,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>As this is the first time the program is launched, you can choose where %1 will store its data.</source>
         <translation type="unfinished">Mivel ez a program első indulása, megváltoztathatja, hogy a %1 hova mentse az adatokat.</translation>
-    </message>
-    <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation type="unfinished">Ha az OK-ra kattint, %1 megkezdi a teljes %4 blokk lánc letöltését és feldolgozását (%2GB) a legkorábbi tranzakciókkal kezdve %3 -ben, amikor a %4 bevezetésre került.</translation>
     </message>
     <message>
         <source>Limit block chain storage to</source>
@@ -2049,7 +2102,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Unknown. Syncing Headers (%1, %2%)…</source>
         <translation type="unfinished">Ismeretlen. Fejlécek szinkronizálása (%1, %2%)…</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>OpenURIDialog</name>
     <message>
@@ -2210,7 +2263,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
-        <translation type="unfinished">A Bitcoin-kliens portjának automatikus megnyitása a routeren. Ez csak akkor működik, ha a routered támogatja az UPnP-t és az engedélyezve is van rajta.</translation>
+        <translation type="unfinished">A Bitcoin-kliens portjának automatikus megnyitása a routeren. Ez csak akkor működik, ha a router támogatja az UPnP-t és az engedélyezve is van rajta.</translation>
     </message>
     <message>
         <source>Map port using &amp;UPnP</source>
@@ -2262,7 +2315,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Show only a tray icon after minimizing the window.</source>
-        <translation type="unfinished">Kicsinyítés után csak eszköztár-ikont mutass</translation>
+        <translation type="unfinished">Kicsinyítés után csak az eszköztár-ikont mutassa.</translation>
     </message>
     <message>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
@@ -2270,7 +2323,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>M&amp;inimize on close</source>
-        <translation type="unfinished">K&amp;icsinyítés záráskor</translation>
+        <translation type="unfinished">K&amp;icsinyítés bezáráskor</translation>
     </message>
     <message>
         <source>&amp;Display</source>
@@ -2325,10 +2378,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">legjobb találat "%1"</translation>
     </message>
     <message>
-        <source>Options set in this dialog are overridden by the command line or in the configuration file:</source>
-        <translation type="unfinished">Az itt beállított opciók felülbírálásra kerültek a parancssor vagy a konfigurációs fájl által:</translation>
-    </message>
-    <message>
         <source>&amp;Cancel</source>
         <translation type="unfinished">&amp;Mégse</translation>
     </message>
@@ -2347,14 +2396,17 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Confirm options reset</source>
+        <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
         <translation type="unfinished">Beállítások törlésének jóváhagyása.</translation>
     </message>
     <message>
         <source>Client restart required to activate changes.</source>
+        <extracomment>Text explaining that the settings changed will not come into effect until the client is restarted.</extracomment>
         <translation type="unfinished">A változtatások aktiválásahoz újra kell indítani a klienst.</translation>
     </message>
     <message>
         <source>Client will be shut down. Do you want to proceed?</source>
+        <extracomment>Text asking the user to confirm if they would like to proceed with a client shutdown.</extracomment>
         <translation type="unfinished">A kliens le fog állni. Szeretné folytatni?</translation>
     </message>
     <message>
@@ -2649,6 +2701,11 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <translation type="unfinished">Partner</translation>
     </message>
     <message>
+        <source>Age</source>
+        <extracomment>Title of Peers Table column which indicates the duration (length of time) since the peer connection started.</extracomment>
+        <translation type="unfinished">Életkor</translation>
+    </message>
+    <message>
         <source>Direction</source>
         <extracomment>Title of Peers Table column which indicates the direction the peer connection was initiated from.</extracomment>
         <translation type="unfinished">Irány</translation>
@@ -2849,29 +2906,22 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Whether we relay addresses to this peer.</source>
-        <extracomment>Tooltip text for the Address Relay field in the peer details area.</extracomment>
+        <extracomment>Tooltip text for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
         <translation type="unfinished">Továbbítsunk-e címeket ennek a partnernek.</translation>
     </message>
     <message>
         <source>Address Relay</source>
+        <extracomment>Text title for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
         <translation type="unfinished">Cím Továbbítás</translation>
     </message>
     <message>
-        <source>Total number of addresses processed, excluding those dropped due to rate-limiting.</source>
-        <extracomment>Tooltip text for the Addresses Processed field in the peer details area.</extracomment>
-        <translation type="unfinished">Az eddig feldolgozott címek összesen, nem számolva a sebességkorlát miatt eldobott címeket.</translation>
-    </message>
-    <message>
         <source>Addresses Processed</source>
+        <extracomment>Text title for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
         <translation type="unfinished">Feldolgozott Címek</translation>
     </message>
     <message>
-        <source>Total number of addresses dropped due to rate-limiting.</source>
-        <extracomment>Tooltip text for the Addresses Rate-Limited field in the peer details area.</extracomment>
-        <translation type="unfinished">Sebességkorlát miatt eldobott címek összesen.</translation>
-    </message>
-    <message>
         <source>Addresses Rate-Limited</source>
+        <extracomment>Text title for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
         <translation type="unfinished">Eldobott Címek</translation>
     </message>
     <message>
@@ -2912,7 +2962,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>The network protocol this peer is connected through: IPv4, IPv6, Onion, I2P, or CJDNS.</source>
-        <translation type="unfinished">A hálózati protokoll amin keresztül ez a csomópont kapcsolódik: IPv4, IPv6, Onion, I2P vagy CJDNS.</translation>
+        <translation type="unfinished">A hálózati protokoll amin keresztül ez a partner kapcsolódik: IPv4, IPv6, Onion, I2P vagy CJDNS.</translation>
     </message>
     <message>
         <source>Services</source>
@@ -2940,7 +2990,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Elapsed time since a novel block passing initial validity checks was received from this peer.</source>
-        <translation type="unfinished">A csomóponttól érkező új blokkokra vonatkozó érvényességet igazoló ellenőrzések óta eltelt idő.</translation>
+        <translation type="unfinished">A partnertől érkező új blokkokra vonatkozó érvényességet igazoló ellenőrzések óta eltelt idő.</translation>
     </message>
     <message>
         <source>Last Block</source>
@@ -2949,7 +2999,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     <message>
         <source>Elapsed time since a novel transaction accepted into our mempool was received from this peer.</source>
         <extracomment>Tooltip text for the Last Transaction field in the peer details area.</extracomment>
-        <translation type="unfinished">Az eltelt idő, amióta egy új, a mempoolunkba elfogadott tranzakció érkezett ettől a társtulajdonostól.</translation>
+        <translation type="unfinished">Az eltelt idő, amióta egy új, a saját memóriahalomba elfogadott tranzakció érkezett ettől a partnertől.</translation>
     </message>
     <message>
         <source>Last Send</source>
@@ -3153,7 +3203,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>&amp;Label:</source>
-        <translation type="unfinished">Címke:</translation>
+        <translation type="unfinished">Cím&amp;ke:</translation>
     </message>
     <message>
         <source>&amp;Message:</source>
@@ -3237,7 +3287,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Could not unlock wallet.</source>
-        <translation type="unfinished">Nem sikerült a tárca megnyitása</translation>
+        <translation type="unfinished">Nem sikerült a tárca feloldása</translation>
     </message>
     <message>
         <source>Could not generate new %1 address</source>
@@ -3386,7 +3436,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until you have validated the complete chain.</source>
-        <translation type="unfinished">A tartalék díj (failback fee) használata egy órákig, napokig tartó, vagy akár sosem végbemenő tranzakciót eredményezhet. Fontolja meg, hogy Ön adja meg a díjat, vagy várjon amíg a teljes láncot érvényesíti.</translation>
+        <translation type="unfinished">A tartalék díj (fallback fee) használata egy órákig, napokig tartó, vagy akár sosem végbemenő tranzakciót eredményezhet. Fontolja meg, hogy Ön adja meg a díjat, vagy várjon amíg a teljes láncot érvényesíti.</translation>
     </message>
     <message>
         <source>Warning: Fee estimation is currently not possible.</source>
@@ -3661,14 +3711,10 @@ Megjegyzés: Mivel a díj bájtonként van kiszámítva, egy "100 satoshi kvB-nk
         <source>A fee higher than %1 is considered an absurdly high fee.</source>
         <translation type="unfinished">A díj magasabb, mint %1 ami abszurd magas díjnak számít.</translation>
     </message>
-    <message>
-        <source>Payment request expired.</source>
-        <translation type="unfinished">A fizetési kérelem lejárt.</translation>
-    </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>A megerősítésnek becsült kezdete %n blokkon belül várható.</numerusform>
         </translation>
     </message>
     <message>
@@ -3743,28 +3789,12 @@ Megjegyzés: Mivel a díj bájtonként van kiszámítva, egy "100 satoshi kvB-nk
         <translation type="unfinished">Üzenet:</translation>
     </message>
     <message>
-        <source>This is an unauthenticated payment request.</source>
-        <translation type="unfinished">Ez egy nem hitelesített fizetési kérelem.</translation>
-    </message>
-    <message>
-        <source>This is an authenticated payment request.</source>
-        <translation type="unfinished">Ez egy hitelesített fizetési kérelem.</translation>
-    </message>
-    <message>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished">Adjon egy címkét ehhez a címhez, hogy bekerüljön a használt címek közé</translation>
     </message>
     <message>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished">Egy üzenet a bitcoin: URI-hoz csatolva, amely a tranzakciócal együtt lesz eltárolva az Ön számára. Megjegyzés: Ez az üzenet nem kerül elküldésre a Bitcoin hálózaton keresztül.</translation>
-    </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">Címzett:</translation>
-    </message>
-    <message>
-        <source>Memo:</source>
-        <translation type="unfinished">Jegyzet:</translation>
     </message>
 </context>
 <context>
@@ -3786,7 +3816,7 @@ Megjegyzés: Mivel a díj bájtonként van kiszámítva, egy "100 satoshi kvB-nk
     </message>
     <message>
         <source>&amp;Sign Message</source>
-        <translation type="unfinished">Üzenet aláírása...</translation>
+        <translation type="unfinished">Üzenet &amp;Aláírása</translation>
     </message>
     <message>
         <source>You can sign messages/agreements with your addresses to prove you can receive bitcoins sent to them. Be careful not to sign anything vague or random, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
@@ -3818,11 +3848,11 @@ Megjegyzés: Mivel a díj bájtonként van kiszámítva, egy "100 satoshi kvB-nk
     </message>
     <message>
         <source>Sign the message to prove you own this Bitcoin address</source>
-        <translation type="unfinished">Üzenet</translation>
+        <translation type="unfinished">Üzenet aláírása, ezzel bizonyítva, hogy Öné ez a Bitcoin cím</translation>
     </message>
     <message>
         <source>Sign &amp;Message</source>
-        <translation type="unfinished">Üzenet &amp;aláírása</translation>
+        <translation type="unfinished">Üzenet &amp;Aláírása</translation>
     </message>
     <message>
         <source>Reset all sign message fields</source>
@@ -3830,7 +3860,7 @@ Megjegyzés: Mivel a díj bájtonként van kiszámítva, egy "100 satoshi kvB-nk
     </message>
     <message>
         <source>Clear &amp;All</source>
-        <translation type="unfinished">Mindent &amp;töröl</translation>
+        <translation type="unfinished">Mindent &amp;Töröl</translation>
     </message>
     <message>
         <source>&amp;Verify Message</source>
@@ -3846,7 +3876,7 @@ Megjegyzés: Mivel a díj bájtonként van kiszámítva, egy "100 satoshi kvB-nk
     </message>
     <message>
         <source>The signed message to verify</source>
-        <translation type="unfinished">Az aláírt üzenet ellenőrzésre</translation>
+        <translation type="unfinished">Az ellenőrizni kívánt aláírt üzenet</translation>
     </message>
     <message>
         <source>The signature given when the message was signed</source>
@@ -3858,7 +3888,7 @@ Megjegyzés: Mivel a díj bájtonként van kiszámítva, egy "100 satoshi kvB-nk
     </message>
     <message>
         <source>Verify &amp;Message</source>
-        <translation type="unfinished">Üzenet ellenőrzése</translation>
+        <translation type="unfinished">Üzenet &amp;Ellenőrzése</translation>
     </message>
     <message>
         <source>Reset all verify message fields</source>
@@ -3874,7 +3904,7 @@ Megjegyzés: Mivel a díj bájtonként van kiszámítva, egy "100 satoshi kvB-nk
     </message>
     <message>
         <source>Please check the address and try again.</source>
-        <translation type="unfinished">Kérem ellenőrizze a címet és próbálja meg újra.</translation>
+        <translation type="unfinished">Ellenőrizze a címet és próbálja meg újra.</translation>
     </message>
     <message>
         <source>The entered address does not refer to a key.</source>
@@ -3906,7 +3936,7 @@ Megjegyzés: Mivel a díj bájtonként van kiszámítva, egy "100 satoshi kvB-nk
     </message>
     <message>
         <source>Please check the signature and try again.</source>
-        <translation type="unfinished">Kérem ellenőrizze az aláírást és próbálja újra.</translation>
+        <translation type="unfinished">Ellenőrizze az aláírást és próbálja újra.</translation>
     </message>
     <message>
         <source>The signature did not match the message digest.</source>
@@ -3936,30 +3966,22 @@ Megjegyzés: Mivel a díj bájtonként van kiszámítva, egy "100 satoshi kvB-nk
     <name>TransactionDesc</name>
     <message>
         <source>conflicted with a transaction with %1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that conflicts with a confirmed transaction.</extracomment>
         <translation type="unfinished">ütközés egy %1 megerősítéssel rendelkező tranzakcióval</translation>
     </message>
     <message>
-        <source>0/unconfirmed, %1</source>
-        <translation type="unfinished">0/megerősítetlen, %1</translation>
-    </message>
-    <message>
-        <source>in memory pool</source>
-        <translation type="unfinished">a memória halomban</translation>
-    </message>
-    <message>
-        <source>not in memory pool</source>
-        <translation type="unfinished">nincs a memória halomban</translation>
-    </message>
-    <message>
         <source>abandoned</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an abandoned transaction.</extracomment>
         <translation type="unfinished">elhagyott</translation>
     </message>
     <message>
         <source>%1/unconfirmed</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
         <translation type="unfinished">%1/megerősítetlen</translation>
     </message>
     <message>
         <source>%1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
         <translation type="unfinished">%1 megerősítés</translation>
     </message>
     <message>
@@ -4009,7 +4031,7 @@ Megjegyzés: Mivel a díj bájtonként van kiszámítva, egy "100 satoshi kvB-nk
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>Beérik %n blokk múlva</numerusform>
         </translation>
     </message>
     <message>
@@ -4140,7 +4162,7 @@ Megjegyzés: Mivel a díj bájtonként van kiszámítva, egy "100 satoshi kvB-nk
     </message>
     <message>
         <source>Conflicted</source>
-        <translation type="unfinished">Konfliktusos</translation>
+        <translation type="unfinished">Ellentmondásos</translation>
     </message>
     <message>
         <source>Immature (%1 confirmations, will be available after %2)</source>
@@ -4168,7 +4190,7 @@ Megjegyzés: Mivel a díj bájtonként van kiszámítva, egy "100 satoshi kvB-nk
     </message>
     <message>
         <source>Mined</source>
-        <translation type="unfinished">Kibányászva</translation>
+        <translation type="unfinished">Bányászva</translation>
     </message>
     <message>
         <source>watch-only</source>
@@ -4349,7 +4371,7 @@ Megjegyzés: Mivel a díj bájtonként van kiszámítva, egy "100 satoshi kvB-nk
     </message>
     <message>
         <source>Exporting Failed</source>
-        <translation type="unfinished">Hiba az exportálás során</translation>
+        <translation type="unfinished">Sikertelen exportálás</translation>
     </message>
     <message>
         <source>There was an error trying to save the transaction history to %1.</source>
@@ -4369,7 +4391,7 @@ Megjegyzés: Mivel a díj bájtonként van kiszámítva, egy "100 satoshi kvB-nk
     </message>
     <message>
         <source>to</source>
-        <translation type="unfinished">meddig</translation>
+        <translation type="unfinished">-</translation>
     </message>
 </context>
 <context>
@@ -4415,7 +4437,7 @@ A "Fájl &gt; Tárca megnyitása" menüben tölthet be egyet.
     <name>WalletModel</name>
     <message>
         <source>Send Coins</source>
-        <translation type="unfinished">Érmék Küldése</translation>
+        <translation type="unfinished">Érmék küldése</translation>
     </message>
     <message>
         <source>Fee bump error</source>
@@ -4512,7 +4534,7 @@ A "Fájl &gt; Tárca megnyitása" menüben tölthet be egyet.
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished">Bezárás</translation>
+        <translation type="unfinished">Mégse</translation>
     </message>
 </context>
 </TS>

--- a/src/qt/locale/bitcoin_id.ts
+++ b/src/qt/locale/bitcoin_id.ts
@@ -3,7 +3,7 @@
     <name>AddressBookPage</name>
     <message>
         <source>Right-click to edit address or label</source>
-        <translation type="unfinished">Klik-kanan untuk mengubah alamat atau label</translation>
+        <translation type="unfinished">Klik kanan untuk mengubah alamat atau label</translation>
     </message>
     <message>
         <source>Create a new address</source>
@@ -23,7 +23,7 @@
     </message>
     <message>
         <source>C&amp;lose</source>
-        <translation type="unfinished">T&amp;utup</translation>
+        <translation type="unfinished">&amp;Tutup</translation>
     </message>
     <message>
         <source>Delete the currently selected address from the list</source>
@@ -48,10 +48,6 @@
     <message>
         <source>Choose the address to send coins to</source>
         <translation type="unfinished">Pilih alamat untuk mengirim koin</translation>
-    </message>
-    <message>
-        <source>Choose the address to receive coins with</source>
-        <translation type="unfinished">Piih alamat untuk menerima koin</translation>
     </message>
     <message>
         <source>C&amp;hoose</source>
@@ -237,22 +233,22 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>BitcoinApplication</name>
     <message>
+        <source>Settings file %1 might be corrupt or invalid.</source>
+        <translation type="unfinished">File pengaturan %1 mungkin rusak atau tidak valid.</translation>
+    </message>
+    <message>
         <source>Runaway exception</source>
         <translation type="unfinished">Pengecualian pelarian</translation>
     </message>
     <message>
         <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
-        <translation type="unfinished">Kesalahan yang fatal telah terjadi. %1 tidak bisa berlanjut dengan selamat dan akan keluar.</translation>
+        <translation type="unfinished">Error yang fatal telah terjadi. %1 tidak bisa berlanjut dengan selamat dan akan keluar.</translation>
     </message>
     <message>
         <source>Internal error</source>
         <translation type="unfinished">Kesalahan internal</translation>
     </message>
-    <message>
-        <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
-        <translation type="unfinished">Terjadi kesalahan internal.  %1 akan mencoba melanjutkan secara aman. Ini adalah bug yang tidak terduga yang dapat dilaporkan seperti penjelasan di bawah ini.</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>QObject</name>
     <message>
@@ -347,31 +343,31 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%ndetik</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n minute(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n menit</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%njam</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n hari</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%nminggu</numerusform>
         </translation>
     </message>
     <message>
@@ -381,7 +377,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n tahun</numerusform>
         </translation>
     </message>
     </context>
@@ -424,6 +420,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Kesalahan membaca %s! Semua kunci dibaca dengan benar, tetapi data transaksi atau entri buku alamat mungkin hilang atau salah.</translation>
     </message>
     <message>
+        <source>Error reading %s! Transaction data may be missing or incorrect. Rescanning wallet.</source>
+        <translation type="unfinished">Kesalahan membaca %s! Data transaksi mungkin hilang atau salah. Memindai ulang dompet.</translation>
+    </message>
+    <message>
         <source>Error: Dumpfile format record is incorrect. Got "%s", expected "format".</source>
         <translation type="unfinished">Kesalahan: Rekaman pengenal dumpfile salah. Mendapat "%s", diharapkan "format". </translation>
     </message>
@@ -438,10 +438,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Error: Legacy wallets only support the "legacy", "p2sh-segwit", and "bech32" address types</source>
         <translation type="unfinished">Kesalahan: Dompet lama hanya mendukung jenis alamat "warisan", "p2sh-segwit", dan "bech32"</translation>
-    </message>
-    <message>
-        <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
-        <translation type="unfinished">Kesalahan: Mendengarkan koneksi yang masuk gagal (dengarkan kesalahan yang dikembalikan %s)</translation>
     </message>
     <message>
         <source>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.</source>
@@ -478,6 +474,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Prune configured below the minimum of %d MiB.  Please use a higher number.</source>
         <translation type="unfinished">Pemangkasan dikonfigurasikan di bawah minimum dari %d MiB. Harap gunakan angka yang lebih tinggi.</translation>
+    </message>
+    <message>
+        <source>Prune mode is incompatible with -reindex-chainstate. Use full -reindex instead.</source>
+        <translation type="unfinished">Mode pangkas tidak kompatibel dengan -reindex-chainstate. Gunakan full -reindex sebagai gantinya.</translation>
     </message>
     <message>
         <source>Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of pruned node)</source>
@@ -528,6 +528,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Format berkas dompet tidak dikenal "%s" tersedia. Berikan salah satu dari "bdb" atau "sqlite". </translation>
     </message>
     <message>
+        <source>Unsupported chainstate database format found. Please restart with -reindex-chainstate. This will rebuild the chainstate database.</source>
+        <translation type="unfinished">Ditemukan format database chainstate yang tidak didukung. Silakan mulai ulang dengan -reindex-chainstate. Ini akan membangun kembali database chainstate.</translation>
+    </message>
+    <message>
+        <source>Wallet created successfully. The legacy wallet type is being deprecated and support for creating and opening legacy wallets will be removed in the future.</source>
+        <translation type="unfinished">Dompet berhasil dibuat. Jenis dompet lama tidak digunakan lagi dan dukungan untuk membuat dan membuka dompet lama akan dihapus di masa mendatang.</translation>
+    </message>
+    <message>
         <source>Warning: Dumpfile wallet format "%s" does not match command line specified format "%s".</source>
         <translation type="unfinished">Peringatan: Dumpfile dompet format "%s" tidak cocok dengan format baris perintah yang ditentukan "%s". </translation>
     </message>
@@ -564,12 +572,88 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Tidak bisa menyelesaikan -%s alamat: '%s'</translation>
     </message>
     <message>
+        <source>Cannot set -forcednsseed to true when setting -dnsseed to false.</source>
+        <translation type="unfinished">Tidak bisa mengatur -forcednsseed ke benar ketika mengatur -dnsseed ke salah</translation>
+    </message>
+    <message>
         <source>Cannot set -peerblockfilters without -blockfilterindex.</source>
         <translation type="unfinished">Tidak dapat menyetel -peerblockfilters tanpa -blockfilterindex.</translation>
     </message>
     <message>
         <source>Cannot write to data directory '%s'; check permissions.</source>
         <translation type="unfinished">Tidak dapat menulis ke direktori data '%s'; periksa izinnya.</translation>
+    </message>
+    <message>
+        <source>-reindex-chainstate option is not compatible with -blockfilterindex. Please temporarily disable blockfilterindex while using -reindex-chainstate, or replace -reindex-chainstate with -reindex to fully rebuild all indexes.</source>
+        <translation type="unfinished">Opsi -reindex-chainstate tidak kompatibel dengan -blockfilterindex. Harap nonaktifkan blockfilterindex sementara saat menggunakan -reindex-chainstate, atau ganti -reindex-chainstate dengan -reindex untuk membangun kembali semua indeks sepenuhnya.</translation>
+    </message>
+    <message>
+        <source>-reindex-chainstate option is not compatible with -coinstatsindex. Please temporarily disable coinstatsindex while using -reindex-chainstate, or replace -reindex-chainstate with -reindex to fully rebuild all indexes.</source>
+        <translation type="unfinished">Opsi -reindex-chainstate tidak kompatibel dengan -coinstatsindex. Harap nonaktifkan sementara coinstatsindex saat menggunakan -reindex-chainstate, atau ganti -reindex-chainstate dengan -reindex untuk membangun kembali semua indeks sepenuhnya.</translation>
+    </message>
+    <message>
+        <source>-reindex-chainstate option is not compatible with -txindex. Please temporarily disable txindex while using -reindex-chainstate, or replace -reindex-chainstate with -reindex to fully rebuild all indexes.</source>
+        <translation type="unfinished">Opsi -reindex-chainstate tidak kompatibel dengan -txindex. Harap nonaktifkan sementara txindex saat menggunakan -reindex-chainstate, atau ganti -reindex-chainstate dengan -reindex untuk sepenuhnya membangun kembali semua indeks.</translation>
+    </message>
+    <message>
+        <source>Assumed-valid: last wallet synchronisation goes beyond available block data. You need to wait for the background validation chain to download more blocks.</source>
+        <translation type="unfinished">Diasumsikan-valid: sinkronisasi dompet terakhir melampaui data blok yang tersedia. Anda harus menunggu rantai validasi latar belakang untuk mengunduh lebih banyak blok.</translation>
+    </message>
+    <message>
+        <source>Error: Address book data in wallet cannot be identified to belong to migrated wallets</source>
+        <translation type="unfinished">Kesalahan: Data buku alamat di dompet tidak dapat diidentifikasi sebagai dompet yang dimigrasikan</translation>
+    </message>
+    <message>
+        <source>Error: Duplicate descriptors created during migration. Your wallet may be corrupted.</source>
+        <translation type="unfinished">Kesalahan: Deskriptor duplikat dibuat selama migrasi. Dompet Anda mungkin rusak.</translation>
+    </message>
+    <message>
+        <source>Error: Transaction %s in wallet cannot be identified to belong to migrated wallets</source>
+        <translation type="unfinished">Kesalahan: %s transaksi di dompet tidak dapat diidentifikasi sebagai dompet yang dimigrasikan</translation>
+    </message>
+    <message>
+        <source>Error: Unable to produce descriptors for this legacy wallet. Make sure the wallet is unlocked first</source>
+        <translation type="unfinished">Kesalahan: Tidak dapat membuat deskriptor untuk dompet lawas ini. Pastikan dompet tidak terkunci terlebih dahulu</translation>
+    </message>
+    <message>
+        <source>Incompatible options: -dnsseed=1 was explicitly specified, but -onlynet forbids connections to IPv4/IPv6</source>
+        <translation type="unfinished">Opsi yang tidak kompatibel: -dnsseed=1 secara eksplisit ditentukan, tetapi -onlynet melarang koneksi ke IPv4/IPv6</translation>
+    </message>
+    <message>
+        <source>Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is explicitly forbidden: -onion=0</source>
+        <translation type="unfinished">Koneksi keluar dibatasi untuk Tor (-onlynet=onion) tetapi proxy untuk mencapai jaringan Tor secara eksplisit dilarang: -onion=0</translation>
+    </message>
+    <message>
+        <source>Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is not provided: none of -proxy, -onion or -listenonion is given</source>
+        <translation type="unfinished">Koneksi keluar dibatasi untuk Tor (-onlynet=onion) tetapi proxy untuk mencapai jaringan Tor tidak disediakan: tidak ada -proxy, -onion atau -listenonion yang diberikan</translation>
+    </message>
+    <message>
+        <source>Unrecognized descriptor found. Loading wallet %s
+
+The wallet might had been created on a newer version.
+Please try running the latest software version.
+</source>
+        <translation type="unfinished">Ditemukan deskriptor yang tidak dikenal. Memuat dompet %s
+
+Dompet mungkin telah dibuat pada versi yang lebih baru.
+Silakan coba jalankan versi perangkat lunak terbaru.
+</translation>
+    </message>
+    <message>
+        <source>Unsupported category-specific logging level -loglevel=%s. Expected -loglevel=&lt;category&gt;:&lt;loglevel&gt;. Valid categories: %s. Valid loglevels: %s.</source>
+        <translation type="unfinished">Level logging khusus kategori yang tidak didukung -loglevel=%s. Diharapkan -loglevel=&lt;category&gt;:&lt;loglevel&gt;. Kategori yang valid: %s. Level log yang valid: %s.</translation>
+    </message>
+    <message>
+        <source>
+Unable to cleanup failed migration</source>
+        <translation type="unfinished">
+Tidak dapat membersihkan migrasi yang gagal</translation>
+    </message>
+    <message>
+        <source>
+Unable to restore backup of wallet.</source>
+        <translation type="unfinished">
+Tidak dapat memulihkan cadangan dompet..</translation>
     </message>
     <message>
         <source>Config setting for %s only applied on %s network when in [%s] section.</source>
@@ -648,8 +732,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Kesalahan membaca catatan berikutnya dari basis data dompet</translation>
     </message>
     <message>
-        <source>Error upgrading chainstate database</source>
-        <translation type="unfinished">Kesalahan memutakhirkan basis data chainstate</translation>
+        <source>Error: Could not add watchonly tx to watchonly wallet</source>
+        <translation type="unfinished">Kesalahan: Tidak dapat menambahkan watchonly tx ke dompet watchonly</translation>
+    </message>
+    <message>
+        <source>Error: Could not delete watchonly transactions</source>
+        <translation type="unfinished">Kesalahan: Tidak dapat menghapus transaksi hanya menonton</translation>
     </message>
     <message>
         <source>Error: Couldn't create cursor into database</source>
@@ -662,6 +750,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Error: Dumpfile checksum does not match. Computed %s, expected %s</source>
         <translation type="unfinished">Kesalahan: Checksum dumpfile tidak cocok. Dihitung %s, diharapkan %s</translation>
+    </message>
+    <message>
+        <source>Error: Failed to create new watchonly wallet</source>
+        <translation type="unfinished">Kesalahan: Gagal membuat dompet baru yang hanya dilihat</translation>
     </message>
     <message>
         <source>Error: Got key that was not hex: %s</source>
@@ -684,8 +776,36 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Kesalahan: Tidak ada %s alamat yang tersedia.</translation>
     </message>
     <message>
+        <source>Error: Not all watchonly txs could be deleted</source>
+        <translation type="unfinished">Kesalahan: Tidak semua txs watchonly dapat dihapus</translation>
+    </message>
+    <message>
+        <source>Error: This wallet already uses SQLite</source>
+        <translation type="unfinished">Kesalahan: Dompet ini sudah menggunakan SQLite</translation>
+    </message>
+    <message>
+        <source>Error: This wallet is already a descriptor wallet</source>
+        <translation type="unfinished">Kesalahan: Dompet ini sudah menjadi dompet deskriptor</translation>
+    </message>
+    <message>
+        <source>Error: Unable to begin reading all records in the database</source>
+        <translation type="unfinished">Kesalahan: Tidak dapat mulai membaca semua catatan dalam database</translation>
+    </message>
+    <message>
+        <source>Error: Unable to make a backup of your wallet</source>
+        <translation type="unfinished">Kesalahan: Tidak dapat membuat cadangan dompet Anda</translation>
+    </message>
+    <message>
         <source>Error: Unable to parse version %u as a uint32_t</source>
         <translation type="unfinished">Kesalahan: Tidak dapat mengurai versi %u sebagai uint32_t </translation>
+    </message>
+    <message>
+        <source>Error: Unable to read all records in the database</source>
+        <translation type="unfinished">Kesalahan: Tidak dapat membaca semua catatan dalam database</translation>
+    </message>
+    <message>
+        <source>Error: Unable to remove watchonly address book data</source>
+        <translation type="unfinished">Kesalahan: Tidak dapat menghapus data buku alamat yang hanya dilihat</translation>
     </message>
     <message>
         <source>Error: Unable to write record to new wallet</source>
@@ -724,6 +844,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Inisialisasi pemeriksa kewarasan gagal. %s sedang dimatikan.</translation>
     </message>
     <message>
+        <source>Input not found or already spent</source>
+        <translation type="unfinished">Input tidak ditemukan atau sudah dibelanjakan</translation>
+    </message>
+    <message>
         <source>Insufficient funds</source>
         <translation type="unfinished">Saldo tidak mencukupi</translation>
     </message>
@@ -760,6 +884,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Netmask tidak valid yang ditentukan di -whitelist: '%s'</translation>
     </message>
     <message>
+        <source>Listening for incoming connections failed (listen returned error %s)</source>
+        <translation type="unfinished">Mendengarkan koneksi masuk gagal (mendengarkan kesalahan yang dikembalikan %s)</translation>
+    </message>
+    <message>
         <source>Loading P2P addresses…</source>
         <translation type="unfinished">Memuat alamat P2P....</translation>
     </message>
@@ -776,12 +904,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Memuat dompet...</translation>
     </message>
     <message>
+        <source>Missing amount</source>
+        <translation type="unfinished">Jumlah tidak ada</translation>
+    </message>
+    <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
         <translation type="unfinished">Perlu menentukan port dengan -whitebind: '%s'</translation>
     </message>
     <message>
-        <source>No proxy server specified. Use -proxy=&lt;ip&gt; or -proxy=&lt;ip:port&gt;.</source>
-        <translation type="unfinished">Tidak ada server proxy yang ditentukan. Gunakan -proxy=&lt;ip&gt; atau -proxy=&lt;ip:port&gt;.</translation>
+        <source>No addresses available</source>
+        <translation type="unfinished">Tidak ada alamat tersedia</translation>
     </message>
     <message>
         <source>Not enough file descriptors available.</source>
@@ -790,10 +922,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Prune cannot be configured with a negative value.</source>
         <translation type="unfinished">Pemangkasan tidak dapat dikonfigurasi dengan nilai negatif.</translation>
-    </message>
-    <message>
-        <source>Prune mode is incompatible with -coinstatsindex.</source>
-        <translation type="unfinished">Mode pangkas tidak kompatibel dengan -coinstatsindex.</translation>
     </message>
     <message>
         <source>Prune mode is incompatible with -txindex.</source>
@@ -904,8 +1032,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Transaksi harus mempunyai paling tidak satu penerima</translation>
     </message>
     <message>
+        <source>Transaction needs a change address, but we can't generate it.</source>
+        <translation type="unfinished">Transaksi memerlukan alamat perubahan, tetapi kami tidak dapat membuatnya.</translation>
+    </message>
+    <message>
         <source>Transaction too large</source>
         <translation type="unfinished">Transaksi terlalu besar</translation>
+    </message>
+    <message>
+        <source>Unable to allocate memory for -maxsigcachesize: '%s' MiB</source>
+        <translation type="unfinished">Tidak dapat mengalokasikan memori untuk -maxsigcachesize: '%s' MiB</translation>
     </message>
     <message>
         <source>Unable to bind to %s on this computer (bind returned error %s)</source>
@@ -918,6 +1054,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Unable to create the PID file '%s': %s</source>
         <translation type="unfinished">Tidak dapat membuat berkas PID '%s': %s</translation>
+    </message>
+    <message>
+        <source>Unable to find UTXO for external input</source>
+        <translation type="unfinished">Tidak dapat menemukan UTXO untuk input eksternal</translation>
     </message>
     <message>
         <source>Unable to generate initial keys</source>
@@ -934,6 +1074,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
         <translation type="unfinished">Tidak dapat memulai server HTTP. Lihat log debug untuk detailnya.</translation>
+    </message>
+    <message>
+        <source>Unable to unload the wallet before migrating</source>
+        <translation type="unfinished">Tidak dapat membongkar dompet sebelum bermigrasi</translation>
     </message>
     <message>
         <source>Unknown -blockfilterindex value %s.</source>
@@ -956,12 +1100,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Aturan baru yang tidak diketahui diaktifkan (bit versi %i)</translation>
     </message>
     <message>
-        <source>Unsupported logging category %s=%s.</source>
-        <translation type="unfinished">Kategori logging yang tidak didukung %s=%s.</translation>
+        <source>Unsupported global logging level -loglevel=%s. Valid values: %s.</source>
+        <translation type="unfinished">Level logging global yang tidak didukung -loglevel=%s. Nilai yang valid: %s.</translation>
     </message>
     <message>
-        <source>Upgrading UTXO database</source>
-        <translation type="unfinished">Memutakhirkan basis data UTXO</translation>
+        <source>Unsupported logging category %s=%s.</source>
+        <translation type="unfinished">Kategori logging yang tidak didukung %s=%s.</translation>
     </message>
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
@@ -1089,7 +1233,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
-        <translation type="unfinished">Tanda tangani sebuah pesan menggunakan alamat Bitcoin Anda untuk membuktikan bahwa Anda adalah pemiliknya</translation>
+        <translation type="unfinished">Tanda tangani sebuah pesan menggunakan alamat Bitcoin Anda untuk membuktikan bahwa Anda adalah pemilik alamat tersebut</translation>
     </message>
     <message>
         <source>&amp;Verify message…</source>
@@ -1178,7 +1322,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n blok riwayat transaksi diproses.</numerusform>
         </translation>
     </message>
     <message>
@@ -1258,6 +1402,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Tutup wallet</translation>
     </message>
     <message>
+        <source>Restore Wallet…</source>
+        <extracomment>Name of the menu item that restores wallet from a backup file.</extracomment>
+        <translation type="unfinished">Pulihkan Dompet…</translation>
+    </message>
+    <message>
+        <source>Restore a wallet from a backup file</source>
+        <extracomment>Status tip for Restore Wallet menu item</extracomment>
+        <translation type="unfinished">Pulihkan dompet dari file cadangan</translation>
+    </message>
+    <message>
         <source>Close all wallets</source>
         <translation type="unfinished">Tutup semua dompet</translation>
     </message>
@@ -1282,6 +1436,26 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Tidak ada wallet tersedia</translation>
     </message>
     <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">Data Dompet</translation>
+    </message>
+    <message>
+        <source>Load Wallet Backup</source>
+        <extracomment>The title for Restore Wallet File Windows</extracomment>
+        <translation type="unfinished">Muat Pencadangan Dompet</translation>
+    </message>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of pop-up window shown when the user is attempting to restore a wallet.</extracomment>
+        <translation type="unfinished">Pulihkan Dompet</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">Nama Dompet</translation>
+    </message>
+    <message>
         <source>&amp;Window</source>
         <translation type="unfinished">&amp;Jendela</translation>
     </message>
@@ -1293,11 +1467,19 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>%1 client</source>
         <translation type="unfinished">%1 klien</translation>
     </message>
+    <message>
+        <source>&amp;Hide</source>
+        <translation type="unfinished">Sembunyi</translation>
+    </message>
+    <message>
+        <source>S&amp;how</source>
+        <translation type="unfinished">Tampilkan</translation>
+    </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n koneksi yang aktif ke jaringan Bitcoin</numerusform>
         </translation>
     </message>
     <message>
@@ -1319,6 +1501,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Enable network activity</source>
         <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
         <translation type="unfinished">aktifkan aktivitas jaringan</translation>
+    </message>
+    <message>
+        <source>Pre-syncing Headers (%1%)…</source>
+        <translation type="unfinished">Pra-Singkronisasi Header (%1%)...</translation>
     </message>
     <message>
         <source>Error: %1</source>
@@ -1559,6 +1745,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Can't list signers</source>
         <translation type="unfinished">Tidak dapat mencantumkan penandatangan</translation>
     </message>
+    <message>
+        <source>Too many external signers found</source>
+        <translation type="unfinished">Terlalu banyak penanda tangan eksternal ditemukan</translation>
+    </message>
 </context>
 <context>
     <name>LoadWalletsActivity</name>
@@ -1596,6 +1786,34 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
         <extracomment>Descriptive text of the open wallet progress window which indicates to the user which wallet is currently being opened.</extracomment>
         <translation type="unfinished">Membuka Wallet &lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+</context>
+<context>
+    <name>RestoreWalletActivity</name>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of progress window which is displayed when wallets are being restored.</extracomment>
+        <translation type="unfinished">Pulihkan Dompet</translation>
+    </message>
+    <message>
+        <source>Restoring Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the restore wallets progress window which indicates to the user that wallets are currently being restored.</extracomment>
+        <translation type="unfinished">Memulihkan Dompet &lt;b&gt;%1&lt;/b&gt;…</translation>
+    </message>
+    <message>
+        <source>Restore wallet failed</source>
+        <extracomment>Title of message box which is displayed when the wallet could not be restored.</extracomment>
+        <translation type="unfinished">Pemulihan dompet gagal</translation>
+    </message>
+    <message>
+        <source>Restore wallet warning</source>
+        <extracomment>Title of message box which is displayed when the wallet is restored with some warning.</extracomment>
+        <translation type="unfinished">Peringatan pemulihan dompet</translation>
+    </message>
+    <message>
+        <source>Restore wallet message</source>
+        <extracomment>Title of message box which is displayed when the wallet is successfully restored.</extracomment>
+        <translation type="unfinished">Pesan pemulihan dompet</translation>
     </message>
 </context>
 <context>
@@ -1769,13 +1987,23 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 </context>
 <context>
     <name>Intro</name>
-    <message>
-        <source>(of %1 GB needed)</source>
-        <translation type="unfinished">(dari %1 GB yang dibutuhkan)</translation>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform>%n GB ruang tersedia</numerusform>
+        </translation>
     </message>
-    <message>
-        <source>(%1 GB needed for full chain)</source>
-        <translation type="unfinished">(%1 GB dibutuhkan untuk rantai penuh)</translation>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform>(dari %n GB yang dibutuhkan)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform>(%n GB dibutuhkan untuk rantai penuh)</numerusform>
+        </translation>
     </message>
     <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
@@ -1789,7 +2017,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>(cukup untuk memulihkan cadangan %n hari)</numerusform>
         </translation>
     </message>
     <message>
@@ -1821,10 +2049,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Karena ini adalah pertama kalinya program dijalankan, Anda dapat memilih lokasi %1 akan menyimpan data.</translation>
     </message>
     <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation type="unfinished">Ketika Anda mengklik OK, %1 akan mulai mengunduh dan memproses %4 block chain penuh (%2GB), dimulai dari transaksi-transaksi awal di %3 saat %4 diluncurkan pertama kali.</translation>
-    </message>
-    <message>
         <source>Limit block chain storage to</source>
         <translation type="unfinished">Batasi penyimpanan rantai blok menjadi </translation>
     </message>
@@ -1839,6 +2063,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
         <translation type="unfinished">Sinkronisasi awal sangat berat dan mungkin akan menunjukkan permasalahan pada perangkat keras komputer Anda yang sebelumnya tidak tampak. Setiap kali Anda menjalankan %1, aplikasi ini akan melanjutkan pengunduhan dari posisi terakhir.</translation>
+    </message>
+    <message>
+        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2 GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
+        <translation type="unfinished">Ketika Anda mengklik OK, %1 akan mulai mengunduh dan memproses %4 block chain penuh (%2 GB) dimulai dari transaksi-transaksi awal di %3 saat %4 diluncurkan pertama kali.</translation>
     </message>
     <message>
         <source>If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</source>
@@ -1933,6 +2161,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Unknown. Syncing Headers (%1, %2%)…</source>
         <translation type="unfinished">Tidak diketahui. Sinkronisasi Header (%1, %2%)...</translation>
     </message>
+    <message>
+        <source>Unknown. Pre-syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">Tidak diketahui. Pra-sinkronisasi Header (%1, %2%)...</translation>
+    </message>
 </context>
 <context>
     <name>OpenURIDialog</name>
@@ -1989,6 +2221,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Minimalisasi aplikasi ketika jendela ditutup. Ketika pilihan ini dipilih, aplikasi akan menutup seluruhnya jika anda memilih Keluar di menu yang tersedia.</translation>
     </message>
     <message>
+        <source>Options set in this dialog are overridden by the command line:</source>
+        <translation type="unfinished">Set opsi pengaturan pada jendela dialog ini tertutup oleh baris perintah:</translation>
+    </message>
+    <message>
         <source>Open the %1 configuration file from the working directory.</source>
         <translation type="unfinished">Buka file konfigurasi %1 dari direktori kerja.</translation>
     </message>
@@ -2027,8 +2263,28 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Set nomor thread script verifikasi. Nilai negatif sesuai dengan core yang tidak ingin digunakan di dalam system.</translation>
     </message>
     <message>
+        <source>This allows you or a third party tool to communicate with the node through command-line and JSON-RPC commands.</source>
+        <extracomment>Tooltip text for Options window setting that enables the RPC server.</extracomment>
+        <translation type="unfinished">Ini memungkinkan Anda atau alat pihak ketiga untuk berkomunikasi dengan node melalui perintah baris perintah dan JSON-RPC.</translation>
+    </message>
+    <message>
+        <source>Enable R&amp;PC server</source>
+        <extracomment>An Options window setting to enable the RPC server.</extracomment>
+        <translation type="unfinished">Aktifkan server R&amp;PC</translation>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished">D&amp;ompet</translation>
+    </message>
+    <message>
+        <source>Whether to set subtract fee from amount as default or not.</source>
+        <extracomment>Tooltip text for Options window setting that sets subtracting the fee from a sending amount as default.</extracomment>
+        <translation type="unfinished">Apakah akan menetapkan biaya pengurangan dari jumlah sebagai default atau tidak.</translation>
+    </message>
+    <message>
+        <source>Subtract &amp;fee from amount by default</source>
+        <extracomment>An Options window setting to set subtracting the fee from a sending amount as default.</extracomment>
+        <translation type="unfinished">Kurangi biaya dari jumlah secara default</translation>
     </message>
     <message>
         <source>Expert</source>
@@ -2045,6 +2301,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>&amp;Spend unconfirmed change</source>
         <translation type="unfinished">&amp;Perubahan saldo untuk transaksi yang belum dikonfirmasi</translation>
+    </message>
+    <message>
+        <source>Enable &amp;PSBT controls</source>
+        <extracomment>An options window setting to enable PSBT controls.</extracomment>
+        <translation type="unfinished">Aktifkan kontrol &amp;PSBT</translation>
+    </message>
+    <message>
+        <source>Whether to show PSBT controls.</source>
+        <extracomment>Tooltip text for options window setting that enables PSBT controls.</extracomment>
+        <translation type="unfinished">Apakah akan menampilkan kontrol PSBT.</translation>
     </message>
     <message>
         <source>External Signer (e.g. hardware wallet)</source>
@@ -2147,6 +2413,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Pilihan standar unit yang ingin ditampilkan pada layar aplikasi dan saat mengirim koin.</translation>
     </message>
     <message>
+        <source>Third-party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</source>
+        <translation type="unfinished">URL pihak ketika (misalnya sebuah block explorer) yang mumcul dalam tab transaksi sebagai konteks menu. %s dalam URL diganti dengan kode transaksi. URL dipisahkan dengan tanda vertikal |.</translation>
+    </message>
+    <message>
+        <source>&amp;Third-party transaction URLs</source>
+        <translation type="unfinished">&amp;URL transaksi Pihak Ketiga</translation>
+    </message>
+    <message>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished">Ingin menunjukkan cara pengaturan koin atau tidak.</translation>
     </message>
@@ -2161,10 +2435,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Monospaced font in the Overview tab:</source>
         <translation type="unfinished">Font spasi tunggal di tab Ringkasan: </translation>
-    </message>
-    <message>
-        <source>Options set in this dialog are overridden by the command line or in the configuration file:</source>
-        <translation type="unfinished">Set opsi pengaturan pada jendela dialog ini tertutup oleh baris perintah atau dalam konfigurasi file:</translation>
     </message>
     <message>
         <source>&amp;OK</source>
@@ -2189,14 +2459,22 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Confirm options reset</source>
+        <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
         <translation type="unfinished">Memastikan reset pilihan</translation>
     </message>
     <message>
         <source>Client restart required to activate changes.</source>
+        <extracomment>Text explaining that the settings changed will not come into effect until the client is restarted.</extracomment>
         <translation type="unfinished">Restart klien diperlukan untuk mengaktifkan perubahan.</translation>
     </message>
     <message>
+        <source>Current settings will be backed up at "%1".</source>
+        <extracomment>Text explaining to the user that the client's current settings will be backed up at a specific location. %1 is a stand-in argument for the backup location's path.</extracomment>
+        <translation type="unfinished">Pengaturan saat ini akan dicadangkan di "%1".</translation>
+    </message>
+    <message>
         <source>Client will be shut down. Do you want to proceed?</source>
+        <extracomment>Text asking the user to confirm if they would like to proceed with a client shutdown.</extracomment>
         <translation type="unfinished">Klien akan dimatikan, apakah anda hendak melanjutkan?</translation>
     </message>
     <message>
@@ -2208,6 +2486,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>The configuration file is used to specify advanced user options which override GUI settings. Additionally, any command-line options will override this configuration file.</source>
         <extracomment>Explanatory text about the priority order of instructions considered by client. The order from high to low being: command-line, configuration file, GUI settings.</extracomment>
         <translation type="unfinished">File konfigurasi digunakan untuk menspesifikkan pilihan khusus pengguna yang akan menimpa pengaturan GUI. Sebagai tambahan, pengaturan command-line apapun akan menimpa file konfigurasi itu.</translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation type="unfinished">Lanjutkan</translation>
     </message>
     <message>
         <source>Cancel</source>
@@ -2228,6 +2510,13 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>The supplied proxy address is invalid.</source>
         <translation type="unfinished">Alamat proxy yang diisi tidak valid.</translation>
+    </message>
+</context>
+<context>
+    <name>OptionsModel</name>
+    <message>
+        <source>Could not read setting "%1", %2.</source>
+        <translation type="unfinished">Tidak dapat membaca setelan "%1", %2.</translation>
     </message>
 </context>
 <context>
@@ -2336,6 +2625,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Gagal untuk menandatangani transaksi: %1</translation>
     </message>
     <message>
+        <source>Cannot sign inputs while wallet is locked.</source>
+        <translation type="unfinished">Tidak dapat menandatangani input saat dompet terkunci.</translation>
+    </message>
+    <message>
         <source>Could not sign any more inputs.</source>
         <translation type="unfinished">Tidak bisa menandatangani lagi input apapun.</translation>
     </message>
@@ -2405,6 +2698,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Transaksi masih membutuhkan tanda tangan(s).</translation>
     </message>
     <message>
+        <source>(But no wallet is loaded.)</source>
+        <translation type="unfinished">(Tapi tidak ada dompet yang dimuat.)</translation>
+    </message>
+    <message>
         <source>(But this wallet cannot sign transactions.)</source>
         <translation type="unfinished">(Tetapi dompet ini tidak dapat menandatangani transaksi.)</translation>
     </message>
@@ -2464,6 +2761,11 @@ Jika Anda menerima kesalahan ini, Anda harus meminta pedagang untuk memberikan U
         <translation type="unfinished">Agen Pengguna
 
 </translation>
+    </message>
+    <message>
+        <source>Age</source>
+        <extracomment>Title of Peers Table column which indicates the duration (length of time) since the peer connection started.</extracomment>
+        <translation type="unfinished">Umur</translation>
     </message>
     <message>
         <source>Direction</source>
@@ -2647,6 +2949,36 @@ Jika Anda menerima kesalahan ini, Anda harus meminta pedagang untuk memberikan U
     <message>
         <source>Mapped AS</source>
         <translation type="unfinished">AS yang Dipetakan</translation>
+    </message>
+    <message>
+        <source>Whether we relay addresses to this peer.</source>
+        <extracomment>Tooltip text for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
+        <translation type="unfinished">Apakah kita menyampaikan alamat ke rekan ini.</translation>
+    </message>
+    <message>
+        <source>Address Relay</source>
+        <extracomment>Text title for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
+        <translation type="unfinished">Alamat Relay</translation>
+    </message>
+    <message>
+        <source>The total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</source>
+        <extracomment>Tooltip text for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
+        <translation type="unfinished">Jumlah total alamat yang diterima dari rekan ini yang diproses (tidak termasuk alamat yang dihapus karena pembatasan tarif).</translation>
+    </message>
+    <message>
+        <source>The total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</source>
+        <extracomment>Tooltip text for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
+        <translation type="unfinished">Jumlah total alamat yang diterima dari rekan ini yang dihapus (tidak diproses) karena pembatasan tarif.</translation>
+    </message>
+    <message>
+        <source>Addresses Processed</source>
+        <extracomment>Text title for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
+        <translation type="unfinished">Alamat Diproses</translation>
+    </message>
+    <message>
+        <source>Addresses Rate-Limited</source>
+        <extracomment>Text title for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
+        <translation type="unfinished">Tarif Alamat Terbatas</translation>
     </message>
     <message>
         <source>User Agent</source>
@@ -2853,6 +3185,11 @@ Jika Anda menerima kesalahan ini, Anda harus meminta pedagang untuk memberikan U
     <message>
         <source>1 &amp;year</source>
         <translation type="unfinished">1 &amp;tahun</translation>
+    </message>
+    <message>
+        <source>&amp;Copy IP/Netmask</source>
+        <extracomment>Context menu action to copy the IP/Netmask of a banned peer. IP/Netmask is the combination of a peer's IP address and its Netmask. For IP address, see: https://en.wikipedia.org/wiki/IP_address.</extracomment>
+        <translation type="unfinished">&amp;Salin IP/Netmask</translation>
     </message>
     <message>
         <source>&amp;Unban</source>
@@ -3338,6 +3675,16 @@ Catatan: Karena biaya dihitung berdasarkan per byte, tarif biaya "100 satoshi pe
         <translation type="unfinished">Anda dapat menambah biaya kemudian (sinyal Replace-By-Fee, BIP-125).</translation>
     </message>
     <message>
+        <source>Do you want to create this transaction?</source>
+        <extracomment>Message displayed when attempting to create a transaction. Cautionary text to prompt the user to verify that the displayed transaction details represent the transaction the user intends to create.</extracomment>
+        <translation type="unfinished">Apakah Anda ingin membuat transaksi ini?</translation>
+    </message>
+    <message>
+        <source>Please, review your transaction. You can create and send this transaction or create a Partially Signed Bitcoin Transaction (PSBT), which you can save or copy and then sign with, e.g., an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
+        <extracomment>Text to inform a user attempting to create a transaction of their current options. At this stage, a user can send their transaction or create a PSBT. This string is displayed when both private keys and PSBT controls are enabled.</extracomment>
+        <translation type="unfinished">Harap untuk analisi proposal transaksi anda kembali. Anda dapat membuat dan mengirim transaksi ini atau membuat transaksi bitcoin yang ditandai tangani sebagaian (PSBT) yang bisa anda simpan atau salin dan tanda tangan dengan contoh dompet offline %1, atau dompet yang kompatibel dengan PSBT</translation>
+    </message>
+    <message>
         <source>Please, review your transaction.</source>
         <extracomment>Text to prompt a user to review the details of the transaction they are attempting to send.</extracomment>
         <translation type="unfinished">Mohon periksa kembali transaksi anda.</translation>
@@ -3386,14 +3733,10 @@ Catatan: Karena biaya dihitung berdasarkan per byte, tarif biaya "100 satoshi pe
         <source>A fee higher than %1 is considered an absurdly high fee.</source>
         <translation type="unfinished">Biaya yang lebih tinggi dari %1 dianggap sebagai biaya yang sangat tinggi.</translation>
     </message>
-    <message>
-        <source>Payment request expired.</source>
-        <translation type="unfinished">Permintaan pembayaran telah kadaluarsa.</translation>
-    </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>Diperkirakan akan memulai konfirmasi dalam %n blok.</numerusform>
         </translation>
     </message>
     <message>
@@ -3468,28 +3811,12 @@ Catatan: Karena biaya dihitung berdasarkan per byte, tarif biaya "100 satoshi pe
         <translation type="unfinished">Pesan:</translation>
     </message>
     <message>
-        <source>This is an unauthenticated payment request.</source>
-        <translation type="unfinished">Ini permintaan pembayaran yang tidak diautentikasi.</translation>
-    </message>
-    <message>
-        <source>This is an authenticated payment request.</source>
-        <translation type="unfinished">Ini permintaan pembayaran yang diautentikasi.</translation>
-    </message>
-    <message>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished">Masukkan label untuk alamat ini untuk dimasukan dalam daftar alamat yang pernah digunakan</translation>
     </message>
     <message>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished">Pesan yang dilampirkan ke bitcoin: URI yang akan disimpan dengan transaksi untuk referensi Anda. Catatan: Pesan ini tidak akan dikirim melalui jaringan Bitcoin.</translation>
-    </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">Kirim Ke:</translation>
-    </message>
-    <message>
-        <source>Memo:</source>
-        <translation type="unfinished">Catatan Peringatan:</translation>
     </message>
 </context>
 <context>
@@ -3651,33 +3978,46 @@ Catatan: Karena biaya dihitung berdasarkan per byte, tarif biaya "100 satoshi pe
     </message>
 </context>
 <context>
+    <name>SplashScreen</name>
+    <message>
+        <source>(press q to shutdown and continue later)</source>
+        <translation type="unfinished">(tekan q untuk mematikan dan melanjutkan nanti)</translation>
+    </message>
+    <message>
+        <source>press q to shutdown</source>
+        <translation type="unfinished">tekan q untuk mematikan</translation>
+    </message>
+</context>
+<context>
     <name>TransactionDesc</name>
     <message>
         <source>conflicted with a transaction with %1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that conflicts with a confirmed transaction.</extracomment>
         <translation type="unfinished">Konflik dengan sebuah transaksi dengan %1 konfirmasi</translation>
     </message>
     <message>
-        <source>0/unconfirmed, %1</source>
-        <translation type="unfinished">0/belum dikonfirmasi, %1</translation>
+        <source>0/unconfirmed, in memory pool</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is in the memory pool.</extracomment>
+        <translation type="unfinished">0/belum dikonfirmasi, di kumpulan memori</translation>
     </message>
     <message>
-        <source>in memory pool</source>
-        <translation type="unfinished">Dalam pool memory</translation>
-    </message>
-    <message>
-        <source>not in memory pool</source>
-        <translation type="unfinished">Tidak dalam pool memory</translation>
+        <source>0/unconfirmed, not in memory pool</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is not in the memory pool.</extracomment>
+        <translation type="unfinished">0/belum dikonfirmasi, tidak di kumpulan memori</translation>
     </message>
     <message>
         <source>abandoned</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an abandoned transaction.</extracomment>
         <translation type="unfinished">ditinggalkan</translation>
     </message>
     <message>
         <source>%1/unconfirmed</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
         <translation type="unfinished">%1/belum dikonfirmasi</translation>
     </message>
     <message>
         <source>%1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
         <translation type="unfinished">%1 konfirmasi</translation>
     </message>
     <message>
@@ -3719,7 +4059,7 @@ Catatan: Karena biaya dihitung berdasarkan per byte, tarif biaya "100 satoshi pe
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>matang dalam %n blok lagi</numerusform>
         </translation>
     </message>
     <message>
@@ -3990,6 +4330,11 @@ Catatan: Karena biaya dihitung berdasarkan per byte, tarif biaya "100 satoshi pe
     <message>
         <source>&amp;Edit address label</source>
         <translation type="unfinished">&amp;Ubah label alamat</translation>
+    </message>
+    <message>
+        <source>Show in %1</source>
+        <extracomment>Transactions table context menu action to show the selected transaction in a third-party block explorer. %1 is a stand-in argument for the URL of the explorer.</extracomment>
+        <translation type="unfinished">Menunjukkan %1</translation>
     </message>
     <message>
         <source>Export Transaction History</source>

--- a/src/qt/locale/bitcoin_is.ts
+++ b/src/qt/locale/bitcoin_is.ts
@@ -601,6 +601,27 @@
 <context>
     <name>Intro</name>
     <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">

--- a/src/qt/locale/bitcoin_it.ts
+++ b/src/qt/locale/bitcoin_it.ts
@@ -7,7 +7,7 @@
     </message>
     <message>
         <source>Create a new address</source>
-        <translation type="unfinished">Crea un nuovo indirizzo</translation>
+        <translation type="unfinished">Crea un indirizzo nuovo</translation>
     </message>
     <message>
         <source>&amp;New</source>
@@ -242,6 +242,10 @@ E' possibile firmare solo con indirizzi di tipo "legacy".</translation>
 <context>
     <name>BitcoinApplication</name>
     <message>
+        <source>Settings file %1 might be corrupt or invalid.</source>
+        <translation type="unfinished">Il file di impostazioni %1 potrebbe essere corrotto o invalido.</translation>
+    </message>
+    <message>
         <source>Runaway exception</source>
         <translation type="unfinished">Eccezione runaway</translation>
     </message>
@@ -347,36 +351,36 @@ E' possibile firmare solo con indirizzi di tipo "legacy".</translation>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n secondo</numerusform>
+            <numerusform>%n secondi</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n minute(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n minuto</numerusform>
+            <numerusform>%n minuti</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n ora</numerusform>
+            <numerusform>%n ore</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n giorno</numerusform>
+            <numerusform>%n giorni</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%nsettimana</numerusform>
+            <numerusform>%nsettimane</numerusform>
         </translation>
     </message>
     <message>
@@ -386,8 +390,8 @@ E' possibile firmare solo con indirizzi di tipo "legacy".</translation>
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n anno</numerusform>
+            <numerusform>%n anni</numerusform>
         </translation>
     </message>
     </context>
@@ -454,10 +458,6 @@ E' possibile firmare solo con indirizzi di tipo "legacy".</translation>
         <translation type="unfinished">Errore: i portafogli elettronici obsoleti supportano solo i seguenti tipi di indirizzi: "legacy", "p2sh-segwit", e "bech32"</translation>
     </message>
     <message>
-        <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
-        <translation type="unfinished">Errore: attesa per connessioni in arrivo fallita (errore riportato %s)</translation>
-    </message>
-    <message>
         <source>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.</source>
         <translation type="unfinished">Stima della commissione non riuscita. Fallbackfee è disabilitato. Attendi qualche blocco o abilita -fallbackfee.</translation>
     </message>
@@ -500,6 +500,10 @@ E' possibile firmare solo con indirizzi di tipo "legacy".</translation>
     <message>
         <source>Prune configured below the minimum of %d MiB.  Please use a higher number.</source>
         <translation type="unfinished">La modalità epurazione è configurata al di sotto del minimo di %d MB. Si prega di utilizzare un valore più elevato.</translation>
+    </message>
+    <message>
+        <source>Prune mode is incompatible with -reindex-chainstate. Use full -reindex instead.</source>
+        <translation type="unfinished">La modalità prune è incompatibile con -reindex-chainstate. Utilizzare invece -reindex completo.</translation>
     </message>
     <message>
         <source>Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of pruned node)</source>
@@ -554,6 +558,14 @@ E' possibile firmare solo con indirizzi di tipo "legacy".</translation>
         <translation type="unfinished">Il formato “%s” del file portafoglio fornito non è riconosciuto. si prega di fornire uno che sia “bdb” o “sqlite”. </translation>
     </message>
     <message>
+        <source>Unsupported chainstate database format found. Please restart with -reindex-chainstate. This will rebuild the chainstate database.</source>
+        <translation type="unfinished">Formato del database chainstate non supportato. Riavviare con -reindex-chainstate. In questo modo si ricostruisce il database dello stato della catena.</translation>
+    </message>
+    <message>
+        <source>Wallet created successfully. The legacy wallet type is being deprecated and support for creating and opening legacy wallets will be removed in the future.</source>
+        <translation type="unfinished">Portafoglio creato con successo. Il tipo di portafoglio legacy è stato deprecato e il supporto per la creazione e l'apertura di portafogli legacy sarà rimosso in futuro.</translation>
+    </message>
+    <message>
         <source>Warning: Dumpfile wallet format "%s" does not match command line specified format "%s".</source>
         <translation type="unfinished">Attenzione: il formato “%s” del file dump di portafoglio non combacia con il formato “%s” specificato nella riga di comando.</translation>
     </message>
@@ -600,6 +612,98 @@ E' possibile firmare solo con indirizzi di tipo "legacy".</translation>
     <message>
         <source>Cannot write to data directory '%s'; check permissions.</source>
         <translation type="unfinished">Impossibile scrivere nella directory dei dati ' %s'; controlla le autorizzazioni.</translation>
+    </message>
+    <message>
+        <source>The -txindex upgrade started by a previous version cannot be completed. Restart with the previous version or run a full -reindex.</source>
+        <translation type="unfinished">L'upgrade -txindex avviato su una versione precedente non può essere completato. Riavviare con la versione precedente o eseguire un -reindex completo.</translation>
+    </message>
+    <message>
+        <source>%s request to listen on port %u. This port is considered "bad" and thus it is unlikely that any Bitcoin Core peers connect to it. See doc/p2p-bad-ports.md for details and a full list.</source>
+        <translation type="unfinished">%s richiede di ascoltare sulla porta %u.  Questa porta è considerata "cattiva" e quindi è improbabile che qualsiasi peer Bitcoin Core si colleghi ad essa. Guardare doc/p2p-bad-ports.md per i dettagli ed un elenco completo.</translation>
+    </message>
+    <message>
+        <source>-reindex-chainstate option is not compatible with -blockfilterindex. Please temporarily disable blockfilterindex while using -reindex-chainstate, or replace -reindex-chainstate with -reindex to fully rebuild all indexes.</source>
+        <translation type="unfinished">L'opzione -reindex-chainstate non è compatibile con -blockfilterindex. Disattivare temporaneamente blockfilterindex mentre si usa -reindex-chainstate, oppure sostituire -reindex-chainstate con -reindex per ricostruire completamente tutti gli indici.</translation>
+    </message>
+    <message>
+        <source>-reindex-chainstate option is not compatible with -coinstatsindex. Please temporarily disable coinstatsindex while using -reindex-chainstate, or replace -reindex-chainstate with -reindex to fully rebuild all indexes.</source>
+        <translation type="unfinished">L'opzione -reindex-chainstate non è compatibile con -coinstatsindex. Si prega di disabilitare temporaneamente coinstatsindex mentre si usa -reindex-chainstate, oppure di sostituire -reindex-chainstate con -reindex per ricostruire completamente tutti gli indici.</translation>
+    </message>
+    <message>
+        <source>-reindex-chainstate option is not compatible with -txindex. Please temporarily disable txindex while using -reindex-chainstate, or replace -reindex-chainstate with -reindex to fully rebuild all indexes.</source>
+        <translation type="unfinished">L'opzione -reindex-chainstate non è compatibile con -txindex. Si prega di disabilitare temporaneamente txindex mentre si usa -reindex-chainstate, oppure di sostituire -reindex-chainstate con -reindex per ricostruire completamente tutti gli indici.</translation>
+    </message>
+    <message>
+        <source>Assumed-valid: last wallet synchronisation goes beyond available block data. You need to wait for the background validation chain to download more blocks.</source>
+        <translation type="unfinished">Presunto-valido: l'ultima sincronizzazione del portafoglio va oltre i dati dei blocchi disponibili. È necessario attendere che la catena di convalida in background scarichi altri blocchi.</translation>
+    </message>
+    <message>
+        <source>Cannot provide specific connections and have addrman find outgoing connections at the same time.</source>
+        <translation type="unfinished">Non e' possibile fornire connessioni specifiche e contemporaneamente usare addrman per trovare connessioni uscenti.  </translation>
+    </message>
+    <message>
+        <source>Error loading %s: External signer wallet being loaded without external signer support compiled</source>
+        <translation type="unfinished">Errore caricando %s: il wallet del dispositivo esterno di firma é stato caricato senza che il supporto del dispositivo esterno di firma sia stato compilato.</translation>
+    </message>
+    <message>
+        <source>Error: Address book data in wallet cannot be identified to belong to migrated wallets</source>
+        <translation type="unfinished">Errore: I dati della rubrica nel portafoglio non possono essere identificati come appartenenti a portafogli migrati</translation>
+    </message>
+    <message>
+        <source>Error: Duplicate descriptors created during migration. Your wallet may be corrupted.</source>
+        <translation type="unfinished">Errore: Descrittori duplicati creati durante la migrazione. Il portafoglio potrebbe essere danneggiato.</translation>
+    </message>
+    <message>
+        <source>Error: Transaction %s in wallet cannot be identified to belong to migrated wallets</source>
+        <translation type="unfinished">Errore: La transazione %s nel portafoglio non può essere identificata come appartenente ai portafogli migrati.</translation>
+    </message>
+    <message>
+        <source>Error: Unable to produce descriptors for this legacy wallet. Make sure the wallet is unlocked first</source>
+        <translation type="unfinished">Errore: Impossibile produrre descrittori per questo portafoglio legacy. Assicurarsi che il portafoglio sia prima sbloccato</translation>
+    </message>
+    <message>
+        <source>Failed to rename invalid peers.dat file. Please move or delete it and try again.</source>
+        <translation type="unfinished">Mancata rinominazione del file peers.dat non valido. Per favore spostarlo o eliminarlo e provare di nuovo.</translation>
+    </message>
+    <message>
+        <source>Incompatible options: -dnsseed=1 was explicitly specified, but -onlynet forbids connections to IPv4/IPv6</source>
+        <translation type="unfinished">Opzioni incompatibili: -dnsseed=1 è stato specificato esplicitamente, ma -onlynet vieta le connessioni a IPv4/IPv6</translation>
+    </message>
+    <message>
+        <source>Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is explicitly forbidden: -onion=0</source>
+        <translation type="unfinished">Connessioni in uscita limitate a Tor (-onlynet=onion) ma il proxy per raggiungere la rete Tor è esplicitamente vietato: -onion=0</translation>
+    </message>
+    <message>
+        <source>Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is not provided: none of -proxy, -onion or -listenonion is given</source>
+        <translation type="unfinished">Connessioni in uscita limitate a Tor (-onlynet=onion) ma il proxy per raggiungere la rete Tor non è stato dato: nessuna tra le opzioni -proxy, -onion o -listenonion è fornita</translation>
+    </message>
+    <message>
+        <source>Unrecognized descriptor found. Loading wallet %s
+
+The wallet might had been created on a newer version.
+Please try running the latest software version.
+</source>
+        <translation type="unfinished">Trovato descrittore non riconosciuto. Caricamento del portafoglio %s
+
+Il portafoglio potrebbe essere stato creato con una versione più recente.
+Provare a eseguire l'ultima versione del software.
+</translation>
+    </message>
+    <message>
+        <source>Unsupported category-specific logging level -loglevel=%s. Expected -loglevel=&lt;category&gt;:&lt;loglevel&gt;. Valid categories: %s. Valid loglevels: %s.</source>
+        <translation type="unfinished">Livello di log specifico della categoria non supportato -loglevel=%s. Atteso -loglevel=&lt;category&gt;:&lt;loglevel&gt;. Categorie valide: %s. Livelli di log validi: %s.</translation>
+    </message>
+    <message>
+        <source>
+Unable to cleanup failed migration</source>
+        <translation type="unfinished">
+Non in grado di pulire la migrazione fallita</translation>
+    </message>
+    <message>
+        <source>
+Unable to restore backup of wallet.</source>
+        <translation type="unfinished">
+Non in grado di ripristinare il backup del portafoglio.</translation>
     </message>
     <message>
         <source>Config setting for %s only applied on %s network when in [%s] section.</source>
@@ -682,8 +786,12 @@ E' possibile firmare solo con indirizzi di tipo "legacy".</translation>
         <translation type="unfinished">Si è verificato un errore leggendo la voce successiva dal database del portafogli elettronico</translation>
     </message>
     <message>
-        <source>Error upgrading chainstate database</source>
-        <translation type="unfinished">Errore durante l'aggiornamento del database chainstate</translation>
+        <source>Error: Could not add watchonly tx to watchonly wallet</source>
+        <translation type="unfinished">Errore: Impossibile aggiungere la transazione in sola consultazione al wallet in sola consultazione</translation>
+    </message>
+    <message>
+        <source>Error: Could not delete watchonly transactions</source>
+        <translation type="unfinished">Errore: Non in grado di rimuovere le transazioni di sola lettura</translation>
     </message>
     <message>
         <source>Error: Couldn't create cursor into database</source>
@@ -696,6 +804,10 @@ E' possibile firmare solo con indirizzi di tipo "legacy".</translation>
     <message>
         <source>Error: Dumpfile checksum does not match. Computed %s, expected %s</source>
         <translation type="unfinished">Errore: Il Cheksum del dumpfile non corrisponde. Rilevato: %s, sarebbe dovuto essere: %s</translation>
+    </message>
+    <message>
+        <source>Error: Failed to create new watchonly wallet</source>
+        <translation type="unfinished">Errore: Fallimento nella creazione di un portafoglio nuovo di sola lettura</translation>
     </message>
     <message>
         <source>Error: Got key that was not hex: %s</source>
@@ -718,8 +830,32 @@ E' possibile firmare solo con indirizzi di tipo "legacy".</translation>
         <translation type="unfinished">Errore:  Nessun %s indirizzo disponibile</translation>
     </message>
     <message>
+        <source>Error: Not all watchonly txs could be deleted</source>
+        <translation type="unfinished">Errore: Non è stato possibile cancellare tutte le transazioni in sola consultazione</translation>
+    </message>
+    <message>
+        <source>Error: This wallet already uses SQLite</source>
+        <translation type="unfinished">Errore: Questo portafoglio utilizza già SQLite</translation>
+    </message>
+    <message>
+        <source>Error: This wallet is already a descriptor wallet</source>
+        <translation type="unfinished">Errore: Questo portafoglio è già un portafoglio descrittore</translation>
+    </message>
+    <message>
+        <source>Error: Unable to begin reading all records in the database</source>
+        <translation type="unfinished">Errore: Impossibile iniziare la lettura di tutti i record del database</translation>
+    </message>
+    <message>
+        <source>Error: Unable to make a backup of your wallet</source>
+        <translation type="unfinished">Errore: Non in grado di creare un backup del tuo portafoglio</translation>
+    </message>
+    <message>
         <source>Error: Unable to parse version %u as a uint32_t</source>
         <translation type="unfinished">Errore: impossibile analizzare la versione %u come uint32_t</translation>
+    </message>
+    <message>
+        <source>Error: Unable to read all records in the database</source>
+        <translation type="unfinished">Errore: Non in grado di leggere tutti i record nel database</translation>
     </message>
     <message>
         <source>Error: Unable to write record to new wallet</source>
@@ -830,20 +966,12 @@ E' possibile firmare solo con indirizzi di tipo "legacy".</translation>
         <translation type="unfinished">Nessun indirizzo disponibile</translation>
     </message>
     <message>
-        <source>No proxy server specified. Use -proxy=&lt;ip&gt; or -proxy=&lt;ip:port&gt;.</source>
-        <translation type="unfinished">Nessun server proxy specificato. Usa -proxy=&lt;ip&gt; o -proxy=&lt;ip:port&gt;.</translation>
-    </message>
-    <message>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished">Non ci sono abbastanza descrittori di file disponibili.</translation>
     </message>
     <message>
         <source>Prune cannot be configured with a negative value.</source>
         <translation type="unfinished">La modalità epurazione non può essere configurata con un valore negativo.</translation>
-    </message>
-    <message>
-        <source>Prune mode is incompatible with -coinstatsindex.</source>
-        <translation type="unfinished">La modalità epurazione è incompatibile con l'opzione -coinstatsindex.</translation>
     </message>
     <message>
         <source>Prune mode is incompatible with -txindex.</source>
@@ -946,6 +1074,10 @@ E' possibile firmare solo con indirizzi di tipo "legacy".</translation>
         <translation type="unfinished">Gli importi di transazione non devono essere negativi</translation>
     </message>
     <message>
+        <source>Transaction change output index out of range</source>
+        <translation type="unfinished">La transazione cambia l' indice dell'output fuori dal limite.</translation>
+    </message>
+    <message>
         <source>Transaction has too long of a mempool chain</source>
         <translation type="unfinished">La transazione ha una sequenza troppo lunga nella mempool</translation>
     </message>
@@ -1016,10 +1148,6 @@ E' possibile firmare solo con indirizzi di tipo "legacy".</translation>
     <message>
         <source>Unsupported logging category %s=%s.</source>
         <translation type="unfinished">Categoria di registrazione non supportata %s=%s.</translation>
-    </message>
-    <message>
-        <source>Upgrading UTXO database</source>
-        <translation type="unfinished">Aggiornamento del database UTXO</translation>
     </message>
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
@@ -1131,19 +1259,19 @@ E' possibile firmare solo con indirizzi di tipo "legacy".</translation>
     </message>
     <message>
         <source>&amp;Encrypt Wallet…</source>
-        <translation type="unfinished">&amp;Cifra il portafoglio...</translation>
+        <translation type="unfinished">&amp;Cripta il portafoglio</translation>
     </message>
     <message>
         <source>Encrypt the private keys that belong to your wallet</source>
-        <translation type="unfinished">Cifra le chiavi private che appartengono al tuo portafoglio</translation>
+        <translation type="unfinished">Cifra le chiavi private che appartengono al tuo portamonete</translation>
     </message>
     <message>
         <source>&amp;Backup Wallet…</source>
-        <translation type="unfinished">&amp;Backup Portafoglio...</translation>
+        <translation type="unfinished">&amp;Archivia Wallet...</translation>
     </message>
     <message>
         <source>&amp;Change Passphrase…</source>
-        <translation type="unfinished">&amp;Cambia Passphrase...</translation>
+        <translation type="unfinished">&amp;Cambia Frase di sicurezza</translation>
     </message>
     <message>
         <source>Sign &amp;message…</source>
@@ -1236,8 +1364,8 @@ E' possibile firmare solo con indirizzi di tipo "legacy".</translation>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>Processati %n blocchi di cronologia di transazioni.</numerusform>
+            <numerusform> %nblocchi di cronologia di transazioni processati.</numerusform>
         </translation>
     </message>
     <message>
@@ -1274,7 +1402,7 @@ E' possibile firmare solo con indirizzi di tipo "legacy".</translation>
     </message>
     <message>
         <source>Load Partially Signed Bitcoin Transaction</source>
-        <translation type="unfinished">Carica Partially Signed Bitcoin Transaction</translation>
+        <translation type="unfinished">Carica Transazione Bitcoin Parzialmente Firmata (PSBT)</translation>
     </message>
     <message>
         <source>Load PSBT from &amp;clipboard…</source>
@@ -1317,6 +1445,16 @@ E' possibile firmare solo con indirizzi di tipo "legacy".</translation>
         <translation type="unfinished">Chiudi portafoglio</translation>
     </message>
     <message>
+        <source>Restore Wallet…</source>
+        <extracomment>Name of the menu item that restores wallet from a backup file.</extracomment>
+        <translation type="unfinished">Ripristina Portafoglio...</translation>
+    </message>
+    <message>
+        <source>Restore a wallet from a backup file</source>
+        <extracomment>Status tip for Restore Wallet menu item</extracomment>
+        <translation type="unfinished">Ripristina un portafoglio da un file di backup</translation>
+    </message>
+    <message>
         <source>Close all wallets</source>
         <translation type="unfinished">Chiudi tutti i portafogli</translation>
     </message>
@@ -1341,6 +1479,26 @@ E' possibile firmare solo con indirizzi di tipo "legacy".</translation>
         <translation type="unfinished">Nessun portafoglio disponibile</translation>
     </message>
     <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">Dati del Portafoglio</translation>
+    </message>
+    <message>
+        <source>Load Wallet Backup</source>
+        <extracomment>The title for Restore Wallet File Windows</extracomment>
+        <translation type="unfinished">Carica Backup del Portafoglio</translation>
+    </message>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of pop-up window shown when the user is attempting to restore a wallet.</extracomment>
+        <translation type="unfinished">Ripristina Portafoglio</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">Nome Portafoglio</translation>
+    </message>
+    <message>
         <source>&amp;Window</source>
         <translation type="unfinished">&amp;Finestra</translation>
     </message>
@@ -1348,12 +1506,20 @@ E' possibile firmare solo con indirizzi di tipo "legacy".</translation>
         <source>Main Window</source>
         <translation type="unfinished">Finestra principale</translation>
     </message>
+    <message>
+        <source>&amp;Hide</source>
+        <translation type="unfinished">&amp;Nascondi</translation>
+    </message>
+    <message>
+        <source>S&amp;how</source>
+        <translation type="unfinished">S&amp;come</translation>
+    </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%nconnessione attiva alla rete Bitcoin</numerusform>
+            <numerusform>%nconnessioni attive alla rete Bitcoin</numerusform>
         </translation>
     </message>
     <message>
@@ -1375,6 +1541,10 @@ E' possibile firmare solo con indirizzi di tipo "legacy".</translation>
         <source>Enable network activity</source>
         <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
         <translation type="unfinished">Abilita attività di rete</translation>
+    </message>
+    <message>
+        <source>Pre-syncing Headers (%1%)…</source>
+        <translation type="unfinished">Pre-sincronizzazione Headers (%1%)…</translation>
     </message>
     <message>
         <source>Error: %1</source>
@@ -1544,7 +1714,7 @@ E' possibile firmare solo con indirizzi di tipo "legacy".</translation>
     </message>
     <message>
         <source>Copy &amp;amount</source>
-        <translation type="unfinished">Copia &amp;importo</translation>
+        <translation type="unfinished">Copi&amp;a importo</translation>
     </message>
     <message>
         <source>Copy transaction &amp;ID and output index</source>
@@ -1635,6 +1805,10 @@ E' possibile firmare solo con indirizzi di tipo "legacy".</translation>
         <source>Can't list signers</source>
         <translation type="unfinished">Impossibile elencare firmatari</translation>
     </message>
+    <message>
+        <source>Too many external signers found</source>
+        <translation type="unfinished">Troppi firmatari esterni trovati</translation>
+    </message>
 </context>
 <context>
     <name>LoadWalletsActivity</name>
@@ -1672,6 +1846,34 @@ E' possibile firmare solo con indirizzi di tipo "legacy".</translation>
         <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
         <extracomment>Descriptive text of the open wallet progress window which indicates to the user which wallet is currently being opened.</extracomment>
         <translation type="unfinished">Apertura portafoglio &lt;b&gt;%1&lt;/b&gt; in corso…</translation>
+    </message>
+</context>
+<context>
+    <name>RestoreWalletActivity</name>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of progress window which is displayed when wallets are being restored.</extracomment>
+        <translation type="unfinished">Ripristina Portafoglio</translation>
+    </message>
+    <message>
+        <source>Restoring Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the restore wallets progress window which indicates to the user that wallets are currently being restored.</extracomment>
+        <translation type="unfinished">Ripristinando Portafoglio  &lt;b&gt;%1&lt;/b&gt;…</translation>
+    </message>
+    <message>
+        <source>Restore wallet failed</source>
+        <extracomment>Title of message box which is displayed when the wallet could not be restored.</extracomment>
+        <translation type="unfinished">Ripristino del portafoglio non riuscito</translation>
+    </message>
+    <message>
+        <source>Restore wallet warning</source>
+        <extracomment>Title of message box which is displayed when the wallet is restored with some warning.</extracomment>
+        <translation type="unfinished">Avviso di ripristino del portafoglio</translation>
+    </message>
+    <message>
+        <source>Restore wallet message</source>
+        <extracomment>Title of message box which is displayed when the wallet is successfully restored.</extracomment>
+        <translation type="unfinished">Messaggio di ripristino del portafoglio</translation>
     </message>
 </context>
 <context>
@@ -1849,13 +2051,26 @@ E' possibile firmare solo con indirizzi di tipo "legacy".</translation>
 </context>
 <context>
     <name>Intro</name>
-    <message>
-        <source>(of %1 GB needed)</source>
-        <translation type="unfinished">(di %1 GB necessari)</translation>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform>%n GB di spazio disponibile</numerusform>
+            <numerusform>%n GB di spazio disponibile</numerusform>
+        </translation>
     </message>
-    <message>
-        <source>(%1 GB needed for full chain)</source>
-        <translation type="unfinished">(%1 GB necessari per la catena completa)</translation>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform>(di %n GB richiesto)</numerusform>
+            <numerusform>(di %n GB richiesti)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform>(%n GB richiesti per la catena completa)</numerusform>
+            <numerusform>(%n GB richiesti per la catena completa)</numerusform>
+        </translation>
     </message>
     <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
@@ -1869,8 +2084,8 @@ E' possibile firmare solo con indirizzi di tipo "legacy".</translation>
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>(sufficiente per ripristinare i backup di %n giorno fa)</numerusform>
+            <numerusform>(sufficiente per ripristinare i backup di %n giorni fa)</numerusform>
         </translation>
     </message>
     <message>
@@ -1902,10 +2117,6 @@ E' possibile firmare solo con indirizzi di tipo "legacy".</translation>
         <translation type="unfinished">Dato che questa è la prima volta che il programma viene lanciato, puoi scegliere dove %1 salverà i suoi dati.</translation>
     </message>
     <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation type="unfinished">Quando fai click su OK, %1 comincerà a scaricare e processare l'intera %4 catena di blocchi (%2GB) a partire dalla prime transazioni del %3 quando %4 venne inaugurato.</translation>
-    </message>
-    <message>
         <source>Limit block chain storage to</source>
         <translation type="unfinished">Limita l'archiviazione della catena di blocchi a</translation>
     </message>
@@ -1916,6 +2127,10 @@ E' possibile firmare solo con indirizzi di tipo "legacy".</translation>
     <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
         <translation type="unfinished">La sincronizzazione iniziale è molto dispendiosa e potrebbe mettere in luce problemi harware del tuo computer che passavano prima inosservati. Ogni volta che lanci %1 continuerà a scaricare da dove si era interrotto.</translation>
+    </message>
+    <message>
+        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2 GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
+        <translation type="unfinished">Facendo clic su OK, %1 inizierà a scaricare ed elaborare l'intera catena di blocchi di %4 (%2 GB) partendo dalle prime transazioni del %3quando %4 è stato inizialmente lanciato.</translation>
     </message>
     <message>
         <source>If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</source>
@@ -2014,6 +2229,10 @@ E' possibile firmare solo con indirizzi di tipo "legacy".</translation>
         <source>Unknown. Syncing Headers (%1, %2%)…</source>
         <translation type="unfinished">Sconosciuto. Sincronizzazione Intestazioni in corso (%1,%2%)…</translation>
     </message>
+    <message>
+        <source>Unknown. Pre-syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">Sconosciuto. Pre-sincronizzazione delle intestazioni (%1, %2%)...</translation>
+    </message>
 </context>
 <context>
     <name>OpenURIDialog</name>
@@ -2070,6 +2289,10 @@ E' possibile firmare solo con indirizzi di tipo "legacy".</translation>
         <translation type="unfinished">Riduci ad icona invece di uscire dall'applicazione quando la finestra viene chiusa. Attivando questa opzione l'applicazione terminerà solo dopo aver selezionato Esci dal menu File.</translation>
     </message>
     <message>
+        <source>Options set in this dialog are overridden by the command line:</source>
+        <translation type="unfinished">Le azioni da riga di comando hanno precedenza su quelle impostate da questo pannello:</translation>
+    </message>
+    <message>
         <source>Open the %1 configuration file from the working directory.</source>
         <translation type="unfinished">Apri il %1 file di configurazione dalla cartella attiva.</translation>
     </message>
@@ -2091,7 +2314,7 @@ E' possibile firmare solo con indirizzi di tipo "legacy".</translation>
     </message>
     <message>
         <source>Prune &amp;block storage to</source>
-        <translation type="unfinished">Eliminare e bloccare l'archiviazione su</translation>
+        <translation type="unfinished">Modalità "prune": elimina i blocchi dal disco dopo</translation>
     </message>
     <message>
         <source>Reverting this setting requires re-downloading the entire blockchain.</source>
@@ -2294,17 +2517,13 @@ E' possibile firmare solo con indirizzi di tipo "legacy".</translation>
         <translation type="unfinished">corrispondenza più vicina "%1"</translation>
     </message>
     <message>
-        <source>Options set in this dialog are overridden by the command line or in the configuration file:</source>
-        <translation type="unfinished">Le impostazioni sulla riga di comando o nell'archivio di configurazione hanno precedenza su quelle impostate in questo pannello:</translation>
-    </message>
-    <message>
         <source>&amp;Cancel</source>
         <translation type="unfinished">&amp;Cancella</translation>
     </message>
     <message>
         <source>Compiled without external signing support (required for external signing)</source>
         <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
-        <translation type="unfinished">Compilato senza supporto per firmatario esterno (richiesto per firmare con periferiche)</translation>
+        <translation type="unfinished">Compilato senza supporto per firma esterna (richiesto per firma esterna)</translation>
     </message>
     <message>
         <source>default</source>
@@ -2316,14 +2535,22 @@ E' possibile firmare solo con indirizzi di tipo "legacy".</translation>
     </message>
     <message>
         <source>Confirm options reset</source>
+        <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
         <translation type="unfinished">Conferma ripristino opzioni</translation>
     </message>
     <message>
         <source>Client restart required to activate changes.</source>
+        <extracomment>Text explaining that the settings changed will not come into effect until the client is restarted.</extracomment>
         <translation type="unfinished">È necessario un riavvio del client per applicare le modifiche.</translation>
     </message>
     <message>
+        <source>Current settings will be backed up at "%1".</source>
+        <extracomment>Text explaining to the user that the client's current settings will be backed up at a specific location. %1 is a stand-in argument for the backup location's path.</extracomment>
+        <translation type="unfinished">Le impostazioni attuali saranno copiate al "%1".</translation>
+    </message>
+    <message>
         <source>Client will be shut down. Do you want to proceed?</source>
+        <extracomment>Text asking the user to confirm if they would like to proceed with a client shutdown.</extracomment>
         <translation type="unfinished">Il client sarà arrestato. Si desidera procedere?</translation>
     </message>
     <message>
@@ -2359,6 +2586,13 @@ E' possibile firmare solo con indirizzi di tipo "legacy".</translation>
     <message>
         <source>The supplied proxy address is invalid.</source>
         <translation type="unfinished">L'indirizzo proxy che hai fornito non è valido.</translation>
+    </message>
+</context>
+<context>
+    <name>OptionsModel</name>
+    <message>
+        <source>Could not read setting "%1", %2.</source>
+        <translation type="unfinished">Non posso leggere l'impostazione "%1", %2,</translation>
     </message>
 </context>
 <context>
@@ -2615,6 +2849,11 @@ Se ricevi questo errore, dovresti richiedere al commerciante di fornire un URI c
         <translation type="unfinished">Nodo</translation>
     </message>
     <message>
+        <source>Age</source>
+        <extracomment>Title of Peers Table column which indicates the duration (length of time) since the peer connection started.</extracomment>
+        <translation type="unfinished">Età</translation>
+    </message>
+    <message>
         <source>Direction</source>
         <extracomment>Title of Peers Table column which indicates the direction the peer connection was initiated from.</extracomment>
         <translation type="unfinished">Direzione</translation>
@@ -2803,29 +3042,32 @@ Se ricevi questo errore, dovresti richiedere al commerciante di fornire un URI c
     </message>
     <message>
         <source>Whether we relay addresses to this peer.</source>
-        <extracomment>Tooltip text for the Address Relay field in the peer details area.</extracomment>
+        <extracomment>Tooltip text for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
         <translation type="unfinished">Se gli indirizzi vengono ritrasmessi o meno a questo peer.</translation>
     </message>
     <message>
         <source>Address Relay</source>
+        <extracomment>Text title for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
         <translation type="unfinished">Trasmissione dell'Indirizzo</translation>
     </message>
     <message>
-        <source>Total number of addresses processed, excluding those dropped due to rate-limiting.</source>
-        <extracomment>Tooltip text for the Addresses Processed field in the peer details area.</extracomment>
-        <translation type="unfinished">Numero totale di indirizzi elaborati, esclusi quelli scartati a causa delle limitazioni nella quota.</translation>
+        <source>The total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</source>
+        <extracomment>Tooltip text for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
+        <translation type="unfinished">Totale di indirizzi ricevuti ed elaborati da questo peer (Sono esclusi gli indirizzi che sono stati eliminati a causa della limitazione di velocità).</translation>
+    </message>
+    <message>
+        <source>The total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</source>
+        <extracomment>Tooltip text for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
+        <translation type="unfinished">Il numero totale di indirizzi ricevuti da questo peer che sono stati abbandonati (non elaborati) a causa della limitazione della velocità.</translation>
     </message>
     <message>
         <source>Addresses Processed</source>
+        <extracomment>Text title for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
         <translation type="unfinished">Indirizzi Processati</translation>
     </message>
     <message>
-        <source>Total number of addresses dropped due to rate-limiting.</source>
-        <extracomment>Tooltip text for the Addresses Rate-Limited field in the peer details area.</extracomment>
-        <translation type="unfinished">Numero totale di indirizzi scartati a causa delle limitazioni della quota.</translation>
-    </message>
-    <message>
         <source>Addresses Rate-Limited</source>
+        <extracomment>Text title for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
         <translation type="unfinished">Limite di Quota per gli Indirizzi</translation>
     </message>
     <message>
@@ -3040,6 +3282,10 @@ Se ricevi questo errore, dovresti richiedere al commerciante di fornire un URI c
     <message>
         <source>Executing command without any wallet</source>
         <translation type="unfinished">Esecuzione del comando senza alcun portafoglio</translation>
+    </message>
+    <message>
+        <source>Ctrl+I</source>
+        <translation type="unfinished">Ctrl+W</translation>
     </message>
     <message>
         <source>Executing command using "%1" wallet</source>
@@ -3361,7 +3607,7 @@ Per ulteriori informazioni su come usare la console, premi %6.
     </message>
     <message>
         <source>Clear all fields of the form.</source>
-        <translation type="unfinished">Cancellare tutti i campi del modulo.</translation>
+        <translation type="unfinished">Cancella tutti i campi del modulo.</translation>
     </message>
     <message>
         <source>Inputs…</source>
@@ -3600,15 +3846,11 @@ Nota: poiché la commissione è calcolata su base per byte, una commissione di "
         <source>A fee higher than %1 is considered an absurdly high fee.</source>
         <translation type="unfinished">Una commissione maggiore di %1 è considerata irragionevolmente elevata.</translation>
     </message>
-    <message>
-        <source>Payment request expired.</source>
-        <translation type="unfinished">Richiesta di pagamento scaduta.</translation>
-    </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>Si stima che la conferma inizi entro %nblocco</numerusform>
+            <numerusform>Si stima che la conferma inizi entro %n blocchi</numerusform>
         </translation>
     </message>
     <message>
@@ -3683,14 +3925,6 @@ Nota: poiché la commissione è calcolata su base per byte, una commissione di "
         <translation type="unfinished">Messaggio:</translation>
     </message>
     <message>
-        <source>This is an unauthenticated payment request.</source>
-        <translation type="unfinished">Questa è una richiesta di pagamento non autenticata.</translation>
-    </message>
-    <message>
-        <source>This is an authenticated payment request.</source>
-        <translation type="unfinished">Questa è una richiesta di pagamento autenticata.</translation>
-    </message>
-    <message>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished">Inserisci un'etichetta per questo indirizzo per aggiungerlo alla lista degli indirizzi utilizzati</translation>
     </message>
@@ -3698,11 +3932,7 @@ Nota: poiché la commissione è calcolata su base per byte, una commissione di "
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished">Messaggio incluso nel bitcoin URI e che sarà memorizzato con la transazione per tuo riferimento. Nota: Questo messaggio non sarà inviato attraverso la rete Bitcoin.</translation>
     </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">Pagare a:</translation>
-    </message>
-    </context>
+</context>
 <context>
     <name>SendConfirmationDialog</name>
     <message>
@@ -3766,7 +3996,7 @@ Nota: poiché la commissione è calcolata su base per byte, una commissione di "
     </message>
     <message>
         <source>Clear &amp;All</source>
-        <translation type="unfinished">Cancella &amp;Tutto</translation>
+        <translation type="unfinished">Cancell&amp;a Tutto</translation>
     </message>
     <message>
         <source>&amp;Verify Message</source>
@@ -3872,30 +4102,32 @@ Nota: poiché la commissione è calcolata su base per byte, una commissione di "
     <name>TransactionDesc</name>
     <message>
         <source>conflicted with a transaction with %1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that conflicts with a confirmed transaction.</extracomment>
         <translation type="unfinished">in conflitto con una transazione con %1 conferme</translation>
     </message>
     <message>
-        <source>0/unconfirmed, %1</source>
-        <translation type="unfinished">0/non confermati, %1</translation>
+        <source>0/unconfirmed, in memory pool</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is in the memory pool.</extracomment>
+        <translation type="unfinished">0/non confermata, nel pool di memoria</translation>
     </message>
     <message>
-        <source>in memory pool</source>
-        <translation type="unfinished">nella riserva di memoria</translation>
-    </message>
-    <message>
-        <source>not in memory pool</source>
-        <translation type="unfinished">non nella riserva di memoria</translation>
+        <source>0/unconfirmed, not in memory pool</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is not in the memory pool.</extracomment>
+        <translation type="unfinished">0/non confermata, non nel pool di memoria</translation>
     </message>
     <message>
         <source>abandoned</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an abandoned transaction.</extracomment>
         <translation type="unfinished">abbandonato</translation>
     </message>
     <message>
         <source>%1/unconfirmed</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
         <translation type="unfinished">%1/non confermato</translation>
     </message>
     <message>
         <source>%1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
         <translation type="unfinished">%1 conferme</translation>
     </message>
     <message>
@@ -3945,8 +4177,8 @@ Nota: poiché la commissione è calcolata su base per byte, una commissione di "
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>matura fra %n blocco di più</numerusform>
+            <numerusform>matura fra %n blocchi di più</numerusform>
         </translation>
     </message>
     <message>
@@ -4212,7 +4444,7 @@ Nota: poiché la commissione è calcolata su base per byte, una commissione di "
     </message>
     <message>
         <source>Copy &amp;amount</source>
-        <translation type="unfinished">Copia &amp;amount</translation>
+        <translation type="unfinished">Copi&amp;a importo</translation>
     </message>
     <message>
         <source>Copy transaction &amp;ID</source>
@@ -4348,7 +4580,7 @@ Vai su File &gt; Apri Portafoglio per caricare un portafoglio.
     <name>WalletModel</name>
     <message>
         <source>Send Coins</source>
-        <translation type="unfinished">Invia Bitcoin</translation>
+        <translation type="unfinished">Invia Monete</translation>
     </message>
     <message>
         <source>Fee bump error</source>
@@ -4405,7 +4637,7 @@ Vai su File &gt; Apri Portafoglio per caricare un portafoglio.
     </message>
     <message>
         <source>default wallet</source>
-        <translation type="unfinished">Portafoglio predefinito:</translation>
+        <translation type="unfinished">portafoglio predefinito</translation>
     </message>
 </context>
 <context>
@@ -4416,7 +4648,7 @@ Vai su File &gt; Apri Portafoglio per caricare un portafoglio.
     </message>
     <message>
         <source>Export the data in the current tab to a file</source>
-        <translation type="unfinished">Esporta i dati della tabella corrente in un file</translation>
+        <translation type="unfinished">Esporta su file i dati contenuti nella tabella corrente</translation>
     </message>
     <message>
         <source>Backup Wallet</source>

--- a/src/qt/locale/bitcoin_ja.ts
+++ b/src/qt/locale/bitcoin_ja.ts
@@ -247,6 +247,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>BitcoinApplication</name>
     <message>
+        <source>Settings file %1 might be corrupt or invalid.</source>
+        <translation type="unfinished">設定ファイル %1 が壊れているか無効である可能性があります。</translation>
+    </message>
+    <message>
         <source>Runaway exception</source>
         <translation type="unfinished">暴走例外が発生</translation>
     </message>
@@ -379,7 +383,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>%n minute(s)</source>
         <translation type="unfinished">
-            <numerusform>%n 分</numerusform>
+            <numerusform>%n 記録</numerusform>
         </translation>
     </message>
     <message numerus="yes">
@@ -391,7 +395,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
-            <numerusform>%n 日</numerusform>
+            <numerusform>%n 日々</numerusform>
         </translation>
     </message>
     <message numerus="yes">
@@ -478,10 +482,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">エラー: レガシーウォレットは、アドレスタイプ「legacy」および「p2sh-segwit」、「bech32」のみをサポートします</translation>
     </message>
     <message>
-        <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
-        <translation type="unfinished">エラー: 内向きの接続をリッスンするのに失敗しました（%s エラーが返却されました）</translation>
-    </message>
-    <message>
         <source>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.</source>
         <translation type="unfinished">手数料推定に失敗しました。代替手数料が無効です。数ブロック待つか、-fallbackfee オプションを有効にしてください。</translation>
     </message>
@@ -524,6 +524,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Prune configured below the minimum of %d MiB.  Please use a higher number.</source>
         <translation type="unfinished">剪定設定が、設定可能最小値の %d MiBより低く設定されています。より大きい値を使用してください。</translation>
+    </message>
+    <message>
+        <source>Prune mode is incompatible with -reindex-chainstate. Use full -reindex instead.</source>
+        <translation type="unfinished">プルーン モードは -reindex-chainstate と互換性がありません。代わりに完全再インデックスを使用してください。</translation>
     </message>
     <message>
         <source>Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of pruned node)</source>
@@ -578,6 +582,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">未知のウォレットフォーマット"%s"が指定されました。"bdb"もしくは"sqlite"のどちらかを指定してください。</translation>
     </message>
     <message>
+        <source>Unsupported chainstate database format found. Please restart with -reindex-chainstate. This will rebuild the chainstate database.</source>
+        <translation type="unfinished">サポートされていないチェーンステート データベース形式が見つかりました。 -reindex-chainstate で再起動してください。これにより、チェーンステート データベースが再構築されます。</translation>
+    </message>
+    <message>
+        <source>Wallet created successfully. The legacy wallet type is being deprecated and support for creating and opening legacy wallets will be removed in the future.</source>
+        <translation type="unfinished">ウォレットが正常に作成されました。レガシー ウォレット タイプは非推奨になり、レガシー ウォレットの作成とオープンのサポートは将来的に削除される予定です。</translation>
+    </message>
+    <message>
         <source>Warning: Dumpfile wallet format "%s" does not match command line specified format "%s".</source>
         <translation type="unfinished">警告: ダンプファイルウォレットフォーマット"%s"は、コマンドラインで指定されたフォーマット"%s"と合致していません。</translation>
     </message>
@@ -628,6 +640,94 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>The -txindex upgrade started by a previous version cannot be completed. Restart with the previous version or run a full -reindex.</source>
         <translation type="unfinished">以前のバージョンで開始された -txindex アップグレードを完了できません。 以前のバージョンで再起動するか、 -reindex を実行してください。</translation>
+    </message>
+    <message>
+        <source>%s request to listen on port %u. This port is considered "bad" and thus it is unlikely that any Bitcoin Core peers connect to it. See doc/p2p-bad-ports.md for details and a full list.</source>
+        <translation type="unfinished">%s ポート %u でリッスンするように要求します。このポートは「不良」と見なされるため、Bitcoin Core ピアが接続する可能性はほとんどありません。詳細と完全なリストについては、doc/p2p-bad-ports.md を参照してください。</translation>
+    </message>
+    <message>
+        <source>-reindex-chainstate option is not compatible with -blockfilterindex. Please temporarily disable blockfilterindex while using -reindex-chainstate, or replace -reindex-chainstate with -reindex to fully rebuild all indexes.</source>
+        <translation type="unfinished">-reindex-chainstate オプションは -blockfilterindex と互換性がありません。 -reindex-chainstate の使用中は blockfilterindex を一時的に無効にするか、-reindex-chainstate を -reindex に置き換えてすべてのインデックスを完全に再構築してください。</translation>
+    </message>
+    <message>
+        <source>-reindex-chainstate option is not compatible with -coinstatsindex. Please temporarily disable coinstatsindex while using -reindex-chainstate, or replace -reindex-chainstate with -reindex to fully rebuild all indexes.</source>
+        <translation type="unfinished">-reindex-chainstate オプションは -coinstatsindex と互換性がありません。 -reindex-chainstate の使用中は一時的に coinstatsindex を無効にするか、-reindex-chainstate を -reindex に置き換えてすべてのインデックスを完全に再構築してください。</translation>
+    </message>
+    <message>
+        <source>-reindex-chainstate option is not compatible with -txindex. Please temporarily disable txindex while using -reindex-chainstate, or replace -reindex-chainstate with -reindex to fully rebuild all indexes.</source>
+        <translation type="unfinished">-reindex-chainstate オプションは -txindex と互換性がありません。 -reindex-chainstate の使用中は一時的に txindex を無効にするか、-reindex-chainstate を -reindex に置き換えてすべてのインデックスを完全に再構築してください。</translation>
+    </message>
+    <message>
+        <source>Assumed-valid: last wallet synchronisation goes beyond available block data. You need to wait for the background validation chain to download more blocks.</source>
+        <translation type="unfinished">有効とみなされる: 最後のウォレット同期は、利用可能なブロック データを超えています。バックグラウンド検証チェーンがさらにブロックをダウンロードするまで待つ必要があります。</translation>
+    </message>
+    <message>
+        <source>Cannot provide specific connections and have addrman find outgoing connections at the same time.</source>
+        <translation type="unfinished">特定の接続を提供することはできず、同時に addrman に発信接続を見つけさせることはできません。</translation>
+    </message>
+    <message>
+        <source>Error loading %s: External signer wallet being loaded without external signer support compiled</source>
+        <translation type="unfinished">%s のロード中にエラーが発生しました：外​​部署名者ウォレットがロードされています</translation>
+    </message>
+    <message>
+        <source>Error: Address book data in wallet cannot be identified to belong to migrated wallets</source>
+        <translation type="unfinished">エラー: ウォレット内のアドレス帳データが、移行されたウォレットに属していると識別できません</translation>
+    </message>
+    <message>
+        <source>Error: Duplicate descriptors created during migration. Your wallet may be corrupted.</source>
+        <translation type="unfinished">エラー: 移行中に作成された重複した記述子。ウォレットが破損している可能性があります。</translation>
+    </message>
+    <message>
+        <source>Error: Transaction %s in wallet cannot be identified to belong to migrated wallets</source>
+        <translation type="unfinished">エラー: ウォレット内のトランザクション %s は、移行されたウォレットに属していると識別できません</translation>
+    </message>
+    <message>
+        <source>Error: Unable to produce descriptors for this legacy wallet. Make sure the wallet is unlocked first</source>
+        <translation type="unfinished">エラー: このレガシー ウォレットの記述子を生成できません。最初にウォレットのロックが解除されていることを確認してください</translation>
+    </message>
+    <message>
+        <source>Failed to rename invalid peers.dat file. Please move or delete it and try again.</source>
+        <translation type="unfinished">無効な peers.dat ファイルの名前を変更できませんでした。移動または削除してから、もう一度お試しください。</translation>
+    </message>
+    <message>
+        <source>Incompatible options: -dnsseed=1 was explicitly specified, but -onlynet forbids connections to IPv4/IPv6</source>
+        <translation type="unfinished">互換性のないオプション: -dnsseed=1 が明示的に指定されましたが、-onlynet は IPv4/IPv6 への接続を禁止します</translation>
+    </message>
+    <message>
+        <source>Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is explicitly forbidden: -onion=0</source>
+        <translation type="unfinished">アウトバウンド接続は Tor (-onlynet=onion) に制限されていますが、Tor ネットワークに到達するためのプロキシは明示的に禁止されています: -onion=0</translation>
+    </message>
+    <message>
+        <source>Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is not provided: none of -proxy, -onion or -listenonion is given</source>
+        <translation type="unfinished">アウトバウンド接続は Tor (-onlynet=onion) に制限されていますが、Tor ネットワークに到達するためのプロキシは提供されていません: -proxy、-onion、または -listenonion のいずれも指定されていません</translation>
+    </message>
+    <message>
+        <source>Unrecognized descriptor found. Loading wallet %s
+
+The wallet might had been created on a newer version.
+Please try running the latest software version.
+</source>
+        <translation type="unfinished">認識できない記述子が見つかりました。ウォレットをロードしています %s
+
+ウォレットが新しいバージョンで作成された可能性があります。
+最新のソフトウェア バージョンを実行してみてください。
+</translation>
+    </message>
+    <message>
+        <source>Unsupported category-specific logging level -loglevel=%s. Expected -loglevel=&lt;category&gt;:&lt;loglevel&gt;. Valid categories: %s. Valid loglevels: %s.</source>
+        <translation type="unfinished">サポートされていないカテゴリ固有のログ レベル -loglevel=%s。 -loglevel=&lt;category&gt;:&lt;loglevel&gt;. が必要です。有効なカテゴリ:%s 。有効なログレベル:%s .</translation>
+    </message>
+    <message>
+        <source>
+Unable to cleanup failed migration</source>
+        <translation type="unfinished">
+失敗した移行をクリーンアップできません</translation>
+    </message>
+    <message>
+        <source>
+Unable to restore backup of wallet.</source>
+        <translation type="unfinished">
+ウォレットのバックアップを復元できません。</translation>
     </message>
     <message>
         <source>Config setting for %s only applied on %s network when in [%s] section.</source>
@@ -706,8 +806,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">ウォレットデータベースから次のレコードの読み取りでエラー</translation>
     </message>
     <message>
-        <source>Error upgrading chainstate database</source>
-        <translation type="unfinished">chainstate データベースの更新時にエラーが発生しました</translation>
+        <source>Error: Could not add watchonly tx to watchonly wallet</source>
+        <translation type="unfinished">¡エラー: watchonly tx を watchonly ウォレットに追加できませんでした</translation>
+    </message>
+    <message>
+        <source>Error: Could not delete watchonly transactions</source>
+        <translation type="unfinished">エラー: watchonly トランザクションを削除できませんでした</translation>
     </message>
     <message>
         <source>Error: Couldn't create cursor into database</source>
@@ -720,6 +824,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Error: Dumpfile checksum does not match. Computed %s, expected %s</source>
         <translation type="unfinished">エラー: ダンプファイルのチェックサムが合致しません。計算された値%s、期待される値%s</translation>
+    </message>
+    <message>
+        <source>Error: Failed to create new watchonly wallet</source>
+        <translation type="unfinished">エラー: 新しい watchonly ウォレットを作成できませんでした</translation>
     </message>
     <message>
         <source>Error: Got key that was not hex: %s</source>
@@ -742,8 +850,36 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">エラー:  %sアドレスはありません。</translation>
     </message>
     <message>
+        <source>Error: Not all watchonly txs could be deleted</source>
+        <translation type="unfinished">エラー: 一部の watchonly tx を削除できませんでした</translation>
+    </message>
+    <message>
+        <source>Error: This wallet already uses SQLite</source>
+        <translation type="unfinished">エラー: このウォレットはすでに SQLite を使用しています</translation>
+    </message>
+    <message>
+        <source>Error: This wallet is already a descriptor wallet</source>
+        <translation type="unfinished">エラー: このウォレットはすでに記述子ウォレットです</translation>
+    </message>
+    <message>
+        <source>Error: Unable to begin reading all records in the database</source>
+        <translation type="unfinished">エラー: データベース内のすべてのレコードの読み取りを開始できません</translation>
+    </message>
+    <message>
+        <source>Error: Unable to make a backup of your wallet</source>
+        <translation type="unfinished">エラー: ウォレットのバックアップを作成できません</translation>
+    </message>
+    <message>
         <source>Error: Unable to parse version %u as a uint32_t</source>
         <translation type="unfinished">エラー: バージョン%uをuint32_tとしてパースできませんでした</translation>
+    </message>
+    <message>
+        <source>Error: Unable to read all records in the database</source>
+        <translation type="unfinished">エラー: データベース内のすべてのレコードを読み取ることができません</translation>
+    </message>
+    <message>
+        <source>Error: Unable to remove watchonly address book data</source>
+        <translation type="unfinished">エラー: watchonly アドレス帳データを削除できません</translation>
     </message>
     <message>
         <source>Error: Unable to write record to new wallet</source>
@@ -826,6 +962,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">-whitelist オプションに対する不正なネットマスク: '%s'</translation>
     </message>
     <message>
+        <source>Listening for incoming connections failed (listen returned error %s)</source>
+        <translation type="unfinished">着信接続のリッスンに失敗しました (listen が error を返しました %s)</translation>
+    </message>
+    <message>
         <source>Loading P2P addresses…</source>
         <translation type="unfinished">P2Pアドレスの読み込み中…</translation>
     </message>
@@ -858,20 +998,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">アドレスが使えません</translation>
     </message>
     <message>
-        <source>No proxy server specified. Use -proxy=&lt;ip&gt; or -proxy=&lt;ip:port&gt;.</source>
-        <translation type="unfinished">プロキシサーバーが指定されてません. -proxy=&lt;ip&gt; か -proxy=&lt;ip:port&gt; を使用してください.</translation>
-    </message>
-    <message>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished">使用可能なファイルディスクリプタが不足しています。</translation>
     </message>
     <message>
         <source>Prune cannot be configured with a negative value.</source>
         <translation type="unfinished">剪定モードの設定値は負の値にはできません。</translation>
-    </message>
-    <message>
-        <source>Prune mode is incompatible with -coinstatsindex.</source>
-        <translation type="unfinished">剪定モードは -txindex オプションと互換性がありません。</translation>
     </message>
     <message>
         <source>Prune mode is incompatible with -txindex.</source>
@@ -994,6 +1126,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">トランザクションが大きすぎます</translation>
     </message>
     <message>
+        <source>Unable to allocate memory for -maxsigcachesize: '%s' MiB</source>
+        <translation type="unfinished">-maxsigcachesize にメモリを割り当てることができません: '%s' MiB</translation>
+    </message>
+    <message>
         <source>Unable to bind to %s on this computer (bind returned error %s)</source>
         <translation type="unfinished">このコンピュータの %s にバインドすることができません（%s エラーが返却されました）</translation>
     </message>
@@ -1004,6 +1140,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Unable to create the PID file '%s': %s</source>
         <translation type="unfinished">PIDファイルの作成に失敗しました ('%s': %s)</translation>
+    </message>
+    <message>
+        <source>Unable to find UTXO for external input</source>
+        <translation type="unfinished">外部入力用のUTXOが見つかりません</translation>
     </message>
     <message>
         <source>Unable to generate initial keys</source>
@@ -1026,6 +1166,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">HTTPサーバを開始できませんでした。詳細は debug.log を参照してください。</translation>
     </message>
     <message>
+        <source>Unable to unload the wallet before migrating</source>
+        <translation type="unfinished">移行前にウォレットをアンロードできません</translation>
+    </message>
+    <message>
         <source>Unknown -blockfilterindex value %s.</source>
         <translation type="unfinished">不明な -blockfilterindex の値 %s。</translation>
     </message>
@@ -1046,12 +1190,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">不明な新ルールがアクティベートされました (versionbit %i)</translation>
     </message>
     <message>
-        <source>Unsupported logging category %s=%s.</source>
-        <translation type="unfinished">サポートされていないログカテゴリ %s=%s 。</translation>
+        <source>Unsupported global logging level -loglevel=%s. Valid values: %s.</source>
+        <translation type="unfinished">サポートされていないグローバル ログ レベル -loglevel=%s。有効な値: %s.</translation>
     </message>
     <message>
-        <source>Upgrading UTXO database</source>
-        <translation type="unfinished">UTXOデータベースの更新中</translation>
+        <source>Unsupported logging category %s=%s.</source>
+        <translation type="unfinished">サポートされていないログカテゴリ %s=%s 。</translation>
     </message>
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
@@ -1272,7 +1416,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation type="unfinished">
-            <numerusform>%n ブロックの取引履歴を処理しました。</numerusform>
+            <numerusform>トランザクション履歴の %n ブロックを処理しました。</numerusform>
         </translation>
     </message>
     <message>
@@ -1352,6 +1496,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">ウォレットを閉じる</translation>
     </message>
     <message>
+        <source>Restore Wallet…</source>
+        <extracomment>Name of the menu item that restores wallet from a backup file.</extracomment>
+        <translation type="unfinished">ウォレットを復元…</translation>
+    </message>
+    <message>
+        <source>Restore a wallet from a backup file</source>
+        <extracomment>Status tip for Restore Wallet menu item</extracomment>
+        <translation type="unfinished">バックアップ ファイルからウォレットを復元する</translation>
+    </message>
+    <message>
         <source>Close all wallets</source>
         <translation type="unfinished">全てのウォレットを閉じる</translation>
     </message>
@@ -1374,6 +1528,26 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>No wallets available</source>
         <translation type="unfinished">ウォレットは利用できません</translation>
+    </message>
+    <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">ウォレットデータ</translation>
+    </message>
+    <message>
+        <source>Load Wallet Backup</source>
+        <extracomment>The title for Restore Wallet File Windows</extracomment>
+        <translation type="unfinished">ウォレットのバックアップをロード</translation>
+    </message>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of pop-up window shown when the user is attempting to restore a wallet.</extracomment>
+        <translation type="unfinished">ウォレットを復</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">ウォレット名</translation>
     </message>
     <message>
         <source>&amp;Window</source>
@@ -1403,7 +1577,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform>Bitcoin Networkへのアクティブな接続数: %n</numerusform>
+            <numerusform>%n ビットコイン ネットワークへのアクティブな接続。</numerusform>
         </translation>
     </message>
     <message>
@@ -1425,6 +1599,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Enable network activity</source>
         <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
         <translation type="unfinished">ネットワーク活動を有効化する</translation>
+    </message>
+    <message>
+        <source>Pre-syncing Headers (%1%)…</source>
+        <translation type="unfinished">事前同期ヘッダー (%1%)…</translation>
     </message>
     <message>
         <source>Error: %1</source>
@@ -1689,6 +1867,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Can't list signers</source>
         <translation type="unfinished">署名者をリストできません</translation>
     </message>
+    <message>
+        <source>Too many external signers found</source>
+        <translation type="unfinished">見つかった外部署名者が多すぎます</translation>
+    </message>
 </context>
 <context>
     <name>LoadWalletsActivity</name>
@@ -1726,6 +1908,34 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
         <extracomment>Descriptive text of the open wallet progress window which indicates to the user which wallet is currently being opened.</extracomment>
         <translation type="unfinished">ウォレットを開いています &lt;b&gt;%1&lt;/b&gt;…</translation>
+    </message>
+</context>
+<context>
+    <name>RestoreWalletActivity</name>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of progress window which is displayed when wallets are being restored.</extracomment>
+        <translation type="unfinished">ウォレットを復</translation>
+    </message>
+    <message>
+        <source>Restoring Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the restore wallets progress window which indicates to the user that wallets are currently being restored.</extracomment>
+        <translation type="unfinished">ウォレットの復元 &lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+    <message>
+        <source>Restore wallet failed</source>
+        <extracomment>Title of message box which is displayed when the wallet could not be restored.</extracomment>
+        <translation type="unfinished">ウォレットの復元に失敗しました</translation>
+    </message>
+    <message>
+        <source>Restore wallet warning</source>
+        <extracomment>Title of message box which is displayed when the wallet is restored with some warning.</extracomment>
+        <translation type="unfinished">ウォレットの復元に関する警告</translation>
+    </message>
+    <message>
+        <source>Restore wallet message</source>
+        <extracomment>Title of message box which is displayed when the wallet is successfully restored.</extracomment>
+        <translation type="unfinished">ウォレット メッセージの復元</translation>
     </message>
 </context>
 <context>
@@ -1903,17 +2113,23 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 </context>
 <context>
     <name>Intro</name>
-    <message>
-        <source>%1 GB of space available</source>
-        <translation type="unfinished">%1 GBの空き容量が利用可能</translation>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform>%n GB の空き容量</numerusform>
+        </translation>
     </message>
-    <message>
-        <source>(of %1 GB needed)</source>
-        <translation type="unfinished">(内 %1 GB が必要)</translation>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform>(必要な %n GB のうち)</numerusform>
+        </translation>
     </message>
-    <message>
-        <source>(%1 GB needed for full chain)</source>
-        <translation type="unfinished">(フルチェーンには %1 GB が必要)</translation>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform>(完全なチェーンには %n GB が必要)</numerusform>
+        </translation>
     </message>
     <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
@@ -1927,7 +2143,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform>(%n 日前のバックアップを復元するのに充分です)</numerusform>
+            <numerusform>(%n 日経過したバックアップを復元するのに十分です)</numerusform>
         </translation>
     </message>
     <message>
@@ -1957,10 +2173,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>As this is the first time the program is launched, you can choose where %1 will store its data.</source>
         <translation type="unfinished">これはプログラムの最初の起動です。%1 がデータを保存する場所を選択してください。</translation>
-    </message>
-    <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation type="unfinished">OKをクリックすると、%1 は %4 がリリースされた%3年における最初の取引からの完全な %4 ブロックチェーン（%2GB）のダウンロードおよび処理を開始します。</translation>
     </message>
     <message>
         <source>Limit block chain storage to</source>
@@ -2067,6 +2279,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Unknown. Syncing Headers (%1, %2%)…</source>
         <translation type="unfinished">不明。ヘッダ (%1, %2%) の同期中…</translation>
     </message>
+    <message>
+        <source>Unknown. Pre-syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">わからない。ヘッダーを事前同期しています (%1, %2%)…</translation>
+    </message>
 </context>
 <context>
     <name>OpenURIDialog</name>
@@ -2121,6 +2337,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
         <translation type="unfinished">ウィンドウが閉じられたとき、アプリケーションを終了するのではなく最小化します。このオプションが有効の場合、メニューから終了が選択されたときのみアプリケーションが終了します。</translation>
+    </message>
+    <message>
+        <source>Options set in this dialog are overridden by the command line:</source>
+        <translation type="unfinished">このダイアログで設定されたオプションは、コマンド ラインによって上書きされます。</translation>
     </message>
     <message>
         <source>Open the %1 configuration file from the working directory.</source>
@@ -2351,10 +2571,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">最もマッチする  "%1"</translation>
     </message>
     <message>
-        <source>Options set in this dialog are overridden by the command line or in the configuration file:</source>
-        <translation type="unfinished">このダイアログで指定したオプションは、コマンドラインや設定ファイルの内容でオーバーライドされます:</translation>
-    </message>
-    <message>
         <source>&amp;Cancel</source>
         <translation type="unfinished">キャンセル(&amp;C)</translation>
     </message>
@@ -2373,14 +2589,22 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Confirm options reset</source>
+        <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
         <translation type="unfinished">設定リセットの確認</translation>
     </message>
     <message>
         <source>Client restart required to activate changes.</source>
+        <extracomment>Text explaining that the settings changed will not come into effect until the client is restarted.</extracomment>
         <translation type="unfinished">変更を有効化するにはクライアントを再起動する必要があります。</translation>
     </message>
     <message>
+        <source>Current settings will be backed up at "%1".</source>
+        <extracomment>Text explaining to the user that the client's current settings will be backed up at a specific location. %1 is a stand-in argument for the backup location's path.</extracomment>
+        <translation type="unfinished">現在の設定は「%1」にバックアップされます。</translation>
+    </message>
+    <message>
         <source>Client will be shut down. Do you want to proceed?</source>
+        <extracomment>Text asking the user to confirm if they would like to proceed with a client shutdown.</extracomment>
         <translation type="unfinished">クライアントを終了します。よろしいですか？</translation>
     </message>
     <message>
@@ -2416,6 +2640,13 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>The supplied proxy address is invalid.</source>
         <translation type="unfinished">プロキシアドレスが無効です。</translation>
+    </message>
+</context>
+<context>
+    <name>OptionsModel</name>
+    <message>
+        <source>Could not read setting "%1", %2.</source>
+        <translation type="unfinished">設定 "%1", %2 を読み取れませんでした。</translation>
     </message>
 </context>
 <context>
@@ -2677,6 +2908,11 @@ BIP70には広範なセキュリティー上の問題があるので、ウォレ
         <translation type="unfinished">ピア</translation>
     </message>
     <message>
+        <source>Age</source>
+        <extracomment>Title of Peers Table column which indicates the duration (length of time) since the peer connection started.</extracomment>
+        <translation type="unfinished">年</translation>
+    </message>
+    <message>
         <source>Direction</source>
         <extracomment>Title of Peers Table column which indicates the direction the peer connection was initiated from.</extracomment>
         <translation type="unfinished">方向</translation>
@@ -2873,29 +3109,32 @@ BIP70には広範なセキュリティー上の問題があるので、ウォレ
     </message>
     <message>
         <source>Whether we relay addresses to this peer.</source>
-        <extracomment>Tooltip text for the Address Relay field in the peer details area.</extracomment>
+        <extracomment>Tooltip text for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
         <translation type="unfinished">このピアにアドレスを中継するか否か。</translation>
     </message>
     <message>
         <source>Address Relay</source>
+        <extracomment>Text title for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
         <translation type="unfinished">アドレスの中継</translation>
     </message>
     <message>
-        <source>Total number of addresses processed, excluding those dropped due to rate-limiting.</source>
-        <extracomment>Tooltip text for the Addresses Processed field in the peer details area.</extracomment>
-        <translation type="unfinished">レート制限のために除外されたアドレスを除く、処理されたアドレスの総数。</translation>
+        <source>The total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</source>
+        <extracomment>Tooltip text for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
+        <translation type="unfinished">このピアから受信され、処理されたアドレスの総数 (レート制限のためにドロップされたアドレスを除く)。</translation>
+    </message>
+    <message>
+        <source>The total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</source>
+        <extracomment>Tooltip text for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
+        <translation type="unfinished">レート制限が原因でドロップされた (処理されなかった) このピアから受信したアドレスの総数。</translation>
     </message>
     <message>
         <source>Addresses Processed</source>
+        <extracomment>Text title for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
         <translation type="unfinished">処理されたアドレス</translation>
     </message>
     <message>
-        <source>Total number of addresses dropped due to rate-limiting.</source>
-        <extracomment>Tooltip text for the Addresses Rate-Limited field in the peer details area.</extracomment>
-        <translation type="unfinished">レート制限のために除外されたアドレスの総数。</translation>
-    </message>
-    <message>
         <source>Addresses Rate-Limited</source>
+        <extracomment>Text title for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
         <translation type="unfinished">レート制限対象のアドレス</translation>
     </message>
     <message>
@@ -3702,14 +3941,10 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
         <source>A fee higher than %1 is considered an absurdly high fee.</source>
         <translation type="unfinished">%1 よりも高い手数料は、異常に高すぎです。</translation>
     </message>
-    <message>
-        <source>Payment request expired.</source>
-        <translation type="unfinished">支払いリクエストが期限切れです。</translation>
-    </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
-            <numerusform>%n ブロック以内に承認が開始される見込みです。</numerusform>
+            <numerusform>%n ブロック以内に確認を開始すると推定されます。</numerusform>
         </translation>
     </message>
     <message>
@@ -3784,28 +4019,12 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
         <translation type="unfinished">メッセージ:</translation>
     </message>
     <message>
-        <source>This is an unauthenticated payment request.</source>
-        <translation type="unfinished">これは未認証の支払いリクエストです。</translation>
-    </message>
-    <message>
-        <source>This is an authenticated payment request.</source>
-        <translation type="unfinished">これは認証済みの支払いリクエストです。</translation>
-    </message>
-    <message>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished">このアドレスに対するラベルを入力することで、送金したことがあるアドレスの一覧に追加することができます</translation>
     </message>
     <message>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished">bitcoin URIに添付されていたメッセージです。これは参照用として取引とともに保存されます。注意: メッセージは Bitcoin ネットワーク上へ送信されません。</translation>
-    </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">送金先:</translation>
-    </message>
-    <message>
-        <source>Memo:</source>
-        <translation type="unfinished">メモ:</translation>
     </message>
 </context>
 <context>
@@ -3984,30 +4203,32 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     <name>TransactionDesc</name>
     <message>
         <source>conflicted with a transaction with %1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that conflicts with a confirmed transaction.</extracomment>
         <translation type="unfinished">%1 承認の取引と衝突</translation>
     </message>
     <message>
-        <source>0/unconfirmed, %1</source>
-        <translation type="unfinished">0/未承認, %1</translation>
+        <source>0/unconfirmed, in memory pool</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is in the memory pool.</extracomment>
+        <translation type="unfinished">0/未確認、メモリープール内</translation>
     </message>
     <message>
-        <source>in memory pool</source>
-        <translation type="unfinished">メモリプール内</translation>
-    </message>
-    <message>
-        <source>not in memory pool</source>
-        <translation type="unfinished">メモリプール外</translation>
+        <source>0/unconfirmed, not in memory pool</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is not in the memory pool.</extracomment>
+        <translation type="unfinished">0/未確認、メモリ プールにない</translation>
     </message>
     <message>
         <source>abandoned</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an abandoned transaction.</extracomment>
         <translation type="unfinished">送信中止</translation>
     </message>
     <message>
         <source>%1/unconfirmed</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
         <translation type="unfinished">%1/未承認</translation>
     </message>
     <message>
         <source>%1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
         <translation type="unfinished">%1 承認</translation>
     </message>
     <message>
@@ -4057,7 +4278,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
-            <numerusform>あと %n ブロックで熟成します</numerusform>
+            <numerusform>%n 個以上のブロックで成熟する</numerusform>
         </translation>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_ka.ts
+++ b/src/qt/locale/bitcoin_ka.ts
@@ -70,6 +70,12 @@
         <translation type="unfinished">ეს არის თქვენი ბიტკოინ-მისამართები, რომელთაგანაც შეგიძლიათ გადახდა. აუცილებლად შეამოწმეთ თანხა და მიმღები მისამართი გაგზავნამდე.</translation>
     </message>
     <message>
+        <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
+Signing is only possible with addresses of the type 'legacy'.</source>
+        <translation type="unfinished">ეს თქვენი ბიტკოინის მიმღები მიმსამართებია. ისარგებლეთ ღილაკით "შექმენით ახალი მიმღები მისამართები", როემლიც მოცემულია მიმღების ჩანართში ახალი მისამართების შესაქმნელად.
+ხელმოწერა მხოლოდ "მემკვიდრეობის" ტიპის მისამართებთანაა შესაძლებელია</translation>
+    </message>
+    <message>
         <source>&amp;Copy Address</source>
         <translation type="unfinished">მისამართის კოპირება</translation>
     </message>
@@ -84,6 +90,11 @@
     <message>
         <source>Export Address List</source>
         <translation type="unfinished">მისამართების სიის ექსპორტი</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">CSV (სპეციალური ტექსტური ფაილი)</translation>
     </message>
     <message>
         <source>There was an error trying to save the address list to %1. Please try again.</source>
@@ -239,6 +250,14 @@
         <translation type="unfinished">შეცდომა: მითითებული მონაცემთა კატალოგი "%1" არ არსებობს.</translation>
     </message>
     <message>
+        <source>Error: Cannot parse configuration file: %1.</source>
+        <translation type="unfinished">შეცდომა: შეუძლებელია კონფიგურაციის ფაილის წაკითხვა: %1</translation>
+    </message>
+    <message>
+        <source>Error: %1</source>
+        <translation type="unfinished">შეცდუმა: %1</translation>
+    </message>
+    <message>
         <source>unknown</source>
         <translation type="unfinished">უცნობია</translation>
     </message>
@@ -356,6 +375,10 @@
         <translation type="unfinished">არ არის საკმარისი თანხა</translation>
     </message>
     <message>
+        <source>No addresses available</source>
+        <translation type="unfinished">არცერთი მისამართი არ არსებობს</translation>
+    </message>
+    <message>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished">არ არის საკმარისი ფაილ-დესკრიპტორები.</translation>
     </message>
@@ -425,6 +448,10 @@
     <message>
         <source>Create a new wallet</source>
         <translation type="unfinished">შექმენით ახალი საფულე</translation>
+    </message>
+    <message>
+        <source>&amp;Minimize</source>
+        <translation type="unfinished">&amp;ჩახურვა</translation>
     </message>
     <message>
         <source>Wallet:</source>
@@ -563,12 +590,25 @@
         <translation type="unfinished">გახსენით საფულე</translation>
     </message>
     <message>
+        <source>Close wallet</source>
+        <translation type="unfinished">საფულის დახურვა</translation>
+    </message>
+    <message>
+        <source>Close all wallets</source>
+        <translation type="unfinished">ყველა საფულის დახურვა</translation>
+    </message>
+    <message>
         <source>default wallet</source>
         <translation type="unfinished">ნაგულისხმევი საფულე</translation>
     </message>
     <message>
         <source>No wallets available</source>
         <translation type="unfinished">არ არის ჩატვირთული საფულე.</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">საფულის სახელი</translation>
     </message>
     <message>
         <source>&amp;Window</source>
@@ -589,6 +629,15 @@
             <numerusform />
             <numerusform />
         </translation>
+    </message>
+    <message>
+        <source>Click for more actions.</source>
+        <extracomment>A substring of the tooltip. "More actions" are available via the context menu.</extracomment>
+        <translation type="unfinished">მეტი...</translation>
+    </message>
+    <message>
+        <source>Error: %1</source>
+        <translation type="unfinished">შეცდუმა: %1</translation>
     </message>
     <message>
         <source>Date: %1
@@ -645,6 +694,10 @@
     </context>
 <context>
     <name>CoinControlDialog</name>
+    <message>
+        <source>Coin Selection</source>
+        <translation type="unfinished">Coin-ები</translation>
+    </message>
     <message>
         <source>Quantity:</source>
         <translation type="unfinished">რაოდენობა:</translation>
@@ -755,6 +808,31 @@
     </message>
 </context>
 <context>
+    <name>CreateWalletActivity</name>
+    <message>
+        <source>Create Wallet</source>
+        <extracomment>Title of window indicating the progress of creation of a new wallet.</extracomment>
+        <translation type="unfinished">ახალი საფულე</translation>
+    </message>
+    <message>
+        <source>Create wallet failed</source>
+        <translation type="unfinished">საფულე ვერ შეიქმნა</translation>
+    </message>
+    </context>
+<context>
+    <name>LoadWalletsActivity</name>
+    <message>
+        <source>Load Wallets</source>
+        <extracomment>Title of progress window which is displayed when wallets are being loaded.</extracomment>
+        <translation type="unfinished">საფულეების ჩატვირთვა</translation>
+    </message>
+    <message>
+        <source>Loading wallets…</source>
+        <extracomment>Descriptive text of the load wallets progress window which indicates to the user that wallets are currently being loaded.</extracomment>
+        <translation type="unfinished">იტვირთება საფულეები...</translation>
+    </message>
+</context>
+<context>
     <name>OpenWalletActivity</name>
     <message>
         <source>default wallet</source>
@@ -767,10 +845,45 @@
     </message>
     </context>
 <context>
+    <name>WalletController</name>
+    <message>
+        <source>Close wallet</source>
+        <translation type="unfinished">საფულის დახურვა</translation>
+    </message>
+    <message>
+        <source>Are you sure you wish to close the wallet &lt;i&gt;%1&lt;/i&gt;?</source>
+        <translation type="unfinished">დაიხუროს საფულე&lt;i&gt;%1&lt;/i&gt; ?</translation>
+    </message>
+    <message>
+        <source>Close all wallets</source>
+        <translation type="unfinished">ყველა საფულის დახურვა</translation>
+    </message>
+    </context>
+<context>
     <name>CreateWalletDialog</name>
+    <message>
+        <source>Create Wallet</source>
+        <translation type="unfinished">ახალი საფულე</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <translation type="unfinished">საფულის სახელი</translation>
+    </message>
     <message>
         <source>Wallet</source>
         <translation type="unfinished">საფულე</translation>
+    </message>
+    <message>
+        <source>Encrypt Wallet</source>
+        <translation type="unfinished">საფულის დაცვა [Encrypt Wallet]</translation>
+    </message>
+    <message>
+        <source>Advanced Options</source>
+        <translation type="unfinished">დამატებითი ფუნქციები</translation>
+    </message>
+    <message>
+        <source>Create</source>
+        <translation type="unfinished">ახალი</translation>
     </message>
     </context>
 <context>
@@ -846,6 +959,27 @@
 <context>
     <name>Intro</name>
     <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
@@ -864,6 +998,10 @@
     <message>
         <source>Welcome to %1.</source>
         <translation type="unfinished">კეთილი იყოს თქვენი მობრძანება %1-ში.</translation>
+    </message>
+    <message>
+        <source> GB</source>
+        <translation type="unfinished">GB</translation>
     </message>
     <message>
         <source>Use the default data directory</source>
@@ -892,6 +1030,10 @@
 <context>
     <name>ShutdownWindow</name>
     <message>
+        <source>%1 is shutting down…</source>
+        <translation type="unfinished"> დახურულია %1...</translation>
+    </message>
+    <message>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished">არ გამორთოთ კომპიუტერი ამ ფანჯრის გაქრობამდე.</translation>
     </message>
@@ -903,12 +1045,28 @@
         <translation type="unfinished">ფორმა</translation>
     </message>
     <message>
+        <source>Number of blocks left</source>
+        <translation type="unfinished">დარჩენილი ბლოკების რაოდენობა</translation>
+    </message>
+    <message>
+        <source>Unknown…</source>
+        <translation type="unfinished">უცნობი...</translation>
+    </message>
+    <message>
+        <source>calculating…</source>
+        <translation type="unfinished">გამოთვლა...</translation>
+    </message>
+    <message>
         <source>Last block time</source>
         <translation type="unfinished">ბოლო ბლოკის დრო</translation>
     </message>
     <message>
         <source>Progress</source>
         <translation type="unfinished">პროგრესი</translation>
+    </message>
+    <message>
+        <source>Estimated time left until synced</source>
+        <translation type="unfinished">სინქრონიზაციის დასრულებამდე დარჩენილი დრო</translation>
     </message>
     <message>
         <source>Hide</source>
@@ -1039,11 +1197,26 @@
     </message>
     <message>
         <source>Confirm options reset</source>
+        <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
         <translation type="unfinished">დაადასტურეთ პარამეტრების დაბრუნება ნაგულისხმევზე</translation>
     </message>
     <message>
         <source>Client restart required to activate changes.</source>
+        <extracomment>Text explaining that the settings changed will not come into effect until the client is restarted.</extracomment>
         <translation type="unfinished">ცვლილებები ძალაში შევა კლიენტის ხელახალი გაშვების შემდეგ.</translation>
+    </message>
+    <message>
+        <source>Configuration options</source>
+        <extracomment>Window title text of pop-up box that allows opening up of configuration file.</extracomment>
+        <translation type="unfinished">კონფიგურაციის პარამეტრები</translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation type="unfinished">გაგრძელება</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">გაუქმება</translation>
     </message>
     <message>
         <source>Error</source>
@@ -1207,6 +1380,22 @@
         <translation type="unfinished">კვანძის ფანჯარა</translation>
     </message>
     <message>
+        <source>Connection Time</source>
+        <translation type="unfinished">დაკავშირების დრო</translation>
+    </message>
+    <message>
+        <source>Last Block</source>
+        <translation type="unfinished">ბოლო "ბლოკი"</translation>
+    </message>
+    <message>
+        <source>Last Send</source>
+        <translation type="unfinished">ბოლო გაგზავნილი</translation>
+    </message>
+    <message>
+        <source>Ping Time</source>
+        <translation type="unfinished">"Ping"-ის ხანგრძლივობა</translation>
+    </message>
+    <message>
         <source>Last block time</source>
         <translation type="unfinished">ბოლო ბლოკის დრო</translation>
     </message>
@@ -1250,7 +1439,15 @@
         <source>From</source>
         <translation type="unfinished">გამგზავნი</translation>
     </message>
-    </context>
+    <message>
+        <source>Never</source>
+        <translation type="unfinished">არასოდეს</translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">უცნობი</translation>
+    </message>
+</context>
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
@@ -1431,6 +1628,10 @@
         <translation type="unfinished">დამალვა</translation>
     </message>
     <message>
+        <source>Recommended:</source>
+        <translation type="unfinished">სასურველია:</translation>
+    </message>
+    <message>
         <source>Send to multiple recipients at once</source>
         <translation type="unfinished">გაგზავნა რამდენიმე რეციპიენტთან ერთდროულად</translation>
     </message>
@@ -1491,8 +1692,17 @@
         <translation type="unfinished">%1-დან %2-ში</translation>
     </message>
     <message>
+        <source>PSBT saved</source>
+        <translation type="unfinished">PSBT შენახულია</translation>
+    </message>
+    <message>
         <source>or</source>
         <translation type="unfinished">ან</translation>
+    </message>
+    <message>
+        <source>You can increase the fee later (signals Replace-By-Fee, BIP-125).</source>
+        <translation type="unfinished">საკომისიო [fee] შეგიძლიათ შცვალოთ მოგვიანებით (სიგნალები Replace-By-Fee, BIP-125}.
+ </translation>
     </message>
     <message>
         <source>Transaction fee</source>
@@ -1575,14 +1785,6 @@
     <message>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished">მესიჯი, რომელიც თან ერთვის მონეტებს:  URI, რომელიც შეინახება ტრანსაქციასთან ერთად თქვენთვის. შენიშვნა: მესიჯი არ გაყვება გადახდას ბითქოინის ქსელში.</translation>
-    </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">ადრესატი:</translation>
-    </message>
-    <message>
-        <source>Memo:</source>
-        <translation type="unfinished">შენიშვნა:</translation>
     </message>
 </context>
 <context>
@@ -1701,13 +1903,26 @@
     </message>
 </context>
 <context>
+    <name>SplashScreen</name>
+    <message>
+        <source>(press q to shutdown and continue later)</source>
+        <translation type="unfinished">'q' - დახურვა და მოგვიანებით გაგრძელება</translation>
+    </message>
+    <message>
+        <source>press q to shutdown</source>
+        <translation type="unfinished">დახურვა 'q'</translation>
+    </message>
+</context>
+<context>
     <name>TransactionDesc</name>
     <message>
         <source>%1/unconfirmed</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
         <translation type="unfinished">%1/დაუდასტურებელია</translation>
     </message>
     <message>
         <source>%1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
         <translation type="unfinished">%1 დადასტურებულია</translation>
     </message>
     <message>
@@ -1963,6 +2178,11 @@
         <translation type="unfinished">ტრანსაქციების ისტორიის ექსპორტი</translation>
     </message>
     <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">CSV (სპეციალური ტექსტური ფაილი)</translation>
+    </message>
+    <message>
         <source>Confirmed</source>
         <translation type="unfinished">დადასტურებულია</translation>
     </message>
@@ -2059,5 +2279,9 @@
         <source>The wallet data was successfully saved to %1.</source>
         <translation type="unfinished">საფულის მონაცემები შენახულია %1-ში.</translation>
     </message>
-    </context>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">გაუქმება</translation>
+    </message>
+</context>
 </TS>

--- a/src/qt/locale/bitcoin_kk.ts
+++ b/src/qt/locale/bitcoin_kk.ts
@@ -606,6 +606,10 @@
         <translation type="unfinished">Растық</translation>
     </message>
     <message>
+        <source>yes</source>
+        <translation type="unfinished">Иа</translation>
+    </message>
+    <message>
         <source>(no label)</source>
         <translation type="unfinished">(белгі жоқ)</translation>
     </message>
@@ -646,6 +650,27 @@
         <translation type="unfinished">Биткоин</translation>
     </message>
     <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
@@ -659,7 +684,7 @@
     </message>
     <message>
         <source>Error</source>
-        <translation type="unfinished">Қате</translation>
+        <translation type="unfinished">қате</translation>
     </message>
     <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
@@ -690,7 +715,7 @@
     </message>
     <message>
         <source>Error</source>
-        <translation type="unfinished">Қате</translation>
+        <translation type="unfinished">қате</translation>
     </message>
     </context>
 <context>
@@ -815,10 +840,6 @@
 <context>
     <name>TransactionDesc</name>
     <message>
-        <source>0/unconfirmed, %1</source>
-        <translation type="unfinished">0/расталмаған, %1</translation>
-    </message>
-    <message>
         <source>Date</source>
         <translation type="unfinished">Күні</translation>
     </message>
@@ -889,7 +910,7 @@
     </message>
     <message>
         <source>Error</source>
-        <translation type="unfinished">Қате</translation>
+        <translation type="unfinished">қате</translation>
     </message>
     </context>
 <context>

--- a/src/qt/locale/bitcoin_kl.ts
+++ b/src/qt/locale/bitcoin_kl.ts
@@ -206,6 +206,27 @@
 <context>
     <name>Intro</name>
     <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">

--- a/src/qt/locale/bitcoin_km.ts
+++ b/src/qt/locale/bitcoin_km.ts
@@ -86,6 +86,11 @@
         <translation type="unfinished">នាំចេញនូវបញ្ជីអាសយដ្ឋាន</translation>
     </message>
     <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">Comma បំបែកឯកសារ</translation>
+    </message>
+    <message>
         <source>Exporting Failed</source>
         <translation type="unfinished">ការនាំចេញបានបរាជ័យ</translation>
     </message>
@@ -216,7 +221,36 @@
     </message>
 </context>
 <context>
+    <name>BitcoinApplication</name>
+    <message>
+        <source>Runaway exception</source>
+        <translation type="unfinished">ករណីលើកលែងដែលរត់គេចខ្លួន</translation>
+    </message>
+    <message>
+        <source>Internal error</source>
+        <translation type="unfinished">ខាងក្នុងបញ្ហា</translation>
+    </message>
+    <message>
+        <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
+        <translation type="unfinished">កំហុសខាងក្នុងបានកើតឡើង។ %1នឹងព្យាយាមបន្តដោយសុវត្ថិភាព។ នេះ​ជា​កំហុស​ដែល​មិន​នឹក​ស្មាន​ដល់ ដែល​អាច​ត្រូវ​បាន​រាយការណ៍​ដូច​បាន​ពណ៌នា​ខាង​ក្រោម។</translation>
+    </message>
+</context>
+<context>
     <name>QObject</name>
+    <message>
+        <source>Do you want to reset settings to default values, or to abort without making changes?</source>
+        <extracomment>Explanatory text shown on startup when the settings file cannot be read. Prompts user to make a choice between resetting or aborting.</extracomment>
+        <translation type="unfinished">តើ​អ្នក​ចង់​កំណត់​ការ​កំណត់​ឡើង​វិញ​ទៅ​ជា​តម្លៃ​លំនាំដើម ឬ​បោះបង់​ដោយ​មិន​ធ្វើ​ការ​ផ្លាស់ប្ដូរ?</translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. Check that settings file is writable, or try running with -nosettings.</source>
+        <extracomment>Explanatory text shown on startup when the settings file could not be written. Prompts user to check that we have the ability to write to the file. Explains that the user has the option of running without a settings file.</extracomment>
+        <translation type="unfinished">កំហុសធ្ងន់ធ្ងរបានកើតឡើង។ ពិនិត្យមើលថាឯកសារការកំណត់អាចសរសេរបាន ឬព្យាយាមដំណើរការជាមួយ -nosettings។</translation>
+    </message>
+    <message>
+        <source>%1 didn't yet exit safely…</source>
+        <translation type="unfinished">%1មិនទាន់ចេញដោយសុវត្ថិភាពទេ…</translation>
+    </message>
     <message>
         <source>unknown</source>
         <translation type="unfinished">មិនស្គាល់</translation>
@@ -274,6 +308,14 @@
     </context>
 <context>
     <name>bitcoin-core</name>
+    <message>
+        <source>Settings file could not be read</source>
+        <translation type="unfinished">ការកំណត់ឯកសារមិនអាចអានបានទេ។</translation>
+    </message>
+    <message>
+        <source>Settings file could not be written</source>
+        <translation type="unfinished">ការកំណត់ឯកសារមិនអាចសរសេរបានទេ។</translation>
+    </message>
     <message>
         <source>-maxtxfee is set very high! Fees this large could be paid on a single transaction.</source>
         <translation type="unfinished">-maxtxfee មានតំម្លៃខ្ពស់ពេក។​ តំម្លៃនេះ អាចគួរត្រូវបានបង់សម្រាប់មួយប្រត្តិបត្តិការ។</translation>
@@ -430,6 +472,10 @@
         <translation type="unfinished">បង្កើតកាបូបចល័តថ្មីមួយ</translation>
     </message>
     <message>
+        <source>&amp;Minimize</source>
+        <translation type="unfinished">&amp;បង្រួមអប្បបរមា</translation>
+    </message>
+    <message>
         <source>Wallet:</source>
         <translation type="unfinished">កាបូបចល័ត៖</translation>
     </message>
@@ -463,16 +509,60 @@
         <translation type="unfinished">&amp;ទទួល</translation>
     </message>
     <message>
+        <source>&amp;Options…</source>
+        <translation type="unfinished">&amp;ជម្រើស…</translation>
+    </message>
+    <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation type="unfinished">&amp;អ៊ិនគ្រីបកាបូប</translation>
+    </message>
+    <message>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation type="unfinished">បំលែងលេខសំម្ងាត់សម្រាប់កាបូបអេឡិចត្រូនិច របស់អ្នកឲ្យទៅជាភាសាកុំព្យូទ័រ </translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation type="unfinished">&amp;ការបម្រុងទុកកាបូប...</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation type="unfinished">&amp;ការផ្លាស់ប្តូរឃ្លាសម្ងាត់</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation type="unfinished">ចុះហត្ថលេខា&amp;សារ…</translation>
     </message>
     <message>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation type="unfinished">ចុះហត្ថលេខាលើសារ អាសយដ្ឋានប៊ីតខញរបស់អ្នក ដើម្បីបញ្ចាក់ថាអ្នកជាម្ចាស់</translation>
     </message>
     <message>
+        <source>&amp;Verify message…</source>
+        <translation type="unfinished">&amp;ផ្ទៀងផ្ទាត់សារ...</translation>
+    </message>
+    <message>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation type="unfinished">ធ្វើការបញ្ចាក់សារ ដើម្បីធានាថាសារទាំំងនោះបានចុះហត្ថលេខា ជាមួយអាសយដ្ខានប៊ីតខញ</translation>
+    </message>
+    <message>
+        <source>&amp;Load PSBT from file…</source>
+        <translation type="unfinished">&amp;ផ្ទុក PSBT ពីឯកសារ...</translation>
+    </message>
+    <message>
+        <source>Open &amp;URI…</source>
+        <translation type="unfinished">បើក &amp;URI…</translation>
+    </message>
+    <message>
+        <source>Close Wallet…</source>
+        <translation type="unfinished">បិទកាបូប…</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation type="unfinished">បង្កើតកាបូប...</translation>
+    </message>
+    <message>
+        <source>Close All Wallets…</source>
+        <translation type="unfinished">បិទកាបូបអេឡិចត្រូនិចទាំងអស់...</translation>
     </message>
     <message>
         <source>&amp;File</source>
@@ -489,6 +579,30 @@
     <message>
         <source>Tabs toolbar</source>
         <translation type="unfinished">ធូបារថេប</translation>
+    </message>
+    <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation type="unfinished">កំពុងសមកាល បឋមកថា (%1%)...</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation type="unfinished">កំពុងធ្វើសមកាលកម្មជាមួយបណ្ដាញ...</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation type="unfinished">កំពុងធ្វើលិបិក្រមប្លុកនៅលើថាស...</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation type="unfinished">កំពុងដំណើរការប្លុកនៅលើថាស...</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation type="unfinished">កំពុងដំណើរការប្លុកនៅលើថាស...</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation type="unfinished">កំពុងភ្ជាប់ទៅមិត្តភក្ដិ...</translation>
     </message>
     <message>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
@@ -509,9 +623,13 @@
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>បានដំណើរការ %n ប្លុកនៃប្រវត្តិប្រត្តិបត្តិការ។</numerusform>
             <numerusform />
         </translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation type="unfinished">កំពុងចាប់...</translation>
     </message>
     <message>
         <source>Transactions after this will not yet be visible.</source>
@@ -536,6 +654,10 @@
     <message>
         <source>Load Partially Signed Bitcoin Transaction</source>
         <translation type="unfinished">បង្ហាញប្រត្តិបត្តិការប៊ីតខញដែលបានចុះហត្ថលេខាដោយផ្នែក</translation>
+    </message>
+    <message>
+        <source>Load PSBT from &amp;clipboard…</source>
+        <translation type="unfinished">ផ្ទុក PSBT ពី &amp;clipboard...</translation>
     </message>
     <message>
         <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
@@ -570,16 +692,49 @@
         <translation type="unfinished">មិនមានកាបូបអេឡិចត្រូនិច</translation>
     </message>
     <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">ឈ្មោះកាបូប</translation>
+    </message>
+    <message>
         <source>&amp;Window</source>
         <translation type="unfinished">&amp;វិនដូ</translation>
+    </message>
+    <message>
+        <source>&amp;Hide</source>
+        <translation type="unfinished">&amp;លាក់</translation>
+    </message>
+    <message>
+        <source>S&amp;how</source>
+        <translation type="unfinished">S&amp;របៀប</translation>
     </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n ការតភ្ជាប់សកម្មទៅបណ្តាញ Bitcoin ។</numerusform>
             <numerusform />
         </translation>
+    </message>
+    <message>
+        <source>Click for more actions.</source>
+        <extracomment>A substring of the tooltip. "More actions" are available via the context menu.</extracomment>
+        <translation type="unfinished">ចុចសម្រាប់សកម្មភាពបន្ថែម។</translation>
+    </message>
+    <message>
+        <source>Show Peers tab</source>
+        <extracomment>A context menu item. The "Peers tab" is an element of the "Node window".</extracomment>
+        <translation type="unfinished">បង្ហាញផ្ទាំង Peers</translation>
+    </message>
+    <message>
+        <source>Disable network activity</source>
+        <extracomment>A context menu item.</extracomment>
+        <translation type="unfinished">បិទសកម្មភាពបណ្តាញ</translation>
+    </message>
+    <message>
+        <source>Enable network activity</source>
+        <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
+        <translation type="unfinished">បើកសកម្មភាពបណ្តាញ</translation>
     </message>
     <message>
         <source>Sent transaction</source>
@@ -649,6 +804,30 @@
         <translation type="unfinished">បានបញ្ចាក់រួចរាល់</translation>
     </message>
     <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;ចម្លងអាសយដ្ឋាន</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">ចម្លង &amp; ស្លាក</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">ចម្លង &amp; ចំនួន</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID and output index</source>
+        <translation type="unfinished">ចម្លងប្រតិបត្តិការ &amp; លេខសម្គាល់ និងសន្ទស្សន៍ទិន្នផល</translation>
+    </message>
+    <message>
+        <source>L&amp;ock unspent</source>
+        <translation type="unfinished">L&amp;ock មិនបានចំណាយ</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock unspent</source>
+        <translation type="unfinished">&amp;ដោះសោដោយមិនបានចំណាយ</translation>
+    </message>
+    <message>
         <source>yes</source>
         <translation type="unfinished">បាទ ឬ ចាស</translation>
     </message>
@@ -677,10 +856,32 @@
         <translation type="unfinished">បង្កើតកាបូប</translation>
     </message>
     <message>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the create wallet progress window which indicates to the user which wallet is currently being created.</extracomment>
+        <translation type="unfinished">ការបង្កើតកាបូប&lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+    <message>
         <source>Create wallet failed</source>
         <translation type="unfinished">បង្កើតកាបូបអេឡិចត្រូនិច មិនជោគជ័យ</translation>
     </message>
+    <message>
+        <source>Can't list signers</source>
+        <translation type="unfinished">មិនអាចចុះបញ្ជីអ្នកចុះហត្ថលេខាបានទេ។</translation>
+    </message>
     </context>
+<context>
+    <name>LoadWalletsActivity</name>
+    <message>
+        <source>Load Wallets</source>
+        <extracomment>Title of progress window which is displayed when wallets are being loaded.</extracomment>
+        <translation type="unfinished">ផ្ទុកកាបូប</translation>
+    </message>
+    <message>
+        <source>Loading wallets…</source>
+        <extracomment>Descriptive text of the load wallets progress window which indicates to the user that wallets are currently being loaded.</extracomment>
+        <translation type="unfinished">កំពុងផ្ទុកកាបូប...</translation>
+    </message>
+</context>
 <context>
     <name>OpenWalletActivity</name>
     <message>
@@ -696,7 +897,12 @@
         <extracomment>Title of window indicating the progress of opening of a wallet.</extracomment>
         <translation type="unfinished">បើកកាបូបអេឡិចត្រូនិច</translation>
     </message>
-    </context>
+    <message>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the open wallet progress window which indicates to the user which wallet is currently being opened.</extracomment>
+        <translation type="unfinished">កាបូបការបើកកាបូប&lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+</context>
 <context>
     <name>WalletController</name>
     <message>
@@ -743,10 +949,23 @@
         <translation type="unfinished">ធ្វើឲ្យកាបូបអេឡិចត្រូនិចទទេ</translation>
     </message>
     <message>
+        <source>Use an external signing device such as a hardware wallet. Configure the external signer script in wallet preferences first.</source>
+        <translation type="unfinished">ប្រើឧបករណ៍ចុះហត្ថលេខាខាងក្រៅ ដូចជាកាបូបផ្នែករឹង។ កំណត់រចនាសម្ព័ន្ធស្គ្រីបអ្នកចុះហត្ថលេខាខាងក្រៅនៅក្នុងចំណូលចិត្តកាបូបជាមុនសិន។</translation>
+    </message>
+    <message>
+        <source>External signer</source>
+        <translation type="unfinished">អ្នកចុះហត្ថលេខាខាងក្រៅ</translation>
+    </message>
+    <message>
         <source>Create</source>
         <translation type="unfinished">បង្កើត</translation>
     </message>
-    </context>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">ចងក្រងដោយមិនមានការគាំទ្រការចុះហត្ថលេខាខាងក្រៅ (ទាមទារសម្រាប់ការចុះហត្ថលេខាខាងក្រៅ)</translation>
+    </message>
+</context>
 <context>
     <name>EditAddressDialog</name>
     <message>
@@ -810,6 +1029,27 @@
     <message>
         <source>Bitcoin</source>
         <translation type="unfinished">ប៊ីតខញ</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform>(នៃ%n ជីហ្គាប៊ៃ ដែលត្រូវការ)</numerusform>
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform>(%n GB needed for full chain)</numerusform>
+            <numerusform />
+        </translation>
     </message>
     <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
@@ -960,11 +1200,18 @@
         <translation type="unfinished">&amp;បង្ហាញ</translation>
     </message>
     <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">ចងក្រងដោយមិនមានការគាំទ្រការចុះហត្ថលេខាខាងក្រៅ (ទាមទារសម្រាប់ការចុះហត្ថលេខាខាងក្រៅ)</translation>
+    </message>
+    <message>
         <source>Confirm options reset</source>
+        <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
         <translation type="unfinished">បញ្ចាក់ជម្រើសការកែសម្រួលឡើងវិញ</translation>
     </message>
     <message>
         <source>Client will be shut down. Do you want to proceed?</source>
+        <extracomment>Text asking the user to confirm if they would like to proceed with a client shutdown.</extracomment>
         <translation type="unfinished">ផ្ទាំងអតិថិជននិងត្រូវបិទ។ តើអ្នកចង់បន្តទៀតឫទេ?</translation>
     </message>
     <message>
@@ -1314,6 +1561,11 @@
         <translation type="unfinished">ចេញៈ</translation>
     </message>
     <message>
+        <source>&amp;Copy address</source>
+        <extracomment>Context menu action to copy the address of a peer.</extracomment>
+        <translation type="unfinished">&amp;ចម្លងអាសយដ្ឋាន</translation>
+    </message>
+    <message>
         <source>Network activity disabled</source>
         <translation type="unfinished">សកម្មភាពបណ្តាញ ត្រូវបានដាក់អោយប្រើការលែងបាន។</translation>
     </message>
@@ -1403,6 +1655,18 @@
     <message>
         <source>Copy &amp;URI</source>
         <translation type="unfinished">ថតចម្លង &amp;RUl</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;ចម្លងអាសយដ្ឋាន</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">ចម្លង &amp; ស្លាក</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">ចម្លង &amp; ចំនួន</translation>
     </message>
     <message>
         <source>Could not unlock wallet.</source>
@@ -1594,10 +1858,6 @@
         <source>Transaction creation failed!</source>
         <translation type="unfinished">បង្កើតប្រត្តិបត្តិការមិនជោគជ័យ!</translation>
     </message>
-    <message>
-        <source>Payment request expired.</source>
-        <translation type="unfinished">សំណើរទូរទាត់ប្រាក់បានផុតកំណត់។</translation>
-    </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
@@ -1649,26 +1909,10 @@
         <translation type="unfinished">សារៈ</translation>
     </message>
     <message>
-        <source>This is an unauthenticated payment request.</source>
-        <translation type="unfinished">នេះជាសំណើរទូរទាត់ប្រាក់មិនទាន់បានបញ្ចាក់តាមច្បាប់ត្រឹមត្រូវ។</translation>
-    </message>
-    <message>
-        <source>This is an authenticated payment request.</source>
-        <translation type="unfinished">នេះជាសំណើរទូរទាត់ប្រាក់ដែលបានបញ្ចាក់តាមច្បាប់ត្រឹមត្រូវ។</translation>
-    </message>
-    <message>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished">បញ្ចូលស្លាក​សញ្ញាមួយ សម្រាប់អាសយដ្ឋាននេះ ដើម្បីបញ្ចូលវាទៅក្នងបញ្ចីរអាសយដ្ឋានដែលបានប្រើប្រាស់</translation>
     </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">បង់ទៅកាន់</translation>
-    </message>
-    <message>
-        <source>Memo:</source>
-        <translation type="unfinished">អនុស្សរណៈ</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>SendConfirmationDialog</name>
     <message>
@@ -1803,6 +2047,7 @@
     <name>TransactionDesc</name>
     <message>
         <source>abandoned</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an abandoned transaction.</extracomment>
         <translation type="unfinished">បានបោះបង់ចោល</translation>
     </message>
     <message>
@@ -2031,8 +2276,25 @@
         <translation type="unfinished">ចំនួនតិចបំផុត</translation>
     </message>
     <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;ចម្លងអាសយដ្ឋាន</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">ចម្លង &amp; ស្លាក</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">ចម្លង &amp; ចំនួន</translation>
+    </message>
+    <message>
         <source>Export Transaction History</source>
         <translation type="unfinished">ប្រវត្តិនៃការនាំចេញប្រត្តិបត្តិការ</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">Comma បំបែកឯកសារ</translation>
     </message>
     <message>
         <source>Confirmed</source>

--- a/src/qt/locale/bitcoin_ko.ts
+++ b/src/qt/locale/bitcoin_ko.ts
@@ -3,11 +3,11 @@
     <name>AddressBookPage</name>
     <message>
         <source>Right-click to edit address or label</source>
-        <translation type="unfinished">지갑 주소나 라벨을 수정하려면 우클릭을 하십시오.</translation>
+        <translation type="unfinished">우클릭하여 주소나 상표 수정하기</translation>
     </message>
     <message>
         <source>Create a new address</source>
-        <translation type="unfinished">새로운 지갑 주소 생성</translation>
+        <translation type="unfinished">새로운 주소 생성 </translation>
     </message>
     <message>
         <source>&amp;New</source>
@@ -51,7 +51,7 @@
     </message>
     <message>
         <source>Choose the address to receive coins with</source>
-        <translation type="unfinished">코인을 받을 주소를 선택하십시오.</translation>
+        <translation type="unfinished">코인을 받을 주소를 선택하십시오</translation>
     </message>
     <message>
         <source>C&amp;hoose</source>
@@ -153,7 +153,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Unlock wallet</source>
-        <translation type="unfinished">지갑 잠금을 해제</translation>
+        <translation type="unfinished">지갑 잠금 해제</translation>
     </message>
     <message>
         <source>Change passphrase</source>
@@ -169,7 +169,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Are you sure you wish to encrypt your wallet?</source>
-        <translation type="unfinished">지갑 암호화를 허용하시겠습니까?</translation>
+        <translation type="unfinished">정말로 지갑을 암호화하시겠습니까?</translation>
     </message>
     <message>
         <source>Wallet encrypted</source>
@@ -246,6 +246,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>BitcoinApplication</name>
     <message>
+        <source>Settings file %1 might be corrupt or invalid.</source>
+        <translation type="unfinished">%1파일 세팅이 잘못되었거나 유효하지 않습니다.</translation>
+    </message>
+    <message>
         <source>Runaway exception</source>
         <translation type="unfinished">런어웨이 예외</translation>
     </message>
@@ -264,6 +268,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 </context>
 <context>
     <name>QObject</name>
+    <message>
+        <source>Do you want to reset settings to default values, or to abort without making changes?</source>
+        <extracomment>Explanatory text shown on startup when the settings file cannot be read. Prompts user to make a choice between resetting or aborting.</extracomment>
+        <translation type="unfinished">초기값으로 리셋하거나 변동사항없이 진행하시겠습니까?</translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. Check that settings file is writable, or try running with -nosettings.</source>
+        <extracomment>Explanatory text shown on startup when the settings file could not be written. Prompts user to check that we have the ability to write to the file. Explains that the user has the option of running without a settings file.</extracomment>
+        <translation type="unfinished">심각한 문제가 발생하였습니다. 세팅 파일이 작성가능한지 확인하거나 세팅없이 실행을 시도해보세요.</translation>
+    </message>
     <message>
         <source>Error: Specified data directory "%1" does not exist.</source>
         <translation type="unfinished">오류: 지정한 데이터 폴더 "%1"은 존재하지 않습니다.</translation>
@@ -358,31 +372,31 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n초</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n minute(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n분</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n시간</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n일</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n주</numerusform>
         </translation>
     </message>
     <message>
@@ -392,7 +406,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n년</numerusform>
         </translation>
     </message>
     <message>
@@ -431,8 +445,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">-maxtxfee 값이 너무 큽니다!  하나의 거래에 너무 큰 수수료가 지불 됩니다.</translation>
     </message>
     <message>
+        <source>Cannot downgrade wallet from version %i to version %i. Wallet version unchanged.</source>
+        <translation type="unfinished">%i버젼에서 %i버젼으로 다운그레이드 할 수 없습니다. 월렛 버젼은 변경되지 않았습니다.</translation>
+    </message>
+    <message>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running.</source>
         <translation type="unfinished">데이터 디렉토리 %s 에 락을 걸 수 없었습니다. %s가 이미 실행 중인 것으로 보입니다.</translation>
+    </message>
+    <message>
+        <source>Cannot upgrade a non HD split wallet from version %i to version %i without upgrading to support pre-split keypool. Please use version %i or no version specified.</source>
+        <translation type="unfinished">사전분리 키풀를 지원하기 위해서 업그레이드 하지 않고는 Non HD split 지갑의 %i버젼을 %i버젼으로 업그레이드 할 수 없습니다. %i버젼을 활용하거나 구체화되지 않은 버젼을 활용하세요.</translation>
     </message>
     <message>
         <source>Distributed under the MIT software license, see the accompanying file %s or %s</source>
@@ -443,20 +465,56 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">%s 불러오기 오류! 주소 키는 모두 정확하게 로드되었으나 거래 데이터와 주소록 필드에서 누락이나 오류가 존재할 수 있습니다.</translation>
     </message>
     <message>
-        <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
-        <translation type="unfinished">오류: 들어오는 연결을 허용하는데 실패했습니다 (리슨 오류: %s)</translation>
+        <source>Error reading %s! Transaction data may be missing or incorrect. Rescanning wallet.</source>
+        <translation type="unfinished">%s를 읽는데 에러가 생겼습니다. 트랜잭션 데이터가 잘못되었거나 누락되었습니다. 지갑을 다시 스캐닝합니다.</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile format record is incorrect. Got "%s", expected "format".</source>
+        <translation type="unfinished">오류 : 덤프파일 포맷 기록이 잘못되었습니다. "포맷"이 아니라 "%s"를 얻었습니다.</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile identifier record is incorrect. Got "%s", expected "%s".</source>
+        <translation type="unfinished">오류 : 덤프파일 식별자 기록이 잘못되었습니다. "%s"이 아닌 "%s"를 얻었습니다.</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile version is not supported. This version of bitcoin-wallet only supports version 1 dumpfiles. Got dumpfile with version %s</source>
+        <translation type="unfinished">오류 : 덤프파일 버젼이 지원되지 않습니다. 이 비트코인 지갑 버젼은 오직 버젼1의 덤프파일을 지원합니다. %s버젼의 덤프파일을 얻었습니다.</translation>
+    </message>
+    <message>
+        <source>Error: Legacy wallets only support the "legacy", "p2sh-segwit", and "bech32" address types</source>
+        <translation type="unfinished">오류 : 레거시 지갑주소는 "레거시", "p2sh-segwit", "bech32" 지갑 주소의 타입만 지원합니다.</translation>
     </message>
     <message>
         <source>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.</source>
         <translation type="unfinished">수수료 추정이 실패했습니다. 고장 대체 수수료가 비활성화 상태입니다. 몇 블록을 기다리거나 -fallbackfee를 활성화 하십시오.</translation>
     </message>
     <message>
+        <source>File %s already exists. If you are sure this is what you want, move it out of the way first.</source>
+        <translation type="unfinished">%s 파일이 이미 존재합니다. 무엇을 하고자 하는지 확실하시다면, 파일을 먼저 다른 곳으로 옮기십시오.</translation>
+    </message>
+    <message>
         <source>Invalid amount for -maxtxfee=&lt;amount&gt;: '%s' (must be at least the minrelay fee of %s to prevent stuck transactions)</source>
         <translation type="unfinished">유효하지 않은 금액 -maxtxfee=&lt;amount&gt;: '%s' (거래가 막히는 상황을 방지하게 위해 적어도 %s 의 중계 수수료를 지정해야 합니다)</translation>
     </message>
     <message>
+        <source>Invalid or corrupt peers.dat (%s). If you believe this is a bug, please report it to %s. As a workaround, you can move the file (%s) out of the way (rename, move, or delete) to have a new one created on the next start.</source>
+        <translation type="unfinished">유효하지 않거나 손상된 peers.dat(%s). 만약 이게 버그인 경우에, %s이쪽으로 리포트해주세요.  새로 만들어서 시작하기 위한 해결방법으로 %s파일을 옮길 수 있습니다. (이름 재설정, 파일 옮기기 혹은 삭제).</translation>
+    </message>
+    <message>
         <source>More than one onion bind address is provided. Using %s for the automatically created Tor onion service.</source>
         <translation type="unfinished">하나 이상의 양파 바인딩 주소가 제공됩니다. 자동으로 생성 된 Tor onion 서비스에 %s 사용.</translation>
+    </message>
+    <message>
+        <source>No dump file provided. To use createfromdump, -dumpfile=&lt;filename&gt; must be provided.</source>
+        <translation type="unfinished">덤프파일이 입력되지 않았습니다. 덤프파일을 사용하기 위해서는 -dumpfile=&lt;filename&gt;이 반드시 입력되어야 합니다. </translation>
+    </message>
+    <message>
+        <source>No dump file provided. To use dump, -dumpfile=&lt;filename&gt; must be provided.</source>
+        <translation type="unfinished">덤프파일이 입력되지 않았습니다. 덤프를 사용하기 위해서는 -dumpfile=&lt;filename&gt;이 반드시 입력되어야 합니다.</translation>
+    </message>
+    <message>
+        <source>No wallet file format provided. To use createfromdump, -format=&lt;format&gt; must be provided.</source>
+        <translation type="unfinished">shshhdchb bdfjj fb  rciivfjb doffbfbdjdj</translation>
     </message>
     <message>
         <source>Please check that your computer's date and time are correct! If your clock is wrong, %s will not work properly.</source>
@@ -481,6 +539,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>The block database contains a block which appears to be from the future. This may be due to your computer's date and time being set incorrectly. Only rebuild the block database if you are sure that your computer's date and time are correct</source>
         <translation type="unfinished">블록 데이터베이스에 미래의 블록이 포함되어 있습니다. 이것은 사용자의 컴퓨터의 날짜와 시간이 올바르게 설정되어 있지 않을때 나타날 수 있습니다. 블록 데이터 베이스의 재구성은 사용자의 컴퓨터의 날짜와 시간이 올바르다고 확신할 때에만 하십시오.</translation>
+    </message>
+    <message>
+        <source>The block index db contains a legacy 'txindex'. To clear the occupied disk space, run a full -reindex, otherwise ignore this error. This error message will not be displayed again.</source>
+        <translation type="unfinished">udhdbfjfjdnbdjfjf hdhdbjcn2owkd. jjwbdbdof dkdbdnck wdkdj </translation>
     </message>
     <message>
         <source>The transaction amount is too small to send after the fee has been deducted</source>
@@ -543,6 +605,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">%s 주소를 확인할 수 없습니다: '%s'</translation>
     </message>
     <message>
+        <source>Cannot set -forcednsseed to true when setting -dnsseed to false.</source>
+        <translation type="unfinished">naravfbj. dufb jdncnlfs. jx dhcji djc d jcbc jdnbfbicb </translation>
+    </message>
+    <message>
         <source>Cannot set -peerblockfilters without -blockfilterindex.</source>
         <translation type="unfinished">-blockfilterindex는 -peerblockfilters 없이 사용할 수 없습니다.</translation>
     </message>
@@ -576,7 +642,17 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Done loading</source>
-        <translation type="unfinished">로딩 완료</translation>
+        <translation type="unfinished">불러오기 완료</translation>
+    </message>
+    <message>
+        <source>Dump file %s does not exist.</source>
+        <translation type="unfinished">파일 버리기 1%s 존재 안함
+</translation>
+    </message>
+    <message>
+        <source>Error creating %s</source>
+        <translation type="unfinished">만들기 오류 1%s
+</translation>
     </message>
     <message>
         <source>Error initializing block database</source>
@@ -592,7 +668,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Error loading %s: Private keys can only be disabled during creation</source>
-        <translation type="unfinished">%s 로딩 실패: 개인키는 생성할때만 비활성화 할 수 있습니다</translation>
+        <translation type="unfinished">%s 불러오기 오류: 개인키는 생성할때만 비활성화 할 수 있습니다</translation>
     </message>
     <message>
         <source>Error loading %s: Wallet corrupted</source>
@@ -612,11 +688,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Error reading from database, shutting down.</source>
-        <translation type="unfinished">블록 데이터베이스를 불러오는데 오류가 발생하였습니다, 곧 종료됩니다.</translation>
+        <translation type="unfinished">데이터베이스를 불러오는데 오류가 발생하였습니다, 곧 종료됩니다.</translation>
     </message>
     <message>
-        <source>Error upgrading chainstate database</source>
-        <translation type="unfinished">체인 상태 데이터베이스 업그레이드 중 오류가 발생했습니다.</translation>
+        <source>Error reading next record from wallet database</source>
+        <translation type="unfinished">지갑 데이터베이스에서 다음 기록을 불러오는데 오류가 발생하였습니다.</translation>
     </message>
     <message>
         <source>Error: Disk space is low for %s</source>
@@ -625,6 +701,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Error: Keypool ran out, please call keypoolrefill first</source>
         <translation type="unfinished">오류: 키풀이 바닥남, 키풀 리필을 먼저 호출할 하십시오</translation>
+    </message>
+    <message>
+        <source>Error: Missing checksum</source>
+        <translation type="unfinished">오류: 체크섬 누락</translation>
+    </message>
+    <message>
+        <source>Error: Unable to write record to new wallet</source>
+        <translation type="unfinished">오류: 새로운 지갑에 기록하지 못했습니다.</translation>
     </message>
     <message>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
@@ -711,20 +795,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">-whitebind: '%s' 를 이용하여 포트를 지정해야 합니다</translation>
     </message>
     <message>
-        <source>No proxy server specified. Use -proxy=&lt;ip&gt; or -proxy=&lt;ip:port&gt;.</source>
-        <translation type="unfinished">프록시 서버가 지정되지 않았습니다. -proxy =&lt;ip&gt; 또는 -proxy =&lt;ip:port&gt;를 사용하십시오.</translation>
-    </message>
-    <message>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished">파일 디스크립터가 부족합니다.</translation>
     </message>
     <message>
         <source>Prune cannot be configured with a negative value.</source>
         <translation type="unfinished">블록 축소는 음수로 설정할 수 없습니다.</translation>
-    </message>
-    <message>
-        <source>Prune mode is incompatible with -coinstatsindex.</source>
-        <translation type="unfinished">블록 축소 모드는 -coinstatsindex와 호환되지 않습니다.</translation>
     </message>
     <message>
         <source>Prune mode is incompatible with -txindex.</source>
@@ -851,6 +927,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">키 생성 불가</translation>
     </message>
     <message>
+        <source>Unable to open %s for writing</source>
+        <translation type="unfinished">%s을 쓰기 위하여 열 수 없습니다.</translation>
+    </message>
+    <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
         <translation type="unfinished">HTTP 서버를 시작할 수 없습니다. 자세한 사항은 디버그 로그를 확인 하세요.</translation>
     </message>
@@ -867,12 +947,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">-onlynet: '%s' 에 알수없는 네트워크가 지정되었습니다</translation>
     </message>
     <message>
-        <source>Unsupported logging category %s=%s.</source>
-        <translation type="unfinished">지원되지 않는 로깅 카테고리 %s = %s.</translation>
+        <source>Unknown new rules activated (versionbit %i)</source>
+        <translation type="unfinished">알 수 없는 새로운 규칙이 활성화 되었습니다. (versionbit %i)</translation>
     </message>
     <message>
-        <source>Upgrading UTXO database</source>
-        <translation type="unfinished">UTXO 데이터베이스 업그레이드</translation>
+        <source>Unsupported logging category %s=%s.</source>
+        <translation type="unfinished">지원되지 않는 로깅 카테고리 %s = %s.</translation>
     </message>
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
@@ -1093,7 +1173,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n블록의 트랜잭션 내역이 처리되었습니다.</numerusform>
         </translation>
     </message>
     <message>
@@ -1129,8 +1209,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">최신 정보</translation>
     </message>
     <message>
+        <source>Ctrl+Q</source>
+        <translation type="unfinished">Crtl + Q</translation>
+    </message>
+    <message>
         <source>Load Partially Signed Bitcoin Transaction</source>
         <translation type="unfinished">부분적으로 서명된 비트코인 트랜잭션 불러오기</translation>
+    </message>
+    <message>
+        <source>Load PSBT from &amp;clipboard…</source>
+        <translation type="unfinished">PSBT 혹은 클립보드에서 불러오기</translation>
     </message>
     <message>
         <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
@@ -1169,6 +1257,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">지갑 닫기</translation>
     </message>
     <message>
+        <source>Restore Wallet…</source>
+        <extracomment>Name of the menu item that restores wallet from a backup file.</extracomment>
+        <translation type="unfinished">지갑 복구</translation>
+    </message>
+    <message>
+        <source>Restore a wallet from a backup file</source>
+        <extracomment>Status tip for Restore Wallet menu item</extracomment>
+        <translation type="unfinished">백업파일에서 지갑 복구하기</translation>
+    </message>
+    <message>
         <source>Close all wallets</source>
         <translation type="unfinished">모든 지갑 닫기</translation>
     </message>
@@ -1193,6 +1291,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">사용 가능한 블록이 없습니다.</translation>
     </message>
     <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">지갑 정보</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">지갑 이름</translation>
+    </message>
+    <message>
         <source>&amp;Window</source>
         <translation type="unfinished">창(&amp;W)</translation>
     </message>
@@ -1212,11 +1320,15 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>&amp;Hide</source>
         <translation type="unfinished">&amp;숨기기</translation>
     </message>
+    <message>
+        <source>S&amp;how</source>
+        <translation type="unfinished">보여주기</translation>
+    </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>비트코인 네트워크에 활성화된 %n연결</numerusform>
         </translation>
     </message>
     <message>
@@ -1410,6 +1522,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">복사 &amp; 금액</translation>
     </message>
     <message>
+        <source>Copy transaction &amp;ID and output index</source>
+        <translation type="unfinished">거래 &amp; 결과 인덱스값 혹은 ID 복사</translation>
+    </message>
+    <message>
         <source>L&amp;ock unspent</source>
         <translation type="unfinished">L&amp;ock 미사용</translation>
     </message>
@@ -1497,6 +1613,19 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Can't list signers</source>
         <translation type="unfinished">서명자를 나열할 수 없습니다.</translation>
+    </message>
+    </context>
+<context>
+    <name>LoadWalletsActivity</name>
+    <message>
+        <source>Load Wallets</source>
+        <extracomment>Title of progress window which is displayed when wallets are being loaded.</extracomment>
+        <translation type="unfinished">지갑 불러오기</translation>
+    </message>
+    <message>
+        <source>Loading wallets…</source>
+        <extracomment>Descriptive text of the load wallets progress window which indicates to the user that wallets are currently being loaded.</extracomment>
+        <translation type="unfinished">지갑 불러오는 중...</translation>
     </message>
 </context>
 <context>
@@ -1703,13 +1832,23 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Bitcoin</source>
         <translation type="unfinished">비트코인</translation>
     </message>
-    <message>
-        <source>(of %1 GB needed)</source>
-        <translation type="unfinished">(필요한 %1GB 중)</translation>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+        </translation>
     </message>
-    <message>
-        <source>(%1 GB needed for full chain)</source>
-        <translation type="unfinished">(전체 체인에 필요한 %1GB)</translation>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform>(%n GB가 필요합니다.)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform>(Full 체인이 되려면 %n GB 가 필요합니다.)</numerusform>
+        </translation>
     </message>
     <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
@@ -1723,7 +1862,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n일차 백업을 복구하기에 충분합니다.</numerusform>
         </translation>
     </message>
     <message>
@@ -1753,10 +1892,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>As this is the first time the program is launched, you can choose where %1 will store its data.</source>
         <translation type="unfinished">프로그램이 처음으로 실행되고 있습니다. %1가 어디에 데이터를 저장할지 선택할 수 있습니다.</translation>
-    </message>
-    <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation type="unfinished">'확인'을 클릭하면, %1은 모든 %4 블록 체인 (%2GB) 장부를 가장 최근 거래 부터 %3 안에 다운로드하고 처리하는데, 이것은 %4가 활성화 될때 시작됩니다. </translation>
     </message>
     <message>
         <source>Limit block chain storage to</source>
@@ -1867,7 +2002,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Unknown. Syncing Headers (%1, %2%)…</source>
         <translation type="unfinished">알 수 없음. 헤더 동기화 중(%1, %2)...</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>OpenURIDialog</name>
     <message>
@@ -1951,12 +2086,42 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">이 설정을 되돌리려면 처음부터 블록체인을 다시 다운로드 받아야 합니다.</translation>
     </message>
     <message>
+        <source>Maximum database cache size. A larger cache can contribute to faster sync, after which the benefit is less pronounced for most use cases. Lowering the cache size will reduce memory usage. Unused mempool memory is shared for this cache.</source>
+        <extracomment>Tooltip text for Options window setting that sets the size of the database cache. Explains the corresponding effects of increasing/decreasing this value.</extracomment>
+        <translation type="unfinished">최대 데이터베이스 캐시 사이즈에 도달했습니다. 더 큰 용량의 캐시는 더 빠르게 싱크를 맞출 수 있으며 대부분의 유저 경우에 유리합니다. 캐시 사이즈를 작게 만드는 것은 메모리 사용을 줄입니다. 미사용 멤풀의 메모리는 이 캐시를 위해 공유됩니다.</translation>
+    </message>
+    <message>
+        <source>Set the number of script verification threads. Negative values correspond to the number of cores you want to leave free to the system.</source>
+        <extracomment>Tooltip text for Options window setting that sets the number of script verification threads. Explains that negative values mean to leave these many cores free to the system.</extracomment>
+        <translation type="unfinished">스크립트 검증 수명의 숫자를 설정하세요. 음수는 시스템에 묶이지 않는 자유로운 코어의 수를 뜻합니다.</translation>
+    </message>
+    <message>
         <source>(0 = auto, &lt;0 = leave that many cores free)</source>
         <translation type="unfinished">(0 = 자동, &lt;0 = 지정된 코어 개수만큼 사용 안함)</translation>
     </message>
     <message>
+        <source>This allows you or a third party tool to communicate with the node through command-line and JSON-RPC commands.</source>
+        <extracomment>Tooltip text for Options window setting that enables the RPC server.</extracomment>
+        <translation type="unfinished">당신 혹은 3자의 개발툴이 JSON-RPC 명령과 커맨드라인을 통해 노드와 소통하는 것을 허락합니다.</translation>
+    </message>
+    <message>
+        <source>Enable R&amp;PC server</source>
+        <extracomment>An Options window setting to enable the RPC server.</extracomment>
+        <translation type="unfinished">R&amp;PC 서버를 가능하게 합니다.</translation>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished">지갑(&amp;A)</translation>
+    </message>
+    <message>
+        <source>Whether to set subtract fee from amount as default or not.</source>
+        <extracomment>Tooltip text for Options window setting that sets subtracting the fee from a sending amount as default.</extracomment>
+        <translation type="unfinished">수수료 감면을 초기값으로 할지 혹은 설정하지 않을지를 결정합니다.</translation>
+    </message>
+    <message>
+        <source>Subtract &amp;fee from amount by default</source>
+        <extracomment>An Options window setting to set subtracting the fee from a sending amount as default.</extracomment>
+        <translation type="unfinished">초기 설정값으로 수수료를 뺍니다.</translation>
     </message>
     <message>
         <source>Expert</source>
@@ -1975,8 +2140,23 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">검증되지 않은 잔돈 쓰기 (&amp;S)</translation>
     </message>
     <message>
+        <source>Enable &amp;PSBT controls</source>
+        <extracomment>An options window setting to enable PSBT controls.</extracomment>
+        <translation type="unfinished">PSBT 컨트롤을 가능하게 합니다.</translation>
+    </message>
+    <message>
+        <source>Whether to show PSBT controls.</source>
+        <extracomment>Tooltip text for options window setting that enables PSBT controls.</extracomment>
+        <translation type="unfinished">PSBT 컨트롤을 보여줄지를 결정합니다.</translation>
+    </message>
+    <message>
         <source>External Signer (e.g. hardware wallet)</source>
         <translation type="unfinished">외부 서명자 (예: 하드웨어 지갑)</translation>
+    </message>
+    <message>
+        <source>&amp;External signer script path</source>
+        <translation type="unfinished">외부 서명자 스크립트 경로
+ </translation>
     </message>
     <message>
         <source>Full path to a Bitcoin Core compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</source>
@@ -2075,6 +2255,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">인터페이스에 표시하고 코인을 보낼때 사용할 기본 최소화 단위를 선택하십시오.</translation>
     </message>
     <message>
+        <source>Third-party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</source>
+        <translation type="unfinished">내용 메뉴 아이템으로 거래내역 탭이 보이는 제3자 URL (블록익스프로러). URL에 %s는 트랜잭션 해시값으로 대체됩니다. 복수의 URL은 수직항목으로부터 분리됩니다. </translation>
+    </message>
+    <message>
+        <source>&amp;Third-party transaction URLs</source>
+        <translation type="unfinished">제3자 트랜잭션 URL</translation>
+    </message>
+    <message>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished">코인 상세 제어기능에 대한 표시 여부를 선택할 수 있습니다.</translation>
     </message>
@@ -2095,8 +2283,8 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">%1 포함됨</translation>
     </message>
     <message>
-        <source>Options set in this dialog are overridden by the command line or in the configuration file:</source>
-        <translation type="unfinished">이 다이얼로그에서 설정한 옵션은 커맨드라인이나 설정파일에 의해 바뀔 수 있습니다:</translation>
+        <source>closest matching "%1"</source>
+        <translation type="unfinished">가장 가까운 의미 "1%1"</translation>
     </message>
     <message>
         <source>&amp;OK</source>
@@ -2121,14 +2309,17 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Confirm options reset</source>
+        <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
         <translation type="unfinished">옵션 초기화를 확실화하기</translation>
     </message>
     <message>
         <source>Client restart required to activate changes.</source>
+        <extracomment>Text explaining that the settings changed will not come into effect until the client is restarted.</extracomment>
         <translation type="unfinished">변경 사항을 적용하기 위해서는 프로그램이 종료 후 재시작되어야 합니다.</translation>
     </message>
     <message>
         <source>Client will be shut down. Do you want to proceed?</source>
+        <extracomment>Text asking the user to confirm if they would like to proceed with a client shutdown.</extracomment>
         <translation type="unfinished">클라이언트가 종료됩니다, 계속 진행하시겠습니까?</translation>
     </message>
     <message>
@@ -2280,8 +2471,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">거래 서명 실패: %1</translation>
     </message>
     <message>
+        <source>Cannot sign inputs while wallet is locked.</source>
+        <translation type="unfinished">지갑이 잠겨있는 동안 입력을 서명할 수 없습니다.</translation>
+    </message>
+    <message>
         <source>Could not sign any more inputs.</source>
-        <translation type="unfinished">더 이상 추가적인 인풋에 대해 서명할 수 없음</translation>
+        <translation type="unfinished">더 이상 추가적인 입력에 대해 서명할 수 없습니다.</translation>
     </message>
     <message>
         <source>Signed transaction successfully. Transaction is ready to broadcast.</source>
@@ -2347,6 +2542,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Transaction still needs signature(s).</source>
         <translation type="unfinished">거래가 아직 서명(들)을 필요로 합니다.</translation>
+    </message>
+    <message>
+        <source>(But no wallet is loaded.)</source>
+        <translation type="unfinished">하지만 지갑 로딩이 되지 않았습니다.</translation>
     </message>
     <message>
         <source>(But this wallet cannot sign transactions.)</source>
@@ -2609,6 +2808,26 @@ BIP70의 광범위한 보안 결함으로 인해 모든 가맹점에서는 지�
         <translation type="unfinished">매핑된 AS</translation>
     </message>
     <message>
+        <source>Whether we relay addresses to this peer.</source>
+        <extracomment>Tooltip text for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
+        <translation type="unfinished">이 피어에게 지갑주소를 릴레이할지를 결정합니다.</translation>
+    </message>
+    <message>
+        <source>Address Relay</source>
+        <extracomment>Text title for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
+        <translation type="unfinished">지갑주소를 릴레이합니다.</translation>
+    </message>
+    <message>
+        <source>Addresses Processed</source>
+        <extracomment>Text title for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
+        <translation type="unfinished">처리된 지갑</translation>
+    </message>
+    <message>
+        <source>Addresses Rate-Limited</source>
+        <extracomment>Text title for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
+        <translation type="unfinished">지갑의 Rate제한</translation>
+    </message>
+    <message>
         <source>User Agent</source>
         <translation type="unfinished">유저 에이전트</translation>
     </message>
@@ -2746,12 +2965,47 @@ BIP70의 광범위한 보안 결함으로 인해 모든 가맹점에서는 지�
         <translation type="unfinished">출력:</translation>
     </message>
     <message>
+        <source>Inbound: initiated by peer</source>
+        <extracomment>Explanatory text for an inbound peer connection.</extracomment>
+        <translation type="unfinished">시작점 : 동기에 의해 시작됨</translation>
+    </message>
+    <message>
+        <source>Outbound Full Relay: default</source>
+        <extracomment>Explanatory text for an outbound peer connection that relays all network information. This is the default behavior for outbound connections.</extracomment>
+        <translation type="unfinished">아웃바운드 전체 릴레이: 기본값</translation>
+    </message>
+    <message>
+        <source>Outbound Block Relay: does not relay transactions or addresses</source>
+        <extracomment>Explanatory text for an outbound peer connection that relays network information about blocks and not transactions or addresses.</extracomment>
+        <translation type="unfinished">아웃바운드 블록 릴레이: 트랜잭션 또는 주소를 릴레이하지 않음</translation>
+    </message>
+    <message>
+        <source>Outbound Manual: added using RPC %1 or %2/%3 configuration options</source>
+        <extracomment>Explanatory text for an outbound peer connection that was established manually through one of several methods. The numbered arguments are stand-ins for the methods available to establish manual connections.</extracomment>
+        <translation type="unfinished">아웃바운드 매뉴얼 : RPC 1%1 이나 2%2/3%3 을 사용해서 환경설정 옵션을 추가</translation>
+    </message>
+    <message>
+        <source>Outbound Feeler: short-lived, for testing addresses</source>
+        <extracomment>Explanatory text for a short-lived outbound peer connection that is used to test the aliveness of known addresses.</extracomment>
+        <translation type="unfinished">Outbound Feeler: 짧은 용도, 주소 테스트용</translation>
+    </message>
+    <message>
+        <source>Outbound Address Fetch: short-lived, for soliciting addresses</source>
+        <extracomment>Explanatory text for a short-lived outbound peer connection that is used to request addresses from a peer.</extracomment>
+        <translation type="unfinished">아웃바운드 주소 가져오기: 단기, 주소 요청용
+ </translation>
+    </message>
+    <message>
         <source>we selected the peer for high bandwidth relay</source>
         <translation type="unfinished">저희는 가장 빠른 대역폭을 가지고 있는 피어를 선택합니다.</translation>
     </message>
     <message>
         <source>the peer selected us for high bandwidth relay</source>
         <translation type="unfinished">피어는 높은 대역폭을 위해 우리를 선택합니다</translation>
+    </message>
+    <message>
+        <source>no high bandwidth relay selected</source>
+        <translation type="unfinished">고대역폭 릴레이가 선택되지 않음</translation>
     </message>
     <message>
         <source>&amp;Copy address</source>
@@ -2779,6 +3033,11 @@ BIP70의 광범위한 보안 결함으로 인해 모든 가맹점에서는 지�
         <translation type="unfinished">1년(&amp;Y)</translation>
     </message>
     <message>
+        <source>&amp;Copy IP/Netmask</source>
+        <extracomment>Context menu action to copy the IP/Netmask of a banned peer. IP/Netmask is the combination of a peer's IP address and its Netmask. For IP address, see: https://en.wikipedia.org/wiki/IP_address.</extracomment>
+        <translation type="unfinished">IP/Netmask 복사하기</translation>
+    </message>
+    <message>
         <source>&amp;Unban</source>
         <translation type="unfinished">노드 차단 취소(&amp;U)</translation>
     </message>
@@ -2793,6 +3052,23 @@ BIP70의 광범위한 보안 결함으로 인해 모든 가맹점에서는 지�
     <message>
         <source>Executing command using "%1" wallet</source>
         <translation type="unfinished">"%1" 지갑을 사용하여 명령 실행</translation>
+    </message>
+    <message>
+        <source>Welcome to the %1 RPC console.
+Use up and down arrows to navigate history, and %2 to clear screen.
+Use %3 and %4 to increase or decrease the font size.
+Type %5 for an overview of available commands.
+For more information on using this console, type %6.
+
+%7WARNING: Scammers have been active, telling users to type commands here, stealing their wallet contents. Do not use this console without fully understanding the ramifications of a command.%8</source>
+        <extracomment>RPC console welcome message. Placeholders %7 and %8 are style tags for the warning content, and they are not space separated from the rest of the text intentionally.</extracomment>
+        <translation type="unfinished">1%1 RPC 콘솔에 오신 것을 환영합니다.
+위쪽 및 아래쪽 화살표를 사용하여 기록 탐색을하고 2%2를 사용하여 화면을 지우세요. 
+3%3과 4%4을 사용하여 글꼴 크기 증가 또는 감소하세요
+사용 가능한 명령의 개요를 보려면 5%5를 입력하십시오.
+이 콘솔 사용에 대한 자세한 내용을 보려면 6%6을 입력하십시오.
+7%7 경고: 사기꾼들은 사용자들에게 여기에 명령을 입력하라고 말하고 활발히 금품을 훔칩니다. 완전히 이해하지 않고 이 콘솔을 사용하지 마십시오. 8%8
+</translation>
     </message>
     <message>
         <source>Executing…</source>
@@ -3242,6 +3518,14 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
         <translation type="unfinished">%1을 %2로</translation>
     </message>
     <message>
+        <source>To review recipient list click "Show Details…"</source>
+        <translation type="unfinished">수신자 목록을 검토하기 위해 "자세히 보기"를 클릭하세요</translation>
+    </message>
+    <message>
+        <source>Sign failed</source>
+        <translation type="unfinished">서명 실패</translation>
+    </message>
+    <message>
         <source>External signer not found</source>
         <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
         <translation type="unfinished">외부 서명자를 찾을 수 없음</translation>
@@ -3265,6 +3549,10 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
         <translation type="unfinished">PSBT 저장됨</translation>
     </message>
     <message>
+        <source>External balance:</source>
+        <translation type="unfinished">외부의 잔고</translation>
+    </message>
+    <message>
         <source>or</source>
         <translation type="unfinished">또는</translation>
     </message>
@@ -3276,6 +3564,16 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
         <source>Please, review your transaction proposal. This will produce a Partially Signed Bitcoin Transaction (PSBT) which you can save or copy and then sign with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
         <extracomment>Text to inform a user attempting to create a transaction of their current options. At this stage, a user can only create a PSBT. This string is displayed when private keys are disabled and an external signer is not available.</extracomment>
         <translation type="unfinished">거래 제안을 검토해 주십시오. 이것은 당신이 저장하거나 복사한 뒤 e.g. 오프라인 %1 지갑 또는 PSBT 호환 하드웨어 지갑으로 서명할 수 있는 PSBT (부분적으로 서명된 비트코인 트랜잭션)를 생성할 것입니다.</translation>
+    </message>
+    <message>
+        <source>Do you want to create this transaction?</source>
+        <extracomment>Message displayed when attempting to create a transaction. Cautionary text to prompt the user to verify that the displayed transaction details represent the transaction the user intends to create.</extracomment>
+        <translation type="unfinished">이 트랜잭션을 생성하겠습니까?</translation>
+    </message>
+    <message>
+        <source>Please, review your transaction. You can create and send this transaction or create a Partially Signed Bitcoin Transaction (PSBT), which you can save or copy and then sign with, e.g., an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
+        <extracomment>Text to inform a user attempting to create a transaction of their current options. At this stage, a user can send their transaction or create a PSBT. This string is displayed when both private keys and PSBT controls are enabled.</extracomment>
+        <translation type="unfinished">당신의 트랜잭션을 검토하세요. 당신은 트랜잭션을 생성하고 보낼 수 있습니다. 혹은 부분적으로 서명된 비트코인 트랜잭션 (PSBT, Partially Signed Bitcoin Transaction)을 생성하고, 저장하거나 복사하여 오프라인 %1지갑으로 서명할수도 있습니다. PSBT가 적용되는 하드월렛으로 서명할 수도 있습니다. </translation>
     </message>
     <message>
         <source>Please, review your transaction.</source>
@@ -3330,14 +3628,10 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
         <source>A fee higher than %1 is considered an absurdly high fee.</source>
         <translation type="unfinished">%1 보다 큰 수수료는 지나치게 높은 수수료 입니다.</translation>
     </message>
-    <message>
-        <source>Payment request expired.</source>
-        <translation type="unfinished">지불 요청이 만료되었습니다.</translation>
-    </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n블록내로 컨펌이 시작될 것으로 예상됩니다.</numerusform>
         </translation>
     </message>
     <message>
@@ -3412,28 +3706,12 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
         <translation type="unfinished">메시지:</translation>
     </message>
     <message>
-        <source>This is an unauthenticated payment request.</source>
-        <translation type="unfinished">인증 되지 않은 지불 요청입니다.</translation>
-    </message>
-    <message>
-        <source>This is an authenticated payment request.</source>
-        <translation type="unfinished">인증 된 지불 요청 입니다.</translation>
-    </message>
-    <message>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished">이 주소에 라벨을 입력하면 사용된 주소 목록에 라벨이 표시됩니다</translation>
     </message>
     <message>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished">bitcoin: URI에 추가된 메시지는 참고를 위해 거래내역과 함께 저장될 것입니다. Note: 이 메시지는 비트코인 네트워크로 전송되지 않습니다.</translation>
-    </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">보낼 주소:</translation>
-    </message>
-    <message>
-        <source>Memo:</source>
-        <translation type="unfinished">메모:</translation>
     </message>
 </context>
 <context>
@@ -3591,33 +3869,36 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     </message>
 </context>
 <context>
+    <name>SplashScreen</name>
+    <message>
+        <source>(press q to shutdown and continue later)</source>
+        <translation type="unfinished">q 를 눌러 종료하거나 나중에 계속하세요.</translation>
+    </message>
+    <message>
+        <source>press q to shutdown</source>
+        <translation type="unfinished">q를 눌러 종료하세요</translation>
+    </message>
+</context>
+<context>
     <name>TransactionDesc</name>
     <message>
         <source>conflicted with a transaction with %1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that conflicts with a confirmed transaction.</extracomment>
         <translation type="unfinished">%1 승인이 있는 거래와 충돌함</translation>
     </message>
     <message>
-        <source>0/unconfirmed, %1</source>
-        <translation type="unfinished">0/미승인, %1</translation>
-    </message>
-    <message>
-        <source>in memory pool</source>
-        <translation type="unfinished">메모리 풀 안에 있음</translation>
-    </message>
-    <message>
-        <source>not in memory pool</source>
-        <translation type="unfinished">메모리 풀 안에 없음</translation>
-    </message>
-    <message>
         <source>abandoned</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an abandoned transaction.</extracomment>
         <translation type="unfinished">버려진</translation>
     </message>
     <message>
         <source>%1/unconfirmed</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
         <translation type="unfinished">%1/미확인</translation>
     </message>
     <message>
         <source>%1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
         <translation type="unfinished">%1 확인 완료</translation>
     </message>
     <message>
@@ -3667,7 +3948,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n개 이상 블록 이내에 완료됩니다.</numerusform>
         </translation>
     </message>
     <message>
@@ -3940,8 +4221,33 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
         <translation type="unfinished">복사 트랜잭션 &amp; 아이디</translation>
     </message>
     <message>
+        <source>Copy &amp;raw transaction</source>
+        <translation type="unfinished">처리되지 않은 트랜잭션 복사</translation>
+    </message>
+    <message>
+        <source>Copy full transaction &amp;details</source>
+        <translation type="unfinished">트랜잭션 전체와 상세내역 복사</translation>
+    </message>
+    <message>
+        <source>&amp;Show transaction details</source>
+        <translation type="unfinished">트랜잭션 상세내역 보여주기</translation>
+    </message>
+    <message>
+        <source>Increase transaction &amp;fee</source>
+        <translation type="unfinished">트랜잭션 수수료 올리기</translation>
+    </message>
+    <message>
+        <source>A&amp;bandon transaction</source>
+        <translation type="unfinished">트랜잭션 폐기하기</translation>
+    </message>
+    <message>
         <source>&amp;Edit address label</source>
         <translation type="unfinished">&amp;주소 라벨 수정하기</translation>
+    </message>
+    <message>
+        <source>Show in %1</source>
+        <extracomment>Transactions table context menu action to show the selected transaction in a third-party block explorer. %1 is a stand-in argument for the URL of the explorer.</extracomment>
+        <translation type="unfinished">%1내로 보여주기</translation>
     </message>
     <message>
         <source>Export Transaction History</source>

--- a/src/qt/locale/bitcoin_ku.ts
+++ b/src/qt/locale/bitcoin_ku.ts
@@ -1,0 +1,357 @@
+<TS version="2.1" language="ku">
+<context>
+    <name>AddressBookPage</name>
+    <message>
+        <source>&amp;New</source>
+        <translation type="unfinished">&amp;Nû</translation>
+    </message>
+    <message>
+        <source>&amp;Copy</source>
+        <translation type="unfinished">&amp;Kopi bike</translation>
+    </message>
+    <message>
+        <source>C&amp;lose</source>
+        <translation type="unfinished">Bigire</translation>
+    </message>
+    <message>
+        <source>Delete the currently selected address from the list</source>
+        <translation type="unfinished">Navnîşana hilbijartî ji lîsteyê rake</translation>
+    </message>
+    <message>
+        <source>Enter address or label to search</source>
+        <translation type="unfinished">Ji bo lêgerînê navnîşan an jî etîketê têkeve</translation>
+    </message>
+    <message>
+        <source>Export the data in the current tab to a file</source>
+        <translation type="unfinished">Daneya di hilpekîna niha de bi rêya dosyayekê derxîne</translation>
+    </message>
+    <message>
+        <source>&amp;Export</source>
+        <translation type="unfinished">Derxîne</translation>
+    </message>
+    <message>
+        <source>&amp;Delete</source>
+        <translation type="unfinished">Jê bibe</translation>
+    </message>
+    <message>
+        <source>Choose the address to send coins to</source>
+        <translation type="unfinished">Navnîşana ku ew ê koîn were şandin, hilbijêre</translation>
+    </message>
+    <message>
+        <source>Choose the address to receive coins with</source>
+        <translation type="unfinished">Navnîşana ku ew ê koînan bistîne, hilbijêre</translation>
+    </message>
+    <message>
+        <source>C&amp;hoose</source>
+        <translation type="unfinished">H&amp;ilbijêre</translation>
+    </message>
+    <message>
+        <source>Sending addresses</source>
+        <translation type="unfinished">Navnîşanên şandinê</translation>
+    </message>
+    <message>
+        <source>Receiving addresses</source>
+        <translation type="unfinished">Navnîşanên stendinê</translation>
+    </message>
+    <message>
+        <source>&amp;Copy Address</source>
+        <translation type="unfinished">&amp;Navnîşanê kopî bike</translation>
+    </message>
+    <message>
+        <source>Copy &amp;Label</source>
+        <translation type="unfinished">Etîketê &amp;kopî bike</translation>
+    </message>
+    <message>
+        <source>&amp;Edit</source>
+        <translation type="unfinished">&amp;Serrast bike</translation>
+    </message>
+    <message>
+        <source>Export Address List</source>
+        <translation type="unfinished">Lîsteya navnîşanan derxîne</translation>
+    </message>
+    </context>
+<context>
+    <name>AddressTableModel</name>
+    <message>
+        <source>Label</source>
+        <translation type="unfinished">Etîket</translation>
+    </message>
+    <message>
+        <source>Address</source>
+        <translation type="unfinished">Navnîşan</translation>
+    </message>
+    <message>
+        <source>(no label)</source>
+        <translation type="unfinished">(etîket tune)</translation>
+    </message>
+</context>
+<context>
+    <name>AskPassphraseDialog</name>
+    <message>
+        <source>Enter passphrase</source>
+        <translation type="unfinished">Pêborîna xwe têkevê</translation>
+    </message>
+    <message>
+        <source>New passphrase</source>
+        <translation type="unfinished">Pêborîna nû</translation>
+    </message>
+    <message>
+        <source>Repeat new passphrase</source>
+        <translation type="unfinished">Pêborîna xwe ya nû dubare bike</translation>
+    </message>
+    <message>
+        <source>Show passphrase</source>
+        <translation type="unfinished">Pêborînê nîşan bide</translation>
+    </message>
+    <message>
+        <source>Encrypt wallet</source>
+        <translation type="unfinished">Şîfrekirina cizdên</translation>
+    </message>
+    <message>
+        <source>Unlock wallet</source>
+        <translation type="unfinished">Kilîda cizdên veke</translation>
+    </message>
+    <message>
+        <source>Change passphrase</source>
+        <translation type="unfinished">Pêborînê biguherîne</translation>
+    </message>
+    <message>
+        <source>Confirm wallet encryption</source>
+        <translation type="unfinished">Şîfrekirina cizdên bipejirîne</translation>
+    </message>
+    <message>
+        <source>Are you sure you wish to encrypt your wallet?</source>
+        <translation type="unfinished">Tu bi rastî jî dixwazî cizdanê xwe şîfre bikî?</translation>
+    </message>
+    <message>
+        <source>Wallet encrypted</source>
+        <translation type="unfinished">Cizdan hate şîfrekirin</translation>
+    </message>
+    </context>
+<context>
+    <name>QObject</name>
+    <message numerus="yes">
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n week(s)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n year(s)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    </context>
+<context>
+    <name>BitcoinGUI</name>
+    <message>
+        <source>Wallet:</source>
+        <translation type="unfinished">Cizdan:</translation>
+    </message>
+    <message numerus="yes">
+        <source>Processed %n block(s) of transaction history.</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message>
+        <source>Information</source>
+        <translation type="unfinished">Agahî</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n active connection(s) to Bitcoin network.</source>
+        <extracomment>A substring of the tooltip.</extracomment>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    </context>
+<context>
+    <name>CoinControlDialog</name>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">Tarîx</translation>
+    </message>
+    <message>
+        <source>(no label)</source>
+        <translation type="unfinished">(etîket tune)</translation>
+    </message>
+    </context>
+<context>
+    <name>Intro</name>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(sufficient to restore backups %n day(s) old)</source>
+        <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    </context>
+<context>
+    <name>PeerTableModel</name>
+    <message>
+        <source>Address</source>
+        <extracomment>Title of Peers Table column which contains the IP/Onion/I2P address of the connected peer.</extracomment>
+        <translation type="unfinished">Navnîşan</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <extracomment>Title of Peers Table column which describes the type of peer connection. The "type" describes why the connection exists.</extracomment>
+        <translation type="unfinished">Cure</translation>
+    </message>
+    </context>
+<context>
+    <name>ReceiveRequestDialog</name>
+    <message>
+        <source>Wallet:</source>
+        <translation type="unfinished">Cizdan:</translation>
+    </message>
+    </context>
+<context>
+    <name>RecentRequestsTableModel</name>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">Tarîx</translation>
+    </message>
+    <message>
+        <source>Label</source>
+        <translation type="unfinished">Etîket</translation>
+    </message>
+    <message>
+        <source>(no label)</source>
+        <translation type="unfinished">(etîket tune)</translation>
+    </message>
+    </context>
+<context>
+    <name>SendCoinsDialog</name>
+    <message numerus="yes">
+        <source>Estimated to begin confirmation within %n block(s).</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message>
+        <source>(no label)</source>
+        <translation type="unfinished">(etîket tune)</translation>
+    </message>
+</context>
+<context>
+    <name>TransactionDesc</name>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">Tarîx</translation>
+    </message>
+    <message numerus="yes">
+        <source>matures in %n more block(s)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    </context>
+<context>
+    <name>TransactionTableModel</name>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">Tarîx</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished">Cure</translation>
+    </message>
+    <message>
+        <source>Label</source>
+        <translation type="unfinished">Etîket</translation>
+    </message>
+    <message>
+        <source>(no label)</source>
+        <translation type="unfinished">(etîket tune)</translation>
+    </message>
+    </context>
+<context>
+    <name>TransactionView</name>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">Tarîx</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished">Cure</translation>
+    </message>
+    <message>
+        <source>Label</source>
+        <translation type="unfinished">Etîket</translation>
+    </message>
+    <message>
+        <source>Address</source>
+        <translation type="unfinished">Navnîşan</translation>
+    </message>
+    </context>
+<context>
+    <name>WalletView</name>
+    <message>
+        <source>&amp;Export</source>
+        <translation type="unfinished">Derxîne</translation>
+    </message>
+    <message>
+        <source>Export the data in the current tab to a file</source>
+        <translation type="unfinished">Daneya di hilpekîna niha de bi rêya dosyayekê derxîne</translation>
+    </message>
+    </context>
+</TS>

--- a/src/qt/locale/bitcoin_ku_IQ.ts
+++ b/src/qt/locale/bitcoin_ku_IQ.ts
@@ -137,6 +137,22 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">دووبارەکردنەوەی دەستەواژەی تێپەڕی نوێ</translation>
     </message>
     <message>
+        <source>Show passphrase</source>
+        <translation type="unfinished">نیشان دانا ناوه چونه</translation>
+    </message>
+    <message>
+        <source>Encrypt wallet</source>
+        <translation type="unfinished">کیف خو یه پاره رمزه دانینه بر</translation>
+    </message>
+    <message>
+        <source>This operation needs your wallet passphrase to unlock the wallet.</source>
+        <translation type="unfinished">او شوله بو ور کرنا کیف پاره گرکه رمزا کیفه وؤ یه پاره بزانی</translation>
+    </message>
+    <message>
+        <source>Are you sure you wish to encrypt your wallet?</source>
+        <translation type="unfinished">به راستی اون هشیارن کا دخازن بو کیف خو یه پاره رمزه دانین</translation>
+    </message>
+    <message>
         <source>Enter the new passphrase for the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished">دەستەواژەی تێپەڕەوی نوێ تێبنووسە بۆ جزدان.1 تکایە دەستەواژەی تێپەڕێک بەکاربێنە لە 2ten یان زیاتر لە هێما هەڕەمەکیەکان2، یان 38 یان زیاتر ووشەکان3.</translation>
     </message>
@@ -239,6 +255,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </context>
 <context>
     <name>BitcoinGUI</name>
+    <message>
+        <source>&amp;About %1</source>
+        <translation type="unfinished">&amp;دەربارەی %1</translation>
+    </message>
     <message>
         <source>&amp;Send</source>
         <translation type="unfinished">&amp;ناردن</translation>
@@ -348,6 +368,27 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>Intro</name>
     <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
@@ -366,10 +407,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Welcome</source>
         <translation type="unfinished">بەخێربێن</translation>
-    </message>
-    <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation type="unfinished">کاتێک کرتە لە پەسەندە دەکەیت، %1 دەست دەکات بە داگرتن و پرۆسەی زنجیرەبلۆکی %4 (%2GB) بە سەرەتاییترین مامەڵەکان لە %3 دەست پێدەکات کاتێک %4 لە سەرەتادا دەستی پێکرد.</translation>
     </message>
     <message>
         <source>Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</source>

--- a/src/qt/locale/bitcoin_ky.ts
+++ b/src/qt/locale/bitcoin_ky.ts
@@ -144,6 +144,27 @@
 <context>
     <name>Intro</name>
     <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">

--- a/src/qt/locale/bitcoin_la.ts
+++ b/src/qt/locale/bitcoin_la.ts
@@ -521,6 +521,27 @@
 <context>
     <name>Intro</name>
     <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
@@ -647,6 +668,7 @@
     </message>
     <message>
         <source>Confirm options reset</source>
+        <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
         <translation type="unfinished">Confirma optionum reconstituere</translation>
     </message>
     <message>
@@ -933,10 +955,6 @@
         <source>Message:</source>
         <translation type="unfinished">Nuntius:</translation>
     </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">Pensa Ad:</translation>
-    </message>
     </context>
 <context>
     <name>SignVerifyMessageDialog</name>
@@ -1053,10 +1071,12 @@
     <name>TransactionDesc</name>
     <message>
         <source>%1/unconfirmed</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
         <translation type="unfinished">%1/non confirmata</translation>
     </message>
     <message>
         <source>%1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
         <translation type="unfinished">%1 confirmationes</translation>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_lt.ts
+++ b/src/qt/locale/bitcoin_lt.ts
@@ -3,7 +3,7 @@
     <name>AddressBookPage</name>
     <message>
         <source>Right-click to edit address or label</source>
-        <translation type="unfinished">Spustelėkite dešinįjį klavišą norint keisti adresą arba etiketę</translation>
+        <translation type="unfinished">Spustelėkite dešinįjį pelės klavišą norint keisti adresą arba etiketę </translation>
     </message>
     <message>
         <source>Create a new address</source>
@@ -70,6 +70,12 @@
         <translation type="unfinished">Tai yra jūsų Bitcoin adresai išeinantiems mokėjimams. Visada pasitikrinkite sumą ir gavėjo adresą prieš siunčiant lėšas.</translation>
     </message>
     <message>
+        <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
+Signing is only possible with addresses of the type 'legacy'.</source>
+        <translation type="unfinished">Tai jūsų Bitcoin mokėjimų gavimo adresai. Naudokite 'Sukurti naują gavimo adresą' mygtuką gavimų skirtuke kad sukurtumėte naujus adresus.
+Pasirašymas galimas tik su 'legacy' tipo adresais.</translation>
+    </message>
+    <message>
         <source>&amp;Copy Address</source>
         <translation type="unfinished">&amp;Kopijuoti adresą</translation>
     </message>
@@ -84,6 +90,11 @@
     <message>
         <source>Export Address List</source>
         <translation type="unfinished">Eksportuoti adresų sąrašą</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">Kableliais atskirtas failas</translation>
     </message>
     <message>
         <source>There was an error trying to save the address list to %1. Please try again.</source>
@@ -190,7 +201,7 @@
     </message>
     <message>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
-        <translation type="unfinished">Dėl vidinės klaidos nepavyko užšifruoti piniginę.Piniginė neužšifruota.</translation>
+        <translation type="unfinished">Dėl vidinės klaidos nepavyko užšifruoti piniginę. Piniginė neužšifruota.</translation>
     </message>
     <message>
         <source>The supplied passphrases do not match.</source>
@@ -227,6 +238,10 @@
 <context>
     <name>BitcoinApplication</name>
     <message>
+        <source>Settings file %1 might be corrupt or invalid.</source>
+        <translation type="unfinished">Nustatymų failas %1 galimai sugadintas arba klaidingas</translation>
+    </message>
+    <message>
         <source>Internal error</source>
         <translation type="unfinished">Vidinė klaida</translation>
     </message>
@@ -244,6 +259,10 @@
     <message>
         <source>Error: %1</source>
         <translation type="unfinished">Klaida: %1</translation>
+    </message>
+    <message>
+        <source>%1 didn't yet exit safely…</source>
+        <translation type="unfinished">%1 dar saugiai neužbaigė darbo...</translation>
     </message>
     <message>
         <source>unknown</source>
@@ -339,6 +358,14 @@
     </context>
 <context>
     <name>bitcoin-core</name>
+    <message>
+        <source>Settings file could not be read</source>
+        <translation type="unfinished">Nustatymų failas negalėjo būti perskaitytas</translation>
+    </message>
+    <message>
+        <source>Settings file could not be written</source>
+        <translation type="unfinished">Nustatymų failas negalėjo būti parašytas</translation>
+    </message>
     <message>
         <source>The %s developers</source>
         <translation type="unfinished">%s kūrėjai</translation>
@@ -476,10 +503,6 @@
         <translation type="unfinished">Nežinomas adreso tipas '%s'</translation>
     </message>
     <message>
-        <source>Upgrading UTXO database</source>
-        <translation type="unfinished">UTXO duomenų bazės atnaujinimas</translation>
-    </message>
-    <message>
         <source>Verifying blocks…</source>
         <translation type="unfinished">Tikrinami blokai...</translation>
     </message>
@@ -539,6 +562,10 @@
         <translation type="unfinished">Sukurti naują piniginę</translation>
     </message>
     <message>
+        <source>&amp;Minimize</source>
+        <translation type="unfinished">&amp;Sumažinti</translation>
+    </message>
+    <message>
         <source>Wallet:</source>
         <translation type="unfinished">Piniginė</translation>
     </message>
@@ -570,6 +597,10 @@
     <message>
         <source>&amp;Receive</source>
         <translation type="unfinished">&amp;Gauti</translation>
+    </message>
+    <message>
+        <source>&amp;Options…</source>
+        <translation type="unfinished">&amp;Nustatymai</translation>
     </message>
     <message>
         <source>Encrypt the private keys that belong to your wallet</source>
@@ -698,6 +729,11 @@
     <message>
         <source>No wallets available</source>
         <translation type="unfinished">Piniginių nėra</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">Piniginės Pavadinimas</translation>
     </message>
     <message>
         <source>&amp;Window</source>
@@ -1129,6 +1165,30 @@
 </context>
 <context>
     <name>Intro</name>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform>(reikalinga %n GB)</numerusform>
+            <numerusform>(reikalinga %n GB)</numerusform>
+            <numerusform>(reikalinga %n GB)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
     <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
         <translation type="unfinished">Šiame kataloge bus saugomi bent %1 GB duomenų, kurie laikui bėgant didės.</translation>
@@ -1173,10 +1233,6 @@
     <message>
         <source>As this is the first time the program is launched, you can choose where %1 will store its data.</source>
         <translation type="unfinished">Kadangi tai yra pirmas kartas, kai programa paleidžiama, galite pasirinkti, kur %1 išsaugos savo duomenis.</translation>
-    </message>
-    <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation type="unfinished">Spustelėjus Gerai, %1 pradės atsisiųsti ir apdoroti visą %4 blokų grandinę (%2GB), pradedant nuo ankstesnių operacijų %3, kai iš pradžių buvo paleista %4.</translation>
     </message>
     <message>
         <source> GB</source>
@@ -1447,10 +1503,6 @@
         <translation type="unfinished">Rodyti monetų valdymo funkcijas, ar ne.</translation>
     </message>
     <message>
-        <source>Options set in this dialog are overridden by the command line or in the configuration file:</source>
-        <translation type="unfinished">Šiame dialogo lange nustatytos parinktys yra panaikintos komandų eilutėje arba konfigūracijos faile:</translation>
-    </message>
-    <message>
         <source>&amp;OK</source>
         <translation type="unfinished">&amp;Gerai</translation>
     </message>
@@ -1468,14 +1520,17 @@
     </message>
     <message>
         <source>Confirm options reset</source>
+        <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
         <translation type="unfinished">Patvirtinti nustatymų atstatymą</translation>
     </message>
     <message>
         <source>Client restart required to activate changes.</source>
+        <extracomment>Text explaining that the settings changed will not come into effect until the client is restarted.</extracomment>
         <translation type="unfinished">Kliento perkrovimas reikalingas nustatymų aktyvavimui</translation>
     </message>
     <message>
         <source>Client will be shut down. Do you want to proceed?</source>
+        <extracomment>Text asking the user to confirm if they would like to proceed with a client shutdown.</extracomment>
         <translation type="unfinished">Klientas bus uždarytas. Ar norite testi?</translation>
     </message>
     <message>
@@ -2333,10 +2388,6 @@
         <source>A fee higher than %1 is considered an absurdly high fee.</source>
         <translation type="unfinished">Mokestis, didesnis nei %1, laikomas absurdiškai aukštu mokesčiu.</translation>
     </message>
-    <message>
-        <source>Payment request expired.</source>
-        <translation type="unfinished">Mokėjimo prašymas pasibaigė</translation>
-    </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
@@ -2413,28 +2464,12 @@
         <translation type="unfinished">Žinutė:</translation>
     </message>
     <message>
-        <source>This is an unauthenticated payment request.</source>
-        <translation type="unfinished">Tai yra nepatvirtinta mokėjimo užklausos suma</translation>
-    </message>
-    <message>
-        <source>This is an authenticated payment request.</source>
-        <translation type="unfinished">Tai yra patvirtintas mokėjimo prašymas.</translation>
-    </message>
-    <message>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished">Įveskite šio adreso etiketę, kad ją pridėtumėte prie naudojamų adresų sąrašo</translation>
     </message>
     <message>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished">Pranešimas, kuris buvo pridėtas prie bitcoin: URI, kuris bus saugomas kartu su sandoriu jūsų nuoroda. Pastaba: šis pranešimas nebus išsiųstas per „Bitcoin“ tinklą.</translation>
-    </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">Mokėti gavėjui:</translation>
-    </message>
-    <message>
-        <source>Memo:</source>
-        <translation type="unfinished">Atmintinė:</translation>
     </message>
 </context>
 <context>
@@ -2571,30 +2606,22 @@
     <name>TransactionDesc</name>
     <message>
         <source>conflicted with a transaction with %1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that conflicts with a confirmed transaction.</extracomment>
         <translation type="unfinished">prieštaravo sandoriui su %1 patvirtinimais</translation>
     </message>
     <message>
-        <source>0/unconfirmed, %1</source>
-        <translation type="unfinished">0/nepatvirtintas, %1</translation>
-    </message>
-    <message>
-        <source>in memory pool</source>
-        <translation type="unfinished">atminties talpykloje</translation>
-    </message>
-    <message>
-        <source>not in memory pool</source>
-        <translation type="unfinished">ne atminties talpykloje</translation>
-    </message>
-    <message>
         <source>abandoned</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an abandoned transaction.</extracomment>
         <translation type="unfinished">paliktas</translation>
     </message>
     <message>
         <source>%1/unconfirmed</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
         <translation type="unfinished">%1/nepatvirtintas</translation>
     </message>
     <message>
         <source>%1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
         <translation type="unfinished">%1 patvirtinimų</translation>
     </message>
     <message>
@@ -2881,6 +2908,11 @@
     <message>
         <source>Export Transaction History</source>
         <translation type="unfinished">Eksportuoti sandorių istoriją</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">Kableliais atskirtas failas</translation>
     </message>
     <message>
         <source>Confirmed</source>

--- a/src/qt/locale/bitcoin_lv.ts
+++ b/src/qt/locale/bitcoin_lv.ts
@@ -88,7 +88,7 @@
     <message>
         <source>There was an error trying to save the address list to %1. Please try again.</source>
         <extracomment>An error message. %1 is a stand-in argument for the name of the file we attempted to save to.</extracomment>
-        <translation type="unfinished">Mēģinot saglabāt adrešu sarakstu %1 radās kļūda. Mēģiniet vēlreiz.</translation>
+        <translation type="unfinished">Mēģinot saglabāt adrešu sarakstu %1 radās kļūda. Lūdzu mēģiniet vēlreiz.</translation>
     </message>
     <message>
         <source>Exporting Failed</source>
@@ -126,7 +126,7 @@
     </message>
     <message>
         <source>Repeat new passphrase</source>
-        <translation type="unfinished">Jaunā parole vēlreiz</translation>
+        <translation type="unfinished">Ievadiet jauno paroli vēlreiz</translation>
     </message>
     <message>
         <source>Show passphrase</source>
@@ -185,10 +185,18 @@
         <translation type="unfinished">Maciņa šifrēšana neizdevās</translation>
     </message>
     <message>
+        <source>The supplied passphrases do not match.</source>
+        <translation type="unfinished">Ievadītās paroles nav vienādas.</translation>
+    </message>
+    <message>
         <source>Wallet unlock failed</source>
         <translation type="unfinished">Maciņa atslēgšana neizdevās</translation>
     </message>
-    </context>
+    <message>
+        <source>Warning: The Caps Lock key is on!</source>
+        <translation type="unfinished">Uzmanību! Caps Lock uz klavietūras ir ieslēgts!</translation>
+    </message>
+</context>
 <context>
     <name>QObject</name>
     <message>
@@ -318,12 +326,20 @@
         <translation type="unfinished">&amp;Par %1</translation>
     </message>
     <message>
+        <source>Show information about %1</source>
+        <translation type="unfinished">Rādīt informāciju par %1</translation>
+    </message>
+    <message>
         <source>About &amp;Qt</source>
         <translation type="unfinished">Par &amp;Qt</translation>
     </message>
     <message>
         <source>Show information about Qt</source>
         <translation type="unfinished">Parādīt informāciju par Qt</translation>
+    </message>
+    <message>
+        <source>Create a new wallet</source>
+        <translation type="unfinished">Izveidot jaunu maciņu</translation>
     </message>
     <message>
         <source>Wallet:</source>
@@ -348,6 +364,10 @@
     <message>
         <source>&amp;Receive</source>
         <translation type="unfinished">&amp;Saņemt</translation>
+    </message>
+    <message>
+        <source>&amp;Options…</source>
+        <translation type="unfinished">&amp;Opcijas...</translation>
     </message>
     <message>
         <source>Encrypt the private keys that belong to your wallet</source>
@@ -376,6 +396,10 @@
     <message>
         <source>Tabs toolbar</source>
         <translation type="unfinished">Ciļņu rīkjosla</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation type="unfinished">Sinhronizē ar tīklu</translation>
     </message>
     <message>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
@@ -549,6 +573,30 @@
 </context>
 <context>
     <name>Intro</name>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
     <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
@@ -740,7 +788,13 @@
     </message>
     <message>
         <source>Confirm options reset</source>
+        <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
         <translation type="unfinished">Apstiprināt iestatījumu atiestatīšanu</translation>
+    </message>
+    <message>
+        <source>Configuration options</source>
+        <extracomment>Window title text of pop-up box that allows opening up of configuration file.</extracomment>
+        <translation type="unfinished">Konfigurāciju Opcijas</translation>
     </message>
     <message>
         <source>Error</source>
@@ -788,6 +842,33 @@
     <message>
         <source>Your current total balance</source>
         <translation type="unfinished">Jūsu kopējā tekošā bilance</translation>
+    </message>
+    <message>
+        <source>Spendable:</source>
+        <translation type="unfinished">Iztērējams:</translation>
+    </message>
+    <message>
+        <source>Recent transactions</source>
+        <translation type="unfinished">Nesenās transakcijas</translation>
+    </message>
+    </context>
+<context>
+    <name>PSBTOperationsDialog</name>
+    <message>
+        <source>Dialog</source>
+        <translation type="unfinished">Dialogs</translation>
+    </message>
+    <message>
+        <source>Copy to Clipboard</source>
+        <translation type="unfinished">Nokopēt</translation>
+    </message>
+    <message>
+        <source>Save…</source>
+        <translation type="unfinished">Saglabāt...</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation type="unfinished">Aiztaisīt</translation>
     </message>
     </context>
 <context>
@@ -1084,10 +1165,6 @@
         <source>Message:</source>
         <translation type="unfinished">Ziņojums:</translation>
     </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">Maksāt:</translation>
-    </message>
     </context>
 <context>
     <name>SignVerifyMessageDialog</name>
@@ -1222,6 +1299,10 @@
     </context>
 <context>
     <name>WalletFrame</name>
+    <message>
+        <source>Create a new wallet</source>
+        <translation type="unfinished">Izveidot jaunu maciņu</translation>
+    </message>
     <message>
         <source>Error</source>
         <translation type="unfinished">Kļūda</translation>

--- a/src/qt/locale/bitcoin_mk.ts
+++ b/src/qt/locale/bitcoin_mk.ts
@@ -341,6 +341,30 @@
         <translation type="unfinished">Биткоин</translation>
     </message>
     <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">

--- a/src/qt/locale/bitcoin_ml.ts
+++ b/src/qt/locale/bitcoin_ml.ts
@@ -317,10 +317,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">ഡാറ്റാബേസിൽ നിന്നും വായിച്ചെടുക്കുന്നതിനു തടസം നേരിട്ടു, പ്രവർത്തനം അവസാനിപ്പിക്കുന്നു.</translation>
     </message>
     <message>
-        <source>Error upgrading chainstate database</source>
-        <translation type="unfinished">ചെയിൻസ്റ്റേറ്റ് ഡാറ്റാബേസ് അപ്ഗ്രേഡ് ചെയ്യുന്നതിൽ തടസം നേരിട്ടു</translation>
-    </message>
-    <message>
         <source>Error: Disk space is low for %s</source>
         <translation type="unfinished">Error: %s ൽ ഡിസ്ക് സ്പേസ് വളരെ കുറവാണ്</translation>
     </message>
@@ -622,6 +618,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>No wallets available</source>
         <translation type="unfinished">വാലറ്റ് ഒന്നും ലഭ്യം അല്ല </translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">വാലറ്റ് പേര്</translation>
     </message>
     <message>
         <source>&amp;Window</source>
@@ -986,6 +987,27 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">ബിറ്റ്കോയിൻ</translation>
     </message>
     <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
@@ -1234,10 +1256,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Copy change</source>
         <translation type="unfinished">ചേഞ്ച് പകർത്തു</translation>
     </message>
-    <message>
-        <source>Payment request expired.</source>
-        <translation type="unfinished">പെയ്മെന്റിനുള്ള അഭ്യർത്ഥന  കാലഹരണപ്പെട്ടു പോയിരിക്കുന്നു. </translation>
-    </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
@@ -1272,6 +1290,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <name>TransactionDesc</name>
     <message>
         <source>%1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
         <translation type="unfinished">%1 സ്ഥിരീകരണങ്ങൾ</translation>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_mn.ts
+++ b/src/qt/locale/bitcoin_mn.ts
@@ -81,7 +81,11 @@
         <source>Export Address List</source>
         <translation type="unfinished">Экспорт хийх хаягуудын жагсаалт</translation>
     </message>
-    </context>
+    <message>
+        <source>Exporting Failed</source>
+        <translation type="unfinished">Экспорт амжилтгүй боллоо</translation>
+    </message>
+</context>
 <context>
     <name>AddressTableModel</name>
     <message>
@@ -158,6 +162,13 @@
     <message>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished">Түрүйвчийн нууц үг амжилттай ѳѳр</translation>
+    </message>
+    </context>
+<context>
+    <name>BitcoinApplication</name>
+    <message>
+        <source>Internal error</source>
+        <translation type="unfinished">Дотоод алдаа</translation>
     </message>
     </context>
 <context>
@@ -259,8 +270,17 @@
         <translation type="unfinished">Клиентийн тухай мэдээллийг харуул</translation>
     </message>
     <message>
+        <source>Create a new wallet</source>
+        <translation type="unfinished">Шинэ түрийвч үүсгэх</translation>
+    </message>
+    <message>
         <source>Wallet:</source>
         <translation type="unfinished">Хэтэвч:</translation>
+    </message>
+    <message>
+        <source>Network activity disabled.</source>
+        <extracomment>A substring of the tooltip.</extracomment>
+        <translation type="unfinished">Сүлжээний үйл ажиллагааг идэвхгүй болгосон.</translation>
     </message>
     <message>
         <source>Change the passphrase used for wallet encryption</source>
@@ -335,6 +355,46 @@
         <translation type="unfinished">Алдаа: %1</translation>
     </message>
     <message>
+        <source>Warning: %1</source>
+        <translation type="unfinished">Анхааруулга:%1</translation>
+    </message>
+    <message>
+        <source>Date: %1
+</source>
+        <translation type="unfinished">Огноо%1
+</translation>
+    </message>
+    <message>
+        <source>Amount: %1
+</source>
+        <translation type="unfinished">Дүн: %1
+</translation>
+    </message>
+    <message>
+        <source>Wallet: %1
+</source>
+        <translation type="unfinished">Түрийвч: %1
+</translation>
+    </message>
+    <message>
+        <source>Type: %1
+</source>
+        <translation type="unfinished">Төрөл: %1
+</translation>
+    </message>
+    <message>
+        <source>Label: %1
+</source>
+        <translation type="unfinished">Шошго: %1
+</translation>
+    </message>
+    <message>
+        <source>Address: %1
+</source>
+        <translation type="unfinished">Хаяг: %1
+</translation>
+    </message>
+    <message>
         <source>Sent transaction</source>
         <translation type="unfinished">Гадагшаа гүйлгээ</translation>
     </message>
@@ -350,7 +410,11 @@
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation type="unfinished">Түрүйвч &lt;b&gt;цоожтой&lt;/b&gt; ба одоогоор цоож &lt;b&gt;хаалттай&lt;/b&gt; байна</translation>
     </message>
-    </context>
+    <message>
+        <source>Original message:</source>
+        <translation type="unfinished">Эх зурвас:</translation>
+    </message>
+</context>
 <context>
     <name>CoinControlDialog</name>
     <message>
@@ -439,6 +503,27 @@
         <translation type="unfinished">Биткойн</translation>
     </message>
     <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
@@ -500,6 +585,7 @@
     </message>
     <message>
         <source>Client restart required to activate changes.</source>
+        <extracomment>Text explaining that the settings changed will not come into effect until the client is restarted.</extracomment>
         <translation type="unfinished">Ѳѳрчлѳлтүүдийг идэвхижүүлхийн тулд клиентийг ахин эхлүүлэх шаардлагтай</translation>
     </message>
     <message>
@@ -779,10 +865,6 @@
         <source>Message:</source>
         <translation type="unfinished">Зурвас:</translation>
     </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">Тѳлѳх хаяг:</translation>
-    </message>
     </context>
 <context>
     <name>SignVerifyMessageDialog</name>
@@ -799,10 +881,12 @@
     <name>TransactionDesc</name>
     <message>
         <source>%1/unconfirmed</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
         <translation type="unfinished">%1/баталгаажаагүй</translation>
     </message>
     <message>
         <source>%1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
         <translation type="unfinished">%1 баталгаажилтууд</translation>
     </message>
     <message>
@@ -990,6 +1074,10 @@
         <translation type="unfinished">Тодорхойлолт</translation>
     </message>
     <message>
+        <source>Exporting Failed</source>
+        <translation type="unfinished">Экспорт амжилтгүй боллоо</translation>
+    </message>
+    <message>
         <source>The transaction history was successfully saved to %1.</source>
         <translation type="unfinished">Гүйлгээнүй түүхийг %1-д амжилттай хадгаллаа.</translation>
     </message>
@@ -1000,6 +1088,10 @@
 </context>
 <context>
     <name>WalletFrame</name>
+    <message>
+        <source>Create a new wallet</source>
+        <translation type="unfinished">Шинэ түрийвч үүсгэх</translation>
+    </message>
     <message>
         <source>Error</source>
         <translation type="unfinished">Алдаа</translation>

--- a/src/qt/locale/bitcoin_mr_IN.ts
+++ b/src/qt/locale/bitcoin_mr_IN.ts
@@ -86,6 +86,11 @@
         <translation type="unfinished">पत्त्याची निर्यात करा</translation>
     </message>
     <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">कॉमा सेपरेटेड फ़ाइल</translation>
+    </message>
+    <message>
         <source>Exporting Failed</source>
         <translation type="unfinished">निर्यात अयशस्वी</translation>
     </message>
@@ -106,7 +111,22 @@
     </message>
 </context>
 <context>
+    <name>BitcoinApplication</name>
+    <message>
+        <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
+        <translation type="unfinished">एक गंभीर त्रुटी आली. %1यापुढे सुरक्षितपणे सुरू ठेवू शकत नाही आणि संपेल.</translation>
+    </message>
+    <message>
+        <source>Internal error</source>
+        <translation type="unfinished">अंतर्गत त्रुटी</translation>
+    </message>
+    </context>
+<context>
     <name>QObject</name>
+    <message>
+        <source>%1 didn't yet exit safely…</source>
+        <translation type="unfinished">%1अजून सुरक्षितपणे बाहेर पडलो नाही...</translation>
+    </message>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation type="unfinished">
@@ -151,7 +171,79 @@
     </message>
     </context>
 <context>
+    <name>bitcoin-core</name>
+    <message>
+        <source>Settings file could not be read</source>
+        <translation type="unfinished">सेटिंग्ज फाइल वाचता आली नाही</translation>
+    </message>
+    <message>
+        <source>Settings file could not be written</source>
+        <translation type="unfinished">सेटिंग्ज फाइल लिहिता आली नाही</translation>
+    </message>
+    </context>
+<context>
     <name>BitcoinGUI</name>
+    <message>
+        <source>&amp;Minimize</source>
+        <translation type="unfinished">&amp;मिनीमाइज़</translation>
+    </message>
+    <message>
+        <source>&amp;Options…</source>
+        <translation type="unfinished">&amp;पर्याय</translation>
+    </message>
+    <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation type="unfinished">&amp;एनक्रिप्ट वॉलेट</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation type="unfinished">&amp;बॅकअप वॉलेट…
+ </translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation type="unfinished">&amp;पासफ्रेज बदला...</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation type="unfinished">स्वाक्षरी आणि संदेश...</translation>
+    </message>
+    <message>
+        <source>&amp;Verify message…</source>
+        <translation type="unfinished">&amp;संदेश सत्यापित करा...</translation>
+    </message>
+    <message>
+        <source>&amp;Load PSBT from file…</source>
+        <translation type="unfinished">फाइलमधून PSBT &amp;लोड करा...</translation>
+    </message>
+    <message>
+        <source>Close Wallet…</source>
+        <translation type="unfinished">वॉलेट बंद करा...</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation type="unfinished">वॉलेट तयार करा...</translation>
+    </message>
+    <message>
+        <source>Close All Wallets…</source>
+        <translation type="unfinished">सर्व वॉलेट बंद करा...</translation>
+    </message>
+    <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation type="unfinished">शीर्षलेख समक्रमित करत आहे (%1%)…</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation type="unfinished">नेटवर्कसह सिंक्रोनाइझ करत आहे...</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation type="unfinished">डिस्कवर ब्लॉक अनुक्रमित करत आहे...</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation type="unfinished">डिस्कवर ब्लॉक्सवर प्रक्रिया करत आहे...</translation>
+    </message>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation type="unfinished">
@@ -177,6 +269,27 @@
     </context>
 <context>
     <name>Intro</name>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform>(of %n GB needed)</numerusform>
+            <numerusform>(of %n GB needed)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform>(%n GB needed for full chain)</numerusform>
+            <numerusform>(%n GB needed for full chain)</numerusform>
+        </translation>
+    </message>
     <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
@@ -242,6 +355,11 @@
     </context>
 <context>
     <name>TransactionView</name>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">कॉमा सेपरेटेड फ़ाइल</translation>
+    </message>
     <message>
         <source>Label</source>
         <translation type="unfinished">लेबल</translation>

--- a/src/qt/locale/bitcoin_ms.ts
+++ b/src/qt/locale/bitcoin_ms.ts
@@ -445,6 +445,24 @@ Alihkan fail data ke dalam tab semasa</translation>
 <context>
     <name>Intro</name>
     <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform>(of %n GB needed)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform>(%n GB needed for full chain)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">

--- a/src/qt/locale/bitcoin_my.ts
+++ b/src/qt/locale/bitcoin_my.ts
@@ -66,6 +66,10 @@
         <translation type="unfinished">လိပ်စာလက်ခံရရှိသည်</translation>
     </message>
     <message>
+        <source>&amp;Edit</source>
+        <translation type="unfinished">&amp;ပြင်ဆင်</translation>
+    </message>
+    <message>
         <source>Exporting Failed</source>
         <translation type="unfinished">တင်ပို့မှုမအောင်မြင်ပါ</translation>
     </message>
@@ -83,6 +87,10 @@
     </context>
 <context>
     <name>QObject</name>
+    <message>
+        <source>Error: %1</source>
+        <translation type="unfinished">အမှား-%1</translation>
+    </message>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation type="unfinished">
@@ -155,6 +163,10 @@
             <numerusform />
         </translation>
     </message>
+    <message>
+        <source>Error: %1</source>
+        <translation type="unfinished">အမှား-%1</translation>
+    </message>
     </context>
 <context>
     <name>CoinControlDialog</name>
@@ -173,6 +185,24 @@
     </context>
 <context>
     <name>Intro</name>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform />
+        </translation>
+    </message>
     <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>

--- a/src/qt/locale/bitcoin_nb.ts
+++ b/src/qt/locale/bitcoin_nb.ts
@@ -269,6 +269,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Vil du tilbakestille innstillingene til utgangsverdiene, eller vil du avbryte uten å gjøre endringer?</translation>
     </message>
     <message>
+        <source>A fatal error occurred. Check that settings file is writable, or try running with -nosettings.</source>
+        <extracomment>Explanatory text shown on startup when the settings file could not be written. Prompts user to check that we have the ability to write to the file. Explains that the user has the option of running without a settings file.</extracomment>
+        <translation type="unfinished">En fatal feil har oppstått. Sjekk at filen med innstillinger er skrivbar eller prøv å kjøre med -nosettings.</translation>
+    </message>
+    <message>
         <source>Error: Specified data directory "%1" does not exist.</source>
         <translation type="unfinished">Feil: Den spesifiserte datamappen "%1" finnes ikke.</translation>
     </message>
@@ -321,6 +326,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Blokkrelé</translation>
     </message>
     <message>
+        <source>Manual</source>
+        <extracomment>Peer connection type established manually through one of several methods.</extracomment>
+        <translation type="unfinished">Håndbok</translation>
+    </message>
+    <message>
         <source>Feeler</source>
         <extracomment>Short-lived peer connection type that tests the aliveness of known addresses.</extracomment>
         <translation type="unfinished">Føler</translation>
@@ -345,36 +355,36 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n sekund</numerusform>
+            <numerusform>%n sekunder</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n minute(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n minutt</numerusform>
+            <numerusform>%n minutter</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n time</numerusform>
+            <numerusform>%n timer</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n dag</numerusform>
+            <numerusform>%n dager</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n uke</numerusform>
+            <numerusform>%n uker</numerusform>
         </translation>
     </message>
     <message>
@@ -384,8 +394,8 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n år</numerusform>
+            <numerusform>%n år</numerusform>
         </translation>
     </message>
     </context>
@@ -442,10 +452,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Error: Dumpfile version is not supported. This version of bitcoin-wallet only supports version 1 dumpfiles. Got dumpfile with version %s</source>
         <translation type="unfinished">Feil: Dumpfil versjon er ikke støttet. Denne versjonen av bitcoin-lommebok støtter kun versjon 1 dumpfiler. Fikk dumpfil med versjon %s</translation>
-    </message>
-    <message>
-        <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
-        <translation type="unfinished">Feil: Lytting etter innkommende tilkoblinger feilet (lytting returnerte feil %s)</translation>
     </message>
     <message>
         <source>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.</source>
@@ -552,6 +558,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Kan ikke sette -peerblockfilters uten -blockfilterindex</translation>
     </message>
     <message>
+        <source>
+Unable to restore backup of wallet.</source>
+        <translation type="unfinished">
+Kunne ikke gjenopprette sikkerhetskopi av lommebok.</translation>
+    </message>
+    <message>
         <source>Copyright (C) %i-%i</source>
         <translation type="unfinished">Kopirett © %i-%i</translation>
     </message>
@@ -624,10 +636,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Feil ved lesing av neste oppføring fra lommebokdatabase</translation>
     </message>
     <message>
-        <source>Error upgrading chainstate database</source>
-        <translation type="unfinished">Feil ved oppgradering av kjedetilstandsdatabase</translation>
-    </message>
-    <message>
         <source>Error: Disk space is low for %s</source>
         <translation type="unfinished">Feil: Ikke nok ledig diskplass for %s</translation>
     </message>
@@ -654,6 +662,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Error: No %s addresses available.</source>
         <translation type="unfinished">Feil: Ingen %s adresser tilgjengelige.</translation>
+    </message>
+    <message>
+        <source>Error: Unable to write record to new wallet</source>
+        <translation type="unfinished">Feil: Kan ikke skrive rekord til ny lommebok</translation>
     </message>
     <message>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
@@ -686,6 +698,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Initialization sanity check failed. %s is shutting down.</source>
         <translation type="unfinished">Sunnhetssjekk ved oppstart mislyktes. %s skrus av.</translation>
+    </message>
+    <message>
+        <source>Input not found or already spent</source>
+        <translation type="unfinished">Finner ikke data eller er allerede brukt</translation>
     </message>
     <message>
         <source>Insufficient funds</source>
@@ -736,12 +752,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Laster lommebok...</translation>
     </message>
     <message>
+        <source>Missing amount</source>
+        <translation type="unfinished">Mangler beløp</translation>
+    </message>
+    <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
         <translation type="unfinished">Må oppgi en port med -whitebind: '%s'</translation>
     </message>
     <message>
-        <source>No proxy server specified. Use -proxy=&lt;ip&gt; or -proxy=&lt;ip:port&gt;.</source>
-        <translation type="unfinished">Ingen proxyserver er spesifisert. Bruk -proxy=&lt;ip&gt; eller -proxy=&lt;ip:port&gt;.</translation>
+        <source>No addresses available</source>
+        <translation type="unfinished">Ingen adresser tilgjengelig</translation>
     </message>
     <message>
         <source>Not enough file descriptors available.</source>
@@ -750,10 +770,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Prune cannot be configured with a negative value.</source>
         <translation type="unfinished">Beskjæringsmodus kan ikke konfigureres med en negativ verdi.</translation>
-    </message>
-    <message>
-        <source>Prune mode is incompatible with -coinstatsindex.</source>
-        <translation type="unfinished">Beskjæringsmodus er inkompatibel med -coinstatsindex.</translation>
     </message>
     <message>
         <source>Prune mode is incompatible with -txindex.</source>
@@ -766,6 +782,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
         <translation type="unfinished">Reduserer -maxconnections fra %d til %d, pga. systembegrensninger.</translation>
+    </message>
+    <message>
+        <source>Replaying blocks…</source>
+        <translation type="unfinished">Spiller av blokker på nytt …</translation>
     </message>
     <message>
         <source>Rescanning…</source>
@@ -890,10 +910,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Unsupported logging category %s=%s.</source>
         <translation type="unfinished">Ustøttet loggingskategori %s=%s.</translation>
-    </message>
-    <message>
-        <source>Upgrading UTXO database</source>
-        <translation type="unfinished">Oppgraderer UTXO-database</translation>
     </message>
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
@@ -1187,6 +1203,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Lukk lommebok</translation>
     </message>
     <message>
+        <source>Restore Wallet…</source>
+        <extracomment>Name of the menu item that restores wallet from a backup file.</extracomment>
+        <translation type="unfinished">Gjenopprett lommebok...</translation>
+    </message>
+    <message>
+        <source>Restore a wallet from a backup file</source>
+        <extracomment>Status tip for Restore Wallet menu item</extracomment>
+        <translation type="unfinished">Gjenopprett en lommebok fra en sikkerhetskopi</translation>
+    </message>
+    <message>
         <source>Close all wallets</source>
         <translation type="unfinished">Lukk alle lommebøker</translation>
     </message>
@@ -1211,6 +1237,26 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Ingen lommebøker tilgjengelig</translation>
     </message>
     <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">Lommebokdata</translation>
+    </message>
+    <message>
+        <source>Load Wallet Backup</source>
+        <extracomment>The title for Restore Wallet File Windows</extracomment>
+        <translation type="unfinished">Last lommebok sikkerhetskopi</translation>
+    </message>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of pop-up window shown when the user is attempting to restore a wallet.</extracomment>
+        <translation type="unfinished">Gjenopprett lommebok</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">Lommeboknavn</translation>
+    </message>
+    <message>
         <source>&amp;Window</source>
         <translation type="unfinished">&amp;Vindu</translation>
     </message>
@@ -1226,8 +1272,8 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform> %n aktiv tilkobling til Bitcoin-nettverket.</numerusform>
+            <numerusform>%n aktive tilkoblinger til Bitcoin-nettverket.</numerusform>
         </translation>
     </message>
     <message>
@@ -1249,6 +1295,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Enable network activity</source>
         <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
         <translation type="unfinished">Klikk for å aktivere nettverksaktivitet.</translation>
+    </message>
+    <message>
+        <source>Pre-syncing Headers (%1%)…</source>
+        <translation type="unfinished">Synkroniserer blokkhoder (%1%)...</translation>
     </message>
     <message>
         <source>Error: %1</source>
@@ -1499,7 +1549,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Can't list signers</source>
         <translation type="unfinished">Kan ikke vise liste over undertegnere</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>LoadWalletsActivity</name>
     <message>
@@ -1538,6 +1588,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Åpner lommebok &lt;b&gt;%1&lt;/b&gt;...</translation>
     </message>
 </context>
+<context>
+    <name>RestoreWalletActivity</name>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of progress window which is displayed when wallets are being restored.</extracomment>
+        <translation type="unfinished">Gjenopprett lommebok</translation>
+    </message>
+    </context>
 <context>
     <name>WalletController</name>
     <message>
@@ -1709,13 +1767,26 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 </context>
 <context>
     <name>Intro</name>
-    <message>
-        <source>(of %1 GB needed)</source>
-        <translation type="unfinished">(av %1 GB som trengs)</translation>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
     </message>
-    <message>
-        <source>(%1 GB needed for full chain)</source>
-        <translation type="unfinished">(%1 GB kreves for hele kjeden)</translation>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform>(av %n GB som trengs)</numerusform>
+            <numerusform>(av %n GB som trengs)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform>(%n GB kreves for hele kjeden)</numerusform>
+            <numerusform>(%n GB kreves for hele kjeden)</numerusform>
+        </translation>
     </message>
     <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
@@ -1729,8 +1800,8 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>(Tilstrekkelig å gjenopprette backuper som er %n dag gammel) </numerusform>
+            <numerusform>(Tilstrekkelig å gjenopprette backuper som er %n dager gamle) </numerusform>
         </translation>
     </message>
     <message>
@@ -1760,10 +1831,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>As this is the first time the program is launched, you can choose where %1 will store its data.</source>
         <translation type="unfinished">Siden dette er første gang programmet starter, kan du nå velge hvor %1 skal lagre sine data.</translation>
-    </message>
-    <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation type="unfinished">Når du klikker OK, vil %1 starte nedlasting og behandle hele den %4 blokkjeden (%2GB) fra de eldste transaksjonene i %3 når %4 først startet.</translation>
     </message>
     <message>
         <source>Limit block chain storage to</source>
@@ -1870,7 +1937,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>%1 is currently syncing.  It will download headers and blocks from peers and validate them until reaching the tip of the block chain.</source>
         <translation type="unfinished">%1 synkroniseres for øyeblikket. Den vil laste ned blokkhoder og blokker fra likemenn og  validere dem til de når enden av blokkjeden.</translation>
     </message>
-    </context>
+    <message>
+        <source>Unknown. Pre-syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">Ukjent.Synkroniser blokkhoder (%1,%2%)...</translation>
+    </message>
+</context>
 <context>
     <name>OpenURIDialog</name>
     <message>
@@ -1920,6 +1991,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
         <translation type="unfinished">Minimer i stedet for å avslutte applikasjonen når vinduet lukkes. Når dette er valgt, vil applikasjonen avsluttes kun etter at Avslutte er valgt i menyen.</translation>
+    </message>
+    <message>
+        <source>Options set in this dialog are overridden by the command line:</source>
+        <translation type="unfinished">Alternativer som er satt i denne dialogboksen overstyres av kommandolinjen:</translation>
     </message>
     <message>
         <source>Open the %1 configuration file from the working directory.</source>
@@ -2082,10 +2157,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">nærmeste treff "%1"</translation>
     </message>
     <message>
-        <source>Options set in this dialog are overridden by the command line or in the configuration file:</source>
-        <translation type="unfinished">Alternativer som er satt i denne dialogboksen overstyres av kommandolinjen eller i konfigurasjonsfilen:</translation>
-    </message>
-    <message>
         <source>&amp;Cancel</source>
         <translation type="unfinished">&amp;Avbryt</translation>
     </message>
@@ -2104,14 +2175,17 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Confirm options reset</source>
+        <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
         <translation type="unfinished">Bekreft tilbakestilling av innstillinger</translation>
     </message>
     <message>
         <source>Client restart required to activate changes.</source>
+        <extracomment>Text explaining that the settings changed will not come into effect until the client is restarted.</extracomment>
         <translation type="unfinished">Omstart av klienten er nødvendig for å aktivere endringene.</translation>
     </message>
     <message>
         <source>Client will be shut down. Do you want to proceed?</source>
+        <extracomment>Text asking the user to confirm if they would like to proceed with a client shutdown.</extracomment>
         <translation type="unfinished">Klienten vil bli lukket. Ønsker du å gå videre?</translation>
     </message>
     <message>
@@ -2332,6 +2406,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Transaksjonen trenger signatur(er).</translation>
     </message>
     <message>
+        <source>(But no wallet is loaded.)</source>
+        <translation type="unfinished">(Men ingen lommebok er lastet.)</translation>
+    </message>
+    <message>
         <source>(But this wallet cannot sign transactions.)</source>
         <translation type="unfinished">(Men denne lommeboken kan ikke signere transaksjoner.)</translation>
     </message>
@@ -2399,6 +2477,11 @@ Hvis du får denne feilen burde du be forretningsdrivende om å tilby en BIP21 k
         <source>Peer</source>
         <extracomment>Title of Peers Table column which contains a unique number used to identify a connection.</extracomment>
         <translation type="unfinished">Likemann</translation>
+    </message>
+    <message>
+        <source>Age</source>
+        <extracomment>Title of Peers Table column which indicates the duration (length of time) since the peer connection started.</extracomment>
+        <translation type="unfinished">Alder</translation>
     </message>
     <message>
         <source>Direction</source>
@@ -2571,12 +2654,21 @@ Hvis du får denne feilen burde du be forretningsdrivende om å tilby en BIP21 k
         <translation type="unfinished">Synkroniserte Blokker</translation>
     </message>
     <message>
+        <source>Last Transaction</source>
+        <translation type="unfinished">Siste transaksjon</translation>
+    </message>
+    <message>
         <source>The mapped Autonomous System used for diversifying peer selection.</source>
         <translation type="unfinished">Det kartlagte Autonome Systemet som brukes til å diversifisere valg av likemenn.</translation>
     </message>
     <message>
         <source>Mapped AS</source>
         <translation type="unfinished">Kartlagt AS</translation>
+    </message>
+    <message>
+        <source>Addresses Processed</source>
+        <extracomment>Text title for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
+        <translation type="unfinished">Adresser Prosessert</translation>
     </message>
     <message>
         <source>User Agent</source>
@@ -3249,6 +3341,11 @@ Hvis du får denne feilen burde du be forretningsdrivende om å tilby en BIP21 k
         <translation type="unfinished">Se over ditt transaksjonsforslag. Dette kommer til å produsere en Delvis Signert Bitcoin Transaksjon (PSBT) som du kan lagre eller kopiere og så signere med f.eks. en offline %1 lommebok, eller en PSBT kompatibel hardware lommebok.</translation>
     </message>
     <message>
+        <source>Do you want to create this transaction?</source>
+        <extracomment>Message displayed when attempting to create a transaction. Cautionary text to prompt the user to verify that the displayed transaction details represent the transaction the user intends to create.</extracomment>
+        <translation type="unfinished">Vil du lage denne transaksjonen?</translation>
+    </message>
+    <message>
         <source>Please, review your transaction.</source>
         <extracomment>Text to prompt a user to review the details of the transaction they are attempting to send.</extracomment>
         <translation type="unfinished">Vennligst se over transaksjonen din.</translation>
@@ -3300,10 +3397,6 @@ Hvis du får denne feilen burde du be forretningsdrivende om å tilby en BIP21 k
     <message>
         <source>A fee higher than %1 is considered an absurdly high fee.</source>
         <translation type="unfinished">Et gebyr høyere enn %1 anses som absurd høyt.</translation>
-    </message>
-    <message>
-        <source>Payment request expired.</source>
-        <translation type="unfinished">Tidsavbrudd for betalingsforespørsel</translation>
     </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
@@ -3384,14 +3477,6 @@ Hvis du får denne feilen burde du be forretningsdrivende om å tilby en BIP21 k
         <translation type="unfinished">Melding:</translation>
     </message>
     <message>
-        <source>This is an unauthenticated payment request.</source>
-        <translation type="unfinished">Dette er en uautorisert betalingsetterspørring.</translation>
-    </message>
-    <message>
-        <source>This is an authenticated payment request.</source>
-        <translation type="unfinished">Dette er en autorisert betalingsetterspørring.</translation>
-    </message>
-    <message>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished">Skriv inn en merkelapp for denne adressen for å legge den til listen av brukte adresser</translation>
     </message>
@@ -3399,11 +3484,7 @@ Hvis du får denne feilen burde du be forretningsdrivende om å tilby en BIP21 k
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished">En melding som var tilknyttet bitcoinen: URI vil bli lagret med transaksjonen for din oversikt. Denne meldingen vil ikke bli sendt over Bitcoin-nettverket.</translation>
     </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">Betal Til:</translation>
-    </message>
-    </context>
+</context>
 <context>
     <name>SendConfirmationDialog</name>
     <message>
@@ -3560,35 +3641,31 @@ Hvis du får denne feilen burde du be forretningsdrivende om å tilby en BIP21 k
         <source>(press q to shutdown and continue later)</source>
         <translation type="unfinished">(trykk q for å skru av og fortsette senere)</translation>
     </message>
-    </context>
+    <message>
+        <source>press q to shutdown</source>
+        <translation type="unfinished">trykk på q for å slå av</translation>
+    </message>
+</context>
 <context>
     <name>TransactionDesc</name>
     <message>
         <source>conflicted with a transaction with %1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that conflicts with a confirmed transaction.</extracomment>
         <translation type="unfinished">gikk ikke overens med en transaksjon med %1 bekreftelser</translation>
     </message>
     <message>
-        <source>0/unconfirmed, %1</source>
-        <translation type="unfinished">0/ubekreftet, %1</translation>
-    </message>
-    <message>
-        <source>in memory pool</source>
-        <translation type="unfinished">i minnepool</translation>
-    </message>
-    <message>
-        <source>not in memory pool</source>
-        <translation type="unfinished">ikke i minnepool</translation>
-    </message>
-    <message>
         <source>abandoned</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an abandoned transaction.</extracomment>
         <translation type="unfinished">forlatt</translation>
     </message>
     <message>
         <source>%1/unconfirmed</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
         <translation type="unfinished">%1/ubekreftet</translation>
     </message>
     <message>
         <source>%1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
         <translation type="unfinished">%1 bekreftelser</translation>
     </message>
     <message>
@@ -3634,8 +3711,8 @@ Hvis du får denne feilen burde du be forretningsdrivende om å tilby en BIP21 k
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>modner om %n blokk</numerusform>
+            <numerusform>modner om %n blokker</numerusform>
         </translation>
     </message>
     <message>
@@ -4072,7 +4149,7 @@ Gå til Fil &gt; Åpne lommebok for å laste en lommebok.
     <name>WalletView</name>
     <message>
         <source>&amp;Export</source>
-        <translation type="unfinished">&amp;Eksporter</translation>
+        <translation type="unfinished">&amp;Eksport</translation>
     </message>
     <message>
         <source>Export the data in the current tab to a file</source>

--- a/src/qt/locale/bitcoin_ne.ts
+++ b/src/qt/locale/bitcoin_ne.ts
@@ -23,11 +23,15 @@
     </message>
     <message>
         <source>C&amp;lose</source>
-        <translation type="unfinished">बन्द गर्नुहोस्</translation>
+        <translation type="unfinished">छनौट गर्नुहोस्</translation>
     </message>
     <message>
         <source>Delete the currently selected address from the list</source>
         <translation type="unfinished">भर्खरै चयन गरेको ठेगाना सूचीबाट मेटाउनुहोस्</translation>
+    </message>
+    <message>
+        <source>Enter address or label to search</source>
+        <translation type="unfinished">खोज्नको लागि ठेगाना वा लेबल दर्ता गर्नुहोस</translation>
     </message>
     <message>
         <source>Export the data in the current tab to a file</source>
@@ -42,20 +46,69 @@
         <translation type="unfinished">&amp;amp;मेटाउनुहोस्</translation>
     </message>
     <message>
+        <source>Choose the address to send coins to</source>
+        <translation type="unfinished">सिक्काहरु पठाउने ठेगाना छान्नुहोस् </translation>
+    </message>
+    <message>
+        <source>Choose the address to receive coins with</source>
+        <translation type="unfinished">सिक्काहरु प्राप्त गर्ने ठेगाना छान्नुहोस्</translation>
+    </message>
+    <message>
         <source>C&amp;hoose</source>
         <translation type="unfinished">छनौट गर्नुहोस्...</translation>
     </message>
     <message>
         <source>Sending addresses</source>
-        <translation type="unfinished">पठाउने ठेगानाहरू...</translation>
+        <translation type="unfinished">पठाउने ठेगानाहरू</translation>
     </message>
     <message>
         <source>Receiving addresses</source>
         <translation type="unfinished">प्राप्त गर्ने ठेगानाहरू...</translation>
     </message>
     <message>
+        <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
+        <translation type="unfinished">यी भुक्तानी गर्नका लागि तपाइका बिट्कोइन ठेगानाहरू हुन्। सिक्काहरू पठाउनुअघि रकम र प्राप्त गर्ने ठेगाना जाँच गर्नुहोस।</translation>
+    </message>
+    <message>
         <source>&amp;Copy Address</source>
         <translation type="unfinished">ठेगाना कपी गर्नुहोस्</translation>
+    </message>
+    <message>
+        <source>Copy &amp;Label</source>
+        <translation type="unfinished">लेबल कपी गर्नुहोस्</translation>
+    </message>
+    <message>
+        <source>&amp;Edit</source>
+        <translation type="unfinished">सम्पादन</translation>
+    </message>
+    <message>
+        <source>Export Address List</source>
+        <translation type="unfinished">ठेगाना सुची निर्यात</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">अल्पविरामले छुट्टिएको फाइल</translation>
+    </message>
+    <message>
+        <source>There was an error trying to save the address list to %1. Please try again.</source>
+        <extracomment>An error message. %1 is a stand-in argument for the name of the file we attempted to save to.</extracomment>
+        <translation type="unfinished">ठेगाना सुची %1मा बचत गर्ने प्रयासमा त्रुटि भएको छ। कृपया पुनः प्रयास गर्नुहोस।</translation>
+    </message>
+    <message>
+        <source>Exporting Failed</source>
+        <translation type="unfinished">निर्यात असफल</translation>
+    </message>
+</context>
+<context>
+    <name>AddressTableModel</name>
+    <message>
+        <source>Label</source>
+        <translation type="unfinished">लेबल</translation>
+    </message>
+    <message>
+        <source>Address</source>
+        <translation type="unfinished">ठेगाना</translation>
     </message>
     </context>
 <context>
@@ -75,6 +128,30 @@
     <message>
         <source>Repeat new passphrase</source>
         <translation type="unfinished">नयाँ पासफ्रेज दोहोर्याउनुहोस्</translation>
+    </message>
+    <message>
+        <source>Encrypt wallet</source>
+        <translation type="unfinished">वालेट इन्क्रिप्ट गर्नुहोस् </translation>
+    </message>
+    <message>
+        <source>Confirm wallet encryption</source>
+        <translation type="unfinished">वालेट इन्क्रिप्सन सुनिश्चित गर्नुहोस</translation>
+    </message>
+    <message>
+        <source>Wallet encrypted</source>
+        <translation type="unfinished">वालेट इन्क्रिप्ट भयो</translation>
+    </message>
+    <message>
+        <source>Your wallet is now encrypted. </source>
+        <translation type="unfinished">अब वालेट इन्क्रिप्ट भएको छ।</translation>
+    </message>
+    <message>
+        <source>Wallet encryption failed</source>
+        <translation type="unfinished">वालेट इन्क्रिप्सन असफल </translation>
+    </message>
+    <message>
+        <source>Wallet unlock failed</source>
+        <translation type="unfinished">वालेट अनलक असफल </translation>
     </message>
     </context>
 <context>
@@ -143,10 +220,6 @@
     </context>
 <context>
     <name>bitcoin-core</name>
-    <message>
-        <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
-        <translation type="unfinished">त्रुटि: आगमन कनेक्सनमा सुन्ने कार्य असफल भयो (सुन्ने कार्यले त्रुटि %s फर्कायो)</translation>
-    </message>
     <message>
         <source>Invalid amount for -maxtxfee=&lt;amount&gt;: '%s' (must be at least the minrelay fee of %s to prevent stuck transactions)</source>
         <translation type="unfinished">maxtxfee=&amp;lt;रकम&amp;gt;: का लागि अमान्य रकम &amp;apos;%s&amp;apos; (कारोबारलाई अड्कन नदिन अनिवार्य रूपमा कम्तिमा %s को न्यूनतम रिले शुल्क हुनु पर्छ)</translation>
@@ -288,6 +361,27 @@
 <context>
     <name>Intro</name>
     <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
@@ -339,7 +433,7 @@
     </message>
     <message>
         <source>Balances</source>
-        <translation type="unfinished">ब्यालेन्स</translation>
+        <translation type="unfinished">ब्यालेन्सहरु</translation>
     </message>
     <message>
         <source>Mined balance in watch-only addresses that has not yet matured</source>
@@ -357,6 +451,11 @@
         <extracomment>Title of Peers Table column which contains the peer's User Agent string.</extracomment>
         <translation type="unfinished">प्रयोगकर्ता एजेन्ट</translation>
     </message>
+    <message>
+        <source>Address</source>
+        <extracomment>Title of Peers Table column which contains the IP/Onion/I2P address of the connected peer.</extracomment>
+        <translation type="unfinished">ठेगाना</translation>
+    </message>
     </context>
 <context>
     <name>RPCConsole</name>
@@ -367,6 +466,13 @@
     <message>
         <source>Ping Time</source>
         <translation type="unfinished">पिङ समय</translation>
+    </message>
+    </context>
+<context>
+    <name>RecentRequestsTableModel</name>
+    <message>
+        <source>Label</source>
+        <translation type="unfinished">लेबल</translation>
     </message>
     </context>
 <context>
@@ -397,7 +503,7 @@
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished">बिटकोइनमा संलग्न गरिएको सन्देश: तपाईंको मध्यस्थको लागि कारोबारको साथमा भण्डारण गरिने URI । नोट: यो सन्देश बिटकोइन नेटवर्क मार्फत पठाइने छैन ।</translation>
     </message>
-    </context>
+</context>
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
@@ -429,6 +535,33 @@
     <message>
         <source>Amount</source>
         <translation type="unfinished">रकम</translation>
+    </message>
+    </context>
+<context>
+    <name>TransactionTableModel</name>
+    <message>
+        <source>Label</source>
+        <translation type="unfinished">लेबल</translation>
+    </message>
+    </context>
+<context>
+    <name>TransactionView</name>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">अल्पविरामले छुट्टिएको फाइल</translation>
+    </message>
+    <message>
+        <source>Label</source>
+        <translation type="unfinished">लेबल</translation>
+    </message>
+    <message>
+        <source>Address</source>
+        <translation type="unfinished">ठेगाना</translation>
+    </message>
+    <message>
+        <source>Exporting Failed</source>
+        <translation type="unfinished">निर्यात असफल</translation>
     </message>
     </context>
 <context>

--- a/src/qt/locale/bitcoin_pa.ts
+++ b/src/qt/locale/bitcoin_pa.ts
@@ -1,0 +1,492 @@
+<TS version="2.1" language="pa">
+<context>
+    <name>AddressBookPage</name>
+    <message>
+        <source>Right-click to edit address or label</source>
+        <translation type="unfinished">ਪਤੇ ਜਾਂ ਲੇਬਲ ਦਾ ਸੰਪਾਦਨ ਕਰਨ ਲਈ ਸੱਜਾ-ਕਲਿੱਕ ਕਰੋ</translation>
+    </message>
+    <message>
+        <source>Create a new address</source>
+        <translation type="unfinished">ਨਵਾਂ ਪਤਾ ਬਣਾਓ</translation>
+    </message>
+    <message>
+        <source>&amp;New</source>
+        <translation type="unfinished">&amp;ਨਵਾਂ</translation>
+    </message>
+    <message>
+        <source>Copy the currently selected address to the system clipboard</source>
+        <translation type="unfinished">ਚੁਣੇ ਪਤੇ ਦੀ ਸਿਸਟਮ ਦੀ ਚੂੰਢੀ-ਤਖਤੀ 'ਤੇ ਨਕਲ ਲਾਹੋ</translation>
+    </message>
+    <message>
+        <source>&amp;Copy</source>
+        <translation type="unfinished">&amp;ਨਕਲ ਲਾਹੋ</translation>
+    </message>
+    <message>
+        <source>C&amp;lose</source>
+        <translation type="unfinished">ਬੰ&amp;ਦ ਕਰੋ</translation>
+    </message>
+    <message>
+        <source>Delete the currently selected address from the list</source>
+        <translation type="unfinished">ਚੁਣੇ ਪਤੇ ਨੂੰ ਸੂਚੀ ਵਿੱਚੋਂ ਮਿਟਾਓ</translation>
+    </message>
+    <message>
+        <source>Enter address or label to search</source>
+        <translation type="unfinished">ਖੋਜਣ ਲਈ ਪਤਾ ਜਾਂ ਲੇਬਲ ਦਾਖਲ ਕਰੋ</translation>
+    </message>
+    <message>
+        <source>Export the data in the current tab to a file</source>
+        <translation type="unfinished">ਮੌਜੂਦਾ ਟੈਬ ਵਿੱਚ ਡੇਟਾ ਨੂੰ ਫਾਈਲ ਵਿੱਚ ਐਕਸਪੋਰਟ ਕਰੋ</translation>
+    </message>
+    <message>
+        <source>&amp;Export</source>
+        <translation type="unfinished">&amp;ਨਿਰਯਾਤ</translation>
+    </message>
+    <message>
+        <source>&amp;Delete</source>
+        <translation type="unfinished">&amp;ਮਿਟਾਓ</translation>
+    </message>
+    <message>
+        <source>Choose the address to send coins to</source>
+        <translation type="unfinished">ਸਿੱਕੇ ਭੇਜਣ ਲਈ ਪਤਾ ਚੁਣੋ</translation>
+    </message>
+    <message>
+        <source>Choose the address to receive coins with</source>
+        <translation type="unfinished">ਸਿੱਕੇ ਪ੍ਰਾਪਤ ਕਰਨ ਲਈ ਪਤਾ ਚੁਣੋ</translation>
+    </message>
+    <message>
+        <source>C&amp;hoose</source>
+        <translation type="unfinished">ਚੁਣੋ </translation>
+    </message>
+    <message>
+        <source>Sending addresses</source>
+        <translation type="unfinished">bhejan wale pate</translation>
+    </message>
+    <message>
+        <source>Receiving addresses</source>
+        <translation type="unfinished">ਆਉਣ ਵਾਲੇ ਪਤੇ </translation>
+    </message>
+    <message>
+        <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
+        <translation type="unfinished">ਇਹ ਭੁਗਤਾਨ ਭੇਜਣ ਲਈ ਤੁਹਾਡੇ ਬਿਟਕੋਇਨ ਪਤੇ ਹਨ। ਸਿੱਕੇ ਭੇਜਣ ਤੋਂ ਪਹਿਲਾਂ ਹਮੇਸ਼ਾਂ ਰਕਮ ਅਤੇ ਪ੍ਰਾਪਤ ਕਰਨ ਵਾਲੇ ਪਤੇ ਦੀ ਜਾਂਚ ਕਰੋ।</translation>
+    </message>
+    <message>
+        <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
+Signing is only possible with addresses of the type 'legacy'.</source>
+        <translation type="unfinished">ਏਹ ਤੁਹਾਡੇ ਰਕਮ ਪ੍ਰਾਪਤ ਕਰਨ ਵਾਲੇ ਬਿਟਕਾਅਨ ਪਤੇ ਹਨ। ਪ੍ਰਾਪਤੀ ਟੈਬ ਤੇ ਨਵੇਂ ਪਤੇ ਦਰਜ ਕਰਨ ਲਈ "ਨਵਾਂ ਪ੍ਰਾਪਤੀ ਪਤਾ ਦਰਜ ਕਰੋ" ਬਟਨ ਤੇ ਟੈਪ ਕਰੋ। ਜੁੜਨ ਲਈ "ਲੈਗਸੀ" ਪ੍ਰਕਾਰ ਦੇ ਹੀ ਪਤੇ ਦਰਜ ਕੀਤੇ ਜਾਂ ਸਕਦੇ ਹਨ। </translation>
+    </message>
+    <message>
+        <source>&amp;Copy Address</source>
+        <translation type="unfinished">&amp;ਕਾਪੀ ਪਤਾ</translation>
+    </message>
+    <message>
+        <source>Copy &amp;Label</source>
+        <translation type="unfinished">&amp;ਲੇਬਲ ਕਾਪੀ ਕਰੋ</translation>
+    </message>
+    <message>
+        <source>&amp;Edit</source>
+        <translation type="unfinished">&amp;ਸੋਧੋ</translation>
+    </message>
+    <message>
+        <source>Export Address List</source>
+        <translation type="unfinished">ਪਤਾ ਸੂਚੀ ਨਿਰਯਾਤ ਕਰੋ</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">ਕਾਮੇ ਨਾਲ ਵੱਖ ਕੀਤੀ ਫਾਈਲ</translation>
+    </message>
+    <message>
+        <source>Exporting Failed</source>
+        <translation type="unfinished">ਨਿਰਯਾਤ ਅਸਫਲ ਰਿਹਾ</translation>
+    </message>
+</context>
+<context>
+    <name>AddressTableModel</name>
+    <message>
+        <source>Label</source>
+        <translation type="unfinished">ਲੇਬਲ</translation>
+    </message>
+    <message>
+        <source>Address</source>
+        <translation type="unfinished">ਪਤਾ</translation>
+    </message>
+    <message>
+        <source>(no label)</source>
+        <translation type="unfinished">ਕੋਈ ਲੇਬਲ ਨਹੀਂ </translation>
+    </message>
+</context>
+<context>
+    <name>AskPassphraseDialog</name>
+    <message>
+        <source>Passphrase Dialog</source>
+        <translation type="unfinished">ਪਾਸਫਰੇਜ ਡਾਇਲਾਗ</translation>
+    </message>
+    <message>
+        <source>Enter passphrase</source>
+        <translation type="unfinished">ਪਾਸਫਰੇਜ ਲਿਖੋ</translation>
+    </message>
+    <message>
+        <source>New passphrase</source>
+        <translation type="unfinished">ਨਵਾਂ ਪਾਸਫਰੇਜ</translation>
+    </message>
+    <message>
+        <source>Repeat new passphrase</source>
+        <translation type="unfinished">ਨਵਾਂ ਪਾਸਫਰੇਜ ਦੁਹਰਾਓ</translation>
+    </message>
+    <message>
+        <source>Show passphrase</source>
+        <translation type="unfinished">ਪਾਸਫਰੇਜ ਦਿਖਾਓ</translation>
+    </message>
+    <message>
+        <source>Encrypt wallet</source>
+        <translation type="unfinished">ਵਾਲਿਟ ਐਨਕ੍ਰਿਪਟ ਕਰੋ</translation>
+    </message>
+    <message>
+        <source>This operation needs your wallet passphrase to unlock the wallet.</source>
+        <translation type="unfinished">ਏਸ ਕਾਰੇ ਲਈ ਤੁਹਾਡਾ ਵੱਲੇਟ ਖੋਲਣ ਵਾਸਤੇ ਵੱਲੇਟ ਪਾਸ ਲੱਗੇਗਾ </translation>
+    </message>
+    <message>
+        <source>Unlock wallet</source>
+        <translation type="unfinished">ਵਾਲਿਟ ਨੂੰ ਅਨਲੌਕ ਕਰੋ</translation>
+    </message>
+    <message>
+        <source>Change passphrase</source>
+        <translation type="unfinished">ਪਾਸਫਰੇਜ ਬਦਲੋ</translation>
+    </message>
+    <message>
+        <source>Confirm wallet encryption</source>
+        <translation type="unfinished">ਵਾਲਿਟ ਇਨਕ੍ਰਿਪਸ਼ਨ ਦੀ ਪੁਸ਼ਟੀ ਕਰੋ</translation>
+    </message>
+    <message>
+        <source>Are you sure you wish to encrypt your wallet?</source>
+        <translation type="unfinished">ਕੀ ਤੁਸੀਂ ਯਕੀਨੀ ਤੌਰ 'ਤੇ ਆਪਣੇ ਵਾਲਿਟ ਨੂੰ ਐਨਕ੍ਰਿਪਟ ਕਰਨਾ ਚਾਹੁੰਦੇ ਹੋ?</translation>
+    </message>
+    <message>
+        <source>Wallet encrypted</source>
+        <translation type="unfinished">ਵਾਲਿਟ ਨੂੰ ਐਨਕ੍ਰਿਪਟ ਕੀਤਾ ਗਿਆ</translation>
+    </message>
+    <message>
+        <source>Wallet to be encrypted</source>
+        <translation type="unfinished">ਇਨਕ੍ਰਿਪਟਡ ਹੋਣ ਲਈ ਵਾਲਿਟ</translation>
+    </message>
+    <message>
+        <source>Your wallet is about to be encrypted. </source>
+        <translation type="unfinished">ਤੁਹਾਡਾ ਵਾਲਿਟ ਐਨਕ੍ਰਿਪਟ ਹੋਣ ਵਾਲਾ ਹੈ।</translation>
+    </message>
+    <message>
+        <source>Your wallet is now encrypted. </source>
+        <translation type="unfinished">ਤੁਹਾਡਾ ਵਾਲਿਟ ਹੁਣ ਏਨਕ੍ਰਿਪਟ ਹੋ ਗਿਆ ਹੈ।</translation>
+    </message>
+    <message>
+        <source>Wallet encryption failed</source>
+        <translation type="unfinished">ਵਾਲਿਟ ਇਨਕ੍ਰਿਪਸ਼ਨ ਅਸਫਲ</translation>
+    </message>
+    <message>
+        <source>The supplied passphrases do not match.</source>
+        <translation type="unfinished">ਸਪਲਾਈ ਕੀਤੇ ਪਾਸਫਰੇਜ਼ ਮੇਲ ਨਹੀਂ ਖਾਂਦੇ।</translation>
+    </message>
+    <message>
+        <source>Wallet unlock failed</source>
+        <translation type="unfinished">ਵਾਲਿਟ ਅਨਲੌਕ ਅਸਫਲ ਰਿਹਾ</translation>
+    </message>
+    <message>
+        <source>Wallet passphrase was successfully changed.</source>
+        <translation type="unfinished">ਵਾਲਿਟ ਪਾਸਫਰੇਜ ਸਫਲਤਾਪੂਰਵਕ ਬਦਲਿਆ ਗਿਆ।</translation>
+    </message>
+    <message>
+        <source>Warning: The Caps Lock key is on!</source>
+        <translation type="unfinished">ਚੇਤਾਵਨੀ: Caps Lock ਕੁੰਜੀ ਚਾਲੂ ਹੈ!</translation>
+    </message>
+</context>
+<context>
+    <name>BitcoinApplication</name>
+    <message>
+        <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
+        <translation type="unfinished">ਇੱਕ ਘਾਤਕ ਗਲਤੀ ਆਈ ਹੈ। %1ਹੁਣ ਸੁਰੱਖਿਅਤ ਢੰਗ ਨਾਲ ਜਾਰੀ ਨਹੀਂ ਰਹਿ ਸਕਦਾ ਹੈ ਅਤੇ ਛੱਡ ਦੇਵੇਗਾ।</translation>
+    </message>
+    <message>
+        <source>Internal error</source>
+        <translation type="unfinished">ਅੰਦਰੂਨੀ ਗੜਬੜ</translation>
+    </message>
+    </context>
+<context>
+    <name>QObject</name>
+    <message>
+        <source>Error: %1</source>
+        <translation type="unfinished">ਗਲਤੀ: %1</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n week(s)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n year(s)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    </context>
+<context>
+    <name>bitcoin-core</name>
+    <message>
+        <source>Settings file could not be read</source>
+        <translation type="unfinished">ਸੈਟਿੰਗ ਫਾਈਲ ਨੂੰ ਪੜ੍ਹਨ ਵਿੱਚ ਅਸਫਲ</translation>
+    </message>
+    <message>
+        <source>Settings file could not be written</source>
+        <translation type="unfinished">ਸੈਟਿੰਗ ਫਾਈਲ ਲਿਖਣ ਵਿੱਚ ਅਸਫਲ</translation>
+    </message>
+    </context>
+<context>
+    <name>BitcoinGUI</name>
+    <message>
+        <source>&amp;Overview</source>
+        <translation type="unfinished">&amp;ਓਵਰਵਿਊ</translation>
+    </message>
+    <message>
+        <source>&amp;Transactions</source>
+        <translation type="unfinished">&amp;ਲੈਣ-ਦੇਣ</translation>
+    </message>
+    <message>
+        <source>Browse transaction history</source>
+        <translation type="unfinished">ਲੈਣ-ਦੇਣ ਦਾ ਇਤਿਹਾਸ ਬ੍ਰਾਊਜ਼ ਕਰੋ</translation>
+    </message>
+    <message>
+        <source>Quit application</source>
+        <translation type="unfinished">ਐਪਲੀਕੇਸ਼ਨ ਛੱਡੋ</translation>
+    </message>
+    <message>
+        <source>Create a new wallet</source>
+        <translation type="unfinished">ਨਵਾਂ ਵਾਲਿਟ ਬਣਾਓ</translation>
+    </message>
+    <message>
+        <source>Wallet:</source>
+        <translation type="unfinished">ਬਟੂਆ: </translation>
+    </message>
+    <message>
+        <source>Send coins to a Bitcoin address</source>
+        <translation type="unfinished">ਬਿਟਕੋਇਨ ਪਤੇ 'ਤੇ ਸਿੱਕੇ ਭੇਜੋ</translation>
+    </message>
+    <message>
+        <source>Backup wallet to another location</source>
+        <translation type="unfinished">ਵਾਲਿਟ ਨੂੰ ਕਿਸੇ ਹੋਰ ਥਾਂ 'ਤੇ ਬੈਕਅੱਪ ਕਰੋ</translation>
+    </message>
+    <message>
+        <source>Change the passphrase used for wallet encryption</source>
+        <translation type="unfinished">ਵਾਲਿਟ ਇਨਕ੍ਰਿਪਸ਼ਨ ਲਈ ਵਰਤਿਆ ਜਾਣ ਵਾਲਾ ਪਾਸਫਰੇਜ ਬਦਲੋ</translation>
+    </message>
+    <message>
+        <source>&amp;Send</source>
+        <translation type="unfinished">&amp;ਭੇਜੋ</translation>
+    </message>
+    <message>
+        <source>&amp;Receive</source>
+        <translation type="unfinished">&amp;ਪ੍ਰਾਪਤ ਕਰੋ</translation>
+    </message>
+    <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation type="unfinished">&amp;ਵਾਲਿਟ ਇਨਕ੍ਰਿਪਟ ਕਰੋ...</translation>
+    </message>
+    <message>
+        <source>Encrypt the private keys that belong to your wallet</source>
+        <translation type="unfinished">ਨਿੱਜੀ ਕੁੰਜੀਆਂ ਨੂੰ ਐਨਕ੍ਰਿਪਟ ਕਰੋ ਜੋ ਤੁਹਾਡੇ ਵਾਲਿਟ ਨਾਲ ਸਬੰਧਤ ਹਨ</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation type="unfinished">&amp;ਬੈਕਅੱਪ ਵਾਲਿਟ…</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation type="unfinished">ਪਾਸਫਰੇਜ &amp;ਬਦਲੋ...</translation>
+    </message>
+    <message numerus="yes">
+        <source>Processed %n block(s) of transaction history.</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n active connection(s) to Bitcoin network.</source>
+        <extracomment>A substring of the tooltip.</extracomment>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message>
+        <source>Error: %1</source>
+        <translation type="unfinished">ਗਲਤੀ: %1</translation>
+    </message>
+    </context>
+<context>
+    <name>CoinControlDialog</name>
+    <message>
+        <source>(no label)</source>
+        <translation type="unfinished">ਕੋਈ ਲੇਬਲ ਨਹੀਂ </translation>
+    </message>
+    </context>
+<context>
+    <name>Intro</name>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(sufficient to restore backups %n day(s) old)</source>
+        <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    </context>
+<context>
+    <name>PeerTableModel</name>
+    <message>
+        <source>Address</source>
+        <extracomment>Title of Peers Table column which contains the IP/Onion/I2P address of the connected peer.</extracomment>
+        <translation type="unfinished">ਪਤਾ</translation>
+    </message>
+    </context>
+<context>
+    <name>ReceiveRequestDialog</name>
+    <message>
+        <source>Wallet:</source>
+        <translation type="unfinished">ਬਟੂਆ: </translation>
+    </message>
+    </context>
+<context>
+    <name>RecentRequestsTableModel</name>
+    <message>
+        <source>Label</source>
+        <translation type="unfinished">ਲੇਬਲ</translation>
+    </message>
+    <message>
+        <source>(no label)</source>
+        <translation type="unfinished">ਕੋਈ ਲੇਬਲ ਨਹੀਂ </translation>
+    </message>
+    </context>
+<context>
+    <name>SendCoinsDialog</name>
+    <message numerus="yes">
+        <source>Estimated to begin confirmation within %n block(s).</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message>
+        <source>(no label)</source>
+        <translation type="unfinished">ਕੋਈ ਲੇਬਲ ਨਹੀਂ </translation>
+    </message>
+</context>
+<context>
+    <name>TransactionDesc</name>
+    <message numerus="yes">
+        <source>matures in %n more block(s)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    </context>
+<context>
+    <name>TransactionTableModel</name>
+    <message>
+        <source>Label</source>
+        <translation type="unfinished">ਲੇਬਲ</translation>
+    </message>
+    <message>
+        <source>(no label)</source>
+        <translation type="unfinished">ਕੋਈ ਲੇਬਲ ਨਹੀਂ </translation>
+    </message>
+    </context>
+<context>
+    <name>TransactionView</name>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">ਕਾਮੇ ਨਾਲ ਵੱਖ ਕੀਤੀ ਫਾਈਲ</translation>
+    </message>
+    <message>
+        <source>Label</source>
+        <translation type="unfinished">ਲੇਬਲ</translation>
+    </message>
+    <message>
+        <source>Address</source>
+        <translation type="unfinished">ਪਤਾ</translation>
+    </message>
+    <message>
+        <source>Exporting Failed</source>
+        <translation type="unfinished">ਨਿਰਯਾਤ ਅਸਫਲ ਰਿਹਾ</translation>
+    </message>
+    </context>
+<context>
+    <name>WalletFrame</name>
+    <message>
+        <source>Create a new wallet</source>
+        <translation type="unfinished">ਨਵਾਂ ਵਾਲਿਟ ਬਣਾਓ</translation>
+    </message>
+    </context>
+<context>
+    <name>WalletView</name>
+    <message>
+        <source>&amp;Export</source>
+        <translation type="unfinished">&amp;ਨਿਰਯਾਤ</translation>
+    </message>
+    <message>
+        <source>Export the data in the current tab to a file</source>
+        <translation type="unfinished">ਮੌਜੂਦਾ ਟੈਬ ਵਿੱਚ ਡੇਟਾ ਨੂੰ ਫਾਈਲ ਵਿੱਚ ਐਕਸਪੋਰਟ ਕਰੋ</translation>
+    </message>
+    </context>
+</TS>

--- a/src/qt/locale/bitcoin_pam.ts
+++ b/src/qt/locale/bitcoin_pam.ts
@@ -427,6 +427,24 @@
 <context>
     <name>Intro</name>
     <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
@@ -745,10 +763,6 @@
         <source>Message:</source>
         <translation type="unfinished">Mensayi:</translation>
     </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">Ibayad kang:</translation>
-    </message>
     </context>
 <context>
     <name>SignVerifyMessageDialog</name>
@@ -865,10 +879,12 @@
     <name>TransactionDesc</name>
     <message>
         <source>%1/unconfirmed</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
         <translation type="unfinished">%1/ali me-kumpirma</translation>
     </message>
     <message>
         <source>%1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
         <translation type="unfinished">%1 kumpirmasion</translation>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_pl.ts
+++ b/src/qt/locale/bitcoin_pl.ts
@@ -3,7 +3,7 @@
     <name>AddressBookPage</name>
     <message>
         <source>Right-click to edit address or label</source>
-        <translation type="unfinished">Kliknij prawy przycisk myszy, aby edytować adres lub etykietę</translation>
+        <translation type="unfinished">Kliknij prawym przyciskiem myszy, aby edytować adres lub etykietę</translation>
     </message>
     <message>
         <source>Create a new address</source>
@@ -43,7 +43,7 @@
     </message>
     <message>
         <source>&amp;Delete</source>
-        <translation type="unfinished">Usuń</translation>
+        <translation type="unfinished">&amp;Usuń</translation>
     </message>
     <message>
         <source>Choose the address to send coins to</source>
@@ -59,7 +59,7 @@
     </message>
     <message>
         <source>Sending addresses</source>
-        <translation type="unfinished">Wysyłające adresy</translation>
+        <translation type="unfinished">&amp;Adresy wysyłania8f0451c0-ec7d-4357-a370-eff72fb0685f</translation>
     </message>
     <message>
         <source>Receiving addresses</source>
@@ -103,7 +103,7 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
     </message>
     <message>
         <source>Exporting Failed</source>
-        <translation type="unfinished"> Eksportowanie nie powiodło się </translation>
+        <translation type="unfinished">Eksportowanie nie powiodło się </translation>
     </message>
 </context>
 <context>
@@ -125,7 +125,7 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
     <name>AskPassphraseDialog</name>
     <message>
         <source>Passphrase Dialog</source>
-        <translation type="unfinished"> Okienko Hasła </translation>
+        <translation type="unfinished">Okienko Hasła </translation>
     </message>
     <message>
         <source>Enter passphrase</source>
@@ -157,7 +157,7 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
     </message>
     <message>
         <source>Change passphrase</source>
-        <translation type="unfinished"> Zmień hasło </translation>
+        <translation type="unfinished">Zmień hasło </translation>
     </message>
     <message>
         <source>Confirm wallet encryption</source>
@@ -185,11 +185,11 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
     </message>
     <message>
         <source>Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
-        <translation type="unfinished">Zwróć uwagę, że zaszyfrowanie portfela nie zabezpieczy się w pełni przed kradzieżą przez malware jakie może zainfekować twój komputer. </translation>
+        <translation type="unfinished">Pamiętaj, że zaszyfrowanie portfela nie pomoże w zapobiegnięciu kradzieży twoich bitcoinów jeśli komputer zostanie zainfekowany przez złośliwe oprogramowanie.</translation>
     </message>
     <message>
         <source>Wallet to be encrypted</source>
-        <translation type="unfinished"> Portfel do zaszyfrowania </translation>
+        <translation type="unfinished">Portfel do zaszyfrowania </translation>
     </message>
     <message>
         <source>Your wallet is about to be encrypted. </source>
@@ -246,8 +246,16 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
 <context>
     <name>BitcoinApplication</name>
     <message>
+        <source>Settings file %1 might be corrupt or invalid.</source>
+        <translation type="unfinished">Plik ustawień 1%1 może być uszkodzony lub nieprawidłowy</translation>
+    </message>
+    <message>
+        <source>Runaway exception</source>
+        <translation type="unfinished">Błąd zapisu do portfela</translation>
+    </message>
+    <message>
         <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
-        <translation type="unfinished">Wystąpił krytyczny błąd. %1 nie może dalej bezpiecznie pracować i zostanie zakończony.</translation>
+        <translation type="unfinished">Wystąpił fatalny błąd. %1 nie może być kontynuowany i zostanie zakończony.</translation>
     </message>
     <message>
         <source>Internal error</source>
@@ -260,6 +268,16 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
 </context>
 <context>
     <name>QObject</name>
+    <message>
+        <source>Do you want to reset settings to default values, or to abort without making changes?</source>
+        <extracomment>Explanatory text shown on startup when the settings file cannot be read. Prompts user to make a choice between resetting or aborting.</extracomment>
+        <translation type="unfinished">Przywrócić ustawienia domyślne czy zrezygnować bez dokonywania zmian?</translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. Check that settings file is writable, or try running with -nosettings.</source>
+        <extracomment>Explanatory text shown on startup when the settings file could not be written. Prompts user to check that we have the ability to write to the file. Explains that the user has the option of running without a settings file.</extracomment>
+        <translation type="unfinished">Wystąpił krytyczny błąd. Upewnij się, że plik ustawień można nadpisać lub uruchom klienta z parametrem -nosettings.</translation>
+    </message>
     <message>
         <source>Error: Specified data directory "%1" does not exist.</source>
         <translation type="unfinished">Błąd: Określony folder danych "%1" nie istnieje.</translation>
@@ -303,9 +321,29 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
         <translation type="unfinished">Wyjściowy</translation>
     </message>
     <message>
+        <source>Full Relay</source>
+        <extracomment>Peer connection type that relays all network information.</extracomment>
+        <translation type="unfinished">Pełny Przekaźnik</translation>
+    </message>
+    <message>
+        <source>Block Relay</source>
+        <extracomment>Peer connection type that relays network information about blocks and not transactions or addresses.</extracomment>
+        <translation type="unfinished">Przekaźnik Blokowy</translation>
+    </message>
+    <message>
         <source>Manual</source>
         <extracomment>Peer connection type established manually through one of several methods.</extracomment>
         <translation type="unfinished">Ręczny</translation>
+    </message>
+    <message>
+        <source>Feeler</source>
+        <extracomment>Short-lived peer connection type that tests the aliveness of known addresses.</extracomment>
+        <translation type="unfinished">Szczelinomierz</translation>
+    </message>
+    <message>
+        <source>Address Fetch</source>
+        <extracomment>Short-lived peer connection type that solicits known addresses from a peer.</extracomment>
+        <translation type="unfinished">Pobieranie adresu</translation>
     </message>
     <message>
         <source>None</source>
@@ -318,41 +356,41 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n sekunda</numerusform>
+            <numerusform>%n sekund</numerusform>
+            <numerusform>%n sekund</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n minute(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n minuta</numerusform>
+            <numerusform>%n minut</numerusform>
+            <numerusform>%n minut</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n godzina</numerusform>
+            <numerusform>%n godzin</numerusform>
+            <numerusform>%n godzin</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n dzień</numerusform>
+            <numerusform>%n dni</numerusform>
+            <numerusform>%n dni</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n tydzień</numerusform>
+            <numerusform>%n tygodnie</numerusform>
+            <numerusform>%n tygodnie</numerusform>
         </translation>
     </message>
     <message>
@@ -362,14 +400,22 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n rok</numerusform>
+            <numerusform>%n lata</numerusform>
+            <numerusform>%n lata</numerusform>
         </translation>
     </message>
     </context>
 <context>
     <name>bitcoin-core</name>
+    <message>
+        <source>Settings file could not be read</source>
+        <translation type="unfinished">Nie udało się odczytać pliku ustawień</translation>
+    </message>
+    <message>
+        <source>Settings file could not be written</source>
+        <translation type="unfinished">Nie udało się zapisać pliku ustawień</translation>
+    </message>
     <message>
         <source>The %s developers</source>
         <translation type="unfinished">Deweloperzy %s</translation>
@@ -383,8 +429,16 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
         <translation type="unfinished">-maxtxfee ma ustawioną badzo dużą wartość! Tak wysokie opłaty mogą być zapłacone w jednej transakcji.</translation>
     </message>
     <message>
+        <source>Cannot downgrade wallet from version %i to version %i. Wallet version unchanged.</source>
+        <translation type="unfinished">Nie można zmienić wersji portfela z wersji %ina wersje %i. Wersja portfela pozostaje niezmieniona.</translation>
+    </message>
+    <message>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running.</source>
         <translation type="unfinished">Nie można uzyskać blokady na katalogu z danymi %s. %s najprawdopodobniej jest już uruchomiony.</translation>
+    </message>
+    <message>
+        <source>Cannot upgrade a non HD split wallet from version %i to version %i without upgrading to support pre-split keypool. Please use version %i or no version specified.</source>
+        <translation type="unfinished">Nie można zaktualizować portfela dzielonego innego niż HD z wersji 1%i do wersji 1%i bez aktualizacji w celu obsługi wstępnie podzielonej puli kluczy. Użyj wersji 1%i lub nie określono wersji.</translation>
     </message>
     <message>
         <source>Distributed under the MIT software license, see the accompanying file %s or %s</source>
@@ -395,16 +449,52 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
         <translation type="unfinished">Błąd odczytu %s! Wszystkie klucze zostały odczytane poprawnie, ale może brakować  danych transakcji lub wpisów w książce adresowej, lub mogą one być nieprawidłowe.</translation>
     </message>
     <message>
-        <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
-        <translation type="unfinished">Błąd: Nasłuchiwanie połączeń przychodzących nie powiodło się (nasłuch zwrócił błąd %s)</translation>
+        <source>Error reading %s! Transaction data may be missing or incorrect. Rescanning wallet.</source>
+        <translation type="unfinished">Błąd odczytu 1%s! Może brakować danych transakcji lub mogą być one nieprawidłowe. Ponowne skanowanie portfela.</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile format record is incorrect. Got "%s", expected "format".</source>
+        <translation type="unfinished">Błąd: rekord formatu pliku zrzutu jest nieprawidłowy. Otrzymano „1%s”, oczekiwany „format”.</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile identifier record is incorrect. Got "%s", expected "%s".</source>
+        <translation type="unfinished">Błąd: rekord identyfikatora pliku zrzutu jest nieprawidłowy. Otrzymano „1%s”, oczekiwano „1%s”.</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile version is not supported. This version of bitcoin-wallet only supports version 1 dumpfiles. Got dumpfile with version %s</source>
+        <translation type="unfinished">Błąd: wersja pliku zrzutu nie jest obsługiwana. Ta wersja bitcoin-wallet obsługuje tylko pliki zrzutów w wersji 1. Mam plik zrzutu w wersji 1%s</translation>
+    </message>
+    <message>
+        <source>Error: Legacy wallets only support the "legacy", "p2sh-segwit", and "bech32" address types</source>
+        <translation type="unfinished">Błąd: starsze portfele obsługują tylko typy adresów „legacy”, „p2sh-segwit” i „bech32”</translation>
     </message>
     <message>
         <source>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.</source>
         <translation type="unfinished">Estymacja opłat nieudana. Domyślna opłata jest wyłączona. Poczekaj kilka bloków lub włącz  -fallbackfee.</translation>
     </message>
     <message>
+        <source>File %s already exists. If you are sure this is what you want, move it out of the way first.</source>
+        <translation type="unfinished">Plik 1%s już istnieje. Jeśli jesteś pewien, że tego chcesz, najpierw usuń to z drogi.</translation>
+    </message>
+    <message>
         <source>Invalid amount for -maxtxfee=&lt;amount&gt;: '%s' (must be at least the minrelay fee of %s to prevent stuck transactions)</source>
         <translation type="unfinished">Niewłaściwa ilość dla -maxtxfee=&lt;ilość&gt;: '%s' (musi wynosić przynajmniej minimalną wielkość %s aby zapobiec utknięciu transakcji)</translation>
+    </message>
+    <message>
+        <source>Invalid or corrupt peers.dat (%s). If you believe this is a bug, please report it to %s. As a workaround, you can move the file (%s) out of the way (rename, move, or delete) to have a new one created on the next start.</source>
+        <translation type="unfinished">Nieprawidłowy lub uszkodzony plik peers.dat (1%s). Jeśli uważasz, że to błąd, zgłoś go do 1%s. Jako obejście, możesz przenieść plik (1%s) z drogi (zmień nazwę, przenieś lub usuń), aby przy następnym uruchomieniu utworzyć nowy.</translation>
+    </message>
+    <message>
+        <source>No dump file provided. To use createfromdump, -dumpfile=&lt;filename&gt; must be provided.</source>
+        <translation type="unfinished">Nie dostarczono pliku zrzutu. Aby użyć funkcji createfromdump, należy podać -dumpfile=1.</translation>
+    </message>
+    <message>
+        <source>No dump file provided. To use dump, -dumpfile=&lt;filename&gt; must be provided.</source>
+        <translation type="unfinished">Nie dostarczono pliku zrzutu. Aby użyć funkcji createfromdump, należy podać -dumpfile=1.</translation>
+    </message>
+    <message>
+        <source>No wallet file format provided. To use createfromdump, -format=&lt;format&gt; must be provided.</source>
+        <translation type="unfinished">Nie dostarczono pliku zrzutu. Aby użyć funkcji createfromdump, należy podać -dumpfile=1.</translation>
     </message>
     <message>
         <source>Please check that your computer's date and time are correct! If your clock is wrong, %s will not work properly.</source>
@@ -429,6 +519,10 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
     <message>
         <source>The block database contains a block which appears to be from the future. This may be due to your computer's date and time being set incorrectly. Only rebuild the block database if you are sure that your computer's date and time are correct</source>
         <translation type="unfinished">Baza bloków zawiera blok, który wydaje się pochodzić z przyszłości. Może to wynikać z nieprawidłowego ustawienia daty i godziny Twojego komputera. Bazę danych bloków dobuduj tylko, jeśli masz pewność, że data i godzina twojego komputera są poprawne</translation>
+    </message>
+    <message>
+        <source>The block index db contains a legacy 'txindex'. To clear the occupied disk space, run a full -reindex, otherwise ignore this error. This error message will not be displayed again.</source>
+        <translation type="unfinished">Baza danych indeksu bloku zawiera odziedziczony „txindex”. Aby wyczyścić zajęte miejsce na dysku, uruchom pełną indeksację, w przeciwnym razie zignoruj ten błąd. Ten komunikat o błędzie nie zostanie ponownie wyświetlony.</translation>
     </message>
     <message>
         <source>The transaction amount is too small to send after the fee has been deducted</source>
@@ -461,6 +555,10 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
     <message>
         <source>Unable to replay blocks. You will need to rebuild the database using -reindex-chainstate.</source>
         <translation type="unfinished">Nie można przetworzyć bloków. Konieczne będzie przebudowanie bazy danych za pomocą -reindex-chainstate.</translation>
+    </message>
+    <message>
+        <source>Unknown wallet file format "%s" provided. Please provide one of "bdb" or "sqlite".</source>
+        <translation type="unfinished">Podano nieznany typ pliku portfela "%s". Proszę podać jeden z "bdb" lub "sqlite".</translation>
     </message>
     <message>
         <source>Warning: Private keys detected in wallet {%s} with disabled private keys</source>
@@ -499,6 +597,10 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
         <translation type="unfinished">Nie mogę zapisać do katalogu danych '%s'; sprawdź uprawnienia.</translation>
     </message>
     <message>
+        <source>Failed to rename invalid peers.dat file. Please move or delete it and try again.</source>
+        <translation type="unfinished">Zmiana nazwy nieprawidłowego pliku peers.dat nie powiodła się. Przenieś go lub usuń i spróbuj ponownie.</translation>
+    </message>
+    <message>
         <source>Config setting for %s only applied on %s network when in [%s] section.</source>
         <translation type="unfinished">Ustawienie konfiguracyjne %s działa na sieć %s tylko, jeżeli jest w sekcji [%s].</translation>
     </message>
@@ -529,6 +631,10 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
     <message>
         <source>Done loading</source>
         <translation type="unfinished">Wczytywanie zakończone</translation>
+    </message>
+    <message>
+        <source>Error creating %s</source>
+        <translation type="unfinished">Błąd podczas tworzenia %s</translation>
     </message>
     <message>
         <source>Error initializing block database</source>
@@ -567,16 +673,32 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
         <translation type="unfinished">Błąd odczytu z bazy danych, wyłączam się.</translation>
     </message>
     <message>
-        <source>Error upgrading chainstate database</source>
-        <translation type="unfinished">Błąd ładowania bazy bloków</translation>
+        <source>Error reading next record from wallet database</source>
+        <translation type="unfinished">Błąd odczytu kolejnego rekordu z bazy danych portfela</translation>
     </message>
     <message>
         <source>Error: Disk space is low for %s</source>
         <translation type="unfinished">Błąd: zbyt mało miejsca na dysku dla %s</translation>
     </message>
     <message>
+        <source>Error: Dumpfile checksum does not match. Computed %s, expected %s</source>
+        <translation type="unfinished">Błąd: Plik zrzutu suma kontrolna nie pasuje. Obliczone %s,  spodziewane %s</translation>
+    </message>
+    <message>
         <source>Error: Keypool ran out, please call keypoolrefill first</source>
         <translation type="unfinished">Błąd: Pula kluczy jest pusta, odwołaj się do puli kluczy.</translation>
+    </message>
+    <message>
+        <source>Error: Missing checksum</source>
+        <translation type="unfinished">Bład: Brak suma kontroly</translation>
+    </message>
+    <message>
+        <source>Error: No %s addresses available.</source>
+        <translation type="unfinished">Błąd: %s adres nie dostępny</translation>
+    </message>
+    <message>
+        <source>Error: Unable to write record to new wallet</source>
+        <translation type="unfinished">Błąd: Wpisanie rekordu do nowego portfela jest niemożliwe</translation>
     </message>
     <message>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
@@ -597,6 +719,10 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
     <message>
         <source>Ignoring duplicate -wallet %s.</source>
         <translation type="unfinished">Ignorowanie duplikatu -wallet %s</translation>
+    </message>
+    <message>
+        <source>Importing…</source>
+        <translation type="unfinished">Importowanie...</translation>
     </message>
     <message>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
@@ -643,12 +769,32 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
         <translation type="unfinished">Nieprawidłowa maska sieci określona w -whitelist: '%s'</translation>
     </message>
     <message>
+        <source>Loading P2P addresses…</source>
+        <translation type="unfinished">Ładowanie adresów P2P...</translation>
+    </message>
+    <message>
+        <source>Loading banlist…</source>
+        <translation type="unfinished">Ładowanie listy zablokowanych...</translation>
+    </message>
+    <message>
+        <source>Loading block index…</source>
+        <translation type="unfinished">Ładowanie indeksu bloku...</translation>
+    </message>
+    <message>
+        <source>Loading wallet…</source>
+        <translation type="unfinished">Ładowanie portfela...</translation>
+    </message>
+    <message>
+        <source>Missing amount</source>
+        <translation type="unfinished">Brakująca kwota</translation>
+    </message>
+    <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
         <translation type="unfinished">Musisz określić port z -whitebind: '%s'</translation>
     </message>
     <message>
-        <source>No proxy server specified. Use -proxy=&lt;ip&gt; or -proxy=&lt;ip:port&gt;.</source>
-        <translation type="unfinished">Żaden serwer proxy nie jest ustawiony. Użyj -proxy=&lt;ip&gt; lub -proxy=&lt;ip:port&gt;.</translation>
+        <source>No addresses available</source>
+        <translation type="unfinished">Brak dostępnych adresów</translation>
     </message>
     <message>
         <source>Not enough file descriptors available.</source>
@@ -665,6 +811,10 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
     <message>
         <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
         <translation type="unfinished">Zmniejszanie -maxconnections z %d do %d z powodu ograniczeń systemu.</translation>
+    </message>
+    <message>
+        <source>Rescanning…</source>
+        <translation type="unfinished">Ponowne skanowanie...</translation>
     </message>
     <message>
         <source>SQLiteDatabase: Failed to execute statement to verify database: %s</source>
@@ -706,6 +856,10 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
         <source>Specified blocks directory "%s" does not exist.</source>
         <translation type="unfinished">Podany folder bloków "%s" nie istnieje.
 </translation>
+    </message>
+    <message>
+        <source>Starting network threads…</source>
+        <translation type="unfinished">Startowanie wątków sieciowych...</translation>
     </message>
     <message>
         <source>The source code is available from %s.</source>
@@ -772,6 +926,14 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
         <translation type="unfinished">Nie można wygenerować kluczy</translation>
     </message>
     <message>
+        <source>Unable to open %s for writing</source>
+        <translation type="unfinished">Nie można otworzyć %s w celu zapisu</translation>
+    </message>
+    <message>
+        <source>Unable to parse -maxuploadtarget: '%s'</source>
+        <translation type="unfinished">Nie można przeanalizować -maxuploadtarget: „%s”</translation>
+    </message>
+    <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
         <translation type="unfinished">Uruchomienie serwera HTTP nie powiodło się. Zobacz dziennik debugowania, aby uzyskać więcej szczegółów.</translation>
     </message>
@@ -792,16 +954,24 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
         <translation type="unfinished">Nieznana sieć w -onlynet: '%s'</translation>
     </message>
     <message>
+        <source>Unknown new rules activated (versionbit %i)</source>
+        <translation type="unfinished">Aktywowano nieznane nowe reguły (versionbit %i)</translation>
+    </message>
+    <message>
         <source>Unsupported logging category %s=%s.</source>
         <translation type="unfinished">Nieobsługiwana kategoria rejestrowania %s=%s.</translation>
     </message>
     <message>
-        <source>Upgrading UTXO database</source>
-        <translation type="unfinished">Aktualizowanie bazy danych UTXO</translation>
-    </message>
-    <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
         <translation type="unfinished">Komentarz User Agent (%s) zawiera niebezpieczne znaki.</translation>
+    </message>
+    <message>
+        <source>Verifying blocks…</source>
+        <translation type="unfinished">Weryfikowanie bloków...</translation>
+    </message>
+    <message>
+        <source>Verifying wallet(s)…</source>
+        <translation type="unfinished">Weryfikowanie porfela(li)...</translation>
     </message>
     <message>
         <source>Wallet needed to be rewritten: restart %s to complete</source>
@@ -859,6 +1029,10 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
         <translation type="unfinished">Stwórz nowy portfel</translation>
     </message>
     <message>
+        <source>&amp;Minimize</source>
+        <translation type="unfinished">Z&amp;minimalizuj</translation>
+    </message>
+    <message>
         <source>Wallet:</source>
         <translation type="unfinished">Portfel:</translation>
     </message>
@@ -897,11 +1071,15 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
     </message>
     <message>
         <source>&amp;Encrypt Wallet…</source>
-        <translation type="unfinished">Zaszyfruj portf&amp;el...</translation>
+        <translation type="unfinished">&amp;Zaszyfruj portfel</translation>
     </message>
     <message>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation type="unfinished">Szyfruj klucze prywatne, które są w twoim portfelu</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation type="unfinished">Utwórz kopię zapasową portfela...</translation>
     </message>
     <message>
         <source>&amp;Change Passphrase…</source>
@@ -913,7 +1091,7 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
     </message>
     <message>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
-        <translation type="unfinished">Podpisz wiadomości swoim adresem, aby udowodnić jego posiadanie</translation>
+        <translation type="unfinished">Podpisz wiadomości swoim adresem aby udowodnić jego posiadanie</translation>
     </message>
     <message>
         <source>&amp;Verify message…</source>
@@ -922,6 +1100,10 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
     <message>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation type="unfinished">Zweryfikuj wiadomość,  aby upewnić się, że została podpisana podanym adresem bitcoinowym.</translation>
+    </message>
+    <message>
+        <source>&amp;Load PSBT from file…</source>
+        <translation type="unfinished">Wczytaj PSBT z pliku...</translation>
     </message>
     <message>
         <source>Open &amp;URI…</source>
@@ -956,8 +1138,32 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
         <translation type="unfinished">Pasek zakładek</translation>
     </message>
     <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation type="unfinished">Synchronizuję nagłówki (%1%)…</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation type="unfinished">Synchronizacja z siecią...</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation type="unfinished">Indeksowanie bloków...</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation type="unfinished">Przetwarzanie bloków...</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation type="unfinished">Ponowne indeksowanie bloków...</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation type="unfinished">Łączenie z uczestnikami sieci...</translation>
+    </message>
+    <message>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
-        <translation type="unfinished">Żądaj płatności (generuje kod QR oraz bitcoinowe URI)</translation>
+        <translation type="unfinished">Zażądaj płatności (wygeneruj QE code i bitcoin: URI)</translation>
     </message>
     <message>
         <source>Show the list of used sending addresses and labels</source>
@@ -974,14 +1180,18 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>Przetworzono %n blok historii transakcji.</numerusform>
+            <numerusform>Przetworzono 1%n bloków historii transakcji.</numerusform>
+            <numerusform>Przetworzono 1%n bloków historii transakcji.</numerusform>
         </translation>
     </message>
     <message>
         <source>%1 behind</source>
         <translation type="unfinished">%1 za</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation type="unfinished">Synchronizuję...</translation>
     </message>
     <message>
         <source>Last received block was generated %1 ago.</source>
@@ -1010,6 +1220,10 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
     <message>
         <source>Load Partially Signed Bitcoin Transaction</source>
         <translation type="unfinished">Załaduj częściowo podpisaną transakcję Bitcoin</translation>
+    </message>
+    <message>
+        <source>Load PSBT from &amp;clipboard…</source>
+        <translation type="unfinished">Wczytaj PSBT ze schowka...</translation>
     </message>
     <message>
         <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
@@ -1048,6 +1262,16 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
         <translation type="unfinished">Zamknij portfel</translation>
     </message>
     <message>
+        <source>Restore Wallet…</source>
+        <extracomment>Name of the menu item that restores wallet from a backup file.</extracomment>
+        <translation type="unfinished">Przywróć Portfel…</translation>
+    </message>
+    <message>
+        <source>Restore a wallet from a backup file</source>
+        <extracomment>Status tip for Restore Wallet menu item</extracomment>
+        <translation type="unfinished">Przywróć portfel z pliku kopii zapasowej</translation>
+    </message>
+    <message>
         <source>Close all wallets</source>
         <translation type="unfinished">Zamknij wszystkie portfele</translation>
     </message>
@@ -1072,6 +1296,26 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
         <translation type="unfinished">Brak dostępnych portfeli</translation>
     </message>
     <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">Informacje portfela</translation>
+    </message>
+    <message>
+        <source>Load Wallet Backup</source>
+        <extracomment>The title for Restore Wallet File Windows</extracomment>
+        <translation type="unfinished">Załaduj kopię zapasową portfela</translation>
+    </message>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of pop-up window shown when the user is attempting to restore a wallet.</extracomment>
+        <translation type="unfinished">Przywróć portfel</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">Nazwa portfela</translation>
+    </message>
+    <message>
         <source>&amp;Window</source>
         <translation type="unfinished">&amp;Okno</translation>
     </message>
@@ -1087,14 +1331,38 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
         <source>%1 client</source>
         <translation type="unfinished">%1 klient</translation>
     </message>
+    <message>
+        <source>&amp;Hide</source>
+        <translation type="unfinished">&amp;Ukryj</translation>
+    </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n aktywne połączenie z siecią Bitcoin.</numerusform>
+            <numerusform>%n aktywnych połączeń z siecią Bitcoin.</numerusform>
+            <numerusform>%n aktywnych połączeń z siecią Bitcoin.</numerusform>
         </translation>
+    </message>
+    <message>
+        <source>Click for more actions.</source>
+        <extracomment>A substring of the tooltip. "More actions" are available via the context menu.</extracomment>
+        <translation type="unfinished">Kliknij po więcej funkcji.</translation>
+    </message>
+    <message>
+        <source>Show Peers tab</source>
+        <extracomment>A context menu item. The "Peers tab" is an element of the "Node window".</extracomment>
+        <translation type="unfinished">Wyświetl połączenia</translation>
+    </message>
+    <message>
+        <source>Disable network activity</source>
+        <extracomment>A context menu item.</extracomment>
+        <translation type="unfinished">Wyłącz aktywność sieciową</translation>
+    </message>
+    <message>
+        <source>Enable network activity</source>
+        <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
+        <translation type="unfinished">Włącz aktywność sieciową</translation>
     </message>
     <message>
         <source>Error: %1</source>
@@ -1170,7 +1438,7 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
     </message>
     <message>
         <source>Original message:</source>
-        <translation type="unfinished">Wiadomość oryginalna:</translation>
+        <translation type="unfinished">Orginalna wiadomość:</translation>
     </message>
 </context>
 <context>
@@ -1212,11 +1480,11 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
     </message>
     <message>
         <source>Change:</source>
-        <translation type="unfinished">Reszta:</translation>
+        <translation type="unfinished">Zmiana:</translation>
     </message>
     <message>
         <source>(un)select all</source>
-        <translation type="unfinished">Zaznacz/Odznacz wszystko</translation>
+        <translation type="unfinished">zaznacz/odznacz wszytsko</translation>
     </message>
     <message>
         <source>Tree mode</source>
@@ -1244,15 +1512,39 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
     </message>
     <message>
         <source>Confirmations</source>
-        <translation type="unfinished">Potwierdzenia</translation>
+        <translation type="unfinished">Potwierdzenie</translation>
     </message>
     <message>
         <source>Confirmed</source>
-        <translation type="unfinished">Potwierdzony</translation>
+        <translation type="unfinished">Potwerdzone</translation>
     </message>
     <message>
         <source>Copy amount</source>
+        <translation type="unfinished">Kopiuj kwote</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">Kopiuj adres</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Kopiuj etykietę</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
         <translation type="unfinished">Kopiuj kwotę</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID and output index</source>
+        <translation type="unfinished">Skopiuj &amp;ID transakcji oraz wyjściowy indeks</translation>
+    </message>
+    <message>
+        <source>L&amp;ock unspent</source>
+        <translation type="unfinished">Zabl&amp;okuj niewydane</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock unspent</source>
+        <translation type="unfinished">Odblok&amp;uj niewydane</translation>
     </message>
     <message>
         <source>Copy quantity</source>
@@ -1316,31 +1608,48 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
     <message>
         <source>Create Wallet</source>
         <extracomment>Title of window indicating the progress of creation of a new wallet.</extracomment>
-        <translation type="unfinished">Stwórz portfel</translation>
+        <translation type="unfinished">Stwórz potrfel</translation>
     </message>
     <message>
         <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
         <extracomment>Descriptive text of the create wallet progress window which indicates to the user which wallet is currently being created.</extracomment>
-        <translation type="unfinished">Otwieranie portfela &lt;b&gt;%1&lt;/b&gt;...</translation>
+        <translation type="unfinished">Tworzenie portfela &lt;b&gt;%1&lt;/b&gt;...</translation>
     </message>
     <message>
         <source>Create wallet failed</source>
-        <translation type="unfinished">Tworzenie portfela nieudane</translation>
+        <translation type="unfinished">Nieudane tworzenie potrfela</translation>
     </message>
     <message>
         <source>Create wallet warning</source>
         <translation type="unfinished">Ostrzeżenie przy tworzeniu portfela</translation>
     </message>
+    <message>
+        <source>Can't list signers</source>
+        <translation type="unfinished">Nie można wyświetlić sygnatariuszy</translation>
+    </message>
     </context>
+<context>
+    <name>LoadWalletsActivity</name>
+    <message>
+        <source>Load Wallets</source>
+        <extracomment>Title of progress window which is displayed when wallets are being loaded.</extracomment>
+        <translation type="unfinished"> Ładuj portfele</translation>
+    </message>
+    <message>
+        <source>Loading wallets…</source>
+        <extracomment>Descriptive text of the load wallets progress window which indicates to the user that wallets are currently being loaded.</extracomment>
+        <translation type="unfinished">Ładowanie portfeli...</translation>
+    </message>
+</context>
 <context>
     <name>OpenWalletActivity</name>
     <message>
         <source>Open wallet failed</source>
-        <translation type="unfinished">Otwarcie portfela nie powiodło się</translation>
+        <translation type="unfinished">Otworzenie portfela nie powiodło się</translation>
     </message>
     <message>
         <source>Open wallet warning</source>
-        <translation type="unfinished">Ostrzeżenie przy otwieraniu portfela</translation>
+        <translation type="unfinished">Ostrzeżenie przy otworzeniu potrfela</translation>
     </message>
     <message>
         <source>default wallet</source>
@@ -1350,6 +1659,19 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
         <source>Open Wallet</source>
         <extracomment>Title of window indicating the progress of opening of a wallet.</extracomment>
         <translation type="unfinished">Otwórz Portfel</translation>
+    </message>
+    <message>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the open wallet progress window which indicates to the user which wallet is currently being opened.</extracomment>
+        <translation type="unfinished">Otwieranie portfela &lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+</context>
+<context>
+    <name>RestoreWalletActivity</name>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of progress window which is displayed when wallets are being restored.</extracomment>
+        <translation type="unfinished">Przywróć portfel</translation>
     </message>
     </context>
 <context>
@@ -1379,7 +1701,7 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
     <name>CreateWalletDialog</name>
     <message>
         <source>Create Wallet</source>
-        <translation type="unfinished">Stwórz portfel</translation>
+        <translation type="unfinished">Stwórz potrfel</translation>
     </message>
     <message>
         <source>Wallet Name</source>
@@ -1426,6 +1748,14 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
         <translation type="unfinished">Portfel deskryptora</translation>
     </message>
     <message>
+        <source>Use an external signing device such as a hardware wallet. Configure the external signer script in wallet preferences first.</source>
+        <translation type="unfinished">Użyj zewnętrznego urządzenia podpisującego, takiego jak portfel sprzętowy. Najpierw skonfiguruj zewnętrzny skrypt podpisujący w preferencjach portfela.</translation>
+    </message>
+    <message>
+        <source>External signer</source>
+        <translation type="unfinished">Zewnętrzny sygnatariusz</translation>
+    </message>
+    <message>
         <source>Create</source>
         <translation type="unfinished">Stwórz</translation>
     </message>
@@ -1433,7 +1763,12 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
         <source>Compiled without sqlite support (required for descriptor wallets)</source>
         <translation type="unfinished">Skompilowano bez wsparcia sqlite (wymaganego dla deskryptorów potfeli)</translation>
     </message>
-    </context>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Skompilowany bez obsługi podpisywania zewnętrznego (wymagany do podpisywania zewnętrzengo)</translation>
+    </message>
+</context>
 <context>
     <name>EditAddressDialog</name>
     <message>
@@ -1514,6 +1849,30 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
 </context>
 <context>
     <name>Intro</name>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform>(z %n GB potrzebnych)</numerusform>
+            <numerusform>(z %n GB potrzebnych)</numerusform>
+            <numerusform>(z %n GB potrzebnych)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform>(%n GB potrzebny na pełny łańcuch)</numerusform>
+            <numerusform>(%n GB potrzebne na pełny łańcuch)</numerusform>
+            <numerusform>(%n GB potrzebnych na pełny łańcuch)</numerusform>
+        </translation>
+    </message>
     <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
         <translation type="unfinished">Co najmniej %1 GB danych, zostanie zapisane w tym katalogu, dane te będą przyrastały w czasie.</translation>
@@ -1526,9 +1885,9 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>(wystarcza do przywrócenia kopii zapasowych sprzed %n dnia)</numerusform>
+            <numerusform>(wystarcza do przywrócenia kopii zapasowych sprzed %n dni)</numerusform>
+            <numerusform>(wystarcza do przywrócenia kopii zapasowych sprzed %n dni)</numerusform>
         </translation>
     </message>
     <message>
@@ -1560,12 +1919,16 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
         <translation type="unfinished">Ponieważ jest to pierwsze uruchomienie programu, możesz wybrać gdzie %1 będzie przechowywał swoje dane.</translation>
     </message>
     <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation type="unfinished">Gdy naciśniesz OK, %1 zacznie się pobieranie i przetwarzanie całego %4 łańcucha bloków (%2GB) zaczynając od najwcześniejszych transakcji w %3 gdy %4 został uruchomiony.</translation>
+        <source>Limit block chain storage to</source>
+        <translation type="unfinished">Ogranicz przechowywanie łańcucha bloków do</translation>
     </message>
     <message>
         <source>Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</source>
         <translation type="unfinished">Wyłączenie tej opcji spowoduje konieczność pobrania całego łańcucha bloków. Szybciej jest najpierw pobrać cały łańcuch a następnie go przyciąć (prune). Wyłącza niektóre zaawansowane funkcje.</translation>
+    </message>
+    <message>
+        <source> GB</source>
+        <translation type="unfinished">GB</translation>
     </message>
     <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
@@ -1602,6 +1965,10 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
 <context>
     <name>ShutdownWindow</name>
     <message>
+        <source>%1 is shutting down…</source>
+        <translation type="unfinished">%1 się zamyka...</translation>
+    </message>
+    <message>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished">Nie wyłączaj komputera dopóki to okno nie zniknie.</translation>
     </message>
@@ -1623,6 +1990,14 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
     <message>
         <source>Number of blocks left</source>
         <translation type="unfinished">Pozostało bloków</translation>
+    </message>
+    <message>
+        <source>Unknown…</source>
+        <translation type="unfinished">Nieznany...</translation>
+    </message>
+    <message>
+        <source>calculating…</source>
+        <translation type="unfinished">obliczanie...</translation>
     </message>
     <message>
         <source>Last block time</source>
@@ -1651,6 +2026,10 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
     <message>
         <source>%1 is currently syncing.  It will download headers and blocks from peers and validate them until reaching the tip of the block chain.</source>
         <translation type="unfinished">%1 jest w trakcie synchronizacji. Trwa pobieranie i weryfikacja nagłówków oraz bloków z sieci w celu uzyskania aktualnego stanu łańcucha.</translation>
+    </message>
+    <message>
+        <source>Unknown. Syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">nieznany, Synchronizowanie nagłówków (1%1, 2%2%)</translation>
     </message>
     </context>
 <context>
@@ -1682,6 +2061,10 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
     <message>
         <source>&amp;Start %1 on system login</source>
         <translation type="unfinished">Uruchamiaj %1 wraz z zalogowaniem do &amp;systemu</translation>
+    </message>
+    <message>
+        <source>Enabling pruning significantly reduces the disk space required to store transactions. All blocks are still fully validated. Reverting this setting requires re-downloading the entire blockchain.</source>
+        <translation type="unfinished">Włączenie czyszczenia znacznie zmniejsza ilość miejsca na dysku wymaganego do przechowywania transakcji. Wszystkie bloki są nadal w pełni zweryfikowane. Przywrócenie tego ustawienia wymaga ponownego pobrania całego łańcucha bloków.</translation>
     </message>
     <message>
         <source>Size of &amp;database cache</source>
@@ -1732,12 +2115,42 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
         <translation type="unfinished">Cofnięcie tego ustawienia wymaga ponownego załadowania całego łańcucha bloków.</translation>
     </message>
     <message>
+        <source>Maximum database cache size. A larger cache can contribute to faster sync, after which the benefit is less pronounced for most use cases. Lowering the cache size will reduce memory usage. Unused mempool memory is shared for this cache.</source>
+        <extracomment>Tooltip text for Options window setting that sets the size of the database cache. Explains the corresponding effects of increasing/decreasing this value.</extracomment>
+        <translation type="unfinished">Maksymalny rozmiar pamięci podręcznej bazy danych. Większa pamięć podręczna może przyczynić się do szybszej synchronizacji, po której korzyści są mniej widoczne w większości przypadków użycia. Zmniejszenie rozmiaru pamięci podręcznej zmniejszy zużycie pamięci. Nieużywana pamięć mempool jest współdzielona dla tej pamięci podręcznej.</translation>
+    </message>
+    <message>
+        <source>Set the number of script verification threads. Negative values correspond to the number of cores you want to leave free to the system.</source>
+        <extracomment>Tooltip text for Options window setting that sets the number of script verification threads. Explains that negative values mean to leave these many cores free to the system.</extracomment>
+        <translation type="unfinished">Ustaw liczbę wątków weryfikacji skryptu. Wartości ujemne odpowiadają liczbie rdzeni, które chcesz pozostawić systemowi.</translation>
+    </message>
+    <message>
         <source>(0 = auto, &lt;0 = leave that many cores free)</source>
         <translation type="unfinished">(0 = automatycznie, &lt;0 = zostaw tyle wolnych rdzeni)</translation>
     </message>
     <message>
+        <source>This allows you or a third party tool to communicate with the node through command-line and JSON-RPC commands.</source>
+        <extracomment>Tooltip text for Options window setting that enables the RPC server.</extracomment>
+        <translation type="unfinished">Umożliwia tobie lub narzędziu innej firmy komunikowanie się z węzłem za pomocą wiersza polecenia i poleceń JSON-RPC.</translation>
+    </message>
+    <message>
+        <source>Enable R&amp;PC server</source>
+        <extracomment>An Options window setting to enable the RPC server.</extracomment>
+        <translation type="unfinished">Włącz serwer R&amp;PC</translation>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished">Portfel</translation>
+    </message>
+    <message>
+        <source>Whether to set subtract fee from amount as default or not.</source>
+        <extracomment>Tooltip text for Options window setting that sets subtracting the fee from a sending amount as default.</extracomment>
+        <translation type="unfinished">Czy ustawić opłatę odejmowaną od kwoty jako domyślną, czy nie.</translation>
+    </message>
+    <message>
+        <source>Subtract &amp;fee from amount by default</source>
+        <extracomment>An Options window setting to set subtracting the fee from a sending amount as default.</extracomment>
+        <translation type="unfinished">Domyślnie odejmij opłatę od kwoty</translation>
     </message>
     <message>
         <source>Expert</source>
@@ -1756,12 +2169,38 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
         <translation type="unfinished">Wydaj niepotwierdzoną re&amp;sztę</translation>
     </message>
     <message>
+        <source>Enable &amp;PSBT controls</source>
+        <extracomment>An options window setting to enable PSBT controls.</extracomment>
+        <translation type="unfinished">Włącz ustawienia &amp;PSBT</translation>
+    </message>
+    <message>
+        <source>Whether to show PSBT controls.</source>
+        <extracomment>Tooltip text for options window setting that enables PSBT controls.</extracomment>
+        <translation type="unfinished">Czy wyświetlać opcje PSBT.</translation>
+    </message>
+    <message>
+        <source>External Signer (e.g. hardware wallet)</source>
+        <translation type="unfinished">Zewnętrzny sygnatariusz (np. portfel sprzętowy) </translation>
+    </message>
+    <message>
+        <source>&amp;External signer script path</source>
+        <translation type="unfinished">&amp;Ścieżka zewnętrznego skryptu podpisującego</translation>
+    </message>
+    <message>
+        <source>Full path to a Bitcoin Core compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</source>
+        <translation type="unfinished">Pełna ścieżka do skryptu zgodnego z Bitcoin Core (np. C:\Downloads\hwi.exe lub /Users/you/Downloads/hwi.py). Uwaga: złośliwe oprogramowanie może ukraść Twoje monety!</translation>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation type="unfinished">Automatycznie otwiera port klienta Bitcoin na routerze. Ta opcja dzieła tylko jeśli twój router wspiera UPnP i jest ono włączone.</translation>
     </message>
     <message>
         <source>Map port using &amp;UPnP</source>
         <translation type="unfinished">Mapuj port używając &amp;UPnP</translation>
+    </message>
+    <message>
+        <source>Automatically open the Bitcoin client port on the router. This only works when your router supports NAT-PMP and it is enabled. The external port could be random.</source>
+        <translation type="unfinished">Automatycznie otwiera port klienta Bitcoin w routerze. Działa jedynie wtedy, gdy router wspiera NAT-PMP i usługa ta jest włączona. Zewnętrzny port może być losowy.</translation>
     </message>
     <message>
         <source>Map port using NA&amp;T-PMP</source>
@@ -1840,6 +2279,14 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
         <translation type="unfinished">Wybierz podział jednostki pokazywany w interfejsie  oraz podczas wysyłania monet</translation>
     </message>
     <message>
+        <source>Third-party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</source>
+        <translation type="unfinished">Adresy URL stron trzecich (np. eksplorator bloków), które pojawiają się na karcie transakcji jako pozycje menu kontekstowego. %s w adresie URL jest zastępowane hashem transakcji. Wiele adresów URL jest oddzielonych pionową kreską |.</translation>
+    </message>
+    <message>
+        <source>&amp;Third-party transaction URLs</source>
+        <translation type="unfinished">&amp;Adresy URL transakcji stron trzecich</translation>
+    </message>
+    <message>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished">Wybierz pokazywanie lub nie funkcji kontroli monet.</translation>
     </message>
@@ -1852,12 +2299,21 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
         <translation type="unfinished">Użyj oddzielnego proxy SOCKS&amp;5 aby osiągnąć węzły w ukrytych usługach Tor:</translation>
     </message>
     <message>
-        <source>Options set in this dialog are overridden by the command line or in the configuration file:</source>
-        <translation type="unfinished">Opcje ustawione w tym oknie są nadpisane przez linię komend lub plik konfiguracyjny:</translation>
+        <source>Monospaced font in the Overview tab:</source>
+        <translation type="unfinished">Czcionka o stałej szerokości w zakładce Przegląd:</translation>
+    </message>
+    <message>
+        <source>closest matching "%1"</source>
+        <translation type="unfinished">najbliższy pasujący "%1"</translation>
     </message>
     <message>
         <source>&amp;Cancel</source>
         <translation type="unfinished">&amp;Anuluj</translation>
+    </message>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Skompilowany bez obsługi podpisywania zewnętrznego (wymagany do podpisywania zewnętrzengo)</translation>
     </message>
     <message>
         <source>default</source>
@@ -1869,14 +2325,17 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
     </message>
     <message>
         <source>Confirm options reset</source>
+        <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
         <translation type="unfinished">Potwierdź reset ustawień</translation>
     </message>
     <message>
         <source>Client restart required to activate changes.</source>
+        <extracomment>Text explaining that the settings changed will not come into effect until the client is restarted.</extracomment>
         <translation type="unfinished">Wymagany restart programu, aby uaktywnić zmiany.</translation>
     </message>
     <message>
         <source>Client will be shut down. Do you want to proceed?</source>
+        <extracomment>Text asking the user to confirm if they would like to proceed with a client shutdown.</extracomment>
         <translation type="unfinished">Program zostanie wyłączony. Czy chcesz kontynuować?</translation>
     </message>
     <message>
@@ -1888,6 +2347,10 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
         <source>The configuration file is used to specify advanced user options which override GUI settings. Additionally, any command-line options will override this configuration file.</source>
         <extracomment>Explanatory text about the priority order of instructions considered by client. The order from high to low being: command-line, configuration file, GUI settings.</extracomment>
         <translation type="unfinished">Plik konfiguracyjny jest używany celem zdefiniowania zaawansowanych opcji nadpisujących ustawienia aplikacji okienkowej (GUI). Parametry zdefiniowane z poziomu linii poleceń nadpisują parametry określone w tym pliku.</translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation type="unfinished">Kontynuuj</translation>
     </message>
     <message>
         <source>Cancel</source>
@@ -2004,6 +2467,10 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
         <translation type="unfinished">Kopiuj do schowka</translation>
     </message>
     <message>
+        <source>Save…</source>
+        <translation type="unfinished">Zapisz...</translation>
+    </message>
+    <message>
         <source>Close</source>
         <translation type="unfinished">Zamknij</translation>
     </message>
@@ -2014,6 +2481,10 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
     <message>
         <source>Failed to sign transaction: %1</source>
         <translation type="unfinished">Nie udało się podpisać transakcji: %1</translation>
+    </message>
+    <message>
+        <source>Cannot sign inputs while wallet is locked.</source>
+        <translation type="unfinished">Nie można podpisywać danych wejściowych, gdy portfel jest zablokowany.</translation>
     </message>
     <message>
         <source>Could not sign any more inputs.</source>
@@ -2042,6 +2513,11 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
     <message>
         <source>Save Transaction Data</source>
         <translation type="unfinished">Zapisz dane transakcji</translation>
+    </message>
+    <message>
+        <source>Partially Signed Transaction (Binary)</source>
+        <extracomment>Expanded name of the binary PSBT file format. See: BIP 174.</extracomment>
+        <translation type="unfinished">Częściowo podpisana transakcja (binarna)</translation>
     </message>
     <message>
         <source>PSBT saved to disk.</source>
@@ -2080,6 +2556,10 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
         <translation type="unfinished">Transakcja ciągle oczekuje na podpis(y).</translation>
     </message>
     <message>
+        <source>(But no wallet is loaded.)</source>
+        <translation type="unfinished">(Ale żaden portfel nie jest załadowany.)</translation>
+    </message>
+    <message>
         <source>(But this wallet cannot sign transactions.)</source>
         <translation type="unfinished">(Ale ten portfel nie może podipisać transakcji.)</translation>
     </message>
@@ -2113,6 +2593,14 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
     <message>
         <source>'bitcoin://' is not a valid URI. Use 'bitcoin:' instead.</source>
         <translation type="unfinished">'bitcoin://' nie jest poprawnym URI. Użyj 'bitcoin:'.</translation>
+    </message>
+    <message>
+        <source>Cannot process payment request because BIP70 is not supported.
+Due to widespread security flaws in BIP70 it's strongly recommended that any merchant instructions to switch wallets be ignored.
+If you are receiving this error you should request the merchant provide a BIP21 compatible URI.</source>
+        <translation type="unfinished">Nie można przetworzyć żądanie zapłaty poniewasz BIP70 nie jest obsługiwany.
+Ze względu na wady bezpieczeństwa w BIP70 jest zalecane ignorować wszelkich instrukcji od sprzedawcę dotyczących zmiany portfela.
+Jeśli pojawia się ten błąd, poproś sprzedawcę o podanie URI zgodnego z BIP21. </translation>
     </message>
     <message>
         <source>URI cannot be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
@@ -2173,6 +2661,10 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
 </context>
 <context>
     <name>QRImageWidget</name>
+    <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">Zapi&amp;sz Obraz...</translation>
+    </message>
     <message>
         <source>&amp;Copy Image</source>
         <translation type="unfinished">&amp;Kopiuj obraz</translation>
@@ -2306,12 +2798,36 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
         <translation type="unfinished">Zsynchronizowane bloki</translation>
     </message>
     <message>
+        <source>Last Transaction</source>
+        <translation type="unfinished">Ostatnia Transakcja</translation>
+    </message>
+    <message>
         <source>The mapped Autonomous System used for diversifying peer selection.</source>
         <translation type="unfinished">Zmapowany autonomiczny system (ang. asmap) używany do dywersyfikacji wyboru węzłów.</translation>
     </message>
     <message>
         <source>Mapped AS</source>
         <translation type="unfinished">Zmapowany autonomiczny system (ang. asmap)</translation>
+    </message>
+    <message>
+        <source>Whether we relay addresses to this peer.</source>
+        <extracomment>Tooltip text for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
+        <translation type="unfinished">Czy przekazujemy adresy do tego peera.</translation>
+    </message>
+    <message>
+        <source>Address Relay</source>
+        <extracomment>Text title for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
+        <translation type="unfinished">Adres Przekaźnika</translation>
+    </message>
+    <message>
+        <source>Addresses Processed</source>
+        <extracomment>Text title for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
+        <translation type="unfinished">Przetworzone Adresy</translation>
+    </message>
+    <message>
+        <source>Addresses Rate-Limited</source>
+        <extracomment>Text title for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
+        <translation type="unfinished">Wskaźnik-Ograniczeń Adresów</translation>
     </message>
     <message>
         <source>User Agent</source>
@@ -2342,6 +2858,10 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
         <translation type="unfinished">Uprawnienia</translation>
     </message>
     <message>
+        <source>Direction/Type</source>
+        <translation type="unfinished">Kierunek/Rodzaj</translation>
+    </message>
+    <message>
         <source>The network protocol this peer is connected through: IPv4, IPv6, Onion, I2P, or CJDNS.</source>
         <translation type="unfinished">Protokół sieciowy używany przez ten węzeł: IPv4, IPv6, Onion, I2P, lub CJDNS.</translation>
     </message>
@@ -2350,12 +2870,33 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
         <translation type="unfinished">Usługi</translation>
     </message>
     <message>
+        <source>Whether the peer requested us to relay transactions.</source>
+        <translation type="unfinished">Czy peer poprosił nas o przekazanie transakcji.</translation>
+    </message>
+    <message>
+        <source>Wants Tx Relay</source>
+        <translation type="unfinished">Chce przekaźnik Tx</translation>
+    </message>
+    <message>
+        <source>High bandwidth BIP152 compact block relay: %1</source>
+        <translation type="unfinished">Kompaktowy przekaźnik blokowy BIP152 o dużej przepustowości: 1 %1</translation>
+    </message>
+    <message>
+        <source>High Bandwidth</source>
+        <translation type="unfinished">Wysoka Przepustowość</translation>
+    </message>
+    <message>
         <source>Connection Time</source>
         <translation type="unfinished">Czas połączenia</translation>
     </message>
     <message>
         <source>Last Block</source>
         <translation type="unfinished">Ostatni Blok</translation>
+    </message>
+    <message>
+        <source>Elapsed time since a novel transaction accepted into our mempool was received from this peer.</source>
+        <extracomment>Tooltip text for the Last Transaction field in the peer details area.</extracomment>
+        <translation type="unfinished">Czas, który upłynął od otrzymania nowej transakcji przyjętej do naszej pamięci od tego partnera.</translation>
     </message>
     <message>
         <source>Last Send</source>
@@ -2427,6 +2968,48 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
         <translation type="unfinished">Przychodzące: zainicjowane przez węzeł</translation>
     </message>
     <message>
+        <source>Outbound Full Relay: default</source>
+        <extracomment>Explanatory text for an outbound peer connection that relays all network information. This is the default behavior for outbound connections.</extracomment>
+        <translation type="unfinished">Pełny przekaźnik wychodzący: domyślnie</translation>
+    </message>
+    <message>
+        <source>Outbound Block Relay: does not relay transactions or addresses</source>
+        <extracomment>Explanatory text for an outbound peer connection that relays network information about blocks and not transactions or addresses.</extracomment>
+        <translation type="unfinished">Outbound Block Relay: nie przekazuje transakcji ani adresów</translation>
+    </message>
+    <message>
+        <source>Outbound Manual: added using RPC %1 or %2/%3 configuration options</source>
+        <extracomment>Explanatory text for an outbound peer connection that was established manually through one of several methods. The numbered arguments are stand-ins for the methods available to establish manual connections.</extracomment>
+        <translation type="unfinished">Outbound Manual: dodano przy użyciu opcji konfiguracyjnych RPC 1%1 lub 2%2/3%3</translation>
+    </message>
+    <message>
+        <source>Outbound Feeler: short-lived, for testing addresses</source>
+        <extracomment>Explanatory text for a short-lived outbound peer connection that is used to test the aliveness of known addresses.</extracomment>
+        <translation type="unfinished">Outbound Feeler: krótkotrwały, do testowania adresów</translation>
+    </message>
+    <message>
+        <source>Outbound Address Fetch: short-lived, for soliciting addresses</source>
+        <extracomment>Explanatory text for a short-lived outbound peer connection that is used to request addresses from a peer.</extracomment>
+        <translation type="unfinished">Pobieranie adresu wychodzącego: krótkotrwałe, do pozyskiwania adresów</translation>
+    </message>
+    <message>
+        <source>we selected the peer for high bandwidth relay</source>
+        <translation type="unfinished">wybraliśmy peera dla przekaźnika o dużej przepustowości</translation>
+    </message>
+    <message>
+        <source>the peer selected us for high bandwidth relay</source>
+        <translation type="unfinished">peer wybrał nas do przekaźnika o dużej przepustowości</translation>
+    </message>
+    <message>
+        <source>no high bandwidth relay selected</source>
+        <translation type="unfinished">nie wybrano przekaźnika o dużej przepustowości</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <extracomment>Context menu action to copy the address of a peer.</extracomment>
+        <translation type="unfinished">Kopiuj adres</translation>
+    </message>
+    <message>
         <source>&amp;Disconnect</source>
         <translation type="unfinished">&amp;Rozłącz</translation>
     </message>
@@ -2435,12 +3018,21 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
         <translation type="unfinished">1 &amp;godzina</translation>
     </message>
     <message>
+        <source>1 d&amp;ay</source>
+        <translation type="unfinished">1 dzień</translation>
+    </message>
+    <message>
         <source>1 &amp;week</source>
         <translation type="unfinished">1 &amp;tydzień</translation>
     </message>
     <message>
         <source>1 &amp;year</source>
         <translation type="unfinished">1 &amp;rok</translation>
+    </message>
+    <message>
+        <source>&amp;Copy IP/Netmask</source>
+        <extracomment>Context menu action to copy the IP/Netmask of a banned peer. IP/Netmask is the combination of a peer's IP address and its Netmask. For IP address, see: https://en.wikipedia.org/wiki/IP_address.</extracomment>
+        <translation type="unfinished">Skopiuj IP/Maskę Sieci</translation>
     </message>
     <message>
         <source>&amp;Unban</source>
@@ -2457,6 +3049,11 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
     <message>
         <source>Executing command using "%1" wallet</source>
         <translation type="unfinished">Wykonuję komendę używając portfela "%1"</translation>
+    </message>
+    <message>
+        <source>Executing…</source>
+        <extracomment>A console message indicating an entered command is currently being executed.</extracomment>
+        <translation type="unfinished">Wykonuję...</translation>
     </message>
     <message>
         <source>via %1</source>
@@ -2566,6 +3163,22 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
         <translation type="unfinished">Kopiuj &amp;URI</translation>
     </message>
     <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">Kopiuj adres</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Kopiuj etykietę</translation>
+    </message>
+    <message>
+        <source>Copy &amp;message</source>
+        <translation type="unfinished">Skopiuj wiado&amp;mość</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Kopiuj kwotę</translation>
+    </message>
+    <message>
         <source>Could not unlock wallet.</source>
         <translation type="unfinished">Nie można było odblokować portfela.</translation>
     </message>
@@ -2576,6 +3189,10 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
 </context>
 <context>
     <name>ReceiveRequestDialog</name>
+    <message>
+        <source>Request payment to …</source>
+        <translation type="unfinished">Żądaj płatności do ...</translation>
+    </message>
     <message>
         <source>Address:</source>
         <translation type="unfinished">Adres:</translation>
@@ -2603,6 +3220,18 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
     <message>
         <source>Copy &amp;Address</source>
         <translation type="unfinished">Kopiuj &amp;adres</translation>
+    </message>
+    <message>
+        <source>&amp;Verify</source>
+        <translation type="unfinished">Zweryfikuj</translation>
+    </message>
+    <message>
+        <source>Verify this address on e.g. a hardware wallet screen</source>
+        <translation type="unfinished">Zweryfikuj ten adres np. na ekranie portfela sprzętowego</translation>
+    </message>
+    <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">Zapi&amp;sz Obraz...</translation>
     </message>
     <message>
         <source>Payment information</source>
@@ -2684,7 +3313,7 @@ Podpisywanie jest możliwe tylko z adresami typu 'legacy'.</translation>
     </message>
     <message>
         <source>Change:</source>
-        <translation type="unfinished">Reszta:</translation>
+        <translation type="unfinished">Zmiana:</translation>
     </message>
     <message>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
@@ -2736,12 +3365,28 @@ Korzystanie z opłaty domyślnej może skutkować wysłaniem transakcji, która 
         <translation type="unfinished">Wyczyść wszystkie pola formularza.</translation>
     </message>
     <message>
+        <source>Inputs…</source>
+        <translation type="unfinished">Wejścia…</translation>
+    </message>
+    <message>
         <source>Dust:</source>
         <translation type="unfinished">Pył:</translation>
     </message>
     <message>
+        <source>Choose…</source>
+        <translation type="unfinished">Wybierz...</translation>
+    </message>
+    <message>
         <source>Hide transaction fee settings</source>
         <translation type="unfinished">Ukryj ustawienia opłat transakcyjnych</translation>
+    </message>
+    <message>
+        <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
+
+Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satoshis per kvB" for a transaction size of 500 virtual bytes (half of 1 kvB) would ultimately yield a fee of only 50 satoshis.</source>
+        <translation type="unfinished">Określ niestandardową opłatę za kB (1000 bajtów) wirtualnego rozmiaru transakcji.
+
+Uwaga: Ponieważ opłata jest naliczana za każdy bajt, opłata "100 satoshi za kB" w przypadku transakcji o wielkości 500 bajtów (połowa 1 kB) ostatecznie da opłatę w wysokości tylko 50 satoshi.</translation>
     </message>
     <message>
         <source>When there is less transaction volume than space in the blocks, miners as well as relaying nodes may enforce a minimum fee. Paying only this minimum fee is just fine, but be aware that this can result in a never confirming transaction once there is more demand for bitcoin transactions than the network can process.</source>
@@ -2750,6 +3395,10 @@ Korzystanie z opłaty domyślnej może skutkować wysłaniem transakcji, która 
     <message>
         <source>A too low fee might result in a never confirming transaction (read the tooltip)</source>
         <translation type="unfinished">Zbyt niska opłata może spowodować, że transakcja nigdy nie zostanie zatwierdzona (przeczytaj podpowiedź)</translation>
+    </message>
+    <message>
+        <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
+        <translation type="unfinished">(Sprytne opłaty nie są jeszcze zainicjowane. Trwa to zwykle kilka bloków...)</translation>
     </message>
     <message>
         <source>Confirmation time target:</source>
@@ -2785,7 +3434,7 @@ Korzystanie z opłaty domyślnej może skutkować wysłaniem transakcji, która 
     </message>
     <message>
         <source>Copy amount</source>
-        <translation type="unfinished">Kopiuj kwotę</translation>
+        <translation type="unfinished">Kopiuj kwote</translation>
     </message>
     <message>
         <source>Copy fee</source>
@@ -2809,7 +3458,21 @@ Korzystanie z opłaty domyślnej może skutkować wysłaniem transakcji, która 
     </message>
     <message>
         <source>%1 (%2 blocks)</source>
-        <translation type="unfinished">%1 (%2 bloków)</translation>
+        <translation type="unfinished">%1 (%2 bloków)github.com </translation>
+    </message>
+    <message>
+        <source>Sign on device</source>
+        <extracomment>"device" usually means a hardware wallet.</extracomment>
+        <translation type="unfinished">Podpisz na urządzeniu</translation>
+    </message>
+    <message>
+        <source>Connect your hardware wallet first.</source>
+        <translation type="unfinished">Najpierw podłącz swój sprzętowy portfel.</translation>
+    </message>
+    <message>
+        <source>Set external signer script path in Options -&gt; Wallet</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Ustaw ścieżkę zewnętrznego skryptu podpisującego w Opcje -&gt; Portfel</translation>
     </message>
     <message>
         <source>Cr&amp;eate Unsigned</source>
@@ -2825,23 +3488,46 @@ Korzystanie z opłaty domyślnej może skutkować wysłaniem transakcji, która 
     </message>
     <message>
         <source>%1 to '%2'</source>
-        <translation type="unfinished">%1 do '%2'</translation>
+        <translation type="unfinished">%1 do '%2'8f0451c0-ec7d-4357-a370-eff72fb0685f</translation>
     </message>
     <message>
         <source>%1 to %2</source>
         <translation type="unfinished">%1 do %2</translation>
     </message>
     <message>
+        <source>To review recipient list click "Show Details…"</source>
+        <translation type="unfinished">Aby przejrzeć listę odbiorców kliknij "Pokaż szczegóły..."</translation>
+    </message>
+    <message>
         <source>Sign failed</source>
         <translation type="unfinished">Podpisywanie nie powiodło się.</translation>
+    </message>
+    <message>
+        <source>External signer not found</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Nie znaleziono zewnętrznego sygnatariusza </translation>
+    </message>
+    <message>
+        <source>External signer failure</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Błąd zewnętrznego sygnatariusza </translation>
     </message>
     <message>
         <source>Save Transaction Data</source>
         <translation type="unfinished">Zapisz dane transakcji</translation>
     </message>
     <message>
+        <source>Partially Signed Transaction (Binary)</source>
+        <extracomment>Expanded name of the binary PSBT file format. See: BIP 174.</extracomment>
+        <translation type="unfinished">Częściowo podpisana transakcja (binarna)</translation>
+    </message>
+    <message>
         <source>PSBT saved</source>
         <translation type="unfinished">Zapisano PSBT</translation>
+    </message>
+    <message>
+        <source>External balance:</source>
+        <translation type="unfinished">Zewnętrzny balans:</translation>
     </message>
     <message>
         <source>or</source>
@@ -2854,6 +3540,16 @@ Korzystanie z opłaty domyślnej może skutkować wysłaniem transakcji, która 
     <message>
         <source>Please, review your transaction proposal. This will produce a Partially Signed Bitcoin Transaction (PSBT) which you can save or copy and then sign with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
         <extracomment>Text to inform a user attempting to create a transaction of their current options. At this stage, a user can only create a PSBT. This string is displayed when private keys are disabled and an external signer is not available.</extracomment>
+        <translation type="unfinished">Proszę przejrzeć propozycję transakcji. Zostanie utworzona częściowo podpisana transakcja (ang. PSBT), którą można skopiować, a następnie podpisać np. offline z portfelem %1 lub z innym portfelem zgodnym z PSBT.</translation>
+    </message>
+    <message>
+        <source>Do you want to create this transaction?</source>
+        <extracomment>Message displayed when attempting to create a transaction. Cautionary text to prompt the user to verify that the displayed transaction details represent the transaction the user intends to create.</extracomment>
+        <translation type="unfinished">Czy chcesz utworzyć tę transakcję?</translation>
+    </message>
+    <message>
+        <source>Please, review your transaction. You can create and send this transaction or create a Partially Signed Bitcoin Transaction (PSBT), which you can save or copy and then sign with, e.g., an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
+        <extracomment>Text to inform a user attempting to create a transaction of their current options. At this stage, a user can send their transaction or create a PSBT. This string is displayed when both private keys and PSBT controls are enabled.</extracomment>
         <translation type="unfinished">Proszę przejrzeć propozycję transakcji. Zostanie utworzona częściowo podpisana transakcja (ang. PSBT), którą można skopiować, a następnie podpisać np. offline z portfelem %1 lub z innym portfelem zgodnym z PSBT.</translation>
     </message>
     <message>
@@ -2909,16 +3605,12 @@ Korzystanie z opłaty domyślnej może skutkować wysłaniem transakcji, która 
         <source>A fee higher than %1 is considered an absurdly high fee.</source>
         <translation type="unfinished">Opłata wyższa niż %1 jest uznawana za absurdalnie dużą.</translation>
     </message>
-    <message>
-        <source>Payment request expired.</source>
-        <translation type="unfinished">Żądanie płatności upłynęło.</translation>
-    </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>Szacuje się, że potwierdzenie rozpocznie się w %n bloku.</numerusform>
+            <numerusform>Szacuje się, że potwierdzenie rozpocznie się w %n bloków.</numerusform>
+            <numerusform>Szacuje się, że potwierdzenie rozpocznie się w %n bloków.</numerusform>
         </translation>
     </message>
     <message>
@@ -2993,28 +3685,12 @@ Korzystanie z opłaty domyślnej może skutkować wysłaniem transakcji, która 
         <translation type="unfinished">Wiadomość:</translation>
     </message>
     <message>
-        <source>This is an unauthenticated payment request.</source>
-        <translation type="unfinished">To żądanie zapłaty nie zostało zweryfikowane.</translation>
-    </message>
-    <message>
-        <source>This is an authenticated payment request.</source>
-        <translation type="unfinished">To żądanie zapłaty jest zweryfikowane.</translation>
-    </message>
-    <message>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished">Wprowadź etykietę dla tego adresu by dodać go do listy użytych adresów</translation>
     </message>
     <message>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished">Wiadomość, która została dołączona do URI bitcoin:, która będzie przechowywana wraz z transakcją w celach informacyjnych. Uwaga: Ta wiadomość nie będzie rozsyłana w sieci Bitcoin.</translation>
-    </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">Wpłać do:</translation>
-    </message>
-    <message>
-        <source>Memo:</source>
-        <translation type="unfinished">Notatka:</translation>
     </message>
 </context>
 <context>
@@ -3178,35 +3854,31 @@ Zwróć uwagę, że poprawnie zweryfikowana wiadomość potwierdza to, że nadaw
         <source>(press q to shutdown and continue later)</source>
         <translation type="unfinished">(naciśnij q by zamknąć i kontynuować póżniej)</translation>
     </message>
-    </context>
+    <message>
+        <source>press q to shutdown</source>
+        <translation type="unfinished">wciśnij q aby wyłączyć</translation>
+    </message>
+</context>
 <context>
     <name>TransactionDesc</name>
     <message>
         <source>conflicted with a transaction with %1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that conflicts with a confirmed transaction.</extracomment>
         <translation type="unfinished">sprzeczny z transakcją posiadającą %1 potwierdzeń</translation>
     </message>
     <message>
-        <source>0/unconfirmed, %1</source>
-        <translation type="unfinished">0/niezatwierdzone, %1</translation>
-    </message>
-    <message>
-        <source>in memory pool</source>
-        <translation type="unfinished">w obszarze pamięci</translation>
-    </message>
-    <message>
-        <source>not in memory pool</source>
-        <translation type="unfinished">nie w obszarze pamięci</translation>
-    </message>
-    <message>
         <source>abandoned</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an abandoned transaction.</extracomment>
         <translation type="unfinished">porzucone</translation>
     </message>
     <message>
         <source>%1/unconfirmed</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
         <translation type="unfinished">%1/niezatwierdzone</translation>
     </message>
     <message>
         <source>%1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
         <translation type="unfinished">%1 potwierdzeń</translation>
     </message>
     <message>
@@ -3507,6 +4179,55 @@ Zwróć uwagę, że poprawnie zweryfikowana wiadomość potwierdza to, że nadaw
         <translation type="unfinished">Minimalna kwota</translation>
     </message>
     <message>
+        <source>Range…</source>
+        <translation type="unfinished">Zakres...</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">Kopiuj adres</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Kopiuj etykietę</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Kopiuj kwotę</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">Skopiuj &amp;ID transakcji</translation>
+    </message>
+    <message>
+        <source>Copy &amp;raw transaction</source>
+        <translation type="unfinished">Kopiuj &amp;raw transakcje</translation>
+    </message>
+    <message>
+        <source>Copy full transaction &amp;details</source>
+        <translation type="unfinished">Skopiuj pełne &amp;detale transakcji</translation>
+    </message>
+    <message>
+        <source>&amp;Show transaction details</source>
+        <translation type="unfinished">Wyświetl &amp;szczegóły transakcji</translation>
+    </message>
+    <message>
+        <source>Increase transaction &amp;fee</source>
+        <translation type="unfinished">Zwiększ opłatę transakcji</translation>
+    </message>
+    <message>
+        <source>A&amp;bandon transaction</source>
+        <translation type="unfinished">Porzuć transakcję</translation>
+    </message>
+    <message>
+        <source>&amp;Edit address label</source>
+        <translation type="unfinished">Wy&amp;edytuj adres etykiety</translation>
+    </message>
+    <message>
+        <source>Show in %1</source>
+        <extracomment>Transactions table context menu action to show the selected transaction in a third-party block explorer. %1 is a stand-in argument for the URL of the explorer.</extracomment>
+        <translation type="unfinished">Wyświetl w %1</translation>
+    </message>
+    <message>
         <source>Export Transaction History</source>
         <translation type="unfinished">Eksport historii transakcji</translation>
     </message>
@@ -3517,7 +4238,7 @@ Zwróć uwagę, że poprawnie zweryfikowana wiadomość potwierdza to, że nadaw
     </message>
     <message>
         <source>Confirmed</source>
-        <translation type="unfinished">Potwierdzony</translation>
+        <translation type="unfinished">Potwerdzone</translation>
     </message>
     <message>
         <source>Watch-only</source>
@@ -3541,7 +4262,7 @@ Zwróć uwagę, że poprawnie zweryfikowana wiadomość potwierdza to, że nadaw
     </message>
     <message>
         <source>Exporting Failed</source>
-        <translation type="unfinished"> Eksportowanie nie powiodło się </translation>
+        <translation type="unfinished">Eksportowanie nie powiodło się </translation>
     </message>
     <message>
         <source>There was an error trying to save the transaction history to %1.</source>
@@ -3635,6 +4356,10 @@ Przejdź do Plik &gt; Otwórz Portfel aby wgrać portfel.
         <translation type="unfinished">Nowa opłata:</translation>
     </message>
     <message>
+        <source>Warning: This may pay the additional fee by reducing change outputs or adding inputs, when necessary. It may add a new change output if one does not already exist. These changes may potentially leak privacy.</source>
+        <translation type="unfinished">Ostrzeżenie: Może to spowodować uiszczenie dodatkowej opłaty poprzez zmniejszenie zmian wyjść lub dodanie danych wejściowych, jeśli jest to konieczne. Może dodać nowe wyjście zmiany, jeśli jeszcze nie istnieje. Te zmiany mogą potencjalnie spowodować utratę prywatności.</translation>
+    </message>
+    <message>
         <source>Confirm fee bump</source>
         <translation type="unfinished">Potwierdź zwiększenie opłaty</translation>
     </message>
@@ -3655,6 +4380,10 @@ Przejdź do Plik &gt; Otwórz Portfel aby wgrać portfel.
         <translation type="unfinished">Nie można zatwierdzić transakcji</translation>
     </message>
     <message>
+        <source>Can't display address</source>
+        <translation type="unfinished">Nie można wyświetlić adresu</translation>
+    </message>
+    <message>
         <source>default wallet</source>
         <translation type="unfinished">domyślny portfel</translation>
     </message>
@@ -3672,6 +4401,11 @@ Przejdź do Plik &gt; Otwórz Portfel aby wgrać portfel.
     <message>
         <source>Backup Wallet</source>
         <translation type="unfinished">Kopia zapasowa portfela</translation>
+    </message>
+    <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">Informacje portfela</translation>
     </message>
     <message>
         <source>Backup Failed</source>

--- a/src/qt/locale/bitcoin_pt.ts
+++ b/src/qt/locale/bitcoin_pt.ts
@@ -165,7 +165,7 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     </message>
     <message>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
-        <translation type="unfinished">Aviso: se encriptar a sua carteira e perder a sua frase de segurnça, &lt;b&gt;PERDERÁ TODOS OS SEUS BITCOINS&lt;/b&gt;!</translation>
+        <translation type="unfinished">Aviso: se encriptar a sua carteira e perder a sua frase de segurança, &lt;b&gt;PERDERÁ TODAS AS SUAS BITCOINS&lt;/b&gt;!</translation>
     </message>
     <message>
         <source>Are you sure you wish to encrypt your wallet?</source>
@@ -245,6 +245,10 @@ Assinar só é possível com endereços do tipo "legado".</translation>
 </context>
 <context>
     <name>BitcoinApplication</name>
+    <message>
+        <source>Settings file %1 might be corrupt or invalid.</source>
+        <translation type="unfinished">O ficheiro de configurações %1 pode estar corrompido ou inválido.</translation>
+    </message>
     <message>
         <source>Runaway exception</source>
         <translation type="unfinished">Exceção de Runaway</translation>
@@ -331,6 +335,11 @@ Assinar só é possível com endereços do tipo "legado".</translation>
         <translation type="unfinished">Retransmissão de Blocos</translation>
     </message>
     <message>
+        <source>Feeler</source>
+        <extracomment>Short-lived peer connection type that tests the aliveness of known addresses.</extracomment>
+        <translation type="unfinished">Antena</translation>
+    </message>
+    <message>
         <source>Address Fetch</source>
         <extracomment>Short-lived peer connection type that solicits known addresses from a peer.</extracomment>
         <translation type="unfinished">Procura de endreços</translation>
@@ -346,36 +355,36 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n segundo</numerusform>
+            <numerusform>%n segundos</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n minute(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n minuto</numerusform>
+            <numerusform>%n minutos</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n hora</numerusform>
+            <numerusform>%n horas</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n dia</numerusform>
+            <numerusform>%n dias</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n semana</numerusform>
+            <numerusform>%n semanas</numerusform>
         </translation>
     </message>
     <message>
@@ -385,8 +394,8 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n ano</numerusform>
+            <numerusform>%n anos </numerusform>
         </translation>
     </message>
     </context>
@@ -431,10 +440,6 @@ Assinar só é possível com endereços do tipo "legado".</translation>
     <message>
         <source>Error: Dumpfile version is not supported. This version of bitcoin-wallet only supports version 1 dumpfiles. Got dumpfile with version %s</source>
         <translation type="unfinished">Erro: Esta versão do bitcoin-wallet apenas suporta arquivos de despejo na versão 1. (Versão atual: %s)</translation>
-    </message>
-    <message>
-        <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
-        <translation type="unfinished">Erro: a escuta de ligações de entrada falhou (escuta devolveu o erro %s)</translation>
     </message>
     <message>
         <source>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.</source>
@@ -630,10 +635,6 @@ deve ser fornecido.</translation>
         <translation type="unfinished">Erro ao ler o registo seguinte da base de dados da carteira</translation>
     </message>
     <message>
-        <source>Error upgrading chainstate database</source>
-        <translation type="unfinished">Erro ao atualizar a base de dados do estado da cadeia (chainstate)</translation>
-    </message>
-    <message>
         <source>Error: Disk space is low for %s</source>
         <translation type="unfinished">Erro: espaço em disco demasiado baixo para %s</translation>
     </message>
@@ -660,6 +661,10 @@ deve ser fornecido.</translation>
     <message>
         <source>Error: Unable to parse version %u as a uint32_t</source>
         <translation type="unfinished">Erro: Não foi possível converter versão %u como uint32_t</translation>
+    </message>
+    <message>
+        <source>Error: Unable to read all records in the database</source>
+        <translation type="unfinished">Error: Não é possivel ler todos os registros no banco de dados</translation>
     </message>
     <message>
         <source>Error: Unable to write record to new wallet</source>
@@ -754,12 +759,16 @@ deve ser fornecido.</translation>
         <translation type="unfinished">A carregar a carteira…</translation>
     </message>
     <message>
+        <source>Missing amount</source>
+        <translation type="unfinished">Falta a quantia</translation>
+    </message>
+    <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
         <translation type="unfinished">Necessário especificar uma porta com -whitebind: '%s'</translation>
     </message>
     <message>
-        <source>No proxy server specified. Use -proxy=&lt;ip&gt; or -proxy=&lt;ip:port&gt;.</source>
-        <translation type="unfinished">Sem servidor de proxy especificado. Use -proxy=&lt;ip&gt; ou -proxy=&lt;ip:port&gt;.</translation>
+        <source>No addresses available</source>
+        <translation type="unfinished">Sem endereços disponíveis</translation>
     </message>
     <message>
         <source>Not enough file descriptors available.</source>
@@ -768,10 +777,6 @@ deve ser fornecido.</translation>
     <message>
         <source>Prune cannot be configured with a negative value.</source>
         <translation type="unfinished">A redução não pode ser configurada com um valor negativo.</translation>
-    </message>
-    <message>
-        <source>Prune mode is incompatible with -coinstatsindex.</source>
-        <translation type="unfinished">Modo de poda é incompatível com -coinstatsindex.</translation>
     </message>
     <message>
         <source>Prune mode is incompatible with -txindex.</source>
@@ -884,6 +889,10 @@ A pasta de blocos especificados "%s" não existe.</translation>
         <translation type="unfinished">A transação dever pelo menos um destinatário</translation>
     </message>
     <message>
+        <source>Transaction needs a change address, but we can't generate it.</source>
+        <translation type="unfinished">Transação precisa de uma mudança de endereço, mas nós não a podemos gerar.</translation>
+    </message>
+    <message>
         <source>Transaction too large</source>
         <translation type="unfinished">Transação grande demais</translation>
     </message>
@@ -938,10 +947,6 @@ A pasta de blocos especificados "%s" não existe.</translation>
     <message>
         <source>Unsupported logging category %s=%s.</source>
         <translation type="unfinished">Categoria de registos desconhecida %s=%s.</translation>
-    </message>
-    <message>
-        <source>Upgrading UTXO database</source>
-        <translation type="unfinished">A atualizar a base de dados UTXO</translation>
     </message>
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
@@ -1162,8 +1167,8 @@ A pasta de blocos especificados "%s" não existe.</translation>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform> %n bloco processado do histórico de transações.</numerusform>
+            <numerusform> %n blocos processados do histórico de transações.</numerusform>
         </translation>
     </message>
     <message>
@@ -1243,6 +1248,16 @@ A pasta de blocos especificados "%s" não existe.</translation>
         <translation type="unfinished">Fechar a carteira</translation>
     </message>
     <message>
+        <source>Restore Wallet…</source>
+        <extracomment>Name of the menu item that restores wallet from a backup file.</extracomment>
+        <translation type="unfinished">Restaurar carteira…</translation>
+    </message>
+    <message>
+        <source>Restore a wallet from a backup file</source>
+        <extracomment>Status tip for Restore Wallet menu item</extracomment>
+        <translation type="unfinished">Restaurar uma carteira a partir de um ficheiro de cópia de segurança</translation>
+    </message>
+    <message>
         <source>Close all wallets</source>
         <translation type="unfinished">Fechar todas carteiras.</translation>
     </message>
@@ -1267,6 +1282,26 @@ A pasta de blocos especificados "%s" não existe.</translation>
         <translation type="unfinished">Sem carteiras disponíveis</translation>
     </message>
     <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">Dados da carteira</translation>
+    </message>
+    <message>
+        <source>Load Wallet Backup</source>
+        <extracomment>The title for Restore Wallet File Windows</extracomment>
+        <translation type="unfinished">Carregar cópia de segurança de carteira</translation>
+    </message>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of pop-up window shown when the user is attempting to restore a wallet.</extracomment>
+        <translation type="unfinished">Restaurar carteira</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">Nome da Carteira</translation>
+    </message>
+    <message>
         <source>&amp;Window</source>
         <translation type="unfinished">&amp;Janela</translation>
     </message>
@@ -1282,12 +1317,20 @@ A pasta de blocos especificados "%s" não existe.</translation>
         <source>%1 client</source>
         <translation type="unfinished">Cliente %1</translation>
     </message>
+    <message>
+        <source>&amp;Hide</source>
+        <translation type="unfinished">Ocultar</translation>
+    </message>
+    <message>
+        <source>S&amp;how</source>
+        <translation type="unfinished">Mo&amp;strar</translation>
+    </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n conexão ativa na rede Bitcoin.</numerusform>
+            <numerusform>%n conexões ativas na rede Bitcoin.</numerusform>
         </translation>
     </message>
     <message>
@@ -1309,6 +1352,10 @@ A pasta de blocos especificados "%s" não existe.</translation>
         <source>Enable network activity</source>
         <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
         <translation type="unfinished">Activar atividade da rede</translation>
+    </message>
+    <message>
+        <source>Pre-syncing Headers (%1%)…</source>
+        <translation type="unfinished">A pré-sincronizar cabeçalhos (%1%)…</translation>
     </message>
     <message>
         <source>Error: %1</source>
@@ -1569,6 +1616,10 @@ A pasta de blocos especificados "%s" não existe.</translation>
         <source>Can't list signers</source>
         <translation type="unfinished">Não é possível listar signatários</translation>
     </message>
+    <message>
+        <source>Too many external signers found</source>
+        <translation type="unfinished">Encontrados demasiados assinantes externos</translation>
+    </message>
 </context>
 <context>
     <name>LoadWalletsActivity</name>
@@ -1606,6 +1657,34 @@ A pasta de blocos especificados "%s" não existe.</translation>
         <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
         <extracomment>Descriptive text of the open wallet progress window which indicates to the user which wallet is currently being opened.</extracomment>
         <translation type="unfinished">A abrir a carteira &lt;b&gt;%1&lt;/b&gt;…</translation>
+    </message>
+</context>
+<context>
+    <name>RestoreWalletActivity</name>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of progress window which is displayed when wallets are being restored.</extracomment>
+        <translation type="unfinished">Restaurar carteira</translation>
+    </message>
+    <message>
+        <source>Restoring Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the restore wallets progress window which indicates to the user that wallets are currently being restored.</extracomment>
+        <translation type="unfinished">A restaurar a carteira &lt;b&gt;%1&lt;/b&gt;…</translation>
+    </message>
+    <message>
+        <source>Restore wallet failed</source>
+        <extracomment>Title of message box which is displayed when the wallet could not be restored.</extracomment>
+        <translation type="unfinished">Falha ao restaurar a carteira</translation>
+    </message>
+    <message>
+        <source>Restore wallet warning</source>
+        <extracomment>Title of message box which is displayed when the wallet is restored with some warning.</extracomment>
+        <translation type="unfinished">Aviso de restaurar carteira</translation>
+    </message>
+    <message>
+        <source>Restore wallet message</source>
+        <extracomment>Title of message box which is displayed when the wallet is successfully restored.</extracomment>
+        <translation type="unfinished">Mensagem de restaurar a carteira</translation>
     </message>
 </context>
 <context>
@@ -1783,13 +1862,26 @@ A pasta de blocos especificados "%s" não existe.</translation>
 </context>
 <context>
     <name>Intro</name>
-    <message>
-        <source>(of %1 GB needed)</source>
-        <translation type="unfinished">(de %1 GB necessários)</translation>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform>%n GB de espaço disponível</numerusform>
+            <numerusform>%n GB de espaço disponível</numerusform>
+        </translation>
     </message>
-    <message>
-        <source>(%1 GB needed for full chain)</source>
-        <translation type="unfinished">(1%1 GB necessários para a blockchain  completa)</translation>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform>(de %n GB necessário)</numerusform>
+            <numerusform>(de %n GB necessários)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform>(%n GB necessário para a cadeia completa)</numerusform>
+            <numerusform>(%n GB necessários para a cadeia completa)</numerusform>
+        </translation>
     </message>
     <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
@@ -1803,8 +1895,8 @@ A pasta de blocos especificados "%s" não existe.</translation>
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>(suficiente para restaurar backups de %n dia atrás)</numerusform>
+            <numerusform>(suficiente para restaurar backups de %n dias atrás)</numerusform>
         </translation>
     </message>
     <message>
@@ -1836,10 +1928,6 @@ A pasta de blocos especificados "%s" não existe.</translation>
         <translation type="unfinished">Sendo esta a primeira vez que o programa é iniciado, poderá escolher onde o %1 irá guardar os seus dados.</translation>
     </message>
     <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation type="unfinished">Quando clicar OK, %1 vai começar a descarregar e processar a cadeia de blocos %4 completa (%2GB) começando com as transações mais antigas em %3 quando a %4 foi inicialmente lançada.</translation>
-    </message>
-    <message>
         <source>Limit block chain storage to</source>
         <translation type="unfinished">Limitar o tamanho da blockchain para</translation>
     </message>
@@ -1850,6 +1938,10 @@ A pasta de blocos especificados "%s" não existe.</translation>
     <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
         <translation type="unfinished">Esta sincronização inicial é muito exigente, e pode expor problemas com o seu computador que previamente podem ter passado despercebidos. Cada vez que corre %1, este vai continuar a descarregar de onde deixou.</translation>
+    </message>
+    <message>
+        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2 GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
+        <translation type="unfinished">Quando clicar em OK, %1 iniciará o download e irá processar a cadeia de blocos completa %4 (%2 GB) iniciando com as transações mais recentes em %3 enquanto %4 é processado. </translation>
     </message>
     <message>
         <source>If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</source>
@@ -1948,6 +2040,10 @@ A pasta de blocos especificados "%s" não existe.</translation>
         <source>Unknown. Syncing Headers (%1, %2%)…</source>
         <translation type="unfinished">Desconhecido. A sincronizar cabeçalhos (%1, %2%)...</translation>
     </message>
+    <message>
+        <source>Unknown. Pre-syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">Desconhecido. Pré-Sincronizando Cabeçalhos (%1, %2%)...</translation>
+    </message>
 </context>
 <context>
     <name>OpenURIDialog</name>
@@ -2004,6 +2100,10 @@ A pasta de blocos especificados "%s" não existe.</translation>
         <translation type="unfinished">Minimize em vez de sair da aplicação quando a janela é fechada. Quando esta opção é ativada, a aplicação apenas será encerrada quando escolher Sair no menu.</translation>
     </message>
     <message>
+        <source>Options set in this dialog are overridden by the command line:</source>
+        <translation type="unfinished">Opções configuradas nessa caixa de diálogo serão sobrescritas pela linhas de comando: </translation>
+    </message>
+    <message>
         <source>Open the %1 configuration file from the working directory.</source>
         <translation type="unfinished">Abrir o ficheiro de configuração %1 da pasta aberta.</translation>
     </message>
@@ -2041,12 +2141,37 @@ A pasta de blocos especificados "%s" não existe.</translation>
         <translation type="unfinished">Tamanho máximo da cache da base de dados. Uma cache maior pode contribuir para uma sincronização mais rápida, a partir do qual os benefícios são menos visíveis. Ao baixar o tamanho da cache irá diminuir a utilização de memória. Memória da mempool não usada será partilhada com esta cache.</translation>
     </message>
     <message>
+        <source>Set the number of script verification threads. Negative values correspond to the number of cores you want to leave free to the system.</source>
+        <extracomment>Tooltip text for Options window setting that sets the number of script verification threads. Explains that negative values mean to leave these many cores free to the system.</extracomment>
+        <translation type="unfinished">Define o número de threads do script de verificação. Valores negativos correspondem ao número de núcleos que deseja deixar livres para o sistema.</translation>
+    </message>
+    <message>
         <source>(0 = auto, &lt;0 = leave that many cores free)</source>
         <translation type="unfinished">(0 = automático, &lt;0 = deixar essa quantidade de núcleos livre)</translation>
     </message>
     <message>
+        <source>This allows you or a third party tool to communicate with the node through command-line and JSON-RPC commands.</source>
+        <extracomment>Tooltip text for Options window setting that enables the RPC server.</extracomment>
+        <translation type="unfinished">Isto permite-lhe comunicar a si ou a ferramentas de terceiros com o nó através da linha de comandos e comandos JSON-RPC.</translation>
+    </message>
+    <message>
+        <source>Enable R&amp;PC server</source>
+        <extracomment>An Options window setting to enable the RPC server.</extracomment>
+        <translation type="unfinished">Ativar servidor R&amp;PC</translation>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished">C&amp;arteira</translation>
+    </message>
+    <message>
+        <source>Whether to set subtract fee from amount as default or not.</source>
+        <extracomment>Tooltip text for Options window setting that sets subtracting the fee from a sending amount as default.</extracomment>
+        <translation type="unfinished">Mostrar a quantia com a taxa já subtraída, por padrão.</translation>
+    </message>
+    <message>
+        <source>Subtract &amp;fee from amount by default</source>
+        <extracomment>An Options window setting to set subtracting the fee from a sending amount as default.</extracomment>
+        <translation type="unfinished">Subtrair &amp;taxa da quantia por padrão</translation>
     </message>
     <message>
         <source>Expert</source>
@@ -2063,6 +2188,16 @@ A pasta de blocos especificados "%s" não existe.</translation>
     <message>
         <source>&amp;Spend unconfirmed change</source>
         <translation type="unfinished">&amp;Gastar troco não confirmado</translation>
+    </message>
+    <message>
+        <source>Enable &amp;PSBT controls</source>
+        <extracomment>An options window setting to enable PSBT controls.</extracomment>
+        <translation type="unfinished">Ativar os controlos &amp;PSBT</translation>
+    </message>
+    <message>
+        <source>Whether to show PSBT controls.</source>
+        <extracomment>Tooltip text for options window setting that enables PSBT controls.</extracomment>
+        <translation type="unfinished">Mostrar os controlos PSBT.</translation>
     </message>
     <message>
         <source>External Signer (e.g. hardware wallet)</source>
@@ -2083,6 +2218,10 @@ A pasta de blocos especificados "%s" não existe.</translation>
     <message>
         <source>Map port using &amp;UPnP</source>
         <translation type="unfinished">Mapear porta usando &amp;UPnP</translation>
+    </message>
+    <message>
+        <source>Automatically open the Bitcoin client port on the router. This only works when your router supports NAT-PMP and it is enabled. The external port could be random.</source>
+        <translation type="unfinished">Abrir a porta do cliente bitcoin automaticamente no seu router. Isto só funciona se o seu router suportar NAT-PMP e este se encontrar ligado. A porta externa poderá ser aleatória.</translation>
     </message>
     <message>
         <source>Map port using NA&amp;T-PMP</source>
@@ -2165,6 +2304,14 @@ A pasta de blocos especificados "%s" não existe.</translation>
         <translation type="unfinished">Escolha a unidade da subdivisão predefinida para ser mostrada na interface e quando enviar as moedas.</translation>
     </message>
     <message>
+        <source>Third-party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</source>
+        <translation type="unfinished">URLs de outrem (ex. um explorador de blocos) que aparece no separador de transações como itens do menu de contexto. %s do URL é substituído pela hash de transação. Múltiplos URLs são separados pela barra vertical I.</translation>
+    </message>
+    <message>
+        <source>&amp;Third-party transaction URLs</source>
+        <translation type="unfinished">URLs de transação de &amp;terceiros</translation>
+    </message>
+    <message>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished">Escolha se deve mostrar as funcionalidades de controlo de moedas ou não.</translation>
     </message>
@@ -2181,8 +2328,12 @@ A pasta de blocos especificados "%s" não existe.</translation>
         <translation type="unfinished">Fonte no painel de visualização:</translation>
     </message>
     <message>
-        <source>Options set in this dialog are overridden by the command line or in the configuration file:</source>
-        <translation type="unfinished">As opções nesta janela são substituídas pela linha de comandos ou no ficheiro de configuração:</translation>
+        <source>embedded "%1"</source>
+        <translation type="unfinished">embutido "%1"</translation>
+    </message>
+    <message>
+        <source>closest matching "%1"</source>
+        <translation type="unfinished">resultado mais aproximado "%1"</translation>
     </message>
     <message>
         <source>&amp;Cancel</source>
@@ -2203,14 +2354,22 @@ A pasta de blocos especificados "%s" não existe.</translation>
     </message>
     <message>
         <source>Confirm options reset</source>
+        <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
         <translation type="unfinished">Confirme a reposição das opções</translation>
     </message>
     <message>
         <source>Client restart required to activate changes.</source>
+        <extracomment>Text explaining that the settings changed will not come into effect until the client is restarted.</extracomment>
         <translation type="unfinished">É necessário reiniciar o cliente para ativar as alterações.</translation>
     </message>
     <message>
+        <source>Current settings will be backed up at "%1".</source>
+        <extracomment>Text explaining to the user that the client's current settings will be backed up at a specific location. %1 is a stand-in argument for the backup location's path.</extracomment>
+        <translation type="unfinished">Configuração atuais serão copiadas em "%1".</translation>
+    </message>
+    <message>
         <source>Client will be shut down. Do you want to proceed?</source>
+        <extracomment>Text asking the user to confirm if they would like to proceed with a client shutdown.</extracomment>
         <translation type="unfinished">O cliente será desligado. Deseja continuar?</translation>
     </message>
     <message>
@@ -2222,6 +2381,10 @@ A pasta de blocos especificados "%s" não existe.</translation>
         <source>The configuration file is used to specify advanced user options which override GUI settings. Additionally, any command-line options will override this configuration file.</source>
         <extracomment>Explanatory text about the priority order of instructions considered by client. The order from high to low being: command-line, configuration file, GUI settings.</extracomment>
         <translation type="unfinished">O ficheiro de configuração é usado para especificar opções de utilizador avançado, que sobrescrevem as configurações do interface gráfico. Adicionalmente, qualquer opção da linha de comandos vai sobrescrever este ficheiro de configuração.</translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation type="unfinished">Continuar</translation>
     </message>
     <message>
         <source>Cancel</source>
@@ -2242,6 +2405,13 @@ A pasta de blocos especificados "%s" não existe.</translation>
     <message>
         <source>The supplied proxy address is invalid.</source>
         <translation type="unfinished">O endereço de proxy introduzido é inválido.</translation>
+    </message>
+</context>
+<context>
+    <name>OptionsModel</name>
+    <message>
+        <source>Could not read setting "%1", %2.</source>
+        <translation type="unfinished">Não foi possível ler as configurações "%1", %2.</translation>
     </message>
 </context>
 <context>
@@ -2354,6 +2524,10 @@ A pasta de blocos especificados "%s" não existe.</translation>
         <translation type="unfinished">Falha ao assinar transação: %1</translation>
     </message>
     <message>
+        <source>Cannot sign inputs while wallet is locked.</source>
+        <translation type="unfinished">Não é possível assinar entradas enquanto a carteira está trancada.</translation>
+    </message>
+    <message>
         <source>Could not sign any more inputs.</source>
         <translation type="unfinished">Não pode assinar mais nenhuma entrada.</translation>
     </message>
@@ -2428,6 +2602,10 @@ ID transação: %1</translation>
         <translation type="unfinished">Transação continua precisando de assinatura(s).</translation>
     </message>
     <message>
+        <source>(But no wallet is loaded.)</source>
+        <translation type="unfinished">(Mas nenhuma carteira está carregada)</translation>
+    </message>
+    <message>
         <source>(But this wallet cannot sign transactions.)</source>
         <translation type="unfinished">(Porém esta carteira não pode assinar transações.)</translation>
     </message>
@@ -2463,6 +2641,14 @@ ID transação: %1</translation>
         <translation type="unfinished">'bitcoin://' não é um URI válido. Utilize 'bitcoin:'.</translation>
     </message>
     <message>
+        <source>Cannot process payment request because BIP70 is not supported.
+Due to widespread security flaws in BIP70 it's strongly recommended that any merchant instructions to switch wallets be ignored.
+If you are receiving this error you should request the merchant provide a BIP21 compatible URI.</source>
+        <translation type="unfinished">Não é possível processar o pagamento pedido porque o BIP70 não é suportado.
+Devido a falhas de segurança no BIP70, é recomendado que todas as instruçōes ao comerciante para mudar de carteiras sejam ignorada.
+Se está a receber este erro, deverá pedir ao comerciante para fornecer um URI compatível com BIP21.</translation>
+    </message>
+    <message>
         <source>URI cannot be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation type="unfinished">URI não foi lido corretamente! Isto pode ser causado por um endereço Bitcoin inválido ou por parâmetros URI malformados.</translation>
     </message>
@@ -2482,6 +2668,11 @@ ID transação: %1</translation>
         <source>Peer</source>
         <extracomment>Title of Peers Table column which contains a unique number used to identify a connection.</extracomment>
         <translation type="unfinished">Par</translation>
+    </message>
+    <message>
+        <source>Age</source>
+        <extracomment>Title of Peers Table column which indicates the duration (length of time) since the peer connection started.</extracomment>
+        <translation type="unfinished">idade</translation>
     </message>
     <message>
         <source>Direction</source>
@@ -2663,12 +2854,46 @@ ID transação: %1</translation>
         <translation type="unfinished">Blocos Sincronizados</translation>
     </message>
     <message>
+        <source>Last Transaction</source>
+        <translation type="unfinished">Última Transação</translation>
+    </message>
+    <message>
         <source>The mapped Autonomous System used for diversifying peer selection.</source>
         <translation type="unfinished">O sistema autónomo mapeado usado para diversificar a seleção de pares.</translation>
     </message>
     <message>
         <source>Mapped AS</source>
         <translation type="unfinished">Mapeado como</translation>
+    </message>
+    <message>
+        <source>Whether we relay addresses to this peer.</source>
+        <extracomment>Tooltip text for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
+        <translation type="unfinished">Endereços são retransmitidos para este nó.</translation>
+    </message>
+    <message>
+        <source>Address Relay</source>
+        <extracomment>Text title for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
+        <translation type="unfinished">Retransmissão de endereços</translation>
+    </message>
+    <message>
+        <source>The total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</source>
+        <extracomment>Tooltip text for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
+        <translation type="unfinished">O número total de endereços recebidos deste peer que foram processados (exclui endereços que foram descartados devido à limitação de taxa).</translation>
+    </message>
+    <message>
+        <source>The total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</source>
+        <extracomment>Tooltip text for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
+        <translation type="unfinished">O número total de endereços recebidos deste peer que não foram processados devido à limitação da taxa.</translation>
+    </message>
+    <message>
+        <source>Addresses Processed</source>
+        <extracomment>Text title for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
+        <translation type="unfinished">Endereços Processados</translation>
+    </message>
+    <message>
+        <source>Addresses Rate-Limited</source>
+        <extracomment>Text title for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
+        <translation type="unfinished">Endereços com limite de taxa</translation>
     </message>
     <message>
         <source>Node window</source>
@@ -2840,6 +3065,11 @@ ID transação: %1</translation>
     <message>
         <source>1 &amp;year</source>
         <translation type="unfinished">1 &amp;ano</translation>
+    </message>
+    <message>
+        <source>&amp;Copy IP/Netmask</source>
+        <extracomment>Context menu action to copy the IP/Netmask of a banned peer. IP/Netmask is the combination of a peer's IP address and its Netmask. For IP address, see: https://en.wikipedia.org/wiki/IP_address.</extracomment>
+        <translation type="unfinished">&amp;Copiar IP/Netmask</translation>
     </message>
     <message>
         <source>&amp;Unban</source>
@@ -3200,6 +3430,14 @@ Para mais informação acerca da utilização desta consola, escreva %6.
         <translation type="unfinished">Esconder configurações de taxas de transação</translation>
     </message>
     <message>
+        <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
+
+Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satoshis per kvB" for a transaction size of 500 virtual bytes (half of 1 kvB) would ultimately yield a fee of only 50 satoshis.</source>
+        <translation type="unfinished">Especifique uma taxa personalizada por kB (1.000 bytes) do tamanho virtual da transação.
+
+Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para um tamanho de transação de 500 bytes virtuais (metade de 1 kvB) resultaria em uma taxa de apenas 50 satoshis.</translation>
+    </message>
+    <message>
         <source>When there is less transaction volume than space in the blocks, miners as well as relaying nodes may enforce a minimum fee. Paying only this minimum fee is just fine, but be aware that this can result in a never confirming transaction once there is more demand for bitcoin transactions than the network can process.</source>
         <translation type="unfinished">Quando o volume de transações é maior que o espaço nos blocos, os mineradores, bem como os nós de retransmissão, podem impor uma taxa mínima. Pagar apenas esta taxa mínima é muito bom, mas esteja ciente que isso pode resultar numa transação nunca confirmada, uma vez que há mais pedidos para transações do que a rede pode processar.</translation>
     </message>
@@ -3245,7 +3483,7 @@ Para mais informação acerca da utilização desta consola, escreva %6.
     </message>
     <message>
         <source>Copy amount</source>
-        <translation type="unfinished">Copiar quantia</translation>
+        <translation type="unfinished">Copiar valor</translation>
     </message>
     <message>
         <source>Copy fee</source>
@@ -3279,6 +3517,11 @@ Para mais informação acerca da utilização desta consola, escreva %6.
     <message>
         <source>Connect your hardware wallet first.</source>
         <translation type="unfinished">Por favor conecte a sua wallet física primeiro.</translation>
+    </message>
+    <message>
+        <source>Set external signer script path in Options -&gt; Wallet</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Defina o caminho do script do assinante externo em Opções -&gt; Carteira</translation>
     </message>
     <message>
         <source>Cr&amp;eate Unsigned</source>
@@ -3349,6 +3592,16 @@ Para mais informação acerca da utilização desta consola, escreva %6.
         <translation type="unfinished">Por favor, reveja sua proposta de transação. Isto irá produzir uma Transação de Bitcoin parcialmente assinada (PSBT, sigla em inglês) a qual você pode salvar ou copiar e então assinar com por exemplo uma carteira %1 offiline ou uma PSBT compatível com carteira de hardware.</translation>
     </message>
     <message>
+        <source>Do you want to create this transaction?</source>
+        <extracomment>Message displayed when attempting to create a transaction. Cautionary text to prompt the user to verify that the displayed transaction details represent the transaction the user intends to create.</extracomment>
+        <translation type="unfinished">Deseja criar esta transação?</translation>
+    </message>
+    <message>
+        <source>Please, review your transaction. You can create and send this transaction or create a Partially Signed Bitcoin Transaction (PSBT), which you can save or copy and then sign with, e.g., an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
+        <extracomment>Text to inform a user attempting to create a transaction of their current options. At this stage, a user can send their transaction or create a PSBT. This string is displayed when both private keys and PSBT controls are enabled.</extracomment>
+        <translation type="unfinished">Por favor, revise sua transação. Você pode assinar e enviar a transação ou criar uma Transação de Bitcoin Parcialmente Assinada (PSBT), que você pode copiar e assinar com, por exemplo, uma carteira %1 offline ou uma carteira física compatível com PSBT.</translation>
+    </message>
+    <message>
         <source>Please, review your transaction.</source>
         <extracomment>Text to prompt a user to review the details of the transaction they are attempting to send.</extracomment>
         <translation type="unfinished">Por favor, reveja a sua transação.</translation>
@@ -3401,15 +3654,11 @@ Para mais informação acerca da utilização desta consola, escreva %6.
         <source>A fee higher than %1 is considered an absurdly high fee.</source>
         <translation type="unfinished">Uma taxa superior a %1 é considerada uma taxa altamente absurda.</translation>
     </message>
-    <message>
-        <source>Payment request expired.</source>
-        <translation type="unfinished">Pedido de pagamento expirado.</translation>
-    </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>Confirmação estimada para iniciar em %n bloco.</numerusform>
+            <numerusform>Confirmação estimada para iniciar em %n blocos.</numerusform>
         </translation>
     </message>
     <message>
@@ -3484,28 +3733,12 @@ Para mais informação acerca da utilização desta consola, escreva %6.
         <translation type="unfinished">Mensagem:</translation>
     </message>
     <message>
-        <source>This is an unauthenticated payment request.</source>
-        <translation type="unfinished">Pedido de pagamento não autenticado.</translation>
-    </message>
-    <message>
-        <source>This is an authenticated payment request.</source>
-        <translation type="unfinished">Pedido de pagamento autenticado.</translation>
-    </message>
-    <message>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished">Introduza uma etiqueta para este endereço para o adicionar à sua lista de endereços usados</translation>
     </message>
     <message>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished">Uma mensagem que estava anexada ao URI bitcoin: que será armazenada com a transação para sua referência. Nota: Esta mensagem não será enviada através da rede Bitcoin.</translation>
-    </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">Pagar a:</translation>
-    </message>
-    <message>
-        <source>Memo:</source>
-        <translation type="unfinished">Memorando:</translation>
     </message>
 </context>
 <context>
@@ -3663,33 +3896,46 @@ Para mais informação acerca da utilização desta consola, escreva %6.
     </message>
 </context>
 <context>
+    <name>SplashScreen</name>
+    <message>
+        <source>(press q to shutdown and continue later)</source>
+        <translation type="unfinished">(tecle q para desligar e continuar mais tarde)</translation>
+    </message>
+    <message>
+        <source>press q to shutdown</source>
+        <translation type="unfinished">Carregue q para desligar</translation>
+    </message>
+</context>
+<context>
     <name>TransactionDesc</name>
     <message>
         <source>conflicted with a transaction with %1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that conflicts with a confirmed transaction.</extracomment>
         <translation type="unfinished">incompatível com uma transação com %1 confirmações</translation>
     </message>
     <message>
-        <source>0/unconfirmed, %1</source>
-        <translation type="unfinished">0/não confirmada, %1</translation>
+        <source>0/unconfirmed, in memory pool</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is in the memory pool.</extracomment>
+        <translation type="unfinished">0/não confirmada, no memory pool</translation>
     </message>
     <message>
-        <source>in memory pool</source>
-        <translation type="unfinished">no banco de memória</translation>
-    </message>
-    <message>
-        <source>not in memory pool</source>
-        <translation type="unfinished">não está no banco de memória</translation>
+        <source>0/unconfirmed, not in memory pool</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is not in the memory pool.</extracomment>
+        <translation type="unfinished">0/não confirmada, ausente no memory pool</translation>
     </message>
     <message>
         <source>abandoned</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an abandoned transaction.</extracomment>
         <translation type="unfinished">abandonada</translation>
     </message>
     <message>
         <source>%1/unconfirmed</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
         <translation type="unfinished">%1/não confirmada</translation>
     </message>
     <message>
         <source>%1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
         <translation type="unfinished">%1 confirmações</translation>
     </message>
     <message>
@@ -3739,8 +3985,8 @@ Para mais informação acerca da utilização desta consola, escreva %6.
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>pronta em mais %n bloco</numerusform>
+            <numerusform>prontas em mais %n blocos</numerusform>
         </translation>
     </message>
     <message>
@@ -4013,8 +4259,33 @@ Para mais informação acerca da utilização desta consola, escreva %6.
         <translation type="unfinished">Copiar Id. da transação</translation>
     </message>
     <message>
+        <source>Copy &amp;raw transaction</source>
+        <translation type="unfinished">Copiar &amp;transação bruta</translation>
+    </message>
+    <message>
+        <source>Copy full transaction &amp;details</source>
+        <translation type="unfinished">Copie toda a transação &amp;details</translation>
+    </message>
+    <message>
+        <source>&amp;Show transaction details</source>
+        <translation type="unfinished">Mo&amp;strar detalhes da transação</translation>
+    </message>
+    <message>
+        <source>Increase transaction &amp;fee</source>
+        <translation type="unfinished">Aumentar &amp;taxa da transação</translation>
+    </message>
+    <message>
+        <source>A&amp;bandon transaction</source>
+        <translation type="unfinished">A&amp;bandonar transação</translation>
+    </message>
+    <message>
         <source>&amp;Edit address label</source>
         <translation type="unfinished">&amp;Editar etiqueta do endereço</translation>
+    </message>
+    <message>
+        <source>Show in %1</source>
+        <extracomment>Transactions table context menu action to show the selected transaction in a third-party block explorer. %1 is a stand-in argument for the URL of the explorer.</extracomment>
+        <translation type="unfinished">Mostrar em %1</translation>
     </message>
     <message>
         <source>Export Transaction History</source>

--- a/src/qt/locale/bitcoin_pt_BR.ts
+++ b/src/qt/locale/bitcoin_pt_BR.ts
@@ -3,7 +3,7 @@
     <name>AddressBookPage</name>
     <message>
         <source>Right-click to edit address or label</source>
-        <translation type="unfinished">Clique com o botão direito para editar endereço ou etiqueta</translation>
+        <translation type="unfinished">Clique com o botão direito para editar o endereço ou a etiqueta</translation>
     </message>
     <message>
         <source>Create a new address</source>
@@ -35,7 +35,7 @@
     </message>
     <message>
         <source>Export the data in the current tab to a file</source>
-        <translation type="unfinished">Exportar os dados do separador atual para um ficheiro</translation>
+        <translation type="unfinished">Exportar os dados do separador atual para um arquivo</translation>
     </message>
     <message>
         <source>&amp;Export</source>
@@ -43,7 +43,7 @@
     </message>
     <message>
         <source>&amp;Delete</source>
-        <translation type="unfinished">&amp;Excluir</translation>
+        <translation type="unfinished">E&amp;xcluir</translation>
     </message>
     <message>
         <source>Choose the address to send coins to</source>
@@ -246,6 +246,10 @@ Somente é possível assinar com endereços do tipo 'legado'.</translation>
 <context>
     <name>BitcoinApplication</name>
     <message>
+        <source>Settings file %1 might be corrupt or invalid.</source>
+        <translation type="unfinished">Arquivos de configurações %1 podem estar corrompidos ou inválidos</translation>
+    </message>
+    <message>
         <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
         <translation type="unfinished">Aconteceu um erro fatal. %1 não pode continuar com segurança e será fechado.</translation>
     </message>
@@ -295,6 +299,10 @@ Somente é possível assinar com endereços do tipo 'legado'.</translation>
         <translation type="unfinished">Informe um endereço Bitcoin (ex: %1)</translation>
     </message>
     <message>
+        <source>Ctrl+W</source>
+        <translation type="unfinished">Control+W</translation>
+    </message>
+    <message>
         <source>Inbound</source>
         <extracomment>An inbound connection from a peer. An inbound connection is a connection initiated by a peer.</extracomment>
         <translation type="unfinished">Entrada</translation>
@@ -311,36 +319,36 @@ Somente é possível assinar com endereços do tipo 'legado'.</translation>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n segundo</numerusform>
+            <numerusform>%n segundos</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n minute(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n minuto</numerusform>
+            <numerusform>%n minutos</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n hora</numerusform>
+            <numerusform>%n horas</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n dia</numerusform>
+            <numerusform>%n dias</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n semana</numerusform>
+            <numerusform>%n semanas</numerusform>
         </translation>
     </message>
     <message>
@@ -350,8 +358,8 @@ Somente é possível assinar com endereços do tipo 'legado'.</translation>
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n ano</numerusform>
+            <numerusform>%nanos </numerusform>
         </translation>
     </message>
     </context>
@@ -390,8 +398,8 @@ Somente é possível assinar com endereços do tipo 'legado'.</translation>
         <translation type="unfinished">Erro ao ler arquivo %s! Todas as chaves privadas foram lidas corretamente, mas os dados de transação ou o livro de endereços podem estar faltando ou incorretos.</translation>
     </message>
     <message>
-        <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
-        <translation type="unfinished">Erro: A escuta de conexões de entrada falhou (vincular retornou erro %s)</translation>
+        <source>Error reading %s! Transaction data may be missing or incorrect. Rescanning wallet.</source>
+        <translation type="unfinished">Erro ao ler %s! Dados de transações podem estar incorretos ou faltando. Reescaneando a carteira.</translation>
     </message>
     <message>
         <source>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.</source>
@@ -400,6 +408,10 @@ Somente é possível assinar com endereços do tipo 'legado'.</translation>
     <message>
         <source>Invalid amount for -maxtxfee=&lt;amount&gt;: '%s' (must be at least the minrelay fee of %s to prevent stuck transactions)</source>
         <translation type="unfinished">Valor inválido para -maxtxfee=&lt;valor&gt;: '%s' (precisa ser pelo menos a taxa de minrelay de %s para prevenir que a transação nunca seja confirmada)</translation>
+    </message>
+    <message>
+        <source>Invalid or corrupt peers.dat (%s). If you believe this is a bug, please report it to %s. As a workaround, you can move the file (%s) out of the way (rename, move, or delete) to have a new one created on the next start.</source>
+        <translation type="unfinished">O arquivo peers.dat (%s) está corrompido ou inválido. Se você acredita se tratar de um bug, por favor reporte para %s. Como solução, você pode mover, renomear ou deletar (%s) para um novo ser criado na próxima inicialização</translation>
     </message>
     <message>
         <source>More than one onion bind address is provided. Using %s for the automatically created Tor onion service.</source>
@@ -418,6 +430,10 @@ Somente é possível assinar com endereços do tipo 'legado'.</translation>
         <translation type="unfinished">Configuração de prune abaixo do mínimo de %d MiB.Por gentileza use um número mais alto.</translation>
     </message>
     <message>
+        <source>Prune mode is incompatible with -reindex-chainstate. Use full -reindex instead.</source>
+        <translation type="unfinished">O modo Prune é incompatível com a opção "-reindex-chainstate". Ao invés disso utilize "-reindex".</translation>
+    </message>
+    <message>
         <source>Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of pruned node)</source>
         <translation type="unfinished">Prune: A ultima sincronização da carteira foi além dos dados podados. Você precisa usar -reindex (fazer o download de toda a blockchain novamente no caso de nós com prune)</translation>
     </message>
@@ -428,6 +444,10 @@ Somente é possível assinar com endereços do tipo 'legado'.</translation>
     <message>
         <source>The block database contains a block which appears to be from the future. This may be due to your computer's date and time being set incorrectly. Only rebuild the block database if you are sure that your computer's date and time are correct</source>
         <translation type="unfinished">O banco de dados de blocos contém um bloco que parece ser do futuro. Isso pode ser devido à data e hora do seu computador estarem configuradas incorretamente. Apenas reconstrua o banco de dados de blocos se você estiver certo de que a data e hora de seu computador estão corretas.</translation>
+    </message>
+    <message>
+        <source>The block index db contains a legacy 'txindex'. To clear the occupied disk space, run a full -reindex, otherwise ignore this error. This error message will not be displayed again.</source>
+        <translation type="unfinished">O banco de dados de índices de bloco contém um 'txindex' antigo. Faça um -reindex completo para liberar espaço em disco, se desejar. Este erro não será exibido novamente.</translation>
     </message>
     <message>
         <source>The transaction amount is too small to send after the fee has been deducted</source>
@@ -462,6 +482,14 @@ Somente é possível assinar com endereços do tipo 'legado'.</translation>
         <translation type="unfinished">Não é possível reproduzir blocos. Você precisará reconstruir o banco de dados usando -reindex-chainstate.</translation>
     </message>
     <message>
+        <source>Unsupported chainstate database format found. Please restart with -reindex-chainstate. This will rebuild the chainstate database.</source>
+        <translation type="unfinished">Formato de banco de dados incompatível na chainstate. Por favor reinicie com a opção "-reindex-chainstate". Isto irá recriar o banco de dados da chainstate.</translation>
+    </message>
+    <message>
+        <source>Wallet created successfully. The legacy wallet type is being deprecated and support for creating and opening legacy wallets will be removed in the future.</source>
+        <translation type="unfinished">Carteira criada com sucesso. As carteiras antigas estão sendo descontinuadas e o suporte para a criação de abertura de carteiras antigas será removido no futuro.</translation>
+    </message>
+    <message>
         <source>Warning: Private keys detected in wallet {%s} with disabled private keys</source>
         <translation type="unfinished">Aviso: Chaves privadas detectadas na carteira {%s} com chaves privadas desativadas</translation>
     </message>
@@ -494,12 +522,108 @@ Somente é possível assinar com endereços do tipo 'legado'.</translation>
         <translation type="unfinished">Não foi possível encontrar o endereço de -%s: '%s'</translation>
     </message>
     <message>
+        <source>Cannot set -forcednsseed to true when setting -dnsseed to false.</source>
+        <translation type="unfinished">Não é possível definir -forcednsseed para true quando -dnsseed for false.</translation>
+    </message>
+    <message>
         <source>Cannot set -peerblockfilters without -blockfilterindex.</source>
         <translation type="unfinished">Não pode definir -peerblockfilters sem -blockfilterindex.</translation>
     </message>
     <message>
         <source>Cannot write to data directory '%s'; check permissions.</source>
         <translation type="unfinished">Não foi possível escrever no diretório '%s': verifique as permissões.</translation>
+    </message>
+    <message>
+        <source>The -txindex upgrade started by a previous version cannot be completed. Restart with the previous version or run a full -reindex.</source>
+        <translation type="unfinished">O processo de atualização do -txindex iniciado por uma versão anterior não foi concluído. Reinicie com a versão antiga ou faça um -reindex completo.</translation>
+    </message>
+    <message>
+        <source>%s request to listen on port %u. This port is considered "bad" and thus it is unlikely that any Bitcoin Core peers connect to it. See doc/p2p-bad-ports.md for details and a full list.</source>
+        <translation type="unfinished">%s solicitou abertura da porta %u. Esta porta é considerada "ruim" e é improvável que outros usuários do Bitcoin Core conseguirão se conectar. Veja doc/p2p-bad-ports.md para detalhes e uma lista completa.</translation>
+    </message>
+    <message>
+        <source>-reindex-chainstate option is not compatible with -blockfilterindex. Please temporarily disable blockfilterindex while using -reindex-chainstate, or replace -reindex-chainstate with -reindex to fully rebuild all indexes.</source>
+        <translation type="unfinished">a opção "-reindex-chainstate" não é compatível com "-blockfilterindex". Por favor, desabilite temporariamente a opção "blockfilterindex" enquanto utilizar a opção "-reindex-chainstate", ou troque "-reindex-chainstate" por "-reindex" para recriar completamente todos os índices. </translation>
+    </message>
+    <message>
+        <source>-reindex-chainstate option is not compatible with -coinstatsindex. Please temporarily disable coinstatsindex while using -reindex-chainstate, or replace -reindex-chainstate with -reindex to fully rebuild all indexes.</source>
+        <translation type="unfinished">a opção "-reindex-chainstate" não é compatível com a opção "-coinstatsindex". Por favor desative temporariamente a opção "coinstatsindex" enquanto estiver utilizando "-reindex-chainstate", ou troque "-reindex-chainstate" por "-reindex" para recriar completamente todos os índices.</translation>
+    </message>
+    <message>
+        <source>-reindex-chainstate option is not compatible with -txindex. Please temporarily disable txindex while using -reindex-chainstate, or replace -reindex-chainstate with -reindex to fully rebuild all indexes.</source>
+        <translation type="unfinished">a opção "-reindex-chainstate" não é compatível com a opção "-coinstatsindex". Por favor desative temporariamente a opção "coinstatsindex" enquanto estiver utilizando "-reindex-chainstate", ou troque "-reindex-chainstate" por "-reindex" para recriar completamente todos os índices.</translation>
+    </message>
+    <message>
+        <source>Assumed-valid: last wallet synchronisation goes beyond available block data. You need to wait for the background validation chain to download more blocks.</source>
+        <translation type="unfinished">Assumed-valid: a ultima sincronização da carteira foi além dos blocos de dados disponíveis. Você deve aguardar que a validação em segundo plano baixe mais blocos.  </translation>
+    </message>
+    <message>
+        <source>Cannot provide specific connections and have addrman find outgoing connections at the same time.</source>
+        <translation type="unfinished">Não é possível fornecer conexões específicas e ter addrman procurando conexões ao mesmo tempo.</translation>
+    </message>
+    <message>
+        <source>Error loading %s: External signer wallet being loaded without external signer support compiled</source>
+        <translation type="unfinished">Erro ao abrir %s: Carteira com assinador externo. Não foi compilado suporte para assinadores externos</translation>
+    </message>
+    <message>
+        <source>Error: Address book data in wallet cannot be identified to belong to migrated wallets</source>
+        <translation type="unfinished">Erro: Os dados do livro de endereços da carteira  não puderam ser identificados por pertencerem a carteiras migradas</translation>
+    </message>
+    <message>
+        <source>Error: Duplicate descriptors created during migration. Your wallet may be corrupted.</source>
+        <translation type="unfinished">Erro: Descritores duplicados criados durante a migração. Sua carteira pode estar corrompida.</translation>
+    </message>
+    <message>
+        <source>Error: Transaction %s in wallet cannot be identified to belong to migrated wallets</source>
+        <translation type="unfinished">Erro: A transação %s na carteira não pôde ser identificada por pertencer a carteiras migradas</translation>
+    </message>
+    <message>
+        <source>Error: Unable to produce descriptors for this legacy wallet. Make sure the wallet is unlocked first</source>
+        <translation type="unfinished">Erro: Impossível produzir descritores para esta carteira antiga. Certifique-se que a carteira foi desbloqueada antes</translation>
+    </message>
+    <message>
+        <source>Failed to rename invalid peers.dat file. Please move or delete it and try again.</source>
+        <translation type="unfinished">Impossível renomear o arquivo peers.dat (inválido). Por favor mova-o ou delete-o e tente novamente.</translation>
+    </message>
+    <message>
+        <source>Incompatible options: -dnsseed=1 was explicitly specified, but -onlynet forbids connections to IPv4/IPv6</source>
+        <translation type="unfinished">Opções incompatíveis: "-dnsseed=1" foi explicitamente específicada, mas "-onlynet" proíbe conexões para IPv4/IPv6</translation>
+    </message>
+    <message>
+        <source>Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is explicitly forbidden: -onion=0</source>
+        <translation type="unfinished">As conexões de saída foram restringidas a rede Tor (-onlynet-onion) mas o proxy para alcançar a rede Tor foi explicitamente proibido: "-onion=0"</translation>
+    </message>
+    <message>
+        <source>Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is not provided: none of -proxy, -onion or -listenonion is given</source>
+        <translation type="unfinished">As conexões de saída foram restringidas a rede Tor  (-onlynet=onion) mas o proxy para acessar a rede Tor não foi fornecido: nenhuma opção "-proxy", "-onion" ou "-listenonion" foi fornecida</translation>
+    </message>
+    <message>
+        <source>Unrecognized descriptor found. Loading wallet %s
+
+The wallet might had been created on a newer version.
+Please try running the latest software version.
+</source>
+        <translation type="unfinished">Descriptor não reconhecido foi encontrado. Carregando carteira %s
+
+A carteira pode ter sido criada em uma versão mais nova.
+Por favor tente atualizar o software para a última versão.
+</translation>
+    </message>
+    <message>
+        <source>Unsupported category-specific logging level -loglevel=%s. Expected -loglevel=&lt;category&gt;:&lt;loglevel&gt;. Valid categories: %s. Valid loglevels: %s.</source>
+        <translation type="unfinished">Categoria especificada no nível de log não suportada "-loglevel=%s". Esperado "-loglevel=&lt;category&gt;:&lt;loglevel&gt;. Categorias validas: %s. Níveis de log válidos: %s.</translation>
+    </message>
+    <message>
+        <source>
+Unable to cleanup failed migration</source>
+        <translation type="unfinished">
+Impossível limpar a falha de migração</translation>
+    </message>
+    <message>
+        <source>
+Unable to restore backup of wallet.</source>
+        <translation type="unfinished">
+Impossível restaurar backup da carteira.</translation>
     </message>
     <message>
         <source>Config setting for %s only applied on %s network when in [%s] section.</source>
@@ -566,16 +690,56 @@ Somente é possível assinar com endereços do tipo 'legado'.</translation>
         <translation type="unfinished">Erro ao ler o banco de dados. Encerrando.</translation>
     </message>
     <message>
-        <source>Error upgrading chainstate database</source>
-        <translation type="unfinished">Erro ao atualizar banco de dados do chainstate</translation>
+        <source>Error: Could not add watchonly tx to watchonly wallet</source>
+        <translation type="unfinished">Erro: impossível adicionar tx apenas-visualização para carteira apenas-visualização</translation>
+    </message>
+    <message>
+        <source>Error: Could not delete watchonly transactions</source>
+        <translation type="unfinished">Erro: Impossível excluir transações apenas-visualização </translation>
     </message>
     <message>
         <source>Error: Disk space is low for %s</source>
         <translation type="unfinished">Erro: Espaço em disco menor que %s</translation>
     </message>
     <message>
+        <source>Error: Failed to create new watchonly wallet</source>
+        <translation type="unfinished">Erro: Falha ao criar carteira apenas-visualização</translation>
+    </message>
+    <message>
         <source>Error: Keypool ran out, please call keypoolrefill first</source>
         <translation type="unfinished">Keypool exaurida, por gentileza execute keypoolrefill primeiro</translation>
+    </message>
+    <message>
+        <source>Error: Not all watchonly txs could be deleted</source>
+        <translation type="unfinished">Erro: Nem todos os txs apenas-visualização foram excluídos</translation>
+    </message>
+    <message>
+        <source>Error: This wallet already uses SQLite</source>
+        <translation type="unfinished">Erro: Essa carteira já utiliza o SQLite</translation>
+    </message>
+    <message>
+        <source>Error: This wallet is already a descriptor wallet</source>
+        <translation type="unfinished">Erro: Esta carteira já contém um descritor</translation>
+    </message>
+    <message>
+        <source>Error: Unable to begin reading all records in the database</source>
+        <translation type="unfinished">Erro: impossível ler todos os registros no banco de dados</translation>
+    </message>
+    <message>
+        <source>Error: Unable to make a backup of your wallet</source>
+        <translation type="unfinished">Erro: Impossível efetuar backup da carteira</translation>
+    </message>
+    <message>
+        <source>Error: Unable to parse version %u as a uint32_t</source>
+        <translation type="unfinished">Erro: Impossível analisar versão %u como uint32_t</translation>
+    </message>
+    <message>
+        <source>Error: Unable to read all records in the database</source>
+        <translation type="unfinished">Erro: Impossível ler todos os registros no banco de dados</translation>
+    </message>
+    <message>
+        <source>Error: Unable to remove watchonly address book data</source>
+        <translation type="unfinished">Erro: Impossível remover dados somente-visualização do Livro de Endereços </translation>
     </message>
     <message>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
@@ -608,6 +772,10 @@ Somente é possível assinar com endereços do tipo 'legado'.</translation>
     <message>
         <source>Initialization sanity check failed. %s is shutting down.</source>
         <translation type="unfinished">O teste de integridade de inicialização falhou. O %s está sendo desligado.</translation>
+    </message>
+    <message>
+        <source>Input not found or already spent</source>
+        <translation type="unfinished">Entrada não encontrada ou já gasta</translation>
     </message>
     <message>
         <source>Insufficient funds</source>
@@ -646,6 +814,10 @@ Somente é possível assinar com endereços do tipo 'legado'.</translation>
         <translation type="unfinished">Máscara de rede especificada em -whitelist: '%s' é inválida</translation>
     </message>
     <message>
+        <source>Listening for incoming connections failed (listen returned error %s)</source>
+        <translation type="unfinished">A espera por conexões de entrada falharam (a espera retornou o erro %s)</translation>
+    </message>
+    <message>
         <source>Loading P2P addresses…</source>
         <translation type="unfinished">Carregando endereços P2P...</translation>
     </message>
@@ -662,12 +834,20 @@ Somente é possível assinar com endereços do tipo 'legado'.</translation>
         <translation type="unfinished">Carregando carteira...</translation>
     </message>
     <message>
+        <source>Missing amount</source>
+        <translation type="unfinished">Faltando quantia</translation>
+    </message>
+    <message>
+        <source>Missing solving data for estimating transaction size</source>
+        <translation type="unfinished">Não há dados suficientes para estimar o tamanho da transação</translation>
+    </message>
+    <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
         <translation type="unfinished">Necessário informar uma porta com -whitebind: '%s'</translation>
     </message>
     <message>
-        <source>No proxy server specified. Use -proxy=&lt;ip&gt; or -proxy=&lt;ip:port&gt;.</source>
-        <translation type="unfinished">Nenhum servidor proxy especificado. Use -proxy=&lt;ip&gt; ou proxy=&lt;ip:port&gt;.</translation>
+        <source>No addresses available</source>
+        <translation type="unfinished">Nenhum endereço disponível</translation>
     </message>
     <message>
         <source>Not enough file descriptors available.</source>
@@ -676,10 +856,6 @@ Somente é possível assinar com endereços do tipo 'legado'.</translation>
     <message>
         <source>Prune cannot be configured with a negative value.</source>
         <translation type="unfinished">O modo prune não pode ser configurado com um valor negativo.</translation>
-    </message>
-    <message>
-        <source>Prune mode is incompatible with -coinstatsindex.</source>
-        <translation type="unfinished">O modo prune é incompatível com -txindex.</translation>
     </message>
     <message>
         <source>Prune mode is incompatible with -txindex.</source>
@@ -778,6 +954,10 @@ Somente é possível assinar com endereços do tipo 'legado'.</translation>
         <translation type="unfinished">As quantidades nas transações não podem ser negativas.</translation>
     </message>
     <message>
+        <source>Transaction change output index out of range</source>
+        <translation type="unfinished">Endereço de troco da transação fora da faixa</translation>
+    </message>
+    <message>
         <source>Transaction has too long of a mempool chain</source>
         <translation type="unfinished">A transação demorou muito na memória</translation>
     </message>
@@ -786,8 +966,16 @@ Somente é possível assinar com endereços do tipo 'legado'.</translation>
         <translation type="unfinished">A transação deve ter ao menos um destinatário</translation>
     </message>
     <message>
+        <source>Transaction needs a change address, but we can't generate it.</source>
+        <translation type="unfinished">Transação necessita de um endereço de troco, mas não conseguimos gera-lo. </translation>
+    </message>
+    <message>
         <source>Transaction too large</source>
         <translation type="unfinished">Transação muito grande</translation>
+    </message>
+    <message>
+        <source>Unable to allocate memory for -maxsigcachesize: '%s' MiB</source>
+        <translation type="unfinished">Impossível alocar memória para a opção "-maxsigcachesize: '%s' MiB</translation>
     </message>
     <message>
         <source>Unable to bind to %s on this computer (bind returned error %s)</source>
@@ -802,6 +990,10 @@ Somente é possível assinar com endereços do tipo 'legado'.</translation>
         <translation type="unfinished">Não foi possível criar arquivo de PID '%s': %s</translation>
     </message>
     <message>
+        <source>Unable to find UTXO for external input</source>
+        <translation type="unfinished">Impossível localizar e entrada externa UTXO</translation>
+    </message>
+    <message>
         <source>Unable to generate initial keys</source>
         <translation type="unfinished">Não foi possível gerar as chaves iniciais</translation>
     </message>
@@ -810,8 +1002,16 @@ Somente é possível assinar com endereços do tipo 'legado'.</translation>
         <translation type="unfinished">Não foi possível gerar chaves</translation>
     </message>
     <message>
+        <source>Unable to parse -maxuploadtarget: '%s'</source>
+        <translation type="unfinished">Impossível analisar -maxuploadtarget: '%s'</translation>
+    </message>
+    <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
         <translation type="unfinished">Não foi possível iniciar o servidor HTTP. Veja o log de depuração para detaihes.</translation>
+    </message>
+    <message>
+        <source>Unable to unload the wallet before migrating</source>
+        <translation type="unfinished">Impossível desconectar carteira antes de migrá-la</translation>
     </message>
     <message>
         <source>Unknown -blockfilterindex value %s.</source>
@@ -830,12 +1030,12 @@ Somente é possível assinar com endereços do tipo 'legado'.</translation>
         <translation type="unfinished">Rede desconhecida especificada em -onlynet: '%s'</translation>
     </message>
     <message>
-        <source>Unsupported logging category %s=%s.</source>
-        <translation type="unfinished">Categoria de log desconhecida %s=%s.</translation>
+        <source>Unsupported global logging level -loglevel=%s. Valid values: %s.</source>
+        <translation type="unfinished">Nível de log global inválido "-loglevel=%s". Valores válidos: %s.</translation>
     </message>
     <message>
-        <source>Upgrading UTXO database</source>
-        <translation type="unfinished">Atualizando banco de dados UTXO</translation>
+        <source>Unsupported logging category %s=%s.</source>
+        <translation type="unfinished">Categoria de log desconhecida %s=%s.</translation>
     </message>
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
@@ -1056,8 +1256,8 @@ Somente é possível assinar com endereços do tipo 'legado'.</translation>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n bloco processado do histórico de transações.</numerusform>
+            <numerusform>%n blocos processados do histórico de transações.</numerusform>
         </translation>
     </message>
     <message>
@@ -1094,7 +1294,7 @@ Somente é possível assinar com endereços do tipo 'legado'.</translation>
     </message>
     <message>
         <source>Load Partially Signed Bitcoin Transaction</source>
-        <translation type="unfinished">Carregar Transação de Bitcoin Parcialmente Assinada</translation>
+        <translation type="unfinished">Carregar</translation>
     </message>
     <message>
         <source>Load PSBT from &amp;clipboard…</source>
@@ -1137,6 +1337,16 @@ Somente é possível assinar com endereços do tipo 'legado'.</translation>
         <translation type="unfinished">Fechar carteira</translation>
     </message>
     <message>
+        <source>Restore Wallet…</source>
+        <extracomment>Name of the menu item that restores wallet from a backup file.</extracomment>
+        <translation type="unfinished">Restaurar Carteira...</translation>
+    </message>
+    <message>
+        <source>Restore a wallet from a backup file</source>
+        <extracomment>Status tip for Restore Wallet menu item</extracomment>
+        <translation type="unfinished">Restaurar uma carteira a partir de um arquivo de backup</translation>
+    </message>
+    <message>
         <source>Close all wallets</source>
         <translation type="unfinished">Fechar todas as carteiras</translation>
     </message>
@@ -1161,6 +1371,21 @@ Somente é possível assinar com endereços do tipo 'legado'.</translation>
         <translation type="unfinished">Nenhuma carteira disponível</translation>
     </message>
     <message>
+        <source>Load Wallet Backup</source>
+        <extracomment>The title for Restore Wallet File Windows</extracomment>
+        <translation type="unfinished">Carregar Backup da Carteira</translation>
+    </message>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of pop-up window shown when the user is attempting to restore a wallet.</extracomment>
+        <translation type="unfinished">Restaurar Carteira</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">Nome da Carteira</translation>
+    </message>
+    <message>
         <source>&amp;Window</source>
         <translation type="unfinished">&amp;Janelas</translation>
     </message>
@@ -1178,18 +1403,18 @@ Somente é possível assinar com endereços do tipo 'legado'.</translation>
     </message>
     <message>
         <source>&amp;Hide</source>
-        <translation type="unfinished">&amp;Esconder</translation>
+        <translation type="unfinished">E&amp;sconder</translation>
     </message>
     <message>
         <source>S&amp;how</source>
-        <translation type="unfinished">S&amp;como</translation>
+        <translation type="unfinished">Mo&amp;strar</translation>
     </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n conexão ativa na rede Bitcoin.</numerusform>
+            <numerusform>%nconexões ativas na rede Bitcoin.</numerusform>
         </translation>
     </message>
     <message>
@@ -1200,7 +1425,7 @@ Somente é possível assinar com endereços do tipo 'legado'.</translation>
     <message>
         <source>Show Peers tab</source>
         <extracomment>A context menu item. The "Peers tab" is an element of the "Node window".</extracomment>
-        <translation type="unfinished">Mostrar abas De pares.</translation>
+        <translation type="unfinished">Mostra aba de Pares</translation>
     </message>
     <message>
         <source>Disable network activity</source>
@@ -1211,6 +1436,10 @@ Somente é possível assinar com endereços do tipo 'legado'.</translation>
         <source>Enable network activity</source>
         <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
         <translation type="unfinished">Ativar atividade de conexões</translation>
+    </message>
+    <message>
+        <source>Pre-syncing Headers (%1%)…</source>
+        <translation type="unfinished">Pré-Sincronizando cabeçalhos (%1%)...</translation>
     </message>
     <message>
         <source>Error: %1</source>
@@ -1447,7 +1676,11 @@ Somente é possível assinar com endereços do tipo 'legado'.</translation>
         <source>Create wallet warning</source>
         <translation type="unfinished">Criar carteira alerta</translation>
     </message>
-    </context>
+    <message>
+        <source>Too many external signers found</source>
+        <translation type="unfinished">Encontrados muitos assinantes externos</translation>
+    </message>
+</context>
 <context>
     <name>LoadWalletsActivity</name>
     <message>
@@ -1484,6 +1717,34 @@ Somente é possível assinar com endereços do tipo 'legado'.</translation>
         <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
         <extracomment>Descriptive text of the open wallet progress window which indicates to the user which wallet is currently being opened.</extracomment>
         <translation type="unfinished">Abrindo carteira &lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+</context>
+<context>
+    <name>RestoreWalletActivity</name>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of progress window which is displayed when wallets are being restored.</extracomment>
+        <translation type="unfinished">Restaurar Carteira</translation>
+    </message>
+    <message>
+        <source>Restoring Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the restore wallets progress window which indicates to the user that wallets are currently being restored.</extracomment>
+        <translation type="unfinished">Restaurando Carteira &lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+    <message>
+        <source>Restore wallet failed</source>
+        <extracomment>Title of message box which is displayed when the wallet could not be restored.</extracomment>
+        <translation type="unfinished">Falha ao restaurar carteira</translation>
+    </message>
+    <message>
+        <source>Restore wallet warning</source>
+        <extracomment>Title of message box which is displayed when the wallet is restored with some warning.</extracomment>
+        <translation type="unfinished">Aviso ao restaurar carteira</translation>
+    </message>
+    <message>
+        <source>Restore wallet message</source>
+        <extracomment>Title of message box which is displayed when the wallet is successfully restored.</extracomment>
+        <translation type="unfinished">Mensagem da carteira restaurada</translation>
     </message>
 </context>
 <context>
@@ -1648,17 +1909,26 @@ Somente é possível assinar com endereços do tipo 'legado'.</translation>
 </context>
 <context>
     <name>Intro</name>
-    <message>
-        <source>%1 GB of space available</source>
-        <translation type="unfinished">%1 GB de espaço disponível</translation>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform>%n GB de espaço disponível</numerusform>
+            <numerusform>%n GB de espaço disponível</numerusform>
+        </translation>
     </message>
-    <message>
-        <source>(of %1 GB needed)</source>
-        <translation type="unfinished">(de %1 GB necessário)</translation>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform>(de %n GB necessário)</numerusform>
+            <numerusform>(de %n GB necessários)</numerusform>
+        </translation>
     </message>
-    <message>
-        <source>(%1 GB needed for full chain)</source>
-        <translation type="unfinished">(%1 GB necessário para a blockchain completa)</translation>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform>(%n GB necessário para a cadeia completa)</numerusform>
+            <numerusform>(%n GB necessários para a cadeia completa)</numerusform>
+        </translation>
     </message>
     <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
@@ -1672,8 +1942,8 @@ Somente é possível assinar com endereços do tipo 'legado'.</translation>
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>(suficiente para restaurar backup de %n dia atrás)</numerusform>
+            <numerusform>(suficiente para restaurar backups de %n dias atrás)</numerusform>
         </translation>
     </message>
     <message>
@@ -1705,10 +1975,6 @@ Somente é possível assinar com endereços do tipo 'legado'.</translation>
         <translation type="unfinished">Como essa é a primeira vez que o programa é executado, você pode escolher onde %1 armazenará seus dados.</translation>
     </message>
     <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation type="unfinished">Quando você clica OK, %1 vai começar a baixar e processar todos os %4 da block chain (%2GB) começando com a mais recente transação em %3 quando %4 inicialmente foi lançado.</translation>
-    </message>
-    <message>
         <source>Limit block chain storage to</source>
         <translation type="unfinished">Limitar o tamanho da blockchain para</translation>
     </message>
@@ -1723,6 +1989,10 @@ Somente é possível assinar com endereços do tipo 'legado'.</translation>
     <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
         <translation type="unfinished">Esta sincronização inicial é muito exigente e pode expor problemas de hardware com o computador que passaram despercebidos anteriormente. Cada vez que você executar o %1, irá continuar baixando de onde parou.</translation>
+    </message>
+    <message>
+        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2 GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
+        <translation type="unfinished">Quando clicar em OK, %1 iniciará o download e irá processar a cadeia de blocos completa %4 (%2 GB) iniciando com as mais recentes transações em %3 enquanto %4 é processado. </translation>
     </message>
     <message>
         <source>If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</source>
@@ -1817,6 +2087,10 @@ Somente é possível assinar com endereços do tipo 'legado'.</translation>
         <source>Unknown. Syncing Headers (%1, %2%)…</source>
         <translation type="unfinished">Desconhecido. Sincronizando cabeçalhos (%1, %2%)...</translation>
     </message>
+    <message>
+        <source>Unknown. Pre-syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">Desconhecido. Pré-Sincronizando Cabeçalhos (%1, %2%)...</translation>
+    </message>
 </context>
 <context>
     <name>OpenURIDialog</name>
@@ -1869,6 +2143,10 @@ Somente é possível assinar com endereços do tipo 'legado'.</translation>
         <translation type="unfinished">Minimizar em vez de fechar o programa quando a janela for fechada. Quando essa opção estiver ativa, o programa só será fechado somente pela opção Sair no menu Arquivo.</translation>
     </message>
     <message>
+        <source>Options set in this dialog are overridden by the command line:</source>
+        <translation type="unfinished">Opções configuradas nessa caixa de diálogo serão sobrescritas pela linhas de comando: </translation>
+    </message>
+    <message>
         <source>Open the %1 configuration file from the working directory.</source>
         <translation type="unfinished">Abrir o arquivo de configuração %1 apartir do diretório trabalho.</translation>
     </message>
@@ -1897,8 +2175,23 @@ Somente é possível assinar com endereços do tipo 'legado'.</translation>
         <translation type="unfinished">Reverter esta configuração requer baixar de novo a blockchain inteira.</translation>
     </message>
     <message>
+        <source>Maximum database cache size. A larger cache can contribute to faster sync, after which the benefit is less pronounced for most use cases. Lowering the cache size will reduce memory usage. Unused mempool memory is shared for this cache.</source>
+        <extracomment>Tooltip text for Options window setting that sets the size of the database cache. Explains the corresponding effects of increasing/decreasing this value.</extracomment>
+        <translation type="unfinished">Tamanho máximo do cache do banco de dados. Um cache maior pode contribuir para uma sincronização mais rápida, após a qual o benefício é menos pronunciado para a maioria dos casos de uso. Reduzir o tamanho do cache reduzirá o uso de memória. A memória do mempool não utilizada é compartilhada para este cache.</translation>
+    </message>
+    <message>
+        <source>Set the number of script verification threads. Negative values correspond to the number of cores you want to leave free to the system.</source>
+        <extracomment>Tooltip text for Options window setting that sets the number of script verification threads. Explains that negative values mean to leave these many cores free to the system.</extracomment>
+        <translation type="unfinished">Define o número de threads para script de verificação. Valores negativos correspondem ao número de núcleos que você quer deixar livre para o sistema.</translation>
+    </message>
+    <message>
         <source>(0 = auto, &lt;0 = leave that many cores free)</source>
         <translation type="unfinished">(0 = automático, &lt;0 = número de núcleos deixados livres)</translation>
+    </message>
+    <message>
+        <source>This allows you or a third party tool to communicate with the node through command-line and JSON-RPC commands.</source>
+        <extracomment>Tooltip text for Options window setting that enables the RPC server.</extracomment>
+        <translation type="unfinished">Isso permite que você ou ferramentas de terceiros comunique-se  com o node através de linha de comando e comandos JSON-RPC.</translation>
     </message>
     <message>
         <source>Enable R&amp;PC server</source>
@@ -1908,6 +2201,11 @@ Somente é possível assinar com endereços do tipo 'legado'.</translation>
     <message>
         <source>W&amp;allet</source>
         <translation type="unfinished">C&amp;arteira</translation>
+    </message>
+    <message>
+        <source>Whether to set subtract fee from amount as default or not.</source>
+        <extracomment>Tooltip text for Options window setting that sets subtracting the fee from a sending amount as default.</extracomment>
+        <translation type="unfinished">Mostra a quantia com a taxa já subtraída.</translation>
     </message>
     <message>
         <source>Subtract &amp;fee from amount by default</source>
@@ -1934,6 +2232,11 @@ Somente é possível assinar com endereços do tipo 'legado'.</translation>
         <source>Enable &amp;PSBT controls</source>
         <extracomment>An options window setting to enable PSBT controls.</extracomment>
         <translation type="unfinished">Ative controles &amp;PSBT</translation>
+    </message>
+    <message>
+        <source>Whether to show PSBT controls.</source>
+        <extracomment>Tooltip text for options window setting that enables PSBT controls.</extracomment>
+        <translation type="unfinished">Mostrar os controles de PSBT (Transação de Bitcoin Parcialmente Assinada).</translation>
     </message>
     <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
@@ -2012,6 +2315,14 @@ Somente é possível assinar com endereços do tipo 'legado'.</translation>
         <translation type="unfinished">Escolha a unidade de subdivisão padrão para exibição na interface ou quando enviando moedas.</translation>
     </message>
     <message>
+        <source>Third-party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</source>
+        <translation type="unfinished">URLs de terceiros (exemplo: explorador de blocos) que aparecem na aba de transações como itens do menu de contexto. %s na URL é substituido pela hash da transação. Múltiplas URLs são separadas pela barra vertical |.</translation>
+    </message>
+    <message>
+        <source>&amp;Third-party transaction URLs</source>
+        <translation type="unfinished">URLs de transação de &amp;terceiros</translation>
+    </message>
+    <message>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished">Mostrar ou não opções de controle da moeda.</translation>
     </message>
@@ -2028,10 +2339,6 @@ Somente é possível assinar com endereços do tipo 'legado'.</translation>
         <translation type="unfinished">Fonte no painel de visualização:</translation>
     </message>
     <message>
-        <source>Options set in this dialog are overridden by the command line or in the configuration file:</source>
-        <translation type="unfinished">Opções nesta tela foram sobreescritas por comandos ou no arquivo de configuração:</translation>
-    </message>
-    <message>
         <source>&amp;Cancel</source>
         <translation type="unfinished">&amp;Cancelar</translation>
     </message>
@@ -2045,14 +2352,22 @@ Somente é possível assinar com endereços do tipo 'legado'.</translation>
     </message>
     <message>
         <source>Confirm options reset</source>
+        <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
         <translation type="unfinished">Confirmar redefinição de opções</translation>
     </message>
     <message>
         <source>Client restart required to activate changes.</source>
+        <extracomment>Text explaining that the settings changed will not come into effect until the client is restarted.</extracomment>
         <translation type="unfinished">Reinicialização do aplicativo necessária para efetivar alterações.</translation>
     </message>
     <message>
+        <source>Current settings will be backed up at "%1".</source>
+        <extracomment>Text explaining to the user that the client's current settings will be backed up at a specific location. %1 is a stand-in argument for the backup location's path.</extracomment>
+        <translation type="unfinished">Configuração atuais serão copiadas em "%1".</translation>
+    </message>
+    <message>
         <source>Client will be shut down. Do you want to proceed?</source>
+        <extracomment>Text asking the user to confirm if they would like to proceed with a client shutdown.</extracomment>
         <translation type="unfinished">O programa será encerrado. Deseja continuar?</translation>
     </message>
     <message>
@@ -2084,6 +2399,13 @@ Somente é possível assinar com endereços do tipo 'legado'.</translation>
     <message>
         <source>The supplied proxy address is invalid.</source>
         <translation type="unfinished">O endereço proxy fornecido é inválido.</translation>
+    </message>
+</context>
+<context>
+    <name>OptionsModel</name>
+    <message>
+        <source>Could not read setting "%1", %2.</source>
+        <translation type="unfinished">Não foi possível ler as configurações "%1", %2.</translation>
     </message>
 </context>
 <context>
@@ -2194,6 +2516,10 @@ Somente é possível assinar com endereços do tipo 'legado'.</translation>
     <message>
         <source>Failed to sign transaction: %1</source>
         <translation type="unfinished">Falhou ao assinar transação: %1</translation>
+    </message>
+    <message>
+        <source>Cannot sign inputs while wallet is locked.</source>
+        <translation type="unfinished">Não é possível assinar entradas enquanto a carteira está trancada.</translation>
     </message>
     <message>
         <source>Could not sign any more inputs.</source>
@@ -2317,6 +2643,11 @@ Somente é possível assinar com endereços do tipo 'legado'.</translation>
         <source>Peer</source>
         <extracomment>Title of Peers Table column which contains a unique number used to identify a connection.</extracomment>
         <translation type="unfinished">Nós</translation>
+    </message>
+    <message>
+        <source>Age</source>
+        <extracomment>Title of Peers Table column which indicates the duration (length of time) since the peer connection started.</extracomment>
+        <translation type="unfinished">Ano</translation>
     </message>
     <message>
         <source>Direction</source>
@@ -2502,15 +2833,41 @@ Somente é possível assinar com endereços do tipo 'legado'.</translation>
     </message>
     <message>
         <source>The mapped Autonomous System used for diversifying peer selection.</source>
-        <translation type="unfinished">O sistema autônomo delineado usado para a diversificação de seleção de nós.</translation>
+        <translation type="unfinished">O sistema autônomo de mapeamento usado para a diversificação de seleção de nós.</translation>
     </message>
     <message>
         <source>Mapped AS</source>
         <translation type="unfinished">Mapeado como</translation>
     </message>
     <message>
+        <source>Whether we relay addresses to this peer.</source>
+        <extracomment>Tooltip text for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
+        <translation type="unfinished">Endereços são retransmitidos para este nó.</translation>
+    </message>
+    <message>
+        <source>Address Relay</source>
+        <extracomment>Text title for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
+        <translation type="unfinished">Retransmissão de endereços</translation>
+    </message>
+    <message>
+        <source>The total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</source>
+        <extracomment>Tooltip text for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
+        <translation type="unfinished">O número total de endereços recebidos deste peer que foram processados (exclui endereços que foram descartados devido à limitação de taxa).</translation>
+    </message>
+    <message>
+        <source>The total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</source>
+        <extracomment>Tooltip text for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
+        <translation type="unfinished">O número total de endereços recebidos deste peer que não foram processados devido à limitação da taxa.</translation>
+    </message>
+    <message>
         <source>Addresses Processed</source>
+        <extracomment>Text title for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
         <translation type="unfinished">Endereços Processados</translation>
+    </message>
+    <message>
+        <source>Addresses Rate-Limited</source>
+        <extracomment>Text title for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
+        <translation type="unfinished">Endereços com limite de taxa</translation>
     </message>
     <message>
         <source>Node window</source>
@@ -2539,6 +2896,10 @@ Somente é possível assinar com endereços do tipo 'legado'.</translation>
     <message>
         <source>Services</source>
         <translation type="unfinished">Serviços</translation>
+    </message>
+    <message>
+        <source>Whether the peer requested us to relay transactions.</source>
+        <translation type="unfinished">O nó solicita retransmissão de transações.</translation>
     </message>
     <message>
         <source>Connection Time</source>
@@ -2636,6 +2997,22 @@ Somente é possível assinar com endereços do tipo 'legado'.</translation>
     <message>
         <source>Executing command without any wallet</source>
         <translation type="unfinished">Executando comando sem nenhuma carteira</translation>
+    </message>
+    <message>
+        <source>Ctrl+I</source>
+        <translation type="unfinished">Control+I</translation>
+    </message>
+    <message>
+        <source>Ctrl+T</source>
+        <translation type="unfinished">Control+T</translation>
+    </message>
+    <message>
+        <source>Ctrl+N</source>
+        <translation type="unfinished">Control+N</translation>
+    </message>
+    <message>
+        <source>Ctrl+P</source>
+        <translation type="unfinished">Control+P</translation>
     </message>
     <message>
         <source>Executing command using "%1" wallet</source>
@@ -3041,7 +3418,7 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     </message>
     <message>
         <source>Creates a Partially Signed Bitcoin Transaction (PSBT) for use with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
-        <translation type="unfinished">Cria uma Transação de Bitcoin Parcialmente Assinada (PSBT) para usar com ex: uma carteira %1 offline, ou uma PSBT-compatível hardware wallet.</translation>
+        <translation type="unfinished">Cria uma Transação de Bitcoin Parcialmente Assinada (PSBT) para usar com, por exemplo, uma carteira %1 offline ou uma carteira física compatível com PSBTs.</translation>
     </message>
     <message>
         <source> from wallet '%1'</source>
@@ -3082,12 +3459,17 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     <message>
         <source>Please, review your transaction proposal. This will produce a Partially Signed Bitcoin Transaction (PSBT) which you can save or copy and then sign with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
         <extracomment>Text to inform a user attempting to create a transaction of their current options. At this stage, a user can only create a PSBT. This string is displayed when private keys are disabled and an external signer is not available.</extracomment>
-        <translation type="unfinished">Por favor, reveja sua proposta de transação. Será produzido uma Transação de Bitcoin Parcialmente Assinada (PSBT) que você pode copiar e assinar com ex: uma carteira %1 offline, ou uma PSBT-compatível hardware wallet.</translation>
+        <translation type="unfinished">Por favor, revise a transação. Será produzido uma Transação de Bitcoin Parcialmente Assinada (PSBT) que você pode copiar e assinar com, por exemplo, uma carteira %1 offline, ou uma carteira física compatível com PSBTs.</translation>
     </message>
     <message>
         <source>Do you want to create this transaction?</source>
         <extracomment>Message displayed when attempting to create a transaction. Cautionary text to prompt the user to verify that the displayed transaction details represent the transaction the user intends to create.</extracomment>
         <translation type="unfinished">Deseja criar esta transação?</translation>
+    </message>
+    <message>
+        <source>Please, review your transaction. You can create and send this transaction or create a Partially Signed Bitcoin Transaction (PSBT), which you can save or copy and then sign with, e.g., an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
+        <extracomment>Text to inform a user attempting to create a transaction of their current options. At this stage, a user can send their transaction or create a PSBT. This string is displayed when both private keys and PSBT controls are enabled.</extracomment>
+        <translation type="unfinished">Por favor, revise a transação. Você pode assinar e enviar a transação ou criar uma Transação de Bitcoin Parcialmente Assinada (PSBT), que você pode copiar e assinar com, por exemplo, uma carteira %1 offline ou uma carteira física compatível com PSBTs.</translation>
     </message>
     <message>
         <source>Please, review your transaction.</source>
@@ -3142,15 +3524,11 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
         <source>A fee higher than %1 is considered an absurdly high fee.</source>
         <translation type="unfinished">Uma taxa maior que %1 é considerada uma taxa absurdamente alta.</translation>
     </message>
-    <message>
-        <source>Payment request expired.</source>
-        <translation type="unfinished">Pedido de pagamento expirado.</translation>
-    </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>Confirmação estimada para iniciar em %n bloco.</numerusform>
+            <numerusform>Confirmação estimada para iniciar em %n blocos.</numerusform>
         </translation>
     </message>
     <message>
@@ -3225,28 +3603,12 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
         <translation type="unfinished">Mensagem:</translation>
     </message>
     <message>
-        <source>This is an unauthenticated payment request.</source>
-        <translation type="unfinished">Esta é uma cobrança não autenticada.</translation>
-    </message>
-    <message>
-        <source>This is an authenticated payment request.</source>
-        <translation type="unfinished">Esta é uma cobrança autenticada.</translation>
-    </message>
-    <message>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished">Digite um rótulo para este endereço para adicioná-lo no catálogo</translation>
     </message>
     <message>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished">A mensagem que foi anexada ao bitcoin: URI na qual será gravada na transação para sua referência. Nota: Essa mensagem não será gravada publicamente na rede Bitcoin.</translation>
-    </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">Pague Para:</translation>
-    </message>
-    <message>
-        <source>Memo:</source>
-        <translation type="unfinished">Memorizar:</translation>
     </message>
 </context>
 <context>
@@ -3418,30 +3780,32 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     <name>TransactionDesc</name>
     <message>
         <source>conflicted with a transaction with %1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that conflicts with a confirmed transaction.</extracomment>
         <translation type="unfinished">conflitado com uma transação com %1 confirmações</translation>
     </message>
     <message>
-        <source>0/unconfirmed, %1</source>
-        <translation type="unfinished">0/não confirmado, %1</translation>
+        <source>0/unconfirmed, in memory pool</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is in the memory pool.</extracomment>
+        <translation type="unfinished">0/não confirmada, na memória</translation>
     </message>
     <message>
-        <source>in memory pool</source>
-        <translation type="unfinished">no pool de memória</translation>
-    </message>
-    <message>
-        <source>not in memory pool</source>
-        <translation type="unfinished">não está no pool de memóra</translation>
+        <source>0/unconfirmed, not in memory pool</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is not in the memory pool.</extracomment>
+        <translation type="unfinished">0/não confirmada, fora da memória</translation>
     </message>
     <message>
         <source>abandoned</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an abandoned transaction.</extracomment>
         <translation type="unfinished">abandonado</translation>
     </message>
     <message>
         <source>%1/unconfirmed</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
         <translation type="unfinished">%1/não confirmado</translation>
     </message>
     <message>
         <source>%1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
         <translation type="unfinished">%1 confirmações</translation>
     </message>
     <message>
@@ -3487,8 +3851,8 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>pronta em mais %n bloco</numerusform>
+            <numerusform>prontas em mais %n blocos</numerusform>
         </translation>
     </message>
     <message>
@@ -3671,7 +4035,7 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     </message>
     <message>
         <source>Whether or not a watch-only address is involved in this transaction.</source>
-        <translation type="unfinished">Mostrar ou não endereços monitorados na lista de transações.</translation>
+        <translation type="unfinished">Se um endereço monitorado está envolvido nesta transação.</translation>
     </message>
     <message>
         <source>User-defined intent/purpose of the transaction.</source>
@@ -3739,6 +4103,11 @@ Nota: Como a taxa é calculada por byte, uma taxa de "100 satoshis por kvB" para
     <message>
         <source>Range…</source>
         <translation type="unfinished">Alcance...</translation>
+    </message>
+    <message>
+        <source>Show in %1</source>
+        <extracomment>Transactions table context menu action to show the selected transaction in a third-party block explorer. %1 is a stand-in argument for the URL of the explorer.</extracomment>
+        <translation type="unfinished">Mostrar em %1</translation>
     </message>
     <message>
         <source>Export Transaction History</source>
@@ -3832,7 +4201,7 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <source>Unable to decode PSBT</source>
-        <translation type="unfinished">Não foi possível decodificar PSDBT</translation>
+        <translation type="unfinished">Não foi possível decodificar PSBT</translation>
     </message>
 </context>
 <context>

--- a/src/qt/locale/bitcoin_ro.ts
+++ b/src/qt/locale/bitcoin_ro.ts
@@ -239,6 +239,10 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
 <context>
     <name>BitcoinApplication</name>
     <message>
+        <source>Settings file %1 might be corrupt or invalid.</source>
+        <translation type="unfinished">Fișierul de configurări %1 poate fi corupt sau invalid.</translation>
+    </message>
+    <message>
         <source>Runaway exception</source>
         <translation type="unfinished">Excepție de fugă</translation>
     </message>
@@ -383,10 +387,6 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
         <translation type="unfinished">Eroare la citirea %s! Toate cheile sînt citite corect, dar datele tranzactiei sau anumite intrări din agenda sînt incorecte sau lipsesc.</translation>
     </message>
     <message>
-        <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
-        <translation type="unfinished">Eroare: Ascultarea conexiunilor de intrare nu a reuşit (ascultarea a reurnat eroarea %s)</translation>
-    </message>
-    <message>
         <source>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.</source>
         <translation type="unfinished">Estimarea taxei a esuat. Taxa implicita este dezactivata. Asteptati cateva blocuri, sau activati -fallbackfee.</translation>
     </message>
@@ -517,10 +517,6 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
     <message>
         <source>Error reading from database, shutting down.</source>
         <translation type="unfinished">Eroare la citirea bazei de date. Oprire.</translation>
-    </message>
-    <message>
-        <source>Error upgrading chainstate database</source>
-        <translation type="unfinished">Eroare la actualizarea bazei de date chainstate</translation>
     </message>
     <message>
         <source>Error: Disk space is low for %s</source>
@@ -685,10 +681,6 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
     <message>
         <source>Unsupported logging category %s=%s.</source>
         <translation type="unfinished">Categoria de logging %s=%s nu este suportata.</translation>
-    </message>
-    <message>
-        <source>Upgrading UTXO database</source>
-        <translation type="unfinished">Actualizarea bazei de date UTXO</translation>
     </message>
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
@@ -997,6 +989,11 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
     <message>
         <source>No wallets available</source>
         <translation type="unfinished">Niciun portofel disponibil</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">Numele portofelului</translation>
     </message>
     <message>
         <source>&amp;Window</source>
@@ -1424,6 +1421,30 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
 </context>
 <context>
     <name>Intro</name>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform>(din %n GB necesar)</numerusform>
+            <numerusform>(din %n GB necesari)</numerusform>
+            <numerusform>(din %n GB necesari)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
     <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
         <translation type="unfinished">Cel putin %1GB de date vor fi stocate in acest director, si aceasta valoare va creste in timp.</translation>
@@ -1468,10 +1489,6 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
     <message>
         <source>As this is the first time the program is launched, you can choose where %1 will store its data.</source>
         <translation type="unfinished">Deoarece este prima lansare a programului poți alege unde %1 va stoca datele sale.</translation>
-    </message>
-    <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation type="unfinished">Cand apasati OK, %1 va incepe descarcarea si procesarea intregului %4 blockchain (%2GB) incepand cu cele mai vechi tranzactii din %3 de la lansarea initiala a %4.</translation>
     </message>
     <message>
         <source>Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</source>
@@ -1747,14 +1764,17 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
     </message>
     <message>
         <source>Confirm options reset</source>
+        <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
         <translation type="unfinished">Confirmă resetarea opţiunilor</translation>
     </message>
     <message>
         <source>Client restart required to activate changes.</source>
+        <extracomment>Text explaining that the settings changed will not come into effect until the client is restarted.</extracomment>
         <translation type="unfinished">Este necesară repornirea clientului pentru a activa schimbările.</translation>
     </message>
     <message>
         <source>Client will be shut down. Do you want to proceed?</source>
+        <extracomment>Text asking the user to confirm if they would like to proceed with a client shutdown.</extracomment>
         <translation type="unfinished">Clientul va fi închis. Doriţi să continuaţi?</translation>
     </message>
     <message>
@@ -2575,10 +2595,6 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
         <source>A fee higher than %1 is considered an absurdly high fee.</source>
         <translation type="unfinished">O taxă mai mare de %1 este considerată o taxă absurd de mare</translation>
     </message>
-    <message>
-        <source>Payment request expired.</source>
-        <translation type="unfinished">Cerere de plată expirata</translation>
-    </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
@@ -2655,14 +2671,6 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
         <translation type="unfinished">Mesaj:</translation>
     </message>
     <message>
-        <source>This is an unauthenticated payment request.</source>
-        <translation type="unfinished">Aceasta este o cerere de plata neautentificata.</translation>
-    </message>
-    <message>
-        <source>This is an authenticated payment request.</source>
-        <translation type="unfinished">Aceasta este o cerere de plata autentificata.</translation>
-    </message>
-    <message>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished">Introduceţi eticheta pentru ca această adresa să fie introdusă în lista de adrese folosite</translation>
     </message>
@@ -2670,11 +2678,7 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished">un mesaj a fost ataşat la bitcoin: URI care va fi stocat cu tranzacţia pentru referinţa dvs. Notă: Acest mesaj nu va fi trimis către reţeaua bitcoin.</translation>
     </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">Plăteşte către:</translation>
-    </message>
-    </context>
+</context>
 <context>
     <name>SendConfirmationDialog</name>
     <message>
@@ -2821,26 +2825,22 @@ Semnarea este posibilă numai cu adrese de tip "legacy".</translation>
     <name>TransactionDesc</name>
     <message>
         <source>conflicted with a transaction with %1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that conflicts with a confirmed transaction.</extracomment>
         <translation type="unfinished">in conflict cu o tranzactie cu %1 confirmari</translation>
     </message>
     <message>
-        <source>0/unconfirmed, %1</source>
-        <translation type="unfinished">0/neconfirmat, %1</translation>
-    </message>
-    <message>
-        <source>not in memory pool</source>
-        <translation type="unfinished">nu e in memory pool</translation>
-    </message>
-    <message>
         <source>abandoned</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an abandoned transaction.</extracomment>
         <translation type="unfinished">abandonat</translation>
     </message>
     <message>
         <source>%1/unconfirmed</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
         <translation type="unfinished">%1/neconfirmat</translation>
     </message>
     <message>
         <source>%1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
         <translation type="unfinished">%1 confirmări</translation>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_ru.ts
+++ b/src/qt/locale/bitcoin_ru.ts
@@ -6,12 +6,16 @@
         <translation type="unfinished">Нажмите правой кнопкой мыши, чтобы изменить адрес или метку</translation>
     </message>
     <message>
+        <source>Create a new address</source>
+        <translation type="unfinished">Создать новый адрес</translation>
+    </message>
+    <message>
         <source>&amp;New</source>
         <translation type="unfinished">&amp;Новый</translation>
     </message>
     <message>
         <source>Copy the currently selected address to the system clipboard</source>
-        <translation type="unfinished">Скопировать выбранный адрес в буфер обмена</translation>
+        <translation type="unfinished">Скопировать выбранные адреса в буфер обмена</translation>
     </message>
     <message>
         <source>&amp;Copy</source>
@@ -23,7 +27,7 @@
     </message>
     <message>
         <source>Delete the currently selected address from the list</source>
-        <translation type="unfinished">Удалить текущий выбранный адрес из списка</translation>
+        <translation type="unfinished">Удалить выбранные адреса из списка</translation>
     </message>
     <message>
         <source>Enter address or label to search</source>
@@ -35,15 +39,19 @@
     </message>
     <message>
         <source>&amp;Export</source>
-        <translation type="unfinished">&amp;Экспорт</translation>
+        <translation type="unfinished">&amp;Экспортировать</translation>
     </message>
     <message>
         <source>&amp;Delete</source>
         <translation type="unfinished">&amp;Удалить</translation>
     </message>
     <message>
+        <source>Choose the address to send coins to</source>
+        <translation type="unfinished">Выберите адреса, для отправки на них монет</translation>
+    </message>
+    <message>
         <source>Choose the address to receive coins with</source>
-        <translation type="unfinished">Выберите адрес для получения монет</translation>
+        <translation type="unfinished">Выберите адреса для получения монет</translation>
     </message>
     <message>
         <source>C&amp;hoose</source>
@@ -58,10 +66,14 @@
         <translation type="unfinished">Адреса получения</translation>
     </message>
     <message>
+        <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
+        <translation type="unfinished">Это ваши биткоин-адреса для отправки платежей. Всегда проверяйте сумму и адрес получателя перед отправкой перевода.</translation>
+    </message>
+    <message>
         <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
 Signing is only possible with addresses of the type 'legacy'.</source>
-        <translation type="unfinished">Это ваши биткойн-адреса для приема платежей. Используйте кнопку 'Создать новый адрес получения' на вкладке получения, чтобы создать новые адреса.
-Подпись возможна только с адресами типа 'устаревший'.</translation>
+        <translation type="unfinished">Это ваши биткоин-адреса для приема платежей. Используйте кнопку "Создать новый адрес получения" на вкладке получения, чтобы создать новые адреса.
+Подпись возможна только с адресами типа "устаревший".</translation>
     </message>
     <message>
         <source>&amp;Copy Address</source>
@@ -91,7 +103,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Exporting Failed</source>
-        <translation type="unfinished">Ошибка экспорта</translation>
+        <translation type="unfinished">Ошибка при экспорте</translation>
     </message>
 </context>
 <context>
@@ -137,7 +149,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
-        <translation type="unfinished">Данная операция требует введения пароля для разблокировки вашего кошелька.</translation>
+        <translation type="unfinished">Данная операция требует введения парольной фразы для разблокировки вашего кошелька.</translation>
     </message>
     <message>
         <source>Unlock wallet</source>
@@ -169,11 +181,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Enter the old passphrase and new passphrase for the wallet.</source>
-        <translation type="unfinished">Введите старый и новый пароли для кошелька</translation>
+        <translation type="unfinished">Введите старую и новую парольные фразы для кошелька</translation>
     </message>
     <message>
         <source>Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
-        <translation type="unfinished">Помните, что шифрование кошелька не может полностью защитить ваши биткойны от кражи вредоносными программами, заразившими ваш компьютер.</translation>
+        <translation type="unfinished">Помните, что шифрование кошелька не может полностью защитить ваши биткоины от кражи вредоносными программами, заразившими ваш компьютер.</translation>
     </message>
     <message>
         <source>Wallet to be encrypted</source>
@@ -185,11 +197,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Your wallet is now encrypted. </source>
-        <translation type="unfinished">Ваш кошелёк теперь зашифрован.</translation>
+        <translation type="unfinished">Сейчас ваш кошелёк зашифрован.</translation>
     </message>
     <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <translation type="unfinished">ВАЖНО: Все предыдущие резервные копии вашего кошелька, которые вы сделали, необходимо заменить недавно сгенерированным, зашифрованным файлом кошелька. Из соображений безопасности, предыдущие резервные копии незашифрованного файла кошелька станут бесполезными как только вы начнёте использовать новый, зашифрованный кошелёк.</translation>
+        <translation type="unfinished">ВАЖНО: Все ранее созданные резервные копии вашего кошелька, необходимо заменить только что сгенерированным зашифрованным файлом кошелька. Как только вы начнёте использовать новый, зашифрованный кошелёк, из соображений безопасности, предыдущие резервные копии незашифрованного файла кошелька станут бесполезными.</translation>
     </message>
     <message>
         <source>Wallet encryption failed</source>
@@ -224,7 +236,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <name>BanTableModel</name>
     <message>
         <source>IP/Netmask</source>
-        <translation type="unfinished">IP/маска подсети</translation>
+        <translation type="unfinished">IP/Маска подсети</translation>
     </message>
     <message>
         <source>Banned Until</source>
@@ -234,12 +246,17 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>BitcoinApplication</name>
     <message>
+        <source>Settings file %1 might be corrupt or invalid.</source>
+        <translation type="unfinished">Файл настроек %1 повреждён или имеет неверный формат.</translation>
+    </message>
+    <message>
         <source>Runaway exception</source>
-        <translation type="unfinished">Неизвестная ошибка</translation>
+        <translation type="unfinished">Неуправляемое исключение</translation>
     </message>
     <message>
         <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
-        <translation type="unfinished">Произошла фатальная ошибка. %1 больше не может безопасно продолжить и будет закрыт.</translation>
+        <translation type="unfinished">Произошла критическая ошибка. %1 больше не может продолжать безопасную работу и будет закрыт.
+ </translation>
     </message>
     <message>
         <source>Internal error</source>
@@ -247,11 +264,21 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
-        <translation type="unfinished">Возникла внутренняя ошибка. %1 попытается продолжить работу безопасно. Это неожиданная ошибка, о которой можно сообщить, как описано ниже.</translation>
+        <translation type="unfinished">Произошла внутренняя ошибка. %1 попытается безопасно продолжить работу. Вы можете сообщить об этой ошибке по инструкции ниже.</translation>
     </message>
 </context>
 <context>
     <name>QObject</name>
+    <message>
+        <source>Do you want to reset settings to default values, or to abort without making changes?</source>
+        <extracomment>Explanatory text shown on startup when the settings file cannot be read. Prompts user to make a choice between resetting or aborting.</extracomment>
+        <translation type="unfinished">Cбросить настройки до значений по умолчанию или завершить программу без внесения изменений?</translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. Check that settings file is writable, or try running with -nosettings.</source>
+        <extracomment>Explanatory text shown on startup when the settings file could not be written. Prompts user to check that we have the ability to write to the file. Explains that the user has the option of running without a settings file.</extracomment>
+        <translation type="unfinished">Произошла фатальная ошибка. Проверьте, доступна ли запись в файл настроек, или повторите запуск с параметром -nosettings.</translation>
+    </message>
     <message>
         <source>Error: Specified data directory "%1" does not exist.</source>
         <translation type="unfinished">Ошибка: указанный каталог данных "%1" не существует.</translation>
@@ -266,7 +293,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>%1 didn't yet exit safely…</source>
-        <translation type="unfinished">%1 ещё не закрылся безопасно...</translation>
+        <translation type="unfinished">%1 ещё не закрылся безопасно…</translation>
     </message>
     <message>
         <source>unknown</source>
@@ -278,7 +305,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Enter a Bitcoin address (e.g. %1)</source>
-        <translation type="unfinished">Введите биткоин-адрес (напр. %1)</translation>
+        <translation type="unfinished">Введите биткоин-адрес (например,%1)</translation>
     </message>
     <message>
         <source>Unroutable</source>
@@ -354,41 +381,41 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n секунда</numerusform>
+            <numerusform>%n секунды</numerusform>
+            <numerusform>%n секунд</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n minute(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n минута</numerusform>
+            <numerusform>%n минуты</numerusform>
+            <numerusform>%n минут</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n час</numerusform>
+            <numerusform>%n часа</numerusform>
+            <numerusform>%n часов</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n день</numerusform>
+            <numerusform>%n дня</numerusform>
+            <numerusform>%n дней</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n неделя</numerusform>
+            <numerusform>%n недели</numerusform>
+            <numerusform>%n недель</numerusform>
         </translation>
     </message>
     <message>
@@ -398,9 +425,9 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n год</numerusform>
+            <numerusform>%n года</numerusform>
+            <numerusform>%n лет</numerusform>
         </translation>
     </message>
     <message>
@@ -423,12 +450,20 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>bitcoin-core</name>
     <message>
+        <source>Settings file could not be read</source>
+        <translation type="unfinished">Файл настроек не может быть прочитан</translation>
+    </message>
+    <message>
+        <source>Settings file could not be written</source>
+        <translation type="unfinished">Файл настроек не может быть записан</translation>
+    </message>
+    <message>
         <source>The %s developers</source>
         <translation type="unfinished">Разработчики %s</translation>
     </message>
     <message>
         <source>%s corrupt. Try using the wallet tool bitcoin-wallet to salvage or restoring a backup.</source>
-        <translation type="unfinished">%s испорчен. Попробуйте восстановить с помощью инструмента bitcoin-wallet или восстановите из резервной копии.</translation>
+        <translation type="unfinished">%s испорчен. Попробуйте восстановить его с помощью инструмента bitcoin-wallet или из резервной копии.</translation>
     </message>
     <message>
         <source>-maxtxfee is set very high! Fees this large could be paid on a single transaction.</source>
@@ -444,15 +479,19 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Cannot upgrade a non HD split wallet from version %i to version %i without upgrading to support pre-split keypool. Please use version %i or no version specified.</source>
-        <translation type="unfinished">Невозможно обновить разделённый кошелёк без HD с версии %i до версии %i, не обновившись для поддержки предварительно разделённого пула ключей. Пожалуйста, используйте версию %iили повторите без указания версии.</translation>
+        <translation type="unfinished">Невозможно обновить разделённый кошелёк без HD с версии %i до версии %i, не обновившись для поддержки предварительно разделённого пула ключей. Пожалуйста, используйте версию %i или повторите без указания версии.</translation>
     </message>
     <message>
         <source>Distributed under the MIT software license, see the accompanying file %s or %s</source>
-        <translation type="unfinished">Распространяется под лицензией MIT, см. приложенный файл %s или %s</translation>
+        <translation type="unfinished">Распространяется по лицензии MIT. Её текст находится в файле %s и по адресу %s</translation>
     </message>
     <message>
         <source>Error reading %s! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation type="unfinished">Ошибка чтения %s! Все ключи прочитаны верно, но данные транзакций или записи адресной книги могут отсутствовать или быть неправильными.</translation>
+    </message>
+    <message>
+        <source>Error reading %s! Transaction data may be missing or incorrect. Rescanning wallet.</source>
+        <translation type="unfinished">Ошибка чтения %s! Данные транзакций отсутствуют или неправильны. Кошелёк сканируется заново.</translation>
     </message>
     <message>
         <source>Error: Dumpfile format record is incorrect. Got "%s", expected "format".</source>
@@ -464,11 +503,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Error: Dumpfile version is not supported. This version of bitcoin-wallet only supports version 1 dumpfiles. Got dumpfile with version %s</source>
-        <translation type="unfinished">Ошибка: версия дамп-файла не поддерживается. Эта версия bitcoin-wallet поддерживает только дамп-файлы версии 1. Обнаружено дамп-файл версии %s</translation>
+        <translation type="unfinished">Ошибка: версия дамп-файла не поддерживается. Эта версия биткоин-кошелька поддерживает только дамп-файлы версии 1. Обнаружен дамп-файл версии %s</translation>
     </message>
     <message>
-        <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
-        <translation type="unfinished">Ошибка: Не удалось начать прослушивание входящих подключений (прослушивание вернуло ошибку %s)</translation>
+        <source>Error: Legacy wallets only support the "legacy", "p2sh-segwit", and "bech32" address types</source>
+        <translation type="unfinished">Ошибка: устаревшие кошельки поддерживают только следующие типы адресов: "legacy", "p2sh-segwit", и "bech32".</translation>
     </message>
     <message>
         <source>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.</source>
@@ -480,7 +519,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Invalid amount for -maxtxfee=&lt;amount&gt;: '%s' (must be at least the minrelay fee of %s to prevent stuck transactions)</source>
-        <translation type="unfinished">Неверное значение для -maxtxfee=&lt;amount&gt;: '%s' (должна быть не ниже минимально ретранслируемой комиссии %s для предотвращения зависания транзакций)</translation>
+        <translation type="unfinished">Неверное значение для -maxtxfee=&lt;amount&gt;: "%s" (должно быть не ниже минимально ретранслируемой комиссии %s для предотвращения зависания транзакций)</translation>
+    </message>
+    <message>
+        <source>Invalid or corrupt peers.dat (%s). If you believe this is a bug, please report it to %s. As a workaround, you can move the file (%s) out of the way (rename, move, or delete) to have a new one created on the next start.</source>
+        <translation type="unfinished">Неверный или поврежденный peers.dat (%s). Если вы считаете что это ошибка, сообщите о ней %s. В качестве временной меры вы можете переместить, переименовать или удалить файл (%s). Новый файл будет создан при следующем запуске программы.</translation>
     </message>
     <message>
         <source>More than one onion bind address is provided. Using %s for the automatically created Tor onion service.</source>
@@ -500,7 +543,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Please check that your computer's date and time are correct! If your clock is wrong, %s will not work properly.</source>
-        <translation type="unfinished">Пожалуйста, убедитесь, что на вашем компьютере верно установлены дата и время. Если ваши часы неверны, %s не будет работать правильно.</translation>
+        <translation type="unfinished">Пожалуйста, убедитесь, что на вашем компьютере верно установлены дата и время. Если ваши часы сбились, %s будет работать неправильно.</translation>
     </message>
     <message>
         <source>Please contribute if you find %s useful. Visit %s for further information about the software.</source>
@@ -511,32 +554,40 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Обрезка блоков выставлена меньше, чем минимум в %d МиБ. Пожалуйста, используйте большее значение.</translation>
     </message>
     <message>
+        <source>Prune mode is incompatible with -reindex-chainstate. Use full -reindex instead.</source>
+        <translation type="unfinished">Режим обрезки несовместим с -reindex-chainstate. Используйте вместо этого полный -reindex.</translation>
+    </message>
+    <message>
         <source>Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of pruned node)</source>
         <translation type="unfinished">Обрезка: последняя синхронизация кошелька вышла за рамки обрезанных данных. Необходимо сделать -reindex (снова скачать всю цепочку блоков, если у вас узел с обрезкой)</translation>
     </message>
     <message>
         <source>SQLiteDatabase: Unknown sqlite wallet schema version %d. Only version %d is supported</source>
-        <translation type="unfinished">SQLiteDatabase: Неизвестная версия схемы sqlite кошелька: %d. Поддерживается только версия %d</translation>
+        <translation type="unfinished">SQLiteDatabase: неизвестная версия схемы SQLite кошелька: %d. Поддерживается только версия %d</translation>
     </message>
     <message>
         <source>The block database contains a block which appears to be from the future. This may be due to your computer's date and time being set incorrectly. Only rebuild the block database if you are sure that your computer's date and time are correct</source>
         <translation type="unfinished">В базе данных блоков найден блок из будущего. Это может произойти из-за неверно установленных даты и времени на вашем компьютере. Перестраивайте базу данных блоков только если вы уверены, что дата и время установлены верно.</translation>
     </message>
     <message>
+        <source>The block index db contains a legacy 'txindex'. To clear the occupied disk space, run a full -reindex, otherwise ignore this error. This error message will not be displayed again.</source>
+        <translation type="unfinished">База данных индексации блоков содержит устаревший "txindex". Чтобы освободить место на диске, выполните полный -reindex, или игнорируйте эту ошибку. Это сообщение об ошибке больше показано не будет.</translation>
+    </message>
+    <message>
         <source>The transaction amount is too small to send after the fee has been deducted</source>
-        <translation type="unfinished">Сумма транзакции за вычетом комиссии слишком мала</translation>
+        <translation type="unfinished">Сумма транзакции за вычетом комиссии слишком мала для отправки</translation>
     </message>
     <message>
         <source>This error could occur if this wallet was not shutdown cleanly and was last loaded using a build with a newer version of Berkeley DB. If so, please use the software that last loaded this wallet</source>
-        <translation type="unfinished">Данная ошибка может произойти в том случае, если этот кошелёк не был правильно закрыт и в последний раз был загружен используя версию с более новой версией Berkley DB. Если это так, воспользуйтесь той программой, в которой этот кошелёк открывался в последний раз.</translation>
+        <translation type="unfinished">Это могло произойти, если кошелёк был некорректно закрыт, а затем загружен сборкой с более новой версией Berkley DB. Если это так, воспользуйтесь сборкой, в которой этот кошелёк открывался в последний раз</translation>
     </message>
     <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
-        <translation type="unfinished">Это тестовая сборка - используйте на свой страх и риск - не используйте для добычи или торговых приложений</translation>
+        <translation type="unfinished">Это тестовая сборка. Используйте её на свой страх и риск. Не используйте её для добычи или в торговых приложениях</translation>
     </message>
     <message>
         <source>This is the maximum transaction fee you pay (in addition to the normal fee) to prioritize partial spend avoidance over regular coin selection.</source>
-        <translation type="unfinished">Это максимальная транзакция, которую вы заплатите (в добавок к обычной плате), чтобы отдать приоритет избежанию частичной траты перед обычным управлением монетами.</translation>
+        <translation type="unfinished">Это максимальная комиссия за транзакцию, которую вы заплатите (в добавок к обычной комиссии), чтобы отдать приоритет избежанию частичной траты перед обычным управлением монетами.</translation>
     </message>
     <message>
         <source>This is the transaction fee you may discard if change is smaller than dust at this level</source>
@@ -552,15 +603,23 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Unable to replay blocks. You will need to rebuild the database using -reindex-chainstate.</source>
-        <translation type="unfinished">Невозможно воспроизвести блоки. Вам необходимо перестроить базу данных, используя -reindex-chaintate.</translation>
+        <translation type="unfinished">Невозможно воспроизвести блоки. Вам необходимо перестроить базу данных, используя -reindex-chainstate.</translation>
     </message>
     <message>
         <source>Unknown wallet file format "%s" provided. Please provide one of "bdb" or "sqlite".</source>
         <translation type="unfinished">Указан неизвестный формат файла кошелька "%s". Укажите "bdb" либо "sqlite".</translation>
     </message>
     <message>
+        <source>Unsupported chainstate database format found. Please restart with -reindex-chainstate. This will rebuild the chainstate database.</source>
+        <translation type="unfinished">Обнаружен неподдерживаемый формат базы данных состояния цепочки блоков. Пожалуйста, перезапустите программу с ключом -reindex-chainstate. Это перестроит базу данных состояния цепочки блоков.</translation>
+    </message>
+    <message>
+        <source>Wallet created successfully. The legacy wallet type is being deprecated and support for creating and opening legacy wallets will be removed in the future.</source>
+        <translation type="unfinished">Кошелёк успешно создан. Старый формат кошелька признан устаревшим. Поддержка создания кошелька в этом формате и его открытие в будущем будут удалены.</translation>
+    </message>
+    <message>
         <source>Warning: Dumpfile wallet format "%s" does not match command line specified format "%s".</source>
-        <translation type="unfinished">Внимание: формат кошелька дамп-файла "%s" не соответствует указанному в командной строке формату "%s".</translation>
+        <translation type="unfinished">Внимание: формат дамп-файла кошелька "%s" не соответствует указанному в командной строке формату "%s".</translation>
     </message>
     <message>
         <source>Warning: Private keys detected in wallet {%s} with disabled private keys</source>
@@ -568,7 +627,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
-        <translation type="unfinished">Внимание: мы не полностью согласны с другими узлами! Вам или другим участникам, возможно, следует обновить клиент.</translation>
+        <translation type="unfinished">Внимание: мы не полностью согласны с другими узлами! Вам или другим участникам, возможно, следует обновиться.</translation>
     </message>
     <message>
         <source>Witness data for blocks after height %d requires validation. Please restart with -reindex.</source>
@@ -584,27 +643,127 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>-maxmempool must be at least %d MB</source>
-        <translation type="unfinished">-maxmempool должен быть как минимум %d МБ</translation>
+        <translation type="unfinished">-maxmempool должен быть минимум %d МБ</translation>
     </message>
     <message>
         <source>A fatal internal error occurred, see debug.log for details</source>
-        <translation type="unfinished">Ошибка: произошла критическая внутренняя ошибка, для получения деталей см. debug.log</translation>
+        <translation type="unfinished">Произошла критическая внутренняя ошибка, подробности в файле debug.log</translation>
     </message>
     <message>
         <source>Cannot resolve -%s address: '%s'</source>
-        <translation type="unfinished">Не удается разрешить -%s адрес: '%s'</translation>
+        <translation type="unfinished">Не удается разрешить -%s адрес: "%s"</translation>
+    </message>
+    <message>
+        <source>Cannot set -forcednsseed to true when setting -dnsseed to false.</source>
+        <translation type="unfinished">Нельзя установить -forcednsseed в true, если -dnsseed установлен в false.</translation>
     </message>
     <message>
         <source>Cannot set -peerblockfilters without -blockfilterindex.</source>
-        <translation type="unfinished">Нельзя указывать -peerblockfilters без -blockfilterindex.</translation>
+        <translation type="unfinished">Нельзя указывать -peerblockfilters без указания -blockfilterindex.</translation>
     </message>
     <message>
         <source>Cannot write to data directory '%s'; check permissions.</source>
-        <translation type="unfinished">Не удается выполнить запись в каталог данных '%s'; проверьте разрешения.</translation>
+        <translation type="unfinished">Не удается выполнить запись в каталог данных "%s"; проверьте разрешения.</translation>
+    </message>
+    <message>
+        <source>The -txindex upgrade started by a previous version cannot be completed. Restart with the previous version or run a full -reindex.</source>
+        <translation type="unfinished">Обновление -txindex, запущенное при предыдущей версии не может быть завершено. Перезапустите с предыдущей версией или запустите весь процесс заново с ключом -reindex.</translation>
+    </message>
+    <message>
+        <source>%s request to listen on port %u. This port is considered "bad" and thus it is unlikely that any Bitcoin Core peers connect to it. See doc/p2p-bad-ports.md for details and a full list.</source>
+        <translation type="unfinished">%s попытался открыть на прослушивание порт %u. Этот порт считается "плохим". Вероятность, что узлы Bitcoin Core к нему подключатся, крайне мала. Подробности и полный список плохих портов в документации: doc/p2p-bad-ports.md. </translation>
+    </message>
+    <message>
+        <source>-reindex-chainstate option is not compatible with -blockfilterindex. Please temporarily disable blockfilterindex while using -reindex-chainstate, or replace -reindex-chainstate with -reindex to fully rebuild all indexes.</source>
+        <translation type="unfinished">Опция -reindex-chainstate не совместима с -blockfilterindex. Пожалуйста, выключите на время blockfilterindex, пока используется -reindex-chainstate, либо замените -reindex-chainstate на -reindex для полной перестройки всех индексов.</translation>
+    </message>
+    <message>
+        <source>-reindex-chainstate option is not compatible with -coinstatsindex. Please temporarily disable coinstatsindex while using -reindex-chainstate, or replace -reindex-chainstate with -reindex to fully rebuild all indexes.</source>
+        <translation type="unfinished">Опция -reindex-chainstate не совместима с -coinstatsindex. Пожалуйста, выключите на время coinstatsindex, пока используется -reindex-chainstate, либо замените -reindex-chainstate на -reindex для полной перестройки всех индексов.</translation>
+    </message>
+    <message>
+        <source>-reindex-chainstate option is not compatible with -txindex. Please temporarily disable txindex while using -reindex-chainstate, or replace -reindex-chainstate with -reindex to fully rebuild all indexes.</source>
+        <translation type="unfinished">Опция -reindex-chainstate не совместима с -txindex. Пожалуйста, выключите на время txindex, пока используется -reindex-chainstate, либо замените -reindex-chainstate на -reindex для полной перестройки всех индексов.</translation>
+    </message>
+    <message>
+        <source>Assumed-valid: last wallet synchronisation goes beyond available block data. You need to wait for the background validation chain to download more blocks.</source>
+        <translation type="unfinished">Предположительно действительный: последняя синхронизация кошелька была с более новым блоком данных, чем имеется у нас. Подождите, пока фоновый процесс проверки цепочки блоков загрузит новые данные.</translation>
+    </message>
+    <message>
+        <source>Cannot provide specific connections and have addrman find outgoing connections at the same time.</source>
+        <translation type="unfinished">Не удаётся предоставить определённые соединения, чтобы при этом addrman нашёл в них исходящие соединения.</translation>
+    </message>
+    <message>
+        <source>Error loading %s: External signer wallet being loaded without external signer support compiled</source>
+        <translation type="unfinished">Ошибка загрузки %s: не удалось загрузить кошелёк с внешней подписью, так как эта версия программы собрана без поддержки внешней подписи</translation>
+    </message>
+    <message>
+        <source>Error: Address book data in wallet cannot be identified to belong to migrated wallets</source>
+        <translation type="unfinished">Ошибка: адресная книга в кошельке не принадлежит к мигрируемым кошелькам</translation>
+    </message>
+    <message>
+        <source>Error: Duplicate descriptors created during migration. Your wallet may be corrupted.</source>
+        <translation type="unfinished">Ошибка: при миграции были созданы дублирующиеся дескрипторы. Возможно, ваш кошелёк повреждён.</translation>
+    </message>
+    <message>
+        <source>Error: Transaction %s in wallet cannot be identified to belong to migrated wallets</source>
+        <translation type="unfinished">Ошибка: транзакция %s не принадлежит к мигрируемым кошелькам</translation>
+    </message>
+    <message>
+        <source>Error: Unable to produce descriptors for this legacy wallet. Make sure the wallet is unlocked first</source>
+        <translation type="unfinished">Ошибка: не удалось создать дескрипторы для этого кошелька старого формата. Для начала убедитесь, что кошелёк разблокирован</translation>
+    </message>
+    <message>
+        <source>Failed to rename invalid peers.dat file. Please move or delete it and try again.</source>
+        <translation type="unfinished">Не удалось переименовать файл peers.dat. Пожалуйста, переместите или удалите его и попробуйте снова.</translation>
+    </message>
+    <message>
+        <source>Incompatible options: -dnsseed=1 was explicitly specified, but -onlynet forbids connections to IPv4/IPv6</source>
+        <translation type="unfinished">Несовместимые ключи: был явно указан -dnsseed=1, но -onlynet не разрешены соединения через IPv4/IPv6</translation>
+    </message>
+    <message>
+        <source>Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is explicitly forbidden: -onion=0</source>
+        <translation type="unfinished">Исходящие соединения разрешены только через сеть Tor (-onlynet=onion), однако прокси для подключения к сети Tor явно запрещен: -onion=0</translation>
+    </message>
+    <message>
+        <source>Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is not provided: none of -proxy, -onion or -listenonion is given</source>
+        <translation type="unfinished">Исходящие соединения разрешены только через сеть Tor (-onlynet=onion), однако прокси для подключения к сети Tor не указан: не заданы ни -proxy, ни -onion, ни -listenonion</translation>
+    </message>
+    <message>
+        <source>Unrecognized descriptor found. Loading wallet %s
+
+The wallet might had been created on a newer version.
+Please try running the latest software version.
+</source>
+        <translation type="unfinished">При загрузке кошелька %s найден нераспознаваемый дескриптор
+
+Кошелёк мог быть создан на более новой версии программы.
+Пожалуйста, попробуйте обновить программу до последней версии.
+</translation>
+    </message>
+    <message>
+        <source>Unsupported category-specific logging level -loglevel=%s. Expected -loglevel=&lt;category&gt;:&lt;loglevel&gt;. Valid categories: %s. Valid loglevels: %s.</source>
+        <translation type="unfinished">Неподдерживаемый уровень подробности журнала для категории -loglevel=%s. Ожидалось -loglevel=&lt;category&gt;:&lt;loglevel&gt;. Доступные категории: %s. Доступные уровни подробности журнала: %s.</translation>
+    </message>
+    <message>
+        <source>
+Unable to cleanup failed migration</source>
+        <translation type="unfinished">
+Не удалось очистить следы после неуспешной миграции</translation>
+    </message>
+    <message>
+        <source>
+Unable to restore backup of wallet.</source>
+        <translation type="unfinished">
+Не удалось восстановить кошелёк из резервной копии.</translation>
     </message>
     <message>
         <source>Config setting for %s only applied on %s network when in [%s] section.</source>
-        <translation type="unfinished">Настройка конфигурации %s применяется в сети %s только если находится в разделе [%s].</translation>
+        <translation type="unfinished">Настройка конфигурации %s применяется для сети %s только если находится в разделе [%s].</translation>
+    </message>
+    <message>
+        <source>Copyright (C) %i-%i</source>
+        <translation type="unfinished">Авторское право (C) %i-%i</translation>
     </message>
     <message>
         <source>Corrupted block database detected</source>
@@ -616,11 +775,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Could not parse asmap file %s</source>
-        <translation type="unfinished">Не могу разобрать файл asmap %s</translation>
+        <translation type="unfinished">Не удалось разобрать файл asmap %s</translation>
     </message>
     <message>
         <source>Disk space is too low!</source>
-        <translation type="unfinished">Мало места на диске!</translation>
+        <translation type="unfinished">Место на диске заканчивается!</translation>
     </message>
     <message>
         <source>Do you want to rebuild the block database now?</source>
@@ -632,23 +791,23 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Dump file %s does not exist.</source>
-        <translation type="unfinished">Дамп файл %s не существует.</translation>
+        <translation type="unfinished">Дамп-файл %s не существует.</translation>
     </message>
     <message>
         <source>Error creating %s</source>
-        <translation type="unfinished">Ошибка загрузки %s</translation>
+        <translation type="unfinished">Ошибка при создании %s</translation>
     </message>
     <message>
         <source>Error initializing block database</source>
-        <translation type="unfinished">Ошибка инициализации базы данных блоков</translation>
+        <translation type="unfinished">Ошибка при инициализации базы данных блоков</translation>
     </message>
     <message>
         <source>Error initializing wallet database environment %s!</source>
-        <translation type="unfinished">Ошибка инициализации окружения базы данных кошелька %s!</translation>
+        <translation type="unfinished">Ошибка при инициализации окружения базы данных кошелька %s!</translation>
     </message>
     <message>
         <source>Error loading %s</source>
-        <translation type="unfinished">Ошибка загрузки %s</translation>
+        <translation type="unfinished">Ошибка при загрузке %s</translation>
     </message>
     <message>
         <source>Error loading %s: Private keys can only be disabled during creation</source>
@@ -679,8 +838,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Ошибка чтения следующей записи из базы данных кошелька</translation>
     </message>
     <message>
-        <source>Error upgrading chainstate database</source>
-        <translation type="unfinished">Ошибка обновления базы данных chainstate</translation>
+        <source>Error: Could not add watchonly tx to watchonly wallet</source>
+        <translation type="unfinished">Ошибка: не удалось добавить транзакцию для наблюдения в кошелек для наблюдения</translation>
+    </message>
+    <message>
+        <source>Error: Could not delete watchonly transactions</source>
+        <translation type="unfinished">Ошибка: транзакции только для наблюдения не удаляются</translation>
     </message>
     <message>
         <source>Error: Couldn't create cursor into database</source>
@@ -692,11 +855,15 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Error: Dumpfile checksum does not match. Computed %s, expected %s</source>
-        <translation type="unfinished">Ошибка: контрольная сумма дамп-файла не совпадает. Вычислено %s, ожидалось %s.</translation>
+        <translation type="unfinished">Ошибка: контрольные суммы дамп-файла не совпадают. Вычислено %s, ожидалось %s.</translation>
+    </message>
+    <message>
+        <source>Error: Failed to create new watchonly wallet</source>
+        <translation type="unfinished">Ошибка: не удалось создать кошелёк только на просмотр</translation>
     </message>
     <message>
         <source>Error: Got key that was not hex: %s</source>
-        <translation type="unfinished">Ошибка: получен ключ, оказавшийся не шестнадцатеричным: %s</translation>
+        <translation type="unfinished">Ошибка: получен ключ, не являющийся шестнадцатеричным: %s</translation>
     </message>
     <message>
         <source>Error: Got value that was not hex: %s</source>
@@ -704,15 +871,47 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Error: Keypool ran out, please call keypoolrefill first</source>
-        <translation type="unfinished">Ошибка: пул ключей опустел, пожалуйста сначала выполните keypoolrefill</translation>
+        <translation type="unfinished">Ошибка: пул ключей опустел. Пожалуйста, выполните keypoolrefill</translation>
     </message>
     <message>
         <source>Error: Missing checksum</source>
         <translation type="unfinished">Ошибка: отсутствует контрольная сумма</translation>
     </message>
     <message>
+        <source>Error: No %s addresses available.</source>
+        <translation type="unfinished">Ошибка: нет %s доступных адресов.</translation>
+    </message>
+    <message>
+        <source>Error: Not all watchonly txs could be deleted</source>
+        <translation type="unfinished">Ошибка: не все наблюдаемые транзакции могут быть удалены</translation>
+    </message>
+    <message>
+        <source>Error: This wallet already uses SQLite</source>
+        <translation type="unfinished">Ошибка: этот кошелёк уже использует SQLite</translation>
+    </message>
+    <message>
+        <source>Error: This wallet is already a descriptor wallet</source>
+        <translation type="unfinished">Ошибка: этот кошелёк уже является дескрипторным</translation>
+    </message>
+    <message>
+        <source>Error: Unable to begin reading all records in the database</source>
+        <translation type="unfinished">Ошибка: не удалось начать читать все записи из базе данных</translation>
+    </message>
+    <message>
+        <source>Error: Unable to make a backup of your wallet</source>
+        <translation type="unfinished">Ошибка: не удалось создать резервную копию кошелька</translation>
+    </message>
+    <message>
         <source>Error: Unable to parse version %u as a uint32_t</source>
         <translation type="unfinished">Ошибка: невозможно разобрать версию %u как uint32_t</translation>
+    </message>
+    <message>
+        <source>Error: Unable to read all records in the database</source>
+        <translation type="unfinished">Ошибка: не удалось прочитать все записи из базе данных</translation>
+    </message>
+    <message>
+        <source>Error: Unable to remove watchonly address book data</source>
+        <translation type="unfinished">Ошибка: не удалось удалить данные из адресной книги только для наблюдения</translation>
     </message>
     <message>
         <source>Error: Unable to write record to new wallet</source>
@@ -720,7 +919,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
-        <translation type="unfinished">Не удалось начать прослушивание на порту. Используйте -listen=0, если вас это устраивает.</translation>
+        <translation type="unfinished">Не удалось открыть никакой порт на прослушивание. Используйте -listen=0, если вас это устроит.</translation>
     </message>
     <message>
         <source>Failed to rescan the wallet during initialization</source>
@@ -740,7 +939,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Importing…</source>
-        <translation type="unfinished">Импорт...</translation>
+        <translation type="unfinished">Импорт…</translation>
     </message>
     <message>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
@@ -751,68 +950,84 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Начальная проверка исправности не удалась. %s завершает работу.</translation>
     </message>
     <message>
+        <source>Input not found or already spent</source>
+        <translation type="unfinished">Вход для тразакции не найден или уже использован</translation>
+    </message>
+    <message>
         <source>Insufficient funds</source>
         <translation type="unfinished">Недостаточно средств</translation>
     </message>
     <message>
         <source>Invalid -i2psam address or hostname: '%s'</source>
-        <translation type="unfinished">Неверный адрес или имя хоста в -i2psam: '%s'</translation>
+        <translation type="unfinished">Неверный адрес или имя хоста в -i2psam: "%s"</translation>
     </message>
     <message>
         <source>Invalid -onion address or hostname: '%s'</source>
-        <translation type="unfinished">Неверный -onion адрес или имя хоста: '%s'</translation>
+        <translation type="unfinished">Неверный -onion адрес или имя хоста: "%s"</translation>
     </message>
     <message>
         <source>Invalid -proxy address or hostname: '%s'</source>
-        <translation type="unfinished">Неверный адрес -proxy или имя хоста: '%s'</translation>
+        <translation type="unfinished">Неверный адрес -proxy или имя хоста: "%s"</translation>
     </message>
     <message>
         <source>Invalid P2P permission: '%s'</source>
-        <translation type="unfinished">Неверные разрешение для P2P: '%s'</translation>
+        <translation type="unfinished">Неверные разрешения для P2P: "%s"</translation>
     </message>
     <message>
         <source>Invalid amount for -%s=&lt;amount&gt;: '%s'</source>
-        <translation type="unfinished">Неверная сумма для -%s=&lt;amount&gt;: '%s'</translation>
+        <translation type="unfinished">Неверная сумма для -%s=&lt;amount&gt;: "%s"</translation>
     </message>
     <message>
         <source>Invalid amount for -discardfee=&lt;amount&gt;: '%s'</source>
-        <translation type="unfinished">Неверная сумма для -discardfee=&lt;amount&gt;: '%s'</translation>
+        <translation type="unfinished">Неверная сумма для -discardfee=&lt;amount&gt;: "%s"</translation>
     </message>
     <message>
         <source>Invalid amount for -fallbackfee=&lt;amount&gt;: '%s'</source>
-        <translation type="unfinished">Неверная сумма для -fallbackfee=&lt;amount&gt;: '%s'</translation>
+        <translation type="unfinished">Неверная сумма для -fallbackfee=&lt;amount&gt;: "%s"</translation>
     </message>
     <message>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: '%s' (must be at least %s)</source>
-        <translation type="unfinished">Неверная сумма для -paytxfee=&lt;amount&gt;: '%s' (должно быть как минимум %s)</translation>
+        <translation type="unfinished">Неверная сумма для -paytxfee=&lt;amount&gt;: "%s" (должно быть как минимум %s)</translation>
     </message>
     <message>
         <source>Invalid netmask specified in -whitelist: '%s'</source>
-        <translation type="unfinished">Указана неверная сетевая маска в -whitelist: '%s'</translation>
+        <translation type="unfinished">Указана неверная сетевая маска в -whitelist: "%s"</translation>
+    </message>
+    <message>
+        <source>Listening for incoming connections failed (listen returned error %s)</source>
+        <translation type="unfinished">Ошибка при прослушивании входящих подключений (%s)</translation>
     </message>
     <message>
         <source>Loading P2P addresses…</source>
-        <translation type="unfinished">Загрузка P2P адресов...</translation>
+        <translation type="unfinished">Загрузка P2P адресов…</translation>
     </message>
     <message>
         <source>Loading banlist…</source>
-        <translation type="unfinished">Загрузка черного списка...</translation>
+        <translation type="unfinished">Загрузка черного списка…</translation>
     </message>
     <message>
         <source>Loading block index…</source>
-        <translation type="unfinished">Загрузка индекса блоков...</translation>
+        <translation type="unfinished">Загрузка индекса блоков…</translation>
     </message>
     <message>
         <source>Loading wallet…</source>
-        <translation type="unfinished">Загрузка кошелька...</translation>
+        <translation type="unfinished">Загрузка кошелька…</translation>
+    </message>
+    <message>
+        <source>Missing amount</source>
+        <translation type="unfinished">Отсутствует сумма</translation>
+    </message>
+    <message>
+        <source>Missing solving data for estimating transaction size</source>
+        <translation type="unfinished">Недостаточно данных для оценки размера транзакции</translation>
     </message>
     <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
-        <translation type="unfinished">Необходимо указать порт с -whitebind: '%s'</translation>
+        <translation type="unfinished">Необходимо указать порт с -whitebind: "%s"</translation>
     </message>
     <message>
-        <source>No proxy server specified. Use -proxy=&lt;ip&gt; or -proxy=&lt;ip:port&gt;.</source>
-        <translation type="unfinished">Не указан прокси-сервер. Используйте -proxy=&lt;ip&gt; или -proxy=&lt;ip:port&gt;</translation>
+        <source>No addresses available</source>
+        <translation type="unfinished">Нет доступных адресов</translation>
     </message>
     <message>
         <source>Not enough file descriptors available.</source>
@@ -823,48 +1038,44 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Обрезка блоков не может использовать отрицательное значение.</translation>
     </message>
     <message>
-        <source>Prune mode is incompatible with -coinstatsindex.</source>
-        <translation type="unfinished">Режим удаления блоков несовместим с -coinstatsindex.</translation>
-    </message>
-    <message>
         <source>Prune mode is incompatible with -txindex.</source>
         <translation type="unfinished">Режим обрезки несовместим с -txindex.</translation>
     </message>
     <message>
         <source>Pruning blockstore…</source>
-        <translation type="unfinished">Сокращение объема хранилища блоков...</translation>
+        <translation type="unfinished">Сокращение хранилища блоков…</translation>
     </message>
     <message>
         <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
-        <translation type="unfinished">Уменьшите -maxconnections с %d до %d из-за ограничений системы.</translation>
+        <translation type="unfinished">Уменьшение -maxconnections с %d до %d из-за ограничений системы.</translation>
     </message>
     <message>
         <source>Replaying blocks…</source>
-        <translation type="unfinished">Пересборка блоков...</translation>
+        <translation type="unfinished">Пересборка блоков…</translation>
     </message>
     <message>
         <source>Rescanning…</source>
-        <translation type="unfinished">Пересканирование...</translation>
+        <translation type="unfinished">Повторное сканирование…</translation>
     </message>
     <message>
         <source>SQLiteDatabase: Failed to execute statement to verify database: %s</source>
-        <translation type="unfinished">SQLiteDatabase: Не удалось выполнить запрос для проверки базы данных: %s</translation>
+        <translation type="unfinished">SQLiteDatabase: не удалось выполнить запрос для проверки базы данных: %s</translation>
     </message>
     <message>
         <source>SQLiteDatabase: Failed to prepare statement to verify database: %s</source>
-        <translation type="unfinished">SQLiteDatabase: Не удалось подготовить запрос для проверки базы данных: %s</translation>
+        <translation type="unfinished">SQLiteDatabase: не удалось подготовить запрос для проверки базы данных: %s</translation>
     </message>
     <message>
         <source>SQLiteDatabase: Failed to read database verification error: %s</source>
-        <translation type="unfinished">SQLiteDatabase: Ошибка при проверке базы данных: %s</translation>
+        <translation type="unfinished">SQLiteDatabase: ошибка при проверке базы данных: %s</translation>
     </message>
     <message>
         <source>SQLiteDatabase: Unexpected application id. Expected %u, got %u</source>
-        <translation type="unfinished">SQLiteDatabase: Неожиданный id приложения. Ожидалось %u, но получено %u</translation>
+        <translation type="unfinished">SQLiteDatabase: неожиданный id приложения. Ожидалось %u, но получено %u</translation>
     </message>
     <message>
         <source>Section [%s] is not recognized.</source>
-        <translation type="unfinished">Раздел [%s] не распознан.</translation>
+        <translation type="unfinished">Секция [%s] не распознана.</translation>
     </message>
     <message>
         <source>Signing transaction failed</source>
@@ -880,19 +1091,19 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Specified -walletdir "%s" is not a directory</source>
-        <translation type="unfinished">Указанный -walletdir "%s" не является директорией</translation>
+        <translation type="unfinished">Указанный -walletdir "%s" не является каталогом</translation>
     </message>
     <message>
         <source>Specified blocks directory "%s" does not exist.</source>
-        <translation type="unfinished">Указанная директория для блоков "%s" не существует.</translation>
+        <translation type="unfinished">Указанный каталог блоков "%s" не существует.</translation>
     </message>
     <message>
         <source>Starting network threads…</source>
-        <translation type="unfinished">Запуск сетевых потоков...</translation>
+        <translation type="unfinished">Запуск сетевых потоков…</translation>
     </message>
     <message>
         <source>The source code is available from %s.</source>
-        <translation type="unfinished">Исходный код доступен в %s.</translation>
+        <translation type="unfinished">Исходный код доступен по адресу %s.</translation>
     </message>
     <message>
         <source>The specified config file %s does not exist</source>
@@ -904,11 +1115,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>The wallet will avoid paying less than the minimum relay fee.</source>
-        <translation type="unfinished">Кошелёк будет стараться не платить меньше, чем минимальная комиссии ретрансляции.</translation>
+        <translation type="unfinished">Кошелёк будет стараться платить не меньше минимальной комиссии для ретрансляции.</translation>
     </message>
     <message>
         <source>This is experimental software.</source>
-        <translation type="unfinished">Это экспериментальная программа.</translation>
+        <translation type="unfinished">Это экспериментальное программное обеспечение.</translation>
     </message>
     <message>
         <source>This is the minimum transaction fee you pay on every transaction.</source>
@@ -927,28 +1138,44 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Сумма транзакции не должна быть отрицательной</translation>
     </message>
     <message>
+        <source>Transaction change output index out of range</source>
+        <translation type="unfinished">Индекс получателя адреса сдачи вне диапазона</translation>
+    </message>
+    <message>
         <source>Transaction has too long of a mempool chain</source>
-        <translation type="unfinished">В транзакции слишком длинная цепочка пула памяти</translation>
+        <translation type="unfinished">У транзакции слишком длинная цепочка в пуле в памяти</translation>
     </message>
     <message>
         <source>Transaction must have at least one recipient</source>
         <translation type="unfinished">Транзакция должна иметь хотя бы одного получателя</translation>
     </message>
     <message>
+        <source>Transaction needs a change address, but we can't generate it.</source>
+        <translation type="unfinished">Для транзакции требуется адрес сдачи, но сгенерировать его не удалось.</translation>
+    </message>
+    <message>
         <source>Transaction too large</source>
         <translation type="unfinished">Транзакция слишком большая</translation>
     </message>
     <message>
+        <source>Unable to allocate memory for -maxsigcachesize: '%s' MiB</source>
+        <translation type="unfinished">Не удалось выделить память для -maxsigcachesize: "%s" МиБ</translation>
+    </message>
+    <message>
         <source>Unable to bind to %s on this computer (bind returned error %s)</source>
-        <translation type="unfinished">Невозможно привязаться к %s на этом компьютере (bind вернул ошибку %s)</translation>
+        <translation type="unfinished">Невозможно привязаться (bind) к %s на этом компьютере (ошибка %s)</translation>
     </message>
     <message>
         <source>Unable to bind to %s on this computer. %s is probably already running.</source>
-        <translation type="unfinished">Невозможно привязаться к %s на этом компьютере. Возможно, %s уже запущен.</translation>
+        <translation type="unfinished">Невозможно привязаться (bind) к %s на этом компьютере. Возможно, %s уже запущен.</translation>
     </message>
     <message>
         <source>Unable to create the PID file '%s': %s</source>
-        <translation type="unfinished">Невозможно создать файл PID '%s': %s</translation>
+        <translation type="unfinished">Не удалось создать PID-файл "%s": %s</translation>
+    </message>
+    <message>
+        <source>Unable to find UTXO for external input</source>
+        <translation type="unfinished">Не удалось найти UTXO для внешнего входа</translation>
     </message>
     <message>
         <source>Unable to generate initial keys</source>
@@ -963,8 +1190,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Не удается открыть %s для записи</translation>
     </message>
     <message>
+        <source>Unable to parse -maxuploadtarget: '%s'</source>
+        <translation type="unfinished">Ошибка при разборе параметра -maxuploadtarget: "%s"</translation>
+    </message>
+    <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
-        <translation type="unfinished">Невозможно запустить HTTP-сервер. См. подробности в журнале отладки.</translation>
+        <translation type="unfinished">Невозможно запустить HTTP-сервер. Подробности в файле debug.log.</translation>
+    </message>
+    <message>
+        <source>Unable to unload the wallet before migrating</source>
+        <translation type="unfinished">Не удалось выгрузить кошелёк перед миграцией</translation>
     </message>
     <message>
         <source>Unknown -blockfilterindex value %s.</source>
@@ -972,23 +1207,27 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Unknown address type '%s'</source>
-        <translation type="unfinished">Неизвестный тип адреса '%s'</translation>
+        <translation type="unfinished">Неизвестный тип адреса "%s"</translation>
     </message>
     <message>
         <source>Unknown change type '%s'</source>
-        <translation type="unfinished">Неизвестный тип сдачи '%s'</translation>
+        <translation type="unfinished">Неизвестный тип сдачи "%s"</translation>
     </message>
     <message>
         <source>Unknown network specified in -onlynet: '%s'</source>
-        <translation type="unfinished">Неизвестная сеть указана в -onlynet: '%s'</translation>
+        <translation type="unfinished">В -onlynet указана неизвестная сеть: "%s"</translation>
+    </message>
+    <message>
+        <source>Unknown new rules activated (versionbit %i)</source>
+        <translation type="unfinished">В силу вступили неизвестные правила (versionbit %i)</translation>
+    </message>
+    <message>
+        <source>Unsupported global logging level -loglevel=%s. Valid values: %s.</source>
+        <translation type="unfinished">Неподдерживаемый уровень подробности ведения журнала -loglevel=%s. Доступные значения: %s.</translation>
     </message>
     <message>
         <source>Unsupported logging category %s=%s.</source>
-        <translation type="unfinished">Неподдерживаемая категория ведения журнала %s=%s.</translation>
-    </message>
-    <message>
-        <source>Upgrading UTXO database</source>
-        <translation type="unfinished">Обновление базы данных UTXO</translation>
+        <translation type="unfinished">Неподдерживаемый уровень ведения журнала %s=%s.</translation>
     </message>
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
@@ -996,15 +1235,15 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Verifying blocks…</source>
-        <translation type="unfinished">Проверка блоков...</translation>
+        <translation type="unfinished">Проверка блоков…</translation>
     </message>
     <message>
         <source>Verifying wallet(s)…</source>
-        <translation type="unfinished">Проверка кошелька(ов)...</translation>
+        <translation type="unfinished">Проверка кошелька(ов)…</translation>
     </message>
     <message>
         <source>Wallet needed to be rewritten: restart %s to complete</source>
-        <translation type="unfinished">Необходимо перезаписать кошелёк, перезапустите %s для завершения операции</translation>
+        <translation type="unfinished">Необходимо перезаписать кошелёк. Перезапустите %s для завершения операции</translation>
     </message>
 </context>
 <context>
@@ -1015,7 +1254,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Show general overview of wallet</source>
-        <translation type="unfinished">Отобразить основное окно кошелька</translation>
+        <translation type="unfinished">Показать текущее состояние кошелька</translation>
     </message>
     <message>
         <source>&amp;Transactions</source>
@@ -1058,6 +1297,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Создать новый кошелёк</translation>
     </message>
     <message>
+        <source>&amp;Minimize</source>
+        <translation type="unfinished">&amp;Свернуть</translation>
+    </message>
+    <message>
         <source>Wallet:</source>
         <translation type="unfinished">Кошелёк:</translation>
     </message>
@@ -1072,7 +1315,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Send coins to a Bitcoin address</source>
-        <translation type="unfinished">Отправить средства на Биткоин адрес</translation>
+        <translation type="unfinished">Отправить средства на биткоин-адрес</translation>
     </message>
     <message>
         <source>Backup wallet to another location</source>
@@ -1080,7 +1323,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Change the passphrase used for wallet encryption</source>
-        <translation type="unfinished">Изменить пароль используемый для шифрования кошелька</translation>
+        <translation type="unfinished">Изменить парольную фразу, используемую для шифрования кошелька</translation>
     </message>
     <message>
         <source>&amp;Send</source>
@@ -1092,11 +1335,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>&amp;Options…</source>
-        <translation type="unfinished">&amp;Параметры...</translation>
+        <translation type="unfinished">&amp;Параметры…</translation>
     </message>
     <message>
         <source>&amp;Encrypt Wallet…</source>
-        <translation type="unfinished">&amp;Зашифровать Кошелёк...</translation>
+        <translation type="unfinished">&amp;Зашифровать кошелёк…</translation>
     </message>
     <message>
         <source>Encrypt the private keys that belong to your wallet</source>
@@ -1104,47 +1347,47 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>&amp;Backup Wallet…</source>
-        <translation type="unfinished">&amp;Создать резервную копию кошелька...</translation>
+        <translation type="unfinished">&amp;Сделать резервную копию кошелька…</translation>
     </message>
     <message>
         <source>&amp;Change Passphrase…</source>
-        <translation type="unfinished">&amp;Изменить пароль...</translation>
+        <translation type="unfinished">&amp;Изменить парольную фразу…</translation>
     </message>
     <message>
         <source>Sign &amp;message…</source>
-        <translation type="unfinished">Подписать &amp;сообщение...</translation>
+        <translation type="unfinished">Подписать &amp;сообщение…</translation>
     </message>
     <message>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
-        <translation type="unfinished">Подписать сообщения своими Биткоин кошельками, что-бы доказать, что вы ими владеете</translation>
+        <translation type="unfinished">Подписать сообщение биткоин-адресом, чтобы доказать, что вы им владеете</translation>
     </message>
     <message>
         <source>&amp;Verify message…</source>
-        <translation type="unfinished">&amp;Проверить сообщение</translation>
+        <translation type="unfinished">&amp;Проверить сообщение…</translation>
     </message>
     <message>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
-        <translation type="unfinished">Проверяйте сообщения, чтобы убедиться, что они подписаны конкретными биткоин-адресами</translation>
+        <translation type="unfinished">Проверить подпись сообщения, чтобы убедиться, что оно подписано конкретным биткоин-адресом</translation>
     </message>
     <message>
         <source>&amp;Load PSBT from file…</source>
-        <translation type="unfinished">&amp;Загрузить PSBT из файла...</translation>
+        <translation type="unfinished">&amp;Загрузить PSBT из файла…</translation>
     </message>
     <message>
         <source>Open &amp;URI…</source>
-        <translation type="unfinished">О&amp;ткрыть URI...</translation>
+        <translation type="unfinished">Открыть &amp;URI…</translation>
     </message>
     <message>
         <source>Close Wallet…</source>
-        <translation type="unfinished">Закрыть кошелёк...</translation>
+        <translation type="unfinished">Закрыть кошелёк…</translation>
     </message>
     <message>
         <source>Create Wallet…</source>
-        <translation type="unfinished">Создать кошелёк...</translation>
+        <translation type="unfinished">Создать кошелёк…</translation>
     </message>
     <message>
         <source>Close All Wallets…</source>
-        <translation type="unfinished">Закрыть все кошельки...</translation>
+        <translation type="unfinished">Закрыть все кошельки…</translation>
     </message>
     <message>
         <source>&amp;File</source>
@@ -1164,27 +1407,27 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Syncing Headers (%1%)…</source>
-        <translation type="unfinished">Синхронизация заголовков (%1%)...</translation>
+        <translation type="unfinished">Синхронизация заголовков (%1%)…</translation>
     </message>
     <message>
         <source>Synchronizing with network…</source>
-        <translation type="unfinished">Синхронизация с сетью...</translation>
+        <translation type="unfinished">Синхронизация с сетью…</translation>
     </message>
     <message>
         <source>Indexing blocks on disk…</source>
-        <translation type="unfinished">Индексация блоков на диске...</translation>
+        <translation type="unfinished">Индексация блоков на диске…</translation>
     </message>
     <message>
         <source>Processing blocks on disk…</source>
-        <translation type="unfinished">Обработка блоков на диске...</translation>
+        <translation type="unfinished">Обработка блоков на диске…</translation>
     </message>
     <message>
         <source>Reindexing blocks on disk…</source>
-        <translation type="unfinished">Переиндексация блоков на диске...</translation>
+        <translation type="unfinished">Переиндексация блоков на диске…</translation>
     </message>
     <message>
         <source>Connecting to peers…</source>
-        <translation type="unfinished">Подключение к узлам...</translation>
+        <translation type="unfinished">Подключение к узлам…</translation>
     </message>
     <message>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
@@ -1192,22 +1435,22 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Show the list of used sending addresses and labels</source>
-        <translation type="unfinished">Показать список адресов, на которые были отправлены средства, и их метки</translation>
+        <translation type="unfinished">Показать список использованных адресов отправки и меток</translation>
     </message>
     <message>
         <source>Show the list of used receiving addresses and labels</source>
-        <translation type="unfinished">Показать список адресов, на которые были получены средства, и их метки</translation>
+        <translation type="unfinished">Показать список использованных адресов получения и меток</translation>
     </message>
     <message>
         <source>&amp;Command-line options</source>
-        <translation type="unfinished">Параметры &amp;командной строки</translation>
+        <translation type="unfinished">&amp;Параметры командной строки</translation>
     </message>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>Обработан %n блок истории транзакций.</numerusform>
+            <numerusform>Обработано %n блока истории транзакций.</numerusform>
+            <numerusform>Обработано %n блоков истории транзакций.</numerusform>
         </translation>
     </message>
     <message>
@@ -1216,7 +1459,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Catching up…</source>
-        <translation type="unfinished">Синхронизация...</translation>
+        <translation type="unfinished">Синхронизация…</translation>
     </message>
     <message>
         <source>Last received block was generated %1 ago.</source>
@@ -1240,11 +1483,15 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Up to date</source>
-        <translation type="unfinished">Синхронизировано</translation>
+        <translation type="unfinished">Синхронизированно</translation>
     </message>
     <message>
         <source>Load Partially Signed Bitcoin Transaction</source>
         <translation type="unfinished">Загрузить частично подписанную биткоин-транзакцию (PSBT)</translation>
+    </message>
+    <message>
+        <source>Load PSBT from &amp;clipboard…</source>
+        <translation type="unfinished">Загрузить PSBT из &amp;буфера обмена…</translation>
     </message>
     <message>
         <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
@@ -1283,12 +1530,22 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Закрыть кошелёк</translation>
     </message>
     <message>
+        <source>Restore Wallet…</source>
+        <extracomment>Name of the menu item that restores wallet from a backup file.</extracomment>
+        <translation type="unfinished">Восстановить кошелёк…</translation>
+    </message>
+    <message>
+        <source>Restore a wallet from a backup file</source>
+        <extracomment>Status tip for Restore Wallet menu item</extracomment>
+        <translation type="unfinished">Восстановить кошелек из резервной копии</translation>
+    </message>
+    <message>
         <source>Close all wallets</source>
         <translation type="unfinished">Закрыть все кошельки</translation>
     </message>
     <message>
         <source>Show the %1 help message to get a list with possible Bitcoin command-line options</source>
-        <translation type="unfinished">Показать помощь по %1, чтобы получить список доступных параметров командной строки</translation>
+        <translation type="unfinished">Показать справку %1 со списком доступных параметров командной строки</translation>
     </message>
     <message>
         <source>&amp;Mask values</source>
@@ -1307,12 +1564,32 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Нет доступных кошельков</translation>
     </message>
     <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">Данные кошелька</translation>
+    </message>
+    <message>
+        <source>Load Wallet Backup</source>
+        <extracomment>The title for Restore Wallet File Windows</extracomment>
+        <translation type="unfinished">Загрузить резервную копию кошелька</translation>
+    </message>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of pop-up window shown when the user is attempting to restore a wallet.</extracomment>
+        <translation type="unfinished">Восстановить кошелёк</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">Название кошелька</translation>
+    </message>
+    <message>
         <source>&amp;Window</source>
         <translation type="unfinished">&amp;Окно</translation>
     </message>
     <message>
         <source>Zoom</source>
-        <translation type="unfinished">Масштаб</translation>
+        <translation type="unfinished">Развернуть</translation>
     </message>
     <message>
         <source>Main Window</source>
@@ -1322,13 +1599,21 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>%1 client</source>
         <translation type="unfinished">%1 клиент</translation>
     </message>
+    <message>
+        <source>&amp;Hide</source>
+        <translation type="unfinished">&amp;Скрыть</translation>
+    </message>
+    <message>
+        <source>S&amp;how</source>
+        <translation type="unfinished">&amp;Показать</translation>
+    </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n активное подключение к сети Bitcoin.</numerusform>
+            <numerusform>%n активных подключения к сети Bitcoin.</numerusform>
+            <numerusform>%n активных подключений к сети Bitcoin.</numerusform>
         </translation>
     </message>
     <message>
@@ -1350,6 +1635,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Enable network activity</source>
         <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
         <translation type="unfinished">Включить взаимодействие с сетью</translation>
+    </message>
+    <message>
+        <source>Pre-syncing Headers (%1%)…</source>
+        <translation type="unfinished">Предсинхронизация заголовков (%1%)…</translation>
     </message>
     <message>
         <source>Error: %1</source>
@@ -1386,7 +1675,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Label: %1
 </source>
-        <translation type="unfinished">Ярлык: %1
+        <translation type="unfinished">Метка: %1
 </translation>
     </message>
     <message>
@@ -1487,7 +1776,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Received with label</source>
-        <translation type="unfinished">Получено на метку</translation>
+        <translation type="unfinished">Получено с меткой</translation>
     </message>
     <message>
         <source>Received with address</source>
@@ -1510,6 +1799,30 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Копировать сумму</translation>
     </message>
     <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Копировать адрес</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Копировать &amp;метку</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Копировать с&amp;умму</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID and output index</source>
+        <translation type="unfinished">Скопировать &amp;ID транзакции и индекс вывода</translation>
+    </message>
+    <message>
+        <source>L&amp;ock unspent</source>
+        <translation type="unfinished">З&amp;аблокировать неизрасходованный остаток</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock unspent</source>
+        <translation type="unfinished">&amp;Разблокировать неизрасходованный остаток</translation>
+    </message>
+    <message>
         <source>Copy quantity</source>
         <translation type="unfinished">Копировать количество</translation>
     </message>
@@ -1519,7 +1832,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Copy after fee</source>
-        <translation type="unfinished">Копировать после комиссии</translation>
+        <translation type="unfinished">Копировать сумму после комиссии</translation>
     </message>
     <message>
         <source>Copy bytes</source>
@@ -1551,7 +1864,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Can vary +/- %1 satoshi(s) per input.</source>
-        <translation type="unfinished">Может меняться +/- %1 сатоши за вход.</translation>
+        <translation type="unfinished">Может меняться на +/- %1 сатоши за каждый вход.</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -1576,7 +1889,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
         <extracomment>Descriptive text of the create wallet progress window which indicates to the user which wallet is currently being created.</extracomment>
-        <translation type="unfinished">Создание кошелька &lt;b&gt;%1&lt;/b&gt;...</translation>
+        <translation type="unfinished">Создание кошелька &lt;b&gt;%1&lt;/b&gt;…</translation>
     </message>
     <message>
         <source>Create wallet failed</source>
@@ -1584,9 +1897,30 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Create wallet warning</source>
-        <translation type="unfinished">Кошелёк создан</translation>
+        <translation type="unfinished">Предупреждение при создании кошелька</translation>
     </message>
-    </context>
+    <message>
+        <source>Can't list signers</source>
+        <translation type="unfinished">Невозможно отобразить подписантов</translation>
+    </message>
+    <message>
+        <source>Too many external signers found</source>
+        <translation type="unfinished">Обнаружено слишком много внешних подписантов</translation>
+    </message>
+</context>
+<context>
+    <name>LoadWalletsActivity</name>
+    <message>
+        <source>Load Wallets</source>
+        <extracomment>Title of progress window which is displayed when wallets are being loaded.</extracomment>
+        <translation type="unfinished">Загрузить кошельки</translation>
+    </message>
+    <message>
+        <source>Loading wallets…</source>
+        <extracomment>Descriptive text of the load wallets progress window which indicates to the user that wallets are currently being loaded.</extracomment>
+        <translation type="unfinished">Загрузка кошельков…</translation>
+    </message>
+</context>
 <context>
     <name>OpenWalletActivity</name>
     <message>
@@ -1609,7 +1943,35 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
         <extracomment>Descriptive text of the open wallet progress window which indicates to the user which wallet is currently being opened.</extracomment>
-        <translation type="unfinished">Открывается кошелёк &lt;b&gt;%1&lt;/b&gt;...</translation>
+        <translation type="unfinished">Открывается кошелёк &lt;b&gt;%1&lt;/b&gt;…</translation>
+    </message>
+</context>
+<context>
+    <name>RestoreWalletActivity</name>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of progress window which is displayed when wallets are being restored.</extracomment>
+        <translation type="unfinished">Восстановить кошелёк</translation>
+    </message>
+    <message>
+        <source>Restoring Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the restore wallets progress window which indicates to the user that wallets are currently being restored.</extracomment>
+        <translation type="unfinished">Восстановление кошелька &lt;b&gt;%1&lt;/b&gt;…</translation>
+    </message>
+    <message>
+        <source>Restore wallet failed</source>
+        <extracomment>Title of message box which is displayed when the wallet could not be restored.</extracomment>
+        <translation type="unfinished">Не удалось восстановить кошелек</translation>
+    </message>
+    <message>
+        <source>Restore wallet warning</source>
+        <extracomment>Title of message box which is displayed when the wallet is restored with some warning.</extracomment>
+        <translation type="unfinished">Предупреждение при восстановлении кошелька</translation>
+    </message>
+    <message>
+        <source>Restore wallet message</source>
+        <extracomment>Title of message box which is displayed when the wallet is successfully restored.</extracomment>
+        <translation type="unfinished">Сообщение при восстановлении кошелька</translation>
     </message>
 </context>
 <context>
@@ -1632,7 +1994,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Are you sure you wish to close all wallets?</source>
-        <translation type="unfinished">Вы уверенны, что хотите закрыть все кошельки?</translation>
+        <translation type="unfinished">Вы уверены, что хотите закрыть все кошельки?</translation>
     </message>
 </context>
 <context>
@@ -1663,7 +2025,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Disable private keys for this wallet. Wallets with private keys disabled will have no private keys and cannot have an HD seed or imported private keys. This is ideal for watch-only wallets.</source>
-        <translation type="unfinished">Отключить приватные ключи для этого кошелька. В кошельках с отключёнными приватными ключами не сохраняются приватные ключи, в них нельзя создать HD мастер-ключ или импортировать приватные ключи. Это удобно для наблюдающих кошельков.</translation>
+        <translation type="unfinished">Отключить приватные ключи для этого кошелька. В кошельках с отключёнными приватными ключами не сохраняются приватные ключи, в них нельзя создать HD мастер-ключ или импортировать приватные ключи. Это отличный вариант для кошельков для наблюдения за балансом.</translation>
     </message>
     <message>
         <source>Disable Private Keys</source>
@@ -1686,14 +2048,27 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Дескрипторный кошелёк</translation>
     </message>
     <message>
+        <source>Use an external signing device such as a hardware wallet. Configure the external signer script in wallet preferences first.</source>
+        <translation type="unfinished">Использовать внешнее устройство для подписи. Например, аппаратный кошелек. Сначала настройте сценарий внешней подписи в настройках кошелька.</translation>
+    </message>
+    <message>
+        <source>External signer</source>
+        <translation type="unfinished">Внешняя подписывающая сторона</translation>
+    </message>
+    <message>
         <source>Create</source>
         <translation type="unfinished">Создать</translation>
     </message>
     <message>
         <source>Compiled without sqlite support (required for descriptor wallets)</source>
-        <translation type="unfinished">Скомпилирован без поддержки sqlite (необходимо для дескрипторных кошельков)</translation>
+        <translation type="unfinished">Скомпилирован без поддержки SQLite (он необходим для дескрипторных кошельков)</translation>
     </message>
-    </context>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Скомпилирован без поддержки внешней подписи (требуется для внешней подписи)</translation>
+    </message>
+</context>
 <context>
     <name>EditAddressDialog</name>
     <message>
@@ -1710,7 +2085,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
-        <translation type="unfinished">Адрес, связанный с этой записью адресной книги. Он может быть изменён только если это адрес для отправки.</translation>
+        <translation type="unfinished">Адрес, связанный с этой записью адресной книги. Если это адрес для отправки, его можно изменить.</translation>
     </message>
     <message>
         <source>&amp;Address</source>
@@ -1718,15 +2093,15 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>New sending address</source>
-        <translation type="unfinished">Новый адрес для отправки</translation>
+        <translation type="unfinished">Новый адрес отправки</translation>
     </message>
     <message>
         <source>Edit receiving address</source>
-        <translation type="unfinished">Изменить адрес для получения</translation>
+        <translation type="unfinished">Изменить адрес получения</translation>
     </message>
     <message>
         <source>Edit sending address</source>
-        <translation type="unfinished">Изменить адрес для отправки</translation>
+        <translation type="unfinished">Изменить адрес отправки</translation>
     </message>
     <message>
         <source>The entered address "%1" is not a valid Bitcoin address.</source>
@@ -1746,74 +2121,86 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>New key generation failed.</source>
-        <translation type="unfinished">Произошла ошибка при генерации нового ключа.</translation>
+        <translation type="unfinished">Не удалось сгенерировать новый ключ.</translation>
     </message>
 </context>
 <context>
     <name>FreespaceChecker</name>
     <message>
         <source>A new data directory will be created.</source>
-        <translation type="unfinished">Будет создана новая директория данных.</translation>
+        <translation type="unfinished">Будет создан новый каталог данных.</translation>
     </message>
     <message>
         <source>name</source>
-        <translation type="unfinished">имя</translation>
+        <translation type="unfinished">название</translation>
     </message>
     <message>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
-        <translation type="unfinished">Директория уже существует. Добавьте %1, если хотите создать здесь новую директорию.</translation>
+        <translation type="unfinished">Каталог уже существует. Добавьте %1, если хотите создать здесь новый каталог.</translation>
     </message>
     <message>
         <source>Path already exists, and is not a directory.</source>
-        <translation type="unfinished">Данный путь уже существует, и это не директория.</translation>
+        <translation type="unfinished">Данный путь уже существует, и это не каталог.</translation>
     </message>
     <message>
         <source>Cannot create data directory here.</source>
-        <translation type="unfinished">Невозможно создать директорию данных здесь.</translation>
+        <translation type="unfinished">Невозможно создать здесь каталог данных.</translation>
     </message>
 </context>
 <context>
     <name>Intro</name>
-    <message>
-        <source>Bitcoin</source>
-        <translation type="unfinished">биткоин</translation>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform>%n ГБ места доступен</numerusform>
+            <numerusform>%n ГБ места доступно</numerusform>
+            <numerusform>%n ГБ места доступно</numerusform>
+        </translation>
     </message>
-    <message>
-        <source>(of %1 GB needed)</source>
-        <translation type="unfinished">(из необходимых %1 ГБ)</translation>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform>(из требуемого %n ГБ)</numerusform>
+            <numerusform>(из требуемых %n ГБ)</numerusform>
+            <numerusform>(из требуемых %n ГБ)</numerusform>
+        </translation>
     </message>
-    <message>
-        <source>(%1 GB needed for full chain)</source>
-        <translation type="unfinished">(необходимо %1 ГБ для полной цепочки блоков)</translation>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform>(%n ГБ необходим для полной цепочки)</numerusform>
+            <numerusform>(%n ГБ необходимо для полной цепочки)</numerusform>
+            <numerusform>(%n ГБ необходимо для полной цепочки)</numerusform>
+        </translation>
     </message>
     <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
-        <translation type="unfinished">В эту директорию будет сохранено не менее %1 ГБ данных, и со временем их объём будет увеличиваться.</translation>
+        <translation type="unfinished">В этот каталог будет сохранено не менее %1 ГБ данных, и со временем их объём будет увеличиваться.</translation>
     </message>
     <message>
         <source>Approximately %1 GB of data will be stored in this directory.</source>
-        <translation type="unfinished">В эту директорию будет сохранено приблизительно %1 ГБ данных.</translation>
+        <translation type="unfinished">В этот каталог будет сохранено приблизительно %1 ГБ данных.</translation>
     </message>
     <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>(достаточно для восстановления резервной копии возрастом %n день)</numerusform>
+            <numerusform>(достаточно для восстановления резервной копии возрастом %n дня)</numerusform>
+            <numerusform>(достаточно для восстановления резервной копии возрастом %n дней)</numerusform>
         </translation>
     </message>
     <message>
         <source>%1 will download and store a copy of the Bitcoin block chain.</source>
-        <translation type="unfinished">%1 скачает и сохранит копию цепочки блоков биткоина.</translation>
+        <translation type="unfinished">%1 скачает и сохранит копию цепочки блоков Bitcoin.</translation>
     </message>
     <message>
         <source>The wallet will also be stored in this directory.</source>
-        <translation type="unfinished">Кошелёк также будет сохранен в эту директорию.</translation>
+        <translation type="unfinished">Кошелёк также будет сохранён в этот каталог.</translation>
     </message>
     <message>
         <source>Error: Specified data directory "%1" cannot be created.</source>
-        <translation type="unfinished">Ошибка: невозможно создать указанную директорию данных "%1".</translation>
+        <translation type="unfinished">Ошибка: не удалось создать указанный каталог данных "%1".</translation>
     </message>
     <message>
         <source>Error</source>
@@ -1832,10 +2219,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Поскольку программа запущена впервые, вы можете выбрать, где %1 будет хранить свои данные.</translation>
     </message>
     <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation type="unfinished">Когда вы нажмёте ОК, %1 начнет скачивать и обрабатывать полную цепочку блоков %4а (%2 ГБ), начиная с самых первых транзакций в %3, когда %4 был изначально запущен.</translation>
-    </message>
-    <message>
         <source>Limit block chain storage to</source>
         <translation type="unfinished">Ограничить размер сохранённой цепочки блоков до</translation>
     </message>
@@ -1852,16 +2235,20 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Эта первичная синхронизация очень требовательна к ресурсам и может выявить проблемы с аппаратным обеспечением вашего компьютера, которые ранее оставались незамеченными. Каждый раз, когда вы запускаете %1, скачивание будет продолжено с места остановки.</translation>
     </message>
     <message>
+        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2 GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
+        <translation type="unfinished">Когда вы нажмете ОК, %1 начнет загружать и обрабатывать полную цепочку блоков %4 (%2 ГБ)  начиная с самых ранних транзакций в %3, когда %4 был первоначально запущен.</translation>
+    </message>
+    <message>
         <source>If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</source>
-        <translation type="unfinished">Если вы решили ограничить объём хранимого блокчейна (обрезка), все исторические данные всё равно необходимо скачать и обработать, но после этого они будут удалены для экономии места на диске.</translation>
+        <translation type="unfinished">Если вы решили ограничить (обрезать) объём хранимой цепи блоков, все ранние данные всё равно должны быть скачаны и обработаны. После обработки они будут удалены с целью экономии места на диске.</translation>
     </message>
     <message>
         <source>Use the default data directory</source>
-        <translation type="unfinished">Использовать стандартную директорию данных</translation>
+        <translation type="unfinished">Использовать каталог данных по умолчанию</translation>
     </message>
     <message>
         <source>Use a custom data directory:</source>
-        <translation type="unfinished">Использовать пользовательскую директорию данных</translation>
+        <translation type="unfinished">Использовать пользовательский каталог данных:</translation>
     </message>
 </context>
 <context>
@@ -1876,14 +2263,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Command-line options</source>
-        <translation type="unfinished">Параметры командной строки</translation>
+        <translation type="unfinished">Опции командной строки</translation>
     </message>
 </context>
 <context>
     <name>ShutdownWindow</name>
     <message>
         <source>%1 is shutting down…</source>
-        <translation type="unfinished">%1 завершает работу...</translation>
+        <translation type="unfinished">%1 выключается…</translation>
     </message>
     <message>
         <source>Do not shut down the computer until this window disappears.</source>
@@ -1898,11 +2285,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Recent transactions may not yet be visible, and therefore your wallet's balance might be incorrect. This information will be correct once your wallet has finished synchronizing with the bitcoin network, as detailed below.</source>
-        <translation type="unfinished">Недавние транзакции могут быть пока не видны, и поэтому отображаемый баланс вашего кошелька может быть неверным. Информация станет верной после завершения синхронизации с сетью биткоина, прогресс которой вы можете видеть ниже.</translation>
+        <translation type="unfinished">Недавние транзакции могут быть пока не видны, и поэтому отображаемый баланс вашего кошелька может быть неверным. Информация станет верной после завершения синхронизации с сетью Bitcoin. Прогресс синхронизации вы можете видеть снизу.</translation>
     </message>
     <message>
         <source>Attempting to spend bitcoins that are affected by not-yet-displayed transactions will not be accepted by the network.</source>
-        <translation type="unfinished">Попытка потратить средства, затронутые не видными пока транзакциями, будет отклонена сетью.</translation>
+        <translation type="unfinished">Попытка потратить средства, использованные в транзакциях, которые ещё не синхронизированы, будет отклонена сетью.</translation>
     </message>
     <message>
         <source>Number of blocks left</source>
@@ -1910,11 +2297,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Unknown…</source>
-        <translation type="unfinished">Неизвестно...</translation>
+        <translation type="unfinished">Неизвестно…</translation>
     </message>
     <message>
         <source>calculating…</source>
-        <translation type="unfinished">вычисляется...</translation>
+        <translation type="unfinished">вычисляется…</translation>
     </message>
     <message>
         <source>Last block time</source>
@@ -1930,7 +2317,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Estimated time left until synced</source>
-        <translation type="unfinished">Расчётное время до завершения синхронизации</translation>
+        <translation type="unfinished">Расчетное время до завершения синхронизации</translation>
     </message>
     <message>
         <source>Hide</source>
@@ -1938,7 +2325,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Esc</source>
-        <translation type="unfinished">Выйти</translation>
+        <translation type="unfinished">Выход</translation>
     </message>
     <message>
         <source>%1 is currently syncing.  It will download headers and blocks from peers and validate them until reaching the tip of the block chain.</source>
@@ -1946,14 +2333,18 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Unknown. Syncing Headers (%1, %2%)…</source>
-        <translation type="unfinished">Неизвестно. Синхронизируются заголовки (%1, %2%)...</translation>
+        <translation type="unfinished">Неизвестно. Синхронизация заголовков (%1, %2%)…</translation>
+    </message>
+    <message>
+        <source>Unknown. Pre-syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">Неизвестно. Предсинхронизация заголовков (%1, %2%)…</translation>
     </message>
 </context>
 <context>
     <name>OpenURIDialog</name>
     <message>
         <source>Open bitcoin URI</source>
-        <translation type="unfinished">Открыть URI биткоина</translation>
+        <translation type="unfinished">Открыть URI bitcoin</translation>
     </message>
     <message>
         <source>Paste address from clipboard</source>
@@ -1969,11 +2360,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>&amp;Main</source>
-        <translation type="unfinished">&amp;Главные</translation>
+        <translation type="unfinished">&amp;Основное</translation>
     </message>
     <message>
         <source>Automatically start %1 after logging in to the system.</source>
-        <translation type="unfinished">Автоматически запускать %1 после входа в систему.</translation>
+        <translation type="unfinished">Автоматически запускать %1после входа в систему.</translation>
     </message>
     <message>
         <source>&amp;Start %1 on system login</source>
@@ -1997,15 +2388,19 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Shows if the supplied default SOCKS5 proxy is used to reach peers via this network type.</source>
-        <translation type="unfinished">Показывает, используется ли прокси SOCKS5 по умолчанию для доступа к узлам через этот тип сети.</translation>
+        <translation type="unfinished">Использовать SOCKS5 прокси для доступа к узлам через этот тип сети.</translation>
     </message>
     <message>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
         <translation type="unfinished">Сворачивать вместо выхода из приложения при закрытии окна. Если данный параметр включён, приложение закроется только после нажатия "Выход" в меню.</translation>
     </message>
     <message>
+        <source>Options set in this dialog are overridden by the command line:</source>
+        <translation type="unfinished">Параметры командной строки, которые переопределили параметры из этого окна:</translation>
+    </message>
+    <message>
         <source>Open the %1 configuration file from the working directory.</source>
-        <translation type="unfinished">Открывает файл конфигурации %1 из рабочей директории.</translation>
+        <translation type="unfinished">Открывает файл конфигурации %1 из рабочего каталога.</translation>
     </message>
     <message>
         <source>Open Configuration File</source>
@@ -2025,7 +2420,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Prune &amp;block storage to</source>
-        <translation type="unfinished">Обрезать объём хранимых блоков до</translation>
+        <translation type="unfinished">Обрезать &amp;объём хранимых блоков до</translation>
     </message>
     <message>
         <source>GB</source>
@@ -2036,8 +2431,18 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Возврат этой настройки в прежнее значение потребует повторного скачивания всей цепочки блоков.</translation>
     </message>
     <message>
+        <source>Maximum database cache size. A larger cache can contribute to faster sync, after which the benefit is less pronounced for most use cases. Lowering the cache size will reduce memory usage. Unused mempool memory is shared for this cache.</source>
+        <extracomment>Tooltip text for Options window setting that sets the size of the database cache. Explains the corresponding effects of increasing/decreasing this value.</extracomment>
+        <translation type="unfinished">Максимальный размер кэша базы данных. Большой размер кэша может ускорить синхронизацию, после чего уже особой роли не играет. Уменьшение размера кэша уменьшит использование памяти. Неиспользуемая память mempool используется совместно для этого кэша.</translation>
+    </message>
+    <message>
         <source>MiB</source>
         <translation type="unfinished">МиБ</translation>
+    </message>
+    <message>
+        <source>Set the number of script verification threads. Negative values correspond to the number of cores you want to leave free to the system.</source>
+        <extracomment>Tooltip text for Options window setting that sets the number of script verification threads. Explains that negative values mean to leave these many cores free to the system.</extracomment>
+        <translation type="unfinished">Число потоков проверки скриптов. Отрицательные значения задают число ядер ЦП, которые не будут нагружаться (останутся свободны).</translation>
     </message>
     <message>
         <source>(0 = auto, &lt;0 = leave that many cores free)</source>
@@ -2046,16 +2451,26 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>This allows you or a third party tool to communicate with the node through command-line and JSON-RPC commands.</source>
         <extracomment>Tooltip text for Options window setting that enables the RPC server.</extracomment>
-        <translation type="unfinished">Это позволяет вам или сторонней программе взаимодействовать с этим узлом через командную строку и команды JSON-RPC</translation>
+        <translation type="unfinished">Разрешает вам или сторонней программе взаимодействовать с этим узлом через командную строку и команды JSON-RPC.</translation>
     </message>
     <message>
         <source>Enable R&amp;PC server</source>
         <extracomment>An Options window setting to enable the RPC server.</extracomment>
-        <translation type="unfinished">Включить R&amp;PC сервер</translation>
+        <translation type="unfinished">Включить RPC &amp;сервер</translation>
     </message>
     <message>
         <source>W&amp;allet</source>
         <translation type="unfinished">&amp;Кошелёк</translation>
+    </message>
+    <message>
+        <source>Whether to set subtract fee from amount as default or not.</source>
+        <extracomment>Tooltip text for Options window setting that sets subtracting the fee from a sending amount as default.</extracomment>
+        <translation type="unfinished">Вычитать комиссию из суммы по умолчанию или нет.</translation>
+    </message>
+    <message>
+        <source>Subtract &amp;fee from amount by default</source>
+        <extracomment>An Options window setting to set subtracting the fee from a sending amount as default.</extracomment>
+        <translation type="unfinished">Вычесть &amp;комиссию из суммы</translation>
     </message>
     <message>
         <source>Expert</source>
@@ -2067,11 +2482,33 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
-        <translation type="unfinished">Если вы отключите трату неподтверждённой сдачи, сдачу от транзакции нельзя будет использвать до тех пор, пока у этой транзакции не будет хотя бы одного подтверждения. Это также влияет на расчёт вашего баланса.</translation>
+        <translation type="unfinished">Если вы отключите трату неподтверждённой сдачи, сдачу от транзакции нельзя будет использовать до тех пор, пока у этой транзакции не будет хотя бы одного подтверждения. Это также влияет на расчёт вашего баланса.</translation>
     </message>
     <message>
         <source>&amp;Spend unconfirmed change</source>
         <translation type="unfinished">&amp;Тратить неподтверждённую сдачу</translation>
+    </message>
+    <message>
+        <source>Enable &amp;PSBT controls</source>
+        <extracomment>An options window setting to enable PSBT controls.</extracomment>
+        <translation type="unfinished">Включить управление частично подписанными транзакциями (PSBT)</translation>
+    </message>
+    <message>
+        <source>Whether to show PSBT controls.</source>
+        <extracomment>Tooltip text for options window setting that enables PSBT controls.</extracomment>
+        <translation type="unfinished">Показать элементы управления частично подписанными биткоин-транзакциями (PSBT)</translation>
+    </message>
+    <message>
+        <source>External Signer (e.g. hardware wallet)</source>
+        <translation type="unfinished">Внешний подписант (например, аппаратный кошелёк)</translation>
+    </message>
+    <message>
+        <source>&amp;External signer script path</source>
+        <translation type="unfinished">&amp;Внешний скрипт для подписи</translation>
+    </message>
+    <message>
+        <source>Full path to a Bitcoin Core compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</source>
+        <translation type="unfinished">Путь к скрипту, совместимому с Bitcoin Core (напр. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Внимание: остерегайтесь вредоносных скриптов!</translation>
     </message>
     <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
@@ -2083,7 +2520,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports NAT-PMP and it is enabled. The external port could be random.</source>
-        <translation type="unfinished">Автоматически открыть порт биткоин-клиента на роутере. Работает? если ваш роутер поддерживает NAT-PMP, и данная функция на нём включена. Внешний порт может быть случайным.</translation>
+        <translation type="unfinished">Автоматически открыть порт биткоин-клиента на роутере. Сработает только если ваш роутер поддерживает NAT-PMP, и данная функция на нём включена. Внешний порт может быть случайным.</translation>
     </message>
     <message>
         <source>Map port using NA&amp;T-PMP</source>
@@ -2095,11 +2532,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Allow incomin&amp;g connections</source>
-        <translation type="unfinished">Разрешить входящие соединения</translation>
+        <translation type="unfinished">Разрешить &amp;входящие соединения</translation>
     </message>
     <message>
         <source>Connect to the Bitcoin network through a SOCKS5 proxy.</source>
-        <translation type="unfinished">Подключиться к сети биткоина через прокси SOCKS5.</translation>
+        <translation type="unfinished">Подключиться к сети Bitcoin через SOCKS5 прокси.</translation>
     </message>
     <message>
         <source>&amp;Connect through SOCKS5 proxy (default proxy):</source>
@@ -2107,7 +2544,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Proxy &amp;IP:</source>
-        <translation type="unfinished">IP прокси:</translation>
+        <translation type="unfinished">IP &amp;прокси:</translation>
     </message>
     <message>
         <source>&amp;Port:</source>
@@ -2115,11 +2552,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Port of the proxy (e.g. 9050)</source>
-        <translation type="unfinished">Порт прокси: (напр. 9050)</translation>
+        <translation type="unfinished">Порт прокси (например, 9050)</translation>
     </message>
     <message>
         <source>Used for reaching peers via:</source>
-        <translation type="unfinished">Используется для подключения к узлам по:</translation>
+        <translation type="unfinished">Использовать для подключения к узлам по:</translation>
     </message>
     <message>
         <source>&amp;Window</source>
@@ -2151,11 +2588,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>User Interface &amp;language:</source>
-        <translation type="unfinished">Язык пользовательского интерфейса:</translation>
+        <translation type="unfinished">Язык &amp;интерфейса:</translation>
     </message>
     <message>
         <source>The user interface language can be set here. This setting will take effect after restarting %1.</source>
-        <translation type="unfinished">Здесь можно выбрать язык пользовательского интерфейса. Параметры будут применены после перезапуска %1</translation>
+        <translation type="unfinished">Здесь можно выбрать язык пользовательского интерфейса. Язык будет изменён после перезапуска %1.</translation>
     </message>
     <message>
         <source>&amp;Unit to show amounts in:</source>
@@ -2166,16 +2603,24 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Выберите единицу измерения, которая будет показана по умолчанию в интерфейсе и при отправке монет.</translation>
     </message>
     <message>
+        <source>Third-party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</source>
+        <translation type="unfinished">Сторонние URL-адреса (например, на обозреватель блоков), которые будут показаны на вкладке транзакций в контекстном меню. %s в URL будет заменён на хэш транзакции. Несколько адресов разделяются друг от друга вертикальной чертой |.</translation>
+    </message>
+    <message>
+        <source>&amp;Third-party transaction URLs</source>
+        <translation type="unfinished">&amp;Ссылки на транзакции на сторонних сервисах</translation>
+    </message>
+    <message>
         <source>Whether to show coin control features or not.</source>
-        <translation type="unfinished">Показывать ли параметры управления монетами.</translation>
+        <translation type="unfinished">Показывать параметры управления монетами.</translation>
     </message>
     <message>
         <source>Connect to the Bitcoin network through a separate SOCKS5 proxy for Tor onion services.</source>
-        <translation type="unfinished">Подключаться к сети биткоина через отдельный прокси SOCKS5 для скрытых сервисов Tor.</translation>
+        <translation type="unfinished">Подключаться к сети Bitcoin через отдельный SOCKS5 прокси для скрытых сервисов Tor.</translation>
     </message>
     <message>
         <source>Use separate SOCKS&amp;5 proxy to reach peers via Tor onion services:</source>
-        <translation type="unfinished">Использовать отдельный прокси SOCKS&amp;5 для соединения с узлами через скрытые сервисы Tor:</translation>
+        <translation type="unfinished">Использовать &amp;отдельный прокси SOCKS5 для соединения с узлами через скрытые сервисы Tor:</translation>
     </message>
     <message>
         <source>Monospaced font in the Overview tab:</source>
@@ -2187,11 +2632,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>closest matching "%1"</source>
-        <translation type="unfinished">ближайшее совпадение "%1"</translation>
-    </message>
-    <message>
-        <source>Options set in this dialog are overridden by the command line or in the configuration file:</source>
-        <translation type="unfinished">Параметры, установленные в этом диалоговом окне, были переопределены командной строкой или в файле конфигурации:</translation>
+        <translation type="unfinished">самый похожий системный "%1"</translation>
     </message>
     <message>
         <source>&amp;OK</source>
@@ -2202,23 +2643,36 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">О&amp;тмена</translation>
     </message>
     <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Скомпилирован без поддержки внешней подписи (требуется для внешней подписи)</translation>
+    </message>
+    <message>
         <source>default</source>
         <translation type="unfinished">по умолчанию</translation>
     </message>
     <message>
         <source>none</source>
-        <translation type="unfinished">ни один</translation>
+        <translation type="unfinished">ни одного</translation>
     </message>
     <message>
         <source>Confirm options reset</source>
-        <translation type="unfinished">Подтвердить сброс опций</translation>
+        <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
+        <translation type="unfinished">Подтверждение сброса настроек</translation>
     </message>
     <message>
         <source>Client restart required to activate changes.</source>
+        <extracomment>Text explaining that the settings changed will not come into effect until the client is restarted.</extracomment>
         <translation type="unfinished">Для активации изменений необходим перезапуск клиента.</translation>
     </message>
     <message>
+        <source>Current settings will be backed up at "%1".</source>
+        <extracomment>Text explaining to the user that the client's current settings will be backed up at a specific location. %1 is a stand-in argument for the backup location's path.</extracomment>
+        <translation type="unfinished">Резервная копия текущих настроек будет сохранена в "%1".</translation>
+    </message>
+    <message>
         <source>Client will be shut down. Do you want to proceed?</source>
+        <extracomment>Text asking the user to confirm if they would like to proceed with a client shutdown.</extracomment>
         <translation type="unfinished">Клиент будет закрыт. Продолжить?</translation>
     </message>
     <message>
@@ -2257,6 +2711,13 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
 </context>
 <context>
+    <name>OptionsModel</name>
+    <message>
+        <source>Could not read setting "%1", %2.</source>
+        <translation type="unfinished">Не удалось прочитать настройку "%1", %2.</translation>
+    </message>
+</context>
+<context>
     <name>OverviewPage</name>
     <message>
         <source>Form</source>
@@ -2264,11 +2725,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
-        <translation type="unfinished">Показанная информация может быть устаревшей. Ваш кошелёк автоматически синхронизируется с сетью биткоина после подключения, но этот процесс пока не завершён.</translation>
+        <translation type="unfinished">Отображаемая информация может быть устаревшей. Ваш кошелёк автоматически синхронизируется с сетью Bitcoin после подключения, и этот процесс пока не завершён.</translation>
     </message>
     <message>
         <source>Watch-only:</source>
-        <translation type="unfinished">Только наблюдение:</translation>
+        <translation type="unfinished">Только просмотр:</translation>
     </message>
     <message>
         <source>Available:</source>
@@ -2284,7 +2745,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
-        <translation type="unfinished">Общая сумма всех транзакций, которые ещё не подтверждены и не учитываются в балансе, который можно расходовать</translation>
+        <translation type="unfinished">Сумма по неподтверждённым транзакциям. Они не учитываются в балансе, который можно расходовать</translation>
     </message>
     <message>
         <source>Immature:</source>
@@ -2296,7 +2757,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Balances</source>
-        <translation type="unfinished">Балансы</translation>
+        <translation type="unfinished">Баланс</translation>
     </message>
     <message>
         <source>Total:</source>
@@ -2332,7 +2793,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Privacy mode activated for the Overview tab. To unmask the values, uncheck Settings-&gt;Mask values.</source>
-        <translation type="unfinished">Включён режим приватности для вкладки обзора. Чтобы показать данные, отключите пункт Настройки -&gt; Скрыть значения.</translation>
+        <translation type="unfinished">Включён режим приватности для вкладки Обзор. Чтобы показать данные, снимите отметку с пункта Настройки -&gt; Скрыть значения.</translation>
     </message>
 </context>
 <context>
@@ -2355,7 +2816,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Save…</source>
-        <translation type="unfinished">Сохранить...</translation>
+        <translation type="unfinished">Сохранить…</translation>
     </message>
     <message>
         <source>Close</source>
@@ -2447,6 +2908,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Транзакции требуется по крайней мере ещё одна подпись.</translation>
     </message>
     <message>
+        <source>(But no wallet is loaded.)</source>
+        <translation type="unfinished">(Но ни один кошелек не загружен.)</translation>
+    </message>
+    <message>
         <source>(But this wallet cannot sign transactions.)</source>
         <translation type="unfinished">(Но этот кошелёк не может подписывать транзакции.)</translation>
     </message>
@@ -2456,7 +2921,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Transaction is fully signed and ready for broadcast.</source>
-        <translation type="unfinished">Транзакция полностью подписана, и готова к отправке.</translation>
+        <translation type="unfinished">Транзакция полностью подписана и готова к отправке.</translation>
     </message>
     <message>
         <source>Transaction status is unknown.</source>
@@ -2479,19 +2944,19 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>'bitcoin://' is not a valid URI. Use 'bitcoin:' instead.</source>
-        <translation type="unfinished">«bitcoin://» — это неверный URI. Используйте вместо него «bitcoin:».</translation>
+        <translation type="unfinished">"bitcoin://" — это неверный URI. Используйте вместо него "bitcoin:".</translation>
     </message>
     <message>
         <source>Cannot process payment request because BIP70 is not supported.
 Due to widespread security flaws in BIP70 it's strongly recommended that any merchant instructions to switch wallets be ignored.
 If you are receiving this error you should request the merchant provide a BIP21 compatible URI.</source>
         <translation type="unfinished">Не удалось обработать транзакцию, потому что BIP70 не поддерживается.
-Из-за широко распространённых уязвимостей в BIP70 настоятельно рекомендуется игнорировать любые инструкции продавцов сменить кошелёк.
+Из-за широко распространённых уязвимостей в BIP70, настоятельно рекомендуется игнорировать любые инструкции продавцов сменить кошелёк.
 Если вы получили эту ошибку, вам следует попросить у продавца URI, совместимый с BIP21.</translation>
     </message>
     <message>
         <source>URI cannot be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
-        <translation type="unfinished">Не удалось обработать URI! Это может быть вызвано тем, что биткоин-адрес неверен или параметры URI неправильно сформированы.</translation>
+        <translation type="unfinished">Не удалось обработать URI! Это может быть вызвано тем, что биткоин-адрес неверен или параметры URI сформированы неправильно.</translation>
     </message>
     <message>
         <source>Payment request file handling</source>
@@ -2508,12 +2973,17 @@ If you are receiving this error you should request the merchant provide a BIP21 
     <message>
         <source>Ping</source>
         <extracomment>Title of Peers Table column which indicates the current latency of the connection with the peer.</extracomment>
-        <translation type="unfinished">Отклик</translation>
+        <translation type="unfinished">Пинг</translation>
     </message>
     <message>
         <source>Peer</source>
         <extracomment>Title of Peers Table column which contains a unique number used to identify a connection.</extracomment>
         <translation type="unfinished">Узел</translation>
+    </message>
+    <message>
+        <source>Age</source>
+        <extracomment>Title of Peers Table column which indicates the duration (length of time) since the peer connection started.</extracomment>
+        <translation type="unfinished">Возраст</translation>
     </message>
     <message>
         <source>Direction</source>
@@ -2560,7 +3030,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     <name>QRImageWidget</name>
     <message>
         <source>&amp;Save Image…</source>
-        <translation type="unfinished">&amp;Сохранить изображение...</translation>
+        <translation type="unfinished">&amp;Сохранить изображение…</translation>
     </message>
     <message>
         <source>&amp;Copy Image</source>
@@ -2568,7 +3038,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
-        <translation type="unfinished">Получившийся URI слишком длинный, попробуйте сократить текст метки / сообщения.</translation>
+        <translation type="unfinished">Получившийся URI слишком длинный, попробуйте сократить текст метки или сообщения.</translation>
     </message>
     <message>
         <source>Error encoding URI into QR Code.</source>
@@ -2576,7 +3046,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>QR code support not available.</source>
-        <translation type="unfinished">Поддержка QR кодов недоступна.</translation>
+        <translation type="unfinished">Поддержка QR-кодов недоступна.</translation>
     </message>
     <message>
         <source>Save QR Code</source>
@@ -2604,7 +3074,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>General</source>
-        <translation type="unfinished">Общий</translation>
+        <translation type="unfinished">Общие</translation>
     </message>
     <message>
         <source>Datadir</source>
@@ -2612,7 +3082,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>To specify a non-default location of the data directory use the '%1' option.</source>
-        <translation type="unfinished">Чтобы указать нестандартное расположение директории для данных, используйте параметр '%1'.</translation>
+        <translation type="unfinished">Чтобы указать нестандартное расположение каталога данных, используйте параметр "%1".</translation>
     </message>
     <message>
         <source>Blocksdir</source>
@@ -2620,7 +3090,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>To specify a non-default location of the blocks directory use the '%1' option.</source>
-        <translation type="unfinished">Чтобы указать нестандартное расположение директории для блоков, используйте параметр '%1'.</translation>
+        <translation type="unfinished">Чтобы указать нестандартное расположение каталога блоков, используйте параметр "%1".</translation>
     </message>
     <message>
         <source>Startup time</source>
@@ -2664,7 +3134,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>&amp;Reset</source>
-        <translation type="unfinished">&amp;Сбросить</translation>
+        <translation type="unfinished">&amp;Сброс</translation>
     </message>
     <message>
         <source>Received</source>
@@ -2684,7 +3154,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Select a peer to view detailed information.</source>
-        <translation type="unfinished">Выберите узел для просмотра детальной информации.</translation>
+        <translation type="unfinished">Выберите узел для просмотра подробностей.</translation>
     </message>
     <message>
         <source>Version</source>
@@ -2703,6 +3173,10 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <translation type="unfinished">Синхронизировано блоков</translation>
     </message>
     <message>
+        <source>Last Transaction</source>
+        <translation type="unfinished">Последняя транзакция</translation>
+    </message>
+    <message>
         <source>The mapped Autonomous System used for diversifying peer selection.</source>
         <translation type="unfinished">Подключённая автономная система, используемая для диверсификации узлов, к которым производится подключение.</translation>
     </message>
@@ -2711,12 +3185,42 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <translation type="unfinished">Подключённая АС</translation>
     </message>
     <message>
+        <source>Whether we relay addresses to this peer.</source>
+        <extracomment>Tooltip text for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
+        <translation type="unfinished">Передаем ли мы адреса этому узлу.</translation>
+    </message>
+    <message>
+        <source>Address Relay</source>
+        <extracomment>Text title for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
+        <translation type="unfinished">Ретранслятор адресов</translation>
+    </message>
+    <message>
+        <source>The total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</source>
+        <extracomment>Tooltip text for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
+        <translation type="unfinished">Количество адресов, полученных от этого узла, которые были обработаны (за исключением адресов, отброшенных из-за ограничений по частоте).</translation>
+    </message>
+    <message>
+        <source>The total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</source>
+        <extracomment>Tooltip text for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
+        <translation type="unfinished">Количество адресов, полученных от этого узла, которые были отброшены (не обработаны) из-за ограничений по частоте.</translation>
+    </message>
+    <message>
+        <source>Addresses Processed</source>
+        <extracomment>Text title for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
+        <translation type="unfinished">Обработанные адреса</translation>
+    </message>
+    <message>
+        <source>Addresses Rate-Limited</source>
+        <extracomment>Text title for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
+        <translation type="unfinished">Отброшенные адреса</translation>
+    </message>
+    <message>
         <source>User Agent</source>
         <translation type="unfinished">Пользовательский агент</translation>
     </message>
     <message>
         <source>Node window</source>
-        <translation type="unfinished">Окно ноды</translation>
+        <translation type="unfinished">Окно узла</translation>
     </message>
     <message>
         <source>Current block height</source>
@@ -2724,7 +3228,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Open the %1 debug log file from the current data directory. This can take a few seconds for large log files.</source>
-        <translation type="unfinished">Открыть файл журнала отладки %1 из текущей директории данных. Для больших файлов журнала это может занять несколько секунд.</translation>
+        <translation type="unfinished">Открыть файл журнала отладки %1 из текущего каталога данных. Для больших файлов журнала это может занять несколько секунд.</translation>
     </message>
     <message>
         <source>Decrease font size</source>
@@ -2752,7 +3256,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Services</source>
-        <translation type="unfinished">Сервисы</translation>
+        <translation type="unfinished">Службы</translation>
     </message>
     <message>
         <source>Whether the peer requested us to relay transactions.</source>
@@ -2776,7 +3280,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Elapsed time since a novel block passing initial validity checks was received from this peer.</source>
-        <translation type="unfinished">Время с момента получения нового блока, прошедшего базовую проверку, от этого узла</translation>
+        <translation type="unfinished">Время с момента получения нового блока, прошедшего базовую проверку, от этого узла.</translation>
     </message>
     <message>
         <source>Last Block</source>
@@ -2785,15 +3289,15 @@ If you are receiving this error you should request the merchant provide a BIP21 
     <message>
         <source>Elapsed time since a novel transaction accepted into our mempool was received from this peer.</source>
         <extracomment>Tooltip text for the Last Transaction field in the peer details area.</extracomment>
-        <translation type="unfinished">Время с момента принятия новой транзакции в наш мемпул от этого узла.</translation>
+        <translation type="unfinished">Время с момента принятия новой транзакции в наш mempool от этого узла.</translation>
     </message>
     <message>
         <source>Last Send</source>
-        <translation type="unfinished">Посл. время отправки</translation>
+        <translation type="unfinished">Последнее время отправки</translation>
     </message>
     <message>
         <source>Last Receive</source>
-        <translation type="unfinished">Посл. время получения</translation>
+        <translation type="unfinished">Последнее время получения</translation>
     </message>
     <message>
         <source>Ping Time</source>
@@ -2801,7 +3305,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>The duration of a currently outstanding ping.</source>
-        <translation type="unfinished">Продолжительность текущего времени отклика.</translation>
+        <translation type="unfinished">Задержка между запросом к узлу и ответом от него.</translation>
     </message>
     <message>
         <source>Ping Wait</source>
@@ -2809,7 +3313,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Min Ping</source>
-        <translation type="unfinished">Мин. время отклика</translation>
+        <translation type="unfinished">Минимальное время отклика</translation>
     </message>
     <message>
         <source>Time Offset</source>
@@ -2894,6 +3398,11 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <translation type="unfinished">широкополосный передатчик не выбран</translation>
     </message>
     <message>
+        <source>&amp;Copy address</source>
+        <extracomment>Context menu action to copy the address of a peer.</extracomment>
+        <translation type="unfinished">&amp;Копировать адрес</translation>
+    </message>
+    <message>
         <source>&amp;Disconnect</source>
         <translation type="unfinished">О&amp;тключиться</translation>
     </message>
@@ -2902,12 +3411,21 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <translation type="unfinished">1 &amp;час</translation>
     </message>
     <message>
+        <source>1 d&amp;ay</source>
+        <translation type="unfinished">1 &amp;день</translation>
+    </message>
+    <message>
         <source>1 &amp;week</source>
         <translation type="unfinished">1 &amp;неделя</translation>
     </message>
     <message>
         <source>1 &amp;year</source>
         <translation type="unfinished">1 &amp;год</translation>
+    </message>
+    <message>
+        <source>&amp;Copy IP/Netmask</source>
+        <extracomment>Context menu action to copy the IP/Netmask of a banned peer. IP/Netmask is the combination of a peer's IP address and its Netmask. For IP address, see: https://en.wikipedia.org/wiki/IP_address.</extracomment>
+        <translation type="unfinished">&amp;Копировать IP или маску подсети</translation>
     </message>
     <message>
         <source>&amp;Unban</source>
@@ -2935,17 +3453,17 @@ For more information on using this console, type %6.
 %7WARNING: Scammers have been active, telling users to type commands here, stealing their wallet contents. Do not use this console without fully understanding the ramifications of a command.%8</source>
         <extracomment>RPC console welcome message. Placeholders %7 and %8 are style tags for the warning content, and they are not space separated from the rest of the text intentionally.</extracomment>
         <translation type="unfinished">Добро пожаловать в RPC-консоль %1.
-Используйте стрелки вверх и вниз, чтобы перемещаться по истории и %2, чтобы очистить экране.
+Используйте стрелки вверх и вниз, чтобы перемещаться по истории и %2, чтобы очистить экран.
 Чтобы увеличить или уменьшить размер шрифта, нажмите %3 или %4.
 Наберите %5, чтобы получить список доступных команд.
 Чтобы получить больше информации об этой консоли, наберите %6.
 
-%7ВНИМАНИЕ: мошенники очень часто просят пользователей вводить здесь различные команды и таким образом крадут содержимое кошельков. Не используйте эту консоль, если не полностью понимаете последствия каждой команды.%8</translation>
+%7ВНИМАНИЕ: Мошенники очень часто просят пользователей вводить здесь различные команды и таким образом крадут содержимое кошельков. Не используйте эту консоль, если не полностью понимаете последствия каждой команды.%8</translation>
     </message>
     <message>
         <source>Executing…</source>
         <extracomment>A console message indicating an entered command is currently being executed.</extracomment>
-        <translation type="unfinished">Выполняется...</translation>
+        <translation type="unfinished">Выполняется…</translation>
     </message>
     <message>
         <source>(peer: %1)</source>
@@ -2953,7 +3471,7 @@ For more information on using this console, type %6.
     </message>
     <message>
         <source>via %1</source>
-        <translation type="unfinished">с помощью %1</translation>
+        <translation type="unfinished">через %1</translation>
     </message>
     <message>
         <source>Yes</source>
@@ -2965,11 +3483,11 @@ For more information on using this console, type %6.
     </message>
     <message>
         <source>To</source>
-        <translation type="unfinished">Кому</translation>
+        <translation type="unfinished">От нас</translation>
     </message>
     <message>
         <source>From</source>
-        <translation type="unfinished">От</translation>
+        <translation type="unfinished">К нам</translation>
     </message>
     <message>
         <source>Ban for</source>
@@ -3000,11 +3518,11 @@ For more information on using this console, type %6.
     </message>
     <message>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
-        <translation type="unfinished">Необязательное сообщение для запроса платежа, которое будет показано при открытии запроса. Внимание: это сообщение не будет отправлено вместе с платежом через сеть биткоина.</translation>
+        <translation type="unfinished">Необязательное сообщение для запроса платежа, которое будет показано при открытии запроса. Внимание: это сообщение не будет отправлено вместе с платежом через сеть Bitcoin.</translation>
     </message>
     <message>
         <source>An optional label to associate with the new receiving address.</source>
-        <translation type="unfinished">Для нового адреса получения можно добавить метку.</translation>
+        <translation type="unfinished">Необязательная метка для нового адреса получения.</translation>
     </message>
     <message>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
@@ -3012,11 +3530,11 @@ For more information on using this console, type %6.
     </message>
     <message>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
-        <translation type="unfinished">Можно указать сумму, платёж на которую вы запрашиваете. Оставьте пустой или введите ноль, чтобы не запрашивать определённую сумму.</translation>
+        <translation type="unfinished">Можно указать сумму, которую вы хотите запросить. Оставьте поле пустым или введите ноль, если не хотите запрашивать конкретную сумму.</translation>
     </message>
     <message>
         <source>An optional label to associate with the new receiving address (used by you to identify an invoice).  It is also attached to the payment request.</source>
-        <translation type="unfinished">Можно указать метку, которая будет присвоена новому адресу получения (чтобы вы могли идентифицировать выставленный счёт). Также она присоединяется к запросу платежа.</translation>
+        <translation type="unfinished">Можно указать метку, которая будет присвоена новому адресу получения (чтобы вы могли идентифицировать выставленный счёт). Она присоединяется к запросу платежа.</translation>
     </message>
     <message>
         <source>An optional message that is attached to the payment request and may be displayed to the sender.</source>
@@ -3028,7 +3546,7 @@ For more information on using this console, type %6.
     </message>
     <message>
         <source>Clear all fields of the form.</source>
-        <translation type="unfinished">Очищает все поля формы.</translation>
+        <translation type="unfinished">Очистить все поля формы.</translation>
     </message>
     <message>
         <source>Clear</source>
@@ -3040,7 +3558,7 @@ For more information on using this console, type %6.
     </message>
     <message>
         <source>Show the selected request (does the same as double clicking an entry)</source>
-        <translation type="unfinished">Показывает выбранный запрос (двойное нажатие на записи делает то же самое)</translation>
+        <translation type="unfinished">Показать выбранный запрос (двойное нажатие на записи сделает то же самое)</translation>
     </message>
     <message>
         <source>Show</source>
@@ -3048,7 +3566,7 @@ For more information on using this console, type %6.
     </message>
     <message>
         <source>Remove the selected entries from the list</source>
-        <translation type="unfinished">Удаляет выбранные записи из списка</translation>
+        <translation type="unfinished">Удалить выбранные записи из списка</translation>
     </message>
     <message>
         <source>Remove</source>
@@ -3057,6 +3575,22 @@ For more information on using this console, type %6.
     <message>
         <source>Copy &amp;URI</source>
         <translation type="unfinished">Копировать &amp;URI</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Копировать адрес</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Копировать &amp;метку</translation>
+    </message>
+    <message>
+        <source>Copy &amp;message</source>
+        <translation type="unfinished">Копировать &amp;сообщение</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Копировать с&amp;умму</translation>
     </message>
     <message>
         <source>Could not unlock wallet.</source>
@@ -3071,7 +3605,7 @@ For more information on using this console, type %6.
     <name>ReceiveRequestDialog</name>
     <message>
         <source>Request payment to …</source>
-        <translation type="unfinished">Запросить платёж на ...</translation>
+        <translation type="unfinished">Запросить платёж на …</translation>
     </message>
     <message>
         <source>Address:</source>
@@ -3102,8 +3636,16 @@ For more information on using this console, type %6.
         <translation type="unfinished">Копировать &amp;адрес</translation>
     </message>
     <message>
+        <source>&amp;Verify</source>
+        <translation type="unfinished">&amp;Проверить</translation>
+    </message>
+    <message>
+        <source>Verify this address on e.g. a hardware wallet screen</source>
+        <translation type="unfinished">Проверьте адрес на, к примеру, экране аппаратного кошелька</translation>
+    </message>
+    <message>
         <source>&amp;Save Image…</source>
-        <translation type="unfinished">&amp;Сохранить изображение...</translation>
+        <translation type="unfinished">&amp;Сохранить изображение…</translation>
     </message>
     <message>
         <source>Payment information</source>
@@ -3189,7 +3731,7 @@ For more information on using this console, type %6.
     </message>
     <message>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
-        <translation type="unfinished">Если адрес для сдачи пустой или неверный, сдача будет отправлена на вновь сгенерированный адрес.</translation>
+        <translation type="unfinished">Если это выбрано, но адрес для сдачи пустой или неверный, сдача будет отправлена на новый сгенерированный адрес.</translation>
     </message>
     <message>
         <source>Custom change address</source>
@@ -3233,11 +3775,11 @@ For more information on using this console, type %6.
     </message>
     <message>
         <source>Clear all fields of the form.</source>
-        <translation type="unfinished">Очищает все поля формы.</translation>
+        <translation type="unfinished">Очистить все поля формы.</translation>
     </message>
     <message>
         <source>Inputs…</source>
-        <translation type="unfinished">Входы...</translation>
+        <translation type="unfinished">Входы…</translation>
     </message>
     <message>
         <source>Dust:</source>
@@ -3245,7 +3787,7 @@ For more information on using this console, type %6.
     </message>
     <message>
         <source>Choose…</source>
-        <translation type="unfinished">Выбрать...</translation>
+        <translation type="unfinished">Выбрать…</translation>
     </message>
     <message>
         <source>Hide transaction fee settings</source>
@@ -3257,11 +3799,11 @@ For more information on using this console, type %6.
 Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satoshis per kvB" for a transaction size of 500 virtual bytes (half of 1 kvB) would ultimately yield a fee of only 50 satoshis.</source>
         <translation type="unfinished">Укажите пользовательскую комиссию за КБ (1000 байт) виртуального размера транзакции.
 
-Примечание: так как комиссия рассчитывается пропорционально размеру в байтах, комиссия «100 сатоши за ВКБ» для транзакции размером 500 виртуальных байт (половина 1 ВКБ) приведет к сбору в размере всего 50 сатоши.</translation>
+Примечание: комиссия рассчитывается пропорционально размеру в байтах. Так при комиссии "100 сатоши за kvB (виртуальный КБ)" для транзакции размером 500 виртуальных байт (половина 1 kvB) комиссия будет всего 50 сатоши.</translation>
     </message>
     <message>
         <source>When there is less transaction volume than space in the blocks, miners as well as relaying nodes may enforce a minimum fee. Paying only this minimum fee is just fine, but be aware that this can result in a never confirming transaction once there is more demand for bitcoin transactions than the network can process.</source>
-        <translation type="unfinished">Когда объём транзакций меньше, чем пространство в блоках, майнеры и ретранслирующие узлы могут устанавливать минимальную комиссию. Платить только эту минимальную комиссию вполне допустимо, но примите во внимание,  что ваша транзакция может никогда не подтвердиться, если впоследствии транзакций окажется больше, чем может обработать сеть.</translation>
+        <translation type="unfinished">Когда объём транзакций меньше, чем пространство в блоках, майнеры и ретранслирующие узлы могут устанавливать минимальную комиссию. Платить только эту минимальную комиссию вполне допустимо, но примите во внимание, что ваша транзакция может никогда не подтвердиться, если транзакций окажется больше, чем может обработать сеть.</translation>
     </message>
     <message>
         <source>A too low fee might result in a never confirming transaction (read the tooltip)</source>
@@ -3269,11 +3811,11 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     </message>
     <message>
         <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
-        <translation type="unfinished">(Умная комиссия пока не инициализирована. Обычно для этого требуется несколько блоков...)</translation>
+        <translation type="unfinished">(Умная комиссия пока не инициализирована. Обычно для этого требуется несколько блоков…)</translation>
     </message>
     <message>
         <source>Confirmation time target:</source>
-        <translation type="unfinished">Целевое время подтверждения</translation>
+        <translation type="unfinished">Целевое время подтверждения:</translation>
     </message>
     <message>
         <source>Enable Replace-By-Fee</source>
@@ -3281,7 +3823,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     </message>
     <message>
         <source>With Replace-By-Fee (BIP-125) you can increase a transaction's fee after it is sent. Without this, a higher fee may be recommended to compensate for increased transaction delay risk.</source>
-        <translation type="unfinished">С помощью Replace-By-Fee (BIP-125) вы можете увеличить комиссию после отправки транзакции. Если эта опция выключена, рекомендуемая комиссия может увеличиться, чтобы компенсировать риск задержки транзакции.</translation>
+        <translation type="unfinished">С помощью Replace-By-Fee (BIP-125) вы можете увеличить комиссию после отправки транзакции. Если вы выключите эту опцию, рекомендуется увеличить комиссию перед отправкой, чтобы снизить риск задержки транзакции.</translation>
     </message>
     <message>
         <source>Clear &amp;All</source>
@@ -3293,7 +3835,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     </message>
     <message>
         <source>Confirm the send action</source>
-        <translation type="unfinished">Подтвердите отправку</translation>
+        <translation type="unfinished">Подтвердить отправку</translation>
     </message>
     <message>
         <source>S&amp;end</source>
@@ -3313,7 +3855,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     </message>
     <message>
         <source>Copy after fee</source>
-        <translation type="unfinished">Копировать после комиссии</translation>
+        <translation type="unfinished">Копировать сумму после комиссии</translation>
     </message>
     <message>
         <source>Copy bytes</source>
@@ -3332,6 +3874,20 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
         <translation type="unfinished">%1 (%2 блоков)</translation>
     </message>
     <message>
+        <source>Sign on device</source>
+        <extracomment>"device" usually means a hardware wallet.</extracomment>
+        <translation type="unfinished">Подтвердите на устройстве</translation>
+    </message>
+    <message>
+        <source>Connect your hardware wallet first.</source>
+        <translation type="unfinished">Сначала подключите ваш аппаратный кошелёк.</translation>
+    </message>
+    <message>
+        <source>Set external signer script path in Options -&gt; Wallet</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Укажите внешний скрипт подписи в Настройки -&gt; Кошелек</translation>
+    </message>
+    <message>
         <source>Cr&amp;eate Unsigned</source>
         <translation type="unfinished">Создать &amp;без подписи</translation>
     </message>
@@ -3341,23 +3897,33 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     </message>
     <message>
         <source> from wallet '%1'</source>
-        <translation type="unfinished">с кошелька '%1'</translation>
+        <translation type="unfinished">с кошелька "%1"</translation>
     </message>
     <message>
         <source>%1 to '%2'</source>
-        <translation type="unfinished">%1 на '%2'</translation>
+        <translation type="unfinished">%1 на "%2"</translation>
     </message>
     <message>
         <source>%1 to %2</source>
-        <translation type="unfinished">С %1 на %2</translation>
+        <translation type="unfinished">%1 на %2</translation>
     </message>
     <message>
         <source>To review recipient list click "Show Details…"</source>
-        <translation type="unfinished">Чтобы просмотреть список получателей, нажмите «Показать подробности...»</translation>
+        <translation type="unfinished">Чтобы просмотреть список получателей, нажмите "Показать подробности…"</translation>
     </message>
     <message>
         <source>Sign failed</source>
-        <translation type="unfinished">Подписание не удалось.</translation>
+        <translation type="unfinished">Не удалось подписать</translation>
+    </message>
+    <message>
+        <source>External signer not found</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Внешний скрипт подписи не найден</translation>
+    </message>
+    <message>
+        <source>External signer failure</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Внешний скрипта подписи вернул ошибку</translation>
     </message>
     <message>
         <source>Save Transaction Data</source>
@@ -3373,22 +3939,36 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
         <translation type="unfinished">PSBT сохранена</translation>
     </message>
     <message>
+        <source>External balance:</source>
+        <translation type="unfinished">Внешний баланс:</translation>
+    </message>
+    <message>
         <source>or</source>
         <translation type="unfinished">или</translation>
     </message>
     <message>
         <source>You can increase the fee later (signals Replace-By-Fee, BIP-125).</source>
-        <translation type="unfinished">Вы можете увеличить комиссию позже (указан Replace-By-Fee, BIP-125).</translation>
+        <translation type="unfinished">Вы можете увеличить комиссию позже (используется Replace-By-Fee, BIP-125).</translation>
     </message>
     <message>
         <source>Please, review your transaction proposal. This will produce a Partially Signed Bitcoin Transaction (PSBT) which you can save or copy and then sign with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
         <extracomment>Text to inform a user attempting to create a transaction of their current options. At this stage, a user can only create a PSBT. This string is displayed when private keys are disabled and an external signer is not available.</extracomment>
-        <translation type="unfinished">Пожалуйста, ещё раз просмотрите черновик вашей транзакции. Будет создана частично подписанная биткоин-транзакция (PSBT), которую можно сохранить или скопировать, после чего подписать, например, офлайновым кошельком %1 или PSBT-совместимым аппаратным кошельком.</translation>
+        <translation type="unfinished">Пожалуйста, проверьте черновик вашей транзакции. Будет создана частично подписанная биткоин-транзакция (PSBT), которую можно сохранить или скопировать, после чего подписать, например, офлайновым кошельком %1 или PSBT-совместимым аппаратным кошельком.</translation>
+    </message>
+    <message>
+        <source>Do you want to create this transaction?</source>
+        <extracomment>Message displayed when attempting to create a transaction. Cautionary text to prompt the user to verify that the displayed transaction details represent the transaction the user intends to create.</extracomment>
+        <translation type="unfinished">Вы хотите создать эту транзакцию?</translation>
+    </message>
+    <message>
+        <source>Please, review your transaction. You can create and send this transaction or create a Partially Signed Bitcoin Transaction (PSBT), which you can save or copy and then sign with, e.g., an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
+        <extracomment>Text to inform a user attempting to create a transaction of their current options. At this stage, a user can send their transaction or create a PSBT. This string is displayed when both private keys and PSBT controls are enabled.</extracomment>
+        <translation type="unfinished">Пожалуйста, проверьте вашу транзакцию. Вы можете создать и отправить эту транзакцию, либо создать частично подписанную биткоин-транзакцию (PSBT), которую можно сохранить или скопировать, после чего подписать, например, офлайновым кошельком %1 или PSBT-совместимым аппаратным кошельком.</translation>
     </message>
     <message>
         <source>Please, review your transaction.</source>
         <extracomment>Text to prompt a user to review the details of the transaction they are attempting to send.</extracomment>
-        <translation type="unfinished">Пожалуйста, ещё раз просмотрите вашу транзакцию.</translation>
+        <translation type="unfinished">Пожалуйста, проверьте вашу транзакцию.</translation>
     </message>
     <message>
         <source>Transaction fee</source>
@@ -3396,7 +3976,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     </message>
     <message>
         <source>Not signalling Replace-By-Fee, BIP-125.</source>
-        <translation type="unfinished">Не указан Replace-By-Fee, BIP-125.</translation>
+        <translation type="unfinished">Не используется Replace-By-Fee, BIP-125.</translation>
     </message>
     <message>
         <source>Total Amount</source>
@@ -3404,11 +3984,11 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     </message>
     <message>
         <source>Confirm send coins</source>
-        <translation type="unfinished">Подтвердите отправку монет</translation>
+        <translation type="unfinished">Подтвердить отправку монет</translation>
     </message>
     <message>
         <source>Watch-only balance:</source>
-        <translation type="unfinished">Наблюдаемый баланс:</translation>
+        <translation type="unfinished">Баланс только для просмотра:</translation>
     </message>
     <message>
         <source>The recipient address is not valid. Please recheck.</source>
@@ -3436,27 +4016,23 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     </message>
     <message>
         <source>A fee higher than %1 is considered an absurdly high fee.</source>
-        <translation type="unfinished">Комиссия более чем в %1 считается абсурдно высокой.</translation>
-    </message>
-    <message>
-        <source>Payment request expired.</source>
-        <translation type="unfinished">Истекло время ожидания запроса платежа</translation>
+        <translation type="unfinished">Комиссия более %1 считается абсурдно высокой.</translation>
     </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>Подтверждение ожидается через %n блок.</numerusform>
+            <numerusform>Подтверждение ожидается через %n блока.</numerusform>
+            <numerusform>Подтверждение ожидается через %n блоков.</numerusform>
         </translation>
     </message>
     <message>
         <source>Warning: Invalid Bitcoin address</source>
-        <translation type="unfinished">Предупреждение: неверный биткоин-адрес</translation>
+        <translation type="unfinished">Внимание: неверный биткоин-адрес</translation>
     </message>
     <message>
         <source>Warning: Unknown change address</source>
-        <translation type="unfinished">Предупреждение: неизвестный адрес сдачи</translation>
+        <translation type="unfinished">Внимание: неизвестный адрес сдачи</translation>
     </message>
     <message>
         <source>Confirm custom change address</source>
@@ -3464,7 +4040,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     </message>
     <message>
         <source>The address you selected for change is not part of this wallet. Any or all funds in your wallet may be sent to this address. Are you sure?</source>
-        <translation type="unfinished">Выбранный вами адрес для сдачи не принадлежит этому кошельку. Часть или все средства в вашем кошельке могут быть отправлены на этот адрес. Вы уверены?</translation>
+        <translation type="unfinished">Выбранный вами адрес для сдачи не принадлежит этому кошельку. Часть средств, а то и всё содержимое вашего кошелька будет отправлено на этот адрес. Вы уверены в своих действиях?</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -3507,7 +4083,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     </message>
     <message>
         <source>The fee will be deducted from the amount being sent. The recipient will receive less bitcoins than you enter in the amount field. If multiple recipients are selected, the fee is split equally.</source>
-        <translation type="unfinished">Комиссия будет вычтена из отправляемой суммы. Получателю придёт меньше биткоинов, чем вы ввели в поле «Сумма». Если выбрано несколько получателей, комиссия распределяется поровну.</translation>
+        <translation type="unfinished">Комиссия будет вычтена из отправляемой суммы. Получателю придёт меньше биткоинов, чем вы ввели в поле "Сумма". Если выбрано несколько получателей, комиссия распределится поровну.</translation>
     </message>
     <message>
         <source>S&amp;ubtract fee from amount</source>
@@ -3522,28 +4098,12 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
         <translation type="unfinished">Сообщение:</translation>
     </message>
     <message>
-        <source>This is an unauthenticated payment request.</source>
-        <translation type="unfinished">Это непроверенный запрос на оплату.</translation>
-    </message>
-    <message>
-        <source>This is an authenticated payment request.</source>
-        <translation type="unfinished">Это проверенный запрос на оплату.</translation>
-    </message>
-    <message>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished">Введите метку для этого адреса, чтобы добавить его в список использованных адресов</translation>
     </message>
     <message>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
-        <translation type="unfinished">Сообщение, которое было прикреплено к URI и которое будет сохранено вместе с транзакцией для вашего сведения. Обратите внимание: сообщение не будет отправлено через сеть биткоина.</translation>
-    </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">Отправить на:</translation>
-    </message>
-    <message>
-        <source>Memo:</source>
-        <translation type="unfinished">Примечание:</translation>
+        <translation type="unfinished">Сообщение, которое было прикреплено к URI. Оно будет сохранено вместе с транзакцией для вашего удобства. Обратите внимание: это сообщение не будет отправлено в сеть Bitcoin.</translation>
     </message>
 </context>
 <context>
@@ -3617,7 +4177,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     </message>
     <message>
         <source>Enter the receiver's address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack. Note that this only proves the signing party receives with the address, it cannot prove sendership of any transaction!</source>
-        <translation type="unfinished">Введите ниже адрес получателя, сообщение (убедитесь, что переводы строк, пробелы, знаки табуляции и т. п. скопированы в точности) и подпись, чтобы проверить сообщение. Убедитесь, что вы не придаёте сообщению большего смысла, чем оно на самом деле несёт, чтобы не стать жертвой атаки "человек посередине". Обратите внимание, что подпись доказывает лишь то, что подписавший может получать биткоины на этот адрес, но никак не то, что он отправил какую-либо транзакцию!</translation>
+        <translation type="unfinished">Введите ниже адрес получателя, сообщение (убедитесь, что переводы строк, пробелы, знаки табуляции и т.п. скопированы в точности) и подпись, чтобы проверить сообщение. Не придавайте сообщению большего смысла, чем в нём содержится, чтобы не стать жертвой атаки "человек посередине". Обратите внимание, что подпись доказывает лишь то, что подписавший может получать биткоины на этот адрес, но никак не то, что он отправил какую-либо транзакцию!</translation>
     </message>
     <message>
         <source>The Bitcoin address the message was signed with</source>
@@ -3665,11 +4225,11 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     </message>
     <message>
         <source>No error</source>
-        <translation type="unfinished">Нет ошибок</translation>
+        <translation type="unfinished">Без ошибок</translation>
     </message>
     <message>
         <source>Private key for the entered address is not available.</source>
-        <translation type="unfinished">Недоступен секретный ключ для введённого адреса.</translation>
+        <translation type="unfinished">Приватный ключ для введённого адреса недоступен.</translation>
     </message>
     <message>
         <source>Message signing failed.</source>
@@ -3689,7 +4249,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     </message>
     <message>
         <source>The signature did not match the message digest.</source>
-        <translation type="unfinished">Подпись не соответствует отпечатку сообщения.</translation>
+        <translation type="unfinished">Подпись не соответствует хэшу сообщения.</translation>
     </message>
     <message>
         <source>Message verification failed.</source>
@@ -3706,7 +4266,11 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
         <source>(press q to shutdown and continue later)</source>
         <translation type="unfinished">(нажмите q, чтобы завершить работу и продолжить позже)</translation>
     </message>
-    </context>
+    <message>
+        <source>press q to shutdown</source>
+        <translation type="unfinished">нажмите q для выключения</translation>
+    </message>
+</context>
 <context>
     <name>TrafficGraphWidget</name>
     <message>
@@ -3718,30 +4282,32 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     <name>TransactionDesc</name>
     <message>
         <source>conflicted with a transaction with %1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that conflicts with a confirmed transaction.</extracomment>
         <translation type="unfinished">конфликтует с транзакцией с %1 подтверждениями</translation>
     </message>
     <message>
-        <source>0/unconfirmed, %1</source>
-        <translation type="unfinished">0 / не подтверждено, %1</translation>
+        <source>0/unconfirmed, in memory pool</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is in the memory pool.</extracomment>
+        <translation type="unfinished">0/нет подтверждений, в пуле памяти</translation>
     </message>
     <message>
-        <source>in memory pool</source>
-        <translation type="unfinished">в пуле памяти</translation>
-    </message>
-    <message>
-        <source>not in memory pool</source>
-        <translation type="unfinished">не в пуле памяти</translation>
+        <source>0/unconfirmed, not in memory pool</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is not in the memory pool.</extracomment>
+        <translation type="unfinished">0/нет подтверждений, не в пуле памяти</translation>
     </message>
     <message>
         <source>abandoned</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an abandoned transaction.</extracomment>
         <translation type="unfinished">отброшена</translation>
     </message>
     <message>
         <source>%1/unconfirmed</source>
-        <translation type="unfinished">%1 / не подтверждено</translation>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
+        <translation type="unfinished">%1/нет подтверждений</translation>
     </message>
     <message>
         <source>%1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
         <translation type="unfinished">%1 подтверждений</translation>
     </message>
     <message>
@@ -3762,7 +4328,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     </message>
     <message>
         <source>From</source>
-        <translation type="unfinished">От</translation>
+        <translation type="unfinished">От кого</translation>
     </message>
     <message>
         <source>unknown</source>
@@ -3791,9 +4357,9 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>созреет через %n блок</numerusform>
+            <numerusform>созреет через %n блока</numerusform>
+            <numerusform>созреет через %n блоков</numerusform>
         </translation>
     </message>
     <message>
@@ -3818,7 +4384,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     </message>
     <message>
         <source>Net amount</source>
-        <translation type="unfinished">Сумма нетто</translation>
+        <translation type="unfinished">Чистая сумма</translation>
     </message>
     <message>
         <source>Message</source>
@@ -3932,7 +4498,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     </message>
     <message>
         <source>Generated but not accepted</source>
-        <translation type="unfinished">Сгенерирована, но не принята</translation>
+        <translation type="unfinished">Сгенерирован, но не принят</translation>
     </message>
     <message>
         <source>Received with</source>
@@ -3952,7 +4518,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     </message>
     <message>
         <source>Mined</source>
-        <translation type="unfinished">Добыта</translation>
+        <translation type="unfinished">Добыто</translation>
     </message>
     <message>
         <source>watch-only</source>
@@ -4003,19 +4569,19 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     </message>
     <message>
         <source>This week</source>
-        <translation type="unfinished">Эта неделя</translation>
+        <translation type="unfinished">На этой неделе</translation>
     </message>
     <message>
         <source>This month</source>
-        <translation type="unfinished">Этот месяц</translation>
+        <translation type="unfinished">В этом месяце</translation>
     </message>
     <message>
         <source>Last month</source>
-        <translation type="unfinished">Последний месяц</translation>
+        <translation type="unfinished">В прошлом месяце</translation>
     </message>
     <message>
         <source>This year</source>
-        <translation type="unfinished">Этот год</translation>
+        <translation type="unfinished">В этом году</translation>
     </message>
     <message>
         <source>Received with</source>
@@ -4031,7 +4597,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     </message>
     <message>
         <source>Mined</source>
-        <translation type="unfinished">Добыта</translation>
+        <translation type="unfinished">Добыто</translation>
     </message>
     <message>
         <source>Other</source>
@@ -4039,15 +4605,60 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     </message>
     <message>
         <source>Enter address, transaction id, or label to search</source>
-        <translation type="unfinished">Введите адрес, идентификатор транзакции или метку для поиска</translation>
+        <translation type="unfinished">Введите адрес, идентификатор транзакции, или метку для поиска</translation>
     </message>
     <message>
         <source>Min amount</source>
-        <translation type="unfinished">Мин. сумма</translation>
+        <translation type="unfinished">Минимальная сумма</translation>
     </message>
     <message>
         <source>Range…</source>
         <translation type="unfinished">Диапазон...</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Копировать адрес</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Копировать &amp;метку</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Копировать с&amp;умму</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">Копировать ID &amp;транзакции</translation>
+    </message>
+    <message>
+        <source>Copy &amp;raw transaction</source>
+        <translation type="unfinished">Копировать &amp;исходный код транзакции</translation>
+    </message>
+    <message>
+        <source>Copy full transaction &amp;details</source>
+        <translation type="unfinished">Копировать &amp;все подробности транзакции</translation>
+    </message>
+    <message>
+        <source>&amp;Show transaction details</source>
+        <translation type="unfinished">&amp;Показать подробности транзакции</translation>
+    </message>
+    <message>
+        <source>Increase transaction &amp;fee</source>
+        <translation type="unfinished">Увеличить комиссию</translation>
+    </message>
+    <message>
+        <source>A&amp;bandon transaction</source>
+        <translation type="unfinished">&amp;Отказ от транзакции</translation>
+    </message>
+    <message>
+        <source>&amp;Edit address label</source>
+        <translation type="unfinished">&amp;Изменить метку адреса</translation>
+    </message>
+    <message>
+        <source>Show in %1</source>
+        <extracomment>Transactions table context menu action to show the selected transaction in a third-party block explorer. %1 is a stand-in argument for the URL of the explorer.</extracomment>
+        <translation type="unfinished">Показать в %1</translation>
     </message>
     <message>
         <source>Export Transaction History</source>
@@ -4084,7 +4695,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     </message>
     <message>
         <source>ID</source>
-        <translation type="unfinished">Идентификатр</translation>
+        <translation type="unfinished">Идентификатор</translation>
     </message>
     <message>
         <source>Exporting Failed</source>
@@ -4108,7 +4719,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     </message>
     <message>
         <source>to</source>
-        <translation type="unfinished">для</translation>
+        <translation type="unfinished">до</translation>
     </message>
 </context>
 <context>
@@ -4175,7 +4786,7 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <source>Increase:</source>
-        <translation type="unfinished">Увеличение:</translation>
+        <translation type="unfinished">Увеличить на:</translation>
     </message>
     <message>
         <source>New fee:</source>
@@ -4183,15 +4794,15 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <source>Warning: This may pay the additional fee by reducing change outputs or adding inputs, when necessary. It may add a new change output if one does not already exist. These changes may potentially leak privacy.</source>
-        <translation type="unfinished">Внимание: комиссия может быть увеличена путём уменьшения выводов для сдачи или добавления входов (по необходимости). Может быть добавлен новый вывод для сдачи, если он не существует. Эти изменения могут привести к ухудшению вашей конфиденциальности.ё</translation>
+        <translation type="unfinished">Внимание: комиссия может быть увеличена путём уменьшения выходов для сдачи или добавления входов (по необходимости). Может быть добавлен новый вывод для сдачи, если он не существует. Эти изменения могут привести к ухудшению вашей конфиденциальности.</translation>
     </message>
     <message>
         <source>Confirm fee bump</source>
-        <translation type="unfinished">Подтвердите увеличение комиссии</translation>
+        <translation type="unfinished">Подтвердить увеличение комиссии</translation>
     </message>
     <message>
         <source>Can't draft transaction.</source>
-        <translation type="unfinished">Невозможно подготовить черновик транзакции.</translation>
+        <translation type="unfinished">Не удалось подготовить черновик транзакции.</translation>
     </message>
     <message>
         <source>PSBT copied</source>
@@ -4204,6 +4815,10 @@ Go to File &gt; Open Wallet to load a wallet.
     <message>
         <source>Could not commit transaction</source>
         <translation type="unfinished">Не удалось отправить транзакцию</translation>
+    </message>
+    <message>
+        <source>Can't display address</source>
+        <translation type="unfinished">Не удалось отобразить адрес</translation>
     </message>
     <message>
         <source>default wallet</source>

--- a/src/qt/locale/bitcoin_si.ts
+++ b/src/qt/locale/bitcoin_si.ts
@@ -3,7 +3,7 @@
     <name>AddressBookPage</name>
     <message>
         <source>Right-click to edit address or label</source>
-        <translation type="unfinished">ලිපිනය හෝ ලේබලය සංස්කරණය කිරීමට දකුණු මූසික බොත්තම  ක්ලික් කරන්න</translation>
+        <translation type="unfinished">ලිපිනය හෝ නම්පත සංශෝධනයට දකුණු බොත්තම  ඔබන්න</translation>
     </message>
     <message>
         <source>Create a new address</source>
@@ -15,11 +15,11 @@
     </message>
     <message>
         <source>Copy the currently selected address to the system clipboard</source>
-        <translation type="unfinished">දැනට තෝරාගෙන ඇති ලිපිනය පද්ධති පසුරු පුවරුවට (clipboard) පිටපත් කරන්න</translation>
+        <translation type="unfinished">තෝරාගෙන ඇති ලිපිනය පද්ධතියේ පසුරු පුවරුවට පිටපත් කරන්න</translation>
     </message>
     <message>
         <source>&amp;Copy</source>
-        <translation type="unfinished">&amp;පිටපත් කරන්න</translation>
+        <translation type="unfinished">&amp;පිටපත්</translation>
     </message>
     <message>
         <source>C&amp;lose</source>
@@ -27,15 +27,23 @@
     </message>
     <message>
         <source>Delete the currently selected address from the list</source>
-        <translation type="unfinished">දැනට තෝරාගත් ලිපිනය ලැයිස්තුවෙන් ඉවත් කරන්න</translation>
+        <translation type="unfinished">තේරූ ලිපිනය ලේඛනයෙන් මකන්න</translation>
     </message>
     <message>
         <source>Enter address or label to search</source>
-        <translation type="unfinished">සෙවීමට ලිපිනය හෝ ලේබලය ඇතුළත් කරන්න</translation>
+        <translation type="unfinished">සෙවීමට ලිපිනය හෝ නම්පත යොදන්න</translation>
+    </message>
+    <message>
+        <source>Export the data in the current tab to a file</source>
+        <translation type="unfinished">වත්මන් පටියෙයි දත්ත ගොනුවකට නිර්යාත කරන්න</translation>
     </message>
     <message>
         <source>&amp;Export</source>
-        <translation type="unfinished">&amp;නිර්යාත කරන්න</translation>
+        <translation type="unfinished">&amp;නිර්යාතය</translation>
+    </message>
+    <message>
+        <source>&amp;Delete</source>
+        <translation type="unfinished">&amp;මකන්න</translation>
     </message>
     <message>
         <source>Choose the address to send coins to</source>
@@ -47,7 +55,7 @@
     </message>
     <message>
         <source>C&amp;hoose</source>
-        <translation type="unfinished">තෝරන්න</translation>
+        <translation type="unfinished">තෝ&amp;රන්න</translation>
     </message>
     <message>
         <source>Sending addresses</source>
@@ -59,11 +67,15 @@
     </message>
     <message>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
-        <translation type="unfinished">මේවා ඔබගේ ගෙවීම් යැවීම සඳහා වන බිට්කොයින් ලිපින වේ. කාසි යැවීමට පෙර සෑම විටම මුදල සහ ලැබීමේ ලිපිනය පරීක්ෂා කරන්න.</translation>
+        <translation type="unfinished">මේ ඔබගේ ගෙවීම් යැවීම සඳහා වන බිට්කොයින් ලිපින වේ. කාසි යැවීමට පෙර සෑම විටම මුදල සහ ලැබීමේ ලිපිනය පරීක්‍ෂා කරන්න.</translation>
     </message>
     <message>
         <source>&amp;Copy Address</source>
-        <translation type="unfinished">&amp;ලිපිනය පිටපත්</translation>
+        <translation type="unfinished">&amp;ලිපිනයෙහි පිටපතක්</translation>
+    </message>
+    <message>
+        <source>Copy &amp;Label</source>
+        <translation type="unfinished">නම්පතෙහි &amp;පිටපතක්</translation>
     </message>
     <message>
         <source>&amp;Edit</source>
@@ -72,7 +84,7 @@
     <message>
         <source>Comma separated file</source>
         <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
-        <translation type="unfinished">අල්පවිරාම වලින් වෙන්වූ ගොනුව</translation>
+        <translation type="unfinished">අල්පවිරාම යෙදූ ගොනුව</translation>
     </message>
     <message>
         <source>There was an error trying to save the address list to %1. Please try again.</source>
@@ -81,14 +93,14 @@
     </message>
     <message>
         <source>Exporting Failed</source>
-        <translation type="unfinished">නිර්යාත වීමට අසමත් විය</translation>
+        <translation type="unfinished">නිර්යාතයට අසමත් විය</translation>
     </message>
 </context>
 <context>
     <name>AddressTableModel</name>
     <message>
         <source>Label</source>
-        <translation type="unfinished">ලේබලය</translation>
+        <translation type="unfinished">නම්පත</translation>
     </message>
     <message>
         <source>Address</source>
@@ -96,7 +108,7 @@
     </message>
     <message>
         <source>(no label)</source>
-        <translation type="unfinished">(ලේබලයක් නැත)</translation>
+        <translation type="unfinished">(නම්පතක් නැත)</translation>
     </message>
 </context>
 <context>
@@ -123,7 +135,7 @@
     </message>
     <message>
         <source>Encrypt wallet</source>
-        <translation type="unfinished">පසුම්බිය සංකේතනය කරන්න</translation>
+        <translation type="unfinished">පසුම්බිය සංකේතනය</translation>
     </message>
     <message>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
@@ -151,7 +163,7 @@
     </message>
     <message>
         <source>Wallet encrypted</source>
-        <translation type="unfinished">පසුම්බිය සංකේතනය කර ඇත</translation>
+        <translation type="unfinished">පසුම්බිය සංකේතිතයි</translation>
     </message>
     <message>
         <source>Enter the new passphrase for the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
@@ -171,11 +183,11 @@
     </message>
     <message>
         <source>Your wallet is about to be encrypted. </source>
-        <translation type="unfinished">ඔබේ මුදල් පසුම්බිය සංකේතනය කිරීමට ආසන්නයි.</translation>
+        <translation type="unfinished">පසුම්බිය සංකේතනය කිරීමට ආසන්නයි.</translation>
     </message>
     <message>
         <source>Your wallet is now encrypted. </source>
-        <translation type="unfinished">ඔබගේ මුදල් පසුම්බිය දැන් සංකේතනය කර ඇත.</translation>
+        <translation type="unfinished">ඔබගේ මුදල් පසුම්බිය දැන් සංකේතිතයි.</translation>
     </message>
     <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
@@ -183,7 +195,7 @@
     </message>
     <message>
         <source>Wallet encryption failed</source>
-        <translation type="unfinished">පසුම්බි සංකේතනය අසාර්ථක විය</translation>
+        <translation type="unfinished">පසුම්බිය සංකේතනයට අසමත්!</translation>
     </message>
     <message>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
@@ -216,12 +228,25 @@
         <source>Internal error</source>
         <translation type="unfinished">අභ්‍යන්තර දෝෂයකි</translation>
     </message>
-    </context>
+    <message>
+        <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
+        <translation type="unfinished">අභ්‍යන්තර දෝෂයක් සිදු විය. %1 ආරක්ෂිතව ඉදිරියට යාමට උත්සාහ කරනු ඇත. මෙය පහත විස්තර කර ඇති පරිදි වාර්තා කළ හැකි අනපේක්ෂිත දෝෂයකි.</translation>
+    </message>
+</context>
 <context>
     <name>QObject</name>
     <message>
+        <source>Do you want to reset settings to default values, or to abort without making changes?</source>
+        <extracomment>Explanatory text shown on startup when the settings file cannot be read. Prompts user to make a choice between resetting or aborting.</extracomment>
+        <translation type="unfinished">ඔබට සැකසීම් පෙරනිමි අගයන් වෙත යළි පිහිටුවීමට අවශ්‍යද, නැතහොත් වෙනස්කම් සිදු නොකර නවතා දැමීමටද?</translation>
+    </message>
+    <message>
         <source>Error: %1</source>
         <translation type="unfinished">දෝෂය: %1</translation>
+    </message>
+    <message>
+        <source>%1 didn't yet exit safely…</source>
+        <translation type="unfinished">%1 තවමත් ආරක්ෂිතව පිටව ගොස් නැත ...</translation>
     </message>
     <message>
         <source>unknown</source>
@@ -234,48 +259,52 @@
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n second(s)</numerusform>
+            <numerusform>%n second(s)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n minute(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n minute(s)</numerusform>
+            <numerusform>%n minute(s)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n hour(s)</numerusform>
+            <numerusform>%n hour(s)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n day(s)</numerusform>
+            <numerusform>%n day(s)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n week(s)</numerusform>
+            <numerusform>%n week(s)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n year(s)</numerusform>
+            <numerusform>%n year(s)</numerusform>
         </translation>
     </message>
     </context>
 <context>
     <name>bitcoin-core</name>
+    <message>
+        <source>Settings file could not be read</source>
+        <translation type="unfinished">සැකසීම් ගොනුව කියවිය නොහැක</translation>
+    </message>
     <message>
         <source>The %s developers</source>
         <translation type="unfinished">%s සංවර්ධකයින්</translation>
@@ -287,6 +316,10 @@
     <message>
         <source>Error loading %s</source>
         <translation type="unfinished">%s පූරණය වීමේ දෝෂයකි</translation>
+    </message>
+    <message>
+        <source>Error: Unable to make a backup of your wallet</source>
+        <translation type="unfinished">දෝෂය: ඔබගේ පසුම්බිය ප්‍රතිස්ථාපනය කල නොහැකි විය.</translation>
     </message>
     <message>
         <source>Importing…</source>
@@ -316,6 +349,14 @@
         <translation type="unfinished">&amp;දළ විශ්ලේෂණය</translation>
     </message>
     <message>
+        <source>Show general overview of wallet</source>
+        <translation type="unfinished">පසුම්බිය පිළිබඳ සාමාන්‍ය දළ විශ්ලේෂණය පෙන්වන්න</translation>
+    </message>
+    <message>
+        <source>&amp;Transactions</source>
+        <translation type="unfinished">&amp;ගනුදෙනු</translation>
+    </message>
+    <message>
         <source>Browse transaction history</source>
         <translation type="unfinished">ගනුදෙනු ඉතිහාසය පිරික්සන්න</translation>
     </message>
@@ -325,7 +366,7 @@
     </message>
     <message>
         <source>Quit application</source>
-        <translation type="unfinished">යෙදුමෙන් පිටවන්න</translation>
+        <translation type="unfinished">යෙදුම වසන්න</translation>
     </message>
     <message>
         <source>&amp;About %1</source>
@@ -333,7 +374,7 @@
     </message>
     <message>
         <source>Show information about %1</source>
-        <translation type="unfinished">%1 පිළිබඳව තොරතුරු පෙන්වන්න</translation>
+        <translation type="unfinished">%1 ගැන තොරතුරු පෙන්වන්න</translation>
     </message>
     <message>
         <source>About &amp;Qt</source>
@@ -341,11 +382,15 @@
     </message>
     <message>
         <source>Show information about Qt</source>
-        <translation type="unfinished">කියුටී පිළිබඳව තොරතුරු පෙන්වන්න</translation>
+        <translation type="unfinished">කියුටී ගැන තොරතුරු පෙන්වන්න</translation>
     </message>
     <message>
         <source>Create a new wallet</source>
         <translation type="unfinished">නව පසුම්බියක් සාදන්න</translation>
+    </message>
+    <message>
+        <source>&amp;Minimize</source>
+        <translation type="unfinished">&amp;හකුළන්න</translation>
     </message>
     <message>
         <source>Wallet:</source>
@@ -358,7 +403,7 @@
     </message>
     <message>
         <source>Send coins to a Bitcoin address</source>
-        <translation type="unfinished">බිට්කොයින් ලිපිනයට කාසි යවන්න</translation>
+        <translation type="unfinished">බිට්කොයින් ලිපිනයකට කාසි යවන්න</translation>
     </message>
     <message>
         <source>Backup wallet to another location</source>
@@ -378,7 +423,7 @@
     </message>
     <message>
         <source>&amp;Backup Wallet…</source>
-        <translation type="unfinished">&amp;පසුම්බිය උපස්ථකරන්න…</translation>
+        <translation type="unfinished">&amp;පසුම්බිය උපස්ථය…</translation>
     </message>
     <message>
         <source>Close Wallet…</source>
@@ -406,7 +451,7 @@
     </message>
     <message>
         <source>Syncing Headers (%1%)…</source>
-        <translation type="unfinished">(%1%) ශීර්ෂ සමමුහූර්ත වෙමින්…</translation>
+        <translation type="unfinished">(%1%) ශ්‍රීර්ෂ සමමුහූර්ත වෙමින්…</translation>
     </message>
     <message>
         <source>Synchronizing with network…</source>
@@ -415,8 +460,8 @@
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>Processed %n block(s) of transaction history.</numerusform>
+            <numerusform>Processed %n block(s) of transaction history.</numerusform>
         </translation>
     </message>
     <message>
@@ -430,6 +475,10 @@
     <message>
         <source>Information</source>
         <translation type="unfinished">තොරතුර</translation>
+    </message>
+    <message>
+        <source>Up to date</source>
+        <translation type="unfinished">යාවත්කාලීනයි</translation>
     </message>
     <message>
         <source>&amp;Sending addresses</source>
@@ -452,6 +501,11 @@
         <translation type="unfinished">පසුම්බිය වසන්න</translation>
     </message>
     <message>
+        <source>Restore Wallet…</source>
+        <extracomment>Name of the menu item that restores wallet from a backup file.</extracomment>
+        <translation type="unfinished">පසුම්බිය ප්‍රතිස්ථාපනය කිරීම</translation>
+    </message>
+    <message>
         <source>Close all wallets</source>
         <translation type="unfinished">සියළු පසුම්බි වසන්න</translation>
     </message>
@@ -460,12 +514,27 @@
         <translation type="unfinished">පෙරනිමි පසුම්බිය</translation>
     </message>
     <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">පසුම්බියේ දත්ත</translation>
+    </message>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of pop-up window shown when the user is attempting to restore a wallet.</extracomment>
+        <translation type="unfinished">පසුම්බිය ප්‍රතිස්ථාපනය කිරීම</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">පසුම්බියේ නම</translation>
+    </message>
+    <message>
         <source>&amp;Window</source>
         <translation type="unfinished">&amp;කවුළුව</translation>
     </message>
     <message>
         <source>Zoom</source>
-        <translation type="unfinished">විශාල කරන්න</translation>
+        <translation type="unfinished">විශාලනය</translation>
     </message>
     <message>
         <source>Main Window</source>
@@ -475,12 +544,20 @@
         <source>%1 client</source>
         <translation type="unfinished">%1 අනුග්‍රාහකය</translation>
     </message>
+    <message>
+        <source>&amp;Hide</source>
+        <translation type="unfinished">&amp;සඟවන්න</translation>
+    </message>
+    <message>
+        <source>S&amp;how</source>
+        <translation type="unfinished">පෙ&amp;න්වන්න</translation>
+    </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n active connection(s) to Bitcoin network.</numerusform>
+            <numerusform>%n active connection(s) to Bitcoin network.</numerusform>
         </translation>
     </message>
     <message>
@@ -513,6 +590,12 @@
 </translation>
     </message>
     <message>
+        <source>Amount: %1
+</source>
+        <translation type="unfinished">ගණන: %1
+</translation>
+    </message>
+    <message>
         <source>Wallet: %1
 </source>
         <translation type="unfinished">පසුම්බිය: %1
@@ -522,6 +605,12 @@
         <source>Type: %1
 </source>
         <translation type="unfinished">වර්ගය: %1
+</translation>
+    </message>
+    <message>
+        <source>Label: %1
+</source>
+        <translation type="unfinished">නම්පත: %1
 </translation>
     </message>
     <message>
@@ -575,7 +664,7 @@
     </message>
     <message>
         <source>&amp;Copy address</source>
-        <translation type="unfinished">&amp;ලිපිනය පිටපත්</translation>
+        <translation type="unfinished">&amp;ලිපිනයෙහි පිටපතක්</translation>
     </message>
     <message>
         <source>Copy bytes</source>
@@ -591,7 +680,7 @@
     </message>
     <message>
         <source>(no label)</source>
-        <translation type="unfinished">(ලේබලයක් නැත)</translation>
+        <translation type="unfinished">(නම්පතක් නැත)</translation>
     </message>
     <message>
         <source>(change)</source>
@@ -618,6 +707,24 @@
         <translation type="unfinished">පසුම්බිය විවෘත කරන්න</translation>
     </message>
     </context>
+<context>
+    <name>RestoreWalletActivity</name>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of progress window which is displayed when wallets are being restored.</extracomment>
+        <translation type="unfinished">පසුම්බිය ප්‍රතිස්ථාපනය කිරීම</translation>
+    </message>
+    <message>
+        <source>Restore wallet failed</source>
+        <extracomment>Title of message box which is displayed when the wallet could not be restored.</extracomment>
+        <translation type="unfinished">පසුම්බිය ප්‍රතිස්ථාපනය කිරීම අසාර්ථකයි</translation>
+    </message>
+    <message>
+        <source>Restore wallet message</source>
+        <extracomment>Title of message box which is displayed when the wallet is successfully restored.</extracomment>
+        <translation type="unfinished">පසුම්බිය ප්‍රතිස්ථාපනය කිරීමේ පණිවිඩය </translation>
+    </message>
+</context>
 <context>
     <name>WalletController</name>
     <message>
@@ -697,11 +804,32 @@
         <translation type="unfinished">බිට්කොයින්</translation>
     </message>
     <message numerus="yes">
-        <source>(sufficient to restore backups %n day(s) old)</source>
-        <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
+        <source>%n GB of space available</source>
         <translation type="unfinished">
             <numerusform />
             <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(sufficient to restore backups %n day(s) old)</source>
+        <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
+        <translation type="unfinished">
+            <numerusform>(sufficient to restore backups %n day(s) old)</numerusform>
+            <numerusform>(sufficient to restore backups %n day(s) old)</numerusform>
         </translation>
     </message>
     <message>
@@ -855,6 +983,11 @@
 <context>
     <name>PeerTableModel</name>
     <message>
+        <source>Age</source>
+        <extracomment>Title of Peers Table column which indicates the duration (length of time) since the peer connection started.</extracomment>
+        <translation type="unfinished">වයස</translation>
+    </message>
+    <message>
         <source>Address</source>
         <extracomment>Title of Peers Table column which contains the IP/Onion/I2P address of the connected peer.</extracomment>
         <translation type="unfinished">ලිපිනය</translation>
@@ -870,7 +1003,7 @@
     <message>
         <source>&amp;Copy address</source>
         <extracomment>Context menu action to copy the address of a peer.</extracomment>
-        <translation type="unfinished">&amp;ලිපිනය පිටපත්</translation>
+        <translation type="unfinished">&amp;ලිපිනයෙහි පිටපතක්</translation>
     </message>
     <message>
         <source>To</source>
@@ -885,7 +1018,7 @@
     <name>ReceiveCoinsDialog</name>
     <message>
         <source>&amp;Copy address</source>
-        <translation type="unfinished">&amp;ලිපිනය පිටපත්</translation>
+        <translation type="unfinished">&amp;ලිපිනයෙහි පිටපතක්</translation>
     </message>
     </context>
 <context>
@@ -907,7 +1040,7 @@
     </message>
     <message>
         <source>Label</source>
-        <translation type="unfinished">ලේබලය</translation>
+        <translation type="unfinished">නම්පත</translation>
     </message>
     <message>
         <source>Message</source>
@@ -915,7 +1048,7 @@
     </message>
     <message>
         <source>(no label)</source>
-        <translation type="unfinished">(ලේබලයක් නැත)</translation>
+        <translation type="unfinished">(නම්පතක් නැත)</translation>
     </message>
     </context>
 <context>
@@ -971,13 +1104,13 @@
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>Estimated to begin confirmation within %n block(s).</numerusform>
+            <numerusform>Estimated to begin confirmation within %n block(s).</numerusform>
         </translation>
     </message>
     <message>
         <source>(no label)</source>
-        <translation type="unfinished">(ලේබලයක් නැත)</translation>
+        <translation type="unfinished">(නම්පතක් නැත)</translation>
     </message>
 </context>
 <context>
@@ -1023,8 +1156,8 @@
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>matures in %n more block(s)</numerusform>
+            <numerusform>matures in %n more block(s)</numerusform>
         </translation>
     </message>
     <message>
@@ -1060,7 +1193,7 @@
     </message>
     <message>
         <source>Label</source>
-        <translation type="unfinished">ලේබලය</translation>
+        <translation type="unfinished">නම්පත</translation>
     </message>
     <message>
         <source>(n/a)</source>
@@ -1068,7 +1201,7 @@
     </message>
     <message>
         <source>(no label)</source>
-        <translation type="unfinished">(ලේබලයක් නැත)</translation>
+        <translation type="unfinished">(නම්පතක් නැත)</translation>
     </message>
     <message>
         <source>Type of transaction.</source>
@@ -1103,7 +1236,7 @@
     </message>
     <message>
         <source>&amp;Copy address</source>
-        <translation type="unfinished">&amp;ලිපිනය පිටපත්</translation>
+        <translation type="unfinished">&amp;ලිපිනයෙහි පිටපතක්</translation>
     </message>
     <message>
         <source>Copy transaction &amp;ID</source>
@@ -1112,7 +1245,7 @@
     <message>
         <source>Comma separated file</source>
         <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
-        <translation type="unfinished">අල්පවිරාම වලින් වෙන්වූ ගොනුව</translation>
+        <translation type="unfinished">අල්පවිරාම යෙදූ ගොනුව</translation>
     </message>
     <message>
         <source>Date</source>
@@ -1124,7 +1257,7 @@
     </message>
     <message>
         <source>Label</source>
-        <translation type="unfinished">ලේබලය</translation>
+        <translation type="unfinished">නම්පත</translation>
     </message>
     <message>
         <source>Address</source>
@@ -1136,7 +1269,7 @@
     </message>
     <message>
         <source>Exporting Failed</source>
-        <translation type="unfinished">නිර්යාත වීමට අසමත් විය</translation>
+        <translation type="unfinished">නිර්යාතයට අසමත් විය</translation>
     </message>
     <message>
         <source>Exporting Successful</source>
@@ -1173,7 +1306,11 @@
     <name>WalletView</name>
     <message>
         <source>&amp;Export</source>
-        <translation type="unfinished">&amp;නිර්යාත කරන්න</translation>
+        <translation type="unfinished">&amp;නිර්යාතය</translation>
+    </message>
+    <message>
+        <source>Export the data in the current tab to a file</source>
+        <translation type="unfinished">වත්මන් පටියෙයි දත්ත ගොනුවකට නිර්යාත කරන්න</translation>
     </message>
     <message>
         <source>Backup Wallet</source>

--- a/src/qt/locale/bitcoin_sk.ts
+++ b/src/qt/locale/bitcoin_sk.ts
@@ -264,6 +264,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>QObject</name>
     <message>
+        <source>Do you want to reset settings to default values, or to abort without making changes?</source>
+        <extracomment>Explanatory text shown on startup when the settings file cannot be read. Prompts user to make a choice between resetting or aborting.</extracomment>
+        <translation type="unfinished">Chcete vrátiť nastavenia na predvolené hodnoty alebo ukončiť bez vykonania zmien?</translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. Check that settings file is writable, or try running with -nosettings.</source>
+        <extracomment>Explanatory text shown on startup when the settings file could not be written. Prompts user to check that we have the ability to write to the file. Explains that the user has the option of running without a settings file.</extracomment>
+        <translation type="unfinished">Nastala kritická chyba. Skontrolujte, že je možné zapisovať do súboru nastavení alebo skúste spustiť s parametrom -nosettings.</translation>
+    </message>
+    <message>
         <source>Error: Specified data directory "%1" does not exist.</source>
         <translation type="unfinished">Chyba: Zadaný adresár pre dáta „%1“ neexistuje.</translation>
     </message>
@@ -340,41 +350,41 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n sekunda</numerusform>
+            <numerusform>%n sekundy</numerusform>
+            <numerusform>%n sekúnd</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n minute(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n minúta</numerusform>
+            <numerusform>%n minúty</numerusform>
+            <numerusform>%n minút</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n hodina</numerusform>
+            <numerusform>%n hodiny</numerusform>
+            <numerusform>%n hodín</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n deň</numerusform>
+            <numerusform>%n dni</numerusform>
+            <numerusform>%n dní</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n týždeň</numerusform>
+            <numerusform>%n týždne</numerusform>
+            <numerusform>%n týždňov</numerusform>
         </translation>
     </message>
     <message>
@@ -384,14 +394,22 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n rok</numerusform>
+            <numerusform>%n roky</numerusform>
+            <numerusform>%n rokov</numerusform>
         </translation>
     </message>
     </context>
 <context>
     <name>bitcoin-core</name>
+    <message>
+        <source>Settings file could not be read</source>
+        <translation type="unfinished">Súbor nastavení nemohol byť prečítaný</translation>
+    </message>
+    <message>
+        <source>Settings file could not be written</source>
+        <translation type="unfinished">Súbor nastavení nemohol byť zapísaný</translation>
+    </message>
     <message>
         <source>The %s developers</source>
         <translation type="unfinished">Vývojári %s</translation>
@@ -425,6 +443,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Nastala chyba pri čítaní súboru %s! Všetkz kľúče sa prečítali správne, ale dáta o transakcíách alebo záznamy v adresári môžu chýbať alebo byť nesprávne.</translation>
     </message>
     <message>
+        <source>Error reading %s! Transaction data may be missing or incorrect. Rescanning wallet.</source>
+        <translation type="unfinished">Chyba pri čítaní %s! Transakčné údaje môžu chýbať alebo sú chybné. Znovu prečítam peňaženku.</translation>
+    </message>
+    <message>
         <source>Error: Dumpfile format record is incorrect. Got "%s", expected "format".</source>
         <translation type="unfinished">Chyba: Formát záznamu v súbore dumpu je nesprávny. Obdržaný "%s", očakávaný "format".</translation>
     </message>
@@ -441,10 +463,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Chyba: Staršie peňaženky podporujú len adresy typu "legacy", "p2sh-segwit", a "bech32"</translation>
     </message>
     <message>
-        <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
-        <translation type="unfinished">Chyba: Počúvanie prichádzajúcich spojení zlyhalo (vrátená chyba je %s)</translation>
-    </message>
-    <message>
         <source>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.</source>
         <translation type="unfinished">Odhad poplatku sa nepodaril. Fallbackfee je zakázaný. Počkajte niekoľko blokov alebo povoľte -fallbackfee.</translation>
     </message>
@@ -455,6 +473,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Invalid amount for -maxtxfee=&lt;amount&gt;: '%s' (must be at least the minrelay fee of %s to prevent stuck transactions)</source>
         <translation type="unfinished">Neplatná suma pre -maxtxfee=&lt;amount&gt;: '%s' (aby sa transakcia nezasekla, minimálny prenosový poplatok musí byť aspoň %s)</translation>
+    </message>
+    <message>
+        <source>Invalid or corrupt peers.dat (%s). If you believe this is a bug, please report it to %s. As a workaround, you can move the file (%s) out of the way (rename, move, or delete) to have a new one created on the next start.</source>
+        <translation type="unfinished">Chybný alebo poškodený súbor peers.dat (%s). Ak si myslíte, že ide o chybu, prosím nahláste to na %s. Ako dočasné riešenie môžete súbor odsunúť (%s) z umiestnenia (premenovať, presunúť, vymazať), aby sa pri ďalšom spustení vytvoril nový.</translation>
     </message>
     <message>
         <source>More than one onion bind address is provided. Using %s for the automatically created Tor onion service.</source>
@@ -495,6 +517,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>The block database contains a block which appears to be from the future. This may be due to your computer's date and time being set incorrectly. Only rebuild the block database if you are sure that your computer's date and time are correct</source>
         <translation type="unfinished">Databáza blokov obsahuje blok, ktorý vyzerá byť z budúcnosti. Toto môže byť spôsobené nesprávnym systémovým časom vášho počítača. Obnovujte databázu blokov len keď ste si istý, že systémový čas je nastavený správne.</translation>
+    </message>
+    <message>
+        <source>The block index db contains a legacy 'txindex'. To clear the occupied disk space, run a full -reindex, otherwise ignore this error. This error message will not be displayed again.</source>
+        <translation type="unfinished">Databáza indexov blokov obsahuje 'txindex' staršieho typu. Pre uvoľnenie obsadeného miesta spustite s parametrom -reindex, inak môžete ignorovať túto chybu. Táto správa sa už nabudúce nezobrazí.</translation>
     </message>
     <message>
         <source>The transaction amount is too small to send after the fee has been deducted</source>
@@ -569,12 +595,36 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Nedá preložiť -%s adresu: '%s'</translation>
     </message>
     <message>
+        <source>Cannot set -forcednsseed to true when setting -dnsseed to false.</source>
+        <translation type="unfinished">Nie je možné zapnúť -forcednsseed keď je -dnsseed vypnuté.</translation>
+    </message>
+    <message>
         <source>Cannot set -peerblockfilters without -blockfilterindex.</source>
         <translation type="unfinished">Nepodarilo sa určiť -peerblockfilters bez -blockfilterindex.</translation>
     </message>
     <message>
         <source>Cannot write to data directory '%s'; check permissions.</source>
         <translation type="unfinished">Nie je možné zapísať do adresára ' %s'. Skontrolujte povolenia.</translation>
+    </message>
+    <message>
+        <source>The -txindex upgrade started by a previous version cannot be completed. Restart with the previous version or run a full -reindex.</source>
+        <translation type="unfinished">Upgrade -txindex spustený predchádzajúcou verziou nemôže byť dokončený. Reštartujte s prechdádzajúcou verziou programu alebo spustite s parametrom -reindex.</translation>
+    </message>
+    <message>
+        <source>%s request to listen on port %u. This port is considered "bad" and thus it is unlikely that any Bitcoin Core peers connect to it. See doc/p2p-bad-ports.md for details and a full list.</source>
+        <translation type="unfinished">Požiadavka %s na počúvanie na porte %u. Tento port je považovaný za "zlý" preto je nepravdepodobné, že sa naň pripojí nejaký Bitcoin Core partner. Pozrite doc/p2p-bad-ports.md pre detaily a celý zoznam.</translation>
+    </message>
+    <message>
+        <source>Cannot provide specific connections and have addrman find outgoing connections at the same time.</source>
+        <translation type="unfinished">Nie je možné zadať špecifické spojenia a zároveň nechať addrman hľadať odchádzajúce spojenia.</translation>
+    </message>
+    <message>
+        <source>Error loading %s: External signer wallet being loaded without external signer support compiled</source>
+        <translation type="unfinished">Chyba pri načítaní %s: Načíta sa peňaženka s externým podpisovaním, ale podpora pre externé podpisovanie nebola začlenená do programu</translation>
+    </message>
+    <message>
+        <source>Failed to rename invalid peers.dat file. Please move or delete it and try again.</source>
+        <translation type="unfinished">Nepodarilo sa premenovať chybný súbor peers.dat. Prosím presuňte ho alebo vymažte a skúste znovu.</translation>
     </message>
     <message>
         <source>Config setting for %s only applied on %s network when in [%s] section.</source>
@@ -653,10 +703,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Chyba pri čítaní ďalšieho záznamu z databázy peňaženky</translation>
     </message>
     <message>
-        <source>Error upgrading chainstate database</source>
-        <translation type="unfinished">Chyba pri vylepšení databáze reťzcov blokov</translation>
-    </message>
-    <message>
         <source>Error: Couldn't create cursor into database</source>
         <translation type="unfinished">Chyba: Nepodarilo sa vytvoriť kurzor do databázy</translation>
     </message>
@@ -729,6 +775,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Kontrola čistoty pri inicializácií zlyhala. %s sa vypína.</translation>
     </message>
     <message>
+        <source>Input not found or already spent</source>
+        <translation type="unfinished">Vstup nenájdený alebo už minutý</translation>
+    </message>
+    <message>
         <source>Insufficient funds</source>
         <translation type="unfinished">Nedostatok prostriedkov</translation>
     </message>
@@ -785,12 +835,20 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Načítavam peňaženku…</translation>
     </message>
     <message>
+        <source>Missing amount</source>
+        <translation type="unfinished">Chýba suma</translation>
+    </message>
+    <message>
+        <source>Missing solving data for estimating transaction size</source>
+        <translation type="unfinished">Chýbajú údaje pre odhad veľkosti transakcie</translation>
+    </message>
+    <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
         <translation type="unfinished">Je potrebné zadať port s -whitebind: '%s'</translation>
     </message>
     <message>
-        <source>No proxy server specified. Use -proxy=&lt;ip&gt; or -proxy=&lt;ip:port&gt;.</source>
-        <translation type="unfinished">Nie je špecifikovaný proxy server. Použite -proxy=&lt;ip&gt; alebo -proxy=&lt;ip:port&gt;.</translation>
+        <source>No addresses available</source>
+        <translation type="unfinished">Nie sú dostupné žiadne adresy</translation>
     </message>
     <message>
         <source>Not enough file descriptors available.</source>
@@ -799,10 +857,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Prune cannot be configured with a negative value.</source>
         <translation type="unfinished">Redukovanie nemôže byť nastavené na zápornú hodnotu.</translation>
-    </message>
-    <message>
-        <source>Prune mode is incompatible with -coinstatsindex.</source>
-        <translation type="unfinished">Režim redukovania je nekompatibilný s -coinstatsindex.</translation>
     </message>
     <message>
         <source>Prune mode is incompatible with -txindex.</source>
@@ -905,12 +959,20 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Sumy transakcií nesmú byť záporné</translation>
     </message>
     <message>
+        <source>Transaction change output index out of range</source>
+        <translation type="unfinished">Výstupný index transakcie zmeny je mimo rozsahu</translation>
+    </message>
+    <message>
         <source>Transaction has too long of a mempool chain</source>
         <translation type="unfinished">Transakcia má v transakčnom zásobníku príliš dlhý reťazec</translation>
     </message>
     <message>
         <source>Transaction must have at least one recipient</source>
         <translation type="unfinished">Transakcia musí mať aspoň jedného príjemcu</translation>
+    </message>
+    <message>
+        <source>Transaction needs a change address, but we can't generate it.</source>
+        <translation type="unfinished">Transakcia potrebuje adresu na zmenu, ale nemôžeme ju vygenerovať.</translation>
     </message>
     <message>
         <source>Transaction too large</source>
@@ -941,6 +1003,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Nepodarilo sa otvoriť %s pre zapisovanie</translation>
     </message>
     <message>
+        <source>Unable to parse -maxuploadtarget: '%s'</source>
+        <translation type="unfinished">Nepodarilo sa prečítať -maxuploadtarget: '%s'</translation>
+    </message>
+    <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
         <translation type="unfinished">Nepodarilo sa spustiť HTTP server. Pre viac detailov zobrazte debug log.</translation>
     </message>
@@ -967,10 +1033,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Unsupported logging category %s=%s.</source>
         <translation type="unfinished">Nepodporovaná logovacia kategória %s=%s.</translation>
-    </message>
-    <message>
-        <source>Upgrading UTXO database</source>
-        <translation type="unfinished">Vylepšuje sa databáza neminutých výstupov (UTXO)</translation>
     </message>
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
@@ -1038,6 +1100,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Create a new wallet</source>
         <translation type="unfinished">Vytvoriť novú peňaženku</translation>
+    </message>
+    <message>
+        <source>&amp;Minimize</source>
+        <translation type="unfinished">&amp;Minimalizovať</translation>
     </message>
     <message>
         <source>Wallet:</source>
@@ -1187,9 +1253,9 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>Spracovaný %n blok transakčnej histórie.</numerusform>
+            <numerusform>Spracované %n bloky transakčnej histórie.</numerusform>
+            <numerusform>Spracovaných %n blokov transakčnej histórie.</numerusform>
         </translation>
     </message>
     <message>
@@ -1227,6 +1293,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Load Partially Signed Bitcoin Transaction</source>
         <translation type="unfinished">Načítať sčasti podpísanú Bitcoin transakciu</translation>
+    </message>
+    <message>
+        <source>Load PSBT from &amp;clipboard…</source>
+        <translation type="unfinished">Načítať PSBT zo s&amp;chránky…</translation>
     </message>
     <message>
         <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
@@ -1289,6 +1359,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Nie je dostupná žiadna peňaženka</translation>
     </message>
     <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">Dáta peňaženky</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">Názov peňaženky</translation>
+    </message>
+    <message>
         <source>&amp;Window</source>
         <translation type="unfinished">&amp;Okno</translation>
     </message>
@@ -1304,13 +1384,21 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>%1 client</source>
         <translation type="unfinished">%1 klient</translation>
     </message>
+    <message>
+        <source>&amp;Hide</source>
+        <translation type="unfinished">&amp;Skryť</translation>
+    </message>
+    <message>
+        <source>S&amp;how</source>
+        <translation type="unfinished">Z&amp;obraziť</translation>
+    </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n aktívne pripojenie do siete Bitcoin</numerusform>
+            <numerusform>%n aktívne pripojenia do siete Bitcoin</numerusform>
+            <numerusform>%n aktívnych pripojení do siete Bitcoin</numerusform>
         </translation>
     </message>
     <message>
@@ -1504,6 +1592,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Kopírovať &amp;sumu</translation>
     </message>
     <message>
+        <source>Copy transaction &amp;ID and output index</source>
+        <translation type="unfinished">Skopírovať &amp;ID transakcie a výstupný index</translation>
+    </message>
+    <message>
         <source>L&amp;ock unspent</source>
         <translation type="unfinished">U&amp;zamknúť neminuté</translation>
     </message>
@@ -1591,6 +1683,19 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Can't list signers</source>
         <translation type="unfinished">Nemôžem zobraziť podpisovateľov</translation>
+    </message>
+    </context>
+<context>
+    <name>LoadWalletsActivity</name>
+    <message>
+        <source>Load Wallets</source>
+        <extracomment>Title of progress window which is displayed when wallets are being loaded.</extracomment>
+        <translation type="unfinished">Načítať peňaženky</translation>
+    </message>
+    <message>
+        <source>Loading wallets…</source>
+        <extracomment>Descriptive text of the load wallets progress window which indicates to the user that wallets are currently being loaded.</extracomment>
+        <translation type="unfinished">Načítavam peňaženky…</translation>
     </message>
 </context>
 <context>
@@ -1793,13 +1898,29 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 </context>
 <context>
     <name>Intro</name>
-    <message>
-        <source>(of %1 GB needed)</source>
-        <translation type="unfinished">(z %1 GB potrebných)</translation>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+            <numerusform />
+        </translation>
     </message>
-    <message>
-        <source>(%1 GB needed for full chain)</source>
-        <translation type="unfinished">(%1 GB potrebných pre plný reťazec)</translation>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform>(z %n GB potrebného)</numerusform>
+            <numerusform>(z %n GB potrebných)</numerusform>
+            <numerusform>(z %n GB potrebných)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform>(%n GB potrebný pre plný reťazec)</numerusform>
+            <numerusform>(%n GB potrebné pre plný reťazec)</numerusform>
+            <numerusform>(%n GB potrebných pre plný reťazec)</numerusform>
+        </translation>
     </message>
     <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
@@ -1813,9 +1934,9 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>(dostatočné pre obnovenie záloh %n deň starých)</numerusform>
+            <numerusform>(dostatočné pre obnovenie záloh %n dni starých)</numerusform>
+            <numerusform>(dostatočné pre obnovenie záloh %n dní starých)</numerusform>
         </translation>
     </message>
     <message>
@@ -1845,10 +1966,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>As this is the first time the program is launched, you can choose where %1 will store its data.</source>
         <translation type="unfinished">Keďže toto je prvé spustenie programu, môžete si vybrať, kam %1 bude ukladať vaše údaje.</translation>
-    </message>
-    <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation type="unfinished">Hneď po stlačení OK, začne %1 sťahovať a spracovávať celý %4 blockchain (%2G B), začínajúc najaktuálnejšími transakciami z roku %3, kedy bol %4 spustený.</translation>
     </message>
     <message>
         <source>Limit block chain storage to</source>
@@ -1959,7 +2076,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Unknown. Syncing Headers (%1, %2%)…</source>
         <translation type="unfinished">Neznámy. Synchronizujú sa hlavičky (%1, %2%)…</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>OpenURIDialog</name>
     <message>
@@ -2043,12 +2160,42 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Obnovenie tohto nastavenia vyžaduje opätovné stiahnutie celého blockchainu.</translation>
     </message>
     <message>
+        <source>Maximum database cache size. A larger cache can contribute to faster sync, after which the benefit is less pronounced for most use cases. Lowering the cache size will reduce memory usage. Unused mempool memory is shared for this cache.</source>
+        <extracomment>Tooltip text for Options window setting that sets the size of the database cache. Explains the corresponding effects of increasing/decreasing this value.</extracomment>
+        <translation type="unfinished">Maximálna veľkosť vyrovnávacej pamäte databázy. Väčšia pamäť môže urýchliť synchronizáciu, ale pri ďalšom používaní už nemá efekt. Zmenšenie vyrovnávacej pamäte zníži použitie pamäte. Nevyužitá pamäť mempool je zdieľaná pre túto vyrovnávaciu pamäť.</translation>
+    </message>
+    <message>
+        <source>Set the number of script verification threads. Negative values correspond to the number of cores you want to leave free to the system.</source>
+        <extracomment>Tooltip text for Options window setting that sets the number of script verification threads. Explains that negative values mean to leave these many cores free to the system.</extracomment>
+        <translation type="unfinished">Nastaví počet vlákien na overenie skriptov. Záporné hodnoty zodpovedajú počtu jadier procesora, ktoré chcete nechať voľné pre systém.</translation>
+    </message>
+    <message>
         <source>(0 = auto, &lt;0 = leave that many cores free)</source>
         <translation type="unfinished">(0 = auto, &lt;0 = toľko jadier nechať  voľných)</translation>
     </message>
     <message>
+        <source>This allows you or a third party tool to communicate with the node through command-line and JSON-RPC commands.</source>
+        <extracomment>Tooltip text for Options window setting that enables the RPC server.</extracomment>
+        <translation type="unfinished">Toto umožňuje vám alebo nástroju tretej strany komunikovať s uzlom pomocou príkazov z príkazového riadka alebo JSON-RPC.</translation>
+    </message>
+    <message>
+        <source>Enable R&amp;PC server</source>
+        <extracomment>An Options window setting to enable the RPC server.</extracomment>
+        <translation type="unfinished">Povoliť server R&amp;PC</translation>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished">&amp;Peňaženka</translation>
+    </message>
+    <message>
+        <source>Whether to set subtract fee from amount as default or not.</source>
+        <extracomment>Tooltip text for Options window setting that sets subtracting the fee from a sending amount as default.</extracomment>
+        <translation type="unfinished">Nastaviť predvolenie odpočítavania poplatku zo sumy.</translation>
+    </message>
+    <message>
+        <source>Subtract &amp;fee from amount by default</source>
+        <extracomment>An Options window setting to set subtracting the fee from a sending amount as default.</extracomment>
+        <translation type="unfinished">Predvolene odpočítavať &amp;poplatok zo sumy</translation>
     </message>
     <message>
         <source>Enable coin &amp;control features</source>
@@ -2061,6 +2208,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>&amp;Spend unconfirmed change</source>
         <translation type="unfinished">&amp;Minúť nepotvrdený výdavok</translation>
+    </message>
+    <message>
+        <source>Enable &amp;PSBT controls</source>
+        <extracomment>An options window setting to enable PSBT controls.</extracomment>
+        <translation type="unfinished">Povoliť ovládanie &amp;PSBT</translation>
+    </message>
+    <message>
+        <source>Whether to show PSBT controls.</source>
+        <extracomment>Tooltip text for options window setting that enables PSBT controls.</extracomment>
+        <translation type="unfinished">Zobrazenie ovládania PSBT.</translation>
     </message>
     <message>
         <source>External Signer (e.g. hardware wallet)</source>
@@ -2159,6 +2316,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Zvoľte ako deliť bitcoin pri zobrazovaní pri platbách a užívateľskom rozhraní.</translation>
     </message>
     <message>
+        <source>Third-party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</source>
+        <translation type="unfinished">URL tretích strán (napr. prehliadač blokov), ktoré sa zobrazujú v záložke transakcií ako položky kontextového menu. %s v URL je nahradené hash-om transakcie. Viaceré URL sú oddelené zvislou čiarou |.</translation>
+    </message>
+    <message>
+        <source>&amp;Third-party transaction URLs</source>
+        <translation type="unfinished">URL &amp;transakcií tretích strán</translation>
+    </message>
+    <message>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished">Či zobrazovať možnosti kontroly mincí alebo nie.</translation>
     </message>
@@ -2183,10 +2348,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">najbližší zodpovedajúci "%1"</translation>
     </message>
     <message>
-        <source>Options set in this dialog are overridden by the command line or in the configuration file:</source>
-        <translation type="unfinished">Voľby nastavené v tomto dialógovom okne sú prepísané príkazovým riadkom alebo konfiguračným súborom:</translation>
-    </message>
-    <message>
         <source>&amp;Cancel</source>
         <translation type="unfinished">&amp;Zrušiť</translation>
     </message>
@@ -2205,14 +2366,17 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Confirm options reset</source>
+        <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
         <translation type="unfinished">Potvrdiť obnovenie možností</translation>
     </message>
     <message>
         <source>Client restart required to activate changes.</source>
+        <extracomment>Text explaining that the settings changed will not come into effect until the client is restarted.</extracomment>
         <translation type="unfinished">Reštart klienta potrebný pre aktivovanie zmien.</translation>
     </message>
     <message>
         <source>Client will be shut down. Do you want to proceed?</source>
+        <extracomment>Text asking the user to confirm if they would like to proceed with a client shutdown.</extracomment>
         <translation type="unfinished">Klient bude vypnutý, chcete pokračovať?</translation>
     </message>
     <message>
@@ -2224,6 +2388,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>The configuration file is used to specify advanced user options which override GUI settings. Additionally, any command-line options will override this configuration file.</source>
         <extracomment>Explanatory text about the priority order of instructions considered by client. The order from high to low being: command-line, configuration file, GUI settings.</extracomment>
         <translation type="unfinished">Konfiguračný súbor slúži k nastavovaniu užívateľsky pokročilých možností, ktoré majú prednosť pred konfiguráciou z grafického rozhrania. Parametre z príkazového riadka však majú pred konfiguračným súborom prednosť.</translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation type="unfinished">Pokračovať</translation>
     </message>
     <message>
         <source>Cancel</source>
@@ -2360,6 +2528,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Nepodarilo sa podpísať transakciu: %1</translation>
     </message>
     <message>
+        <source>Cannot sign inputs while wallet is locked.</source>
+        <translation type="unfinished">Nemôžem podpísať vstupy kým je peňaženka zamknutá.</translation>
+    </message>
+    <message>
         <source>Could not sign any more inputs.</source>
         <translation type="unfinished">Nie je možné podpísať žiadne ďalšie vstupy.</translation>
     </message>
@@ -2433,6 +2605,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Transakcii stále chýbajú podpis(y).</translation>
     </message>
     <message>
+        <source>(But no wallet is loaded.)</source>
+        <translation type="unfinished">(Ale nie je načítaná žiadna peňaženka.)</translation>
+    </message>
+    <message>
         <source>(But this wallet cannot sign transactions.)</source>
         <translation type="unfinished">(Ale táto peňaženka nemôže podpisovať transakcie)</translation>
     </message>
@@ -2500,6 +2676,11 @@ Ak ste dostali túto chybu mali by ste požiadať obchodníka o URI kompatibiln�
         <source>Peer</source>
         <extracomment>Title of Peers Table column which contains a unique number used to identify a connection.</extracomment>
         <translation type="unfinished">Partneri</translation>
+    </message>
+    <message>
+        <source>Age</source>
+        <extracomment>Title of Peers Table column which indicates the duration (length of time) since the peer connection started.</extracomment>
+        <translation type="unfinished">Vek</translation>
     </message>
     <message>
         <source>Direction</source>
@@ -2689,6 +2870,10 @@ Ak ste dostali túto chybu mali by ste požiadať obchodníka o URI kompatibiln�
         <translation type="unfinished">Zosynchronizované bloky</translation>
     </message>
     <message>
+        <source>Last Transaction</source>
+        <translation type="unfinished">Posledná transakcia</translation>
+    </message>
+    <message>
         <source>The mapped Autonomous System used for diversifying peer selection.</source>
         <translation type="unfinished">Mapovaný nezávislý - Autonómny Systém používaný na rozšírenie vzájomného výberu peerov.</translation>
     </message>
@@ -2697,12 +2882,32 @@ Ak ste dostali túto chybu mali by ste požiadať obchodníka o URI kompatibiln�
         <translation type="unfinished">Mapovaný AS</translation>
     </message>
     <message>
+        <source>Whether we relay addresses to this peer.</source>
+        <extracomment>Tooltip text for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
+        <translation type="unfinished">Postupovanie adries tomuto partnerovi.</translation>
+    </message>
+    <message>
+        <source>Address Relay</source>
+        <extracomment>Text title for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
+        <translation type="unfinished">Postupovanie adries</translation>
+    </message>
+    <message>
+        <source>Addresses Processed</source>
+        <extracomment>Text title for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
+        <translation type="unfinished">Spracované adresy</translation>
+    </message>
+    <message>
+        <source>Addresses Rate-Limited</source>
+        <extracomment>Text title for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
+        <translation type="unfinished">Obmedzené adresy</translation>
+    </message>
+    <message>
         <source>User Agent</source>
         <translation type="unfinished">Aplikácia</translation>
     </message>
     <message>
         <source>Node window</source>
-        <translation type="unfinished">Okno uzlov</translation>
+        <translation type="unfinished">Uzlové okno</translation>
     </message>
     <message>
         <source>Current block height</source>
@@ -2903,6 +3108,11 @@ Ak ste dostali túto chybu mali by ste požiadať obchodníka o URI kompatibiln�
     <message>
         <source>1 &amp;year</source>
         <translation type="unfinished">1 &amp;rok</translation>
+    </message>
+    <message>
+        <source>&amp;Copy IP/Netmask</source>
+        <extracomment>Context menu action to copy the IP/Netmask of a banned peer. IP/Netmask is the combination of a peer's IP address and its Netmask. For IP address, see: https://en.wikipedia.org/wiki/IP_address.</extracomment>
+        <translation type="unfinished">&amp;Kopírovať IP/Masku siete</translation>
     </message>
     <message>
         <source>&amp;Unban</source>
@@ -3433,6 +3643,16 @@ Poznámka: Keďže poplatok je počítaný za bajt, poplatok pri sadzbe "100 sat
         <translation type="unfinished">Prečítajte si prosím svoj návrh transakcie. Výsledkom bude čiastočne podpísaná bitcoinová transakcia (PSBT), ktorú môžete uložiť alebo skopírovať a potom podpísať napr. cez offline peňaženku %1 alebo hardvérovú peňaženku kompatibilnú s PSBT.</translation>
     </message>
     <message>
+        <source>Do you want to create this transaction?</source>
+        <extracomment>Message displayed when attempting to create a transaction. Cautionary text to prompt the user to verify that the displayed transaction details represent the transaction the user intends to create.</extracomment>
+        <translation type="unfinished">Chcete vytvoriť túto transakciu?</translation>
+    </message>
+    <message>
+        <source>Please, review your transaction. You can create and send this transaction or create a Partially Signed Bitcoin Transaction (PSBT), which you can save or copy and then sign with, e.g., an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
+        <extracomment>Text to inform a user attempting to create a transaction of their current options. At this stage, a user can send their transaction or create a PSBT. This string is displayed when both private keys and PSBT controls are enabled.</extracomment>
+        <translation type="unfinished">Skontrolujte prosím svoj návrh transakcie. Môžete vytvoriť a odoslať túto transakciu alebo vytvoriť čiastočne podpísanú bitcoinovú transakciu (PSBT), ktorú môžete uložiť alebo skopírovať a potom podpísať napr. cez offline peňaženku %1 alebo hardvérovú peňaženku kompatibilnú s PSBT.</translation>
+    </message>
+    <message>
         <source>Please, review your transaction.</source>
         <extracomment>Text to prompt a user to review the details of the transaction they are attempting to send.</extracomment>
         <translation type="unfinished">Prosím, skontrolujte Vašu transakciu.</translation>
@@ -3485,16 +3705,12 @@ Poznámka: Keďže poplatok je počítaný za bajt, poplatok pri sadzbe "100 sat
         <source>A fee higher than %1 is considered an absurdly high fee.</source>
         <translation type="unfinished">Poplatok vyšší ako %1 sa považuje za neprimerane vysoký.</translation>
     </message>
-    <message>
-        <source>Payment request expired.</source>
-        <translation type="unfinished">Vypršala platnosť požiadavky na platbu.</translation>
-    </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>Odhadované potvrdenie o %n blok.</numerusform>
+            <numerusform>Odhadované potvrdenie o %n bloky.</numerusform>
+            <numerusform>Odhadované potvrdenie o %n blokov.</numerusform>
         </translation>
     </message>
     <message>
@@ -3569,28 +3785,12 @@ Poznámka: Keďže poplatok je počítaný za bajt, poplatok pri sadzbe "100 sat
         <translation type="unfinished">Správa:</translation>
     </message>
     <message>
-        <source>This is an unauthenticated payment request.</source>
-        <translation type="unfinished">Toto je neoverená výzva k platbe.</translation>
-    </message>
-    <message>
-        <source>This is an authenticated payment request.</source>
-        <translation type="unfinished">Toto je overená výzva k platbe.</translation>
-    </message>
-    <message>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished">Vložte popis pre túto adresu aby sa uložila do zoznamu použitých adries</translation>
     </message>
     <message>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished">Správa ktorá bola pripojená k bitcoin: URI a ktorá bude uložená s transakcou pre Vaše potreby. Poznámka: Táto správa nebude poslaná cez sieť Bitcoin.</translation>
-    </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">Platba pre:</translation>
-    </message>
-    <message>
-        <source>Memo:</source>
-        <translation type="unfinished">Poznámka:</translation>
     </message>
 </context>
 <context>
@@ -3753,35 +3953,31 @@ Poznámka: Keďže poplatok je počítaný za bajt, poplatok pri sadzbe "100 sat
         <source>(press q to shutdown and continue later)</source>
         <translation type="unfinished">(stlačte Q pre ukončenie a pokračovanie neskôr)</translation>
     </message>
-    </context>
+    <message>
+        <source>press q to shutdown</source>
+        <translation type="unfinished">stlačte q pre ukončenie</translation>
+    </message>
+</context>
 <context>
     <name>TransactionDesc</name>
     <message>
         <source>conflicted with a transaction with %1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that conflicts with a confirmed transaction.</extracomment>
         <translation type="unfinished">koliduje s transakciou s %1 potvrdeniami</translation>
     </message>
     <message>
-        <source>0/unconfirmed, %1</source>
-        <translation type="unfinished">0/nepotvrdené, %1</translation>
-    </message>
-    <message>
-        <source>in memory pool</source>
-        <translation type="unfinished">v transakčnom zásobníku</translation>
-    </message>
-    <message>
-        <source>not in memory pool</source>
-        <translation type="unfinished">nie je v transakčnom zásobníku</translation>
-    </message>
-    <message>
         <source>abandoned</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an abandoned transaction.</extracomment>
         <translation type="unfinished">zanechaná</translation>
     </message>
     <message>
         <source>%1/unconfirmed</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
         <translation type="unfinished">%1/nepotvrdené</translation>
     </message>
     <message>
         <source>%1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
         <translation type="unfinished">%1 potvrdení</translation>
     </message>
     <message>
@@ -3831,9 +4027,9 @@ Poznámka: Keďže poplatok je počítaný za bajt, poplatok pri sadzbe "100 sat
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>dozrie o ďalší %n blok</numerusform>
+            <numerusform>dozrie o ďalšie %n bloky</numerusform>
+            <numerusform>dozrie o ďalších %n blokov</numerusform>
         </translation>
     </message>
     <message>
@@ -4124,6 +4320,11 @@ Poznámka: Keďže poplatok je počítaný za bajt, poplatok pri sadzbe "100 sat
     <message>
         <source>&amp;Edit address label</source>
         <translation type="unfinished">&amp;Upraviť popis transakcie</translation>
+    </message>
+    <message>
+        <source>Show in %1</source>
+        <extracomment>Transactions table context menu action to show the selected transaction in a third-party block explorer. %1 is a stand-in argument for the URL of the explorer.</extracomment>
+        <translation type="unfinished">Zobraziť v %1</translation>
     </message>
     <message>
         <source>Export Transaction History</source>

--- a/src/qt/locale/bitcoin_sl.ts
+++ b/src/qt/locale/bitcoin_sl.ts
@@ -242,22 +242,10 @@ Podpisovanje je možno le s podedovanimi ("legacy") naslovi.</translation>
 <context>
     <name>BitcoinApplication</name>
     <message>
-        <source>Runaway exception</source>
-        <translation type="unfinished">Pobegla izjema</translation>
+        <source>Settings file %1 might be corrupt or invalid.</source>
+        <translation type="unfinished">Datoteka z nastavitvami %1 je morda ovkarjena ali neveljavna.</translation>
     </message>
-    <message>
-        <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
-        <translation type="unfinished">Prišlo je do usodne napake. %1 ne more več varno nadaljevati s tekom in se bo ustavil.</translation>
-    </message>
-    <message>
-        <source>Internal error</source>
-        <translation type="unfinished">Interna napaka</translation>
-    </message>
-    <message>
-        <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
-        <translation type="unfinished">Prišlo je do interne napake. %1 bo skušal varno nadaljevati. To je nepričakovana napaka, ki jo lahko prijavite, kot je opisano spodaj.</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>QObject</name>
     <message>
@@ -464,10 +452,6 @@ Podpisovanje je možno le s podedovanimi ("legacy") naslovi.</translation>
         <translation type="unfinished">Napaka: podedovane denarnice podpirajo le naslove vrst "legacy", "p2sh-segwit" in "bech32".</translation>
     </message>
     <message>
-        <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
-        <translation type="unfinished">Napaka: ni mogoče biti odprt za dohodne povezave (vrnjena napaka: %s)</translation>
-    </message>
-    <message>
         <source>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.</source>
         <translation type="unfinished">Ocena provizije ni uspela. Uporaba nadomestne provizije (fallback fee) je onemogočena. Počakajte nekaj blokov ali omogočite -fallbackfee.</translation>
     </message>
@@ -510,6 +494,10 @@ Podpisovanje je možno le s podedovanimi ("legacy") naslovi.</translation>
     <message>
         <source>Prune configured below the minimum of %d MiB.  Please use a higher number.</source>
         <translation type="unfinished">Obrezovanje ne sme biti nastavljeno pod %d miB. Prosimo, uporabite večjo številko.</translation>
+    </message>
+    <message>
+        <source>Prune mode is incompatible with -reindex-chainstate. Use full -reindex instead.</source>
+        <translation type="unfinished">Način obrezovanja ni združljiv z možnostjo -reindex-chainstate. Namesto tega uporabite polni -reindex.</translation>
     </message>
     <message>
         <source>Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of pruned node)</source>
@@ -564,6 +552,14 @@ Podpisovanje je možno le s podedovanimi ("legacy") naslovi.</translation>
         <translation type="unfinished">Nastavljena je neznana oblika datoteke denarnice "%s". Prosimo, uporabite "bdb" ali "sqlite".</translation>
     </message>
     <message>
+        <source>Unsupported chainstate database format found. Please restart with -reindex-chainstate. This will rebuild the chainstate database.</source>
+        <translation type="unfinished">Podatkovna baza stanja verige (chainstate) je v formatu, ki ni podprt. Prosimo, ponovno zaženite program z možnostjo -reindex-chainstate. S tem bo baza stanja verige zgrajena ponovno.</translation>
+    </message>
+    <message>
+        <source>Wallet created successfully. The legacy wallet type is being deprecated and support for creating and opening legacy wallets will be removed in the future.</source>
+        <translation type="unfinished">Denarnica uspešno ustvarjena. Podedovani tip denarnice je zastarel in v opuščanju. Podpora za tvorbo in odpiranje denarnic podedovanega tipa bo v prihodnosti odstranjena.</translation>
+    </message>
+    <message>
         <source>Warning: Dumpfile wallet format "%s" does not match command line specified format "%s".</source>
         <translation type="unfinished">Opozorilo: oblika izvozne (dump) datoteke "%s" ne ustreza obliki "%s", izbrani v ukazni vrstici.</translation>
     </message>
@@ -612,12 +608,44 @@ Podpisovanje je možno le s podedovanimi ("legacy") naslovi.</translation>
         <translation type="unfinished">Nadgradnja -txindex je bila začeta s prejšnjo različico programske opreme in je ni mogoče dokončati. Poskusite ponovno s prejšnjo različico ali pa zaženite poln -reindex.</translation>
     </message>
     <message>
+        <source>-reindex-chainstate option is not compatible with -blockfilterindex. Please temporarily disable blockfilterindex while using -reindex-chainstate, or replace -reindex-chainstate with -reindex to fully rebuild all indexes.</source>
+        <translation type="unfinished">Možnost -reindex-chainstate ni združljiva z -blockfilterindex. Prosimo, ali začasno onemogočite blockfilterindex in uporabite -reindex-chainstate ali pa namesto reindex-chainstate uporabite -reindex za popolno ponovno tvorbo vseh kazal.</translation>
+    </message>
+    <message>
+        <source>-reindex-chainstate option is not compatible with -coinstatsindex. Please temporarily disable coinstatsindex while using -reindex-chainstate, or replace -reindex-chainstate with -reindex to fully rebuild all indexes.</source>
+        <translation type="unfinished">Možnost -reindex-chainstate option ni združljiva z -coinstatsindex. Prosimo, ali začasno onemogočite coinstatsindex in uporabite -reindex-chainstate ali pa namesto reindex-chainstate uporabite -reindex za popolno ponovno tvorbo vseh kazal.</translation>
+    </message>
+    <message>
+        <source>-reindex-chainstate option is not compatible with -txindex. Please temporarily disable txindex while using -reindex-chainstate, or replace -reindex-chainstate with -reindex to fully rebuild all indexes.</source>
+        <translation type="unfinished">Možnost -reindex-chainstate option ni združljiva s -txindex. Prosimo, ali začasno onemogočite txindex in uporabite -reindex-chainstate ali pa namesto reindex-chainstate uporabite -reindex za popolno ponovno tvorbo vseh kazal.</translation>
+    </message>
+    <message>
+        <source>Assumed-valid: last wallet synchronisation goes beyond available block data. You need to wait for the background validation chain to download more blocks.</source>
+        <translation type="unfinished">Zadnja sinhronizacija denarnice pade izven obdobja blokov, katerih podatki so na voljo. Potrebno je počakati, da preverjanje v ozadju prenese potrebne bloke.</translation>
+    </message>
+    <message>
         <source>Cannot provide specific connections and have addrman find outgoing connections at the same time.</source>
         <translation type="unfinished">Nezdružljivi nastavitvi: navedene so specifične povezave in hkrati se uporablja addrman za iskanje izhodnih povezav.</translation>
     </message>
     <message>
         <source>Error loading %s: External signer wallet being loaded without external signer support compiled</source>
         <translation type="unfinished">Napaka pri nalaganu %s: Denarnica za zunanje podpisovanje naložena, podpora za zunanje podpisovanje pa ni prevedena</translation>
+    </message>
+    <message>
+        <source>Failed to rename invalid peers.dat file. Please move or delete it and try again.</source>
+        <translation type="unfinished">Preimenovanje neveljavne datoteke peers.dat je spodletelo. Prosimo, premaknite ali izbrišite jo in poskusite znova.</translation>
+    </message>
+    <message>
+        <source>
+Unable to cleanup failed migration</source>
+        <translation type="unfinished">
+Čiščenje po spodleteli migraciji je spodletelo.</translation>
+    </message>
+    <message>
+        <source>
+Unable to restore backup of wallet.</source>
+        <translation type="unfinished">
+Obnovitev varnostne kopije denarnice ni bila mogoča.</translation>
     </message>
     <message>
         <source>Config setting for %s only applied on %s network when in [%s] section.</source>
@@ -694,10 +722,6 @@ Podpisovanje je možno le s podedovanimi ("legacy") naslovi.</translation>
     <message>
         <source>Error reading next record from wallet database</source>
         <translation type="unfinished">Napaka pri branju naslednjega zapisa v podatkovni bazi denarnice.</translation>
-    </message>
-    <message>
-        <source>Error upgrading chainstate database</source>
-        <translation type="unfinished">Napaka pri nadgradnji baze podatkov stanja verige.</translation>
     </message>
     <message>
         <source>Error: Couldn't create cursor into database</source>
@@ -848,20 +872,12 @@ Podpisovanje je možno le s podedovanimi ("legacy") naslovi.</translation>
         <translation type="unfinished">Noben naslov ni na voljo</translation>
     </message>
     <message>
-        <source>No proxy server specified. Use -proxy=&lt;ip&gt; or -proxy=&lt;ip:port&gt;.</source>
-        <translation type="unfinished">Posredniški strežnik (proxy) ni nastavljen. Uporabite -proxy=&lt;ip&gt; ali -proxy=&lt;ip:port&gt;.</translation>
-    </message>
-    <message>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished">Na voljo ni dovolj deskriptorjev datotek.</translation>
     </message>
     <message>
         <source>Prune cannot be configured with a negative value.</source>
         <translation type="unfinished">Negativne vrednosti parametra funkcije obrezovanja niso sprejemljive.</translation>
-    </message>
-    <message>
-        <source>Prune mode is incompatible with -coinstatsindex.</source>
-        <translation type="unfinished">Funkcija obrezovanja ni združljiva z opcijo -coinstatsindex.</translation>
     </message>
     <message>
         <source>Prune mode is incompatible with -txindex.</source>
@@ -984,6 +1000,10 @@ Podpisovanje je možno le s podedovanimi ("legacy") naslovi.</translation>
         <translation type="unfinished">Transkacija je prevelika</translation>
     </message>
     <message>
+        <source>Unable to allocate memory for -maxsigcachesize: '%s' MiB</source>
+        <translation type="unfinished">Spodletelo je dodeljevanje pomnilnika za -maxsigcachesize: '%s' MiB</translation>
+    </message>
+    <message>
         <source>Unable to bind to %s on this computer (bind returned error %s)</source>
         <translation type="unfinished">Na tem računalniku ni bilo mogoče vezati naslova %s (vrnjena napaka: %s)</translation>
     </message>
@@ -994,6 +1014,10 @@ Podpisovanje je možno le s podedovanimi ("legacy") naslovi.</translation>
     <message>
         <source>Unable to create the PID file '%s': %s</source>
         <translation type="unfinished">Ne morem ustvariti PID-datoteke '%s': %s</translation>
+    </message>
+    <message>
+        <source>Unable to find UTXO for external input</source>
+        <translation type="unfinished">Ne najdem UTXO-ja za zunanji vhod</translation>
     </message>
     <message>
         <source>Unable to generate initial keys</source>
@@ -1038,10 +1062,6 @@ Podpisovanje je možno le s podedovanimi ("legacy") naslovi.</translation>
     <message>
         <source>Unsupported logging category %s=%s.</source>
         <translation type="unfinished">Nepodprta kategorija beleženja %s=%s.</translation>
-    </message>
-    <message>
-        <source>Upgrading UTXO database</source>
-        <translation type="unfinished">Nadgrajujem podatkovno bazo UTXO (nepotrošenih kovancev)</translation>
     </message>
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
@@ -1187,14 +1207,30 @@ Podpisovanje je možno le s podedovanimi ("legacy") naslovi.</translation>
         <source>&amp;Load PSBT from file…</source>
         <translation type="unfinished">&amp;Naloži DPBT iz datoteke...</translation>
     </message>
+    <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation type="unfinished">Sinhroniziram zaglavja (%1 %)…</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation type="unfinished">Sinhroniziram z omrežjem...</translation>
+    </message>
+    <message>
+        <source>&amp;Command-line options</source>
+        <translation type="unfinished">&amp;Možnosti iz ukazne vrstice</translation>
+    </message>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation type="unfinished">
-            <numerusform>Obdelan je %n blok zgodovine transakcij.</numerusform>
-            <numerusform>Obdelana sta %n bloka zgodovine transakcij.</numerusform>
-            <numerusform>Obdelani so %n bloki zgodovine transakcij.</numerusform>
-            <numerusform>Obdelanih je %n blokov zgodovine transakcij.</numerusform>
+            <numerusform>Obdelan %n blok zgodovine transakcij.</numerusform>
+            <numerusform>Obdelana %n bloka zgodovine transakcij.</numerusform>
+            <numerusform>Obdelani %n bloki zgodovine transakcij.</numerusform>
+            <numerusform>Obdelanih %n blokov zgodovine transakcij.</numerusform>
         </translation>
+    </message>
+    <message>
+        <source>Load Partially Signed Bitcoin Transaction</source>
+        <translation type="unfinished">Naloži delno podpisano bitcoin-transakcijo</translation>
     </message>
     <message>
         <source>Load PSBT from &amp;clipboard…</source>
@@ -1237,6 +1273,16 @@ Podpisovanje je možno le s podedovanimi ("legacy") naslovi.</translation>
         <translation type="unfinished">Zapri denarnico</translation>
     </message>
     <message>
+        <source>Restore Wallet…</source>
+        <extracomment>Name of the menu item that restores wallet from a backup file.</extracomment>
+        <translation type="unfinished">Obnovi denarnico...</translation>
+    </message>
+    <message>
+        <source>Restore a wallet from a backup file</source>
+        <extracomment>Status tip for Restore Wallet menu item</extracomment>
+        <translation type="unfinished">Obnovi denarnico iz datoteke z varnostno kopijo</translation>
+    </message>
+    <message>
         <source>Close all wallets</source>
         <translation type="unfinished">Zapri vse denarnice</translation>
     </message>
@@ -1261,6 +1307,26 @@ Podpisovanje je možno le s podedovanimi ("legacy") naslovi.</translation>
         <translation type="unfinished">Ni denarnic na voljo</translation>
     </message>
     <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">Podatki o denarnici</translation>
+    </message>
+    <message>
+        <source>Load Wallet Backup</source>
+        <extracomment>The title for Restore Wallet File Windows</extracomment>
+        <translation type="unfinished">Naloži varnostno kopijo denarnice</translation>
+    </message>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of pop-up window shown when the user is attempting to restore a wallet.</extracomment>
+        <translation type="unfinished">Obnovi denarnico</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">Ime denarnice</translation>
+    </message>
+    <message>
         <source>&amp;Window</source>
         <translation type="unfinished">O&amp;kno</translation>
     </message>
@@ -1276,10 +1342,10 @@ Podpisovanje je možno le s podedovanimi ("legacy") naslovi.</translation>
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform>%n aktivna povezava v omrežje bitcoin</numerusform>
-            <numerusform>%n aktivni povezavi v omrežje bitcoin</numerusform>
-            <numerusform>%n aktivne povezave v omrežje bitcoin</numerusform>
-            <numerusform>%n aktivnih povezav v omrežje bitcoin</numerusform>
+            <numerusform>%n aktivna povezava v omrežje bitcoin. </numerusform>
+            <numerusform>%n aktivni povezavi v omrežje bitcoin.</numerusform>
+            <numerusform>%n aktivne povezave v omrežje bitcoin.</numerusform>
+            <numerusform>%n aktivnih povezav v omrežje bitcoin.</numerusform>
         </translation>
     </message>
     <message>
@@ -1301,6 +1367,10 @@ Podpisovanje je možno le s podedovanimi ("legacy") naslovi.</translation>
         <source>Enable network activity</source>
         <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
         <translation type="unfinished">Omogoči omrežno aktivnost</translation>
+    </message>
+    <message>
+        <source>Pre-syncing Headers (%1%)…</source>
+        <translation type="unfinished">Predsinhronizacija zaglavij (%1 %)...</translation>
     </message>
     <message>
         <source>Error: %1</source>
@@ -1557,6 +1627,10 @@ Podpisovanje je možno le s podedovanimi ("legacy") naslovi.</translation>
         <source>Can't list signers</source>
         <translation type="unfinished">Ne morem našteti podpisnikov</translation>
     </message>
+    <message>
+        <source>Too many external signers found</source>
+        <translation type="unfinished">Zunanjih podpisnikov je preveč</translation>
+    </message>
 </context>
 <context>
     <name>LoadWalletsActivity</name>
@@ -1594,6 +1668,34 @@ Podpisovanje je možno le s podedovanimi ("legacy") naslovi.</translation>
         <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
         <extracomment>Descriptive text of the open wallet progress window which indicates to the user which wallet is currently being opened.</extracomment>
         <translation type="unfinished">Odpiram denarnico &lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+</context>
+<context>
+    <name>RestoreWalletActivity</name>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of progress window which is displayed when wallets are being restored.</extracomment>
+        <translation type="unfinished">Obnovi denarnico</translation>
+    </message>
+    <message>
+        <source>Restoring Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the restore wallets progress window which indicates to the user that wallets are currently being restored.</extracomment>
+        <translation type="unfinished">Obnavljanje denarnice &lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+    <message>
+        <source>Restore wallet failed</source>
+        <extracomment>Title of message box which is displayed when the wallet could not be restored.</extracomment>
+        <translation type="unfinished">Obnova denarnice je spodletela</translation>
+    </message>
+    <message>
+        <source>Restore wallet warning</source>
+        <extracomment>Title of message box which is displayed when the wallet is restored with some warning.</extracomment>
+        <translation type="unfinished">Obnova denarnice - opozorilo</translation>
+    </message>
+    <message>
+        <source>Restore wallet message</source>
+        <extracomment>Title of message box which is displayed when the wallet is successfully restored.</extracomment>
+        <translation type="unfinished">Obnova denarnice - sporočilo</translation>
     </message>
 </context>
 <context>
@@ -1771,13 +1873,32 @@ Podpisovanje je možno le s podedovanimi ("legacy") naslovi.</translation>
 </context>
 <context>
     <name>Intro</name>
-    <message>
-        <source>%1 GB of space available</source>
-        <translation type="unfinished">Na voljo je %1 GB prostora.</translation>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform>%n GB prostora na voljo</numerusform>
+            <numerusform>%n GB prostora na voljo</numerusform>
+            <numerusform>%n GB prostora na voljo</numerusform>
+            <numerusform>%n GB prostora na voljo</numerusform>
+        </translation>
     </message>
-    <message>
-        <source>(of %1 GB needed)</source>
-        <translation type="unfinished">(od potrebnih %1 GB)</translation>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform>(od potrebnih %n GiB)</numerusform>
+            <numerusform>(od potrebnih %n GiB)</numerusform>
+            <numerusform>(od potrebnih %n GiB)</numerusform>
+            <numerusform>(od potrebnih %n GB)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform>(%n GB potreben za celotno verigo blokov)</numerusform>
+            <numerusform>(%n GB potrebna za celotno verigo blokov)</numerusform>
+            <numerusform>(%n GB potrebni za celotno verigo blokov)</numerusform>
+            <numerusform>(%n GB potrebnih za celotno verigo blokov)</numerusform>
+        </translation>
     </message>
     <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
@@ -1810,10 +1931,6 @@ Podpisovanje je možno le s podedovanimi ("legacy") naslovi.</translation>
         <translation type="unfinished">Napaka: Ni mogoče ustvariti mape "%1".</translation>
     </message>
     <message>
-        <source>Error</source>
-        <translation type="unfinished">Napaka</translation>
-    </message>
-    <message>
         <source>Welcome</source>
         <translation type="unfinished">Dobrodošli</translation>
     </message>
@@ -1826,10 +1943,6 @@ Podpisovanje je možno le s podedovanimi ("legacy") naslovi.</translation>
         <translation type="unfinished">Ker ste program zagnali prvič, lahko izberete, kje bo %1 shranil podatke.</translation>
     </message>
     <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation type="unfinished">Ko kliknete OK, bo %1 začel prenašati podatke in procesirati celotno verigo blokov %4 (%2 GB), začenši z najstarejšo transakcijo iz %3 ob prvotnem začetku %4.</translation>
-    </message>
-    <message>
         <source>Limit block chain storage to</source>
         <translation type="unfinished">Omeji velikost shrambe verige blokov na </translation>
     </message>
@@ -1840,6 +1953,10 @@ Podpisovanje je možno le s podedovanimi ("legacy") naslovi.</translation>
     <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
         <translation type="unfinished">Začetna sinhronizacija je zelo zahtevna in lahko odkrije probleme s strojno opremo v vašem računalniku, ki so prej bili neopaženi. Vsakič, ko zaženete %1, bo le-ta nadaljeval s prenosom, kjer je prejšnjič ostal.</translation>
+    </message>
+    <message>
+        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2 GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
+        <translation type="unfinished">Ko kliknete OK, bo %1 pričel prenašati in obdelovati celotno verigo blokov %4 (%2 GB), začenši s prvimi transakcijami iz %3, ko je bil %4 zagnan.</translation>
     </message>
     <message>
         <source>If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</source>
@@ -1934,6 +2051,10 @@ Podpisovanje je možno le s podedovanimi ("legacy") naslovi.</translation>
         <source>Unknown. Syncing Headers (%1, %2%)…</source>
         <translation type="unfinished">Neznano. Sinhroniziram zaglavja (%1, %2%)...</translation>
     </message>
+    <message>
+        <source>Unknown. Pre-syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">Neznano. Predsinhronizacija zaglavij (%1, %2 %)...</translation>
+    </message>
 </context>
 <context>
     <name>OpenURIDialog</name>
@@ -1988,6 +2109,10 @@ Podpisovanje je možno le s podedovanimi ("legacy") naslovi.</translation>
     <message>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
         <translation type="unfinished">Ko zaprete glavno okno programa, bo program tekel še naprej, okno pa bo zgolj minimirano. Program v tem primeru ustavite tako, da v meniju izberete ukaz Izhod.</translation>
+    </message>
+    <message>
+        <source>Options set in this dialog are overridden by the command line:</source>
+        <translation type="unfinished">Možnosti, nastavljene v tem oknu, preglasi ukazna vrstica:</translation>
     </message>
     <message>
         <source>Open the %1 configuration file from the working directory.</source>
@@ -2218,10 +2343,6 @@ Podpisovanje je možno le s podedovanimi ("legacy") naslovi.</translation>
         <translation type="unfinished">najboljše ujemanje "%1"</translation>
     </message>
     <message>
-        <source>Options set in this dialog are overridden by the command line or in the configuration file:</source>
-        <translation type="unfinished">Možnosti, nastavljene v tem pogovornem oknu, ki so bile preglašene v ukazni vrstici ali konfiguracijski datoteki:</translation>
-    </message>
-    <message>
         <source>&amp;OK</source>
         <translation type="unfinished">&amp;V redu</translation>
     </message>
@@ -2244,14 +2365,22 @@ Podpisovanje je možno le s podedovanimi ("legacy") naslovi.</translation>
     </message>
     <message>
         <source>Confirm options reset</source>
+        <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
         <translation type="unfinished">Potrdi ponastavitev</translation>
     </message>
     <message>
         <source>Client restart required to activate changes.</source>
+        <extracomment>Text explaining that the settings changed will not come into effect until the client is restarted.</extracomment>
         <translation type="unfinished">Za udejanjenje sprememb je potreben ponoven zagon programa.</translation>
     </message>
     <message>
+        <source>Current settings will be backed up at "%1".</source>
+        <extracomment>Text explaining to the user that the client's current settings will be backed up at a specific location. %1 is a stand-in argument for the backup location's path.</extracomment>
+        <translation type="unfinished">Trenutne nastavitve bodo varnostno shranjene na mesto "%1".</translation>
+    </message>
+    <message>
         <source>Client will be shut down. Do you want to proceed?</source>
+        <extracomment>Text asking the user to confirm if they would like to proceed with a client shutdown.</extracomment>
         <translation type="unfinished">Program bo zaustavljen. Želite nadaljevati z izhodom?</translation>
     </message>
     <message>
@@ -2273,10 +2402,6 @@ Podpisovanje je možno le s podedovanimi ("legacy") naslovi.</translation>
         <translation type="unfinished">Prekliči</translation>
     </message>
     <message>
-        <source>Error</source>
-        <translation type="unfinished">Napaka</translation>
-    </message>
-    <message>
         <source>The configuration file could not be opened.</source>
         <translation type="unfinished">Konfiguracijske datoteke ni bilo moč odpreti.</translation>
     </message>
@@ -2287,6 +2412,13 @@ Podpisovanje je možno le s podedovanimi ("legacy") naslovi.</translation>
     <message>
         <source>The supplied proxy address is invalid.</source>
         <translation type="unfinished">Vnešeni naslov posredniškega strežnika ni veljaven.</translation>
+    </message>
+</context>
+<context>
+    <name>OptionsModel</name>
+    <message>
+        <source>Could not read setting "%1", %2.</source>
+        <translation type="unfinished">Branje nastavitve "%1" je spodletelo, %2.</translation>
     </message>
 </context>
 <context>
@@ -2553,6 +2685,11 @@ Svetujemo, da prodajalca prosite, naj vam priskrbi URI na podlagi BIP21.</transl
         <translation type="unfinished">Soležnik</translation>
     </message>
     <message>
+        <source>Age</source>
+        <extracomment>Title of Peers Table column which indicates the duration (length of time) since the peer connection started.</extracomment>
+        <translation type="unfinished">Starost</translation>
+    </message>
+    <message>
         <source>Direction</source>
         <extracomment>Title of Peers Table column which indicates the direction the peer connection was initiated from.</extracomment>
         <translation type="unfinished">Smer povezave</translation>
@@ -2753,29 +2890,32 @@ Svetujemo, da prodajalca prosite, naj vam priskrbi URI na podlagi BIP21.</transl
     </message>
     <message>
         <source>Whether we relay addresses to this peer.</source>
-        <extracomment>Tooltip text for the Address Relay field in the peer details area.</extracomment>
+        <extracomment>Tooltip text for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
         <translation type="unfinished">Ali temu soležniku posredujemo naslove</translation>
     </message>
     <message>
         <source>Address Relay</source>
+        <extracomment>Text title for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
         <translation type="unfinished">Posrednik naslovov</translation>
     </message>
     <message>
-        <source>Total number of addresses processed, excluding those dropped due to rate-limiting.</source>
-        <extracomment>Tooltip text for the Addresses Processed field in the peer details area.</extracomment>
-        <translation type="unfinished">Skupno število obdelanih naslovov, razen opuščenih zaradi omejitev hitrosti</translation>
+        <source>The total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</source>
+        <extracomment>Tooltip text for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
+        <translation type="unfinished">Skupno število obdelanih naslovov, prejetih od tega soležnika (naslovi, ki niso bili sprejeti zaradi omejevanja gostote komunikacije, niso šteti).</translation>
+    </message>
+    <message>
+        <source>The total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</source>
+        <extracomment>Tooltip text for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
+        <translation type="unfinished">Skupno število naslovov, prejetih od tega soležnika, ki so bili zavrnjeni (niso bili obdelani) zaradi omejevanja gostote komunikacije.</translation>
     </message>
     <message>
         <source>Addresses Processed</source>
+        <extracomment>Text title for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
         <translation type="unfinished">Obdelanih naslovov</translation>
     </message>
     <message>
-        <source>Total number of addresses dropped due to rate-limiting.</source>
-        <extracomment>Tooltip text for the Addresses Rate-Limited field in the peer details area.</extracomment>
-        <translation type="unfinished">Skupno število naslovov, opuščenih zaradi omejitev hitrosti</translation>
-    </message>
-    <message>
         <source>Addresses Rate-Limited</source>
+        <extracomment>Text title for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
         <translation type="unfinished">Omejenih naslovov</translation>
     </message>
     <message>
@@ -3389,10 +3529,6 @@ Opomba: Ker se provizija izračuna na bajt, bi provizija "100 satoshijev na kvB"
         <translation type="unfinished">Kopiraj količino</translation>
     </message>
     <message>
-        <source>Copy amount</source>
-        <translation type="unfinished">Kopiraj znesek</translation>
-    </message>
-    <message>
         <source>Copy fee</source>
         <translation type="unfinished">Kopiraj provizijo</translation>
     </message>
@@ -3561,10 +3697,6 @@ Opomba: Ker se provizija izračuna na bajt, bi provizija "100 satoshijev na kvB"
         <source>A fee higher than %1 is considered an absurdly high fee.</source>
         <translation type="unfinished">Provizija, ki je večja od %1, velja za nesmiselno veliko.</translation>
     </message>
-    <message>
-        <source>Payment request expired.</source>
-        <translation type="unfinished">Zahtevek za plačilo je potekel.</translation>
-    </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
@@ -3646,28 +3778,12 @@ Opomba: Ker se provizija izračuna na bajt, bi provizija "100 satoshijev na kvB"
         <translation type="unfinished">Sporočilo:</translation>
     </message>
     <message>
-        <source>This is an unauthenticated payment request.</source>
-        <translation type="unfinished">Ta zahtevek za plačilo je neoverjen.</translation>
-    </message>
-    <message>
-        <source>This is an authenticated payment request.</source>
-        <translation type="unfinished">Ta zahtevek za plačilo je overjen.</translation>
-    </message>
-    <message>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished">Če vnesete oznako za zgornji naslov, se bo skupaj z naslovom shranila v imenik že uporabljenih naslovov</translation>
     </message>
     <message>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished">Sporočilo, ki je bilo pripeto na URI tipa bitcoin: in bo shranjeno skupaj s podatki o transakciji. Opomba: Sporočilo ne bo poslano preko omrežja Bitcoin.</translation>
-    </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">Prejemnik:</translation>
-    </message>
-    <message>
-        <source>Memo:</source>
-        <translation type="unfinished">Opomba:</translation>
     </message>
 </context>
 <context>
@@ -3835,30 +3951,32 @@ Opomba: Ker se provizija izračuna na bajt, bi provizija "100 satoshijev na kvB"
     <name>TransactionDesc</name>
     <message>
         <source>conflicted with a transaction with %1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that conflicts with a confirmed transaction.</extracomment>
         <translation type="unfinished">v sporu s transakcijo z %1 potrditvami</translation>
     </message>
     <message>
-        <source>0/unconfirmed, %1</source>
-        <translation type="unfinished">0/nepotrjeno, %1</translation>
+        <source>0/unconfirmed, in memory pool</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is in the memory pool.</extracomment>
+        <translation type="unfinished">0 / nepotrjena, v čakalni vrsti</translation>
     </message>
     <message>
-        <source>in memory pool</source>
-        <translation type="unfinished">v čakalni vrsti</translation>
-    </message>
-    <message>
-        <source>not in memory pool</source>
-        <translation type="unfinished">ni v čakalni vrsti</translation>
+        <source>0/unconfirmed, not in memory pool</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is not in the memory pool.</extracomment>
+        <translation type="unfinished">0 / nepotrjena, ni v čakalni vrsti</translation>
     </message>
     <message>
         <source>abandoned</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an abandoned transaction.</extracomment>
         <translation type="unfinished">opuščena</translation>
     </message>
     <message>
         <source>%1/unconfirmed</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
         <translation type="unfinished">%1/nepotrjena</translation>
     </message>
     <message>
         <source>%1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
         <translation type="unfinished">%1 potrditev</translation>
     </message>
     <message>
@@ -4219,7 +4337,7 @@ Opomba: Ker se provizija izračuna na bajt, bi provizija "100 satoshijev na kvB"
     <message>
         <source>Comma separated file</source>
         <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
-        <translation type="unfinished">Datoteka CSV (podatki ločeni z vejicami)</translation>
+        <translation type="unfinished">Vrednosti ločene z vejicami</translation>
     </message>
     <message>
         <source>Confirmed</source>
@@ -4283,10 +4401,6 @@ Za odpiranje denarnice kliknite Datoteka &gt; Odpri denarnico
     <message>
         <source>Create a new wallet</source>
         <translation type="unfinished">Ustvari novo denarnico</translation>
-    </message>
-    <message>
-        <source>Error</source>
-        <translation type="unfinished">Napaka</translation>
     </message>
     <message>
         <source>Unable to decode PSBT from clipboard (invalid base64)</source>

--- a/src/qt/locale/bitcoin_sn.ts
+++ b/src/qt/locale/bitcoin_sn.ts
@@ -212,6 +212,27 @@
 <context>
     <name>Intro</name>
     <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">

--- a/src/qt/locale/bitcoin_sq.ts
+++ b/src/qt/locale/bitcoin_sq.ts
@@ -207,6 +207,21 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     </context>
 <context>
+    <name>BitcoinApplication</name>
+    <message>
+        <source>Settings file %1 might be corrupt or invalid.</source>
+        <translation type="unfinished">Skedari i cilësimeve %1 mund të jetë i korruptuar ose i pavlefshëm.</translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
+        <translation type="unfinished">Ndodhi një gabim fatal. %1 nuk mund të vazhdojë më i sigurt dhe do të heqë dorë.</translation>
+    </message>
+    <message>
+        <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
+        <translation type="unfinished">Ndodhi një gabim i brendshëm. %1 do të përpiqet të vazhdojë në mënyrë të sigurt. Ky është një gabim i papritur që mund të raportohet siç përshkruhet më poshtë.</translation>
+    </message>
+</context>
+<context>
     <name>QObject</name>
     <message>
         <source>unknown</source>
@@ -455,6 +470,27 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>Intro</name>
     <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
@@ -652,10 +688,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Paste address from clipboard</source>
         <translation type="unfinished">Ngjit nga memorja e sistemit</translation>
     </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">Paguaj drejt:</translation>
-    </message>
     </context>
 <context>
     <name>SignVerifyMessageDialog</name>
@@ -668,10 +700,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <name>TransactionDesc</name>
     <message>
         <source>%1/unconfirmed</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
         <translation type="unfinished">%1/I pakonfirmuar</translation>
     </message>
     <message>
         <source>%1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
         <translation type="unfinished">%1 konfirmimet</translation>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_sr.ts
+++ b/src/qt/locale/bitcoin_sr.ts
@@ -92,6 +92,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Извези Листу Адреса</translation>
     </message>
     <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">CSV фајл</translation>
+    </message>
+    <message>
         <source>There was an error trying to save the address list to %1. Please try again.</source>
         <extracomment>An error message. %1 is a stand-in argument for the name of the file we attempted to save to.</extracomment>
         <translation type="unfinished">Десила се грешка приликом покушаја да се листа адреса упамти на  %1. Молимо покушајте поново.</translation>
@@ -241,10 +246,22 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>BitcoinApplication</name>
     <message>
+        <source>Runaway exception</source>
+        <translation type="unfinished">Изузетак покретања</translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
+        <translation type="unfinished">Дошло је до фаталне грешке. 1%1 даље не може безбедно да настави, те ће се угасити.</translation>
+    </message>
+    <message>
         <source>Internal error</source>
         <translation type="unfinished">Интерна грешка</translation>
     </message>
-    </context>
+    <message>
+        <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
+        <translation type="unfinished">Догодила се интерна грешка. %1 ће покушати да настави безбедно. Ово је неочекивана грешка која може да се пријави као што је објашњено испод.</translation>
+    </message>
+</context>
 <context>
     <name>QObject</name>
     <message>
@@ -254,6 +271,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Error: %1</source>
         <translation type="unfinished">Грешка: %1</translation>
+    </message>
+    <message>
+        <source>%1 didn't yet exit safely…</source>
+        <translation type="unfinished">1%1 још увек није изашао безбедно…</translation>
     </message>
     <message>
         <source>unknown</source>
@@ -268,6 +289,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Унеси Биткоин адресу, (нпр %1)</translation>
     </message>
     <message>
+        <source>Unroutable</source>
+        <translation type="unfinished">Немогуће преусмерити</translation>
+    </message>
+    <message>
+        <source>Internal</source>
+        <translation type="unfinished">Унутрашње</translation>
+    </message>
+    <message>
         <source>Inbound</source>
         <extracomment>An inbound connection from a peer. An inbound connection is a connection initiated by a peer.</extracomment>
         <translation type="unfinished">Долазеће</translation>
@@ -276,6 +305,31 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Outbound</source>
         <extracomment>An outbound connection to a peer. An outbound connection is a connection initiated by us.</extracomment>
         <translation type="unfinished">Одлазеће</translation>
+    </message>
+    <message>
+        <source>Full Relay</source>
+        <extracomment>Peer connection type that relays all network information.</extracomment>
+        <translation type="unfinished">Потпуна предаја</translation>
+    </message>
+    <message>
+        <source>Block Relay</source>
+        <extracomment>Peer connection type that relays network information about blocks and not transactions or addresses.</extracomment>
+        <translation type="unfinished">Блокирана предаја</translation>
+    </message>
+    <message>
+        <source>Manual</source>
+        <extracomment>Peer connection type established manually through one of several methods.</extracomment>
+        <translation type="unfinished">Упутство</translation>
+    </message>
+    <message>
+        <source>Feeler</source>
+        <extracomment>Short-lived peer connection type that tests the aliveness of known addresses.</extracomment>
+        <translation type="unfinished">Сензор</translation>
+    </message>
+    <message>
+        <source>Address Fetch</source>
+        <extracomment>Short-lived peer connection type that solicits known addresses from a peer.</extracomment>
+        <translation type="unfinished">Преузимање адресе</translation>
     </message>
     <message>
         <source>None</source>
@@ -337,9 +391,21 @@ Signing is only possible with addresses of the type 'legacy'.</source>
             <numerusform />
         </translation>
     </message>
+    <message>
+        <source>%1 kB</source>
+        <translation type="unfinished">%1 килобајта</translation>
+    </message>
     </context>
 <context>
     <name>bitcoin-core</name>
+    <message>
+        <source>Settings file could not be read</source>
+        <translation type="unfinished">Фајл са подешавањима се не може прочитати</translation>
+    </message>
+    <message>
+        <source>Settings file could not be written</source>
+        <translation type="unfinished">Фајл са подешавањима се не може записати</translation>
+    </message>
     <message>
         <source>The %s developers</source>
         <translation type="unfinished">%s девелопери</translation>
@@ -359,10 +425,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Error reading %s! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation type="unfinished">Грешка у читању %s! Сви кључеви су прочитани коректно, али подаци о трансакцији или уноси у адресар могу недостајати или бити нетачни.</translation>
-    </message>
-    <message>
-        <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
-        <translation type="unfinished">Грешка: Претрага за долазним конекцијама није успела (претрага враћа грешку %s)</translation>
     </message>
     <message>
         <source>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.</source>
@@ -511,10 +573,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Error reading from database, shutting down.</source>
         <translation type="unfinished">Грешка приликом читања из базе података, искључивање у току.</translation>
-    </message>
-    <message>
-        <source>Error upgrading chainstate database</source>
-        <translation type="unfinished">Грешка приликом надоградње базе података стања ланца</translation>
     </message>
     <message>
         <source>Error: Disk space is low for %s</source>
@@ -705,10 +763,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Категорија записа није подржана %s=%s.</translation>
     </message>
     <message>
-        <source>Upgrading UTXO database</source>
-        <translation type="unfinished">Надоградња UTXO базе података</translation>
-    </message>
-    <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
         <translation type="unfinished">Коментар агента корисника (%s) садржи небезбедне знакове.</translation>
     </message>
@@ -766,6 +820,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Create a new wallet</source>
         <translation type="unfinished">Направи нови ночаник</translation>
+    </message>
+    <message>
+        <source>&amp;Minimize</source>
+        <translation type="unfinished">&amp;Minimalizuj</translation>
     </message>
     <message>
         <source>Wallet:</source>
@@ -837,6 +895,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Верификуј поруке и утврди да ли су потписане од стране спецификованих Биткоин адреса</translation>
     </message>
     <message>
+        <source>&amp;Load PSBT from file…</source>
+        <translation type="unfinished">&amp;Учитава ”PSBT” из датотеке…</translation>
+    </message>
+    <message>
+        <source>Open &amp;URI…</source>
+        <translation type="unfinished">Отвори &amp;URI</translation>
+    </message>
+    <message>
         <source>Close Wallet…</source>
         <translation type="unfinished">Затвори новчаник...</translation>
     </message>
@@ -869,6 +935,22 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Синхронизација са мрежом...</translation>
     </message>
     <message>
+        <source>Indexing blocks on disk…</source>
+        <translation type="unfinished">Индексирање блокова на диску…</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation type="unfinished">Процесуирање блокова на диску</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation type="unfinished">Реиндексирање блокова на диску…</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation type="unfinished">Повезивање са клијентима...</translation>
+    </message>
+    <message>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished">Затражи плаћање (генерише QR кодове и биткоин: URI-е)</translation>
     </message>
@@ -897,6 +979,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">%1 уназад</translation>
     </message>
     <message>
+        <source>Catching up…</source>
+        <translation type="unfinished">Ажурирање у току...</translation>
+    </message>
+    <message>
         <source>Last received block was generated %1 ago.</source>
         <translation type="unfinished">Последњи примљени блок је направљен пре %1.</translation>
     </message>
@@ -919,6 +1005,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Up to date</source>
         <translation type="unfinished">Ажурирано</translation>
+    </message>
+    <message>
+        <source>Load Partially Signed Bitcoin Transaction</source>
+        <translation type="unfinished">Учитај делимично потписану Bitcoin трансакцију</translation>
+    </message>
+    <message>
+        <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
+        <translation type="unfinished">Учитај делимично потписану Bitcoin трансакцију из clipboard-a</translation>
     </message>
     <message>
         <source>Node window</source>
@@ -961,12 +1055,25 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Прикажи  поруку помоћи %1 за листу са могућим опцијама Биткоин командне линије</translation>
     </message>
     <message>
+        <source>&amp;Mask values</source>
+        <translation type="unfinished">&amp;Маскирај вредности</translation>
+    </message>
+    <message>
+        <source>Mask the values in the Overview tab</source>
+        <translation type="unfinished">Филтрирај вредности у картици за преглед</translation>
+    </message>
+    <message>
         <source>default wallet</source>
         <translation type="unfinished">подразумевани новчаник</translation>
     </message>
     <message>
         <source>No wallets available</source>
         <translation type="unfinished">Нема доступних новчаника</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">Име Новчаника</translation>
     </message>
     <message>
         <source>Zoom</source>
@@ -980,14 +1087,42 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>%1 client</source>
         <translation type="unfinished">%1 клијент</translation>
     </message>
+    <message>
+        <source>&amp;Hide</source>
+        <translation type="unfinished">&amp;Sakrij</translation>
+    </message>
+    <message>
+        <source>S&amp;how</source>
+        <translation type="unfinished">&amp;Прикажи</translation>
+    </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>%n активних конекција са Биткоин мрежом</numerusform>
+            <numerusform>%n активних конекција са Биткоин мрежом</numerusform>
+            <numerusform>%n активних конекција са Биткоин мрежом</numerusform>
         </translation>
+    </message>
+    <message>
+        <source>Click for more actions.</source>
+        <extracomment>A substring of the tooltip. "More actions" are available via the context menu.</extracomment>
+        <translation type="unfinished">Клик за више акција</translation>
+    </message>
+    <message>
+        <source>Show Peers tab</source>
+        <extracomment>A context menu item. The "Peers tab" is an element of the "Node window".</extracomment>
+        <translation type="unfinished">Прикажи картицу са ”Клијентима”</translation>
+    </message>
+    <message>
+        <source>Disable network activity</source>
+        <extracomment>A context menu item.</extracomment>
+        <translation type="unfinished">Онемогући мрежне активности</translation>
+    </message>
+    <message>
+        <source>Enable network activity</source>
+        <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
+        <translation type="unfinished">Омогући мрежне активности</translation>
     </message>
     <message>
         <source>Error: %1</source>
@@ -1148,6 +1283,26 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Копирај износ</translation>
     </message>
     <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Копирај адресу</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Копирај &amp;означи</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Копирај &amp;износ</translation>
+    </message>
+    <message>
+        <source>L&amp;ock unspent</source>
+        <translation type="unfinished">Закључај непотрошено</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock unspent</source>
+        <translation type="unfinished">Откључај непотрошено</translation>
+    </message>
+    <message>
         <source>Copy quantity</source>
         <translation type="unfinished">Копирај количину</translation>
     </message>
@@ -1219,7 +1374,24 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Create wallet warning</source>
         <translation type="unfinished">Направи упозорење за новчаник</translation>
     </message>
+    <message>
+        <source>Can't list signers</source>
+        <translation type="unfinished">Не могу да излистам потписнике</translation>
+    </message>
     </context>
+<context>
+    <name>LoadWalletsActivity</name>
+    <message>
+        <source>Load Wallets</source>
+        <extracomment>Title of progress window which is displayed when wallets are being loaded.</extracomment>
+        <translation type="unfinished">Učitaj Novčanik</translation>
+    </message>
+    <message>
+        <source>Loading wallets…</source>
+        <extracomment>Descriptive text of the load wallets progress window which indicates to the user that wallets are currently being loaded.</extracomment>
+        <translation type="unfinished">Učitavanje Novčanika</translation>
+    </message>
+</context>
 <context>
     <name>OpenWalletActivity</name>
     <message>
@@ -1239,7 +1411,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <extracomment>Title of window indicating the progress of opening of a wallet.</extracomment>
         <translation type="unfinished">Отвори новчаник</translation>
     </message>
-    </context>
+    <message>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the open wallet progress window which indicates to the user which wallet is currently being opened.</extracomment>
+        <translation type="unfinished">Отвањаре новчаника &lt;b&gt;%1&lt;/b&gt;</translation>
+    </message>
+</context>
 <context>
     <name>WalletController</name>
     <message>
@@ -1286,6 +1463,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Шифрирај новчаник</translation>
     </message>
     <message>
+        <source>Advanced Options</source>
+        <translation type="unfinished">Напредне опције</translation>
+    </message>
+    <message>
         <source>Disable private keys for this wallet. Wallets with private keys disabled will have no private keys and cannot have an HD seed or imported private keys. This is ideal for watch-only wallets.</source>
         <translation type="unfinished">Онемогући приватни кључ за овај новчаник. Новчаници са онемогућеним приватним кључем неће  имати приватни кључ и не могу имати HD семе или увезени приватни кључ. Ова опција идеална је за новчанике који су искључиво за посматрање.</translation>
     </message>
@@ -1302,10 +1483,36 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Направи Празан Новчаник</translation>
     </message>
     <message>
+        <source>Use descriptors for scriptPubKey management</source>
+        <translation type="unfinished">Користите дескрипторе за управљање сцриптПубКеи-ом</translation>
+    </message>
+    <message>
+        <source>Descriptor Wallet</source>
+        <translation type="unfinished">Дескриптор Новчаник</translation>
+    </message>
+    <message>
+        <source>Use an external signing device such as a hardware wallet. Configure the external signer script in wallet preferences first.</source>
+        <translation type="unfinished">Користите спољни уређај за потписивање као што је хардверски новчаник. Прво конфигуришите скрипту спољног потписника у подешавањима новчаника.
+</translation>
+    </message>
+    <message>
+        <source>External signer</source>
+        <translation type="unfinished">Екстерни потписник</translation>
+    </message>
+    <message>
         <source>Create</source>
         <translation type="unfinished">Направи</translation>
     </message>
-    </context>
+    <message>
+        <source>Compiled without sqlite support (required for descriptor wallets)</source>
+        <translation type="unfinished">Састављено без склите подршке (потребно за новчанике дескриптора)</translation>
+    </message>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Састављено без подршке за спољно потписивање (потребно за спољно потписивање)</translation>
+    </message>
+</context>
 <context>
     <name>EditAddressDialog</name>
     <message>
@@ -1390,6 +1597,30 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Bitcoin</source>
         <translation type="unfinished">Биткоин</translation>
     </message>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform>(од потребних %n GB)</numerusform>
+            <numerusform>(од потребних %n GB)</numerusform>
+            <numerusform>(од  потребних  %n GB)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform>(%n GB потребно за цео ланац)</numerusform>
+            <numerusform>(%n GB потребно за цео ланац)</numerusform>
+            <numerusform>(%n GB потребно за цео ланац)</numerusform>
+        </translation>
+    </message>
     <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
         <translation type="unfinished">Најмање %1 GB подататака биће складиштен у овај директорјиум који ће временом порасти.</translation>
@@ -1402,9 +1633,9 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
-            <numerusform />
+            <numerusform>(довољно за враћање резервних копија старих %n дана)</numerusform>
+            <numerusform>(довољно за враћање резервних копија старих %n дана)</numerusform>
+            <numerusform>(довољно за враћање резервних копија старих %n дана)</numerusform>
         </translation>
     </message>
     <message>
@@ -1436,12 +1667,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Пошто је ово први пут да је програм покренут, можете изабрати где ће %1 чувати своје податке.</translation>
     </message>
     <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation type="unfinished">Када кликнете на ОК, %1 ће почети с преузимањем и процесуирањем целокупног ланца блокова %4 (%2GB), почевши од најранијих трансакција у %3 када је %4 покренут.</translation>
+        <source>Limit block chain storage to</source>
+        <translation type="unfinished">Ограничите складиштење блок ланца на</translation>
     </message>
     <message>
         <source>Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</source>
         <translation type="unfinished">Враћање ове опције захтева поновно преузимање целокупног блокчејна - ланца блокова. Брже је преузети цели ланац и касније га скратити. Онемогућава неке напредне опције.</translation>
+    </message>
+    <message>
+        <source> GB</source>
+        <translation type="unfinished">Гигабајт</translation>
     </message>
     <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
@@ -1540,6 +1775,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>%1 is currently syncing.  It will download headers and blocks from peers and validate them until reaching the tip of the block chain.</source>
         <translation type="unfinished">%1 се синхронузује. Преузеће заглавља и блокове од клијената и потврдити их док не стигне на крај ланца блокова.</translation>
     </message>
+    <message>
+        <source>Unknown. Syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">Непознато. Синхронизација заглавља (%1, %2%)...</translation>
+    </message>
     </context>
 <context>
     <name>OpenURIDialog</name>
@@ -1570,6 +1809,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>&amp;Start %1 on system login</source>
         <translation type="unfinished">&amp;Покрени %1 приликом пријаве на систем</translation>
+    </message>
+    <message>
+        <source>Enabling pruning significantly reduces the disk space required to store transactions. All blocks are still fully validated. Reverting this setting requires re-downloading the entire blockchain.</source>
+        <translation type="unfinished">Омогућавање смањења значајно смањује простор на диску потребан за складиштење трансакција. Сви блокови су још увек у потпуности валидирани. Враћање ове поставке захтева поновно преузимање целог блоцкцхаина.</translation>
     </message>
     <message>
         <source>Size of &amp;database cache</source>
@@ -1624,6 +1867,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">(0 = аутоматски одреди, &lt;0 = остави слободно толико језгара)</translation>
     </message>
     <message>
+        <source>Enable R&amp;PC server</source>
+        <extracomment>An Options window setting to enable the RPC server.</extracomment>
+        <translation type="unfinished">Omogući R&amp;PC server</translation>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished">Н&amp;овчаник</translation>
     </message>
@@ -1644,12 +1892,32 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">&amp;Троши непотврђени кусур</translation>
     </message>
     <message>
+        <source>External Signer (e.g. hardware wallet)</source>
+        <translation type="unfinished">Екстерни потписник (нпр. хардверски новчаник)</translation>
+    </message>
+    <message>
+        <source>&amp;External signer script path</source>
+        <translation type="unfinished">&amp;Путања скрипте спољног потписника</translation>
+    </message>
+    <message>
+        <source>Full path to a Bitcoin Core compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</source>
+        <translation type="unfinished">Пуна путања до скрипте компатибилне са Битцоин Цоре (нпр. Ц:\Довнлоадс\хви.еке или /Усерс/иоу/Довнлоадс/хви.пи). Пазите: злонамерни софтвер може украсти ваше новчиће</translation>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation type="unfinished">Аутоматски отвори Биткоин клијент порт на рутеру. Ова опција ради само уколико твој рутер подржава и има омогућен UPnP.</translation>
     </message>
     <message>
         <source>Map port using &amp;UPnP</source>
         <translation type="unfinished">Мапирај порт користећи &amp;UPnP</translation>
+    </message>
+    <message>
+        <source>Automatically open the Bitcoin client port on the router. This only works when your router supports NAT-PMP and it is enabled. The external port could be random.</source>
+        <translation type="unfinished">Аутоматски отворите порт за Битцоин клијент на рутеру. Ово функционише само када ваш рутер подржава НАТ-ПМП и када је омогућен. Спољни порт би могао бити насумичан.</translation>
+    </message>
+    <message>
+        <source>Map port using NA&amp;T-PMP</source>
+        <translation type="unfinished">Мапирајте порт користећи НА&amp;Т-ПМП</translation>
     </message>
     <message>
         <source>Accept connections from outside.</source>
@@ -1688,6 +1956,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Тор</translation>
     </message>
     <message>
+        <source>Show the icon in the system tray.</source>
+        <translation type="unfinished">Прикажите икону у системској палети.</translation>
+    </message>
+    <message>
+        <source>&amp;Show tray icon</source>
+        <translation type="unfinished">&amp;Прикажи икону у траци</translation>
+    </message>
+    <message>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation type="unfinished">Покажи само иконицу у панелу након минимизирања прозора</translation>
     </message>
@@ -1724,8 +2000,24 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Да ли да се прикажу опције контроле новчића или не.</translation>
     </message>
     <message>
-        <source>Options set in this dialog are overridden by the command line or in the configuration file:</source>
-        <translation type="unfinished">Опције постављене у овом диалогу су поништене командном линијом или у конфигурационој датотеци:</translation>
+        <source>Connect to the Bitcoin network through a separate SOCKS5 proxy for Tor onion services.</source>
+        <translation type="unfinished">Повежите се на Битцоин мрежу преко засебног СОЦКС5 проксија за Тор онион услуге.</translation>
+    </message>
+    <message>
+        <source>Use separate SOCKS&amp;5 proxy to reach peers via Tor onion services:</source>
+        <translation type="unfinished">Користите посебан СОЦКС&amp;5 прокси да бисте дошли до вршњака преко услуга Тор онион:</translation>
+    </message>
+    <message>
+        <source>Monospaced font in the Overview tab:</source>
+        <translation type="unfinished">Једноразредни фонт на картици Преглед:</translation>
+    </message>
+    <message>
+        <source>embedded "%1"</source>
+        <translation type="unfinished">уграђено ”%1”</translation>
+    </message>
+    <message>
+        <source>closest matching "%1"</source>
+        <translation type="unfinished">Најближа сличност ”%1”</translation>
     </message>
     <message>
         <source>&amp;OK</source>
@@ -1734,6 +2026,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>&amp;Cancel</source>
         <translation type="unfinished">&amp;Откажи</translation>
+    </message>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Састављено без подршке за спољно потписивање (потребно за спољно потписивање)</translation>
     </message>
     <message>
         <source>default</source>
@@ -1745,14 +2042,17 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Confirm options reset</source>
+        <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
         <translation type="unfinished">Потврди ресет опција</translation>
     </message>
     <message>
         <source>Client restart required to activate changes.</source>
+        <extracomment>Text explaining that the settings changed will not come into effect until the client is restarted.</extracomment>
         <translation type="unfinished">Рестарт клијента захтеван како би се промене активирале.</translation>
     </message>
     <message>
         <source>Client will be shut down. Do you want to proceed?</source>
+        <extracomment>Text asking the user to confirm if they would like to proceed with a client shutdown.</extracomment>
         <translation type="unfinished">Клијент ће се искључити. Да ли желите да наставите?</translation>
     </message>
     <message>
@@ -1764,6 +2064,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>The configuration file is used to specify advanced user options which override GUI settings. Additionally, any command-line options will override this configuration file.</source>
         <extracomment>Explanatory text about the priority order of instructions considered by client. The order from high to low being: command-line, configuration file, GUI settings.</extracomment>
         <translation type="unfinished">Конфигурациона датотека се користи да одреди напредне корисничке опције које поништају подешавања у графичком корисничком интерфејсу.</translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation type="unfinished">Nastavi</translation>
     </message>
     <message>
         <source>Cancel</source>
@@ -1860,7 +2164,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Current total balance in watch-only addresses</source>
         <translation type="unfinished">Тренутни укупни салдо у адресама у опцији само-гледај</translation>
     </message>
-    </context>
+    <message>
+        <source>Privacy mode activated for the Overview tab. To unmask the values, uncheck Settings-&gt;Mask values.</source>
+        <translation type="unfinished">Режим приватности је активиран за картицу Преглед. Да бисте демаскирали вредности, поништите избор Подешавања-&gt;Маск вредности.</translation>
+    </message>
+</context>
 <context>
     <name>PSBTOperationsDialog</name>
     <message>
@@ -1888,8 +2196,65 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Затвори</translation>
     </message>
     <message>
+        <source>Failed to load transaction: %1</source>
+        <translation type="unfinished">Неуспело учитавање трансакције: %1</translation>
+    </message>
+    <message>
+        <source>Failed to sign transaction: %1</source>
+        <translation type="unfinished">Неуспело потписивање трансакције: %1</translation>
+    </message>
+    <message>
+        <source>Could not sign any more inputs.</source>
+        <translation type="unfinished">Није могуће потписати више уноса.</translation>
+    </message>
+    <message>
+        <source>Signed %1 inputs, but more signatures are still required.</source>
+        <translation type="unfinished">Потписано %1 поље, али је потребно још потписа.</translation>
+    </message>
+    <message>
+        <source>Signed transaction successfully. Transaction is ready to broadcast.</source>
+        <translation type="unfinished">Потписана трансакција је успешно. Трансакција је спремна за емитовање.</translation>
+    </message>
+    <message>
+        <source>Unknown error processing transaction.</source>
+        <translation type="unfinished">Непозната грешка у обради трансакције.</translation>
+    </message>
+    <message>
+        <source>Transaction broadcast successfully! Transaction ID: %1</source>
+        <translation type="unfinished">Трансакција је успешно емитована! Идентификација трансакције (ID): %1</translation>
+    </message>
+    <message>
+        <source>Transaction broadcast failed: %1</source>
+        <translation type="unfinished">Неуспело емитовање трансакције: %1</translation>
+    </message>
+    <message>
+        <source>PSBT copied to clipboard.</source>
+        <translation type="unfinished">ПСБТ је копиран у међуспремник.</translation>
+    </message>
+    <message>
         <source>Save Transaction Data</source>
         <translation type="unfinished">Сачувај Податке Трансакције</translation>
+    </message>
+    <message>
+        <source>Partially Signed Transaction (Binary)</source>
+        <extracomment>Expanded name of the binary PSBT file format. See: BIP 174.</extracomment>
+        <translation type="unfinished">Делимично потписана трансакција (бинарна)</translation>
+    </message>
+    <message>
+        <source>PSBT saved to disk.</source>
+        <translation type="unfinished">ПСБТ је сачуван на диску.</translation>
+    </message>
+    <message>
+        <source> * Sends %1 to %2</source>
+        <translation type="unfinished">*Шаље %1 до %2</translation>
+    </message>
+    <message>
+        <source>Unable to calculate transaction fee or total transaction amount.</source>
+        <translation type="unfinished">Није могуће израчунати накнаду за трансакцију или укупан износ трансакције.</translation>
+    </message>
+    <message>
+        <source>Pays transaction fee: </source>
+        <translation type="unfinished">Плаћа накнаду за трансакцију:</translation>
     </message>
     <message>
         <source>Total Amount</source>
@@ -1898,6 +2263,30 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>or</source>
         <translation type="unfinished">или</translation>
+    </message>
+    <message>
+        <source>Transaction has %1 unsigned inputs.</source>
+        <translation type="unfinished">Трансакција има %1 непотписана поља.</translation>
+    </message>
+    <message>
+        <source>Transaction is missing some information about inputs.</source>
+        <translation type="unfinished">Трансакцији недостају неке информације о улазима.</translation>
+    </message>
+    <message>
+        <source>Transaction still needs signature(s).</source>
+        <translation type="unfinished">Трансакција и даље треба потпис(е).</translation>
+    </message>
+    <message>
+        <source>(But this wallet cannot sign transactions.)</source>
+        <translation type="unfinished">(Али овај новчаник не може да потписује трансакције.)</translation>
+    </message>
+    <message>
+        <source>(But this wallet does not have the right keys.)</source>
+        <translation type="unfinished">(Али овај новчаник нема праве кључеве.)</translation>
+    </message>
+    <message>
+        <source>Transaction is fully signed and ready for broadcast.</source>
+        <translation type="unfinished">Трансакција је у потпуности потписана и спремна за емитовање.</translation>
     </message>
     <message>
         <source>Transaction status is unknown.</source>
@@ -1923,6 +2312,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">'bitcoin://' није важећи URI. Уместо тога користити  'bitcoin:'.</translation>
     </message>
     <message>
+        <source>Cannot process payment request because BIP70 is not supported.
+Due to widespread security flaws in BIP70 it's strongly recommended that any merchant instructions to switch wallets be ignored.
+If you are receiving this error you should request the merchant provide a BIP21 compatible URI.</source>
+        <translation type="unfinished">Није могуће обрадити захтев за плаћање јер БИП70 није подржан.
+Због широко распрострањених безбедносних пропуста у БИП70, топло се препоручује да се игноришу сва упутства трговца за промену новчаника.
+Ако добијете ову грешку, требало би да затражите од трговца да достави УРИ компатибилан са БИП21.</translation>
+    </message>
+    <message>
         <source>URI cannot be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation type="unfinished">URI се не може рашчланити! Ово може бити проузроковано неважећом Биткоин адресом или погрешно форматираним URI параметрима.</translation>
     </message>
@@ -1942,6 +2339,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Ping</source>
         <extracomment>Title of Peers Table column which indicates the current latency of the connection with the peer.</extracomment>
         <translation type="unfinished">Пинг</translation>
+    </message>
+    <message>
+        <source>Peer</source>
+        <extracomment>Title of Peers Table column which contains a unique number used to identify a connection.</extracomment>
+        <translation type="unfinished">Пеер</translation>
     </message>
     <message>
         <source>Direction</source>
@@ -1987,6 +2389,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>QRImageWidget</name>
     <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">&amp;Сачували слику…</translation>
+    </message>
+    <message>
         <source>&amp;Copy Image</source>
         <translation type="unfinished">&amp;Копирај Слику</translation>
     </message>
@@ -2006,7 +2412,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Save QR Code</source>
         <translation type="unfinished">Упамти QR Код</translation>
     </message>
-    </context>
+    <message>
+        <source>PNG Image</source>
+        <extracomment>Expanded name of the PNG file format. See: https://en.wikipedia.org/wiki/Portable_Network_Graphics.</extracomment>
+        <translation type="unfinished">ПНГ слика</translation>
+    </message>
+</context>
 <context>
     <name>RPCConsole</name>
     <message>
@@ -2130,6 +2541,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Ноде прозор</translation>
     </message>
     <message>
+        <source>Current block height</source>
+        <translation type="unfinished">Тренутна висина блока</translation>
+    </message>
+    <message>
         <source>Open the %1 debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation type="unfinished">Отворите %1 датотеку са записима о отклоњеним грешкама из тренутног директоријума датотека. Ово може потрајати неколико секунди за велике датотеке записа.</translation>
     </message>
@@ -2142,12 +2557,57 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Увећај величину фонта</translation>
     </message>
     <message>
+        <source>Permissions</source>
+        <translation type="unfinished">Дозволе</translation>
+    </message>
+    <message>
+        <source>The direction and type of peer connection: %1</source>
+        <translation type="unfinished">Смер и тип конекције клијената: %1</translation>
+    </message>
+    <message>
+        <source>Direction/Type</source>
+        <translation type="unfinished">Смер/Тип</translation>
+    </message>
+    <message>
+        <source>The network protocol this peer is connected through: IPv4, IPv6, Onion, I2P, or CJDNS.</source>
+        <translation type="unfinished">Мрежни протокол који је овај пеер повезан преко: ИПв4, ИПв6, Онион, И2П или ЦЈДНС.</translation>
+    </message>
+    <message>
         <source>Services</source>
         <translation type="unfinished">Услуге</translation>
     </message>
     <message>
+        <source>Whether the peer requested us to relay transactions.</source>
+        <translation type="unfinished">Да ли је колега тражио од нас да пренесемо трансакције</translation>
+    </message>
+    <message>
+        <source>Wants Tx Relay</source>
+        <translation type="unfinished">Жели Тк Релаciju</translation>
+    </message>
+    <message>
+        <source>High bandwidth BIP152 compact block relay: %1</source>
+        <translation type="unfinished">Висок проток ”BIP152” преноса компактних блокова: %1</translation>
+    </message>
+    <message>
+        <source>High Bandwidth</source>
+        <translation type="unfinished">Висок проток</translation>
+    </message>
+    <message>
         <source>Connection Time</source>
         <translation type="unfinished">Време конекције</translation>
+    </message>
+    <message>
+        <source>Elapsed time since a novel block passing initial validity checks was received from this peer.</source>
+        <translation type="unfinished">Прошло је време од када је нови блок који је прошао почетне провере валидности примљен од овог равноправног корисника.</translation>
+    </message>
+    <message>
+        <source>Last Block</source>
+        <translation type="unfinished">Последњи блок</translation>
+    </message>
+    <message>
+        <source>Elapsed time since a novel transaction accepted into our mempool was received from this peer.</source>
+        <extracomment>Tooltip text for the Last Transaction field in the peer details area.</extracomment>
+        <translation type="unfinished">Прошло је време од када је нова трансакција прихваћена у наш мемпул примљена од овог партнера</translation>
     </message>
     <message>
         <source>Last Send</source>
@@ -2214,6 +2674,53 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Одлазно:</translation>
     </message>
     <message>
+        <source>Inbound: initiated by peer</source>
+        <extracomment>Explanatory text for an inbound peer connection.</extracomment>
+        <translation type="unfinished">Долазни: покренут од стране вршњака</translation>
+    </message>
+    <message>
+        <source>Outbound Full Relay: default</source>
+        <extracomment>Explanatory text for an outbound peer connection that relays all network information. This is the default behavior for outbound connections.</extracomment>
+        <translation type="unfinished">Одлазни пуни релеј: подразумевано</translation>
+    </message>
+    <message>
+        <source>Outbound Block Relay: does not relay transactions or addresses</source>
+        <extracomment>Explanatory text for an outbound peer connection that relays network information about blocks and not transactions or addresses.</extracomment>
+        <translation type="unfinished">Оутбоунд Блоцк Релаи: не преноси трансакције или адресе</translation>
+    </message>
+    <message>
+        <source>Outbound Manual: added using RPC %1 or %2/%3 configuration options</source>
+        <extracomment>Explanatory text for an outbound peer connection that was established manually through one of several methods. The numbered arguments are stand-ins for the methods available to establish manual connections.</extracomment>
+        <translation type="unfinished">Изворно упутство: додато је коришћење ”RPC” %1 или %2 / %3 конфигурационих опција</translation>
+    </message>
+    <message>
+        <source>Outbound Feeler: short-lived, for testing addresses</source>
+        <extracomment>Explanatory text for a short-lived outbound peer connection that is used to test the aliveness of known addresses.</extracomment>
+        <translation type="unfinished">Оутбоунд Феелер: краткотрајан, за тестирање адреса</translation>
+    </message>
+    <message>
+        <source>Outbound Address Fetch: short-lived, for soliciting addresses</source>
+        <extracomment>Explanatory text for a short-lived outbound peer connection that is used to request addresses from a peer.</extracomment>
+        <translation type="unfinished">Дохваћање излазне адресе: краткотрајно, за тражење адреса</translation>
+    </message>
+    <message>
+        <source>we selected the peer for high bandwidth relay</source>
+        <translation type="unfinished">одабрали смо клијента за висок пренос података</translation>
+    </message>
+    <message>
+        <source>the peer selected us for high bandwidth relay</source>
+        <translation type="unfinished">клијент нас је одабрао за висок пренос података</translation>
+    </message>
+    <message>
+        <source>no high bandwidth relay selected</source>
+        <translation type="unfinished">није одабран проток за висок пренос података</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <extracomment>Context menu action to copy the address of a peer.</extracomment>
+        <translation type="unfinished">&amp;Копирај адресу</translation>
+    </message>
+    <message>
         <source>&amp;Disconnect</source>
         <translation type="unfinished">&amp;Прекини везу</translation>
     </message>
@@ -2222,12 +2729,21 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">1 &amp;Сат</translation>
     </message>
     <message>
+        <source>1 d&amp;ay</source>
+        <translation type="unfinished">1 дан</translation>
+    </message>
+    <message>
         <source>1 &amp;week</source>
         <translation type="unfinished">1 &amp;недеља</translation>
     </message>
     <message>
         <source>1 &amp;year</source>
         <translation type="unfinished">1 &amp;година</translation>
+    </message>
+    <message>
+        <source>&amp;Copy IP/Netmask</source>
+        <extracomment>Context menu action to copy the IP/Netmask of a banned peer. IP/Netmask is the combination of a peer's IP address and its Netmask. For IP address, see: https://en.wikipedia.org/wiki/IP_address.</extracomment>
+        <translation type="unfinished">&amp;Kopiraj IP/Netmask</translation>
     </message>
     <message>
         <source>&amp;Unban</source>
@@ -2244,6 +2760,31 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Executing command using "%1" wallet</source>
         <translation type="unfinished">Извршење команде коришћењем  "%1" новчаника</translation>
+    </message>
+    <message>
+        <source>Welcome to the %1 RPC console.
+Use up and down arrows to navigate history, and %2 to clear screen.
+Use %3 and %4 to increase or decrease the font size.
+Type %5 for an overview of available commands.
+For more information on using this console, type %6.
+
+%7WARNING: Scammers have been active, telling users to type commands here, stealing their wallet contents. Do not use this console without fully understanding the ramifications of a command.%8</source>
+        <extracomment>RPC console welcome message. Placeholders %7 and %8 are style tags for the warning content, and they are not space separated from the rest of the text intentionally.</extracomment>
+        <translation type="unfinished">Добродошли у %1 "RPC” конзолу.
+Користи тастере за горе и доле да наводиш историју, и %2 да очистиш екран.
+Користи %3 и %4 да увећаш и смањиш величину фонта.
+Унеси %5 за преглед доступних комади.
+За више информација о коришћењу конзоле, притисни %6
+%7 УПОЗОРЕЊЕ: Преваранти су се активирали, говорећи корисницима да уносе команде овде, и тако краду садржај новчаника. Не користи ову конзолу без потпуног схватања комплексности ове команде. %8</translation>
+    </message>
+    <message>
+        <source>Executing…</source>
+        <extracomment>A console message indicating an entered command is currently being executed.</extracomment>
+        <translation type="unfinished">Обрада...</translation>
+    </message>
+    <message>
+        <source>(peer: %1)</source>
+        <translation type="unfinished">(клијент: %1)</translation>
     </message>
     <message>
         <source>via %1</source>
@@ -2268,6 +2809,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Ban for</source>
         <translation type="unfinished">Забрани за</translation>
+    </message>
+    <message>
+        <source>Never</source>
+        <translation type="unfinished">Никада</translation>
     </message>
     <message>
         <source>Unknown</source>
@@ -2349,12 +2894,36 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Копирај &amp;URI</translation>
     </message>
     <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Копирај адресу</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Копирај &amp;означи</translation>
+    </message>
+    <message>
+        <source>Copy &amp;message</source>
+        <translation type="unfinished">Копирај &amp;поруку</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Копирај &amp;износ</translation>
+    </message>
+    <message>
         <source>Could not unlock wallet.</source>
         <translation type="unfinished">Новчаник није могуће откључати.</translation>
     </message>
-    </context>
+    <message>
+        <source>Could not generate new %1 address</source>
+        <translation type="unfinished">Немогуће је генерисати нову %1 адресу</translation>
+    </message>
+</context>
 <context>
     <name>ReceiveRequestDialog</name>
+    <message>
+        <source>Request payment to …</source>
+        <translation type="unfinished">Захтевај уплату ка ...</translation>
+    </message>
     <message>
         <source>Address:</source>
         <translation type="unfinished">Адреса:</translation>
@@ -2382,6 +2951,18 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Copy &amp;Address</source>
         <translation type="unfinished">Копирај &amp;Адресу</translation>
+    </message>
+    <message>
+        <source>&amp;Verify</source>
+        <translation type="unfinished">&amp;Верификуј</translation>
+    </message>
+    <message>
+        <source>Verify this address on e.g. a hardware wallet screen</source>
+        <translation type="unfinished">Верификуј ову адресу на пример на екрану хардвер новчаника</translation>
+    </message>
+    <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">&amp;Сачували слику…</translation>
     </message>
     <message>
         <source>Payment information</source>
@@ -2514,12 +3095,28 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Очисти сва поља форме.</translation>
     </message>
     <message>
+        <source>Inputs…</source>
+        <translation type="unfinished">Поља...</translation>
+    </message>
+    <message>
         <source>Dust:</source>
         <translation type="unfinished">Прашина:</translation>
     </message>
     <message>
+        <source>Choose…</source>
+        <translation type="unfinished">Одабери...</translation>
+    </message>
+    <message>
         <source>Hide transaction fee settings</source>
         <translation type="unfinished">Сакријте износ накнаде за трансакцију</translation>
+    </message>
+    <message>
+        <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
+
+Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satoshis per kvB" for a transaction size of 500 virtual bytes (half of 1 kvB) would ultimately yield a fee of only 50 satoshis.</source>
+        <translation type="unfinished">Одредити прилагођену провизију по kB (1,000 битова) виртуелне величине трансакције. 
+
+Напомена: С обзиром да се провизија рачуна на основу броја бајтова, провизија за "100 сатошија по kB" за величину трансакције од 500 бајтова (пола од 1 kB) ће аутоматски износити само 50 сатошија.</translation>
     </message>
     <message>
         <source>When there is less transaction volume than space in the blocks, miners as well as relaying nodes may enforce a minimum fee. Paying only this minimum fee is just fine, but be aware that this can result in a never confirming transaction once there is more demand for bitcoin transactions than the network can process.</source>
@@ -2528,6 +3125,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>A too low fee might result in a never confirming transaction (read the tooltip)</source>
         <translation type="unfinished">Сувише ниска провизија може резултовати да трансакција никада не  буде потврђена (прочитајте опис)</translation>
+    </message>
+    <message>
+        <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
+        <translation type="unfinished">(Паметна провизија још није покренута. Ово уобичајено траје неколико блокова...)</translation>
     </message>
     <message>
         <source>Confirmation time target:</source>
@@ -2590,6 +3191,20 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">%1 (%2 блокова)</translation>
     </message>
     <message>
+        <source>Sign on device</source>
+        <extracomment>"device" usually means a hardware wallet.</extracomment>
+        <translation type="unfinished">Потпиши на уређају</translation>
+    </message>
+    <message>
+        <source>Connect your hardware wallet first.</source>
+        <translation type="unfinished">Повежи прво свој хардвер новчаник.</translation>
+    </message>
+    <message>
+        <source>Set external signer script path in Options -&gt; Wallet</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Подси екстерну скрипту за потписивање у : Options -&gt; Wallet</translation>
+    </message>
+    <message>
         <source>Cr&amp;eate Unsigned</source>
         <translation type="unfinished">Креирај непотписано</translation>
     </message>
@@ -2610,12 +3225,39 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">%1 до %2</translation>
     </message>
     <message>
+        <source>To review recipient list click "Show Details…"</source>
+        <translation type="unfinished">Да би сте прегледали листу примаоца кликните на "Прикажи детаље..."</translation>
+    </message>
+    <message>
+        <source>Sign failed</source>
+        <translation type="unfinished">Потписивање је неуспело</translation>
+    </message>
+    <message>
+        <source>External signer not found</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Екстерни потписник није пронађен</translation>
+    </message>
+    <message>
+        <source>External signer failure</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Грешка при екстерном потписивању</translation>
+    </message>
+    <message>
         <source>Save Transaction Data</source>
         <translation type="unfinished">Сачувај Податке Трансакције</translation>
     </message>
     <message>
+        <source>Partially Signed Transaction (Binary)</source>
+        <extracomment>Expanded name of the binary PSBT file format. See: BIP 174.</extracomment>
+        <translation type="unfinished">Делимично потписана трансакција (бинарна)</translation>
+    </message>
+    <message>
         <source>PSBT saved</source>
         <translation type="unfinished">PSBT сачуван</translation>
+    </message>
+    <message>
+        <source>External balance:</source>
+        <translation type="unfinished">Екстерни баланс (стање):</translation>
     </message>
     <message>
         <source>or</source>
@@ -2624,6 +3266,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>You can increase the fee later (signals Replace-By-Fee, BIP-125).</source>
         <translation type="unfinished">Можете повећати провизију касније (сигнали Замени-са-Провизијом, BIP-125).</translation>
+    </message>
+    <message>
+        <source>Please, review your transaction proposal. This will produce a Partially Signed Bitcoin Transaction (PSBT) which you can save or copy and then sign with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
+        <extracomment>Text to inform a user attempting to create a transaction of their current options. At this stage, a user can only create a PSBT. This string is displayed when private keys are disabled and an external signer is not available.</extracomment>
+        <translation type="unfinished">Молимо, проверите ваш предлог трансакције. Ово ће произвести делимично потписану Биткоин трансакцију (PSBT) коју можете копирати и онда потписати са нпр. офлајн %1 новчаником, или PSBT компатибилним хардверским новчаником.</translation>
+    </message>
+    <message>
+        <source>Do you want to create this transaction?</source>
+        <extracomment>Message displayed when attempting to create a transaction. Cautionary text to prompt the user to verify that the displayed transaction details represent the transaction the user intends to create.</extracomment>
+        <translation type="unfinished">Da li želite da napravite ovu transakciju?</translation>
     </message>
     <message>
         <source>Please, review your transaction.</source>
@@ -2677,10 +3329,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>A fee higher than %1 is considered an absurdly high fee.</source>
         <translation type="unfinished">Провизија већа од %1 се сматра апсурдно високом провизијом.</translation>
-    </message>
-    <message>
-        <source>Payment request expired.</source>
-        <translation type="unfinished">Захтев за плаћање је истекао.</translation>
     </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
@@ -2762,28 +3410,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Порука:</translation>
     </message>
     <message>
-        <source>This is an unauthenticated payment request.</source>
-        <translation type="unfinished">Ово је неовлашћени захтев за плаћање.</translation>
-    </message>
-    <message>
-        <source>This is an authenticated payment request.</source>
-        <translation type="unfinished">Ово је овлашћени захтев за плаћање.</translation>
-    </message>
-    <message>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished">Унесите ознаку за ову адресу да бисте је додали на листу коришћених адреса</translation>
     </message>
     <message>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished">Порука која је приложена биткоину: URI која ће бити сачувана уз трансакцију ради референце. Напомена: Ова порука се шаље преко Биткоин мреже.</translation>
-    </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">Плати ка:</translation>
-    </message>
-    <message>
-        <source>Memo:</source>
-        <translation type="unfinished">Мемо:</translation>
     </message>
 </context>
 <context>
@@ -2792,7 +3424,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Send</source>
         <translation type="unfinished">Пошаљи</translation>
     </message>
-    </context>
+    <message>
+        <source>Create Unsigned</source>
+        <translation type="unfinished">Креирај непотписано</translation>
+    </message>
+</context>
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
@@ -2933,29 +3569,34 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
 </context>
 <context>
+    <name>SplashScreen</name>
+    <message>
+        <source>press q to shutdown</source>
+        <translation type="unfinished">pritisni q za gašenje</translation>
+    </message>
+</context>
+<context>
+    <name>TrafficGraphWidget</name>
+    <message>
+        <source>kB/s</source>
+        <translation type="unfinished">KB/s</translation>
+    </message>
+</context>
+<context>
     <name>TransactionDesc</name>
     <message>
-        <source>0/unconfirmed, %1</source>
-        <translation type="unfinished">0/непотврђено, %1</translation>
-    </message>
-    <message>
-        <source>in memory pool</source>
-        <translation type="unfinished">у удруженој меморији</translation>
-    </message>
-    <message>
-        <source>not in memory pool</source>
-        <translation type="unfinished">није у удруженој меморији</translation>
-    </message>
-    <message>
         <source>abandoned</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an abandoned transaction.</extracomment>
         <translation type="unfinished">напуштено</translation>
     </message>
     <message>
         <source>%1/unconfirmed</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
         <translation type="unfinished">%1/непотврђено</translation>
     </message>
     <message>
         <source>%1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
         <translation type="unfinished">%1 порврде</translation>
     </message>
     <message>
@@ -3256,8 +3897,53 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Минимални износ</translation>
     </message>
     <message>
+        <source>Range…</source>
+        <translation type="unfinished">Опсег:</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Копирај адресу</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">Копирај &amp;означи</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Копирај &amp;износ</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">Копирај трансакцију &amp;ID</translation>
+    </message>
+    <message>
+        <source>Copy &amp;raw transaction</source>
+        <translation type="unfinished">Копирајте &amp;необрађену трансакцију</translation>
+    </message>
+    <message>
+        <source>Copy full transaction &amp;details</source>
+        <translation type="unfinished">Копирајте све детаље трансакције</translation>
+    </message>
+    <message>
+        <source>&amp;Show transaction details</source>
+        <translation type="unfinished">&amp;Прикажи детаље транакције</translation>
+    </message>
+    <message>
+        <source>Increase transaction &amp;fee</source>
+        <translation type="unfinished">Повећај провизију трансакције</translation>
+    </message>
+    <message>
+        <source>&amp;Edit address label</source>
+        <translation type="unfinished">&amp;Promeni adresu etikete</translation>
+    </message>
+    <message>
         <source>Export Transaction History</source>
         <translation type="unfinished">Извези Детаље Трансакције</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">CSV фајл</translation>
     </message>
     <message>
         <source>Confirmed</source>

--- a/src/qt/locale/bitcoin_sr@latin.ts
+++ b/src/qt/locale/bitcoin_sr@latin.ts
@@ -533,6 +533,30 @@
 <context>
     <name>Intro</name>
     <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
@@ -646,10 +670,12 @@
     <name>TransactionDesc</name>
     <message>
         <source>%1/unconfirmed</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
         <translation type="unfinished">%1/nepotvrdjeno</translation>
     </message>
     <message>
         <source>%1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
         <translation type="unfinished">%1 potvrdjeno/ih</translation>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_sv.ts
+++ b/src/qt/locale/bitcoin_sv.ts
@@ -70,6 +70,11 @@
         <translation type="unfinished">Detta är dina Bitcoin-adresser för att skicka betalningar. Kontrollera alltid belopp och mottagaradress innan du skickar bitcoin.</translation>
     </message>
     <message>
+        <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
+Signing is only possible with addresses of the type 'legacy'.</source>
+        <translation type="unfinished">Detta är dina Bitcoinadresser för att ta emot betalningar. Använd knappen 'Skapa ny mottagaradress' i mottagsfliken för att skapa nya adresser. Signering är bara tillgänglig för adresser av typen 'legacy'</translation>
+    </message>
+    <message>
         <source>&amp;Copy Address</source>
         <translation type="unfinished">&amp;Kopiera adress</translation>
     </message>
@@ -244,9 +249,18 @@ Försök igen.</translation>
         <source>Internal error</source>
         <translation type="unfinished">Internt fel</translation>
     </message>
-    </context>
+    <message>
+        <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
+        <translation type="unfinished">Ett internt fel har uppstått. %1 kommer försöka att fortsätta. Detta är en oväntad bugg som kan rapporteras enligt nedan beskrivning.</translation>
+    </message>
+</context>
 <context>
     <name>QObject</name>
+    <message>
+        <source>A fatal error occurred. Check that settings file is writable, or try running with -nosettings.</source>
+        <extracomment>Explanatory text shown on startup when the settings file could not be written. Prompts user to check that we have the ability to write to the file. Explains that the user has the option of running without a settings file.</extracomment>
+        <translation type="unfinished">Ett allvarligt fel skedde. Se att filen för inställningar är möjlig att skriva, eller försök köra med "-nosettings"</translation>
+    </message>
     <message>
         <source>Error: Specified data directory "%1" does not exist.</source>
         <translation type="unfinished">Fel: Angiven datakatalog "%1" finns inte.</translation>
@@ -258,6 +272,10 @@ Försök igen.</translation>
     <message>
         <source>Error: %1</source>
         <translation type="unfinished">Fel: %1</translation>
+    </message>
+    <message>
+        <source>%1 didn't yet exit safely…</source>
+        <translation type="unfinished">%1 har inte avslutats korrekt än...</translation>
     </message>
     <message>
         <source>unknown</source>
@@ -348,6 +366,14 @@ Försök igen.</translation>
 <context>
     <name>bitcoin-core</name>
     <message>
+        <source>Settings file could not be read</source>
+        <translation type="unfinished">Filen för inställningar kunde inte läsas</translation>
+    </message>
+    <message>
+        <source>Settings file could not be written</source>
+        <translation type="unfinished">Filen för inställningar kunde inte skapas</translation>
+    </message>
+    <message>
         <source>The %s developers</source>
         <translation type="unfinished">%s-utvecklarna</translation>
     </message>
@@ -370,10 +396,6 @@ Försök igen.</translation>
     <message>
         <source>Error reading %s! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation type="unfinished">Fel vid läsning av %s! Alla nycklar lästes korrekt, men transaktionsdata eller poster i adressboken kanske saknas eller är felaktiga.</translation>
-    </message>
-    <message>
-        <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
-        <translation type="unfinished">Fel: Avlyssning av inkommande anslutningar misslyckades (Avlyssningen returnerade felkod %s)</translation>
     </message>
     <message>
         <source>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.</source>
@@ -540,10 +562,6 @@ Försök igen.</translation>
         <translation type="unfinished">Fel vid läsning från databas, avslutar.</translation>
     </message>
     <message>
-        <source>Error upgrading chainstate database</source>
-        <translation type="unfinished">Fel vid uppgradering av blockdatabasen</translation>
-    </message>
-    <message>
         <source>Error: Disk space is low for %s</source>
         <translation type="unfinished">Fel: Diskutrymme är lågt för %s</translation>
     </message>
@@ -624,16 +642,28 @@ Försök igen.</translation>
         <translation type="unfinished">Laddar P2P-adresser…</translation>
     </message>
     <message>
+        <source>Loading banlist…</source>
+        <translation type="unfinished">Läser in listan över bannlysningar …</translation>
+    </message>
+    <message>
+        <source>Loading block index…</source>
+        <translation type="unfinished">Läser in blockindex...</translation>
+    </message>
+    <message>
         <source>Loading wallet…</source>
         <translation type="unfinished">Laddar plånboken…</translation>
+    </message>
+    <message>
+        <source>Missing amount</source>
+        <translation type="unfinished">Saknat belopp</translation>
     </message>
     <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
         <translation type="unfinished">Port måste anges med -whitelist: '%s'</translation>
     </message>
     <message>
-        <source>No proxy server specified. Use -proxy=&lt;ip&gt; or -proxy=&lt;ip:port&gt;.</source>
-        <translation type="unfinished">Ingen proxy-server vald. Använd -proxy=&lt;ip&gt; eller -proxy=&lt;ip:port&gt;.</translation>
+        <source>No addresses available</source>
+        <translation type="unfinished">Inga adresser tillgängliga</translation>
     </message>
     <message>
         <source>Not enough file descriptors available.</source>
@@ -646,6 +676,10 @@ Försök igen.</translation>
     <message>
         <source>Prune mode is incompatible with -txindex.</source>
         <translation type="unfinished">Gallringsläge är inkompatibelt med -txindex.</translation>
+    </message>
+    <message>
+        <source>Pruning blockstore…</source>
+        <translation type="unfinished">Rensar blockstore...</translation>
     </message>
     <message>
         <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
@@ -764,6 +798,10 @@ Försök igen.</translation>
         <translation type="unfinished">Det gick inte att skapa nycklar</translation>
     </message>
     <message>
+        <source>Unable to open %s for writing</source>
+        <translation type="unfinished">Det går inte att öppna %s för skrivning</translation>
+    </message>
+    <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
         <translation type="unfinished">Kunde inte starta HTTP-server. Se felsökningsloggen för detaljer.</translation>
     </message>
@@ -786,10 +824,6 @@ Försök igen.</translation>
     <message>
         <source>Unsupported logging category %s=%s.</source>
         <translation type="unfinished">Saknar stöd för loggningskategori %s=%s.</translation>
-    </message>
-    <message>
-        <source>Upgrading UTXO database</source>
-        <translation type="unfinished">Uppgraderar UTXO-databasen</translation>
     </message>
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
@@ -859,6 +893,10 @@ Försök igen.</translation>
         <translation type="unfinished">Skapa ny plånbok</translation>
     </message>
     <message>
+        <source>&amp;Minimize</source>
+        <translation type="unfinished">&amp;Minimera</translation>
+    </message>
+    <message>
         <source>Wallet:</source>
         <translation type="unfinished">Plånbok:</translation>
     </message>
@@ -902,6 +940,10 @@ Försök igen.</translation>
     <message>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation type="unfinished">Kryptera de privata nycklar som tillhör din plånbok</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation type="unfinished">&amp;Säkerhetskopiera plånbok...</translation>
     </message>
     <message>
         <source>&amp;Change Passphrase…</source>
@@ -960,8 +1002,28 @@ Försök igen.</translation>
         <translation type="unfinished">Verktygsfält för flikar</translation>
     </message>
     <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation type="unfinished">Synkar huvuden (%1%)...</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation type="unfinished">Synkroniserar med nätverket...</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation type="unfinished">Indexerar block på disken...</translation>
+    </message>
+    <message>
         <source>Processing blocks on disk…</source>
         <translation type="unfinished">Behandlar block på disken…</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation type="unfinished">Indexerar om block på disken...</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation type="unfinished">Ansluter till noder...</translation>
     </message>
     <message>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
@@ -982,8 +1044,8 @@ Försök igen.</translation>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>Bearbetade %n block av transaktionshistoriken.</numerusform>
+            <numerusform>Bearbetade %n block av transaktionshistoriken.</numerusform>
         </translation>
     </message>
     <message>
@@ -1017,6 +1079,10 @@ Försök igen.</translation>
     <message>
         <source>Load Partially Signed Bitcoin Transaction</source>
         <translation type="unfinished">Läs in Delvis signerad Bitcoin transaktion (PSBT)</translation>
+    </message>
+    <message>
+        <source>Load PSBT from &amp;clipboard…</source>
+        <translation type="unfinished">Ladda PSBT från &amp;urklipp...</translation>
     </message>
     <message>
         <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
@@ -1055,6 +1121,16 @@ Försök igen.</translation>
         <translation type="unfinished">Stäng plånboken</translation>
     </message>
     <message>
+        <source>Restore Wallet…</source>
+        <extracomment>Name of the menu item that restores wallet from a backup file.</extracomment>
+        <translation type="unfinished">Återställ Plånboken...</translation>
+    </message>
+    <message>
+        <source>Restore a wallet from a backup file</source>
+        <extracomment>Status tip for Restore Wallet menu item</extracomment>
+        <translation type="unfinished">Återställt en plånbok från en backup-fil</translation>
+    </message>
+    <message>
         <source>Close all wallets</source>
         <translation type="unfinished">Stäng alla plånböcker</translation>
     </message>
@@ -1079,6 +1155,21 @@ Försök igen.</translation>
         <translation type="unfinished">Inga plånböcker tillgängliga</translation>
     </message>
     <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">Plånboksdata</translation>
+    </message>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of pop-up window shown when the user is attempting to restore a wallet.</extracomment>
+        <translation type="unfinished">Återställ Plånbok</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">Namn på plånboken</translation>
+    </message>
+    <message>
         <source>&amp;Window</source>
         <translation type="unfinished">&amp;Fönster</translation>
     </message>
@@ -1094,18 +1185,32 @@ Försök igen.</translation>
         <source>%1 client</source>
         <translation type="unfinished">%1-klient</translation>
     </message>
+    <message>
+        <source>&amp;Hide</source>
+        <translation type="unfinished">och göm</translation>
+    </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n aktiva anslutningar till Bitcoin-nätverket.</numerusform>
+            <numerusform>%n aktiva anslutningar till Bitcoin-nätverket.</numerusform>
         </translation>
+    </message>
+    <message>
+        <source>Click for more actions.</source>
+        <extracomment>A substring of the tooltip. "More actions" are available via the context menu.</extracomment>
+        <translation type="unfinished">Klicka för fler alternativ</translation>
     </message>
     <message>
         <source>Disable network activity</source>
         <extracomment>A context menu item.</extracomment>
         <translation type="unfinished">Stäng av nätverksaktivitet</translation>
+    </message>
+    <message>
+        <source>Enable network activity</source>
+        <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
+        <translation type="unfinished">Aktivera nätverksaktivitet</translation>
     </message>
     <message>
         <source>Error: %1</source>
@@ -1358,6 +1463,19 @@ Försök igen.</translation>
         <source>Can't list signers</source>
         <translation type="unfinished">Kan inte lista signerare</translation>
     </message>
+    </context>
+<context>
+    <name>LoadWalletsActivity</name>
+    <message>
+        <source>Load Wallets</source>
+        <extracomment>Title of progress window which is displayed when wallets are being loaded.</extracomment>
+        <translation type="unfinished">Ladda plånböcker</translation>
+    </message>
+    <message>
+        <source>Loading wallets…</source>
+        <extracomment>Descriptive text of the load wallets progress window which indicates to the user that wallets are currently being loaded.</extracomment>
+        <translation type="unfinished">Laddar plånböcker…</translation>
+    </message>
 </context>
 <context>
     <name>OpenWalletActivity</name>
@@ -1377,6 +1495,29 @@ Försök igen.</translation>
         <source>Open Wallet</source>
         <extracomment>Title of window indicating the progress of opening of a wallet.</extracomment>
         <translation type="unfinished">Öppna plånbok</translation>
+    </message>
+    <message>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the open wallet progress window which indicates to the user which wallet is currently being opened.</extracomment>
+        <translation type="unfinished">Öppnar Plånboken &lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+</context>
+<context>
+    <name>RestoreWalletActivity</name>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of progress window which is displayed when wallets are being restored.</extracomment>
+        <translation type="unfinished">Återställ Plånbok</translation>
+    </message>
+    <message>
+        <source>Restoring Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the restore wallets progress window which indicates to the user that wallets are currently being restored.</extracomment>
+        <translation type="unfinished">Återskapar Plånboken &lt;b&gt;%1&lt;/b&gt;…</translation>
+    </message>
+    <message>
+        <source>Restore wallet failed</source>
+        <extracomment>Title of message box which is displayed when the wallet could not be restored.</extracomment>
+        <translation type="unfinished">Det gick inte att återställa plånboken</translation>
     </message>
     </context>
 <context>
@@ -1529,9 +1670,26 @@ Försök igen.</translation>
 </context>
 <context>
     <name>Intro</name>
-    <message>
-        <source>(of %1 GB needed)</source>
-        <translation type="unfinished">(av %1 GB krävs)</translation>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform>(av %n GB behövs)</numerusform>
+            <numerusform>(av de %n GB som behövs)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform>(%n GB behövs för hela kedjan)</numerusform>
+            <numerusform>(%n GB behövs för hela kedjan)</numerusform>
+        </translation>
     </message>
     <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
@@ -1578,8 +1736,8 @@ Försök igen.</translation>
         <translation type="unfinished">Eftersom detta är första gången som programmet startas får du välja var %1 skall lagra sina data.</translation>
     </message>
     <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation type="unfinished">När du trycker OK kommer %1 att börja ladda ner och bearbeta den fullständiga %4-blockkedjan (%2 GB), med början vid de första transaktionerna %3 när %4 först lanserades.</translation>
+        <source>Limit block chain storage to</source>
+        <translation type="unfinished">Begränsa lagringsplats för blockkedjan till </translation>
     </message>
     <message>
         <source>Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</source>
@@ -1758,8 +1916,18 @@ Försök igen.</translation>
         <translation type="unfinished">(0 = auto, &lt;0 = lämna så många kärnor lediga)</translation>
     </message>
     <message>
+        <source>Enable R&amp;PC server</source>
+        <extracomment>An Options window setting to enable the RPC server.</extracomment>
+        <translation type="unfinished">Aktivera R&amp;PC-server</translation>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished">&amp;Plånbok</translation>
+    </message>
+    <message>
+        <source>Subtract &amp;fee from amount by default</source>
+        <extracomment>An Options window setting to set subtracting the fee from a sending amount as default.</extracomment>
+        <translation type="unfinished">Ta bort avgift från summa som standard</translation>
     </message>
     <message>
         <source>Enable coin &amp;control features</source>
@@ -1774,12 +1942,21 @@ Försök igen.</translation>
         <translation type="unfinished">&amp;Spendera obekräftad växel</translation>
     </message>
     <message>
+        <source>Enable &amp;PSBT controls</source>
+        <extracomment>An options window setting to enable PSBT controls.</extracomment>
+        <translation type="unfinished">Aktivera &amp;PSBT-kontroll</translation>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation type="unfinished">Öppna automatiskt Bitcoin-klientens port på routern. Detta fungerar endast om din router stödjer UPnP och det är är aktiverat.</translation>
     </message>
     <message>
         <source>Map port using &amp;UPnP</source>
         <translation type="unfinished">Tilldela port med hjälp av &amp;UPnP</translation>
+    </message>
+    <message>
+        <source>Automatically open the Bitcoin client port on the router. This only works when your router supports NAT-PMP and it is enabled. The external port could be random.</source>
+        <translation type="unfinished">Öppna automatiskt Bitcoin-klientens port på routern. Detta fungerar endast om din router stödjer NAT-PMP och det är är aktiverat. Den externa porten kan vara slumpmässig.</translation>
     </message>
     <message>
         <source>Accept connections from outside.</source>
@@ -1816,6 +1993,10 @@ Försök igen.</translation>
     <message>
         <source>Show the icon in the system tray.</source>
         <translation type="unfinished">Visa ikonen i systemfältet.</translation>
+    </message>
+    <message>
+        <source>&amp;Show tray icon</source>
+        <translation type="unfinished">&amp;Visa ikon i systemfältet</translation>
     </message>
     <message>
         <source>Show only a tray icon after minimizing the window.</source>
@@ -1858,10 +2039,6 @@ Försök igen.</translation>
         <translation type="unfinished">Anslut till Bitcoin-nätverket genom en separat SOCKS5-proxy för onion-tjänster genom Tor.</translation>
     </message>
     <message>
-        <source>Options set in this dialog are overridden by the command line or in the configuration file:</source>
-        <translation type="unfinished">Alternativ som anges i denna dialog åsidosätts av kommandoraden eller i konfigurationsfilen:</translation>
-    </message>
-    <message>
         <source>&amp;Cancel</source>
         <translation type="unfinished">&amp;Avbryt</translation>
     </message>
@@ -1875,14 +2052,17 @@ Försök igen.</translation>
     </message>
     <message>
         <source>Confirm options reset</source>
+        <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
         <translation type="unfinished">Bekräfta att alternativen ska återställs</translation>
     </message>
     <message>
         <source>Client restart required to activate changes.</source>
+        <extracomment>Text explaining that the settings changed will not come into effect until the client is restarted.</extracomment>
         <translation type="unfinished">Klientomstart är nödvändig för att aktivera ändringarna.</translation>
     </message>
     <message>
         <source>Client will be shut down. Do you want to proceed?</source>
+        <extracomment>Text asking the user to confirm if they would like to proceed with a client shutdown.</extracomment>
         <translation type="unfinished">Programmet kommer att stängas. Vill du fortsätta?</translation>
     </message>
     <message>
@@ -1894,6 +2074,10 @@ Försök igen.</translation>
         <source>The configuration file is used to specify advanced user options which override GUI settings. Additionally, any command-line options will override this configuration file.</source>
         <extracomment>Explanatory text about the priority order of instructions considered by client. The order from high to low being: command-line, configuration file, GUI settings.</extracomment>
         <translation type="unfinished">Konfigurationsfilen används för att ange avancerade användaralternativ som åsidosätter inställningar i GUI. Dessutom kommer alla kommandoradsalternativ att åsidosätta denna konfigurationsfil.</translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation type="unfinished">Fortsätt</translation>
     </message>
     <message>
         <source>Cancel</source>
@@ -2034,6 +2218,10 @@ Försök igen.</translation>
         <translation type="unfinished">Ett fel uppstod när transaktionen behandlades.</translation>
     </message>
     <message>
+        <source>PSBT copied to clipboard.</source>
+        <translation type="unfinished">PSBT kopierad till urklipp.</translation>
+    </message>
+    <message>
         <source>Save Transaction Data</source>
         <translation type="unfinished">Spara transaktionsdetaljer</translation>
     </message>
@@ -2119,6 +2307,11 @@ Försök igen.</translation>
         <source>User Agent</source>
         <extracomment>Title of Peers Table column which contains the peer's User Agent string.</extracomment>
         <translation type="unfinished">Användaragent</translation>
+    </message>
+    <message>
+        <source>Age</source>
+        <extracomment>Title of Peers Table column which indicates the duration (length of time) since the peer connection started.</extracomment>
+        <translation type="unfinished">Ålder</translation>
     </message>
     <message>
         <source>Direction</source>
@@ -2298,6 +2491,10 @@ Försök igen.</translation>
     <message>
         <source>Synced Blocks</source>
         <translation type="unfinished">Synkade block</translation>
+    </message>
+    <message>
+        <source>Last Transaction</source>
+        <translation type="unfinished">Senaste Transaktion</translation>
     </message>
     <message>
         <source>Mapped AS</source>
@@ -2571,6 +2768,10 @@ Försök igen.</translation>
 </context>
 <context>
     <name>ReceiveRequestDialog</name>
+    <message>
+        <source>Request payment to …</source>
+        <translation type="unfinished">Begär betalning till ...</translation>
+    </message>
     <message>
         <source>Address:</source>
         <translation type="unfinished">Adress</translation>
@@ -2911,10 +3112,6 @@ Försök igen.</translation>
         <source>A fee higher than %1 is considered an absurdly high fee.</source>
         <translation type="unfinished">En avgift högre än %1 anses vara en absurd hög avgift.</translation>
     </message>
-    <message>
-        <source>Payment request expired.</source>
-        <translation type="unfinished">Betalningsbegäran löpte ut.</translation>
-    </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
@@ -2994,28 +3191,12 @@ Försök igen.</translation>
         <translation type="unfinished">Meddelande:</translation>
     </message>
     <message>
-        <source>This is an unauthenticated payment request.</source>
-        <translation type="unfinished">Detta är en oautentiserad betalningsbegäran.</translation>
-    </message>
-    <message>
-        <source>This is an authenticated payment request.</source>
-        <translation type="unfinished">Detta är en autentiserad betalningsbegäran.</translation>
-    </message>
-    <message>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished">Ange en etikett för denna adress för att lägga till den i listan med använda adresser</translation>
     </message>
     <message>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished">Ett meddelande som bifogades bitcoin: -URIn och som sparas med transaktionen som referens. Obs: Meddelandet sänds inte över Bitcoin-nätverket.</translation>
-    </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">Betala till:</translation>
-    </message>
-    <message>
-        <source>Memo:</source>
-        <translation type="unfinished">PM:</translation>
     </message>
 </context>
 <context>
@@ -3183,30 +3364,22 @@ Försök igen.</translation>
     <name>TransactionDesc</name>
     <message>
         <source>conflicted with a transaction with %1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that conflicts with a confirmed transaction.</extracomment>
         <translation type="unfinished">konflikt med en transaktion med %1 bekräftelser</translation>
     </message>
     <message>
-        <source>0/unconfirmed, %1</source>
-        <translation type="unfinished">0/obekräftade, %1</translation>
-    </message>
-    <message>
-        <source>in memory pool</source>
-        <translation type="unfinished">i minnespoolen</translation>
-    </message>
-    <message>
-        <source>not in memory pool</source>
-        <translation type="unfinished">ej i minnespoolen</translation>
-    </message>
-    <message>
         <source>abandoned</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an abandoned transaction.</extracomment>
         <translation type="unfinished">övergiven</translation>
     </message>
     <message>
         <source>%1/unconfirmed</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
         <translation type="unfinished">%1/obekräftade</translation>
     </message>
     <message>
         <source>%1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
         <translation type="unfinished">%1 bekräftelser</translation>
     </message>
     <message>
@@ -3687,6 +3860,11 @@ Gå till Fil &gt; Öppna plånbok för att läsa in en plånbok.
     <message>
         <source>Backup Wallet</source>
         <translation type="unfinished">Säkerhetskopiera Plånbok</translation>
+    </message>
+    <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">Plånboksdata</translation>
     </message>
     <message>
         <source>Backup Failed</source>

--- a/src/qt/locale/bitcoin_sw.ts
+++ b/src/qt/locale/bitcoin_sw.ts
@@ -115,6 +115,27 @@
 <context>
     <name>Intro</name>
     <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">

--- a/src/qt/locale/bitcoin_szl.ts
+++ b/src/qt/locale/bitcoin_szl.ts
@@ -802,6 +802,24 @@
 </context>
 <context>
     <name>Intro</name>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform>(z %n GB przidajnego)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform />
+        </translation>
+    </message>
     <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
         <translation type="unfinished">Co nojmynij %1 GB datōw ôstanie spamiyntane w tym katalogu, daty te bydōm z czasym corŏz srogsze.</translation>
@@ -844,10 +862,6 @@
     <message>
         <source>As this is the first time the program is launched, you can choose where %1 will store its data.</source>
         <translation type="unfinished">Pōniywŏż je to piyrsze sztartniyńcie programu, możesz ôbrać kaj %1 bydzie spamiyntować swoje daty.</translation>
-    </message>
-    <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation type="unfinished">Kej naciśniesz OK, %1 zacznie pobiyrać i przetwŏrzać cołkõ %4 keta blokōw (%2GB) przi zaczynaniu ôd piyrszych transakcyji w %3 kej %4 ôstoł sztartniynty.</translation>
     </message>
     <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
@@ -1498,7 +1512,7 @@
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished">Wiadōmość, kerŏ ôstała prziwstōnŏ do URI bitcoin:, kerŏ bydzie przechowowanŏ z transakcyjōm w cylach informacyjnych. Napōmniynie: Ta wiadōmość niy bydzie rozszyrzowanŏ w necu Bitcoin.</translation>
     </message>
-    </context>
+</context>
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>

--- a/src/qt/locale/bitcoin_ta.ts
+++ b/src/qt/locale/bitcoin_ta.ts
@@ -92,6 +92,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">முகவரி பட்டியல் ஏக்ஸ்போர்ட் செய்க </translation>
     </message>
     <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">கமா பிரிக்கப்பட்ட கோப்பு</translation>
+    </message>
+    <message>
         <source>There was an error trying to save the address list to %1. Please try again.</source>
         <extracomment>An error message. %1 is a stand-in argument for the name of the file we attempted to save to.</extracomment>
         <translation type="unfinished">முகவரி பட்டியலை %1 க்கு சேமிக்க முயற்சிக்கும் ஒரு பிழை ஏற்பட்டது. தயவுசெய்து மீண்டும் முயற்சிக்கவும்.</translation>
@@ -235,7 +240,32 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
 </context>
 <context>
+    <name>BitcoinApplication</name>
+    <message>
+        <source>Runaway exception</source>
+        <translation type="unfinished">ரனவே எக்ஸெப்ஷன்</translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
+        <translation type="unfinished">ஒரு அபாயகரமான ஏரற் ஏற்பட்டது. %1 இனி பாதுகாப்பாக தொடர முடியாது மற்றும் வெளியேறும்</translation>
+    </message>
+    <message>
+        <source>Internal error</source>
+        <translation type="unfinished">உள் எறர்</translation>
+    </message>
+    </context>
+<context>
     <name>QObject</name>
+    <message>
+        <source>Do you want to reset settings to default values, or to abort without making changes?</source>
+        <extracomment>Explanatory text shown on startup when the settings file cannot be read. Prompts user to make a choice between resetting or aborting.</extracomment>
+        <translation type="unfinished">அமைப்புகளை இயல்புநிலை மதிப்புகளுக்கு மீட்டமைக்க வேண்டுமா அல்லது மாற்றங்களைச் செய்யாமல் நிறுத்த வேண்டுமா?</translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. Check that settings file is writable, or try running with -nosettings.</source>
+        <extracomment>Explanatory text shown on startup when the settings file could not be written. Prompts user to check that we have the ability to write to the file. Explains that the user has the option of running without a settings file.</extracomment>
+        <translation type="unfinished">ஒரு அபாயகரமான பிழை ஏற்பட்டது. அமைப்புகள் கோப்பு எழுதக்கூடியதா என்பதைச் சரிபார்க்கவும் அல்லது -nosettings மூலம் இயக்க முயற்சிக்கவும்.</translation>
+    </message>
     <message>
         <source>Error: Specified data directory "%1" does not exist.</source>
         <translation type="unfinished">பிழை: குறிப்பிட்ட தரவு அடைவு "%1" இல்லை.</translation>
@@ -247,6 +277,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Error: %1</source>
         <translation type="unfinished">பிழை: %1</translation>
+    </message>
+    <message>
+        <source>%1 didn't yet exit safely…</source>
+        <translation type="unfinished">%1இன்னும் பாதுகாப்பாக வெளியேரவில்லை ...</translation>
     </message>
     <message>
         <source>unknown</source>
@@ -324,6 +358,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>bitcoin-core</name>
     <message>
+        <source>Settings file could not be read</source>
+        <translation type="unfinished">அமைப்புகள் கோப்பைப் படிக்க முடியவில்லை</translation>
+    </message>
+    <message>
+        <source>Settings file could not be written</source>
+        <translation type="unfinished">அமைப்புகள் கோப்பை எழுத முடியவில்லை</translation>
+    </message>
+    <message>
         <source>The %s developers</source>
         <translation type="unfinished">%s டெவலப்பர்கள்</translation>
     </message>
@@ -400,6 +442,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">தீர்க்க முடியாது -%s முகவரி: '%s'</translation>
     </message>
     <message>
+        <source>Cannot set -peerblockfilters without -blockfilterindex.</source>
+        <translation type="unfinished">-blockfiltersindex இல்லாத -peerblockfilters அமைப்பு முடியாது </translation>
+    </message>
+    <message>
         <source>Copyright (C) %i-%i</source>
         <translation type="unfinished">பதிப்புரிமை (ப) %i-%i</translation>
     </message>
@@ -450,10 +496,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Error reading from database, shutting down.</source>
         <translation type="unfinished">டேட்டாபேசிலிருந்து படிப்பதில் பிழை, ஷட் டவுன் செய்யப்படுகிறது.</translation>
-    </message>
-    <message>
-        <source>Error upgrading chainstate database</source>
-        <translation type="unfinished">செயின்ஸ்டேட் தகவல்தளத்தை மேம்படுத்துவதில் பிழை</translation>
     </message>
     <message>
         <source>Error: Disk space is low for %s</source>
@@ -596,10 +638,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">தெரியாத மாற்று வகை '%s'</translation>
     </message>
     <message>
-        <source>Upgrading UTXO database</source>
-        <translation type="unfinished">UTXO தகவல்தளம் மேம்படுத்தப்படுகிறது</translation>
-    </message>
-    <message>
         <source>Wallet needed to be rewritten: restart %s to complete</source>
         <translation type="unfinished">வாலட் மீண்டும் எழுத படவேண்டும்: முடிக்க %s ஐ மறுதொடக்கம் செய்யுங்கள்</translation>
     </message>
@@ -655,6 +693,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">புதிய வாலட்டை உருவாக்கு</translation>
     </message>
     <message>
+        <source>&amp;Minimize</source>
+        <translation type="unfinished">&amp;குறைத்தல்</translation>
+    </message>
+    <message>
         <source>Wallet:</source>
         <translation type="unfinished">கைப்பை:</translation>
     </message>
@@ -688,8 +730,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">&amp;பெறு</translation>
     </message>
     <message>
+        <source>&amp;Options…</source>
+        <translation type="unfinished">&amp;விருப்பங்கள்</translation>
+    </message>
+    <message>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation type="unfinished">உங்கள் பணப்பைச் சேர்ந்த தனிப்பட்ட விசைகளை குறியாக்குக</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation type="unfinished">&amp;பேக்கப் வாலட்...</translation>
     </message>
     <message>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
@@ -698,6 +748,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation type="unfinished">குறிப்பிடப்பட்ட விக்கிபீடியா முகவர்களுடன் கையொப்பமிடப்பட்டதை உறுதிப்படுத்த, செய்திகளை சரிபார்க்கவும்</translation>
+    </message>
+    <message>
+        <source>Open &amp;URI…</source>
+        <translation type="unfinished">திறந்த &amp;யூஆற்ஐ...</translation>
     </message>
     <message>
         <source>&amp;File</source>
@@ -826,6 +880,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>No wallets available</source>
         <translation type="unfinished">வாலட் எதுவும் இல்லை</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">வாலட் பெயர்</translation>
     </message>
     <message>
         <source>&amp;Window</source>
@@ -1244,6 +1303,20 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 </context>
 <context>
     <name>Intro</name>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform>(%n ஜிபி தேவை)</numerusform>
+            <numerusform>(%n ஜிபி தேவை)</numerusform>
+        </translation>
+    </message>
     <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
         <translation type="unfinished">குறைந்தது %1 ஜிபி தரவு இந்த அடைவில் சேமிக்கப்படும், மேலும் காலப்போக்கில் அது வளரும்.</translation>
@@ -1287,10 +1360,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>As this is the first time the program is launched, you can choose where %1 will store its data.</source>
         <translation type="unfinished">இது முதல் முறையாக துவங்கியது, நீங்கள் %1 அதன் தரவை எங்கு சேமித்து வைக்கும் என்பதை தேர்வு செய்யலாம்.</translation>
-    </message>
-    <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation type="unfinished">நீங்கள் சரி என்பதைக் கிளிக் செய்தால் %1 ஆரம்பத்தில் %4 இல் ஆரம்பிக்கப்பட்ட %3 இன் ஆரம்ப பரிவர்த்தனைகளைத் தொடங்கும் போது முழு %4 தொகுதி சங்கிலி (%2GB) பதிவிறக்க மற்றும் செயலாக்கத் தொடங்கும்.</translation>
     </message>
     <message>
         <source>Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</source>
@@ -1565,10 +1634,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">நாணயக் கட்டுப்பாட்டு அம்சங்களைக் காட்டலாமா அல்லது இல்லையா.</translation>
     </message>
     <message>
-        <source>Options set in this dialog are overridden by the command line or in the configuration file:</source>
-        <translation type="unfinished">இந்த உரையாடலில் அமைக்கப்பட்டுள்ள விருப்பங்கள் கட்டளை வரியில் அல்லது கட்டமைப்பு கோப்பில் மீளமைக்கப்படும்:</translation>
-    </message>
-    <message>
         <source>&amp;OK</source>
         <translation type="unfinished">&amp;சரி</translation>
     </message>
@@ -1582,14 +1647,17 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Confirm options reset</source>
+        <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
         <translation type="unfinished">விருப்பங்களை மீட்டமைக்கவும்</translation>
     </message>
     <message>
         <source>Client restart required to activate changes.</source>
+        <extracomment>Text explaining that the settings changed will not come into effect until the client is restarted.</extracomment>
         <translation type="unfinished">மாற்றங்களைச் செயல்படுத்த கிளையன் மறுதொடக்கம் தேவை.</translation>
     </message>
     <message>
         <source>Client will be shut down. Do you want to proceed?</source>
+        <extracomment>Text asking the user to confirm if they would like to proceed with a client shutdown.</extracomment>
         <translation type="unfinished">கிளையண்ட் மூடப்படும். நீங்கள் தொடர விரும்புகிறீர்களா?</translation>
     </message>
     <message>
@@ -1696,6 +1764,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </context>
 <context>
     <name>PSBTOperationsDialog</name>
+    <message>
+        <source>Sign Tx</source>
+        <translation type="unfinished">கையெழுத்து Tx</translation>
+    </message>
     <message>
         <source>Close</source>
         <translation type="unfinished">நெருக்கமான</translation>
@@ -2419,10 +2491,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Transaction creation failed!</source>
         <translation type="unfinished">பரிவர்த்தனை உருவாக்கம் தோல்வியடைந்தது!</translation>
     </message>
-    <message>
-        <source>Payment request expired.</source>
-        <translation type="unfinished">கட்டணம் கோரிக்கை காலாவதியானது.</translation>
-    </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
@@ -2498,28 +2566,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">செய்தி:</translation>
     </message>
     <message>
-        <source>This is an unauthenticated payment request.</source>
-        <translation type="unfinished">இது ஒரு அங்கீகரிக்கப்படாத கட்டண கோரிக்கை.</translation>
-    </message>
-    <message>
-        <source>This is an authenticated payment request.</source>
-        <translation type="unfinished">இது ஒரு அங்கீகரிக்கப்பட்ட கட்டண கோரிக்கை.</translation>
-    </message>
-    <message>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished">இந்த முகவரியை பயன்படுத்தப்பட்ட முகவரிகளின் பட்டியலில் சேர்க்க ஒரு லேபிளை உள்ளிடவும்.</translation>
     </message>
     <message>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished">பிட்காயினுடன் இணைக்கப்பட்ட செய்தி: உங்கள் எதிர்கால குறிப்புக்காக பரிவர்த்தனையுடன் யூஆர்ஐ சேமிக்கப்படும். குறிப்பு: இந்த செய்தி பிட்காயின் வலையமைப்பிற்கு அனுப்பப்படாது.</translation>
-    </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">பணம் செலுத்து:</translation>
-    </message>
-    <message>
-        <source>Memo:</source>
-        <translation type="unfinished">குறிப்பாணை:</translation>
     </message>
 </context>
 <context>
@@ -2665,33 +2717,32 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
 </context>
 <context>
+    <name>SplashScreen</name>
+    <message>
+        <source>press q to shutdown</source>
+        <translation type="unfinished">ஷட்டவுன் செய்ய, "q" ஐ அழுத்தவும்</translation>
+    </message>
+</context>
+<context>
     <name>TransactionDesc</name>
     <message>
         <source>conflicted with a transaction with %1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that conflicts with a confirmed transaction.</extracomment>
         <translation type="unfinished">%1 உறுதிப்படுத்தல்களுடன் ஒரு பரிவர்த்தனை முரண்பட்டது</translation>
     </message>
     <message>
-        <source>0/unconfirmed, %1</source>
-        <translation type="unfinished">0/உறுதிப்படுத்தப்படாதது, %1</translation>
-    </message>
-    <message>
-        <source>in memory pool</source>
-        <translation type="unfinished">மெமரி பூலில் உள்ளது</translation>
-    </message>
-    <message>
-        <source>not in memory pool</source>
-        <translation type="unfinished">மெமரி பூலில் இல்லை</translation>
-    </message>
-    <message>
         <source>abandoned</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an abandoned transaction.</extracomment>
         <translation type="unfinished">கைவிடப்பட்டது</translation>
     </message>
     <message>
         <source>%1/unconfirmed</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
         <translation type="unfinished">%1/உறுதிப்படுத்தப்படாதது</translation>
     </message>
     <message>
         <source>%1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
         <translation type="unfinished">%1 உறுதிப்படுத்தல்</translation>
     </message>
     <message>
@@ -2981,6 +3032,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Export Transaction History</source>
         <translation type="unfinished">பரிவர்த்தனையின் வரலாற்றை எக்ஸ்போர்ட் செய்</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">கமா பிரிக்கப்பட்ட கோப்பு</translation>
     </message>
     <message>
         <source>Confirmed</source>

--- a/src/qt/locale/bitcoin_te.ts
+++ b/src/qt/locale/bitcoin_te.ts
@@ -70,6 +70,12 @@
         <translation type="unfinished">ఇవి మీరు పంపే చెల్లింపుల బిట్‌కాయిన్ చిరునామాలు. నాణేలు పంపే ముందు ప్రతిసారి అందుకునే చిరునామా మరియు చెల్లింపు మొత్తం సరిచూసుకోండి.</translation>
     </message>
     <message>
+        <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
+Signing is only possible with addresses of the type 'legacy'.</source>
+        <translation type="unfinished">చెల్లింపులను స్వీకరించడానికి ఇవి మీ బిట్‌కాయిన్ చిరునామాలు. కొత్త చిరునామాలను సృష్టించడానికి స్వీకరించే ట్యాబ్‌లోని 'కొత్త స్వీకరించే చిరునామాను సృష్టించు' బటన్‌ను ఉపయోగించండి. 
+'లెగసీ' రకం చిరునామాలతో మాత్రమే సంతకం చేయడం సాధ్యమవుతుంది.</translation>
+    </message>
+    <message>
         <source>&amp;Copy Address</source>
         <translation type="unfinished">చిరునామాను కాపీ చెయ్యండి</translation>
     </message>
@@ -84,6 +90,11 @@
     <message>
         <source>Export Address List</source>
         <translation type="unfinished">చిరునామా జాబితాను ఎగుమతి చేయండి</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">కామాతో వేరు చేయబడిన ఫైల్</translation>
     </message>
     <message>
         <source>There was an error trying to save the address list to %1. Please try again.</source>
@@ -229,7 +240,56 @@
     </message>
 </context>
 <context>
+    <name>BitcoinApplication</name>
+    <message>
+        <source>Settings file %1 might be corrupt or invalid.</source>
+        <translation type="unfinished">సెట్టింగ్‌ల ఫైల్ 1 %1 పాడై ఉండవచ్చు లేదా చెల్లదు</translation>
+    </message>
+    <message>
+        <source>Runaway exception</source>
+        <translation type="unfinished">రన్అవే మినహాయింపు</translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
+        <translation type="unfinished">ఘోరమైన లోపం సంభవించింది. %1 ఇకపై సురక్షితంగా కొనసాగదు మరియు నిష్క్రమిస్తుంది.</translation>
+    </message>
+    <message>
+        <source>Internal error</source>
+        <translation type="unfinished">అంతర్గత లోపం</translation>
+    </message>
+    <message>
+        <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
+        <translation type="unfinished">అంతర్గత లోపం సంభవించింది. %1 సురక్షితంగా కొనసాగించడానికి ప్రయత్నిస్తుంది. ఇది ఊహించని బగ్, దీనిని దిగువ వివరించిన విధంగా నివేదించవచ్చు.</translation>
+    </message>
+</context>
+<context>
     <name>QObject</name>
+    <message>
+        <source>Do you want to reset settings to default values, or to abort without making changes?</source>
+        <extracomment>Explanatory text shown on startup when the settings file cannot be read. Prompts user to make a choice between resetting or aborting.</extracomment>
+        <translation type="unfinished">మీరు సెట్టింగ్‌లను డిఫాల్ట్ విలువలకు రీసెట్ చేయాలనుకుంటున్నారా లేదా మార్పులు చేయకుండానే నిలిపివేయాలనుకుంటున్నారా?</translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. Check that settings file is writable, or try running with -nosettings.</source>
+        <extracomment>Explanatory text shown on startup when the settings file could not be written. Prompts user to check that we have the ability to write to the file. Explains that the user has the option of running without a settings file.</extracomment>
+        <translation type="unfinished">ఘోరమైన లోపం సంభవించింది. సెట్టింగుల ఫైల్ వ్రాయదగినదో లేదో తనిఖీ చేయండి లేదా - నోసెట్టింగ్స్ తో అమలు చేయడానికి ప్రయత్నించండి.</translation>
+    </message>
+    <message>
+        <source>Error: Specified data directory "%1" does not exist.</source>
+        <translation type="unfinished">లోపం: పేర్కొన్న డేటా డైరెక్టరీ " %1 " లేదు.</translation>
+    </message>
+    <message>
+        <source>Error: Cannot parse configuration file: %1.</source>
+        <translation type="unfinished">లోపం: కాన్ఫిగరేషన్ ఫైల్‌ను అన్వయించలేరు: %1.</translation>
+    </message>
+    <message>
+        <source>Error: %1</source>
+        <translation type="unfinished">లోపం: %1</translation>
+    </message>
+    <message>
+        <source>%1 didn't yet exit safely…</source>
+        <translation type="unfinished">%1 ఇంకా సురక్షితంగా బయటకు రాలేదు...</translation>
+    </message>
     <message>
         <source>unknown</source>
         <translation type="unfinished">తెలియదు</translation>
@@ -238,49 +298,295 @@
         <source>Amount</source>
         <translation type="unfinished">మొత్తం</translation>
     </message>
+    <message>
+        <source>Enter a Bitcoin address (e.g. %1)</source>
+        <translation type="unfinished">బిట్‌కాయిన్ చిరునామాను నమోదు చేయండి (ఉదా. %1)</translation>
+    </message>
+    <message>
+        <source>Unroutable</source>
+        <translation type="unfinished">రూట్ చేయలేనిది</translation>
+    </message>
+    <message>
+        <source>Internal</source>
+        <translation type="unfinished">అంతర్గత</translation>
+    </message>
+    <message>
+        <source>Inbound</source>
+        <extracomment>An inbound connection from a peer. An inbound connection is a connection initiated by a peer.</extracomment>
+        <translation type="unfinished">ఇన్‌బౌండ్</translation>
+    </message>
+    <message>
+        <source>Outbound</source>
+        <extracomment>An outbound connection to a peer. An outbound connection is a connection initiated by us.</extracomment>
+        <translation type="unfinished">అవుట్ బౌండ్</translation>
+    </message>
+    <message>
+        <source>Full Relay</source>
+        <extracomment>Peer connection type that relays all network information.</extracomment>
+        <translation type="unfinished">పూర్తిగా  ఏర్పరచుట</translation>
+    </message>
+    <message>
+        <source>Block Relay</source>
+        <extracomment>Peer connection type that relays network information about blocks and not transactions or addresses.</extracomment>
+        <translation type="unfinished">ఏర్పాటు చేయుటను నిరోధించండి</translation>
+    </message>
+    <message>
+        <source>Manual</source>
+        <extracomment>Peer connection type established manually through one of several methods.</extracomment>
+        <translation type="unfinished">మానవీయంగా</translation>
+    </message>
+    <message>
+        <source>Feeler</source>
+        <extracomment>Short-lived peer connection type that tests the aliveness of known addresses.</extracomment>
+        <translation type="unfinished">అనుభూతి</translation>
+    </message>
+    <message>
+        <source>Address Fetch</source>
+        <extracomment>Short-lived peer connection type that solicits known addresses from a peer.</extracomment>
+        <translation type="unfinished">చిరునామా పొందండి</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished">ఏదీ లేదు</translation>
+    </message>
+    <message>
+        <source>N/A</source>
+        <translation type="unfinished">వర్తించదు</translation>
+    </message>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n సెకను(లు)</numerusform>
+            <numerusform>%n సెకను(లు)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n minute(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n నిమిషం(లు)</numerusform>
+            <numerusform>%n నిమిషం(లు)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n గంట(లు)</numerusform>
+            <numerusform>%n గంట(లు)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n రోజు(లు)</numerusform>
+            <numerusform>%n రోజు(లు)</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n వారం(లు)</numerusform>
+            <numerusform>%n వారం(లు)</numerusform>
         </translation>
+    </message>
+    <message>
+        <source>%1 and %2</source>
+        <translation type="unfinished">%1 మరియు %2</translation>
     </message>
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n సంవత్సరం(లు)</numerusform>
+            <numerusform>%n సంవత్సరం(లు)</numerusform>
         </translation>
     </message>
     </context>
+<context>
+    <name>bitcoin-core</name>
+    <message>
+        <source>Settings file could not be read</source>
+        <translation type="unfinished">సెట్టింగ్‌ల ఫైల్ చదవడం సాధ్యం కాలేదు</translation>
+    </message>
+    <message>
+        <source>Settings file could not be written</source>
+        <translation type="unfinished">సెట్టింగుల ఫైల్ వ్రాయబడదు</translation>
+    </message>
+    <message>
+        <source>Cannot set -peerblockfilters without -blockfilterindex.</source>
+        <translation type="unfinished">-blockfilterindex లేకుండా -peerblockfilters సెట్ చేయలేము.</translation>
+    </message>
+    <message>
+        <source>Error reading from database, shutting down.</source>
+        <translation type="unfinished">డేటాబేస్ నుండి చదవడంలో లోపం, షట్ డౌన్.</translation>
+    </message>
+    <message>
+        <source>Missing solving data for estimating transaction size</source>
+        <translation type="unfinished">లావాదేవీ పరిమాణాన్ని అంచనా వేయడానికి పరిష్కార డేటా లేదు</translation>
+    </message>
+    <message>
+        <source>Prune cannot be configured with a negative value.</source>
+        <translation type="unfinished">ప్రూనే ప్రతికూల విలువతో కాన్ఫిగర్ చేయబడదు.</translation>
+    </message>
+    <message>
+        <source>Prune mode is incompatible with -txindex.</source>
+        <translation type="unfinished">ప్రూన్ మోడ్ -txindexకి అనుకూలంగా లేదు.</translation>
+    </message>
+    <message>
+        <source>Section [%s] is not recognized.</source>
+        <translation type="unfinished">విభాగం [%s] గుర్తించబడలేదు.</translation>
+    </message>
+    <message>
+        <source>Specified blocks directory "%s" does not exist.</source>
+        <translation type="unfinished">పేర్కొన్న బ్లాక్‌ల డైరెక్టరీ "%s" ఉనికిలో లేదు.</translation>
+    </message>
+    <message>
+        <source>Starting network threads…</source>
+        <translation type="unfinished">నెట్‌వర్క్ థ్రెడ్‌లను ప్రారంభిస్తోంది…</translation>
+    </message>
+    <message>
+        <source>The source code is available from %s.</source>
+        <translation type="unfinished">%s నుండి సోర్స్ కోడ్ అందుబాటులో ఉంది.</translation>
+    </message>
+    <message>
+        <source>The specified config file %s does not exist</source>
+        <translation type="unfinished">పేర్కొన్న కాన్ఫిగర్ ఫైల్ %s ఉనికిలో లేదు</translation>
+    </message>
+    <message>
+        <source>The transaction amount is too small to pay the fee</source>
+        <translation type="unfinished">రుసుము చెల్లించడానికి లావాదేవీ మొత్తం చాలా చిన్నది</translation>
+    </message>
+    <message>
+        <source>The wallet will avoid paying less than the minimum relay fee.</source>
+        <translation type="unfinished">వాలెట్ కనీస రిలే రుసుము కంటే తక్కువ చెల్లించడాన్ని నివారిస్తుంది.</translation>
+    </message>
+    <message>
+        <source>This is experimental software.</source>
+        <translation type="unfinished">ఇది ప్రయోగాత్మక సాఫ్ట్‌వేర్.</translation>
+    </message>
+    <message>
+        <source>This is the minimum transaction fee you pay on every transaction.</source>
+        <translation type="unfinished">ఇది ప్రతి లావాదేవీకి మీరు చెల్లించే కనీస లావాదేవీ రుసుము.</translation>
+    </message>
+    <message>
+        <source>This is the transaction fee you will pay if you send a transaction.</source>
+        <translation type="unfinished">మీరు లావాదేవీని పంపితే మీరు చెల్లించే లావాదేవీ రుసుము ఇది.</translation>
+    </message>
+    <message>
+        <source>Transaction amount too small</source>
+        <translation type="unfinished">లావాదేవీ మొత్తం చాలా చిన్నది</translation>
+    </message>
+    <message>
+        <source>Transaction amounts must not be negative</source>
+        <translation type="unfinished">లావాదేవీ మొత్తాలు ప్రతికూలంగా ఉండకూడదు</translation>
+    </message>
+    <message>
+        <source>Transaction change output index out of range</source>
+        <translation type="unfinished">లావాదేవీ మార్పు అవుట్‌పుట్ సూచిక పరిధి వెలుపల ఉంది</translation>
+    </message>
+    <message>
+        <source>Transaction has too long of a mempool chain</source>
+        <translation type="unfinished">లావాదేవీ మెంపూల్ చైన్‌లో చాలా పొడవుగా ఉంది</translation>
+    </message>
+    <message>
+        <source>Transaction must have at least one recipient</source>
+        <translation type="unfinished">లావాదేవీకి కనీసం ఒక గ్రహీత ఉండాలి</translation>
+    </message>
+    <message>
+        <source>Transaction needs a change address, but we can't generate it.</source>
+        <translation type="unfinished">లావాదేవీకి చిరునామా మార్పు అవసరం, కానీ మేము దానిని రూపొందించలేము.</translation>
+    </message>
+    <message>
+        <source>Transaction too large</source>
+        <translation type="unfinished">లావాదేవీ చాలా పెద్దది</translation>
+    </message>
+    <message>
+        <source>Unable to allocate memory for -maxsigcachesize: '%s' MiB</source>
+        <translation type="unfinished">-maxsigcacheize కోసం మెమరీని కేటాయించడం సాధ్యం కాలేదు: '%s' MiB</translation>
+    </message>
+    <message>
+        <source>Unable to bind to %s on this computer (bind returned error %s)</source>
+        <translation type="unfinished">బైండ్ చేయడం సాధ్యపడలేదు %s ఈ కంప్యూటర్‌లో  (బైండ్ రిటర్న్ ఎర్రర్ %s)</translation>
+    </message>
+    <message>
+        <source>Unable to bind to %s on this computer. %s is probably already running.</source>
+        <translation type="unfinished">బైండ్ చేయడం సాధ్యపడలేదు %s ఈ కంప్యూటర్‌లో. %s బహుశా ఇప్పటికే అమలులో ఉంది.</translation>
+    </message>
+    <message>
+        <source>Unable to create the PID file '%s': %s</source>
+        <translation type="unfinished">PID ఫైల్‌ని సృష్టించడం సాధ్యం కాలేదు '%s': %s</translation>
+    </message>
+    <message>
+        <source>Unable to find UTXO for external input</source>
+        <translation type="unfinished">బాహ్య ఇన్‌పుట్ కోసం UTXOని కనుగొనడం సాధ్యం కాలేదు</translation>
+    </message>
+    <message>
+        <source>Unable to generate initial keys</source>
+        <translation type="unfinished">ప్రారంభ కీలను రూపొందించడం సాధ్యం కాలేదు</translation>
+    </message>
+    <message>
+        <source>Unable to generate keys</source>
+        <translation type="unfinished">కీలను రూపొందించడం సాధ్యం కాలేదు</translation>
+    </message>
+    <message>
+        <source>Unable to open %s for writing</source>
+        <translation type="unfinished">తెరవడం సాధ్యం కాదు %s రాయడం కోసం</translation>
+    </message>
+    <message>
+        <source>Unable to parse -maxuploadtarget: '%s'</source>
+        <translation type="unfinished">-maxuploadtarget అన్వయించడం సాధ్యం కాలేదు: '%s'</translation>
+    </message>
+    <message>
+        <source>Unable to start HTTP server. See debug log for details.</source>
+        <translation type="unfinished">HTTP సర్వర్‌ని ప్రారంభించడం సాధ్యం కాలేదు. వివరాల కోసం డీబగ్ లాగ్ చూడండి.</translation>
+    </message>
+    <message>
+        <source>Unable to unload the wallet before migrating</source>
+        <translation type="unfinished">తరలించడానికి ముందు వాలెట్‌ని అన్‌లోడ్ చేయడం సాధ్యపడలేదు</translation>
+    </message>
+    <message>
+        <source>Unknown -blockfilterindex value %s.</source>
+        <translation type="unfinished">తెలియని -blockfilterindex విలువ %s.</translation>
+    </message>
+    <message>
+        <source>Unknown address type '%s'</source>
+        <translation type="unfinished">తెలియని చిరునామా రకం '%s'</translation>
+    </message>
+    <message>
+        <source>Unknown change type '%s'</source>
+        <translation type="unfinished">తెలియని మార్పు రకం '%s'</translation>
+    </message>
+    <message>
+        <source>Unknown network specified in -onlynet: '%s'</source>
+        <translation type="unfinished">తెలియని నెట్‌వర్క్ -onlynetలో పేర్కొనబడింది: '%s'</translation>
+    </message>
+    <message>
+        <source>Unknown new rules activated (versionbit %i)</source>
+        <translation type="unfinished">తెలియని కొత్త నియమాలు (వెర్షన్‌బిట్‌ %i)ని యాక్టివేట్ చేశాయి</translation>
+    </message>
+    <message>
+        <source>Unsupported global logging level -loglevel=%s. Valid values: %s.</source>
+        <translation type="unfinished">మద్దతు లేని గ్లోబల్ లాగింగ్ స్థాయి -లాగ్‌లెవెల్=%s. చెల్లుబాటు అయ్యే విలువలు: %s.</translation>
+    </message>
+    <message>
+        <source>Unsupported logging category %s=%s.</source>
+        <translation type="unfinished">మద్దతు లేని లాగింగ్ వర్గం %s=%s</translation>
+    </message>
+    <message>
+        <source>User Agent comment (%s) contains unsafe characters.</source>
+        <translation type="unfinished">వినియోగదారు ఏజెంట్ వ్యాఖ్య (%s)లో అసురక్షిత అక్షరాలు ఉన్నాయి.</translation>
+    </message>
+    <message>
+        <source>Verifying blocks…</source>
+        <translation type="unfinished">బ్లాక్‌లను ధృవీకరిస్తోంది…</translation>
+    </message>
+    <message>
+        <source>Verifying wallet(s)…</source>
+        <translation type="unfinished">వాలెట్(ల)ని ధృవీకరిస్తోంది...</translation>
+    </message>
+    <message>
+        <source>Wallet needed to be rewritten: restart %s to complete</source>
+        <translation type="unfinished">వాలెట్‌ని మళ్లీ వ్రాయాలి: పూర్తి చేయడానికి పునఃప్రారంభించండి %s</translation>
+    </message>
+</context>
 <context>
     <name>BitcoinGUI</name>
     <message>
@@ -332,13 +638,21 @@
         <translation type="unfinished">&lt;div&gt;&lt;/div&gt;</translation>
     </message>
     <message>
+        <source>&amp;Minimize</source>
+        <translation type="unfinished">&amp;తగ్గించడానికి</translation>
+    </message>
+    <message>
         <source>Wallet:</source>
-        <translation type="unfinished">ధనమును తీసుకొనిపోవు సంచి</translation>
+        <translation type="unfinished">వాలెట్‌:</translation>
     </message>
     <message>
         <source>Network activity disabled.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">నెట్‌వర్క్ కార్యాచరణ నిలిపివేయబడింది.</translation>
+    </message>
+    <message>
+        <source>Proxy is &lt;b&gt;enabled&lt;/b&gt;: %1</source>
+        <translation type="unfinished">ప్రాక్సీ &lt;b&gt;ప్రారంభించబడింది&lt;/b&gt;: %1</translation>
     </message>
     <message>
         <source>Send coins to a Bitcoin address</source>
@@ -360,12 +674,140 @@
         <source>&amp;Receive</source>
         <translation type="unfinished">స్వీకరించండి</translation>
     </message>
+    <message>
+        <source>&amp;Options…</source>
+        <translation type="unfinished">&amp;ఎంపికలు...</translation>
+    </message>
+    <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation type="unfinished">&amp;వాలెట్‌ని గుప్తీకరించు...</translation>
+    </message>
+    <message>
+        <source>Encrypt the private keys that belong to your wallet</source>
+        <translation type="unfinished">మీ వాలెట్‌కు చెందిన ప్రైవేట్ కీలను గుప్తీకరించండి</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation type="unfinished">&amp;బ్యాకప్ వాలెట్...</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation type="unfinished">&amp;సంకేతపదం మార్చండి</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation type="unfinished">సంతకం &amp;సందేశం...</translation>
+    </message>
+    <message>
+        <source>Sign messages with your Bitcoin addresses to prove you own them</source>
+        <translation type="unfinished">మీ బిట్‌కాయిన్ చిరునామాలు మీ స్వంతమని నిరూపించుకోవడానికి వాటితో సందేశాలను సంతకం చేయండి</translation>
+    </message>
+    <message>
+        <source>&amp;Verify message…</source>
+        <translation type="unfinished">&amp;సందేశాన్ని ధృవీకరించండి...</translation>
+    </message>
+    <message>
+        <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
+        <translation type="unfinished">సందేశాలు పేర్కొన్న బిట్‌కాయిన్ చిరునామాలతో సంతకం చేసినట్లు నిర్ధారించుకోవడానికి వాటిని ధృవీకరించండి</translation>
+    </message>
+    <message>
+        <source>&amp;Load PSBT from file…</source>
+        <translation type="unfinished">&amp;ఫైల్ నుండి PSBTని లోడ్ చేయండి...</translation>
+    </message>
+    <message>
+        <source>Open &amp;URI…</source>
+        <translation type="unfinished">&amp;URI ని తెరవండి...</translation>
+    </message>
+    <message>
+        <source>Close Wallet…</source>
+        <translation type="unfinished">వాలెట్ ని మూసివేయి...</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation type="unfinished">వాలెట్ ని సృష్టించండి...</translation>
+    </message>
+    <message>
+        <source>Close All Wallets…</source>
+        <translation type="unfinished">అన్ని వాలెట్లను మూసివేయి…</translation>
+    </message>
+    <message>
+        <source>&amp;File</source>
+        <translation type="unfinished">&amp;ఫైల్</translation>
+    </message>
+    <message>
+        <source>&amp;Settings</source>
+        <translation type="unfinished">&amp;సెట్టింగ్‌లు</translation>
+    </message>
+    <message>
+        <source>&amp;Help</source>
+        <translation type="unfinished">&amp;సహాయం</translation>
+    </message>
+    <message>
+        <source>Tabs toolbar</source>
+        <translation type="unfinished">ట్యాబ్‌ల టూల్‌బార్</translation>
+    </message>
+    <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation type="unfinished">శీర్షికలను సమకాలీకరించడం (%1%)...</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation type="unfinished">నెట్‌వర్క్‌తో సమకాలీకరించబడుతోంది...</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation type="unfinished">డిస్క్‌లో బ్లాక్‌లను సూచిక చేస్తోంది…</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation type="unfinished">డిస్క్‌లో బ్లాక్‌లను ప్రాసెస్ చేస్తోంది...</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation type="unfinished">డిస్క్‌లోని బ్లాక్‌లను రీఇండెక్సింగ్ చేస్తోంది...</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation type="unfinished">తోటివారితో కలుస్తుంది…</translation>
+    </message>
+    <message>
+        <source>Request payments (generates QR codes and bitcoin: URIs)</source>
+        <translation type="unfinished">చెల్లింపులను అభ్యర్థించండి (QR కోడ్‌లు మరియు బిట్‌కాయిన్‌లను ఉత్పత్తి చేస్తుంది: URIలు)</translation>
+    </message>
+    <message>
+        <source>Show the list of used sending addresses and labels</source>
+        <translation type="unfinished">ఉపయోగించిన పంపే చిరునామాలు మరియు లేబుల్‌ల జాబితాను చూపండి</translation>
+    </message>
+    <message>
+        <source>Show the list of used receiving addresses and labels</source>
+        <translation type="unfinished">ఉపయోగించిన స్వీకరించే చిరునామాలు మరియు లేబుల్‌ల జాబితాను చూపండి</translation>
+    </message>
+    <message>
+        <source>&amp;Command-line options</source>
+        <translation type="unfinished">&amp;కమాండ్-లైన్ ఎంపికలు</translation>
+    </message>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>లావాదేవీ %n చరిత్ర యొక్క ప్రాసెస్ చేయబడిన బ్లాక్(లు).</numerusform>
+            <numerusform>లావాదేవీ %n చరిత్ర యొక్క ప్రాసెస్ చేయబడిన బ్లాక్(లు).</numerusform>
         </translation>
+    </message>
+    <message>
+        <source>%1 behind</source>
+        <translation type="unfinished">%1 వెనుక</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation type="unfinished">పట్టుకోవడం...</translation>
+    </message>
+    <message>
+        <source>Last received block was generated %1 ago.</source>
+        <translation type="unfinished">చివరిగా అందుకున్న బ్లాక్ రూపొందించబడింది %1 క్రితం</translation>
+    </message>
+    <message>
+        <source>Transactions after this will not yet be visible.</source>
+        <translation type="unfinished">దీని తర్వాత లావాదేవీలు ఇంకా కనిపించవు.</translation>
     </message>
     <message>
         <source>Error</source>
@@ -383,15 +825,244 @@
         <source>Up to date</source>
         <translation type="unfinished">తాజాగా ఉంది</translation>
     </message>
+    <message>
+        <source>Load Partially Signed Bitcoin Transaction</source>
+        <translation type="unfinished">పాక్షికంగా సంతకం చేసిన బిట్‌కాయిన్ లావాదేవీని లోడ్ చేయండి</translation>
+    </message>
+    <message>
+        <source>Load PSBT from &amp;clipboard…</source>
+        <translation type="unfinished">&amp;క్లిప్‌బోర్డ్ నుండి PSBTని లోడ్ చేయండి...</translation>
+    </message>
+    <message>
+        <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
+        <translation type="unfinished">క్లిప్‌బోర్డ్ నుండి పాక్షికంగా సంతకం చేసిన బిట్‌కాయిన్ లావాదేవీని లోడ్ చేయండి</translation>
+    </message>
+    <message>
+        <source>Node window</source>
+        <translation type="unfinished">నోడ్ విండో</translation>
+    </message>
+    <message>
+        <source>Open node debugging and diagnostic console</source>
+        <translation type="unfinished">నోడ్ డీబగ్గింగ్ మరియు డయాగ్నస్టిక్ కన్సోల్ తెరవండి</translation>
+    </message>
+    <message>
+        <source>&amp;Sending addresses</source>
+        <translation type="unfinished">&amp;చిరునామా పంపుతోంది</translation>
+    </message>
+    <message>
+        <source>&amp;Receiving addresses</source>
+        <translation type="unfinished">&amp;చిరునామాలను స్వీకరిస్తోంది</translation>
+    </message>
+    <message>
+        <source>Open a bitcoin: URI</source>
+        <translation type="unfinished">బిట్‌కాయిన్‌ను తెరవండి: URI</translation>
+    </message>
+    <message>
+        <source>Open Wallet</source>
+        <translation type="unfinished">వాలెట్ తెరవండి</translation>
+    </message>
+    <message>
+        <source>Open a wallet</source>
+        <translation type="unfinished">ఒక వాలెట్ తెరవండి</translation>
+    </message>
+    <message>
+        <source>Close wallet</source>
+        <translation type="unfinished">వాలెట్‌ని మూసివేయండి</translation>
+    </message>
+    <message>
+        <source>Restore Wallet…</source>
+        <extracomment>Name of the menu item that restores wallet from a backup file.</extracomment>
+        <translation type="unfinished">వాలెట్‌ని పునరుద్ధరించు…</translation>
+    </message>
+    <message>
+        <source>Restore a wallet from a backup file</source>
+        <extracomment>Status tip for Restore Wallet menu item</extracomment>
+        <translation type="unfinished">బ్యాకప్ ఫైల్ నుండి వాలెట్‌ను పునరుద్ధరించండి</translation>
+    </message>
+    <message>
+        <source>Close all wallets</source>
+        <translation type="unfinished">అన్ని వాలెట్లను మూసివేయండి</translation>
+    </message>
+    <message>
+        <source>Show the %1 help message to get a list with possible Bitcoin command-line options</source>
+        <translation type="unfinished">%1 సాధ్యమయ్యే బిట్‌కాయిన్ కమాండ్-లైన్ ఎంపికలతో జాబితాను పొందడానికి సహాయ సందేశాన్ని చూపండి</translation>
+    </message>
+    <message>
+        <source>&amp;Mask values</source>
+        <translation type="unfinished">&amp;విలువలను కప్పిపుచ్చు</translation>
+    </message>
+    <message>
+        <source>Mask the values in the Overview tab</source>
+        <translation type="unfinished">ఓవర్‌వ్యూ ట్యాబ్‌లోని విలువలను కప్పిపుచ్చడం చేయండి</translation>
+    </message>
+    <message>
+        <source>default wallet</source>
+        <translation type="unfinished">డిఫాల్ట్ వాలెట్</translation>
+    </message>
+    <message>
+        <source>No wallets available</source>
+        <translation type="unfinished">వాలెట్లు అందుబాటులో లేవు</translation>
+    </message>
+    <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">వాలెట్ సమాచారం</translation>
+    </message>
+    <message>
+        <source>Load Wallet Backup</source>
+        <extracomment>The title for Restore Wallet File Windows</extracomment>
+        <translation type="unfinished">వాలెట్ బ్యాకప్ లోడ్ చేయండి</translation>
+    </message>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of pop-up window shown when the user is attempting to restore a wallet.</extracomment>
+        <translation type="unfinished">వాలెట్‌ని పునరుద్ధరించండి</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">వాలెట్ పేరు</translation>
+    </message>
+    <message>
+        <source>&amp;Window</source>
+        <translation type="unfinished">&amp;విండో</translation>
+    </message>
+    <message>
+        <source>Zoom</source>
+        <translation type="unfinished">జూమ్ చేయండి</translation>
+    </message>
+    <message>
+        <source>Main Window</source>
+        <translation type="unfinished">ప్రధాన విండో</translation>
+    </message>
+    <message>
+        <source>%1 client</source>
+        <translation type="unfinished">%1 క్లయింట్</translation>
+    </message>
+    <message>
+        <source>&amp;Hide</source>
+        <translation type="unfinished">&amp;దాచు</translation>
+    </message>
+    <message>
+        <source>S&amp;how</source>
+        <translation type="unfinished">S&amp;ఎలా</translation>
+    </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n బిట్‌కాయిన్ నెట్‌వర్క్‌కు క్రియాశీల కనెక్షన్(లు).</numerusform>
+            <numerusform>%n బిట్‌కాయిన్ నెట్‌వర్క్‌కు క్రియాశీల కనెక్షన్(లు).</numerusform>
         </translation>
     </message>
-    </context>
+    <message>
+        <source>Click for more actions.</source>
+        <extracomment>A substring of the tooltip. "More actions" are available via the context menu.</extracomment>
+        <translation type="unfinished">మరిన్ని చర్యల కోసం క్లిక్ చేయండి.</translation>
+    </message>
+    <message>
+        <source>Show Peers tab</source>
+        <extracomment>A context menu item. The "Peers tab" is an element of the "Node window".</extracomment>
+        <translation type="unfinished">పీర్స్ ట్యాబ్‌ని చూపించు</translation>
+    </message>
+    <message>
+        <source>Disable network activity</source>
+        <extracomment>A context menu item.</extracomment>
+        <translation type="unfinished">నెట్‌వర్క్ కార్యాచరణను నిలిపివేయండి</translation>
+    </message>
+    <message>
+        <source>Enable network activity</source>
+        <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
+        <translation type="unfinished">నెట్‌వర్క్ కార్యాచరణను ప్రారంభించండి</translation>
+    </message>
+    <message>
+        <source>Pre-syncing Headers (%1%)…</source>
+        <translation type="unfinished">హెడ్‌లను ప్రీ-సింక్ చేస్తోంది (%1%)...</translation>
+    </message>
+    <message>
+        <source>Error: %1</source>
+        <translation type="unfinished">లోపం: %1</translation>
+    </message>
+    <message>
+        <source>Warning: %1</source>
+        <translation type="unfinished">హెచ్చరిక: %1</translation>
+    </message>
+    <message>
+        <source>Date: %1
+</source>
+        <translation type="unfinished">తేదీ: %1
+</translation>
+    </message>
+    <message>
+        <source>Amount: %1
+</source>
+        <translation type="unfinished">మొత్తం: %1
+</translation>
+    </message>
+    <message>
+        <source>Wallet: %1
+</source>
+        <translation type="unfinished">వాలెట్: %1
+</translation>
+    </message>
+    <message>
+        <source>Type: %1
+</source>
+        <translation type="unfinished">రకం: %1
+</translation>
+    </message>
+    <message>
+        <source>Label: %1
+</source>
+        <translation type="unfinished">లేబుల్: %1
+</translation>
+    </message>
+    <message>
+        <source>Address: %1
+</source>
+        <translation type="unfinished">చిరునామా: %1
+</translation>
+    </message>
+    <message>
+        <source>Sent transaction</source>
+        <translation type="unfinished">పంపిన లావాదేవీ</translation>
+    </message>
+    <message>
+        <source>Incoming transaction</source>
+        <translation type="unfinished">కొత్తగా వచ్చిన లావాదేవీ</translation>
+    </message>
+    <message>
+        <source>HD key generation is &lt;b&gt;enabled&lt;/b&gt;</source>
+        <translation type="unfinished">HD కీ ఉత్పత్తి &lt;b&gt;ప్రారంభించబడింది&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>HD key generation is &lt;b&gt;disabled&lt;/b&gt;</source>
+        <translation type="unfinished">HD కీ ఉత్పత్తి &lt;b&gt;నిలిపివేయబడింది&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Private key &lt;b&gt;disabled&lt;/b&gt;</source>
+        <translation type="unfinished">ప్రైవేట్ కీ &lt;b&gt;నిలిపివేయబడింది&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
+        <translation type="unfinished">వాలెట్ &lt;b&gt;ఎన్‌క్రిప్ట్ చేయబడింది&lt;/b&gt; మరియు ప్రస్తుతం &lt;b&gt;అన్‌లాక్ చేయబడింది&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
+        <translation type="unfinished">వాలెట్ &lt;b&gt;ఎన్‌క్రిప్ట్ చేయబడింది&lt;/b&gt; మరియు ప్రస్తుతం &lt;b&gt;లాక్ చేయబడింది&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Original message:</source>
+        <translation type="unfinished">అసలు సందేశం:</translation>
+    </message>
+</context>
+<context>
+    <name>UnitDisplayStatusBarControl</name>
+    <message>
+        <source>Unit to show amounts in. Click to select another unit.</source>
+        <translation type="unfinished">అమౌంట్ ని చూపించడానికి యూనిట్. మరొక యూనిట్‌ని ఎంచుకోవడానికి క్లిక్ చేయండి.</translation>
+    </message>
+</context>
 <context>
     <name>CoinControlDialog</name>
     <message>
@@ -403,25 +1074,402 @@
         <translation type="unfinished">పరిమాణం</translation>
     </message>
     <message>
+        <source>Bytes:</source>
+        <translation type="unfinished">బైట్‌లు:</translation>
+    </message>
+    <message>
+        <source>Amount:</source>
+        <translation type="unfinished">మొత్తం:</translation>
+    </message>
+    <message>
+        <source>Fee:</source>
+        <translation type="unfinished">రుసుము:</translation>
+    </message>
+    <message>
+        <source>Dust:</source>
+        <translation type="unfinished">దుమ్ము:</translation>
+    </message>
+    <message>
+        <source>After Fee:</source>
+        <translation type="unfinished">రుసుము తర్వాత:</translation>
+    </message>
+    <message>
+        <source>Change:</source>
+        <translation type="unfinished">మార్చు:</translation>
+    </message>
+    <message>
+        <source>(un)select all</source>
+        <translation type="unfinished">ఎంచుకున్నవన్నీ తొలగించు</translation>
+    </message>
+    <message>
+        <source>Tree mode</source>
+        <translation type="unfinished">చెట్టు విధానం</translation>
+    </message>
+    <message>
+        <source>List mode</source>
+        <translation type="unfinished">జాబితా విధానం</translation>
+    </message>
+    <message>
         <source>Amount</source>
         <translation type="unfinished">మొత్తం</translation>
+    </message>
+    <message>
+        <source>Received with label</source>
+        <translation type="unfinished">లేబుల్‌తో స్వీకరించబడింది</translation>
+    </message>
+    <message>
+        <source>Received with address</source>
+        <translation type="unfinished">చిరునామాతో స్వీకరించబడింది</translation>
     </message>
     <message>
         <source>Date</source>
         <translation type="unfinished">తేదీ</translation>
     </message>
     <message>
+        <source>Confirmations</source>
+        <translation type="unfinished">నిర్ధారణలు</translation>
+    </message>
+    <message>
+        <source>Confirmed</source>
+        <translation type="unfinished">నిర్ధారించబడినది</translation>
+    </message>
+    <message>
+        <source>Copy amount</source>
+        <translation type="unfinished">కాపీ అమౌంట్</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;కాపీ చిరునామా</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">కాపీ &amp;లేబుల్</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">కాపీ &amp;అమౌంట్</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID and output index</source>
+        <translation type="unfinished">లావాదేవీ &amp;ID మరియు అవుట్‌పుట్ సూచికను కాపీ చేయండి</translation>
+    </message>
+    <message>
+        <source>L&amp;ock unspent</source>
+        <translation type="unfinished">ఖర్చు చేయనిది లాక్ చేయండి</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock unspent</source>
+        <translation type="unfinished">&amp;ఖర్చు చేయనిది విడిపించండి</translation>
+    </message>
+    <message>
+        <source>Copy quantity</source>
+        <translation type="unfinished">కాపీ పరిమాణం</translation>
+    </message>
+    <message>
+        <source>Copy fee</source>
+        <translation type="unfinished">రుసుము కాపీ</translation>
+    </message>
+    <message>
+        <source>Copy after fee</source>
+        <translation type="unfinished">రుసుము తర్వాత కాపీ చేయండి</translation>
+    </message>
+    <message>
+        <source>Copy bytes</source>
+        <translation type="unfinished">బైట్‌లను కాపీ చేయండి</translation>
+    </message>
+    <message>
+        <source>Copy dust</source>
+        <translation type="unfinished">దుమ్మును కాపీ చేయండి</translation>
+    </message>
+    <message>
+        <source>Copy change</source>
+        <translation type="unfinished">మార్పుని కాపీ చేయండి</translation>
+    </message>
+    <message>
+        <source>(%1 locked)</source>
+        <translation type="unfinished">(%1 లాక్ చేయబడింది)</translation>
+    </message>
+    <message>
+        <source>yes</source>
+        <translation type="unfinished">అవును</translation>
+    </message>
+    <message>
+        <source>no</source>
+        <translation type="unfinished">లేదు</translation>
+    </message>
+    <message>
+        <source>This label turns red if any recipient receives an amount smaller than the current dust threshold.</source>
+        <translation type="unfinished">ఏదైనా గ్రహీత ప్రస్తుత ధూళి థ్రెషోల్డ్ కంటే చిన్న మొత్తాన్ని స్వీకరిస్తే ఈ లేబుల్ ఎరుపు రంగులోకి మారుతుంది.</translation>
+    </message>
+    <message>
+        <source>Can vary +/- %1 satoshi(s) per input.</source>
+        <translation type="unfinished">ఒక్కో ఇన్‌పుట్‌కు +/- %1 సతోషి(లు) మారవచ్చు.</translation>
+    </message>
+    <message>
         <source>(no label)</source>
         <translation type="unfinished">( ఉల్లాకు లేదు )</translation>
     </message>
-    </context>
+    <message>
+        <source>change from %1 (%2)</source>
+        <translation type="unfinished">నుండి మార్చండి %1 (%2)</translation>
+    </message>
+    <message>
+        <source>(change)</source>
+        <translation type="unfinished">(మార్పు)</translation>
+    </message>
+</context>
+<context>
+    <name>CreateWalletActivity</name>
+    <message>
+        <source>Create Wallet</source>
+        <extracomment>Title of window indicating the progress of creation of a new wallet.</extracomment>
+        <translation type="unfinished">వాలెట్‌ని సృష్టించండి</translation>
+    </message>
+    <message>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the create wallet progress window which indicates to the user which wallet is currently being created.</extracomment>
+        <translation type="unfinished">వాలెట్‌ని సృష్టించండి &lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+    <message>
+        <source>Create wallet failed</source>
+        <translation type="unfinished">వాలెట్‌ని సృష్టించడం విఫలమైంది</translation>
+    </message>
+    <message>
+        <source>Create wallet warning</source>
+        <translation type="unfinished">వాలెట్ హెచ్చరికను సృష్టించండి</translation>
+    </message>
+    <message>
+        <source>Can't list signers</source>
+        <translation type="unfinished">సంతకం చేసేవారిని జాబితా చేయలేరు</translation>
+    </message>
+    <message>
+        <source>Too many external signers found</source>
+        <translation type="unfinished">చాలా ఎక్కువ బాహ్య సంతకాలు కనుగొనబడ్డాయి</translation>
+    </message>
+</context>
+<context>
+    <name>LoadWalletsActivity</name>
+    <message>
+        <source>Load Wallets</source>
+        <extracomment>Title of progress window which is displayed when wallets are being loaded.</extracomment>
+        <translation type="unfinished">వాలెట్లను లోడ్ చేయండి</translation>
+    </message>
+    <message>
+        <source>Loading wallets…</source>
+        <extracomment>Descriptive text of the load wallets progress window which indicates to the user that wallets are currently being loaded.</extracomment>
+        <translation type="unfinished">వాలెట్లను లోడ్ చేస్తోంది…</translation>
+    </message>
+</context>
+<context>
+    <name>OpenWalletActivity</name>
+    <message>
+        <source>Open wallet failed</source>
+        <translation type="unfinished">ఓపెన్ వాలెట్ విఫలమైంది</translation>
+    </message>
+    <message>
+        <source>Open wallet warning</source>
+        <translation type="unfinished">ఓపెన్ వాలెట్ హెచ్చరిక</translation>
+    </message>
+    <message>
+        <source>default wallet</source>
+        <translation type="unfinished">డిఫాల్ట్ వాలెట్</translation>
+    </message>
+    <message>
+        <source>Open Wallet</source>
+        <extracomment>Title of window indicating the progress of opening of a wallet.</extracomment>
+        <translation type="unfinished">వాలెట్ తెరవండి</translation>
+    </message>
+    <message>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the open wallet progress window which indicates to the user which wallet is currently being opened.</extracomment>
+        <translation type="unfinished">వాలెట్‌ని తెరుస్తోంది &lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+</context>
+<context>
+    <name>RestoreWalletActivity</name>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of progress window which is displayed when wallets are being restored.</extracomment>
+        <translation type="unfinished">వాలెట్‌ని పునరుద్ధరించండి</translation>
+    </message>
+    <message>
+        <source>Restoring Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the restore wallets progress window which indicates to the user that wallets are currently being restored.</extracomment>
+        <translation type="unfinished">వాలెట్‌ని పునరుద్ధరిస్తోంది &lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+    <message>
+        <source>Restore wallet failed</source>
+        <extracomment>Title of message box which is displayed when the wallet could not be restored.</extracomment>
+        <translation type="unfinished">వాలెట్‌ని పునరుద్ధరించడం విఫలమైంది</translation>
+    </message>
+    <message>
+        <source>Restore wallet warning</source>
+        <extracomment>Title of message box which is displayed when the wallet is restored with some warning.</extracomment>
+        <translation type="unfinished">వాలెట్ హెచ్చరికను పునరుద్ధరించండి</translation>
+    </message>
+    <message>
+        <source>Restore wallet message</source>
+        <extracomment>Title of message box which is displayed when the wallet is successfully restored.</extracomment>
+        <translation type="unfinished">వాలెట్ సందేశాన్ని పునరుద్ధరించండి</translation>
+    </message>
+</context>
+<context>
+    <name>WalletController</name>
+    <message>
+        <source>Close wallet</source>
+        <translation type="unfinished">వాలెట్‌ని మూసివేయండి</translation>
+    </message>
+    <message>
+        <source>Are you sure you wish to close the wallet &lt;i&gt;%1&lt;/i&gt;?</source>
+        <translation type="unfinished">మీరు ఖచ్చితంగా వాలెట్‌ని మూసివేయాలనుకుంటున్నారా &lt;i&gt;%1&lt;/i&gt;?</translation>
+    </message>
+    <message>
+        <source>Closing the wallet for too long can result in having to resync the entire chain if pruning is enabled.</source>
+        <translation type="unfinished">కత్తిరింపు ప్రారంభించబడితే, వాలెట్‌ను ఎక్కువసేపు మూసివేయడం వలన మొత్తం గొలుసును మళ్లీ సమకాలీకరించవలసి ఉంటుంది.</translation>
+    </message>
+    <message>
+        <source>Close all wallets</source>
+        <translation type="unfinished">అన్ని వాలెట్లను మూసివేయండి</translation>
+    </message>
+    <message>
+        <source>Are you sure you wish to close all wallets?</source>
+        <translation type="unfinished">మీరు ఖచ్చితంగా అన్ని వాలెట్లను మూసివేయాలనుకుంటున్నారా?</translation>
+    </message>
+</context>
 <context>
     <name>CreateWalletDialog</name>
+    <message>
+        <source>Create Wallet</source>
+        <translation type="unfinished">వాలెట్‌ని సృష్టించండి</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <translation type="unfinished">వాలెట్ పేరు</translation>
+    </message>
     <message>
         <source>Wallet</source>
         <translation type="unfinished">వాలెట్</translation>
     </message>
-    </context>
+    <message>
+        <source>Encrypt the wallet. The wallet will be encrypted with a passphrase of your choice.</source>
+        <translation type="unfinished">వాలెట్‌ని ఎన్‌క్రిప్ట్ చేయండి. వాలెట్ మీకు నచ్చిన పాస్‌ఫ్రేజ్‌తో ఎన్‌క్రిప్ట్ చేయబడుతుంది.</translation>
+    </message>
+    <message>
+        <source>Encrypt Wallet</source>
+        <translation type="unfinished">వాలెట్‌ని గుప్తీకరించండి</translation>
+    </message>
+    <message>
+        <source>Advanced Options</source>
+        <translation type="unfinished">అధునాతన ఎంపికలు</translation>
+    </message>
+    <message>
+        <source>Disable Private Keys</source>
+        <translation type="unfinished">ప్రైవేట్ కీలను నిలిపివేయండి</translation>
+    </message>
+    <message>
+        <source>Make Blank Wallet</source>
+        <translation type="unfinished">ఖాళీ వాలెట్‌ని తయారు చేయండి</translation>
+    </message>
+    <message>
+        <source>Use descriptors for scriptPubKey management</source>
+        <translation type="unfinished">scriptPubKey నిర్వహణ కోసం డిస్క్రిప్టర్‌లను ఉపయోగించండి</translation>
+    </message>
+    <message>
+        <source>Descriptor Wallet</source>
+        <translation type="unfinished">డిస్క్రిప్టర్ వాలెట్</translation>
+    </message>
+    <message>
+        <source>External signer</source>
+        <translation type="unfinished">బాహ్య సంతకందారు</translation>
+    </message>
+    <message>
+        <source>Create</source>
+        <translation type="unfinished">సృష్టించు</translation>
+    </message>
+    <message>
+        <source>Compiled without sqlite support (required for descriptor wallets)</source>
+        <translation type="unfinished">Sqlite మద్దతు లేకుండా కంపైల్ చేయబడింది (డిస్క్రిప్టర్ వాలెట్‌లకు అవసరం)</translation>
+    </message>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">బాహ్య సంతకం మద్దతు లేకుండా సంకలనం చేయబడింది (బాహ్య సంతకం కోసం అవసరం)</translation>
+    </message>
+</context>
+<context>
+    <name>EditAddressDialog</name>
+    <message>
+        <source>Edit Address</source>
+        <translation type="unfinished">చిరునామాను సవరించండి</translation>
+    </message>
+    <message>
+        <source>&amp;Label</source>
+        <translation type="unfinished">&amp;లేబుల్</translation>
+    </message>
+    <message>
+        <source>The label associated with this address list entry</source>
+        <translation type="unfinished">ఈ చిరునామా జాబితా నమోదుతో అనుబంధించబడిన లేబుల్</translation>
+    </message>
+    <message>
+        <source>&amp;Address</source>
+        <translation type="unfinished">&amp;చిరునామా</translation>
+    </message>
+    <message>
+        <source>New sending address</source>
+        <translation type="unfinished">కొత్త పంపే చిరునామా</translation>
+    </message>
+    <message>
+        <source>Edit receiving address</source>
+        <translation type="unfinished">స్వీకరించే చిరునామాను సవరించండి</translation>
+    </message>
+    <message>
+        <source>Edit sending address</source>
+        <translation type="unfinished">పంపే చిరునామాను సవరించండి</translation>
+    </message>
+    <message>
+        <source>The entered address "%1" is not a valid Bitcoin address.</source>
+        <translation type="unfinished">నమోదు చేసిన చిరునామా "%1" చెల్లుబాటు అయ్యే బిట్‌కాయిన్ చిరునామా కాదు.</translation>
+    </message>
+    <message>
+        <source>Address "%1" already exists as a receiving address with label "%2" and so cannot be added as a sending address.</source>
+        <translation type="unfinished">చిరునామా "%1" ఇప్పటికే "%2" లేబుల్‌తో స్వీకరించే చిరునామాగా ఉంది మరియు పంపే చిరునామాగా జోడించబడదు.</translation>
+    </message>
+    <message>
+        <source>The entered address "%1" is already in the address book with label "%2".</source>
+        <translation type="unfinished">నమోదు చేసిన చిరునామా "%1" ఇప్పటికే చిరునామా పుస్తకంలో "%2" లేబుల్‌తో ఉంది.</translation>
+    </message>
+    <message>
+        <source>Could not unlock wallet.</source>
+        <translation type="unfinished">వాలెట్‌ని అన్‌లాక్ చేయడం సాధ్యపడలేదు.</translation>
+    </message>
+    <message>
+        <source>New key generation failed.</source>
+        <translation type="unfinished">కొత్త కీ జనరేషన్ విఫలమైంది.</translation>
+    </message>
+</context>
+<context>
+    <name>FreespaceChecker</name>
+    <message>
+        <source>A new data directory will be created.</source>
+        <translation type="unfinished">కొత్త డేటా డైరెక్టరీ సృష్టించబడుతుంది.</translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished">పేరు</translation>
+    </message>
+    <message>
+        <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
+        <translation type="unfinished">డైరెక్టరీ ఇప్పటికే ఉంది. %1 మీరు ఇక్కడ కొత్త డైరెక్టరీని సృష్టించాలనుకుంటే జోడించండి.</translation>
+    </message>
+    <message>
+        <source>Path already exists, and is not a directory.</source>
+        <translation type="unfinished">మార్గం ఇప్పటికే ఉంది మరియు ఇది డైరెక్టరీ కాదు.</translation>
+    </message>
+    <message>
+        <source>Cannot create data directory here.</source>
+        <translation type="unfinished">ఇక్కడ డేటా డైరెక్టరీని సృష్టించలేరు.</translation>
+    </message>
+</context>
 <context>
     <name>Intro</name>
     <message>
@@ -429,35 +1477,931 @@
         <translation type="unfinished">బిట్కోయిన్</translation>
     </message>
     <message numerus="yes">
-        <source>(sufficient to restore backups %n day(s) old)</source>
-        <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
+        <source>%n GB of space available</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n GB స్థలం అందుబాటులో ఉంది</numerusform>
+            <numerusform>%n GB స్థలం అందుబాటులో ఉంది</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform>(అవసరమైన %n GB)</numerusform>
+            <numerusform>(అవసరమైన %n GB)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform>(పూర్తి గొలుసు కోసం %n GB అవసరం)</numerusform>
+            <numerusform>(పూర్తి గొలుసు కోసం %n GB అవసరం)</numerusform>
         </translation>
     </message>
     <message>
-        <source>Error</source>
-        <translation type="unfinished">లోపం</translation>
+        <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
+        <translation type="unfinished">ఈ డైరెక్టరీలో కనీసం %1 GB డేటా నిల్వ చేయబడుతుంది మరియు ఇది కాలక్రమేణా పెరుగుతుంది.</translation>
     </message>
-    </context>
-<context>
-    <name>OptionsDialog</name>
+    <message>
+        <source>Approximately %1 GB of data will be stored in this directory.</source>
+        <translation type="unfinished">ఈ డైరెక్టరీలో సుమారు %1 GB డేటా నిల్వ చేయబడుతుంది.</translation>
+    </message>
+    <message numerus="yes">
+        <source>(sufficient to restore backups %n day(s) old)</source>
+        <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
+        <translation type="unfinished">
+            <numerusform>(బ్యాకప్‌లను పునరుద్ధరించడానికి సరిపోతుంది %n రోజు(లు) పాతది)</numerusform>
+            <numerusform>(బ్యాకప్‌లను పునరుద్ధరించడానికి సరిపోతుంది %n రోజు(లు) పాతది)</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>%1 will download and store a copy of the Bitcoin block chain.</source>
+        <translation type="unfinished">%1 బిట్‌కాయిన్ బ్లాక్ చైన్ కాపీని డౌన్‌లోడ్ చేసి నిల్వ చేస్తుంది.</translation>
+    </message>
+    <message>
+        <source>The wallet will also be stored in this directory.</source>
+        <translation type="unfinished">వాలెట్ కూడా ఈ డైరెక్టరీలో నిల్వ చేయబడుతుంది.</translation>
+    </message>
+    <message>
+        <source>Error: Specified data directory "%1" cannot be created.</source>
+        <translation type="unfinished">లోపం: పేర్కొన్న డేటా డైరెక్టరీ "%1" సృష్టించబడదు.</translation>
+    </message>
     <message>
         <source>Error</source>
         <translation type="unfinished">లోపం</translation>
     </message>
-    </context>
+    <message>
+        <source>Welcome</source>
+        <translation type="unfinished">స్వాగతం</translation>
+    </message>
+    <message>
+        <source>Welcome to %1.</source>
+        <translation type="unfinished">%1 కు స్వాగతం</translation>
+    </message>
+    <message>
+        <source>As this is the first time the program is launched, you can choose where %1 will store its data.</source>
+        <translation type="unfinished">ప్రోగ్రామ్ ప్రారంభించబడటం ఇదే మొదటిసారి కాబట్టి, %1 దాని డేటాను ఎక్కడ నిల్వ చేయాలో మీరు ఎంచుకోవచ్చు.</translation>
+    </message>
+    <message>
+        <source>Limit block chain storage to</source>
+        <translation type="unfinished">బ్లాక్ చైన్ నిల్వను పరిమితం చేయండి</translation>
+    </message>
+    <message>
+        <source> GB</source>
+        <translation type="unfinished">GB</translation>
+    </message>
+    <message>
+        <source>Use the default data directory</source>
+        <translation type="unfinished">డిఫాల్ట్ డేటా డైరెక్టరీని ఉపయోగించండి</translation>
+    </message>
+    <message>
+        <source>Use a custom data directory:</source>
+        <translation type="unfinished">అనుకూల డేటా డైరెక్టరీని ఉపయోగించండి:</translation>
+    </message>
+</context>
+<context>
+    <name>HelpMessageDialog</name>
+    <message>
+        <source>version</source>
+        <translation type="unfinished">సంస్కరణ</translation>
+    </message>
+    <message>
+        <source>About %1</source>
+        <translation type="unfinished">గురించి %1</translation>
+    </message>
+    <message>
+        <source>Command-line options</source>
+        <translation type="unfinished">కమాండ్ లైన్ ఎంపికలు</translation>
+    </message>
+</context>
+<context>
+    <name>ShutdownWindow</name>
+    <message>
+        <source>%1 is shutting down…</source>
+        <translation type="unfinished">%1 షట్ డౌన్ అవుతోంది…</translation>
+    </message>
+    <message>
+        <source>Do not shut down the computer until this window disappears.</source>
+        <translation type="unfinished">ఈ విండో అదృశ్యమయ్యే వరకు కంప్యూటర్‌ను ఆపివేయవద్దు.</translation>
+    </message>
+</context>
+<context>
+    <name>ModalOverlay</name>
+    <message>
+        <source>Form</source>
+        <translation type="unfinished">రూపం</translation>
+    </message>
+    <message>
+        <source>Number of blocks left</source>
+        <translation type="unfinished">మిగిలి ఉన్న బ్లాక్‌ల సంఖ్య</translation>
+    </message>
+    <message>
+        <source>Unknown…</source>
+        <translation type="unfinished">తెలియని…</translation>
+    </message>
+    <message>
+        <source>calculating…</source>
+        <translation type="unfinished">లెక్కిస్తోంది...</translation>
+    </message>
+    <message>
+        <source>Last block time</source>
+        <translation type="unfinished">చివరి బ్లాక్ సమయం</translation>
+    </message>
+    <message>
+        <source>Progress</source>
+        <translation type="unfinished">పురోగతి</translation>
+    </message>
+    <message>
+        <source>Progress increase per hour</source>
+        <translation type="unfinished">గంటకు పురోగతి పెరుగుతుంది</translation>
+    </message>
+    <message>
+        <source>Estimated time left until synced</source>
+        <translation type="unfinished">సమకాలీకరించబడే వరకు అంచనా సమయం మిగిలి ఉంది</translation>
+    </message>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished">దాచు</translation>
+    </message>
+    <message>
+        <source>Unknown. Syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">తెలియదు. శీర్షికలను సమకాలీకరించడం (%1, %2%)...</translation>
+    </message>
+    <message>
+        <source>Unknown. Pre-syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">తెలియదు. ముందస్తు సమకాలీకరణ శీర్షికలు (%1, %2%)...</translation>
+    </message>
+</context>
+<context>
+    <name>OpenURIDialog</name>
+    <message>
+        <source>Open bitcoin URI</source>
+        <translation type="unfinished">బిట్‌కాయిన్ URIని తెరవండి</translation>
+    </message>
+    <message>
+        <source>Paste address from clipboard</source>
+        <extracomment>Tooltip text for button that allows you to paste an address that is in your clipboard.</extracomment>
+        <translation type="unfinished">క్లిప్‌బోర్డ్ నుండి చిరునామాను అతికించండి</translation>
+    </message>
+</context>
+<context>
+    <name>OptionsDialog</name>
+    <message>
+        <source>Options</source>
+        <translation type="unfinished">ఎంపికలు</translation>
+    </message>
+    <message>
+        <source>&amp;Main</source>
+        <translation type="unfinished">&amp;ప్రధాన</translation>
+    </message>
+    <message>
+        <source>Automatically start %1 after logging in to the system.</source>
+        <translation type="unfinished">సిస్టమ్‌కు లాగిన్ అయిన తర్వాత స్వయంచాలకంగా "%1" ని ప్రారంభించండి.</translation>
+    </message>
+    <message>
+        <source>&amp;Start %1 on system login</source>
+        <translation type="unfinished">సిస్టమ్ లాగిన్‌లో "%1" ని &amp;ప్రారంభించండి</translation>
+    </message>
+    <message>
+        <source>Size of &amp;database cache</source>
+        <translation type="unfinished">డేటాబేస్ కాష్ యొక్క పరిమాణం</translation>
+    </message>
+    <message>
+        <source>Number of script &amp;verification threads</source>
+        <translation type="unfinished">స్క్రిప్ట్ &amp; ధృవీకరణ థ్రెడ్‌ల సంఖ్య</translation>
+    </message>
+    <message>
+        <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
+        <translation type="unfinished">ప్రాక్సీ యొక్క IP చిరునామా (ఉదా. IPv4: 127.0.0.1 / IPv6: ::1)</translation>
+    </message>
+    <message>
+        <source>Open Configuration File</source>
+        <translation type="unfinished">కాన్ఫిగరేషన్ ఫైల్‌ని తెరవండి</translation>
+    </message>
+    <message>
+        <source>Reset all client options to default.</source>
+        <translation type="unfinished">అన్ని క్లయింట్ ఎంపికలను డిఫాల్ట్‌గా రీసెట్ చేయండి.</translation>
+    </message>
+    <message>
+        <source>&amp;Reset Options</source>
+        <translation type="unfinished">&amp;రీసెట్ ఎంపికలు</translation>
+    </message>
+    <message>
+        <source>&amp;Network</source>
+        <translation type="unfinished">&amp;నెట్‌వర్క్</translation>
+    </message>
+    <message>
+        <source>Prune &amp;block storage to</source>
+        <translation type="unfinished">స్టోరేజ్‌ను కత్తిరించు &amp; బ్లాక్ చేయండి</translation>
+    </message>
+    <message>
+        <source>Reverting this setting requires re-downloading the entire blockchain.</source>
+        <translation type="unfinished">ఈ సెట్టింగ్‌ని తిరిగి మార్చడానికి మొత్తం బ్లాక్‌చెయిన్‌ను మళ్లీ డౌన్‌లోడ్ చేయడం అవసరం.</translation>
+    </message>
+    <message>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation type="unfinished">(0 = ఆటో, &lt;0 = చాలా కోర్లను ఉచితంగా వదిలివేయండి)</translation>
+    </message>
+    <message>
+        <source>This allows you or a third party tool to communicate with the node through command-line and JSON-RPC commands.</source>
+        <extracomment>Tooltip text for Options window setting that enables the RPC server.</extracomment>
+        <translation type="unfinished">కమాండ్-లైన్ మరియు JSON-RPC ఆదేశాల ద్వారా నోడ్‌తో కమ్యూనికేట్ చేయడానికి ఇది మిమ్మల్ని లేదా మూడవ పక్షం సాధనాన్ని అనుమతిస్తుంది.</translation>
+    </message>
+    <message>
+        <source>Enable R&amp;PC server</source>
+        <extracomment>An Options window setting to enable the RPC server.</extracomment>
+        <translation type="unfinished">R&amp;PC సర్వర్‌ని ప్రారంభించండి</translation>
+    </message>
+    <message>
+        <source>W&amp;allet</source>
+        <translation type="unfinished">వా&amp;లెట్</translation>
+    </message>
+    <message>
+        <source>Whether to set subtract fee from amount as default or not.</source>
+        <extracomment>Tooltip text for Options window setting that sets subtracting the fee from a sending amount as default.</extracomment>
+        <translation type="unfinished">డిఫాల్ట్‌గా మొత్తం నుండి రుసుమును తీసివేయాలా లేదా అని సెట్ చేయాలా.</translation>
+    </message>
+    <message>
+        <source>Subtract &amp;fee from amount by default</source>
+        <extracomment>An Options window setting to set subtracting the fee from a sending amount as default.</extracomment>
+        <translation type="unfinished">డిఫాల్ట్‌గా మొత్తం నుండి &amp;ఫీజును తీసివేయండి</translation>
+    </message>
+    <message>
+        <source>Expert</source>
+        <translation type="unfinished">నిపుణుడు</translation>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation type="unfinished">నాణెం &amp;నియంత్రణ లక్షణాలను ప్రారంభించండి</translation>
+    </message>
+    <message>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation type="unfinished">&amp;ధృవీకరించబడని మార్పును ఖర్చు చేయండి</translation>
+    </message>
+    <message>
+        <source>Enable &amp;PSBT controls</source>
+        <extracomment>An options window setting to enable PSBT controls.</extracomment>
+        <translation type="unfinished">&amp;PSBT నియంత్రణలను ప్రారంభించండి</translation>
+    </message>
+    <message>
+        <source>Whether to show PSBT controls.</source>
+        <extracomment>Tooltip text for options window setting that enables PSBT controls.</extracomment>
+        <translation type="unfinished">PSBT నియంత్రణలను చూపాలా వద్దా.</translation>
+    </message>
+    <message>
+        <source>External Signer (e.g. hardware wallet)</source>
+        <translation type="unfinished">బాహ్య సంతకం (ఉదా. హార్డ్‌వేర్ వాలెట్)</translation>
+    </message>
+    <message>
+        <source>&amp;External signer script path</source>
+        <translation type="unfinished">&amp;బాహ్య సంతకం స్క్రిప్ట్ మార్గం</translation>
+    </message>
+    <message>
+        <source>Full path to a Bitcoin Core compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</source>
+        <translation type="unfinished">బిట్‌కాయిన్ కోర్ అనుకూల స్క్రిప్ట్‌కి పూర్తి మార్గం (ఉదా. C:\Downloads\hwi.exe లేదా /Users/you/Downloads/hwi.py). జాగ్రత్త: మాల్వేర్ మీ నాణేలను దొంగిలించగలదు!</translation>
+    </message>
+    <message>
+        <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
+        <translation type="unfinished">రౌటర్‌లో బిట్‌కాయిన్ క్లయింట్ పోర్ట్‌ను స్వయంచాలకంగా తెరవండి. ఇది మీ రూటర్ UPnPకి మద్దతు ఇచ్చినప్పుడు మరియు అది ప్రారంభించబడినప్పుడు మాత్రమే పని చేస్తుంది.</translation>
+    </message>
+    <message>
+        <source>Map port using &amp;UPnP</source>
+        <translation type="unfinished">&amp;UPnPని ఉపయోగించి మ్యాప్ పోర్ట్</translation>
+    </message>
+    <message>
+        <source>Map port using NA&amp;T-PMP</source>
+        <translation type="unfinished">NA&amp;T-PMPని ఉపయోగించి మ్యాప్ పోర్ట్</translation>
+    </message>
+    <message>
+        <source>Accept connections from outside.</source>
+        <translation type="unfinished">బయటి నుండి కనెక్షన్లను అంగీకరించండి.</translation>
+    </message>
+    <message>
+        <source>Allow incomin&amp;g connections</source>
+        <translation type="unfinished">ఇన్‌కమిం&amp;g కనెక్షన్‌లను అనుమతించండి</translation>
+    </message>
+    <message>
+        <source>Connect to the Bitcoin network through a SOCKS5 proxy.</source>
+        <translation type="unfinished">SOCKS5 ప్రాక్సీ ద్వారా బిట్‌కాయిన్ నెట్‌వర్క్‌కు కనెక్ట్ చేయండి.</translation>
+    </message>
+    <message>
+        <source>&amp;Connect through SOCKS5 proxy (default proxy):</source>
+        <translation type="unfinished">&amp;SOCKS5 ప్రాక్సీ ద్వారా కనెక్ట్ చేయండి (డిఫాల్ట్ ప్రాక్సీ):</translation>
+    </message>
+    <message>
+        <source>Proxy &amp;IP:</source>
+        <translation type="unfinished">ప్రాక్సీ &amp;IP:</translation>
+    </message>
+    <message>
+        <source>&amp;Port:</source>
+        <translation type="unfinished">&amp;పోర్ట్:</translation>
+    </message>
+    <message>
+        <source>Port of the proxy (e.g. 9050)</source>
+        <translation type="unfinished">ప్రాక్సీ పోర్ట్ (ఉదా. 9050)</translation>
+    </message>
+    <message>
+        <source>Used for reaching peers via:</source>
+        <translation type="unfinished">దీని ద్వారా సహచరులను చేరుకోవడానికి ఉపయోగించబడుతుంది:</translation>
+    </message>
+    <message>
+        <source>&amp;Window</source>
+        <translation type="unfinished">&amp;విండో</translation>
+    </message>
+    <message>
+        <source>Show the icon in the system tray.</source>
+        <translation type="unfinished">సిస్టమ్ ట్రేలో చిహ్నాన్ని చూపించు.</translation>
+    </message>
+    <message>
+        <source>&amp;Show tray icon</source>
+        <translation type="unfinished">&amp;ట్రే చిహ్నాన్ని చూపు</translation>
+    </message>
+    <message>
+        <source>Show only a tray icon after minimizing the window.</source>
+        <translation type="unfinished">విండోను కనిష్టీకరించిన తర్వాత ట్రే చిహ్నాన్ని మాత్రమే చూపించు.</translation>
+    </message>
+    <message>
+        <source>&amp;Minimize to the tray instead of the taskbar</source>
+        <translation type="unfinished">&amp;టాస్క్‌బార్‌కు బదులుగా ట్రేకి కనిష్టీకరించండి</translation>
+    </message>
+    <message>
+        <source>M&amp;inimize on close</source>
+        <translation type="unfinished">ద&amp;గ్గరగా కనిష్టీకరించండి</translation>
+    </message>
+    <message>
+        <source>&amp;Display</source>
+        <translation type="unfinished">&amp;ప్రదర్శన</translation>
+    </message>
+    <message>
+        <source>User Interface &amp;language:</source>
+        <translation type="unfinished">వినియోగదారు ఇంటర్‌ఫేస్ &amp;భాష:</translation>
+    </message>
+    <message>
+        <source>The user interface language can be set here. This setting will take effect after restarting %1.</source>
+        <translation type="unfinished">వినియోగదారు ఇంటర్‌ఫేస్ భాషను ఇక్కడ సెట్ చేయవచ్చు. %1 ని పునఃప్రారంభించిన తర్వాత ఈ సెట్టింగ్ ప్రభావం చూపుతుంది.</translation>
+    </message>
+    <message>
+        <source>&amp;Unit to show amounts in:</source>
+        <translation type="unfinished">&amp;యూనిట్‌లో మొత్తాలను చూపడానికి:</translation>
+    </message>
+    <message>
+        <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
+        <translation type="unfinished">ఇంటర్‌ఫేస్‌లో మరియు నాణేలను పంపేటప్పుడు చూపించడానికి డిఫాల్ట్ సబ్‌డివిజన్ యూనిట్‌ని ఎంచుకోండి.</translation>
+    </message>
+    <message>
+        <source>&amp;Third-party transaction URLs</source>
+        <translation type="unfinished">&amp;మూడవ పక్షం లావాదేవీ URLలు</translation>
+    </message>
+    <message>
+        <source>Whether to show coin control features or not.</source>
+        <translation type="unfinished">కాయిన్ కంట్రోల్ ఫీచర్‌లను చూపించాలా వద్దా.</translation>
+    </message>
+    <message>
+        <source>Connect to the Bitcoin network through a separate SOCKS5 proxy for Tor onion services.</source>
+        <translation type="unfinished">Tor onion సేవల కోసం ప్రత్యేక SOCKS5 ప్రాక్సీ ద్వారా బిట్‌కాయిన్ నెట్‌వర్క్‌కు కనెక్ట్ చేయండి.</translation>
+    </message>
+    <message>
+        <source>Use separate SOCKS&amp;5 proxy to reach peers via Tor onion services:</source>
+        <translation type="unfinished">Tor onion సేవల ద్వారా సహచరులను చేరుకోవడానికి ప్రత్యేక SOCKS&amp;5 ప్రాక్సీని ఉపయోగించండి:</translation>
+    </message>
+    <message>
+        <source>Monospaced font in the Overview tab:</source>
+        <translation type="unfinished">ఓవర్‌వ్యూ ట్యాబ్‌లో మోనోస్పేస్డ్ ఫాంట్:</translation>
+    </message>
+    <message>
+        <source>embedded "%1"</source>
+        <translation type="unfinished">పొందుపరిచారు "%1"</translation>
+    </message>
+    <message>
+        <source>closest matching "%1"</source>
+        <translation type="unfinished">సన్నిహిత సరిపోలిక "%1"</translation>
+    </message>
+    <message>
+        <source>&amp;OK</source>
+        <translation type="unfinished">&amp;అలాగే</translation>
+    </message>
+    <message>
+        <source>&amp;Cancel</source>
+        <translation type="unfinished">&amp;రద్దు చేయండి</translation>
+    </message>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">బాహ్య సంతకం మద్దతు లేకుండా సంకలనం చేయబడింది (బాహ్య సంతకం కోసం అవసరం)</translation>
+    </message>
+    <message>
+        <source>default</source>
+        <translation type="unfinished">డిఫాల్ట్</translation>
+    </message>
+    <message>
+        <source>none</source>
+        <translation type="unfinished">ఏదీ లేదు</translation>
+    </message>
+    <message>
+        <source>Confirm options reset</source>
+        <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
+        <translation type="unfinished">ఎంపికల రీసెట్‌ని నిర్ధారించండి</translation>
+    </message>
+    <message>
+        <source>Client restart required to activate changes.</source>
+        <extracomment>Text explaining that the settings changed will not come into effect until the client is restarted.</extracomment>
+        <translation type="unfinished">మార్పులను సక్రియం చేయడానికి క్లయింట్ పునఃప్రారంభించాల్సిన అవసరం ఉంది.</translation>
+    </message>
+    <message>
+        <source>Current settings will be backed up at "%1".</source>
+        <extracomment>Text explaining to the user that the client's current settings will be backed up at a specific location. %1 is a stand-in argument for the backup location's path.</extracomment>
+        <translation type="unfinished">ప్రస్తుత సెట్టింగ్‌లు "%1" వద్ద బ్యాకప్ చేయబడతాయి.</translation>
+    </message>
+    <message>
+        <source>Client will be shut down. Do you want to proceed?</source>
+        <extracomment>Text asking the user to confirm if they would like to proceed with a client shutdown.</extracomment>
+        <translation type="unfinished">క్లయింట్ మూసివేయబడుతుంది. మీరు కొనసాగించాలనుకుంటున్నారా?</translation>
+    </message>
+    <message>
+        <source>Configuration options</source>
+        <extracomment>Window title text of pop-up box that allows opening up of configuration file.</extracomment>
+        <translation type="unfinished">కాన్ఫిగరేషన్ ఎంపికలు</translation>
+    </message>
+    <message>
+        <source>The configuration file is used to specify advanced user options which override GUI settings. Additionally, any command-line options will override this configuration file.</source>
+        <extracomment>Explanatory text about the priority order of instructions considered by client. The order from high to low being: command-line, configuration file, GUI settings.</extracomment>
+        <translation type="unfinished">GUI సెట్టింగ్‌లను భర్తీ చేసే అధునాతన వినియోగదారు ఎంపికలను పేర్కొనడానికి కాన్ఫిగరేషన్ ఫైల్ ఉపయోగించబడుతుంది. అదనంగా, ఏదైనా కమాండ్-లైన్ ఎంపికలు ఈ కాన్ఫిగరేషన్ ఫైల్‌ను భర్తీ చేస్తాయి.</translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation type="unfinished">కొనసాగించు</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">రద్దు చేయండి</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">లోపం</translation>
+    </message>
+    <message>
+        <source>The configuration file could not be opened.</source>
+        <translation type="unfinished">కాన్ఫిగరేషన్ ఫైల్ తెరవబడలేదు.</translation>
+    </message>
+    <message>
+        <source>This change would require a client restart.</source>
+        <translation type="unfinished">ఈ మార్పుకు క్లయింట్ పునఃప్రారంభం అవసరం.</translation>
+    </message>
+    <message>
+        <source>The supplied proxy address is invalid.</source>
+        <translation type="unfinished">సరఫరా చేయబడిన ప్రాక్సీ చిరునామా చెల్లదు.</translation>
+    </message>
+</context>
+<context>
+    <name>OptionsModel</name>
+    <message>
+        <source>Could not read setting "%1", %2.</source>
+        <translation type="unfinished">సెట్టింగ్ "%1", %2 చదవడం సాధ్యపడలేదు, .</translation>
+    </message>
+</context>
+<context>
+    <name>OverviewPage</name>
+    <message>
+        <source>Form</source>
+        <translation type="unfinished">రూపం</translation>
+    </message>
+    <message>
+        <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
+        <translation type="unfinished">ప్రదర్శించబడిన సమాచారం పాతది కావచ్చు. కనెక్షన్ స్థాపించబడిన తర్వాత మీ వాలెట్ స్వయంచాలకంగా బిట్‌కాయిన్ నెట్‌వర్క్‌తో సమకాలీకరించబడుతుంది, కానీ ఈ ప్రక్రియ ఇంకా పూర్తి కాలేదు.</translation>
+    </message>
+    <message>
+        <source>Watch-only:</source>
+        <translation type="unfinished">చూడటానికి మాత్రమే:</translation>
+    </message>
+    <message>
+        <source>Available:</source>
+        <translation type="unfinished">అందుబాటులో ఉంది:</translation>
+    </message>
+    <message>
+        <source>Your current spendable balance</source>
+        <translation type="unfinished">మీ ప్రస్తుత ఖర్చు చేయదగిన బ్యాలెన్స్</translation>
+    </message>
+    <message>
+        <source>Pending:</source>
+        <translation type="unfinished">పెండింగ్‌లో ఉంది:</translation>
+    </message>
+    <message>
+        <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
+        <translation type="unfinished">ఇంకా ధృవీకరించబడని లావాదేవీల మొత్తం మరియు ఇంకా ఖర్చు చేయదగిన బ్యాలెన్స్‌లో లెక్కించబడదు</translation>
+    </message>
+    <message>
+        <source>Immature:</source>
+        <translation type="unfinished">పరిపక్వత లేని:</translation>
+    </message>
+    <message>
+        <source>Mined balance that has not yet matured</source>
+        <translation type="unfinished">ఇంకా పరిపక్వం చెందని సంతులనం తవ్వబడింది</translation>
+    </message>
+    <message>
+        <source>Balances</source>
+        <translation type="unfinished">బ్యాలెన్స్‌లు</translation>
+    </message>
+    <message>
+        <source>Total:</source>
+        <translation type="unfinished">మొత్తం:</translation>
+    </message>
+    <message>
+        <source>Your current total balance</source>
+        <translation type="unfinished">మీ ప్రస్తుత మొత్తం బ్యాలెన్స్</translation>
+    </message>
+    <message>
+        <source>Your current balance in watch-only addresses</source>
+        <translation type="unfinished">వీక్షణ-మాత్రమే చిరునామాలలో మీ ప్రస్తుత బ్యాలెన్స్</translation>
+    </message>
+    <message>
+        <source>Spendable:</source>
+        <translation type="unfinished">ఖర్చు చేయదగినది:</translation>
+    </message>
+    <message>
+        <source>Recent transactions</source>
+        <translation type="unfinished">ఇటీవలి లావాదేవీలు</translation>
+    </message>
+    <message>
+        <source>Unconfirmed transactions to watch-only addresses</source>
+        <translation type="unfinished">వీక్షణ-మాత్రమే చిరునామాలకు ధృవీకరించబడని లావాదేవీలు</translation>
+    </message>
+    <message>
+        <source>Mined balance in watch-only addresses that has not yet matured</source>
+        <translation type="unfinished">ఇంకా మెచ్యూర్ కాని వాచ్-ఓన్లీ అడ్రస్‌లలో మైన్ చేయబడిన బ్యాలెన్స్</translation>
+    </message>
+    <message>
+        <source>Current total balance in watch-only addresses</source>
+        <translation type="unfinished">వీక్షణ-మాత్రమే చిరునామాలలో ప్రస్తుత మొత్తం బ్యాలెన్స్</translation>
+    </message>
+    <message>
+        <source>Privacy mode activated for the Overview tab. To unmask the values, uncheck Settings-&gt;Mask values.</source>
+        <translation type="unfinished">అవలోకనం ట్యాబ్ కోసం గోప్యతా మోడ్ సక్రియం చేయబడింది. విలువలను అన్‌మాస్క్ చేయడానికి, సెట్టింగ్‌లు-&gt;మాస్క్ విలువల ఎంపికను తీసివేయండి.</translation>
+    </message>
+</context>
+<context>
+    <name>PSBTOperationsDialog</name>
+    <message>
+        <source>Dialog</source>
+        <translation type="unfinished">డైలాగ్</translation>
+    </message>
+    <message>
+        <source>Sign Tx</source>
+        <translation type="unfinished">లావాదేవీ పై సంతకం చేయండి</translation>
+    </message>
+    <message>
+        <source>Broadcast Tx</source>
+        <translation type="unfinished">ప్రసారం చేయు లావాదేవీ</translation>
+    </message>
+    <message>
+        <source>Copy to Clipboard</source>
+        <translation type="unfinished">క్లిప్‌బోర్డ్‌కి కాపీ చేయండి</translation>
+    </message>
+    <message>
+        <source>Save…</source>
+        <translation type="unfinished">సేవ్ చేయి...</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation type="unfinished">మూసివేయి</translation>
+    </message>
+    <message>
+        <source>Failed to load transaction: %1</source>
+        <translation type="unfinished">లావాదేవీని లోడ్ చేయడంలో విఫలమైంది: %1</translation>
+    </message>
+    <message>
+        <source>Failed to sign transaction: %1</source>
+        <translation type="unfinished">లావాదేవీపై సంతకం చేయడంలో విఫలమైంది: %1</translation>
+    </message>
+    <message>
+        <source>Cannot sign inputs while wallet is locked.</source>
+        <translation type="unfinished">వాలెట్ లాక్ చేయబడినప్పుడు ఇన్‌పుట్‌లపై సంతకం చేయలేరు.</translation>
+    </message>
+    <message>
+        <source>Could not sign any more inputs.</source>
+        <translation type="unfinished">మరిన్ని ఇన్‌పుట్‌లపై సంతకం చేయడం సాధ్యపడలేదు.</translation>
+    </message>
+    <message>
+        <source>Signed %1 inputs, but more signatures are still required.</source>
+        <translation type="unfinished">సంతకం చేయబడిన %1 ఇన్‌పుట్‌లు, కానీ మరిన్ని సంతకాలు ఇంకా అవసరం.</translation>
+    </message>
+    <message>
+        <source>Signed transaction successfully. Transaction is ready to broadcast.</source>
+        <translation type="unfinished">లావాదేవీ విజయవంతంగా సంతకం చేయబడింది. లావాదేవీ ప్రసారానికి సిద్ధంగా ఉంది.</translation>
+    </message>
+    <message>
+        <source>Unknown error processing transaction.</source>
+        <translation type="unfinished">లావాదేవీని ప్రాసెస్ చేయడంలో తెలియని లోపం.</translation>
+    </message>
+    <message>
+        <source>Transaction broadcast successfully! Transaction ID: %1</source>
+        <translation type="unfinished">లావాదేవీ విజయవంతంగా ప్రసారం చేయబడింది! లావాదేవి ఐడి: %1</translation>
+    </message>
+    <message>
+        <source>Transaction broadcast failed: %1</source>
+        <translation type="unfinished">లావాదేవీ ప్రసారం విఫలమైంది: %1</translation>
+    </message>
+    <message>
+        <source>PSBT copied to clipboard.</source>
+        <translation type="unfinished">PSBT క్లిప్‌బోర్డ్‌కి కాపీ చేయబడింది.</translation>
+    </message>
+    <message>
+        <source>Save Transaction Data</source>
+        <translation type="unfinished">లావాదేవీ డేటాను సేవ్ చేయండి</translation>
+    </message>
+    <message>
+        <source>Partially Signed Transaction (Binary)</source>
+        <extracomment>Expanded name of the binary PSBT file format. See: BIP 174.</extracomment>
+        <translation type="unfinished">పాక్షికంగా సంతకం చేసిన లావాదేవీ (బైనరీ)</translation>
+    </message>
+    <message>
+        <source>PSBT saved to disk.</source>
+        <translation type="unfinished">PSBT డిస్క్‌లో సేవ్ చేయబడింది.</translation>
+    </message>
+    <message>
+        <source> * Sends %1 to %2</source>
+        <translation type="unfinished">* %1 ని %2 కి పంపుతుంది</translation>
+    </message>
+    <message>
+        <source>Unable to calculate transaction fee or total transaction amount.</source>
+        <translation type="unfinished">లావాదేవీ రుసుము లేదా మొత్తం లావాదేవీ మొత్తాన్ని లెక్కించడం సాధ్యం కాలేదు.</translation>
+    </message>
+    <message>
+        <source>Pays transaction fee: </source>
+        <translation type="unfinished">లావాదేవీ రుసుము చెల్లిస్తుంది:</translation>
+    </message>
+    <message>
+        <source>Total Amount</source>
+        <translation type="unfinished">పూర్తి మొత్తము</translation>
+    </message>
+    <message>
+        <source>or</source>
+        <translation type="unfinished">లేదా</translation>
+    </message>
+    <message>
+        <source>Transaction has %1 unsigned inputs.</source>
+        <translation type="unfinished">లావాదేవీ %1 సంతకం చేయని ఇన్‌పుట్‌లను కలిగి ఉంది.</translation>
+    </message>
+    <message>
+        <source>Transaction is missing some information about inputs.</source>
+        <translation type="unfinished">లావాదేవీ ఇన్‌పుట్‌ల గురించి కొంత సమాచారం లేదు.</translation>
+    </message>
+    <message>
+        <source>Transaction still needs signature(s).</source>
+        <translation type="unfinished">లావాదేవీకి ఇంకా సంతకం(లు) అవసరం.</translation>
+    </message>
+    <message>
+        <source>(But no wallet is loaded.)</source>
+        <translation type="unfinished">(కానీ వాలెట్ లోడ్ చేయబడలేదు.)</translation>
+    </message>
+    <message>
+        <source>(But this wallet cannot sign transactions.)</source>
+        <translation type="unfinished">(కానీ ఈ వాలెట్ లావాదేవీలపై సంతకం చేయదు.)</translation>
+    </message>
+    <message>
+        <source>(But this wallet does not have the right keys.)</source>
+        <translation type="unfinished">(కానీ ఈ వాలెట్‌లో సరైన కీలు లేవు.)</translation>
+    </message>
+    <message>
+        <source>Transaction is fully signed and ready for broadcast.</source>
+        <translation type="unfinished">లావాదేవీ పూర్తిగా సంతకం చేయబడింది మరియు ప్రసారానికి సిద్ధంగా ఉంది.</translation>
+    </message>
+    <message>
+        <source>Transaction status is unknown.</source>
+        <translation type="unfinished">లావాదేవీ స్థితి తెలియదు.</translation>
+    </message>
+</context>
+<context>
+    <name>PaymentServer</name>
+    <message>
+        <source>Payment request error</source>
+        <translation type="unfinished">చెల్లింపు అభ్యర్ధన లోపం</translation>
+    </message>
+    <message>
+        <source>Cannot start bitcoin: click-to-pay handler</source>
+        <translation type="unfinished">బిట్‌కాయిన్‌ను ప్రారంభించడం సాధ్యం కాదు: క్లిక్-టు-పే హ్యాండ్లర్</translation>
+    </message>
+    <message>
+        <source>URI handling</source>
+        <translation type="unfinished">URI నిర్వహణ</translation>
+    </message>
+    <message>
+        <source>'bitcoin://' is not a valid URI. Use 'bitcoin:' instead.</source>
+        <translation type="unfinished">'bitcoin://' చెల్లుబాటు అయ్యే URI కాదు. బదులుగా 'bitcoin:' ఉపయోగించండి.</translation>
+    </message>
+    <message>
+        <source>URI cannot be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
+        <translation type="unfinished">URI అన్వయించబడదు! ఇది చెల్లని బిట్‌కాయిన్ చిరునామా లేదా తప్పుగా రూపొందించబడిన URI పారామీటర్‌ల వల్ల సంభవించవచ్చు.</translation>
+    </message>
+    <message>
+        <source>Payment request file handling</source>
+        <translation type="unfinished">చెల్లింపు అభ్యర్థన ఫైల్ నిర్వహణ</translation>
+    </message>
+</context>
 <context>
     <name>PeerTableModel</name>
+    <message>
+        <source>User Agent</source>
+        <extracomment>Title of Peers Table column which contains the peer's User Agent string.</extracomment>
+        <translation type="unfinished">వినియోగదారు ఏజెంట్</translation>
+    </message>
+    <message>
+        <source>Ping</source>
+        <extracomment>Title of Peers Table column which indicates the current latency of the connection with the peer.</extracomment>
+        <translation type="unfinished">పింగ్</translation>
+    </message>
+    <message>
+        <source>Peer</source>
+        <extracomment>Title of Peers Table column which contains a unique number used to identify a connection.</extracomment>
+        <translation type="unfinished">పీర్</translation>
+    </message>
+    <message>
+        <source>Age</source>
+        <extracomment>Title of Peers Table column which indicates the duration (length of time) since the peer connection started.</extracomment>
+        <translation type="unfinished">వయస్సు</translation>
+    </message>
+    <message>
+        <source>Direction</source>
+        <extracomment>Title of Peers Table column which indicates the direction the peer connection was initiated from.</extracomment>
+        <translation type="unfinished">దిశ</translation>
+    </message>
+    <message>
+        <source>Sent</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have sent to the peer.</extracomment>
+        <translation type="unfinished">పంపారు</translation>
+    </message>
+    <message>
+        <source>Received</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have received from the peer.</extracomment>
+        <translation type="unfinished">స్వీకరించబడింది</translation>
+    </message>
     <message>
         <source>Address</source>
         <extracomment>Title of Peers Table column which contains the IP/Onion/I2P address of the connected peer.</extracomment>
         <translation type="unfinished">చిరునామా</translation>
     </message>
-    </context>
+    <message>
+        <source>Type</source>
+        <extracomment>Title of Peers Table column which describes the type of peer connection. The "type" describes why the connection exists.</extracomment>
+        <translation type="unfinished">రకము</translation>
+    </message>
+    <message>
+        <source>Network</source>
+        <extracomment>Title of Peers Table column which states the network the peer connected through.</extracomment>
+        <translation type="unfinished">నెట్‌వర్క్</translation>
+    </message>
+    <message>
+        <source>Inbound</source>
+        <extracomment>An Inbound Connection from a Peer.</extracomment>
+        <translation type="unfinished">ఇన్‌బౌండ్</translation>
+    </message>
+    <message>
+        <source>Outbound</source>
+        <extracomment>An Outbound Connection to a Peer.</extracomment>
+        <translation type="unfinished">అవుట్ బౌండ్</translation>
+    </message>
+</context>
+<context>
+    <name>QRImageWidget</name>
+    <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">&amp;చిత్రాన్ని సేవ్ చేయి...</translation>
+    </message>
+    <message>
+        <source>&amp;Copy Image</source>
+        <translation type="unfinished">&amp;ఇమేజ్ కాపీ చేయి</translation>
+    </message>
+    <message>
+        <source>Resulting URI too long, try to reduce the text for label / message.</source>
+        <translation type="unfinished">URI చాలా పొడవుగా ఉంది, లేబుల్ / సందేశం కోసం వచనాన్ని తగ్గించడానికి ప్రయత్నించండి.</translation>
+    </message>
+    <message>
+        <source>Error encoding URI into QR Code.</source>
+        <translation type="unfinished">URIని QR కోడ్‌లోకి ఎన్‌కోడ్ చేయడంలో లోపం.</translation>
+    </message>
+    <message>
+        <source>QR code support not available.</source>
+        <translation type="unfinished">QR కోడ్ మద్దతు అందుబాటులో లేదు.</translation>
+    </message>
+    <message>
+        <source>Save QR Code</source>
+        <translation type="unfinished">QR కోడ్‌ని సేవ్ చేయండి</translation>
+    </message>
+    <message>
+        <source>PNG Image</source>
+        <extracomment>Expanded name of the PNG file format. See: https://en.wikipedia.org/wiki/Portable_Network_Graphics.</extracomment>
+        <translation type="unfinished">PNG చిత్రం</translation>
+    </message>
+</context>
 <context>
     <name>RPCConsole</name>
+    <message>
+        <source>N/A</source>
+        <translation type="unfinished">వర్తించదు</translation>
+    </message>
+    <message>
+        <source>Client version</source>
+        <translation type="unfinished">క్లయింట్ వెర్షన్</translation>
+    </message>
+    <message>
+        <source>&amp;Information</source>
+        <translation type="unfinished">&amp;సమాచారం</translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation type="unfinished">సాధారణ</translation>
+    </message>
+    <message>
+        <source>Datadir</source>
+        <translation type="unfinished">సమాచార డైరెక్టరీ</translation>
+    </message>
+    <message>
+        <source>To specify a non-default location of the data directory use the '%1' option.</source>
+        <translation type="unfinished">డేటా డైరెక్టరీ యొక్క నాన్-డిఫాల్ట్ స్థానాన్ని పేర్కొనడానికి '%1' ఎంపికను ఉపయోగించండి.</translation>
+    </message>
+    <message>
+        <source>Blocksdir</source>
+        <translation type="unfinished">బ్లాక్స్ డైరెక్టరీ</translation>
+    </message>
+    <message>
+        <source>To specify a non-default location of the blocks directory use the '%1' option.</source>
+        <translation type="unfinished">బ్లాక్స్ డైరెక్టరీ యొక్క నాన్-డిఫాల్ట్ స్థానాన్ని పేర్కొనడానికి '%1' ఎంపికను ఉపయోగించండి.</translation>
+    </message>
+    <message>
+        <source>Startup time</source>
+        <translation type="unfinished">ప్రారంభ సమయం</translation>
+    </message>
+    <message>
+        <source>Network</source>
+        <translation type="unfinished">నెట్‌వర్క్</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished">పేరు</translation>
+    </message>
+    <message>
+        <source>Number of connections</source>
+        <translation type="unfinished">కనెక్షన్ల సంఖ్య</translation>
+    </message>
+    <message>
+        <source>Block chain</source>
+        <translation type="unfinished">బ్లాక్ చైన్</translation>
+    </message>
+    <message>
+        <source>Memory Pool</source>
+        <translation type="unfinished">మెమరీ పూల్</translation>
+    </message>
+    <message>
+        <source>Current number of transactions</source>
+        <translation type="unfinished">ప్రస్తుత లావాదేవీల సంఖ్య</translation>
+    </message>
+    <message>
+        <source>Memory usage</source>
+        <translation type="unfinished">మెమరీ వినియోగం</translation>
+    </message>
+    <message>
+        <source>(none)</source>
+        <translation type="unfinished">(ఏదీ లేదు)</translation>
+    </message>
+    <message>
+        <source>&amp;Reset</source>
+        <translation type="unfinished">&amp;రీసెట్</translation>
+    </message>
+    <message>
+        <source>Received</source>
+        <translation type="unfinished">స్వీకరించబడింది</translation>
+    </message>
+    <message>
+        <source>Sent</source>
+        <translation type="unfinished">పంపారు</translation>
+    </message>
+    <message>
+        <source>&amp;Peers</source>
+        <translation type="unfinished">&amp;తోటివారి</translation>
+    </message>
+    <message>
+        <source>Banned peers</source>
+        <translation type="unfinished">సహచరులను నిషేధించారు</translation>
+    </message>
+    <message>
+        <source>Select a peer to view detailed information.</source>
+        <translation type="unfinished">వివరణాత్మక సమాచారాన్ని వీక్షించడానికి పీర్‌ని ఎంచుకోండి.</translation>
+    </message>
+    <message>
+        <source>User Agent</source>
+        <translation type="unfinished">వినియోగదారు ఏజెంట్</translation>
+    </message>
+    <message>
+        <source>Node window</source>
+        <translation type="unfinished">నోడ్ విండో</translation>
+    </message>
+    <message>
+        <source>Last block time</source>
+        <translation type="unfinished">చివరి బ్లాక్ సమయం</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <extracomment>Context menu action to copy the address of a peer.</extracomment>
+        <translation type="unfinished">&amp;కాపీ చిరునామా</translation>
+    </message>
     <message>
         <source>To</source>
         <translation type="unfinished">కు</translation>
@@ -468,10 +2412,81 @@
     </message>
     </context>
 <context>
+    <name>ReceiveCoinsDialog</name>
+    <message>
+        <source>Remove the selected entries from the list</source>
+        <translation type="unfinished">జాబితా నుండి ఎంచుకున్న ఎంట్రీలను తీసివేయండి</translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation type="unfinished">తొలగించు</translation>
+    </message>
+    <message>
+        <source>Copy &amp;URI</source>
+        <translation type="unfinished">కాపీ &amp;URI</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;కాపీ చిరునామా</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">కాపీ &amp;లేబుల్</translation>
+    </message>
+    <message>
+        <source>Copy &amp;message</source>
+        <translation type="unfinished">కాపీ &amp;సందేశం</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">కాపీ &amp;అమౌంట్</translation>
+    </message>
+    <message>
+        <source>Could not unlock wallet.</source>
+        <translation type="unfinished">వాలెట్‌ని అన్‌లాక్ చేయడం సాధ్యపడలేదు.</translation>
+    </message>
+    <message>
+        <source>Could not generate new %1 address</source>
+        <translation type="unfinished">కొత్త %1 చిరునామాను రూపొందించడం సాధ్యం కాలేదు</translation>
+    </message>
+</context>
+<context>
     <name>ReceiveRequestDialog</name>
+    <message>
+        <source>Request payment to …</source>
+        <translation type="unfinished">దీనికి చెల్లింపును అభ్యర్థించండి…</translation>
+    </message>
+    <message>
+        <source>Address:</source>
+        <translation type="unfinished">చిరునామా:</translation>
+    </message>
+    <message>
+        <source>Amount:</source>
+        <translation type="unfinished">మొత్తం:</translation>
+    </message>
+    <message>
+        <source>Label:</source>
+        <translation type="unfinished">లేబుల్:</translation>
+    </message>
+    <message>
+        <source>Message:</source>
+        <translation type="unfinished">సందేశం:</translation>
+    </message>
     <message>
         <source>Wallet:</source>
         <translation type="unfinished">ధనమును తీసుకొనిపోవు సంచి</translation>
+    </message>
+    <message>
+        <source>Copy &amp;URI</source>
+        <translation type="unfinished">కాపీ &amp;URI</translation>
+    </message>
+    <message>
+        <source>Copy &amp;Address</source>
+        <translation type="unfinished">కాపీ &amp;చిరునామా </translation>
+    </message>
+    <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">&amp;చిత్రాన్ని సేవ్ చేయి...</translation>
     </message>
     </context>
 <context>
@@ -499,16 +2514,142 @@
         <source>Quantity:</source>
         <translation type="unfinished">పరిమాణం</translation>
     </message>
+    <message>
+        <source>Bytes:</source>
+        <translation type="unfinished">బైట్‌లు:</translation>
+    </message>
+    <message>
+        <source>Amount:</source>
+        <translation type="unfinished">మొత్తం:</translation>
+    </message>
+    <message>
+        <source>Fee:</source>
+        <translation type="unfinished">రుసుము:</translation>
+    </message>
+    <message>
+        <source>After Fee:</source>
+        <translation type="unfinished">రుసుము తర్వాత:</translation>
+    </message>
+    <message>
+        <source>Change:</source>
+        <translation type="unfinished">మార్చు:</translation>
+    </message>
+    <message>
+        <source>Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until you have validated the complete chain.</source>
+        <translation type="unfinished">ఫాల్‌బ్యాక్‌ఫీని ఉపయోగించడం వలన లావాదేవీని పంపడం ద్వారా నిర్ధారించడానికి చాలా గంటలు లేదా రోజులు (లేదా ఎప్పుడూ) పట్టవచ్చు. మీ రుసుమును మాన్యువల్‌గా ఎంచుకోవడాన్ని పరిగణించండి లేదా మీరు పూర్తి గొలుసును ధృవీకరించే వరకు వేచి ఉండండి.</translation>
+    </message>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished">దాచు</translation>
+    </message>
+    <message>
+        <source>Dust:</source>
+        <translation type="unfinished">దుమ్ము:</translation>
+    </message>
+    <message>
+        <source>Copy quantity</source>
+        <translation type="unfinished">కాపీ పరిమాణం</translation>
+    </message>
+    <message>
+        <source>Copy amount</source>
+        <translation type="unfinished">కాపీ అమౌంట్</translation>
+    </message>
+    <message>
+        <source>Copy fee</source>
+        <translation type="unfinished">రుసుము కాపీ</translation>
+    </message>
+    <message>
+        <source>Copy after fee</source>
+        <translation type="unfinished">రుసుము తర్వాత కాపీ చేయండి</translation>
+    </message>
+    <message>
+        <source>Copy bytes</source>
+        <translation type="unfinished">బైట్‌లను కాపీ చేయండి</translation>
+    </message>
+    <message>
+        <source>Copy dust</source>
+        <translation type="unfinished">దుమ్మును కాపీ చేయండి</translation>
+    </message>
+    <message>
+        <source>Copy change</source>
+        <translation type="unfinished">మార్పుని కాపీ చేయండి</translation>
+    </message>
+    <message>
+        <source>%1 (%2 blocks)</source>
+        <translation type="unfinished">%1 (%2 బ్లాక్‌లు)</translation>
+    </message>
+    <message>
+        <source> from wallet '%1'</source>
+        <translation type="unfinished">వాలెట్ నుండి '%1'</translation>
+    </message>
+    <message>
+        <source>%1 to '%2'</source>
+        <translation type="unfinished">%1 కు '%2'</translation>
+    </message>
+    <message>
+        <source>%1 to %2</source>
+        <translation type="unfinished">%1 కు %2</translation>
+    </message>
+    <message>
+        <source>Save Transaction Data</source>
+        <translation type="unfinished">లావాదేవీ డేటాను సేవ్ చేయండి</translation>
+    </message>
+    <message>
+        <source>Partially Signed Transaction (Binary)</source>
+        <extracomment>Expanded name of the binary PSBT file format. See: BIP 174.</extracomment>
+        <translation type="unfinished">పాక్షికంగా సంతకం చేసిన లావాదేవీ (బైనరీ)</translation>
+    </message>
+    <message>
+        <source>or</source>
+        <translation type="unfinished">లేదా</translation>
+    </message>
+    <message>
+        <source>Total Amount</source>
+        <translation type="unfinished">పూర్తి మొత్తము</translation>
+    </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n బ్లాక్(ల)లో నిర్ధారణ ప్రారంభమవుతుందని అంచనా వేయబడింది.</numerusform>
+            <numerusform>%n బ్లాక్(ల)లో నిర్ధారణ ప్రారంభమవుతుందని అంచనా వేయబడింది.</numerusform>
         </translation>
     </message>
     <message>
         <source>(no label)</source>
         <translation type="unfinished">( ఉల్లాకు లేదు )</translation>
+    </message>
+</context>
+<context>
+    <name>SendCoinsEntry</name>
+    <message>
+        <source>Paste address from clipboard</source>
+        <translation type="unfinished">క్లిప్‌బోర్డ్ నుండి చిరునామాను అతికించండి</translation>
+    </message>
+    <message>
+        <source>Message:</source>
+        <translation type="unfinished">సందేశం:</translation>
+    </message>
+    </context>
+<context>
+    <name>SignVerifyMessageDialog</name>
+    <message>
+        <source>Paste address from clipboard</source>
+        <translation type="unfinished">క్లిప్‌బోర్డ్ నుండి చిరునామాను అతికించండి</translation>
+    </message>
+    <message>
+        <source>Enter the message you want to sign here</source>
+        <translation type="unfinished">మీరు సంతకం చేయాలనుకుంటున్న సందేశాన్ని ఇక్కడ నమోదు చేయండి</translation>
+    </message>
+    <message>
+        <source>Signature</source>
+        <translation type="unfinished">సంతకం</translation>
+    </message>
+    </context>
+<context>
+    <name>SplashScreen</name>
+    <message>
+        <source>press q to shutdown</source>
+        <translation type="unfinished">షట్‌డౌన్ చేయడానికి q నొక్కండి</translation>
     </message>
 </context>
 <context>
@@ -536,8 +2677,8 @@
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n మరిన్ని బ్లాక్(లు)లో మెచ్యూర్ అవుతుంది</numerusform>
+            <numerusform>%n మరిన్ని బ్లాక్(లు)లో మెచ్యూర్ అవుతుంది</numerusform>
         </translation>
     </message>
     <message>
@@ -560,6 +2701,10 @@
         <translation type="unfinished">తేదీ</translation>
     </message>
     <message>
+        <source>Type</source>
+        <translation type="unfinished">రకము</translation>
+    </message>
+    <message>
         <source>Label</source>
         <translation type="unfinished">ఉల్లాకు</translation>
     </message>
@@ -571,12 +2716,37 @@
 <context>
     <name>TransactionView</name>
     <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;కాపీ చిరునామా</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">కాపీ &amp;లేబుల్</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">కాపీ &amp;అమౌంట్</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">కామాతో వేరు చేయబడిన ఫైల్</translation>
+    </message>
+    <message>
+        <source>Confirmed</source>
+        <translation type="unfinished">నిర్ధారించబడినది</translation>
+    </message>
+    <message>
         <source>Date</source>
         <translation type="unfinished">తేదీ</translation>
     </message>
     <message>
+        <source>Type</source>
+        <translation type="unfinished">రకము</translation>
+    </message>
+    <message>
         <source>Label</source>
-        <translation type="unfinished">ఉల్లాకు</translation>
+        <translation type="unfinished">లేబుల్</translation>
     </message>
     <message>
         <source>Address</source>
@@ -595,13 +2765,20 @@
     <name>WalletFrame</name>
     <message>
         <source>Create a new wallet</source>
-        <translation type="unfinished">&lt;div&gt;&lt;/div&gt;</translation>
+        <translation type="unfinished">కొత్త వాలెట్‌ని సృష్టించండి</translation>
     </message>
     <message>
         <source>Error</source>
         <translation type="unfinished">లోపం</translation>
     </message>
     </context>
+<context>
+    <name>WalletModel</name>
+    <message>
+        <source>default wallet</source>
+        <translation type="unfinished">డిఫాల్ట్ వాలెట్</translation>
+    </message>
+</context>
 <context>
     <name>WalletView</name>
     <message>
@@ -612,5 +2789,18 @@
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished">ప్రస్తుతం ఉన్న సమాచారాన్ని ఫైల్ లోనికి ఎగుమతి చేసుకోండి</translation>
     </message>
-    </context>
+    <message>
+        <source>Backup Wallet</source>
+        <translation type="unfinished">బ్యాకప్ వాలెట్</translation>
+    </message>
+    <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">వాలెట్ సమాచారం</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">రద్దు చేయండి</translation>
+    </message>
+</context>
 </TS>

--- a/src/qt/locale/bitcoin_th.ts
+++ b/src/qt/locale/bitcoin_th.ts
@@ -3,11 +3,11 @@
     <name>AddressBookPage</name>
     <message>
         <source>Right-click to edit address or label</source>
-        <translation type="unfinished">คลิกขวาเพื่อแก้ไขที่อยู่หรือป้ายชื่อ</translation>
+        <translation type="unfinished">คลิกขวา เพื่อ แก้ไข แอดเดรส หรือ เลเบล</translation>
     </message>
     <message>
         <source>Create a new address</source>
-        <translation type="unfinished">สร้างที่อยู่ใหม่</translation>
+        <translation type="unfinished">สร้าง แอดเดรส ใหม่</translation>
     </message>
     <message>
         <source>&amp;New</source>
@@ -15,7 +15,7 @@
     </message>
     <message>
         <source>Copy the currently selected address to the system clipboard</source>
-        <translation type="unfinished">คัดลอกที่อยู่ที่เลือกในปัจจุบันไปยังคลิปบอร์ดของระบบ</translation>
+        <translation type="unfinished">คัดลอก แอดเดรส ที่เลือก ในปัจจุบัน ไปยัง คลิปบอร์ด ของระบบ</translation>
     </message>
     <message>
         <source>&amp;Copy</source>
@@ -27,11 +27,11 @@
     </message>
     <message>
         <source>Delete the currently selected address from the list</source>
-        <translation type="unfinished">ลบที่อยู่ที่เลือกในปัจจุบันออกจากรายการ</translation>
+        <translation type="unfinished">ลบแอดเดรสที่เลือกในปัจจุบันออกจากรายการ</translation>
     </message>
     <message>
         <source>Enter address or label to search</source>
-        <translation type="unfinished">ป้อนที่อยู่หรือป้ายชื่อเพื่อค้นหา</translation>
+        <translation type="unfinished">ป้อน แอดเดรส หรือ เลเบล เพื่อ ทำการค้นหา</translation>
     </message>
     <message>
         <source>Export the data in the current tab to a file</source>
@@ -47,11 +47,11 @@
     </message>
     <message>
         <source>Choose the address to send coins to</source>
-        <translation type="unfinished">เลือกที่อยู่ที่จะส่งเหรียญ</translation>
+        <translation type="unfinished">เลือก แอดเดรส ที่จะ ส่ง คอยน์ ไป</translation>
     </message>
     <message>
         <source>Choose the address to receive coins with</source>
-        <translation type="unfinished">เลือกที่อยู่ที่จะรับเหรียญ</translation>
+        <translation type="unfinished">เลือก แอดเดรส ที่จะ รับ คอยน์</translation>
     </message>
     <message>
         <source>C&amp;hoose</source>
@@ -59,19 +59,29 @@
     </message>
     <message>
         <source>Sending addresses</source>
-        <translation type="unfinished">ที่อยู่การส่ง</translation>
+        <translation type="unfinished">แอดเดรส การส่ง</translation>
     </message>
     <message>
         <source>Receiving addresses</source>
-        <translation type="unfinished">ที่อยู่การรับ</translation>
+        <translation type="unfinished">แอดเดรส การรับ</translation>
+    </message>
+    <message>
+        <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
+        <translation type="unfinished">These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins</translation>
+    </message>
+    <message>
+        <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
+Signing is only possible with addresses of the type 'legacy'.</source>
+        <translation type="unfinished">These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
+Signing is only possible with addresses of the type 'legacy'</translation>
     </message>
     <message>
         <source>&amp;Copy Address</source>
-        <translation type="unfinished">&amp;คัดลอกที่อยู่</translation>
+        <translation type="unfinished">&amp;คัดลอก แอดเดรส</translation>
     </message>
     <message>
         <source>Copy &amp;Label</source>
-        <translation type="unfinished">&amp;คัดลอกป้ายชื่อ</translation>
+        <translation type="unfinished">คัดลอก &amp;เลเบล</translation>
     </message>
     <message>
         <source>&amp;Edit</source>
@@ -79,12 +89,17 @@
     </message>
     <message>
         <source>Export Address List</source>
-        <translation type="unfinished">ส่งออกรายการที่อยู่</translation>
+        <translation type="unfinished">ส่งออกรายการแอดเดรส</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">เครื่องหมายจุลภาค (Comma) เพื่อแยกไฟล์</translation>
     </message>
     <message>
         <source>There was an error trying to save the address list to %1. Please try again.</source>
         <extracomment>An error message. %1 is a stand-in argument for the name of the file we attempted to save to.</extracomment>
-        <translation type="unfinished">เกิดข้อผิดพลาดขณะพยายามบันทึกรายการที่อยู่ไปยัง %1 โปรดลองอีกครั้ง</translation>
+        <translation type="unfinished">เกิดข้อผิดพลาดขณะพยายามบันทึกรายการแอดเดรสไปยัง %1 โปรดลองอีกครั้ง</translation>
     </message>
     <message>
         <source>Exporting Failed</source>
@@ -95,92 +110,140 @@
     <name>AddressTableModel</name>
     <message>
         <source>Label</source>
-        <translation type="unfinished">ป้ายชื่อ</translation>
+        <translation type="unfinished">เลเบล</translation>
     </message>
     <message>
         <source>Address</source>
-        <translation type="unfinished">ที่อยู่</translation>
+        <translation type="unfinished">แอดเดรส</translation>
     </message>
     <message>
         <source>(no label)</source>
-        <translation type="unfinished">(ไม่มีป้ายชื่อ)</translation>
+        <translation type="unfinished">(ไม่มีเลเบล)</translation>
     </message>
 </context>
 <context>
     <name>AskPassphraseDialog</name>
     <message>
         <source>Passphrase Dialog</source>
-        <translation type="unfinished">กล่องโต้ตอบวลีรหัสผ่าน</translation>
+        <translation type="unfinished">พาสเฟส ไดอะล็อก</translation>
     </message>
     <message>
         <source>Enter passphrase</source>
-        <translation type="unfinished">ป้อนวลีรหัสผ่าน</translation>
+        <translation type="unfinished">ป้อน พาสเฟส</translation>
     </message>
     <message>
         <source>New passphrase</source>
-        <translation type="unfinished">วลีรหัสผ่านใหม่</translation>
+        <translation type="unfinished">พาสดฟสใหม่</translation>
     </message>
     <message>
         <source>Repeat new passphrase</source>
-        <translation type="unfinished">ทำซ้ำวลีรหัสผ่านใหม่</translation>
+        <translation type="unfinished">ทำซ้ำ พาสเฟส ใหม่</translation>
     </message>
     <message>
         <source>Show passphrase</source>
-        <translation type="unfinished">แสดงวลีรหัสผ่าน</translation>
+        <translation type="unfinished">แสดงพาสเฟส</translation>
     </message>
     <message>
         <source>Encrypt wallet</source>
-        <translation type="unfinished">เข้ารหัสกระเป๋าสตางค์</translation>
+        <translation type="unfinished">เข้ารหัสวอลเล็ต</translation>
+    </message>
+    <message>
+        <source>This operation needs your wallet passphrase to unlock the wallet.</source>
+        <translation type="unfinished">การดำเนินการ นี้ ต้องการ วอลเล็ต พาสเฟส ของ คุณ เพื่อ ปลดล็อค วอลเล็ต</translation>
     </message>
     <message>
         <source>Unlock wallet</source>
-        <translation type="unfinished">ปลดล็อคกระเป๋าสตางค์</translation>
+        <translation type="unfinished">ปลดล็อควอลเล็ต</translation>
     </message>
     <message>
         <source>Change passphrase</source>
-        <translation type="unfinished">เปลี่ยนวลีรหัสผ่าน</translation>
+        <translation type="unfinished">เปลี่ยนพาสเฟส</translation>
     </message>
     <message>
         <source>Confirm wallet encryption</source>
-        <translation type="unfinished">ยืนยันการเข้ารหัสกระเป๋าสตางค์</translation>
+        <translation type="unfinished">ยืนยันการเข้ารหัสวอลเล็ต</translation>
+    </message>
+    <message>
+        <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
+        <translation type="unfinished">คำเตือน: หาก คุณ เข้ารหัส วอลเล็ต ของคุณ และ ทำพาสเฟส หาย , คุณ จะ สูญเสีย &lt;b&gt;BITCOINS ทั้งหมดของคุณ&lt;/b&gt;!</translation>
     </message>
     <message>
         <source>Are you sure you wish to encrypt your wallet?</source>
-        <translation type="unfinished">คุณแน่ใจหรือไม่ว่าต้องการเข้ารหัสกระเป๋าสตางค์ของคุณ?</translation>
+        <translation type="unfinished">คุณ แน่ใจ หรือไม่ว่า ต้องการ เข้ารหัส วอลเล็ต ของคุณ?</translation>
     </message>
     <message>
         <source>Wallet encrypted</source>
-        <translation type="unfinished">เข้ารหัสบัญชีเรียบร้อย</translation>
+        <translation type="unfinished">เข้ารหัสวอลเล็ตเรียบร้อย</translation>
+    </message>
+    <message>
+        <source>Enter the new passphrase for the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
+        <translation type="unfinished">ป้อน พาสเฟส ใหม่ สำหรับ วอลเล็ต&lt;br/&gt;กรุณา ใช้ พาสเฟส ของ &lt;b&gt;สิบ หรือ อักขระ สุ่ม สิบ ตัว ขึ้นไป &lt;/b&gt;, หรือ &lt;b&gt;แปด หรือ แปดคำขึ้นไป&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Enter the old passphrase and new passphrase for the wallet.</source>
+        <translation type="unfinished">ป้อนพาสเฟสเก่าและพาสเฟสใหม่สำหรับวอลเล็ต</translation>
+    </message>
+    <message>
+        <source>Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
+        <translation type="unfinished">โปรดจำ ไว้ว่า การเข้ารหัส วอลเล็ต ของคุณ ไม่สามารถ ปกป้อง bitcoins ของคุณ ได้อย่างเต็มที่ จากการ ถูกขโมย โดยมัลแวร์ ที่ติดไวรัส บนคอมพิวเตอร์ ของคุณ</translation>
+    </message>
+    <message>
+        <source>Wallet to be encrypted</source>
+        <translation type="unfinished">วอลเล็ตที่จะเข้ารหัส</translation>
     </message>
     <message>
         <source>Your wallet is about to be encrypted. </source>
-        <translation type="unfinished">บัญชีของคุณกำลังถูกเข้ารหัส</translation>
+        <translation type="unfinished">วอลเล็ตของคุณกำลังถูกเข้ารหัส</translation>
     </message>
     <message>
         <source>Your wallet is now encrypted. </source>
-        <translation type="unfinished">บัญชีของคุณถูกเข้ารหัสเรียบร้อยแล้ว</translation>
+        <translation type="unfinished">วอลเล็ตของคุณถูกเข้ารหัสเรียบร้อยแล้ว</translation>
+    </message>
+    <message>
+        <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
+        <translation type="unfinished">สำคัญ: การสำรองข้อมูลใด ๆ ก่อนหน้านี้ที่คุณได้ทำขึ้นจากไฟล์วอลเล็ตของคุณควรถูกแทนที่ด้วยไฟล์วอลเล็ตที่เข้ารหัสที่สร้างขึ้นใหม่ ด้วยเหตุผลด้านความปลอดภัย การสำรองข้อมูลก่อนหน้าของไฟล์วอลเล็ตที่ไม่ได้เข้ารหัสจะไม่มีประโยชน์ทันทีที่คุณเริ่มใช้วอลเล็ตใหม่ที่เข้ารหัส</translation>
     </message>
     <message>
         <source>Wallet encryption failed</source>
-        <translation type="unfinished">การเข้ารหัสกระเป๋าสตางค์ล้มเหลว</translation>
+        <translation type="unfinished">การเข้ารหัสวอลเล็ตล้มเหลว</translation>
+    </message>
+    <message>
+        <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
+        <translation type="unfinished">การเข้ารหัส วอลเลต ล้มเหลว เนื่องจาก ข้อผิดพลาด ภายใน วอลเล็ต ของคุณ ไม่ได้ เข้ารหัส</translation>
+    </message>
+    <message>
+        <source>The supplied passphrases do not match.</source>
+        <translation type="unfinished">พาสเฟสที่ป้อนไม่ถูกต้อง</translation>
     </message>
     <message>
         <source>Wallet unlock failed</source>
-        <translation type="unfinished">การปลดล็อคกระเป๋าสตางค์ล้มเหลว</translation>
+        <translation type="unfinished">การปลดล็อควอลเล็ตล้มเหลว</translation>
     </message>
-    </context>
+    <message>
+        <source>The passphrase entered for the wallet decryption was incorrect.</source>
+        <translation type="unfinished">พาสเฟส ที่ป้อน สำหรับ การถอดรหัส วอลเล็ต ไม่ถูกต้อง</translation>
+    </message>
+    <message>
+        <source>Wallet passphrase was successfully changed.</source>
+        <translation type="unfinished">เปลี่ยนพาสเฟสวอลเล็ตสำเร็จแล้ว</translation>
+    </message>
+    <message>
+        <source>Warning: The Caps Lock key is on!</source>
+        <translation type="unfinished">คำเตือน:แป้นคีย์ตัวอักษรพิมพ์ใหญ่ (Cap Lock) ถูกเปิด!</translation>
+    </message>
+</context>
 <context>
     <name>BanTableModel</name>
     <message>
         <source>Banned Until</source>
-        <translation type="unfinished">ห้ามจนถึง</translation>
+        <translation type="unfinished">ห้าม จนถึง</translation>
     </message>
 </context>
 <context>
     <name>BitcoinApplication</name>
     <message>
-        <source>Internal error</source>
-        <translation type="unfinished">ข้อผิดพลาดภายใน</translation>
+        <source>Settings file %1 might be corrupt or invalid.</source>
+        <translation type="unfinished">ไฟล์ตั้งค่า%1 อาจเสียหายหรือไม่ถูกต้อง</translation>
     </message>
     </context>
 <context>
@@ -196,41 +259,84 @@
         <translation type="unfinished">เกิดข้อผิดพลาดร้ายแรงขึ้น, โปรดตรวจสอบว่าไฟล์ตั้งค่านั้นสามารถเขียนทับได้หรือลองใช้งานด้วยคำสั่ง -nosettings</translation>
     </message>
     <message>
+        <source>Error: Specified data directory "%1" does not exist.</source>
+        <translation type="unfinished">ข้อผิดพลาด: ข้อมูล ไดเร็กทอรี ที่เจาะจง "%1" นั้น ไม่ มี</translation>
+    </message>
+    <message>
+        <source>Error: Cannot parse configuration file: %1.</source>
+        <translation type="unfinished">ข้อผิดพลาด: ไม่สามารถ parse configuration ไฟล์: %1.</translation>
+    </message>
+    <message>
         <source>Error: %1</source>
         <translation type="unfinished">ข้อผิดพลาด: %1</translation>
+    </message>
+    <message>
+        <source>%1 didn't yet exit safely…</source>
+        <translation type="unfinished">%1 ยังไม่ออกอย่างปลอดภัย...</translation>
+    </message>
+    <message>
+        <source>unknown</source>
+        <translation type="unfinished">ไม่ทราบ</translation>
     </message>
     <message>
         <source>Amount</source>
         <translation type="unfinished">จำนวน</translation>
     </message>
+    <message>
+        <source>Internal</source>
+        <translation type="unfinished">ภายใน</translation>
+    </message>
+    <message>
+        <source>Inbound</source>
+        <extracomment>An inbound connection from a peer. An inbound connection is a connection initiated by a peer.</extracomment>
+        <translation type="unfinished">ขาเข้า</translation>
+    </message>
+    <message>
+        <source>Outbound</source>
+        <extracomment>An outbound connection to a peer. An outbound connection is a connection initiated by us.</extracomment>
+        <translation type="unfinished">ขาออก</translation>
+    </message>
+    <message>
+        <source>Manual</source>
+        <extracomment>Peer connection type established manually through one of several methods.</extracomment>
+        <translation type="unfinished">คู่มือ</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished">ไม่มี</translation>
+    </message>
+    <message>
+        <source>%1 ms</source>
+        <translation type="unfinished">%1 มิลลิวินาที</translation>
+    </message>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation type="unfinished">
-            <numerusform>%n วินาที</numerusform>
+            <numerusform>%nวินาที</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n minute(s)</source>
         <translation type="unfinished">
-            <numerusform>%n นาที</numerusform>
+            <numerusform>%nนาที</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
         <translation type="unfinished">
-            <numerusform>%n ชั่วโมง</numerusform>
+            <numerusform>%nชั่วโมง</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
-            <numerusform>%n วัน</numerusform>
+            <numerusform>%nวัน</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
-            <numerusform>%n สัปดาห์</numerusform>
+            <numerusform>%nสัปดาห์</numerusform>
         </translation>
     </message>
     <message>
@@ -240,10 +346,26 @@
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
-            <numerusform>%n ปี</numerusform>
+            <numerusform>%nปี</numerusform>
         </translation>
     </message>
-    </context>
+    <message>
+        <source>%1 B</source>
+        <translation type="unfinished">%1 ไบต์</translation>
+    </message>
+    <message>
+        <source>%1 kB</source>
+        <translation type="unfinished">%1 กิโลไบต์</translation>
+    </message>
+    <message>
+        <source>%1 MB</source>
+        <translation type="unfinished">%1 เมกะไบต์</translation>
+    </message>
+    <message>
+        <source>%1 GB</source>
+        <translation type="unfinished">%1 จิกะไบต์</translation>
+    </message>
+</context>
 <context>
     <name>bitcoin-core</name>
     <message>
@@ -255,18 +377,346 @@
         <translation type="unfinished">ไม่สามารถเขียนข้อมูลลงบนไฟล์ตั้งค่าได้</translation>
     </message>
     <message>
+        <source>The %s developers</source>
+        <translation type="unfinished">%s นักพัฒนา</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile version is not supported. This version of bitcoin-wallet only supports version 1 dumpfiles. Got dumpfile with version %s</source>
+        <translation type="unfinished">ข้อผิดพลาด: ดัมพ์ไฟล์เวอร์ชัน ไม่รองรับเวอร์ชัน บิตคอยน์-วอลเล็ต รุ่นนี้รองรับไฟล์ดัมพ์เวอร์ชัน 1 เท่านั้น รับดัมพ์ไฟล์พร้อมเวอร์ชัน %s</translation>
+    </message>
+    <message>
+        <source>Error: Legacy wallets only support the "legacy", "p2sh-segwit", and "bech32" address types</source>
+        <translation type="unfinished">ข้อผิดพลาด: เลกาซี วอลเล็ต เพียง สนับสนุน "legacy", "p2sh-segwit", และ "bech32" ชนิด แอดเดรส</translation>
+    </message>
+    <message>
+        <source>The transaction amount is too small to send after the fee has been deducted</source>
+        <translation type="unfinished">จำนวนเงินที่ทำธุรกรรมน้อยเกินไปที่จะส่งหลังจากหักค่าธรรมเนียมแล้ว</translation>
+    </message>
+    <message>
+        <source>%s is set very high!</source>
+        <translation type="unfinished">%s ตั้งไว้สูงมาก</translation>
+    </message>
+    <message>
         <source>Cannot set -forcednsseed to true when setting -dnsseed to false.</source>
         <translation type="unfinished">ไม่สามารถตั้ง -forcednsseed เป็น true ได้เมื่อการตั้งค่า -dnsseed เป็น false</translation>
     </message>
     <message>
+        <source>Cannot set -peerblockfilters without -blockfilterindex.</source>
+        <translation type="unfinished">ไม่สามารถตั้งค่า -peerblockfilters โดยที่ไม่มี -blockfilterindex</translation>
+    </message>
+    <message>
+        <source>%s request to listen on port %u. This port is considered "bad" and thus it is unlikely that any Bitcoin Core peers connect to it. See doc/p2p-bad-ports.md for details and a full list.</source>
+        <translation type="unfinished">%sขอฟังความเห็นเรื่องพอร์ต%u พอร์ตนี้ถือว่า "ไม่ดี" ดังนั้นจึงไม่น่าเป็นไปได้ที่ Bitcoin Core จะเชื่อมต่อกับพอร์ตนี้ ดู doc/p2p-bad-ports.md สำหรับรายละเอียดและรายการทั้งหมด</translation>
+    </message>
+    <message>
+        <source>Error loading %s: External signer wallet being loaded without external signer support compiled</source>
+        <translation type="unfinished">เกิดข้อผิดพลาดในการโหลด %s: กำลังโหลดวอลเล็ตผู้ลงนามภายนอกโดยไม่มีการรวบรวมการสนับสนุนผู้ลงนามภายนอก</translation>
+    </message>
+    <message>
+        <source>Failed to rename invalid peers.dat file. Please move or delete it and try again.</source>
+        <translation type="unfinished">ไม่สามารถเปลี่ยนชื่อไฟล์ peers.dat ที่ไม่ถูกต้อง โปรดย้ายหรือลบแล้วลองอีกครั้ง</translation>
+    </message>
+    <message>
+        <source>Could not find asmap file %s</source>
+        <translation type="unfinished">ไม่ ตรวจพบ ไฟล์ asmap %s</translation>
+    </message>
+    <message>
+        <source>Could not parse asmap file %s</source>
+        <translation type="unfinished">ไม่ สามารถ แยก วิเคราะห์ ไฟล์ asmap %s</translation>
+    </message>
+    <message>
+        <source>Disk space is too low!</source>
+        <translation type="unfinished">พื้นที่ว่าง ดิสก์ เหลือ น้อย เกินไป!</translation>
+    </message>
+    <message>
+        <source>Do you want to rebuild the block database now?</source>
+        <translation type="unfinished">คุณต้องการาร้างฐานข้อมูลบล็อกใหม่ตอนนี้หรือไม่?</translation>
+    </message>
+    <message>
+        <source>Done loading</source>
+        <translation type="unfinished">การโหลด เสร็จสิ้น</translation>
+    </message>
+    <message>
+        <source>Dump file %s does not exist.</source>
+        <translation type="unfinished"> ไม่มีไฟล์ดัมพ์ %s </translation>
+    </message>
+    <message>
+        <source>Error creating %s</source>
+        <translation type="unfinished">เกิดข้อผิดพลาด ในการสร้าง%s</translation>
+    </message>
+    <message>
+        <source>Error initializing block database</source>
+        <translation type="unfinished">เกิดข้อผิดพลาดในการเริ่มต้นฐานข้อมูลบล็อก</translation>
+    </message>
+    <message>
+        <source>Error loading %s</source>
+        <translation type="unfinished">การโหลด เกิดข้อผิดพลาด %s</translation>
+    </message>
+    <message>
+        <source>Error loading %s: Private keys can only be disabled during creation</source>
+        <translation type="unfinished">การโหลดเกิดข้อผิดพลาด %s: Private keys สามารถปิดการใช้งานระหว่างการสร้างขึ้นเท่านั้น</translation>
+    </message>
+    <message>
+        <source>Error loading %s: Wallet corrupted</source>
+        <translation type="unfinished">เกิดข้อผิดพลาดในการโหลด %s: วอลเล็ตเกิดความเสียหาย</translation>
+    </message>
+    <message>
+        <source>Error loading %s: Wallet requires newer version of %s</source>
+        <translation type="unfinished">เกิดข้อผิดพลาดในการโหลด %s: วอลเล็ตต้องการเวอร์ชันใหม่กว่า %s</translation>
+    </message>
+    <message>
+        <source>Error loading block database</source>
+        <translation type="unfinished">เกิดข้อผิดพลาด ในการโหลด ฐานข้อมูล บล็อก</translation>
+    </message>
+    <message>
+        <source>Error opening block database</source>
+        <translation type="unfinished">เกิดข้อผิดพลาด ในการเปิด ฐานข้อมูล บล็อก</translation>
+    </message>
+    <message>
+        <source>Error reading from database, shutting down.</source>
+        <translation type="unfinished">เกิดข้อผิดพลาด ในการอ่าน จาก ฐานข้อมูล, กำลังปิด</translation>
+    </message>
+    <message>
+        <source>Error reading next record from wallet database</source>
+        <translation type="unfinished">เกิดข้อผิดพลาด ในการอ่าน บันทึก ถัดไป จาก ฐานข้อมูล วอลเล็ต</translation>
+    </message>
+    <message>
+        <source>Error: Couldn't create cursor into database</source>
+        <translation type="unfinished">ข้อผิดพลาด: ไม่สามารถ สร้าง เคอร์เซอร์ ใน ฐานข้อมูล</translation>
+    </message>
+    <message>
+        <source>Error: Disk space is low for %s</source>
+        <translation type="unfinished">ข้อผิดพลาด: พื้นที่ ดิสก์ เหลือน้อย สำหรับ %s</translation>
+    </message>
+    <message>
+        <source>Error: Missing checksum</source>
+        <translation type="unfinished">ข้อผิดพลาด: ไม่มี เช็คซัม</translation>
+    </message>
+    <message>
+        <source>Error: No %s addresses available.</source>
+        <translation type="unfinished">ข้อผิดพลาด: ไม่มี %s แอดเดรสพร้อมใช้งาน</translation>
+    </message>
+    <message>
+        <source>Error: This wallet already uses SQLite</source>
+        <translation type="unfinished">ข้อผิดพลาด: วอลเล็ตนี้ใช้ SQLite อยู่แล้ว</translation>
+    </message>
+    <message>
+        <source>Error: Unable to make a backup of your wallet</source>
+        <translation type="unfinished">ข้อผิดพลาด: ไม่สามารถสำรองข้อมูลของวอลเล็ตได้</translation>
+    </message>
+    <message>
+        <source>Error: Unable to read all records in the database</source>
+        <translation type="unfinished">ข้อผิดพลาด: ไม่สามารถอ่านข้อมูลทั้งหมดในฐานข้อมูลได้</translation>
+    </message>
+    <message>
+        <source>Error: Unable to write record to new wallet</source>
+        <translation type="unfinished">ข้อผิดพลาด: ไม่สามารถเขียนบันทึกไปยังวอลเล็ตใหม่</translation>
+    </message>
+    <message>
+        <source>Failed to rescan the wallet during initialization</source>
+        <translation type="unfinished">ไม่สามารถสแกนวอลเล็ตอีกครั้งในระหว่างการเริ่มต้น</translation>
+    </message>
+    <message>
+        <source>Failed to verify database</source>
+        <translation type="unfinished">ไม่สามารถตรวจสอบฐานข้อมูล</translation>
+    </message>
+    <message>
+        <source>Fee rate (%s) is lower than the minimum fee rate setting (%s)</source>
+        <translation type="unfinished">อัตราค่าธรรมเนียม (%s) ต่ำกว่าอัตราค่าธรรมเนียมขั้นต่ำที่ตั้งไว้  (%s)</translation>
+    </message>
+    <message>
+        <source>Ignoring duplicate -wallet %s.</source>
+        <translation type="unfinished">ละเว้นการทำซ้ำ -วอลเล็ต %s.</translation>
+    </message>
+    <message>
+        <source>Importing…</source>
+        <translation type="unfinished">กำลังนำเข้า…</translation>
+    </message>
+    <message>
+        <source>Input not found or already spent</source>
+        <translation type="unfinished">ไม่พบข้อมูลที่ป้อนหรือใช้ไปแล้ว</translation>
+    </message>
+    <message>
+        <source>Insufficient funds</source>
+        <translation type="unfinished">เงินทุน ไม่เพียงพอ</translation>
+    </message>
+    <message>
+        <source>Loading P2P addresses…</source>
+        <translation type="unfinished">กำลังโหลด P2P addresses…</translation>
+    </message>
+    <message>
+        <source>Loading banlist…</source>
+        <translation type="unfinished">กำลังโหลด banlist…</translation>
+    </message>
+    <message>
+        <source>Loading block index…</source>
+        <translation type="unfinished">กำลังโหลด block index…</translation>
+    </message>
+    <message>
+        <source>Loading wallet…</source>
+        <translation type="unfinished">กำลังโหลด วอลเล็ต...</translation>
+    </message>
+    <message>
         <source>Missing amount</source>
-        <translation type="unfinished">จำนวนที่หายไป</translation>
+        <translation type="unfinished">จำนวน ที่หายไป</translation>
+    </message>
+    <message>
+        <source>Missing solving data for estimating transaction size</source>
+        <translation type="unfinished">ไม่มีข้อมูลการแก้ไขสำหรับการประมาณค่าขนาดธุรกรรม</translation>
     </message>
     <message>
         <source>No addresses available</source>
-        <translation type="unfinished">ไม่มีที่อยู่ที่ใช้งานได้</translation>
+        <translation type="unfinished">ไม่มี แอดเดรส ที่ใช้งานได้</translation>
     </message>
-    </context>
+    <message>
+        <source>Not enough file descriptors available.</source>
+        <translation type="unfinished">มีตัวอธิบายไฟล์ไม่เพียงพอ</translation>
+    </message>
+    <message>
+        <source>Prune cannot be configured with a negative value.</source>
+        <translation type="unfinished">ไม่สามารถกำหนดค่าพรุนด้วยค่าลบ</translation>
+    </message>
+    <message>
+        <source>Prune mode is incompatible with -txindex.</source>
+        <translation type="unfinished">โหมดพรุนเข้ากันไม่ได้กับ -txindex</translation>
+    </message>
+    <message>
+        <source>Rescanning…</source>
+        <translation type="unfinished">ทำการสแกนซ้ำ…</translation>
+    </message>
+    <message>
+        <source>Section [%s] is not recognized.</source>
+        <translation type="unfinished">ส่วน [%s] ไม่เป็นที่รู้จัก</translation>
+    </message>
+    <message>
+        <source>Specified -walletdir "%s" does not exist</source>
+        <translation type="unfinished">Specified -walletdir "%s" ไม่มีอยู่</translation>
+    </message>
+    <message>
+        <source>Specified -walletdir "%s" is a relative path</source>
+        <translation type="unfinished">Specified -walletdir "%s" เป็นพาธสัมพัทธ์</translation>
+    </message>
+    <message>
+        <source>Specified -walletdir "%s" is not a directory</source>
+        <translation type="unfinished">Specified -walletdir "%s" ไม่ใช่ไดเร็กทอรี</translation>
+    </message>
+    <message>
+        <source>Specified blocks directory "%s" does not exist.</source>
+        <translation type="unfinished">ไม่มีไดเร็กทอรีบล็อกที่ระบุ "%s" </translation>
+    </message>
+    <message>
+        <source>Starting network threads…</source>
+        <translation type="unfinished">การเริ่มเธรดเครือข่าย…</translation>
+    </message>
+    <message>
+        <source>The source code is available from %s.</source>
+        <translation type="unfinished">ซอร์สโค๊ดสามารถใช้ได้จาก %s.</translation>
+    </message>
+    <message>
+        <source>The specified config file %s does not exist</source>
+        <translation type="unfinished">ไฟล์กำหนดค่าที่ระบุ %s ไม่มีอยู่</translation>
+    </message>
+    <message>
+        <source>The transaction amount is too small to pay the fee</source>
+        <translation type="unfinished">จำนวนธุรกรรมน้อยเกินไปที่จะชำระค่าธรรมเนียม</translation>
+    </message>
+    <message>
+        <source>The wallet will avoid paying less than the minimum relay fee.</source>
+        <translation type="unfinished">วอลเล็ตจะหลีกเลี่ยงการจ่ายน้อยกว่าค่าธรรมเนียมรีเลย์ขั้นต่ำ</translation>
+    </message>
+    <message>
+        <source>This is experimental software.</source>
+        <translation type="unfinished">นี่คือซอฟต์แวร์ทดลอง</translation>
+    </message>
+    <message>
+        <source>This is the minimum transaction fee you pay on every transaction.</source>
+        <translation type="unfinished">นี่คือค่าธรรมเนียมการทำธุรกรรมขั้นต่ำที่คุณจ่ายในทุกธุรกรรม</translation>
+    </message>
+    <message>
+        <source>This is the transaction fee you will pay if you send a transaction.</source>
+        <translation type="unfinished">นี่คือค่าธรรมเนียมการทำธุรกรรมที่คุณจะจ่ายหากคุณส่งธุรกรรม</translation>
+    </message>
+    <message>
+        <source>Transaction amount too small</source>
+        <translation type="unfinished">จำนวนธุรกรรมน้อยเกินไป</translation>
+    </message>
+    <message>
+        <source>Transaction amounts must not be negative</source>
+        <translation type="unfinished">จำนวนเงินที่ทำธุรกรรมต้องไม่เป็นค่าติดลบ</translation>
+    </message>
+    <message>
+        <source>Transaction has too long of a mempool chain</source>
+        <translation type="unfinished">ธุรกรรมมี เชนเมมพูล ยาวเกินไป</translation>
+    </message>
+    <message>
+        <source>Transaction must have at least one recipient</source>
+        <translation type="unfinished">ธุรกรรมต้องมีผู้รับอย่างน้อยหนึ่งราย</translation>
+    </message>
+    <message>
+        <source>Transaction needs a change address, but we can't generate it.</source>
+        <translation type="unfinished">การทำธุรกรรมต้องการการเปลี่ยนแปลงที่อยู่ แต่เราไม่สามารถสร้างมันขึ้นมาได้</translation>
+    </message>
+    <message>
+        <source>Transaction too large</source>
+        <translation type="unfinished">ธุรกรรมใหญ่เกินไป</translation>
+    </message>
+    <message>
+        <source>Unable to bind to %s on this computer. %s is probably already running.</source>
+        <translation type="unfinished">ไม่สามารถผูก %s บนคอมพิวเตอร์นี้ %s อาจเนื่องมาจากเคยใช้แล้ว</translation>
+    </message>
+    <message>
+        <source>Unable to create the PID file '%s': %s</source>
+        <translation type="unfinished">ไม่สามารถสร้างไฟล์ PID '%s': %s</translation>
+    </message>
+    <message>
+        <source>Unable to generate initial keys</source>
+        <translation type="unfinished">ไม่สามารถ สร้าง คีย์ เริ่มต้น</translation>
+    </message>
+    <message>
+        <source>Unable to generate keys</source>
+        <translation type="unfinished">ไม่สามารถ สร้าง คีย์</translation>
+    </message>
+    <message>
+        <source>Unable to open %s for writing</source>
+        <translation type="unfinished">ไม่สามารถเปิด %s สำหรับการเขียนข้อมูล</translation>
+    </message>
+    <message>
+        <source>Unknown -blockfilterindex value %s.</source>
+        <translation type="unfinished">ไม่รู้จัก -ค่า blockfilterindex value %s</translation>
+    </message>
+    <message>
+        <source>Unknown address type '%s'</source>
+        <translation type="unfinished">ไม่รู้จัก ประเภท แอดเดรส '%s'</translation>
+    </message>
+    <message>
+        <source>Unknown change type '%s'</source>
+        <translation type="unfinished">ไม่รู้จัก ประเภท การเปลี่ยนแปลง '%s'</translation>
+    </message>
+    <message>
+        <source>Unknown network specified in -onlynet: '%s'</source>
+        <translation type="unfinished">ไม่รู้จัก เครือข่าย ที่ระบุ ใน -onlynet: '%s'</translation>
+    </message>
+    <message>
+        <source>Unsupported logging category %s=%s.</source>
+        <translation type="unfinished">หมวดหมู่การบันทึกที่ไม่รองรับ %s=%s</translation>
+    </message>
+    <message>
+        <source>User Agent comment (%s) contains unsafe characters.</source>
+        <translation type="unfinished">ความคิดเห็นของ User Agent (%s) มีอักขระที่ไม่ปลอดภัย</translation>
+    </message>
+    <message>
+        <source>Verifying blocks…</source>
+        <translation type="unfinished">กำลังตรวจสอบ บล็อก…</translation>
+    </message>
+    <message>
+        <source>Verifying wallet(s)…</source>
+        <translation type="unfinished">กำลังตรวจสอบ วอลเล็ต…</translation>
+    </message>
+    <message>
+        <source>Wallet needed to be rewritten: restart %s to complete</source>
+        <translation type="unfinished">ต้องเขียน Wallet ใหม่: restart %s เพื่อให้เสร็จสิ้น</translation>
+    </message>
+</context>
 <context>
     <name>BitcoinGUI</name>
     <message>
@@ -275,23 +725,19 @@
     </message>
     <message>
         <source>Show general overview of wallet</source>
-        <translation type="unfinished">แสดงภาพรวมทั่วไปของกระเป๋าสตางค์</translation>
+        <translation type="unfinished">แสดง ภาพรวม ทั่วไป ของ วอลเล็ต</translation>
     </message>
     <message>
         <source>&amp;Transactions</source>
-        <translation type="unfinished">&amp;ธุรกรรม</translation>
+        <translation type="unfinished">&amp;การทำธุรกรรม</translation>
     </message>
     <message>
         <source>Browse transaction history</source>
-        <translation type="unfinished">เรียกดูประวัติการทำธุรกรรม</translation>
-    </message>
-    <message>
-        <source>E&amp;xit</source>
-        <translation type="unfinished">&amp;ออก</translation>
+        <translation type="unfinished">เรียกดู ประวัติ การทำธุรกรรม</translation>
     </message>
     <message>
         <source>Quit application</source>
-        <translation type="unfinished">ออกจากแอปพลิเคชัน</translation>
+        <translation type="unfinished">ออกจาก แอปพลิเคชัน</translation>
     </message>
     <message>
         <source>&amp;About %1</source>
@@ -299,7 +745,7 @@
     </message>
     <message>
         <source>Show information about %1</source>
-        <translation type="unfinished">แสดงข้อมูลเกี่ยวกับ %1</translation>
+        <translation type="unfinished">แสดง ข้อมูล เกี่ยวกับ %1</translation>
     </message>
     <message>
         <source>About &amp;Qt</source>
@@ -307,15 +753,15 @@
     </message>
     <message>
         <source>Show information about Qt</source>
-        <translation type="unfinished">แสดงข้อมูลเกี่ยวกับ Qt</translation>
+        <translation type="unfinished">แสดง ข้อมูล เกี่ยวกับ Qt</translation>
     </message>
     <message>
         <source>Modify configuration options for %1</source>
-        <translation type="unfinished">ปรับเปลี่ยนตัวเลือกการกำหนดค่าสำหรับ %1</translation>
+        <translation type="unfinished">ปรับเปลี่ยน ตัวเลือก การกำหนดค่า สำหรับ %1</translation>
     </message>
     <message>
         <source>Create a new wallet</source>
-        <translation type="unfinished">สร้างกระเป๋าสตางค์</translation>
+        <translation type="unfinished">สร้าง วอลเล็ต ใหม่</translation>
     </message>
     <message>
         <source>&amp;Minimize</source>
@@ -323,19 +769,28 @@
     </message>
     <message>
         <source>Wallet:</source>
-        <translation type="unfinished">กระเป๋าสตางค์:</translation>
+        <translation type="unfinished">วอลเล็ต:</translation>
+    </message>
+    <message>
+        <source>Network activity disabled.</source>
+        <extracomment>A substring of the tooltip.</extracomment>
+        <translation type="unfinished">กิจกรรม เครือข่าย ถูกปิดใช้งาน</translation>
+    </message>
+    <message>
+        <source>Proxy is &lt;b&gt;enabled&lt;/b&gt;: %1</source>
+        <translation type="unfinished">พร็อกซี่ ถูก &lt;b&gt;เปิดใช้งาน&lt;/b&gt;: %1</translation>
     </message>
     <message>
         <source>Send coins to a Bitcoin address</source>
-        <translation type="unfinished">ส่งเหรียญไปยังที่อยู่ Bitcoin</translation>
+        <translation type="unfinished">ส่ง เหรียญ ไปยัง Bitcoin แอดเดรส</translation>
     </message>
     <message>
         <source>Backup wallet to another location</source>
-        <translation type="unfinished">สำรองข้อมูลกระเป๋าสตางค์ไปยังตำแหน่งที่ตั้งอื่น</translation>
+        <translation type="unfinished">แบ็คอัพวอลเล็ตไปยังตำแหน่งที่ตั้งอื่น</translation>
     </message>
     <message>
         <source>Change the passphrase used for wallet encryption</source>
-        <translation type="unfinished">เปลี่ยนรหัสผ่านที่ใช้สำหรับการเข้ารหัสกระเป๋าเงิน</translation>
+        <translation type="unfinished">เปลี่ยน พาสเฟส ที่ใช้ สำหรับ การเข้ารหัส วอลเล็ต</translation>
     </message>
     <message>
         <source>&amp;Send</source>
@@ -347,39 +802,59 @@
     </message>
     <message>
         <source>&amp;Options…</source>
-        <translation type="unfinished">&amp;ตั้งค่า…</translation>
+        <translation type="unfinished">&amp;ตัวเลือก…</translation>
     </message>
     <message>
         <source>&amp;Encrypt Wallet…</source>
-        <translation type="unfinished">&amp;เข้ารหัสกระเป๋าสตางค์...</translation>
+        <translation type="unfinished">&amp;เข้ารหัส วอลเล็ต...</translation>
+    </message>
+    <message>
+        <source>Encrypt the private keys that belong to your wallet</source>
+        <translation type="unfinished">เข้ารหัสกุญแจส่วนตัวที่เป็นของกระเป๋าสตางค์ของคุณ</translation>
     </message>
     <message>
         <source>&amp;Backup Wallet…</source>
-        <translation type="unfinished">&amp;สำรองข้อมูลกระเป๋าสตางค์...</translation>
+        <translation type="unfinished">&amp;แบ็คอัพวอลเล็ต…</translation>
     </message>
     <message>
         <source>&amp;Change Passphrase…</source>
-        <translation type="unfinished">&amp;เปลี่ยนวลีรหัสผ่าน...</translation>
+        <translation type="unfinished">&amp;เปลี่ยน พาสเฟส...</translation>
     </message>
     <message>
         <source>Sign &amp;message…</source>
-        <translation type="unfinished">&amp;เซ็นข้อความ...</translation>
+        <translation type="unfinished">เซ็น &amp;ข้อความ...</translation>
+    </message>
+    <message>
+        <source>Sign messages with your Bitcoin addresses to prove you own them</source>
+        <translation type="unfinished">เซ็นชื่อด้วยข้อความ ที่เก็บ Bitcoin เพื่อแสดงว่าท่านเป็นเจ้าของ bitcoin นี้จริง</translation>
+    </message>
+    <message>
+        <source>&amp;Verify message…</source>
+        <translation type="unfinished">&amp;ยืนยัน ข้อความ…</translation>
+    </message>
+    <message>
+        <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
+        <translation type="unfinished">ตรวจสอบ ข้อความ เพื่อให้แน่ใจว่า การเซ็นต์ชื่อ ด้วยที่เก็บ Bitcoin แล้ว</translation>
+    </message>
+    <message>
+        <source>&amp;Load PSBT from file…</source>
+        <translation type="unfinished">&amp;โหลด PSBT จาก ไฟล์...</translation>
     </message>
     <message>
         <source>Open &amp;URI…</source>
-        <translation type="unfinished">&amp;เปิด URI...</translation>
+        <translation type="unfinished">เปิด &amp;URI…</translation>
     </message>
     <message>
         <source>Close Wallet…</source>
-        <translation type="unfinished">ปิดกระเป๋าสตางค์</translation>
+        <translation type="unfinished">ปิด วอลเล็ต…</translation>
     </message>
     <message>
         <source>Create Wallet…</source>
-        <translation type="unfinished">สร้างกระเป๋าสตางค์ใหม่</translation>
+        <translation type="unfinished">สร้าง วอลเล็ต…</translation>
     </message>
     <message>
         <source>Close All Wallets…</source>
-        <translation type="unfinished">ปิดกระเป๋าสตางค์ทั้งหมด...</translation>
+        <translation type="unfinished">ปิด วอลเล็ต ทั้งหมด...</translation>
     </message>
     <message>
         <source>&amp;File</source>
@@ -395,23 +870,43 @@
     </message>
     <message>
         <source>Tabs toolbar</source>
-        <translation type="unfinished">แถบเครื่องมือแท็บ</translation>
+        <translation type="unfinished">แถบ เครื่องมือ</translation>
+    </message>
+    <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation type="unfinished">กำลังซิงค์ส่วนหัว (%1%)…</translation>
     </message>
     <message>
         <source>Synchronizing with network…</source>
-        <translation type="unfinished">กำลังซิงค์ข้อมูลกับทางเครือข่าย ...</translation>
+        <translation type="unfinished">กำลังซิงค์ข้อมูล กับทาง เครือข่าย ...</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation type="unfinished">การสร้างดัชนีบล็อกบนดิสก์…</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation type="unfinished">กำลังประมวลผลบล็อกบนดิสก์…</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation type="unfinished">การสร้างดัชนีบล็อกใหม่บนดิสก์…</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation type="unfinished">กำลังเชื่อมต่อ ไปยัง peers…</translation>
     </message>
     <message>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
-        <translation type="unfinished">เรียกเก็บ การชำระเงิน (สร้าง QR codes และ bitcoin: URIs)</translation>
+        <translation type="unfinished">ขอการชำระเงิน (สร้างรหัส QR และ bitcoin: URIs)</translation>
     </message>
     <message>
         <source>Show the list of used sending addresses and labels</source>
-        <translation type="unfinished">แสดงรายการ ที่เก็บเงินที่จะส่ง bitcoin ออก และป้ายชื่อ ที่ใช้ไปแล้ว</translation>
+        <translation type="unfinished">แสดงรายการที่ใช้ในการส่งแอดเดรสและเลเบลที่ใช้แล้ว</translation>
     </message>
     <message>
         <source>Show the list of used receiving addresses and labels</source>
-        <translation type="unfinished">แสดงรายการ ที่เก็บเงินที่จะรับ bitcoin เข้า และป้ายชื่อ ที่ใช้ไปแล้ว</translation>
+        <translation type="unfinished">แสดงรายการที่ได้ใช้ในการรับแอดเดรสและเลเบล</translation>
     </message>
     <message>
         <source>&amp;Command-line options</source>
@@ -420,20 +915,24 @@
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>ประมวลผล %n บล็อกของประวัติการทำธุรกรรม</numerusform>
         </translation>
     </message>
     <message>
         <source>%1 behind</source>
-        <translation type="unfinished">%1 ตามหลัง</translation>
+        <translation type="unfinished">%1 เบื้องหลัง</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation type="unfinished">กำลังติดตามถึงรายการล่าสุด…</translation>
     </message>
     <message>
         <source>Last received block was generated %1 ago.</source>
-        <translation type="unfinished">บล็อกสุดท้ายที่ได้รับ สร้างขึ้นเมื่อ %1 มาแล้ว</translation>
+        <translation type="unfinished">บล็อกที่ได้รับล่าสุดถูกสร้างขึ้นเมื่อ %1 ที่แล้ว</translation>
     </message>
     <message>
         <source>Transactions after this will not yet be visible.</source>
-        <translation type="unfinished">ธุรกรรมหลังจากนี้จะยังไม่สามารถมองเห็น</translation>
+        <translation type="unfinished">ธุรกรรมหลังจากนี้จะยังไม่ปรากฏให้เห็น</translation>
     </message>
     <message>
         <source>Error</source>
@@ -449,7 +948,85 @@
     </message>
     <message>
         <source>Up to date</source>
-        <translation type="unfinished">ทันสมัย</translation>
+        <translation type="unfinished">ปัจจุบัน</translation>
+    </message>
+    <message>
+        <source>Load PSBT from &amp;clipboard…</source>
+        <translation type="unfinished">โหลด PSBT จากคลิปบอร์ด...</translation>
+    </message>
+    <message>
+        <source>Node window</source>
+        <translation type="unfinished">หน้าต่างโหนด</translation>
+    </message>
+    <message>
+        <source>&amp;Sending addresses</source>
+        <translation type="unfinished">&amp;ที่อยู่การส่ง</translation>
+    </message>
+    <message>
+        <source>&amp;Receiving addresses</source>
+        <translation type="unfinished">&amp;ที่อยู่การรับ</translation>
+    </message>
+    <message>
+        <source>Open Wallet</source>
+        <translation type="unfinished">เปิดกระเป๋าสตางค์</translation>
+    </message>
+    <message>
+        <source>Open a wallet</source>
+        <translation type="unfinished">เปิดกระเป๋าสตางค์</translation>
+    </message>
+    <message>
+        <source>Close wallet</source>
+        <translation type="unfinished">ปิดกระเป๋าสตางค์</translation>
+    </message>
+    <message>
+        <source>Restore Wallet…</source>
+        <extracomment>Name of the menu item that restores wallet from a backup file.</extracomment>
+        <translation type="unfinished">กู้คืนวอลเล็ต…</translation>
+    </message>
+    <message>
+        <source>Restore a wallet from a backup file</source>
+        <extracomment>Status tip for Restore Wallet menu item</extracomment>
+        <translation type="unfinished">กู้คืนวอลเล็ตจากไฟล์สำรองข้อมูล</translation>
+    </message>
+    <message>
+        <source>Close all wallets</source>
+        <translation type="unfinished">ปิด วอลเล็ต ทั้งหมด</translation>
+    </message>
+    <message>
+        <source>&amp;Mask values</source>
+        <translation type="unfinished">&amp;ค่ามาสก์</translation>
+    </message>
+    <message>
+        <source>default wallet</source>
+        <translation type="unfinished">วอลเล็ต เริ่มต้น</translation>
+    </message>
+    <message>
+        <source>No wallets available</source>
+        <translation type="unfinished">ไม่มี วอลเล็ต ที่พร้อมใช้งาน</translation>
+    </message>
+    <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">ข้อมูล วอลเล็ต</translation>
+    </message>
+    <message>
+        <source>Load Wallet Backup</source>
+        <extracomment>The title for Restore Wallet File Windows</extracomment>
+        <translation type="unfinished">โหลดสำรองข้อมูลวอลเล็ต</translation>
+    </message>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of pop-up window shown when the user is attempting to restore a wallet.</extracomment>
+        <translation type="unfinished">กู้คืนวอลเล็ต</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">ชื่อ วอลเล็ต</translation>
+    </message>
+    <message>
+        <source>&amp;Window</source>
+        <translation type="unfinished">&amp;วินโดว์</translation>
     </message>
     <message>
         <source>Zoom</source>
@@ -457,7 +1034,7 @@
     </message>
     <message>
         <source>Main Window</source>
-        <translation type="unfinished">หน้าต่างหลัก</translation>
+        <translation type="unfinished">วินโดว์ หลัก</translation>
     </message>
     <message>
         <source>%1 client</source>
@@ -469,14 +1046,34 @@
     </message>
     <message>
         <source>S&amp;how</source>
-        <translation type="unfinished">แสดง</translation>
+        <translation type="unfinished">&amp;แสดง</translation>
     </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform>%n การเชื่อมต่อที่ใช้งานได้ เพื่อเชื่อมกับเครือข่าย Bitcoin</numerusform>
+            <numerusform>%n เครือข่ายที่สามารถใช้เชื่อมต่อไปยังเครือข่ายบิตคอยน์ได้</numerusform>
         </translation>
+    </message>
+    <message>
+        <source>Click for more actions.</source>
+        <extracomment>A substring of the tooltip. "More actions" are available via the context menu.</extracomment>
+        <translation type="unfinished">คลิกเพื่อดูการดำเนินการเพิ่มเติม</translation>
+    </message>
+    <message>
+        <source>Show Peers tab</source>
+        <extracomment>A context menu item. The "Peers tab" is an element of the "Node window".</extracomment>
+        <translation type="unfinished">แสดง Peers แท็ป</translation>
+    </message>
+    <message>
+        <source>Disable network activity</source>
+        <extracomment>A context menu item.</extracomment>
+        <translation type="unfinished">ปิดใช้งาน กิจกรรม เครือข่าย</translation>
+    </message>
+    <message>
+        <source>Enable network activity</source>
+        <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
+        <translation type="unfinished">เปิดใช้งาน กิจกรรม เครือข่าย</translation>
     </message>
     <message>
         <source>Error: %1</source>
@@ -501,61 +1098,80 @@
     <message>
         <source>Wallet: %1
 </source>
-        <translation type="unfinished">กระเป๋าสตางค์: %1
+        <translation type="unfinished">วอลเล็ต: %1
 </translation>
     </message>
     <message>
         <source>Type: %1
 </source>
-        <translation type="unfinished">ชนิด: %1
+        <translation type="unfinished">รูปแบบ: %1
 </translation>
     </message>
     <message>
         <source>Label: %1
 </source>
-        <translation type="unfinished">ป้ายชื่อ: %1
+        <translation type="unfinished">เลเบล: %1
 </translation>
     </message>
     <message>
         <source>Address: %1
 </source>
-        <translation type="unfinished">ที่อยู่: %1
+        <translation type="unfinished">แอดเดรส: %1
 </translation>
     </message>
     <message>
         <source>Sent transaction</source>
-        <translation type="unfinished">รายการที่ส่ง</translation>
+        <translation type="unfinished">รายการ ที่ส่ง</translation>
     </message>
     <message>
         <source>Incoming transaction</source>
-        <translation type="unfinished">การทำรายการขาเข้า</translation>
+        <translation type="unfinished">การทำรายการ ขาเข้า</translation>
+    </message>
+    <message>
+        <source>HD key generation is &lt;b&gt;enabled&lt;/b&gt;</source>
+        <translation type="unfinished">HD key generation ถูก &lt;b&gt;เปิดใช้งาน&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>HD key generation is &lt;b&gt;disabled&lt;/b&gt;</source>
+        <translation type="unfinished">HD key generation ถูก &lt;b&gt;ปิดใช้งาน&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Private key &lt;b&gt;disabled&lt;/b&gt;</source>
+        <translation type="unfinished">คีย์ ส่วนตัว &lt;b&gt;ถูกปิดใช้งาน&lt;/b&gt;</translation>
     </message>
     <message>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
-        <translation type="unfinished">ระเป๋าเงินถูก &lt;b&gt;เข้ารหัส&lt;/b&gt; และในขณะนี้ &lt;b&gt;ปลดล็อคแล้ว&lt;/b&gt;</translation>
+        <translation type="unfinished">วอลเล็ต ถูก &lt;b&gt;เข้ารหัส&lt;/b&gt; และ ในขณะนี้ &lt;b&gt;ปลดล็อคแล้ว&lt;/b&gt;</translation>
     </message>
     <message>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
-        <translation type="unfinished">กระเป๋าเงินถูก &lt;b&gt;เข้ารหัส&lt;/b&gt; และในปัจจุบัน &lt;b&gt;ล็อค &lt;/b&gt;</translation>
+        <translation type="unfinished">วอลเล็ต ถูก &lt;b&gt;เข้ารหัส&lt;/b&gt; และ ในขณะนี้ &lt;b&gt;ล็อคแล้ว &lt;/b&gt;</translation>
     </message>
     <message>
         <source>Original message:</source>
-        <translation type="unfinished">ข้อความดั้งเดิม:</translation>
+        <translation type="unfinished">ข้อความ ดั้งเดิม:</translation>
+    </message>
+</context>
+<context>
+    <name>UnitDisplayStatusBarControl</name>
+    <message>
+        <source>Unit to show amounts in. Click to select another unit.</source>
+        <translation type="unfinished">หน่วยแสดงจำนวนเงิน คลิกเพื่อเลือกหน่วยอื่น</translation>
     </message>
 </context>
 <context>
     <name>CoinControlDialog</name>
     <message>
         <source>Coin Selection</source>
-        <translation type="unfinished">การเลือกเหรียญ</translation>
+        <translation type="unfinished">การเลือกคอยน์</translation>
     </message>
     <message>
         <source>Quantity:</source>
-        <translation type="unfinished">จำนวน:</translation>
+        <translation type="unfinished">ปริมาณ:</translation>
     </message>
     <message>
         <source>Bytes:</source>
-        <translation type="unfinished">ไบต์:</translation>
+        <translation type="unfinished">ไบทส์:</translation>
     </message>
     <message>
         <source>Amount:</source>
@@ -567,27 +1183,27 @@
     </message>
     <message>
         <source>Dust:</source>
-        <translation type="unfinished">เศษ:</translation>
+        <translation type="unfinished">ดัสท์:</translation>
     </message>
     <message>
         <source>After Fee:</source>
-        <translation type="unfinished">ส่วนที่เหลือจากค่าธรรมเนียม:</translation>
+        <translation type="unfinished">หลังค่าธรรมเนียม:</translation>
     </message>
     <message>
         <source>Change:</source>
-        <translation type="unfinished">เงินทอน:</translation>
+        <translation type="unfinished">เปลี่ยน:</translation>
     </message>
     <message>
         <source>(un)select all</source>
-        <translation type="unfinished">(ไม่)เลือกทั้งหมด</translation>
+        <translation type="unfinished">(un)เลือกทั้งหมด</translation>
     </message>
     <message>
         <source>Tree mode</source>
-        <translation type="unfinished">โหมดแบบต้นไม้</translation>
+        <translation type="unfinished">โหมด แบบTree</translation>
     </message>
     <message>
         <source>List mode</source>
-        <translation type="unfinished">โหมดแบบรายการ</translation>
+        <translation type="unfinished">โหมด แบบรายการ</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -595,11 +1211,11 @@
     </message>
     <message>
         <source>Received with label</source>
-        <translation type="unfinished">รับด้วยป้ายชื่อ</translation>
+        <translation type="unfinished">รับ ด้วย เลเบล</translation>
     </message>
     <message>
         <source>Received with address</source>
-        <translation type="unfinished">รับด้วยที่อยู่</translation>
+        <translation type="unfinished">รับ ด้วย แอดเดรส</translation>
     </message>
     <message>
         <source>Date</source>
@@ -607,7 +1223,7 @@
     </message>
     <message>
         <source>Confirmations</source>
-        <translation type="unfinished">การยืนยัน</translation>
+        <translation type="unfinished">ทำการยืนยัน</translation>
     </message>
     <message>
         <source>Confirmed</source>
@@ -615,15 +1231,75 @@
     </message>
     <message>
         <source>Copy amount</source>
-        <translation type="unfinished">คัดลอกจำนวนเงิน</translation>
+        <translation type="unfinished">คัดลอก จำนวน</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;คัดลอก แอดเดรส</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">คัดลอก &amp;เลเบล</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">คัดลอก &amp;จำนวน</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID and output index</source>
+        <translation type="unfinished">คัดล็อก &amp;ID ธุรกรรม และ ส่งออก เป็นดัชนี</translation>
+    </message>
+    <message>
+        <source>L&amp;ock unspent</source>
+        <translation type="unfinished">L&amp;ock ที่ไม่ได้ใข้</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock unspent</source>
+        <translation type="unfinished">&amp;ปลดล็อค ที่ไม่ไดใช้</translation>
+    </message>
+    <message>
+        <source>Copy quantity</source>
+        <translation type="unfinished">คัดลอก ปริมาณ</translation>
+    </message>
+    <message>
+        <source>Copy fee</source>
+        <translation type="unfinished">คัดลอก ค่าธรรมเนียม</translation>
+    </message>
+    <message>
+        <source>Copy after fee</source>
+        <translation type="unfinished">คัดลอก หลัง ค่าธรรมเนียม</translation>
+    </message>
+    <message>
+        <source>Copy bytes</source>
+        <translation type="unfinished">คัดลอก bytes</translation>
+    </message>
+    <message>
+        <source>Copy dust</source>
+        <translation type="unfinished">คัดลอก dust</translation>
+    </message>
+    <message>
+        <source>Copy change</source>
+        <translation type="unfinished">คัดลอก change</translation>
+    </message>
+    <message>
+        <source>(%1 locked)</source>
+        <translation type="unfinished">(%1 ล็อคแล้ว)</translation>
+    </message>
+    <message>
+        <source>yes</source>
+        <translation type="unfinished">ใช่</translation>
+    </message>
+    <message>
+        <source>no</source>
+        <translation type="unfinished">ไม่</translation>
     </message>
     <message>
         <source>(no label)</source>
-        <translation type="unfinished">(ไม่มีป้ายชื่อ)</translation>
+        <translation type="unfinished">(ไม่มีเลเบล)</translation>
     </message>
     <message>
         <source>change from %1 (%2)</source>
-        <translation type="unfinished">เปลี่ยนจาก %1 (%2)</translation>
+        <translation type="unfinished">เปลี่ยน จาก %1 (%2)</translation>
     </message>
     <message>
         <source>(change)</source>
@@ -635,7 +1311,24 @@
     <message>
         <source>Create Wallet</source>
         <extracomment>Title of window indicating the progress of creation of a new wallet.</extracomment>
-        <translation type="unfinished">สร้างกระเป๋าสตางค์</translation>
+        <translation type="unfinished">สร้าง วอลเล็ต</translation>
+    </message>
+    <message>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the create wallet progress window which indicates to the user which wallet is currently being created.</extracomment>
+        <translation type="unfinished">กำลังสร้าง วอลเล็ต &lt;b&gt;%1&lt;/b&gt;…</translation>
+    </message>
+    <message>
+        <source>Create wallet failed</source>
+        <translation type="unfinished">การสร้าง วอลเล็ต ล้มเหลว</translation>
+    </message>
+    <message>
+        <source>Create wallet warning</source>
+        <translation type="unfinished">คำเตือน การสร้าง วอลเล็ต</translation>
+    </message>
+    <message>
+        <source>Can't list signers</source>
+        <translation type="unfinished">ไม่สามารถ จัดรายการ ผู้เซ็น</translation>
     </message>
     </context>
 <context>
@@ -643,26 +1336,67 @@
     <message>
         <source>Load Wallets</source>
         <extracomment>Title of progress window which is displayed when wallets are being loaded.</extracomment>
-        <translation type="unfinished">โหลดกระเป๋า</translation>
+        <translation type="unfinished">โหลด วอลเล็ต</translation>
     </message>
     <message>
         <source>Loading wallets…</source>
         <extracomment>Descriptive text of the load wallets progress window which indicates to the user that wallets are currently being loaded.</extracomment>
-        <translation type="unfinished">กำลังโหลดกระเป๋า...</translation>
+        <translation type="unfinished">กำลังโหลด วอลเล็ต...</translation>
     </message>
 </context>
 <context>
     <name>OpenWalletActivity</name>
     <message>
+        <source>Open wallet failed</source>
+        <translation type="unfinished">เปิด วอลเล็ต ล้มเหลว</translation>
+    </message>
+    <message>
+        <source>Open wallet warning</source>
+        <translation type="unfinished">คำเตือน การเปิด วอลเล็ต</translation>
+    </message>
+    <message>
         <source>default wallet</source>
-        <translation type="unfinished">กระเป๋าสตางค์เริ่มต้น</translation>
+        <translation type="unfinished">วอลเล็ต เริ่มต้น</translation>
     </message>
     <message>
         <source>Open Wallet</source>
         <extracomment>Title of window indicating the progress of opening of a wallet.</extracomment>
         <translation type="unfinished">เปิดกระเป๋าสตางค์</translation>
     </message>
-    </context>
+    <message>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the open wallet progress window which indicates to the user which wallet is currently being opened.</extracomment>
+        <translation type="unfinished">กำลังเปิด วอลเล็ต &lt;b&gt;%1&lt;/b&gt;…</translation>
+    </message>
+</context>
+<context>
+    <name>RestoreWalletActivity</name>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of progress window which is displayed when wallets are being restored.</extracomment>
+        <translation type="unfinished">กู้คืนวอลเล็ต</translation>
+    </message>
+    <message>
+        <source>Restoring Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the restore wallets progress window which indicates to the user that wallets are currently being restored.</extracomment>
+        <translation type="unfinished">ทำการกู้คืนวอลเล็ต &lt;b&gt;%1&lt;/b&gt;…</translation>
+    </message>
+    <message>
+        <source>Restore wallet failed</source>
+        <extracomment>Title of message box which is displayed when the wallet could not be restored.</extracomment>
+        <translation type="unfinished">การกู้คืนวอลเล็ตล้มเหลว</translation>
+    </message>
+    <message>
+        <source>Restore wallet warning</source>
+        <extracomment>Title of message box which is displayed when the wallet is restored with some warning.</extracomment>
+        <translation type="unfinished">คำเตือนการกู้คืนวอลเล็ต</translation>
+    </message>
+    <message>
+        <source>Restore wallet message</source>
+        <extracomment>Title of message box which is displayed when the wallet is successfully restored.</extracomment>
+        <translation type="unfinished">ข้อความการกู้คืนวอลเล็ต</translation>
+    </message>
+</context>
 <context>
     <name>WalletController</name>
     <message>
@@ -670,131 +1404,177 @@
         <translation type="unfinished">ปิดกระเป๋าสตางค์</translation>
     </message>
     <message>
+        <source>Are you sure you wish to close the wallet &lt;i&gt;%1&lt;/i&gt;?</source>
+        <translation type="unfinished">คุณ แน่ใจ หรือไม่ว่า ต้องการ ปิด วอลเล็ต &lt;i&gt;%1&lt;/i&gt;?</translation>
+    </message>
+    <message>
+        <source>Closing the wallet for too long can result in having to resync the entire chain if pruning is enabled.</source>
+        <translation type="unfinished">Closing the wallet for too long can result in having to resync the entire chain if pruning is enabled</translation>
+    </message>
+    <message>
         <source>Close all wallets</source>
-        <translation type="unfinished">ปิดกระเป๋าสตางค์ทั้งหมด</translation>
+        <translation type="unfinished">ปิด วอลเล็ต ทั้งหมด</translation>
     </message>
     <message>
         <source>Are you sure you wish to close all wallets?</source>
-        <translation type="unfinished">คุณแน่ใจหรือไม่ว่าต้องการปิดกระเป๋าสตางค์ทั้งหมด?</translation>
+        <translation type="unfinished">คุณ แน่ใจ หรือไม่ว่า ต้องการ ปิด วอลเล็ต ทั้งหมด?</translation>
     </message>
 </context>
 <context>
     <name>CreateWalletDialog</name>
     <message>
         <source>Create Wallet</source>
-        <translation type="unfinished">สร้างกระเป๋าสตางค์</translation>
+        <translation type="unfinished">สร้าง วอลเล็ต</translation>
     </message>
     <message>
         <source>Wallet Name</source>
-        <translation type="unfinished">ชื่อกระเป๋าสตางค์</translation>
+        <translation type="unfinished">ชื่อ วอลเล็ต</translation>
     </message>
     <message>
         <source>Wallet</source>
-        <translation type="unfinished">กระเป๋าเงิน</translation>
+        <translation type="unfinished">วอลเล็ต</translation>
+    </message>
+    <message>
+        <source>Encrypt the wallet. The wallet will be encrypted with a passphrase of your choice.</source>
+        <translation type="unfinished">เข้ารหัส วอลเล็ต วอลเล็ต จะถูก เข้ารหัส ด้วย พาสเฟส ที่ คุณ เลือก</translation>
     </message>
     <message>
         <source>Encrypt Wallet</source>
-        <translation type="unfinished">เข้ารหัสกระเป๋าสตางค์</translation>
+        <translation type="unfinished">เข้ารหัส วอลเล็ต</translation>
+    </message>
+    <message>
+        <source>Advanced Options</source>
+        <translation type="unfinished">ตัวเลือก ขั้นสูง</translation>
+    </message>
+    <message>
+        <source>Disable private keys for this wallet. Wallets with private keys disabled will have no private keys and cannot have an HD seed or imported private keys. This is ideal for watch-only wallets.</source>
+        <translation type="unfinished">Disable private keys for this wallet. Wallets with private keys disabled will have no private keys and cannot have an HD seed or imported private keys. This is ideal for watch-only wallets</translation>
     </message>
     <message>
         <source>Disable Private Keys</source>
-        <translation type="unfinished">ปิดใช้งานกุญแจส่วนตัว</translation>
+        <translation type="unfinished">ปิดใช้งาน คีย์ ส่วนตัว</translation>
+    </message>
+    <message>
+        <source>Make a blank wallet. Blank wallets do not initially have private keys or scripts. Private keys and addresses can be imported, or an HD seed can be set, at a later time.</source>
+        <translation type="unfinished">Make a blank wallet. Blank wallets do not initially have private keys or scripts. Private keys and addresses can be imported, or an HD seed can be set, at a later time</translation>
     </message>
     <message>
         <source>Make Blank Wallet</source>
-        <translation type="unfinished">สร้างกระเป๋าสตางค์เปล่า</translation>
+        <translation type="unfinished">ทำ วอลเล็ต ให้ว่างเปล่า</translation>
     </message>
     <message>
-        <source>Create</source>
-        <translation type="unfinished">สร้าง</translation>
+        <source>Descriptor Wallet</source>
+        <translation type="unfinished">ตัวอธิบาย วอลเล็ต</translation>
+    </message>
+    <message>
+        <source>Use an external signing device such as a hardware wallet. Configure the external signer script in wallet preferences first.</source>
+        <translation type="unfinished">Use an external signing device such as a hardware wallet. Configure the external signer script in wallet preferences first</translation>
     </message>
     </context>
 <context>
     <name>EditAddressDialog</name>
     <message>
         <source>Edit Address</source>
-        <translation type="unfinished">แก้ไขที่อยู่</translation>
+        <translation type="unfinished">แก้ไข แอดเดรส</translation>
     </message>
     <message>
         <source>&amp;Label</source>
-        <translation type="unfinished">&amp;ป้ายชื่อ</translation>
+        <translation type="unfinished">&amp;เลเบล</translation>
     </message>
     <message>
         <source>The label associated with this address list entry</source>
-        <translation type="unfinished">รายการแสดง ป้ายชื่อที่เกี่ยวข้องกับที่เก็บนี้</translation>
-    </message>
-    <message>
-        <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
-        <translation type="unfinished">ที่เก็บที่เกี่ยวข้องกับ ที่เก็บที่แสดงรายการนี้ การปรับปรุงนี้ทำได้สำหรับ ที่เก็บเงินที่จะใช่ส่งเงิน เท่านั้น</translation>
+        <translation type="unfinished">รายการ แสดง เลเบล ที่ เกี่ยวข้องกับ ที่เก็บ นี้</translation>
     </message>
     <message>
         <source>&amp;Address</source>
-        <translation type="unfinished">&amp;ที่อยู่</translation>
+        <translation type="unfinished">&amp;แอดเดรส</translation>
     </message>
     <message>
         <source>New sending address</source>
-        <translation type="unfinished">ที่อยู่การส่งใหม่</translation>
+        <translation type="unfinished">แอดเดรส การส่ง ใหม่</translation>
     </message>
     <message>
         <source>Edit receiving address</source>
-        <translation type="unfinished">แก้ไขที่อยู่การรับ</translation>
+        <translation type="unfinished">แก้ไข แอดเดรส การรับ</translation>
     </message>
     <message>
         <source>Edit sending address</source>
-        <translation type="unfinished">แก้ไขที่อยู่การส่ง</translation>
+        <translation type="unfinished">แก้ไข แอดเดรส การส่ง</translation>
+    </message>
+    <message>
+        <source>The entered address "%1" is not a valid Bitcoin address.</source>
+        <translation type="unfinished">แอดเดรส ที่ป้อน "%1" เป็น Bitcoin แอดเดรส ที่ ไม่ ถูกต้อง</translation>
+    </message>
+    <message>
+        <source>Address "%1" already exists as a receiving address with label "%2" and so cannot be added as a sending address.</source>
+        <translation type="unfinished">Address "%1" already exists as a receiving address with label "%2" and so cannot be added as a sending address</translation>
+    </message>
+    <message>
+        <source>The entered address "%1" is already in the address book with label "%2".</source>
+        <translation type="unfinished">The entered address "%1" is already in the address book with label "%2"</translation>
     </message>
     <message>
         <source>Could not unlock wallet.</source>
-        <translation type="unfinished">ไม่สามารถปลดล็อคกระเป๋าสตางค์</translation>
+        <translation type="unfinished">ไม่สามารถปลดล็อกวอลเล็ตได้</translation>
     </message>
-    </context>
+    <message>
+        <source>New key generation failed.</source>
+        <translation type="unfinished">การสร้างคีย์ใหม่ล้มเหลว</translation>
+    </message>
+</context>
 <context>
     <name>FreespaceChecker</name>
     <message>
         <source>A new data directory will be created.</source>
-        <translation type="unfinished">ไดเร็กทอรี่ใหม่ที่ใช้เก็บข้อมูลจะถูกสร้างขึ้นมา</translation>
-    </message>
-    <message>
-        <source>name</source>
-        <translation type="unfinished">ชื่อ</translation>
-    </message>
-    <message>
-        <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
-        <translation type="unfinished">มีไดเรกทอรีอยู่แล้ว เพิ่ม %1 หากคุณต้องการสร้างไดเรกทอรีใหม่ที่นี่</translation>
-    </message>
-    <message>
-        <source>Path already exists, and is not a directory.</source>
-        <translation type="unfinished">มีเส้นทางอยู่แล้วและไม่ใช่ไดเรกทอรี</translation>
+        <translation type="unfinished">ไดเร็กทอรีข้อมูลใหม่จะถูกสร้างขึ้น</translation>
     </message>
     <message>
         <source>Cannot create data directory here.</source>
-        <translation type="unfinished">ไม่สามารถสร้างไดเรกทอรีข้อมูลที่นี่</translation>
+        <translation type="unfinished">ไม่สามารถสร้างไดเร็กทอรีข้อมูลที่นี่</translation>
     </message>
 </context>
 <context>
     <name>Intro</name>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform>มีพื้นที่ว่าง %n GB ที่ใช้งานได้</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform>(ต้องการพื้นที่ %n GB )</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform>(%n GB needed for full chain)</numerusform>
+        </translation>
+    </message>
     <message>
-        <source>%1 GB of space available</source>
-        <translation type="unfinished">มีพื้นที่ว่าง %1 GB ที่ใช้งานได้</translation>
+        <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
+        <translation type="unfinished">At least %1 GB of data will be stored in this directory, and it will grow over time</translation>
     </message>
     <message>
         <source>Approximately %1 GB of data will be stored in this directory.</source>
-        <translation type="unfinished">ประมาณ %1 GB ของข้อมูลจะเก็บในไดเร็กทอรี่</translation>
+        <translation type="unfinished">ข้อมูลประมาณ %1 GB จะถูกเก็บไว้ในไดเร็กทอรีนี้</translation>
     </message>
     <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>(sufficient to restore backups %n day(s) old)</numerusform>
         </translation>
     </message>
     <message>
-        <source>The wallet will also be stored in this directory.</source>
-        <translation type="unfinished">The wallet เก็บใว้ในไดเร็กทอรี่</translation>
+        <source>%1 will download and store a copy of the Bitcoin block chain.</source>
+        <translation type="unfinished">%1 จะดาวน์โหลดและจัดเก็บสำเนาของบล็อกเชน Bitcoin</translation>
     </message>
     <message>
-        <source>Error: Specified data directory "%1" cannot be created.</source>
-        <translation type="unfinished">ข้อผิดพลาด: ไดเร็กทอรี่ข้อมูลที่ต้องการ "%1" ไม่สามารถสร้างได้</translation>
+        <source>The wallet will also be stored in this directory.</source>
+        <translation type="unfinished"> วอลเล็ตจะถูกเก็บใว้ในไดเร็กทอรีนี้เช่นกัน</translation>
     </message>
     <message>
         <source>Error</source>
@@ -806,26 +1586,38 @@
     </message>
     <message>
         <source>Welcome to %1.</source>
-        <translation type="unfinished">ยินดีต้อนรับสู่ %1</translation>
+        <translation type="unfinished">ยินดีต้อนรับเข้าสู่ %1.</translation>
     </message>
     <message>
         <source>As this is the first time the program is launched, you can choose where %1 will store its data.</source>
-        <translation type="unfinished">นี่เป็นการรันโปรแกรมครั้งแรก ท่านสามารถเลือก ว่าจะเก็บข้อมูลไว้ที่ %1</translation>
+        <translation type="unfinished">เนื่องจากนี่เป็นครั้งแรกที่โปรแกรมเปิดตัว คุณสามารถเลือกได้ว่า %1 จะเก็บข้อมูลไว้ที่ใด</translation>
+    </message>
+    <message>
+        <source>Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</source>
+        <translation type="unfinished">Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features</translation>
+    </message>
+    <message>
+        <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
+        <translation type="unfinished">This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off</translation>
+    </message>
+    <message>
+        <source>If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</source>
+        <translation type="unfinished">If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low</translation>
     </message>
     <message>
         <source>Use the default data directory</source>
-        <translation type="unfinished">ใช้ไดเรกทอรีข้อมูลเริ่มต้น</translation>
+        <translation type="unfinished">ใช้ ไดเรกทอรี ข้อมูล เริ่มต้น</translation>
     </message>
     <message>
         <source>Use a custom data directory:</source>
-        <translation type="unfinished">ใช้ไดเรกทอรีข้อมูลที่กำหนดเอง:</translation>
+        <translation type="unfinished">ใช้ ไดเรกทอรี ข้อมูล ที่กำหนดเอง:</translation>
     </message>
 </context>
 <context>
     <name>HelpMessageDialog</name>
     <message>
         <source>version</source>
-        <translation type="unfinished">รุ่น</translation>
+        <translation type="unfinished">เวอร์ชัน</translation>
     </message>
     <message>
         <source>About %1</source>
@@ -833,32 +1625,58 @@
     </message>
     <message>
         <source>Command-line options</source>
-        <translation type="unfinished">ตัวเลือกบรรทัดคำสั่ง</translation>
+        <translation type="unfinished">ตัวเลือก Command-line </translation>
+    </message>
+</context>
+<context>
+    <name>ShutdownWindow</name>
+    <message>
+        <source>%1 is shutting down…</source>
+        <translation type="unfinished">%1 กำลังถูกปิดลง…</translation>
+    </message>
+    <message>
+        <source>Do not shut down the computer until this window disappears.</source>
+        <translation type="unfinished">อย่าปิดเครื่องคอมพิวเตอร์จนกว่าหน้าต่างนี้จะหายไป</translation>
     </message>
 </context>
 <context>
     <name>ModalOverlay</name>
     <message>
         <source>Form</source>
-        <translation type="unfinished">รูป</translation>
+        <translation type="unfinished">รูปแบบ</translation>
     </message>
     <message>
-        <source>Progress</source>
-        <translation type="unfinished">ความคืบหน้า</translation>
+        <source>Number of blocks left</source>
+        <translation type="unfinished">ตัวเลข ของ บล็อก ที่เหลือ</translation>
     </message>
     <message>
-        <source>Hide</source>
-        <translation type="unfinished">ซ่อน</translation>
+        <source>Unknown…</source>
+        <translation type="unfinished">ไม่รู้จัก…</translation>
+    </message>
+    <message>
+        <source>calculating…</source>
+        <translation type="unfinished">กำลังคำนวณ…</translation>
+    </message>
+    <message>
+        <source>Last block time</source>
+        <translation type="unfinished">บล็อกเวลาล่าสุด</translation>
+    </message>
+    <message>
+        <source>Progress increase per hour</source>
+        <translation type="unfinished">ความคืบหน้าเพิ่มขึ้นต่อชั่วโมง</translation>
+    </message>
+    <message>
+        <source>Estimated time left until synced</source>
+        <translation type="unfinished">เวลาโดยประมาณที่เหลือจนกว่าจะซิงค์</translation>
     </message>
     </context>
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <source>Paste address from clipboard</source>
-        <extracomment>Tooltip text for button that allows you to paste an address that is in your clipboard.</extracomment>
-        <translation type="unfinished">วางที่อยู่จากคลิปบอร์ด</translation>
+        <source>Open bitcoin URI</source>
+        <translation type="unfinished">เปิด bitcoin: URI</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>OptionsDialog</name>
     <message>
@@ -870,48 +1688,19 @@
         <translation type="unfinished">&amp;หลัก</translation>
     </message>
     <message>
-        <source>Automatically start %1 after logging in to the system.</source>
-        <translation type="unfinished">เริ่มต้นอัตโนมัติ %1 หลังจาก ล็อกอิน เข้าสู่ระบบแล้ว</translation>
+        <source>Maximum database cache size. A larger cache can contribute to faster sync, after which the benefit is less pronounced for most use cases. Lowering the cache size will reduce memory usage. Unused mempool memory is shared for this cache.</source>
+        <extracomment>Tooltip text for Options window setting that sets the size of the database cache. Explains the corresponding effects of increasing/decreasing this value.</extracomment>
+        <translation type="unfinished">ขนาดแคชฐานข้อมูลสูงสุด แคชที่ใหญ่ขึ้นสามารถนำไปสู่การซิงค์ได้เร็วยิ่งขึ้น หลังจากนั้นประโยชน์จะเด่นชัดน้อยลงสำหรับกรณีการใช้งานส่วนใหญ่ การลดขนาดแคชจะลดการใช้หน่วยความจำ มีการแชร์หน่วยความจำ mempool ที่ไม่ได้ใช้สำหรับแคชนี้</translation>
     </message>
     <message>
-        <source>&amp;Start %1 on system login</source>
-        <translation type="unfinished">&amp;เริ่ม %1 ในการล็อกอินระบบ</translation>
+        <source>Set the number of script verification threads. Negative values correspond to the number of cores you want to leave free to the system.</source>
+        <extracomment>Tooltip text for Options window setting that sets the number of script verification threads. Explains that negative values mean to leave these many cores free to the system.</extracomment>
+        <translation type="unfinished">กำหนดจำนวนเธรดการตรวจสอบสคริปต์ ค่าลบสอดคล้องกับจำนวนคอร์ที่คุณต้องการปล่อยให้ระบบว่าง</translation>
     </message>
     <message>
-        <source>Size of &amp;database cache</source>
-        <translation type="unfinished">ขนาดของ &amp;database cache</translation>
-    </message>
-    <message>
-        <source>Number of script &amp;verification threads</source>
-        <translation type="unfinished">จำนวนของสคริปท์ &amp;verification threads</translation>
-    </message>
-    <message>
-        <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
-        <translation type="unfinished">IP แอดเดส ของ proxy (เช่น IPv4: 127.0.0.1 / IPv6: ::1)</translation>
-    </message>
-    <message>
-        <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
-        <translation type="unfinished">มินิไมซ์แอพ แทนการออกจากแอพพลิเคชั่น เมื่อวินโดว์ได้รับการปิด เมื่อเลือกตัวเลือกนี้ แอพพลิเคชั่น จะถูกปิด ก็ต่อเมื่อ มีการเลือกเมนู Exit/ออกจากระบบ เท่านั้น</translation>
-    </message>
-    <message>
-        <source>Open Configuration File</source>
-        <translation type="unfinished">เปิดไฟล์การกำหนดค่า</translation>
-    </message>
-    <message>
-        <source>Reset all client options to default.</source>
-        <translation type="unfinished">รีเซต ไคลเอ็นออพชั่น กลับไปเป็นค่าเริ่มต้น</translation>
-    </message>
-    <message>
-        <source>&amp;Reset Options</source>
-        <translation type="unfinished">&amp;รีเซต ออพชั่น</translation>
-    </message>
-    <message>
-        <source>&amp;Network</source>
-        <translation type="unfinished">&amp;เครือข่าย</translation>
-    </message>
-    <message>
-        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
-        <translation type="unfinished">(0 = อัตโนมัติ, &lt;0 = ปล่อย คอร์ อิสระ)</translation>
+        <source>This allows you or a third party tool to communicate with the node through command-line and JSON-RPC commands.</source>
+        <extracomment>Tooltip text for Options window setting that enables the RPC server.</extracomment>
+        <translation type="unfinished">สิ่งนี้ช่วยให้คุณหรือเครื่องมือของบุคคลที่สามสามารถสื่อสารกับโหนดผ่านคำสั่งบรรทัดคำสั่งและ JSON-RPC</translation>
     </message>
     <message>
         <source>Enable R&amp;PC server</source>
@@ -920,23 +1709,7 @@
     </message>
     <message>
         <source>W&amp;allet</source>
-        <translation type="unfinished">&amp;กระเป๋าสตางค์</translation>
-    </message>
-    <message>
-        <source>Expert</source>
-        <translation type="unfinished">ผู้เชี่ยวชาญ</translation>
-    </message>
-    <message>
-        <source>Enable coin &amp;control features</source>
-        <translation type="unfinished">เปิดใช้ coin &amp; รูปแบบการควบคุม</translation>
-    </message>
-    <message>
-        <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
-        <translation type="unfinished">หากท่านไม่เปิดใช้ การใช้เงินทอนที่ยังไม่ยืนยัน เงินทอนจากการทำรายการจะไม่สามารถใช้ได้ จนกว่ารายการที่ทำการ จะได้รับการยืนยันหนึ่งครั้ง และจะกระทบการคำนวณยอดคงเหลือของท่านด้วย</translation>
-    </message>
-    <message>
-        <source>&amp;Spend unconfirmed change</source>
-        <translation type="unfinished">&amp;ใช้เงินทอนที่ยังไม่ยืนยัน</translation>
+        <translation type="unfinished">ว&amp;อลเล็ต</translation>
     </message>
     <message>
         <source>Enable &amp;PSBT controls</source>
@@ -944,48 +1717,24 @@
         <translation type="unfinished">เปิดใช้งานการควบคุม &amp;PSBT</translation>
     </message>
     <message>
-        <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
-        <translation type="unfinished">เปิด Bitcoin ไคล์เอ็นท์พอร์ต/client port บน router โดยอัตโนมัติ วิธีนี้ใช้ได้เมื่อ router สนับสนุน UPnP และสถานะเปิดใช้งาน</translation>
-    </message>
-    <message>
-        <source>Map port using &amp;UPnP</source>
-        <translation type="unfinished">จองพอร์ต โดยใช้ &amp;UPnP</translation>
-    </message>
-    <message>
-        <source>Connect to the Bitcoin network through a SOCKS5 proxy.</source>
-        <translation type="unfinished">เชื่อมต่อกับ Bitcoin เน็ตเวิร์ก ผ่านพร็อกซี่แบบ SOCKS5</translation>
-    </message>
-    <message>
-        <source>&amp;Connect through SOCKS5 proxy (default proxy):</source>
-        <translation type="unfinished">&amp;เชื่อมต่อผ่าน พร็อกซี่ SOCKS5 (พร็อกซี่เริ่มต้น):</translation>
-    </message>
-    <message>
-        <source>Proxy &amp;IP:</source>
-        <translation type="unfinished">พร็อกซี่ &amp;IP:</translation>
+        <source>External Signer (e.g. hardware wallet)</source>
+        <translation type="unfinished">ผู้ลงนามภายนอก (เช่น ฮาร์ดแวร์วอลเล็ต)</translation>
     </message>
     <message>
         <source>&amp;Port:</source>
-        <translation type="unfinished">&amp;พอร์ต</translation>
-    </message>
-    <message>
-        <source>Port of the proxy (e.g. 9050)</source>
-        <translation type="unfinished">พอร์ตของพร็อกซี่ (ตัวอย่าง 9050)</translation>
-    </message>
-    <message>
-        <source>Used for reaching peers via:</source>
-        <translation type="unfinished">ใช้ในการเข้าถึงอีกฝ่ายหนึ่ง peer โดย:</translation>
+        <translation type="unfinished">&amp;พอร์ต:</translation>
     </message>
     <message>
         <source>&amp;Window</source>
-        <translation type="unfinished">&amp;หน้าต่าง</translation>
+        <translation type="unfinished">&amp;วินโดว์</translation>
     </message>
     <message>
-        <source>Show only a tray icon after minimizing the window.</source>
-        <translation type="unfinished">แสดงเฉพาะไอคอนถาดหลังจากย่อหน้าต่าง</translation>
+        <source>Third-party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</source>
+        <translation type="unfinished">URL ของบุคคลที่สาม (เช่น เครื่องมือสำรวจการบล็อก) ที่ปรากฏในแท็บธุรกรรมเป็นรายการเมนูบริบท %s ใน URL จะถูกแทนที่ด้วยแฮชธุรกรรม URL หลายรายการถูกคั่นด้วยแถบแนวตั้ง |</translation>
     </message>
     <message>
-        <source>User Interface &amp;language:</source>
-        <translation type="unfinished">&amp;ภาษาส่วนติดต่อผู้ใช้:</translation>
+        <source>&amp;Third-party transaction URLs</source>
+        <translation type="unfinished">&amp;URL ธุรกรรมบุคคลที่สาม</translation>
     </message>
     <message>
         <source>&amp;OK</source>
@@ -996,9 +1745,8 @@
         <translation type="unfinished">&amp;ยกเลิก</translation>
     </message>
     <message>
-        <source>Configuration options</source>
-        <extracomment>Window title text of pop-up box that allows opening up of configuration file.</extracomment>
-        <translation type="unfinished">ตัวเลือกการกำหนดค่า</translation>
+        <source>none</source>
+        <translation type="unfinished">ไม่มี</translation>
     </message>
     <message>
         <source>Continue</source>
@@ -1017,66 +1765,286 @@
     <name>OverviewPage</name>
     <message>
         <source>Form</source>
-        <translation type="unfinished">รูป</translation>
+        <translation type="unfinished">รูปแบบ</translation>
+    </message>
+    <message>
+        <source>Available:</source>
+        <translation type="unfinished">พร้อมใช้งาน:</translation>
     </message>
     <message>
         <source>Balances</source>
-        <translation type="unfinished">ยอดดุล</translation>
+        <translation type="unfinished">ยอดคงเหลือ</translation>
+    </message>
+    <message>
+        <source>Total:</source>
+        <translation type="unfinished">ทั้งหมด:</translation>
+    </message>
+    <message>
+        <source>Your current total balance</source>
+        <translation type="unfinished">ยอดคงเหลือ ทั้งหมด ในปัจจุบัน ของคุณ</translation>
+    </message>
+    <message>
+        <source>Spendable:</source>
+        <translation type="unfinished">ที่สามารถใช้จ่ายได้:</translation>
+    </message>
+    <message>
+        <source>Recent transactions</source>
+        <translation type="unfinished">การทำธุรกรรม ล่าสุด</translation>
     </message>
     </context>
 <context>
     <name>PSBTOperationsDialog</name>
     <message>
-        <source>Copy to Clipboard</source>
-        <translation type="unfinished">คัดลอกไปยังคลิปบอร์ด</translation>
+        <source>Save…</source>
+        <translation type="unfinished">บันทึก…</translation>
     </message>
     <message>
-        <source>Close</source>
-        <translation type="unfinished">ปิด</translation>
+        <source>Cannot sign inputs while wallet is locked.</source>
+        <translation type="unfinished">ไม่สามารถลงนามอินพุตในขณะที่วอลเล็ตถูกล็อค</translation>
+    </message>
+    <message>
+        <source>Unknown error processing transaction.</source>
+        <translation type="unfinished">ข้อผิดพลาดที่ไม่รู้จักของการประมวลผลธุรกรรม</translation>
+    </message>
+    <message>
+        <source>PSBT copied to clipboard.</source>
+        <translation type="unfinished">PSBT คัดลอกไปยังคลิปบอร์ดแล้ว</translation>
+    </message>
+    <message>
+        <source> * Sends %1 to %2</source>
+        <translation type="unfinished"> * ส่ง %1 ถึง %2</translation>
+    </message>
+    <message>
+        <source>Total Amount</source>
+        <translation type="unfinished">จำนวน ทั้งหมด</translation>
+    </message>
+    <message>
+        <source>or</source>
+        <translation type="unfinished">หรือ</translation>
+    </message>
+    <message>
+        <source>Transaction has %1 unsigned inputs.</source>
+        <translation type="unfinished">ธุรกรรมมี %1 อินพุตที่ไม่ได้ลงนาม</translation>
+    </message>
+    <message>
+        <source>(But no wallet is loaded.)</source>
+        <translation type="unfinished">(แต่ไม่มีการโหลดวอลเล็ต)</translation>
+    </message>
+    <message>
+        <source>(But this wallet cannot sign transactions.)</source>
+        <translation type="unfinished">(แต่วอลเล็ทนี้ไม่สามารถลงนามการทำธุรกรรมได้)</translation>
     </message>
     </context>
 <context>
     <name>PeerTableModel</name>
+    <message>
+        <source>Peer</source>
+        <extracomment>Title of Peers Table column which contains a unique number used to identify a connection.</extracomment>
+        <translation type="unfinished">เพียร์</translation>
+    </message>
+    <message>
+        <source>Age</source>
+        <extracomment>Title of Peers Table column which indicates the duration (length of time) since the peer connection started.</extracomment>
+        <translation type="unfinished">อายุ</translation>
+    </message>
     <message>
         <source>Direction</source>
         <extracomment>Title of Peers Table column which indicates the direction the peer connection was initiated from.</extracomment>
         <translation type="unfinished">ทิศทาง</translation>
     </message>
     <message>
+        <source>Sent</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have sent to the peer.</extracomment>
+        <translation type="unfinished">ส่งแล้ว</translation>
+    </message>
+    <message>
+        <source>Received</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have received from the peer.</extracomment>
+        <translation type="unfinished">รับแล้ว</translation>
+    </message>
+    <message>
         <source>Address</source>
         <extracomment>Title of Peers Table column which contains the IP/Onion/I2P address of the connected peer.</extracomment>
-        <translation type="unfinished">ที่อยู่</translation>
+        <translation type="unfinished">แอดเดรส</translation>
     </message>
     <message>
         <source>Type</source>
         <extracomment>Title of Peers Table column which describes the type of peer connection. The "type" describes why the connection exists.</extracomment>
-        <translation type="unfinished">ชนิด</translation>
+        <translation type="unfinished">รูปแบบ</translation>
     </message>
-    </context>
+    <message>
+        <source>Network</source>
+        <extracomment>Title of Peers Table column which states the network the peer connected through.</extracomment>
+        <translation type="unfinished">เครือข่าย</translation>
+    </message>
+    <message>
+        <source>Inbound</source>
+        <extracomment>An Inbound Connection from a Peer.</extracomment>
+        <translation type="unfinished">ขาเข้า</translation>
+    </message>
+    <message>
+        <source>Outbound</source>
+        <extracomment>An Outbound Connection to a Peer.</extracomment>
+        <translation type="unfinished">ขาออก</translation>
+    </message>
+</context>
 <context>
     <name>QRImageWidget</name>
     <message>
-        <source>Save QR Code</source>
-        <translation type="unfinished">บันทึกรหัส QR</translation>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">&amp;บันทึก ภาพ…</translation>
     </message>
-    </context>
+    <message>
+        <source>&amp;Copy Image</source>
+        <translation type="unfinished">&amp;คัดลอก ภาพ</translation>
+    </message>
+    <message>
+        <source>Save QR Code</source>
+        <translation type="unfinished">บันทึก QR Code</translation>
+    </message>
+    <message>
+        <source>PNG Image</source>
+        <extracomment>Expanded name of the PNG file format. See: https://en.wikipedia.org/wiki/Portable_Network_Graphics.</extracomment>
+        <translation type="unfinished">ภาพ PNG</translation>
+    </message>
+</context>
 <context>
     <name>RPCConsole</name>
     <message>
+        <source>&amp;Information</source>
+        <translation type="unfinished">&amp;ข้อมูล</translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation type="unfinished">ทั่วไป</translation>
+    </message>
+    <message>
+        <source>Network</source>
+        <translation type="unfinished">เครือข่าย</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished">ชื่อ</translation>
+    </message>
+    <message>
+        <source>Number of connections</source>
+        <translation type="unfinished">ตัวเลข ของ connections</translation>
+    </message>
+    <message>
+        <source>Block chain</source>
+        <translation type="unfinished">บล็อกเชน</translation>
+    </message>
+    <message>
+        <source>Memory Pool</source>
+        <translation type="unfinished">พูลเมมโมรี่</translation>
+    </message>
+    <message>
+        <source>Memory usage</source>
+        <translation type="unfinished">การใช้เมมโมรี่</translation>
+    </message>
+    <message>
         <source>Wallet: </source>
-        <translation type="unfinished">กระเป๋าสตางค์: </translation>
+        <translation type="unfinished">วอลเล็ต: </translation>
+    </message>
+    <message>
+        <source>(none)</source>
+        <translation type="unfinished">(ไม่มี)</translation>
+    </message>
+    <message>
+        <source>&amp;Reset</source>
+        <translation type="unfinished">&amp;รีเซ็ต</translation>
+    </message>
+    <message>
+        <source>Received</source>
+        <translation type="unfinished">รับแล้ว</translation>
+    </message>
+    <message>
+        <source>Sent</source>
+        <translation type="unfinished">ส่งแล้ว</translation>
+    </message>
+    <message>
+        <source>Version</source>
+        <translation type="unfinished">เวอร์ชัน</translation>
     </message>
     <message>
         <source>Last Transaction</source>
         <translation type="unfinished">ธุรกรรมก่อนหน้า</translation>
     </message>
     <message>
+        <source>Whether we relay addresses to this peer.</source>
+        <extracomment>Tooltip text for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
+        <translation type="unfinished">ไม่ว่าเราจะรีเลย์แอดเดรสปยังเพียร์นี้หรือไม่</translation>
+    </message>
+    <message>
         <source>Address Relay</source>
-        <translation type="unfinished">รีเลย์ที่อยู่</translation>
+        <extracomment>Text title for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
+        <translation type="unfinished">รีเลย์ แอดเดรส</translation>
+    </message>
+    <message>
+        <source>Addresses Processed</source>
+        <extracomment>Text title for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
+        <translation type="unfinished">แอดเดรส ที่ประมวลผลแล้ว</translation>
+    </message>
+    <message>
+        <source>Addresses Rate-Limited</source>
+        <extracomment>Text title for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
+        <translation type="unfinished">แอดเดรส จำกัดอัตรา</translation>
     </message>
     <message>
         <source>Node window</source>
         <translation type="unfinished">หน้าต่างโหนด</translation>
+    </message>
+    <message>
+        <source>Decrease font size</source>
+        <translation type="unfinished">ลด ขนาด ตัวอักษร</translation>
+    </message>
+    <message>
+        <source>Increase font size</source>
+        <translation type="unfinished">เพิ่ม ขนาด ตัวอักษร</translation>
+    </message>
+    <message>
+        <source>Permissions</source>
+        <translation type="unfinished">การอนุญาต</translation>
+    </message>
+    <message>
+        <source>Services</source>
+        <translation type="unfinished">การบริการ</translation>
+    </message>
+    <message>
+        <source>High Bandwidth</source>
+        <translation type="unfinished">แบนด์วิดท์สูง</translation>
+    </message>
+    <message>
+        <source>Connection Time</source>
+        <translation type="unfinished">เวลาในการเชื่อมต่อ</translation>
+    </message>
+    <message>
+        <source>Last Block</source>
+        <translation type="unfinished">Block สุดท้าย</translation>
+    </message>
+    <message>
+        <source>Last Send</source>
+        <translation type="unfinished">การส่งล่าสุด</translation>
+    </message>
+    <message>
+        <source>Last Receive</source>
+        <translation type="unfinished">การรับล่าสุด</translation>
+    </message>
+    <message>
+        <source>Ping Time</source>
+        <translation type="unfinished">เวลาในการ Ping</translation>
+    </message>
+    <message>
+        <source>Ping Wait</source>
+        <translation type="unfinished">คอยในการ Ping</translation>
+    </message>
+    <message>
+        <source>Min Ping</source>
+        <translation type="unfinished">วินาทีในการ Ping</translation>
+    </message>
+    <message>
+        <source>Last block time</source>
+        <translation type="unfinished">บล็อกเวลาล่าสุด</translation>
     </message>
     <message>
         <source>&amp;Open</source>
@@ -1087,24 +2055,107 @@
         <translation type="unfinished">&amp;คอนโซล</translation>
     </message>
     <message>
+        <source>Totals</source>
+        <translation type="unfinished">ทั้งหมด</translation>
+    </message>
+    <message>
+        <source>Debug log file</source>
+        <translation type="unfinished">ไฟล์บันทึกการดีบัก</translation>
+    </message>
+    <message>
+        <source>In:</source>
+        <translation type="unfinished">เข้า:</translation>
+    </message>
+    <message>
+        <source>Out:</source>
+        <translation type="unfinished">ออก:</translation>
+    </message>
+    <message>
+        <source>Inbound: initiated by peer</source>
+        <extracomment>Explanatory text for an inbound peer connection.</extracomment>
+        <translation type="unfinished">ขาเข้า: เริ่มต้นด้วย peer</translation>
+    </message>
+    <message>
+        <source>Outbound Full Relay: default</source>
+        <extracomment>Explanatory text for an outbound peer connection that relays all network information. This is the default behavior for outbound connections.</extracomment>
+        <translation type="unfinished">ขาออก Full Relay: ค่าเริ่มต้น</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <extracomment>Context menu action to copy the address of a peer.</extracomment>
+        <translation type="unfinished">&amp;คัดลอก แอดเดรส</translation>
+    </message>
+    <message>
+        <source>&amp;Disconnect</source>
+        <translation type="unfinished">&amp;หยุดเชื่อมต่อ</translation>
+    </message>
+    <message>
+        <source>1 &amp;hour</source>
+        <translation type="unfinished">1 &amp;ขั่วโมง</translation>
+    </message>
+    <message>
+        <source>1 d&amp;ay</source>
+        <translation type="unfinished">1 &amp;วัน</translation>
+    </message>
+    <message>
+        <source>1 &amp;week</source>
+        <translation type="unfinished">1 &amp;สัปดาห์</translation>
+    </message>
+    <message>
+        <source>1 &amp;year</source>
+        <translation type="unfinished">1 &amp;ปี</translation>
+    </message>
+    <message>
         <source>&amp;Copy IP/Netmask</source>
         <extracomment>Context menu action to copy the IP/Netmask of a banned peer. IP/Netmask is the combination of a peer's IP address and its Netmask. For IP address, see: https://en.wikipedia.org/wiki/IP_address.</extracomment>
         <translation type="unfinished">&amp;คัดลอก IP/Netmask</translation>
     </message>
     <message>
+        <source>Executing command without any wallet</source>
+        <translation type="unfinished">ดำเนินการคำสั่งโดยไม่มีวอลเล็ตใด ๆ</translation>
+    </message>
+    <message>
+        <source>Executing command using "%1" wallet</source>
+        <translation type="unfinished">ดำเนินการคำสั่งโดยใช้ "%1" วอลเล็ต</translation>
+    </message>
+    <message>
+        <source>via %1</source>
+        <translation type="unfinished">โดยผ่าน %1</translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished">ใช่</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished">ไม่</translation>
+    </message>
+    <message>
         <source>To</source>
-        <translation type="unfinished">ถึง</translation>
+        <translation type="unfinished">ไปยัง</translation>
     </message>
     <message>
         <source>From</source>
         <translation type="unfinished">จาก</translation>
     </message>
-    </context>
+    <message>
+        <source>Never</source>
+        <translation type="unfinished">ไม่เคย</translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">ไม่รู้จัก</translation>
+    </message>
+</context>
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
+        <source>&amp;Amount:</source>
+        <translation type="unfinished">&amp;จำนวน:</translation>
+    </message>
+    <message>
         <source>&amp;Label:</source>
-        <translation type="unfinished">&amp;ป้ายชื่อ:</translation>
+        <translation type="unfinished">&amp;เลเบล:</translation>
     </message>
     <message>
         <source>&amp;Message:</source>
@@ -1112,7 +2163,7 @@
     </message>
     <message>
         <source>Clear</source>
-        <translation type="unfinished">ล้าง</translation>
+        <translation type="unfinished">เคลียร์</translation>
     </message>
     <message>
         <source>Show</source>
@@ -1120,22 +2171,38 @@
     </message>
     <message>
         <source>Remove</source>
-        <translation type="unfinished">เอาออก</translation>
+        <translation type="unfinished">นำออก</translation>
     </message>
     <message>
         <source>Copy &amp;URI</source>
-        <translation type="unfinished">&amp;คัดลอก URI</translation>
+        <translation type="unfinished">คัดลอก &amp;URI</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;คัดลอก แอดเดรส</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">คัดลอก &amp;เลเบล</translation>
+    </message>
+    <message>
+        <source>Copy &amp;message</source>
+        <translation type="unfinished">คัดลอก &amp;ข้อความ</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">คัดลอก &amp;จำนวน</translation>
     </message>
     <message>
         <source>Could not unlock wallet.</source>
-        <translation type="unfinished">ไม่สามารถปลดล็อคกระเป๋าสตางค์</translation>
+        <translation type="unfinished">ไม่สามารถปลดล็อกวอลเล็ตได้</translation>
     </message>
     </context>
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
         <source>Address:</source>
-        <translation type="unfinished">ที่อยู่:</translation>
+        <translation type="unfinished">แอดเดรส:</translation>
     </message>
     <message>
         <source>Amount:</source>
@@ -1143,7 +2210,7 @@
     </message>
     <message>
         <source>Label:</source>
-        <translation type="unfinished">ป้ายชื่อ:</translation>
+        <translation type="unfinished">เลเบล:</translation>
     </message>
     <message>
         <source>Message:</source>
@@ -1151,15 +2218,31 @@
     </message>
     <message>
         <source>Wallet:</source>
-        <translation type="unfinished">กระเป๋าสตางค์:</translation>
+        <translation type="unfinished">วอลเล็ต:</translation>
     </message>
     <message>
         <source>Copy &amp;URI</source>
-        <translation type="unfinished">&amp;คัดลอก URI</translation>
+        <translation type="unfinished">คัดลอก &amp;URI</translation>
     </message>
     <message>
         <source>Copy &amp;Address</source>
-        <translation type="unfinished">&amp;คัดลอกที่อยู่</translation>
+        <translation type="unfinished">คัดลอก &amp;แอดเดรส</translation>
+    </message>
+    <message>
+        <source>&amp;Verify</source>
+        <translation type="unfinished">&amp;ตรวจสอบ</translation>
+    </message>
+    <message>
+        <source>Verify this address on e.g. a hardware wallet screen</source>
+        <translation type="unfinished">ยืนยัน แอดเดรส นี้ อยู่ใน เช่น ฮาร์ดแวร์ วอลเล็ต สกรีน</translation>
+    </message>
+    <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">&amp;บันทึก ภาพ…</translation>
+    </message>
+    <message>
+        <source>Payment information</source>
+        <translation type="unfinished">ข้อมูการชำระเงิน</translation>
     </message>
     </context>
 <context>
@@ -1170,7 +2253,7 @@
     </message>
     <message>
         <source>Label</source>
-        <translation type="unfinished">ป้ายชื่อ</translation>
+        <translation type="unfinished">เลเบล</translation>
     </message>
     <message>
         <source>Message</source>
@@ -1178,22 +2261,34 @@
     </message>
     <message>
         <source>(no label)</source>
-        <translation type="unfinished">(ไม่มีป้ายชื่อ)</translation>
+        <translation type="unfinished">(ไม่มีเลเบล)</translation>
     </message>
-    </context>
+    <message>
+        <source>(no message)</source>
+        <translation type="unfinished">(ไม่มีข้อความ)</translation>
+    </message>
+    <message>
+        <source>Requested</source>
+        <translation type="unfinished">ร้องขอแล้ว</translation>
+    </message>
+</context>
 <context>
     <name>SendCoinsDialog</name>
     <message>
         <source>Send Coins</source>
-        <translation type="unfinished">ส่งเหรียญ</translation>
+        <translation type="unfinished">ส่ง คอยน์</translation>
+    </message>
+    <message>
+        <source>automatically selected</source>
+        <translation type="unfinished">ทำการเลือก โดยอัตโนมัติแล้ว</translation>
     </message>
     <message>
         <source>Quantity:</source>
-        <translation type="unfinished">จำนวน:</translation>
+        <translation type="unfinished">ปริมาณ:</translation>
     </message>
     <message>
         <source>Bytes:</source>
-        <translation type="unfinished">ไบต์:</translation>
+        <translation type="unfinished">ไบทส์:</translation>
     </message>
     <message>
         <source>Amount:</source>
@@ -1205,61 +2300,164 @@
     </message>
     <message>
         <source>After Fee:</source>
-        <translation type="unfinished">ส่วนที่เหลือจากค่าธรรมเนียม:</translation>
+        <translation type="unfinished">หลังค่าธรรมเนียม:</translation>
     </message>
     <message>
         <source>Change:</source>
-        <translation type="unfinished">เงินทอน:</translation>
+        <translation type="unfinished">เปลี่ยน:</translation>
     </message>
     <message>
-        <source>Hide</source>
-        <translation type="unfinished">ซ่อน</translation>
+        <source>Custom change address</source>
+        <translation type="unfinished">เปลี่ยน แอดเดรส แบบกำหนดเอง</translation>
     </message>
     <message>
-        <source>Recommended:</source>
-        <translation type="unfinished">แนะนำ:</translation>
+        <source>Transaction Fee:</source>
+        <translation type="unfinished">ค่าธรรมเนียม การทำธุรกรรม:</translation>
     </message>
     <message>
-        <source>Custom:</source>
-        <translation type="unfinished">กำหนดเอง:</translation>
+        <source>Add &amp;Recipient</source>
+        <translation type="unfinished">เพิ่ม &amp;รายชื่อผู้รับ</translation>
     </message>
     <message>
         <source>Dust:</source>
-        <translation type="unfinished">เศษ:</translation>
+        <translation type="unfinished">ดัสท์:</translation>
+    </message>
+    <message>
+        <source>Choose…</source>
+        <translation type="unfinished">เลือก…</translation>
+    </message>
+    <message>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished">ล้าง &amp;ทั้งหมด</translation>
+    </message>
+    <message>
+        <source>Balance:</source>
+        <translation type="unfinished">ยอดคงเหลือ:</translation>
+    </message>
+    <message>
+        <source>S&amp;end</source>
+        <translation type="unfinished">&amp;ส่ง</translation>
+    </message>
+    <message>
+        <source>Copy quantity</source>
+        <translation type="unfinished">คัดลอก ปริมาณ</translation>
     </message>
     <message>
         <source>Copy amount</source>
-        <translation type="unfinished">คัดลอกจำนวนเงิน</translation>
+        <translation type="unfinished">คัดลอก จำนวน</translation>
+    </message>
+    <message>
+        <source>Copy fee</source>
+        <translation type="unfinished">คัดลอก ค่าธรรมเนียม</translation>
+    </message>
+    <message>
+        <source>Copy after fee</source>
+        <translation type="unfinished">คัดลอก หลัง ค่าธรรมเนียม</translation>
+    </message>
+    <message>
+        <source>Copy bytes</source>
+        <translation type="unfinished">คัดลอก bytes</translation>
+    </message>
+    <message>
+        <source>Copy dust</source>
+        <translation type="unfinished">คัดลอก dust</translation>
+    </message>
+    <message>
+        <source>Copy change</source>
+        <translation type="unfinished">คัดลอก change</translation>
+    </message>
+    <message>
+        <source>%1 (%2 blocks)</source>
+        <translation type="unfinished">%1 (%2 บล็อก)</translation>
+    </message>
+    <message>
+        <source>Sign on device</source>
+        <extracomment>"device" usually means a hardware wallet.</extracomment>
+        <translation type="unfinished">ลงชื่อบนอุปกรณ์</translation>
+    </message>
+    <message>
+        <source>Connect your hardware wallet first.</source>
+        <translation type="unfinished">เชื่อมต่อฮาร์ดแวร์วอลเล็ตของคุณก่อน</translation>
     </message>
     <message>
         <source> from wallet '%1'</source>
-        <translation type="unfinished">จากกระเป๋าสตางค์ '%1'</translation>
+        <translation type="unfinished">จาก วอลเล็ต '%1'</translation>
+    </message>
+    <message>
+        <source>%1 to '%2'</source>
+        <translation type="unfinished">%1 ไปยัง '%2'</translation>
+    </message>
+    <message>
+        <source>%1 to %2</source>
+        <translation type="unfinished">%1 ไปยัง %2</translation>
+    </message>
+    <message>
+        <source>Sign failed</source>
+        <translation type="unfinished">เซ็น ล้มเหลว</translation>
+    </message>
+    <message>
+        <source>PSBT saved</source>
+        <translation type="unfinished">PSBT บันทึก</translation>
+    </message>
+    <message>
+        <source>or</source>
+        <translation type="unfinished">หรือ</translation>
     </message>
     <message>
         <source>Do you want to create this transaction?</source>
         <extracomment>Message displayed when attempting to create a transaction. Cautionary text to prompt the user to verify that the displayed transaction details represent the transaction the user intends to create.</extracomment>
         <translation type="unfinished">คุณต้องการสร้างธุรกรรมนี้หรือไม่?</translation>
     </message>
+    <message>
+        <source>Please, review your transaction. You can create and send this transaction or create a Partially Signed Bitcoin Transaction (PSBT), which you can save or copy and then sign with, e.g., an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
+        <extracomment>Text to inform a user attempting to create a transaction of their current options. At this stage, a user can send their transaction or create a PSBT. This string is displayed when both private keys and PSBT controls are enabled.</extracomment>
+        <translation type="unfinished">โปรดตรวจสอบธุรกรรมของคุณ คุณสามารถสร้างและส่งธุรกรรมนี้หรือสร้างธุรกรรม Bitcoin ที่ลงชื่อบางส่วน (PSBT) ซึ่งคุณสามารถบันทึกหรือคัดลอกแล้วลงชื่อเข้าใช้ เช่น วอลเล็ต %1 ออฟไลน์, หรือ PSBT-compatible hardware wallet</translation>
+    </message>
+    <message>
+        <source>Please, review your transaction.</source>
+        <extracomment>Text to prompt a user to review the details of the transaction they are attempting to send.</extracomment>
+        <translation type="unfinished">โปรดตรวจสอบธุรกรรมของคุณ</translation>
+    </message>
+    <message>
+        <source>Transaction fee</source>
+        <translation type="unfinished">ค่าธรรมเนียม การทำธุรกรรม</translation>
+    </message>
+    <message>
+        <source>Total Amount</source>
+        <translation type="unfinished">จำนวน ทั้งหมด</translation>
+    </message>
+    <message>
+        <source>Confirm send coins</source>
+        <translation type="unfinished">ยืนยัน คอยน์ ที่ส่ง</translation>
+    </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
-            <numerusform>คาดการณ์ว่าจะเริ่มการยืนยันภายใน %n บล็อก</numerusform>
+            <numerusform>Estimated to begin confirmation within %n block(s).</numerusform>
         </translation>
     </message>
     <message>
+        <source>Confirm custom change address</source>
+        <translation type="unfinished">ยืนยันการเปลี่ยนแปลงแอดเดรสที่กำหนดเอง</translation>
+    </message>
+    <message>
         <source>(no label)</source>
-        <translation type="unfinished">(ไม่มีป้ายชื่อ)</translation>
+        <translation type="unfinished">(ไม่มีเลเบล)</translation>
     </message>
 </context>
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <source>&amp;Label:</source>
-        <translation type="unfinished">&amp;ป้ายชื่อ:</translation>
+        <source>A&amp;mount:</source>
+        <translation type="unfinished">&amp;จำนวน:</translation>
     </message>
     <message>
-        <source>Paste address from clipboard</source>
-        <translation type="unfinished">วางที่อยู่จากคลิปบอร์ด</translation>
+        <source>Pay &amp;To:</source>
+        <translation type="unfinished">ชำระ &amp;ให้:</translation>
+    </message>
+    <message>
+        <source>&amp;Label:</source>
+        <translation type="unfinished">&amp;เลเบล:</translation>
     </message>
     <message>
         <source>Message:</source>
@@ -1276,22 +2474,46 @@
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <source>Paste address from clipboard</source>
-        <translation type="unfinished">วางที่อยู่จากคลิปบอร์ด</translation>
-    </message>
-    <message>
-        <source>Signature</source>
-        <translation type="unfinished">ลายเซ็น</translation>
+        <source>&amp;Sign Message</source>
+        <translation type="unfinished">&amp;เซ็น ข้อความ</translation>
     </message>
     <message>
         <source>Sign &amp;Message</source>
-        <translation type="unfinished">&amp;เซ็นข้อความ</translation>
+        <translation type="unfinished">เซ็น &amp;ข้อความ</translation>
+    </message>
+    <message>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished">ล้าง &amp;ทั้งหมด</translation>
+    </message>
+    <message>
+        <source>&amp;Verify Message</source>
+        <translation type="unfinished">&amp;ตรวจสอบ ข้อความ</translation>
+    </message>
+    <message>
+        <source>Verify &amp;Message</source>
+        <translation type="unfinished">ตรวจสอบ &amp;ข้อความ</translation>
+    </message>
+    <message>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished">ปลดล็อควอลเล็ตถูกยกเลิก</translation>
     </message>
     <message>
         <source>No error</source>
-        <translation type="unfinished">ไม่มีข้อผิดพลาด</translation>
+        <translation type="unfinished">ไม่มี ข้อผิดพลาด</translation>
     </message>
-    </context>
+    <message>
+        <source>Message signed.</source>
+        <translation type="unfinished">ข้อความ เซ็นแล้ว</translation>
+    </message>
+    <message>
+        <source>Please check the signature and try again.</source>
+        <translation type="unfinished">โปรดตรวจสอบลายเซ็นต์และลองใหม่อีกครั้ง</translation>
+    </message>
+    <message>
+        <source>Message verified.</source>
+        <translation type="unfinished">ข้อความ ตรวจสอบแล้ว</translation>
+    </message>
+</context>
 <context>
     <name>SplashScreen</name>
     <message>
@@ -1306,40 +2528,102 @@
 <context>
     <name>TransactionDesc</name>
     <message>
-        <source>Status</source>
-        <translation type="unfinished">สถานะ</translation>
+        <source>conflicted with a transaction with %1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that conflicts with a confirmed transaction.</extracomment>
+        <translation type="unfinished">ขัดแย้งกับการทำธุรกรรมกับ %1 การยืนยัน</translation>
+    </message>
+    <message>
+        <source>%1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
+        <translation type="unfinished">%1 ทำการยืนยัน</translation>
     </message>
     <message>
         <source>Date</source>
         <translation type="unfinished">วันที่</translation>
     </message>
     <message>
+        <source>Source</source>
+        <translation type="unfinished">แหล่งที่มา</translation>
+    </message>
+    <message>
         <source>From</source>
         <translation type="unfinished">จาก</translation>
     </message>
     <message>
+        <source>unknown</source>
+        <translation type="unfinished">ไม่ทราบ</translation>
+    </message>
+    <message>
         <source>To</source>
-        <translation type="unfinished">ถึง</translation>
+        <translation type="unfinished">ไปยัง</translation>
+    </message>
+    <message>
+        <source>own address</source>
+        <translation type="unfinished">แอดเดรส คุณเอง</translation>
+    </message>
+    <message>
+        <source>label</source>
+        <translation type="unfinished">เลเบล</translation>
+    </message>
+    <message>
+        <source>Credit</source>
+        <translation type="unfinished">เครดิต</translation>
     </message>
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>matures in %n more block(s)</numerusform>
         </translation>
+    </message>
+    <message>
+        <source>not accepted</source>
+        <translation type="unfinished">ไม่ ยอมรับ</translation>
+    </message>
+    <message>
+        <source>Debit</source>
+        <translation type="unfinished">เดบิต</translation>
+    </message>
+    <message>
+        <source>Total debit</source>
+        <translation type="unfinished">เดบิต ทั้งหมด</translation>
+    </message>
+    <message>
+        <source>Total credit</source>
+        <translation type="unfinished">เครดิต ทั้งหมด</translation>
+    </message>
+    <message>
+        <source>Transaction fee</source>
+        <translation type="unfinished">ค่าธรรมเนียม การทำธุรกรรม</translation>
+    </message>
+    <message>
+        <source>Net amount</source>
+        <translation type="unfinished">จำนวน สุทธิ</translation>
     </message>
     <message>
         <source>Message</source>
         <translation type="unfinished">ข้อความ</translation>
     </message>
     <message>
-        <source>Comment</source>
-        <translation type="unfinished">ความคิดเห็น</translation>
+        <source>Merchant</source>
+        <translation type="unfinished">ร้านค้า</translation>
+    </message>
+    <message>
+        <source>Transaction</source>
+        <translation type="unfinished">การทำธุรกรรม</translation>
     </message>
     <message>
         <source>Amount</source>
         <translation type="unfinished">จำนวน</translation>
     </message>
-    </context>
+    <message>
+        <source>true</source>
+        <translation type="unfinished">ถูก</translation>
+    </message>
+    <message>
+        <source>false</source>
+        <translation type="unfinished">ผิด</translation>
+    </message>
+</context>
 <context>
     <name>TransactionTableModel</name>
     <message>
@@ -1348,46 +2632,124 @@
     </message>
     <message>
         <source>Type</source>
-        <translation type="unfinished">ชนิด</translation>
+        <translation type="unfinished">รูปแบบ</translation>
     </message>
     <message>
         <source>Label</source>
-        <translation type="unfinished">ป้ายชื่อ</translation>
+        <translation type="unfinished">เลเบล</translation>
+    </message>
+    <message>
+        <source>Unconfirmed</source>
+        <translation type="unfinished">ไม่ยืนยัน</translation>
+    </message>
+    <message>
+        <source>Abandoned</source>
+        <translation type="unfinished">เพิกเฉย</translation>
+    </message>
+    <message>
+        <source>Received with</source>
+        <translation type="unfinished">รับ ด้วย</translation>
+    </message>
+    <message>
+        <source>Received from</source>
+        <translation type="unfinished">รับ จาก</translation>
+    </message>
+    <message>
+        <source>Sent to</source>
+        <translation type="unfinished">ส่ง ถึง</translation>
     </message>
     <message>
         <source>(no label)</source>
-        <translation type="unfinished">(ไม่มีป้ายชื่อ)</translation>
+        <translation type="unfinished">(ไม่มีเลเบล)</translation>
+    </message>
+    <message>
+        <source>Type of transaction.</source>
+        <translation type="unfinished">ประเภท ของ การทำธุรกรรม</translation>
     </message>
     </context>
 <context>
     <name>TransactionView</name>
     <message>
-        <source>All</source>
-        <translation type="unfinished">ทั้งหมด</translation>
-    </message>
-    <message>
-        <source>Today</source>
-        <translation type="unfinished">วันนี้</translation>
-    </message>
-    <message>
         <source>This week</source>
         <translation type="unfinished">สัปดาห์นี้</translation>
     </message>
     <message>
-        <source>This month</source>
-        <translation type="unfinished">เดือนนี้</translation>
+        <source>Received with</source>
+        <translation type="unfinished">รับ ด้วย</translation>
     </message>
     <message>
-        <source>Last month</source>
-        <translation type="unfinished">เดือนที่แล้ว</translation>
+        <source>Sent to</source>
+        <translation type="unfinished">ส่ง ถึง</translation>
     </message>
     <message>
-        <source>This year</source>
-        <translation type="unfinished">ปีนี้</translation>
+        <source>To yourself</source>
+        <translation type="unfinished">ถึง ตัวคุณเอง</translation>
+    </message>
+    <message>
+        <source>Other</source>
+        <translation type="unfinished">อื่นๆ</translation>
+    </message>
+    <message>
+        <source>Min amount</source>
+        <translation type="unfinished">จำนวน ขั้นต่ำ</translation>
+    </message>
+    <message>
+        <source>Range…</source>
+        <translation type="unfinished">ช่วง…</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;คัดลอก แอดเดรส</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">คัดลอก &amp;เลเบล</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">คัดลอก &amp;จำนวน</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">คัดลอก transaction &amp;ID</translation>
+    </message>
+    <message>
+        <source>Copy &amp;raw transaction</source>
+        <translation type="unfinished">คัดลอก &amp;raw transaction</translation>
+    </message>
+    <message>
+        <source>Copy full transaction &amp;details</source>
+        <translation type="unfinished">คัดลอก full transaction &amp;details</translation>
+    </message>
+    <message>
+        <source>&amp;Show transaction details</source>
+        <translation type="unfinished">&amp;แสดงรายละเอียดการทำธุรกรรม</translation>
+    </message>
+    <message>
+        <source>&amp;Edit address label</source>
+        <translation type="unfinished">&amp;แก้ไข แอดเดรส เลเบล</translation>
+    </message>
+    <message>
+        <source>Show in %1</source>
+        <extracomment>Transactions table context menu action to show the selected transaction in a third-party block explorer. %1 is a stand-in argument for the URL of the explorer.</extracomment>
+        <translation type="unfinished">แสดง ใน %1</translation>
+    </message>
+    <message>
+        <source>Export Transaction History</source>
+        <translation type="unfinished">ส่งออกประวัติการทำธุรกรรม</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">เครื่องหมายจุลภาค (Comma) เพื่อแยกไฟล์</translation>
     </message>
     <message>
         <source>Confirmed</source>
         <translation type="unfinished">ยืนยันแล้ว</translation>
+    </message>
+    <message>
+        <source>Watch-only</source>
+        <translation type="unfinished">ดูอย่างเดียว</translation>
     </message>
     <message>
         <source>Date</source>
@@ -1395,45 +2757,114 @@
     </message>
     <message>
         <source>Type</source>
-        <translation type="unfinished">ชนิด</translation>
+        <translation type="unfinished">รูปแบบ</translation>
     </message>
     <message>
         <source>Label</source>
-        <translation type="unfinished">ป้ายชื่อ</translation>
+        <translation type="unfinished">เลเบล</translation>
     </message>
     <message>
         <source>Address</source>
-        <translation type="unfinished">ที่อยู่</translation>
+        <translation type="unfinished">แอดเดรส</translation>
+    </message>
+    <message>
+        <source>ID</source>
+        <translation type="unfinished">ไอดี</translation>
     </message>
     <message>
         <source>Exporting Failed</source>
         <translation type="unfinished">การส่งออกล้มเหลว</translation>
     </message>
-    </context>
+    <message>
+        <source>Exporting Successful</source>
+        <translation type="unfinished">ส่งออกสำเร็จ</translation>
+    </message>
+    <message>
+        <source>Range:</source>
+        <translation type="unfinished">ช่วง:</translation>
+    </message>
+    <message>
+        <source>to</source>
+        <translation type="unfinished">ถึง</translation>
+    </message>
+</context>
 <context>
     <name>WalletFrame</name>
     <message>
         <source>Create a new wallet</source>
-        <translation type="unfinished">สร้างกระเป๋าสตางค์</translation>
+        <translation type="unfinished">สร้าง วอลเล็ต ใหม่</translation>
     </message>
     <message>
         <source>Error</source>
         <translation type="unfinished">ข้อผิดพลาด</translation>
     </message>
-    </context>
+    <message>
+        <source>Load Transaction Data</source>
+        <translation type="unfinished">โหลด Transaction Data</translation>
+    </message>
+    <message>
+        <source>Partially Signed Transaction (*.psbt)</source>
+        <translation type="unfinished">ธุรกรรมที่ลงนามบางส่วน (*.psbt)</translation>
+    </message>
+    <message>
+        <source>PSBT file must be smaller than 100 MiB</source>
+        <translation type="unfinished">ไฟล์ PSBT ต้องมีขนาดเล็กกว่า 100 MiB</translation>
+    </message>
+    <message>
+        <source>Unable to decode PSBT</source>
+        <translation type="unfinished">ไม่สามารถถอดรหัส PSBT</translation>
+    </message>
+</context>
 <context>
     <name>WalletModel</name>
     <message>
         <source>Send Coins</source>
-        <translation type="unfinished">ส่งเหรียญ</translation>
+        <translation type="unfinished">ส่ง คอยน์</translation>
     </message>
     <message>
-        <source>PSBT copied</source>
-        <translation type="unfinished">คัดลอก PSBT แล้ว</translation>
+        <source>Increasing transaction fee failed</source>
+        <translation type="unfinished">ค่าธรรมเนียมการทำธุรกรรมที่เพิ่มขึ้นล้มเหลว</translation>
+    </message>
+    <message>
+        <source>Do you want to increase the fee?</source>
+        <extracomment>Asks a user if they would like to manually increase the fee of a transaction that has already been created.</extracomment>
+        <translation type="unfinished">คุณต้องการเพิ่มค่าธรรมเนียมหรือไม่?</translation>
+    </message>
+    <message>
+        <source>Current fee:</source>
+        <translation type="unfinished">ค่าธรรมเนียมปัจจุบัน:</translation>
+    </message>
+    <message>
+        <source>Increase:</source>
+        <translation type="unfinished">เพิ่มขึ้น:</translation>
+    </message>
+    <message>
+        <source>New fee:</source>
+        <translation type="unfinished">ค่าธรรมเนียม ใหม่:</translation>
+    </message>
+    <message>
+        <source>Confirm fee bump</source>
+        <translation type="unfinished">ยืนยันค่าธรรมเนียมที่เพิ่มขึ้น</translation>
+    </message>
+    <message>
+        <source>Can't draft transaction.</source>
+        <translation type="unfinished">ไม่สามารถร่างธุรกรรมได้</translation>
+    </message>
+    <message>
+        <source>Can't sign transaction.</source>
+        <translation type="unfinished">ไม่สามารถลงนามในการทำธุรกรรม</translation>
+    </message>
+    <message>
+        <source>Could not commit transaction</source>
+        <translation type="unfinished">ไม่สามารถทำธุรกรรมได้</translation>
+    </message>
+    <message>
+        <source>Can't display address</source>
+        <translation type="unfinished">ไม่สามารถ แสดง แอดเดรส</translation>
     </message>
     <message>
         <source>default wallet</source>
-        <translation type="unfinished">กระเป๋าสตางค์เริ่มต้น</translation>
+        <translation type="unfinished">วอลเล็ต เริ่มต้น</translation>
     </message>
 </context>
 <context>
@@ -1448,11 +2879,24 @@
     </message>
     <message>
         <source>Backup Wallet</source>
-        <translation type="unfinished">สำรองข้อมูลกระเป๋าสตางค์</translation>
+        <translation type="unfinished">แบ็คอัพวอลเล็ต</translation>
+    </message>
+    <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">ข้อมูล วอลเล็ต</translation>
     </message>
     <message>
         <source>Backup Failed</source>
-        <translation type="unfinished">การสำรองข้อมูลล้มเหลว</translation>
+        <translation type="unfinished">การสำรองข้อมูล ล้มเหลว</translation>
+    </message>
+    <message>
+        <source>Backup Successful</source>
+        <translation type="unfinished">สำรองข้อมูล สำเร็จแล้ว</translation>
+    </message>
+    <message>
+        <source>The wallet data was successfully saved to %1.</source>
+        <translation type="unfinished">บันทึกข้อมูลวอลเล็ตไว้ที่ %1 เรียบร้อยแล้ว</translation>
     </message>
     <message>
         <source>Cancel</source>

--- a/src/qt/locale/bitcoin_tk.ts
+++ b/src/qt/locale/bitcoin_tk.ts
@@ -1,0 +1,1577 @@
+<TS version="2.1" language="tk">
+<context>
+    <name>AddressBookPage</name>
+    <message>
+        <source>Right-click to edit address or label</source>
+        <translation type="unfinished">Salgyny ýa-da belligi rejelemek üçin syçanjygyň sag düwmesine basyň</translation>
+    </message>
+    <message>
+        <source>Create a new address</source>
+        <translation type="unfinished">Täze salgy döret</translation>
+    </message>
+    <message>
+        <source>&amp;New</source>
+        <translation type="unfinished">&amp;Täze</translation>
+    </message>
+    <message>
+        <source>Copy the currently selected address to the system clipboard</source>
+        <translation type="unfinished">Häzir saýlanan salgyny ulgamyň alyş-çalyş paneline göçür</translation>
+    </message>
+    <message>
+        <source>&amp;Copy</source>
+        <translation type="unfinished">&amp;Göçür</translation>
+    </message>
+    <message>
+        <source>C&amp;lose</source>
+        <translation type="unfinished">Ý&amp;ap</translation>
+    </message>
+    <message>
+        <source>Delete the currently selected address from the list</source>
+        <translation type="unfinished">Häzir saýlanan salgyny bu sanawdan poz</translation>
+    </message>
+    <message>
+        <source>Enter address or label to search</source>
+        <translation type="unfinished">Gözlemek üçin salgy ýa-da belligi ýaz</translation>
+    </message>
+    <message>
+        <source>Export the data in the current tab to a file</source>
+        <translation type="unfinished">Häzirki bellikdäki maglumaty faýla geçir</translation>
+    </message>
+    <message>
+        <source>&amp;Export</source>
+        <translation type="unfinished">&amp;Geçir</translation>
+    </message>
+    <message>
+        <source>&amp;Delete</source>
+        <translation type="unfinished">&amp;Poz</translation>
+    </message>
+    <message>
+        <source>Choose the address to send coins to</source>
+        <translation type="unfinished">Teňňeleriň haýsy salga iberiljekdigini saýla</translation>
+    </message>
+    <message>
+        <source>Choose the address to receive coins with</source>
+        <translation type="unfinished">Teňňeleriň haýsy salgydan alynjakdygyny saýla</translation>
+    </message>
+    <message>
+        <source>C&amp;hoose</source>
+        <translation type="unfinished">S&amp;aýla</translation>
+    </message>
+    <message>
+        <source>Sending addresses</source>
+        <translation type="unfinished">Iberýän salgylar</translation>
+    </message>
+    <message>
+        <source>Receiving addresses</source>
+        <translation type="unfinished">Kabul edýän salgylar</translation>
+    </message>
+    <message>
+        <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
+        <translation type="unfinished">Tölegleri ibermek üçin siziň Bitkoin salgylaryňyz şulardyr. Teňňeleri ibermezden ozal hemişe möçberi we kabul edýän salgyny barlaň.</translation>
+    </message>
+    <message>
+        <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
+Signing is only possible with addresses of the type 'legacy'.</source>
+        <translation type="unfinished">Tölegleri kabul etmek üçin siziň Bitkoin salgylaryňyz şulardyr. Täze salgylary döretmek üçin kabul etmek bölüminde "Täze kabul ediji salgyny döret" düwmesini ulan.
+Diňe "miras" görnüşli salgylar bilen gol çekmek mümkin.</translation>
+    </message>
+    <message>
+        <source>&amp;Copy Address</source>
+        <translation type="unfinished">Salgyny göçür</translation>
+    </message>
+    <message>
+        <source>Copy &amp;Label</source>
+        <translation type="unfinished">&amp;Belligi göçür</translation>
+    </message>
+    <message>
+        <source>&amp;Edit</source>
+        <translation type="unfinished">&amp;Rejele</translation>
+    </message>
+    <message>
+        <source>Export Address List</source>
+        <translation type="unfinished">Salgylar sanawyny geçir</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">Otur bilen aýrylan faýl</translation>
+    </message>
+    <message>
+        <source>There was an error trying to save the address list to %1. Please try again.</source>
+        <extracomment>An error message. %1 is a stand-in argument for the name of the file we attempted to save to.</extracomment>
+        <translation type="unfinished">Salgylar sanawyny %1 içine bellemäge çalşylanda ýalňyşlyk ýüze çykdy. Täzeden synap görüň.</translation>
+    </message>
+    <message>
+        <source>Exporting Failed</source>
+        <translation type="unfinished">Geçirip bolmady</translation>
+    </message>
+</context>
+<context>
+    <name>AddressTableModel</name>
+    <message>
+        <source>Label</source>
+        <translation type="unfinished">Bellik</translation>
+    </message>
+    <message>
+        <source>Address</source>
+        <translation type="unfinished">Salgy</translation>
+    </message>
+    <message>
+        <source>(no label)</source>
+        <translation type="unfinished">(bellik ýok)</translation>
+    </message>
+</context>
+<context>
+    <name>AskPassphraseDialog</name>
+    <message>
+        <source>Passphrase Dialog</source>
+        <translation type="unfinished">Parol sözlemi gepleşigi</translation>
+    </message>
+    <message>
+        <source>Enter passphrase</source>
+        <translation type="unfinished">Parol sözlemini ýaz</translation>
+    </message>
+    <message>
+        <source>New passphrase</source>
+        <translation type="unfinished">Täze parol sözlemi</translation>
+    </message>
+    <message>
+        <source>Repeat new passphrase</source>
+        <translation type="unfinished">Täze parol sözlemini gaýtala</translation>
+    </message>
+    <message>
+        <source>Show passphrase</source>
+        <translation type="unfinished">Parol sözlemini görkez</translation>
+    </message>
+    <message>
+        <source>Encrypt wallet</source>
+        <translation type="unfinished">Gapjygy şifrle</translation>
+    </message>
+    <message>
+        <source>This operation needs your wallet passphrase to unlock the wallet.</source>
+        <translation type="unfinished">Bu amal üçin gapjygyň parol sözlemi bilen gapjygyňyzyň gulpuny açmagyňyz gerek.</translation>
+    </message>
+    <message>
+        <source>Unlock wallet</source>
+        <translation type="unfinished">Gapjygyň gulpuny aç</translation>
+    </message>
+    <message>
+        <source>Change passphrase</source>
+        <translation type="unfinished">Parol sözlemini çalyş</translation>
+    </message>
+    <message>
+        <source>Confirm wallet encryption</source>
+        <translation type="unfinished">Gapjygyň şifrlenmegini tassykla</translation>
+    </message>
+    <message>
+        <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
+        <translation type="unfinished">Duýduryş: Eger gapjygyňy şifrleseň we parol sözlemiňi ýitirseň, sen &lt;b&gt;ÄHLI BITKOINLERIŇI ÝITIRERSIŇ&lt;/b&gt;!</translation>
+    </message>
+    <message>
+        <source>Are you sure you wish to encrypt your wallet?</source>
+        <translation type="unfinished">Gapjygyňy şifrlemek isleýäniň çynmy?</translation>
+    </message>
+    <message>
+        <source>Wallet encrypted</source>
+        <translation type="unfinished">Gapjyk şifrlenen</translation>
+    </message>
+    <message>
+        <source>Enter the new passphrase for the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
+        <translation type="unfinished">Gapjyk üçin täze parol sözlemini ýaz.&lt;br/&gt;&lt;b&gt;On ýa-da has köp tötänleýin nyşandan&lt;/b&gt; ýa-da &lt;b&gt;sekiz ýa-da has köp sözden&lt;/b&gt; ybarat parol sözlemini ulanyň.</translation>
+    </message>
+    <message>
+        <source>Enter the old passphrase and new passphrase for the wallet.</source>
+        <translation type="unfinished">Gapjyk üçin öňki we täze parol sözlemiňi ýaz.</translation>
+    </message>
+    <message>
+        <source>Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
+        <translation type="unfinished">Gapjygyňy şifrlemek kompýuteriňe zyýanly programma ýokuşmak arkaly bitkoinleriň ogurlanmagyndan doly gorap bilmejekdigini ýatdan çykarma.</translation>
+    </message>
+    <message>
+        <source>Wallet to be encrypted</source>
+        <translation type="unfinished">Şifrlenmeli gapjyk</translation>
+    </message>
+    <message>
+        <source>Your wallet is about to be encrypted. </source>
+        <translation type="unfinished">Gapjygyň şifrlener.</translation>
+    </message>
+    <message>
+        <source>Your wallet is now encrypted. </source>
+        <translation type="unfinished">Gapjygyň häzir şifrlenen.</translation>
+    </message>
+    <message>
+        <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
+        <translation type="unfinished">WAJYP: Gapjyk faýlyň islendik ozalky ätiýaçlyk nusgalary täze emele gelen, şifrlenen gapjyk faýly bilen çalşyrylmaly. Howpsuzlyk maksady bilen, şifrlenen gapjyk faýlynyň ozalky ätiýaçlyk nusgalary täze şifrlenen gapjygy ulanyp başlan badyňyza peýdasyz bolup galar.</translation>
+    </message>
+    <message>
+        <source>Wallet encryption failed</source>
+        <translation type="unfinished">Gapjygy şifrläp bolmady</translation>
+    </message>
+    <message>
+        <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
+        <translation type="unfinished">Içki ýalňyşlyk sebäpli gapjygy şifrläp bolmady. Gapjygyň şifrlenmedi.</translation>
+    </message>
+    <message>
+        <source>The supplied passphrases do not match.</source>
+        <translation type="unfinished">Üpjün edilen parol sözlemleri gabat gelenok.</translation>
+    </message>
+    <message>
+        <source>Wallet unlock failed</source>
+        <translation type="unfinished">Gapjygyň gulpuny açyp bolmady</translation>
+    </message>
+    <message>
+        <source>The passphrase entered for the wallet decryption was incorrect.</source>
+        <translation type="unfinished">Gapjygyň şifrini açmak üçin ýazylan parol sözlemi nädogry.</translation>
+    </message>
+    <message>
+        <source>Wallet passphrase was successfully changed.</source>
+        <translation type="unfinished">Gapjygyň parol sözlemi üstünlikli çalşyldy.</translation>
+    </message>
+    <message>
+        <source>Warning: The Caps Lock key is on!</source>
+        <translation type="unfinished">Duýduryş: Caps Lock düwmesi açyk!</translation>
+    </message>
+</context>
+<context>
+    <name>BanTableModel</name>
+    <message>
+        <source>Banned Until</source>
+        <translation type="unfinished">Gadagan edilen möhleti</translation>
+    </message>
+</context>
+<context>
+    <name>BitcoinApplication</name>
+    <message>
+        <source>Runaway exception</source>
+        <translation type="unfinished">Dolandyryp bolmaýan ýagdaý</translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
+        <translation type="unfinished">Ýowuz ýalňyşlyk ýüze çykdy. %1 indi ygtybarly dowam edip bilenok we çykar.</translation>
+    </message>
+    <message>
+        <source>Internal error</source>
+        <translation type="unfinished">Içki ýalňyşlyk</translation>
+    </message>
+    <message>
+        <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
+        <translation type="unfinished">Içki ýalňyşlyk ýüze çykdy. %1 ygtybarly dowam etmäge çalyşar. Bu garaşylmadyk näsazlyk we ol barada aşakda beýan edilişi ýaly hasabat berip bolar.</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <source>Do you want to reset settings to default values, or to abort without making changes?</source>
+        <extracomment>Explanatory text shown on startup when the settings file cannot be read. Prompts user to make a choice between resetting or aborting.</extracomment>
+        <translation type="unfinished">Sazlamalary deslapky ýagdaýyna getirmek isleýäňmi ýa-da hiçhili üýtgeşme girizmezden ýatyrmak?</translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. Check that settings file is writable, or try running with -nosettings.</source>
+        <extracomment>Explanatory text shown on startup when the settings file could not be written. Prompts user to check that we have the ability to write to the file. Explains that the user has the option of running without a settings file.</extracomment>
+        <translation type="unfinished">Ýowuz ýalňyşlyk ýüze çykdy. Sazlamalar faýlyna ýazmak mümkinçiliginiň bardygyny ýa-da ýokdugyny barla, bolmasa -nosettings bilen işletmäge çalyş.</translation>
+    </message>
+    <message>
+        <source>Error: Specified data directory "%1" does not exist.</source>
+        <translation type="unfinished">Ýalňyşlyk: Görkezilen maglumatlar katalogy "%1" ýok.</translation>
+    </message>
+    <message>
+        <source>Error: Cannot parse configuration file: %1.</source>
+        <translation type="unfinished">Ýalňyşlyk: %1 konfigurasiýa faýlyny derňäp bolanok.</translation>
+    </message>
+    <message>
+        <source>Error: %1</source>
+        <translation type="unfinished">Ýalňyşlyk: %1</translation>
+    </message>
+    <message>
+        <source>%1 didn't yet exit safely…</source>
+        <translation type="unfinished">%1 entek ygtybarly çykmady...</translation>
+    </message>
+    <message>
+        <source>Amount</source>
+        <translation type="unfinished">Möçber</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n week(s)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n year(s)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    </context>
+<context>
+    <name>bitcoin-core</name>
+    <message>
+        <source>Settings file could not be read</source>
+        <translation type="unfinished">Sazlamalar faýlyny okap bolanok</translation>
+    </message>
+    <message>
+        <source>Settings file could not be written</source>
+        <translation type="unfinished">Sazlamalar faýlyny ýazdyryp bolanok</translation>
+    </message>
+    </context>
+<context>
+    <name>BitcoinGUI</name>
+    <message>
+        <source>&amp;Overview</source>
+        <translation type="unfinished">&amp;Umumy syn</translation>
+    </message>
+    <message>
+        <source>Show general overview of wallet</source>
+        <translation type="unfinished">Gapjygyň umumy synyny görkez</translation>
+    </message>
+    <message>
+        <source>&amp;Transactions</source>
+        <translation type="unfinished">&amp;Geleşikler</translation>
+    </message>
+    <message>
+        <source>Browse transaction history</source>
+        <translation type="unfinished">Geleşikleriň geçmişine göz aýla</translation>
+    </message>
+    <message>
+        <source>E&amp;xit</source>
+        <translation type="unfinished">Ç&amp;yk</translation>
+    </message>
+    <message>
+        <source>Quit application</source>
+        <translation type="unfinished">Programmadan çyk</translation>
+    </message>
+    <message>
+        <source>&amp;About %1</source>
+        <translation type="unfinished">%1 &amp;barada</translation>
+    </message>
+    <message>
+        <source>Show information about %1</source>
+        <translation type="unfinished">%1 barada maglumat görkez</translation>
+    </message>
+    <message>
+        <source>About &amp;Qt</source>
+        <translation type="unfinished">&amp;Qt barada</translation>
+    </message>
+    <message>
+        <source>Show information about Qt</source>
+        <translation type="unfinished">Qt barada maglumat görkez</translation>
+    </message>
+    <message>
+        <source>Modify configuration options for %1</source>
+        <translation type="unfinished">%1 üçin konfigurasiýa opsiýalaryny üýtget</translation>
+    </message>
+    <message>
+        <source>Create a new wallet</source>
+        <translation type="unfinished">Taze gapjyk döret</translation>
+    </message>
+    <message>
+        <source>&amp;Minimize</source>
+        <translation type="unfinished">&amp;Kiçelt</translation>
+    </message>
+    <message>
+        <source>Wallet:</source>
+        <translation type="unfinished">Gapjyk:</translation>
+    </message>
+    <message>
+        <source>Network activity disabled.</source>
+        <extracomment>A substring of the tooltip.</extracomment>
+        <translation type="unfinished">Ulgamyň işleýşi ýapyk.</translation>
+    </message>
+    <message>
+        <source>Proxy is &lt;b&gt;enabled&lt;/b&gt;: %1</source>
+        <translation type="unfinished">Proksi &lt;b&gt;işleýär&lt;/b&gt;: %1</translation>
+    </message>
+    <message>
+        <source>Send coins to a Bitcoin address</source>
+        <translation type="unfinished">Bitkoin salgysyna teňňeleri iber</translation>
+    </message>
+    <message>
+        <source>Backup wallet to another location</source>
+        <translation type="unfinished">Gapjygyň ätiýaçlyk nusgasyny başga ýere goý</translation>
+    </message>
+    <message>
+        <source>Change the passphrase used for wallet encryption</source>
+        <translation type="unfinished">Gapjygy şifrlemek üçin ulanylan parol sözlemini üýtget</translation>
+    </message>
+    <message>
+        <source>&amp;Send</source>
+        <translation type="unfinished">&amp;Iber</translation>
+    </message>
+    <message>
+        <source>&amp;Receive</source>
+        <translation type="unfinished">&amp;Kabul edip al</translation>
+    </message>
+    <message>
+        <source>&amp;Options…</source>
+        <translation type="unfinished">&amp;Opsiýalar…</translation>
+    </message>
+    <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation type="unfinished">&amp;Gapjygy şifrle…</translation>
+    </message>
+    <message>
+        <source>Encrypt the private keys that belong to your wallet</source>
+        <translation type="unfinished">Gapjygyňa degişli hususy açarlary şifrle</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation type="unfinished">&amp;Gapjygyň ätiýaçlyk nusgasyny sakla…</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation type="unfinished">&amp;Parol sözlemini çalyş...</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation type="unfinished">&amp;Habara gol çek…</translation>
+    </message>
+    <message>
+        <source>Sign messages with your Bitcoin addresses to prove you own them</source>
+        <translation type="unfinished">Bitkoin salgylarynyň eýesidigini subut etmek üçin habarlara öz Bitkoin salgylaryň bilen gol çek</translation>
+    </message>
+    <message>
+        <source>&amp;Verify message…</source>
+        <translation type="unfinished">&amp;Habary tassykla…</translation>
+    </message>
+    <message>
+        <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
+        <translation type="unfinished">Habarlaryň görkezilen Bitkoin salgylary bilen gol çekilendigini kepillendirmek üçin habarlary tassykla</translation>
+    </message>
+    <message>
+        <source>&amp;Load PSBT from file…</source>
+        <translation type="unfinished">Faýldan BGÇBA &amp;ýükle…</translation>
+    </message>
+    <message>
+        <source>Open &amp;URI…</source>
+        <translation type="unfinished">&amp;URI aç…</translation>
+    </message>
+    <message>
+        <source>Close Wallet…</source>
+        <translation type="unfinished">Gapjygy ýap...</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation type="unfinished">Gapjyk döret...</translation>
+    </message>
+    <message>
+        <source>Close All Wallets…</source>
+        <translation type="unfinished">Ähli gapjyklary ýap...</translation>
+    </message>
+    <message>
+        <source>&amp;File</source>
+        <translation type="unfinished">&amp;Faýl</translation>
+    </message>
+    <message>
+        <source>&amp;Settings</source>
+        <translation type="unfinished">&amp;Sazlamalar</translation>
+    </message>
+    <message>
+        <source>&amp;Help</source>
+        <translation type="unfinished">&amp;Kömek</translation>
+    </message>
+    <message>
+        <source>Tabs toolbar</source>
+        <translation type="unfinished">Bölümler gurallar paneli</translation>
+    </message>
+    <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation type="unfinished">Sözbaşylary sinhron ýagdaýa getirmek (%1%)...</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation type="unfinished">Ulgam bilen utgaşdyrmak...</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation type="unfinished">Diskde bloklar indekslenýär...</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation type="unfinished">Diskde bloklar işlenýär...</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation type="unfinished">Diskde bloklar gaýtadan indekslenýär...</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation type="unfinished">Deňdeşlere baglanylýar...</translation>
+    </message>
+    <message>
+        <source>Request payments (generates QR codes and bitcoin: URIs)</source>
+        <translation type="unfinished">Tölegleri sora (QR kodlary we bitkoin: URIleri döredýär)</translation>
+    </message>
+    <message>
+        <source>Show the list of used sending addresses and labels</source>
+        <translation type="unfinished">Ulanylan iberilýän salgylaryň we bellikleriň sanawyny görkez</translation>
+    </message>
+    <message>
+        <source>Show the list of used receiving addresses and labels</source>
+        <translation type="unfinished">Ulanylan kabul edip alýan salgylaryň we bellikleriň sanawyny görkez</translation>
+    </message>
+    <message>
+        <source>&amp;Command-line options</source>
+        <translation type="unfinished">&amp;Buýruk setiri opsiýalary</translation>
+    </message>
+    <message numerus="yes">
+        <source>Processed %n block(s) of transaction history.</source>
+        <translation type="unfinished">
+            <numerusform>Amallar geçmişinden %n blok(lar) işlendi.</numerusform>
+            <numerusform>Amallar geçmişinden %n blok(lar) işlendi.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>%1 behind</source>
+        <translation type="unfinished">%1 galdy</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation type="unfinished">Tutulýar...</translation>
+    </message>
+    <message>
+        <source>Last received block was generated %1 ago.</source>
+        <translation type="unfinished">Soňky kabul edilen blok %1 öň döredilipdi.</translation>
+    </message>
+    <message>
+        <source>Transactions after this will not yet be visible.</source>
+        <translation type="unfinished">Mundan soňky geleşikler entek görünmez.</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Ýalňyşlyk</translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished">Duýduryş</translation>
+    </message>
+    <message>
+        <source>Information</source>
+        <translation type="unfinished">Maglumat</translation>
+    </message>
+    <message>
+        <source>Up to date</source>
+        <translation type="unfinished">Döwrebap</translation>
+    </message>
+    <message>
+        <source>Load Partially Signed Bitcoin Transaction</source>
+        <translation type="unfinished">Bölekleýýin gol çekilen bitkoin geleşigini ýükle</translation>
+    </message>
+    <message>
+        <source>Load PSBT from &amp;clipboard…</source>
+        <translation type="unfinished">&amp;alyş-çalyş panelinden BGÇBA ýükle…</translation>
+    </message>
+    <message>
+        <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
+        <translation type="unfinished">Bölekleýin gol çekilen bitkoin geleşigini alyş-çalyş panelinden ýükle</translation>
+    </message>
+    <message>
+        <source>Node window</source>
+        <translation type="unfinished">Düwün penjiresi</translation>
+    </message>
+    <message>
+        <source>Open node debugging and diagnostic console</source>
+        <translation type="unfinished">Düwüni zyýansyzlaşdyrma we anyklaýyş konsolyny aç</translation>
+    </message>
+    <message>
+        <source>&amp;Sending addresses</source>
+        <translation type="unfinished">&amp;Iberilýän salgylar</translation>
+    </message>
+    <message>
+        <source>&amp;Receiving addresses</source>
+        <translation type="unfinished">&amp;Kabul edýän salgylar</translation>
+    </message>
+    <message>
+        <source>Open a bitcoin: URI</source>
+        <translation type="unfinished">Bitkoin aç: URI</translation>
+    </message>
+    <message>
+        <source>Open Wallet</source>
+        <translation type="unfinished">Gapjygy aç</translation>
+    </message>
+    <message>
+        <source>Open a wallet</source>
+        <translation type="unfinished">Gapjyk aç</translation>
+    </message>
+    <message>
+        <source>Close wallet</source>
+        <translation type="unfinished">Gapjygy ýap</translation>
+    </message>
+    <message>
+        <source>Close all wallets</source>
+        <translation type="unfinished">Ähli gapjyklary ýap</translation>
+    </message>
+    <message>
+        <source>Show the %1 help message to get a list with possible Bitcoin command-line options</source>
+        <translation type="unfinished">Mümkin bolan Bitkoin buýruk setiri opsiýalarynyň sanawyny görmek üçin %1 goldaw habaryny görkez</translation>
+    </message>
+    <message>
+        <source>&amp;Mask values</source>
+        <translation type="unfinished">&amp;Sanlaryň üstüni ört</translation>
+    </message>
+    <message>
+        <source>Mask the values in the Overview tab</source>
+        <translation type="unfinished">Gözden geçir bölüminde sanlaryň üstüni ört</translation>
+    </message>
+    <message>
+        <source>default wallet</source>
+        <translation type="unfinished">deslapky bellenen gapjyk</translation>
+    </message>
+    <message>
+        <source>No wallets available</source>
+        <translation type="unfinished">Elýeterli gapjyk ýok</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">Gapjygyň ady</translation>
+    </message>
+    <message>
+        <source>&amp;Window</source>
+        <translation type="unfinished">&amp;Penjire</translation>
+    </message>
+    <message>
+        <source>Zoom</source>
+        <translation type="unfinished">Ulalt</translation>
+    </message>
+    <message>
+        <source>Main Window</source>
+        <translation type="unfinished">Esasy penjire</translation>
+    </message>
+    <message>
+        <source>%1 client</source>
+        <translation type="unfinished">%1 müşderi</translation>
+    </message>
+    <message>
+        <source>&amp;Hide</source>
+        <translation type="unfinished">&amp;Gizle</translation>
+    </message>
+    <message>
+        <source>S&amp;how</source>
+        <translation type="unfinished">G&amp;örkez</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n active connection(s) to Bitcoin network.</source>
+        <extracomment>A substring of the tooltip.</extracomment>
+        <translation type="unfinished">
+            <numerusform>Bitkoin toruna %n işjeň arabaglanyşyk.</numerusform>
+            <numerusform>Bitkoin ulgamyna %n işjeň arabaglanyşyk.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Click for more actions.</source>
+        <extracomment>A substring of the tooltip. "More actions" are available via the context menu.</extracomment>
+        <translation type="unfinished">Başga hereketler üçin bas.</translation>
+    </message>
+    <message>
+        <source>Show Peers tab</source>
+        <extracomment>A context menu item. The "Peers tab" is an element of the "Node window".</extracomment>
+        <translation type="unfinished">Deňdeşler bölümini görkez</translation>
+    </message>
+    <message>
+        <source>Disable network activity</source>
+        <extracomment>A context menu item.</extracomment>
+        <translation type="unfinished">Ulgamyň işjeňligini öçür</translation>
+    </message>
+    <message>
+        <source>Enable network activity</source>
+        <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
+        <translation type="unfinished">Ulgamyň işjeňligini aç</translation>
+    </message>
+    <message>
+        <source>Error: %1</source>
+        <translation type="unfinished">Ýalňyşlyk: %1</translation>
+    </message>
+    <message>
+        <source>Warning: %1</source>
+        <translation type="unfinished">Duýduryş: %1</translation>
+    </message>
+    <message>
+        <source>Date: %1
+</source>
+        <translation type="unfinished">Sene: %1
+</translation>
+    </message>
+    <message>
+        <source>Amount: %1
+</source>
+        <translation type="unfinished">Möçber: %1
+</translation>
+    </message>
+    <message>
+        <source>Wallet: %1
+</source>
+        <translation type="unfinished">Gapjyk: %1
+</translation>
+    </message>
+    <message>
+        <source>Type: %1
+</source>
+        <translation type="unfinished">Görnüş: %1
+</translation>
+    </message>
+    <message>
+        <source>Label: %1
+</source>
+        <translation type="unfinished">Bellik: %1
+</translation>
+    </message>
+    <message>
+        <source>Address: %1
+</source>
+        <translation type="unfinished">Salgy: %1
+</translation>
+    </message>
+    <message>
+        <source>Sent transaction</source>
+        <translation type="unfinished">Iberilen geleşik</translation>
+    </message>
+    <message>
+        <source>Incoming transaction</source>
+        <translation type="unfinished">Gelýän geleşik</translation>
+    </message>
+    <message>
+        <source>HD key generation is &lt;b&gt;enabled&lt;/b&gt;</source>
+        <translation type="unfinished">HD açar döretmeklik &lt;b&gt;işjeň&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>HD key generation is &lt;b&gt;disabled&lt;/b&gt;</source>
+        <translation type="unfinished">HD açar döretmeklik &lt;b&gt;öçük&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Private key &lt;b&gt;disabled&lt;/b&gt;</source>
+        <translation type="unfinished">Hususy açar &lt;b&gt;öçük&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
+        <translation type="unfinished">Gapjyk &lt;b&gt;şifrlenen&lt;/b&gt; we häzirki wagtda &lt;b&gt;gulpy açyk&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
+        <translation type="unfinished">Gapjyk &lt;b&gt;şifrlenen&lt;/b&gt; we häzirki wagtda &lt;b&gt;gulply&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Original message:</source>
+        <translation type="unfinished">Başdaky habar:</translation>
+    </message>
+</context>
+<context>
+    <name>UnitDisplayStatusBarControl</name>
+    <message>
+        <source>Unit to show amounts in. Click to select another unit.</source>
+        <translation type="unfinished">Möçberleri görkezmek üçin ölçeg birligi. Başga ölçeg birligini saýlamak üçin bas.</translation>
+    </message>
+</context>
+<context>
+    <name>CoinControlDialog</name>
+    <message>
+        <source>Coin Selection</source>
+        <translation type="unfinished">Teňňe saýlamak</translation>
+    </message>
+    <message>
+        <source>Quantity:</source>
+        <translation type="unfinished">Sany:</translation>
+    </message>
+    <message>
+        <source>Bytes:</source>
+        <translation type="unfinished">Baýtlar:</translation>
+    </message>
+    <message>
+        <source>Amount:</source>
+        <translation type="unfinished">Möçber:</translation>
+    </message>
+    <message>
+        <source>Fee:</source>
+        <translation type="unfinished">Gatanç:</translation>
+    </message>
+    <message>
+        <source>Dust:</source>
+        <translation type="unfinished">Toz:</translation>
+    </message>
+    <message>
+        <source>After Fee:</source>
+        <translation type="unfinished">Soňundan gatanç:</translation>
+    </message>
+    <message>
+        <source>Change:</source>
+        <translation type="unfinished">Çalyş:</translation>
+    </message>
+    <message>
+        <source>(un)select all</source>
+        <translation type="unfinished">hemmesini saýla(ma)</translation>
+    </message>
+    <message>
+        <source>Tree mode</source>
+        <translation type="unfinished">Agaç tertibi</translation>
+    </message>
+    <message>
+        <source>List mode</source>
+        <translation type="unfinished">Sanaw tertibi</translation>
+    </message>
+    <message>
+        <source>Amount</source>
+        <translation type="unfinished">Möçber</translation>
+    </message>
+    <message>
+        <source>Received with label</source>
+        <translation type="unfinished">Bellik bilen kabul edildi</translation>
+    </message>
+    <message>
+        <source>Received with address</source>
+        <translation type="unfinished">Salgy bilen kabul edildi</translation>
+    </message>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">Sene</translation>
+    </message>
+    <message>
+        <source>Confirmations</source>
+        <translation type="unfinished">Tassyklamalar</translation>
+    </message>
+    <message>
+        <source>Confirmed</source>
+        <translation type="unfinished">Tassyklandy</translation>
+    </message>
+    <message>
+        <source>Copy amount</source>
+        <translation type="unfinished">Möçberi göçür</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Salgyny göçür</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">&amp;Belligi göçür</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">&amp;Möçberi göçür</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID and output index</source>
+        <translation type="unfinished">Amal &amp;IDsini we çykyş indeksini göçür</translation>
+    </message>
+    <message>
+        <source>L&amp;ock unspent</source>
+        <translation type="unfinished">Ulanylmadygyny g&amp;ulpla</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock unspent</source>
+        <translation type="unfinished">Ulanylmadygynyň &amp;gulpuny aç</translation>
+    </message>
+    <message>
+        <source>Copy quantity</source>
+        <translation type="unfinished">Sany göçür</translation>
+    </message>
+    <message>
+        <source>Copy fee</source>
+        <translation type="unfinished">Gatanjy göçür</translation>
+    </message>
+    <message>
+        <source>Copy after fee</source>
+        <translation type="unfinished">Soňundan gatanjy göçür</translation>
+    </message>
+    <message>
+        <source>Copy bytes</source>
+        <translation type="unfinished">Baýtlary göçür</translation>
+    </message>
+    <message>
+        <source>Copy dust</source>
+        <translation type="unfinished">Tozy göçür</translation>
+    </message>
+    <message>
+        <source>Copy change</source>
+        <translation type="unfinished">Gaýtargyny göçür</translation>
+    </message>
+    <message>
+        <source>(%1 locked)</source>
+        <translation type="unfinished">(%1 gulply)</translation>
+    </message>
+    <message>
+        <source>yes</source>
+        <translation type="unfinished">hawa</translation>
+    </message>
+    <message>
+        <source>no</source>
+        <translation type="unfinished">ýok</translation>
+    </message>
+    <message>
+        <source>This label turns red if any recipient receives an amount smaller than the current dust threshold.</source>
+        <translation type="unfinished">Islendik kabul ediji häzirki toz çäginden has kiçi möçberi kabul edip alsa, bu bellik gyzyla öwrülýär.</translation>
+    </message>
+    <message>
+        <source>Can vary +/- %1 satoshi(s) per input.</source>
+        <translation type="unfinished">Her giriş üçin +/- %1 satosi üýtgäp biler.</translation>
+    </message>
+    <message>
+        <source>(no label)</source>
+        <translation type="unfinished">(bellik ýok)</translation>
+    </message>
+    <message>
+        <source>change from %1 (%2)</source>
+        <translation type="unfinished">%1-den gaýtargy (%2)</translation>
+    </message>
+    <message>
+        <source>(change)</source>
+        <translation type="unfinished">(gaýtargy)</translation>
+    </message>
+</context>
+<context>
+    <name>CreateWalletActivity</name>
+    <message>
+        <source>Create Wallet</source>
+        <extracomment>Title of window indicating the progress of creation of a new wallet.</extracomment>
+        <translation type="unfinished">Gapjyk döret</translation>
+    </message>
+    <message>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the create wallet progress window which indicates to the user which wallet is currently being created.</extracomment>
+        <translation type="unfinished">&lt;b&gt;%1&lt;/b&gt; gapjyk döredilýär...</translation>
+    </message>
+    <message>
+        <source>Create wallet failed</source>
+        <translation type="unfinished">Gapjyk döredip bolmady</translation>
+    </message>
+    <message>
+        <source>Create wallet warning</source>
+        <translation type="unfinished">Gapjyk döretmek duýduryşy</translation>
+    </message>
+    <message>
+        <source>Can't list signers</source>
+        <translation type="unfinished">Gol çekenleriň sanawyny görkezip bolanok</translation>
+    </message>
+    </context>
+<context>
+    <name>OpenWalletActivity</name>
+    <message>
+        <source>Open wallet failed</source>
+        <translation type="unfinished">Gapjyk açyp bolmady</translation>
+    </message>
+    <message>
+        <source>Open wallet warning</source>
+        <translation type="unfinished">Gapjyk açmak duýduryşy</translation>
+    </message>
+    <message>
+        <source>default wallet</source>
+        <translation type="unfinished">deslapky bellenen gapjyk</translation>
+    </message>
+    <message>
+        <source>Open Wallet</source>
+        <extracomment>Title of window indicating the progress of opening of a wallet.</extracomment>
+        <translation type="unfinished">Gapjygy aç</translation>
+    </message>
+    <message>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the open wallet progress window which indicates to the user which wallet is currently being opened.</extracomment>
+        <translation type="unfinished">&lt;b&gt;%1&lt;/b&gt; gapjyk açylýar...</translation>
+    </message>
+</context>
+<context>
+    <name>WalletController</name>
+    <message>
+        <source>Close wallet</source>
+        <translation type="unfinished">Gapjygy ýap</translation>
+    </message>
+    <message>
+        <source>Are you sure you wish to close the wallet &lt;i&gt;%1&lt;/i&gt;?</source>
+        <translation type="unfinished">&lt;i&gt;%1&lt;/i&gt; gapjygy ýapmak isleýäniňiz çynmy?</translation>
+    </message>
+    <message>
+        <source>Closing the wallet for too long can result in having to resync the entire chain if pruning is enabled.</source>
+        <translation type="unfinished">Kesip gysgaltmaklyk işjeň bolsa, aşa uzak wagtlap gapjygyň ýapylmagy tutuş zynjyryň gaýtadan utgaşmak zerurlygyna getirip biler.</translation>
+    </message>
+    <message>
+        <source>Close all wallets</source>
+        <translation type="unfinished">Ähli gapjyklary ýap</translation>
+    </message>
+    <message>
+        <source>Are you sure you wish to close all wallets?</source>
+        <translation type="unfinished">Ähli gapjyklary ýapmak isleýäniňiz çynmy?</translation>
+    </message>
+</context>
+<context>
+    <name>CreateWalletDialog</name>
+    <message>
+        <source>Create Wallet</source>
+        <translation type="unfinished">Gapjyk döret</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <translation type="unfinished">Gapjygyň ady</translation>
+    </message>
+    <message>
+        <source>Wallet</source>
+        <translation type="unfinished">Gapjyk</translation>
+    </message>
+    <message>
+        <source>Encrypt the wallet. The wallet will be encrypted with a passphrase of your choice.</source>
+        <translation type="unfinished">Gapjygy şifrle. Gapjyk siziň saýlan parol sözlemi bilen şifrlener.</translation>
+    </message>
+    <message>
+        <source>Encrypt Wallet</source>
+        <translation type="unfinished">Gapjygy şifrle</translation>
+    </message>
+    <message>
+        <source>Advanced Options</source>
+        <translation type="unfinished">Giňişleýin opsiýalar</translation>
+    </message>
+    <message>
+        <source>Disable private keys for this wallet. Wallets with private keys disabled will have no private keys and cannot have an HD seed or imported private keys. This is ideal for watch-only wallets.</source>
+        <translation type="unfinished">Bu gapjyk üçin hususy açarlary öçür. Hususy açarlary öçük gapjyklaryň hiçhili hususy açary bolmaz we HD esasy açary ýa-da import edilen hususy açary bolmaz. Diňe gözden geçirip bolýan gapjyklar üçin iň göwnejaýydyr.</translation>
+    </message>
+    <message>
+        <source>Disable Private Keys</source>
+        <translation type="unfinished">Hususy açarlary öçür</translation>
+    </message>
+    <message>
+        <source>Make a blank wallet. Blank wallets do not initially have private keys or scripts. Private keys and addresses can be imported, or an HD seed can be set, at a later time.</source>
+        <translation type="unfinished">Boş gapjyk emele getir. Boş gapjyklaryň başda hususy açary ýa-da skripti bolmaýar. Soňra hususy açarlar ýa-da salgylar import edilip bilner ýa-da HD esasy açar bellenip bilner.</translation>
+    </message>
+    <message>
+        <source>Make Blank Wallet</source>
+        <translation type="unfinished">Boş gapjyk emele getir</translation>
+    </message>
+    <message>
+        <source>Use descriptors for scriptPubKey management</source>
+        <translation type="unfinished">scriptPubKey dolandyryşy üçin beýan edijileri ulan</translation>
+    </message>
+    <message>
+        <source>Descriptor Wallet</source>
+        <translation type="unfinished">Beýan ediji gapjyk</translation>
+    </message>
+    <message>
+        <source>Use an external signing device such as a hardware wallet. Configure the external signer script in wallet preferences first.</source>
+        <translation type="unfinished">Enjam gapjygy ýaly daşyndan gol çekilýän enjamy ulan. Ilki bilen gapjygyň ileri tutmalarynda daşyndan gol çekiji skriptini sazla.</translation>
+    </message>
+    <message>
+        <source>External signer</source>
+        <translation type="unfinished">Daşyndan gol çekiji</translation>
+    </message>
+    <message>
+        <source>Create</source>
+        <translation type="unfinished">Döret</translation>
+    </message>
+    <message>
+        <source>Compiled without sqlite support (required for descriptor wallets)</source>
+        <translation type="unfinished">Sqlite goldawsyz (beýan ediji gapjyklar üçin gerek) düzüldi</translation>
+    </message>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Daşyndan gol çekmek üçin goldawsyz (daşyndan gol çekmek üçin gerek) düzüldi</translation>
+    </message>
+</context>
+<context>
+    <name>EditAddressDialog</name>
+    <message>
+        <source>Edit Address</source>
+        <translation type="unfinished">Salgyny rejele</translation>
+    </message>
+    <message>
+        <source>&amp;Label</source>
+        <translation type="unfinished">&amp;Bellik</translation>
+    </message>
+    <message>
+        <source>The label associated with this address list entry</source>
+        <translation type="unfinished">Bu salgy sanawyndaky ýazgy bilen baglanyşykly bellik</translation>
+    </message>
+    <message>
+        <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
+        <translation type="unfinished">Bu salgy sanawyndaky ýazgy bilen baglanyşykly salgy. Bu diňe iberýän salgylar üçin üýtgedilip bilner.</translation>
+    </message>
+    <message>
+        <source>&amp;Address</source>
+        <translation type="unfinished">&amp;Salgy</translation>
+    </message>
+    <message>
+        <source>New sending address</source>
+        <translation type="unfinished">Täze iberýän salgy</translation>
+    </message>
+    <message>
+        <source>Edit receiving address</source>
+        <translation type="unfinished">Kabul edýän salgyny rejele</translation>
+    </message>
+    <message>
+        <source>Edit sending address</source>
+        <translation type="unfinished">Iberýän salgyny rejele</translation>
+    </message>
+    <message>
+        <source>The entered address "%1" is not a valid Bitcoin address.</source>
+        <translation type="unfinished">Ýazylan salgy %1 ýaly Bitkoin salgysy ýok.</translation>
+    </message>
+    <message>
+        <source>Address "%1" already exists as a receiving address with label "%2" and so cannot be added as a sending address.</source>
+        <translation type="unfinished">%1 salgysy %2 bellikli kabul edýän salgy hökmünde eýýäm bar we şonuň üçin ony iberýän salgy hökmünde goşup bolanok.</translation>
+    </message>
+    <message>
+        <source>The entered address "%1" is already in the address book with label "%2".</source>
+        <translation type="unfinished">Ýazylan %1 salgysy salgylar kitabynda %2 belligi astynda eýýäm bar.</translation>
+    </message>
+    <message>
+        <source>Could not unlock wallet.</source>
+        <translation type="unfinished">Gapjygyň gulpuny açyp bolmady.</translation>
+    </message>
+    <message>
+        <source>New key generation failed.</source>
+        <translation type="unfinished">Täze açar döredip bolmady.</translation>
+    </message>
+</context>
+<context>
+    <name>FreespaceChecker</name>
+    <message>
+        <source>A new data directory will be created.</source>
+        <translation type="unfinished">Täze maglumat sanawy dörediler. </translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished">at</translation>
+    </message>
+    <message>
+        <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
+        <translation type="unfinished">Sanaw eýýäm bar. Bu ýerde täze sanaw döretmekçi bolsaňyz, %1 goşuň.</translation>
+    </message>
+    <message>
+        <source>Path already exists, and is not a directory.</source>
+        <translation type="unfinished">Ýol eýýäm bar we ol sanaw däldir.</translation>
+    </message>
+    <message>
+        <source>Cannot create data directory here.</source>
+        <translation type="unfinished">Bu ýerde maglumat sanawyny döredip bolanok.</translation>
+    </message>
+</context>
+<context>
+    <name>Intro</name>
+    <message>
+        <source>Bitcoin</source>
+        <translation type="unfinished">Bitkoin</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message>
+        <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
+        <translation type="unfinished">Bu sanawda azyndan %1 GB maglumat saklanar we ol wagtyň geçmegi bilen köpeler.</translation>
+    </message>
+    <message>
+        <source>Approximately %1 GB of data will be stored in this directory.</source>
+        <translation type="unfinished">Bu sanawda takmynan %1 GB maglumat saklanar.</translation>
+    </message>
+    <message numerus="yes">
+        <source>(sufficient to restore backups %n day(s) old)</source>
+        <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
+        <translation type="unfinished">
+            <numerusform>(%n gün geçen ätiýaçlyk nusgalaryny dikeltmek üçin ýeterlik)</numerusform>
+            <numerusform>(%n gün geçen ätiýaçlyk nusgalaryny dikeltmek üçin ýeterlik)</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>%1 will download and store a copy of the Bitcoin block chain.</source>
+        <translation type="unfinished">%1 Bitkoin blok zynjyrynyň nusgasyny ýükläp alar we göçürer.</translation>
+    </message>
+    <message>
+        <source>The wallet will also be stored in this directory.</source>
+        <translation type="unfinished">Gapjyk hem bu sanawa saklanar.</translation>
+    </message>
+    <message>
+        <source>Error: Specified data directory "%1" cannot be created.</source>
+        <translation type="unfinished">Ýalňyşlyk: Görkezilen %1 maglumat sanawyny döredip bolanok.</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Ýalňyşlyk</translation>
+    </message>
+    <message>
+        <source>Welcome</source>
+        <translation type="unfinished">Hoş geldiňiz</translation>
+    </message>
+    <message>
+        <source>Welcome to %1.</source>
+        <translation type="unfinished">%1-a hoş geldiňiz.</translation>
+    </message>
+    <message>
+        <source>As this is the first time the program is launched, you can choose where %1 will store its data.</source>
+        <translation type="unfinished">Bu programma ilkinji gezek başlandygy sebäpli, %1-nyň öz maglumatlaryny nirä saklajakdygyny saýlap bilersiň.</translation>
+    </message>
+    <message>
+        <source>Limit block chain storage to</source>
+        <translation type="unfinished">Blok zynjyrynyň saklanmagyny çäklendir</translation>
+    </message>
+    <message>
+        <source>Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</source>
+        <translation type="unfinished">Bu sazlamany yzyna gaýtarmaklyk tutuş blok zynjyryny gaýtadan ýükläp almak zerur. Ilki bilen tutuş zynjyry ýükläp almak we soň ony kesmek has çalt bolar. Käbir giňişleýin aýratynlyklary öçürer.</translation>
+    </message>
+    <message>
+        <source> GB</source>
+        <translation type="unfinished">GB</translation>
+    </message>
+    <message>
+        <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
+        <translation type="unfinished">Bu başdaky utgaşdyrma örän çylşyrymlydyr we kompýuteriňiziň ozal üns berilmedik enjam näsazlyklaryny ýüze çykaryp biler. Her sapar %1 işledeniňizde ol säginen ýerinden ýükläp almaga dowam eder.</translation>
+    </message>
+    <message>
+        <source>If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</source>
+        <translation type="unfinished">Blok zynjyrynyň saklanyşyny çäklendirmegi (kesip aýyrmagy) saýlan bolsaňyz, geçmiş maglumatlary ýene-de ýüklenip alynmaly we işlenmelidir, emma diskiňiziň ulanylyşyny azaltmak üçin soňundan pozular. </translation>
+    </message>
+    <message>
+        <source>Use the default data directory</source>
+        <translation type="unfinished">Deslapky bellenen maglumat sanawyny ulan</translation>
+    </message>
+    <message>
+        <source>Use a custom data directory:</source>
+        <translation type="unfinished">Aýratyn maglumat sanawyny ulan:</translation>
+    </message>
+</context>
+<context>
+    <name>HelpMessageDialog</name>
+    <message>
+        <source>version</source>
+        <translation type="unfinished">wersiýa</translation>
+    </message>
+    <message>
+        <source>About %1</source>
+        <translation type="unfinished">%1 barada</translation>
+    </message>
+    <message>
+        <source>Command-line options</source>
+        <translation type="unfinished">Buýruk setiri opsiýalary</translation>
+    </message>
+</context>
+<context>
+    <name>ShutdownWindow</name>
+    <message>
+        <source>%1 is shutting down…</source>
+        <translation type="unfinished">%1 ýapylýar...</translation>
+    </message>
+    <message>
+        <source>Do not shut down the computer until this window disappears.</source>
+        <translation type="unfinished">Bu penjire ýitýänçä kompýuteri ýapmaň.</translation>
+    </message>
+</context>
+<context>
+    <name>ModalOverlay</name>
+    <message>
+        <source>Form</source>
+        <translation type="unfinished">Forma</translation>
+    </message>
+    <message>
+        <source>Recent transactions may not yet be visible, and therefore your wallet's balance might be incorrect. This information will be correct once your wallet has finished synchronizing with the bitcoin network, as detailed below.</source>
+        <translation type="unfinished">Soňky geleşikler entek görünmän biler, şonuň üçin gapjygyňyzdaky galyndy nädogry bolup biler. Bu maglumat aşakda beýan edilişi ýaly gapjygyňyz bitkoin tory bilen utgaşmagy tamamlanda dogry bolar.</translation>
+    </message>
+    <message>
+        <source>Attempting to spend bitcoins that are affected by not-yet-displayed transactions will not be accepted by the network.</source>
+        <translation type="unfinished">Entek görkezilmedik geleşikleriň täsirine düşen bitkoinleri sarp etmek synanyşygy ulgam tarapyndan kabul edilmez.</translation>
+    </message>
+    </context>
+<context>
+    <name>OptionsDialog</name>
+    <message>
+        <source>&amp;Window</source>
+        <translation type="unfinished">&amp;Penjire</translation>
+    </message>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Daşyndan gol çekmek üçin goldawsyz (daşyndan gol çekmek üçin gerek) düzüldi</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Ýalňyşlyk</translation>
+    </message>
+    </context>
+<context>
+    <name>OverviewPage</name>
+    <message>
+        <source>Form</source>
+        <translation type="unfinished">Forma</translation>
+    </message>
+    </context>
+<context>
+    <name>PeerTableModel</name>
+    <message>
+        <source>Address</source>
+        <extracomment>Title of Peers Table column which contains the IP/Onion/I2P address of the connected peer.</extracomment>
+        <translation type="unfinished">Salgy</translation>
+    </message>
+    </context>
+<context>
+    <name>RPCConsole</name>
+    <message>
+        <source>Node window</source>
+        <translation type="unfinished">Düwün penjiresi</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <extracomment>Context menu action to copy the address of a peer.</extracomment>
+        <translation type="unfinished">&amp;Salgyny göçür</translation>
+    </message>
+    </context>
+<context>
+    <name>ReceiveCoinsDialog</name>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Salgyny göçür</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">&amp;Belligi göçür</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">&amp;Möçberi göçür</translation>
+    </message>
+    <message>
+        <source>Could not unlock wallet.</source>
+        <translation type="unfinished">Gapjygyň gulpuny açyp bolmady.</translation>
+    </message>
+    </context>
+<context>
+    <name>ReceiveRequestDialog</name>
+    <message>
+        <source>Amount:</source>
+        <translation type="unfinished">Möçber:</translation>
+    </message>
+    <message>
+        <source>Wallet:</source>
+        <translation type="unfinished">Gapjyk:</translation>
+    </message>
+    </context>
+<context>
+    <name>RecentRequestsTableModel</name>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">Sene</translation>
+    </message>
+    <message>
+        <source>Label</source>
+        <translation type="unfinished">Bellik</translation>
+    </message>
+    <message>
+        <source>(no label)</source>
+        <translation type="unfinished">(bellik ýok)</translation>
+    </message>
+    </context>
+<context>
+    <name>SendCoinsDialog</name>
+    <message>
+        <source>Quantity:</source>
+        <translation type="unfinished">Sany:</translation>
+    </message>
+    <message>
+        <source>Bytes:</source>
+        <translation type="unfinished">Baýtlar:</translation>
+    </message>
+    <message>
+        <source>Amount:</source>
+        <translation type="unfinished">Möçber:</translation>
+    </message>
+    <message>
+        <source>Fee:</source>
+        <translation type="unfinished">Gatanç:</translation>
+    </message>
+    <message>
+        <source>After Fee:</source>
+        <translation type="unfinished">Soňundan gatanç:</translation>
+    </message>
+    <message>
+        <source>Change:</source>
+        <translation type="unfinished">Çalyş:</translation>
+    </message>
+    <message>
+        <source>Dust:</source>
+        <translation type="unfinished">Toz:</translation>
+    </message>
+    <message>
+        <source>Copy quantity</source>
+        <translation type="unfinished">Sany göçür</translation>
+    </message>
+    <message>
+        <source>Copy amount</source>
+        <translation type="unfinished">Möçberi göçür</translation>
+    </message>
+    <message>
+        <source>Copy fee</source>
+        <translation type="unfinished">Gatanjy göçür</translation>
+    </message>
+    <message>
+        <source>Copy after fee</source>
+        <translation type="unfinished">Soňundan gatanjy göçür</translation>
+    </message>
+    <message>
+        <source>Copy bytes</source>
+        <translation type="unfinished">Baýtlary göçür</translation>
+    </message>
+    <message>
+        <source>Copy dust</source>
+        <translation type="unfinished">Tozy göçür</translation>
+    </message>
+    <message>
+        <source>Copy change</source>
+        <translation type="unfinished">Gaýtargyny göçür</translation>
+    </message>
+    <message numerus="yes">
+        <source>Estimated to begin confirmation within %n block(s).</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message>
+        <source>(no label)</source>
+        <translation type="unfinished">(bellik ýok)</translation>
+    </message>
+</context>
+<context>
+    <name>TransactionDesc</name>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">Sene</translation>
+    </message>
+    <message numerus="yes">
+        <source>matures in %n more block(s)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message>
+        <source>Amount</source>
+        <translation type="unfinished">Möçber</translation>
+    </message>
+    </context>
+<context>
+    <name>TransactionTableModel</name>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">Sene</translation>
+    </message>
+    <message>
+        <source>Label</source>
+        <translation type="unfinished">Bellik</translation>
+    </message>
+    <message>
+        <source>(no label)</source>
+        <translation type="unfinished">(bellik ýok)</translation>
+    </message>
+    </context>
+<context>
+    <name>TransactionView</name>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Salgyny göçür</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">&amp;Belligi göçür</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">&amp;Möçberi göçür</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">Geleşigiň &amp;ID-sini göçür</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">Otur bilen aýrylan faýl</translation>
+    </message>
+    <message>
+        <source>Confirmed</source>
+        <translation type="unfinished">Tassyklandy</translation>
+    </message>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">Sene</translation>
+    </message>
+    <message>
+        <source>Label</source>
+        <translation type="unfinished">Bellik</translation>
+    </message>
+    <message>
+        <source>Address</source>
+        <translation type="unfinished">Salgy</translation>
+    </message>
+    <message>
+        <source>Exporting Failed</source>
+        <translation type="unfinished">Geçirip bolmady</translation>
+    </message>
+    </context>
+<context>
+    <name>WalletFrame</name>
+    <message>
+        <source>Create a new wallet</source>
+        <translation type="unfinished">Taze gapjyk döret</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Ýalňyşlyk</translation>
+    </message>
+    </context>
+<context>
+    <name>WalletModel</name>
+    <message>
+        <source>default wallet</source>
+        <translation type="unfinished">deslapky bellenen gapjyk</translation>
+    </message>
+</context>
+<context>
+    <name>WalletView</name>
+    <message>
+        <source>&amp;Export</source>
+        <translation type="unfinished">&amp;Geçir</translation>
+    </message>
+    <message>
+        <source>Export the data in the current tab to a file</source>
+        <translation type="unfinished">Häzirki bellikdäki maglumaty faýla geçir</translation>
+    </message>
+    </context>
+</TS>

--- a/src/qt/locale/bitcoin_tl.ts
+++ b/src/qt/locale/bitcoin_tl.ts
@@ -1,0 +1,1527 @@
+<TS version="2.1" language="tl">
+<context>
+    <name>AddressBookPage</name>
+    <message>
+        <source>Right-click to edit address or label</source>
+        <translation type="unfinished">I-right-click upang i-edit ang ♦address♦ o ♦label♦</translation>
+    </message>
+    <message>
+        <source>Create a new address</source>
+        <translation type="unfinished">Gumawa ng bagong ♦address♦</translation>
+    </message>
+    <message>
+        <source>&amp;New</source>
+        <translation type="unfinished">&amp;Bago</translation>
+    </message>
+    <message>
+        <source>Copy the currently selected address to the system clipboard</source>
+        <translation type="unfinished">Kopyahin ang pinipiling ♦address♦ sa kasalakuyan sa ♦clipboard♦ ng sistema</translation>
+    </message>
+    <message>
+        <source>C&amp;lose</source>
+        <translation type="unfinished">Isara</translation>
+    </message>
+    <message>
+        <source>Delete the currently selected address from the list</source>
+        <translation type="unfinished">Tanggalin ang kasalukuyang napiling ♦address♦ sa listahan</translation>
+    </message>
+    <message>
+        <source>Enter address or label to search</source>
+        <translation type="unfinished">Ilagay ang address o tatak na hahanapin</translation>
+    </message>
+    <message>
+        <source>Export the data in the current tab to a file</source>
+        <translation type="unfinished">I-export ang datos sa kasalukuyang ♦tab♦ sa isang file</translation>
+    </message>
+    <message>
+        <source>&amp;Export</source>
+        <translation type="unfinished">&amp;I-export</translation>
+    </message>
+    <message>
+        <source>&amp;Delete</source>
+        <translation type="unfinished">&amp;Tanggalin</translation>
+    </message>
+    <message>
+        <source>Choose the address to send coins to</source>
+        <translation type="unfinished">Piliin ang ♦address♦ kung saan ipapadala ang mga coin</translation>
+    </message>
+    <message>
+        <source>Choose the address to receive coins with</source>
+        <translation type="unfinished">Piliin ang ♦address♦ kung saan tatanggap ng mga coin</translation>
+    </message>
+    <message>
+        <source>C&amp;hoose</source>
+        <translation type="unfinished">&amp;Pumili</translation>
+    </message>
+    <message>
+        <source>Sending addresses</source>
+        <translation type="unfinished">Pinapadala ang mga ♦address♦</translation>
+    </message>
+    <message>
+        <source>Receiving addresses</source>
+        <translation type="unfinished">Tinatanggap ang mga ♦address♦</translation>
+    </message>
+    <message>
+        <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
+        <translation type="unfinished">Ito ang mga ♦address♦ ng ♦Bitcoin♦ mo para pagpapadala ng mga bayad. Palaging suriin mo ang halaga at address kung saan tatanggap bago magpadala ka ng mga ♦coin.</translation>
+    </message>
+    <message>
+        <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
+Signing is only possible with addresses of the type 'legacy'.</source>
+        <translation type="unfinished">Ito ang mga address ng ♦Bitcoin♦ para sa pagtanggap ng mga baya. Gamitin ang 'Create new receiving address' na button sa receive tab para gumawa ng bagong mga address. Ang pag-sign ay posible lamang sa uri ng mga address na 'legacy'.</translation>
+    </message>
+    <message>
+        <source>&amp;Copy Address</source>
+        <translation type="unfinished">&amp;Kopyahin ang ♦Address♦</translation>
+    </message>
+    <message>
+        <source>Copy &amp;Label</source>
+        <translation type="unfinished">Kopyahin ang &amp;Tatak</translation>
+    </message>
+    <message>
+        <source>&amp;Edit</source>
+        <translation type="unfinished">&amp;I-edit</translation>
+    </message>
+    <message>
+        <source>Export Address List</source>
+        <translation type="unfinished">I-Export ang Listahan ng ♦Address♦</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">Kuwir hiwalay na file</translation>
+    </message>
+    <message>
+        <source>There was an error trying to save the address list to %1. Please try again.</source>
+        <extracomment>An error message. %1 is a stand-in argument for the name of the file we attempted to save to.</extracomment>
+        <translation type="unfinished">May mali sa pagsubok na i-save ang listahan ng address  sa 1%1. Pakisubukan ulit.</translation>
+    </message>
+    <message>
+        <source>Exporting Failed</source>
+        <translation type="unfinished">Ang pag-export ay Nabigo</translation>
+    </message>
+</context>
+<context>
+    <name>AddressTableModel</name>
+    <message>
+        <source>Label</source>
+        <translation type="unfinished">Tatak</translation>
+    </message>
+    <message>
+        <source>Address</source>
+        <translation type="unfinished">♦Address♦</translation>
+    </message>
+    <message>
+        <source>(no label)</source>
+        <translation type="unfinished">(walang tatak)</translation>
+    </message>
+</context>
+<context>
+    <name>AskPassphraseDialog</name>
+    <message>
+        <source>Passphrase Dialog</source>
+        <translation type="unfinished">♦Passphrase♦ na ♦Dialog♦</translation>
+    </message>
+    <message>
+        <source>Enter passphrase</source>
+        <translation type="unfinished">Ilagay ang ♦passphrase♦</translation>
+    </message>
+    <message>
+        <source>New passphrase</source>
+        <translation type="unfinished">Bagong ♦passphrase♦</translation>
+    </message>
+    <message>
+        <source>Repeat new passphrase</source>
+        <translation type="unfinished">Ulitin ang bagong ♦passphrase♦</translation>
+    </message>
+    <message>
+        <source>Show passphrase</source>
+        <translation type="unfinished">Ipakita ang ♦passphrase♦</translation>
+    </message>
+    <message>
+        <source>Encrypt wallet</source>
+        <translation type="unfinished">I-encrypt ang pitaka</translation>
+    </message>
+    <message>
+        <source>This operation needs your wallet passphrase to unlock the wallet.</source>
+        <translation type="unfinished">Ang operasyon na ito ay nangangailangan ng iyong pitaka ♦passphrase♦ para i-unlock ang pitaka.</translation>
+    </message>
+    <message>
+        <source>Unlock wallet</source>
+        <translation type="unfinished">I-unlock ang pitaka</translation>
+    </message>
+    <message>
+        <source>Change passphrase</source>
+        <translation type="unfinished">Palitan ang ♦passphrase♦</translation>
+    </message>
+    <message>
+        <source>Confirm wallet encryption</source>
+        <translation type="unfinished">Kumpirmahin ang ♦encryption♦ ng pitaka</translation>
+    </message>
+    <message>
+        <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
+        <translation type="unfinished">Babala: IKung i-encrypt mo ang iyong pitaka at mawawala ang ♦passphrase♦,  &lt;b&gt;MAWAWALA MO ANG LAHAT NG IYONG MGA BITCOIN&lt;/b&gt;!</translation>
+    </message>
+    <message>
+        <source>Are you sure you wish to encrypt your wallet?</source>
+        <translation type="unfinished">Sigurado ka ba na gusto mong i-encrypt ang iyong pitaka?</translation>
+    </message>
+    <message>
+        <source>Wallet encrypted</source>
+        <translation type="unfinished">Ang pitaka ay na-encrypt na</translation>
+    </message>
+    <message>
+        <source>Enter the new passphrase for the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
+        <translation type="unfinished">Ilagay ang bagong ♦passphrase♦ para sa pitaka.&lt;br/&gt;Pakigamit ang ♦passphrase♦ of &lt;b&gt;sampu o higit pa na mga ♦random♦ na mga karakter&lt;/b&gt;, o &lt;b&gt;walo o higit pang mga salita&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <source>Enter the old passphrase and new passphrase for the wallet.</source>
+        <translation type="unfinished">Ilagay ang lumang ♦passphrase♦ at ang bagong ♦passphrase♦ para sa pitaka.</translation>
+    </message>
+    <message>
+        <source>Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
+        <translation type="unfinished">Tandaan na ang pag-encrypt sa iyong pitaka ay hindi ganap na mapoprotektahan ang mga ♦bitcoin♦ sa pagnanakaw ng ♦malware♦ na makakahawa sa iyong kompyuter.</translation>
+    </message>
+    <message>
+        <source>Wallet to be encrypted</source>
+        <translation type="unfinished">Ang pitaka ay i-encrypt</translation>
+    </message>
+    <message>
+        <source>Your wallet is about to be encrypted. </source>
+        <translation type="unfinished">Ang iyong pitaka ay mae-encrypt na.</translation>
+    </message>
+    <message>
+        <source>Your wallet is now encrypted. </source>
+        <translation type="unfinished">Ang iyong pitaka ay na-encrypt na.</translation>
+    </message>
+    <message>
+        <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
+        <translation type="unfinished">MAHALAGA: Kahit anong dating mga ♦backup♦ na ginawa mo sa ♦file♦ ng pitaka mo ay dapat na mapalitan ng bagong gawang, na-encrypt na ♦file♦ ng pitaka. Para sa mga rason ng seguridad, dating mga ♦backup♦ sa hindi na-encrypt na ♦file♦ ng pitaka ay magiging walang silbi sa lalong madaling panahon na sisimulan mong gamitin ang bago, na na-encrypt na pitaka.</translation>
+    </message>
+    <message>
+        <source>Wallet encryption failed</source>
+        <translation type="unfinished">Ang pag-encrypt sa pitaka ay nabigo</translation>
+    </message>
+    <message>
+        <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
+        <translation type="unfinished">Nabigo ang pag-encrypt sa pitaka dahil sa panloob na pagkakamali. Ang iyong pitaka ay hindi na-encrypt.</translation>
+    </message>
+    <message>
+        <source>The supplied passphrases do not match.</source>
+        <translation type="unfinished">Ang mga ibinigay na mga ♦passphrase♦ ay hindi nagtugma.</translation>
+    </message>
+    <message>
+        <source>Wallet unlock failed</source>
+        <translation type="unfinished">Ang pag-unlock sa pitaka ay nabigo</translation>
+    </message>
+    <message>
+        <source>The passphrase entered for the wallet decryption was incorrect.</source>
+        <translation type="unfinished">Ang ♦passphrase♦ na ipinasok sa ♦decryption♦ sa pitaka ay hindi tama.</translation>
+    </message>
+    <message>
+        <source>Wallet passphrase was successfully changed.</source>
+        <translation type="unfinished">Ang ♦passphrase♦ ng pitaka ay matagumpay na nabago.</translation>
+    </message>
+    <message>
+        <source>Warning: The Caps Lock key is on!</source>
+        <translation type="unfinished">Babala: Ang ♦Caps Lock Key♦ ay naka-on!</translation>
+    </message>
+</context>
+<context>
+    <name>BanTableModel</name>
+    <message>
+        <source>IP/Netmask</source>
+        <translation type="unfinished">♦IP/Netmask♦</translation>
+    </message>
+    <message>
+        <source>Banned Until</source>
+        <translation type="unfinished">Ipinagbabawal Hanggang</translation>
+    </message>
+</context>
+<context>
+    <name>BitcoinApplication</name>
+    <message>
+        <source>Runaway exception</source>
+        <translation type="unfinished">Pagbubukod sa pagtakbo papalayo </translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
+        <translation type="unfinished">Malubhang pagkakamali ay naganap. 1%1 hindi na pwedeng magpatuloy ng ligtas at ihihinto na.</translation>
+    </message>
+    <message>
+        <source>Internal error</source>
+        <translation type="unfinished">Panloob na pagkakamali</translation>
+    </message>
+    <message>
+        <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
+        <translation type="unfinished">May panloob na pagkakamali ang naganap. 1%1 ay magtatangkang ituloy na ligtas. Ito ay hindi inaasahan na problema na maaaring i-ulat katulad ng pagkalarawan sa ibaba.</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <source>Do you want to reset settings to default values, or to abort without making changes?</source>
+        <extracomment>Explanatory text shown on startup when the settings file cannot be read. Prompts user to make a choice between resetting or aborting.</extracomment>
+        <translation type="unfinished">Gusto mo bang i-reset ang mga ♦setting♦ sa ♦default♦ na mga ♦value♦, o itigil na hindi gumagawa ng mga pagbabago?</translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. Check that settings file is writable, or try running with -nosettings.</source>
+        <extracomment>Explanatory text shown on startup when the settings file could not be written. Prompts user to check that we have the ability to write to the file. Explains that the user has the option of running without a settings file.</extracomment>
+        <translation type="unfinished">Isang malubhang pagkakamali ang naganap. Suriin ang mga ♦setting♦ ng ♦file♦ na ♦writable♦, o subukan na patakbuhin sa ♦-nosettings♦.</translation>
+    </message>
+    <message>
+        <source>Error: Specified data directory "%1" does not exist.</source>
+        <translation type="unfinished">Pagkakamali: Ang natukoy na datos na ♦directory♦ "1%1" ay wala.</translation>
+    </message>
+    <message>
+        <source>Error: Cannot parse configuration file: %1.</source>
+        <translation type="unfinished">Pagkakamali: Hindi ma-parse ang ♦configuration file♦: %1.</translation>
+    </message>
+    <message>
+        <source>Error: %1</source>
+        <translation type="unfinished">Pagkakamali: 1%1</translation>
+    </message>
+    <message>
+        <source>%1 didn't yet exit safely…</source>
+        <translation type="unfinished">1%1 hindi pa nag-exit ng ligtas...</translation>
+    </message>
+    <message>
+        <source>Amount</source>
+        <translation type="unfinished">Halaga</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n second(s)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n minute(s)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n hour(s)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n day(s)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n week(s)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n year(s)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    </context>
+<context>
+    <name>bitcoin-core</name>
+    <message>
+        <source>Settings file could not be read</source>
+        <translation type="unfinished">Ang mga ♦setting file♦ ay hindi mabasa</translation>
+    </message>
+    <message>
+        <source>Settings file could not be written</source>
+        <translation type="unfinished">Ang mga ♦settings file♦ ay hindi maisulat</translation>
+    </message>
+    </context>
+<context>
+    <name>BitcoinGUI</name>
+    <message>
+        <source>&amp;Overview</source>
+        <translation type="unfinished">&amp;Pangkalahatang ideya</translation>
+    </message>
+    <message>
+        <source>Show general overview of wallet</source>
+        <translation type="unfinished">Ipakita ang pangkalahatang ideya ng pitaka</translation>
+    </message>
+    <message>
+        <source>&amp;Transactions</source>
+        <translation type="unfinished">&amp;Mga transaksyon</translation>
+    </message>
+    <message>
+        <source>Browse transaction history</source>
+        <translation type="unfinished">Tignan ang kasaysayan ng transaksyon</translation>
+    </message>
+    <message>
+        <source>E&amp;xit</source>
+        <translation type="unfinished">♦E&amp;xit</translation>
+    </message>
+    <message>
+        <source>Quit application</source>
+        <translation type="unfinished">Ihinto ang aplikasyon</translation>
+    </message>
+    <message>
+        <source>&amp;About %1</source>
+        <translation type="unfinished">&amp;Tungkol sa %1</translation>
+    </message>
+    <message>
+        <source>Show information about %1</source>
+        <translation type="unfinished">Ipakita ang impormasyon tungkol sa %1</translation>
+    </message>
+    <message>
+        <source>About &amp;Qt</source>
+        <translation type="unfinished">Tungkol sa &amp;♦Qt♦</translation>
+    </message>
+    <message>
+        <source>Modify configuration options for %1</source>
+        <translation type="unfinished">Baguhin ang mga pagpipilian sa ♦configuration♦ para sa %1</translation>
+    </message>
+    <message>
+        <source>Create a new wallet</source>
+        <translation type="unfinished">Gumawa ng bagong pitaka</translation>
+    </message>
+    <message>
+        <source>Wallet:</source>
+        <translation type="unfinished">Pitaka:</translation>
+    </message>
+    <message>
+        <source>Network activity disabled.</source>
+        <extracomment>A substring of the tooltip.</extracomment>
+        <translation type="unfinished">Na-disable ang aktibidad ng ♦network♦</translation>
+    </message>
+    <message>
+        <source>Proxy is &lt;b&gt;enabled&lt;/b&gt;: %1</source>
+        <translation type="unfinished">Ang paghalili ay  &lt;b&gt;na-enable&lt;/b&gt;: %1</translation>
+    </message>
+    <message>
+        <source>Send coins to a Bitcoin address</source>
+        <translation type="unfinished">Magpadala ng mga ♦coin♦ sa ♦address♦ ng Bitcoin</translation>
+    </message>
+    <message>
+        <source>Backup wallet to another location</source>
+        <translation type="unfinished">I-backup ang pitaka sa ibang lokasyon</translation>
+    </message>
+    <message>
+        <source>Change the passphrase used for wallet encryption</source>
+        <translation type="unfinished">Palitan ang ♦passphrase♦ na ginamit para sa pag-encrypt sa pitaka</translation>
+    </message>
+    <message>
+        <source>&amp;Send</source>
+        <translation type="unfinished">&amp;Ipadala</translation>
+    </message>
+    <message>
+        <source>&amp;Receive</source>
+        <translation type="unfinished">&amp;Tumanggap</translation>
+    </message>
+    <message>
+        <source>&amp;Options…</source>
+        <translation type="unfinished">&amp;Mga pagpipilian...</translation>
+    </message>
+    <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation type="unfinished">&amp;I-encrypt ang Pitaka</translation>
+    </message>
+    <message>
+        <source>Encrypt the private keys that belong to your wallet</source>
+        <translation type="unfinished">I-encrypt ang mga pribadong mga susi na nabibilang sa iyong pitaka</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation type="unfinished">&amp;I-backup ang Pitaka...</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation type="unfinished">&amp;Palitan ang ♦Passphrase♦...</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation type="unfinished">Pirmahan &amp;magmensahe...</translation>
+    </message>
+    <message>
+        <source>Sign messages with your Bitcoin addresses to prove you own them</source>
+        <translation type="unfinished">Tanda na mga mensahe sa mga ♦address♦ ng iyong ♦Bitcoin♦ para patunayan na pagmamay-ari mo sila</translation>
+    </message>
+    <message>
+        <source>&amp;Verify message…</source>
+        <translation type="unfinished">&amp;Patunayan ang mensahe...</translation>
+    </message>
+    <message>
+        <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
+        <translation type="unfinished">Patunayan ang mga mensahe para matiyak na sila ay napirmahan ng may tinukoy na mga ♦Bitcoin address♦</translation>
+    </message>
+    <message>
+        <source>&amp;Load PSBT from file…</source>
+        <translation type="unfinished">&amp;I-load ang PSBT mula sa ♦file♦...</translation>
+    </message>
+    <message>
+        <source>Open &amp;URI…</source>
+        <translation type="unfinished">Buksan ang &amp;♦URL♦...</translation>
+    </message>
+    <message>
+        <source>Close Wallet…</source>
+        <translation type="unfinished">Isara ang Pitaka...</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation type="unfinished">Gumawa ng Pitaka...</translation>
+    </message>
+    <message>
+        <source>Close All Wallets…</source>
+        <translation type="unfinished">Isara ang Lahat ng mga Pitaka...</translation>
+    </message>
+    <message>
+        <source>&amp;File</source>
+        <translation type="unfinished">&amp;♦File♦</translation>
+    </message>
+    <message>
+        <source>&amp;Settings</source>
+        <translation type="unfinished">Mga &amp;♦Setting♦</translation>
+    </message>
+    <message>
+        <source>&amp;Help</source>
+        <translation type="unfinished">&amp;Tulong</translation>
+    </message>
+    <message>
+        <source>Tabs toolbar</source>
+        <translation type="unfinished">♦Tabs toolbar♦</translation>
+    </message>
+    <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation type="unfinished">♦Syncing Headers♦ (%1%)…</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation type="unfinished">Sini-siynchronize sa ♦network♦...</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation type="unfinished">Ini-index ang mga bloke sa ♦disk♦...</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation type="unfinished">Pinoproseso ang mga bloke sa ♦disk♦...</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation type="unfinished">Ni-rere-index ang mga bloke sa ♦disk♦</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation type="unfinished">Kumokonekta sa mga ♦peers♦...</translation>
+    </message>
+    <message>
+        <source>Request payments (generates QR codes and bitcoin: URIs)</source>
+        <translation type="unfinished">Humiling ng mga bayad (gumagawa ng ♦QR codes♦ at ♦bitcoin: URIs♦)</translation>
+    </message>
+    <message>
+        <source>Show the list of used sending addresses and labels</source>
+        <translation type="unfinished">Ipakita ang listahan ng nagamit na pagpapadalhan na mga ♦address♦ at mga tatak</translation>
+    </message>
+    <message>
+        <source>Show the list of used receiving addresses and labels</source>
+        <translation type="unfinished">Ipakita ang listahan ng nagamit na pagtatanggapan na mga ♦address♦ at mga tatak</translation>
+    </message>
+    <message>
+        <source>&amp;Command-line options</source>
+        <translation type="unfinished">&amp;♦Command-line♦ na mga pagpipilian</translation>
+    </message>
+    <message numerus="yes">
+        <source>Processed %n block(s) of transaction history.</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message>
+        <source>%1 behind</source>
+        <translation type="unfinished">%1 sa likod</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation type="unfinished">Humahabol...</translation>
+    </message>
+    <message>
+        <source>Last received block was generated %1 ago.</source>
+        <translation type="unfinished">Ang huling natanggap na bloke ay nagawa %1kanina.</translation>
+    </message>
+    <message>
+        <source>Transactions after this will not yet be visible.</source>
+        <translation type="unfinished">Ang mga transaksyon pagkatapos nito ay hindi pa muna makikita.</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Nagkamali</translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished">Babala</translation>
+    </message>
+    <message>
+        <source>Information</source>
+        <translation type="unfinished">Impormasyon</translation>
+    </message>
+    <message>
+        <source>Load Partially Signed Bitcoin Transaction</source>
+        <translation type="unfinished">Ang ♦Load♦ ay Bahagyang Napirmahan na Transaksyon sa ♦Bitcoin♦</translation>
+    </message>
+    <message>
+        <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
+        <translation type="unfinished">Ang ♦Load♦ ay Bahagyang Napirmahan na Transaksyon sa ♦Bitcoin♦ mula sa ♦clipboard♦</translation>
+    </message>
+    <message>
+        <source>Node window</source>
+        <translation type="unfinished">♦Node window♦</translation>
+    </message>
+    <message>
+        <source>Open node debugging and diagnostic console</source>
+        <translation type="unfinished">Bukas na ♦node debugging♦ at ♦diagnostic console♦</translation>
+    </message>
+    <message>
+        <source>&amp;Sending addresses</source>
+        <translation type="unfinished">&amp;Pagpapadalhan na mga ♦address♦</translation>
+    </message>
+    <message>
+        <source>&amp;Receiving addresses</source>
+        <translation type="unfinished">&amp;Pagtatanggapan na mga ♦address♦</translation>
+    </message>
+    <message>
+        <source>Open a bitcoin: URI</source>
+        <translation type="unfinished">Buksan ang ♦bitcoin: URI♦</translation>
+    </message>
+    <message>
+        <source>Open Wallet</source>
+        <translation type="unfinished">Buksan ang pitaka</translation>
+    </message>
+    <message>
+        <source>Open a wallet</source>
+        <translation type="unfinished">Buksan ang pitaka</translation>
+    </message>
+    <message>
+        <source>Close wallet</source>
+        <translation type="unfinished">Isarado ang pitaka</translation>
+    </message>
+    <message>
+        <source>Close all wallets</source>
+        <translation type="unfinished">Isarado ang lahat na mga pitaka</translation>
+    </message>
+    <message>
+        <source>Show the %1 help message to get a list with possible Bitcoin command-line options</source>
+        <translation type="unfinished">Ipakita ang %1 tumulong sa mensahe na kumuha ng listahan ng posibleng ♦Bitcoin command-line♦ na mga pagpipilian</translation>
+    </message>
+    <message>
+        <source>&amp;Mask values</source>
+        <translation type="unfinished">&amp;♦Mask♦ na mga halaga</translation>
+    </message>
+    <message>
+        <source>Mask the values in the Overview tab</source>
+        <translation type="unfinished">I-mask ang  mga halaga sa loob ng ♦Overview tab♦</translation>
+    </message>
+    <message>
+        <source>default wallet</source>
+        <translation type="unfinished">pitaka na ♦default♦</translation>
+    </message>
+    <message>
+        <source>No wallets available</source>
+        <translation type="unfinished">Walang pitaka na mayroon</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">Pangalan ng pitaka</translation>
+    </message>
+    <message>
+        <source>&amp;Window</source>
+        <translation type="unfinished">&amp;♦Window♦</translation>
+    </message>
+    <message>
+        <source>Zoom</source>
+        <translation type="unfinished">I-zoom</translation>
+    </message>
+    <message>
+        <source>Main Window</source>
+        <translation type="unfinished">Pangunahing ♦Window♦</translation>
+    </message>
+    <message>
+        <source>%1 client</source>
+        <translation type="unfinished">%1 na kliyente</translation>
+    </message>
+    <message>
+        <source>&amp;Hide</source>
+        <translation type="unfinished">&amp;Itago</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n active connection(s) to Bitcoin network.</source>
+        <extracomment>A substring of the tooltip.</extracomment>
+        <translation type="unfinished">
+            <numerusform>%n aktibo na mga ♦connection(s)♦ sa ♦Bitcoin network♦.</numerusform>
+            <numerusform>%n na aktibong mga koneksyon sa ♦Bitcoin network♦</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Click for more actions.</source>
+        <extracomment>A substring of the tooltip. "More actions" are available via the context menu.</extracomment>
+        <translation type="unfinished">Mag-click para sa marami pang gagawin.</translation>
+    </message>
+    <message>
+        <source>Show Peers tab</source>
+        <extracomment>A context menu item. The "Peers tab" is an element of the "Node window".</extracomment>
+        <translation type="unfinished">Ipakita ang ♦Peers tab♦</translation>
+    </message>
+    <message>
+        <source>Disable network activity</source>
+        <extracomment>A context menu item.</extracomment>
+        <translation type="unfinished">I-disable ang aktibidad ng ♦network♦</translation>
+    </message>
+    <message>
+        <source>Enable network activity</source>
+        <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
+        <translation type="unfinished">I-enable ang aktibidad ng ♦network♦</translation>
+    </message>
+    <message>
+        <source>Error: %1</source>
+        <translation type="unfinished">Pagkakamali: 1%1</translation>
+    </message>
+    <message>
+        <source>Warning: %1</source>
+        <translation type="unfinished">Babala: %1</translation>
+    </message>
+    <message>
+        <source>Date: %1
+</source>
+        <translation type="unfinished">Petsa: %1
+</translation>
+    </message>
+    <message>
+        <source>Amount: %1
+</source>
+        <translation type="unfinished">Halaga: %1
+</translation>
+    </message>
+    <message>
+        <source>Wallet: %1
+</source>
+        <translation type="unfinished">Pitaka: %1
+</translation>
+    </message>
+    <message>
+        <source>Type: %1
+</source>
+        <translation type="unfinished">Uri: %1
+</translation>
+    </message>
+    <message>
+        <source>Label: %1
+</source>
+        <translation type="unfinished">Tatak: %1
+</translation>
+    </message>
+    <message>
+        <source>Address: %1
+</source>
+        <translation type="unfinished">♦Address♦: %1
+</translation>
+    </message>
+    <message>
+        <source>Sent transaction</source>
+        <translation type="unfinished">Ipinadalang transaksyon</translation>
+    </message>
+    <message>
+        <source>Incoming transaction</source>
+        <translation type="unfinished">Paparating na transaksyon</translation>
+    </message>
+    <message>
+        <source>HD key generation is &lt;b&gt;enabled&lt;/b&gt;</source>
+        <translation type="unfinished">♦HD♦ na susi sa henerasyon ay &lt;b&gt;na-enable&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>HD key generation is &lt;b&gt;disabled&lt;/b&gt;</source>
+        <translation type="unfinished">♦HD key generation♦ ay &lt;b&gt;na-disable&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Private key &lt;b&gt;disabled&lt;/b&gt;</source>
+        <translation type="unfinished">Pribadong susi &lt;b&gt;na-disable&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
+        <translation type="unfinished">Ang pitaka ay &lt;b&gt;na-encrypt&lt;/b&gt; at kasalukuyang &lt;b&gt;na-unlock&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
+        <translation type="unfinished">Ang pitaka ay &lt;b&gt;na-encrypt&lt;/b&gt; at kasalukuyang &lt;b&gt;na-lock&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Original message:</source>
+        <translation type="unfinished">Orihinal na mensahe:</translation>
+    </message>
+</context>
+<context>
+    <name>UnitDisplayStatusBarControl</name>
+    <message>
+        <source>Unit to show amounts in. Click to select another unit.</source>
+        <translation type="unfinished">Yunit na ipakita sa mga halaga. Mag-click para pumili ng ibang yunit.</translation>
+    </message>
+</context>
+<context>
+    <name>CoinControlDialog</name>
+    <message>
+        <source>Coin Selection</source>
+        <translation type="unfinished">Pagpipilian ng ♦coin♦</translation>
+    </message>
+    <message>
+        <source>Quantity:</source>
+        <translation type="unfinished">Dami:</translation>
+    </message>
+    <message>
+        <source>Bytes:</source>
+        <translation type="unfinished">♦Bytes♦:</translation>
+    </message>
+    <message>
+        <source>Amount:</source>
+        <translation type="unfinished">Halaga:</translation>
+    </message>
+    <message>
+        <source>Fee:</source>
+        <translation type="unfinished">Bayad:</translation>
+    </message>
+    <message>
+        <source>Dust:</source>
+        <translation type="unfinished">Alikabok:</translation>
+    </message>
+    <message>
+        <source>After Fee:</source>
+        <translation type="unfinished">Pagkatapos na Bayad:</translation>
+    </message>
+    <message>
+        <source>Change:</source>
+        <translation type="unfinished">Sukli:</translation>
+    </message>
+    <message>
+        <source>(un)select all</source>
+        <translation type="unfinished">i-(un)select lahat</translation>
+    </message>
+    <message>
+        <source>Tree mode</source>
+        <translation type="unfinished">♦Tree mode♦</translation>
+    </message>
+    <message>
+        <source>List mode</source>
+        <translation type="unfinished">Listajhan na ♦mode♦</translation>
+    </message>
+    <message>
+        <source>Amount</source>
+        <translation type="unfinished">Halaga</translation>
+    </message>
+    <message>
+        <source>Received with label</source>
+        <translation type="unfinished">Natanggap na may kasamang ♦tatak♦</translation>
+    </message>
+    <message>
+        <source>Received with address</source>
+        <translation type="unfinished">Natanggap na may ♦address♦</translation>
+    </message>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">Petsa</translation>
+    </message>
+    <message>
+        <source>Confirmations</source>
+        <translation type="unfinished">Mga kumpirmasyon</translation>
+    </message>
+    <message>
+        <source>Confirmed</source>
+        <translation type="unfinished">Nakumpirma</translation>
+    </message>
+    <message>
+        <source>Copy amount</source>
+        <translation type="unfinished">Kopyahin ang halaga</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Kopyahin ang ♦address♦</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">&amp;Kopyahin ang &amp;tatak</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Kopyahin ang &amp;halaga</translation>
+    </message>
+    <message>
+        <source>L&amp;ock unspent</source>
+        <translation type="unfinished">&amp;I-lock ang hindi nagastos</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock unspent</source>
+        <translation type="unfinished">&amp;I-unlock ang hindi nagastos</translation>
+    </message>
+    <message>
+        <source>Copy quantity</source>
+        <translation type="unfinished">Kopyahin ang dami</translation>
+    </message>
+    <message>
+        <source>Copy fee</source>
+        <translation type="unfinished">Bayad sa pagkopya</translation>
+    </message>
+    <message>
+        <source>Copy after fee</source>
+        <translation type="unfinished">Kopyahin pagkatapos ang bayad</translation>
+    </message>
+    <message>
+        <source>Copy bytes</source>
+        <translation type="unfinished">Kopyahin ang ♦bytes♦</translation>
+    </message>
+    <message>
+        <source>Copy dust</source>
+        <translation type="unfinished">Kopyahin ang ♦dust♦</translation>
+    </message>
+    <message>
+        <source>Copy change</source>
+        <translation type="unfinished">Kopyahin ang pagbabago</translation>
+    </message>
+    <message>
+        <source>(%1 locked)</source>
+        <translation type="unfinished">(%1 naka-lock)</translation>
+    </message>
+    <message>
+        <source>yes</source>
+        <translation type="unfinished">oo</translation>
+    </message>
+    <message>
+        <source>no</source>
+        <translation type="unfinished">hindi</translation>
+    </message>
+    <message>
+        <source>This label turns red if any recipient receives an amount smaller than the current dust threshold.</source>
+        <translation type="unfinished">Ang tatak na ito ay nagiging pula kung ang sinomang tatanggap ay tatanggap ng halaga na mas maliit  sa kasalukuyang ♦dust threshold♦</translation>
+    </message>
+    <message>
+        <source>Can vary +/- %1 satoshi(s) per input.</source>
+        <translation type="unfinished">Maaaring magbago ng +/- %1♦4satoshi(s)♦ kada ♦input♦.</translation>
+    </message>
+    <message>
+        <source>(no label)</source>
+        <translation type="unfinished">(walang tatak)</translation>
+    </message>
+    <message>
+        <source>change from %1 (%2)</source>
+        <translation type="unfinished">ang pagbabago ay mula sa %1 (%2)</translation>
+    </message>
+    <message>
+        <source>(change)</source>
+        <translation type="unfinished">(pagbabago)</translation>
+    </message>
+</context>
+<context>
+    <name>CreateWalletActivity</name>
+    <message>
+        <source>Create Wallet</source>
+        <extracomment>Title of window indicating the progress of creation of a new wallet.</extracomment>
+        <translation type="unfinished">Gumawa ng pitaka</translation>
+    </message>
+    <message>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the create wallet progress window which indicates to the user which wallet is currently being created.</extracomment>
+        <translation type="unfinished">Paggawa ng Pitaka &lt;b&gt;%1&lt;/b&gt;…</translation>
+    </message>
+    <message>
+        <source>Create wallet failed</source>
+        <translation type="unfinished">Ang paggawa ng pitaka ay nabigo</translation>
+    </message>
+    <message>
+        <source>Create wallet warning</source>
+        <translation type="unfinished">Babala sa paggawa ng pitaka</translation>
+    </message>
+    <message>
+        <source>Can't list signers</source>
+        <translation type="unfinished">Hindi mailista ang mga tagapirma</translation>
+    </message>
+    </context>
+<context>
+    <name>OpenWalletActivity</name>
+    <message>
+        <source>Open wallet failed</source>
+        <translation type="unfinished">Pagbukas ng pitaka ay nabigo</translation>
+    </message>
+    <message>
+        <source>Open wallet warning</source>
+        <translation type="unfinished">Babala sa pagbukas ng pitaka</translation>
+    </message>
+    <message>
+        <source>default wallet</source>
+        <translation type="unfinished">pitaka na ♦default♦</translation>
+    </message>
+    <message>
+        <source>Open Wallet</source>
+        <extracomment>Title of window indicating the progress of opening of a wallet.</extracomment>
+        <translation type="unfinished">Buksan ang pitaka</translation>
+    </message>
+    <message>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the open wallet progress window which indicates to the user which wallet is currently being opened.</extracomment>
+        <translation type="unfinished">Pagbukas sa Pitaka &lt;b&gt;%1&lt;/b&gt;…</translation>
+    </message>
+</context>
+<context>
+    <name>WalletController</name>
+    <message>
+        <source>Close wallet</source>
+        <translation type="unfinished">Isarado ang pitaka</translation>
+    </message>
+    <message>
+        <source>Are you sure you wish to close the wallet &lt;i&gt;%1&lt;/i&gt;?</source>
+        <translation type="unfinished">Sigurado ka ba na gusto mong isarado ang pitaka &lt;i&gt;%1&lt;/i&gt;?</translation>
+    </message>
+    <message>
+        <source>Closing the wallet for too long can result in having to resync the entire chain if pruning is enabled.</source>
+        <translation type="unfinished">Ang pagsasarod sa pitaka sa matagal ay maaaring humantong sa pag-resync ng kabuuang ♦chain♦ kung ang pagputol ay na-enable.</translation>
+    </message>
+    <message>
+        <source>Close all wallets</source>
+        <translation type="unfinished">Isarado ang lahat na mga pitaka</translation>
+    </message>
+    <message>
+        <source>Are you sure you wish to close all wallets?</source>
+        <translation type="unfinished">Sigurado ka ba na gusto mong isarado lahat ng mga pitaka?
+</translation>
+    </message>
+</context>
+<context>
+    <name>CreateWalletDialog</name>
+    <message>
+        <source>Create Wallet</source>
+        <translation type="unfinished">Gumawa ng pitaka</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <translation type="unfinished">Pangalan ng pitaka</translation>
+    </message>
+    <message>
+        <source>Wallet</source>
+        <translation type="unfinished">Pitaka</translation>
+    </message>
+    <message>
+        <source>Encrypt the wallet. The wallet will be encrypted with a passphrase of your choice.</source>
+        <translation type="unfinished">I-encrypt ang pitaka. Ang pitaka ay mae-encrypt na may ♦passphrase♦ ng iyong mapipili.</translation>
+    </message>
+    <message>
+        <source>Encrypt Wallet</source>
+        <translation type="unfinished">I-encrypt ang pitaka</translation>
+    </message>
+    <message>
+        <source>Advanced Options</source>
+        <translation type="unfinished">Mga Pagpipilian sa pagsulong</translation>
+    </message>
+    <message>
+        <source>Disable private keys for this wallet. Wallets with private keys disabled will have no private keys and cannot have an HD seed or imported private keys. This is ideal for watch-only wallets.</source>
+        <translation type="unfinished">I-disable ang mga pribadong mga susi para sa pitaka na ito. Ang mga pitaka na may mga pribadong mga susi na na-disable ay mawawalng ng pribadong mga susi at hindi magkakaroon ng ♦HD seed♦ o mga na-import na pribadong mga susi. Ito ay perpekto lamang para sa mga ♦watch-only♦ na mga pitaka.</translation>
+    </message>
+    <message>
+        <source>Disable Private Keys</source>
+        <translation type="unfinished">I-disable ang Pribadong mga Susi</translation>
+    </message>
+    <message>
+        <source>Make a blank wallet. Blank wallets do not initially have private keys or scripts. Private keys and addresses can be imported, or an HD seed can be set, at a later time.</source>
+        <translation type="unfinished">Gumawa ng blankong pitaka. Ang blankong mga pitaka hindi muna nagkakaroon ng pribadong mga susi o mga ♦script♦. Ang pribadong mga susi at mga ♦address♦ ay pwedeng ma-import, o ang ♦HD seed♦ ay pwedeng mai-set, mamaya.</translation>
+    </message>
+    <message>
+        <source>Make Blank Wallet</source>
+        <translation type="unfinished">Gumawa ng Blankong Pitaka</translation>
+    </message>
+    <message>
+        <source>Use descriptors for scriptPubKey management</source>
+        <translation type="unfinished">Gumawa ng  mga ♦descriptors♦ para sa pamamahala sa ♦scriptPubKey♦</translation>
+    </message>
+    <message>
+        <source>Descriptor Wallet</source>
+        <translation type="unfinished">♦Descriptor♦ na pitaka</translation>
+    </message>
+    <message>
+        <source>Use an external signing device such as a hardware wallet. Configure the external signer script in wallet preferences first.</source>
+        <translation type="unfinished">Gumamit ng panlabas na pagpirmang ♦device♦ katulad ng ♦hardware♦ na pitaka. I-configure ang panlabas na ♦signer script♦ sa loob ng ♦preferences♦ ng pitaka n listahan. </translation>
+    </message>
+    <message>
+        <source>External signer</source>
+        <translation type="unfinished">Panlabas na ♦signer♦</translation>
+    </message>
+    <message>
+        <source>Create</source>
+        <translation type="unfinished">Gumawa</translation>
+    </message>
+    <message>
+        <source>Compiled without sqlite support (required for descriptor wallets)</source>
+        <translation type="unfinished">Pinagsama-sama na walang suporta ng ♦sqlite♦ (kailangan para sa ♦descriptor♦ na pitaka)</translation>
+    </message>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Pinagsama-sama na walang suporta ng ♦pag-pirma♦ (kailangan para sa panlabasna pagpirma)</translation>
+    </message>
+</context>
+<context>
+    <name>EditAddressDialog</name>
+    <message>
+        <source>Edit Address</source>
+        <translation type="unfinished">I-edit ang ♦address♦</translation>
+    </message>
+    <message>
+        <source>&amp;Label</source>
+        <translation type="unfinished">&amp;Tatak</translation>
+    </message>
+    <message>
+        <source>The label associated with this address list entry</source>
+        <translation type="unfinished">Ang tatak na nauugnay sa ♦entry♦ ng listahan ng ♦address♦</translation>
+    </message>
+    <message>
+        <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
+        <translation type="unfinished">Ang ♦address♦ na may kaugnayan sa ipinasok sa listahan ng ♦address♦. Ito ay maaari lamang ng mabago para sa pagpapadalhan na mga ♦address♦.</translation>
+    </message>
+    <message>
+        <source>&amp;Address</source>
+        <translation type="unfinished">&amp;♦Address♦</translation>
+    </message>
+    <message>
+        <source>New sending address</source>
+        <translation type="unfinished">Bagong pagpapadalhan na ♦address♦</translation>
+    </message>
+    <message>
+        <source>Edit receiving address</source>
+        <translation type="unfinished">I-edit ang pagtatanggapang ♦address♦</translation>
+    </message>
+    <message>
+        <source>Edit sending address</source>
+        <translation type="unfinished">I-edit ang pagpapadalhan na ♦address♦</translation>
+    </message>
+    <message>
+        <source>The entered address "%1" is not a valid Bitcoin address.</source>
+        <translation type="unfinished">Ang naipasok na ♦address♦ "%1" ay hindi wasto na ♦Bitcoin address♦.</translation>
+    </message>
+    <message>
+        <source>Address "%1" already exists as a receiving address with label "%2" and so cannot be added as a sending address.</source>
+        <translation type="unfinished">Ang ♦Address♦ "%1" ay mayroon na bilang pagtatanggapang ♦address♦ na may tatak "%2" kaya hindi na maaaring maidagdag bilang pagpapadalhan na ♦address♦.</translation>
+    </message>
+    <message>
+        <source>The entered address "%1" is already in the address book with label "%2".</source>
+        <translation type="unfinished">Ang naipasok na ♦address♦ "%1" ay nasa aklat na ng ♦address♦ na may tatak "%2".</translation>
+    </message>
+    <message>
+        <source>Could not unlock wallet.</source>
+        <translation type="unfinished">Hindi maaaring ma-unlock ang pitaka.</translation>
+    </message>
+    <message>
+        <source>New key generation failed.</source>
+        <translation type="unfinished">Ang Bagong susi sa ♦generation♦ ay nabigo.</translation>
+    </message>
+</context>
+<context>
+    <name>FreespaceChecker</name>
+    <message>
+        <source>A new data directory will be created.</source>
+        <translation type="unfinished">May bagong datos na ♦directory♦ ay magagawa.</translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished">pangalan</translation>
+    </message>
+    <message>
+        <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
+        <translation type="unfinished">Ang ♦directory♦ ay mayroon na. Magdagdag ng%1kung balak mong gumawa ng bagong ♦directory♦ dito.</translation>
+    </message>
+    <message>
+        <source>Path already exists, and is not a directory.</source>
+        <translation type="unfinished">Ang ♦path♦ ay mayroon na, at hindi ♦directory♦.</translation>
+    </message>
+    <message>
+        <source>Cannot create data directory here.</source>
+        <translation type="unfinished">Hindi makakagawa ng datos na ♦directory♦ dito.</translation>
+    </message>
+</context>
+<context>
+    <name>Intro</name>
+    <message>
+        <source>Bitcoin</source>
+        <translation type="unfinished">♦Bitcoin♦</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message>
+        <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
+        <translation type="unfinished">Hindi bababa sa %1 ng ♦GB♦ na dato ay mailalagay sa ♦directory♦, at lalaki sa paglipas ng panahon.</translation>
+    </message>
+    <message numerus="yes">
+        <source>(sufficient to restore backups %n day(s) old)</source>
+        <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Nagkamali</translation>
+    </message>
+    <message>
+        <source>Welcome</source>
+        <translation type="unfinished">Maligayang Pagdating</translation>
+    </message>
+    </context>
+<context>
+    <name>HelpMessageDialog</name>
+    <message>
+        <source>version</source>
+        <translation type="unfinished">bersyon</translation>
+    </message>
+    </context>
+<context>
+    <name>ShutdownWindow</name>
+    <message>
+        <source>Do not shut down the computer until this window disappears.</source>
+        <translation type="unfinished">Huwag Patayin ang inyong kompyuter hanggang mawala ang window na ito.</translation>
+    </message>
+</context>
+<context>
+    <name>OptionsDialog</name>
+    <message>
+        <source>&amp;Main</source>
+        <translation type="unfinished">&amp;♦Main♦</translation>
+    </message>
+    <message>
+        <source>&amp;Start %1 on system login</source>
+        <translation type="unfinished">&amp;Simulan %1 sa pag-login sa sistema</translation>
+    </message>
+    <message>
+        <source>Size of &amp;database cache</source>
+        <translation type="unfinished">Laki ng &amp;♦database cache♦</translation>
+    </message>
+    <message>
+        <source>Number of script &amp;verification threads</source>
+        <translation type="unfinished">Bilang ng ♦script♦ &amp;pagpapatunay na mga ♦threads♦</translation>
+    </message>
+    <message>
+        <source>&amp;Reset Options</source>
+        <translation type="unfinished">Mga pagpipilian sa &amp;Pag-reset</translation>
+    </message>
+    <message>
+        <source>&amp;Network</source>
+        <translation type="unfinished">&amp;♦Network♦</translation>
+    </message>
+    <message>
+        <source>Prune &amp;block storage to</source>
+        <translation type="unfinished">Putulan &amp;i-block ang imbakan sa</translation>
+    </message>
+    <message>
+        <source>W&amp;allet</source>
+        <translation type="unfinished">&amp;Pitaka</translation>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation type="unfinished">I-enable ang pag-control na mga tampok ng ♦coin♦ </translation>
+    </message>
+    <message>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation type="unfinished">&amp;Gumastos ng hindi nakumpirmang pagbabago</translation>
+    </message>
+    <message>
+        <source>&amp;External signer script path</source>
+        <translation type="unfinished">&amp;Panlabas na ♦signer script♦ na daanan</translation>
+    </message>
+    <message>
+        <source>Map port using &amp;UPnP</source>
+        <translation type="unfinished">♦Port♦ ng mapa gamit ang &amp;♦UPnP♦</translation>
+    </message>
+    <message>
+        <source>Map port using NA&amp;T-PMP</source>
+        <translation type="unfinished">♦Port♦ ng mapa gamit ang NA&amp;T-PMP</translation>
+    </message>
+    <message>
+        <source>Allow incomin&amp;g connections</source>
+        <translation type="unfinished">Pahintulutan ang paparating na mga &amp;koneksyon</translation>
+    </message>
+    <message>
+        <source>&amp;Connect through SOCKS5 proxy (default proxy):</source>
+        <translation type="unfinished">&amp;Kumonketa sa pamamagitan ng ♦SOCKS5 proxy (default proxy)♦:</translation>
+    </message>
+    <message>
+        <source>&amp;Window</source>
+        <translation type="unfinished">&amp;♦Window♦</translation>
+    </message>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Pinagsama-sama na walang suporta ng ♦pag-pirma♦ (kailangan para sa panlabasna pagpirma)</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Nagkamali</translation>
+    </message>
+    </context>
+<context>
+    <name>PeerTableModel</name>
+    <message>
+        <source>Address</source>
+        <extracomment>Title of Peers Table column which contains the IP/Onion/I2P address of the connected peer.</extracomment>
+        <translation type="unfinished">♦Address♦</translation>
+    </message>
+    </context>
+<context>
+    <name>RPCConsole</name>
+    <message>
+        <source>Node window</source>
+        <translation type="unfinished">♦Node window♦</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <extracomment>Context menu action to copy the address of a peer.</extracomment>
+        <translation type="unfinished">&amp;Kopyahin ang ♦address♦</translation>
+    </message>
+    </context>
+<context>
+    <name>ReceiveCoinsDialog</name>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Kopyahin ang ♦address♦</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">&amp;Kopyahin ang &amp;tatak</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Kopyahin ang &amp;halaga</translation>
+    </message>
+    <message>
+        <source>Could not unlock wallet.</source>
+        <translation type="unfinished">Hindi maaaring ma-unlock ang pitaka.</translation>
+    </message>
+    </context>
+<context>
+    <name>ReceiveRequestDialog</name>
+    <message>
+        <source>Amount:</source>
+        <translation type="unfinished">Halaga:</translation>
+    </message>
+    <message>
+        <source>Wallet:</source>
+        <translation type="unfinished">Pitaka:</translation>
+    </message>
+    </context>
+<context>
+    <name>RecentRequestsTableModel</name>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">Petsa</translation>
+    </message>
+    <message>
+        <source>Label</source>
+        <translation type="unfinished">Tatak</translation>
+    </message>
+    <message>
+        <source>(no label)</source>
+        <translation type="unfinished">(walang tatak)</translation>
+    </message>
+    </context>
+<context>
+    <name>SendCoinsDialog</name>
+    <message>
+        <source>Quantity:</source>
+        <translation type="unfinished">Dami:</translation>
+    </message>
+    <message>
+        <source>Bytes:</source>
+        <translation type="unfinished">♦Bytes♦:</translation>
+    </message>
+    <message>
+        <source>Amount:</source>
+        <translation type="unfinished">Halaga:</translation>
+    </message>
+    <message>
+        <source>Fee:</source>
+        <translation type="unfinished">Bayad:</translation>
+    </message>
+    <message>
+        <source>After Fee:</source>
+        <translation type="unfinished">Pagkatapos na Bayad:</translation>
+    </message>
+    <message>
+        <source>Change:</source>
+        <translation type="unfinished">Sukli:</translation>
+    </message>
+    <message>
+        <source>Dust:</source>
+        <translation type="unfinished">Alikabok:</translation>
+    </message>
+    <message>
+        <source>Copy quantity</source>
+        <translation type="unfinished">Kopyahin ang dami</translation>
+    </message>
+    <message>
+        <source>Copy amount</source>
+        <translation type="unfinished">Kopyahin ang halaga</translation>
+    </message>
+    <message>
+        <source>Copy fee</source>
+        <translation type="unfinished">Bayad sa pagkopya</translation>
+    </message>
+    <message>
+        <source>Copy after fee</source>
+        <translation type="unfinished">Kopyahin pagkatapos ang bayad</translation>
+    </message>
+    <message>
+        <source>Copy bytes</source>
+        <translation type="unfinished">Kopyahin ang ♦bytes♦</translation>
+    </message>
+    <message>
+        <source>Copy dust</source>
+        <translation type="unfinished">Kopyahin ang ♦dust♦</translation>
+    </message>
+    <message>
+        <source>Copy change</source>
+        <translation type="unfinished">Kopyahin ang pagbabago</translation>
+    </message>
+    <message numerus="yes">
+        <source>Estimated to begin confirmation within %n block(s).</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message>
+        <source>(no label)</source>
+        <translation type="unfinished">(walang tatak)</translation>
+    </message>
+</context>
+<context>
+    <name>TransactionDesc</name>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">Petsa</translation>
+    </message>
+    <message numerus="yes">
+        <source>matures in %n more block(s)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message>
+        <source>Amount</source>
+        <translation type="unfinished">Halaga</translation>
+    </message>
+    </context>
+<context>
+    <name>TransactionTableModel</name>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">Petsa</translation>
+    </message>
+    <message>
+        <source>Label</source>
+        <translation type="unfinished">Tatak</translation>
+    </message>
+    <message>
+        <source>(no label)</source>
+        <translation type="unfinished">(walang tatak)</translation>
+    </message>
+    </context>
+<context>
+    <name>TransactionView</name>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Kopyahin ang ♦address♦</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">&amp;Kopyahin ang &amp;tatak</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">Kopyahin ang &amp;halaga</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">Kopyahin ang transaksyon  ng &amp;♦ID♦</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">Kuwir hiwalay na file</translation>
+    </message>
+    <message>
+        <source>Confirmed</source>
+        <translation type="unfinished">Nakumpirma</translation>
+    </message>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">Petsa</translation>
+    </message>
+    <message>
+        <source>Label</source>
+        <translation type="unfinished">Tatak</translation>
+    </message>
+    <message>
+        <source>Address</source>
+        <translation type="unfinished">♦Address♦</translation>
+    </message>
+    <message>
+        <source>Exporting Failed</source>
+        <translation type="unfinished">Ang pag-export ay Nabigo</translation>
+    </message>
+    </context>
+<context>
+    <name>WalletFrame</name>
+    <message>
+        <source>Create a new wallet</source>
+        <translation type="unfinished">Gumawa ng bagong pitaka</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Nagkamali</translation>
+    </message>
+    </context>
+<context>
+    <name>WalletModel</name>
+    <message>
+        <source>default wallet</source>
+        <translation type="unfinished">pitaka na ♦default♦</translation>
+    </message>
+</context>
+<context>
+    <name>WalletView</name>
+    <message>
+        <source>&amp;Export</source>
+        <translation type="unfinished">&amp;I-export</translation>
+    </message>
+    <message>
+        <source>Export the data in the current tab to a file</source>
+        <translation type="unfinished">I-export ang datos sa kasalukuyang ♦tab♦ sa isang file</translation>
+    </message>
+    </context>
+</TS>

--- a/src/qt/locale/bitcoin_tr.ts
+++ b/src/qt/locale/bitcoin_tr.ts
@@ -150,7 +150,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
-        <translation type="unfinished">Bu işlemi yapabilmek için cüzdan parolanızı girmeniz gerekmektedir
+        <translation type="unfinished">kilidi açmakparolaBu işlemi yapabilmek için cüzdan parolanızı girmeniz gerekmektedir
 Cüzdan kilidini aç.</translation>
     </message>
     <message>
@@ -247,6 +247,10 @@ Cüzdan kilidini aç.</translation>
 </context>
 <context>
     <name>BitcoinApplication</name>
+    <message>
+        <source>Settings file %1 might be corrupt or invalid.</source>
+        <translation type="unfinished">%1 ayar dosyası bozuk veya geçersiz olabilir.</translation>
+    </message>
     <message>
         <source>Runaway exception</source>
         <translation type="unfinished">Sızıntı istisnası</translation>
@@ -360,7 +364,7 @@ Cüzdan kilidini aç.</translation>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
-            <numerusform>%ngün</numerusform>
+            <numerusform>%n gün</numerusform>
         </translation>
     </message>
     <message numerus="yes">
@@ -411,12 +415,16 @@ Cüzdan kilidini aç.</translation>
         <translation type="unfinished">%s dosyasının okunması sırasında bir hata meydana geldi! Tüm anahtarlar doğru bir şekilde okundu, ancak işlem verileri ya da adres defteri ögeleri hatalı veya eksik olabilir.</translation>
     </message>
     <message>
-        <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
-        <translation type="unfinished">Hata: İçeri gelen bağlantıların dinlenmesi başarısız oldu (dinleme %s hatasını verdi)</translation>
+        <source>Error reading %s! Transaction data may be missing or incorrect. Rescanning wallet.</source>
+        <translation type="unfinished">%s okuma hatası! İşlem verileri eksik veya yanlış olabilir. Cüzdan yeniden taranıyor.</translation>
     </message>
     <message>
         <source>Invalid amount for -maxtxfee=&lt;amount&gt;: '%s' (must be at least the minrelay fee of %s to prevent stuck transactions)</source>
         <translation type="unfinished">-maxtxfee=&lt;tutar&gt; için geçersiz tutar: '%s' (Sıkışmış işlemleri önlemek için en az %s değerinde en düşük aktarım ücretine eşit olmalıdır)</translation>
+    </message>
+    <message>
+        <source>Invalid or corrupt peers.dat (%s). If you believe this is a bug, please report it to %s. As a workaround, you can move the file (%s) out of the way (rename, move, or delete) to have a new one created on the next start.</source>
+        <translation type="unfinished">Geçersiz veya bozuk peers.dat (%s). Bunun bir hata olduğunu düşünüyorsanız, lütfen %s'e bildirin. Geçici bir çözüm olarak, bir sonraki başlangıçta yeni bir dosya oluşturmak için dosyayı (%s) yoldan çekebilirsiniz (yeniden adlandırabilir, taşıyabilir veya silebilirsiniz).</translation>
     </message>
     <message>
         <source>Please check that your computer's date and time are correct! If your clock is wrong, %s will not work properly.</source>
@@ -437,6 +445,10 @@ Cüzdan kilidini aç.</translation>
     <message>
         <source>The block database contains a block which appears to be from the future. This may be due to your computer's date and time being set incorrectly. Only rebuild the block database if you are sure that your computer's date and time are correct</source>
         <translation type="unfinished">Blok veritabanı gelecekten gibi görünen bir blok içermektedir. Bu, bilgisayarınızın saat ve tarihinin yanlış ayarlanmış olmasından kaynaklanabilir. Blok veritabanını sadece bilgisayarınızın tarih ve saatinin doğru olduğundan eminseniz yeniden derleyin.</translation>
+    </message>
+    <message>
+        <source>The block index db contains a legacy 'txindex'. To clear the occupied disk space, run a full -reindex, otherwise ignore this error. This error message will not be displayed again.</source>
+        <translation type="unfinished">Blok dizini db, eski bir 'txindex' içerir. Dolu disk alanını temizlemek için full -reindex çalıştırın, aksi takdirde bu hatayı yok sayın. Bu hata mesajı tekrar görüntülenmeyecek.</translation>
     </message>
     <message>
         <source>The transaction amount is too small to send after the fee has been deducted</source>
@@ -475,8 +487,32 @@ Cüzdan kilidini aç.</translation>
         <translation type="unfinished">Çözümlenemedi - %s adres: '%s'</translation>
     </message>
     <message>
+        <source>Cannot set -forcednsseed to true when setting -dnsseed to false.</source>
+        <translation type="unfinished">-dnsseed false olarak ayarlanırken -forcednsseed true olarak ayarlanamıyor.</translation>
+    </message>
+    <message>
         <source>Cannot write to data directory '%s'; check permissions.</source>
         <translation type="unfinished">Veriler '%s' klasörüne yazılamıyor ; yetkilendirmeyi kontrol edin.</translation>
+    </message>
+    <message>
+        <source>The -txindex upgrade started by a previous version cannot be completed. Restart with the previous version or run a full -reindex.</source>
+        <translation type="unfinished">Önceki bir sürüm tarafından başlatılan -txindex yükseltmesi tamamlanamaz. Önceki sürümle yeniden başlatın veya full -reindex çalıştırın.</translation>
+    </message>
+    <message>
+        <source>%s request to listen on port %u. This port is considered "bad" and thus it is unlikely that any Bitcoin Core peers connect to it. See doc/p2p-bad-ports.md for details and a full list.</source>
+        <translation type="unfinished">%s, %u bağlantı noktasında dinleme isteğinde bulunur. Bu bağlantı noktası "kötü" olarak kabul edilir ve bu nedenle, herhangi bir Bitcoin Core eşinin ona bağlanması olası değildir. Ayrıntılar ve tam liste için doc/p2p-bad-ports.md'ye bakın.</translation>
+    </message>
+    <message>
+        <source>Cannot provide specific connections and have addrman find outgoing connections at the same time.</source>
+        <translation type="unfinished">Belirli bağlantılar sağlayamaz ve aynı anda addrman'ın giden bağlantıları bulmasını sağlayamaz.</translation>
+    </message>
+    <message>
+        <source>Error loading %s: External signer wallet being loaded without external signer support compiled</source>
+        <translation type="unfinished">%s yüklenirken hata oluştu: Harici imzalayan cüzdanı derlenmiş harici imzalayan desteği olmadan yükleniyor</translation>
+    </message>
+    <message>
+        <source>Failed to rename invalid peers.dat file. Please move or delete it and try again.</source>
+        <translation type="unfinished">Geçersiz peers.dat dosyası yeniden adlandırılamadı. Lütfen taşıyın veya silin ve tekrar deneyin.</translation>
     </message>
     <message>
         <source>Copyright (C) %i-%i</source>
@@ -531,10 +567,6 @@ Cüzdan kilidini aç.</translation>
         <translation type="unfinished">Veritabanı okuma hatası, program kapatılıyor.</translation>
     </message>
     <message>
-        <source>Error upgrading chainstate database</source>
-        <translation type="unfinished">Zincirdurumu veritabanı yükseltme hatası</translation>
-    </message>
-    <message>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished">Herhangi bir portun dinlenmesi başarısız oldu. Bunu istiyorsanız -listen=0 seçeneğini kullanınız.</translation>
     </message>
@@ -557,6 +589,10 @@ Cüzdan kilidini aç.</translation>
     <message>
         <source>Initialization sanity check failed. %s is shutting down.</source>
         <translation type="unfinished">Başlatma sınaması başarısız oldu. %s kapatılıyor.</translation>
+    </message>
+    <message>
+        <source>Input not found or already spent</source>
+        <translation type="unfinished">Girdi bulunamadı veya zaten harcandı</translation>
     </message>
     <message>
         <source>Insufficient funds</source>
@@ -609,6 +645,10 @@ Cüzdan kilidini aç.</translation>
     <message>
         <source>Missing amount</source>
         <translation type="unfinished">Eksik tutar</translation>
+    </message>
+    <message>
+        <source>Missing solving data for estimating transaction size</source>
+        <translation type="unfinished">İşlem boyutunu tahmin etmek için çözümleme verileri eksik</translation>
     </message>
     <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
@@ -687,6 +727,10 @@ Cüzdan kilidini aç.</translation>
         <translation type="unfinished">İşlem tutarı negatif olmamalıdır.</translation>
     </message>
     <message>
+        <source>Transaction change output index out of range</source>
+        <translation type="unfinished">İşlem değişikliği çıktı endeksi aralık dışında</translation>
+    </message>
+    <message>
         <source>Transaction has too long of a mempool chain</source>
         <translation type="unfinished">İşlem çok uzun bir mempool zincirine sahip</translation>
     </message>
@@ -695,8 +739,16 @@ Cüzdan kilidini aç.</translation>
         <translation type="unfinished">İşlem en az bir adet alıcıya sahip olmalı.</translation>
     </message>
     <message>
+        <source>Transaction needs a change address, but we can't generate it.</source>
+        <translation type="unfinished">İşlemin bir değişiklik adresine ihtiyacı var, ancak bunu oluşturamıyoruz.</translation>
+    </message>
+    <message>
         <source>Transaction too large</source>
         <translation type="unfinished">İşlem çok büyük</translation>
+    </message>
+    <message>
+        <source>Unable to allocate memory for -maxsigcachesize: '%s' MiB</source>
+        <translation type="unfinished">-maxsigcachesize: ' %s' MiB için bellek konumlandırılamıyor.</translation>
     </message>
     <message>
         <source>Unable to bind to %s on this computer (bind returned error %s)</source>
@@ -707,12 +759,20 @@ Cüzdan kilidini aç.</translation>
         <translation type="unfinished">Bu bilgisayarda %s unsuruna bağlanılamadı. %s muhtemelen hâlihazırda çalışmaktadır.</translation>
     </message>
     <message>
+        <source>Unable to find UTXO for external input</source>
+        <translation type="unfinished">Harici giriş için UTXO bulunamıyor.</translation>
+    </message>
+    <message>
         <source>Unable to generate initial keys</source>
         <translation type="unfinished">Başlangıç anahtarları üretilemiyor</translation>
     </message>
     <message>
         <source>Unable to generate keys</source>
         <translation type="unfinished">Anahtarlar oluşturulamıyor</translation>
+    </message>
+    <message>
+        <source>Unable to parse -maxuploadtarget: '%s'</source>
+        <translation type="unfinished">-maxuploadtarget ayrıştırılamıyor: '%s'</translation>
     </message>
     <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
@@ -729,10 +789,6 @@ Cüzdan kilidini aç.</translation>
     <message>
         <source>Unsupported logging category %s=%s.</source>
         <translation type="unfinished">Desteklenmeyen günlük kategorisi %s=%s.</translation>
-    </message>
-    <message>
-        <source>Upgrading UTXO database</source>
-        <translation type="unfinished">UTXO veritabanı yükseltiliyor</translation>
     </message>
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
@@ -941,7 +997,7 @@ Cüzdan kilidini aç.</translation>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>İşlem geçmişinin %n bloğu işlendi.</numerusform>
         </translation>
     </message>
     <message>
@@ -1017,6 +1073,16 @@ Cüzdan kilidini aç.</translation>
         <translation type="unfinished">Cüzdan kapat</translation>
     </message>
     <message>
+        <source>Restore Wallet…</source>
+        <extracomment>Name of the menu item that restores wallet from a backup file.</extracomment>
+        <translation type="unfinished">Cüzdanı Geri Yükle...</translation>
+    </message>
+    <message>
+        <source>Restore a wallet from a backup file</source>
+        <extracomment>Status tip for Restore Wallet menu item</extracomment>
+        <translation type="unfinished">Yedekleme dosyasından bir cüzdanı geri yükle</translation>
+    </message>
+    <message>
         <source>Close all wallets</source>
         <translation type="unfinished">Tüm cüzdanları kapat</translation>
     </message>
@@ -1035,6 +1101,26 @@ Cüzdan kilidini aç.</translation>
     <message>
         <source>No wallets available</source>
         <translation type="unfinished">Erişilebilir cüzdan yok</translation>
+    </message>
+    <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">Cüzdan Verisi</translation>
+    </message>
+    <message>
+        <source>Load Wallet Backup</source>
+        <extracomment>The title for Restore Wallet File Windows</extracomment>
+        <translation type="unfinished">Cüzdan Yedeği Yükle</translation>
+    </message>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of pop-up window shown when the user is attempting to restore a wallet.</extracomment>
+        <translation type="unfinished">Cüzdanı Geri Yükle</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">Cüzdan İsmi</translation>
     </message>
     <message>
         <source>&amp;Window</source>
@@ -1064,7 +1150,7 @@ Cüzdan kilidini aç.</translation>
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>Bitcoin ağına %n etkin bağlantı.</numerusform>
         </translation>
     </message>
     <message>
@@ -1081,6 +1167,10 @@ Cüzdan kilidini aç.</translation>
         <source>Enable network activity</source>
         <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
         <translation type="unfinished">Ağ etkinliğini etkinleştir</translation>
+    </message>
+    <message>
+        <source>Pre-syncing Headers (%1%)…</source>
+        <translation type="unfinished">Üstbilgiler senkronize ediliyor (%1%)...</translation>
     </message>
     <message>
         <source>Error: %1</source>
@@ -1168,10 +1258,6 @@ Cüzdan kilidini aç.</translation>
 </context>
 <context>
     <name>CoinControlDialog</name>
-    <message>
-        <source>Coin Selection</source>
-        <translation type="unfinished">Koin Seçimi</translation>
-    </message>
     <message>
         <source>Quantity:</source>
         <translation type="unfinished">Miktar</translation>
@@ -1333,7 +1419,11 @@ Cüzdan kilidini aç.</translation>
         <source>Create wallet warning</source>
         <translation type="unfinished">Cüzdan oluşturma uyarısı</translation>
     </message>
-    </context>
+    <message>
+        <source>Too many external signers found</source>
+        <translation type="unfinished">Çok fazla harici imzalayan bulundu</translation>
+    </message>
+</context>
 <context>
     <name>LoadWalletsActivity</name>
     <message>
@@ -1370,6 +1460,34 @@ Cüzdan kilidini aç.</translation>
         <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
         <extracomment>Descriptive text of the open wallet progress window which indicates to the user which wallet is currently being opened.</extracomment>
         <translation type="unfinished">Cüzdan açılıyor&lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+</context>
+<context>
+    <name>RestoreWalletActivity</name>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of progress window which is displayed when wallets are being restored.</extracomment>
+        <translation type="unfinished">Cüzdanı Geri Yükle</translation>
+    </message>
+    <message>
+        <source>Restoring Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the restore wallets progress window which indicates to the user that wallets are currently being restored.</extracomment>
+        <translation type="unfinished">Cüzdan Onarılıyor&lt;b&gt;%1&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Restore wallet failed</source>
+        <extracomment>Title of message box which is displayed when the wallet could not be restored.</extracomment>
+        <translation type="unfinished">Cüzdan geri yüklenemedi</translation>
+    </message>
+    <message>
+        <source>Restore wallet warning</source>
+        <extracomment>Title of message box which is displayed when the wallet is restored with some warning.</extracomment>
+        <translation type="unfinished">Cüzdan uyarısını geri yükle</translation>
+    </message>
+    <message>
+        <source>Restore wallet message</source>
+        <extracomment>Title of message box which is displayed when the wallet is successfully restored.</extracomment>
+        <translation type="unfinished">Cüzdan onarım mesajı</translation>
     </message>
 </context>
 <context>
@@ -1522,6 +1640,24 @@ Cüzdan kilidini aç.</translation>
 </context>
 <context>
     <name>Intro</name>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform>%n GB alan kullanılabilir</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform>(gereken %n GB alandan)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform>(%n GB tam zincir için gerekli)</numerusform>
+        </translation>
+    </message>
     <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
         <translation type="unfinished">Bu dizinde en az %1 GB veri depolanacak ve zamanla büyüyecek.</translation>
@@ -1534,7 +1670,7 @@ Cüzdan kilidini aç.</translation>
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>(%n günlük yedekleri geri yüklemek için yeterli)</numerusform>
         </translation>
     </message>
     <message>
@@ -1745,8 +1881,23 @@ Cüzdan kilidini aç.</translation>
         <translation type="unfinished">Bu, sizin veya bir üçüncü taraf aracının komut satırı ve JSON-RPC komutları aracılığıyla düğümle iletişim kurmasına olanak tanır.</translation>
     </message>
     <message>
+        <source>Enable R&amp;PC server</source>
+        <extracomment>An Options window setting to enable the RPC server.</extracomment>
+        <translation type="unfinished">R&amp;PC sunucusunu etkinleştir</translation>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished">&amp;Cüzdan</translation>
+    </message>
+    <message>
+        <source>Whether to set subtract fee from amount as default or not.</source>
+        <extracomment>Tooltip text for Options window setting that sets subtracting the fee from a sending amount as default.</extracomment>
+        <translation type="unfinished">Tutardan çıkarma ücretinin varsayılan olarak ayarlanıp ayarlanmayacağı.</translation>
+    </message>
+    <message>
+        <source>Subtract &amp;fee from amount by default</source>
+        <extracomment>An Options window setting to set subtracting the fee from a sending amount as default.</extracomment>
+        <translation type="unfinished">Varsayılan olarak ücreti tutardan düş</translation>
     </message>
     <message>
         <source>Expert</source>
@@ -1763,6 +1914,16 @@ Cüzdan kilidini aç.</translation>
     <message>
         <source>&amp;Spend unconfirmed change</source>
         <translation type="unfinished">&amp; Onaylanmamış bozuk parayı harcayın</translation>
+    </message>
+    <message>
+        <source>Enable &amp;PSBT controls</source>
+        <extracomment>An options window setting to enable PSBT controls.</extracomment>
+        <translation type="unfinished">PSBT kontrollerini etkinleştir</translation>
+    </message>
+    <message>
+        <source>Whether to show PSBT controls.</source>
+        <extracomment>Tooltip text for options window setting that enables PSBT controls.</extracomment>
+        <translation type="unfinished">PSBT kontrollerinin gösterilip gösterilmeyeceği.</translation>
     </message>
     <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
@@ -1837,6 +1998,10 @@ Cüzdan kilidini aç.</translation>
         <translation type="unfinished">Bitcoin gönderildiğinde arayüzde gösterilecek varsayılan alt birimi seçiniz.</translation>
     </message>
     <message>
+        <source>Third-party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</source>
+        <translation type="unfinished">İşlemler sekmesinde bağlam menüsü unsurları olarak görünen üçüncü taraf bağlantıları (mesela bir blok tarayıcısı). URL'deki %s, işlem hash değeri ile değiştirilecektir. Birden çok bağlantılar düşey çubuklar | ile ayrılacaktır.</translation>
+    </message>
+    <message>
         <source>&amp;Third-party transaction URLs</source>
         <translation type="unfinished">&amp;Üçüncü parti işlem URL'leri</translation>
     </message>
@@ -1870,14 +2035,17 @@ Cüzdan kilidini aç.</translation>
     </message>
     <message>
         <source>Confirm options reset</source>
+        <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
         <translation type="unfinished">Seçenekleri sıfırlamayı onayla</translation>
     </message>
     <message>
         <source>Client restart required to activate changes.</source>
+        <extracomment>Text explaining that the settings changed will not come into effect until the client is restarted.</extracomment>
         <translation type="unfinished">Değişikliklerin uygulanması için istemcinin yeniden başlatılması lazımdır.</translation>
     </message>
     <message>
         <source>Client will be shut down. Do you want to proceed?</source>
+        <extracomment>Text asking the user to confirm if they would like to proceed with a client shutdown.</extracomment>
         <translation type="unfinished">İstemci kapanacaktır. Devam etmek istiyor musunuz?</translation>
     </message>
     <message>
@@ -2129,6 +2297,11 @@ Cüzdan kilidini aç.</translation>
         <translation type="unfinished">Gecikme</translation>
     </message>
     <message>
+        <source>Age</source>
+        <extracomment>Title of Peers Table column which indicates the duration (length of time) since the peer connection started.</extracomment>
+        <translation type="unfinished">Yaş</translation>
+    </message>
+    <message>
         <source>Direction</source>
         <extracomment>Title of Peers Table column which indicates the direction the peer connection was initiated from.</extracomment>
         <translation type="unfinished">Yönlendirme</translation>
@@ -2308,12 +2481,24 @@ Cüzdan kilidini aç.</translation>
         <translation type="unfinished">Son İşlem</translation>
     </message>
     <message>
+        <source>Whether we relay addresses to this peer.</source>
+        <extracomment>Tooltip text for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
+        <translation type="unfinished">Adresleri bu eşe iletip iletemeyeceğimiz.</translation>
+    </message>
+    <message>
         <source>Address Relay</source>
+        <extracomment>Text title for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
         <translation type="unfinished">Adres Aktarımı</translation>
     </message>
     <message>
         <source>Addresses Processed</source>
+        <extracomment>Text title for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
         <translation type="unfinished">Adresler İşlendi</translation>
+    </message>
+    <message>
+        <source>Addresses Rate-Limited</source>
+        <extracomment>Text title for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
+        <translation type="unfinished">Adresler Oran-Sınırlı</translation>
     </message>
     <message>
         <source>User Agent</source>
@@ -2851,6 +3036,11 @@ Cüzdan kilidini aç.</translation>
         <translation type="unfinished">Bu işlemi oluşturmak ister misiniz?</translation>
     </message>
     <message>
+        <source>Please, review your transaction. You can create and send this transaction or create a Partially Signed Bitcoin Transaction (PSBT), which you can save or copy and then sign with, e.g., an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
+        <extracomment>Text to inform a user attempting to create a transaction of their current options. At this stage, a user can send their transaction or create a PSBT. This string is displayed when both private keys and PSBT controls are enabled.</extracomment>
+        <translation type="unfinished">Lütfen işleminizi gözden geçirin. Bu işlemi oluşturabilir ve gönderebilir veya örneğin çevrimdışı bir %1 cüzdanı veya PSBT uyumlu bir donanım cüzdanı gibi kaydedebileceğiniz veya kopyalayabileceğiniz ve ardından imzalayabileceğiniz bir Kısmen İmzalı Bitcoin İşlemi (PSBT) oluşturabilirsiniz.</translation>
+    </message>
+    <message>
         <source>Please, review your transaction.</source>
         <extracomment>Text to prompt a user to review the details of the transaction they are attempting to send.</extracomment>
         <translation type="unfinished">Lütfen işleminizi gözden geçirin.</translation>
@@ -2891,14 +3081,10 @@ Cüzdan kilidini aç.</translation>
         <source>A fee higher than %1 is considered an absurdly high fee.</source>
         <translation type="unfinished">%1 tutarından yüksek bir ücret saçma derecede yüksek bir ücret olarak kabul edilir.</translation>
     </message>
-    <message>
-        <source>Payment request expired.</source>
-        <translation type="unfinished">Ödeme talebinin geçerlilik süresi bitti.</translation>
-    </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>Tahmini %n blok içinde doğrulamaya başlanacaktır.</numerusform>
         </translation>
     </message>
     <message>
@@ -2969,28 +3155,12 @@ Cüzdan kilidini aç.</translation>
         <translation type="unfinished">İleti:</translation>
     </message>
     <message>
-        <source>This is an unauthenticated payment request.</source>
-        <translation type="unfinished">Bu, kimliği doğrulanmamış bir ödeme talebidir.</translation>
-    </message>
-    <message>
-        <source>This is an authenticated payment request.</source>
-        <translation type="unfinished">Bu, kimliği doğrulanmış bir ödeme talebidir.</translation>
-    </message>
-    <message>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished">Kullanılmış adres listesine eklemek için bu adrese bir etiket girin</translation>
     </message>
     <message>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished">Referans için bitcoin: URI'siyle iliştirilmiş işlemle birlikte depolanacak bir ileti. Not: Bu mesaj Bitcoin ağı üzerinden gönderilmeyecektir.</translation>
-    </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">Şu adrese öde:</translation>
-    </message>
-    <message>
-        <source>Memo:</source>
-        <translation type="unfinished">Not:</translation>
     </message>
 </context>
 <context>
@@ -3158,30 +3328,22 @@ Cüzdan kilidini aç.</translation>
     <name>TransactionDesc</name>
     <message>
         <source>conflicted with a transaction with %1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that conflicts with a confirmed transaction.</extracomment>
         <translation type="unfinished">%1 doğrulamalı bir işlem ile çelişti</translation>
     </message>
     <message>
-        <source>0/unconfirmed, %1</source>
-        <translation type="unfinished">0/doğrulanmamış, %1</translation>
-    </message>
-    <message>
-        <source>in memory pool</source>
-        <translation type="unfinished">bellek alanında</translation>
-    </message>
-    <message>
-        <source>not in memory pool</source>
-        <translation type="unfinished">bellek alanında değil</translation>
-    </message>
-    <message>
         <source>abandoned</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an abandoned transaction.</extracomment>
         <translation type="unfinished">terk edilmiş</translation>
     </message>
     <message>
         <source>%1/unconfirmed</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
         <translation type="unfinished">%1/doğrulanmadı</translation>
     </message>
     <message>
         <source>%1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
         <translation type="unfinished">%1 doğrulama</translation>
     </message>
     <message>
@@ -3231,7 +3393,7 @@ Cüzdan kilidini aç.</translation>
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n ek blok sonrasında olgunlaşacak</numerusform>
         </translation>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_ug.ts
+++ b/src/qt/locale/bitcoin_ug.ts
@@ -76,6 +76,18 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 پەقەت «ئەنئەنىۋى(legacy)» تىپتىكى ئادرېسلا ئىمزانى قوللايدۇ.</translation>
     </message>
     <message>
+        <source>&amp;Copy Address</source>
+        <translation type="unfinished">ئادرېس كۆچۈر(&amp;C)</translation>
+    </message>
+    <message>
+        <source>Copy &amp;Label</source>
+        <translation type="unfinished">بەلگىنى كۆچۈر(&amp;L)</translation>
+    </message>
+    <message>
+        <source>&amp;Edit</source>
+        <translation type="unfinished">تەھرىر(&amp;E)</translation>
+    </message>
+    <message>
         <source>Export Address List</source>
         <translation type="unfinished">ئادرېس تىزىمىنى چىقار</translation>
     </message>
@@ -109,6 +121,33 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">(بەلگە يوق)</translation>
     </message>
 </context>
+<context>
+    <name>AskPassphraseDialog</name>
+    <message>
+        <source>Passphrase Dialog</source>
+        <translation type="unfinished">ئىم ئىبارە سۆزلەشكۈسى</translation>
+    </message>
+    <message>
+        <source>Enter passphrase</source>
+        <translation type="unfinished">ئىم ئىبارە كىرگۈزۈڭ</translation>
+    </message>
+    <message>
+        <source>New passphrase</source>
+        <translation type="unfinished">يېڭى ئىم ئىبارە</translation>
+    </message>
+    <message>
+        <source>Repeat new passphrase</source>
+        <translation type="unfinished">يېڭى ئىم ئىبارەنى تەكرارلاڭ</translation>
+    </message>
+    <message>
+        <source>Show passphrase</source>
+        <translation type="unfinished">ئىم ئىبارە كۆرسەت</translation>
+    </message>
+    <message>
+        <source>Encrypt wallet</source>
+        <translation type="unfinished">ھەمياننى شىفىرلا</translation>
+    </message>
+    </context>
 <context>
     <name>QObject</name>
     <message numerus="yes">
@@ -192,6 +231,27 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </context>
 <context>
     <name>Intro</name>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
     <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>

--- a/src/qt/locale/bitcoin_uk.ts
+++ b/src/qt/locale/bitcoin_uk.ts
@@ -3,7 +3,7 @@
     <name>AddressBookPage</name>
     <message>
         <source>Right-click to edit address or label</source>
-        <translation type="unfinished">Клацніть правою кнопкою миші для редагування адреси або мітки</translation>
+        <translation type="unfinished">Клацніть правою кнопкою миші, щоб змінити адресу або мітку</translation>
     </message>
     <message>
         <source>Create a new address</source>
@@ -15,7 +15,7 @@
     </message>
     <message>
         <source>Copy the currently selected address to the system clipboard</source>
-        <translation type="unfinished">Копіювати виділену адресу в буфер обміну</translation>
+        <translation type="unfinished">Скопіюйте поточну вибрану адресу в системний буфер обміну</translation>
     </message>
     <message>
         <source>&amp;Copy</source>
@@ -27,19 +27,19 @@
     </message>
     <message>
         <source>Delete the currently selected address from the list</source>
-        <translation type="unfinished">Вилучити вибрану адресу з переліку</translation>
+        <translation type="unfinished">Видалити поточну вибрану адресу зі списку </translation>
     </message>
     <message>
         <source>Enter address or label to search</source>
-        <translation type="unfinished">Введіть адресу чи мітку для пошуку</translation>
+        <translation type="unfinished">Введіть адресу або мітку для пошуку</translation>
     </message>
     <message>
         <source>Export the data in the current tab to a file</source>
-        <translation type="unfinished">Експортувати дані з поточної вкладки в файл</translation>
+        <translation type="unfinished">Експортувати дані з поточної вкладки у файл</translation>
     </message>
     <message>
         <source>&amp;Export</source>
-        <translation type="unfinished">&amp;Экспорт</translation>
+        <translation type="unfinished">&amp;Експортувати</translation>
     </message>
     <message>
         <source>&amp;Delete</source>
@@ -67,7 +67,7 @@
     </message>
     <message>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
-        <translation type="unfinished">Це ваші адреси Bitcoin для надсилання платежів. Завжди перевіряйте суму та адресу одержувача перед відправленням монет.</translation>
+        <translation type="unfinished">Це ваші біткоїн-адреси для надсилання платежів. Завжди перевіряйте суму та адресу одержувача перед відправленням монет.</translation>
     </message>
     <message>
         <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
@@ -246,12 +246,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>BitcoinApplication</name>
     <message>
+        <source>Settings file %1 might be corrupt or invalid.</source>
+        <translation type="unfinished">Файл параметрів %1 можу бути пошкоджений або недійсний.</translation>
+    </message>
+    <message>
         <source>Runaway exception</source>
         <translation type="unfinished">Небажана виняткова ситуація</translation>
     </message>
     <message>
         <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
-        <translation type="unfinished">Сталася критична помилка. %1 більше не може продовжувати безпечно і завершить роботу.</translation>
+        <translation type="unfinished">Сталася фатальна помилка. %1 більше не може продовжувати безпечно і завершить роботу.</translation>
     </message>
     <message>
         <source>Internal error</source>
@@ -259,7 +263,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
-        <translation type="unfinished">Виникла внутрішня помилка. %1 спробує безпечно продовжити роботу. Можете повідомити про цю неочікувану помилку, як це описано нижче.</translation>
+        <translation type="unfinished">Виникла внутрішня помилка. %1 спробує безпечно продовжити роботу. Це неочікувана помилка, про яку можливо повідомити, як це описано нижче.</translation>
     </message>
 </context>
 <context>
@@ -272,7 +276,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>A fatal error occurred. Check that settings file is writable, or try running with -nosettings.</source>
         <extracomment>Explanatory text shown on startup when the settings file could not be written. Prompts user to check that we have the ability to write to the file. Explains that the user has the option of running without a settings file.</extracomment>
-        <translation type="unfinished">Сталася критична помилка. Перевірте, чи файл налаштувань доступний для запису, або спробуйте запустити з -nosettings.</translation>
+        <translation type="unfinished">Сталася критична помилка. Перевірте, чи файл параметрів доступний для запису, або спробуйте запустити з -nosettings.</translation>
     </message>
     <message>
         <source>Error: Specified data directory "%1" does not exist.</source>
@@ -446,11 +450,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <name>bitcoin-core</name>
     <message>
         <source>Settings file could not be read</source>
-        <translation type="unfinished">Не вдалося прочитати файл налаштувань</translation>
+        <translation type="unfinished">Не вдалося прочитати файл параметрів</translation>
     </message>
     <message>
         <source>Settings file could not be written</source>
-        <translation type="unfinished">Не вдалося записати файл налаштувань</translation>
+        <translation type="unfinished">Не вдалося записати файл параметрів</translation>
     </message>
     <message>
         <source>The %s developers</source>
@@ -458,7 +462,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>%s corrupt. Try using the wallet tool bitcoin-wallet to salvage or restoring a backup.</source>
-        <translation type="unfinished">%s пошкоджено. Спробуйте скористатися інструментом гаманця bitcoin-wallet для відновлення або відновлення резервної копії.</translation>
+        <translation type="unfinished">%s пошкоджено. Спробуйте скористатися інструментом гаманця bitcoin-wallet для виправлення або відновлення резервної копії.</translation>
     </message>
     <message>
         <source>-maxtxfee is set very high! Fees this large could be paid on a single transaction.</source>
@@ -505,10 +509,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Помилка: Застарілі гаманці підтримують тільки адреси типів "legacy", "p2sh-segwit" та "bech32"</translation>
     </message>
     <message>
-        <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
-        <translation type="unfinished">Помилка: Не вдалося налаштувати прослуховування вхідних підключень (listen повернув помилку: %s)</translation>
-    </message>
-    <message>
         <source>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.</source>
         <translation type="unfinished">Оцінка комісії не вдалася. Fallbackfee вимкнено. Зачекайте кілька блоків або ввімкніть -fallbackfee.</translation>
     </message>
@@ -550,11 +550,15 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Prune configured below the minimum of %d MiB.  Please use a higher number.</source>
-        <translation type="unfinished">Встановлений розмір ланцюжка блоків є замалим (меншим за %d МіБ). Використовуйте більший розмір.</translation>
+        <translation type="unfinished">Встановлений розмір скороченого блокчейна є замалим (меншим за %d МіБ). Використовуйте більший розмір.</translation>
+    </message>
+    <message>
+        <source>Prune mode is incompatible with -reindex-chainstate. Use full -reindex instead.</source>
+        <translation type="unfinished">Режим скороченого блокчейна несумісний з -reindex-chainstate. Використовуйте натомість повний -reindex.</translation>
     </message>
     <message>
         <source>Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of pruned node)</source>
-        <translation type="unfinished">Операція скорочення: остання синхронізація вмісту гаманцю не обмежується діями над скороченими даними. Вам необхідно зробити повторну індексацію -reindex (заново завантажити весь блокчейн, якщо використовується скорочення)</translation>
+        <translation type="unfinished">Скорочений блокчейн: остання синхронізація гаманця виходить за межі скорочених даних. Потрібно перезапустити з -reindex (заново завантажити весь блокчейн, якщо використовується скорочення)</translation>
     </message>
     <message>
         <source>SQLiteDatabase: Unknown sqlite wallet schema version %d. Only version %d is supported</source>
@@ -598,11 +602,19 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Unable to replay blocks. You will need to rebuild the database using -reindex-chainstate.</source>
-        <translation type="unfinished">Неможливо відтворити блоки. Вам потрібно буде перебудувати базу даних, використовуючи -reindex-chainstate.</translation>
+        <translation type="unfinished">Не вдалося відтворити блоки. Вам потрібно буде перебудувати базу даних, використовуючи -reindex-chainstate.</translation>
     </message>
     <message>
         <source>Unknown wallet file format "%s" provided. Please provide one of "bdb" or "sqlite".</source>
         <translation type="unfinished">Вказано невідомий формат "%s" файлу гаманця. Укажіть "bdb" або "sqlite".</translation>
+    </message>
+    <message>
+        <source>Unsupported chainstate database format found. Please restart with -reindex-chainstate. This will rebuild the chainstate database.</source>
+        <translation type="unfinished">Виявлено несумісний формат бази даних стану блокчейна. Перезапустіть з -reindex-chainstate. Це перебудує базу даних стану блокчейна.</translation>
+    </message>
+    <message>
+        <source>Wallet created successfully. The legacy wallet type is being deprecated and support for creating and opening legacy wallets will be removed in the future.</source>
+        <translation type="unfinished">Гаманець успішно створено. Підтримка гаманців застарілого типу припиняється, і можливість створення та відкриття таких гаманців буде видалена.</translation>
     </message>
     <message>
         <source>Warning: Dumpfile wallet format "%s" does not match command line specified format "%s".</source>
@@ -622,7 +634,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain</source>
-        <translation type="unfinished">Вам необхідно перебудувати базу даних з використанням -reindex для завантаження повного ланцюжка блоків.</translation>
+        <translation type="unfinished">Вам необхідно перебудувати базу даних з використанням -reindex для завантаження повного блокчейна.</translation>
     </message>
     <message>
         <source>%s is set very high!</source>
@@ -655,6 +667,94 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>The -txindex upgrade started by a previous version cannot be completed. Restart with the previous version or run a full -reindex.</source>
         <translation type="unfinished">Оновлення -txindex, що було почате попередньою версією, не вдалося завершити. Перезапустить попередню версію або виконайте повний -reindex.</translation>
+    </message>
+    <message>
+        <source>%s request to listen on port %u. This port is considered "bad" and thus it is unlikely that any Bitcoin Core peers connect to it. See doc/p2p-bad-ports.md for details and a full list.</source>
+        <translation type="unfinished">%s запитує прослуховування порту %u . Цей порт вважається "поганим", і тому малоймовірно, що будь-які інші вузли Bitcoin Core підключаться до нього. Дивіться doc/p2p-bad-ports.md для отримання детальної інформації та повного списку.</translation>
+    </message>
+    <message>
+        <source>-reindex-chainstate option is not compatible with -blockfilterindex. Please temporarily disable blockfilterindex while using -reindex-chainstate, or replace -reindex-chainstate with -reindex to fully rebuild all indexes.</source>
+        <translation type="unfinished">Параметр -reindex-chainstate несумісний з -blockfilterindex. Тимчасово вимкніть blockfilterindex під час використання -reindex-chainstate, або замінить -reindex-chainstate на -reindex для повної перебудови всіх індексів.</translation>
+    </message>
+    <message>
+        <source>-reindex-chainstate option is not compatible with -coinstatsindex. Please temporarily disable coinstatsindex while using -reindex-chainstate, or replace -reindex-chainstate with -reindex to fully rebuild all indexes.</source>
+        <translation type="unfinished">Параметр -reindex-chainstate несумісний з -coinstatsindex. Тимчасово вимкніть coinstatsindex під час використання -reindex-chainstate, або замінить -reindex-chainstate на -reindex для повної перебудови всіх індексів.</translation>
+    </message>
+    <message>
+        <source>-reindex-chainstate option is not compatible with -txindex. Please temporarily disable txindex while using -reindex-chainstate, or replace -reindex-chainstate with -reindex to fully rebuild all indexes.</source>
+        <translation type="unfinished">Параметр -reindex-chainstate несумісний з -txindex. Тимчасово вимкніть txindex під час використання -reindex-chainstate, або замінить -reindex-chainstate на -reindex для повної перебудови всіх індексів.</translation>
+    </message>
+    <message>
+        <source>Assumed-valid: last wallet synchronisation goes beyond available block data. You need to wait for the background validation chain to download more blocks.</source>
+        <translation type="unfinished">Блокчейн, що вважається дійсним: остання синхронізація гаманця виходить за межі доступних даних про блоки. Зачекайте, доки фонова перевірка блокчейна завантажить більше блоків.</translation>
+    </message>
+    <message>
+        <source>Cannot provide specific connections and have addrman find outgoing connections at the same time.</source>
+        <translation type="unfinished">Не вдалося встановити визначені з'єднання і одночасно використовувати addrman для встановлення вихідних з'єднань.</translation>
+    </message>
+    <message>
+        <source>Error loading %s: External signer wallet being loaded without external signer support compiled</source>
+        <translation type="unfinished">Помилка завантаження %s: Завантаження гаманця зі зовнішнім підписувачем, але скомпільовано без підтримки зовнішнього підписування</translation>
+    </message>
+    <message>
+        <source>Error: Address book data in wallet cannot be identified to belong to migrated wallets</source>
+        <translation type="unfinished">Помилка:  Дані адресної книги в гаманці не можна ідентифікувати як належні до перенесених гаманців</translation>
+    </message>
+    <message>
+        <source>Error: Duplicate descriptors created during migration. Your wallet may be corrupted.</source>
+        <translation type="unfinished">Помилка: Ідентичні дескриптори створено під час перенесення. Можливо, гаманець пошкоджено.</translation>
+    </message>
+    <message>
+        <source>Error: Transaction %s in wallet cannot be identified to belong to migrated wallets</source>
+        <translation type="unfinished">Помилка: Транзакцію %s в гаманці не можна ідентифікувати як належну до перенесених гаманців</translation>
+    </message>
+    <message>
+        <source>Error: Unable to produce descriptors for this legacy wallet. Make sure the wallet is unlocked first</source>
+        <translation type="unfinished">Помилка: Не вдалося створити дескриптори для цього застарілого гаманця. Спочатку переконайтеся, що гаманець розблоковано.</translation>
+    </message>
+    <message>
+        <source>Failed to rename invalid peers.dat file. Please move or delete it and try again.</source>
+        <translation type="unfinished">Не вдалося перейменувати недійсний файл peers.dat. Будь ласка, перемістіть його та повторіть спробу </translation>
+    </message>
+    <message>
+        <source>Incompatible options: -dnsseed=1 was explicitly specified, but -onlynet forbids connections to IPv4/IPv6</source>
+        <translation type="unfinished">Несумісні параметри: чітко вказано -dnsseed=1, але -onlynet забороняє IPv4/IPv6 з'єднання</translation>
+    </message>
+    <message>
+        <source>Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is explicitly forbidden: -onion=0</source>
+        <translation type="unfinished">Вихідні з'єднання обмежені мережею Tor (-onlynet=onion), але проксі-сервер для доступу до мережі Tor повністю заборонений: -onion=0</translation>
+    </message>
+    <message>
+        <source>Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is not provided: none of -proxy, -onion or -listenonion is given</source>
+        <translation type="unfinished">Вихідні з'єднання обмежені мережею Tor (-onlynet=onion), але проксі-сервер для доступу до мережі Tor не призначено: не вказано ні -proxy, ні -onion, ані -listenonion</translation>
+    </message>
+    <message>
+        <source>Unrecognized descriptor found. Loading wallet %s
+
+The wallet might had been created on a newer version.
+Please try running the latest software version.
+</source>
+        <translation type="unfinished">Виявлено нерозпізнаний дескриптор. Завантаження гаманця %s
+
+Можливо, гаманець було створено новішою версією.
+Спробуйте найновішу версію програми.
+</translation>
+    </message>
+    <message>
+        <source>Unsupported category-specific logging level -loglevel=%s. Expected -loglevel=&lt;category&gt;:&lt;loglevel&gt;. Valid categories: %s. Valid loglevels: %s.</source>
+        <translation type="unfinished">Непідтримуваний категорійний рівень журналювання -loglevel=%s. Очікується -loglevel=&lt;category&gt;:&lt;loglevel&gt;. Припустимі категорії: %s. Припустимі рівні: %s.</translation>
+    </message>
+    <message>
+        <source>
+Unable to cleanup failed migration</source>
+        <translation type="unfinished">
+Не вдалося очистити помилкове перенесення</translation>
+    </message>
+    <message>
+        <source>
+Unable to restore backup of wallet.</source>
+        <translation type="unfinished">
+Не вдалося відновити резервну копію гаманця.</translation>
     </message>
     <message>
         <source>Config setting for %s only applied on %s network when in [%s] section.</source>
@@ -737,8 +837,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Помилка зчитування наступного запису з бази даних гаманця</translation>
     </message>
     <message>
-        <source>Error upgrading chainstate database</source>
-        <translation type="unfinished">Помилка оновлення бази даних стану ланцюжка</translation>
+        <source>Error: Could not add watchonly tx to watchonly wallet</source>
+        <translation type="unfinished">Помилка: Не вдалося додати транзакцію "тільки перегляд" до гаманця-для-перегляду</translation>
+    </message>
+    <message>
+        <source>Error: Could not delete watchonly transactions</source>
+        <translation type="unfinished">Помилка: Не вдалося видалити транзакції "тільки перегляд"</translation>
     </message>
     <message>
         <source>Error: Couldn't create cursor into database</source>
@@ -751,6 +855,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Error: Dumpfile checksum does not match. Computed %s, expected %s</source>
         <translation type="unfinished">Помилка: Контрольна сума файлу дампа не збігається. Обчислено %s, очікується %s</translation>
+    </message>
+    <message>
+        <source>Error: Failed to create new watchonly wallet</source>
+        <translation type="unfinished">Помилка: Не вдалося створити новий гаманець-для-перегляду</translation>
     </message>
     <message>
         <source>Error: Got key that was not hex: %s</source>
@@ -773,8 +881,36 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Помилка:  Немає доступних %s адрес.</translation>
     </message>
     <message>
+        <source>Error: Not all watchonly txs could be deleted</source>
+        <translation type="unfinished">Помилка: Не всі транзакції "тільки перегляд" вдалося видалити</translation>
+    </message>
+    <message>
+        <source>Error: This wallet already uses SQLite</source>
+        <translation type="unfinished">Помилка; Цей гаманець вже використовує SQLite</translation>
+    </message>
+    <message>
+        <source>Error: This wallet is already a descriptor wallet</source>
+        <translation type="unfinished">Помилка: Цей гаманець вже є гаманцем на основі дескрипторів</translation>
+    </message>
+    <message>
+        <source>Error: Unable to begin reading all records in the database</source>
+        <translation type="unfinished">Помилка: Не вдалося розпочати зчитування всіх записів бази даних</translation>
+    </message>
+    <message>
+        <source>Error: Unable to make a backup of your wallet</source>
+        <translation type="unfinished">Помилка: Не вдалося зробити резервну копію гаманця.</translation>
+    </message>
+    <message>
         <source>Error: Unable to parse version %u as a uint32_t</source>
         <translation type="unfinished">Помилка: Не вдалося проаналізувати версію %u як uint32_t</translation>
+    </message>
+    <message>
+        <source>Error: Unable to read all records in the database</source>
+        <translation type="unfinished">Помилка: Не вдалося зчитати всі записи бази даних</translation>
+    </message>
+    <message>
+        <source>Error: Unable to remove watchonly address book data</source>
+        <translation type="unfinished">Помилка: Не вдалося видалити дані "тільки перегляд" з адресної книги</translation>
     </message>
     <message>
         <source>Error: Unable to write record to new wallet</source>
@@ -850,11 +986,15 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: '%s' (must be at least %s)</source>
-        <translation type="unfinished">Вказано некоректну суму для параметру -paytxfee: «%s» (повинно бути щонайменше %s)</translation>
+        <translation type="unfinished">Вказано некоректну суму для параметра -paytxfee=&lt;amount&gt;: '%s' (повинно бути щонайменше %s)</translation>
     </message>
     <message>
         <source>Invalid netmask specified in -whitelist: '%s'</source>
         <translation type="unfinished">Вказано неправильну маску підмережі для -whitelist: «%s»</translation>
+    </message>
+    <message>
+        <source>Listening for incoming connections failed (listen returned error %s)</source>
+        <translation type="unfinished">Не вдалося налаштувати прослуховування вхідних підключень (listen повернув помилку %s)</translation>
     </message>
     <message>
         <source>Loading P2P addresses…</source>
@@ -889,20 +1029,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Немає доступних адрес</translation>
     </message>
     <message>
-        <source>No proxy server specified. Use -proxy=&lt;ip&gt; or -proxy=&lt;ip:port&gt;.</source>
-        <translation type="unfinished">Не вказано проксі-сервер.  Використовуйте -proxy=&lt;ip&gt; або -proxy=&lt;ip:port&gt;.</translation>
-    </message>
-    <message>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished">Бракує доступних дескрипторів файлів.</translation>
     </message>
     <message>
         <source>Prune cannot be configured with a negative value.</source>
-        <translation type="unfinished">Розмір скороченого ланцюжка блоків не може бути від'ємним.</translation>
-    </message>
-    <message>
-        <source>Prune mode is incompatible with -coinstatsindex.</source>
-        <translation type="unfinished">Режим скороченого блокчейна несумісний з -coinstatsindex.</translation>
+        <translation type="unfinished">Розмір скороченого блокчейна не може бути від'ємним.</translation>
     </message>
     <message>
         <source>Prune mode is incompatible with -txindex.</source>
@@ -1010,7 +1142,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Transaction has too long of a mempool chain</source>
-        <translation type="unfinished">Транзакція має занадто довгий ланцюг у пулі</translation>
+        <translation type="unfinished">Транзакція має занадто довгий ланцюг у пулі транзакцій</translation>
     </message>
     <message>
         <source>Transaction must have at least one recipient</source>
@@ -1025,24 +1157,32 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Транзакція занадто велика</translation>
     </message>
     <message>
+        <source>Unable to allocate memory for -maxsigcachesize: '%s' MiB</source>
+        <translation type="unfinished">Не вдалося виділити пам'ять для -maxsigcachesize: '%s' МіБ</translation>
+    </message>
+    <message>
         <source>Unable to bind to %s on this computer (bind returned error %s)</source>
-        <translation type="unfinished">Неможливо прив'язатися до %s на цьому комп'ютері (bind повернув помилку: %s)</translation>
+        <translation type="unfinished">Не вдалося прив'язатися до %s на цьому комп'ютері (bind повернув помилку: %s)</translation>
     </message>
     <message>
         <source>Unable to bind to %s on this computer. %s is probably already running.</source>
-        <translation type="unfinished">Неможливо прив'язати %s на цьому комп'ютері. %s, ймовірно, вже працює.</translation>
+        <translation type="unfinished">Не вдалося прив'язати %s на цьому комп'ютері. %s, ймовірно, вже працює.</translation>
     </message>
     <message>
         <source>Unable to create the PID file '%s': %s</source>
-        <translation type="unfinished">Неможливо створити PID файл '%s' :%s</translation>
+        <translation type="unfinished">Не вдалося створити PID файл '%s' :%s</translation>
+    </message>
+    <message>
+        <source>Unable to find UTXO for external input</source>
+        <translation type="unfinished">Не вдалося знайти UTXO для зовнішнього входу</translation>
     </message>
     <message>
         <source>Unable to generate initial keys</source>
-        <translation type="unfinished">Не вдається створити початкові ключі</translation>
+        <translation type="unfinished">Не вдалося створити початкові ключі</translation>
     </message>
     <message>
         <source>Unable to generate keys</source>
-        <translation type="unfinished">Не вдається створити ключі</translation>
+        <translation type="unfinished">Не вдалося створити ключі</translation>
     </message>
     <message>
         <source>Unable to open %s for writing</source>
@@ -1054,7 +1194,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
-        <translation type="unfinished">Неможливо запустити HTTP-сервер. Детальніший опис наведено в журналі зневадження.</translation>
+        <translation type="unfinished">Не вдалося запустити HTTP-сервер. Детальніший опис наведено в журналі зневадження.</translation>
+    </message>
+    <message>
+        <source>Unable to unload the wallet before migrating</source>
+        <translation type="unfinished">Не вдалося вивантажити гаманець перед перенесенням</translation>
     </message>
     <message>
         <source>Unknown -blockfilterindex value %s.</source>
@@ -1077,12 +1221,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Активовані невідомі нові правила (versionbit %i)</translation>
     </message>
     <message>
-        <source>Unsupported logging category %s=%s.</source>
-        <translation type="unfinished">Непідтримувана категорія ведення журналу %s=%s.</translation>
+        <source>Unsupported global logging level -loglevel=%s. Valid values: %s.</source>
+        <translation type="unfinished">Непідтримуваний глобальний рівень журналювання -loglevel=%s. Припустимі значення: %s.</translation>
     </message>
     <message>
-        <source>Upgrading UTXO database</source>
-        <translation type="unfinished">Оновлення бази даних UTXO</translation>
+        <source>Unsupported logging category %s=%s.</source>
+        <translation type="unfinished">Непідтримувана категорія ведення журналу %s=%s.</translation>
     </message>
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
@@ -1194,7 +1338,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>&amp;Encrypt Wallet…</source>
-        <translation type="unfinished">За&amp;шифрувати гаманець…</translation>
+        <translation type="unfinished">&amp;Шифрувати Гаманець...</translation>
     </message>
     <message>
         <source>Encrypt the private keys that belong to your wallet</source>
@@ -1206,23 +1350,23 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>&amp;Change Passphrase…</source>
-        <translation type="unfinished">Змінити парол&amp;ь…</translation>
+        <translation type="unfinished">Змінити парол&amp;ь...</translation>
     </message>
     <message>
         <source>Sign &amp;message…</source>
-        <translation type="unfinished">&amp;Підписати повідомлення…</translation>
+        <translation type="unfinished">&amp;Підписати повідомлення...</translation>
     </message>
     <message>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
-        <translation type="unfinished">Підтвердіть, що ви є власником повідомлення підписавши його вашою Bitcoin-адресою</translation>
+        <translation type="unfinished">Підтвердіть, що Ви є власником повідомлення, підписавши його Вашою біткоїн-адресою</translation>
     </message>
     <message>
         <source>&amp;Verify message…</source>
-        <translation type="unfinished">П&amp;еревірити повідомлення…</translation>
+        <translation type="unfinished">П&amp;еревірити повідомлення...</translation>
     </message>
     <message>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
-        <translation type="unfinished">Перевірте повідомлення для впевненості, що воно підписано вказаною Bitcoin-адресою</translation>
+        <translation type="unfinished">Перевірте повідомлення для впевненості, що воно підписано вказаною біткоїн-адресою</translation>
     </message>
     <message>
         <source>&amp;Load PSBT from file…</source>
@@ -1234,15 +1378,15 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Close Wallet…</source>
-        <translation type="unfinished">Закрити Гаманець…</translation>
+        <translation type="unfinished">Закрити гаманець…</translation>
     </message>
     <message>
         <source>Create Wallet…</source>
-        <translation type="unfinished">Створити Гаманець…</translation>
+        <translation type="unfinished">Створити гаманець…</translation>
     </message>
     <message>
         <source>Close All Wallets…</source>
-        <translation type="unfinished">Закрити Всі Гаманці…</translation>
+        <translation type="unfinished">Закрити всі гаманці…</translation>
     </message>
     <message>
         <source>&amp;File</source>
@@ -1341,8 +1485,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Синхронізовано</translation>
     </message>
     <message>
+        <source>Load Partially Signed Bitcoin Transaction</source>
+        <translation type="unfinished">Завантажити частково підписану біткоїн-транзакцію (PSBT)</translation>
+    </message>
+    <message>
         <source>Load PSBT from &amp;clipboard…</source>
         <translation type="unfinished">Завантажити PSBT-транзакцію з &amp;буфера обміну…</translation>
+    </message>
+    <message>
+        <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
+        <translation type="unfinished">Завантажити частково підписану біткоїн-транзакцію (PSBT) з буфера обміну</translation>
     </message>
     <message>
         <source>Node window</source>
@@ -1377,6 +1529,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Закрити гаманець</translation>
     </message>
     <message>
+        <source>Restore Wallet…</source>
+        <extracomment>Name of the menu item that restores wallet from a backup file.</extracomment>
+        <translation type="unfinished">Відновити гаманець…</translation>
+    </message>
+    <message>
+        <source>Restore a wallet from a backup file</source>
+        <extracomment>Status tip for Restore Wallet menu item</extracomment>
+        <translation type="unfinished">Відновити гаманець з файлу резервної копії</translation>
+    </message>
+    <message>
         <source>Close all wallets</source>
         <translation type="unfinished">Закрити всі гаманці</translation>
     </message>
@@ -1386,7 +1548,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>&amp;Mask values</source>
-        <translation type="unfinished">&amp;Приховати значення</translation>
+        <translation type="unfinished">При&amp;ховати значення</translation>
     </message>
     <message>
         <source>Mask the values in the Overview tab</source>
@@ -1399,6 +1561,26 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>No wallets available</source>
         <translation type="unfinished">Гаманців немає</translation>
+    </message>
+    <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">Файл гаманця</translation>
+    </message>
+    <message>
+        <source>Load Wallet Backup</source>
+        <extracomment>The title for Restore Wallet File Windows</extracomment>
+        <translation type="unfinished">Завантажити резервну копію гаманця</translation>
+    </message>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of pop-up window shown when the user is attempting to restore a wallet.</extracomment>
+        <translation type="unfinished">Відновити гаманець</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">Назва гаманця</translation>
     </message>
     <message>
         <source>&amp;Window</source>
@@ -1428,9 +1610,9 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform>%n активне з'єднання з мережею Bitcoin</numerusform>
-            <numerusform>%n активних з'єднання з мережею Bitcoin</numerusform>
-            <numerusform>%n активних з'єднань з мережею Bitcoin</numerusform>
+            <numerusform>%n активне з'єднання з мережею Біткоїн.</numerusform>
+            <numerusform>%n активних з'єднання з мережею Біткоїн.</numerusform>
+            <numerusform>%n активних з'єднань з мережею Біткоїн.</numerusform>
         </translation>
     </message>
     <message>
@@ -1452,6 +1634,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Enable network activity</source>
         <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
         <translation type="unfinished">Увімкнути мережеву активність</translation>
+    </message>
+    <message>
+        <source>Pre-syncing Headers (%1%)…</source>
+        <translation type="unfinished">Триває попередня синхронізація заголовків (%1%)…</translation>
     </message>
     <message>
         <source>Error: %1</source>
@@ -1716,6 +1902,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Can't list signers</source>
         <translation type="unfinished">Неможливо показати зовнішні підписувачі</translation>
     </message>
+    <message>
+        <source>Too many external signers found</source>
+        <translation type="unfinished">Знайдено забагато зовнішних підписувачів</translation>
+    </message>
 </context>
 <context>
     <name>LoadWalletsActivity</name>
@@ -1756,6 +1946,34 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
 </context>
 <context>
+    <name>RestoreWalletActivity</name>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of progress window which is displayed when wallets are being restored.</extracomment>
+        <translation type="unfinished">Відновити гаманець</translation>
+    </message>
+    <message>
+        <source>Restoring Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the restore wallets progress window which indicates to the user that wallets are currently being restored.</extracomment>
+        <translation type="unfinished">Відновлення гаманця &lt;b&gt;%1&lt;/b&gt;…</translation>
+    </message>
+    <message>
+        <source>Restore wallet failed</source>
+        <extracomment>Title of message box which is displayed when the wallet could not be restored.</extracomment>
+        <translation type="unfinished">Помилка відновлення гаманця</translation>
+    </message>
+    <message>
+        <source>Restore wallet warning</source>
+        <extracomment>Title of message box which is displayed when the wallet is restored with some warning.</extracomment>
+        <translation type="unfinished">Попередження відновлення гаманця</translation>
+    </message>
+    <message>
+        <source>Restore wallet message</source>
+        <extracomment>Title of message box which is displayed when the wallet is successfully restored.</extracomment>
+        <translation type="unfinished">Повідомлення під час відновлення гаманця</translation>
+    </message>
+</context>
+<context>
     <name>WalletController</name>
     <message>
         <source>Close wallet</source>
@@ -1786,7 +2004,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Wallet Name</source>
-        <translation type="unfinished">Назва Гаманця</translation>
+        <translation type="unfinished">Назва гаманця</translation>
     </message>
     <message>
         <source>Wallet</source>
@@ -1794,7 +2012,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Encrypt the wallet. The wallet will be encrypted with a passphrase of your choice.</source>
-        <translation type="unfinished">Зашифруйте гаманець. Гаманець буде зашифрований за допомогою пароля на ваш вибір.</translation>
+        <translation type="unfinished">Зашифрувати гаманець. Гаманець буде зашифрований за допомогою обраного вами пароля.</translation>
     </message>
     <message>
         <source>Encrypt Wallet</source>
@@ -1806,7 +2024,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Disable private keys for this wallet. Wallets with private keys disabled will have no private keys and cannot have an HD seed or imported private keys. This is ideal for watch-only wallets.</source>
-        <translation type="unfinished">Вимкнути приватні ключі для цього гаманця. Гаманці з вимкнутими приватними ключами не матимуть приватних ключів і не можуть мати набір HD або імпортовані приватні ключі. Це ідеально підходить лише для тільки-огляд гаманців.</translation>
+        <translation type="unfinished">Вимкнути приватні ключі для цього гаманця. Гаманці з вимкнутими приватними ключами не матимуть приватних ключів і не можуть мати набір HD-генератор або імпортовані приватні ключі. Це ідеально підходить для гаманців-для-перегляду.</translation>
     </message>
     <message>
         <source>Disable Private Keys</source>
@@ -1814,7 +2032,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Make a blank wallet. Blank wallets do not initially have private keys or scripts. Private keys and addresses can be imported, or an HD seed can be set, at a later time.</source>
-        <translation type="unfinished">Зробіть порожній гаманець. Порожні гаманці спочатку не мають приватних ключів або сценаріїв. Пізніше можна імпортувати приватні ключі та адреси або встановити HD-насіння.</translation>
+        <translation type="unfinished">Створити пустий гаманець. Пусті гаманці спочатку не мають приватних ключів або скриптів. Пізніше можна імпортувати приватні ключі та адреси або встановити HD-генератор.</translation>
     </message>
     <message>
         <source>Make Blank Wallet</source>
@@ -1822,11 +2040,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Use descriptors for scriptPubKey management</source>
-        <translation type="unfinished">Використовуйте дескриптори для управління scriptPubKey</translation>
+        <translation type="unfinished">Використовувати дескриптори для управління scriptPubKey</translation>
     </message>
     <message>
         <source>Descriptor Wallet</source>
-        <translation type="unfinished">Гаманець на базі дескрипторів</translation>
+        <translation type="unfinished">Гаманець на основі дескрипторів</translation>
     </message>
     <message>
         <source>Use an external signing device such as a hardware wallet. Configure the external signer script in wallet preferences first.</source>
@@ -1842,12 +2060,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Compiled without sqlite support (required for descriptor wallets)</source>
-        <translation type="unfinished">Зкомпільовано без підтримки sqlite (потрібно для гаманців дескрипторів)</translation>
+        <translation type="unfinished">Скомпільовано без підтримки sqlite (потрібно для гаманців на основі дескрипторів)</translation>
     </message>
     <message>
         <source>Compiled without external signing support (required for external signing)</source>
         <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
-        <translation type="unfinished">Скомпільовано без підтримки зовнішнього підписування</translation>
+        <translation type="unfinished">Скомпільовано без підтримки зовнішнього підписування (потрібно для зовнішнього підписування)</translation>
     </message>
 </context>
 <context>
@@ -1886,7 +2104,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>The entered address "%1" is not a valid Bitcoin address.</source>
-        <translation type="unfinished">Введена адреса "%1" не є дійсною Bitcoin адресою.</translation>
+        <translation type="unfinished">Введена адреса "%1" не є дійсною біткоїн-адресою.</translation>
     </message>
     <message>
         <source>Address "%1" already exists as a receiving address with label "%2" and so cannot be added as a sending address.</source>
@@ -1930,17 +2148,29 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 </context>
 <context>
     <name>Intro</name>
-    <message>
-        <source>%1 GB of space available</source>
-        <translation type="unfinished">Доступно %1 ГБ</translation>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform>Доступний простір: %n ГБ</numerusform>
+            <numerusform>Доступний простір: %n ГБ</numerusform>
+            <numerusform>Доступний простір: %n ГБ</numerusform>
+        </translation>
     </message>
-    <message>
-        <source>(of %1 GB needed)</source>
-        <translation type="unfinished">(з %1 ГБ, що потрібно)</translation>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform>(в той час, як необхідно %n ГБ)</numerusform>
+            <numerusform>(в той час, як необхідно %n ГБ)</numerusform>
+            <numerusform>(в той час, як необхідно %n ГБ)</numerusform>
+        </translation>
     </message>
-    <message>
-        <source>(%1 GB needed for full chain)</source>
-        <translation type="unfinished">(%1  ГБ, необхідних для повного блокчейну)</translation>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform>(%n ГБ необхідно для повного блокчейну)</numerusform>
+            <numerusform>(%n ГБ необхідно для повного блокчейну)</numerusform>
+            <numerusform>(%n ГБ необхідно для повного блокчейну)</numerusform>
+        </translation>
     </message>
     <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
@@ -1988,10 +2218,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Оскільки це перший запуск програми, ви можете обрати, де %1 буде зберігати дані.</translation>
     </message>
     <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation type="unfinished">Після натискання кнопки «OK» %1 почне завантажувати та обробляти повний ланцюжок блоків %4 (%2 ГБ), починаючи з найбільш ранніх транзакцій у %3, коли було запущено %4.</translation>
-    </message>
-    <message>
         <source>Limit block chain storage to</source>
         <translation type="unfinished">Скоротити місце під блоки до</translation>
     </message>
@@ -2008,8 +2234,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Ця початкова синхронізація є дуже вимогливою, і може виявити проблеми з апаратним забезпеченням комп'ютера, які раніше не були непоміченими. Кожен раз, коли ви запускаєте %1, він буде продовжувати завантаження там, де він зупинився.</translation>
     </message>
     <message>
+        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2 GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
+        <translation type="unfinished">Після натискання кнопки «OK» %1 почне завантажувати та обробляти повний блокчейн %4 (%2 ГБ), починаючи з найбільш ранніх транзакцій у %3, коли було запущено %4.</translation>
+    </message>
+    <message>
         <source>If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</source>
-        <translation type="unfinished">Якщо ви вирішили обмежити збереження ланцюжка блоків (відсікання), історичні дані повинні бути завантажені та оброблені, але потім можуть бути видалені, щоб зберегти потрібний простір диска.</translation>
+        <translation type="unfinished">Якщо ви вирішили обмежити обсяг збереження блокчейна, історичні дані повинні бути завантажені та оброблені, але потім можуть бути видалені, щоб зберегти потрібний простір диска.</translation>
     </message>
     <message>
         <source>Use the default data directory</source>
@@ -2054,7 +2284,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Recent transactions may not yet be visible, and therefore your wallet's balance might be incorrect. This information will be correct once your wallet has finished synchronizing with the bitcoin network, as detailed below.</source>
-        <translation type="unfinished">Нещодавні транзакції ще не відображаються, тому баланс вашого гаманця може бути неточним. Ця інформація буде вірною після того, як ваш гаманець завершить синхронізацію з мережею Біткоїн, враховуйте показники нижче.</translation>
+        <translation type="unfinished">Нещодавні транзакції ще не відображаються, тому баланс вашого гаманця може бути неточним. Ця інформація буде вірною після того, як ваш гаманець завершить синхронізацію з мережею Біткоїн (дивіться нижче).</translation>
     </message>
     <message>
         <source>Attempting to spend bitcoins that are affected by not-yet-displayed transactions will not be accepted by the network.</source>
@@ -2078,11 +2308,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Progress</source>
-        <translation type="unfinished">Прогрес</translation>
+        <translation type="unfinished">Перебіг синхронізації</translation>
     </message>
     <message>
         <source>Progress increase per hour</source>
-        <translation type="unfinished">Прогрес за годину</translation>
+        <translation type="unfinished">Прогрес синхронізації за годину</translation>
     </message>
     <message>
         <source>Estimated time left until synced</source>
@@ -2098,7 +2328,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Unknown. Syncing Headers (%1, %2%)…</source>
-        <translation type="unfinished">Невідомо. Синхронізація заголовків (%1, %2%)…</translation>
+        <translation type="unfinished">Невідомо. Триває синхронізація заголовків (%1, %2%)…</translation>
+    </message>
+    <message>
+        <source>Unknown. Pre-syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">Невідомо. Триває попередня синхронізація заголовків (%1, %2%)…</translation>
     </message>
 </context>
 <context>
@@ -2129,7 +2363,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>&amp;Start %1 on system login</source>
-        <translation type="unfinished">&amp;Запускати %1 при вході в систему</translation>
+        <translation type="unfinished">Запускати %1 при в&amp;ході в систему</translation>
     </message>
     <message>
         <source>Enabling pruning significantly reduces the disk space required to store transactions. All blocks are still fully validated. Reverting this setting requires re-downloading the entire blockchain.</source>
@@ -2137,7 +2371,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Size of &amp;database cache</source>
-        <translation type="unfinished">Розмір &amp;кешу бази даних</translation>
+        <translation type="unfinished">Розмір ке&amp;шу бази даних</translation>
     </message>
     <message>
         <source>Number of script &amp;verification threads</source>
@@ -2154,6 +2388,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
         <translation type="unfinished">Згортати замість закриття. Якщо ця опція включена, програма закриється лише після вибору відповідного пункту в меню.</translation>
+    </message>
+    <message>
+        <source>Options set in this dialog are overridden by the command line:</source>
+        <translation type="unfinished">Параметри, які задані в цьому вікні, змінені командним рядком:</translation>
     </message>
     <message>
         <source>Open the %1 configuration file from the working directory.</source>
@@ -2185,7 +2423,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Reverting this setting requires re-downloading the entire blockchain.</source>
-        <translation type="unfinished">Повернення цієї опції вимагає перезавантаження вього ланцюжка блоків.</translation>
+        <translation type="unfinished">Повернення цього параметра вимагає перезавантаження вього блокчейна.</translation>
     </message>
     <message>
         <source>Maximum database cache size. A larger cache can contribute to faster sync, after which the benefit is less pronounced for most use cases. Lowering the cache size will reduce memory usage. Unused mempool memory is shared for this cache.</source>
@@ -2213,7 +2451,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Enable R&amp;PC server</source>
         <extracomment>An Options window setting to enable the RPC server.</extracomment>
-        <translation type="unfinished">Увімкнути RPC &amp;сервер</translation>
+        <translation type="unfinished">Увімкнути RPC се&amp;рвер</translation>
     </message>
     <message>
         <source>W&amp;allet</source>
@@ -2227,7 +2465,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Subtract &amp;fee from amount by default</source>
         <extracomment>An Options window setting to set subtracting the fee from a sending amount as default.</extracomment>
-        <translation type="unfinished">За замовчуванням віднімати &amp;комісію від суми відправлення.</translation>
+        <translation type="unfinished">За замовчуванням віднімати &amp;комісію від суми відправлення</translation>
     </message>
     <message>
         <source>Expert</source>
@@ -2235,7 +2473,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Enable coin &amp;control features</source>
-        <translation type="unfinished">Ввімкнути &amp;керування входами</translation>
+        <translation type="unfinished">Ввімкнути керування в&amp;ходами</translation>
     </message>
     <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
@@ -2243,12 +2481,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>&amp;Spend unconfirmed change</source>
-        <translation type="unfinished">&amp;Витрачати непідтверджену решту</translation>
+        <translation type="unfinished">Витрачати непідтверджену &amp;решту</translation>
     </message>
     <message>
         <source>Enable &amp;PSBT controls</source>
         <extracomment>An options window setting to enable PSBT controls.</extracomment>
-        <translation type="unfinished">Увімкнути елементи керування &amp;PSBT</translation>
+        <translation type="unfinished">Увімкнути функції &amp;частково підписаних біткоїн-транзакцій (PSBT)</translation>
     </message>
     <message>
         <source>Whether to show PSBT controls.</source>
@@ -2261,7 +2499,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>&amp;External signer script path</source>
-        <translation type="unfinished">Шлях до скрипту &amp;зовнішнього підписувача</translation>
+        <translation type="unfinished">&amp;Шлях до скрипту зовнішнього підписувача</translation>
     </message>
     <message>
         <source>Full path to a Bitcoin Core compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</source>
@@ -2293,7 +2531,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Connect to the Bitcoin network through a SOCKS5 proxy.</source>
-        <translation type="unfinished">Підключення до мережі Bitcoin через SOCKS5 проксі.</translation>
+        <translation type="unfinished">Підключення до мережі Біткоїн через SOCKS5 проксі.</translation>
     </message>
     <message>
         <source>&amp;Connect through SOCKS5 proxy (default proxy):</source>
@@ -2325,7 +2563,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>&amp;Show tray icon</source>
-        <translation type="unfinished">&amp;Показувати піктограму у системному треї</translation>
+        <translation type="unfinished">Показувати &amp;піктограму у системному треї</translation>
     </message>
     <message>
         <source>Show only a tray icon after minimizing the window.</source>
@@ -2333,11 +2571,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
-        <translation type="unfinished">Мінімізувати &amp;у трей</translation>
+        <translation type="unfinished">Мінімізувати у &amp;трей</translation>
     </message>
     <message>
         <source>M&amp;inimize on close</source>
-        <translation type="unfinished">Згортати замість закритт&amp;я</translation>
+        <translation type="unfinished">Зго&amp;ртати замість закриття</translation>
     </message>
     <message>
         <source>&amp;Display</source>
@@ -2392,17 +2630,13 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">найбільш подібний "%1"</translation>
     </message>
     <message>
-        <source>Options set in this dialog are overridden by the command line or in the configuration file:</source>
-        <translation type="unfinished">Параметри, які задані в цьому вікні, змінені командним рядком або у файлі конфігурації:</translation>
-    </message>
-    <message>
         <source>&amp;Cancel</source>
         <translation type="unfinished">&amp;Скасувати</translation>
     </message>
     <message>
         <source>Compiled without external signing support (required for external signing)</source>
         <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
-        <translation type="unfinished">Скомпільовано без підтримки зовнішнього підписування</translation>
+        <translation type="unfinished">Скомпільовано без підтримки зовнішнього підписування (потрібно для зовнішнього підписування)</translation>
     </message>
     <message>
         <source>default</source>
@@ -2414,14 +2648,22 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Confirm options reset</source>
+        <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
         <translation type="unfinished">Підтвердження скидання параметрів</translation>
     </message>
     <message>
         <source>Client restart required to activate changes.</source>
+        <extracomment>Text explaining that the settings changed will not come into effect until the client is restarted.</extracomment>
         <translation type="unfinished">Для застосування змін необхідно перезапустити клієнта.</translation>
     </message>
     <message>
+        <source>Current settings will be backed up at "%1".</source>
+        <extracomment>Text explaining to the user that the client's current settings will be backed up at a specific location. %1 is a stand-in argument for the backup location's path.</extracomment>
+        <translation type="unfinished"> Поточні параметри будуть збережені в "%1".</translation>
+    </message>
+    <message>
         <source>Client will be shut down. Do you want to proceed?</source>
+        <extracomment>Text asking the user to confirm if they would like to proceed with a client shutdown.</extracomment>
         <translation type="unfinished">Клієнт буде закрито. Продовжити?</translation>
     </message>
     <message>
@@ -2432,7 +2674,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>The configuration file is used to specify advanced user options which override GUI settings. Additionally, any command-line options will override this configuration file.</source>
         <extracomment>Explanatory text about the priority order of instructions considered by client. The order from high to low being: command-line, configuration file, GUI settings.</extracomment>
-        <translation type="unfinished">Файл конфігурації використовується для вказування додаткових параметрів користувача, що перекривають настройки графічного інтерфейсу користувача. Крім того, будь-які параметри командного рядка замінять цей конфігураційний файл.</translation>
+        <translation type="unfinished">Файл конфігурації використовується для вказування додаткових параметрів, що перевизначають параметри графічного інтерфейсу. Крім того, будь-які параметри командного рядка перевизначать цей конфігураційний файл.</translation>
     </message>
     <message>
         <source>Continue</source>
@@ -2460,6 +2702,13 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
 </context>
 <context>
+    <name>OptionsModel</name>
+    <message>
+        <source>Could not read setting "%1", %2.</source>
+        <translation type="unfinished">Не вдалося прочитати параметр "%1", %2.</translation>
+    </message>
+</context>
+<context>
     <name>OverviewPage</name>
     <message>
         <source>Form</source>
@@ -2471,7 +2720,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Watch-only:</source>
-        <translation type="unfinished">Тільки спостереження:</translation>
+        <translation type="unfinished">Тільки перегляд:</translation>
     </message>
     <message>
         <source>Available:</source>
@@ -2511,7 +2760,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Your current balance in watch-only addresses</source>
-        <translation type="unfinished">Ваш поточний баланс в адресах для спостереження</translation>
+        <translation type="unfinished">Ваш поточний баланс в адресах "тільки перегляд"</translation>
     </message>
     <message>
         <source>Spendable:</source>
@@ -2523,15 +2772,15 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Unconfirmed transactions to watch-only addresses</source>
-        <translation type="unfinished">Непідтверджені транзакції на адреси для спостереження</translation>
+        <translation type="unfinished">Непідтверджені транзакції на адреси "тільки перегляд"</translation>
     </message>
     <message>
         <source>Mined balance in watch-only addresses that has not yet matured</source>
-        <translation type="unfinished">Баланс видобутих монет, що не досягли завершеності, на адресах для спостереження</translation>
+        <translation type="unfinished">Баланс видобутих монет, що не досягли завершеності, на адресах "тільки перегляд"</translation>
     </message>
     <message>
         <source>Current total balance in watch-only addresses</source>
-        <translation type="unfinished">Поточний сукупний баланс в адресах для спостереження</translation>
+        <translation type="unfinished">Поточний сукупний баланс в адресах "тільки перегляд"</translation>
     </message>
     <message>
         <source>Privacy mode activated for the Overview tab. To unmask the values, uncheck Settings-&gt;Mask values.</source>
@@ -2611,7 +2860,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Partially Signed Transaction (Binary)</source>
         <extracomment>Expanded name of the binary PSBT file format. See: BIP 174.</extracomment>
-        <translation type="unfinished">Частково підписана транзакція (Binary)</translation>
+        <translation type="unfinished">Частково підписана біткоїн-транзакція (бінарний файл)</translation>
     </message>
     <message>
         <source>PSBT saved to disk.</source>
@@ -2623,7 +2872,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Unable to calculate transaction fee or total transaction amount.</source>
-        <translation type="unfinished">Неможливо розрахувати комісію за транзакцію або загальну суму транзакції.</translation>
+        <translation type="unfinished">Не вдалося розрахувати комісію за транзакцію або загальну суму транзакції.</translation>
     </message>
     <message>
         <source>Pays transaction fee: </source>
@@ -2721,6 +2970,11 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <source>Peer</source>
         <extracomment>Title of Peers Table column which contains a unique number used to identify a connection.</extracomment>
         <translation type="unfinished">Учасник</translation>
+    </message>
+    <message>
+        <source>Age</source>
+        <extracomment>Title of Peers Table column which indicates the duration (length of time) since the peer connection started.</extracomment>
+        <translation type="unfinished">Тривалість</translation>
     </message>
     <message>
         <source>Direction</source>
@@ -2923,29 +3177,32 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Whether we relay addresses to this peer.</source>
-        <extracomment>Tooltip text for the Address Relay field in the peer details area.</extracomment>
+        <extracomment>Tooltip text for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
         <translation type="unfinished">Чи ретранслювати адреси цьому учаснику.</translation>
     </message>
     <message>
         <source>Address Relay</source>
+        <extracomment>Text title for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
         <translation type="unfinished">Ретранслювання адрес</translation>
     </message>
     <message>
-        <source>Total number of addresses processed, excluding those dropped due to rate-limiting.</source>
-        <extracomment>Tooltip text for the Addresses Processed field in the peer details area.</extracomment>
-        <translation type="unfinished">Загальна кількість оброблених адрес за винятком пропущених через обмеження частоти.</translation>
+        <source>The total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</source>
+        <extracomment>Tooltip text for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
+        <translation type="unfinished">Загальна кількість отриманих від цього учасника адрес, що були оброблені (за винятком адрес, пропущених через обмеження темпу).</translation>
+    </message>
+    <message>
+        <source>The total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</source>
+        <extracomment>Tooltip text for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
+        <translation type="unfinished">Загальна кількість отриманих від цього учасника адрес, що були пропущені (не оброблені) через обмеження темпу.</translation>
     </message>
     <message>
         <source>Addresses Processed</source>
+        <extracomment>Text title for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
         <translation type="unfinished">Адрес оброблено</translation>
     </message>
     <message>
-        <source>Total number of addresses dropped due to rate-limiting.</source>
-        <extracomment>Tooltip text for the Addresses Rate-Limited field in the peer details area.</extracomment>
-        <translation type="unfinished">Загальна кількість адрес, пропущених через обмеження частоти.</translation>
-    </message>
-    <message>
         <source>Addresses Rate-Limited</source>
+        <extracomment>Text title for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
         <translation type="unfinished">Адрес пропущено</translation>
     </message>
     <message>
@@ -2954,7 +3211,7 @@ If you are receiving this error you should request the merchant provide a BIP21 
     </message>
     <message>
         <source>Node window</source>
-        <translation type="unfinished">Вікно вузлів</translation>
+        <translation type="unfinished">Вікно вузла</translation>
     </message>
     <message>
         <source>Current block height</source>
@@ -3252,7 +3509,7 @@ For more information on using this console, type %6.
     </message>
     <message>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
-        <translation type="unfinished">Необов'язкове повідомлення на додаток до запиту платежу, котре буде показане під час відкриття запиту. Примітка: Це повідомлення не буде відправлено з платежем через мережу Bitcoin.</translation>
+        <translation type="unfinished">Необов'язкове повідомлення на додаток до запиту платежу, яке буде показане під час відкриття запиту. Примітка: це повідомлення не буде відправлено з платежем через мережу Біткоїн.</translation>
     </message>
     <message>
         <source>An optional label to associate with the new receiving address.</source>
@@ -3581,7 +3838,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     </message>
     <message>
         <source>Copy amount</source>
-        <translation type="unfinished">Копіювати суму</translation>
+        <translation type="unfinished">Скопіювати суму</translation>
     </message>
     <message>
         <source>Copy fee</source>
@@ -3722,7 +3979,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     </message>
     <message>
         <source>Watch-only balance:</source>
-        <translation type="unfinished">Баланс тільки спостереження:</translation>
+        <translation type="unfinished">Баланс "тільки перегляд":</translation>
     </message>
     <message>
         <source>The recipient address is not valid. Please recheck.</source>
@@ -3751,10 +4008,6 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     <message>
         <source>A fee higher than %1 is considered an absurdly high fee.</source>
         <translation type="unfinished">Комісія більша, ніж %1, вважається абсурдно високою.</translation>
-    </message>
-    <message>
-        <source>Payment request expired.</source>
-        <translation type="unfinished">Запит платежу прострочено.</translation>
     </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
@@ -3805,7 +4058,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     </message>
     <message>
         <source>The Bitcoin address to send the payment to</source>
-        <translation type="unfinished">Адреса Bitcoin для відправлення платежу</translation>
+        <translation type="unfinished">Біткоїн-адреса для відправлення платежу</translation>
     </message>
     <message>
         <source>Paste address from clipboard</source>
@@ -3836,28 +4089,12 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
         <translation type="unfinished">Повідомлення:</translation>
     </message>
     <message>
-        <source>This is an unauthenticated payment request.</source>
-        <translation type="unfinished">Цей запит платежу не є автентифікованим.</translation>
-    </message>
-    <message>
-        <source>This is an authenticated payment request.</source>
-        <translation type="unfinished">Цей запит платежу є автентифікованим.</translation>
-    </message>
-    <message>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished">Введіть мітку для цієї адреси для додавання її в список використаних адрес</translation>
     </message>
     <message>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
-        <translation type="unfinished">Повідомлення, що було додане до bitcoin:URI та буде збережено разом з транзакцією для довідки. Примітка: Це повідомлення не буде відправлено в мережу Bitcoin.</translation>
-    </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">Отримувач:</translation>
-    </message>
-    <message>
-        <source>Memo:</source>
-        <translation type="unfinished">Нотатка:</translation>
+        <translation type="unfinished">Повідомлення, що було додане до bitcoin:URI та буде збережено разом з транзакцією для довідки. Примітка: це повідомлення не буде відправлено в мережу Біткоїн.</translation>
     </message>
 </context>
 <context>
@@ -4036,30 +4273,32 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     <name>TransactionDesc</name>
     <message>
         <source>conflicted with a transaction with %1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that conflicts with a confirmed transaction.</extracomment>
         <translation type="unfinished">конфліктує з транзакцією із %1 підтвердженнями</translation>
     </message>
     <message>
-        <source>0/unconfirmed, %1</source>
-        <translation type="unfinished">0/не підтверджено, %1</translation>
+        <source>0/unconfirmed, in memory pool</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is in the memory pool.</extracomment>
+        <translation type="unfinished">0/не підтверджено, в пулі транзакцій</translation>
     </message>
     <message>
-        <source>in memory pool</source>
-        <translation type="unfinished">у пулі транзакцій</translation>
-    </message>
-    <message>
-        <source>not in memory pool</source>
-        <translation type="unfinished">не в пулі транзакцій</translation>
+        <source>0/unconfirmed, not in memory pool</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is not in the memory pool.</extracomment>
+        <translation type="unfinished">0/не підтверджено, не в пулі транзакцій</translation>
     </message>
     <message>
         <source>abandoned</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an abandoned transaction.</extracomment>
         <translation type="unfinished">відкинуто</translation>
     </message>
     <message>
         <source>%1/unconfirmed</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
         <translation type="unfinished">%1/не підтверджено</translation>
     </message>
     <message>
         <source>%1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
         <translation type="unfinished">%1 підтверджень</translation>
     </message>
     <message>
@@ -4096,7 +4335,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     </message>
     <message>
         <source>watch-only</source>
-        <translation type="unfinished">тільки спостереження</translation>
+        <translation type="unfinished">тільки перегляд</translation>
     </message>
     <message>
         <source>label</source>
@@ -4172,7 +4411,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     </message>
     <message>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to "not accepted" and it won't be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
-        <translation type="unfinished">Згенеровані монети стануть доступні для використання після %1 підтверджень. Коли ви згенерували цей блок, його було відправлено в мережу для внесення до ланцюжку блоків. Якщо блок не буде додано до ланцюжку блоків, його статус зміниться на «не підтверджено», і згенеровані монети неможливо буде витратити. Таке часом трапляється, якщо хтось згенерував інший блок на декілька секунд раніше.</translation>
+        <translation type="unfinished">Згенеровані монети стануть доступні для використання після %1 підтверджень. Коли ви згенерували цей блок, його було відправлено в мережу для приєднання до блокчейна. Якщо блок не буде додано до блокчейна, його статус зміниться на «не підтверджено», і згенеровані монети неможливо буде витратити. Таке часом трапляється, якщо хтось згенерував інший блок на декілька секунд раніше.</translation>
     </message>
     <message>
         <source>Debug information</source>
@@ -4274,7 +4513,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     </message>
     <message>
         <source>watch-only</source>
-        <translation type="unfinished">тільки спостереження</translation>
+        <translation type="unfinished">тільки перегляд</translation>
     </message>
     <message>
         <source>(n/a)</source>
@@ -4298,7 +4537,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     </message>
     <message>
         <source>Whether or not a watch-only address is involved in this transaction.</source>
-        <translation type="unfinished">Чи було залучено адресу для спостереження в цій транзакції.</translation>
+        <translation type="unfinished">Чи було залучено адресу "тільки перегляд" в цій транзакції.</translation>
     </message>
     <message>
         <source>User-defined intent/purpose of the transaction.</source>
@@ -4427,7 +4666,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     </message>
     <message>
         <source>Watch-only</source>
-        <translation type="unfinished">Тільки спостереження:</translation>
+        <translation type="unfinished">Тільки перегляд</translation>
     </message>
     <message>
         <source>Date</source>
@@ -4494,7 +4733,7 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <source>Unable to decode PSBT from clipboard (invalid base64)</source>
-        <translation type="unfinished">Не вдається декодувати PSBT-транзакцію з буфера обміну (неприпустимий base64)</translation>
+        <translation type="unfinished">Не вдалося декодувати PSBT-транзакцію з буфера обміну (неприпустимий base64)</translation>
     </message>
     <message>
         <source>Load Transaction Data</source>
@@ -4510,7 +4749,7 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <source>Unable to decode PSBT</source>
-        <translation type="unfinished">Не вдається декодувати PSBT-транзакцію</translation>
+        <translation type="unfinished">Не вдалося декодувати PSBT-транзакцію</translation>
     </message>
 </context>
 <context>
@@ -4585,7 +4824,7 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <source>Export the data in the current tab to a file</source>
-        <translation type="unfinished">Експортувати дані з поточної вкладки в файл</translation>
+        <translation type="unfinished">Експортувати дані з поточної вкладки у файл</translation>
     </message>
     <message>
         <source>Backup Wallet</source>

--- a/src/qt/locale/bitcoin_ur.ts
+++ b/src/qt/locale/bitcoin_ur.ts
@@ -285,8 +285,29 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">%1ابھی تک سلامتی سے باہر نہیں نکلا…</translation>
     </message>
     <message>
+        <source>unknown</source>
+        <translation type="unfinished">نامعلوم</translation>
+    </message>
+    <message>
         <source>Amount</source>
         <translation type="unfinished">رقم</translation>
+    </message>
+    <message>
+        <source>Unroutable</source>
+        <translation type="unfinished">ناقابل استعمال</translation>
+    </message>
+    <message>
+        <source>Internal</source>
+        <translation type="unfinished">اندرونی</translation>
+    </message>
+    <message>
+        <source>Address Fetch</source>
+        <extracomment>Short-lived peer connection type that solicits known addresses from a peer.</extracomment>
+        <translation type="unfinished">پتہ بازیافت کریں۔</translation>
+    </message>
+    <message>
+        <source>%1 ms</source>
+        <translation type="unfinished">ملی سیکنڈز %1</translation>
     </message>
     <message numerus="yes">
         <source>%n second(s)</source>
@@ -465,6 +486,66 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Create Wallet…</source>
         <translation type="unfinished">والیٹ بنائیں…</translation>
     </message>
+    <message>
+        <source>Close All Wallets…</source>
+        <translation type="unfinished">تمام والیٹس بند کردیں</translation>
+    </message>
+    <message>
+        <source>&amp;File</source>
+        <translation type="unfinished">اور فائل</translation>
+    </message>
+    <message>
+        <source>&amp;Settings</source>
+        <translation type="unfinished">اور ترتیبات</translation>
+    </message>
+    <message>
+        <source>&amp;Help</source>
+        <translation type="unfinished">اور مدد</translation>
+    </message>
+    <message>
+        <source>Tabs toolbar</source>
+        <translation type="unfinished">ٹیبز ٹول بار</translation>
+    </message>
+    <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation type="unfinished"> '%1%' ہیڈرز کی مطابقت پذیری</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation type="unfinished">نیٹ ورک کے ساتھ ہم آہنگ ہو کر</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation type="unfinished">ڈسک پر بلاکس کو ترتیب دینا</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation type="unfinished">ڈسک پر بلاکس کو پراسیس کرنا</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation type="unfinished">ڈسک پر بلاکس کو دوبارہ ترتیب دینا</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation type="unfinished">ساتھیوں سے منسلک کرنے</translation>
+    </message>
+    <message>
+        <source>Request payments (generates QR codes and bitcoin: URIs)</source>
+        <translation type="unfinished">ادائیگی کی درخواست کریں: ( کوئیک رسپانس ( کیو۔آر ) کوڈ اور بٹ کوائن ( یونیورسل ادائیگیوں کا نظام) کے ذریعے سے</translation>
+    </message>
+    <message>
+        <source>Show the list of used sending addresses and labels</source>
+        <translation type="unfinished">استعمال شدہ بھیجنے والے پتے اور لیبلز کی فہرست دکھائیں۔</translation>
+    </message>
+    <message>
+        <source>Show the list of used receiving addresses and labels</source>
+        <translation type="unfinished">استعمال شدہ وصول کرنے والے پتوں اور لیبلز کی فہرست دکھائیں۔</translation>
+    </message>
+    <message>
+        <source>&amp;Command-line options</source>
+        <translation type="unfinished">اور کمانڈ لائن اختیارات</translation>
+    </message>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation type="unfinished">
@@ -473,8 +554,121 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         </translation>
     </message>
     <message>
+        <source>%1 behind</source>
+        <translation type="unfinished">'%1'پیچھے</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation type="unfinished">پکڑنا</translation>
+    </message>
+    <message>
+        <source>Last received block was generated %1 ago.</source>
+        <translation type="unfinished">آخری موصول شدہ 1 '%1' پہلے تیار کیا گیا تھا۔</translation>
+    </message>
+    <message>
+        <source>Transactions after this will not yet be visible.</source>
+        <translation type="unfinished">اس کے بعد کی لین دین ابھی نظر نہیں آئے گی۔</translation>
+    </message>
+    <message>
         <source>Error</source>
         <translation type="unfinished">نقص</translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished">انتباہ</translation>
+    </message>
+    <message>
+        <source>Information</source>
+        <translation type="unfinished">معلومات</translation>
+    </message>
+    <message>
+        <source>Up to date</source>
+        <translation type="unfinished">سب سے نیا</translation>
+    </message>
+    <message>
+        <source>Load Partially Signed Bitcoin Transaction</source>
+        <translation type="unfinished">جزوی طور پر دستخط شدہ بٹ کوائن ٹرانزیکشن لوڈ کریں۔</translation>
+    </message>
+    <message>
+        <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
+        <translation type="unfinished">کلپ بورڈ سے جزوی طور پر دستخط شدہ بٹ کوائن ٹرانزیکشن لوڈ کریں۔</translation>
+    </message>
+    <message>
+        <source>Node window</source>
+        <translation type="unfinished">نوڈ ونڈو</translation>
+    </message>
+    <message>
+        <source>Open node debugging and diagnostic console</source>
+        <translation type="unfinished">نوڈ ڈیبگنگ اور تشخیصی کنسول کھولیں۔</translation>
+    </message>
+    <message>
+        <source>&amp;Sending addresses</source>
+        <translation type="unfinished">اور بھیجنے والے پتے</translation>
+    </message>
+    <message>
+        <source>&amp;Receiving addresses</source>
+        <translation type="unfinished">اور پتے وصول کرنا</translation>
+    </message>
+    <message>
+        <source>Open a bitcoin: URI</source>
+        <translation type="unfinished">بٹ کوائن کا یو۔آر۔آئی۔ کھولیں</translation>
+    </message>
+    <message>
+        <source>Open Wallet</source>
+        <translation type="unfinished">والیٹ کھولیں</translation>
+    </message>
+    <message>
+        <source>Open a wallet</source>
+        <translation type="unfinished">والیٹ کھولیں</translation>
+    </message>
+    <message>
+        <source>Close wallet</source>
+        <translation type="unfinished">والیٹ بند کریں</translation>
+    </message>
+    <message>
+        <source>Close all wallets</source>
+        <translation type="unfinished">تمام والیٹس بند کریں</translation>
+    </message>
+    <message>
+        <source>Show the %1 help message to get a list with possible Bitcoin command-line options</source>
+        <translation type="unfinished">ممکنہ بٹ کوائن کمانڈ لائن اختیارات کے ساتھ فہرست حاصل کرنے کے لیے %1 مدد کا پیغام دکھائیں۔</translation>
+    </message>
+    <message>
+        <source>&amp;Mask values</source>
+        <translation type="unfinished">قدروں کو چھپائیں</translation>
+    </message>
+    <message>
+        <source>Mask the values in the Overview tab</source>
+        <translation type="unfinished">جائزہ ٹیب میں اقدار کو ماسک کریں۔</translation>
+    </message>
+    <message>
+        <source>default wallet</source>
+        <translation type="unfinished">پہلے سے طے شدہ والیٹ</translation>
+    </message>
+    <message>
+        <source>No wallets available</source>
+        <translation type="unfinished">کوئی والیٹ دستیاب نہیں ہیں۔</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">والیٹ کا نام</translation>
+    </message>
+    <message>
+        <source>&amp;Window</source>
+        <translation type="unfinished">اور ونڈو</translation>
+    </message>
+    <message>
+        <source>Zoom</source>
+        <translation type="unfinished">بغور جائزہ لینا</translation>
+    </message>
+    <message>
+        <source>Main Window</source>
+        <translation type="unfinished">مین ونڈو</translation>
+    </message>
+    <message>
+        <source>%1 client</source>
+        <translation type="unfinished">'%1'کلائنٹ</translation>
     </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
@@ -485,42 +679,477 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         </translation>
     </message>
     <message>
+        <source>Click for more actions.</source>
+        <extracomment>A substring of the tooltip. "More actions" are available via the context menu.</extracomment>
+        <translation type="unfinished">مزید کارروائی کے لیے کلک کریں۔</translation>
+    </message>
+    <message>
+        <source>Show Peers tab</source>
+        <extracomment>A context menu item. The "Peers tab" is an element of the "Node window".</extracomment>
+        <translation type="unfinished">پیئرز ٹیب دکھائیں۔</translation>
+    </message>
+    <message>
+        <source>Disable network activity</source>
+        <extracomment>A context menu item.</extracomment>
+        <translation type="unfinished">نیٹ ورک کی سرگرمی کو غیر فعال کریں۔</translation>
+    </message>
+    <message>
+        <source>Enable network activity</source>
+        <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
+        <translation type="unfinished">نیٹ ورک کی سرگرمی کو فعال کریں۔</translation>
+    </message>
+    <message>
         <source>Error: %1</source>
         <translation type="unfinished">خرابی:%1</translation>
     </message>
-    </context>
+    <message>
+        <source>Warning: %1</source>
+        <translation type="unfinished">1%1 انتباہ</translation>
+    </message>
+    <message>
+        <source>Date: %1
+</source>
+        <translation type="unfinished">1%1' تاریخ۔
+</translation>
+    </message>
+    <message>
+        <source>Amount: %1
+</source>
+        <translation type="unfinished">1%1' مقدار
+</translation>
+    </message>
+    <message>
+        <source>Wallet: %1
+</source>
+        <translation type="unfinished">1%1' والیٹ
+</translation>
+    </message>
+    <message>
+        <source>Type: %1
+</source>
+        <translation type="unfinished">1 %1'قسم
+</translation>
+    </message>
+    <message>
+        <source>Label: %1
+</source>
+        <translation type="unfinished">1%1'لیبل
+</translation>
+    </message>
+    <message>
+        <source>Address: %1
+</source>
+        <translation type="unfinished">1%1' پتہ
+</translation>
+    </message>
+    <message>
+        <source>Sent transaction</source>
+        <translation type="unfinished">بھیجی گئی ٹرانزیکشن</translation>
+    </message>
+    <message>
+        <source>Incoming transaction</source>
+        <translation type="unfinished">آنے والی ٹرانزیکشن</translation>
+    </message>
+    <message>
+        <source>HD key generation is &lt;b&gt;enabled&lt;/b&gt;</source>
+        <translation type="unfinished">درجہ بندی کا تعین کرنے والی ایچ۔ڈی کلیدی جنریشن &lt;b&gt;فعال&lt;/b&gt; ہے</translation>
+    </message>
+    <message>
+        <source>HD key generation is &lt;b&gt;disabled&lt;/b&gt;</source>
+        <translation type="unfinished">درجہ بندی کا تعین کرنے والی ایچ۔ ڈی کلیدی جنریشن&lt;b&gt; غیر فعال&lt;/b&gt; ہے</translation>
+    </message>
+    <message>
+        <source>Private key &lt;b&gt;disabled&lt;/b&gt;</source>
+        <translation type="unfinished">نجی کلید &lt;b&gt;غیر فعال &lt;b/&gt;ہے۔</translation>
+    </message>
+    <message>
+        <source>Original message:</source>
+        <translation type="unfinished">اصل پیغام:</translation>
+    </message>
+</context>
+<context>
+    <name>UnitDisplayStatusBarControl</name>
+    <message>
+        <source>Unit to show amounts in. Click to select another unit.</source>
+        <translation type="unfinished">رقم ظاہر کرنے کے لیے یونٹ۔ دوسری اکائی کو منتخب کرنے کے لیے کلک کریں۔</translation>
+    </message>
+</context>
 <context>
     <name>CoinControlDialog</name>
     <message>
+        <source>Coin Selection</source>
+        <translation type="unfinished">سکے کا انتخاب</translation>
+    </message>
+    <message>
+        <source>Quantity:</source>
+        <translation type="unfinished">مقدار:</translation>
+    </message>
+    <message>
+        <source>Bytes:</source>
+        <translation type="unfinished">بائٹس:</translation>
+    </message>
+    <message>
         <source>Amount:</source>
         <translation type="unfinished">رقم:</translation>
+    </message>
+    <message>
+        <source>Fee:</source>
+        <translation type="unfinished">فیس:</translation>
+    </message>
+    <message>
+        <source>Dust:</source>
+        <translation type="unfinished">نہ ہونے کے برابر</translation>
+    </message>
+    <message>
+        <source>After Fee:</source>
+        <translation type="unfinished">فیس کے بعد:</translation>
+    </message>
+    <message>
+        <source>Change:</source>
+        <translation type="unfinished">تبدیلی:</translation>
+    </message>
+    <message>
+        <source>(un)select all</source>
+        <translation type="unfinished">سب کو غیر منتخب کریں</translation>
+    </message>
+    <message>
+        <source>Tree mode</source>
+        <translation type="unfinished">ٹری موڈ</translation>
+    </message>
+    <message>
+        <source>List mode</source>
+        <translation type="unfinished">فہرست موڈ</translation>
     </message>
     <message>
         <source>Amount</source>
         <translation type="unfinished">رقم</translation>
     </message>
     <message>
+        <source>Received with label</source>
+        <translation type="unfinished">لیبل کے ساتھ موصول ہوا۔</translation>
+    </message>
+    <message>
+        <source>Received with address</source>
+        <translation type="unfinished">پتے کے ساتھ موصول ہوا۔</translation>
+    </message>
+    <message>
         <source>Date</source>
         <translation type="unfinished">تاریخ</translation>
+    </message>
+    <message>
+        <source>Confirmations</source>
+        <translation type="unfinished">تصدیقات</translation>
+    </message>
+    <message>
+        <source>Confirmed</source>
+        <translation type="unfinished">تصدیق شدہ</translation>
+    </message>
+    <message>
+        <source>Copy amount</source>
+        <translation type="unfinished">رقم کاپی کریں۔</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">ایڈریس کاپی کریں۔</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">کاپی اور لیبل</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">کاپی اور رقم</translation>
+    </message>
+    <message>
+        <source>L&amp;ock unspent</source>
+        <translation type="unfinished">غیر خرچ شدہ آؤٹ پٹ بند کریں</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock unspent</source>
+        <translation type="unfinished">غیر خرچ شدہ کھولیں</translation>
+    </message>
+    <message>
+        <source>Copy quantity</source>
+        <translation type="unfinished">مقدار کاپی کریں</translation>
+    </message>
+    <message>
+        <source>Copy fee</source>
+        <translation type="unfinished">فیس کاپی کریں</translation>
+    </message>
+    <message>
+        <source>Copy after fee</source>
+        <translation type="unfinished">فیس کے بعد کاپی کریں۔</translation>
+    </message>
+    <message>
+        <source>Copy bytes</source>
+        <translation type="unfinished">بائٹس کاپی کریں</translation>
+    </message>
+    <message>
+        <source>Copy dust</source>
+        <translation type="unfinished">باقی شدہ کاپی کریں</translation>
+    </message>
+    <message>
+        <source>Copy change</source>
+        <translation type="unfinished">تبدیلی کاپی کریں</translation>
+    </message>
+    <message>
+        <source>(%1 locked)</source>
+        <translation type="unfinished">مقفل'%1</translation>
+    </message>
+    <message>
+        <source>yes</source>
+        <translation type="unfinished">جی ہاں</translation>
+    </message>
+    <message>
+        <source>no</source>
+        <translation type="unfinished">نہیں</translation>
+    </message>
+    <message>
+        <source>This label turns red if any recipient receives an amount smaller than the current dust threshold.</source>
+        <translation type="unfinished">یہ لیبل سرخ ہو جاتا ہے اگر کوئی وصول کنندہ موجودہ کم سے کم مقرر کردہ حد سے کم رقم وصول کرتا ہے۔</translation>
+    </message>
+    <message>
+        <source>Can vary +/- %1 satoshi(s) per input.</source>
+        <translation type="unfinished">مختلف ہو سکتے ہیں%1 +/- ساتوشی فی ان پٹ۔</translation>
     </message>
     <message>
         <source>(no label)</source>
         <translation type="unfinished">(کوئی لیبل نہیں)</translation>
     </message>
+    <message>
+        <source>change from %1 (%2)</source>
+        <translation type="unfinished">%1 (%2)سے تبدیل کریں</translation>
+    </message>
+    <message>
+        <source>(change)</source>
+        <translation type="unfinished">تبدیلی</translation>
+    </message>
+</context>
+<context>
+    <name>CreateWalletActivity</name>
+    <message>
+        <source>Create Wallet</source>
+        <extracomment>Title of window indicating the progress of creation of a new wallet.</extracomment>
+        <translation type="unfinished">والیٹ بنائیں</translation>
+    </message>
+    <message>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the create wallet progress window which indicates to the user which wallet is currently being created.</extracomment>
+        <translation type="unfinished">والیٹ بنانا &lt;b&gt; %1&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Create wallet failed</source>
+        <translation type="unfinished">والیٹ بنانا ناکام ہوگیا۔</translation>
+    </message>
+    <message>
+        <source>Create wallet warning</source>
+        <translation type="unfinished">والیٹ بنانے کےلئے انتباہ</translation>
+    </message>
+    <message>
+        <source>Can't list signers</source>
+        <translation type="unfinished">دستخط کنندگان کی فہرست نہیں بن سکتی</translation>
+    </message>
     </context>
 <context>
+    <name>OpenWalletActivity</name>
+    <message>
+        <source>Open wallet failed</source>
+        <translation type="unfinished">والیٹ کھولنا ناکام ہو گیا</translation>
+    </message>
+    <message>
+        <source>Open wallet warning</source>
+        <translation type="unfinished">والیٹ کھولنے کی انتباہ</translation>
+    </message>
+    <message>
+        <source>default wallet</source>
+        <translation type="unfinished">پہلے سے طے شدہ والیٹ</translation>
+    </message>
+    <message>
+        <source>Open Wallet</source>
+        <extracomment>Title of window indicating the progress of opening of a wallet.</extracomment>
+        <translation type="unfinished">والیٹ کھولیں</translation>
+    </message>
+    </context>
+<context>
+    <name>WalletController</name>
+    <message>
+        <source>Close wallet</source>
+        <translation type="unfinished">والیٹ بند کریں</translation>
+    </message>
+    <message>
+        <source>Closing the wallet for too long can result in having to resync the entire chain if pruning is enabled.</source>
+        <translation type="unfinished">والیٹ کو زیادہ دیر تک بند کرنے کے نتیجے میں اگر کانٹ چھانٹ کو فعال کیا جاتا ہے تو پوری چین کو دوبارہ ہم آہنگ کرنا پڑ سکتا ہے۔</translation>
+    </message>
+    <message>
+        <source>Close all wallets</source>
+        <translation type="unfinished">تمام والیٹس بند کریں</translation>
+    </message>
+    <message>
+        <source>Are you sure you wish to close all wallets?</source>
+        <translation type="unfinished">کیا آپ واقعی تمام والیٹس بند کرنا چاہتے ہیں؟</translation>
+    </message>
+</context>
+<context>
+    <name>CreateWalletDialog</name>
+    <message>
+        <source>Create Wallet</source>
+        <translation type="unfinished">والیٹ بنائیں</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <translation type="unfinished">والیٹ کا نام</translation>
+    </message>
+    <message>
+        <source>Wallet</source>
+        <translation type="unfinished">والیٹ</translation>
+    </message>
+    <message>
+        <source>Encrypt the wallet. The wallet will be encrypted with a passphrase of your choice.</source>
+        <translation type="unfinished">والیٹ کو خفیہ کریں۔ والیٹ کو آپ کی پسند کے پاسفریز کے ساتھ خفیہ کیا جائے گا۔</translation>
+    </message>
+    <message>
+        <source>Encrypt Wallet</source>
+        <translation type="unfinished">والیٹ کو خفیہ کریں۔</translation>
+    </message>
+    <message>
+        <source>Advanced Options</source>
+        <translation type="unfinished">اعلی درجے کے اختیارات</translation>
+    </message>
+    <message>
+        <source>Disable private keys for this wallet. Wallets with private keys disabled will have no private keys and cannot have an HD seed or imported private keys. This is ideal for watch-only wallets.</source>
+        <translation type="unfinished">اس والیٹ کے لیے نجی چابیوں کو غیر فعال کریں۔ غیر فعال نجی چابیوں والے والیٹ میں کوئی نجی چابیاں نہیں ہوں گی اور اس میں HD بیج یا درآمد شدہ نجی چابیاں نہیں ہو سکتیں۔ یہ صرف دیکھنے والے والیٹ کے لیے مثالی ہے۔</translation>
+    </message>
+    <message>
+        <source>Disable Private Keys</source>
+        <translation type="unfinished">نجی چابیاں غیر فعال کریں۔</translation>
+    </message>
+    <message>
+        <source>Make a blank wallet. Blank wallets do not initially have private keys or scripts. Private keys and addresses can be imported, or an HD seed can be set, at a later time.</source>
+        <translation type="unfinished">ایک خالی والیٹ بنائیں۔ خالی والیٹ میں ابتدائی طور پر نجی چابیاں یا اسکرپٹ نہیں ہوتے ہیں۔ نجی چابیاں اور پتے درآمد کیے جا سکتے ہیں، یا بعد میں ایک HD بیج سیٹ کیا جا سکتا ہے۔</translation>
+    </message>
+    <message>
+        <source>Make Blank Wallet</source>
+        <translation type="unfinished">خالی والیٹ بنائیں</translation>
+    </message>
+    <message>
+        <source>Use descriptors for scriptPubKey management</source>
+        <translation type="unfinished">ScriptPubKeys کے انتظام کے لیے وضاحت کنندگان کا استعمال کریں۔</translation>
+    </message>
+    <message>
+        <source>Descriptor Wallet</source>
+        <translation type="unfinished">وضاحتی والیٹ</translation>
+    </message>
+    <message>
+        <source>Use an external signing device such as a hardware wallet. Configure the external signer script in wallet preferences first.</source>
+        <translation type="unfinished">بیرونی دستخط کرنے والا آلہ استعمال کریں جیسے ہارڈ ویئر والیٹ۔ پہلے والیٹ کی ترجیحات میں بیرونی دستخط کنندہ اسکرپٹ کو ترتیب دیں۔</translation>
+    </message>
+    <message>
+        <source>External signer</source>
+        <translation type="unfinished">بیرونی دستخط کنندہ</translation>
+    </message>
+    <message>
+        <source>Create</source>
+        <translation type="unfinished">بنائیں</translation>
+    </message>
+    <message>
+        <source>Compiled without sqlite support (required for descriptor wallets)</source>
+        <translation type="unfinished"> SQliteسپورٹ کے بغیر مرتب کیا گیا (ڈسکرپٹر والیٹس کے لیے درکار)</translation>
+    </message>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">بیرونی دستخطی معاونت کے بغیر مرتب کیا گیا (بیرونی دستخط کے لیے درکار)</translation>
+    </message>
+</context>
+<context>
     <name>EditAddressDialog</name>
+    <message>
+        <source>Edit Address</source>
+        <translation type="unfinished">ایڈریس میں ترمیم کریں۔</translation>
+    </message>
     <message>
         <source>&amp;Label</source>
         <translation type="unfinished">چٹ</translation>
     </message>
     <message>
+        <source>The label associated with this address list entry</source>
+        <translation type="unfinished">اس ایڈریس لسٹ کے اندراج سے وابستہ لیبل</translation>
+    </message>
+    <message>
+        <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
+        <translation type="unfinished">اس ایڈریس لسٹ کے اندراج سے وابستہ پتہ۔ اس میں صرف ایڈریس بھیجنے کے لیے ترمیم کی جا سکتی ہے۔</translation>
+    </message>
+    <message>
         <source>&amp;Address</source>
         <translation type="unfinished">پتہ</translation>
     </message>
-    </context>
+    <message>
+        <source>New sending address</source>
+        <translation type="unfinished">نیا بھیجنے کا پتہ</translation>
+    </message>
+    <message>
+        <source>Edit receiving address</source>
+        <translation type="unfinished">وصول کنندہ ایڈریس میں ترمیم کریں۔</translation>
+    </message>
+    <message>
+        <source>Edit sending address</source>
+        <translation type="unfinished">بھیجنے کے پتے میں ترمیم کریں۔</translation>
+    </message>
+    <message>
+        <source>Could not unlock wallet.</source>
+        <translation type="unfinished">والیٹ کو غیر مقفل نہیں کیا جا سکا۔</translation>
+    </message>
+    <message>
+        <source>New key generation failed.</source>
+        <translation type="unfinished">نئی کلیدی نسل ناکام ہوگئی۔</translation>
+    </message>
+</context>
+<context>
+    <name>FreespaceChecker</name>
+    <message>
+        <source>A new data directory will be created.</source>
+        <translation type="unfinished">ایک نئی ڈیٹا ڈائرکٹری بنائی جائے گی۔</translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished">نام</translation>
+    </message>
+    <message>
+        <source>Path already exists, and is not a directory.</source>
+        <translation type="unfinished">پاتھ پہلے سے موجود ہے، اور ڈائرکٹری نہیں ہے۔</translation>
+    </message>
+    <message>
+        <source>Cannot create data directory here.</source>
+        <translation type="unfinished">یہاں ڈیٹا ڈائرکٹری نہیں بن سکتی۔</translation>
+    </message>
+</context>
 <context>
     <name>Intro</name>
+    <message>
+        <source>Bitcoin</source>
+        <translation type="unfinished">بٹ کوائن</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
     <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
@@ -530,30 +1159,708 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         </translation>
     </message>
     <message>
-        <source>Error</source>
-        <translation type="unfinished">نقص</translation>
+        <source>The wallet will also be stored in this directory.</source>
+        <translation type="unfinished">والیٹ بھی اس ڈائرکٹری میں محفوظ کیا جائے گا۔</translation>
     </message>
-    </context>
-<context>
-    <name>OptionsDialog</name>
     <message>
         <source>Error</source>
         <translation type="unfinished">نقص</translation>
+    </message>
+    <message>
+        <source>Welcome</source>
+        <translation type="unfinished">خوش آمدید</translation>
+    </message>
+    <message>
+        <source>Limit block chain storage to</source>
+        <translation type="unfinished">بلاک چین اسٹوریج کو محدود کریں۔</translation>
+    </message>
+    <message>
+        <source>Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</source>
+        <translation type="unfinished">اس ترتیب کو واپس کرنے کے لیے پورے بلاکچین کو دوبارہ ڈاؤن لوڈ کرنے کی ضرورت ہے۔ پہلے پوری چین کو ڈاؤن لوڈ کرنا اور بعد میں اسے کاٹنا تیز تر ہے۔ کچھ جدید خصوصیات کو غیر فعال کرتا ہے۔</translation>
+    </message>
+    <message>
+        <source> GB</source>
+        <translation type="unfinished">جی بی</translation>
+    </message>
+    <message>
+        <source>If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</source>
+        <translation type="unfinished">اگر آپ نے بلاک چین اسٹوریج کو محدود کرنے کا انتخاب کیا ہے (کاٹنا)، تو تاریخی ڈیٹا کو ابھی بھی ڈاؤن لوڈ اور پروسیس کیا جانا چاہیے، لیکن آپ کے ڈسک کے استعمال کو کم رکھنے کے لیے اسے بعد میں حذف کر دیا جائے گا۔</translation>
+    </message>
+    <message>
+        <source>Use the default data directory</source>
+        <translation type="unfinished">پہلے سے طے شدہ ڈیٹا ڈائرکٹری استعمال کریں۔</translation>
+    </message>
+    <message>
+        <source>Use a custom data directory:</source>
+        <translation type="unfinished">اپنی مرضی کے مطابق ڈیٹا ڈائرکٹری کا استعمال کریں:</translation>
+    </message>
+</context>
+<context>
+    <name>HelpMessageDialog</name>
+    <message>
+        <source>version</source>
+        <translation type="unfinished">ورژن</translation>
+    </message>
+    <message>
+        <source>About %1</source>
+        <translation type="unfinished">تقریبآ %1</translation>
+    </message>
+    <message>
+        <source>Command-line options</source>
+        <translation type="unfinished">کمانڈ لائن کے اختیارات</translation>
+    </message>
+</context>
+<context>
+    <name>ShutdownWindow</name>
+    <message>
+        <source>Do not shut down the computer until this window disappears.</source>
+        <translation type="unfinished">جب تک یہ ونڈو غائب نہ ہوجائے کمپیوٹر کو بند نہ کریں۔</translation>
+    </message>
+</context>
+<context>
+    <name>ModalOverlay</name>
+    <message>
+        <source>Form</source>
+        <translation type="unfinished">فارم</translation>
+    </message>
+    <message>
+        <source>Recent transactions may not yet be visible, and therefore your wallet's balance might be incorrect. This information will be correct once your wallet has finished synchronizing with the bitcoin network, as detailed below.</source>
+        <translation type="unfinished">ہو سکتا ہے حالیہ لین دین ابھی تک نظر نہ آئے، اور اس وجہ سے آپ کے والیٹ کا بیلنس غلط ہو سکتا ہے۔ یہ معلومات درست ہوں گی جب آپ کے والیٹ نے بٹ کوائن نیٹ ورک کے ساتھ مطابقت پذیری مکمل کر لی ہو، جیسا کہ ذیل میں تفصیل ہے۔</translation>
+    </message>
+    <message>
+        <source>Attempting to spend bitcoins that are affected by not-yet-displayed transactions will not be accepted by the network.</source>
+        <translation type="unfinished">ایسے بٹ کوائنز خرچ کرنے کی کوشش کرنا جو ابھی تک ظاہر نہ ہونے والے لین دین سے متاثر ہوں نیٹ ورک کے ذریعے قبول نہیں کیا جائے گا۔</translation>
+    </message>
+    <message>
+        <source>Number of blocks left</source>
+        <translation type="unfinished">باقی بلاکس کی تعداد</translation>
+    </message>
+    <message>
+        <source>Unknown…</source>
+        <translation type="unfinished">نامعلوم</translation>
+    </message>
+    <message>
+        <source>calculating…</source>
+        <translation type="unfinished">حساب لگانا</translation>
+    </message>
+    <message>
+        <source>Last block time</source>
+        <translation type="unfinished">آخری بلاک کا وقت</translation>
+    </message>
+    <message>
+        <source>Progress</source>
+        <translation type="unfinished">پیش رفت</translation>
+    </message>
+    <message>
+        <source>Progress increase per hour</source>
+        <translation type="unfinished">فی گھنٹہ پیش رفت میں اضافہ</translation>
+    </message>
+    <message>
+        <source>Estimated time left until synced</source>
+        <translation type="unfinished">مطابقت پذیر ہونے میں تخمینی وقت باقی ہے۔</translation>
+    </message>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished">چھپائیں</translation>
+    </message>
+    </context>
+<context>
+    <name>OpenURIDialog</name>
+    <message>
+        <source>Open bitcoin URI</source>
+        <translation type="unfinished">بٹ کوائن URI کھولیں۔</translation>
+    </message>
+    <message>
+        <source>URI:</source>
+        <translation type="unfinished">URI</translation>
+    </message>
+    <message>
+        <source>Paste address from clipboard</source>
+        <extracomment>Tooltip text for button that allows you to paste an address that is in your clipboard.</extracomment>
+        <translation type="unfinished">کلپ بورڈ سے پتہ چسپاں کریں۔</translation>
+    </message>
+</context>
+<context>
+    <name>OptionsDialog</name>
+    <message>
+        <source>Options</source>
+        <translation type="unfinished">اختیارات</translation>
+    </message>
+    <message>
+        <source>&amp;Main</source>
+        <translation type="unfinished">اور مرکزی</translation>
+    </message>
+    <message>
+        <source>Enabling pruning significantly reduces the disk space required to store transactions. All blocks are still fully validated. Reverting this setting requires re-downloading the entire blockchain.</source>
+        <translation type="unfinished">کٹائی کو فعال کرنا لین دین کو ذخیرہ کرنے کے لیے درکار ڈسک کی جگہ کو نمایاں طور پر کم کرتا ہے۔ تمام بلاکس اب بھی مکمل طور پر درست ہیں۔ اس ترتیب کو واپس کرنے کے لیے پورے بلاکچین کو دوبارہ ڈاؤن لوڈ کرنے کی ضرورت ہے۔</translation>
+    </message>
+    <message>
+        <source>Size of &amp;database cache</source>
+        <translation type="unfinished">ڈیٹا بیس کیشے کا سائز</translation>
+    </message>
+    <message>
+        <source>Number of script &amp;verification threads</source>
+        <translation type="unfinished">اسکرپٹ اور تصدیقی دھاگوں کی تعداد</translation>
+    </message>
+    <message>
+        <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
+        <translation type="unfinished">پراکسی کا IP پتہ (جیسے IPv4: 127.0.0.1 / IPv6: ::1)</translation>
+    </message>
+    <message>
+        <source>Shows if the supplied default SOCKS5 proxy is used to reach peers via this network type.</source>
+        <translation type="unfinished">یہ دکھاتا ہے کہ کیا فراہم کردہ ڈیفالٹ SOCKS5 پراکسی اس نیٹ ورک کی قسم کے ذریعے ساتھی تک پہنچنے کے لیے استعمال ہوتی ہے۔</translation>
+    </message>
+    <message>
+        <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
+        <translation type="unfinished">ونڈو بند ہونے پر ایپلیکیشن سے باہر نکلنے کے بجائے چھوٹا کریں۔ جب یہ آپشن فعال ہو جائے گا تو مینو میں ایگزٹ کو منتخب کرنے کے بعد ہی ایپلیکیشن بند ہو جائے گی۔</translation>
+    </message>
+    <message>
+        <source>Open Configuration File</source>
+        <translation type="unfinished">ترتیب والی فائل کھولیں۔</translation>
+    </message>
+    <message>
+        <source>Reset all client options to default.</source>
+        <translation type="unfinished">کلائنٹ کے تمام اختیارات کو ڈیفالٹ پر دوبارہ ترتیب دیں۔</translation>
+    </message>
+    <message>
+        <source>&amp;Reset Options</source>
+        <translation type="unfinished">اور دوبارہ ترتیب دینے کے اختیارات</translation>
+    </message>
+    <message>
+        <source>&amp;Network</source>
+        <translation type="unfinished">اور نیٹ ورک</translation>
+    </message>
+    <message>
+        <source>GB</source>
+        <translation type="unfinished">جی بی</translation>
+    </message>
+    <message>
+        <source>Reverting this setting requires re-downloading the entire blockchain.</source>
+        <translation type="unfinished">اس ترتیب کو واپس کرنے کے لیے پورے بلاکچین کو دوبارہ ڈاؤن لوڈ کرنے کی ضرورت ہے۔</translation>
+    </message>
+    <message>
+        <source>Expert</source>
+        <translation type="unfinished">ماہر</translation>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation type="unfinished">سکے اور کنٹرول کی خصوصیات کو فعال کریں۔</translation>
+    </message>
+    <message>
+        <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
+        <translation type="unfinished">اگر آپ غیر مصدقہ تبدیلی کے اخراجات کو غیر فعال کرتے ہیں، تو کسی لین دین کی تبدیلی کو اس وقت تک استعمال نہیں کیا جا سکتا جب تک کہ اس لین دین کی کم از کم ایک تصدیق نہ ہو۔ اس سے یہ بھی متاثر ہوتا ہے کہ آپ کے بیلنس کا حساب کیسے لیا جاتا ہے۔</translation>
+    </message>
+    <message>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation type="unfinished">اور غیر مصدقہ تبدیلی خرچ کریں۔</translation>
+    </message>
+    <message>
+        <source>&amp;Window</source>
+        <translation type="unfinished">اور ونڈو</translation>
+    </message>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">بیرونی دستخطی معاونت کے بغیر مرتب کیا گیا (بیرونی دستخط کے لیے درکار)</translation>
+    </message>
+    <message>
+        <source>default</source>
+        <translation type="unfinished">پہلے سے طے شدہ</translation>
+    </message>
+    <message>
+        <source>none</source>
+        <translation type="unfinished">کوئی نہیں</translation>
+    </message>
+    <message>
+        <source>Confirm options reset</source>
+        <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
+        <translation type="unfinished">اختیارات کو دوبارہ ترتیب دینے کی تصدیق کریں۔</translation>
+    </message>
+    <message>
+        <source>Client restart required to activate changes.</source>
+        <extracomment>Text explaining that the settings changed will not come into effect until the client is restarted.</extracomment>
+        <translation type="unfinished">تبدیلیوں کو چالو کرنے کے لیے کلائنٹ کو دوبارہ شروع کرنا ضروری ہے۔</translation>
+    </message>
+    <message>
+        <source>Client will be shut down. Do you want to proceed?</source>
+        <extracomment>Text asking the user to confirm if they would like to proceed with a client shutdown.</extracomment>
+        <translation type="unfinished">کلائنٹ کو بند کر دیا جائے گا۔ کیا آپ آگے بڑھنا چاہتے ہیں؟</translation>
+    </message>
+    <message>
+        <source>Configuration options</source>
+        <extracomment>Window title text of pop-up box that allows opening up of configuration file.</extracomment>
+        <translation type="unfinished">کنفیگریشن کے اختیارات</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">نقص</translation>
+    </message>
+    <message>
+        <source>This change would require a client restart.</source>
+        <translation type="unfinished">اس تبدیلی کو کلائنٹ کو دوبارہ شروع کرنے کی ضرورت ہوگی۔</translation>
+    </message>
+    <message>
+        <source>The supplied proxy address is invalid.</source>
+        <translation type="unfinished">فراہم کردہ پراکسی پتہ غلط ہے۔</translation>
+    </message>
+</context>
+<context>
+    <name>OverviewPage</name>
+    <message>
+        <source>Form</source>
+        <translation type="unfinished">فارم</translation>
+    </message>
+    <message>
+        <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
+        <translation type="unfinished">ظاہر کی گئی معلومات پرانی ہو سکتی ہے۔ کنکشن قائم ہونے کے بعد آپ کا والیٹ خود بخود بٹ کوائن نیٹ ورک کے ساتھ ہم آہنگ ہوجاتا ہے، لیکن یہ عمل ابھی مکمل نہیں ہوا ہے۔</translation>
+    </message>
+    <message>
+        <source>Watch-only:</source>
+        <translation type="unfinished">صرف دیکھنے کے لیے:</translation>
+    </message>
+    <message>
+        <source>Available:</source>
+        <translation type="unfinished">دستیاب:</translation>
+    </message>
+    <message>
+        <source>Your current spendable balance</source>
+        <translation type="unfinished">آپ کا موجودہ قابل خرچ بیلنس</translation>
+    </message>
+    <message>
+        <source>Pending:</source>
+        <translation type="unfinished">زیر التواء</translation>
+    </message>
+    <message>
+        <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
+        <translation type="unfinished">کل ٹرانزیکشنز جن کی تصدیق ہونا باقی ہے، اور ابھی تک قابل خرچ بیلنس میں شمار نہیں ہوتے </translation>
+    </message>
+    <message>
+        <source>Immature:</source>
+        <translation type="unfinished">خام</translation>
+    </message>
+    <message>
+        <source>Mined balance that has not yet matured</source>
+        <translation type="unfinished">کان کنی کا توازن جو ابھی پختہ نہیں ہوا ہے۔</translation>
+    </message>
+    <message>
+        <source>Balances</source>
+        <translation type="unfinished">بیلنس</translation>
+    </message>
+    <message>
+        <source>Total:</source>
+        <translation type="unfinished">کل:</translation>
+    </message>
+    <message>
+        <source>Your current total balance</source>
+        <translation type="unfinished">آپ کا کل موجودہ بیلنس</translation>
+    </message>
+    <message>
+        <source>Your current balance in watch-only addresses</source>
+        <translation type="unfinished">صرف دیکھنے والے ایڈریسز میں آپ کا موجودہ بیلنس</translation>
+    </message>
+    <message>
+        <source>Spendable:</source>
+        <translation type="unfinished">قابل خرچ:</translation>
+    </message>
+    <message>
+        <source>Recent transactions</source>
+        <translation type="unfinished">حالیہ لین دین</translation>
+    </message>
+    <message>
+        <source>Unconfirmed transactions to watch-only addresses</source>
+        <translation type="unfinished">صرف دیکھنے والے پتوں پر غیر تصدیق شدہ لین دین</translation>
+    </message>
+    <message>
+        <source>Current total balance in watch-only addresses</source>
+        <translation type="unfinished">صرف دیکھنے کے پتوں میں کل موجودہ بیلنس</translation>
+    </message>
+    <message>
+        <source>Privacy mode activated for the Overview tab. To unmask the values, uncheck Settings-&gt;Mask values.</source>
+        <translation type="unfinished">جائزہ ٹیب کے لیے پرائیویسی موڈ کو فعال کر دیا گیا ہے۔ اقدار کو ہٹانے کے لیے، سیٹنگز-&gt;ماسک ویلیوز کو غیر چیک کریں۔</translation>
+    </message>
+</context>
+<context>
+    <name>PSBTOperationsDialog</name>
+    <message>
+        <source>Copy to Clipboard</source>
+        <translation type="unfinished">کلپ بورڈ پر کاپی کریں۔</translation>
+    </message>
+    <message>
+        <source>Save…</source>
+        <translation type="unfinished">محفوظ کریں۔</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation type="unfinished">بند کریں</translation>
+    </message>
+    <message>
+        <source>Failed to load transaction: %1</source>
+        <translation type="unfinished">لین دین لوڈ کرنے میں ناکام:%1</translation>
+    </message>
+    <message>
+        <source>Failed to sign transaction: %1</source>
+        <translation type="unfinished">لین دین پر دستخط کرنے میں ناکام:%1</translation>
+    </message>
+    <message>
+        <source>Could not sign any more inputs.</source>
+        <translation type="unfinished">مزید ان پٹ پر دستخط نہیں ہو سکے۔</translation>
+    </message>
+    <message>
+        <source>Save Transaction Data</source>
+        <translation type="unfinished">لین دین کا ڈیٹا محفوظ کریں۔</translation>
+    </message>
+    <message>
+        <source>Total Amount</source>
+        <translation type="unfinished">کل رقم</translation>
+    </message>
+    <message>
+        <source>or</source>
+        <translation type="unfinished">یا</translation>
+    </message>
+    <message>
+        <source>Transaction still needs signature(s).</source>
+        <translation type="unfinished">لین دین کو ابھی بھی دستخط کی ضرورت ہے۔</translation>
+    </message>
+    <message>
+        <source>(But this wallet cannot sign transactions.)</source>
+        <translation type="unfinished">(لیکن یہ والیٹ لین دین پر دستخط نہیں کر سکتا۔)</translation>
+    </message>
+    <message>
+        <source>Transaction status is unknown.</source>
+        <translation type="unfinished">لین دین کی حیثیت نامعلوم ہے۔</translation>
+    </message>
+</context>
+<context>
+    <name>PaymentServer</name>
+    <message>
+        <source>Payment request error</source>
+        <translation type="unfinished">ادائیگی کی درخواست کی خرابی۔</translation>
+    </message>
+    <message>
+        <source>Cannot process payment request because BIP70 is not supported.
+Due to widespread security flaws in BIP70 it's strongly recommended that any merchant instructions to switch wallets be ignored.
+If you are receiving this error you should request the merchant provide a BIP21 compatible URI.</source>
+        <translation type="unfinished">ادائیگی کی درخواست پر کارروائی نہیں کی جا سکتی کیونکہ BIP70 تعاون یافتہ نہیں ہے۔ BIP70 میں سیکورٹی کی وسیع خامیوں کی وجہ سے یہ پرزور مشورہ دیا جاتا ہے کہ والیٹ کو تبدیل کرنے کے لیے کسی بھی تاجر کی ہدایات کو نظر انداز کر دیا جائے۔ اگر آپ کو یہ خرابی موصول ہو رہی ہے تو آپ کو مرچنٹ سے BIP21 مطابقت پذیر URI فراہم کرنے کی درخواست کرنی چاہیے۔</translation>
     </message>
     </context>
 <context>
     <name>PeerTableModel</name>
     <message>
+        <source>User Agent</source>
+        <extracomment>Title of Peers Table column which contains the peer's User Agent string.</extracomment>
+        <translation type="unfinished">صارف ایجنٹ</translation>
+    </message>
+    <message>
+        <source>Ping</source>
+        <extracomment>Title of Peers Table column which indicates the current latency of the connection with the peer.</extracomment>
+        <translation type="unfinished">پنگ</translation>
+    </message>
+    <message>
+        <source>Peer</source>
+        <extracomment>Title of Peers Table column which contains a unique number used to identify a connection.</extracomment>
+        <translation type="unfinished">فریق</translation>
+    </message>
+    <message>
+        <source>Sent</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have sent to the peer.</extracomment>
+        <translation type="unfinished">بھیجا</translation>
+    </message>
+    <message>
+        <source>Received</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have received from the peer.</extracomment>
+        <translation type="unfinished">موصول ہوا۔</translation>
+    </message>
+    <message>
         <source>Address</source>
         <extracomment>Title of Peers Table column which contains the IP/Onion/I2P address of the connected peer.</extracomment>
         <translation type="unfinished">پتہ</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <extracomment>Title of Peers Table column which describes the type of peer connection. The "type" describes why the connection exists.</extracomment>
+        <translation type="unfinished">قسم</translation>
+    </message>
+    <message>
+        <source>Network</source>
+        <extracomment>Title of Peers Table column which states the network the peer connected through.</extracomment>
+        <translation type="unfinished">نیٹ ورک</translation>
+    </message>
+    </context>
+<context>
+    <name>QRImageWidget</name>
+    <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">اور تصویر محفوظ کریں…</translation>
+    </message>
+    <message>
+        <source>&amp;Copy Image</source>
+        <translation type="unfinished">اور تصویر کاپی کریں۔</translation>
+    </message>
+    <message>
+        <source>Save QR Code</source>
+        <translation type="unfinished">کیو آر کوڈ محفوظ کریں۔</translation>
+    </message>
+    </context>
+<context>
+    <name>RPCConsole</name>
+    <message>
+        <source>&amp;Information</source>
+        <translation type="unfinished">اور معلومات</translation>
+    </message>
+    <message>
+        <source>Startup time</source>
+        <translation type="unfinished">آغاز کا وقت</translation>
+    </message>
+    <message>
+        <source>Network</source>
+        <translation type="unfinished">نیٹ ورک</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished">نام</translation>
+    </message>
+    <message>
+        <source>Number of connections</source>
+        <translation type="unfinished">رابطوں کی تعداد</translation>
+    </message>
+    <message>
+        <source>Block chain</source>
+        <translation type="unfinished">بلاک چین</translation>
+    </message>
+    <message>
+        <source>Current number of transactions</source>
+        <translation type="unfinished">لین دین کی موجودہ تعداد</translation>
+    </message>
+    <message>
+        <source>Memory usage</source>
+        <translation type="unfinished">استعمال یاد داشت</translation>
+    </message>
+    <message>
+        <source>Wallet: </source>
+        <translation type="unfinished">والیٹ</translation>
+    </message>
+    <message>
+        <source>(none)</source>
+        <translation type="unfinished">(کوئی نہیں)</translation>
+    </message>
+    <message>
+        <source>Received</source>
+        <translation type="unfinished">موصول ہوا۔</translation>
+    </message>
+    <message>
+        <source>Sent</source>
+        <translation type="unfinished">بھیجا</translation>
+    </message>
+    <message>
+        <source>&amp;Peers</source>
+        <translation type="unfinished">اور فریق</translation>
+    </message>
+    <message>
+        <source>Banned peers</source>
+        <translation type="unfinished">ممنوعہ فریقوں</translation>
+    </message>
+    <message>
+        <source>Select a peer to view detailed information.</source>
+        <translation type="unfinished">تفصیلی معلومات دیکھنے کے لیے فریق کا انتخاب کریں۔</translation>
+    </message>
+    <message>
+        <source>Starting Block</source>
+        <translation type="unfinished">شروع ہونے والا بلاک</translation>
+    </message>
+    <message>
+        <source>Synced Blocks</source>
+        <translation type="unfinished">مطابقت پذیر بلاکس</translation>
+    </message>
+    <message>
+        <source>User Agent</source>
+        <translation type="unfinished">صارف ایجنٹ</translation>
+    </message>
+    <message>
+        <source>Node window</source>
+        <translation type="unfinished">نوڈ ونڈو</translation>
+    </message>
+    <message>
+        <source>Current block height</source>
+        <translation type="unfinished">موجودہ بلاک کی اونچائی</translation>
+    </message>
+    <message>
+        <source>Decrease font size</source>
+        <translation type="unfinished">فونٹ کا سائز کم کریں۔</translation>
+    </message>
+    <message>
+        <source>Increase font size</source>
+        <translation type="unfinished">فونٹ سائز میں اضافہ کریں</translation>
+    </message>
+    <message>
+        <source>Permissions</source>
+        <translation type="unfinished">اجازتیں</translation>
+    </message>
+    <message>
+        <source>Services</source>
+        <translation type="unfinished">خدمات</translation>
+    </message>
+    <message>
+        <source>Connection Time</source>
+        <translation type="unfinished">کنکشن کا وقت</translation>
+    </message>
+    <message>
+        <source>Elapsed time since a novel block passing initial validity checks was received from this peer.</source>
+        <translation type="unfinished">اس فریق کی جانب سے ابتدائی درستگی کی جانچ پڑتال کرنے والا ایک نیا بلاک موصول ہونے کے بعد گزرا ہوا وقت۔</translation>
+    </message>
+    <message>
+        <source>Last Block</source>
+        <translation type="unfinished">آخری بلاک</translation>
+    </message>
+    <message>
+        <source>Last Send</source>
+        <translation type="unfinished">آخری بھیجا۔</translation>
+    </message>
+    <message>
+        <source>Last Receive</source>
+        <translation type="unfinished">آخری موصول</translation>
+    </message>
+    <message>
+        <source>Last block time</source>
+        <translation type="unfinished">آخری بلاک کا وقت</translation>
+    </message>
+    <message>
+        <source>Totals</source>
+        <translation type="unfinished">کل</translation>
+    </message>
+    <message>
+        <source>Clear console</source>
+        <translation type="unfinished">کنسول صاف کریں۔</translation>
+    </message>
+    <message>
+        <source>In:</source>
+        <translation type="unfinished">میں:</translation>
+    </message>
+    <message>
+        <source>Out:</source>
+        <translation type="unfinished">باہر:</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <extracomment>Context menu action to copy the address of a peer.</extracomment>
+        <translation type="unfinished">ایڈریس کاپی کریں۔</translation>
+    </message>
+    <message>
+        <source>&amp;Disconnect</source>
+        <translation type="unfinished">اور منقطع کریں۔</translation>
+    </message>
+    <message>
+        <source>Network activity disabled</source>
+        <translation type="unfinished">نیٹ ورک کی سرگرمی غیر فعال ہے۔</translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished">جی ہاں</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished">نہیں</translation>
+    </message>
+    <message>
+        <source>To</source>
+        <translation type="unfinished">کو</translation>
+    </message>
+    <message>
+        <source>From</source>
+        <translation type="unfinished">سے</translation>
+    </message>
+    <message>
+        <source>Ban for</source>
+        <translation type="unfinished">کے لیے پابندی</translation>
+    </message>
+    <message>
+        <source>Never</source>
+        <translation type="unfinished">کبھی نہیں</translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">نامعلوم</translation>
+    </message>
+</context>
+<context>
+    <name>ReceiveCoinsDialog</name>
+    <message>
+        <source>&amp;Amount:</source>
+        <translation type="unfinished">اور رقم</translation>
+    </message>
+    <message>
+        <source>&amp;Label:</source>
+        <translation type="unfinished">اور لیبل</translation>
+    </message>
+    <message>
+        <source>&amp;Message:</source>
+        <translation type="unfinished">اور پیغام</translation>
+    </message>
+    <message>
+        <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
+        <translation type="unfinished">ادائیگی کی درخواست کے ساتھ منسلک کرنے کے لیے ایک اختیاری پیغام، جو درخواست کے کھلنے پر ظاہر ہوگا۔ نوٹ: پیغام بٹ کوائن نیٹ ورک پر ادائیگی کے ساتھ نہیں بھیجا جائے گا۔</translation>
+    </message>
+    <message>
+        <source>An optional label to associate with the new receiving address.</source>
+        <translation type="unfinished">نئے وصول کنندہ پتے کے ساتھ منسلک کرنے کے لیے ایک اختیاری لیبل۔</translation>
+    </message>
+    <message>
+        <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
+        <translation type="unfinished">درخواست کرنے کے لیے ایک اختیاری رقم۔ کسی مخصوص رقم کی درخواست نہ کرنے کے لیے اسے خالی یا صفر چھوڑ دیں۔</translation>
+    </message>
+    <message>
+        <source>An optional label to associate with the new receiving address (used by you to identify an invoice).  It is also attached to the payment request.</source>
+        <translation type="unfinished">وصول کرنے والے نئے پتے کے ساتھ منسلک کرنے کے لیے ایک اختیاری لیبل (آپ کی طرف سے رسید کی شناخت کے لیے استعمال کیا جاتا ہے)۔ یہ ادائیگی کی درخواست کے ساتھ بھی منسلک ہے۔</translation>
+    </message>
+    <message>
+        <source>An optional message that is attached to the payment request and may be displayed to the sender.</source>
+        <translation type="unfinished">ایک اختیاری پیغام جو ادائیگی کی درخواست کے ساتھ منسلک ہے اور بھیجنے والے کو دکھایا جا سکتا ہے۔</translation>
+    </message>
+    <message>
+        <source>&amp;Create new receiving address</source>
+        <translation type="unfinished">اور وصول کرنے کا نیا پتہ بنائیں</translation>
+    </message>
+    <message>
+        <source>Clear</source>
+        <translation type="unfinished">صاف</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">ایڈریس کاپی کریں۔</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">کاپی اور لیبل</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">کاپی اور رقم</translation>
+    </message>
+    <message>
+        <source>Could not unlock wallet.</source>
+        <translation type="unfinished">والیٹ کو غیر مقفل نہیں کیا جا سکا۔</translation>
     </message>
     </context>
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
+        <source>Request payment to …</source>
+        <translation type="unfinished">ادائیگی کی درخواست کریں…</translation>
+    </message>
+    <message>
+        <source>Address:</source>
+        <translation type="unfinished">پتہ:</translation>
+    </message>
+    <message>
         <source>Amount:</source>
         <translation type="unfinished">رقم:</translation>
+    </message>
+    <message>
+        <source>Label:</source>
+        <translation type="unfinished">لیبل</translation>
+    </message>
+    <message>
+        <source>Message:</source>
+        <translation type="unfinished">پیغام</translation>
     </message>
     <message>
         <source>Wallet:</source>
@@ -562,6 +1869,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Copy &amp;Address</source>
         <translation type="unfinished">کاپی پتہ</translation>
+    </message>
+    <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">اور تصویر محفوظ کریں…</translation>
     </message>
     </context>
 <context>
@@ -575,23 +1886,218 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">لیبل</translation>
     </message>
     <message>
+        <source>Message</source>
+        <translation type="unfinished">پیغام</translation>
+    </message>
+    <message>
         <source>(no label)</source>
         <translation type="unfinished">(کوئی لیبل نہیں)</translation>
     </message>
-    </context>
+    <message>
+        <source>Requested</source>
+        <translation type="unfinished">درخواست کی۔</translation>
+    </message>
+</context>
 <context>
     <name>SendCoinsDialog</name>
     <message>
+        <source>Send Coins</source>
+        <translation type="unfinished">سکے بھیجیں۔</translation>
+    </message>
+    <message>
+        <source>Coin Control Features</source>
+        <translation type="unfinished">سکوں کے کنٹرول کی خصوصیات</translation>
+    </message>
+    <message>
+        <source>automatically selected</source>
+        <translation type="unfinished">خود بخود منتخب</translation>
+    </message>
+    <message>
         <source>Insufficient funds!</source>
         <translation type="unfinished">ناکافی فنڈز</translation>
+    </message>
+    <message>
+        <source>Quantity:</source>
+        <translation type="unfinished">مقدار:</translation>
+    </message>
+    <message>
+        <source>Bytes:</source>
+        <translation type="unfinished">بائٹس:</translation>
     </message>
     <message>
         <source>Amount:</source>
         <translation type="unfinished">رقم:</translation>
     </message>
     <message>
+        <source>Fee:</source>
+        <translation type="unfinished">فیس:</translation>
+    </message>
+    <message>
+        <source>After Fee:</source>
+        <translation type="unfinished">فیس کے بعد:</translation>
+    </message>
+    <message>
+        <source>Change:</source>
+        <translation type="unfinished">تبدیلی:</translation>
+    </message>
+    <message>
+        <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
+        <translation type="unfinished">اگر یہ فعال ہے، لیکن تبدیلی کا پتہ خالی یا غلط ہے، تبدیلی کو نئے پیدا کردہ پتے پر بھیج دیا جائے گا۔</translation>
+    </message>
+    <message>
+        <source>Transaction Fee:</source>
+        <translation type="unfinished">ٹرانزیکشن فیس:</translation>
+    </message>
+    <message>
+        <source>Warning: Fee estimation is currently not possible.</source>
+        <translation type="unfinished">انتباہ: فیس کا تخمینہ فی الحال ممکن نہیں ہے۔</translation>
+    </message>
+    <message>
+        <source>per kilobyte</source>
+        <translation type="unfinished">فی کلو بائٹ(kb)</translation>
+    </message>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished">چھپائیں</translation>
+    </message>
+    <message>
+        <source>Recommended:</source>
+        <translation type="unfinished">تجویز کردہ:</translation>
+    </message>
+    <message>
+        <source>Custom:</source>
+        <translation type="unfinished">اپنی مرضی کے مطابق:</translation>
+    </message>
+    <message>
+        <source>Send to multiple recipients at once</source>
+        <translation type="unfinished">ایک ساتھ متعدد وصول کنندگان کو بھیجیں۔</translation>
+    </message>
+    <message>
+        <source>Dust:</source>
+        <translation type="unfinished">نہ ہونے کے برابر</translation>
+    </message>
+    <message>
+        <source>Choose…</source>
+        <translation type="unfinished">منتخب کریں…</translation>
+    </message>
+    <message>
+        <source>Hide transaction fee settings</source>
+        <translation type="unfinished">لین دین کی فیس کی ترتیبات چھپائیں۔</translation>
+    </message>
+    <message>
+        <source>A too low fee might result in a never confirming transaction (read the tooltip)</source>
+        <translation type="unfinished">بہت کم فیس کے نتیجے میں کبھی بھی تصدیق نہ ہونے والی لین دین ہو سکتی ہے (ٹول ٹپ پڑھیں)</translation>
+    </message>
+    <message>
+        <source>Confirmation time target:</source>
+        <translation type="unfinished">تصدیقی وقت کا ہدف:</translation>
+    </message>
+    <message>
         <source>Balance:</source>
         <translation type="unfinished">بیلنس:</translation>
+    </message>
+    <message>
+        <source>Confirm the send action</source>
+        <translation type="unfinished">بھیجنے کی کارروائی کی تصدیق کریں۔</translation>
+    </message>
+    <message>
+        <source>Copy quantity</source>
+        <translation type="unfinished">مقدار کاپی کریں</translation>
+    </message>
+    <message>
+        <source>Copy amount</source>
+        <translation type="unfinished">رقم کاپی کریں۔</translation>
+    </message>
+    <message>
+        <source>Copy fee</source>
+        <translation type="unfinished">فیس کاپی کریں</translation>
+    </message>
+    <message>
+        <source>Copy after fee</source>
+        <translation type="unfinished">فیس کے بعد کاپی کریں۔</translation>
+    </message>
+    <message>
+        <source>Copy bytes</source>
+        <translation type="unfinished">بائٹس کاپی کریں</translation>
+    </message>
+    <message>
+        <source>Copy dust</source>
+        <translation type="unfinished">باقی شدہ کاپی کریں</translation>
+    </message>
+    <message>
+        <source>Copy change</source>
+        <translation type="unfinished">تبدیلی کاپی کریں</translation>
+    </message>
+    <message>
+        <source>Connect your hardware wallet first.</source>
+        <translation type="unfinished">پہلے اپنے ہارڈویئر والیٹ کو جوڑیں۔</translation>
+    </message>
+    <message>
+        <source>To review recipient list click "Show Details…"</source>
+        <translation type="unfinished">وصول کنندگان کی فہرست کا جائزہ لینے کے لیے "تفصیلات دکھائیں..." پر کلک کریں۔</translation>
+    </message>
+    <message>
+        <source>Sign failed</source>
+        <translation type="unfinished">دستخط ناکام ہوگیا</translation>
+    </message>
+    <message>
+        <source>External signer not found</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">بیرونی دستخط کنندہ نہیں ملا</translation>
+    </message>
+    <message>
+        <source>External signer failure</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">بیرونی دستخط کنندہ کی ناکامی۔</translation>
+    </message>
+    <message>
+        <source>Save Transaction Data</source>
+        <translation type="unfinished">لین دین کا ڈیٹا محفوظ کریں۔</translation>
+    </message>
+    <message>
+        <source>External balance:</source>
+        <translation type="unfinished">بیرونی توازن:</translation>
+    </message>
+    <message>
+        <source>or</source>
+        <translation type="unfinished">یا</translation>
+    </message>
+    <message>
+        <source>Please, review your transaction.</source>
+        <extracomment>Text to prompt a user to review the details of the transaction they are attempting to send.</extracomment>
+        <translation type="unfinished">براہ کرم، اپنے لین دین کا جائزہ لیں۔</translation>
+    </message>
+    <message>
+        <source>Transaction fee</source>
+        <translation type="unfinished">ٹرانزیکشن فیس</translation>
+    </message>
+    <message>
+        <source>Total Amount</source>
+        <translation type="unfinished">کل رقم</translation>
+    </message>
+    <message>
+        <source>Confirm send coins</source>
+        <translation type="unfinished">سکے بھیجنے کی تصدیق کریں۔</translation>
+    </message>
+    <message>
+        <source>The recipient address is not valid. Please recheck.</source>
+        <translation type="unfinished">وصول کنندہ کا پتہ درست نہیں ہے۔ براہ کرم دوبارہ چیک کریں۔</translation>
+    </message>
+    <message>
+        <source>The amount to pay must be larger than 0.</source>
+        <translation type="unfinished">ادا کرنے کی رقم 0 سے زیادہ ہونی چاہیے۔</translation>
+    </message>
+    <message>
+        <source>The amount exceeds your balance.</source>
+        <translation type="unfinished">رقم آپ کے بیلنس سے زیادہ ہے۔</translation>
+    </message>
+    <message>
+        <source>Duplicate address found: addresses should only be used once each.</source>
+        <translation type="unfinished">ڈپلیکیٹ پتہ ملا: پتے صرف ایک بار استعمال کیے جائیں۔</translation>
+    </message>
+    <message>
+        <source>Transaction creation failed!</source>
+        <translation type="unfinished">لین دین کی تخلیق ناکام ہو گئی!</translation>
     </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
@@ -601,8 +2107,130 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         </translation>
     </message>
     <message>
+        <source>Warning: Invalid Bitcoin address</source>
+        <translation type="unfinished">انتباہ: غلط بٹ کوائن ایڈریس</translation>
+    </message>
+    <message>
+        <source>Warning: Unknown change address</source>
+        <translation type="unfinished">انتباہ: نامعلوم تبدیلی کا پتہ</translation>
+    </message>
+    <message>
+        <source>Confirm custom change address</source>
+        <translation type="unfinished">اپنی مرضی کے مطابق ایڈریس کی تبدیلی کی تصدیق کریں۔</translation>
+    </message>
+    <message>
+        <source>The address you selected for change is not part of this wallet. Any or all funds in your wallet may be sent to this address. Are you sure?</source>
+        <translation type="unfinished">آپ نے تبدیلی کے لیے جو پتہ منتخب کیا ہے وہ اس والیٹ کا حصہ نہیں ہے۔ آپ کے والیٹ میں موجود کوئی بھی یا تمام فنڈز اس پتے پر بھیجے جا سکتے ہیں۔ کیا آپ کو یقین ہے؟</translation>
+    </message>
+    <message>
         <source>(no label)</source>
         <translation type="unfinished">(کوئی لیبل نہیں)</translation>
+    </message>
+</context>
+<context>
+    <name>SendCoinsEntry</name>
+    <message>
+        <source>&amp;Label:</source>
+        <translation type="unfinished">اور لیبل</translation>
+    </message>
+    <message>
+        <source>Choose previously used address</source>
+        <translation type="unfinished">پہلے استعمال شدہ پتہ کا انتخاب کریں۔</translation>
+    </message>
+    <message>
+        <source>The Bitcoin address to send the payment to</source>
+        <translation type="unfinished">ادائیگی بھیجنے کے لیے بٹ کوائن کا پتہ</translation>
+    </message>
+    <message>
+        <source>Paste address from clipboard</source>
+        <translation type="unfinished">کلپ بورڈ سے پتہ چسپاں کریں۔</translation>
+    </message>
+    <message>
+        <source>Remove this entry</source>
+        <translation type="unfinished">اس اندراج کو ہٹا دیں۔</translation>
+    </message>
+    <message>
+        <source>The amount to send in the selected unit</source>
+        <translation type="unfinished">منتخب یونٹ میں بھیجی جانے والی رقم</translation>
+    </message>
+    <message>
+        <source>The fee will be deducted from the amount being sent. The recipient will receive less bitcoins than you enter in the amount field. If multiple recipients are selected, the fee is split equally.</source>
+        <translation type="unfinished">بھیجی جانے والی رقم سے فیس کاٹی جائے گی۔ وصول کنندہ کو اس سے کم بٹ کوائنز موصول ہوں گے جو آپ رقم کے خانے میں داخل کریں گے۔ اگر متعدد وصول کنندگان کو منتخب کیا جاتا ہے، تو فیس کو برابر تقسیم کیا جاتا ہے۔</translation>
+    </message>
+    <message>
+        <source>Use available balance</source>
+        <translation type="unfinished">دستیاب بیلنس استعمال کریں۔</translation>
+    </message>
+    <message>
+        <source>Message:</source>
+        <translation type="unfinished">پیغام</translation>
+    </message>
+    <message>
+        <source>Enter a label for this address to add it to the list of used addresses</source>
+        <translation type="unfinished">استعمال شدہ پتوں کی فہرست میں شامل کرنے کے لیے اس پتے کے لیے ایک لیبل درج کریں۔</translation>
+    </message>
+    </context>
+<context>
+    <name>SignVerifyMessageDialog</name>
+    <message>
+        <source>Signatures - Sign / Verify a Message</source>
+        <translation type="unfinished">دستخط - ایک پیغام پر دستخط / تصدیق کریں۔</translation>
+    </message>
+    <message>
+        <source>You can sign messages/agreements with your addresses to prove you can receive bitcoins sent to them. Be careful not to sign anything vague or random, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
+        <translation type="unfinished">آپ یہ ثابت کرنے کے لیے اپنے پتوں کے ساتھ پیغامات/معاہدوں پر دستخط کر سکتے ہیں کہ آپ ان پر بھیجے گئے بٹ کوائنز وصول کر سکتے ہیں۔ ہوشیار رہیں کہ کسی بھی مبہم یا بے ترتیب پر دستخط نہ کریں، کیونکہ فریب دہی کے حملے آپ کو اپنی شناخت پر دستخط کرنے کے لیے دھوکہ دینے کی کوشش کر سکتے ہیں۔ صرف مکمل تفصیلی بیانات پر دستخط کریں جن سے آپ اتفاق کرتے ہیں۔</translation>
+    </message>
+    <message>
+        <source>The Bitcoin address to sign the message with</source>
+        <translation type="unfinished">پیغام پر دستخط کرنے کے لیے بٹ کوائن کا پتہ</translation>
+    </message>
+    <message>
+        <source>Choose previously used address</source>
+        <translation type="unfinished">پہلے استعمال شدہ پتہ کا انتخاب کریں۔</translation>
+    </message>
+    <message>
+        <source>Paste address from clipboard</source>
+        <translation type="unfinished">کلپ بورڈ سے پتہ چسپاں کریں۔</translation>
+    </message>
+    <message>
+        <source>Enter the message you want to sign here</source>
+        <translation type="unfinished">وہ پیغام درج کریں جس پر آپ دستخط کرنا چاہتے ہیں۔</translation>
+    </message>
+    <message>
+        <source>Signature</source>
+        <translation type="unfinished">دستخط</translation>
+    </message>
+    <message>
+        <source>The entered address is invalid.</source>
+        <translation type="unfinished">درج کیا گیا پتہ غلط ہے۔</translation>
+    </message>
+    <message>
+        <source>Please check the address and try again.</source>
+        <translation type="unfinished">براہ کرم پتہ چیک کریں اور دوبارہ کوشش کریں۔</translation>
+    </message>
+    <message>
+        <source>No error</source>
+        <translation type="unfinished">کوئی غلطی نہیں۔</translation>
+    </message>
+    <message>
+        <source>Message signing failed.</source>
+        <translation type="unfinished">پیغام پر دستخط ناکام ہو گئے۔</translation>
+    </message>
+    <message>
+        <source>The signature could not be decoded.</source>
+        <translation type="unfinished">دستخط کو ڈی کوڈ نہیں کیا جا سکا۔</translation>
+    </message>
+    <message>
+        <source>Please check the signature and try again.</source>
+        <translation type="unfinished">براہ کرم دستخط چیک کریں اور دوبارہ کوشش کریں۔</translation>
+    </message>
+    <message>
+        <source>Message verification failed.</source>
+        <translation type="unfinished">پیغام کی تصدیق ناکام ہو گئی۔</translation>
+    </message>
+    <message>
+        <source>Message verified.</source>
+        <translation type="unfinished">پیغام کی تصدیق ہو گئی۔</translation>
     </message>
 </context>
 <context>
@@ -611,12 +2239,32 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Date</source>
         <translation type="unfinished">تاریخ</translation>
     </message>
+    <message>
+        <source>From</source>
+        <translation type="unfinished">سے</translation>
+    </message>
+    <message>
+        <source>unknown</source>
+        <translation type="unfinished">نامعلوم</translation>
+    </message>
+    <message>
+        <source>To</source>
+        <translation type="unfinished">کو</translation>
+    </message>
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform />
             <numerusform />
         </translation>
+    </message>
+    <message>
+        <source>Transaction fee</source>
+        <translation type="unfinished">ٹرانزیکشن فیس</translation>
+    </message>
+    <message>
+        <source>Message</source>
+        <translation type="unfinished">پیغام</translation>
     </message>
     <message>
         <source>Amount</source>
@@ -630,6 +2278,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">تاریخ</translation>
     </message>
     <message>
+        <source>Type</source>
+        <translation type="unfinished">قسم</translation>
+    </message>
+    <message>
         <source>Label</source>
         <translation type="unfinished">لیبل</translation>
     </message>
@@ -641,13 +2293,37 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>TransactionView</name>
     <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">ایڈریس کاپی کریں۔</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">کاپی اور لیبل</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">کاپی اور رقم</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">لین دین اور شناخت کی تفصیلات(ID) کاپی کریں۔</translation>
+    </message>
+    <message>
         <source>Comma separated file</source>
         <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
         <translation type="unfinished">کوما سے الگ فائل</translation>
     </message>
     <message>
+        <source>Confirmed</source>
+        <translation type="unfinished">تصدیق شدہ</translation>
+    </message>
+    <message>
         <source>Date</source>
         <translation type="unfinished">تاریخ</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished">قسم</translation>
     </message>
     <message>
         <source>Label</source>
@@ -673,6 +2349,17 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">نقص</translation>
     </message>
     </context>
+<context>
+    <name>WalletModel</name>
+    <message>
+        <source>Send Coins</source>
+        <translation type="unfinished">سکے بھیجیں۔</translation>
+    </message>
+    <message>
+        <source>default wallet</source>
+        <translation type="unfinished">پہلے سے طے شدہ والیٹ</translation>
+    </message>
+</context>
 <context>
     <name>WalletView</name>
     <message>

--- a/src/qt/locale/bitcoin_uz.ts
+++ b/src/qt/locale/bitcoin_uz.ts
@@ -1,61 +1,95 @@
-<TS version="2.1" language="sc">
+<TS version="2.1" language="uz">
 <context>
     <name>AddressBookPage</name>
     <message>
         <source>Right-click to edit address or label</source>
-        <translation type="unfinished">Tastu deretu po cambiai s'incarreramentu o su nòmini</translation>
+        <translation type="unfinished">Manzil yoki yorliqni o'zgartirish uchun o'ng tugmani bosing</translation>
     </message>
     <message>
         <source>Create a new address</source>
-        <translation type="unfinished">Crea un'incarreramentu nou</translation>
+        <translation type="unfinished">Yangi manzil yaratish</translation>
     </message>
     <message>
         <source>&amp;New</source>
-        <translation type="unfinished">&amp;nou</translation>
+        <translation type="unfinished">Yangi</translation>
+    </message>
+    <message>
+        <source>Copy the currently selected address to the system clipboard</source>
+        <translation type="unfinished">Belgilangan manzilni tizim hotirasiga saqlash</translation>
     </message>
     <message>
         <source>&amp;Copy</source>
-        <translation type="unfinished">&amp;còpia</translation>
+        <translation type="unfinished">&amp;Ko'chirmoq</translation>
     </message>
     <message>
         <source>C&amp;lose</source>
-        <translation type="unfinished">S&amp;erra</translation>
+        <translation type="unfinished">Yo&amp;pish</translation>
+    </message>
+    <message>
+        <source>Delete the currently selected address from the list</source>
+        <translation type="unfinished">Tanlangan manzilni ro'yhatdan o'chiring</translation>
     </message>
     <message>
         <source>Enter address or label to search</source>
-        <translation type="unfinished">Poni s'incarreramentu o s'etiketa po circai</translation>
+        <translation type="unfinished">Qidirish uchun manzil yoki yorliqni kiriting</translation>
     </message>
     <message>
-        <source>&amp;Export</source>
-        <translation type="unfinished">&amp;Esporta</translation>
+        <source>Export the data in the current tab to a file</source>
+        <translation type="unfinished">Joriy ichki oynaning ichidagi malumotlarni faylga yuklab olish</translation>
     </message>
     <message>
         <source>&amp;Delete</source>
-        <translation type="unfinished">&amp;Cantzella</translation>
+        <translation type="unfinished">o'chirish</translation>
     </message>
     <message>
         <source>Choose the address to send coins to</source>
-        <translation type="unfinished">Scebera a cali incarreramentu bolis mandai is monedas</translation>
+        <translation type="unfinished">Tangalarni jo'natish uchun addressni tanlash</translation>
     </message>
     <message>
         <source>Choose the address to receive coins with</source>
-        <translation type="unfinished">Sciobera s'incarreramentu po arrici is monedas cun</translation>
+        <translation type="unfinished">Tangalarni qabul qilib olish uchun manzilni tanlang</translation>
     </message>
     <message>
         <source>C&amp;hoose</source>
-        <translation type="unfinished">S&amp;ciobera</translation>
+        <translation type="unfinished">tanlamoq</translation>
     </message>
     <message>
         <source>Sending addresses</source>
-        <translation type="unfinished">Incarreramentu de inviu</translation>
+        <translation type="unfinished">Yuboriladigan manzillar</translation>
     </message>
     <message>
         <source>Receiving addresses</source>
-        <translation type="unfinished">Incarreramentu destinatàriu</translation>
+        <translation type="unfinished">Qabul qilinadigan manzillar</translation>
     </message>
     <message>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
-        <translation type="unfinished">Custus funt is incarreramentu Bitcoin tuus po mandai pagamentus. Càstia sempri sa cantidadi e s'incarreramentu destinatàriu antis de inviais is monedas</translation>
+        <translation type="unfinished">Quyidagilar to'lovlarni yuborish uchun Bitcoin manzillaringizdir. Har doim yuborishdan oldin yuborilayotgan tangalar sonini va qabul qiluvchi manzilni tekshirib ko'ring.</translation>
+    </message>
+    <message>
+        <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
+Signing is only possible with addresses of the type 'legacy'.</source>
+        <translation type="unfinished">Bular to'lovlarni qabul qilishingiz uchun sizning Bitcoin manzillaringizdir. Yangi qabul qiluvchi manzil yaratish uchun qabul qilish varag'idagi ''Yangi qabul qilish manzilini yaratish'' ustiga bosing. Faqat 'legacy' turdagi manzillar bilan xisobga kirish mumkin.</translation>
+    </message>
+    <message>
+        <source>&amp;Copy Address</source>
+        <translation type="unfinished">&amp;manzildan nusxa olish</translation>
+    </message>
+    <message>
+        <source>Copy &amp;Label</source>
+        <translation type="unfinished">Yorliqni ko'chirish</translation>
+    </message>
+    <message>
+        <source>&amp;Edit</source>
+        <translation type="unfinished">O'zgartirmoq</translation>
+    </message>
+    <message>
+        <source>Export Address List</source>
+        <translation type="unfinished">Manzil ro'yhatini yuklab olish</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">Vergul bilan ajratilgan fayl</translation>
     </message>
     </context>
 <context>
@@ -64,11 +98,13 @@
         <source>%n second(s)</source>
         <translation type="unfinished">
             <numerusform />
+            <numerusform />
         </translation>
     </message>
     <message numerus="yes">
         <source>%n minute(s)</source>
         <translation type="unfinished">
+            <numerusform />
             <numerusform />
         </translation>
     </message>
@@ -76,11 +112,13 @@
         <source>%n hour(s)</source>
         <translation type="unfinished">
             <numerusform />
+            <numerusform />
         </translation>
     </message>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
+            <numerusform />
             <numerusform />
         </translation>
     </message>
@@ -88,11 +126,13 @@
         <source>%n week(s)</source>
         <translation type="unfinished">
             <numerusform />
+            <numerusform />
         </translation>
     </message>
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
+            <numerusform />
             <numerusform />
         </translation>
     </message>
@@ -103,12 +143,14 @@
         <source>Processed %n block(s) of transaction history.</source>
         <translation type="unfinished">
             <numerusform />
+            <numerusform />
         </translation>
     </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
+            <numerusform />
             <numerusform />
         </translation>
     </message>
@@ -119,11 +161,13 @@
         <source>%n GB of space available</source>
         <translation type="unfinished">
             <numerusform />
+            <numerusform />
         </translation>
     </message>
     <message numerus="yes">
         <source>(of %n GB needed)</source>
         <translation type="unfinished">
+            <numerusform />
             <numerusform />
         </translation>
     </message>
@@ -131,12 +175,14 @@
         <source>(%n GB needed for full chain)</source>
         <translation type="unfinished">
             <numerusform />
+            <numerusform />
         </translation>
     </message>
     <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
+            <numerusform />
             <numerusform />
         </translation>
     </message>
@@ -147,6 +193,7 @@
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
             <numerusform />
+            <numerusform />
         </translation>
     </message>
     </context>
@@ -156,14 +203,23 @@
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
             <numerusform />
+            <numerusform />
         </translation>
+    </message>
+    </context>
+<context>
+    <name>TransactionView</name>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">Vergul bilan ajratilgan fayl</translation>
     </message>
     </context>
 <context>
     <name>WalletView</name>
     <message>
-        <source>&amp;Export</source>
-        <translation type="unfinished">&amp;Esporta</translation>
+        <source>Export the data in the current tab to a file</source>
+        <translation type="unfinished">Joriy ichki oynaning ichidagi malumotlarni faylga yuklab olish</translation>
     </message>
     </context>
 </TS>

--- a/src/qt/locale/bitcoin_uz@Cyrl.ts
+++ b/src/qt/locale/bitcoin_uz@Cyrl.ts
@@ -70,6 +70,12 @@
         <translation type="unfinished">Улар тўловларни жўнатиш учун сизнинг Bitcoin манзилларингиз. Доимо тангаларни жўнатишдан олдин сумма ва қабул қилувчи манзилни текшириб кўринг. </translation>
     </message>
     <message>
+        <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
+Signing is only possible with addresses of the type 'legacy'.</source>
+        <translation type="unfinished">Улар тўловларни қабул қилиш учун сизнинг Bitcoin манзилларингиз. Янги манзилларни яратиш учун қабул қилиш варағидаги "Янги қабул қилиш манзилини яратиш" устига босинг. 
+Фақат 'legacy' туридаги манзиллар билан ҳисобга кириш мумкин.</translation>
+    </message>
+    <message>
         <source>&amp;Copy Address</source>
         <translation type="unfinished">Манзилдан &amp;нусха олиш</translation>
     </message>
@@ -84,6 +90,11 @@
     <message>
         <source>Export Address List</source>
         <translation type="unfinished">Манзил рўйхатини экспорт қилиш</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">Вергул билан ажратилган файл</translation>
     </message>
     <message>
         <source>There was an error trying to save the address list to %1. Please try again.</source>
@@ -118,23 +129,27 @@
     </message>
     <message>
         <source>Enter passphrase</source>
-        <translation type="unfinished">Махфий сузни киритинг</translation>
+        <translation type="unfinished">Махфий сўзни киритинг</translation>
     </message>
     <message>
         <source>New passphrase</source>
-        <translation type="unfinished">Янги махфий суз</translation>
+        <translation type="unfinished">Янги махфий сўз</translation>
     </message>
     <message>
         <source>Repeat new passphrase</source>
-        <translation type="unfinished">Янги махфий сузни такрорланг</translation>
+        <translation type="unfinished">Янги махфий сўзни такрорланг</translation>
+    </message>
+    <message>
+        <source>Show passphrase</source>
+        <translation type="unfinished">Махфий сўзни кўрсатиш</translation>
     </message>
     <message>
         <source>Encrypt wallet</source>
-        <translation type="unfinished">Ҳамённи қодлаш</translation>
+        <translation type="unfinished">Ҳамённи шифрлаш</translation>
     </message>
     <message>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
-        <translation type="unfinished">Ушбу операцияни амалга ошириш учун ҳамённи қулфдан чиқариш парол сўзини талаб қилади.</translation>
+        <translation type="unfinished">Ушбу операцияни амалга ошириш учун ҳамённи қулфдан чиқариш махфий сўзини талаб қилади.</translation>
     </message>
     <message>
         <source>Unlock wallet</source>
@@ -158,7 +173,19 @@
     </message>
     <message>
         <source>Wallet encrypted</source>
-        <translation type="unfinished">Ҳамёни кодланган</translation>
+        <translation type="unfinished">Ҳамён шифрланган</translation>
+    </message>
+    <message>
+        <source>Wallet to be encrypted</source>
+        <translation type="unfinished">Шифрланадиган ҳамён</translation>
+    </message>
+    <message>
+        <source>Your wallet is about to be encrypted. </source>
+        <translation type="unfinished">Ҳамёнингиз шифрланиш арафасида.</translation>
+    </message>
+    <message>
+        <source>Your wallet is now encrypted. </source>
+        <translation type="unfinished">Ҳамёнингиз энди шифрланади.</translation>
     </message>
     <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
@@ -664,6 +691,27 @@
 <context>
     <name>Intro</name>
     <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
@@ -806,10 +854,12 @@
     </message>
     <message>
         <source>Confirm options reset</source>
+        <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
         <translation type="unfinished">Тасдиқлаш танловларини рад қилиш</translation>
     </message>
     <message>
         <source>Client restart required to activate changes.</source>
+        <extracomment>Text explaining that the settings changed will not come into effect until the client is restarted.</extracomment>
         <translation type="unfinished">Ўзгаришлар амалга ошиши учун мижозни қайта ишга тушириш талаб қилинади.</translation>
     </message>
     <message>
@@ -1379,10 +1429,6 @@
         <source>Message:</source>
         <translation type="unfinished">Хабар</translation>
     </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">Тўлов олувчи:</translation>
-    </message>
     </context>
 <context>
     <name>SignVerifyMessageDialog</name>
@@ -1411,10 +1457,12 @@
     <name>TransactionDesc</name>
     <message>
         <source>%1/unconfirmed</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
         <translation type="unfinished">%1/тасдиқланмади</translation>
     </message>
     <message>
         <source>%1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
         <translation type="unfinished">%1 тасдиқлашлар</translation>
     </message>
     <message>
@@ -1636,6 +1684,11 @@
     <message>
         <source>Export Transaction History</source>
         <translation type="unfinished">Ўтказмалар тарихини экспорт қилиш</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">Вергул билан ажратилган файл</translation>
     </message>
     <message>
         <source>Confirmed</source>

--- a/src/qt/locale/bitcoin_uz@Latn.ts
+++ b/src/qt/locale/bitcoin_uz@Latn.ts
@@ -14,6 +14,10 @@
         <translation type="unfinished">&amp;Yangi</translation>
     </message>
     <message>
+        <source>Copy the currently selected address to the system clipboard</source>
+        <translation type="unfinished">Tanlangan manzilni tizim buferiga nusxalash</translation>
+    </message>
+    <message>
         <source>&amp;Copy</source>
         <translation type="unfinished">&amp;Nusxalash</translation>
     </message>
@@ -22,14 +26,86 @@
         <translation type="unfinished">Yo&amp;pish</translation>
     </message>
     <message>
+        <source>Delete the currently selected address from the list</source>
+        <translation type="unfinished">Ro'yxatdan hozir tanlangan manzilni o'chiring</translation>
+    </message>
+    <message>
+        <source>Enter address or label to search</source>
+        <translation type="unfinished">Qidirish uchun manzil yoki yorliqni kiriting</translation>
+    </message>
+    <message>
+        <source>Export the data in the current tab to a file</source>
+        <translation type="unfinished">Joriy yorliqdagi ma'lumotlarni faylga eksport qilish</translation>
+    </message>
+    <message>
+        <source>&amp;Export</source>
+        <translation type="unfinished">&amp;Eksport</translation>
+    </message>
+    <message>
         <source>&amp;Delete</source>
         <translation type="unfinished">&amp;O'chirish</translation>
+    </message>
+    <message>
+        <source>Choose the address to send coins to</source>
+        <translation type="unfinished">Coin yuborish uchun manzilni tanlang</translation>
+    </message>
+    <message>
+        <source>Choose the address to receive coins with</source>
+        <translation type="unfinished">Coinlarni qabul qilish uchun manzilni tanlang</translation>
+    </message>
+    <message>
+        <source>C&amp;hoose</source>
+        <translation type="unfinished">&amp;Tanlash</translation>
+    </message>
+    <message>
+        <source>Sending addresses</source>
+        <translation type="unfinished">Manzillarni yuborish</translation>
+    </message>
+    <message>
+        <source>Receiving addresses</source>
+        <translation type="unfinished">Qabul qilish manzillari</translation>
+    </message>
+    <message>
+        <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
+        <translation type="unfinished">Quyida to'lovlarni jo'natish uchun Bitcoin manzillaringiz. Coinlarni yuborishdan oldin har doim miqdor va qabul qilish manzilini tekshiring.</translation>
+    </message>
+    <message>
+        <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
+Signing is only possible with addresses of the type 'legacy'.</source>
+        <translation type="unfinished">Bular to'lovlarni qabul qilish uchun mo'ljallangan Bitkoin manzillar. Yangi manzillar yaratish uchun 'Yangi qabul qilish manzili yaratish' tugmasini ishlating.
+Kirish faqat 'legacy' turidagi manzillar uchun.</translation>
     </message>
     <message>
         <source>&amp;Copy Address</source>
         <translation type="unfinished">&amp;Manzillarni nusxalash</translation>
     </message>
-    </context>
+    <message>
+        <source>Copy &amp;Label</source>
+        <translation type="unfinished">Nusxalash &amp;Yorliq</translation>
+    </message>
+    <message>
+        <source>&amp;Edit</source>
+        <translation type="unfinished">&amp;Tahrirlash</translation>
+    </message>
+    <message>
+        <source>Export Address List</source>
+        <translation type="unfinished">Manzillar ro'yxatini eksport qilish</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">Vergul yordamida ajratilgan fayl</translation>
+    </message>
+    <message>
+        <source>There was an error trying to save the address list to %1. Please try again.</source>
+        <extracomment>An error message. %1 is a stand-in argument for the name of the file we attempted to save to.</extracomment>
+        <translation type="unfinished">Manzillarni ro'yxatini %1 ga saqlashda xatolik yuzaga keldi. Iltimos, qayta urinib ko'ring</translation>
+    </message>
+    <message>
+        <source>Exporting Failed</source>
+        <translation type="unfinished">Eksport qilish amalga oshmadi</translation>
+    </message>
+</context>
 <context>
     <name>AddressTableModel</name>
     <message>
@@ -40,9 +116,184 @@
         <source>Address</source>
         <translation type="unfinished">Manzil</translation>
     </message>
-    </context>
+    <message>
+        <source>(no label)</source>
+        <translation type="unfinished">(Yorliqlar mavjud emas)</translation>
+    </message>
+</context>
+<context>
+    <name>AskPassphraseDialog</name>
+    <message>
+        <source>Passphrase Dialog</source>
+        <translation type="unfinished">Parollar dialogi</translation>
+    </message>
+    <message>
+        <source>Enter passphrase</source>
+        <translation type="unfinished">Parolni kiriting</translation>
+    </message>
+    <message>
+        <source>New passphrase</source>
+        <translation type="unfinished">Yangi parol</translation>
+    </message>
+    <message>
+        <source>Repeat new passphrase</source>
+        <translation type="unfinished">Yangi parolni qaytadan kirgizing</translation>
+    </message>
+    <message>
+        <source>Show passphrase</source>
+        <translation type="unfinished">Parolni ko'rsatish</translation>
+    </message>
+    <message>
+        <source>Encrypt wallet</source>
+        <translation type="unfinished">Hamyonni shifrlash</translation>
+    </message>
+    <message>
+        <source>This operation needs your wallet passphrase to unlock the wallet.</source>
+        <translation type="unfinished">Bu operatsiya uchun hamyoningiz paroli kerak bo'ladi.</translation>
+    </message>
+    <message>
+        <source>Unlock wallet</source>
+        <translation type="unfinished">Hamyonni qulfdan chiqarish</translation>
+    </message>
+    <message>
+        <source>Change passphrase</source>
+        <translation type="unfinished">Parolni almashtirish</translation>
+    </message>
+    <message>
+        <source>Confirm wallet encryption</source>
+        <translation type="unfinished">Hamyon shifrlanishini tasdiqlang</translation>
+    </message>
+    <message>
+        <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
+        <translation type="unfinished">Eslatma: Agar hamyoningizni shifrlasangiz va parolni unutib qo'ysangiz, siz &lt;b&gt;BARCHA BITCOINLARINGIZNI YO'QOTASIZ&lt;/b&gt;! </translation>
+    </message>
+    <message>
+        <source>Are you sure you wish to encrypt your wallet?</source>
+        <translation type="unfinished">Haqiqatan ham hamyoningizni shifrlamoqchimisiz?</translation>
+    </message>
+    <message>
+        <source>Wallet encrypted</source>
+        <translation type="unfinished">Hamyon shifrlangan</translation>
+    </message>
+    <message>
+        <source>Enter the new passphrase for the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
+        <translation type="unfinished">Hamyon uchun yangi maxfiy so'zni kiriting. &lt;br/&gt;Iltimos, &lt;b&gt;10 va undan ortiq istalgan&lt;/b&gt; yoki &lt;b&gt;8 va undan ortiq so'zlardan&lt;/b&gt; iborat maxfiy so'zdan foydalaning.</translation>
+    </message>
+    <message>
+        <source>Enter the old passphrase and new passphrase for the wallet.</source>
+        <translation type="unfinished">Hamyonning oldingi va yangi maxfiy so'zlarini kiriting</translation>
+    </message>
+    <message>
+        <source>Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
+        <translation type="unfinished">Shuni yodda tutingki, hamyonni shifrlash kompyuterdagi virus yoki zararli dasturlar sizning bitcoinlaringizni o'g'irlashidan to'liq himoyalay olmaydi.</translation>
+    </message>
+    <message>
+        <source>Wallet to be encrypted</source>
+        <translation type="unfinished">Hamyon shifrlanmoqda</translation>
+    </message>
+    <message>
+        <source>Your wallet is about to be encrypted. </source>
+        <translation type="unfinished">Hamyon shifrlanish arafasida</translation>
+    </message>
+    <message>
+        <source>Your wallet is now encrypted. </source>
+        <translation type="unfinished">Hamyoningiz shifrlangan</translation>
+    </message>
+    <message>
+        <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
+        <translation type="unfinished">ESLATMA: Siz eski hamyoningiz joylashgan fayldan yaratgan kopiyalaringizni yangi shifrlangan hamyon fayliga almashtirishingiz lozim. Maxfiylik siyosati tufayli, yangi shifrlangan hamyondan foydalanishni boshlashingiz bilanoq eski nusxalar foydalanishga yaroqsiz holga keltiriladi.</translation>
+    </message>
+    <message>
+        <source>Wallet encryption failed</source>
+        <translation type="unfinished">Hamyon shifrlanishi muvaffaqiyatsiz amalga oshdi</translation>
+    </message>
+    <message>
+        <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
+        <translation type="unfinished">Ichki xatolik tufayli hamyon shifrlanishi amalga oshmadi.</translation>
+    </message>
+    <message>
+        <source>The supplied passphrases do not match.</source>
+        <translation type="unfinished">Kiritilgan maxfiy so'zlar bir-biriga mos kelmayapti.</translation>
+    </message>
+    <message>
+        <source>Wallet unlock failed</source>
+        <translation type="unfinished">Hamyonni qulfdan chiqarib bo'lmadi</translation>
+    </message>
+    <message>
+        <source>The passphrase entered for the wallet decryption was incorrect.</source>
+        <translation type="unfinished">Noto'g'ri maxfiy so'z kiritildi</translation>
+    </message>
+    <message>
+        <source>Wallet passphrase was successfully changed.</source>
+        <translation type="unfinished">Hamyon uchun kiritilgan maxfiy so'z yangisiga almashtirildi.</translation>
+    </message>
+    <message>
+        <source>Warning: The Caps Lock key is on!</source>
+        <translation type="unfinished">Eslatma: Caps Lock tugmasi yoniq!</translation>
+    </message>
+</context>
+<context>
+    <name>BanTableModel</name>
+    <message>
+        <source>Banned Until</source>
+        <translation type="unfinished">gacha kirish taqiqlanadi</translation>
+    </message>
+</context>
+<context>
+    <name>BitcoinApplication</name>
+    <message>
+        <source>Runaway exception</source>
+        <translation type="unfinished">qo'shimcha istisno</translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
+        <translation type="unfinished">Fatal xatolik yuz berdi. %1 xavfsiz ravishda davom eta olmaydi va tizimni tark etadi. </translation>
+    </message>
+    <message>
+        <source>Internal error</source>
+        <translation type="unfinished">Ichki xatolik</translation>
+    </message>
+    <message>
+        <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
+        <translation type="unfinished">Ichki xatolik yuzaga keldi. %1 xavfsiz protsessni davom ettirishga harakat qiladi. Bu kutilmagan xato boʻlib, uni quyida tavsiflanganidek xabar qilish mumkin.</translation>
+    </message>
+</context>
 <context>
     <name>QObject</name>
+    <message>
+        <source>Do you want to reset settings to default values, or to abort without making changes?</source>
+        <extracomment>Explanatory text shown on startup when the settings file cannot be read. Prompts user to make a choice between resetting or aborting.</extracomment>
+        <translation type="unfinished">Sozlamalarni asliga qaytarishni xohlaysizmi yoki o'zgartirishlar saqlanmasinmi?</translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. Check that settings file is writable, or try running with -nosettings.</source>
+        <extracomment>Explanatory text shown on startup when the settings file could not be written. Prompts user to check that we have the ability to write to the file. Explains that the user has the option of running without a settings file.</extracomment>
+        <translation type="unfinished">Fatal xatolik yuz berdi. Sozlamalar fayli tahrirlashga yaroqliligini tekshiring yoki -nosettings bilan davom etishga harakat qiling.</translation>
+    </message>
+    <message>
+        <source>Error: Specified data directory "%1" does not exist.</source>
+        <translation type="unfinished">Xatolik. Belgilangan "%1" mavjud emas.</translation>
+    </message>
+    <message>
+        <source>Error: Cannot parse configuration file: %1.</source>
+        <translation type="unfinished">Xatolik. %1 ni tahlil qilish imkonsiz.</translation>
+    </message>
+    <message>
+        <source>Error: %1</source>
+        <translation type="unfinished">Xatolik: %1</translation>
+    </message>
+    <message>
+        <source>%1 didn't yet exit safely…</source>
+        <translation type="unfinished">%1 hali tizimni xavfsiz ravishda tark etgani yo'q...</translation>
+    </message>
+    <message>
+        <source>unknown</source>
+        <translation type="unfinished">noma'lum</translation>
+    </message>
+    <message>
+        <source>Amount</source>
+        <translation type="unfinished">Miqdor</translation>
+    </message>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation type="unfinished">
@@ -87,32 +338,1207 @@
     </message>
     </context>
 <context>
+    <name>bitcoin-core</name>
+    <message>
+        <source>Settings file could not be read</source>
+        <translation type="unfinished">Sozlamalar fayli o'qishga yaroqsiz</translation>
+    </message>
+    <message>
+        <source>Settings file could not be written</source>
+        <translation type="unfinished">Sozlamalar fayli yaratish uchun yaroqsiz</translation>
+    </message>
+    <message>
+        <source>Unable to start HTTP server. See debug log for details.</source>
+        <translation type="unfinished">HTTP serverni ishga tushirib bo'lmadi. Tafsilotlar uchun disk raskadrovka jurnaliga qarang.</translation>
+    </message>
+    <message>
+        <source>Verifying blocks…</source>
+        <translation type="unfinished">Bloklar tekshirilmoqda…</translation>
+    </message>
+    <message>
+        <source>Verifying wallet(s)…</source>
+        <translation type="unfinished">Hamyon(lar) tekshirilmoqda…</translation>
+    </message>
+    <message>
+        <source>Wallet needed to be rewritten: restart %s to complete</source>
+        <translation type="unfinished">Hamyonni qayta yozish kerak: bajarish uchun 1%s ni qayta ishga tushiring</translation>
+    </message>
+</context>
+<context>
     <name>BitcoinGUI</name>
+    <message>
+        <source>&amp;Overview</source>
+        <translation type="unfinished">&amp;Umumiy ko'rinish</translation>
+    </message>
+    <message>
+        <source>Show general overview of wallet</source>
+        <translation type="unfinished">Hamyonning umumiy ko'rinishini ko'rsatish</translation>
+    </message>
+    <message>
+        <source>&amp;Transactions</source>
+        <translation type="unfinished">&amp;Tranzaksiyalar</translation>
+    </message>
+    <message>
+        <source>Browse transaction history</source>
+        <translation type="unfinished">Tranzaksiyalar tarixini ko'rib chiqish</translation>
+    </message>
+    <message>
+        <source>E&amp;xit</source>
+        <translation type="unfinished">Chi&amp;qish</translation>
+    </message>
+    <message>
+        <source>Quit application</source>
+        <translation type="unfinished">Dasturni tark etish</translation>
+    </message>
+    <message>
+        <source>&amp;About %1</source>
+        <translation type="unfinished">&amp;%1 haqida</translation>
+    </message>
+    <message>
+        <source>Show information about %1</source>
+        <translation type="unfinished">%1 haqida axborotni ko'rsatish</translation>
+    </message>
+    <message>
+        <source>About &amp;Qt</source>
+        <translation type="unfinished">&amp;Qt haqida</translation>
+    </message>
+    <message>
+        <source>Show information about Qt</source>
+        <translation type="unfinished">&amp;Qt haqidagi axborotni ko'rsatish</translation>
+    </message>
+    <message>
+        <source>Modify configuration options for %1</source>
+        <translation type="unfinished">%1 konfiguratsiya sozlamalarini o'zgartirish</translation>
+    </message>
+    <message>
+        <source>Create a new wallet</source>
+        <translation type="unfinished">Yangi hamyon yaratish</translation>
+    </message>
+    <message>
+        <source>&amp;Minimize</source>
+        <translation type="unfinished">&amp;Kichraytirish</translation>
+    </message>
+    <message>
+        <source>Wallet:</source>
+        <translation type="unfinished">Hamyon</translation>
+    </message>
+    <message>
+        <source>Network activity disabled.</source>
+        <extracomment>A substring of the tooltip.</extracomment>
+        <translation type="unfinished">Mobil tarmoq faoliyati o'chirilgan</translation>
+    </message>
+    <message>
+        <source>Proxy is &lt;b&gt;enabled&lt;/b&gt;: %1</source>
+        <translation type="unfinished">Proksi &lt;b&gt;yoqildi&lt;/b&gt;: %1</translation>
+    </message>
+    <message>
+        <source>Send coins to a Bitcoin address</source>
+        <translation type="unfinished">Bitkoin manziliga coinlarni yuborish</translation>
+    </message>
+    <message>
+        <source>Backup wallet to another location</source>
+        <translation type="unfinished">Hamyon nusxasini boshqa joyga</translation>
+    </message>
+    <message>
+        <source>Change the passphrase used for wallet encryption</source>
+        <translation type="unfinished">Hamyon shifrlanishi uchun ishlatilgan maxfiy so'zni almashtirish</translation>
+    </message>
+    <message>
+        <source>&amp;Send</source>
+        <translation type="unfinished">&amp;Yuborish</translation>
+    </message>
+    <message>
+        <source>&amp;Receive</source>
+        <translation type="unfinished">&amp;Qabul qilish</translation>
+    </message>
+    <message>
+        <source>&amp;Options…</source>
+        <translation type="unfinished">&amp;Sozlamalar...</translation>
+    </message>
+    <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation type="unfinished">&amp;Hamyonni shifrlash...</translation>
+    </message>
+    <message>
+        <source>Encrypt the private keys that belong to your wallet</source>
+        <translation type="unfinished">Hamyonga tegishli bo'lgan maxfiy so'zlarni shifrlash</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation type="unfinished">&amp;Hamyon nusxasi...</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation type="unfinished">&amp;Maxfiy so'zni o'zgartirish...</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation type="unfinished">Kirish &amp;xabarlashish</translation>
+    </message>
+    <message>
+        <source>Sign messages with your Bitcoin addresses to prove you own them</source>
+        <translation type="unfinished">Bitkoin manzillarga ega ekaningizni tasdiqlash uchun xabarni signlang</translation>
+    </message>
+    <message>
+        <source>&amp;Verify message…</source>
+        <translation type="unfinished">&amp;Xabarni tasdiqlash</translation>
+    </message>
+    <message>
+        <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
+        <translation type="unfinished">Xabar belgilangan Bitkoin manzillari bilan imzolanganligiga ishonch hosil qilish uchun ularni tasdiqlang</translation>
+    </message>
+    <message>
+        <source>&amp;Load PSBT from file…</source>
+        <translation type="unfinished">&amp;PSBT ni fayldan yuklash...</translation>
+    </message>
+    <message>
+        <source>Open &amp;URI…</source>
+        <translation type="unfinished">&amp;URL manzilni ochish</translation>
+    </message>
+    <message>
+        <source>Close Wallet…</source>
+        <translation type="unfinished">Hamyonni yopish</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation type="unfinished">Hamyonni yaratish...</translation>
+    </message>
+    <message>
+        <source>Close All Wallets…</source>
+        <translation type="unfinished">Barcha hamyonlarni yopish...</translation>
+    </message>
+    <message>
+        <source>&amp;File</source>
+        <translation type="unfinished">&amp;Fayl</translation>
+    </message>
+    <message>
+        <source>&amp;Settings</source>
+        <translation type="unfinished">&amp;Sozlamalar</translation>
+    </message>
+    <message>
+        <source>&amp;Help</source>
+        <translation type="unfinished">&amp;Yordam</translation>
+    </message>
+    <message>
+        <source>Tabs toolbar</source>
+        <translation type="unfinished">Yorliqlar menyusi</translation>
+    </message>
+    <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation type="unfinished">Sarlavhalar sinxronlashtirilmoqda (%1%)...</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation type="unfinished">Internet bilan sinxronlash...</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation type="unfinished">Diskdagi bloklarni indekslash</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation type="unfinished">Diskdagi bloklarni protsesslash</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation type="unfinished">Diskdagi bloklarni qayta indekslash...</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation type="unfinished">Pirlarga ulanish...</translation>
+    </message>
+    <message>
+        <source>Request payments (generates QR codes and bitcoin: URIs)</source>
+        <translation type="unfinished">To'lovlarni so'rash(QR kolar va bitkoin yaratish: URL manzillar)</translation>
+    </message>
+    <message>
+        <source>Show the list of used sending addresses and labels</source>
+        <translation type="unfinished">Manzillar va yorliqlar ro'yxatini ko'rsatish</translation>
+    </message>
+    <message>
+        <source>Show the list of used receiving addresses and labels</source>
+        <translation type="unfinished">Qabul qilish manzillari va yorliqlar ro'yxatini ko'rsatish</translation>
+    </message>
+    <message>
+        <source>&amp;Command-line options</source>
+        <translation type="unfinished">&amp;Command-line sozlamalari</translation>
+    </message>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>Tranzaksiya tarixining %n blok(lar)i qayta ishlandi.</numerusform>
             <numerusform />
         </translation>
+    </message>
+    <message>
+        <source>%1 behind</source>
+        <translation type="unfinished">%1 yonida</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation type="unfinished">Yetkazilmoqda...</translation>
+    </message>
+    <message>
+        <source>Last received block was generated %1 ago.</source>
+        <translation type="unfinished">%1 oldin oxirgi marta blok qabul qilingan edi.</translation>
+    </message>
+    <message>
+        <source>Transactions after this will not yet be visible.</source>
+        <translation type="unfinished">Shundan keyingi operatsiyalar hali ko'rinmaydi.</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Xatolik</translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished">Eslatma</translation>
+    </message>
+    <message>
+        <source>Information</source>
+        <translation type="unfinished">Informatsiya</translation>
+    </message>
+    <message>
+        <source>Up to date</source>
+        <translation type="unfinished">Hozirgi kunda</translation>
+    </message>
+    <message>
+        <source>Load Partially Signed Bitcoin Transaction</source>
+        <translation type="unfinished">Qisman signlangan Bitkoin tranzaksiyasini yuklash</translation>
+    </message>
+    <message>
+        <source>Load PSBT from &amp;clipboard…</source>
+        <translation type="unfinished">&amp;Nusxalanganlar dan PSBT ni yuklash</translation>
+    </message>
+    <message>
+        <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
+        <translation type="unfinished">Nusxalanganlar qisman signlangan Bitkoin tranzaksiyalarini yuklash</translation>
+    </message>
+    <message>
+        <source>Node window</source>
+        <translation type="unfinished">Node oynasi</translation>
+    </message>
+    <message>
+        <source>Open node debugging and diagnostic console</source>
+        <translation type="unfinished">Node debuglash va tahlil konsolini ochish</translation>
+    </message>
+    <message>
+        <source>&amp;Sending addresses</source>
+        <translation type="unfinished">&amp;Yuborish manzillari</translation>
+    </message>
+    <message>
+        <source>&amp;Receiving addresses</source>
+        <translation type="unfinished">&amp;Qabul qilish manzillari</translation>
+    </message>
+    <message>
+        <source>Open a bitcoin: URI</source>
+        <translation type="unfinished">Bitkoinni ochish: URI</translation>
+    </message>
+    <message>
+        <source>Open Wallet</source>
+        <translation type="unfinished">Hamyonni ochish</translation>
+    </message>
+    <message>
+        <source>Open a wallet</source>
+        <translation type="unfinished">Hamyonni ochish</translation>
+    </message>
+    <message>
+        <source>Close wallet</source>
+        <translation type="unfinished">Hamyonni yopish</translation>
+    </message>
+    <message>
+        <source>Close all wallets</source>
+        <translation type="unfinished">Barcha hamyonlarni yopish</translation>
+    </message>
+    <message>
+        <source>Show the %1 help message to get a list with possible Bitcoin command-line options</source>
+        <translation type="unfinished">Yozilishi mumkin bo'lgan command-line sozlamalar ro'yxatini olish uchun %1 yordam xabarini ko'rsatish</translation>
+    </message>
+    <message>
+        <source>Mask the values in the Overview tab</source>
+        <translation type="unfinished">Umumiy ko'rinish menyusidagi qiymatlarni maskirovka qilish</translation>
+    </message>
+    <message>
+        <source>default wallet</source>
+        <translation type="unfinished">standart hamyon</translation>
+    </message>
+    <message>
+        <source>No wallets available</source>
+        <translation type="unfinished">Hamyonlar mavjud emas</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">Hamyon nomi</translation>
+    </message>
+    <message>
+        <source>&amp;Window</source>
+        <translation type="unfinished">&amp;Oyna</translation>
+    </message>
+    <message>
+        <source>Zoom</source>
+        <translation type="unfinished">Kattalashtirish</translation>
+    </message>
+    <message>
+        <source>Main Window</source>
+        <translation type="unfinished">Asosiy Oyna</translation>
+    </message>
+    <message>
+        <source>%1 client</source>
+        <translation type="unfinished">%1 mijoz </translation>
+    </message>
+    <message>
+        <source>&amp;Hide</source>
+        <translation type="unfinished">&amp;Yashirish</translation>
+    </message>
+    <message>
+        <source>S&amp;how</source>
+        <translation type="unfinished">Ko'&amp;rsatish</translation>
     </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>Bitkoin tarmog'iga %n aktiv ulanishlar.</numerusform>
             <numerusform />
         </translation>
     </message>
+    <message>
+        <source>Click for more actions.</source>
+        <extracomment>A substring of the tooltip. "More actions" are available via the context menu.</extracomment>
+        <translation type="unfinished">Ko'proq sozlamalar uchun bosing.</translation>
+    </message>
+    <message>
+        <source>Show Peers tab</source>
+        <extracomment>A context menu item. The "Peers tab" is an element of the "Node window".</extracomment>
+        <translation type="unfinished">Pirlar oynasini ko'rsatish</translation>
+    </message>
+    <message>
+        <source>Disable network activity</source>
+        <extracomment>A context menu item.</extracomment>
+        <translation type="unfinished">Ijtimoiy tarmoq faoliyatini cheklash</translation>
+    </message>
+    <message>
+        <source>Enable network activity</source>
+        <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
+        <translation type="unfinished">Ijtimoiy tarmoq faoliyatini yoqish</translation>
+    </message>
+    <message>
+        <source>Error: %1</source>
+        <translation type="unfinished">Xatolik: %1</translation>
+    </message>
+    <message>
+        <source>Warning: %1</source>
+        <translation type="unfinished">Ogohlantirish: %1</translation>
+    </message>
+    <message>
+        <source>Date: %1
+</source>
+        <translation type="unfinished">Sana: %1</translation>
+    </message>
+    <message>
+        <source>Amount: %1
+</source>
+        <translation type="unfinished">Miqdor: %1
+</translation>
+    </message>
+    <message>
+        <source>Wallet: %1
+</source>
+        <translation type="unfinished">Hamyon: %1
+</translation>
+    </message>
+    <message>
+        <source>Type: %1
+</source>
+        <translation type="unfinished">Tip: %1
+</translation>
+    </message>
+    <message>
+        <source>Label: %1
+</source>
+        <translation type="unfinished">Yorliq: %1
+</translation>
+    </message>
+    <message>
+        <source>Address: %1
+</source>
+        <translation type="unfinished">Manzil: %1
+</translation>
+    </message>
+    <message>
+        <source>Sent transaction</source>
+        <translation type="unfinished">Yuborilgan tranzaksiya</translation>
+    </message>
+    <message>
+        <source>Incoming transaction</source>
+        <translation type="unfinished">Kelayotgan tranzaksiya</translation>
+    </message>
+    <message>
+        <source>HD key generation is &lt;b&gt;enabled&lt;/b&gt;</source>
+        <translation type="unfinished">HD kalit yaratish &lt;b&gt;imkonsiz&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>HD key generation is &lt;b&gt;disabled&lt;/b&gt;</source>
+        <translation type="unfinished">HD kalit yaratish &lt;b&gt;imkonsiz&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Private key &lt;b&gt;disabled&lt;/b&gt;</source>
+        <translation type="unfinished">Maxfiy kalit &lt;b&gt;o'chiq&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
+        <translation type="unfinished">Hamyon &lt;b&gt;shifrlangan&lt;/b&gt; va hozircha &lt;b&gt;ochiq&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
+        <translation type="unfinished">Hamyon &lt;b&gt;shifrlangan&lt;/b&gt; va hozirda&lt;b&gt;qulflangan&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Original message:</source>
+        <translation type="unfinished">Asl xabar:</translation>
+    </message>
+</context>
+<context>
+    <name>UnitDisplayStatusBarControl</name>
+    <message>
+        <source>Unit to show amounts in. Click to select another unit.</source>
+        <translation type="unfinished">Miqdorlarni ko'rsatish birligi. Boshqa birlik tanlash uchun bosing.</translation>
+    </message>
+</context>
+<context>
+    <name>CoinControlDialog</name>
+    <message>
+        <source>Coin Selection</source>
+        <translation type="unfinished">Coin tanlash</translation>
+    </message>
+    <message>
+        <source>Quantity:</source>
+        <translation type="unfinished">Miqdor:</translation>
+    </message>
+    <message>
+        <source>Bytes:</source>
+        <translation type="unfinished">Baytlar:</translation>
+    </message>
+    <message>
+        <source>Amount:</source>
+        <translation type="unfinished">Miqdor:</translation>
+    </message>
+    <message>
+        <source>Fee:</source>
+        <translation type="unfinished">Narx:</translation>
+    </message>
+    <message>
+        <source>After Fee:</source>
+        <translation type="unfinished">To'lovdan keyin:</translation>
+    </message>
+    <message>
+        <source>Change:</source>
+        <translation type="unfinished">O'zgartirish:</translation>
+    </message>
+    <message>
+        <source>(un)select all</source>
+        <translation type="unfinished">hammasini(hech qaysini) tanlash</translation>
+    </message>
+    <message>
+        <source>Tree mode</source>
+        <translation type="unfinished">Daraxt rejimi</translation>
+    </message>
+    <message>
+        <source>List mode</source>
+        <translation type="unfinished">Ro'yxat rejimi</translation>
+    </message>
+    <message>
+        <source>Amount</source>
+        <translation type="unfinished">Miqdor</translation>
+    </message>
+    <message>
+        <source>Received with label</source>
+        <translation type="unfinished">Yorliq orqali qabul qilingan</translation>
+    </message>
+    <message>
+        <source>Received with address</source>
+        <translation type="unfinished">Manzil orqali qabul qilingan</translation>
+    </message>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">Sana</translation>
+    </message>
+    <message>
+        <source>Confirmations</source>
+        <translation type="unfinished">Tasdiqlar</translation>
+    </message>
+    <message>
+        <source>Confirmed</source>
+        <translation type="unfinished">Tasdiqlangan</translation>
+    </message>
+    <message>
+        <source>Copy amount</source>
+        <translation type="unfinished">Qiymatni nusxalash</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Manzilni nusxalash</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">&amp;Yorliqni nusxalash</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">&amp;Miqdorni nusxalash</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID and output index</source>
+        <translation type="unfinished">Tranzaksiya &amp;IDsi ni va chiquvchi indeksni nusxalash</translation>
+    </message>
+    <message>
+        <source>L&amp;ock unspent</source>
+        <translation type="unfinished">Sarflanmagan miqdorlarni q&amp;ulflash</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock unspent</source>
+        <translation type="unfinished">Sarflanmaqan tranzaksiyalarni &amp;qulfdan chiqarish</translation>
+    </message>
+    <message>
+        <source>Copy quantity</source>
+        <translation type="unfinished">Miqdorni nusxalash</translation>
+    </message>
+    <message>
+        <source>Copy fee</source>
+        <translation type="unfinished">Narxni nusxalash</translation>
+    </message>
+    <message>
+        <source>Copy after fee</source>
+        <translation type="unfinished">'To'lovdan keyin' ni nusxalash</translation>
+    </message>
+    <message>
+        <source>Copy bytes</source>
+        <translation type="unfinished">Baytlarni nusxalash</translation>
+    </message>
+    <message>
+        <source>Copy dust</source>
+        <translation type="unfinished">'Dust' larni nusxalash</translation>
+    </message>
+    <message>
+        <source>Copy change</source>
+        <translation type="unfinished">O'zgarishni nusxalash</translation>
+    </message>
+    <message>
+        <source>(%1 locked)</source>
+        <translation type="unfinished">(%1 qulflangan)</translation>
+    </message>
+    <message>
+        <source>yes</source>
+        <translation type="unfinished">ha</translation>
+    </message>
+    <message>
+        <source>no</source>
+        <translation type="unfinished">yo'q</translation>
+    </message>
+    <message>
+        <source>This label turns red if any recipient receives an amount smaller than the current dust threshold.</source>
+        <translation type="unfinished">Agar qabul qiluvchi joriy 'dust' chegarasidan kichikroq miqdor olsa, bu yorliq qizil rangga aylanadi</translation>
+    </message>
+    <message>
+        <source>Can vary +/- %1 satoshi(s) per input.</source>
+        <translation type="unfinished">Har bir kiruvchi +/- %1  satoshiga farq qilishi mumkin.</translation>
+    </message>
+    <message>
+        <source>(no label)</source>
+        <translation type="unfinished">(Yorliqlar mavjud emas)</translation>
+    </message>
+    <message>
+        <source>change from %1 (%2)</source>
+        <translation type="unfinished">%1(%2) dan o'zgartirish</translation>
+    </message>
+    <message>
+        <source>(change)</source>
+        <translation type="unfinished">(o'zgartirish)</translation>
+    </message>
+</context>
+<context>
+    <name>CreateWalletActivity</name>
+    <message>
+        <source>Create Wallet</source>
+        <extracomment>Title of window indicating the progress of creation of a new wallet.</extracomment>
+        <translation type="unfinished">Hamyon yaratish</translation>
+    </message>
+    <message>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the create wallet progress window which indicates to the user which wallet is currently being created.</extracomment>
+        <translation type="unfinished">Hamyon yaratilmoqda &lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+    <message>
+        <source>Create wallet failed</source>
+        <translation type="unfinished">Hamyon yaratilishi amalga oshmadi</translation>
+    </message>
+    <message>
+        <source>Create wallet warning</source>
+        <translation type="unfinished">Hamyon yaratish ogohlantirishi</translation>
+    </message>
+    <message>
+        <source>Can't list signers</source>
+        <translation type="unfinished">Signerlarni ro'yxat shakliga keltirib bo'lmaydi</translation>
+    </message>
     </context>
 <context>
+    <name>LoadWalletsActivity</name>
+    <message>
+        <source>Load Wallets</source>
+        <extracomment>Title of progress window which is displayed when wallets are being loaded.</extracomment>
+        <translation type="unfinished">Hamyonni yuklash</translation>
+    </message>
+    <message>
+        <source>Loading wallets…</source>
+        <extracomment>Descriptive text of the load wallets progress window which indicates to the user that wallets are currently being loaded.</extracomment>
+        <translation type="unfinished">Hamyonlar yuklanmoqda...</translation>
+    </message>
+</context>
+<context>
+    <name>OpenWalletActivity</name>
+    <message>
+        <source>Open wallet failed</source>
+        <translation type="unfinished">Hamyonni ochib bo'lmaydi</translation>
+    </message>
+    <message>
+        <source>Open wallet warning</source>
+        <translation type="unfinished">Hamyonni ochish ogohlantirishi</translation>
+    </message>
+    <message>
+        <source>default wallet</source>
+        <translation type="unfinished">standart hamyon</translation>
+    </message>
+    <message>
+        <source>Open Wallet</source>
+        <extracomment>Title of window indicating the progress of opening of a wallet.</extracomment>
+        <translation type="unfinished">Hamyonni ochish</translation>
+    </message>
+    <message>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the open wallet progress window which indicates to the user which wallet is currently being opened.</extracomment>
+        <translation type="unfinished">Hamyonni ochish &lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+</context>
+<context>
+    <name>WalletController</name>
+    <message>
+        <source>Close wallet</source>
+        <translation type="unfinished">Hamyonni yopish</translation>
+    </message>
+    <message>
+        <source>Are you sure you wish to close the wallet &lt;i&gt;%1&lt;/i&gt;?</source>
+        <translation type="unfinished">Ushbu hamyonni&lt;i&gt;%1&lt;/i&gt; yopmoqchi ekaningizga ishonchingiz komilmi?</translation>
+    </message>
+    <message>
+        <source>Closing the wallet for too long can result in having to resync the entire chain if pruning is enabled.</source>
+        <translation type="unfinished">Agar 'pruning' funksiyasi o'chirilgan bo'lsa, hamyondan uzoq vaqt foydalanmaslik butun zanjirnni qayta sinxronlashga olib kelishi mumkin.</translation>
+    </message>
+    <message>
+        <source>Close all wallets</source>
+        <translation type="unfinished">Barcha hamyonlarni yopish</translation>
+    </message>
+    <message>
+        <source>Are you sure you wish to close all wallets?</source>
+        <translation type="unfinished">Hamma hamyonlarni yopmoqchimisiz?</translation>
+    </message>
+</context>
+<context>
+    <name>CreateWalletDialog</name>
+    <message>
+        <source>Create Wallet</source>
+        <translation type="unfinished">Hamyon yaratish</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <translation type="unfinished">Hamyon nomi</translation>
+    </message>
+    <message>
+        <source>Wallet</source>
+        <translation type="unfinished">Hamyon</translation>
+    </message>
+    <message>
+        <source>Encrypt the wallet. The wallet will be encrypted with a passphrase of your choice.</source>
+        <translation type="unfinished">Hamyonni shifrlash. Hamyon siz tanlagan maxfiy so'z bilan shifrlanadi</translation>
+    </message>
+    <message>
+        <source>Encrypt Wallet</source>
+        <translation type="unfinished">Hamyonni shifrlash</translation>
+    </message>
+    <message>
+        <source>Advanced Options</source>
+        <translation type="unfinished">Qo'shimcha sozlamalar</translation>
+    </message>
+    <message>
+        <source>Disable private keys for this wallet. Wallets with private keys disabled will have no private keys and cannot have an HD seed or imported private keys. This is ideal for watch-only wallets.</source>
+        <translation type="unfinished">Ushbu hamyon uchun maxfiy kalitlarni o'chirish. Maxfiy kalitsiz hamyonlar maxfiy kalitlar yoki import qilingan maxfiy kalitlar, shuningdek, HD seedlarga ega bo'la olmaydi.</translation>
+    </message>
+    <message>
+        <source>Disable Private Keys</source>
+        <translation type="unfinished">Maxfiy kalitlarni faolsizlantirish</translation>
+    </message>
+    <message>
+        <source>Make a blank wallet. Blank wallets do not initially have private keys or scripts. Private keys and addresses can be imported, or an HD seed can be set, at a later time.</source>
+        <translation type="unfinished">Bo'sh hamyon yaratish. Bo'sh hamyonlarga keyinchalik maxfiy kalitlar yoki manzillar import qilinishi mumkin, yana HD seedlar ham o'rnatilishi mumkin.</translation>
+    </message>
+    <message>
+        <source>Make Blank Wallet</source>
+        <translation type="unfinished">Bo'sh hamyon yaratish</translation>
+    </message>
+    <message>
+        <source>Use descriptors for scriptPubKey management</source>
+        <translation type="unfinished">scriptPubKey yaratishda izohlovchidan foydalanish</translation>
+    </message>
+    <message>
+        <source>Descriptor Wallet</source>
+        <translation type="unfinished">Izohlovchi hamyon</translation>
+    </message>
+    <message>
+        <source>Use an external signing device such as a hardware wallet. Configure the external signer script in wallet preferences first.</source>
+        <translation type="unfinished">Uskuna hamyoni kabi tashqi signing qurilmasidan foydalaning. Avval hamyon sozlamalarida tashqi signer skriptini sozlang.</translation>
+    </message>
+    <message>
+        <source>External signer</source>
+        <translation type="unfinished">Tashqi signer</translation>
+    </message>
+    <message>
+        <source>Create</source>
+        <translation type="unfinished">Yaratmoq</translation>
+    </message>
+    <message>
+        <source>Compiled without sqlite support (required for descriptor wallets)</source>
+        <translation type="unfinished">Sqlite yordamisiz tuzilgan (deskriptor hamyonlari uchun talab qilinadi)</translation>
+    </message>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Tashqi signing yordamisiz tuzilgan (tashqi signing uchun zarur)</translation>
+    </message>
+</context>
+<context>
+    <name>EditAddressDialog</name>
+    <message>
+        <source>Edit Address</source>
+        <translation type="unfinished">Manzilni tahrirlash</translation>
+    </message>
+    <message>
+        <source>&amp;Label</source>
+        <translation type="unfinished">&amp;Yorliq</translation>
+    </message>
+    <message>
+        <source>The label associated with this address list entry</source>
+        <translation type="unfinished">Bu manzillar roʻyxati yozuvi bilan bogʻlangan yorliq</translation>
+    </message>
+    <message>
+        <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
+        <translation type="unfinished">Bu manzillar roʻyxati yozuvi bilan bogʻlangan yorliq. Bu faqat manzillarni yuborish uchun o'zgartirilishi mumkin.</translation>
+    </message>
+    <message>
+        <source>&amp;Address</source>
+        <translation type="unfinished">&amp;Manzil</translation>
+    </message>
+    <message>
+        <source>New sending address</source>
+        <translation type="unfinished">Yangi jo'natish manzili</translation>
+    </message>
+    <message>
+        <source>Edit receiving address</source>
+        <translation type="unfinished">Qabul qiluvchi manzilini tahrirlash</translation>
+    </message>
+    <message>
+        <source>Edit sending address</source>
+        <translation type="unfinished">Yuboruvchi manzilini tahrirlash</translation>
+    </message>
+    <message>
+        <source>The entered address "%1" is not a valid Bitcoin address.</source>
+        <translation type="unfinished">%1 manzil Bitcoin da mavjud manzil emas</translation>
+    </message>
+    <message>
+        <source>Address "%1" already exists as a receiving address with label "%2" and so cannot be added as a sending address.</source>
+        <translation type="unfinished">Yuboruvchi(%1manzil) va  qabul qiluvchi(%2manzil) bir xil bo'lishi mumkin emas</translation>
+    </message>
+    <message>
+        <source>The entered address "%1" is already in the address book with label "%2".</source>
+        <translation type="unfinished">Kiritilgan %1manzil allaqachon %2yorlig'i bilan manzillar kitobida</translation>
+    </message>
+    <message>
+        <source>Could not unlock wallet.</source>
+        <translation type="unfinished">Hamyonni ochish imkonsiz</translation>
+    </message>
+    <message>
+        <source>New key generation failed.</source>
+        <translation type="unfinished">Yangi kalit yaratilishi amalga oshmadi.</translation>
+    </message>
+</context>
+<context>
+    <name>FreespaceChecker</name>
+    <message>
+        <source>A new data directory will be created.</source>
+        <translation type="unfinished">Yangi ma'lumot manzili yaratiladi.</translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished">nom</translation>
+    </message>
+    <message>
+        <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
+        <translation type="unfinished">Manzil allaqachon yaratilgan. %1 ni qo'shing, agar yangi manzil yaratmoqchi bo'lsangiz.</translation>
+    </message>
+    <message>
+        <source>Path already exists, and is not a directory.</source>
+        <translation type="unfinished">Ushbu manzil allaqachon egallangan.</translation>
+    </message>
+    <message>
+        <source>Cannot create data directory here.</source>
+        <translation type="unfinished">Ma'lumotlar bu yerda saqlanishi mumkin emas.</translation>
+    </message>
+</context>
+<context>
     <name>Intro</name>
+    <message>
+        <source>Bitcoin</source>
+        <translation type="unfinished">Bitkoin</translation>
+    </message>
     <message numerus="yes">
-        <source>(sufficient to restore backups %n day(s) old)</source>
-        <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
+        <source>%n GB of space available</source>
         <translation type="unfinished">
             <numerusform />
             <numerusform />
         </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message>
+        <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
+        <translation type="unfinished">Kamida %1 GB ma'lumot bu yerda saqlanadi va vaqtlar davomida o'sib boradi</translation>
+    </message>
+    <message>
+        <source>Approximately %1 GB of data will be stored in this directory.</source>
+        <translation type="unfinished">Bu katalogda %1  GB ma'lumot saqlanadi</translation>
+    </message>
+    <message numerus="yes">
+        <source>(sufficient to restore backups %n day(s) old)</source>
+        <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
+        <translation type="unfinished">
+            <numerusform>(%n kun oldingi zaxira nusxalarini tiklash uchun etarli)</numerusform>
+            <numerusform />
+        </translation>
+    </message>
+    <message>
+        <source>%1 will download and store a copy of the Bitcoin block chain.</source>
+        <translation type="unfinished"> Bitcoin blok zanjirining%1 nusxasini yuklab oladi va saqlaydi</translation>
+    </message>
+    <message>
+        <source>The wallet will also be stored in this directory.</source>
+        <translation type="unfinished">Hamyon ham ushbu katalogda saqlanadi.</translation>
+    </message>
+    <message>
+        <source>Error: Specified data directory "%1" cannot be created.</source>
+        <translation type="unfinished">Xatolik: Belgilangan %1 ma'lumotlar katalogini yaratib bo'lmaydi</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Xatolik</translation>
+    </message>
+    <message>
+        <source>Welcome</source>
+        <translation type="unfinished">Xush kelibsiz</translation>
+    </message>
+    <message>
+        <source>Welcome to %1.</source>
+        <translation type="unfinished">%1 ga xush kelibsiz</translation>
+    </message>
+    <message>
+        <source>As this is the first time the program is launched, you can choose where %1 will store its data.</source>
+        <translation type="unfinished">Birinchi marta dastur ishga tushirilganda, siz %1 o'z ma'lumotlarini qayerda saqlashini tanlashingiz mumkin</translation>
+    </message>
+    <message>
+        <source>Limit block chain storage to</source>
+        <translation type="unfinished">Blok zanjiri xotirasini bungacha cheklash:</translation>
+    </message>
+    <message>
+        <source>Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</source>
+        <translation type="unfinished">Bu sozlamani qaytarish butun blok zanjirini qayta yuklab olishni talab qiladi. Avval to'liq zanjirni yuklab olish va keyinroq kesish kamroq vaqt oladi. Ba'zi qo'shimcha funksiyalarni cheklaydi.</translation>
+    </message>
+    <message>
+        <source> GB</source>
+        <translation type="unfinished">GB</translation>
+    </message>
+    <message>
+        <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
+        <translation type="unfinished">Ushbu dastlabki sinxronlash juda qiyin va kompyuteringiz bilan ilgari sezilmagan apparat muammolarini yuzaga keltirishi mumkin. Har safar %1 ni ishga tushirganingizda, u yuklab olish jarayonini qayerda to'xtatgan bo'lsa, o'sha yerdan boshlab davom ettiradi.</translation>
+    </message>
+    <message>
+        <source>If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</source>
+        <translation type="unfinished">Agar siz blok zanjirini saqlashni cheklashni tanlagan bo'lsangiz (pruning), eski ma'lumotlar hali ham yuklab olinishi va qayta ishlanishi kerak, ammo diskdan kamroq foydalanish uchun keyin o'chiriladi.</translation>
+    </message>
+    <message>
+        <source>Use the default data directory</source>
+        <translation type="unfinished">Standart ma'lumotlar katalogidan foydalanish</translation>
+    </message>
+    <message>
+        <source>Use a custom data directory:</source>
+        <translation type="unfinished">O'zingiz xohlagan ma'lumotlar katalogidan foydalanish:</translation>
+    </message>
+</context>
+<context>
+    <name>HelpMessageDialog</name>
+    <message>
+        <source>version</source>
+        <translation type="unfinished">versiya</translation>
+    </message>
+    <message>
+        <source>About %1</source>
+        <translation type="unfinished">%1 haqida</translation>
+    </message>
+    <message>
+        <source>Command-line options</source>
+        <translation type="unfinished">Command-line sozlamalari</translation>
+    </message>
+</context>
+<context>
+    <name>ShutdownWindow</name>
+    <message>
+        <source>%1 is shutting down…</source>
+        <translation type="unfinished">%1 yopilmoqda...</translation>
+    </message>
+    <message>
+        <source>Do not shut down the computer until this window disappears.</source>
+        <translation type="unfinished">Bu oyna paydo bo'lmagunicha kompyuterni o'chirmang.</translation>
+    </message>
+</context>
+<context>
+    <name>ModalOverlay</name>
+    <message>
+        <source>Form</source>
+        <translation type="unfinished">Forma</translation>
+    </message>
+    <message>
+        <source>Recent transactions may not yet be visible, and therefore your wallet's balance might be incorrect. This information will be correct once your wallet has finished synchronizing with the bitcoin network, as detailed below.</source>
+        <translation type="unfinished">So'nggi tranzaksiyalar hali ko'rinmasligi mumkin, shuning uchun hamyoningiz balansi noto'g'ri ko'rinishi mumkin. Sizning hamyoningiz bitkoin tarmog'i bilan sinxronlashni tugatgandan so'ng, quyida batafsil tavsiflanganidek, bu ma'lumot to'g'rilanadi.</translation>
+    </message>
+    <message>
+        <source>Attempting to spend bitcoins that are affected by not-yet-displayed transactions will not be accepted by the network.</source>
+        <translation type="unfinished">Hali ko'rsatilmagan tranzaksiyalarga bitkoinlarni sarflashga urinish tarmoq tomonidan qabul qilinmaydi.</translation>
+    </message>
+    <message>
+        <source>Number of blocks left</source>
+        <translation type="unfinished">qolgan bloklar soni</translation>
+    </message>
+    <message>
+        <source>Unknown…</source>
+        <translation type="unfinished">Noma'lum...</translation>
+    </message>
+    <message>
+        <source>calculating…</source>
+        <translation type="unfinished">hisoblanmoqda...</translation>
+    </message>
+    <message>
+        <source>Last block time</source>
+        <translation type="unfinished">Oxirgi bloklash vaqti</translation>
+    </message>
+    <message>
+        <source>Progress</source>
+        <translation type="unfinished">O'sish</translation>
+    </message>
+    <message>
+        <source>Progress increase per hour</source>
+        <translation type="unfinished">Harakatning soatiga o'sishi</translation>
+    </message>
+    <message>
+        <source>Estimated time left until synced</source>
+        <translation type="unfinished">Sinxronizatsiya yakunlanishiga taxminan qolgan vaqt</translation>
+    </message>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished">Yashirmoq</translation>
+    </message>
+    <message>
+        <source>%1 is currently syncing.  It will download headers and blocks from peers and validate them until reaching the tip of the block chain.</source>
+        <translation type="unfinished">%1 sinxronlanmoqda. U pirlardan sarlavhalar va bloklarni yuklab oladi va ularni blok zanjirining uchiga yetguncha tasdiqlaydi.</translation>
+    </message>
+    <message>
+        <source>Unknown. Syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">Noma'lum. Sarlavhalarni sinxronlash(%1, %2%)...</translation>
+    </message>
+    </context>
+<context>
+    <name>OpenURIDialog</name>
+    <message>
+        <source>Open bitcoin URI</source>
+        <translation type="unfinished">Bitkoin URI sini ochish</translation>
+    </message>
+    <message>
+        <source>Paste address from clipboard</source>
+        <extracomment>Tooltip text for button that allows you to paste an address that is in your clipboard.</extracomment>
+        <translation type="unfinished">Manzilni qo'shib qo'yish</translation>
+    </message>
+</context>
+<context>
+    <name>OptionsDialog</name>
+    <message>
+        <source>Options</source>
+        <translation type="unfinished">Sozlamalar</translation>
+    </message>
+    <message>
+        <source>&amp;Main</source>
+        <translation type="unfinished">&amp;Asosiy</translation>
+    </message>
+    <message>
+        <source>Automatically start %1 after logging in to the system.</source>
+        <translation type="unfinished">%1 ni sistemaga kirilishi bilanoq avtomatik ishga tushirish.</translation>
+    </message>
+    <message>
+        <source>&amp;Start %1 on system login</source>
+        <translation type="unfinished">%1 ni sistemaga kirish paytida &amp;ishga tushirish</translation>
+    </message>
+    <message>
+        <source>Enabling pruning significantly reduces the disk space required to store transactions. All blocks are still fully validated. Reverting this setting requires re-downloading the entire blockchain.</source>
+        <translation type="unfinished">Do'kon tranzaksiyalari katta xotira talab qilgani tufayli pruning ni yoqish sezilarli darajada xotirada joy kamayishiga olib keladi. Barcha bloklar hali ham to'liq tasdiqlangan. Bu sozlamani qaytarish butun blok zanjirini qayta yuklab olishni talab qiladi.</translation>
+    </message>
+    <message>
+        <source>Size of &amp;database cache</source>
+        <translation type="unfinished">&amp;Ma'lumotlar bazasi hajmi</translation>
+    </message>
+    <message>
+        <source>Number of script &amp;verification threads</source>
+        <translation type="unfinished">Skriptni &amp;tekshirish thread lari soni</translation>
+    </message>
+    <message>
+        <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
+        <translation type="unfinished">Proksi IP manzili (masalan: IPv4: 127.0.0.1 / IPv6: ::1)</translation>
+    </message>
+    <message>
+        <source>Shows if the supplied default SOCKS5 proxy is used to reach peers via this network type.</source>
+        <translation type="unfinished">Taqdim etilgan standart SOCKS5 proksi-serveridan ushbu tarmoq turi orqali pirlar bilan bog‘lanish uchun foydalanilganini ko'rsatadi.</translation>
+    </message>
+    <message>
+        <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
+        <translation type="unfinished">Oyna yopilganda dasturdan chiqish o'rniga minimallashtirish. Ushbu parametr yoqilganda, dastur faqat menyuda Chiqish ni tanlagandan keyin yopiladi.</translation>
+    </message>
+    <message>
+        <source>Open the %1 configuration file from the working directory.</source>
+        <translation type="unfinished">%1 konfiguratsion faylini ishlash katalogidan ochish.</translation>
+    </message>
+    <message>
+        <source>Open Configuration File</source>
+        <translation type="unfinished">Konfiguratsion faylni ochish</translation>
+    </message>
+    <message>
+        <source>Reset all client options to default.</source>
+        <translation type="unfinished">Barcha mijoz sozlamalarini asl holiga qaytarish.</translation>
+    </message>
+    <message>
+        <source>&amp;Reset Options</source>
+        <translation type="unfinished">Sozlamalarni &amp;qayta o'rnatish</translation>
+    </message>
+    <message>
+        <source>&amp;Network</source>
+        <translation type="unfinished">&amp;Internet tarmog'i</translation>
+    </message>
+    <message>
+        <source>Prune &amp;block storage to</source>
+        <translation type="unfinished">&amp;Blok xotirasini bunga kesish:</translation>
+    </message>
+    <message>
+        <source>Reverting this setting requires re-downloading the entire blockchain.</source>
+        <translation type="unfinished">Bu sozlamani qaytarish butun blok zanjirini qayta yuklab olishni talab qiladi.</translation>
+    </message>
+    <message>
+        <source>Maximum database cache size. A larger cache can contribute to faster sync, after which the benefit is less pronounced for most use cases. Lowering the cache size will reduce memory usage. Unused mempool memory is shared for this cache.</source>
+        <extracomment>Tooltip text for Options window setting that sets the size of the database cache. Explains the corresponding effects of increasing/decreasing this value.</extracomment>
+        <translation type="unfinished">Ma'lumotlar bazasi keshining maksimal hajmi. Kattaroq kesh tezroq sinxronlashtirishga hissa qo'shishi mumkin, ya'ni foyda kamroq sezilishi mumkin.</translation>
+    </message>
+    <message>
+        <source>Set the number of script verification threads. Negative values correspond to the number of cores you want to leave free to the system.</source>
+        <extracomment>Tooltip text for Options window setting that sets the number of script verification threads. Explains that negative values mean to leave these many cores free to the system.</extracomment>
+        <translation type="unfinished">Skriptni tekshirish ip lari sonini belgilang. </translation>
+    </message>
+    <message>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation type="unfinished">(0 = avtomatik, &lt;0 = bu yadrolarni bo'sh qoldirish)</translation>
+    </message>
+    <message>
+        <source>This allows you or a third party tool to communicate with the node through command-line and JSON-RPC commands.</source>
+        <extracomment>Tooltip text for Options window setting that enables the RPC server.</extracomment>
+        <translation type="unfinished">Bu sizga yoki uchinchi tomon vositasiga command-line va JSON-RPC buyruqlari orqali node bilan bog'lanish imkonini beradi.</translation>
+    </message>
+    <message>
+        <source>Enable R&amp;PC server</source>
+        <extracomment>An Options window setting to enable the RPC server.</extracomment>
+        <translation type="unfinished">R&amp;PC serverni yoqish</translation>
+    </message>
+    <message>
+        <source>W&amp;allet</source>
+        <translation type="unfinished">H&amp;amyon</translation>
+    </message>
+    <message>
+        <source>Whether to set subtract fee from amount as default or not.</source>
+        <extracomment>Tooltip text for Options window setting that sets subtracting the fee from a sending amount as default.</extracomment>
+        <translation type="unfinished">Chegirma to'lovini standart qilib belgilash kerakmi yoki yo'qmi?</translation>
+    </message>
+    <message>
+        <source>Subtract &amp;fee from amount by default</source>
+        <extracomment>An Options window setting to set subtracting the fee from a sending amount as default.</extracomment>
+        <translation type="unfinished">Standart bo'yicha chegirma belgilash</translation>
+    </message>
+    <message>
+        <source>Expert</source>
+        <translation type="unfinished">Ekspert</translation>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation type="unfinished">Tangalarni &amp;nazorat qilish funksiyasini yoqish</translation>
+    </message>
+    <message>
+        <source>Enable &amp;PSBT controls</source>
+        <extracomment>An options window setting to enable PSBT controls.</extracomment>
+        <translation type="unfinished">&amp;PSBT nazoratini yoqish</translation>
+    </message>
+    <message>
+        <source>Whether to show PSBT controls.</source>
+        <extracomment>Tooltip text for options window setting that enables PSBT controls.</extracomment>
+        <translation type="unfinished">PSBT boshqaruvlarini ko'rsatish kerakmi?</translation>
+    </message>
+    <message>
+        <source>External Signer (e.g. hardware wallet)</source>
+        <translation type="unfinished">Tashqi Signer(masalan: hamyon apparati)</translation>
+    </message>
+    <message>
+        <source>&amp;External signer script path</source>
+        <translation type="unfinished">&amp;Tashqi signer skripti yo'li</translation>
+    </message>
+    <message>
+        <source>&amp;Window</source>
+        <translation type="unfinished">&amp;Oyna</translation>
+    </message>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Tashqi signing yordamisiz tuzilgan (tashqi signing uchun zarur)</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Xatolik</translation>
+    </message>
+    </context>
+<context>
+    <name>OverviewPage</name>
+    <message>
+        <source>Form</source>
+        <translation type="unfinished">Forma</translation>
     </message>
     </context>
 <context>
@@ -124,14 +1550,124 @@
     </message>
     </context>
 <context>
+    <name>RPCConsole</name>
+    <message>
+        <source>Node window</source>
+        <translation type="unfinished">Node oynasi</translation>
+    </message>
+    <message>
+        <source>Last block time</source>
+        <translation type="unfinished">Oxirgi bloklash vaqti</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <extracomment>Context menu action to copy the address of a peer.</extracomment>
+        <translation type="unfinished">&amp;Manzilni nusxalash</translation>
+    </message>
+    </context>
+<context>
+    <name>ReceiveCoinsDialog</name>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Manzilni nusxalash</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">&amp;Yorliqni nusxalash</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">&amp;Miqdorni nusxalash</translation>
+    </message>
+    <message>
+        <source>Could not unlock wallet.</source>
+        <translation type="unfinished">Hamyonni ochish imkonsiz</translation>
+    </message>
+    </context>
+<context>
+    <name>ReceiveRequestDialog</name>
+    <message>
+        <source>Amount:</source>
+        <translation type="unfinished">Miqdor:</translation>
+    </message>
+    <message>
+        <source>Wallet:</source>
+        <translation type="unfinished">Hamyon</translation>
+    </message>
+    </context>
+<context>
     <name>RecentRequestsTableModel</name>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">Sana</translation>
+    </message>
     <message>
         <source>Label</source>
         <translation type="unfinished">Yorliq</translation>
     </message>
+    <message>
+        <source>(no label)</source>
+        <translation type="unfinished">(Yorliqlar mavjud emas)</translation>
+    </message>
     </context>
 <context>
     <name>SendCoinsDialog</name>
+    <message>
+        <source>Quantity:</source>
+        <translation type="unfinished">Miqdor:</translation>
+    </message>
+    <message>
+        <source>Bytes:</source>
+        <translation type="unfinished">Baytlar:</translation>
+    </message>
+    <message>
+        <source>Amount:</source>
+        <translation type="unfinished">Miqdor:</translation>
+    </message>
+    <message>
+        <source>Fee:</source>
+        <translation type="unfinished">Narx:</translation>
+    </message>
+    <message>
+        <source>After Fee:</source>
+        <translation type="unfinished">To'lovdan keyin:</translation>
+    </message>
+    <message>
+        <source>Change:</source>
+        <translation type="unfinished">O'zgartirish:</translation>
+    </message>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished">Yashirmoq</translation>
+    </message>
+    <message>
+        <source>Copy quantity</source>
+        <translation type="unfinished">Miqdorni nusxalash</translation>
+    </message>
+    <message>
+        <source>Copy amount</source>
+        <translation type="unfinished">Qiymatni nusxalash</translation>
+    </message>
+    <message>
+        <source>Copy fee</source>
+        <translation type="unfinished">Narxni nusxalash</translation>
+    </message>
+    <message>
+        <source>Copy after fee</source>
+        <translation type="unfinished">'To'lovdan keyin' ni nusxalash</translation>
+    </message>
+    <message>
+        <source>Copy bytes</source>
+        <translation type="unfinished">Baytlarni nusxalash</translation>
+    </message>
+    <message>
+        <source>Copy dust</source>
+        <translation type="unfinished">'Dust' larni nusxalash</translation>
+    </message>
+    <message>
+        <source>Copy change</source>
+        <translation type="unfinished">O'zgarishni nusxalash</translation>
+    </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
@@ -139,9 +1675,35 @@
             <numerusform />
         </translation>
     </message>
+    <message>
+        <source>(no label)</source>
+        <translation type="unfinished">(Yorliqlar mavjud emas)</translation>
+    </message>
+</context>
+<context>
+    <name>SendCoinsEntry</name>
+    <message>
+        <source>Paste address from clipboard</source>
+        <translation type="unfinished">Manzilni qo'shib qo'yish</translation>
+    </message>
+    </context>
+<context>
+    <name>SignVerifyMessageDialog</name>
+    <message>
+        <source>Paste address from clipboard</source>
+        <translation type="unfinished">Manzilni qo'shib qo'yish</translation>
+    </message>
     </context>
 <context>
     <name>TransactionDesc</name>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">Sana</translation>
+    </message>
+    <message>
+        <source>unknown</source>
+        <translation type="unfinished">noma'lum</translation>
+    </message>
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
@@ -149,16 +1711,53 @@
             <numerusform />
         </translation>
     </message>
+    <message>
+        <source>Amount</source>
+        <translation type="unfinished">Miqdor</translation>
+    </message>
     </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
+        <source>Date</source>
+        <translation type="unfinished">Sana</translation>
+    </message>
+    <message>
         <source>Label</source>
         <translation type="unfinished">Yorliq</translation>
+    </message>
+    <message>
+        <source>(no label)</source>
+        <translation type="unfinished">(Yorliqlar mavjud emas)</translation>
     </message>
     </context>
 <context>
     <name>TransactionView</name>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;Manzilni nusxalash</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">&amp;Yorliqni nusxalash</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">&amp;Miqdorni nusxalash</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">Vergul yordamida ajratilgan fayl</translation>
+    </message>
+    <message>
+        <source>Confirmed</source>
+        <translation type="unfinished">Tasdiqlangan</translation>
+    </message>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">Sana</translation>
+    </message>
     <message>
         <source>Label</source>
         <translation type="unfinished">Yorliq</translation>
@@ -166,6 +1765,39 @@
     <message>
         <source>Address</source>
         <translation type="unfinished">Manzil</translation>
+    </message>
+    <message>
+        <source>Exporting Failed</source>
+        <translation type="unfinished">Eksport qilish amalga oshmadi</translation>
+    </message>
+    </context>
+<context>
+    <name>WalletFrame</name>
+    <message>
+        <source>Create a new wallet</source>
+        <translation type="unfinished">Yangi hamyon yaratish</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Xatolik</translation>
+    </message>
+    </context>
+<context>
+    <name>WalletModel</name>
+    <message>
+        <source>default wallet</source>
+        <translation type="unfinished">standart hamyon</translation>
+    </message>
+</context>
+<context>
+    <name>WalletView</name>
+    <message>
+        <source>&amp;Export</source>
+        <translation type="unfinished">&amp;Eksport</translation>
+    </message>
+    <message>
+        <source>Export the data in the current tab to a file</source>
+        <translation type="unfinished">Joriy yorliqdagi ma'lumotlarni faylga eksport qilish</translation>
     </message>
     </context>
 </TS>

--- a/src/qt/locale/bitcoin_vi.ts
+++ b/src/qt/locale/bitcoin_vi.ts
@@ -3,7 +3,7 @@
     <name>AddressBookPage</name>
     <message>
         <source>Right-click to edit address or label</source>
-        <translation type="unfinished">Nhấp chuột phải để sửa địa chỉ hoặc nhãn</translation>
+        <translation type="unfinished">Nhấn chuột phải để sửa địa chỉ hoặc nhãn</translation>
     </message>
     <message>
         <source>Create a new address</source>
@@ -15,88 +15,41 @@
     </message>
     <message>
         <source>Copy the currently selected address to the system clipboard</source>
-        <translation type="unfinished">Sao chép các địa chỉ đã được chọn vào bộ nhớ tạm thời của hệ thống</translation>
+        <translation type="unfinished">Sao chép địa chỉ được chọn vào bộ nhớ tạm</translation>
     </message>
     <message>
         <source>&amp;Copy</source>
         <translation type="unfinished">&amp;Sao chép</translation>
     </message>
     <message>
-        <source>C&amp;lose</source>
-        <translation type="unfinished">Đ&amp;óng lại</translation>
-    </message>
-    <message>
         <source>Delete the currently selected address from the list</source>
-        <translation type="unfinished">Xóa địa chỉ đang chọn từ danh sách</translation>
+        <translation type="unfinished">Xoá địa chỉ được chọn khỏi danh sách</translation>
     </message>
     <message>
-        <source>Export the data in the current tab to a file</source>
-        <translation type="unfinished">Xuất dữ liệu trong thẻ hiện tại ra file</translation>
+        <source>Enter address or label to search</source>
+        <translation type="unfinished">Nhập địa chỉ hoặc nhãn để tìm kiếm</translation>
     </message>
     <message>
         <source>&amp;Export</source>
         <translation type="unfinished">&amp;Xuất</translation>
     </message>
     <message>
-        <source>&amp;Delete</source>
-        <translation type="unfinished">&amp;Xóa</translation>
-    </message>
-    <message>
         <source>Choose the address to send coins to</source>
-        <translation type="unfinished">Chọn địa chỉ để gửi coins đến</translation>
-    </message>
-    <message>
-        <source>Choose the address to receive coins with</source>
-        <translation type="unfinished">Chọn địa chỉ để nhận coins với</translation>
-    </message>
-    <message>
-        <source>C&amp;hoose</source>
-        <translation type="unfinished">C&amp;họn</translation>
+        <translation type="unfinished">Chọn địa chỉ để gửi coin đến</translation>
     </message>
     <message>
         <source>Sending addresses</source>
-        <translation type="unfinished">Địa chỉ đang gửi</translation>
+        <translation type="unfinished">Đang gửi địa chỉ</translation>
     </message>
     <message>
-        <source>Receiving addresses</source>
-        <translation type="unfinished">Địa chỉ đang nhận</translation>
-    </message>
-    <message>
-        <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
-        <translation type="unfinished">Đây là những địa chỉ đang thực hiện thanh toán. Luôn kiểm tra số lượng và địa chỉ nhận trước khi gửi coins.</translation>
-    </message>
-    <message>
-        <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
-Signing is only possible with addresses of the type 'legacy'.</source>
-        <translation type="unfinished">Đây là các địa chỉ Bitcoin của bạn để nhận thanh toán. Sử dụng nút 'Tạo địa chỉ nhận mới' trong tab nhận để tạo các địa chỉ mới. Chỉ có thể gán địa chỉ với các địa chỉ thuộc loại 'kế thừa'.</translation>
-    </message>
-    <message>
-        <source>&amp;Copy Address</source>
-        <translation type="unfinished">&amp;Copy Địa Chỉ</translation>
-    </message>
-    <message>
-        <source>Copy &amp;Label</source>
-        <translation type="unfinished">Copy &amp;Nhãn</translation>
+        <source>&amp;Edit</source>
+        <translation type="unfinished">&amp;Chỉnh sửa</translation>
     </message>
     <message>
         <source>Export Address List</source>
-        <translation type="unfinished">Xuất List Địa Chỉ</translation>
+        <translation type="unfinished">Xuất danh sách địa chỉ</translation>
     </message>
-    <message>
-        <source>Comma separated file</source>
-        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
-        <translation type="unfinished">Tệp tách dấu phẩy</translation>
-    </message>
-    <message>
-        <source>There was an error trying to save the address list to %1. Please try again.</source>
-        <extracomment>An error message. %1 is a stand-in argument for the name of the file we attempted to save to.</extracomment>
-        <translation type="unfinished">Có lỗi khi đang save list địa chỉ đến %1. Vui lòng thử lại.</translation>
-    </message>
-    <message>
-        <source>Exporting Failed</source>
-        <translation type="unfinished">Xuất Thất Bại</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>AddressTableModel</name>
     <message>
@@ -109,46 +62,46 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>(no label)</source>
-        <translation type="unfinished">(không nhãn)</translation>
+        <translation type="unfinished">(không có nhãn)</translation>
     </message>
 </context>
 <context>
     <name>AskPassphraseDialog</name>
     <message>
         <source>Passphrase Dialog</source>
-        <translation type="unfinished">Log Cụm Mật Khẩu</translation>
+        <translation type="unfinished">Hộp thoại cụm mật khẩu</translation>
     </message>
     <message>
         <source>Enter passphrase</source>
-        <translation type="unfinished">Nhập cụm mật khẩu</translation>
+        <translation type="unfinished">Nhập mật khẩu</translation>
     </message>
     <message>
         <source>New passphrase</source>
-        <translation type="unfinished">Cụm mật khẩu mới</translation>
+        <translation type="unfinished">Mật khẩu mới</translation>
     </message>
     <message>
         <source>Repeat new passphrase</source>
-        <translation type="unfinished">Lặp lại cụm mật khẩu mới</translation>
+        <translation type="unfinished">Nhập lại mật khẩu</translation>
     </message>
     <message>
         <source>Show passphrase</source>
-        <translation type="unfinished">Hiện cụm từ mật khẩu</translation>
+        <translation type="unfinished">Hiện mật khẩu</translation>
     </message>
     <message>
         <source>Encrypt wallet</source>
-        <translation type="unfinished">Ví mã hóa</translation>
+        <translation type="unfinished">Mã hoá ví</translation>
     </message>
     <message>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
-        <translation type="unfinished">Quá trình này cần cụm mật khẩu của bạn để mở khóa ví.</translation>
+        <translation type="unfinished">Hoạt động này cần mật khẩu ví của bạn để mở khoá ví.</translation>
     </message>
     <message>
         <source>Unlock wallet</source>
-        <translation type="unfinished">Mở khóa ví</translation>
+        <translation type="unfinished">Mở khoá ví</translation>
     </message>
     <message>
         <source>Change passphrase</source>
-        <translation type="unfinished">Đổi cụm mật khẩu</translation>
+        <translation type="unfinished">Đổi mật khẩu</translation>
     </message>
     <message>
         <source>Confirm wallet encryption</source>
@@ -156,457 +109,335 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
-        <translation type="unfinished">Cảnh báo: Nếu bạn mã hóa ví và mất cụm mật khẩu, bạn sẽ &lt;b&gt;MẤT TẤT CẢ BITCOIN&lt;/b&gt;!</translation>
+        <translation type="unfinished">Cảnh báo: Nếu bạn mã hóa ví và mất cụm mật khẩu, bạn sẽ &lt;b&gt;MẤT TẤT CẢ CÁC BITCOIN&lt;/b&gt;!</translation>
     </message>
     <message>
         <source>Are you sure you wish to encrypt your wallet?</source>
-        <translation type="unfinished">Bạn có chắc bạn muốn mã hóa ví của mình?</translation>
+        <translation type="unfinished">Bạn có chắc chắn muốn mã hoá ví không?</translation>
     </message>
     <message>
         <source>Wallet encrypted</source>
-        <translation type="unfinished">Ví đã được mã hóa</translation>
+        <translation type="unfinished">Đã mã hoá ví</translation>
     </message>
     <message>
         <source>Enter the new passphrase for the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
-        <translation type="unfinished">Nhập cụm từ mật khẩu mới cho ví điện tử. Hãy sử dụng cụm mật khẩu với mười hoặc nhiều hơn các ký tự ngẫu nhiên, hoặc nhiều hơn tám từ.</translation>
+        <translation type="unfinished">Nhập cụm mật khẩu mới cho ví.&lt;br/&gt;Vui lòng sử dụng cụm mật khẩu gồm &lt;b&gt;mười ký tự ngẫu nhiên trở lên&lt;/b&gt;, hoặc &lt;b&gt;tám từ trở lên&lt;/b&gt;.</translation>
     </message>
     <message>
         <source>Enter the old passphrase and new passphrase for the wallet.</source>
-        <translation type="unfinished">Nhập cụm mật khẩu cũ và mật khẩu mới cho ví.</translation>
+        <translation type="unfinished">Nhập mật khẩu cũ và mật khẩu mới cho ví.</translation>
     </message>
     <message>
         <source>Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
-        <translation type="unfinished">Xin lưu ý rằng mật mã hóa ví của bạn không thể bảo vệ hoàn toàn bitcoin của bạn khỏi đánh cắp bởi các phẩn mềm gián điệp nhiễm vào máy tính của bạn.</translation>
+        <translation type="unfinished">Xin lưu ý rằng mã hoá ví của bạn không thể bảo về hoàn toàn Bitcoin của bạn khỏi việc bị đánh cắp mới các phần mềm gián điệp nhiễm vào máy tính của bạn.</translation>
     </message>
     <message>
         <source>Wallet to be encrypted</source>
-        <translation type="unfinished">Ví sẽ được mã hóa</translation>
+        <translation type="unfinished">Ví sẽ được mã hoá</translation>
     </message>
     <message>
         <source>Your wallet is about to be encrypted. </source>
-        <translation type="unfinished">Ví của bạn sẽ được mã hóa.</translation>
+        <translation type="unfinished">Ví của bạn sẽ được mã hoá.</translation>
     </message>
     <message>
         <source>Your wallet is now encrypted. </source>
-        <translation type="unfinished">Ví của bạn đã được mã hóa.</translation>
-    </message>
-    <message>
-        <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <translation type="unfinished">QUAN TRỌNG: Bất cứ backup nào bạn từng làm trước đây từ ví của bạn nên được thay thế tạo mới, file mã hóa ví. Vì lý do bảo mật, các backup trước đây của các ví chưa mã hóa sẽ bị vô tác dụng ngay khi bạn bắt đầu sử dụng mới, ví đã được mã hóa.</translation>
+        <translation type="unfinished">Ví của bạn đã được mã hoá.</translation>
     </message>
     <message>
         <source>Wallet encryption failed</source>
-        <translation type="unfinished">Quá trình mã hóa ví thất bại</translation>
+        <translation type="unfinished">Mã hoá ví thất bại</translation>
     </message>
     <message>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
-        <translation type="unfinished">Quá trình mã hóa ví thất bại do một lỗi nội tại. Ví của bạn vẫn chưa được mã hóa.</translation>
+        <translation type="unfinished">Mã hoá ví thất bại do lỗi nội bộ. Ví của bạn vẫn chưa được mã hoá.</translation>
     </message>
     <message>
         <source>The supplied passphrases do not match.</source>
-        <translation type="unfinished">Cụm mật khẩu được cung cấp không đúng.</translation>
+        <translation type="unfinished">Mật khẩu đã nhập không đúng.</translation>
     </message>
-    <message>
-        <source>Wallet unlock failed</source>
-        <translation type="unfinished">Mở khóa ví thất bại</translation>
-    </message>
-    <message>
-        <source>The passphrase entered for the wallet decryption was incorrect.</source>
-        <translation type="unfinished">Cụm mật khẩu đã nhập để giải mã ví không đúng.</translation>
-    </message>
-    <message>
-        <source>Wallet passphrase was successfully changed.</source>
-        <translation type="unfinished">Cụm mật khẩu thay đổi thành công.</translation>
-    </message>
-    <message>
-        <source>Warning: The Caps Lock key is on!</source>
-        <translation type="unfinished">Cảnh báo: chữ Viết Hoa đang bật!</translation>
-    </message>
-</context>
-<context>
-    <name>BanTableModel</name>
-    <message>
-        <source>Banned Until</source>
-        <translation type="unfinished">Cấm Đến</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>BitcoinApplication</name>
+    <message>
+        <source>Settings file %1 might be corrupt or invalid.</source>
+        <translation type="unfinished">Tệp cài đặt %1 có thể bị hư hại hoặc không hợp lệ.</translation>
+    </message>
     <message>
         <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
         <translation type="unfinished">Lỗi nghiêm trong. %1 không thể tiếp tục và sẽ thoát ra</translation>
     </message>
-    </context>
+    <message>
+        <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
+        <translation type="unfinished">Đã xảy ra lỗi nội bộ. %1 sẽ cố gắng tiếp tục một cách an toàn. Đây là một lỗi không mong muốn có thể được báo cáo như mô tả bên dưới.</translation>
+    </message>
+</context>
 <context>
     <name>QObject</name>
     <message>
-        <source>Error: Specified data directory "%1" does not exist.</source>
-        <translation type="unfinished">Error: Xác định data directory "%1" không tồn tại.</translation>
+        <source>Do you want to reset settings to default values, or to abort without making changes?</source>
+        <extracomment>Explanatory text shown on startup when the settings file cannot be read. Prompts user to make a choice between resetting or aborting.</extracomment>
+        <translation type="unfinished">Bạn muốn đặt lại cài đặt về giá trị mặc định hay hủy bỏ mà không thực hiện thay đổi?</translation>
     </message>
     <message>
-        <source>Error: Cannot parse configuration file: %1.</source>
-        <translation type="unfinished">Lỗi: không thể  phân giải tệp cài đặt cấu hình: %1.</translation>
+        <source>A fatal error occurred. Check that settings file is writable, or try running with -nosettings.</source>
+        <extracomment>Explanatory text shown on startup when the settings file could not be written. Prompts user to check that we have the ability to write to the file. Explains that the user has the option of running without a settings file.</extracomment>
+        <translation type="unfinished">Đã xảy ra lỗi nghiêm trọng. Kiểm tra xem tệp cài đặt có thể ghi được không hoặc thử chạy với -nosettings.</translation>
     </message>
     <message>
-        <source>Amount</source>
-        <translation type="unfinished">Số lượng</translation>
+        <source>Error: %1</source>
+        <translation type="unfinished">Lỗi: %1</translation>
     </message>
     <message>
-        <source>Enter a Bitcoin address (e.g. %1)</source>
-        <translation type="unfinished">Nhập một Bitcoin address (e.g. %1)</translation>
-    </message>
-    <message>
-        <source>%1 h</source>
-        <translation type="unfinished">%1 giờ</translation>
-    </message>
-    <message>
-        <source>%1 m</source>
-        <translation type="unfinished">%1 phút</translation>
-    </message>
-    <message>
-        <source>%1 s</source>
-        <translation type="unfinished">%1 giây</translation>
+        <source>%1 didn't yet exit safely…</source>
+        <translation type="unfinished">%1 vẫn chưa thoát ra một cách an toàn…</translation>
     </message>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%ngiây</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n minute(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%nphút</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%ngiờ</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%nngày</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%ntuần</numerusform>
         </translation>
-    </message>
-    <message>
-        <source>%1 and %2</source>
-        <translation type="unfinished">%1 và %2</translation>
     </message>
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%nnăm</numerusform>
         </translation>
     </message>
     </context>
 <context>
     <name>bitcoin-core</name>
     <message>
-        <source>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.</source>
-        <translation type="unfinished">Dự toán phí không thành công. Fallbackfee bị vô hiệu hóa. Đợi sau một vài khối hoặc kích hoạt -fallbackfee.</translation>
+        <source>Settings file could not be read</source>
+        <translation type="unfinished">Không thể đọc tệp cài đặt</translation>
+    </message>
+    <message>
+        <source>Settings file could not be written</source>
+        <translation type="unfinished">Không thể ghi tệp cài đặt</translation>
+    </message>
+    <message>
+        <source>Error reading %s! Transaction data may be missing or incorrect. Rescanning wallet.</source>
+        <translation type="unfinished">Lỗi khi đọc%s! Dữ liệu giao dịch có thể bị thiếu hoặc không chính xác. Đang quét lại ví.</translation>
+    </message>
+    <message>
+        <source>Invalid or corrupt peers.dat (%s). If you believe this is a bug, please report it to %s. As a workaround, you can move the file (%s) out of the way (rename, move, or delete) to have a new one created on the next start.</source>
+        <translation type="unfinished">peers.dat (%s) không hợp lệ hoặc bị hỏng. Nếu bạn cho rằng đây là lỗi, vui lòng báo cáo cho %s. Để giải quyết vấn đề này, bạn có thể di chuyển tệp (%s) ra khỏi (đổi tên, di chuyển hoặc xóa) để tạo tệp mới vào lần bắt đầu tiếp theo.</translation>
+    </message>
+    <message>
+        <source>Prune mode is incompatible with -reindex-chainstate. Use full -reindex instead.</source>
+        <translation type="unfinished">Chế độ rút gọn không tương thích với -reindex-chainstate. Sử dụng -reindex ở chế độ đầy đủ.</translation>
+    </message>
+    <message>
+        <source>The block index db contains a legacy 'txindex'. To clear the occupied disk space, run a full -reindex, otherwise ignore this error. This error message will not be displayed again.</source>
+        <translation type="unfinished">Chỉ mục khối db chứa một 'txindex' kế thừa. Để xóa dung lượng ổ đĩa bị chiếm dụng, hãy chạy -reindex đầy đủ, nếu không, hãy bỏ qua lỗi này. Thông báo lỗi này sẽ không được hiển thị lại.</translation>
     </message>
     <message>
         <source>This is the maximum transaction fee you pay (in addition to the normal fee) to prioritize partial spend avoidance over regular coin selection.</source>
         <translation type="unfinished">Đây là phí giao dịch tối đa bạn phải trả (ngoài phí thông thường) để ưu tiên việc tránh chi xài một phần (partial spend) so với việc lựa chọn đồng coin thông thường.</translation>
     </message>
     <message>
-        <source>Warning: Private keys detected in wallet {%s} with disabled private keys</source>
-        <translation type="unfinished">Cảnh báo: các khóa riêng tư được tìm thấy trong ví {%s} với  khóa riêng tư không kích hoạt</translation>
+        <source>Unsupported chainstate database format found. Please restart with -reindex-chainstate. This will rebuild the chainstate database.</source>
+        <translation type="unfinished">Tìm thấy định dạng cơ sở dữ liệu trạng thái chuỗi không được hỗ trợ. Vui lòng khỏi động lại với -reindex-chainstate. Việc này sẽ tái thiết lập cơ sở dữ liệu trạng thái chuỗi.</translation>
     </message>
     <message>
-        <source>A fatal internal error occurred, see debug.log for details</source>
-        <translation type="unfinished">Lỗi nghiêm trọng xảy ra, xem debug.log để biết chi tiết</translation>
+        <source>Wallet created successfully. The legacy wallet type is being deprecated and support for creating and opening legacy wallets will be removed in the future.</source>
+        <translation type="unfinished">Ví đã được tạo thành công. Loại ví Legacy đang bị phản đối và việc hỗ trợ mở các ví Legacy mới sẽ bị loại bỏ trong tương lai</translation>
     </message>
     <message>
-        <source>Cannot set -peerblockfilters without -blockfilterindex.</source>
-        <translation type="unfinished">Không thể đặt -peerblockfilters mà không có -blockfilterindex.</translation>
+        <source>Cannot set -forcednsseed to true when setting -dnsseed to false.</source>
+        <translation type="unfinished">Không thể đặt -forcednsseed thành true khi đặt -dnsseed thành false.</translation>
     </message>
     <message>
-        <source>Cannot write to data directory '%s'; check permissions.</source>
-        <translation type="unfinished">Không thể ghi vào thư mục dữ liệu  '%s'; kiểm tra lại quyền.</translation>
+        <source>The -txindex upgrade started by a previous version cannot be completed. Restart with the previous version or run a full -reindex.</source>
+        <translation type="unfinished">Không thể hoàn tất nâng cấp -txindex được bắt đầu bởi phiên bản trước. Khởi động lại với phiên bản trước đó hoặc chạy -reindex đầy đủ.</translation>
     </message>
     <message>
-        <source>Config setting for %s only applied on %s network when in [%s] section.</source>
-        <translation type="unfinished">Cài  dặt thuộc tính cho %s chỉ có thể áp dụng cho  mạng %s trong khi  [%s] .</translation>
+        <source>%s request to listen on port %u. This port is considered "bad" and thus it is unlikely that any Bitcoin Core peers connect to it. See doc/p2p-bad-ports.md for details and a full list.</source>
+        <translation type="unfinished">%s yêu cầu lắng nghe trên cổng %u. Cổng này được coi là "xấu" và do đó không có khả năng bất kỳ ngang hàng Bitcoin Core nào kết nối với nó. Xem doc/p2p-bad-ports.md để biết chi tiết và danh sách đầy đủ.</translation>
     </message>
     <message>
-        <source>Could not find asmap file %s</source>
-        <translation type="unfinished">Không tìm thấy tệp asmap %s</translation>
+        <source>-reindex-chainstate option is not compatible with -blockfilterindex. Please temporarily disable blockfilterindex while using -reindex-chainstate, or replace -reindex-chainstate with -reindex to fully rebuild all indexes.</source>
+        <translation type="unfinished">reindex-chainstate tùy chọn không tương thích với -blockfilterindex. Vui lòng tạp thời vô hiệu hóa blockfilterindex trong khi sử dụng -reindex-chainstate, hoặc thay thế -reindex-chainstate bởi -reindex để tái thiết lập đẩy đủ tất cả các chỉ số.</translation>
     </message>
     <message>
-        <source>Could not parse asmap file %s</source>
-        <translation type="unfinished">Không đọc được tệp asmap %s</translation>
+        <source>-reindex-chainstate option is not compatible with -coinstatsindex. Please temporarily disable coinstatsindex while using -reindex-chainstate, or replace -reindex-chainstate with -reindex to fully rebuild all indexes.</source>
+        <translation type="unfinished">reindex-chainstate tùy chọn không tương thích với -coinstatsindex. Vui lòng tạp thời vô hiệu hóa coinstatsindex trong khi sử dụng -reindex-chainstate, hoặc thay thế -reindex-chainstate bởi -reindex để tái thiết lập đẩy đủ tất cả các chỉ số.</translation>
     </message>
     <message>
-        <source>Disk space is too low!</source>
-        <translation type="unfinished">Ổ đĩa còn quá ít</translation>
+        <source>-reindex-chainstate option is not compatible with -txindex. Please temporarily disable txindex while using -reindex-chainstate, or replace -reindex-chainstate with -reindex to fully rebuild all indexes.</source>
+        <translation type="unfinished">reindex-chainstate tùy chọn không tương thích với -txindex. Vui lòng tạp thời vô hiệu hóa txindex trong khi sử dụng -reindex-chainstate, hoặc thay thế -reindex-chainstate bởi -reindex để tái thiết lập đẩy đủ tất cả các chỉ số.</translation>
     </message>
     <message>
-        <source>Error loading %s: Private keys can only be disabled during creation</source>
-        <translation type="unfinished">Lỗi tải %s: Khóa riêng tư chỉ có thể không kích hoạt trong suốt quá trình tạo.</translation>
+        <source>Assumed-valid: last wallet synchronisation goes beyond available block data. You need to wait for the background validation chain to download more blocks.</source>
+        <translation type="unfinished">Giả sử hợp lệ: lần đồng bộ ví gần nhất vượt ra ngoài dữ liệu khả dụng của khối. Bạn cần phải chờ quá trình xác thực nền tảng của chuối để tải về nhiều khối hơn.</translation>
     </message>
     <message>
-        <source>Error: Disk space is low for %s</source>
-        <translation type="unfinished">Lỗi: Đĩa trống ít quá cho %s</translation>
+        <source>Cannot provide specific connections and have addrman find outgoing connections at the same time.</source>
+        <translation type="unfinished">Không thể cung cấp các kết nối cụ thể và yêu cầu addrman tìm các kết nối gửi đi cùng một lúc.</translation>
     </message>
     <message>
-        <source>Error: Keypool ran out, please call keypoolrefill first</source>
-        <translation type="unfinished">Lỗi: Keypool đã hết, vui lòng gọi keypoolrefill trước</translation>
+        <source>Error loading %s: External signer wallet being loaded without external signer support compiled</source>
+        <translation type="unfinished">Lỗi khi tải %s: Ví người ký bên ngoài đang được tải mà không có hỗ trợ người ký bên ngoài được biên dịch</translation>
     </message>
     <message>
-        <source>Failed to rescan the wallet during initialization</source>
-        <translation type="unfinished">Lỗi quét lại ví trong xuất quá trình khởi tạo</translation>
+        <source>Failed to rename invalid peers.dat file. Please move or delete it and try again.</source>
+        <translation type="unfinished">Không thể đổi tên tệp ngang hàng không hợp lệ. Vui lòng di chuyển hoặc xóa nó và thử lại.</translation>
     </message>
     <message>
-        <source>Failed to verify database</source>
-        <translation type="unfinished">Lỗi xác nhận dữ liệu</translation>
+        <source>Input not found or already spent</source>
+        <translation type="unfinished">Đầu vào không được tìm thấy hoặc đã được sử dụng</translation>
     </message>
     <message>
-        <source>Insufficient funds</source>
-        <translation type="unfinished">Không đủ tiền</translation>
+        <source>Listening for incoming connections failed (listen returned error %s)</source>
+        <translation type="unfinished">Lắng nghe những kết nối thất bại sắp xảy ra (lắng nghe lỗi được trả về %s)</translation>
     </message>
     <message>
-        <source>Invalid P2P permission: '%s'</source>
-        <translation type="unfinished">Quyền P2P không hợp lệ: '%s'</translation>
+        <source>Missing amount</source>
+        <translation type="unfinished">Số tiền còn thiếu</translation>
     </message>
     <message>
-        <source>No proxy server specified. Use -proxy=&lt;ip&gt; or -proxy=&lt;ip:port&gt;.</source>
-        <translation type="unfinished">Không có máy chủ proxy nào được chỉ định. Sử dụng -proxy =&lt;ip&gt; hoặc -proxy =&lt;ip:port&gt;.</translation>
+        <source>Missing solving data for estimating transaction size</source>
+        <translation type="unfinished">Thiếu dữ liệu giải quyết để ước tính quy mô giao dịch</translation>
     </message>
     <message>
-        <source>Section [%s] is not recognized.</source>
-        <translation type="unfinished">Mục [%s] không được nhìn nhận.</translation>
+        <source>No addresses available</source>
+        <translation type="unfinished">Không có địa chỉ</translation>
     </message>
     <message>
-        <source>Specified -walletdir "%s" does not exist</source>
-        <translation type="unfinished">Thư mục ví được nêu  -walletdir "%s" không tồn tại</translation>
+        <source>Transaction change output index out of range</source>
+        <translation type="unfinished">Chỉ số đầu ra thay đổi giao dịch nằm ngoài phạm vi</translation>
     </message>
     <message>
-        <source>Specified -walletdir "%s" is a relative path</source>
-        <translation type="unfinished">Chỉ định -walletdir "%s" là đường dẫn tương đối</translation>
+        <source>Transaction needs a change address, but we can't generate it.</source>
+        <translation type="unfinished">Giao dịch cần thay đổi địa chỉ, nhưng chúng tôi không thể tạo địa chỉ đó.</translation>
     </message>
     <message>
-        <source>Specified -walletdir "%s" is not a directory</source>
-        <translation type="unfinished">Chỉ định -walletdir "%s" không phải là một thư mục</translation>
+        <source>Unable to allocate memory for -maxsigcachesize: '%s' MiB</source>
+        <translation type="unfinished">Không có khả năng để phân bổ bộ nhớ cho -maxsigcachesize: '%s' MiB</translation>
     </message>
     <message>
-        <source>Specified blocks directory "%s" does not exist.</source>
-        <translation type="unfinished">Thư mục chứa các khối được chỉ ra "%s"  không tồn tại</translation>
-    </message>
-    <message>
-        <source>The wallet will avoid paying less than the minimum relay fee.</source>
-        <translation type="unfinished">Wallet sẽ hủy thanh toán nhỏ hơn phí relay.</translation>
-    </message>
-    <message>
-        <source>This is the minimum transaction fee you pay on every transaction.</source>
-        <translation type="unfinished">Đây là minimum transaction fee bạn pay cho mỗi transaction.</translation>
-    </message>
-    <message>
-        <source>This is the transaction fee you will pay if you send a transaction.</source>
-        <translation type="unfinished">Đây là transaction fee bạn sẽ pay nếu gửi transaction.</translation>
-    </message>
-    <message>
-        <source>Transaction amounts must not be negative</source>
-        <translation type="unfinished">Transaction amounts phải không âm</translation>
-    </message>
-    <message>
-        <source>Transaction has too long of a mempool chain</source>
-        <translation type="unfinished">Transaction có chuỗi mempool chain quá dài</translation>
-    </message>
-    <message>
-        <source>Transaction must have at least one recipient</source>
-        <translation type="unfinished">Transaction phải có ít nhất một người nhận</translation>
-    </message>
-    <message>
-        <source>Unable to create the PID file '%s': %s</source>
-        <translation type="unfinished">Không thể tạo tệp PID '%s': %s</translation>
-    </message>
-    <message>
-        <source>Unable to generate initial keys</source>
-        <translation type="unfinished">Không thể tạo khóa ban đầu</translation>
-    </message>
-    <message>
-        <source>Unable to generate keys</source>
-        <translation type="unfinished">Không thể tạo khóa</translation>
-    </message>
-    <message>
-        <source>Unknown -blockfilterindex value %s.</source>
-        <translation type="unfinished">Không rõ giá trị  -blockfilterindex  %s.</translation>
-    </message>
-    <message>
-        <source>Unknown address type '%s'</source>
-        <translation type="unfinished">Không biết địa chỉ kiểu '%s'</translation>
-    </message>
-    <message>
-        <source>Unknown change type '%s'</source>
-        <translation type="unfinished">Không biết thay đổi kiểu '%s'</translation>
-    </message>
-    <message>
-        <source>Unknown network specified in -onlynet: '%s'</source>
-        <translation type="unfinished">Unknown network được xác định trong -onlynet: '%s'</translation>
+        <source>Unable to parse -maxuploadtarget: '%s'</source>
+        <translation type="unfinished">Không thể parse -maxuploadtarget '%s</translation>
     </message>
     </context>
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <source>&amp;Overview</source>
-        <translation type="unfinished">&amp;Tổng quan</translation>
+        <source>&amp;Minimize</source>
+        <translation type="unfinished">&amp;Thu nhỏ</translation>
     </message>
     <message>
-        <source>Show general overview of wallet</source>
-        <translation type="unfinished">Hiển thị tổng quan ví</translation>
-    </message>
-    <message>
-        <source>&amp;Transactions</source>
-        <translation type="unfinished">&amp;Các Giao Dịch</translation>
-    </message>
-    <message>
-        <source>Browse transaction history</source>
-        <translation type="unfinished">Trình duyệt lịch sử giao dịch</translation>
-    </message>
-    <message>
-        <source>E&amp;xit</source>
-        <translation type="unfinished">T&amp;hoát</translation>
-    </message>
-    <message>
-        <source>Quit application</source>
-        <translation type="unfinished">Đóng ứng dụng</translation>
-    </message>
-    <message>
-        <source>&amp;About %1</source>
-        <translation type="unfinished">&amp;Khoảng %1</translation>
-    </message>
-    <message>
-        <source>Show information about %1</source>
-        <translation type="unfinished">Hiện thông tin khoảng %1</translation>
-    </message>
-    <message>
-        <source>About &amp;Qt</source>
-        <translation type="unfinished">Về &amp;Qt</translation>
-    </message>
-    <message>
-        <source>Show information about Qt</source>
-        <translation type="unfinished">Hiện thông tin về Qt</translation>
-    </message>
-    <message>
-        <source>Modify configuration options for %1</source>
-        <translation type="unfinished">Sửa đổi tùy chỉnh cấu hình cho %1</translation>
-    </message>
-    <message>
-        <source>Create a new wallet</source>
-        <translation type="unfinished">Tạo một ví mới</translation>
-    </message>
-    <message>
-        <source>Wallet:</source>
-        <translation type="unfinished">Ví tiền</translation>
-    </message>
-    <message>
-        <source>Network activity disabled.</source>
-        <extracomment>A substring of the tooltip.</extracomment>
-        <translation type="unfinished">Hoạt động mạng được vô hiệu.</translation>
-    </message>
-    <message>
-        <source>Proxy is &lt;b&gt;enabled&lt;/b&gt;: %1</source>
-        <translation type="unfinished">Proxy là &lt;b&gt; cho phép &lt;/b&gt;: %1</translation>
-    </message>
-    <message>
-        <source>Send coins to a Bitcoin address</source>
-        <translation type="unfinished">Gửi coin đến một địa chỉ Bitcoin</translation>
-    </message>
-    <message>
-        <source>Backup wallet to another location</source>
-        <translation type="unfinished">Backup ví đến một địa chỉ khác</translation>
-    </message>
-    <message>
-        <source>Change the passphrase used for wallet encryption</source>
-        <translation type="unfinished">Thay đổi cụm mật khẩu cho ví đã mã hóa</translation>
-    </message>
-    <message>
-        <source>&amp;Send</source>
-        <translation type="unfinished">&amp;Gửi</translation>
-    </message>
-    <message>
-        <source>&amp;Receive</source>
-        <translation type="unfinished">&amp;Nhận</translation>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation type="unfinished">&amp;Mã hóa ví…</translation>
     </message>
     <message>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation type="unfinished">Mã hóa private key thuộc về ví của bạn</translation>
     </message>
     <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation type="unfinished">&amp;Thay dổi Passphrase…</translation>
+    </message>
+    <message>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation type="unfinished">Đăng ký lời nhắn với địa chỉ Bitcoin của bạn để chứng minh quyền sở hữu chúng</translation>
+    </message>
+    <message>
+        <source>&amp;Verify message…</source>
+        <translation type="unfinished">&amp;Xác minh tin nhắn…</translation>
     </message>
     <message>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation type="unfinished">Xác minh lời nhắn để chắc chắn đã được đăng ký với địa chỉ Bitcoin xác định</translation>
     </message>
     <message>
-        <source>Tabs toolbar</source>
-        <translation type="unfinished">Các thanh công cụ</translation>
+        <source>Close Wallet…</source>
+        <translation type="unfinished">Đóng ví…</translation>
     </message>
     <message>
-        <source>Request payments (generates QR codes and bitcoin: URIs)</source>
-        <translation type="unfinished">Yêu cầu thanh toán (tạo QR code và bitcoin: URIs)</translation>
+        <source>Create Wallet…</source>
+        <translation type="unfinished">Tạo ví…</translation>
     </message>
     <message>
-        <source>Show the list of used sending addresses and labels</source>
-        <translation type="unfinished">Hiển thị danh sách các địa chỉ và nhãn đã dùng để gửi</translation>
+        <source>Close All Wallets…</source>
+        <translation type="unfinished">Đóng tất cả các ví…</translation>
     </message>
     <message>
-        <source>Show the list of used receiving addresses and labels</source>
-        <translation type="unfinished">Hiển thị danh sách các địa chỉ và nhãn đã dùng để nhận</translation>
+        <source>&amp;File</source>
+        <translation type="unfinished">&amp;Tệp</translation>
     </message>
     <message>
-        <source>&amp;Command-line options</source>
-        <translation type="unfinished">&amp;Tùy chỉnh Command-line</translation>
+        <source>&amp;Settings</source>
+        <translation type="unfinished">&amp;Cài đặt</translation>
+    </message>
+    <message>
+        <source>&amp;Help</source>
+        <translation type="unfinished">&amp;Giúp đỡ</translation>
+    </message>
+    <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation type="unfinished">Đồng bộ hóa tiêu đề (%1%)...</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation type="unfinished">Đồng bộ hóa với network...</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation type="unfinished">Lập chỉ mục các khối trên đĩa…</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation type="unfinished">Xử lý khối trên đĩa…</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation type="unfinished">Lập chỉ mục lại các khối trên đĩa…</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation type="unfinished">Kết nối với các peer…</translation>
     </message>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>Đã xử lý %n khối của lịch sử giao dịch.</numerusform>
         </translation>
     </message>
     <message>
-        <source>%1 behind</source>
-        <translation type="unfinished">%1 phia sau</translation>
-    </message>
-    <message>
-        <source>Last received block was generated %1 ago.</source>
-        <translation type="unfinished">Khối nhận cuối cùng đã được tạo %1.</translation>
-    </message>
-    <message>
-        <source>Transactions after this will not yet be visible.</source>
-        <translation type="unfinished">Các giao dịch sau giao dịch này sẽ không được hiển thị.</translation>
-    </message>
-    <message>
-        <source>Error</source>
-        <translation type="unfinished">Lỗi</translation>
-    </message>
-    <message>
-        <source>Warning</source>
-        <translation type="unfinished">Cảnh báo</translation>
-    </message>
-    <message>
-        <source>Information</source>
-        <translation type="unfinished">Thông tin</translation>
-    </message>
-    <message>
-        <source>Up to date</source>
-        <translation type="unfinished">Đã cập nhật</translation>
+        <source>Catching up…</source>
+        <translation type="unfinished">Đang bắt kịp...</translation>
     </message>
     <message>
         <source>Load Partially Signed Bitcoin Transaction</source>
         <translation type="unfinished">Kết nối với mạng Bitcoin thông qua một proxy SOCKS5 riêng cho các dịch vụ Tor hành.</translation>
+    </message>
+    <message>
+        <source>Load PSBT from &amp;clipboard…</source>
+        <translation type="unfinished">Tải PSBT từ &amp;khay nhớ tạm…</translation>
     </message>
     <message>
         <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
@@ -645,264 +476,171 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">Đông ví</translation>
     </message>
     <message>
-        <source>Close all wallets</source>
-        <translation type="unfinished">Đóng tất cả ví</translation>
+        <source>Restore Wallet…</source>
+        <extracomment>Name of the menu item that restores wallet from a backup file.</extracomment>
+        <translation type="unfinished">Khôi phục ví...</translation>
     </message>
     <message>
-        <source>Show the %1 help message to get a list with possible Bitcoin command-line options</source>
-        <translation type="unfinished">Hiển thị %1 tin nhắn hỗ trợ để nhận được danh sách Bitcoin command-line khả dụng</translation>
+        <source>Restore a wallet from a backup file</source>
+        <extracomment>Status tip for Restore Wallet menu item</extracomment>
+        <translation type="unfinished">Khôi phục ví từ tệp đã sao lưu</translation>
     </message>
     <message>
-        <source>default wallet</source>
-        <translation type="unfinished">ví mặc định</translation>
+        <source>&amp;Mask values</source>
+        <translation type="unfinished">&amp;Giá trị mặt nạ</translation>
     </message>
     <message>
-        <source>No wallets available</source>
-        <translation type="unfinished">Không có ví nào</translation>
+        <source>Mask the values in the Overview tab</source>
+        <translation type="unfinished">Che các giá trị trong tab Tổng quan</translation>
     </message>
     <message>
-        <source>Zoom</source>
-        <translation type="unfinished">Phóng</translation>
+        <source>Load Wallet Backup</source>
+        <extracomment>The title for Restore Wallet File Windows</extracomment>
+        <translation type="unfinished">Tải bản sao lưu ví</translation>
     </message>
     <message>
-        <source>Main Window</source>
-        <translation type="unfinished">Màn hình chính</translation>
+        <source>Restore Wallet</source>
+        <extracomment>Title of pop-up window shown when the user is attempting to restore a wallet.</extracomment>
+        <translation type="unfinished">Khôi phục ví</translation>
     </message>
     <message>
-        <source>%1 client</source>
-        <translation type="unfinished">%1 khách</translation>
+        <source>Ctrl+M</source>
+        <translation type="unfinished">Nhấn Ctrl + M</translation>
+    </message>
+    <message>
+        <source>&amp;Hide</source>
+        <translation type="unfinished">&amp;Ẩn</translation>
+    </message>
+    <message>
+        <source>S&amp;how</source>
+        <translation type="unfinished">Trìn&amp;h diễn</translation>
     </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%nkết nối đang hoạt động với mạng lưới Bitcoin</numerusform>
         </translation>
     </message>
     <message>
-        <source>Warning: %1</source>
-        <translation type="unfinished">Cảnh báo: %1</translation>
+        <source>Click for more actions.</source>
+        <extracomment>A substring of the tooltip. "More actions" are available via the context menu.</extracomment>
+        <translation type="unfinished">Nhấp để có thêm hành động.</translation>
     </message>
     <message>
-        <source>Date: %1
-</source>
-        <translation type="unfinished">Ngày %1
-</translation>
+        <source>Show Peers tab</source>
+        <extracomment>A context menu item. The "Peers tab" is an element of the "Node window".</extracomment>
+        <translation type="unfinished">Hiển thị tab ngang hàng</translation>
     </message>
     <message>
-        <source>Amount: %1
-</source>
-        <translation type="unfinished">Số lượng: %1
-</translation>
+        <source>Disable network activity</source>
+        <extracomment>A context menu item.</extracomment>
+        <translation type="unfinished">Tắt hoạt động mạng</translation>
     </message>
     <message>
-        <source>Wallet: %1
-</source>
-        <translation type="unfinished">Ví: %1
-</translation>
+        <source>Enable network activity</source>
+        <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
+        <translation type="unfinished">Bật hoạt động mạng</translation>
     </message>
     <message>
-        <source>Type: %1
-</source>
-        <translation type="unfinished">Loại: %1
-</translation>
-    </message>
-    <message>
-        <source>Label: %1
-</source>
-        <translation type="unfinished">Nhãn: %1
-</translation>
-    </message>
-    <message>
-        <source>Address: %1
-</source>
-        <translation type="unfinished">Địa chỉ: %1
-</translation>
-    </message>
-    <message>
-        <source>Sent transaction</source>
-        <translation type="unfinished">Giao dịch đã gửi</translation>
-    </message>
-    <message>
-        <source>Incoming transaction</source>
-        <translation type="unfinished">Giao dịch đang nhận</translation>
-    </message>
-    <message>
-        <source>HD key generation is &lt;b&gt;enabled&lt;/b&gt;</source>
-        <translation type="unfinished">Khởi tạo HD key &lt;b&gt;enabled&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>HD key generation is &lt;b&gt;disabled&lt;/b&gt;</source>
-        <translation type="unfinished">Khởi tạo HD key &lt;b&gt;disabled&lt;/b&gt;</translation>
+        <source>Error: %1</source>
+        <translation type="unfinished">Lỗi: %1</translation>
     </message>
     <message>
         <source>Private key &lt;b&gt;disabled&lt;/b&gt;</source>
-        <translation type="unfinished">Khóa riên tư &lt;b&gt;đã tắt&lt;/b&gt;</translation>
+        <translation type="unfinished">Khóa riêng tư &lt;b&gt;đã tắt&lt;/b&gt;</translation>
     </message>
     <message>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
-        <translation type="unfinished">Ví thì &lt;b&gt;encrypted&lt;/b&gt; và hiện tại &lt;b&gt;unlocked&lt;/b&gt;</translation>
+        <translation type="unfinished">Ví thì &lt;b&gt;được mã hóa &lt;/b&gt; và hiện tại &lt;b&gt;đã khóa&lt;/b&gt;</translation>
     </message>
     <message>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
-        <translation type="unfinished">Ví thì &lt;b&gt;encrypted&lt;/b&gt; và hiện tại &lt;b&gt;locked&lt;/b&gt;</translation>
+        <translation type="unfinished">Ví thì &lt;b&gt;được mã hóa &lt;/b&gt; và hiện tại &lt;b&gt;đã khóa&lt;/b&gt;</translation>
     </message>
+    </context>
+<context>
+    <name>UnitDisplayStatusBarControl</name>
     <message>
-        <source>Original message:</source>
-        <translation type="unfinished">Tin nhắn ban đầu:</translation>
+        <source>Unit to show amounts in. Click to select another unit.</source>
+        <translation type="unfinished">Đơn vị để hiển thị số tiền. Nhấp để chọn đơn vị khác.</translation>
     </message>
 </context>
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <source>Coin Selection</source>
-        <translation type="unfinished">Lựa chọn Coin</translation>
+        <source>Tree mode</source>
+        <translation type="unfinished">Chế độ Tree</translation>
     </message>
     <message>
-        <source>Quantity:</source>
-        <translation type="unfinished">Số lượng:</translation>
+        <source>List mode</source>
+        <translation type="unfinished">Chế độ List</translation>
     </message>
     <message>
-        <source>Amount:</source>
-        <translation type="unfinished">Số lượng:</translation>
-    </message>
-    <message>
-        <source>Fee:</source>
-        <translation type="unfinished">Phí:</translation>
-    </message>
-    <message>
-        <source>Dust:</source>
-        <translation type="unfinished">Rác:</translation>
-    </message>
-    <message>
-        <source>After Fee:</source>
-        <translation type="unfinished">Sau Phí:</translation>
-    </message>
-    <message>
-        <source>Change:</source>
-        <translation type="unfinished">Thay đổi:</translation>
-    </message>
-    <message>
-        <source>(un)select all</source>
-        <translation type="unfinished">(không)chọn tất cả</translation>
-    </message>
-    <message>
-        <source>Amount</source>
-        <translation type="unfinished">Số lượng</translation>
-    </message>
-    <message>
-        <source>Received with label</source>
-        <translation type="unfinished">Đã nhận với nhãn</translation>
-    </message>
-    <message>
-        <source>Received with address</source>
-        <translation type="unfinished">Đã nhận với địa chỉ</translation>
-    </message>
-    <message>
-        <source>Date</source>
-        <translation type="unfinished">Ngày</translation>
-    </message>
-    <message>
-        <source>Confirmations</source>
-        <translation type="unfinished">Xác nhận</translation>
-    </message>
-    <message>
-        <source>Confirmed</source>
-        <translation type="unfinished">Đã xác nhận</translation>
-    </message>
-    <message>
-        <source>Copy amount</source>
-        <translation type="unfinished">Sao chép số lượng</translation>
-    </message>
-    <message>
-        <source>Copy quantity</source>
-        <translation type="unfinished">Sao chép số lượng</translation>
-    </message>
-    <message>
-        <source>Copy fee</source>
-        <translation type="unfinished">Sao chép phí</translation>
-    </message>
-    <message>
-        <source>Copy after fee</source>
-        <translation type="unfinished">Sao chép sau phí</translation>
-    </message>
-    <message>
-        <source>Copy bytes</source>
-        <translation type="unfinished">Sao chép bytes</translation>
-    </message>
-    <message>
-        <source>Copy dust</source>
-        <translation type="unfinished">Sao chép rác</translation>
-    </message>
-    <message>
-        <source>Copy change</source>
-        <translation type="unfinished">Sao chép thay đổi</translation>
-    </message>
-    <message>
-        <source>(%1 locked)</source>
-        <translation type="unfinished">(%1 đã khóa)</translation>
-    </message>
-    <message>
-        <source>yes</source>
-        <translation type="unfinished">có</translation>
-    </message>
-    <message>
-        <source>no</source>
-        <translation type="unfinished">không</translation>
-    </message>
-    <message>
-        <source>This label turns red if any recipient receives an amount smaller than the current dust threshold.</source>
-        <translation type="unfinished">Label này chuyển sang đỏ nếu bất cứ giao dịch nhận nào có số lượng nhỏ hơn ngưỡng dust.</translation>
-    </message>
-    <message>
-        <source>Can vary +/- %1 satoshi(s) per input.</source>
-        <translation type="unfinished">Có thể thay đổi +/-%1 satoshi(s) trên input.</translation>
+        <source>Copy transaction &amp;ID and output index</source>
+        <translation type="unfinished">Sao chép giao dịch &amp;ID và chỉ mục đầu ra</translation>
     </message>
     <message>
         <source>(no label)</source>
-        <translation type="unfinished">(không nhãn)</translation>
-    </message>
-    <message>
-        <source>change from %1 (%2)</source>
-        <translation type="unfinished">change từ %1 (%2)</translation>
+        <translation type="unfinished">(không có nhãn)</translation>
     </message>
     </context>
 <context>
     <name>CreateWalletActivity</name>
     <message>
-        <source>Create Wallet</source>
-        <extracomment>Title of window indicating the progress of creation of a new wallet.</extracomment>
-        <translation type="unfinished">Tạo Ví</translation>
+        <source>Too many external signers found</source>
+        <translation type="unfinished">Có quá nhiều người ký từ bên ngoài được tìm thấy</translation>
+    </message>
+</context>
+<context>
+    <name>LoadWalletsActivity</name>
+    <message>
+        <source>Load Wallets</source>
+        <extracomment>Title of progress window which is displayed when wallets are being loaded.</extracomment>
+        <translation type="unfinished">Tải ví</translation>
     </message>
     <message>
-        <source>Create wallet failed</source>
-        <translation type="unfinished">Tạo ví thất bại</translation>
+        <source>Loading wallets…</source>
+        <extracomment>Descriptive text of the load wallets progress window which indicates to the user that wallets are currently being loaded.</extracomment>
+        <translation type="unfinished">Đang tải ví…</translation>
     </message>
-    <message>
-        <source>Create wallet warning</source>
-        <translation type="unfinished">Cảnh báo khi tạo ví</translation>
-    </message>
-    </context>
+</context>
 <context>
     <name>OpenWalletActivity</name>
-    <message>
-        <source>Open wallet failed</source>
-        <translation type="unfinished">Mở ví thất bại</translation>
-    </message>
-    <message>
-        <source>Open wallet warning</source>
-        <translation type="unfinished">Mở ví cảnh báo</translation>
-    </message>
-    <message>
-        <source>default wallet</source>
-        <translation type="unfinished">ví mặc định</translation>
-    </message>
     <message>
         <source>Open Wallet</source>
         <extracomment>Title of window indicating the progress of opening of a wallet.</extracomment>
         <translation type="unfinished">Mớ ví</translation>
     </message>
     </context>
+<context>
+    <name>RestoreWalletActivity</name>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of progress window which is displayed when wallets are being restored.</extracomment>
+        <translation type="unfinished">Khôi phục ví</translation>
+    </message>
+    <message>
+        <source>Restoring Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the restore wallets progress window which indicates to the user that wallets are currently being restored.</extracomment>
+        <translation type="unfinished">Đang khôi phục ví &lt;b&gt;%1&lt;/b&gt;…</translation>
+    </message>
+    <message>
+        <source>Restore wallet failed</source>
+        <extracomment>Title of message box which is displayed when the wallet could not be restored.</extracomment>
+        <translation type="unfinished">Khôi phục ví thất bại</translation>
+    </message>
+    <message>
+        <source>Restore wallet warning</source>
+        <extracomment>Title of message box which is displayed when the wallet is restored with some warning.</extracomment>
+        <translation type="unfinished">Cảnh báo khối phục ví</translation>
+    </message>
+    <message>
+        <source>Restore wallet message</source>
+        <extracomment>Title of message box which is displayed when the wallet is successfully restored.</extracomment>
+        <translation type="unfinished">Tin nhắn khôi phục ví</translation>
+    </message>
+</context>
 <context>
     <name>WalletController</name>
     <message>
@@ -911,1319 +649,380 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Are you sure you wish to close the wallet &lt;i&gt;%1&lt;/i&gt;?</source>
-        <translation type="unfinished">Bạn có chắc bạn muốn đóng ví %1 ?</translation>
-    </message>
-    <message>
-        <source>Closing the wallet for too long can result in having to resync the entire chain if pruning is enabled.</source>
-        <translation type="unfinished">Đóng ví thời gian dài sẽ dẫn đến phải đồng bộ hóa lại cả chuỗi nếu cắt tỉa pruning được kích hoạt</translation>
-    </message>
-    <message>
-        <source>Close all wallets</source>
-        <translation type="unfinished">Đóng tất cả ví</translation>
-    </message>
-    <message>
-        <source>Are you sure you wish to close all wallets?</source>
-        <translation type="unfinished">Bạn có chắc chắn muốn đóng tất cả ví không?</translation>
-    </message>
-</context>
-<context>
-    <name>CreateWalletDialog</name>
-    <message>
-        <source>Create Wallet</source>
-        <translation type="unfinished">Tạo Ví</translation>
-    </message>
-    <message>
-        <source>Wallet Name</source>
-        <translation type="unfinished">Tên Ví</translation>
-    </message>
-    <message>
-        <source>Wallet</source>
-        <translation type="unfinished">Ví</translation>
-    </message>
-    <message>
-        <source>Encrypt the wallet. The wallet will be encrypted with a passphrase of your choice.</source>
-        <translation type="unfinished">Mật mã hóa ví. Ví sẽ được mật mã hóa với cụm mật khẩu của bạn.</translation>
-    </message>
-    <message>
-        <source>Encrypt Wallet</source>
-        <translation type="unfinished">Mật mã hóa ví</translation>
-    </message>
-    <message>
-        <source>Advanced Options</source>
-        <translation type="unfinished">Giao dịch thiếu một số thông tin về đầu vào.</translation>
-    </message>
-    <message>
-        <source>Disable private keys for this wallet. Wallets with private keys disabled will have no private keys and cannot have an HD seed or imported private keys. This is ideal for watch-only wallets.</source>
-        <translation type="unfinished">Tắt các khóa cá nhân cho ví này. Các ví với khóa cá nhân tắt sẽ không có các khóa cá nhân và không thể có nhân HD hoặc nhập thêm khóa cá nhân. Việc này tốt cho các ví chỉ dùng để xem.</translation>
-    </message>
-    <message>
-        <source>Disable Private Keys</source>
-        <translation type="unfinished">Vô hiệu hóa khóa cá nhân</translation>
-    </message>
-    <message>
-        <source>Make a blank wallet. Blank wallets do not initially have private keys or scripts. Private keys and addresses can be imported, or an HD seed can be set, at a later time.</source>
-        <translation type="unfinished">Tạo một ví trống. Ví trống không có các khóa cá nhân hay script ban đầu. Khóa cá nhân và địa chỉ có thể được nhập, hoặc một nhân HD có thể được thiết lập sau đó.</translation>
-    </message>
-    <message>
-        <source>Make Blank Wallet</source>
-        <translation type="unfinished">Tạo ví trống</translation>
-    </message>
-    <message>
-        <source>Use descriptors for scriptPubKey management</source>
-        <translation type="unfinished">Không có máy chủ proxy nào được chỉ định. Sử dụng -proxy = &lt;ip&gt; hoặc -proxy = &lt;ip: port&gt;.</translation>
-    </message>
-    <message>
-        <source>Descriptor Wallet</source>
-        <translation type="unfinished">Mô tả ví</translation>
-    </message>
-    <message>
-        <source>Create</source>
-        <translation type="unfinished">Tạo</translation>
-    </message>
-    <message>
-        <source>Compiled without sqlite support (required for descriptor wallets)</source>
-        <translation type="unfinished">Biên dịch cần hỗ trợ SQLite(Bắt buộc đối với mô tả ví)</translation>
+        <translation type="unfinished">Bạn có chắc chắn muốn đóng ví không &lt;i&gt;%1&lt;/i&gt;?</translation>
     </message>
     </context>
 <context>
+    <name>CreateWalletDialog</name>
+    <message>
+        <source>Use descriptors for scriptPubKey management</source>
+        <translation type="unfinished">Sử dụng bộ mô tả để quản lý scriptPubKey</translation>
+    </message>
+    <message>
+        <source>Use an external signing device such as a hardware wallet. Configure the external signer script in wallet preferences first.</source>
+        <translation type="unfinished">Sử dụng thiết bị ký bên ngoài chẳng hạn như ví phần cứng. Trước tiên, hãy định cấu hình tập lệnh người ký bên ngoài trong tùy chọn ví.</translation>
+    </message>
+    <message>
+        <source>External signer</source>
+        <translation type="unfinished">Người ký tên bên ngoài</translation>
+    </message>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Được biên dịch mà không có hỗ trợ ký bên ngoài (bắt buộc đối với ký bên ngoài)</translation>
+    </message>
+</context>
+<context>
     <name>EditAddressDialog</name>
     <message>
-        <source>&amp;Label</source>
-        <translation type="unfinished">Nhãn dữ liệu</translation>
-    </message>
-    <message>
-        <source>The label associated with this address list entry</source>
-        <translation type="unfinished">Label liên kết với list address ban đầu này</translation>
-    </message>
-    <message>
-        <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
-        <translation type="unfinished">Label liên kết với list address ban đầu này. Điều này chỉ được điều chỉnh cho địa chỉ gửi.</translation>
-    </message>
-    <message>
-        <source>&amp;Address</source>
-        <translation type="unfinished">Địa chỉ</translation>
-    </message>
-    <message>
-        <source>New sending address</source>
-        <translation type="unfinished">Address đang gửi mới</translation>
+        <source>Edit Address</source>
+        <translation type="unfinished">Sửa địa chỉ</translation>
     </message>
     <message>
         <source>Edit receiving address</source>
-        <translation type="unfinished">Edit address đang nhận</translation>
+        <translation type="unfinished">Chỉnh sửa địa chỉ nhận</translation>
     </message>
     <message>
         <source>Edit sending address</source>
-        <translation type="unfinished">Edit address đang gửi</translation>
+        <translation type="unfinished">Chỉnh sửa địa chỉ gửi</translation>
     </message>
-    <message>
-        <source>The entered address "%1" is not a valid Bitcoin address.</source>
-        <translation type="unfinished">Address đã nhập "%1" không valid Bitcoin address.</translation>
-    </message>
-    <message>
-        <source>Address "%1" already exists as a receiving address with label "%2" and so cannot be added as a sending address.</source>
-        <translation type="unfinished">Địa chỉ "%1" đã tồn tại như địa chỉ nhận với nhãn "%2" và vì vậy không thể thêm như là địa chỉ gửi.</translation>
-    </message>
-    <message>
-        <source>The entered address "%1" is already in the address book with label "%2".</source>
-        <translation type="unfinished">Địa chỉ  nhập "%1" đã có trong sổ địa chỉ với nhãn "%2".</translation>
-    </message>
-    <message>
-        <source>Could not unlock wallet.</source>
-        <translation type="unfinished">Không thể unlock wallet.</translation>
-    </message>
-    <message>
-        <source>New key generation failed.</source>
-        <translation type="unfinished">Khởi tạo key mới thất bại.</translation>
-    </message>
-</context>
-<context>
-    <name>FreespaceChecker</name>
-    <message>
-        <source>A new data directory will be created.</source>
-        <translation type="unfinished">Một danh mục dữ liệu mới sẽ được tạo.</translation>
-    </message>
-    <message>
-        <source>name</source>
-        <translation type="unfinished">tên</translation>
-    </message>
-    <message>
-        <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
-        <translation type="unfinished">Danh mục đã tồn tại. Thêm %1 nếu bạn dự định creat một danh mục mới ở đây.</translation>
-    </message>
-    <message>
-        <source>Path already exists, and is not a directory.</source>
-        <translation type="unfinished">Path đã tồn tại, và không là danh mục.</translation>
-    </message>
-    <message>
-        <source>Cannot create data directory here.</source>
-        <translation type="unfinished">Không thể create dữ liệu danh mục tại đây.</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>Intro</name>
-    <message>
-        <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
-        <translation type="unfinished">Ít nhất %1 GB data sẽ được trữ tại danh mục này, và nó sẽ lớn theo thời gian.</translation>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+        </translation>
     </message>
-    <message>
-        <source>Approximately %1 GB of data will be stored in this directory.</source>
-        <translation type="unfinished">Gần đúng %1 GB of data sẽ được lưu giữ trong danh mục này.</translation>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform>(of %n GB cần thiết)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform>(%n GB cần cho toàn blockchain)</numerusform>
+        </translation>
     </message>
     <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>(đủ để khôi phục các bản sao lưu trong %n ngày)</numerusform>
         </translation>
     </message>
     <message>
-        <source>%1 will download and store a copy of the Bitcoin block chain.</source>
-        <translation type="unfinished">%1 sẽ download và lưu trữ một bản copy của Bitcoin block chain.</translation>
-    </message>
-    <message>
-        <source>The wallet will also be stored in this directory.</source>
-        <translation type="unfinished">Wallet sẽ cùng được lưu giữ trong danh mục này.</translation>
-    </message>
-    <message>
         <source>Error: Specified data directory "%1" cannot be created.</source>
-        <translation type="unfinished">Error: Danh mục data xác định "%1" không thể được tạo.</translation>
+        <translation type="unfinished">Lỗi: Danh mục data xác định "%1" không thể được tạo.</translation>
     </message>
     <message>
-        <source>Error</source>
-        <translation type="unfinished">Lỗi</translation>
+        <source>Welcome</source>
+        <translation type="unfinished">Chào mừng</translation>
+    </message>
+    <message>
+        <source>Welcome to %1.</source>
+        <translation type="unfinished">Chào mừng bạn đến %1.</translation>
     </message>
     <message>
         <source>As this is the first time the program is launched, you can choose where %1 will store its data.</source>
-        <translation type="unfinished">Đây là lần đầu chương trình khởi chạy, bạn có thể chọn nơi %1 sẽ lưu trữ data.</translation>
+        <translation type="unfinished">Đây là lần đầu chương trình khởi chạy, bạn có thể chọn nơi %1 sẽ lưu trữ dữ liệu.</translation>
     </message>
     <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation type="unfinished">Khi bạn click OK, %1 sẽ bắt đầu download và process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</translation>
+        <source>Limit block chain storage to</source>
+        <translation type="unfinished">Giới hạn lưu trữ chuỗi khối thành</translation>
     </message>
     <message>
         <source>Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</source>
-        <translation type="unfinished">Đảo ngược lại thiết lập này yêu cầu download lại toàn bộ blockchain. Download toàn bộ blockchain trước và loại nó sau đó sẽ nhanh hơn. Vô hiệu hóa một số tính năng nâng cao.</translation>
-    </message>
-    <message>
-        <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
-        <translation type="unfinished">Đồng bộ hóa ban đầu này rất đòi hỏi, và có thể phơi bày các sự cố về phần cứng với máy tính của bạn trước đó đã không được chú ý. Mỗi khi bạn chạy %1, nó sẽ tiếp tục tải về nơi nó dừng lại.</translation>
-    </message>
-    <message>
-        <source>If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</source>
-        <translation type="unfinished">Nếu bạn đã chọn giới hạn block chain lưu trữ (pruning),dữ liệu lịch sử vẫn phải được tải xuống và xử lý, nhưng sẽ bị xóa sau đó để giữ cho việc sử dụng đĩa của bạn ở mức usage thấp.</translation>
-    </message>
-    <message>
-        <source>Use the default data directory</source>
-        <translation type="unfinished">Sử dụng default danh mục đa ta</translation>
-    </message>
-    <message>
-        <source>Use a custom data directory:</source>
-        <translation type="unfinished">Sử dụng custom danh mục data:</translation>
-    </message>
-</context>
-<context>
-    <name>HelpMessageDialog</name>
-    <message>
-        <source>version</source>
-        <translation type="unfinished">phiên bản</translation>
+        <translation type="unfinished">Đảo ngược lại thiết lập này yêu cầu tại lại toàn bộ chuỗi khối. Tải về toàn bộ chuỗi khối trước và loại nó sau đó sẽ nhanh hơn. Vô hiệu hóa một số tính năng nâng cao.</translation>
     </message>
     </context>
 <context>
-    <name>ShutdownWindow</name>
+    <name>HelpMessageDialog</name>
     <message>
-        <source>Do not shut down the computer until this window disappears.</source>
-        <translation type="unfinished">Đừng tắt máy tính đến khi cửa sổ này đóng.</translation>
+        <source>About %1</source>
+        <translation type="unfinished">Về %1</translation>
+    </message>
+    <message>
+        <source>Command-line options</source>
+        <translation type="unfinished">Tùy chọn dòng lệnh</translation>
     </message>
 </context>
 <context>
+    <name>ShutdownWindow</name>
+    <message>
+        <source>%1 is shutting down…</source>
+        <translation type="unfinished">%1 đang tắt…</translation>
+    </message>
+    </context>
+<context>
     <name>ModalOverlay</name>
     <message>
-        <source>Recent transactions may not yet be visible, and therefore your wallet's balance might be incorrect. This information will be correct once your wallet has finished synchronizing with the bitcoin network, as detailed below.</source>
-        <translation type="unfinished">Giao dịch gần đây có thể chưa được hiển thị, và vì vậy số dư wallet của bạn có thể không dúng. Thông tin này sẽ được làm đúng khi wallet hoàn thành đồng bộ với bitcoin network, như chi tiết bên dưới.</translation>
+        <source>Unknown…</source>
+        <translation type="unfinished">Không xác định…</translation>
     </message>
     <message>
-        <source>Attempting to spend bitcoins that are affected by not-yet-displayed transactions will not be accepted by the network.</source>
-        <translation type="unfinished">Cố gắng spend các bitcoins bị ảnh hưởng bởi các giao dịch chưa được hiển thị sẽ không được chấp nhận bởi mạng.</translation>
+        <source>calculating…</source>
+        <translation type="unfinished">đang tính toán…</translation>
     </message>
     <message>
-        <source>Number of blocks left</source>
-        <translation type="unfinished">Số của blocks còn lại</translation>
-    </message>
-    <message>
-        <source>Last block time</source>
-        <translation type="unfinished">Thời gian block cuối cùng</translation>
-    </message>
-    <message>
-        <source>Progress</source>
-        <translation type="unfinished">Tiến độ</translation>
-    </message>
-    <message>
-        <source>Progress increase per hour</source>
-        <translation type="unfinished">Tiến độ tăng mỗi giờ</translation>
-    </message>
-    <message>
-        <source>Estimated time left until synced</source>
-        <translation type="unfinished">Ước tính thời gian còn lại đến khi đồng bộ</translation>
-    </message>
-    <message>
-        <source>Hide</source>
-        <translation type="unfinished">Ẩn</translation>
-    </message>
-    <message>
-        <source>%1 is currently syncing.  It will download headers and blocks from peers and validate them until reaching the tip of the block chain.</source>
-        <translation type="unfinished">%1 đang được đồng bộ. Header và block sẽ được download từ các nốt lân cận và thẩm định tới khi đạt đỉnh của blockchain.</translation>
+        <source>Unknown. Syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">Không xác định. Đồng bộ hóa tiêu đề (%1, %2%)…</translation>
     </message>
     </context>
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <source>Open bitcoin URI</source>
-        <translation type="unfinished">Mở bitcoin URI</translation>
-    </message>
-    <message>
         <source>Paste address from clipboard</source>
         <extracomment>Tooltip text for button that allows you to paste an address that is in your clipboard.</extracomment>
-        <translation type="unfinished">Paste address từ clipboard</translation>
+        <translation type="unfinished">Dán địa chỉ từ khay nhớ tạm</translation>
     </message>
 </context>
 <context>
     <name>OptionsDialog</name>
     <message>
-        <source>Options</source>
-        <translation type="unfinished">Tùy chỉnh</translation>
-    </message>
-    <message>
-        <source>&amp;Main</source>
-        <translation type="unfinished">&amp;Chính</translation>
-    </message>
-    <message>
         <source>Automatically start %1 after logging in to the system.</source>
-        <translation type="unfinished">Tự động bắt đầu %1 sau khi đăng nhập vào system.</translation>
+        <translation type="unfinished">Tự động bắt đầu %1 sau khi đăng nhập vào hệ thống.</translation>
     </message>
     <message>
         <source>&amp;Start %1 on system login</source>
-        <translation type="unfinished">&amp;Bắt đầu %1 trên đăng nhập system</translation>
+        <translation type="unfinished">&amp;Bắt đầu %1 trên đăng nhập hệ thống</translation>
     </message>
     <message>
-        <source>Shows if the supplied default SOCKS5 proxy is used to reach peers via this network type.</source>
-        <translation type="unfinished">Hiển thị nếu cung cấp default SOCKS5 proxy is used to reach peers via this network type.</translation>
+        <source>Enabling pruning significantly reduces the disk space required to store transactions. All blocks are still fully validated. Reverting this setting requires re-downloading the entire blockchain.</source>
+        <translation type="unfinished">Cho phép cắt bớt làm giảm đáng kể không gian đĩa cần thiết để lưu trữ các giao dịch. Tất cả các khối vẫn được xác nhận đầy đủ. Hoàn nguyên cài đặt này yêu cầu tải xuống lại toàn bộ chuỗi khối.</translation>
     </message>
     <message>
-        <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
-        <translation type="unfinished">Minimize thay vì thoát khỏi ứng dụng khi cửa sổ đóng lại. Khi bật tùy chọn này, ứng dụng sẽ chỉ được đóng sau khi chọn Exit trong menu.</translation>
+        <source>Size of &amp;database cache</source>
+        <translation type="unfinished">Kích thước bộ nhớ cache của &amp;cơ sở dữ liệu</translation>
     </message>
     <message>
-        <source>Open the %1 configuration file from the working directory.</source>
-        <translation type="unfinished">Mở %1 configuration file từ danh mục làm việc working directory.</translation>
+        <source>Number of script &amp;verification threads</source>
+        <translation type="unfinished">Số lượng tập lệnh và chuỗi &amp;xác minh</translation>
     </message>
     <message>
-        <source>Open Configuration File</source>
-        <translation type="unfinished">Mở File cấu hình</translation>
+        <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
+        <translation type="unfinished">Địa chỉ IP của proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</translation>
+    </message>
+    <message>
+        <source>Options set in this dialog are overridden by the command line:</source>
+        <translation type="unfinished">Các tùy chọn trong hộp thoại này bị ghi đè bởi dòng lệnh</translation>
     </message>
     <message>
         <source>Reset all client options to default.</source>
-        <translation type="unfinished">Reset tất cả client options to default.</translation>
+        <translation type="unfinished">Đặt lại tất cả các tùy chọn máy khách về mặc định.</translation>
     </message>
     <message>
-        <source>&amp;Reset Options</source>
-        <translation type="unfinished">&amp;Reset Tùy chọn</translation>
+        <source>&amp;Network</source>
+        <translation type="unfinished">&amp;Mạng</translation>
     </message>
     <message>
-        <source>Prune &amp;block storage to</source>
-        <translation type="unfinished">Cắt tỉa và lưu trữ khối tới</translation>
+        <source>Maximum database cache size. A larger cache can contribute to faster sync, after which the benefit is less pronounced for most use cases. Lowering the cache size will reduce memory usage. Unused mempool memory is shared for this cache.</source>
+        <extracomment>Tooltip text for Options window setting that sets the size of the database cache. Explains the corresponding effects of increasing/decreasing this value.</extracomment>
+        <translation type="unfinished">Kích thước bộ đệm cơ sở dữ liệu tối đa. Bộ nhớ đệm lớn hơn có thể góp phần đồng bộ hóa nhanh hơn, sau đó lợi ích ít rõ rệt hơn đối với hầu hết các trường hợp sử dụng. Giảm kích thước bộ nhớ cache sẽ làm giảm mức sử dụng bộ nhớ. Bộ nhớ mempool không sử dụng được chia sẻ cho bộ nhớ cache này.</translation>
     </message>
     <message>
-        <source>Reverting this setting requires re-downloading the entire blockchain.</source>
-        <translation type="unfinished">Hoàn nguyên cài đặt này yêu cầu tải xuống lại toàn bộ blockchain.</translation>
+        <source>Set the number of script verification threads. Negative values correspond to the number of cores you want to leave free to the system.</source>
+        <extracomment>Tooltip text for Options window setting that sets the number of script verification threads. Explains that negative values mean to leave these many cores free to the system.</extracomment>
+        <translation type="unfinished">Đặt số lượng chuỗi xác minh tập lệnh. Giá trị âm tương ứng với số lõi bạn muốn để lại miễn phí cho hệ thống.</translation>
     </message>
     <message>
-        <source>Accept connections from outside.</source>
-        <translation type="unfinished">Chấp nhận kết nối từ bên ngoài</translation>
+        <source>This allows you or a third party tool to communicate with the node through command-line and JSON-RPC commands.</source>
+        <extracomment>Tooltip text for Options window setting that enables the RPC server.</extracomment>
+        <translation type="unfinished">Điều này cho phép bạn hoặc công cụ của bên thứ ba giao tiếp với nút thông qua các lệnh dòng lệnh và JSON-RPC.</translation>
     </message>
     <message>
-        <source>Allow incomin&amp;g connections</source>
-        <translation type="unfinished">Chấp nhận  kết nối đang tới</translation>
+        <source>Enable R&amp;PC server</source>
+        <extracomment>An Options window setting to enable the RPC server.</extracomment>
+        <translation type="unfinished">Bật máy chủ R&amp;PC</translation>
     </message>
     <message>
-        <source>Connect to the Bitcoin network through a SOCKS5 proxy.</source>
-        <translation type="unfinished">Kết nối đến Bitcoin network qua một SOCKS5 proxy.</translation>
+        <source>Whether to set subtract fee from amount as default or not.</source>
+        <extracomment>Tooltip text for Options window setting that sets subtracting the fee from a sending amount as default.</extracomment>
+        <translation type="unfinished">Có đặt trừ phí khỏi số tiền làm mặc định hay không.</translation>
     </message>
     <message>
-        <source>&amp;Connect through SOCKS5 proxy (default proxy):</source>
-        <translation type="unfinished">&amp;Connect qua SOCKS5 proxy (default proxy):</translation>
+        <source>Subtract &amp;fee from amount by default</source>
+        <extracomment>An Options window setting to set subtracting the fee from a sending amount as default.</extracomment>
+        <translation type="unfinished">Trừ &amp;phí khỏi số tiền theo mặc định</translation>
     </message>
     <message>
-        <source>Used for reaching peers via:</source>
-        <translation type="unfinished">Sử dụng reaching peers via:</translation>
+        <source>Expert</source>
+        <translation type="unfinished">Chuyên gia</translation>
     </message>
     <message>
-        <source>Show only a tray icon after minimizing the window.</source>
-        <translation type="unfinished">Hiển thị chỉ thẻ icon sau khi thu nhỏ cửa sổ.</translation>
+        <source>Enable coin &amp;control features</source>
+        <translation type="unfinished">Bật tính năng &amp;kiểm soát và tiền xu</translation>
     </message>
     <message>
-        <source>&amp;Minimize to the tray instead of the taskbar</source>
-        <translation type="unfinished">&amp;Minimize đến thẻ thay vì taskbar</translation>
+        <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
+        <translation type="unfinished">Nếu bạn vô hiệu hóa chi tiêu của thay đổi chưa được xác nhận, thay đổi từ một giao dịch sẽ không thể được sử dụng cho đến khi giao dịch đó có ít nhất một xác nhận. Điều này cũng ảnh hưởng đến cách tính số dư của bạn.</translation>
     </message>
     <message>
-        <source>User Interface &amp;language:</source>
-        <translation type="unfinished">Giao diện người dùng &amp;language:</translation>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation type="unfinished">&amp;Chi tiêu thay đổi chưa được xác nhận</translation>
     </message>
     <message>
-        <source>The user interface language can be set here. This setting will take effect after restarting %1.</source>
-        <translation type="unfinished">Giao diện ngôn ngữ người dùng có thể được thiết lập tại đây. Tùy chọn này sẽ có hiệu lực sau khi khởi động lại %1.</translation>
+        <source>Enable &amp;PSBT controls</source>
+        <extracomment>An options window setting to enable PSBT controls.</extracomment>
+        <translation type="unfinished">Bật điều khiển &amp;PSBT</translation>
     </message>
     <message>
-        <source>&amp;Unit to show amounts in:</source>
-        <translation type="unfinished">&amp;Unit để hiện số lượng tại đây:</translation>
+        <source>Whether to show PSBT controls.</source>
+        <extracomment>Tooltip text for options window setting that enables PSBT controls.</extracomment>
+        <translation type="unfinished">Có hiển thị các điều khiển PSBT hay không.</translation>
     </message>
     <message>
-        <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
-        <translation type="unfinished">Chọn default đơn vị phân chia để hiện giao diện và đang gửi coins.</translation>
+        <source>Third-party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</source>
+        <translation type="unfinished">URL của bên thứ ba (ví dụ: trình khám phá khối) xuất hiện trong tab giao dịch dưới dạng các mục menu ngữ cảnh. %s trong URL được thay thế bằng mã băm giao dịch. Nhiều URL được phân tách bằng thanh dọc |. </translation>
     </message>
     <message>
-        <source>Whether to show coin control features or not.</source>
-        <translation type="unfinished">Cho hiển thị tính năng coin control hoặc không.</translation>
+        <source>&amp;Third-party transaction URLs</source>
+        <translation type="unfinished">&amp;URL giao dịch của bên thứ ba</translation>
     </message>
     <message>
-        <source>Connect to the Bitcoin network through a separate SOCKS5 proxy for Tor onion services.</source>
-        <translation type="unfinished">Kết nối với mạng Bitcoin thông qua proxy SOCKS5 riêng cho các dịch vụ Tor</translation>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">Được biên dịch mà không có hỗ trợ ký bên ngoài (bắt buộc đối với ký bên ngoài)</translation>
     </message>
     <message>
-        <source>Use separate SOCKS&amp;5 proxy to reach peers via Tor onion services:</source>
-        <translation type="unfinished">Sử dụng proxy SOCKS&amp;5 riêng biệt để tiếp cận các đối tác ngang hàng thông qua các dịch vụ Tor Onion.</translation>
+        <source>Current settings will be backed up at "%1".</source>
+        <extracomment>Text explaining to the user that the client's current settings will be backed up at a specific location. %1 is a stand-in argument for the backup location's path.</extracomment>
+        <translation type="unfinished">Các thiết lập hiện tại sẽ được sao lưu tại"%1".</translation>
     </message>
     <message>
-        <source>Options set in this dialog are overridden by the command line or in the configuration file:</source>
-        <translation type="unfinished">Các tùy chọn được đặt trong hộp thoại này bị ghi đè bởi dòng lệnh hoặc trong tệp cấu hình:</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation type="unfinished">&amp;Hủy</translation>
-    </message>
-    <message>
-        <source>none</source>
-        <translation type="unfinished">không có gì</translation>
-    </message>
-    <message>
-        <source>Confirm options reset</source>
-        <translation type="unfinished">Confirm tùy chọn reset</translation>
-    </message>
-    <message>
-        <source>Client restart required to activate changes.</source>
-        <translation type="unfinished">Client yêu cầu khởi động lại để thay đổi có hiệu lực.</translation>
-    </message>
-    <message>
-        <source>Client will be shut down. Do you want to proceed?</source>
-        <translation type="unfinished">Client sẽ đóng lại. Tiếp tục chứ?</translation>
-    </message>
-    <message>
-        <source>Configuration options</source>
-        <extracomment>Window title text of pop-up box that allows opening up of configuration file.</extracomment>
-        <translation type="unfinished">Tùy chọn cấu hình</translation>
-    </message>
-    <message>
-        <source>The configuration file is used to specify advanced user options which override GUI settings. Additionally, any command-line options will override this configuration file.</source>
-        <extracomment>Explanatory text about the priority order of instructions considered by client. The order from high to low being: command-line, configuration file, GUI settings.</extracomment>
-        <translation type="unfinished">File cấu hình được sử dụng để chỉ định các tùy chọn nâng cao của người dùng mà ghi đè GUI settings. Ngoài ra, bất kỳ tùy chọn dòng lệnh sẽ ghi đè lên tập tin cấu hình này.</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="unfinished">Hủy</translation>
-    </message>
-    <message>
-        <source>Error</source>
-        <translation type="unfinished">Lỗi</translation>
-    </message>
-    <message>
-        <source>The configuration file could not be opened.</source>
-        <translation type="unfinished">Không thẻ mở tệp cấu hình.</translation>
-    </message>
-    <message>
-        <source>This change would require a client restart.</source>
-        <translation type="unfinished">Việc change này sẽ cần một client restart.</translation>
-    </message>
-    <message>
-        <source>The supplied proxy address is invalid.</source>
-        <translation type="unfinished">Cung cấp proxy address thì invalid.</translation>
-    </message>
-</context>
-<context>
-    <name>OverviewPage</name>
-    <message>
-        <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
-        <translation type="unfinished">Thông tin được hiển thị có thể đã lỗi thời. Cái wallet tự động đồng bộ với Bitcoin network sau một connection được thiết lập, nhưng quá trình này vẫn chưa completed yet.</translation>
-    </message>
-    <message>
-        <source>Watch-only:</source>
-        <translation type="unfinished">Chỉ-xem:</translation>
-    </message>
-    <message>
-        <source>Available:</source>
-        <translation type="unfinished">Có hiệu lực:</translation>
-    </message>
-    <message>
-        <source>Your current spendable balance</source>
-        <translation type="unfinished">Số dư khả dụng:</translation>
-    </message>
-    <message>
-        <source>Pending:</source>
-        <translation type="unfinished">Đang xử lý:</translation>
-    </message>
-    <message>
-        <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
-        <translation type="unfinished">Tất cả giao dịch vẫn chưa được confirmed, và chưa tính vào số dư có thể chi tiêu</translation>
-    </message>
-    <message>
-        <source>Immature:</source>
-        <translation type="unfinished">Chưa hoàn thiện:</translation>
-    </message>
-    <message>
-        <source>Mined balance that has not yet matured</source>
-        <translation type="unfinished">Mined balance chưa matured hẳn</translation>
-    </message>
-    <message>
-        <source>Balances</source>
-        <translation type="unfinished">Số dư</translation>
-    </message>
-    <message>
-        <source>Total:</source>
-        <translation type="unfinished">Tổng cộng:</translation>
-    </message>
-    <message>
-        <source>Your current total balance</source>
-        <translation type="unfinished">Tổng số dư hiện tại</translation>
-    </message>
-    <message>
-        <source>Your current balance in watch-only addresses</source>
-        <translation type="unfinished">Số dư hiện tại trong địa chỉ watch-only</translation>
-    </message>
-    <message>
-        <source>Spendable:</source>
-        <translation type="unfinished">Có thể sử dụng</translation>
-    </message>
-    <message>
-        <source>Recent transactions</source>
-        <translation type="unfinished">Giao dịch gần đây</translation>
-    </message>
-    <message>
-        <source>Unconfirmed transactions to watch-only addresses</source>
-        <translation type="unfinished">Giao dịch chưa được xác nhận đến watch-only addresses</translation>
-    </message>
-    <message>
-        <source>Mined balance in watch-only addresses that has not yet matured</source>
-        <translation type="unfinished">Mined số dư trong watch-only address chưa matured hẳn</translation>
-    </message>
-    <message>
-        <source>Current total balance in watch-only addresses</source>
-        <translation type="unfinished">Tổng số dư hiện tại trong watch-only addresses</translation>
+        <source>Continue</source>
+        <translation type="unfinished">Tiếp tục</translation>
     </message>
     </context>
+<context>
+    <name>OptionsModel</name>
+    <message>
+        <source>Could not read setting "%1", %2.</source>
+        <translation type="unfinished">Không thể đọc thiết lập "%1", %2.</translation>
+    </message>
+</context>
 <context>
     <name>PSBTOperationsDialog</name>
     <message>
-        <source>Dialog</source>
-        <translation type="unfinished">Bảng thoại</translation>
+        <source>Cannot sign inputs while wallet is locked.</source>
+        <translation type="unfinished">Không thể ký đầu vào khi ví bị khóa.</translation>
     </message>
     <message>
-        <source>Sign Tx</source>
-        <translation type="unfinished">Đăng ký Tx</translation>
-    </message>
-    <message>
-        <source>Broadcast Tx</source>
-        <translation type="unfinished">Truyền phát Tx</translation>
-    </message>
-    <message>
-        <source>Copy to Clipboard</source>
-        <translation type="unfinished">Lưu vào bảng tạm</translation>
-    </message>
-    <message>
-        <source>Close</source>
-        <translation type="unfinished">Đóng</translation>
-    </message>
-    <message>
-        <source>Failed to load transaction: %1</source>
-        <translation type="unfinished">Tải giao dịch thất bại: %1</translation>
-    </message>
-    <message>
-        <source>Failed to sign transaction: %1</source>
-        <translation type="unfinished">Đăng ký giao dịch thất bại :%1</translation>
-    </message>
-    <message>
-        <source>Could not sign any more inputs.</source>
-        <translation type="unfinished">Không thể thêm bất cứ nguồn vào nào.</translation>
-    </message>
-    <message>
-        <source>Signed %1 inputs, but more signatures are still required.</source>
-        <translation type="unfinished">Nguồn %1 đã nạp, nhưng vẫn cần thêm các nguồn khác.</translation>
-    </message>
-    <message>
-        <source>Unknown error processing transaction.</source>
-        <translation type="unfinished">Lỗi không xác định xử lý giao dịch</translation>
-    </message>
-    <message>
-        <source>Transaction broadcast successfully! Transaction ID: %1</source>
-        <translation type="unfinished">Giao dịch dã được truyền thành công: Mã giao dịch: %1</translation>
-    </message>
-    <message>
-        <source>Transaction broadcast failed: %1</source>
-        <translation type="unfinished">Giao dịch truyền phát không thành công: %1</translation>
-    </message>
-    <message>
-        <source>PSBT copied to clipboard.</source>
-        <translation type="unfinished">Dữ liệu PSBT được sao chép vào bộ nhớ tạm.</translation>
-    </message>
-    <message>
-        <source>Save Transaction Data</source>
-        <translation type="unfinished">Lưu trữ giao dịch</translation>
-    </message>
-    <message>
-        <source>PSBT saved to disk.</source>
-        <translation type="unfinished">Dữ liệu PSBT được lưu vào ổ đĩa.</translation>
-    </message>
-    <message>
-        <source> * Sends %1 to %2</source>
-        <translation type="unfinished">*Gửi %1 tới %2</translation>
-    </message>
-    <message>
-        <source>Unable to calculate transaction fee or total transaction amount.</source>
-        <translation type="unfinished">Không thể tính phí giao dịch hoặc tổng số tiền giao dịch.</translation>
-    </message>
-    <message>
-        <source>Pays transaction fee: </source>
-        <translation type="unfinished">Trả phí giao dịch</translation>
-    </message>
-    <message>
-        <source>Total Amount</source>
-        <translation type="unfinished">Tổng số</translation>
-    </message>
-    <message>
-        <source>or</source>
-        <translation type="unfinished">hoặc</translation>
-    </message>
-    <message>
-        <source>Transaction is missing some information about inputs.</source>
-        <translation type="unfinished">Giao dịch thiếu một số thông tin về đầu vào.</translation>
+        <source>Transaction has %1 unsigned inputs.</source>
+        <translation type="unfinished">Giao dịch có %1 đầu vào chưa được ký.</translation>
     </message>
     <message>
         <source>Transaction still needs signature(s).</source>
-        <translation type="unfinished">Giao dịch cần chữ ký</translation>
+        <translation type="unfinished">Giao dịch vẫn cần (các) chữ ký.</translation>
     </message>
     <message>
-        <source>(But this wallet cannot sign transactions.)</source>
-        <translation type="unfinished">(Nhưng ví này không thể đăng ký giao dịch.)</translation>
-    </message>
-    <message>
-        <source>(But this wallet does not have the right keys.)</source>
-        <translation type="unfinished">(Nhưng ví này không có chìa khóa phù hợp.)</translation>
-    </message>
-    <message>
-        <source>Transaction is fully signed and ready for broadcast.</source>
-        <translation type="unfinished">Giao dịch đã được đăng ký và chuẩn bị để phát lên</translation>
+        <source>(But no wallet is loaded.)</source>
+        <translation type="unfinished">(Nhưng không có ví nào được tải.)</translation>
     </message>
     </context>
 <context>
-    <name>PaymentServer</name>
-    <message>
-        <source>Cannot start bitcoin: click-to-pay handler</source>
-        <translation type="unfinished">Không thể khởi tạo bitcoin: click-to-pay handler</translation>
-    </message>
-    <message>
-        <source>'bitcoin://' is not a valid URI. Use 'bitcoin:' instead.</source>
-        <translation type="unfinished">'bitcoin://' không khả dụng URI. Dùng thay vì 'bitcoin:' .</translation>
-    </message>
-    <message>
-        <source>URI cannot be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
-        <translation type="unfinished">URI không thể phân tích cú pháp! Đây có thể gây nên bởi invalid Bitcoin address hoặc URI không đúng định dạng tham số.</translation>
-    </message>
-    <message>
-        <source>Payment request file handling</source>
-        <translation type="unfinished">Payment request file đang xử lý</translation>
-    </message>
-</context>
-<context>
     <name>PeerTableModel</name>
     <message>
-        <source>User Agent</source>
-        <extracomment>Title of Peers Table column which contains the peer's User Agent string.</extracomment>
-        <translation type="unfinished">User Đặc Vụ</translation>
-    </message>
-    <message>
-        <source>Sent</source>
-        <extracomment>Title of Peers Table column which indicates the total amount of network information we have sent to the peer.</extracomment>
-        <translation type="unfinished">Gửi</translation>
-    </message>
-    <message>
-        <source>Received</source>
-        <extracomment>Title of Peers Table column which indicates the total amount of network information we have received from the peer.</extracomment>
-        <translation type="unfinished">Nhận</translation>
+        <source>Age</source>
+        <extracomment>Title of Peers Table column which indicates the duration (length of time) since the peer connection started.</extracomment>
+        <translation type="unfinished">Tuổi</translation>
     </message>
     <message>
         <source>Address</source>
         <extracomment>Title of Peers Table column which contains the IP/Onion/I2P address of the connected peer.</extracomment>
         <translation type="unfinished">Địa chỉ</translation>
     </message>
-    <message>
-        <source>Network</source>
-        <extracomment>Title of Peers Table column which states the network the peer connected through.</extracomment>
-        <translation type="unfinished">Mạng</translation>
-    </message>
-    </context>
-<context>
-    <name>QRImageWidget</name>
-    <message>
-        <source>&amp;Copy Image</source>
-        <translation type="unfinished">&amp;Sao chép ảnh</translation>
-    </message>
-    <message>
-        <source>Resulting URI too long, try to reduce the text for label / message.</source>
-        <translation type="unfinished">Đang tính toán URI quá dài, cố gắng giảm text cho label / message.</translation>
-    </message>
-    <message>
-        <source>Error encoding URI into QR Code.</source>
-        <translation type="unfinished">Error đang mã hóa URI đến QR Code.</translation>
-    </message>
-    <message>
-        <source>QR code support not available.</source>
-        <translation type="unfinished">Sự hổ trợ mã QR không sẵn có</translation>
-    </message>
-    <message>
-        <source>Save QR Code</source>
-        <translation type="unfinished">Lưu QR Code</translation>
-    </message>
     </context>
 <context>
     <name>RPCConsole</name>
     <message>
-        <source>&amp;Information</source>
-        <translation type="unfinished">&amp;Thông tin</translation>
+        <source>Last Transaction</source>
+        <translation type="unfinished">Giao dịch cuối cùng</translation>
     </message>
     <message>
-        <source>General</source>
-        <translation type="unfinished">Tổng thể</translation>
+        <source>Whether we relay addresses to this peer.</source>
+        <extracomment>Tooltip text for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
+        <translation type="unfinished">Cho dù chúng tôi chuyển tiếp địa chỉ đến đồng đẳng này.</translation>
     </message>
     <message>
-        <source>To specify a non-default location of the data directory use the '%1' option.</source>
-        <translation type="unfinished">Để chỉ ra một nơi không mặt định của thư mục dữ liệu hãy dùng tùy chọn '%1'</translation>
+        <source>Address Relay</source>
+        <extracomment>Text title for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
+        <translation type="unfinished">Chuyển tiếp địa chỉ</translation>
     </message>
     <message>
-        <source>Blocksdir</source>
-        <translation type="unfinished">Thư mục chứa các khối Blocksdir</translation>
+        <source>The total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</source>
+        <extracomment>Tooltip text for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
+        <translation type="unfinished">Tổng số các địa chỉ đã được xử lý thành công nhận được từ người này (ngoại trừ các địa chỉ sụt giảm do giới hạn tốc độ) </translation>
     </message>
     <message>
-        <source>To specify a non-default location of the blocks directory use the '%1' option.</source>
-        <translation type="unfinished">Để chỉ ra một nơi không mặt định của thư mục các khối hãy dùng tùy chọn '%1'</translation>
+        <source>The total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</source>
+        <extracomment>Tooltip text for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
+        <translation type="unfinished">Tổng số các địa chỉ nhận được từ người ngày đã bị sụt giảm (không được xử lý thành công) do giới hạn về tốc độ.</translation>
     </message>
     <message>
-        <source>Startup time</source>
-        <translation type="unfinished">Startup lúc</translation>
+        <source>Addresses Processed</source>
+        <extracomment>Text title for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
+        <translation type="unfinished">Các địa chỉ đã được xử lý</translation>
     </message>
     <message>
-        <source>Network</source>
-        <translation type="unfinished">Mạng</translation>
-    </message>
-    <message>
-        <source>Name</source>
-        <translation type="unfinished">Tên</translation>
-    </message>
-    <message>
-        <source>Number of connections</source>
-        <translation type="unfinished">Số lượng connections</translation>
-    </message>
-    <message>
-        <source>Memory Pool</source>
-        <translation type="unfinished">Pool Bộ Nhớ</translation>
-    </message>
-    <message>
-        <source>Current number of transactions</source>
-        <translation type="unfinished">Số giao dịch hiện tại</translation>
-    </message>
-    <message>
-        <source>Memory usage</source>
-        <translation type="unfinished">Bộ nhớ usage</translation>
-    </message>
-    <message>
-        <source>Wallet: </source>
-        <translation type="unfinished">Ví :</translation>
-    </message>
-    <message>
-        <source>(none)</source>
-        <translation type="unfinished">(không)</translation>
-    </message>
-    <message>
-        <source>Received</source>
-        <translation type="unfinished">Nhận</translation>
-    </message>
-    <message>
-        <source>Sent</source>
-        <translation type="unfinished">Gửi</translation>
-    </message>
-    <message>
-        <source>Banned peers</source>
-        <translation type="unfinished">Bị khóa peers</translation>
-    </message>
-    <message>
-        <source>Select a peer to view detailed information.</source>
-        <translation type="unfinished">Chọn một peer để xem thông tin chi tiết.</translation>
-    </message>
-    <message>
-        <source>Version</source>
-        <translation type="unfinished">Phiên bản</translation>
-    </message>
-    <message>
-        <source>Starting Block</source>
-        <translation type="unfinished">Block Bắt Đầu</translation>
-    </message>
-    <message>
-        <source>Synced Headers</source>
-        <translation type="unfinished">Headers đã được đồng bộ</translation>
-    </message>
-    <message>
-        <source>Synced Blocks</source>
-        <translation type="unfinished">Blocks đã được đồng bộ</translation>
-    </message>
-    <message>
-        <source>The mapped Autonomous System used for diversifying peer selection.</source>
-        <translation type="unfinished">Hệ thống tự động ánh xạ được sử dụng để đa dạng hóa lựa chọn ngang hàng.</translation>
-    </message>
-    <message>
-        <source>Mapped AS</source>
-        <translation type="unfinished">AS đã được map</translation>
-    </message>
-    <message>
-        <source>User Agent</source>
-        <translation type="unfinished">User Đặc Vụ</translation>
+        <source>Addresses Rate-Limited</source>
+        <extracomment>Text title for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
+        <translation type="unfinished">Tỷ lệ địa chỉ có giới hạn</translation>
     </message>
     <message>
         <source>Node window</source>
         <translation type="unfinished">Cửa sổ node</translation>
     </message>
     <message>
-        <source>Current block height</source>
-        <translation type="unfinished">Kích thước khối hiện tại</translation>
+        <source>&amp;Copy IP/Netmask</source>
+        <extracomment>Context menu action to copy the IP/Netmask of a banned peer. IP/Netmask is the combination of a peer's IP address and its Netmask. For IP address, see: https://en.wikipedia.org/wiki/IP_address.</extracomment>
+        <translation type="unfinished">&amp;Sao chép IP/Netmask</translation>
     </message>
-    <message>
-        <source>Open the %1 debug log file from the current data directory. This can take a few seconds for large log files.</source>
-        <translation type="unfinished">Mở cái %1 debug log file từ danh mục dữ liệu hiện tại. Điều này cần vài giây cho large log files.</translation>
-    </message>
-    <message>
-        <source>Decrease font size</source>
-        <translation type="unfinished">Giảm font size</translation>
-    </message>
-    <message>
-        <source>Increase font size</source>
-        <translation type="unfinished">Tăng font size</translation>
-    </message>
-    <message>
-        <source>Permissions</source>
-        <translation type="unfinished">Cho phép</translation>
-    </message>
-    <message>
-        <source>Services</source>
-        <translation type="unfinished">Dịch vụ</translation>
-    </message>
-    <message>
-        <source>Connection Time</source>
-        <translation type="unfinished">Connection Thời Gian</translation>
-    </message>
-    <message>
-        <source>Last Send</source>
-        <translation type="unfinished">Gửi Sau Cùng</translation>
-    </message>
-    <message>
-        <source>Last Receive</source>
-        <translation type="unfinished">Nhận Sau Cùng</translation>
-    </message>
-    <message>
-        <source>The duration of a currently outstanding ping.</source>
-        <translation type="unfinished">Thời hạn của một ping hiện đang nổi trội.</translation>
-    </message>
-    <message>
-        <source>Ping Wait</source>
-        <translation type="unfinished">Ping Chờ</translation>
-    </message>
-    <message>
-        <source>Min Ping</source>
-        <translation type="unfinished">Ping Nhỏ Nhất</translation>
-    </message>
-    <message>
-        <source>Time Offset</source>
-        <translation type="unfinished">Thời gian Offset</translation>
-    </message>
-    <message>
-        <source>Last block time</source>
-        <translation type="unfinished">Thời gian block cuối cùng</translation>
-    </message>
-    <message>
-        <source>&amp;Console</source>
-        <translation type="unfinished">&amp;BangDieuKhien</translation>
-    </message>
-    <message>
-        <source>Debug log file</source>
-        <translation type="unfinished">Debug file log</translation>
-    </message>
-    <message>
-        <source>Clear console</source>
-        <translation type="unfinished">Xóa console</translation>
-    </message>
-    <message>
-        <source>Executing command without any wallet</source>
-        <translation type="unfinished">Đang chạy lệnh khi không có ví nào</translation>
-    </message>
-    <message>
-        <source>Executing command using "%1" wallet</source>
-        <translation type="unfinished">Chạy lệnh bằng ví "%1"</translation>
-    </message>
-    <message>
-        <source>Unknown</source>
-        <translation type="unfinished">Không biết</translation>
-    </message>
-</context>
-<context>
-    <name>ReceiveCoinsDialog</name>
-    <message>
-        <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
-        <translation type="unfinished">Một optional lời nhắn để đính kèm đến payment request, cái mà sẽ được hiển thị khi mà request đang mở. Lưu ý: Tin nhắn này sẽ không được gửi với payment over the Bitcoin network.</translation>
-    </message>
-    <message>
-        <source>An optional label to associate with the new receiving address.</source>
-        <translation type="unfinished">Một optional label để liên kết với address đang nhận mới.</translation>
-    </message>
-    <message>
-        <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
-        <translation type="unfinished">Sử dụng form cho request thanh toán. Tất cả chỗ trống là &lt;b&gt;optional&lt;/b&gt;.</translation>
-    </message>
-    <message>
-        <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
-        <translation type="unfinished">Một optional giá trị để request. Để lại đây khoảng trống hoặc zero để không request một giá trị xác định.</translation>
-    </message>
-    <message>
-        <source>An optional label to associate with the new receiving address (used by you to identify an invoice).  It is also attached to the payment request.</source>
-        <translation type="unfinished">Một nhãn tùy chọn để liên kết với địa chỉ nhận mới (được bạn sử dụng để xác định hóa đơn). Nó cũng được đính kèm với yêu cầu thanh toán.</translation>
-    </message>
-    <message>
-        <source>An optional message that is attached to the payment request and may be displayed to the sender.</source>
-        <translation type="unfinished">Một thông báo tùy chọn được đính kèm với yêu cầu thanh toán và có thể được hiển thị cho người gửi.</translation>
-    </message>
-    <message>
-        <source>&amp;Create new receiving address</source>
-        <translation type="unfinished">&amp;Tạo địa chỉ nhận mới</translation>
-    </message>
-    <message>
-        <source>Clear all fields of the form.</source>
-        <translation type="unfinished">Xóa hết các khoảng trống của form.</translation>
-    </message>
-    <message>
-        <source>Clear</source>
-        <translation type="unfinished">Xóa</translation>
-    </message>
-    <message>
-        <source>Requested payments history</source>
-        <translation type="unfinished">Yêu cầu lịch sử giao dịch</translation>
-    </message>
-    <message>
-        <source>Show the selected request (does the same as double clicking an entry)</source>
-        <translation type="unfinished">Hiển thị request đã chọn (does the same as double clicking an entry)</translation>
-    </message>
-    <message>
-        <source>Show</source>
-        <translation type="unfinished">Hiển thị</translation>
-    </message>
-    <message>
-        <source>Remove the selected entries from the list</source>
-        <translation type="unfinished">Xóa bỏ mục đang chọn từ danh sách</translation>
-    </message>
-    <message>
-        <source>Remove</source>
-        <translation type="unfinished">Gỡ bỏ</translation>
-    </message>
-    <message>
-        <source>Copy &amp;URI</source>
-        <translation type="unfinished">Sao chép &amp;URI</translation>
-    </message>
-    <message>
-        <source>Could not unlock wallet.</source>
-        <translation type="unfinished">Không thể unlock wallet.</translation>
-    </message>
-    <message>
-        <source>Could not generate new %1 address</source>
-        <translation type="unfinished">Không thể tạo ra %1 địa chỉ mới</translation>
-    </message>
-</context>
-<context>
-    <name>ReceiveRequestDialog</name>
-    <message>
-        <source>Address:</source>
-        <translation type="unfinished">Địa chỉ</translation>
-    </message>
-    <message>
-        <source>Amount:</source>
-        <translation type="unfinished">Số lượng:</translation>
-    </message>
-    <message>
-        <source>Label:</source>
-        <translation type="unfinished">Nhãn</translation>
-    </message>
-    <message>
-        <source>Message:</source>
-        <translation type="unfinished">Tin nhắn:</translation>
-    </message>
-    <message>
-        <source>Wallet:</source>
-        <translation type="unfinished">Ví tiền</translation>
-    </message>
-    <message>
-        <source>Copy &amp;URI</source>
-        <translation type="unfinished">Sao chép &amp;URI</translation>
-    </message>
-    <message>
-        <source>Copy &amp;Address</source>
-        <translation type="unfinished">Sao chép địa chỉ</translation>
-    </message>
-    <message>
-        <source>Payment information</source>
-        <translation type="unfinished">Payment thông tin</translation>
-    </message>
-    <message>
-        <source>Request payment to %1</source>
-        <translation type="unfinished">Request payment đến %1</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>RecentRequestsTableModel</name>
-    <message>
-        <source>Date</source>
-        <translation type="unfinished">Ngày</translation>
-    </message>
     <message>
         <source>Label</source>
         <translation type="unfinished">Nhãn</translation>
     </message>
     <message>
-        <source>Message</source>
-        <translation type="unfinished">Tin nhắn</translation>
-    </message>
-    <message>
         <source>(no label)</source>
-        <translation type="unfinished">(không nhãn)</translation>
+        <translation type="unfinished">(không có nhãn)</translation>
     </message>
-    <message>
-        <source>(no message)</source>
-        <translation type="unfinished">(no tin nhắn)</translation>
-    </message>
-    <message>
-        <source>(no amount requested)</source>
-        <translation type="unfinished">(không amount yêu cầu)</translation>
-    </message>
-    <message>
-        <source>Requested</source>
-        <translation type="unfinished">Đã yêu cầu</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <source>Send Coins</source>
-        <translation type="unfinished">Gửi Coins</translation>
+        <source>Do you want to create this transaction?</source>
+        <extracomment>Message displayed when attempting to create a transaction. Cautionary text to prompt the user to verify that the displayed transaction details represent the transaction the user intends to create.</extracomment>
+        <translation type="unfinished">Bạn có muốn tạo giao dịch này không?</translation>
     </message>
     <message>
-        <source>Coin Control Features</source>
-        <translation type="unfinished">Coin Control Tính-năng</translation>
-    </message>
-    <message>
-        <source>automatically selected</source>
-        <translation type="unfinished">được chọn một cách hoàn toàn tự động</translation>
-    </message>
-    <message>
-        <source>Insufficient funds!</source>
-        <translation type="unfinished">Không đủ tiền kìa!</translation>
-    </message>
-    <message>
-        <source>Quantity:</source>
-        <translation type="unfinished">Số lượng:</translation>
-    </message>
-    <message>
-        <source>Amount:</source>
-        <translation type="unfinished">Số lượng:</translation>
-    </message>
-    <message>
-        <source>Fee:</source>
-        <translation type="unfinished">Phí:</translation>
-    </message>
-    <message>
-        <source>After Fee:</source>
-        <translation type="unfinished">Sau Phí:</translation>
-    </message>
-    <message>
-        <source>Change:</source>
-        <translation type="unfinished">Thay đổi:</translation>
-    </message>
-    <message>
-        <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
-        <translation type="unfinished">Nếu cái này được bật, nhưng việc change address thì trống hoặc invalid, change sẽ được gửi cho một address vừa được tạo mới.</translation>
-    </message>
-    <message>
-        <source>Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until you have validated the complete chain.</source>
-        <translation type="unfinished">Sử dụng fallbackfee có thể dẫn đến hết quả đang gửi một transaction mà nó sẽ mất hàng giờ hoặc ngày (hoặc chẳng bao giờ) được confirm. Suy nghĩ chọn fee của bạn bình thường hoặc chờ cho đến khi validated hoàn thành chain.</translation>
-    </message>
-    <message>
-        <source>Warning: Fee estimation is currently not possible.</source>
-        <translation type="unfinished">Warning: Fee ước tính hiện tại không khả thi.</translation>
-    </message>
-    <message>
-        <source>per kilobyte</source>
-        <translation type="unfinished">trên mỗi kilobyte</translation>
-    </message>
-    <message>
-        <source>Hide</source>
-        <translation type="unfinished">Ẩn</translation>
-    </message>
-    <message>
-        <source>Recommended:</source>
-        <translation type="unfinished">Khuyên dùng:</translation>
-    </message>
-    <message>
-        <source>Send to multiple recipients at once</source>
-        <translation type="unfinished">Gửi đến tập thể người nhận một lần</translation>
-    </message>
-    <message>
-        <source>Clear all fields of the form.</source>
-        <translation type="unfinished">Xóa hết các khoảng trống của form.</translation>
-    </message>
-    <message>
-        <source>Dust:</source>
-        <translation type="unfinished">Rác:</translation>
-    </message>
-    <message>
-        <source>Hide transaction fee settings</source>
-        <translation type="unfinished">Ẩn cài đặt phí giao dịch</translation>
-    </message>
-    <message>
-        <source>When there is less transaction volume than space in the blocks, miners as well as relaying nodes may enforce a minimum fee. Paying only this minimum fee is just fine, but be aware that this can result in a never confirming transaction once there is more demand for bitcoin transactions than the network can process.</source>
-        <translation type="unfinished">Khi có khối lượng giao dịch ít hơn chổ trống trong các khối, các nhà đào mỏ cũng như các nút chuyển tiếp có thể thực thi chỉ với một khoản phí tối thiểu. Chỉ trả khoản phí tối thiểu này là tốt, nhưng lưu ý rằng điều này có thể dẫn đến một giao dịch không bao giờ xác nhận một khi có nhu cầu giao dịch bitcoin nhiều hơn khả năng mạng có thể xử lý.</translation>
-    </message>
-    <message>
-        <source>A too low fee might result in a never confirming transaction (read the tooltip)</source>
-        <translation type="unfinished">Một khoản phí quá thấp có thể dẫn đến một giao dịch không bao giờ xác nhận (đọc chú giải công cụ)</translation>
-    </message>
-    <message>
-        <source>Confirmation time target:</source>
-        <translation type="unfinished">Thời gian xác nhận đối tượng:</translation>
-    </message>
-    <message>
-        <source>Enable Replace-By-Fee</source>
-        <translation type="unfinished">Kích hoạt  Phí thay thế</translation>
-    </message>
-    <message>
-        <source>With Replace-By-Fee (BIP-125) you can increase a transaction's fee after it is sent. Without this, a higher fee may be recommended to compensate for increased transaction delay risk.</source>
-        <translation type="unfinished">Với Phí thay thế (BIP-125), bạn có thể tăng phí giao dịch sau khi được gửi. Nếu không có điều này, một khoản phí cao hơn có thể được đề xuất để bù đắp cho rủi ro chậm trễ giao dịch tăng lên.</translation>
-    </message>
-    <message>
-        <source>Balance:</source>
-        <translation type="unfinished">Số dư:</translation>
-    </message>
-    <message>
-        <source>Confirm the send action</source>
-        <translation type="unfinished">Confirm hành động gửi</translation>
-    </message>
-    <message>
-        <source>Copy quantity</source>
-        <translation type="unfinished">Sao chép số lượng</translation>
-    </message>
-    <message>
-        <source>Copy amount</source>
-        <translation type="unfinished">Sao chép số lượng</translation>
-    </message>
-    <message>
-        <source>Copy fee</source>
-        <translation type="unfinished">Sao chép phí</translation>
-    </message>
-    <message>
-        <source>Copy after fee</source>
-        <translation type="unfinished">Sao chép sau phí</translation>
-    </message>
-    <message>
-        <source>Copy bytes</source>
-        <translation type="unfinished">Sao chép bytes</translation>
-    </message>
-    <message>
-        <source>Copy dust</source>
-        <translation type="unfinished">Sao chép rác</translation>
-    </message>
-    <message>
-        <source>Copy change</source>
-        <translation type="unfinished">Sao chép thay đổi</translation>
-    </message>
-    <message>
-        <source>Cr&amp;eate Unsigned</source>
-        <translation type="unfinished">Cr&amp;eate không được ký</translation>
-    </message>
-    <message>
-        <source>Creates a Partially Signed Bitcoin Transaction (PSBT) for use with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
-        <translation type="unfinished">Tạo Giao dịch Bitcoin được ký một phần (PSBT) để sử dụng với các dạng như: ví ngoại tuyến %1 hoặc ví phần cứng tương thích PSBT.</translation>
-    </message>
-    <message>
-        <source> from wallet '%1'</source>
-        <translation type="unfinished">từ ví  '%1'</translation>
-    </message>
-    <message>
-        <source>%1 to '%2'</source>
-        <translation type="unfinished">%1 tới '%2'</translation>
-    </message>
-    <message>
-        <source>%1 to %2</source>
-        <translation type="unfinished">%1 đến%2</translation>
-    </message>
-    <message>
-        <source>Save Transaction Data</source>
-        <translation type="unfinished">Lưu trữ giao dịch</translation>
-    </message>
-    <message>
-        <source>PSBT saved</source>
-        <translation type="unfinished">PSBT đã lưu</translation>
-    </message>
-    <message>
-        <source>or</source>
-        <translation type="unfinished">hoặc</translation>
-    </message>
-    <message>
-        <source>You can increase the fee later (signals Replace-By-Fee, BIP-125).</source>
-        <translation type="unfinished">Bạn có thể tăng phí sau khi gửi( với tín hiệu Phí Thay Thế, BIP-125)</translation>
-    </message>
-    <message>
-        <source>Please, review your transaction.</source>
-        <extracomment>Text to prompt a user to review the details of the transaction they are attempting to send.</extracomment>
-        <translation type="unfinished">Làm ơn xem xét đánh giá giao dịch của bạn.</translation>
-    </message>
-    <message>
-        <source>Not signalling Replace-By-Fee, BIP-125.</source>
-        <translation type="unfinished">Không có tín hiệu Phí Thay Thế, BIP-125.</translation>
-    </message>
-    <message>
-        <source>Total Amount</source>
-        <translation type="unfinished">Tổng số</translation>
-    </message>
-    <message>
-        <source>Confirm send coins</source>
-        <translation type="unfinished">Confirm gửi coins</translation>
-    </message>
-    <message>
-        <source>Watch-only balance:</source>
-        <translation type="unfinished">Số dư chỉ xem:</translation>
-    </message>
-    <message>
-        <source>The recipient address is not valid. Please recheck.</source>
-        <translation type="unfinished">Địa chỉ người nhận address thì không valid. Kiểm tra lại đi.</translation>
-    </message>
-    <message>
-        <source>The amount to pay must be larger than 0.</source>
-        <translation type="unfinished">Giả trị để pay cần phải lớn hơn 0.</translation>
-    </message>
-    <message>
-        <source>The amount exceeds your balance.</source>
-        <translation type="unfinished">Số tiền vượt quá số dư của bạn.</translation>
-    </message>
-    <message>
-        <source>The total exceeds your balance when the %1 transaction fee is included.</source>
-        <translation type="unfinished">Tổng số lớn hơn số dư của bạn khi %1 transaction fee được tính vào.</translation>
-    </message>
-    <message>
-        <source>Duplicate address found: addresses should only be used once each.</source>
-        <translation type="unfinished">Trùng address được tìm thấy: địa chỉ chỉ nên được dùng một lần.</translation>
-    </message>
-    <message>
-        <source>Transaction creation failed!</source>
-        <translation type="unfinished">Transaction khởi tạo thất bại!</translation>
-    </message>
-    <message>
-        <source>A fee higher than %1 is considered an absurdly high fee.</source>
-        <translation type="unfinished">Một fee lớn hơn %1 được coi là ngớ ngẩn cao fee.</translation>
-    </message>
-    <message>
-        <source>Payment request expired.</source>
-        <translation type="unfinished">Payment request hết hạn.</translation>
+        <source>Please, review your transaction. You can create and send this transaction or create a Partially Signed Bitcoin Transaction (PSBT), which you can save or copy and then sign with, e.g., an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
+        <extracomment>Text to inform a user attempting to create a transaction of their current options. At this stage, a user can send their transaction or create a PSBT. This string is displayed when both private keys and PSBT controls are enabled.</extracomment>
+        <translation type="unfinished">Vui lòng xem lại giao dịch của bạn. Bạn có thể tạo và gửi giao dịch này hoặc tạo Giao dịch Bitcoin được ký một phần (PSBT), bạn có thể lưu hoặc sao chép và sau đó ký bằng, ví dụ: ví %1 ngoại tuyến hoặc ví phần cứng tương thích với PSBT.</translation>
     </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>Ước tính sẽ bắt đầu xác nhận trong %n khối.</numerusform>
         </translation>
     </message>
     <message>
-        <source>Warning: Unknown change address</source>
-        <translation type="unfinished">Warning: Không biết change address</translation>
-    </message>
-    <message>
-        <source>The address you selected for change is not part of this wallet. Any or all funds in your wallet may be sent to this address. Are you sure?</source>
-        <translation type="unfinished">The address bạn đã chọn dành cho change thì không phải part of this wallet. Bất kỳ hay tất cả funds in your wallet có thể được gửi đến address này. Bạn chắc chứ?</translation>
-    </message>
-    <message>
         <source>(no label)</source>
-        <translation type="unfinished">(không nhãn)</translation>
+        <translation type="unfinished">(không có nhãn)</translation>
     </message>
 </context>
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <source>Choose previously used address</source>
-        <translation type="unfinished">Chọn mới thì address</translation>
-    </message>
-    <message>
-        <source>The Bitcoin address to send the payment to</source>
-        <translation type="unfinished">The Bitcoin address để gửi the payment đến</translation>
-    </message>
-    <message>
         <source>Paste address from clipboard</source>
-        <translation type="unfinished">Paste address từ clipboard</translation>
+        <translation type="unfinished">Dán địa chỉ từ khay nhớ tạm</translation>
     </message>
-    <message>
-        <source>Remove this entry</source>
-        <translation type="unfinished">Xóa bỏ entry này</translation>
-    </message>
-    <message>
-        <source>The amount to send in the selected unit</source>
-        <translation type="unfinished">Lượng tiền để gửi trong mỗi đơn vị đã chọn</translation>
-    </message>
-    <message>
-        <source>The fee will be deducted from the amount being sent. The recipient will receive less bitcoins than you enter in the amount field. If multiple recipients are selected, the fee is split equally.</source>
-        <translation type="unfinished">The fee sẽ được khấu trừ từ số tiền đang gửi. Người nhận sẽ receive ít bitcoins hơn bạn gõ vào khoảng trống. Nếu nhiều người gửi được chọn, fee sẽ được chia đều.</translation>
-    </message>
-    <message>
-        <source>S&amp;ubtract fee from amount</source>
-        <translation type="unfinished">S&amp;ubtract fee từ amount</translation>
-    </message>
-    <message>
-        <source>Use available balance</source>
-        <translation type="unfinished">Sử dụng số dư sẵn có</translation>
-    </message>
-    <message>
-        <source>Message:</source>
-        <translation type="unfinished">Tin nhắn:</translation>
-    </message>
-    <message>
-        <source>This is an unauthenticated payment request.</source>
-        <translation type="unfinished">Đây là một chưa được chứng thực payment request.</translation>
-    </message>
-    <message>
-        <source>This is an authenticated payment request.</source>
-        <translation type="unfinished">Đây là một chưa được chứng thực payment request.</translation>
-    </message>
-    <message>
-        <source>Enter a label for this address to add it to the list of used addresses</source>
-        <translation type="unfinished">Nhập một label cho cái address này để thêm vào danh sách địa chỉ đã sử dụng</translation>
-    </message>
-    <message>
-        <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
-        <translation type="unfinished">Một tin nhắn được đính kèm với số bitcoin: URI mà sẽ được lưu giữ với transaction dành cho tài liệu tham khảo. Lưu ý: Tin nhắn này sẽ không được gửi thông qua Bitcoin network.</translation>
-    </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">Pay Đến:</translation>
-    </message>
-    <message>
-        <source>Memo:</source>
-        <translation type="unfinished">Bản ghi nhớ:</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>SendConfirmationDialog</name>
     <message>
@@ -2234,196 +1033,57 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <source>Signatures - Sign / Verify a Message</source>
-        <translation type="unfinished">Chữ ký - Sign / Verify a Message</translation>
-    </message>
-    <message>
-        <source>&amp;Sign Message</source>
-        <translation type="unfinished">&amp;Sign Tin nhắn</translation>
-    </message>
-    <message>
-        <source>You can sign messages/agreements with your addresses to prove you can receive bitcoins sent to them. Be careful not to sign anything vague or random, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
-        <translation type="unfinished">Bạn có thể ký/đồng ý với địa chỉ chứng minh bạn có thể receive bitcoins đã gửi đến chúng. Cẩn thận không ký bất cứ không rõ hay random, như các cuộc tấn công lừa đảo có thể cố lừa bạn ký tên vào danh tính của bạn.. Chỉ ký các bản tuyên bố hoàn chỉnh mà bạn đồng ý.</translation>
-    </message>
-    <message>
-        <source>The Bitcoin address to sign the message with</source>
-        <translation type="unfinished">The Bitcoin address để ký với tin nhắn</translation>
-    </message>
-    <message>
-        <source>Choose previously used address</source>
-        <translation type="unfinished">Chọn mới thì address</translation>
-    </message>
-    <message>
         <source>Paste address from clipboard</source>
-        <translation type="unfinished">Paste address từ clipboard</translation>
-    </message>
-    <message>
-        <source>Enter the message you want to sign here</source>
-        <translation type="unfinished">Nhập tin nhắn bạn muốn ký tại đây</translation>
-    </message>
-    <message>
-        <source>Copy the current signature to the system clipboard</source>
-        <translation type="unfinished">Copy hiện tại signature tới system clipboard</translation>
-    </message>
-    <message>
-        <source>Sign the message to prove you own this Bitcoin address</source>
-        <translation type="unfinished">Ký tin nhắn để chứng minh bạn sở hữu Bitcoin address này</translation>
-    </message>
-    <message>
-        <source>Reset all sign message fields</source>
-        <translation type="unfinished">Reset tất cả khoảng chữ ký nhắn</translation>
-    </message>
-    <message>
-        <source>&amp;Verify Message</source>
-        <translation type="unfinished">&amp;Verify Tin nhắn</translation>
-    </message>
-    <message>
-        <source>Enter the receiver's address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack. Note that this only proves the signing party receives with the address, it cannot prove sendership of any transaction!</source>
-        <translation type="unfinished">Nhập vào address người nhận, tin nhắn (chắc rằng bạn copy line breaks, khoảng trống, tabs, etc. chính xác) và signature bên dưới verify tin nhắn. Cẩn thận không đọc nhiều hơn từ signature so với cái được ký trong bản thân tin nhắn, để tránh bị lừa bới man-in-the-middle tấn công. Lưu ý rằng điều này chỉ chứng nhận nhóm những người nhân với address, nó không thể chứng minh bên gửi có bất kỳ transaction!</translation>
-    </message>
-    <message>
-        <source>The Bitcoin address the message was signed with</source>
-        <translation type="unfinished">The Bitcoin address tin nhắn đã ký với</translation>
-    </message>
-    <message>
-        <source>The signed message to verify</source>
-        <translation type="unfinished">Tin nhắn đã được ký để xác nhận</translation>
-    </message>
-    <message>
-        <source>The signature given when the message was signed</source>
-        <translation type="unfinished">Chữ ký được cung cấp khi tin nhắn đã được ký</translation>
-    </message>
-    <message>
-        <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
-        <translation type="unfinished">Verify tin nhắn để chắc rằng nó đã được ký với xác định Bitcoin address</translation>
-    </message>
-    <message>
-        <source>Reset all verify message fields</source>
-        <translation type="unfinished">Reset tất cả verify khoảng trống nhắn</translation>
-    </message>
-    <message>
-        <source>Click "Sign Message" to generate signature</source>
-        <translation type="unfinished">Click "Sign Message" để generate signature</translation>
-    </message>
-    <message>
-        <source>The entered address is invalid.</source>
-        <translation type="unfinished">Đã nhập address thì invalid.</translation>
-    </message>
-    <message>
-        <source>Please check the address and try again.</source>
-        <translation type="unfinished">Vui lòng kiểm tra address và thử lại.</translation>
-    </message>
-    <message>
-        <source>The entered address does not refer to a key.</source>
-        <translation type="unfinished">Đã nhập address không refer to a key.</translation>
-    </message>
-    <message>
-        <source>Wallet unlock was cancelled.</source>
-        <translation type="unfinished">Wallet unlock đã được hủy.</translation>
-    </message>
-    <message>
-        <source>No error</source>
-        <translation type="unfinished">Không lỗi</translation>
-    </message>
-    <message>
-        <source>Private key for the entered address is not available.</source>
-        <translation type="unfinished">Private key cho address đã nhập thì không có sẵn.</translation>
+        <translation type="unfinished">Dán địa chỉ từ khay nhớ tạm</translation>
     </message>
     </context>
 <context>
+    <name>SplashScreen</name>
+    <message>
+        <source>press q to shutdown</source>
+        <translation type="unfinished">nhấn q để tắt máy</translation>
+    </message>
+</context>
+<context>
     <name>TransactionDesc</name>
     <message>
-        <source>Date</source>
-        <translation type="unfinished">Ngày</translation>
+        <source>0/unconfirmed, in memory pool</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is in the memory pool.</extracomment>
+        <translation type="unfinished">0/xác nhận, ở trong bể bộ nhớ - memory pool</translation>
+    </message>
+    <message>
+        <source>0/unconfirmed, not in memory pool</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is not in the memory pool.</extracomment>
+        <translation type="unfinished">0/xác nhận, không ở trong bể bộ nhớ - memory pool</translation>
     </message>
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>sẽ trưởng thành sau%n khối nữa </numerusform>
         </translation>
-    </message>
-    <message>
-        <source>Message</source>
-        <translation type="unfinished">Tin nhắn</translation>
-    </message>
-    <message>
-        <source>Transaction virtual size</source>
-        <translation type="unfinished">Kích cỡ giao dịch ảo</translation>
-    </message>
-    <message>
-        <source> (Certificate was not verified)</source>
-        <translation type="unfinished">(Chứng chỉ chưa được thẩm định)</translation>
-    </message>
-    <message>
-        <source>Amount</source>
-        <translation type="unfinished">Số lượng</translation>
     </message>
     </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <source>Date</source>
-        <translation type="unfinished">Ngày</translation>
-    </message>
-    <message>
         <source>Label</source>
         <translation type="unfinished">Nhãn</translation>
     </message>
     <message>
-        <source>Conflicted</source>
-        <translation type="unfinished">Xung đột</translation>
-    </message>
-    <message>
         <source>(no label)</source>
-        <translation type="unfinished">(không nhãn)</translation>
+        <translation type="unfinished">(không có nhãn)</translation>
     </message>
     </context>
 <context>
     <name>TransactionView</name>
     <message>
-        <source>All</source>
-        <translation type="unfinished">Tất cả</translation>
-    </message>
-    <message>
-        <source>Today</source>
-        <translation type="unfinished">Hôm nay</translation>
-    </message>
-    <message>
-        <source>This week</source>
-        <translation type="unfinished">Tuần này</translation>
-    </message>
-    <message>
-        <source>This month</source>
-        <translation type="unfinished">Tháng này</translation>
-    </message>
-    <message>
-        <source>Last month</source>
-        <translation type="unfinished">Tháng trước</translation>
-    </message>
-    <message>
-        <source>This year</source>
-        <translation type="unfinished">Năm nay</translation>
-    </message>
-    <message>
         <source>Other</source>
         <translation type="unfinished">Khác</translation>
     </message>
     <message>
-        <source>Enter address, transaction id, or label to search</source>
-        <translation type="unfinished">Nhập địa chỉ, số id giao dịch, hoặc nhãn để tìm kiếm</translation>
-    </message>
-    <message>
-        <source>Comma separated file</source>
-        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
-        <translation type="unfinished">Tệp tách dấu phẩy</translation>
-    </message>
-    <message>
-        <source>Confirmed</source>
-        <translation type="unfinished">Đã xác nhận</translation>
-    </message>
-    <message>
-        <source>Date</source>
-        <translation type="unfinished">Ngày</translation>
+        <source>Show in %1</source>
+        <extracomment>Transactions table context menu action to show the selected transaction in a third-party block explorer. %1 is a stand-in argument for the URL of the explorer.</extracomment>
+        <translation type="unfinished">Hiển thị trong %1</translation>
     </message>
     <message>
         <source>Label</source>
@@ -2433,80 +1093,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Address</source>
         <translation type="unfinished">Địa chỉ</translation>
     </message>
-    <message>
-        <source>Exporting Failed</source>
-        <translation type="unfinished">Xuất Thất Bại</translation>
-    </message>
     </context>
-<context>
-    <name>WalletFrame</name>
-    <message>
-        <source>No wallet has been loaded.
-Go to File &gt; Open Wallet to load a wallet.
-- OR -</source>
-        <translation type="unfinished">Chưa có ví nào được tải. Đi tới Tệp&gt; Mở Ví để nạp ví.- HOẶC -</translation>
-    </message>
-    <message>
-        <source>Create a new wallet</source>
-        <translation type="unfinished">Tạo một ví mới</translation>
-    </message>
-    <message>
-        <source>Error</source>
-        <translation type="unfinished">Lỗi</translation>
-    </message>
-    <message>
-        <source>Load Transaction Data</source>
-        <translation type="unfinished">Tải thông tin giao dịch</translation>
-    </message>
-    <message>
-        <source>Partially Signed Transaction (*.psbt)</source>
-        <translation type="unfinished">Giao dịch được đăng ký một phần (*.psbt)</translation>
-    </message>
-    <message>
-        <source>PSBT file must be smaller than 100 MiB</source>
-        <translation type="unfinished">Tệp PSBT phải nhỏ hơn 100 MiB</translation>
-    </message>
-    <message>
-        <source>Unable to decode PSBT</source>
-        <translation type="unfinished">Không thể giải mã PSBT</translation>
-    </message>
-</context>
-<context>
-    <name>WalletModel</name>
-    <message>
-        <source>Send Coins</source>
-        <translation type="unfinished">Gửi Coins</translation>
-    </message>
-    <message>
-        <source>Fee bump error</source>
-        <translation type="unfinished">Fee bơm error</translation>
-    </message>
-    <message>
-        <source>Can't draft transaction.</source>
-        <translation type="unfinished">Không thể tạo tạm giao dịch.</translation>
-    </message>
-    <message>
-        <source>PSBT copied</source>
-        <translation type="unfinished">Đã sao chép PSBT</translation>
-    </message>
-    <message>
-        <source>default wallet</source>
-        <translation type="unfinished">ví mặc định</translation>
-    </message>
-</context>
 <context>
     <name>WalletView</name>
     <message>
         <source>&amp;Export</source>
         <translation type="unfinished">&amp;Xuất</translation>
     </message>
-    <message>
-        <source>Export the data in the current tab to a file</source>
-        <translation type="unfinished">Xuất dữ liệu trong thẻ hiện tại ra file</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="unfinished">Hủy</translation>
-    </message>
-</context>
+    </context>
 </TS>

--- a/src/qt/locale/bitcoin_yo.ts
+++ b/src/qt/locale/bitcoin_yo.ts
@@ -2,8 +2,32 @@
 <context>
     <name>AddressBookPage</name>
     <message>
+        <source>Right-click to edit address or label</source>
+        <translation type="unfinished">Te botiini apa otun lati se atunse si adireesi tabi isaami</translation>
+    </message>
+    <message>
+        <source>Create a new address</source>
+        <translation type="unfinished">si adireesi tuntun</translation>
+    </message>
+    <message>
         <source>&amp;New</source>
         <translation type="unfinished">&amp;ati tuntun</translation>
+    </message>
+    <message>
+        <source>Copy the currently selected address to the system clipboard</source>
+        <translation type="unfinished">da adiresi tuntun ti o sayan ko si eto sileti </translation>
+    </message>
+    <message>
+        <source>&amp;Copy</source>
+        <translation type="unfinished">daako</translation>
+    </message>
+    <message>
+        <source>C&amp;lose</source>
+        <translation type="unfinished">paade</translation>
+    </message>
+    <message>
+        <source>Delete the currently selected address from the list</source>
+        <translation type="unfinished">samukuro adiresi ti o sese sayan kuro ninu akojo</translation>
     </message>
     </context>
 <context>
@@ -104,6 +128,24 @@
     </context>
 <context>
     <name>Intro</name>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform />
+        </translation>
+    </message>
     <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>

--- a/src/qt/locale/bitcoin_zh-Hans.ts
+++ b/src/qt/locale/bitcoin_zh-Hans.ts
@@ -2,95 +2,104 @@
 <context>
     <name>AddressBookPage</name>
     <message>
+        <source>Right-click to edit address or label</source>
+        <translation type="unfinished">鼠标右击编辑地址或标签</translation>
+    </message>
+    <message>
         <source>Create a new address</source>
-        <translation type="unfinished">创建一个新的地址</translation>
+        <translation type="unfinished">创建新地址</translation>
     </message>
     <message>
         <source>&amp;New</source>
-        <translation type="unfinished">新建</translation>
+        <translation type="unfinished">新建(&amp;N)</translation>
     </message>
     <message>
         <source>Copy the currently selected address to the system clipboard</source>
-        <translation type="unfinished">复制选定的地址到系统剪切板</translation>
+        <translation type="unfinished">复制当前选中的地址到系统剪贴板</translation>
     </message>
     <message>
         <source>&amp;Copy</source>
-        <translation type="unfinished">复制</translation>
+        <translation type="unfinished">复制(&amp;C)</translation>
     </message>
     <message>
         <source>C&amp;lose</source>
-        <translation type="unfinished">关闭</translation>
+        <translation type="unfinished">关闭(&amp;L)</translation>
     </message>
     <message>
         <source>Delete the currently selected address from the list</source>
-        <translation type="unfinished">从列表删除选定的地址</translation>
+        <translation type="unfinished">从列表中删除选中的地址</translation>
     </message>
     <message>
         <source>Enter address or label to search</source>
-        <translation type="unfinished">输入地址或者标签进行搜索</translation>
+        <translation type="unfinished">输入地址或标签来搜索</translation>
     </message>
     <message>
         <source>Export the data in the current tab to a file</source>
-        <translation type="unfinished">导出当前数据到文件</translation>
+        <translation type="unfinished">将当前标签页数据导出到文件</translation>
     </message>
     <message>
         <source>&amp;Export</source>
-        <translation type="unfinished">导出</translation>
+        <translation type="unfinished">导出(&amp;E)</translation>
     </message>
     <message>
         <source>&amp;Delete</source>
-        <translation type="unfinished">删除</translation>
+        <translation type="unfinished">删除(&amp;D)</translation>
     </message>
     <message>
         <source>Choose the address to send coins to</source>
-        <translation type="unfinished">选择发送比特币地址</translation>
+        <translation type="unfinished">选择要发币给哪些地址</translation>
     </message>
     <message>
         <source>Choose the address to receive coins with</source>
-        <translation type="unfinished">选择接收比特币地址</translation>
+        <translation type="unfinished">选择要用哪些地址收币</translation>
     </message>
     <message>
         <source>C&amp;hoose</source>
-        <translation type="unfinished">选择</translation>
+        <translation type="unfinished">选择(&amp;H)</translation>
     </message>
     <message>
         <source>Sending addresses</source>
-        <translation type="unfinished">发送地址</translation>
+        <translation type="unfinished">付款地址</translation>
     </message>
     <message>
         <source>Receiving addresses</source>
-        <translation type="unfinished">接收地址</translation>
+        <translation type="unfinished">收款地址</translation>
     </message>
     <message>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
-        <translation type="unfinished">这是你的比特币发币地址。发送前请确认发送数量和接收地址</translation>
+        <translation type="unfinished">您可以给这些比特币地址付款。在付款之前，务必要检查金额和收款地址是否正确。</translation>
     </message>
     <message>
         <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
 Signing is only possible with addresses of the type 'legacy'.</source>
-        <translation type="unfinished">这是你的比特币接收地址。点击接收选项卡中“创建新的接收地址”按钮来创建新的地址。
-签名只能使用“传统”类型的地址。</translation>
+        <translation type="unfinished">这是您用来收款的比特币地址。使用“接收”标签页中的“创建新收款地址”按钮来创建新的收款地址。
+只有“传统（legacy）”类型的地址支持签名。</translation>
     </message>
     <message>
         <source>&amp;Copy Address</source>
-        <translation type="unfinished">复制地址</translation>
+        <translation type="unfinished">复制地址(&amp;C)</translation>
     </message>
     <message>
         <source>Copy &amp;Label</source>
-        <translation type="unfinished">复制标签</translation>
+        <translation type="unfinished">复制标签(&amp;L)</translation>
     </message>
     <message>
         <source>&amp;Edit</source>
-        <translation type="unfinished">编辑</translation>
+        <translation type="unfinished">编辑(&amp;E)</translation>
     </message>
     <message>
         <source>Export Address List</source>
         <translation type="unfinished">导出地址列表</translation>
     </message>
     <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">逗号分隔文件</translation>
+    </message>
+    <message>
         <source>There was an error trying to save the address list to %1. Please try again.</source>
         <extracomment>An error message. %1 is a stand-in argument for the name of the file we attempted to save to.</extracomment>
-        <translation type="unfinished">保存地址列表至%1时发生错误，请重试。</translation>
+        <translation type="unfinished">尝试保存地址列表到 %1 时发生错误。请再试一次。</translation>
     </message>
     <message>
         <source>Exporting Failed</source>
@@ -128,7 +137,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Repeat new passphrase</source>
-        <translation type="unfinished">重复输入新密码</translation>
+        <translation type="unfinished">重复新密码</translation>
     </message>
     <message>
         <source>Show passphrase</source>
@@ -140,7 +149,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
-        <translation type="unfinished">此操作需要您的钱包密码用来解锁钱包。</translation>
+        <translation type="unfinished">这个操作需要你的钱包密码来解锁钱包。</translation>
     </message>
     <message>
         <source>Unlock wallet</source>
@@ -156,11 +165,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
-        <translation type="unfinished">注意:如果你加密了钱包又忘记了密码，你将会丢失所有的比特币！</translation>
+        <translation type="unfinished">警告: 如果把钱包加密后又忘记密码，你就会从此&lt;b&gt;失去其中所有的比特币了&lt;/b&gt;！</translation>
     </message>
     <message>
         <source>Are you sure you wish to encrypt your wallet?</source>
-        <translation type="unfinished">你确定要将钱包加密吗？</translation>
+        <translation type="unfinished">你确定要把钱包加密吗？</translation>
     </message>
     <message>
         <source>Wallet encrypted</source>
@@ -168,131 +177,3814 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Enter the new passphrase for the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
-        <translation type="unfinished">输入钱包的新密码。&lt;br/&gt;密码中请使用&lt;b&gt;10个或更多随机字符&lt;/b&gt;，或&lt;b&gt;8个或更多的单词&lt;/b&gt;。</translation>
+        <translation type="unfinished">为此钱包输入新密码。&lt;br/&gt;请使用由&lt;b&gt;十个或更多的随机字符&lt;/b&gt;，或者&lt;b&gt;八个或更多单词&lt;/b&gt;组成的密码。</translation>
     </message>
     <message>
         <source>Enter the old passphrase and new passphrase for the wallet.</source>
-        <translation type="unfinished">输入钱包的旧密码和新密码。</translation>
+        <translation type="unfinished">输入此钱包的旧密码和新密码。</translation>
+    </message>
+    <message>
+        <source>Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
+        <translation type="unfinished">请注意，当您的计算机感染恶意软件时，加密钱包并不能完全规避您的比特币被偷窃的可能。</translation>
     </message>
     <message>
         <source>Wallet to be encrypted</source>
-        <translation type="unfinished">需要加密的钱包</translation>
+        <translation type="unfinished">要加密的钱包</translation>
     </message>
     <message>
         <source>Your wallet is about to be encrypted. </source>
-        <translation type="unfinished">你的钱包将要被加密</translation>
+        <translation type="unfinished">您的钱包将要被加密。</translation>
     </message>
     <message>
         <source>Your wallet is now encrypted. </source>
-        <translation type="unfinished">你的钱包已被加密</translation>
+        <translation type="unfinished">您的钱包现在已被加密。</translation>
+    </message>
+    <message>
+        <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
+        <translation type="unfinished">重要: 请用新生成的、已加密的钱包备份文件取代你之前留的钱包文件备份。出于安全方面的原因，一旦你开始使用新的已加密钱包，旧的未加密钱包文件备份就失效了。</translation>
     </message>
     <message>
         <source>Wallet encryption failed</source>
         <translation type="unfinished">钱包加密失败</translation>
     </message>
     <message>
+        <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
+        <translation type="unfinished">因为内部错误导致钱包加密失败。你的钱包还是没加密。</translation>
+    </message>
+    <message>
+        <source>The supplied passphrases do not match.</source>
+        <translation type="unfinished">提供的密码不一致。</translation>
+    </message>
+    <message>
         <source>Wallet unlock failed</source>
         <translation type="unfinished">钱包解锁失败</translation>
     </message>
-    </context>
+    <message>
+        <source>The passphrase entered for the wallet decryption was incorrect.</source>
+        <translation type="unfinished">输入的钱包解锁密码不正确。</translation>
+    </message>
+    <message>
+        <source>Wallet passphrase was successfully changed.</source>
+        <translation type="unfinished">钱包密码修改成功。</translation>
+    </message>
+    <message>
+        <source>Warning: The Caps Lock key is on!</source>
+        <translation type="unfinished">警告: 大写字母锁定已开启！</translation>
+    </message>
+</context>
+<context>
+    <name>BanTableModel</name>
+    <message>
+        <source>IP/Netmask</source>
+        <translation type="unfinished">IP/网络掩码</translation>
+    </message>
+    <message>
+        <source>Banned Until</source>
+        <translation type="unfinished">在此之前保持封禁:</translation>
+    </message>
+</context>
+<context>
+    <name>BitcoinApplication</name>
+    <message>
+        <source>Settings file %1 might be corrupt or invalid.</source>
+        <translation type="unfinished">设置文件%1可能已损坏或无效。</translation>
+    </message>
+    <message>
+        <source>Runaway exception</source>
+        <translation type="unfinished">未捕获的异常</translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
+        <translation type="unfinished">发生致命错误。%1 已经无法继续安全运行并即将退出。</translation>
+    </message>
+    <message>
+        <source>Internal error</source>
+        <translation type="unfinished">内部错误</translation>
+    </message>
+    <message>
+        <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
+        <translation type="unfinished">发生了一个内部错误。%1将会尝试安全地继续运行。关于这个未知的错误我们有以下的描述信息用于参考。</translation>
+    </message>
+</context>
 <context>
     <name>QObject</name>
+    <message>
+        <source>Do you want to reset settings to default values, or to abort without making changes?</source>
+        <extracomment>Explanatory text shown on startup when the settings file cannot be read. Prompts user to make a choice between resetting or aborting.</extracomment>
+        <translation type="unfinished">要将设置重置为默认值，还是要放弃更改并中止？</translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. Check that settings file is writable, or try running with -nosettings.</source>
+        <extracomment>Explanatory text shown on startup when the settings file could not be written. Prompts user to check that we have the ability to write to the file. Explains that the user has the option of running without a settings file.</extracomment>
+        <translation type="unfinished">出现致命错误。请检查设置文件是否可写，或者尝试带 -nosettings 参数运行。</translation>
+    </message>
+    <message>
+        <source>Error: Specified data directory "%1" does not exist.</source>
+        <translation type="unfinished">错误:指定的数据目录“%1”不存在。</translation>
+    </message>
+    <message>
+        <source>Error: Cannot parse configuration file: %1.</source>
+        <translation type="unfinished">错误:无法解析配置文件: %1</translation>
+    </message>
+    <message>
+        <source>Error: %1</source>
+        <translation type="unfinished">错误: %1</translation>
+    </message>
+    <message>
+        <source>%1 didn't yet exit safely…</source>
+        <translation type="unfinished">%1 还没有安全退出...</translation>
+    </message>
+    <message>
+        <source>unknown</source>
+        <translation type="unfinished">未知</translation>
+    </message>
+    <message>
+        <source>Amount</source>
+        <translation type="unfinished">金额</translation>
+    </message>
+    <message>
+        <source>Enter a Bitcoin address (e.g. %1)</source>
+        <translation type="unfinished">请输入一个比特币地址 (例如 %1)</translation>
+    </message>
+    <message>
+        <source>Unroutable</source>
+        <translation type="unfinished">不可路由</translation>
+    </message>
+    <message>
+        <source>Internal</source>
+        <translation type="unfinished">内部</translation>
+    </message>
+    <message>
+        <source>Inbound</source>
+        <extracomment>An inbound connection from a peer. An inbound connection is a connection initiated by a peer.</extracomment>
+        <translation type="unfinished">传入</translation>
+    </message>
+    <message>
+        <source>Outbound</source>
+        <extracomment>An outbound connection to a peer. An outbound connection is a connection initiated by us.</extracomment>
+        <translation type="unfinished">传出</translation>
+    </message>
+    <message>
+        <source>Full Relay</source>
+        <extracomment>Peer connection type that relays all network information.</extracomment>
+        <translation type="unfinished">完整转发</translation>
+    </message>
+    <message>
+        <source>Block Relay</source>
+        <extracomment>Peer connection type that relays network information about blocks and not transactions or addresses.</extracomment>
+        <translation type="unfinished">区块转发</translation>
+    </message>
+    <message>
+        <source>Manual</source>
+        <extracomment>Peer connection type established manually through one of several methods.</extracomment>
+        <translation type="unfinished">手册</translation>
+    </message>
+    <message>
+        <source>Feeler</source>
+        <extracomment>Short-lived peer connection type that tests the aliveness of known addresses.</extracomment>
+        <translation type="unfinished">触须</translation>
+    </message>
+    <message>
+        <source>Address Fetch</source>
+        <extracomment>Short-lived peer connection type that solicits known addresses from a peer.</extracomment>
+        <translation type="unfinished">地址取回</translation>
+    </message>
+    <message>
+        <source>%1 d</source>
+        <translation type="unfinished">%1 天</translation>
+    </message>
+    <message>
+        <source>%1 h</source>
+        <translation type="unfinished">%1 小时</translation>
+    </message>
+    <message>
+        <source>%1 m</source>
+        <translation type="unfinished">%1 分钟</translation>
+    </message>
+    <message>
+        <source>%1 s</source>
+        <translation type="unfinished">%1 秒</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished">无</translation>
+    </message>
+    <message>
+        <source>N/A</source>
+        <translation type="unfinished">不可用</translation>
+    </message>
+    <message>
+        <source>%1 ms</source>
+        <translation type="unfinished">%1 毫秒</translation>
+    </message>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n秒</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n minute(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n分钟</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n 小时</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n 天</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n 周</numerusform>
         </translation>
+    </message>
+    <message>
+        <source>%1 and %2</source>
+        <translation type="unfinished">%1 和 %2</translation>
     </message>
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n年</numerusform>
         </translation>
+    </message>
+    <message>
+        <source>%1 B</source>
+        <translation type="unfinished">%1 字节</translation>
     </message>
     </context>
 <context>
+    <name>bitcoin-core</name>
+    <message>
+        <source>Settings file could not be read</source>
+        <translation type="unfinished">无法读取设置文件</translation>
+    </message>
+    <message>
+        <source>Settings file could not be written</source>
+        <translation type="unfinished">无法写入设置文件</translation>
+    </message>
+    <message>
+        <source>The %s developers</source>
+        <translation type="unfinished">%s 开发者</translation>
+    </message>
+    <message>
+        <source>%s corrupt. Try using the wallet tool bitcoin-wallet to salvage or restoring a backup.</source>
+        <translation type="unfinished">%s损坏。请尝试用bitcoin-wallet钱包工具来对其进行急救。或者用一个备份进行还原。</translation>
+    </message>
+    <message>
+        <source>-maxtxfee is set very high! Fees this large could be paid on a single transaction.</source>
+        <translation type="unfinished">参数 -maxtxfee 被设置得非常高！即使是单笔交易也可能付出如此之大的手续费。</translation>
+    </message>
+    <message>
+        <source>Cannot downgrade wallet from version %i to version %i. Wallet version unchanged.</source>
+        <translation type="unfinished">无法把钱包版本从%i降级到%i。钱包版本未改变。</translation>
+    </message>
+    <message>
+        <source>Cannot obtain a lock on data directory %s. %s is probably already running.</source>
+        <translation type="unfinished">无法锁定数据目录 %s。%s 可能已经在运行。</translation>
+    </message>
+    <message>
+        <source>Cannot upgrade a non HD split wallet from version %i to version %i without upgrading to support pre-split keypool. Please use version %i or no version specified.</source>
+        <translation type="unfinished">无法在不支持“拆分前的密钥池”（pre split keypool）的情况下把“非拆分HD钱包”（non HD split wallet）从版本%i升级到%i。请使用版本号%i，或者压根不要指定版本号。</translation>
+    </message>
+    <message>
+        <source>Distributed under the MIT software license, see the accompanying file %s or %s</source>
+        <translation type="unfinished">在MIT协议下分发，参见附带的 %s 或 %s 文件</translation>
+    </message>
+    <message>
+        <source>Error reading %s! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
+        <translation type="unfinished">读取 %s 时发生错误！所有的密钥都可以正确读取，但是交易记录或地址簿数据可能已经丢失或出错。</translation>
+    </message>
+    <message>
+        <source>Error reading %s! Transaction data may be missing or incorrect. Rescanning wallet.</source>
+        <translation type="unfinished">读取%s出错！交易数据可能丢失或有误。重新扫描钱包中。</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile format record is incorrect. Got "%s", expected "format".</source>
+        <translation type="unfinished">错误: 转储文件格式不正确。得到是"%s"，而预期本应得到的是 "format"。</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile identifier record is incorrect. Got "%s", expected "%s".</source>
+        <translation type="unfinished">错误: 转储文件标识符记录不正确。得到的是 "%s"，而预期本应得到的是 "%s"。</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile version is not supported. This version of bitcoin-wallet only supports version 1 dumpfiles. Got dumpfile with version %s</source>
+        <translation type="unfinished">错误: 转储文件版本不被支持。这个版本的 bitcoin-wallet 只支持版本为 1 的转储文件。得到的转储文件版本却是%s</translation>
+    </message>
+    <message>
+        <source>Error: Legacy wallets only support the "legacy", "p2sh-segwit", and "bech32" address types</source>
+        <translation type="unfinished">错误: 传统钱包只支持 "legacy", "p2sh-segwit", 和 "bech32" 这三种地址类型</translation>
+    </message>
+    <message>
+        <source>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.</source>
+        <translation type="unfinished">手续费估计失败。而且备用手续费估计（fallbackfee）已被禁用。请再等一些区块，或者通过-fallbackfee参数启用备用手续费估计。</translation>
+    </message>
+    <message>
+        <source>File %s already exists. If you are sure this is what you want, move it out of the way first.</source>
+        <translation type="unfinished">文件%s已经存在。如果你确定这就是你想做的，先把这个文件挪开。</translation>
+    </message>
+    <message>
+        <source>Invalid amount for -maxtxfee=&lt;amount&gt;: '%s' (must be at least the minrelay fee of %s to prevent stuck transactions)</source>
+        <translation type="unfinished">参数 -maxtxfee=&lt;amount&gt;: '%s' 指定了非法的金额 (手续费必须至少达到最小转发费率(minrelay fee) %s 以避免交易卡着发不出去)</translation>
+    </message>
+    <message>
+        <source>Invalid or corrupt peers.dat (%s). If you believe this is a bug, please report it to %s. As a workaround, you can move the file (%s) out of the way (rename, move, or delete) to have a new one created on the next start.</source>
+        <translation type="unfinished">无效或损坏的peers.dat (%s)。如果你确信这是一个bug，请反馈到%s。作为变通办法，你可以把现有文件 (%s) 移开(重命名、移动或删除)，这样就可以在下次启动时创建一个新文件了。</translation>
+    </message>
+    <message>
+        <source>More than one onion bind address is provided. Using %s for the automatically created Tor onion service.</source>
+        <translation type="unfinished">提供多个洋葱路由绑定地址。对自动创建的洋葱服务用%s</translation>
+    </message>
+    <message>
+        <source>No dump file provided. To use createfromdump, -dumpfile=&lt;filename&gt; must be provided.</source>
+        <translation type="unfinished">没有提供转储文件。要使用 createfromdump ，必须提供 -dumpfile=&lt;filename&gt;。</translation>
+    </message>
+    <message>
+        <source>No dump file provided. To use dump, -dumpfile=&lt;filename&gt; must be provided.</source>
+        <translation type="unfinished">没有提供转储文件。要使用 dump ，必须提供 -dumpfile=&lt;filename&gt;。</translation>
+    </message>
+    <message>
+        <source>No wallet file format provided. To use createfromdump, -format=&lt;format&gt; must be provided.</source>
+        <translation type="unfinished">没有提供钱包格式。要使用 createfromdump ，必须提供 -format=&lt;format&gt;</translation>
+    </message>
+    <message>
+        <source>Please check that your computer's date and time are correct! If your clock is wrong, %s will not work properly.</source>
+        <translation type="unfinished">请检查电脑的日期时间设置是否正确！时间错误可能会导致 %s 运行异常。</translation>
+    </message>
+    <message>
+        <source>Please contribute if you find %s useful. Visit %s for further information about the software.</source>
+        <translation type="unfinished">如果你认为%s对你比较有用的话，请对我们进行一些自愿贡献。请访问%s网站来获取有关这个软件的更多信息。</translation>
+    </message>
+    <message>
+        <source>Prune configured below the minimum of %d MiB.  Please use a higher number.</source>
+        <translation type="unfinished">修剪被设置得太小，已经低于最小值%d MiB，请使用更大的数值。</translation>
+    </message>
+    <message>
+        <source>Prune mode is incompatible with -reindex-chainstate. Use full -reindex instead.</source>
+        <translation type="unfinished">修剪模式与 -reindex-chainstate 不兼容。请进行一次完整的 -reindex 。</translation>
+    </message>
+    <message>
+        <source>Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of pruned node)</source>
+        <translation type="unfinished">修剪:上次同步钱包的位置已经超出（落后于）现有修剪后数据的范围。你需要进行-reindex（对于已经启用修剪节点，就需要重新下载整个区块链）</translation>
+    </message>
+    <message>
+        <source>SQLiteDatabase: Unknown sqlite wallet schema version %d. Only version %d is supported</source>
+        <translation type="unfinished">SQLiteDatabase: SQLite钱包schema版本%d未知。只支持%d版本</translation>
+    </message>
+    <message>
+        <source>The block database contains a block which appears to be from the future. This may be due to your computer's date and time being set incorrectly. Only rebuild the block database if you are sure that your computer's date and time are correct</source>
+        <translation type="unfinished">区块数据库包含未来的交易，这可能是由本机错误的日期时间引起。若确认本机日期时间正确，请重新建立区块数据库。</translation>
+    </message>
+    <message>
+        <source>The block index db contains a legacy 'txindex'. To clear the occupied disk space, run a full -reindex, otherwise ignore this error. This error message will not be displayed again.</source>
+        <translation type="unfinished">区块索引数据库含有历史遗留的 'txindex' 。可以运行完整的 -reindex 来清理被占用的磁盘空间；也可以忽略这个错误。这个错误消息将不会再次显示。</translation>
+    </message>
+    <message>
+        <source>The transaction amount is too small to send after the fee has been deducted</source>
+        <translation type="unfinished">这笔交易在扣除手续费后的金额太小，以至于无法送出</translation>
+    </message>
+    <message>
+        <source>This error could occur if this wallet was not shutdown cleanly and was last loaded using a build with a newer version of Berkeley DB. If so, please use the software that last loaded this wallet</source>
+        <translation type="unfinished">如果这个钱包之前没有正确关闭，而且上一次是被新版的Berkeley DB加载过，就会发生这个错误。如果是这样，请使用上次加载过这个钱包的那个软件。</translation>
+    </message>
+    <message>
+        <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
+        <translation type="unfinished">这是测试用的预发布版本 - 请谨慎使用 - 不要用来挖矿，或者在正式商用环境下使用</translation>
+    </message>
+    <message>
+        <source>This is the maximum transaction fee you pay (in addition to the normal fee) to prioritize partial spend avoidance over regular coin selection.</source>
+        <translation type="unfinished">为了在常规选币过程中优先考虑避免“只花出一个地址上的一部分币”（partial spend）这种情况，您最多还需要（在常规手续费之外）付出的交易手续费。</translation>
+    </message>
+    <message>
+        <source>This is the transaction fee you may discard if change is smaller than dust at this level</source>
+        <translation type="unfinished">找零低于当前粉尘阈值时会被舍弃，并计入手续费，这些交易手续费就是在这种情况下产生的。</translation>
+    </message>
+    <message>
+        <source>This is the transaction fee you may pay when fee estimates are not available.</source>
+        <translation type="unfinished">不能估计手续费时，你会付出这个手续费金额。</translation>
+    </message>
+    <message>
+        <source>Total length of network version string (%i) exceeds maximum length (%i). Reduce the number or size of uacomments.</source>
+        <translation type="unfinished">网络版本字符串的总长度 (%i) 超过最大长度 (%i) 了。请减少 uacomment 参数的数目或长度。</translation>
+    </message>
+    <message>
+        <source>Unable to replay blocks. You will need to rebuild the database using -reindex-chainstate.</source>
+        <translation type="unfinished">无法重放区块。你需要先用-reindex-chainstate参数来重建数据库。</translation>
+    </message>
+    <message>
+        <source>Unknown wallet file format "%s" provided. Please provide one of "bdb" or "sqlite".</source>
+        <translation type="unfinished">提供了未知的钱包格式 "%s" 。请使用 "bdb" 或 "sqlite" 中的一种。</translation>
+    </message>
+    <message>
+        <source>Unsupported chainstate database format found. Please restart with -reindex-chainstate. This will rebuild the chainstate database.</source>
+        <translation type="unfinished">找到了不受支持的 chainstate 数据库格式。请使用 -reindex-chainstate 参数重启。这将会重建 chainstate 数据库。</translation>
+    </message>
+    <message>
+        <source>Wallet created successfully. The legacy wallet type is being deprecated and support for creating and opening legacy wallets will be removed in the future.</source>
+        <translation type="unfinished">钱包创建成功。旧式钱包已被弃用，未来将不再支持创建或打开旧式钱包。</translation>
+    </message>
+    <message>
+        <source>Warning: Dumpfile wallet format "%s" does not match command line specified format "%s".</source>
+        <translation type="unfinished">警告: 转储文件的钱包格式 "%s" 与命令行指定的格式 "%s" 不符。</translation>
+    </message>
+    <message>
+        <source>Warning: Private keys detected in wallet {%s} with disabled private keys</source>
+        <translation type="unfinished">警告：在已经禁用私钥的钱包 {%s} 中仍然检测到私钥</translation>
+    </message>
+    <message>
+        <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
+        <translation type="unfinished">警告：我们和其他节点似乎没达成共识！您可能需要升级，或者就是其他节点可能需要升级。</translation>
+    </message>
+    <message>
+        <source>Witness data for blocks after height %d requires validation. Please restart with -reindex.</source>
+        <translation type="unfinished">需要验证高度在%d之后的区块见证数据。请使用 -reindex 重新启动。</translation>
+    </message>
+    <message>
+        <source>You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain</source>
+        <translation type="unfinished">您需要使用 -reindex 重新构建数据库以回到未修剪模式。这将重新下载整个区块链</translation>
+    </message>
+    <message>
+        <source>%s is set very high!</source>
+        <translation type="unfinished">%s非常高！</translation>
+    </message>
+    <message>
+        <source>-maxmempool must be at least %d MB</source>
+        <translation type="unfinished">-maxmempool 最小为%d MB</translation>
+    </message>
+    <message>
+        <source>A fatal internal error occurred, see debug.log for details</source>
+        <translation type="unfinished">发生了致命的内部错误，请在debug.log中查看详情</translation>
+    </message>
+    <message>
+        <source>Cannot resolve -%s address: '%s'</source>
+        <translation type="unfinished">无法解析 - %s 地址: '%s'</translation>
+    </message>
+    <message>
+        <source>Cannot set -forcednsseed to true when setting -dnsseed to false.</source>
+        <translation type="unfinished">在 -dnsseed 被设为 false 时无法将 -forcednsseed 设为 true 。</translation>
+    </message>
+    <message>
+        <source>Cannot set -peerblockfilters without -blockfilterindex.</source>
+        <translation type="unfinished">没有启用-blockfilterindex，就不能启用-peerblockfilters。</translation>
+    </message>
+    <message>
+        <source>Cannot write to data directory '%s'; check permissions.</source>
+        <translation type="unfinished">不能写入到数据目录'%s'；请检查文件权限。</translation>
+    </message>
+    <message>
+        <source>The -txindex upgrade started by a previous version cannot be completed. Restart with the previous version or run a full -reindex.</source>
+        <translation type="unfinished">无法完成由之前版本启动的 -txindex 升级。请用之前的版本重新启动，或者进行一次完整的 -reindex 。</translation>
+    </message>
+    <message>
+        <source>%s request to listen on port %u. This port is considered "bad" and thus it is unlikely that any Bitcoin Core peers connect to it. See doc/p2p-bad-ports.md for details and a full list.</source>
+        <translation type="unfinished">%s请求监听端口 %u。这个端口被认为是“坏的”，所以不太可能有Bitcoin Core节点会连接到它。有关详细信息和完整列表，请参见 doc/p2p-bad-ports.md 。</translation>
+    </message>
+    <message>
+        <source>-reindex-chainstate option is not compatible with -blockfilterindex. Please temporarily disable blockfilterindex while using -reindex-chainstate, or replace -reindex-chainstate with -reindex to fully rebuild all indexes.</source>
+        <translation type="unfinished">-reindex-chainstate 与 -blockfilterindex 不兼容。请在进行 -reindex-chainstate 时临时禁用 blockfilterindex ，或者改用 -reindex （而不是 -reindex-chainstate ）来完整地重建所有索引。</translation>
+    </message>
+    <message>
+        <source>-reindex-chainstate option is not compatible with -coinstatsindex. Please temporarily disable coinstatsindex while using -reindex-chainstate, or replace -reindex-chainstate with -reindex to fully rebuild all indexes.</source>
+        <translation type="unfinished">-reindex-chainstate 与 -coinstatsindex 不兼容。请在进行  -reindex-chainstate 时临时禁用 coinstatsindex ，或者改用 -reindex （而不是 -reindex-chainstate ）来完整地重建所有索引。</translation>
+    </message>
+    <message>
+        <source>-reindex-chainstate option is not compatible with -txindex. Please temporarily disable txindex while using -reindex-chainstate, or replace -reindex-chainstate with -reindex to fully rebuild all indexes.</source>
+        <translation type="unfinished">-reindex-chainstate 与 -txindex 不兼容。请在进行 -reindex-chainstate 时临时禁用 txindex ，或者改用 -reindex （而不是 -reindex-chainstate ）来完整地重建所有索引。</translation>
+    </message>
+    <message>
+        <source>Assumed-valid: last wallet synchronisation goes beyond available block data. You need to wait for the background validation chain to download more blocks.</source>
+        <translation type="unfinished">假定有效（assume-valid）: 上次同步钱包时进度越过了现有的区块数据。你需要等待后台验证链下载更多的区块。</translation>
+    </message>
+    <message>
+        <source>Cannot provide specific connections and have addrman find outgoing connections at the same time.</source>
+        <translation type="unfinished">在使用地址管理器(addrman)寻找出站连接时，无法同时提供特定的连接。</translation>
+    </message>
+    <message>
+        <source>Error loading %s: External signer wallet being loaded without external signer support compiled</source>
+        <translation type="unfinished">加载%s时出错: 编译时未启用外部签名器支持，却仍然试图加载外部签名器钱包</translation>
+    </message>
+    <message>
+        <source>Error: Address book data in wallet cannot be identified to belong to migrated wallets</source>
+        <translation type="unfinished">错误：钱包中的地址簿数据无法被识别为属于迁移后的钱包</translation>
+    </message>
+    <message>
+        <source>Error: Duplicate descriptors created during migration. Your wallet may be corrupted.</source>
+        <translation type="unfinished">错误：迁移过程中创建了重复的输出描述符。你的钱包可能已损坏。</translation>
+    </message>
+    <message>
+        <source>Error: Transaction %s in wallet cannot be identified to belong to migrated wallets</source>
+        <translation type="unfinished">错误：钱包中的交易%s无法被识别为属于迁移后的钱包</translation>
+    </message>
+    <message>
+        <source>Error: Unable to produce descriptors for this legacy wallet. Make sure the wallet is unlocked first</source>
+        <translation type="unfinished">错误：无法为这个遗留钱包生成输出描述符。请先确定钱包已被解锁</translation>
+    </message>
+    <message>
+        <source>Failed to rename invalid peers.dat file. Please move or delete it and try again.</source>
+        <translation type="unfinished">无法重命名无效的 peers.dat 文件。 请移动或删除它，然后重试。</translation>
+    </message>
+    <message>
+        <source>Incompatible options: -dnsseed=1 was explicitly specified, but -onlynet forbids connections to IPv4/IPv6</source>
+        <translation type="unfinished">互不兼容的选项：-dnsseed=1 已被显式指定，但 -onlynet 禁止了IPv4/IPv6 连接</translation>
+    </message>
+    <message>
+        <source>Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is explicitly forbidden: -onion=0</source>
+        <translation type="unfinished">出站连接被限制为仅使用 Tor (-onlynet=onion)，但是到达 Tor 网络的代理被显式禁止： -onion=0</translation>
+    </message>
+    <message>
+        <source>Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is not provided: none of -proxy, -onion or -listenonion is given</source>
+        <translation type="unfinished">出站连接被限制为仅使用 Tor (-onlynet=onion)，但是未提供到达 Tor 网络的代理：没有提供 -proxy=, -onion= 或 -listenonion 参数</translation>
+    </message>
+    <message>
+        <source>Unrecognized descriptor found. Loading wallet %s
+
+The wallet might had been created on a newer version.
+Please try running the latest software version.
+</source>
+        <translation type="unfinished">找到无法识别的输出描述符。加载钱包%s
+
+钱包可能由新版软件创建，
+请尝试运行最新的软件版本。
+</translation>
+    </message>
+    <message>
+        <source>Unsupported category-specific logging level -loglevel=%s. Expected -loglevel=&lt;category&gt;:&lt;loglevel&gt;. Valid categories: %s. Valid loglevels: %s.</source>
+        <translation type="unfinished">不支持的类别限定日志等级 -loglevel=%s。预期参数 -loglevel=&lt;category&gt;:&lt;loglevel&gt;. Valid categories: %s。有效的类别： %s。</translation>
+    </message>
+    <message>
+        <source>
+Unable to cleanup failed migration</source>
+        <translation type="unfinished">
+无法清理失败的迁移</translation>
+    </message>
+    <message>
+        <source>
+Unable to restore backup of wallet.</source>
+        <translation type="unfinished">
+无法还原钱包备份</translation>
+    </message>
+    <message>
+        <source>Config setting for %s only applied on %s network when in [%s] section.</source>
+        <translation type="unfinished">对 %s 的配置设置只对 %s 网络生效，如果它位于配置的 [%s] 章节的话。</translation>
+    </message>
+    <message>
+        <source>Copyright (C) %i-%i</source>
+        <translation type="unfinished">版权所有 (C) %i-%i</translation>
+    </message>
+    <message>
+        <source>Corrupted block database detected</source>
+        <translation type="unfinished">检测到区块数据库损坏</translation>
+    </message>
+    <message>
+        <source>Could not find asmap file %s</source>
+        <translation type="unfinished">找不到asmap文件%s</translation>
+    </message>
+    <message>
+        <source>Could not parse asmap file %s</source>
+        <translation type="unfinished">无法解析asmap文件%s</translation>
+    </message>
+    <message>
+        <source>Disk space is too low!</source>
+        <translation type="unfinished">磁盘空间太低!</translation>
+    </message>
+    <message>
+        <source>Do you want to rebuild the block database now?</source>
+        <translation type="unfinished">你想现在就重建区块数据库吗？</translation>
+    </message>
+    <message>
+        <source>Done loading</source>
+        <translation type="unfinished">加载完成</translation>
+    </message>
+    <message>
+        <source>Dump file %s does not exist.</source>
+        <translation type="unfinished">转储文件 %s 不存在</translation>
+    </message>
+    <message>
+        <source>Error creating %s</source>
+        <translation type="unfinished">创建%s时出错</translation>
+    </message>
+    <message>
+        <source>Error initializing block database</source>
+        <translation type="unfinished">初始化区块数据库时出错</translation>
+    </message>
+    <message>
+        <source>Error initializing wallet database environment %s!</source>
+        <translation type="unfinished">初始化钱包数据库环境错误 %s!</translation>
+    </message>
+    <message>
+        <source>Error loading %s</source>
+        <translation type="unfinished">载入 %s 时发生错误</translation>
+    </message>
+    <message>
+        <source>Error loading %s: Private keys can only be disabled during creation</source>
+        <translation type="unfinished">加载 %s 时出错：只能在创建钱包时禁用私钥。</translation>
+    </message>
+    <message>
+        <source>Error loading %s: Wallet corrupted</source>
+        <translation type="unfinished">%s 加载出错:钱包损坏</translation>
+    </message>
+    <message>
+        <source>Error loading %s: Wallet requires newer version of %s</source>
+        <translation type="unfinished">%s 加载错误:请升级到最新版 %s</translation>
+    </message>
+    <message>
+        <source>Error loading block database</source>
+        <translation type="unfinished">加载区块数据库时出错</translation>
+    </message>
+    <message>
+        <source>Error opening block database</source>
+        <translation type="unfinished">打开区块数据库时出错</translation>
+    </message>
+    <message>
+        <source>Error reading from database, shutting down.</source>
+        <translation type="unfinished">读取数据库出错，关闭中。</translation>
+    </message>
+    <message>
+        <source>Error reading next record from wallet database</source>
+        <translation type="unfinished">从钱包数据库读取下一条记录时出错</translation>
+    </message>
+    <message>
+        <source>Error: Could not add watchonly tx to watchonly wallet</source>
+        <translation type="unfinished">错误：无法添加仅观察交易至仅观察钱包</translation>
+    </message>
+    <message>
+        <source>Error: Could not delete watchonly transactions</source>
+        <translation type="unfinished">错误：无法删除仅观察交易</translation>
+    </message>
+    <message>
+        <source>Error: Couldn't create cursor into database</source>
+        <translation type="unfinished">错误: 无法在数据库中创建指针</translation>
+    </message>
+    <message>
+        <source>Error: Disk space is low for %s</source>
+        <translation type="unfinished">错误： %s 所在的磁盘空间低。</translation>
+    </message>
+    <message>
+        <source>Error: Dumpfile checksum does not match. Computed %s, expected %s</source>
+        <translation type="unfinished">错误: 转储文件的校验和不符。计算得到%s，预料中本应该得到%s</translation>
+    </message>
+    <message>
+        <source>Error: Failed to create new watchonly wallet</source>
+        <translation type="unfinished">错误：创建新仅观察钱包失败</translation>
+    </message>
+    <message>
+        <source>Error: Got key that was not hex: %s</source>
+        <translation type="unfinished">错误: 得到了不是十六进制的键:%s</translation>
+    </message>
+    <message>
+        <source>Error: Got value that was not hex: %s</source>
+        <translation type="unfinished">错误: 得到了不是十六进制的数值:%s</translation>
+    </message>
+    <message>
+        <source>Error: Keypool ran out, please call keypoolrefill first</source>
+        <translation type="unfinished">错误: 密钥池已被耗尽，请先调用keypoolrefill</translation>
+    </message>
+    <message>
+        <source>Error: Missing checksum</source>
+        <translation type="unfinished">错误：跳过检查检验和</translation>
+    </message>
+    <message>
+        <source>Error: No %s addresses available.</source>
+        <translation type="unfinished">错误: 没有可用的%s地址。</translation>
+    </message>
+    <message>
+        <source>Error: Not all watchonly txs could be deleted</source>
+        <translation type="unfinished">错误：有些仅观察交易无法被删除</translation>
+    </message>
+    <message>
+        <source>Error: This wallet already uses SQLite</source>
+        <translation type="unfinished">错误：此钱包已经在使用SQLite</translation>
+    </message>
+    <message>
+        <source>Error: This wallet is already a descriptor wallet</source>
+        <translation type="unfinished">错误：这个钱包已经是输出描述符钱包</translation>
+    </message>
+    <message>
+        <source>Error: Unable to begin reading all records in the database</source>
+        <translation type="unfinished">错误：无法开始读取这个数据库中的所有记录</translation>
+    </message>
+    <message>
+        <source>Error: Unable to make a backup of your wallet</source>
+        <translation type="unfinished">错误：无法为你的钱包创建备份</translation>
+    </message>
+    <message>
+        <source>Error: Unable to parse version %u as a uint32_t</source>
+        <translation type="unfinished">错误：无法把版本号%u作为unit32_t解析</translation>
+    </message>
+    <message>
+        <source>Error: Unable to read all records in the database</source>
+        <translation type="unfinished">错误：无法读取这个数据库中的所有记录</translation>
+    </message>
+    <message>
+        <source>Error: Unable to remove watchonly address book data</source>
+        <translation type="unfinished">错误：无法移除仅观察地址簿数据</translation>
+    </message>
+    <message>
+        <source>Error: Unable to write record to new wallet</source>
+        <translation type="unfinished">错误: 无法写入记录到新钱包</translation>
+    </message>
+    <message>
+        <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
+        <translation type="unfinished">监听端口失败。如果你愿意的话，请使用 -listen=0 参数。</translation>
+    </message>
+    <message>
+        <source>Failed to rescan the wallet during initialization</source>
+        <translation type="unfinished">初始化时重扫描钱包失败</translation>
+    </message>
+    <message>
+        <source>Failed to verify database</source>
+        <translation type="unfinished">校验数据库失败</translation>
+    </message>
+    <message>
+        <source>Fee rate (%s) is lower than the minimum fee rate setting (%s)</source>
+        <translation type="unfinished">手续费率 (%s) 低于最大手续费率设置 (%s)</translation>
+    </message>
+    <message>
+        <source>Ignoring duplicate -wallet %s.</source>
+        <translation type="unfinished">忽略重复的 -wallet %s。</translation>
+    </message>
+    <message>
+        <source>Importing…</source>
+        <translation type="unfinished">导入...</translation>
+    </message>
+    <message>
+        <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
+        <translation type="unfinished">没有找到创世区块，或者创世区块不正确。是否把数据目录错误地设成了另一个网络（比如测试网络）的？</translation>
+    </message>
+    <message>
+        <source>Initialization sanity check failed. %s is shutting down.</source>
+        <translation type="unfinished">初始化完整性检查失败。%s 即将关闭。</translation>
+    </message>
+    <message>
+        <source>Input not found or already spent</source>
+        <translation type="unfinished">找不到交易输入项，可能已经被花掉了</translation>
+    </message>
+    <message>
+        <source>Insufficient funds</source>
+        <translation type="unfinished">金额不足</translation>
+    </message>
+    <message>
+        <source>Invalid -i2psam address or hostname: '%s'</source>
+        <translation type="unfinished">无效的 -i2psam 地址或主机名: '%s'</translation>
+    </message>
+    <message>
+        <source>Invalid -onion address or hostname: '%s'</source>
+        <translation type="unfinished">无效的 -onion 地址: '%s'</translation>
+    </message>
+    <message>
+        <source>Invalid -proxy address or hostname: '%s'</source>
+        <translation type="unfinished">无效的 -proxy 地址或主机名: '%s'</translation>
+    </message>
+    <message>
+        <source>Invalid P2P permission: '%s'</source>
+        <translation type="unfinished">无效的 P2P 权限：'%s'</translation>
+    </message>
+    <message>
+        <source>Invalid amount for -%s=&lt;amount&gt;: '%s'</source>
+        <translation type="unfinished">参数 -%s=&lt;amount&gt;: '%s' 指定了无效的金额</translation>
+    </message>
+    <message>
+        <source>Invalid amount for -discardfee=&lt;amount&gt;: '%s'</source>
+        <translation type="unfinished">参数 -discardfee=&lt;amount&gt;: '%s' 指定了无效的金额</translation>
+    </message>
+    <message>
+        <source>Invalid amount for -fallbackfee=&lt;amount&gt;: '%s'</source>
+        <translation type="unfinished">参数 -fallbackfee=&lt;amount&gt;: '%s' 指定了无效的金额</translation>
+    </message>
+    <message>
+        <source>Invalid amount for -paytxfee=&lt;amount&gt;: '%s' (must be at least %s)</source>
+        <translation type="unfinished">参数 -paytxfee=&lt;amount&gt; 指定了非法的金额: '%s' (必须至少达到 %s)</translation>
+    </message>
+    <message>
+        <source>Invalid netmask specified in -whitelist: '%s'</source>
+        <translation type="unfinished">参数 -whitelist: '%s' 指定了无效的网络掩码</translation>
+    </message>
+    <message>
+        <source>Listening for incoming connections failed (listen returned error %s)</source>
+        <translation type="unfinished">监听外部连接失败 (listen函数返回了错误 %s)</translation>
+    </message>
+    <message>
+        <source>Loading P2P addresses…</source>
+        <translation type="unfinished">加载P2P地址...</translation>
+    </message>
+    <message>
+        <source>Loading banlist…</source>
+        <translation type="unfinished">加载封禁列表...</translation>
+    </message>
+    <message>
+        <source>Loading block index…</source>
+        <translation type="unfinished">加载区块索引...</translation>
+    </message>
+    <message>
+        <source>Loading wallet…</source>
+        <translation type="unfinished">加载钱包...</translation>
+    </message>
+    <message>
+        <source>Missing amount</source>
+        <translation type="unfinished">找不到金额</translation>
+    </message>
+    <message>
+        <source>Missing solving data for estimating transaction size</source>
+        <translation type="unfinished">找不到用于估计交易大小的解答数据</translation>
+    </message>
+    <message>
+        <source>Need to specify a port with -whitebind: '%s'</source>
+        <translation type="unfinished">-whitebind: '%s' 需要指定一个端口</translation>
+    </message>
+    <message>
+        <source>No addresses available</source>
+        <translation type="unfinished">没有可用的地址</translation>
+    </message>
+    <message>
+        <source>Not enough file descriptors available.</source>
+        <translation type="unfinished">没有足够的文件描述符可用。</translation>
+    </message>
+    <message>
+        <source>Prune cannot be configured with a negative value.</source>
+        <translation type="unfinished">不能把修剪配置成一个负数。</translation>
+    </message>
+    <message>
+        <source>Prune mode is incompatible with -txindex.</source>
+        <translation type="unfinished">修剪模式与 -txindex 不兼容。</translation>
+    </message>
+    <message>
+        <source>Pruning blockstore…</source>
+        <translation type="unfinished">修剪区块存储...</translation>
+    </message>
+    <message>
+        <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
+        <translation type="unfinished">因为系统的限制，将 -maxconnections 参数从 %d 降到了 %d</translation>
+    </message>
+    <message>
+        <source>Replaying blocks…</source>
+        <translation type="unfinished">重放区块...</translation>
+    </message>
+    <message>
+        <source>Rescanning…</source>
+        <translation type="unfinished">重扫描...</translation>
+    </message>
+    <message>
+        <source>SQLiteDatabase: Failed to execute statement to verify database: %s</source>
+        <translation type="unfinished">SQLiteDatabase: 执行校验数据库语句时失败: %s</translation>
+    </message>
+    <message>
+        <source>SQLiteDatabase: Failed to prepare statement to verify database: %s</source>
+        <translation type="unfinished">SQLiteDatabase: 预处理用于校验数据库的语句时失败: %s</translation>
+    </message>
+    <message>
+        <source>SQLiteDatabase: Failed to read database verification error: %s</source>
+        <translation type="unfinished">SQLiteDatabase: 读取数据库失败，校验错误: %s</translation>
+    </message>
+    <message>
+        <source>SQLiteDatabase: Unexpected application id. Expected %u, got %u</source>
+        <translation type="unfinished">SQLiteDatabase: 意料之外的应用ID。预期为%u，实际为%u</translation>
+    </message>
+    <message>
+        <source>Section [%s] is not recognized.</source>
+        <translation type="unfinished">无法识别配置章节 [%s]。</translation>
+    </message>
+    <message>
+        <source>Signing transaction failed</source>
+        <translation type="unfinished">签名交易失败</translation>
+    </message>
+    <message>
+        <source>Specified -walletdir "%s" does not exist</source>
+        <translation type="unfinished">参数 -walletdir "%s" 指定了不存在的路径</translation>
+    </message>
+    <message>
+        <source>Specified -walletdir "%s" is a relative path</source>
+        <translation type="unfinished">参数 -walletdir "%s" 指定了相对路径</translation>
+    </message>
+    <message>
+        <source>Specified -walletdir "%s" is not a directory</source>
+        <translation type="unfinished">参数 -walletdir "%s" 指定的路径不是目录</translation>
+    </message>
+    <message>
+        <source>Specified blocks directory "%s" does not exist.</source>
+        <translation type="unfinished">指定的区块目录"%s"不存在。</translation>
+    </message>
+    <message>
+        <source>Starting network threads…</source>
+        <translation type="unfinished">启动网络线程...</translation>
+    </message>
+    <message>
+        <source>The source code is available from %s.</source>
+        <translation type="unfinished">可以从 %s 获取源代码。</translation>
+    </message>
+    <message>
+        <source>The specified config file %s does not exist</source>
+        <translation type="unfinished">指定的配置文件%s不存在</translation>
+    </message>
+    <message>
+        <source>The transaction amount is too small to pay the fee</source>
+        <translation type="unfinished">交易金额太小，不足以支付交易费</translation>
+    </message>
+    <message>
+        <source>The wallet will avoid paying less than the minimum relay fee.</source>
+        <translation type="unfinished">钱包会避免让手续费低于最小转发费率(minrelay fee)。</translation>
+    </message>
+    <message>
+        <source>This is experimental software.</source>
+        <translation type="unfinished">这是实验性的软件。</translation>
+    </message>
+    <message>
+        <source>This is the minimum transaction fee you pay on every transaction.</source>
+        <translation type="unfinished">这是你每次交易付款时最少要付的手续费。</translation>
+    </message>
+    <message>
+        <source>This is the transaction fee you will pay if you send a transaction.</source>
+        <translation type="unfinished">如果发送交易，这将是你要支付的手续费。</translation>
+    </message>
+    <message>
+        <source>Transaction amount too small</source>
+        <translation type="unfinished">交易金额太小</translation>
+    </message>
+    <message>
+        <source>Transaction amounts must not be negative</source>
+        <translation type="unfinished">交易金额不不可为负数</translation>
+    </message>
+    <message>
+        <source>Transaction change output index out of range</source>
+        <translation type="unfinished">交易找零输出项编号超出范围</translation>
+    </message>
+    <message>
+        <source>Transaction has too long of a mempool chain</source>
+        <translation type="unfinished">此交易在内存池中的存在过长的链条</translation>
+    </message>
+    <message>
+        <source>Transaction must have at least one recipient</source>
+        <translation type="unfinished">交易必须包含至少一个收款人</translation>
+    </message>
+    <message>
+        <source>Transaction needs a change address, but we can't generate it.</source>
+        <translation type="unfinished">交易需要一个找零地址，但是我们无法生成它。</translation>
+    </message>
+    <message>
+        <source>Transaction too large</source>
+        <translation type="unfinished">交易过大</translation>
+    </message>
+    <message>
+        <source>Unable to allocate memory for -maxsigcachesize: '%s' MiB</source>
+        <translation type="unfinished">无法为 -maxsigcachesize: '%s' MiB 分配内存</translation>
+    </message>
+    <message>
+        <source>Unable to bind to %s on this computer (bind returned error %s)</source>
+        <translation type="unfinished">无法在本机绑定%s端口 (bind函数返回了错误 %s)</translation>
+    </message>
+    <message>
+        <source>Unable to bind to %s on this computer. %s is probably already running.</source>
+        <translation type="unfinished">无法在本机绑定 %s 端口。%s 可能已经在运行。</translation>
+    </message>
+    <message>
+        <source>Unable to create the PID file '%s': %s</source>
+        <translation type="unfinished">无法创建PID文件'%s': %s</translation>
+    </message>
+    <message>
+        <source>Unable to find UTXO for external input</source>
+        <translation type="unfinished">无法为外部输入找到UTXO</translation>
+    </message>
+    <message>
+        <source>Unable to generate initial keys</source>
+        <translation type="unfinished">无法生成初始密钥</translation>
+    </message>
+    <message>
+        <source>Unable to generate keys</source>
+        <translation type="unfinished">无法生成密钥</translation>
+    </message>
+    <message>
+        <source>Unable to open %s for writing</source>
+        <translation type="unfinished">无法打开%s用于写入</translation>
+    </message>
+    <message>
+        <source>Unable to parse -maxuploadtarget: '%s'</source>
+        <translation type="unfinished">无法解析 -maxuploadtarget: '%s'</translation>
+    </message>
+    <message>
+        <source>Unable to start HTTP server. See debug log for details.</source>
+        <translation type="unfinished">无法启动HTTP服务，查看日志获取更多信息</translation>
+    </message>
+    <message>
+        <source>Unable to unload the wallet before migrating</source>
+        <translation type="unfinished">在迁移前无法卸载钱包</translation>
+    </message>
+    <message>
+        <source>Unknown -blockfilterindex value %s.</source>
+        <translation type="unfinished">未知的 -blockfilterindex 数值 %s。</translation>
+    </message>
+    <message>
+        <source>Unknown address type '%s'</source>
+        <translation type="unfinished">未知的地址类型 '%s'</translation>
+    </message>
+    <message>
+        <source>Unknown change type '%s'</source>
+        <translation type="unfinished">未知的找零类型 '%s'</translation>
+    </message>
+    <message>
+        <source>Unknown network specified in -onlynet: '%s'</source>
+        <translation type="unfinished">-onlynet 指定的是未知网络: %s</translation>
+    </message>
+    <message>
+        <source>Unknown new rules activated (versionbit %i)</source>
+        <translation type="unfinished">不明的交易规则已经激活 (versionbit %i)</translation>
+    </message>
+    <message>
+        <source>Unsupported global logging level -loglevel=%s. Valid values: %s.</source>
+        <translation type="unfinished">不支持的全局日志等级 -loglevel=%s 。有效的数值：%s 。</translation>
+    </message>
+    <message>
+        <source>Unsupported logging category %s=%s.</source>
+        <translation type="unfinished">不支持的日志分类 %s=%s。</translation>
+    </message>
+    <message>
+        <source>User Agent comment (%s) contains unsafe characters.</source>
+        <translation type="unfinished">用户代理备注(%s)包含不安全的字符。</translation>
+    </message>
+    <message>
+        <source>Verifying blocks…</source>
+        <translation type="unfinished">验证区块...</translation>
+    </message>
+    <message>
+        <source>Verifying wallet(s)…</source>
+        <translation type="unfinished">验证钱包...</translation>
+    </message>
+    <message>
+        <source>Wallet needed to be rewritten: restart %s to complete</source>
+        <translation type="unfinished">钱包需要被重写：请重新启动%s来完成</translation>
+    </message>
+</context>
+<context>
     <name>BitcoinGUI</name>
+    <message>
+        <source>&amp;Overview</source>
+        <translation type="unfinished">概况(&amp;O)</translation>
+    </message>
+    <message>
+        <source>Show general overview of wallet</source>
+        <translation type="unfinished">显示钱包概况</translation>
+    </message>
+    <message>
+        <source>&amp;Transactions</source>
+        <translation type="unfinished">交易记录(&amp;T)</translation>
+    </message>
+    <message>
+        <source>Browse transaction history</source>
+        <translation type="unfinished">浏览交易历史</translation>
+    </message>
+    <message>
+        <source>E&amp;xit</source>
+        <translation type="unfinished">退出(&amp;X)</translation>
+    </message>
+    <message>
+        <source>Quit application</source>
+        <translation type="unfinished">退出程序</translation>
+    </message>
+    <message>
+        <source>&amp;About %1</source>
+        <translation type="unfinished">关于 %1 (&amp;A)</translation>
+    </message>
+    <message>
+        <source>Show information about %1</source>
+        <translation type="unfinished">显示 %1 的相关信息</translation>
+    </message>
+    <message>
+        <source>About &amp;Qt</source>
+        <translation type="unfinished">关于 &amp;Qt</translation>
+    </message>
+    <message>
+        <source>Show information about Qt</source>
+        <translation type="unfinished">显示 Qt 相关信息</translation>
+    </message>
+    <message>
+        <source>Modify configuration options for %1</source>
+        <translation type="unfinished">修改%1的配置选项</translation>
+    </message>
+    <message>
+        <source>Create a new wallet</source>
+        <translation type="unfinished">创建一个新的钱包</translation>
+    </message>
+    <message>
+        <source>&amp;Minimize</source>
+        <translation type="unfinished">最小化(&amp;M)</translation>
+    </message>
+    <message>
+        <source>Wallet:</source>
+        <translation type="unfinished">钱包:</translation>
+    </message>
+    <message>
+        <source>Network activity disabled.</source>
+        <extracomment>A substring of the tooltip.</extracomment>
+        <translation type="unfinished">网络活动已禁用。</translation>
+    </message>
+    <message>
+        <source>Proxy is &lt;b&gt;enabled&lt;/b&gt;: %1</source>
+        <translation type="unfinished">代理服务器已&lt;b&gt;启用&lt;/b&gt;: %1</translation>
+    </message>
+    <message>
+        <source>Send coins to a Bitcoin address</source>
+        <translation type="unfinished">向一个比特币地址发币</translation>
+    </message>
+    <message>
+        <source>Backup wallet to another location</source>
+        <translation type="unfinished">备份钱包到其他位置</translation>
+    </message>
+    <message>
+        <source>Change the passphrase used for wallet encryption</source>
+        <translation type="unfinished">修改钱包加密密码</translation>
+    </message>
+    <message>
+        <source>&amp;Send</source>
+        <translation type="unfinished">发送(&amp;S)</translation>
+    </message>
+    <message>
+        <source>&amp;Receive</source>
+        <translation type="unfinished">接收(&amp;R)</translation>
+    </message>
+    <message>
+        <source>&amp;Options…</source>
+        <translation type="unfinished">选项(&amp;O)</translation>
+    </message>
+    <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation type="unfinished">加密钱包(&amp;E)</translation>
+    </message>
+    <message>
+        <source>Encrypt the private keys that belong to your wallet</source>
+        <translation type="unfinished">把你钱包中的私钥加密</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation type="unfinished">备份钱包(&amp;B)</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation type="unfinished">修改密码(&amp;C)</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation type="unfinished">签名消息(&amp;M)</translation>
+    </message>
+    <message>
+        <source>Sign messages with your Bitcoin addresses to prove you own them</source>
+        <translation type="unfinished">用比特币地址关联的私钥为消息签名，以证明您拥有这个比特币地址</translation>
+    </message>
+    <message>
+        <source>&amp;Verify message…</source>
+        <translation type="unfinished">验证消息(&amp;V)</translation>
+    </message>
+    <message>
+        <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
+        <translation type="unfinished">校验消息，确保该消息是由指定的比特币地址所有者签名的</translation>
+    </message>
+    <message>
+        <source>&amp;Load PSBT from file…</source>
+        <translation type="unfinished">从文件加载PSBT(&amp;L)...</translation>
+    </message>
+    <message>
+        <source>Open &amp;URI…</source>
+        <translation type="unfinished">打开&amp;URI...</translation>
+    </message>
+    <message>
+        <source>Close Wallet…</source>
+        <translation type="unfinished">关闭钱包...</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation type="unfinished">创建钱包...</translation>
+    </message>
+    <message>
+        <source>Close All Wallets…</source>
+        <translation type="unfinished">关闭所有钱包...</translation>
+    </message>
+    <message>
+        <source>&amp;File</source>
+        <translation type="unfinished">文件(&amp;F)</translation>
+    </message>
+    <message>
+        <source>&amp;Settings</source>
+        <translation type="unfinished">设置(&amp;S)</translation>
+    </message>
+    <message>
+        <source>&amp;Help</source>
+        <translation type="unfinished">帮助(&amp;H)</translation>
+    </message>
+    <message>
+        <source>Tabs toolbar</source>
+        <translation type="unfinished">标签页工具栏</translation>
+    </message>
+    <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation type="unfinished">同步区块头 (%1%)…</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation type="unfinished">与网络同步...</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation type="unfinished">对磁盘上的区块进行索引...</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation type="unfinished">处理磁盘上的区块...</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation type="unfinished">重新索引磁盘上的区块...</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation type="unfinished">连接到节点...</translation>
+    </message>
+    <message>
+        <source>Request payments (generates QR codes and bitcoin: URIs)</source>
+        <translation type="unfinished">请求支付 (生成二维码和 bitcoin: URI)</translation>
+    </message>
+    <message>
+        <source>Show the list of used sending addresses and labels</source>
+        <translation type="unfinished">显示用过的付款地址和标签的列表</translation>
+    </message>
+    <message>
+        <source>Show the list of used receiving addresses and labels</source>
+        <translation type="unfinished">显示用过的收款地址和标签的列表</translation>
+    </message>
+    <message>
+        <source>&amp;Command-line options</source>
+        <translation type="unfinished">命令行选项(&amp;C)</translation>
+    </message>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>已处理%n个区块的交易历史。</numerusform>
         </translation>
+    </message>
+    <message>
+        <source>%1 behind</source>
+        <translation type="unfinished">落后 %1</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation type="unfinished">正在追上进度...</translation>
+    </message>
+    <message>
+        <source>Last received block was generated %1 ago.</source>
+        <translation type="unfinished">最新收到的区块产生于 %1 之前。</translation>
+    </message>
+    <message>
+        <source>Transactions after this will not yet be visible.</source>
+        <translation type="unfinished">在此之后的交易尚不可见</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">错误</translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation type="unfinished">警告</translation>
+    </message>
+    <message>
+        <source>Information</source>
+        <translation type="unfinished">信息</translation>
+    </message>
+    <message>
+        <source>Up to date</source>
+        <translation type="unfinished">已是最新</translation>
+    </message>
+    <message>
+        <source>Load Partially Signed Bitcoin Transaction</source>
+        <translation type="unfinished">加载部分签名比特币交易（PSBT）</translation>
+    </message>
+    <message>
+        <source>Load PSBT from &amp;clipboard…</source>
+        <translation type="unfinished">从剪贴板加载PSBT(&amp;C)...</translation>
+    </message>
+    <message>
+        <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
+        <translation type="unfinished">从剪贴板中加载部分签名比特币交易（PSBT）</translation>
+    </message>
+    <message>
+        <source>Node window</source>
+        <translation type="unfinished">节点窗口</translation>
+    </message>
+    <message>
+        <source>Open node debugging and diagnostic console</source>
+        <translation type="unfinished">打开节点调试与诊断控制台</translation>
+    </message>
+    <message>
+        <source>&amp;Sending addresses</source>
+        <translation type="unfinished">付款地址(&amp;S)</translation>
+    </message>
+    <message>
+        <source>&amp;Receiving addresses</source>
+        <translation type="unfinished">收款地址(&amp;R)</translation>
+    </message>
+    <message>
+        <source>Open a bitcoin: URI</source>
+        <translation type="unfinished">打开bitcoin:开头的URI</translation>
+    </message>
+    <message>
+        <source>Open Wallet</source>
+        <translation type="unfinished">打开钱包</translation>
+    </message>
+    <message>
+        <source>Open a wallet</source>
+        <translation type="unfinished">打开一个钱包</translation>
+    </message>
+    <message>
+        <source>Close wallet</source>
+        <translation type="unfinished">卸载钱包</translation>
+    </message>
+    <message>
+        <source>Restore Wallet…</source>
+        <extracomment>Name of the menu item that restores wallet from a backup file.</extracomment>
+        <translation type="unfinished">恢复钱包...</translation>
+    </message>
+    <message>
+        <source>Restore a wallet from a backup file</source>
+        <extracomment>Status tip for Restore Wallet menu item</extracomment>
+        <translation type="unfinished">从备份文件恢复钱包</translation>
+    </message>
+    <message>
+        <source>Close all wallets</source>
+        <translation type="unfinished">关闭所有钱包</translation>
+    </message>
+    <message>
+        <source>Show the %1 help message to get a list with possible Bitcoin command-line options</source>
+        <translation type="unfinished">显示 %1 帮助信息，获取可用命令行选项列表</translation>
+    </message>
+    <message>
+        <source>&amp;Mask values</source>
+        <translation type="unfinished">遮住数值(&amp;M)</translation>
+    </message>
+    <message>
+        <source>Mask the values in the Overview tab</source>
+        <translation type="unfinished">在“概况”标签页中不明文显示数值、只显示掩码</translation>
+    </message>
+    <message>
+        <source>default wallet</source>
+        <translation type="unfinished">默认钱包</translation>
+    </message>
+    <message>
+        <source>No wallets available</source>
+        <translation type="unfinished">没有可用的钱包</translation>
+    </message>
+    <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">钱包数据</translation>
+    </message>
+    <message>
+        <source>Load Wallet Backup</source>
+        <extracomment>The title for Restore Wallet File Windows</extracomment>
+        <translation type="unfinished">加载钱包备份</translation>
+    </message>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of pop-up window shown when the user is attempting to restore a wallet.</extracomment>
+        <translation type="unfinished">恢复钱包</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">钱包名称</translation>
+    </message>
+    <message>
+        <source>&amp;Window</source>
+        <translation type="unfinished">窗口(&amp;W)</translation>
+    </message>
+    <message>
+        <source>Zoom</source>
+        <translation type="unfinished">缩放</translation>
+    </message>
+    <message>
+        <source>Main Window</source>
+        <translation type="unfinished">主窗口</translation>
+    </message>
+    <message>
+        <source>%1 client</source>
+        <translation type="unfinished">%1 客户端</translation>
+    </message>
+    <message>
+        <source>&amp;Hide</source>
+        <translation type="unfinished">隐藏(&amp;H)</translation>
+    </message>
+    <message>
+        <source>S&amp;how</source>
+        <translation type="unfinished">显示(&amp;H)</translation>
     </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n 条到比特币网络的活动连接</numerusform>
         </translation>
     </message>
-    </context>
+    <message>
+        <source>Click for more actions.</source>
+        <extracomment>A substring of the tooltip. "More actions" are available via the context menu.</extracomment>
+        <translation type="unfinished">点击查看更多操作。</translation>
+    </message>
+    <message>
+        <source>Show Peers tab</source>
+        <extracomment>A context menu item. The "Peers tab" is an element of the "Node window".</extracomment>
+        <translation type="unfinished">显示节点标签</translation>
+    </message>
+    <message>
+        <source>Disable network activity</source>
+        <extracomment>A context menu item.</extracomment>
+        <translation type="unfinished">禁用网络活动</translation>
+    </message>
+    <message>
+        <source>Enable network activity</source>
+        <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
+        <translation type="unfinished">启用网络活动</translation>
+    </message>
+    <message>
+        <source>Pre-syncing Headers (%1%)…</source>
+        <translation type="unfinished">预同步区块头 (%1%)…</translation>
+    </message>
+    <message>
+        <source>Error: %1</source>
+        <translation type="unfinished">错误: %1</translation>
+    </message>
+    <message>
+        <source>Warning: %1</source>
+        <translation type="unfinished">警告: %1</translation>
+    </message>
+    <message>
+        <source>Date: %1
+</source>
+        <translation type="unfinished">日期: %1
+</translation>
+    </message>
+    <message>
+        <source>Amount: %1
+</source>
+        <translation type="unfinished">金额: %1
+</translation>
+    </message>
+    <message>
+        <source>Wallet: %1
+</source>
+        <translation type="unfinished">钱包: %1
+</translation>
+    </message>
+    <message>
+        <source>Type: %1
+</source>
+        <translation type="unfinished">类型: %1
+</translation>
+    </message>
+    <message>
+        <source>Label: %1
+</source>
+        <translation type="unfinished">标签: %1
+</translation>
+    </message>
+    <message>
+        <source>Address: %1
+</source>
+        <translation type="unfinished">地址: %1
+</translation>
+    </message>
+    <message>
+        <source>Sent transaction</source>
+        <translation type="unfinished">送出交易</translation>
+    </message>
+    <message>
+        <source>Incoming transaction</source>
+        <translation type="unfinished">流入交易</translation>
+    </message>
+    <message>
+        <source>HD key generation is &lt;b&gt;enabled&lt;/b&gt;</source>
+        <translation type="unfinished">HD密钥生成&lt;b&gt;启用&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>HD key generation is &lt;b&gt;disabled&lt;/b&gt;</source>
+        <translation type="unfinished">HD密钥生成&lt;b&gt;禁用&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Private key &lt;b&gt;disabled&lt;/b&gt;</source>
+        <translation type="unfinished">私钥&lt;b&gt;禁用&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
+        <translation type="unfinished">钱包已被&lt;b&gt;加密&lt;/b&gt;，当前为&lt;b&gt;解锁&lt;/b&gt;状态</translation>
+    </message>
+    <message>
+        <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
+        <translation type="unfinished">钱包已被&lt;b&gt;加密&lt;/b&gt;，当前为&lt;b&gt;锁定&lt;/b&gt;状态</translation>
+    </message>
+    <message>
+        <source>Original message:</source>
+        <translation type="unfinished">原消息:</translation>
+    </message>
+</context>
+<context>
+    <name>UnitDisplayStatusBarControl</name>
+    <message>
+        <source>Unit to show amounts in. Click to select another unit.</source>
+        <translation type="unfinished">金额单位。单击选择别的单位。</translation>
+    </message>
+</context>
 <context>
     <name>CoinControlDialog</name>
+    <message>
+        <source>Coin Selection</source>
+        <translation type="unfinished">手动选币</translation>
+    </message>
+    <message>
+        <source>Quantity:</source>
+        <translation type="unfinished">总量:</translation>
+    </message>
+    <message>
+        <source>Bytes:</source>
+        <translation type="unfinished">字节数:</translation>
+    </message>
+    <message>
+        <source>Amount:</source>
+        <translation type="unfinished">金额:</translation>
+    </message>
+    <message>
+        <source>Fee:</source>
+        <translation type="unfinished">费用:</translation>
+    </message>
+    <message>
+        <source>Dust:</source>
+        <translation type="unfinished">粉尘:</translation>
+    </message>
+    <message>
+        <source>After Fee:</source>
+        <translation type="unfinished">加上交易费用后:</translation>
+    </message>
+    <message>
+        <source>Change:</source>
+        <translation type="unfinished">找零:</translation>
+    </message>
+    <message>
+        <source>(un)select all</source>
+        <translation type="unfinished">全(不)选</translation>
+    </message>
+    <message>
+        <source>Tree mode</source>
+        <translation type="unfinished">树状模式</translation>
+    </message>
+    <message>
+        <source>List mode</source>
+        <translation type="unfinished">列表模式</translation>
+    </message>
+    <message>
+        <source>Amount</source>
+        <translation type="unfinished">金额</translation>
+    </message>
+    <message>
+        <source>Received with label</source>
+        <translation type="unfinished">收款标签</translation>
+    </message>
+    <message>
+        <source>Received with address</source>
+        <translation type="unfinished">收款地址</translation>
+    </message>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">日期</translation>
+    </message>
+    <message>
+        <source>Confirmations</source>
+        <translation type="unfinished">确认</translation>
+    </message>
+    <message>
+        <source>Confirmed</source>
+        <translation type="unfinished">已确认</translation>
+    </message>
+    <message>
+        <source>Copy amount</source>
+        <translation type="unfinished">复制金额</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">复制地址(&amp;C)</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">复制标签(&amp;L)</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">复制金额(&amp;A)</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID and output index</source>
+        <translation type="unfinished">复制交易&amp;ID和输出序号</translation>
+    </message>
+    <message>
+        <source>L&amp;ock unspent</source>
+        <translation type="unfinished">锁定未花费(&amp;O)</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock unspent</source>
+        <translation type="unfinished">解锁未花费(&amp;U)</translation>
+    </message>
+    <message>
+        <source>Copy quantity</source>
+        <translation type="unfinished">复制数目</translation>
+    </message>
+    <message>
+        <source>Copy fee</source>
+        <translation type="unfinished">复制手续费</translation>
+    </message>
+    <message>
+        <source>Copy after fee</source>
+        <translation type="unfinished">复制含交易费的金额</translation>
+    </message>
+    <message>
+        <source>Copy bytes</source>
+        <translation type="unfinished">复制字节数</translation>
+    </message>
+    <message>
+        <source>Copy dust</source>
+        <translation type="unfinished">复制粉尘金额</translation>
+    </message>
+    <message>
+        <source>Copy change</source>
+        <translation type="unfinished">复制找零金额</translation>
+    </message>
+    <message>
+        <source>(%1 locked)</source>
+        <translation type="unfinished">(%1已锁定)</translation>
+    </message>
+    <message>
+        <source>yes</source>
+        <translation type="unfinished">是</translation>
+    </message>
+    <message>
+        <source>no</source>
+        <translation type="unfinished">否</translation>
+    </message>
+    <message>
+        <source>This label turns red if any recipient receives an amount smaller than the current dust threshold.</source>
+        <translation type="unfinished">当任何一个收款金额小于目前的粉尘金额阈值时，文字会变红色。</translation>
+    </message>
+    <message>
+        <source>Can vary +/- %1 satoshi(s) per input.</source>
+        <translation type="unfinished">每个输入可能有 +/- %1 聪 (satoshi) 的误差。</translation>
+    </message>
     <message>
         <source>(no label)</source>
         <translation type="unfinished">(无标签)</translation>
     </message>
-    </context>
+    <message>
+        <source>change from %1 (%2)</source>
+        <translation type="unfinished">来自 %1 的找零 (%2)</translation>
+    </message>
+    <message>
+        <source>(change)</source>
+        <translation type="unfinished">(找零)</translation>
+    </message>
+</context>
+<context>
+    <name>CreateWalletActivity</name>
+    <message>
+        <source>Create Wallet</source>
+        <extracomment>Title of window indicating the progress of creation of a new wallet.</extracomment>
+        <translation type="unfinished">创建钱包</translation>
+    </message>
+    <message>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the create wallet progress window which indicates to the user which wallet is currently being created.</extracomment>
+        <translation type="unfinished">创建钱包&lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+    <message>
+        <source>Create wallet failed</source>
+        <translation type="unfinished">创建钱包失败</translation>
+    </message>
+    <message>
+        <source>Create wallet warning</source>
+        <translation type="unfinished">创建钱包警告</translation>
+    </message>
+    <message>
+        <source>Can't list signers</source>
+        <translation type="unfinished">无法列出签名器</translation>
+    </message>
+    <message>
+        <source>Too many external signers found</source>
+        <translation type="unfinished">找到的外部签名器太多</translation>
+    </message>
+</context>
+<context>
+    <name>LoadWalletsActivity</name>
+    <message>
+        <source>Load Wallets</source>
+        <extracomment>Title of progress window which is displayed when wallets are being loaded.</extracomment>
+        <translation type="unfinished">加载钱包</translation>
+    </message>
+    <message>
+        <source>Loading wallets…</source>
+        <extracomment>Descriptive text of the load wallets progress window which indicates to the user that wallets are currently being loaded.</extracomment>
+        <translation type="unfinished">加载钱包...</translation>
+    </message>
+</context>
+<context>
+    <name>OpenWalletActivity</name>
+    <message>
+        <source>Open wallet failed</source>
+        <translation type="unfinished">打开钱包失败</translation>
+    </message>
+    <message>
+        <source>Open wallet warning</source>
+        <translation type="unfinished">打开钱包警告</translation>
+    </message>
+    <message>
+        <source>default wallet</source>
+        <translation type="unfinished">默认钱包</translation>
+    </message>
+    <message>
+        <source>Open Wallet</source>
+        <extracomment>Title of window indicating the progress of opening of a wallet.</extracomment>
+        <translation type="unfinished">打开钱包</translation>
+    </message>
+    <message>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the open wallet progress window which indicates to the user which wallet is currently being opened.</extracomment>
+        <translation type="unfinished">打开钱包&lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+</context>
+<context>
+    <name>RestoreWalletActivity</name>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of progress window which is displayed when wallets are being restored.</extracomment>
+        <translation type="unfinished">恢复钱包</translation>
+    </message>
+    <message>
+        <source>Restoring Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the restore wallets progress window which indicates to the user that wallets are currently being restored.</extracomment>
+        <translation type="unfinished">恢复钱包&lt;b&gt;%1&lt;/b&gt;…</translation>
+    </message>
+    <message>
+        <source>Restore wallet failed</source>
+        <extracomment>Title of message box which is displayed when the wallet could not be restored.</extracomment>
+        <translation type="unfinished">恢复钱包失败</translation>
+    </message>
+    <message>
+        <source>Restore wallet warning</source>
+        <extracomment>Title of message box which is displayed when the wallet is restored with some warning.</extracomment>
+        <translation type="unfinished">恢复钱包警告</translation>
+    </message>
+    <message>
+        <source>Restore wallet message</source>
+        <extracomment>Title of message box which is displayed when the wallet is successfully restored.</extracomment>
+        <translation type="unfinished">恢复钱包消息</translation>
+    </message>
+</context>
+<context>
+    <name>WalletController</name>
+    <message>
+        <source>Close wallet</source>
+        <translation type="unfinished">卸载钱包</translation>
+    </message>
+    <message>
+        <source>Are you sure you wish to close the wallet &lt;i&gt;%1&lt;/i&gt;?</source>
+        <translation type="unfinished">您确定想要关闭钱包&lt;i&gt;%1&lt;/i&gt;吗？</translation>
+    </message>
+    <message>
+        <source>Closing the wallet for too long can result in having to resync the entire chain if pruning is enabled.</source>
+        <translation type="unfinished">启用修剪时，如果一个钱包被卸载太久，就必须重新同步整条区块链才能再次加载它。</translation>
+    </message>
+    <message>
+        <source>Close all wallets</source>
+        <translation type="unfinished">关闭所有钱包</translation>
+    </message>
+    <message>
+        <source>Are you sure you wish to close all wallets?</source>
+        <translation type="unfinished">您确定想要关闭所有钱包吗?</translation>
+    </message>
+</context>
+<context>
+    <name>CreateWalletDialog</name>
+    <message>
+        <source>Create Wallet</source>
+        <translation type="unfinished">创建钱包</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <translation type="unfinished">钱包名称</translation>
+    </message>
+    <message>
+        <source>Wallet</source>
+        <translation type="unfinished">钱包</translation>
+    </message>
+    <message>
+        <source>Encrypt the wallet. The wallet will be encrypted with a passphrase of your choice.</source>
+        <translation type="unfinished">加密钱包。将会使用您指定的密码将钱包加密。</translation>
+    </message>
+    <message>
+        <source>Encrypt Wallet</source>
+        <translation type="unfinished">加密钱包</translation>
+    </message>
+    <message>
+        <source>Advanced Options</source>
+        <translation type="unfinished">进阶设定</translation>
+    </message>
+    <message>
+        <source>Disable private keys for this wallet. Wallets with private keys disabled will have no private keys and cannot have an HD seed or imported private keys. This is ideal for watch-only wallets.</source>
+        <translation type="unfinished">禁用此钱包的私钥。被禁用私钥的钱包将不会含有任何私钥，而且也不能含有HD种子或导入的私钥。作为仅观察钱包，这是比较理想的。</translation>
+    </message>
+    <message>
+        <source>Disable Private Keys</source>
+        <translation type="unfinished">禁用私钥</translation>
+    </message>
+    <message>
+        <source>Make a blank wallet. Blank wallets do not initially have private keys or scripts. Private keys and addresses can be imported, or an HD seed can be set, at a later time.</source>
+        <translation type="unfinished">创建一个空白的钱包。空白钱包最初不含有任何私钥或脚本。可以以后再导入私钥和地址，或设置HD种子。</translation>
+    </message>
+    <message>
+        <source>Make Blank Wallet</source>
+        <translation type="unfinished">创建空白钱包</translation>
+    </message>
+    <message>
+        <source>Use descriptors for scriptPubKey management</source>
+        <translation type="unfinished">使用输出描述符进行scriptPubKey管理</translation>
+    </message>
+    <message>
+        <source>Descriptor Wallet</source>
+        <translation type="unfinished">输出描述符钱包</translation>
+    </message>
+    <message>
+        <source>Use an external signing device such as a hardware wallet. Configure the external signer script in wallet preferences first.</source>
+        <translation type="unfinished">使用像是硬件钱包这样的外部签名设备。请在钱包偏好设置中先配置号外部签名器脚本。</translation>
+    </message>
+    <message>
+        <source>External signer</source>
+        <translation type="unfinished">外部签名器</translation>
+    </message>
+    <message>
+        <source>Create</source>
+        <translation type="unfinished">创建</translation>
+    </message>
+    <message>
+        <source>Compiled without sqlite support (required for descriptor wallets)</source>
+        <translation type="unfinished">编译时未启用SQLite支持（输出描述符钱包需要它）</translation>
+    </message>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">编译时未启用外部签名支持 (外部签名需要这个功能)</translation>
+    </message>
+</context>
+<context>
+    <name>EditAddressDialog</name>
+    <message>
+        <source>Edit Address</source>
+        <translation type="unfinished">编辑地址</translation>
+    </message>
+    <message>
+        <source>&amp;Label</source>
+        <translation type="unfinished">标签(&amp;L)</translation>
+    </message>
+    <message>
+        <source>The label associated with this address list entry</source>
+        <translation type="unfinished">与此地址关联的标签</translation>
+    </message>
+    <message>
+        <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
+        <translation type="unfinished">与这个列表项关联的地址。只有付款地址才能被修改（收款地址不能被修改）。</translation>
+    </message>
+    <message>
+        <source>&amp;Address</source>
+        <translation type="unfinished">地址(&amp;A)</translation>
+    </message>
+    <message>
+        <source>New sending address</source>
+        <translation type="unfinished">新建付款地址</translation>
+    </message>
+    <message>
+        <source>Edit receiving address</source>
+        <translation type="unfinished">编辑收款地址</translation>
+    </message>
+    <message>
+        <source>Edit sending address</source>
+        <translation type="unfinished">编辑付款地址</translation>
+    </message>
+    <message>
+        <source>The entered address "%1" is not a valid Bitcoin address.</source>
+        <translation type="unfinished">输入的地址 %1 并不是有效的比特币地址。</translation>
+    </message>
+    <message>
+        <source>Address "%1" already exists as a receiving address with label "%2" and so cannot be added as a sending address.</source>
+        <translation type="unfinished">地址“%1”已经存在，它是一个收款地址，标签为“%2”，所以它不能作为一个付款地址被添加进来。</translation>
+    </message>
+    <message>
+        <source>The entered address "%1" is already in the address book with label "%2".</source>
+        <translation type="unfinished">输入的地址“%1”已经存在于地址簿中，标签为“%2”。</translation>
+    </message>
+    <message>
+        <source>Could not unlock wallet.</source>
+        <translation type="unfinished">无法解锁钱包。</translation>
+    </message>
+    <message>
+        <source>New key generation failed.</source>
+        <translation type="unfinished">生成新密钥失败。</translation>
+    </message>
+</context>
+<context>
+    <name>FreespaceChecker</name>
+    <message>
+        <source>A new data directory will be created.</source>
+        <translation type="unfinished">一个新的数据目录将被创建。</translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation type="unfinished">名称</translation>
+    </message>
+    <message>
+        <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
+        <translation type="unfinished">目录已存在。如果您打算在这里创建一个新目录，请添加 %1。</translation>
+    </message>
+    <message>
+        <source>Path already exists, and is not a directory.</source>
+        <translation type="unfinished">路径已存在，并且不是一个目录。</translation>
+    </message>
+    <message>
+        <source>Cannot create data directory here.</source>
+        <translation type="unfinished">无法在此创建数据目录。</translation>
+    </message>
+</context>
 <context>
     <name>Intro</name>
+    <message>
+        <source>Bitcoin</source>
+        <translation type="unfinished">比特币</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform>可用空间 %n GB</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform>(需要 %n GB的空间)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform>(保存完整的链需要 %n GB)</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
+        <translation type="unfinished">此目录中至少会保存 %1 GB 的数据，并且大小还会随着时间增长。</translation>
+    </message>
+    <message>
+        <source>Approximately %1 GB of data will be stored in this directory.</source>
+        <translation type="unfinished">会在此目录中存储约 %1 GB 的数据。</translation>
+    </message>
     <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>(足以恢复 %n 天之内的备份)</numerusform>
         </translation>
     </message>
-    </context>
+    <message>
+        <source>%1 will download and store a copy of the Bitcoin block chain.</source>
+        <translation type="unfinished">%1 将会下载并存储比特币区块链。</translation>
+    </message>
+    <message>
+        <source>The wallet will also be stored in this directory.</source>
+        <translation type="unfinished">钱包也会被保存在这个目录中。</translation>
+    </message>
+    <message>
+        <source>Error: Specified data directory "%1" cannot be created.</source>
+        <translation type="unfinished">错误:无法创建指定的数据目录 "%1"</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">错误</translation>
+    </message>
+    <message>
+        <source>Welcome</source>
+        <translation type="unfinished">欢迎</translation>
+    </message>
+    <message>
+        <source>Welcome to %1.</source>
+        <translation type="unfinished">欢迎使用 %1</translation>
+    </message>
+    <message>
+        <source>As this is the first time the program is launched, you can choose where %1 will store its data.</source>
+        <translation type="unfinished">由于这是第一次启动此程序，您可以选择%1存储数据的位置</translation>
+    </message>
+    <message>
+        <source>Limit block chain storage to</source>
+        <translation type="unfinished">将区块链存储限制到</translation>
+    </message>
+    <message>
+        <source>Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</source>
+        <translation type="unfinished">取消此设置需要重新下载整个区块链。先完整下载整条链再进行修剪会更快。这会禁用一些高级功能。</translation>
+    </message>
+    <message>
+        <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
+        <translation type="unfinished">初始化同步过程是非常吃力的，同时可能会暴露您之前没有注意到的电脑硬件问题。你每次启动%1时，它都会从之前中断的地方继续下载。</translation>
+    </message>
+    <message>
+        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2 GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
+        <translation type="unfinished">当你单击确认后，%1 将会从%4在%3年创始时最早的交易开始，下载并处理完整的 %4 区块链 (%2 GB)。</translation>
+    </message>
+    <message>
+        <source>If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</source>
+        <translation type="unfinished">如果你选择限制区块链存储大小（区块链裁剪模式），程序依然会下载并处理全部历史数据，只是不必须的部分会在使用后被删除，以占用最少的存储空间。</translation>
+    </message>
+    <message>
+        <source>Use the default data directory</source>
+        <translation type="unfinished">使用默认的数据目录</translation>
+    </message>
+    <message>
+        <source>Use a custom data directory:</source>
+        <translation type="unfinished">使用自定义的数据目录:</translation>
+    </message>
+</context>
+<context>
+    <name>HelpMessageDialog</name>
+    <message>
+        <source>version</source>
+        <translation type="unfinished">版本</translation>
+    </message>
+    <message>
+        <source>About %1</source>
+        <translation type="unfinished">关于 %1</translation>
+    </message>
+    <message>
+        <source>Command-line options</source>
+        <translation type="unfinished">命令行选项</translation>
+    </message>
+</context>
+<context>
+    <name>ShutdownWindow</name>
+    <message>
+        <source>%1 is shutting down…</source>
+        <translation type="unfinished">%1正在关闭...</translation>
+    </message>
+    <message>
+        <source>Do not shut down the computer until this window disappears.</source>
+        <translation type="unfinished">在此窗口消失前不要关闭计算机。</translation>
+    </message>
+</context>
+<context>
+    <name>ModalOverlay</name>
+    <message>
+        <source>Form</source>
+        <translation type="unfinished">窗体</translation>
+    </message>
+    <message>
+        <source>Recent transactions may not yet be visible, and therefore your wallet's balance might be incorrect. This information will be correct once your wallet has finished synchronizing with the bitcoin network, as detailed below.</source>
+        <translation type="unfinished">近期交易可能尚未显示，因此当前余额可能不准确。以上信息将在与比特币网络完全同步后更正。详情如下</translation>
+    </message>
+    <message>
+        <source>Attempting to spend bitcoins that are affected by not-yet-displayed transactions will not be accepted by the network.</source>
+        <translation type="unfinished">尝试使用受未可见交易影响的余额将不被网络接受。</translation>
+    </message>
+    <message>
+        <source>Number of blocks left</source>
+        <translation type="unfinished">剩余区块数量</translation>
+    </message>
+    <message>
+        <source>Unknown…</source>
+        <translation type="unfinished">未知...</translation>
+    </message>
+    <message>
+        <source>calculating…</source>
+        <translation type="unfinished">计算中...</translation>
+    </message>
+    <message>
+        <source>Last block time</source>
+        <translation type="unfinished">上一区块时间</translation>
+    </message>
+    <message>
+        <source>Progress</source>
+        <translation type="unfinished">进度</translation>
+    </message>
+    <message>
+        <source>Progress increase per hour</source>
+        <translation type="unfinished">每小时进度增加</translation>
+    </message>
+    <message>
+        <source>Estimated time left until synced</source>
+        <translation type="unfinished">预计剩余同步时间</translation>
+    </message>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished">隐藏</translation>
+    </message>
+    <message>
+        <source>%1 is currently syncing.  It will download headers and blocks from peers and validate them until reaching the tip of the block chain.</source>
+        <translation type="unfinished">%1目前正在同步中。它会从其他节点下载区块头和区块数据并进行验证，直到抵达区块链尖端。</translation>
+    </message>
+    <message>
+        <source>Unknown. Syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">未知。同步区块头(%1, %2%)...</translation>
+    </message>
+    <message>
+        <source>Unknown. Pre-syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">未知。预同步区块头 (%1, %2%)…</translation>
+    </message>
+</context>
+<context>
+    <name>OpenURIDialog</name>
+    <message>
+        <source>Open bitcoin URI</source>
+        <translation type="unfinished">打开比特币URI</translation>
+    </message>
+    <message>
+        <source>Paste address from clipboard</source>
+        <extracomment>Tooltip text for button that allows you to paste an address that is in your clipboard.</extracomment>
+        <translation type="unfinished">从剪贴板粘贴地址</translation>
+    </message>
+</context>
+<context>
+    <name>OptionsDialog</name>
+    <message>
+        <source>Options</source>
+        <translation type="unfinished">选项</translation>
+    </message>
+    <message>
+        <source>&amp;Main</source>
+        <translation type="unfinished">主要(&amp;M)</translation>
+    </message>
+    <message>
+        <source>Automatically start %1 after logging in to the system.</source>
+        <translation type="unfinished">在登入系统后自动启动 %1</translation>
+    </message>
+    <message>
+        <source>&amp;Start %1 on system login</source>
+        <translation type="unfinished">系统登入时启动 %1 (&amp;S)</translation>
+    </message>
+    <message>
+        <source>Enabling pruning significantly reduces the disk space required to store transactions. All blocks are still fully validated. Reverting this setting requires re-downloading the entire blockchain.</source>
+        <translation type="unfinished">启用区块修剪会显著减小存储交易对磁盘空间的需求。所有的区块仍然会被完整校验。取消这个设置需要重新下载整条区块链。</translation>
+    </message>
+    <message>
+        <source>Size of &amp;database cache</source>
+        <translation type="unfinished">数据库缓存大小(&amp;D)</translation>
+    </message>
+    <message>
+        <source>Number of script &amp;verification threads</source>
+        <translation type="unfinished">脚本验证线程数(&amp;V)</translation>
+    </message>
+    <message>
+        <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
+        <translation type="unfinished">代理服务器 IP 地址 (例如 IPv4: 127.0.0.1 / IPv6: ::1)</translation>
+    </message>
+    <message>
+        <source>Shows if the supplied default SOCKS5 proxy is used to reach peers via this network type.</source>
+        <translation type="unfinished">显示默认的SOCKS5代理是否被用于在该类型的网络下连接同伴。</translation>
+    </message>
+    <message>
+        <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
+        <translation type="unfinished">窗口被关闭时最小化程序而不是退出。当此选项启用时，只有在菜单中选择“退出”时才会让程序退出。</translation>
+    </message>
+    <message>
+        <source>Options set in this dialog are overridden by the command line:</source>
+        <translation type="unfinished">这个对话框中的设置已被如下命令行选项覆盖:</translation>
+    </message>
+    <message>
+        <source>Open the %1 configuration file from the working directory.</source>
+        <translation type="unfinished">从工作目录下打开配置文件 %1。</translation>
+    </message>
+    <message>
+        <source>Open Configuration File</source>
+        <translation type="unfinished">打开配置文件</translation>
+    </message>
+    <message>
+        <source>Reset all client options to default.</source>
+        <translation type="unfinished">恢复客户端的缺省设置</translation>
+    </message>
+    <message>
+        <source>&amp;Reset Options</source>
+        <translation type="unfinished">恢复缺省设置(&amp;R)</translation>
+    </message>
+    <message>
+        <source>&amp;Network</source>
+        <translation type="unfinished">网络(&amp;N)</translation>
+    </message>
+    <message>
+        <source>Prune &amp;block storage to</source>
+        <translation type="unfinished">将区块存储修剪至(&amp;B)</translation>
+    </message>
+    <message>
+        <source>Reverting this setting requires re-downloading the entire blockchain.</source>
+        <translation type="unfinished">警告:还原此设置需要重新下载整个区块链。</translation>
+    </message>
+    <message>
+        <source>Maximum database cache size. A larger cache can contribute to faster sync, after which the benefit is less pronounced for most use cases. Lowering the cache size will reduce memory usage. Unused mempool memory is shared for this cache.</source>
+        <extracomment>Tooltip text for Options window setting that sets the size of the database cache. Explains the corresponding effects of increasing/decreasing this value.</extracomment>
+        <translation type="unfinished">数据库缓存的最大大小。加大缓存有助于加快同步，但对于大多数使用场景来说，继续加大后收效会越来越不明显。降低缓存大小将会减小内存使用量。内存池中尚未被使用的那部分内存也会被共享用于这里的数据库缓存。</translation>
+    </message>
+    <message>
+        <source>Set the number of script verification threads. Negative values correspond to the number of cores you want to leave free to the system.</source>
+        <extracomment>Tooltip text for Options window setting that sets the number of script verification threads. Explains that negative values mean to leave these many cores free to the system.</extracomment>
+        <translation type="unfinished">设置脚本验证线程的数量。负值则表示你想要保留给系统的核心数量。</translation>
+    </message>
+    <message>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation type="unfinished">(0 = 自动, &lt;0 = 保持指定数量的CPU核心空闲)</translation>
+    </message>
+    <message>
+        <source>This allows you or a third party tool to communicate with the node through command-line and JSON-RPC commands.</source>
+        <extracomment>Tooltip text for Options window setting that enables the RPC server.</extracomment>
+        <translation type="unfinished">这允许作为用户的你或第三方工具通过命令行和JSON-RPC命令行与节点通信。</translation>
+    </message>
+    <message>
+        <source>Enable R&amp;PC server</source>
+        <extracomment>An Options window setting to enable the RPC server.</extracomment>
+        <translation type="unfinished">启用R&amp;PC服务器</translation>
+    </message>
+    <message>
+        <source>W&amp;allet</source>
+        <translation type="unfinished">钱包(&amp;A)</translation>
+    </message>
+    <message>
+        <source>Whether to set subtract fee from amount as default or not.</source>
+        <extracomment>Tooltip text for Options window setting that sets subtracting the fee from a sending amount as default.</extracomment>
+        <translation type="unfinished">是否要默认从金额中减去手续费。</translation>
+    </message>
+    <message>
+        <source>Subtract &amp;fee from amount by default</source>
+        <extracomment>An Options window setting to set subtracting the fee from a sending amount as default.</extracomment>
+        <translation type="unfinished">默认从金额中减去交易手续费(&amp;F)</translation>
+    </message>
+    <message>
+        <source>Expert</source>
+        <translation type="unfinished">专家</translation>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation type="unfinished">启用手动选币功能(&amp;C)</translation>
+    </message>
+    <message>
+        <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
+        <translation type="unfinished">如果您禁止动用尚未确认的找零资金，则一笔交易的找零资金至少需要有1个确认后才能动用。这同时也会影响账户余额的计算。</translation>
+    </message>
+    <message>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation type="unfinished">动用尚未确认的找零资金(&amp;S)</translation>
+    </message>
+    <message>
+        <source>Enable &amp;PSBT controls</source>
+        <extracomment>An options window setting to enable PSBT controls.</extracomment>
+        <translation type="unfinished">启用&amp;PSBT控件</translation>
+    </message>
+    <message>
+        <source>Whether to show PSBT controls.</source>
+        <extracomment>Tooltip text for options window setting that enables PSBT controls.</extracomment>
+        <translation type="unfinished">是否要显示PSBT控件</translation>
+    </message>
+    <message>
+        <source>External Signer (e.g. hardware wallet)</source>
+        <translation type="unfinished">外部签名器(例如硬件钱包)</translation>
+    </message>
+    <message>
+        <source>&amp;External signer script path</source>
+        <translation type="unfinished">外部签名器脚本路径(&amp;E)</translation>
+    </message>
+    <message>
+        <source>Full path to a Bitcoin Core compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</source>
+        <translation type="unfinished">指向兼容Bitcoin Core的脚本的完整路径 (例如 C:\Downloads\hwi.exe 或者 /Users/you/Downloads/hwi.py )。注意: 恶意软件可能会偷窃您的币！</translation>
+    </message>
+    <message>
+        <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
+        <translation type="unfinished">自动在路由器中为比特币客户端打开端口。只有当您的路由器开启了 UPnP 选项时此功能才会有用。</translation>
+    </message>
+    <message>
+        <source>Map port using &amp;UPnP</source>
+        <translation type="unfinished">使用 &amp;UPnP 映射端口</translation>
+    </message>
+    <message>
+        <source>Automatically open the Bitcoin client port on the router. This only works when your router supports NAT-PMP and it is enabled. The external port could be random.</source>
+        <translation type="unfinished">自动在路由器中为比特币客户端打开端口。只有当您的路由器支持 NAT-PMP 功能并开启它，这个功能才会正常工作。外边端口可以是随机的。</translation>
+    </message>
+    <message>
+        <source>Map port using NA&amp;T-PMP</source>
+        <translation type="unfinished">使用 NA&amp;T-PMP 映射端口</translation>
+    </message>
+    <message>
+        <source>Accept connections from outside.</source>
+        <translation type="unfinished">接受外部连接。</translation>
+    </message>
+    <message>
+        <source>Allow incomin&amp;g connections</source>
+        <translation type="unfinished">允许传入连接(&amp;G)</translation>
+    </message>
+    <message>
+        <source>Connect to the Bitcoin network through a SOCKS5 proxy.</source>
+        <translation type="unfinished">通过 SOCKS5 代理连接比特币网络。</translation>
+    </message>
+    <message>
+        <source>&amp;Connect through SOCKS5 proxy (default proxy):</source>
+        <translation type="unfinished">通过 SO&amp;CKS5 代理连接(默认代理):</translation>
+    </message>
+    <message>
+        <source>Proxy &amp;IP:</source>
+        <translation type="unfinished">代理服务器 &amp;IP:</translation>
+    </message>
+    <message>
+        <source>&amp;Port:</source>
+        <translation type="unfinished">端口(&amp;P):</translation>
+    </message>
+    <message>
+        <source>Port of the proxy (e.g. 9050)</source>
+        <translation type="unfinished">代理服务器端口（例如 9050）</translation>
+    </message>
+    <message>
+        <source>Used for reaching peers via:</source>
+        <translation type="unfinished">在走这些途径连接到节点的时候启用:</translation>
+    </message>
+    <message>
+        <source>&amp;Window</source>
+        <translation type="unfinished">窗口(&amp;W)</translation>
+    </message>
+    <message>
+        <source>Show the icon in the system tray.</source>
+        <translation type="unfinished">在通知区域显示图标。</translation>
+    </message>
+    <message>
+        <source>&amp;Show tray icon</source>
+        <translation type="unfinished">显示通知区域图标(&amp;S)</translation>
+    </message>
+    <message>
+        <source>Show only a tray icon after minimizing the window.</source>
+        <translation type="unfinished">最小化窗口后仅显示托盘图标</translation>
+    </message>
+    <message>
+        <source>&amp;Minimize to the tray instead of the taskbar</source>
+        <translation type="unfinished">最小化到托盘(&amp;M)</translation>
+    </message>
+    <message>
+        <source>M&amp;inimize on close</source>
+        <translation type="unfinished">单击关闭按钮时最小化(&amp;I)</translation>
+    </message>
+    <message>
+        <source>&amp;Display</source>
+        <translation type="unfinished">显示(&amp;D)</translation>
+    </message>
+    <message>
+        <source>User Interface &amp;language:</source>
+        <translation type="unfinished">用户界面语言(&amp;L):</translation>
+    </message>
+    <message>
+        <source>The user interface language can be set here. This setting will take effect after restarting %1.</source>
+        <translation type="unfinished">可以在这里设定用户界面的语言。这个设定在重启 %1 后才会生效。</translation>
+    </message>
+    <message>
+        <source>&amp;Unit to show amounts in:</source>
+        <translation type="unfinished">比特币金额单位(&amp;U):</translation>
+    </message>
+    <message>
+        <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
+        <translation type="unfinished">选择显示及发送比特币时使用的最小单位。</translation>
+    </message>
+    <message>
+        <source>Third-party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</source>
+        <translation type="unfinished">这个第三方网址（比如区块浏览器）会出现在交易选项卡的右键菜单中。 网址中的%s代表交易哈希。多个网址需要用竖线 | 相互分隔。</translation>
+    </message>
+    <message>
+        <source>&amp;Third-party transaction URLs</source>
+        <translation type="unfinished">第三方交易网址(&amp;T)</translation>
+    </message>
+    <message>
+        <source>Whether to show coin control features or not.</source>
+        <translation type="unfinished">是否显示手动选币功能。</translation>
+    </message>
+    <message>
+        <source>Connect to the Bitcoin network through a separate SOCKS5 proxy for Tor onion services.</source>
+        <translation type="unfinished">连接比特币网络时专门为Tor onion服务使用另一个 SOCKS5 代理。</translation>
+    </message>
+    <message>
+        <source>Use separate SOCKS&amp;5 proxy to reach peers via Tor onion services:</source>
+        <translation type="unfinished">连接Tor onion服务节点时使用另一个SOCKS&amp;5代理：</translation>
+    </message>
+    <message>
+        <source>Monospaced font in the Overview tab:</source>
+        <translation type="unfinished">在概览标签页的等宽字体:</translation>
+    </message>
+    <message>
+        <source>embedded "%1"</source>
+        <translation type="unfinished">嵌入的 "%1"</translation>
+    </message>
+    <message>
+        <source>closest matching "%1"</source>
+        <translation type="unfinished">与 "%1" 最接近的匹配</translation>
+    </message>
+    <message>
+        <source>&amp;OK</source>
+        <translation type="unfinished">确定(&amp;O)</translation>
+    </message>
+    <message>
+        <source>&amp;Cancel</source>
+        <translation type="unfinished">取消(&amp;C)</translation>
+    </message>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">编译时未启用外部签名支持 (外部签名需要这个功能)</translation>
+    </message>
+    <message>
+        <source>default</source>
+        <translation type="unfinished">默认</translation>
+    </message>
+    <message>
+        <source>none</source>
+        <translation type="unfinished">无</translation>
+    </message>
+    <message>
+        <source>Confirm options reset</source>
+        <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
+        <translation type="unfinished">确认恢复默认设置</translation>
+    </message>
+    <message>
+        <source>Client restart required to activate changes.</source>
+        <extracomment>Text explaining that the settings changed will not come into effect until the client is restarted.</extracomment>
+        <translation type="unfinished">需要重启客户端才能使更改生效。</translation>
+    </message>
+    <message>
+        <source>Current settings will be backed up at "%1".</source>
+        <extracomment>Text explaining to the user that the client's current settings will be backed up at a specific location. %1 is a stand-in argument for the backup location's path.</extracomment>
+        <translation type="unfinished">当前设置将会被备份到 "%1"。</translation>
+    </message>
+    <message>
+        <source>Client will be shut down. Do you want to proceed?</source>
+        <extracomment>Text asking the user to confirm if they would like to proceed with a client shutdown.</extracomment>
+        <translation type="unfinished">客户端即将关闭，您想继续吗？</translation>
+    </message>
+    <message>
+        <source>Configuration options</source>
+        <extracomment>Window title text of pop-up box that allows opening up of configuration file.</extracomment>
+        <translation type="unfinished">配置选项</translation>
+    </message>
+    <message>
+        <source>The configuration file is used to specify advanced user options which override GUI settings. Additionally, any command-line options will override this configuration file.</source>
+        <extracomment>Explanatory text about the priority order of instructions considered by client. The order from high to low being: command-line, configuration file, GUI settings.</extracomment>
+        <translation type="unfinished">配置文件可以用来设置高级选项。配置文件会覆盖设置界面窗口中的选项。此外，命令行会覆盖配置文件指定的选项。</translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation type="unfinished">继续</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">错误</translation>
+    </message>
+    <message>
+        <source>The configuration file could not be opened.</source>
+        <translation type="unfinished">无法打开配置文件。</translation>
+    </message>
+    <message>
+        <source>This change would require a client restart.</source>
+        <translation type="unfinished">此更改需要重启客户端。</translation>
+    </message>
+    <message>
+        <source>The supplied proxy address is invalid.</source>
+        <translation type="unfinished">提供的代理服务器地址无效。</translation>
+    </message>
+</context>
+<context>
+    <name>OptionsModel</name>
+    <message>
+        <source>Could not read setting "%1", %2.</source>
+        <translation type="unfinished">无法读取设置 "%1"，%2。</translation>
+    </message>
+</context>
+<context>
+    <name>OverviewPage</name>
+    <message>
+        <source>Form</source>
+        <translation type="unfinished">窗体</translation>
+    </message>
+    <message>
+        <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
+        <translation type="unfinished">现在显示的消息可能是过期的。在连接上比特币网络节点后，您的钱包将自动与网络同步，但是这个过程还没有完成。</translation>
+    </message>
+    <message>
+        <source>Watch-only:</source>
+        <translation type="unfinished">仅观察:</translation>
+    </message>
+    <message>
+        <source>Available:</source>
+        <translation type="unfinished">可使用的余额:</translation>
+    </message>
+    <message>
+        <source>Your current spendable balance</source>
+        <translation type="unfinished">您当前可使用的余额</translation>
+    </message>
+    <message>
+        <source>Pending:</source>
+        <translation type="unfinished">等待中的余额:</translation>
+    </message>
+    <message>
+        <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
+        <translation type="unfinished">尚未确认的交易总额，未计入当前余额</translation>
+    </message>
+    <message>
+        <source>Immature:</source>
+        <translation type="unfinished">未成熟的:</translation>
+    </message>
+    <message>
+        <source>Mined balance that has not yet matured</source>
+        <translation type="unfinished">尚未成熟的挖矿收入余额</translation>
+    </message>
+    <message>
+        <source>Balances</source>
+        <translation type="unfinished">余额</translation>
+    </message>
+    <message>
+        <source>Total:</source>
+        <translation type="unfinished">总额:</translation>
+    </message>
+    <message>
+        <source>Your current total balance</source>
+        <translation type="unfinished">您当前的总余额</translation>
+    </message>
+    <message>
+        <source>Your current balance in watch-only addresses</source>
+        <translation type="unfinished">您当前在仅观察观察地址中的余额</translation>
+    </message>
+    <message>
+        <source>Spendable:</source>
+        <translation type="unfinished">可动用:</translation>
+    </message>
+    <message>
+        <source>Recent transactions</source>
+        <translation type="unfinished">最近交易</translation>
+    </message>
+    <message>
+        <source>Unconfirmed transactions to watch-only addresses</source>
+        <translation type="unfinished">仅观察地址的未确认交易</translation>
+    </message>
+    <message>
+        <source>Mined balance in watch-only addresses that has not yet matured</source>
+        <translation type="unfinished">仅观察地址中尚未成熟的挖矿收入余额:</translation>
+    </message>
+    <message>
+        <source>Current total balance in watch-only addresses</source>
+        <translation type="unfinished">仅观察地址中的当前总余额</translation>
+    </message>
+    <message>
+        <source>Privacy mode activated for the Overview tab. To unmask the values, uncheck Settings-&gt;Mask values.</source>
+        <translation type="unfinished">“概况”标签页已启用隐私模式。要明文显示数值，请在设置中取消勾选“不明文显示数值”。</translation>
+    </message>
+</context>
+<context>
+    <name>PSBTOperationsDialog</name>
+    <message>
+        <source>Dialog</source>
+        <translation type="unfinished">会话</translation>
+    </message>
+    <message>
+        <source>Sign Tx</source>
+        <translation type="unfinished">签名交易</translation>
+    </message>
+    <message>
+        <source>Broadcast Tx</source>
+        <translation type="unfinished">广播交易</translation>
+    </message>
+    <message>
+        <source>Copy to Clipboard</source>
+        <translation type="unfinished">复制到剪贴板</translation>
+    </message>
+    <message>
+        <source>Save…</source>
+        <translation type="unfinished">保存...</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation type="unfinished">关闭</translation>
+    </message>
+    <message>
+        <source>Failed to load transaction: %1</source>
+        <translation type="unfinished">加载交易失败: %1</translation>
+    </message>
+    <message>
+        <source>Failed to sign transaction: %1</source>
+        <translation type="unfinished">签名交易失败: %1</translation>
+    </message>
+    <message>
+        <source>Cannot sign inputs while wallet is locked.</source>
+        <translation type="unfinished">钱包已锁定，无法签名交易输入项。</translation>
+    </message>
+    <message>
+        <source>Could not sign any more inputs.</source>
+        <translation type="unfinished">没有交易输入项可供签名了。</translation>
+    </message>
+    <message>
+        <source>Signed %1 inputs, but more signatures are still required.</source>
+        <translation type="unfinished">已签名 %1 个交易输入项，但是仍然还有余下的项目需要签名。</translation>
+    </message>
+    <message>
+        <source>Signed transaction successfully. Transaction is ready to broadcast.</source>
+        <translation type="unfinished">成功签名交易。交易已经可以广播。</translation>
+    </message>
+    <message>
+        <source>Unknown error processing transaction.</source>
+        <translation type="unfinished">处理交易时遇到未知错误。</translation>
+    </message>
+    <message>
+        <source>Transaction broadcast successfully! Transaction ID: %1</source>
+        <translation type="unfinished">已成功广播交易！交易ID: %1</translation>
+    </message>
+    <message>
+        <source>Transaction broadcast failed: %1</source>
+        <translation type="unfinished">交易广播失败: %1</translation>
+    </message>
+    <message>
+        <source>PSBT copied to clipboard.</source>
+        <translation type="unfinished">已复制PSBT到剪贴板</translation>
+    </message>
+    <message>
+        <source>Save Transaction Data</source>
+        <translation type="unfinished">保存交易数据</translation>
+    </message>
+    <message>
+        <source>Partially Signed Transaction (Binary)</source>
+        <extracomment>Expanded name of the binary PSBT file format. See: BIP 174.</extracomment>
+        <translation type="unfinished">部分签名交易(二进制)</translation>
+    </message>
+    <message>
+        <source>PSBT saved to disk.</source>
+        <translation type="unfinished">PSBT已保存到硬盘</translation>
+    </message>
+    <message>
+        <source> * Sends %1 to %2</source>
+        <translation type="unfinished"> * 发送 %1 至 %2</translation>
+    </message>
+    <message>
+        <source>Unable to calculate transaction fee or total transaction amount.</source>
+        <translation type="unfinished">无法计算交易费用或总交易金额。</translation>
+    </message>
+    <message>
+        <source>Pays transaction fee: </source>
+        <translation type="unfinished">支付交易费用:</translation>
+    </message>
+    <message>
+        <source>Total Amount</source>
+        <translation type="unfinished">总额</translation>
+    </message>
+    <message>
+        <source>or</source>
+        <translation type="unfinished">或</translation>
+    </message>
+    <message>
+        <source>Transaction has %1 unsigned inputs.</source>
+        <translation type="unfinished">交易中含有%1个未签名输入项。</translation>
+    </message>
+    <message>
+        <source>Transaction is missing some information about inputs.</source>
+        <translation type="unfinished">交易中有输入项缺失某些信息。</translation>
+    </message>
+    <message>
+        <source>Transaction still needs signature(s).</source>
+        <translation type="unfinished">交易仍然需要签名。</translation>
+    </message>
+    <message>
+        <source>(But no wallet is loaded.)</source>
+        <translation type="unfinished">(但没有加载钱包。)</translation>
+    </message>
+    <message>
+        <source>(But this wallet cannot sign transactions.)</source>
+        <translation type="unfinished">(但这个钱包不能签名交易)</translation>
+    </message>
+    <message>
+        <source>(But this wallet does not have the right keys.)</source>
+        <translation type="unfinished">(但这个钱包没有正确的密钥)</translation>
+    </message>
+    <message>
+        <source>Transaction is fully signed and ready for broadcast.</source>
+        <translation type="unfinished">交易已经完全签名，可以广播。</translation>
+    </message>
+    <message>
+        <source>Transaction status is unknown.</source>
+        <translation type="unfinished">交易状态未知。</translation>
+    </message>
+</context>
+<context>
+    <name>PaymentServer</name>
+    <message>
+        <source>Payment request error</source>
+        <translation type="unfinished">支付请求出错</translation>
+    </message>
+    <message>
+        <source>Cannot start bitcoin: click-to-pay handler</source>
+        <translation type="unfinished">无法启动 bitcoin: 协议的“一键支付”处理程序</translation>
+    </message>
+    <message>
+        <source>URI handling</source>
+        <translation type="unfinished">URI 处理</translation>
+    </message>
+    <message>
+        <source>'bitcoin://' is not a valid URI. Use 'bitcoin:' instead.</source>
+        <translation type="unfinished">‘bitcoin://’不是合法的URI。请改用'bitcoin:'。</translation>
+    </message>
+    <message>
+        <source>Cannot process payment request because BIP70 is not supported.
+Due to widespread security flaws in BIP70 it's strongly recommended that any merchant instructions to switch wallets be ignored.
+If you are receiving this error you should request the merchant provide a BIP21 compatible URI.</source>
+        <translation type="unfinished">因为不支持BIP70，无法处理付款请求。
+由于BIP70具有广泛的安全缺陷，无论哪个商家指引要求您更换钱包，我们都强烈建议您不要听信。
+如果您看到了这个错误，您应该要求商家提供兼容BIP21的URI。</translation>
+    </message>
+    <message>
+        <source>URI cannot be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
+        <translation type="unfinished">无法解析 URI 地址！可能是因为比特币地址无效，或是 URI 参数格式错误。</translation>
+    </message>
+    <message>
+        <source>Payment request file handling</source>
+        <translation type="unfinished">支付请求文件处理</translation>
+    </message>
+</context>
 <context>
     <name>PeerTableModel</name>
+    <message>
+        <source>User Agent</source>
+        <extracomment>Title of Peers Table column which contains the peer's User Agent string.</extracomment>
+        <translation type="unfinished">用户代理</translation>
+    </message>
+    <message>
+        <source>Peer</source>
+        <extracomment>Title of Peers Table column which contains a unique number used to identify a connection.</extracomment>
+        <translation type="unfinished">节点</translation>
+    </message>
+    <message>
+        <source>Age</source>
+        <extracomment>Title of Peers Table column which indicates the duration (length of time) since the peer connection started.</extracomment>
+        <translation type="unfinished">连接时间</translation>
+    </message>
+    <message>
+        <source>Direction</source>
+        <extracomment>Title of Peers Table column which indicates the direction the peer connection was initiated from.</extracomment>
+        <translation type="unfinished">方向</translation>
+    </message>
+    <message>
+        <source>Sent</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have sent to the peer.</extracomment>
+        <translation type="unfinished">已发送</translation>
+    </message>
+    <message>
+        <source>Received</source>
+        <extracomment>Title of Peers Table column which indicates the total amount of network information we have received from the peer.</extracomment>
+        <translation type="unfinished">已接收</translation>
+    </message>
     <message>
         <source>Address</source>
         <extracomment>Title of Peers Table column which contains the IP/Onion/I2P address of the connected peer.</extracomment>
         <translation type="unfinished">地址</translation>
     </message>
-    </context>
+    <message>
+        <source>Type</source>
+        <extracomment>Title of Peers Table column which describes the type of peer connection. The "type" describes why the connection exists.</extracomment>
+        <translation type="unfinished">类型</translation>
+    </message>
+    <message>
+        <source>Network</source>
+        <extracomment>Title of Peers Table column which states the network the peer connected through.</extracomment>
+        <translation type="unfinished">网络</translation>
+    </message>
+    <message>
+        <source>Inbound</source>
+        <extracomment>An Inbound Connection from a Peer.</extracomment>
+        <translation type="unfinished">传入</translation>
+    </message>
+    <message>
+        <source>Outbound</source>
+        <extracomment>An Outbound Connection to a Peer.</extracomment>
+        <translation type="unfinished">传出</translation>
+    </message>
+</context>
+<context>
+    <name>QRImageWidget</name>
+    <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">保存图像(&amp;S)...</translation>
+    </message>
+    <message>
+        <source>&amp;Copy Image</source>
+        <translation type="unfinished">复制图像(&amp;C)</translation>
+    </message>
+    <message>
+        <source>Resulting URI too long, try to reduce the text for label / message.</source>
+        <translation type="unfinished">URI 太长，请试着精简标签或消息文本。</translation>
+    </message>
+    <message>
+        <source>Error encoding URI into QR Code.</source>
+        <translation type="unfinished">把 URI 编码成二维码时发生错误。</translation>
+    </message>
+    <message>
+        <source>QR code support not available.</source>
+        <translation type="unfinished">不支持二维码。</translation>
+    </message>
+    <message>
+        <source>Save QR Code</source>
+        <translation type="unfinished">保存二维码</translation>
+    </message>
+    <message>
+        <source>PNG Image</source>
+        <extracomment>Expanded name of the PNG file format. See: https://en.wikipedia.org/wiki/Portable_Network_Graphics.</extracomment>
+        <translation type="unfinished">PNG图像</translation>
+    </message>
+</context>
+<context>
+    <name>RPCConsole</name>
+    <message>
+        <source>N/A</source>
+        <translation type="unfinished">不可用</translation>
+    </message>
+    <message>
+        <source>Client version</source>
+        <translation type="unfinished">客户端版本</translation>
+    </message>
+    <message>
+        <source>&amp;Information</source>
+        <translation type="unfinished">信息(&amp;I)</translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation type="unfinished">常规</translation>
+    </message>
+    <message>
+        <source>Datadir</source>
+        <translation type="unfinished">数据目录</translation>
+    </message>
+    <message>
+        <source>To specify a non-default location of the data directory use the '%1' option.</source>
+        <translation type="unfinished">如果不想用默认的数据目录位置，请用 '%1' 这个选项来指定新的位置。</translation>
+    </message>
+    <message>
+        <source>Blocksdir</source>
+        <translation type="unfinished">区块存储目录</translation>
+    </message>
+    <message>
+        <source>To specify a non-default location of the blocks directory use the '%1' option.</source>
+        <translation type="unfinished">如果要自定义区块存储目录的位置，请用 '%1' 这个选项来指定新的位置。</translation>
+    </message>
+    <message>
+        <source>Startup time</source>
+        <translation type="unfinished">启动时间</translation>
+    </message>
+    <message>
+        <source>Network</source>
+        <translation type="unfinished">网络</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished">名称</translation>
+    </message>
+    <message>
+        <source>Number of connections</source>
+        <translation type="unfinished">连接数</translation>
+    </message>
+    <message>
+        <source>Block chain</source>
+        <translation type="unfinished">区块链</translation>
+    </message>
+    <message>
+        <source>Memory Pool</source>
+        <translation type="unfinished">内存池</translation>
+    </message>
+    <message>
+        <source>Current number of transactions</source>
+        <translation type="unfinished">当前交易数量</translation>
+    </message>
+    <message>
+        <source>Memory usage</source>
+        <translation type="unfinished">内存使用</translation>
+    </message>
+    <message>
+        <source>Wallet: </source>
+        <translation type="unfinished">钱包:</translation>
+    </message>
+    <message>
+        <source>(none)</source>
+        <translation type="unfinished">(无)</translation>
+    </message>
+    <message>
+        <source>&amp;Reset</source>
+        <translation type="unfinished">重置(&amp;R)</translation>
+    </message>
+    <message>
+        <source>Received</source>
+        <translation type="unfinished">已接收</translation>
+    </message>
+    <message>
+        <source>Sent</source>
+        <translation type="unfinished">已发送</translation>
+    </message>
+    <message>
+        <source>&amp;Peers</source>
+        <translation type="unfinished">节点(&amp;P)</translation>
+    </message>
+    <message>
+        <source>Banned peers</source>
+        <translation type="unfinished">已封禁节点</translation>
+    </message>
+    <message>
+        <source>Select a peer to view detailed information.</source>
+        <translation type="unfinished">选择节点查看详细信息。</translation>
+    </message>
+    <message>
+        <source>Version</source>
+        <translation type="unfinished">版本</translation>
+    </message>
+    <message>
+        <source>Starting Block</source>
+        <translation type="unfinished">起步区块</translation>
+    </message>
+    <message>
+        <source>Synced Headers</source>
+        <translation type="unfinished">已同步区块头</translation>
+    </message>
+    <message>
+        <source>Synced Blocks</source>
+        <translation type="unfinished">已同步区块</translation>
+    </message>
+    <message>
+        <source>Last Transaction</source>
+        <translation type="unfinished">最近交易</translation>
+    </message>
+    <message>
+        <source>The mapped Autonomous System used for diversifying peer selection.</source>
+        <translation type="unfinished">映射到的自治系统，被用来多样化选择节点</translation>
+    </message>
+    <message>
+        <source>Mapped AS</source>
+        <translation type="unfinished">映射到的AS</translation>
+    </message>
+    <message>
+        <source>Whether we relay addresses to this peer.</source>
+        <extracomment>Tooltip text for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
+        <translation type="unfinished">是否把地址转发给这个节点。</translation>
+    </message>
+    <message>
+        <source>Address Relay</source>
+        <extracomment>Text title for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
+        <translation type="unfinished">地址转发</translation>
+    </message>
+    <message>
+        <source>The total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</source>
+        <extracomment>Tooltip text for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
+        <translation type="unfinished">从这个节点接收并处理过的地址总数（除去因频次限制而丢弃的那些地址）。</translation>
+    </message>
+    <message>
+        <source>The total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</source>
+        <extracomment>Tooltip text for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
+        <translation type="unfinished">从这个节点接收后又因频次限制而丢弃（未被处理）的地址总数。</translation>
+    </message>
+    <message>
+        <source>Addresses Processed</source>
+        <extracomment>Text title for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
+        <translation type="unfinished">已处理地址</translation>
+    </message>
+    <message>
+        <source>Addresses Rate-Limited</source>
+        <extracomment>Text title for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
+        <translation type="unfinished">被频率限制丢弃的地址</translation>
+    </message>
+    <message>
+        <source>User Agent</source>
+        <translation type="unfinished">用户代理</translation>
+    </message>
+    <message>
+        <source>Node window</source>
+        <translation type="unfinished">节点窗口</translation>
+    </message>
+    <message>
+        <source>Current block height</source>
+        <translation type="unfinished">当前区块高度</translation>
+    </message>
+    <message>
+        <source>Open the %1 debug log file from the current data directory. This can take a few seconds for large log files.</source>
+        <translation type="unfinished">打开当前数据目录中的 %1 调试日志文件。日志文件大的话可能要等上几秒钟。</translation>
+    </message>
+    <message>
+        <source>Decrease font size</source>
+        <translation type="unfinished">缩小字体大小</translation>
+    </message>
+    <message>
+        <source>Increase font size</source>
+        <translation type="unfinished">放大字体大小</translation>
+    </message>
+    <message>
+        <source>Permissions</source>
+        <translation type="unfinished">权限</translation>
+    </message>
+    <message>
+        <source>The direction and type of peer connection: %1</source>
+        <translation type="unfinished">节点连接的方向和类型: %1</translation>
+    </message>
+    <message>
+        <source>Direction/Type</source>
+        <translation type="unfinished">方向/类型</translation>
+    </message>
+    <message>
+        <source>The network protocol this peer is connected through: IPv4, IPv6, Onion, I2P, or CJDNS.</source>
+        <translation type="unfinished">这个节点是通过这种网络协议连接到的: IPv4, IPv6, Onion, I2P, 或 CJDNS.</translation>
+    </message>
+    <message>
+        <source>Services</source>
+        <translation type="unfinished">服务</translation>
+    </message>
+    <message>
+        <source>Whether the peer requested us to relay transactions.</source>
+        <translation type="unfinished">这个节点是否要求我们转发交易。</translation>
+    </message>
+    <message>
+        <source>Wants Tx Relay</source>
+        <translation type="unfinished">要求交易转发</translation>
+    </message>
+    <message>
+        <source>High bandwidth BIP152 compact block relay: %1</source>
+        <translation type="unfinished">高带宽BIP152密实区块转发: %1</translation>
+    </message>
+    <message>
+        <source>High Bandwidth</source>
+        <translation type="unfinished">高带宽</translation>
+    </message>
+    <message>
+        <source>Connection Time</source>
+        <translation type="unfinished">连接时间</translation>
+    </message>
+    <message>
+        <source>Elapsed time since a novel block passing initial validity checks was received from this peer.</source>
+        <translation type="unfinished">自从这个节点上一次发来可通过初始有效性检查的新区块以来到现在经过的时间</translation>
+    </message>
+    <message>
+        <source>Last Block</source>
+        <translation type="unfinished">上一个区块</translation>
+    </message>
+    <message>
+        <source>Elapsed time since a novel transaction accepted into our mempool was received from this peer.</source>
+        <extracomment>Tooltip text for the Last Transaction field in the peer details area.</extracomment>
+        <translation type="unfinished">自从这个节点上一次发来被我们的内存池接受的新交易到现在经过的时间</translation>
+    </message>
+    <message>
+        <source>Last Send</source>
+        <translation type="unfinished">上次发送</translation>
+    </message>
+    <message>
+        <source>Last Receive</source>
+        <translation type="unfinished">上次接收</translation>
+    </message>
+    <message>
+        <source>Ping Time</source>
+        <translation type="unfinished">Ping 延时</translation>
+    </message>
+    <message>
+        <source>The duration of a currently outstanding ping.</source>
+        <translation type="unfinished">目前这一次 ping 已经过去的时间。</translation>
+    </message>
+    <message>
+        <source>Ping Wait</source>
+        <translation type="unfinished">Ping 等待</translation>
+    </message>
+    <message>
+        <source>Min Ping</source>
+        <translation type="unfinished">最小 Ping 值</translation>
+    </message>
+    <message>
+        <source>Time Offset</source>
+        <translation type="unfinished">时间偏移</translation>
+    </message>
+    <message>
+        <source>Last block time</source>
+        <translation type="unfinished">上一区块时间</translation>
+    </message>
+    <message>
+        <source>&amp;Open</source>
+        <translation type="unfinished">打开(&amp;O)</translation>
+    </message>
+    <message>
+        <source>&amp;Console</source>
+        <translation type="unfinished">控制台(&amp;C)</translation>
+    </message>
+    <message>
+        <source>&amp;Network Traffic</source>
+        <translation type="unfinished">网络流量(&amp;N)</translation>
+    </message>
+    <message>
+        <source>Totals</source>
+        <translation type="unfinished">总数</translation>
+    </message>
+    <message>
+        <source>Debug log file</source>
+        <translation type="unfinished">调试日志文件</translation>
+    </message>
+    <message>
+        <source>Clear console</source>
+        <translation type="unfinished">清空控制台</translation>
+    </message>
+    <message>
+        <source>In:</source>
+        <translation type="unfinished">传入:</translation>
+    </message>
+    <message>
+        <source>Out:</source>
+        <translation type="unfinished">传出:</translation>
+    </message>
+    <message>
+        <source>Inbound: initiated by peer</source>
+        <extracomment>Explanatory text for an inbound peer connection.</extracomment>
+        <translation type="unfinished">入站: 由对端发起</translation>
+    </message>
+    <message>
+        <source>Outbound Full Relay: default</source>
+        <extracomment>Explanatory text for an outbound peer connection that relays all network information. This is the default behavior for outbound connections.</extracomment>
+        <translation type="unfinished">出站完整转发: 默认</translation>
+    </message>
+    <message>
+        <source>Outbound Block Relay: does not relay transactions or addresses</source>
+        <extracomment>Explanatory text for an outbound peer connection that relays network information about blocks and not transactions or addresses.</extracomment>
+        <translation type="unfinished">出站区块转发: 不转发交易和地址</translation>
+    </message>
+    <message>
+        <source>Outbound Manual: added using RPC %1 or %2/%3 configuration options</source>
+        <extracomment>Explanatory text for an outbound peer connection that was established manually through one of several methods. The numbered arguments are stand-ins for the methods available to establish manual connections.</extracomment>
+        <translation type="unfinished">出站手动: 加入使用RPC %1 或 %2/%3 配置选项</translation>
+    </message>
+    <message>
+        <source>Outbound Feeler: short-lived, for testing addresses</source>
+        <extracomment>Explanatory text for a short-lived outbound peer connection that is used to test the aliveness of known addresses.</extracomment>
+        <translation type="unfinished">出站触须: 短暂，用于测试地址</translation>
+    </message>
+    <message>
+        <source>Outbound Address Fetch: short-lived, for soliciting addresses</source>
+        <extracomment>Explanatory text for a short-lived outbound peer connection that is used to request addresses from a peer.</extracomment>
+        <translation type="unfinished">出站地址取回: 短暂，用于请求取回地址</translation>
+    </message>
+    <message>
+        <source>we selected the peer for high bandwidth relay</source>
+        <translation type="unfinished">我们选择了用于高带宽转发的节点</translation>
+    </message>
+    <message>
+        <source>the peer selected us for high bandwidth relay</source>
+        <translation type="unfinished">对端选择了我们用于高带宽转发</translation>
+    </message>
+    <message>
+        <source>no high bandwidth relay selected</source>
+        <translation type="unfinished">未选择高带宽转发</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <extracomment>Context menu action to copy the address of a peer.</extracomment>
+        <translation type="unfinished">复制地址(&amp;C)</translation>
+    </message>
+    <message>
+        <source>&amp;Disconnect</source>
+        <translation type="unfinished">断开(&amp;D)</translation>
+    </message>
+    <message>
+        <source>1 &amp;hour</source>
+        <translation type="unfinished">1 小时(&amp;H)</translation>
+    </message>
+    <message>
+        <source>1 d&amp;ay</source>
+        <translation type="unfinished">1 天(&amp;A)</translation>
+    </message>
+    <message>
+        <source>1 &amp;week</source>
+        <translation type="unfinished">1 周(&amp;W)</translation>
+    </message>
+    <message>
+        <source>1 &amp;year</source>
+        <translation type="unfinished">1 年(&amp;Y)</translation>
+    </message>
+    <message>
+        <source>&amp;Copy IP/Netmask</source>
+        <extracomment>Context menu action to copy the IP/Netmask of a banned peer. IP/Netmask is the combination of a peer's IP address and its Netmask. For IP address, see: https://en.wikipedia.org/wiki/IP_address.</extracomment>
+        <translation type="unfinished">复制IP/网络掩码(&amp;C)</translation>
+    </message>
+    <message>
+        <source>&amp;Unban</source>
+        <translation type="unfinished">解封(&amp;U)</translation>
+    </message>
+    <message>
+        <source>Network activity disabled</source>
+        <translation type="unfinished">网络活动已禁用</translation>
+    </message>
+    <message>
+        <source>Executing command without any wallet</source>
+        <translation type="unfinished">不使用任何钱包执行命令</translation>
+    </message>
+    <message>
+        <source>Executing command using "%1" wallet</source>
+        <translation type="unfinished">使用“%1”钱包执行命令</translation>
+    </message>
+    <message>
+        <source>Welcome to the %1 RPC console.
+Use up and down arrows to navigate history, and %2 to clear screen.
+Use %3 and %4 to increase or decrease the font size.
+Type %5 for an overview of available commands.
+For more information on using this console, type %6.
+
+%7WARNING: Scammers have been active, telling users to type commands here, stealing their wallet contents. Do not use this console without fully understanding the ramifications of a command.%8</source>
+        <extracomment>RPC console welcome message. Placeholders %7 and %8 are style tags for the warning content, and they are not space separated from the rest of the text intentionally.</extracomment>
+        <translation type="unfinished">欢迎来到 %1 RPC 控制台。
+使用上与下箭头以进行历史导航，%2 以清除屏幕。
+使用%3 和 %4 以增加或减小字体大小。
+输入 %5 以显示可用命令的概览。
+查看更多关于此控制台的信息，输入 %6。
+
+%7 警告：骗子们很活跃，告诉用户在这里输入命令，偷走他们钱包中的内容。不要在不完全了解一个命令的后果的情况下使用此控制台。%8</translation>
+    </message>
+    <message>
+        <source>Executing…</source>
+        <extracomment>A console message indicating an entered command is currently being executed.</extracomment>
+        <translation type="unfinished">执行中……</translation>
+    </message>
+    <message>
+        <source>(peer: %1)</source>
+        <translation type="unfinished">(节点: %1)</translation>
+    </message>
+    <message>
+        <source>via %1</source>
+        <translation type="unfinished">通过 %1</translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished">是</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished">否</translation>
+    </message>
+    <message>
+        <source>To</source>
+        <translation type="unfinished">到</translation>
+    </message>
+    <message>
+        <source>From</source>
+        <translation type="unfinished">来自</translation>
+    </message>
+    <message>
+        <source>Ban for</source>
+        <translation type="unfinished">封禁时长</translation>
+    </message>
+    <message>
+        <source>Never</source>
+        <translation type="unfinished">永不</translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">未知</translation>
+    </message>
+</context>
+<context>
+    <name>ReceiveCoinsDialog</name>
+    <message>
+        <source>&amp;Amount:</source>
+        <translation type="unfinished">金额(&amp;A):</translation>
+    </message>
+    <message>
+        <source>&amp;Label:</source>
+        <translation type="unfinished">标签(&amp;L):</translation>
+    </message>
+    <message>
+        <source>&amp;Message:</source>
+        <translation type="unfinished">消息(&amp;M):</translation>
+    </message>
+    <message>
+        <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
+        <translation type="unfinished">可在支付请求上备注一条信息，在打开支付请求时可以看到。注意:该消息不是通过比特币网络传送。</translation>
+    </message>
+    <message>
+        <source>An optional label to associate with the new receiving address.</source>
+        <translation type="unfinished">可为新建的收款地址添加一个标签。</translation>
+    </message>
+    <message>
+        <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
+        <translation type="unfinished">使用此表单请求付款。所有字段都是&lt;b&gt;可选&lt;/b&gt;的。</translation>
+    </message>
+    <message>
+        <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
+        <translation type="unfinished">可选的请求金额。留空或填零为不要求具体金额。</translation>
+    </message>
+    <message>
+        <source>An optional label to associate with the new receiving address (used by you to identify an invoice).  It is also attached to the payment request.</source>
+        <translation type="unfinished">一个关联到新收款地址（被您用来识别发票）的可选标签。它也会被附加到付款请求中。</translation>
+    </message>
+    <message>
+        <source>An optional message that is attached to the payment request and may be displayed to the sender.</source>
+        <translation type="unfinished">一条附加到付款请求中的可选消息，可以显示给付款方。</translation>
+    </message>
+    <message>
+        <source>&amp;Create new receiving address</source>
+        <translation type="unfinished">新建收款地址(&amp;C)</translation>
+    </message>
+    <message>
+        <source>Clear all fields of the form.</source>
+        <translation type="unfinished">清除此表单的所有字段。</translation>
+    </message>
+    <message>
+        <source>Clear</source>
+        <translation type="unfinished">清除</translation>
+    </message>
+    <message>
+        <source>Requested payments history</source>
+        <translation type="unfinished">付款请求历史</translation>
+    </message>
+    <message>
+        <source>Show the selected request (does the same as double clicking an entry)</source>
+        <translation type="unfinished">显示选中的请求 (直接双击项目也可以显示)</translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished">显示</translation>
+    </message>
+    <message>
+        <source>Remove the selected entries from the list</source>
+        <translation type="unfinished">从列表中移除选中的条目</translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation type="unfinished">移除</translation>
+    </message>
+    <message>
+        <source>Copy &amp;URI</source>
+        <translation type="unfinished">复制 &amp;URI</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">复制地址(&amp;C)</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">复制标签(&amp;L)</translation>
+    </message>
+    <message>
+        <source>Copy &amp;message</source>
+        <translation type="unfinished">复制消息(&amp;M)</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">复制金额(&amp;A)</translation>
+    </message>
+    <message>
+        <source>Could not unlock wallet.</source>
+        <translation type="unfinished">无法解锁钱包。</translation>
+    </message>
+    <message>
+        <source>Could not generate new %1 address</source>
+        <translation type="unfinished">无法生成新的%1地址</translation>
+    </message>
+</context>
+<context>
+    <name>ReceiveRequestDialog</name>
+    <message>
+        <source>Request payment to …</source>
+        <translation type="unfinished">请求支付至...</translation>
+    </message>
+    <message>
+        <source>Address:</source>
+        <translation type="unfinished">地址:</translation>
+    </message>
+    <message>
+        <source>Amount:</source>
+        <translation type="unfinished">金额:</translation>
+    </message>
+    <message>
+        <source>Label:</source>
+        <translation type="unfinished">标签：</translation>
+    </message>
+    <message>
+        <source>Message:</source>
+        <translation type="unfinished">消息:</translation>
+    </message>
+    <message>
+        <source>Wallet:</source>
+        <translation type="unfinished">钱包:</translation>
+    </message>
+    <message>
+        <source>Copy &amp;URI</source>
+        <translation type="unfinished">复制 &amp;URI</translation>
+    </message>
+    <message>
+        <source>Copy &amp;Address</source>
+        <translation type="unfinished">复制地址(&amp;A)</translation>
+    </message>
+    <message>
+        <source>&amp;Verify</source>
+        <translation type="unfinished">验证(&amp;V)</translation>
+    </message>
+    <message>
+        <source>Verify this address on e.g. a hardware wallet screen</source>
+        <translation type="unfinished">在像是硬件钱包屏幕的地方检验这个地址</translation>
+    </message>
+    <message>
+        <source>&amp;Save Image…</source>
+        <translation type="unfinished">保存图像(&amp;S)...</translation>
+    </message>
+    <message>
+        <source>Payment information</source>
+        <translation type="unfinished">付款信息</translation>
+    </message>
+    <message>
+        <source>Request payment to %1</source>
+        <translation type="unfinished">请求付款到 %1</translation>
+    </message>
+</context>
 <context>
     <name>RecentRequestsTableModel</name>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">日期</translation>
+    </message>
     <message>
         <source>Label</source>
         <translation type="unfinished">标签</translation>
     </message>
     <message>
+        <source>Message</source>
+        <translation type="unfinished">消息</translation>
+    </message>
+    <message>
         <source>(no label)</source>
         <translation type="unfinished">(无标签)</translation>
     </message>
-    </context>
+    <message>
+        <source>(no message)</source>
+        <translation type="unfinished">(无消息)</translation>
+    </message>
+    <message>
+        <source>(no amount requested)</source>
+        <translation type="unfinished">(未填写请求金额)</translation>
+    </message>
+    <message>
+        <source>Requested</source>
+        <translation type="unfinished">请求金额</translation>
+    </message>
+</context>
 <context>
     <name>SendCoinsDialog</name>
+    <message>
+        <source>Send Coins</source>
+        <translation type="unfinished">发币</translation>
+    </message>
+    <message>
+        <source>Coin Control Features</source>
+        <translation type="unfinished">手动选币功能</translation>
+    </message>
+    <message>
+        <source>automatically selected</source>
+        <translation type="unfinished">自动选择</translation>
+    </message>
+    <message>
+        <source>Insufficient funds!</source>
+        <translation type="unfinished">金额不足！</translation>
+    </message>
+    <message>
+        <source>Quantity:</source>
+        <translation type="unfinished">总量:</translation>
+    </message>
+    <message>
+        <source>Bytes:</source>
+        <translation type="unfinished">字节数:</translation>
+    </message>
+    <message>
+        <source>Amount:</source>
+        <translation type="unfinished">金额:</translation>
+    </message>
+    <message>
+        <source>Fee:</source>
+        <translation type="unfinished">费用:</translation>
+    </message>
+    <message>
+        <source>After Fee:</source>
+        <translation type="unfinished">加上交易费用后:</translation>
+    </message>
+    <message>
+        <source>Change:</source>
+        <translation type="unfinished">找零:</translation>
+    </message>
+    <message>
+        <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
+        <translation type="unfinished">在激活该选项后，如果填写了无效的找零地址，或者干脆没填找零地址，找零资金将会被转入新生成的地址。</translation>
+    </message>
+    <message>
+        <source>Custom change address</source>
+        <translation type="unfinished">自定义找零地址</translation>
+    </message>
+    <message>
+        <source>Transaction Fee:</source>
+        <translation type="unfinished">交易手续费:</translation>
+    </message>
+    <message>
+        <source>Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until you have validated the complete chain.</source>
+        <translation type="unfinished">如果使用备用手续费设置，有可能会导致交易经过几个小时、几天（甚至永远）无法被确认。请考虑手动选择手续费，或等待整个链完成验证。</translation>
+    </message>
+    <message>
+        <source>Warning: Fee estimation is currently not possible.</source>
+        <translation type="unfinished">警告: 目前无法进行手续费估计。</translation>
+    </message>
+    <message>
+        <source>per kilobyte</source>
+        <translation type="unfinished">每KB</translation>
+    </message>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished">隐藏</translation>
+    </message>
+    <message>
+        <source>Recommended:</source>
+        <translation type="unfinished">推荐:</translation>
+    </message>
+    <message>
+        <source>Custom:</source>
+        <translation type="unfinished">自定义:</translation>
+    </message>
+    <message>
+        <source>Send to multiple recipients at once</source>
+        <translation type="unfinished">一次发送给多个收款人</translation>
+    </message>
+    <message>
+        <source>Add &amp;Recipient</source>
+        <translation type="unfinished">添加收款人(&amp;R)</translation>
+    </message>
+    <message>
+        <source>Clear all fields of the form.</source>
+        <translation type="unfinished">清除此表单的所有字段。</translation>
+    </message>
+    <message>
+        <source>Inputs…</source>
+        <translation type="unfinished">输入...</translation>
+    </message>
+    <message>
+        <source>Dust:</source>
+        <translation type="unfinished">粉尘:</translation>
+    </message>
+    <message>
+        <source>Choose…</source>
+        <translation type="unfinished">选择...</translation>
+    </message>
+    <message>
+        <source>Hide transaction fee settings</source>
+        <translation type="unfinished">隐藏交易手续费设置</translation>
+    </message>
+    <message>
+        <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
+
+Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satoshis per kvB" for a transaction size of 500 virtual bytes (half of 1 kvB) would ultimately yield a fee of only 50 satoshis.</source>
+        <translation type="unfinished">指定交易虚拟大小的每kB (1,000字节) 自定义费率。
+
+附注：因为矿工费是按字节计费的，所以如果费率是“每kvB支付100聪”，那么对于一笔500虚拟字节 (1kvB的一半) 的交易，最终将只会产生50聪的矿工费。（译注：这里就是提醒单位是字节，而不是千字节，如果搞错的话，矿工费会过低，导致交易长时间无法确认，或者压根无法发出）</translation>
+    </message>
+    <message>
+        <source>When there is less transaction volume than space in the blocks, miners as well as relaying nodes may enforce a minimum fee. Paying only this minimum fee is just fine, but be aware that this can result in a never confirming transaction once there is more demand for bitcoin transactions than the network can process.</source>
+        <translation type="unfinished">当交易量小于可用区块空间时，矿工和中继节点可能会执行最低手续费率限制。按照这个最低费率来支付手续费也是可以的，但请注意，一旦交易需求超出比特币网络能处理的限度，你的交易可能永远也无法确认。</translation>
+    </message>
+    <message>
+        <source>A too low fee might result in a never confirming transaction (read the tooltip)</source>
+        <translation type="unfinished">过低的手续费率可能导致交易永远无法确认（请阅读工具提示）</translation>
+    </message>
+    <message>
+        <source>(Smart fee not initialized yet. This usually takes a few blocks…)</source>
+        <translation type="unfinished">(智能矿工费尚未被初始化。这一般需要几个区块...)</translation>
+    </message>
+    <message>
+        <source>Confirmation time target:</source>
+        <translation type="unfinished">确认时间目标:</translation>
+    </message>
+    <message>
+        <source>Enable Replace-By-Fee</source>
+        <translation type="unfinished">启用手续费追加</translation>
+    </message>
+    <message>
+        <source>With Replace-By-Fee (BIP-125) you can increase a transaction's fee after it is sent. Without this, a higher fee may be recommended to compensate for increased transaction delay risk.</source>
+        <translation type="unfinished">手续费追加（Replace-By-Fee，BIP-125）可以让你在送出交易后继续追加手续费。不用这个功能的话，建议付比较高的手续费来降低交易延迟的风险。</translation>
+    </message>
+    <message>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished">清除所有(&amp;A)</translation>
+    </message>
+    <message>
+        <source>Balance:</source>
+        <translation type="unfinished">余额:</translation>
+    </message>
+    <message>
+        <source>Confirm the send action</source>
+        <translation type="unfinished">确认发送操作</translation>
+    </message>
+    <message>
+        <source>S&amp;end</source>
+        <translation type="unfinished">发送(&amp;E)</translation>
+    </message>
+    <message>
+        <source>Copy quantity</source>
+        <translation type="unfinished">复制数目</translation>
+    </message>
+    <message>
+        <source>Copy amount</source>
+        <translation type="unfinished">复制金额</translation>
+    </message>
+    <message>
+        <source>Copy fee</source>
+        <translation type="unfinished">复制手续费</translation>
+    </message>
+    <message>
+        <source>Copy after fee</source>
+        <translation type="unfinished">复制含交易费的金额</translation>
+    </message>
+    <message>
+        <source>Copy bytes</source>
+        <translation type="unfinished">复制字节数</translation>
+    </message>
+    <message>
+        <source>Copy dust</source>
+        <translation type="unfinished">复制粉尘金额</translation>
+    </message>
+    <message>
+        <source>Copy change</source>
+        <translation type="unfinished">复制找零金额</translation>
+    </message>
+    <message>
+        <source>%1 (%2 blocks)</source>
+        <translation type="unfinished">%1 (%2个块)</translation>
+    </message>
+    <message>
+        <source>Sign on device</source>
+        <extracomment>"device" usually means a hardware wallet.</extracomment>
+        <translation type="unfinished">在设备上签名</translation>
+    </message>
+    <message>
+        <source>Connect your hardware wallet first.</source>
+        <translation type="unfinished">请先连接您的硬件钱包。</translation>
+    </message>
+    <message>
+        <source>Set external signer script path in Options -&gt; Wallet</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">在 选项 -&gt; 钱包 中设置外部签名器脚本路径</translation>
+    </message>
+    <message>
+        <source>Cr&amp;eate Unsigned</source>
+        <translation type="unfinished">创建未签名交易(&amp;E)</translation>
+    </message>
+    <message>
+        <source>Creates a Partially Signed Bitcoin Transaction (PSBT) for use with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
+        <translation type="unfinished">创建一个“部分签名比特币交易”（PSBT），以用于诸如离线%1钱包，或是兼容PSBT的硬件钱包这类用途。</translation>
+    </message>
+    <message>
+        <source> from wallet '%1'</source>
+        <translation type="unfinished">从钱包%1</translation>
+    </message>
+    <message>
+        <source>%1 to '%2'</source>
+        <translation type="unfinished">%1 到 '%2'</translation>
+    </message>
+    <message>
+        <source>%1 to %2</source>
+        <translation type="unfinished">%1 到 %2</translation>
+    </message>
+    <message>
+        <source>To review recipient list click "Show Details…"</source>
+        <translation type="unfinished">点击“查看详情”以审核收款人列表</translation>
+    </message>
+    <message>
+        <source>Sign failed</source>
+        <translation type="unfinished">签名失败</translation>
+    </message>
+    <message>
+        <source>External signer not found</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">未找到外部签名器</translation>
+    </message>
+    <message>
+        <source>External signer failure</source>
+        <extracomment>"External signer" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">外部签名器失败</translation>
+    </message>
+    <message>
+        <source>Save Transaction Data</source>
+        <translation type="unfinished">保存交易数据</translation>
+    </message>
+    <message>
+        <source>Partially Signed Transaction (Binary)</source>
+        <extracomment>Expanded name of the binary PSBT file format. See: BIP 174.</extracomment>
+        <translation type="unfinished">部分签名交易(二进制)</translation>
+    </message>
+    <message>
+        <source>PSBT saved</source>
+        <translation type="unfinished">已保存PSBT</translation>
+    </message>
+    <message>
+        <source>External balance:</source>
+        <translation type="unfinished">外部余额:</translation>
+    </message>
+    <message>
+        <source>or</source>
+        <translation type="unfinished">或</translation>
+    </message>
+    <message>
+        <source>You can increase the fee later (signals Replace-By-Fee, BIP-125).</source>
+        <translation type="unfinished">你可以后来再追加手续费（打上支持BIP-125手续费追加的标记）</translation>
+    </message>
+    <message>
+        <source>Please, review your transaction proposal. This will produce a Partially Signed Bitcoin Transaction (PSBT) which you can save or copy and then sign with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
+        <extracomment>Text to inform a user attempting to create a transaction of their current options. At this stage, a user can only create a PSBT. This string is displayed when private keys are disabled and an external signer is not available.</extracomment>
+        <translation type="unfinished">请务必仔细检查您的交易请求。这会产生一个部分签名比特币交易(PSBT)，可以把保存下来或复制出去，然后就可以对它进行签名，比如用离线%1钱包，或是用兼容PSBT的硬件钱包。</translation>
+    </message>
+    <message>
+        <source>Do you want to create this transaction?</source>
+        <extracomment>Message displayed when attempting to create a transaction. Cautionary text to prompt the user to verify that the displayed transaction details represent the transaction the user intends to create.</extracomment>
+        <translation type="unfinished">要创建这笔交易吗？</translation>
+    </message>
+    <message>
+        <source>Please, review your transaction. You can create and send this transaction or create a Partially Signed Bitcoin Transaction (PSBT), which you can save or copy and then sign with, e.g., an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
+        <extracomment>Text to inform a user attempting to create a transaction of their current options. At this stage, a user can send their transaction or create a PSBT. This string is displayed when both private keys and PSBT controls are enabled.</extracomment>
+        <translation type="unfinished">请务必仔细检查您的交易。你可以创建并发送这笔交易；也可以创建一个“部分签名比特币交易(PSBT)”，它可以被保存下来或被复制出去，然后就可以对它进行签名，比如用离线%1钱包，或是用兼容PSBT的硬件钱包。</translation>
+    </message>
+    <message>
+        <source>Please, review your transaction.</source>
+        <extracomment>Text to prompt a user to review the details of the transaction they are attempting to send.</extracomment>
+        <translation type="unfinished">请检查您的交易。</translation>
+    </message>
+    <message>
+        <source>Transaction fee</source>
+        <translation type="unfinished">交易手续费</translation>
+    </message>
+    <message>
+        <source>Not signalling Replace-By-Fee, BIP-125.</source>
+        <translation type="unfinished">没有打上BIP-125手续费追加的标记。</translation>
+    </message>
+    <message>
+        <source>Total Amount</source>
+        <translation type="unfinished">总额</translation>
+    </message>
+    <message>
+        <source>Confirm send coins</source>
+        <translation type="unfinished">确认发币</translation>
+    </message>
+    <message>
+        <source>Watch-only balance:</source>
+        <translation type="unfinished">仅观察余额:</translation>
+    </message>
+    <message>
+        <source>The recipient address is not valid. Please recheck.</source>
+        <translation type="unfinished">接收人地址无效。请重新检查。</translation>
+    </message>
+    <message>
+        <source>The amount to pay must be larger than 0.</source>
+        <translation type="unfinished">支付金额必须大于0。</translation>
+    </message>
+    <message>
+        <source>The amount exceeds your balance.</source>
+        <translation type="unfinished">金额超出您的余额。</translation>
+    </message>
+    <message>
+        <source>The total exceeds your balance when the %1 transaction fee is included.</source>
+        <translation type="unfinished">计入 %1 手续费后，金额超出了您的余额。</translation>
+    </message>
+    <message>
+        <source>Duplicate address found: addresses should only be used once each.</source>
+        <translation type="unfinished">发现重复地址:每个地址应该只使用一次。</translation>
+    </message>
+    <message>
+        <source>Transaction creation failed!</source>
+        <translation type="unfinished">交易创建失败！</translation>
+    </message>
+    <message>
+        <source>A fee higher than %1 is considered an absurdly high fee.</source>
+        <translation type="unfinished">超过 %1 的手续费被视为高得离谱。</translation>
+    </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>预计%n个区块内确认。</numerusform>
         </translation>
+    </message>
+    <message>
+        <source>Warning: Invalid Bitcoin address</source>
+        <translation type="unfinished">警告: 比特币地址无效</translation>
+    </message>
+    <message>
+        <source>Warning: Unknown change address</source>
+        <translation type="unfinished">警告:未知的找零地址</translation>
+    </message>
+    <message>
+        <source>Confirm custom change address</source>
+        <translation type="unfinished">确认自定义找零地址</translation>
+    </message>
+    <message>
+        <source>The address you selected for change is not part of this wallet. Any or all funds in your wallet may be sent to this address. Are you sure?</source>
+        <translation type="unfinished">你选择的找零地址未被包含在本钱包中，你钱包中的部分或全部金额将被发送至该地址。你确定要这样做吗？</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -300,27 +3992,634 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
 </context>
 <context>
+    <name>SendCoinsEntry</name>
+    <message>
+        <source>A&amp;mount:</source>
+        <translation type="unfinished">金额(&amp;M)</translation>
+    </message>
+    <message>
+        <source>Pay &amp;To:</source>
+        <translation type="unfinished">付给(&amp;T):</translation>
+    </message>
+    <message>
+        <source>&amp;Label:</source>
+        <translation type="unfinished">标签(&amp;L):</translation>
+    </message>
+    <message>
+        <source>Choose previously used address</source>
+        <translation type="unfinished">选择以前用过的地址</translation>
+    </message>
+    <message>
+        <source>The Bitcoin address to send the payment to</source>
+        <translation type="unfinished">付款目的地址</translation>
+    </message>
+    <message>
+        <source>Paste address from clipboard</source>
+        <translation type="unfinished">从剪贴板粘贴地址</translation>
+    </message>
+    <message>
+        <source>Remove this entry</source>
+        <translation type="unfinished">移除此项</translation>
+    </message>
+    <message>
+        <source>The amount to send in the selected unit</source>
+        <translation type="unfinished">用被选单位表示的待发送金额</translation>
+    </message>
+    <message>
+        <source>The fee will be deducted from the amount being sent. The recipient will receive less bitcoins than you enter in the amount field. If multiple recipients are selected, the fee is split equally.</source>
+        <translation type="unfinished">交易费将从发送金额中扣除。接收人收到的比特币将会比您在金额框中输入的更少。如果选中了多个收件人，交易费平分。</translation>
+    </message>
+    <message>
+        <source>S&amp;ubtract fee from amount</source>
+        <translation type="unfinished">从金额中减去交易费(&amp;U)</translation>
+    </message>
+    <message>
+        <source>Use available balance</source>
+        <translation type="unfinished">使用全部可用余额</translation>
+    </message>
+    <message>
+        <source>Message:</source>
+        <translation type="unfinished">消息:</translation>
+    </message>
+    <message>
+        <source>Enter a label for this address to add it to the list of used addresses</source>
+        <translation type="unfinished">请为此地址输入一个标签以将它加入已用地址列表</translation>
+    </message>
+    <message>
+        <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
+        <translation type="unfinished">bitcoin: URI 附带的备注信息，将会和交易一起存储，备查。 注意：该消息不会通过比特币网络传输。</translation>
+    </message>
+</context>
+<context>
+    <name>SendConfirmationDialog</name>
+    <message>
+        <source>Send</source>
+        <translation type="unfinished">发送</translation>
+    </message>
+    <message>
+        <source>Create Unsigned</source>
+        <translation type="unfinished">创建未签名交易</translation>
+    </message>
+</context>
+<context>
+    <name>SignVerifyMessageDialog</name>
+    <message>
+        <source>Signatures - Sign / Verify a Message</source>
+        <translation type="unfinished">签名 - 为消息签名/验证签名消息</translation>
+    </message>
+    <message>
+        <source>&amp;Sign Message</source>
+        <translation type="unfinished">消息签名(&amp;S)</translation>
+    </message>
+    <message>
+        <source>You can sign messages/agreements with your addresses to prove you can receive bitcoins sent to them. Be careful not to sign anything vague or random, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
+        <translation type="unfinished">您可以用你的地址对消息/协议进行签名，以证明您可以接收发送到该地址的比特币。注意不要对任何模棱两可或者随机的消息进行签名，以免遭受钓鱼式攻击。请确保消息内容准确的表达了您的真实意愿。</translation>
+    </message>
+    <message>
+        <source>The Bitcoin address to sign the message with</source>
+        <translation type="unfinished">用来对消息签名的地址</translation>
+    </message>
+    <message>
+        <source>Choose previously used address</source>
+        <translation type="unfinished">选择以前用过的地址</translation>
+    </message>
+    <message>
+        <source>Paste address from clipboard</source>
+        <translation type="unfinished">从剪贴板粘贴地址</translation>
+    </message>
+    <message>
+        <source>Enter the message you want to sign here</source>
+        <translation type="unfinished">在这里输入您想要签名的消息</translation>
+    </message>
+    <message>
+        <source>Signature</source>
+        <translation type="unfinished">签名</translation>
+    </message>
+    <message>
+        <source>Copy the current signature to the system clipboard</source>
+        <translation type="unfinished">复制当前签名至剪贴板</translation>
+    </message>
+    <message>
+        <source>Sign the message to prove you own this Bitcoin address</source>
+        <translation type="unfinished">签名消息，以证明这个地址属于您</translation>
+    </message>
+    <message>
+        <source>Sign &amp;Message</source>
+        <translation type="unfinished">签名消息(&amp;M)</translation>
+    </message>
+    <message>
+        <source>Reset all sign message fields</source>
+        <translation type="unfinished">清空所有签名消息栏</translation>
+    </message>
+    <message>
+        <source>Clear &amp;All</source>
+        <translation type="unfinished">清除所有(&amp;A)</translation>
+    </message>
+    <message>
+        <source>&amp;Verify Message</source>
+        <translation type="unfinished">消息验证(&amp;V)</translation>
+    </message>
+    <message>
+        <source>Enter the receiver's address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack. Note that this only proves the signing party receives with the address, it cannot prove sendership of any transaction!</source>
+        <translation type="unfinished">请在下面输入接收者地址、消息（确保换行符、空格符、制表符等完全相同）和签名以验证消息。请仔细核对签名信息，以提防中间人攻击。请注意，这只是证明接收方可以用这个地址签名，它不能证明任何交易的发送人身份！</translation>
+    </message>
+    <message>
+        <source>The Bitcoin address the message was signed with</source>
+        <translation type="unfinished">用来签名消息的地址</translation>
+    </message>
+    <message>
+        <source>The signed message to verify</source>
+        <translation type="unfinished">待验证的已签名消息</translation>
+    </message>
+    <message>
+        <source>The signature given when the message was signed</source>
+        <translation type="unfinished">对消息进行签署得到的签名数据</translation>
+    </message>
+    <message>
+        <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
+        <translation type="unfinished">验证消息，确保消息是由指定的比特币地址签名过的。</translation>
+    </message>
+    <message>
+        <source>Verify &amp;Message</source>
+        <translation type="unfinished">验证消息签名(&amp;M)</translation>
+    </message>
+    <message>
+        <source>Reset all verify message fields</source>
+        <translation type="unfinished">清空所有验证消息栏</translation>
+    </message>
+    <message>
+        <source>Click "Sign Message" to generate signature</source>
+        <translation type="unfinished">单击“签名消息“产生签名。</translation>
+    </message>
+    <message>
+        <source>The entered address is invalid.</source>
+        <translation type="unfinished">输入的地址无效。</translation>
+    </message>
+    <message>
+        <source>Please check the address and try again.</source>
+        <translation type="unfinished">请检查地址后重试。</translation>
+    </message>
+    <message>
+        <source>The entered address does not refer to a key.</source>
+        <translation type="unfinished">找不到与输入地址相关的密钥。</translation>
+    </message>
+    <message>
+        <source>Wallet unlock was cancelled.</source>
+        <translation type="unfinished">已取消解锁钱包。</translation>
+    </message>
+    <message>
+        <source>No error</source>
+        <translation type="unfinished">没有错误</translation>
+    </message>
+    <message>
+        <source>Private key for the entered address is not available.</source>
+        <translation type="unfinished">找不到输入地址关联的私钥。</translation>
+    </message>
+    <message>
+        <source>Message signing failed.</source>
+        <translation type="unfinished">消息签名失败。</translation>
+    </message>
+    <message>
+        <source>Message signed.</source>
+        <translation type="unfinished">消息已签名。</translation>
+    </message>
+    <message>
+        <source>The signature could not be decoded.</source>
+        <translation type="unfinished">签名无法解码。</translation>
+    </message>
+    <message>
+        <source>Please check the signature and try again.</source>
+        <translation type="unfinished">请检查签名后重试。</translation>
+    </message>
+    <message>
+        <source>The signature did not match the message digest.</source>
+        <translation type="unfinished">签名与消息摘要不匹配。</translation>
+    </message>
+    <message>
+        <source>Message verification failed.</source>
+        <translation type="unfinished">消息验证失败。</translation>
+    </message>
+    <message>
+        <source>Message verified.</source>
+        <translation type="unfinished">消息验证成功。</translation>
+    </message>
+</context>
+<context>
+    <name>SplashScreen</name>
+    <message>
+        <source>(press q to shutdown and continue later)</source>
+        <translation type="unfinished">(按q退出并在以后继续)</translation>
+    </message>
+    <message>
+        <source>press q to shutdown</source>
+        <translation type="unfinished">按q键关闭并退出</translation>
+    </message>
+</context>
+<context>
     <name>TransactionDesc</name>
+    <message>
+        <source>conflicted with a transaction with %1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that conflicts with a confirmed transaction.</extracomment>
+        <translation type="unfinished">与一个有 %1 个确认的交易冲突</translation>
+    </message>
+    <message>
+        <source>0/unconfirmed, in memory pool</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is in the memory pool.</extracomment>
+        <translation type="unfinished">0/未确认，在内存池中</translation>
+    </message>
+    <message>
+        <source>0/unconfirmed, not in memory pool</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is not in the memory pool.</extracomment>
+        <translation type="unfinished">0/未确认，不在内存池中</translation>
+    </message>
+    <message>
+        <source>abandoned</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an abandoned transaction.</extracomment>
+        <translation type="unfinished">已丢弃</translation>
+    </message>
+    <message>
+        <source>%1/unconfirmed</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
+        <translation type="unfinished">%1/未确认</translation>
+    </message>
+    <message>
+        <source>%1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
+        <translation type="unfinished">%1 个确认</translation>
+    </message>
+    <message>
+        <source>Status</source>
+        <translation type="unfinished">状态</translation>
+    </message>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">日期</translation>
+    </message>
+    <message>
+        <source>Source</source>
+        <translation type="unfinished">来源</translation>
+    </message>
+    <message>
+        <source>Generated</source>
+        <translation type="unfinished">挖矿生成</translation>
+    </message>
+    <message>
+        <source>From</source>
+        <translation type="unfinished">来自</translation>
+    </message>
+    <message>
+        <source>unknown</source>
+        <translation type="unfinished">未知</translation>
+    </message>
+    <message>
+        <source>To</source>
+        <translation type="unfinished">到</translation>
+    </message>
+    <message>
+        <source>own address</source>
+        <translation type="unfinished">自己的地址</translation>
+    </message>
+    <message>
+        <source>watch-only</source>
+        <translation type="unfinished">仅观察:</translation>
+    </message>
+    <message>
+        <source>label</source>
+        <translation type="unfinished">标签</translation>
+    </message>
+    <message>
+        <source>Credit</source>
+        <translation type="unfinished">收入</translation>
+    </message>
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>在%n个区块内成熟</numerusform>
         </translation>
     </message>
-    </context>
+    <message>
+        <source>not accepted</source>
+        <translation type="unfinished">未被接受</translation>
+    </message>
+    <message>
+        <source>Debit</source>
+        <translation type="unfinished">支出</translation>
+    </message>
+    <message>
+        <source>Total debit</source>
+        <translation type="unfinished">总支出</translation>
+    </message>
+    <message>
+        <source>Total credit</source>
+        <translation type="unfinished">总收入</translation>
+    </message>
+    <message>
+        <source>Transaction fee</source>
+        <translation type="unfinished">交易手续费</translation>
+    </message>
+    <message>
+        <source>Net amount</source>
+        <translation type="unfinished">净额</translation>
+    </message>
+    <message>
+        <source>Message</source>
+        <translation type="unfinished">消息</translation>
+    </message>
+    <message>
+        <source>Comment</source>
+        <translation type="unfinished">备注</translation>
+    </message>
+    <message>
+        <source>Transaction ID</source>
+        <translation type="unfinished">交易 ID</translation>
+    </message>
+    <message>
+        <source>Transaction total size</source>
+        <translation type="unfinished">交易总大小</translation>
+    </message>
+    <message>
+        <source>Transaction virtual size</source>
+        <translation type="unfinished">交易虚拟大小</translation>
+    </message>
+    <message>
+        <source>Output index</source>
+        <translation type="unfinished">输出索引</translation>
+    </message>
+    <message>
+        <source> (Certificate was not verified)</source>
+        <translation type="unfinished">(证书未被验证)</translation>
+    </message>
+    <message>
+        <source>Merchant</source>
+        <translation type="unfinished">商家</translation>
+    </message>
+    <message>
+        <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to "not accepted" and it won't be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
+        <translation type="unfinished">新挖出的比特币在可以使用前必须经过 %1 个区块确认的成熟过程。当您挖出此区块后，它将被广播到网络中以加入区块链。如果它未成功进入区块链，其状态将变更为“不接受”并且不可使用。这可能偶尔会发生，在另一个节点比你早几秒钟成功挖出一个区块时就会这样。</translation>
+    </message>
+    <message>
+        <source>Debug information</source>
+        <translation type="unfinished">调试信息</translation>
+    </message>
+    <message>
+        <source>Transaction</source>
+        <translation type="unfinished">交易</translation>
+    </message>
+    <message>
+        <source>Inputs</source>
+        <translation type="unfinished">输入</translation>
+    </message>
+    <message>
+        <source>Amount</source>
+        <translation type="unfinished">金额</translation>
+    </message>
+    <message>
+        <source>true</source>
+        <translation type="unfinished">是</translation>
+    </message>
+    <message>
+        <source>false</source>
+        <translation type="unfinished">否</translation>
+    </message>
+</context>
+<context>
+    <name>TransactionDescDialog</name>
+    <message>
+        <source>This pane shows a detailed description of the transaction</source>
+        <translation type="unfinished">当前面板显示了交易的详细信息</translation>
+    </message>
+    <message>
+        <source>Details for %1</source>
+        <translation type="unfinished">%1 详情</translation>
+    </message>
+</context>
 <context>
     <name>TransactionTableModel</name>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">日期</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished">类型</translation>
+    </message>
     <message>
         <source>Label</source>
         <translation type="unfinished">标签</translation>
     </message>
     <message>
+        <source>Unconfirmed</source>
+        <translation type="unfinished">未确认</translation>
+    </message>
+    <message>
+        <source>Abandoned</source>
+        <translation type="unfinished">已丢弃</translation>
+    </message>
+    <message>
+        <source>Confirming (%1 of %2 recommended confirmations)</source>
+        <translation type="unfinished">确认中 (推荐 %2个确认，已经有 %1个确认)</translation>
+    </message>
+    <message>
+        <source>Confirmed (%1 confirmations)</source>
+        <translation type="unfinished">已确认 (%1 个确认)</translation>
+    </message>
+    <message>
+        <source>Conflicted</source>
+        <translation type="unfinished">有冲突</translation>
+    </message>
+    <message>
+        <source>Immature (%1 confirmations, will be available after %2)</source>
+        <translation type="unfinished">未成熟 (%1 个确认，将在 %2 个后可用)</translation>
+    </message>
+    <message>
+        <source>Generated but not accepted</source>
+        <translation type="unfinished">已生成但未被接受</translation>
+    </message>
+    <message>
+        <source>Received with</source>
+        <translation type="unfinished">接收到</translation>
+    </message>
+    <message>
+        <source>Received from</source>
+        <translation type="unfinished">接收自</translation>
+    </message>
+    <message>
+        <source>Sent to</source>
+        <translation type="unfinished">发送到</translation>
+    </message>
+    <message>
+        <source>Payment to yourself</source>
+        <translation type="unfinished">支付给自己</translation>
+    </message>
+    <message>
+        <source>Mined</source>
+        <translation type="unfinished">挖矿所得</translation>
+    </message>
+    <message>
+        <source>watch-only</source>
+        <translation type="unfinished">仅观察:</translation>
+    </message>
+    <message>
+        <source>(n/a)</source>
+        <translation type="unfinished">(不可用)</translation>
+    </message>
+    <message>
         <source>(no label)</source>
         <translation type="unfinished">(无标签)</translation>
     </message>
-    </context>
+    <message>
+        <source>Transaction status. Hover over this field to show number of confirmations.</source>
+        <translation type="unfinished">交易状态。 鼠标移到此区域可显示确认数。</translation>
+    </message>
+    <message>
+        <source>Date and time that the transaction was received.</source>
+        <translation type="unfinished">交易被接收的时间和日期。</translation>
+    </message>
+    <message>
+        <source>Type of transaction.</source>
+        <translation type="unfinished">交易类型。</translation>
+    </message>
+    <message>
+        <source>Whether or not a watch-only address is involved in this transaction.</source>
+        <translation type="unfinished">该交易中是否涉及仅观察地址。</translation>
+    </message>
+    <message>
+        <source>User-defined intent/purpose of the transaction.</source>
+        <translation type="unfinished">用户自定义的该交易的意图/目的。</translation>
+    </message>
+    <message>
+        <source>Amount removed from or added to balance.</source>
+        <translation type="unfinished">从余额增加或移除的金额。</translation>
+    </message>
+</context>
 <context>
     <name>TransactionView</name>
+    <message>
+        <source>All</source>
+        <translation type="unfinished">全部</translation>
+    </message>
+    <message>
+        <source>Today</source>
+        <translation type="unfinished">今天</translation>
+    </message>
+    <message>
+        <source>This week</source>
+        <translation type="unfinished">本周</translation>
+    </message>
+    <message>
+        <source>This month</source>
+        <translation type="unfinished">本月</translation>
+    </message>
+    <message>
+        <source>Last month</source>
+        <translation type="unfinished">上个月</translation>
+    </message>
+    <message>
+        <source>This year</source>
+        <translation type="unfinished">今年</translation>
+    </message>
+    <message>
+        <source>Received with</source>
+        <translation type="unfinished">接收到</translation>
+    </message>
+    <message>
+        <source>Sent to</source>
+        <translation type="unfinished">发送到</translation>
+    </message>
+    <message>
+        <source>To yourself</source>
+        <translation type="unfinished">给自己</translation>
+    </message>
+    <message>
+        <source>Mined</source>
+        <translation type="unfinished">挖矿所得</translation>
+    </message>
+    <message>
+        <source>Other</source>
+        <translation type="unfinished">其它</translation>
+    </message>
+    <message>
+        <source>Enter address, transaction id, or label to search</source>
+        <translation type="unfinished">输入地址、交易ID或标签进行搜索</translation>
+    </message>
+    <message>
+        <source>Min amount</source>
+        <translation type="unfinished">最小金额</translation>
+    </message>
+    <message>
+        <source>Range…</source>
+        <translation type="unfinished">范围...</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">复制地址(&amp;C)</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">复制标签(&amp;L)</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">复制金额(&amp;A)</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">复制交易 &amp;ID</translation>
+    </message>
+    <message>
+        <source>Copy &amp;raw transaction</source>
+        <translation type="unfinished">复制原始交易(&amp;R)</translation>
+    </message>
+    <message>
+        <source>Copy full transaction &amp;details</source>
+        <translation type="unfinished">复制完整交易详情(&amp;D)</translation>
+    </message>
+    <message>
+        <source>&amp;Show transaction details</source>
+        <translation type="unfinished">显示交易详情(&amp;S)</translation>
+    </message>
+    <message>
+        <source>Increase transaction &amp;fee</source>
+        <translation type="unfinished">增加矿工费(&amp;F)</translation>
+    </message>
+    <message>
+        <source>A&amp;bandon transaction</source>
+        <translation type="unfinished">放弃交易(&amp;B)</translation>
+    </message>
+    <message>
+        <source>&amp;Edit address label</source>
+        <translation type="unfinished">编辑地址标签(&amp;E)</translation>
+    </message>
+    <message>
+        <source>Show in %1</source>
+        <extracomment>Transactions table context menu action to show the selected transaction in a third-party block explorer. %1 is a stand-in argument for the URL of the explorer.</extracomment>
+        <translation type="unfinished">在 %1中显示</translation>
+    </message>
+    <message>
+        <source>Export Transaction History</source>
+        <translation type="unfinished">导出交易历史</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">逗号分隔文件</translation>
+    </message>
+    <message>
+        <source>Confirmed</source>
+        <translation type="unfinished">已确认</translation>
+    </message>
+    <message>
+        <source>Watch-only</source>
+        <translation type="unfinished">仅观察</translation>
+    </message>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished">日期</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished">类型</translation>
+    </message>
     <message>
         <source>Label</source>
         <translation type="unfinished">标签</translation>
@@ -333,12 +4632,168 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Exporting Failed</source>
         <translation type="unfinished">导出失败</translation>
     </message>
-    </context>
+    <message>
+        <source>There was an error trying to save the transaction history to %1.</source>
+        <translation type="unfinished">尝试把交易历史保存到 %1 时发生了错误。</translation>
+    </message>
+    <message>
+        <source>Exporting Successful</source>
+        <translation type="unfinished">导出成功</translation>
+    </message>
+    <message>
+        <source>The transaction history was successfully saved to %1.</source>
+        <translation type="unfinished">已成功将交易历史保存到 %1。</translation>
+    </message>
+    <message>
+        <source>Range:</source>
+        <translation type="unfinished">范围:</translation>
+    </message>
+    <message>
+        <source>to</source>
+        <translation type="unfinished">到</translation>
+    </message>
+</context>
+<context>
+    <name>WalletFrame</name>
+    <message>
+        <source>No wallet has been loaded.
+Go to File &gt; Open Wallet to load a wallet.
+- OR -</source>
+        <translation type="unfinished">未加载钱包。
+请转到“文件”菜单 &gt; “打开钱包”来加载一个钱包。
+- 或者 -</translation>
+    </message>
+    <message>
+        <source>Create a new wallet</source>
+        <translation type="unfinished">创建一个新的钱包</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">错误</translation>
+    </message>
+    <message>
+        <source>Unable to decode PSBT from clipboard (invalid base64)</source>
+        <translation type="unfinished">无法从剪贴板解码PSBT(Base64值无效)</translation>
+    </message>
+    <message>
+        <source>Load Transaction Data</source>
+        <translation type="unfinished">加载交易数据</translation>
+    </message>
+    <message>
+        <source>Partially Signed Transaction (*.psbt)</source>
+        <translation type="unfinished">部分签名交易 (*.psbt)</translation>
+    </message>
+    <message>
+        <source>PSBT file must be smaller than 100 MiB</source>
+        <translation type="unfinished">PSBT文件必须小于100MiB</translation>
+    </message>
+    <message>
+        <source>Unable to decode PSBT</source>
+        <translation type="unfinished">无法解码PSBT</translation>
+    </message>
+</context>
+<context>
+    <name>WalletModel</name>
+    <message>
+        <source>Send Coins</source>
+        <translation type="unfinished">发币</translation>
+    </message>
+    <message>
+        <source>Fee bump error</source>
+        <translation type="unfinished">追加手续费出错</translation>
+    </message>
+    <message>
+        <source>Increasing transaction fee failed</source>
+        <translation type="unfinished">追加交易手续费失败</translation>
+    </message>
+    <message>
+        <source>Do you want to increase the fee?</source>
+        <extracomment>Asks a user if they would like to manually increase the fee of a transaction that has already been created.</extracomment>
+        <translation type="unfinished">您想追加手续费吗？</translation>
+    </message>
+    <message>
+        <source>Current fee:</source>
+        <translation type="unfinished">当前手续费:</translation>
+    </message>
+    <message>
+        <source>Increase:</source>
+        <translation type="unfinished">增加量:</translation>
+    </message>
+    <message>
+        <source>New fee:</source>
+        <translation type="unfinished">新交易费:</translation>
+    </message>
+    <message>
+        <source>Warning: This may pay the additional fee by reducing change outputs or adding inputs, when necessary. It may add a new change output if one does not already exist. These changes may potentially leak privacy.</source>
+        <translation type="unfinished">警告: 因为在必要的时候会减少找零输出个数或增加输入个数，这可能要付出额外的费用。在没有找零输出的情况下可能会新增一个。这些变更可能会导致潜在的隐私泄露。</translation>
+    </message>
+    <message>
+        <source>Confirm fee bump</source>
+        <translation type="unfinished">确认手续费追加</translation>
+    </message>
+    <message>
+        <source>Can't draft transaction.</source>
+        <translation type="unfinished">无法起草交易。</translation>
+    </message>
+    <message>
+        <source>PSBT copied</source>
+        <translation type="unfinished">已复制PSBT</translation>
+    </message>
+    <message>
+        <source>Can't sign transaction.</source>
+        <translation type="unfinished">无法签名交易</translation>
+    </message>
+    <message>
+        <source>Could not commit transaction</source>
+        <translation type="unfinished">无法提交交易</translation>
+    </message>
+    <message>
+        <source>Can't display address</source>
+        <translation type="unfinished">无法显示地址</translation>
+    </message>
+    <message>
+        <source>default wallet</source>
+        <translation type="unfinished">默认钱包</translation>
+    </message>
+</context>
 <context>
     <name>WalletView</name>
     <message>
         <source>&amp;Export</source>
-        <translation type="unfinished">导出</translation>
+        <translation type="unfinished">导出(&amp;E)</translation>
     </message>
-    </context>
+    <message>
+        <source>Export the data in the current tab to a file</source>
+        <translation type="unfinished">将当前标签页数据导出到文件</translation>
+    </message>
+    <message>
+        <source>Backup Wallet</source>
+        <translation type="unfinished">备份钱包</translation>
+    </message>
+    <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">钱包数据</translation>
+    </message>
+    <message>
+        <source>Backup Failed</source>
+        <translation type="unfinished">备份失败</translation>
+    </message>
+    <message>
+        <source>There was an error trying to save the wallet data to %1.</source>
+        <translation type="unfinished">尝试保存钱包数据至 %1 时发生了错误。</translation>
+    </message>
+    <message>
+        <source>Backup Successful</source>
+        <translation type="unfinished">备份成功</translation>
+    </message>
+    <message>
+        <source>The wallet data was successfully saved to %1.</source>
+        <translation type="unfinished">已成功保存钱包数据至 %1。</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished">取消</translation>
+    </message>
+</context>
 </TS>

--- a/src/qt/locale/bitcoin_zh.ts
+++ b/src/qt/locale/bitcoin_zh.ts
@@ -1,6 +1,299 @@
 <TS version="2.1" language="zh">
 <context>
+    <name>AddressBookPage</name>
+    <message>
+        <source>Right-click to edit address or label</source>
+        <translation type="unfinished">右键单击来编辑地址或者标签</translation>
+    </message>
+    <message>
+        <source>Create a new address</source>
+        <translation type="unfinished">创建新地址</translation>
+    </message>
+    <message>
+        <source>&amp;New</source>
+        <translation type="unfinished">新建(&amp;N)</translation>
+    </message>
+    <message>
+        <source>Copy the currently selected address to the system clipboard</source>
+        <translation type="unfinished">复制当前选中的地址到系统剪贴板</translation>
+    </message>
+    <message>
+        <source>&amp;Copy</source>
+        <translation type="unfinished">复制(&amp;C)</translation>
+    </message>
+    <message>
+        <source>C&amp;lose</source>
+        <translation type="unfinished">关闭(&amp;L)</translation>
+    </message>
+    <message>
+        <source>Delete the currently selected address from the list</source>
+        <translation type="unfinished">从列表中删除当前已选地址</translation>
+    </message>
+    <message>
+        <source>Enter address or label to search</source>
+        <translation type="unfinished">输入要搜索的地址或标签</translation>
+    </message>
+    <message>
+        <source>Export the data in the current tab to a file</source>
+        <translation type="unfinished">将当前选项卡中的数据导出到文件</translation>
+    </message>
+    <message>
+        <source>&amp;Export</source>
+        <translation type="unfinished">导出(&amp;E)</translation>
+    </message>
+    <message>
+        <source>&amp;Delete</source>
+        <translation type="unfinished">删除(&amp;D)</translation>
+    </message>
+    <message>
+        <source>Choose the address to send coins to</source>
+        <translation type="unfinished">选择收款人地址</translation>
+    </message>
+    <message>
+        <source>Choose the address to receive coins with</source>
+        <translation type="unfinished">选择接收比特币地址</translation>
+    </message>
+    <message>
+        <source>C&amp;hoose</source>
+        <translation type="unfinished">选择(&amp;H)</translation>
+    </message>
+    <message>
+        <source>Sending addresses</source>
+        <translation type="unfinished">发送地址</translation>
+    </message>
+    <message>
+        <source>Receiving addresses</source>
+        <translation type="unfinished">接收地址</translation>
+    </message>
+    <message>
+        <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
+        <translation type="unfinished">这些是你的比特币支付地址。在发送之前，一定要核对金额和接收地址。</translation>
+    </message>
+    <message>
+        <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
+Signing is only possible with addresses of the type 'legacy'.</source>
+        <translation type="unfinished">你将使用下列比特币地址接受付款。选取收款选项卡中 “产生新收款地址” 按钮来生成新地址。
+签名只能使用“传统”类型的地址。</translation>
+    </message>
+    <message>
+        <source>&amp;Copy Address</source>
+        <translation type="unfinished">&amp;复制地址</translation>
+    </message>
+    <message>
+        <source>Copy &amp;Label</source>
+        <translation type="unfinished">复制 &amp;标签</translation>
+    </message>
+    <message>
+        <source>&amp;Edit</source>
+        <translation type="unfinished">&amp;编辑</translation>
+    </message>
+    <message>
+        <source>Export Address List</source>
+        <translation type="unfinished">出口地址列表</translation>
+    </message>
+    <message>
+        <source>Comma separated file</source>
+        <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
+        <translation type="unfinished">逗号分隔文件</translation>
+    </message>
+    <message>
+        <source>There was an error trying to save the address list to %1. Please try again.</source>
+        <extracomment>An error message. %1 is a stand-in argument for the name of the file we attempted to save to.</extracomment>
+        <translation type="unfinished">试图将地址列表保存到 %1时出错，请再试一次。</translation>
+    </message>
+    <message>
+        <source>Exporting Failed</source>
+        <translation type="unfinished">导出失败</translation>
+    </message>
+</context>
+<context>
+    <name>AddressTableModel</name>
+    <message>
+        <source>Label</source>
+        <translation type="unfinished">标签</translation>
+    </message>
+    <message>
+        <source>Address</source>
+        <translation type="unfinished">地址</translation>
+    </message>
+    <message>
+        <source>(no label)</source>
+        <translation type="unfinished">(无标签)</translation>
+    </message>
+</context>
+<context>
+    <name>AskPassphraseDialog</name>
+    <message>
+        <source>Passphrase Dialog</source>
+        <translation type="unfinished">密码对话框</translation>
+    </message>
+    <message>
+        <source>Enter passphrase</source>
+        <translation type="unfinished">输入密码</translation>
+    </message>
+    <message>
+        <source>New passphrase</source>
+        <translation type="unfinished">新的密码</translation>
+    </message>
+    <message>
+        <source>Repeat new passphrase</source>
+        <translation type="unfinished">重复新密码</translation>
+    </message>
+    <message>
+        <source>Show passphrase</source>
+        <translation type="unfinished">显示密码</translation>
+    </message>
+    <message>
+        <source>Encrypt wallet</source>
+        <translation type="unfinished">加密钱包</translation>
+    </message>
+    <message>
+        <source>This operation needs your wallet passphrase to unlock the wallet.</source>
+        <translation type="unfinished">该操作需要您的钱包密码来解锁钱包。</translation>
+    </message>
+    <message>
+        <source>Unlock wallet</source>
+        <translation type="unfinished">打开钱包</translation>
+    </message>
+    <message>
+        <source>Change passphrase</source>
+        <translation type="unfinished">修改密码</translation>
+    </message>
+    <message>
+        <source>Confirm wallet encryption</source>
+        <translation type="unfinished">确认钱包加密</translation>
+    </message>
+    <message>
+        <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
+        <translation type="unfinished">注意: 如果你忘记了你的钱包，你将会丢失你的&lt;b&gt;密码，并且会丢失你的&lt;/b&gt;比特币。</translation>
+    </message>
+    <message>
+        <source>Are you sure you wish to encrypt your wallet?</source>
+        <translation type="unfinished">您确定要加密您的钱包吗?</translation>
+    </message>
+    <message>
+        <source>Wallet encrypted</source>
+        <translation type="unfinished">钱包加密</translation>
+    </message>
+    <message>
+        <source>Enter the new passphrase for the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
+        <translation type="unfinished">输入钱包的新密码，&lt;br/&gt;请使用&lt;b&gt;10个或以上随机字符的密码&lt;/b&gt;，&lt;b&gt;或者8个以上的复杂单词&lt;/b&gt;。</translation>
+    </message>
+    <message>
+        <source>Enter the old passphrase and new passphrase for the wallet.</source>
+        <translation type="unfinished">输入钱包的旧密码和新密码。</translation>
+    </message>
+    <message>
+        <source>Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
+        <translation type="unfinished">注意，加密你的钱包并不能完全保护你的比特币免受感染你电脑的恶意软件的窃取。</translation>
+    </message>
+    <message>
+        <source>Wallet to be encrypted</source>
+        <translation type="unfinished">加密钱包</translation>
+    </message>
+    <message>
+        <source>Your wallet is about to be encrypted. </source>
+        <translation type="unfinished">你的钱包要被加密了。</translation>
+    </message>
+    <message>
+        <source>Your wallet is now encrypted. </source>
+        <translation type="unfinished">你的钱包现在被加密了。</translation>
+    </message>
+    <message>
+        <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
+        <translation type="unfinished">重要提示:您之前对钱包文件所做的任何备份都应该替换为新生成的加密钱包文件。出于安全原因，一旦开始使用新的加密钱包，以前未加密钱包文件的备份就会失效。</translation>
+    </message>
+    <message>
+        <source>Wallet encryption failed</source>
+        <translation type="unfinished">钱包加密失败</translation>
+    </message>
+    <message>
+        <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
+        <translation type="unfinished">由于内部错误，钱包加密失败。你的钱包没有加密成功。</translation>
+    </message>
+    <message>
+        <source>The supplied passphrases do not match.</source>
+        <translation type="unfinished">提供的密码不匹配。</translation>
+    </message>
+    <message>
+        <source>Wallet unlock failed</source>
+        <translation type="unfinished">钱包打开失败</translation>
+    </message>
+    <message>
+        <source>The passphrase entered for the wallet decryption was incorrect.</source>
+        <translation type="unfinished">钱包解密输入的密码不正确。</translation>
+    </message>
+    <message>
+        <source>Wallet passphrase was successfully changed.</source>
+        <translation type="unfinished">钱包密码已成功更改。</translation>
+    </message>
+    <message>
+        <source>Warning: The Caps Lock key is on!</source>
+        <translation type="unfinished">警告:大写锁定键已打开!</translation>
+    </message>
+</context>
+<context>
+    <name>BanTableModel</name>
+    <message>
+        <source>IP/Netmask</source>
+        <translation type="unfinished">IP/子网掩码</translation>
+    </message>
+    <message>
+        <source>Banned Until</source>
+        <translation type="unfinished">被禁止直到</translation>
+    </message>
+</context>
+<context>
+    <name>BitcoinApplication</name>
+    <message>
+        <source>Settings file %1 might be corrupt or invalid.</source>
+        <translation type="unfinished">设置文件%1可能已损坏或无效。</translation>
+    </message>
+    <message>
+        <source>Runaway exception</source>
+        <translation type="unfinished">失控的例外</translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
+        <translation type="unfinished">发生了一个致命错误。%1不能再安全地继续并将退出。</translation>
+    </message>
+    <message>
+        <source>Internal error</source>
+        <translation type="unfinished">内部错误</translation>
+    </message>
+    <message>
+        <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
+        <translation type="unfinished">发生内部错误。%1将尝试安全继续。这是一个意外的错误，可以报告如下所述。</translation>
+    </message>
+</context>
+<context>
     <name>QObject</name>
+    <message>
+        <source>Do you want to reset settings to default values, or to abort without making changes?</source>
+        <extracomment>Explanatory text shown on startup when the settings file cannot be read. Prompts user to make a choice between resetting or aborting.</extracomment>
+        <translation type="unfinished">要将设置重置为默认值，还是不做任何更改就中止?</translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. Check that settings file is writable, or try running with -nosettings.</source>
+        <extracomment>Explanatory text shown on startup when the settings file could not be written. Prompts user to check that we have the ability to write to the file. Explains that the user has the option of running without a settings file.</extracomment>
+        <translation type="unfinished">发生了一个致命错误。检查设置文件是否可写，或者尝试使用-nosettings运行。</translation>
+    </message>
+    <message>
+        <source>Error: Specified data directory "%1" does not exist.</source>
+        <translation type="unfinished">错误:指定的数据目录“%1“不存在。</translation>
+    </message>
+    <message>
+        <source>Error: Cannot parse configuration file: %1.</source>
+        <translation type="unfinished">错误:无法解析配置文件:%1。</translation>
+    </message>
+    <message>
+        <source>Error: %1</source>
+        <translation type="unfinished">错误: %1</translation>
+    </message>
+    <message>
+        <source>%1 didn't yet exit safely…</source>
+        <translation type="unfinished">%1尚未安全退出…</translation>
+    </message>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation type="unfinished">
@@ -39,7 +332,62 @@
     </message>
     </context>
 <context>
+    <name>bitcoin-core</name>
+    <message>
+        <source>Settings file could not be read</source>
+        <translation type="unfinished">无法读取设置文件</translation>
+    </message>
+    <message>
+        <source>Settings file could not be written</source>
+        <translation type="unfinished">无法写入设置文件</translation>
+    </message>
+    </context>
+<context>
     <name>BitcoinGUI</name>
+    <message>
+        <source>&amp;Overview</source>
+        <translation type="unfinished">&amp;概述</translation>
+    </message>
+    <message>
+        <source>Show general overview of wallet</source>
+        <translation type="unfinished">显示钱包的总体概况</translation>
+    </message>
+    <message>
+        <source>&amp;Transactions</source>
+        <translation type="unfinished">&amp;交易</translation>
+    </message>
+    <message>
+        <source>Browse transaction history</source>
+        <translation type="unfinished">浏览历史交易</translation>
+    </message>
+    <message>
+        <source>E&amp;xit</source>
+        <translation type="unfinished">退&amp;出</translation>
+    </message>
+    <message>
+        <source>Quit application</source>
+        <translation type="unfinished">退出应用程序</translation>
+    </message>
+    <message>
+        <source>&amp;About %1</source>
+        <translation type="unfinished">&amp;关于 %1</translation>
+    </message>
+    <message>
+        <source>Show information about %1</source>
+        <translation type="unfinished">显示信息关于%1</translation>
+    </message>
+    <message>
+        <source>Encrypt the private keys that belong to your wallet</source>
+        <translation type="unfinished">加密您的钱包私钥</translation>
+    </message>
+    <message>
+        <source>Sign messages with your Bitcoin addresses to prove you own them</source>
+        <translation type="unfinished">用您的比特币地址签名信息，以证明拥有它们</translation>
+    </message>
+    <message>
+        <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
+        <translation type="unfinished">验证消息，确保它们是用指定的比特币地址签名的</translation>
+    </message>
     <message>
         <source>&amp;File</source>
         <translation type="unfinished">&amp;文件</translation>
@@ -166,7 +514,7 @@
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n active connection(s) to Bitcoin network.</numerusform>
         </translation>
     </message>
     </context>
@@ -176,19 +524,109 @@
         <source>Copy amount</source>
         <translation type="unfinished">复制金额</translation>
     </message>
+    <message>
+        <source>Copy fee</source>
+        <translation type="unfinished">复制手续费</translation>
+    </message>
+    <message>
+        <source>yes</source>
+        <translation type="unfinished">是</translation>
+    </message>
+    <message>
+        <source>This label turns red if any recipient receives an amount smaller than the current dust threshold.</source>
+        <translation type="unfinished">当任何一个收款金额小于目前的粉尘金额阈值时，文字会变红色。</translation>
+    </message>
+    </context>
+<context>
+    <name>CreateWalletActivity</name>
+    <message>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the create wallet progress window which indicates to the user which wallet is currently being created.</extracomment>
+        <translation type="unfinished">正在创建钱包&lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+    </context>
+<context>
+    <name>OpenWalletActivity</name>
+    <message>
+        <source>Open Wallet</source>
+        <extracomment>Title of window indicating the progress of opening of a wallet.</extracomment>
+        <translation type="unfinished">打开钱包</translation>
+    </message>
+    </context>
+<context>
+    <name>WalletController</name>
+    <message>
+        <source>Close wallet</source>
+        <translation type="unfinished">关闭钱包</translation>
+    </message>
+    </context>
+<context>
+    <name>EditAddressDialog</name>
+    <message>
+        <source>Edit sending address</source>
+        <translation type="unfinished">编辑付款地址</translation>
+    </message>
     </context>
 <context>
     <name>Intro</name>
     <message numerus="yes">
-        <source>(sufficient to restore backups %n day(s) old)</source>
-        <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
+        <source>%n GB of space available</source>
         <translation type="unfinished">
             <numerusform />
         </translation>
     </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(sufficient to restore backups %n day(s) old)</source>
+        <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
+        <translation type="unfinished">
+            <numerusform>(sufficient to restore backups %n day(s) old)</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">错误</translation>
+    </message>
+    </context>
+<context>
+    <name>OptionsDialog</name>
+    <message>
+        <source>&amp;Window</source>
+        <translation type="unfinished">&amp;窗口</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">错误</translation>
+    </message>
+    </context>
+<context>
+    <name>RPCConsole</name>
+    <message>
+        <source>Node window</source>
+        <translation type="unfinished">结点窗口</translation>
+    </message>
     </context>
 <context>
     <name>SendCoinsDialog</name>
+    <message>
+        <source>Copy amount</source>
+        <translation type="unfinished">复制金额</translation>
+    </message>
+    <message>
+        <source>Copy fee</source>
+        <translation type="unfinished">复制手续费</translation>
+    </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
@@ -203,6 +641,24 @@
         <translation type="unfinished">
             <numerusform />
         </translation>
+    </message>
+    </context>
+<context>
+    <name>WalletFrame</name>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">错误</translation>
+    </message>
+    </context>
+<context>
+    <name>WalletView</name>
+    <message>
+        <source>&amp;Export</source>
+        <translation type="unfinished">&amp;导出</translation>
+    </message>
+    <message>
+        <source>Export the data in the current tab to a file</source>
+        <translation type="unfinished">将当前选项卡中的数据导出到文件</translation>
     </message>
     </context>
 </TS>

--- a/src/qt/locale/bitcoin_zh_CN.ts
+++ b/src/qt/locale/bitcoin_zh_CN.ts
@@ -246,6 +246,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>BitcoinApplication</name>
     <message>
+        <source>Settings file %1 might be corrupt or invalid.</source>
+        <translation type="unfinished">设置文件%1可能已损坏或无效。</translation>
+    </message>
+    <message>
         <source>Runaway exception</source>
         <translation type="unfinished">未捕获的异常</translation>
     </message>
@@ -264,6 +268,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 </context>
 <context>
     <name>QObject</name>
+    <message>
+        <source>Do you want to reset settings to default values, or to abort without making changes?</source>
+        <extracomment>Explanatory text shown on startup when the settings file cannot be read. Prompts user to make a choice between resetting or aborting.</extracomment>
+        <translation type="unfinished">要将设置重置为默认值，还是要放弃更改并中止？</translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. Check that settings file is writable, or try running with -nosettings.</source>
+        <extracomment>Explanatory text shown on startup when the settings file could not be written. Prompts user to check that we have the ability to write to the file. Explains that the user has the option of running without a settings file.</extracomment>
+        <translation type="unfinished">出现致命错误。请检查设置文件是否可写，或者尝试带 -nosettings 参数运行。</translation>
+    </message>
     <message>
         <source>Error: Specified data directory "%1" does not exist.</source>
         <translation type="unfinished">错误:指定的数据目录“%1”不存在。</translation>
@@ -366,31 +380,31 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>%n second(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n秒</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n minute(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n分钟</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n 小时</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n day(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n 天</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n week(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n 周</numerusform>
         </translation>
     </message>
     <message>
@@ -400,7 +414,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>%n year(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n年</numerusform>
         </translation>
     </message>
     <message>
@@ -410,6 +424,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </context>
 <context>
     <name>bitcoin-core</name>
+    <message>
+        <source>Settings file could not be read</source>
+        <translation type="unfinished">无法读取设置文件</translation>
+    </message>
+    <message>
+        <source>Settings file could not be written</source>
+        <translation type="unfinished">无法写入设置文件</translation>
+    </message>
     <message>
         <source>The %s developers</source>
         <translation type="unfinished">%s 开发者</translation>
@@ -443,6 +465,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">读取 %s 时发生错误！所有的密钥都可以正确读取，但是交易记录或地址簿数据可能已经丢失或出错。</translation>
     </message>
     <message>
+        <source>Error reading %s! Transaction data may be missing or incorrect. Rescanning wallet.</source>
+        <translation type="unfinished">读取%s出错！交易数据可能丢失或有误。重新扫描钱包中。</translation>
+    </message>
+    <message>
         <source>Error: Dumpfile format record is incorrect. Got "%s", expected "format".</source>
         <translation type="unfinished">错误: 转储文件格式不正确。得到是"%s"，而预期本应得到的是 "format"。</translation>
     </message>
@@ -459,10 +485,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">错误: 传统钱包只支持 "legacy", "p2sh-segwit", 和 "bech32" 这三种地址类型</translation>
     </message>
     <message>
-        <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
-        <translation type="unfinished">错误：监听外部连接失败 (listen函数返回了错误 %s)</translation>
-    </message>
-    <message>
         <source>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.</source>
         <translation type="unfinished">手续费估计失败。而且备用手续费估计（fallbackfee）已被禁用。请再等一些区块，或者通过-fallbackfee参数启用备用手续费估计。</translation>
     </message>
@@ -473,6 +495,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Invalid amount for -maxtxfee=&lt;amount&gt;: '%s' (must be at least the minrelay fee of %s to prevent stuck transactions)</source>
         <translation type="unfinished">参数 -maxtxfee=&lt;amount&gt;: '%s' 指定了非法的金额 (手续费必须至少达到最小转发费率(minrelay fee) %s 以避免交易卡着发不出去)</translation>
+    </message>
+    <message>
+        <source>Invalid or corrupt peers.dat (%s). If you believe this is a bug, please report it to %s. As a workaround, you can move the file (%s) out of the way (rename, move, or delete) to have a new one created on the next start.</source>
+        <translation type="unfinished">无效或损坏的peers.dat (%s)。如果你确信这是一个bug，请反馈到%s。作为变通办法，你可以把现有文件 (%s) 移开(重命名、移动或删除)，这样就可以在下次启动时创建一个新文件了。</translation>
     </message>
     <message>
         <source>More than one onion bind address is provided. Using %s for the automatically created Tor onion service.</source>
@@ -503,6 +529,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">修剪被设置得太小，已经低于最小值%d MiB，请使用更大的数值。</translation>
     </message>
     <message>
+        <source>Prune mode is incompatible with -reindex-chainstate. Use full -reindex instead.</source>
+        <translation type="unfinished">修剪模式与 -reindex-chainstate 不兼容。请进行一次完整的 -reindex 。</translation>
+    </message>
+    <message>
         <source>Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of pruned node)</source>
         <translation type="unfinished">修剪:上次同步钱包的位置已经超出（落后于）现有修剪后数据的范围。你需要进行-reindex（对于已经启用修剪节点，就需要重新下载整个区块链）</translation>
     </message>
@@ -513,6 +543,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>The block database contains a block which appears to be from the future. This may be due to your computer's date and time being set incorrectly. Only rebuild the block database if you are sure that your computer's date and time are correct</source>
         <translation type="unfinished">区块数据库包含未来的交易，这可能是由本机错误的日期时间引起。若确认本机日期时间正确，请重新建立区块数据库。</translation>
+    </message>
+    <message>
+        <source>The block index db contains a legacy 'txindex'. To clear the occupied disk space, run a full -reindex, otherwise ignore this error. This error message will not be displayed again.</source>
+        <translation type="unfinished">区块索引数据库含有历史遗留的 'txindex' 。可以运行完整的 -reindex 来清理被占用的磁盘空间；也可以忽略这个错误。这个错误消息将不会再次显示。</translation>
     </message>
     <message>
         <source>The transaction amount is too small to send after the fee has been deducted</source>
@@ -551,6 +585,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">提供了未知的钱包格式 "%s" 。请使用 "bdb" 或 "sqlite" 中的一种。</translation>
     </message>
     <message>
+        <source>Unsupported chainstate database format found. Please restart with -reindex-chainstate. This will rebuild the chainstate database.</source>
+        <translation type="unfinished">找到了不受支持的 chainstate 数据库格式。请使用 -reindex-chainstate 参数重启。这将会重建 chainstate 数据库。</translation>
+    </message>
+    <message>
+        <source>Wallet created successfully. The legacy wallet type is being deprecated and support for creating and opening legacy wallets will be removed in the future.</source>
+        <translation type="unfinished">钱包创建成功。旧式钱包已被弃用，未来将不再支持创建或打开旧式钱包。</translation>
+    </message>
+    <message>
         <source>Warning: Dumpfile wallet format "%s" does not match command line specified format "%s".</source>
         <translation type="unfinished">警告: 转储文件的钱包格式 "%s" 与命令行指定的格式 "%s" 不符。</translation>
     </message>
@@ -587,12 +629,108 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">无法解析 - %s 地址: '%s'</translation>
     </message>
     <message>
+        <source>Cannot set -forcednsseed to true when setting -dnsseed to false.</source>
+        <translation type="unfinished">在 -dnsseed 被设为 false 时无法将 -forcednsseed 设为 true 。</translation>
+    </message>
+    <message>
         <source>Cannot set -peerblockfilters without -blockfilterindex.</source>
         <translation type="unfinished">没有启用-blockfilterindex，就不能启用-peerblockfilters。</translation>
     </message>
     <message>
         <source>Cannot write to data directory '%s'; check permissions.</source>
         <translation type="unfinished">不能写入到数据目录'%s'；请检查文件权限。</translation>
+    </message>
+    <message>
+        <source>The -txindex upgrade started by a previous version cannot be completed. Restart with the previous version or run a full -reindex.</source>
+        <translation type="unfinished">无法完成由之前版本启动的 -txindex 升级。请用之前的版本重新启动，或者进行一次完整的 -reindex 。</translation>
+    </message>
+    <message>
+        <source>%s request to listen on port %u. This port is considered "bad" and thus it is unlikely that any Bitcoin Core peers connect to it. See doc/p2p-bad-ports.md for details and a full list.</source>
+        <translation type="unfinished">%s请求监听端口 %u。这个端口被认为是“坏的”，所以不太可能有Bitcoin Core节点会连接到它。有关详细信息和完整列表，请参见 doc/p2p-bad-ports.md 。</translation>
+    </message>
+    <message>
+        <source>-reindex-chainstate option is not compatible with -blockfilterindex. Please temporarily disable blockfilterindex while using -reindex-chainstate, or replace -reindex-chainstate with -reindex to fully rebuild all indexes.</source>
+        <translation type="unfinished">-reindex-chainstate 与 -blockfilterindex 不兼容。请在进行 -reindex-chainstate 时临时禁用 blockfilterindex ，或者改用 -reindex （而不是 -reindex-chainstate ）来完整地重建所有索引。</translation>
+    </message>
+    <message>
+        <source>-reindex-chainstate option is not compatible with -coinstatsindex. Please temporarily disable coinstatsindex while using -reindex-chainstate, or replace -reindex-chainstate with -reindex to fully rebuild all indexes.</source>
+        <translation type="unfinished">-reindex-chainstate 与 -coinstatsindex 不兼容。请在进行  -reindex-chainstate 时临时禁用 coinstatsindex ，或者改用 -reindex （而不是 -reindex-chainstate ）来完整地重建所有索引。</translation>
+    </message>
+    <message>
+        <source>-reindex-chainstate option is not compatible with -txindex. Please temporarily disable txindex while using -reindex-chainstate, or replace -reindex-chainstate with -reindex to fully rebuild all indexes.</source>
+        <translation type="unfinished">-reindex-chainstate 与 -txindex 不兼容。请在进行 -reindex-chainstate 时临时禁用 txindex ，或者改用 -reindex （而不是 -reindex-chainstate ）来完整地重建所有索引。</translation>
+    </message>
+    <message>
+        <source>Assumed-valid: last wallet synchronisation goes beyond available block data. You need to wait for the background validation chain to download more blocks.</source>
+        <translation type="unfinished">假定有效（assume-valid）: 上次同步钱包时进度越过了现有的区块数据。你需要等待后台验证链下载更多的区块。</translation>
+    </message>
+    <message>
+        <source>Cannot provide specific connections and have addrman find outgoing connections at the same time.</source>
+        <translation type="unfinished">在使用地址管理器(addrman)寻找出站连接时，无法同时提供特定的连接。</translation>
+    </message>
+    <message>
+        <source>Error loading %s: External signer wallet being loaded without external signer support compiled</source>
+        <translation type="unfinished">加载%s时出错: 编译时未启用外部签名器支持，却仍然试图加载外部签名器钱包</translation>
+    </message>
+    <message>
+        <source>Error: Address book data in wallet cannot be identified to belong to migrated wallets</source>
+        <translation type="unfinished">错误：钱包中的地址簿数据无法被识别为属于迁移后的钱包</translation>
+    </message>
+    <message>
+        <source>Error: Duplicate descriptors created during migration. Your wallet may be corrupted.</source>
+        <translation type="unfinished">错误：迁移过程中创建了重复的输出描述符。你的钱包可能已损坏。</translation>
+    </message>
+    <message>
+        <source>Error: Transaction %s in wallet cannot be identified to belong to migrated wallets</source>
+        <translation type="unfinished">错误：钱包中的交易%s无法被识别为属于迁移后的钱包</translation>
+    </message>
+    <message>
+        <source>Error: Unable to produce descriptors for this legacy wallet. Make sure the wallet is unlocked first</source>
+        <translation type="unfinished">错误：无法为这个遗留钱包生成输出描述符。请先确定钱包已被解锁</translation>
+    </message>
+    <message>
+        <source>Failed to rename invalid peers.dat file. Please move or delete it and try again.</source>
+        <translation type="unfinished">无法重命名无效的 peers.dat 文件。 请移动或删除它，然后重试。</translation>
+    </message>
+    <message>
+        <source>Incompatible options: -dnsseed=1 was explicitly specified, but -onlynet forbids connections to IPv4/IPv6</source>
+        <translation type="unfinished">互不兼容的选项：-dnsseed=1 已被显式指定，但 -onlynet 禁止了IPv4/IPv6 连接</translation>
+    </message>
+    <message>
+        <source>Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is explicitly forbidden: -onion=0</source>
+        <translation type="unfinished">出站连接被限制为仅使用 Tor (-onlynet=onion)，但是到达 Tor 网络的代理被显式禁止： -onion=0</translation>
+    </message>
+    <message>
+        <source>Outbound connections restricted to Tor (-onlynet=onion) but the proxy for reaching the Tor network is not provided: none of -proxy, -onion or -listenonion is given</source>
+        <translation type="unfinished">出站连接被限制为仅使用 Tor (-onlynet=onion)，但是未提供到达 Tor 网络的代理：没有提供 -proxy=, -onion= 或 -listenonion 参数</translation>
+    </message>
+    <message>
+        <source>Unrecognized descriptor found. Loading wallet %s
+
+The wallet might had been created on a newer version.
+Please try running the latest software version.
+</source>
+        <translation type="unfinished">找到无法识别的输出描述符。加载钱包%s
+
+钱包可能由新版软件创建，
+请尝试运行最新的软件版本。
+</translation>
+    </message>
+    <message>
+        <source>Unsupported category-specific logging level -loglevel=%s. Expected -loglevel=&lt;category&gt;:&lt;loglevel&gt;. Valid categories: %s. Valid loglevels: %s.</source>
+        <translation type="unfinished">不支持的类别限定日志等级 -loglevel=%s。预期参数 -loglevel=&lt;category&gt;:&lt;loglevel&gt;. Valid categories: %s。有效的类别： %s。</translation>
+    </message>
+    <message>
+        <source>
+Unable to cleanup failed migration</source>
+        <translation type="unfinished">
+无法清理失败的迁移</translation>
+    </message>
+    <message>
+        <source>
+Unable to restore backup of wallet.</source>
+        <translation type="unfinished">
+无法还原钱包备份</translation>
     </message>
     <message>
         <source>Config setting for %s only applied on %s network when in [%s] section.</source>
@@ -675,8 +813,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">从钱包数据库读取下一条记录时出错</translation>
     </message>
     <message>
-        <source>Error upgrading chainstate database</source>
-        <translation type="unfinished">升级链状态(chainstate)数据库出错</translation>
+        <source>Error: Could not add watchonly tx to watchonly wallet</source>
+        <translation type="unfinished">错误：无法添加仅观察交易至仅观察钱包</translation>
+    </message>
+    <message>
+        <source>Error: Could not delete watchonly transactions</source>
+        <translation type="unfinished">错误：无法删除仅观察交易</translation>
     </message>
     <message>
         <source>Error: Couldn't create cursor into database</source>
@@ -689,6 +831,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Error: Dumpfile checksum does not match. Computed %s, expected %s</source>
         <translation type="unfinished">错误: 转储文件的校验和不符。计算得到%s，预料中本应该得到%s</translation>
+    </message>
+    <message>
+        <source>Error: Failed to create new watchonly wallet</source>
+        <translation type="unfinished">错误：创建新仅观察钱包失败</translation>
     </message>
     <message>
         <source>Error: Got key that was not hex: %s</source>
@@ -711,8 +857,36 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">错误: 没有可用的%s地址。</translation>
     </message>
     <message>
+        <source>Error: Not all watchonly txs could be deleted</source>
+        <translation type="unfinished">错误：有些仅观察交易无法被删除</translation>
+    </message>
+    <message>
+        <source>Error: This wallet already uses SQLite</source>
+        <translation type="unfinished">错误：此钱包已经在使用SQLite</translation>
+    </message>
+    <message>
+        <source>Error: This wallet is already a descriptor wallet</source>
+        <translation type="unfinished">错误：这个钱包已经是输出描述符钱包</translation>
+    </message>
+    <message>
+        <source>Error: Unable to begin reading all records in the database</source>
+        <translation type="unfinished">错误：无法开始读取这个数据库中的所有记录</translation>
+    </message>
+    <message>
+        <source>Error: Unable to make a backup of your wallet</source>
+        <translation type="unfinished">错误：无法为你的钱包创建备份</translation>
+    </message>
+    <message>
         <source>Error: Unable to parse version %u as a uint32_t</source>
         <translation type="unfinished">错误：无法把版本号%u作为unit32_t解析</translation>
+    </message>
+    <message>
+        <source>Error: Unable to read all records in the database</source>
+        <translation type="unfinished">错误：无法读取这个数据库中的所有记录</translation>
+    </message>
+    <message>
+        <source>Error: Unable to remove watchonly address book data</source>
+        <translation type="unfinished">错误：无法移除仅观察地址簿数据</translation>
     </message>
     <message>
         <source>Error: Unable to write record to new wallet</source>
@@ -749,6 +923,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Initialization sanity check failed. %s is shutting down.</source>
         <translation type="unfinished">初始化完整性检查失败。%s 即将关闭。</translation>
+    </message>
+    <message>
+        <source>Input not found or already spent</source>
+        <translation type="unfinished">找不到交易输入项，可能已经被花掉了</translation>
     </message>
     <message>
         <source>Insufficient funds</source>
@@ -791,6 +969,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">参数 -whitelist: '%s' 指定了无效的网络掩码</translation>
     </message>
     <message>
+        <source>Listening for incoming connections failed (listen returned error %s)</source>
+        <translation type="unfinished">监听外部连接失败 (listen函数返回了错误 %s)</translation>
+    </message>
+    <message>
         <source>Loading P2P addresses…</source>
         <translation type="unfinished">加载P2P地址...</translation>
     </message>
@@ -807,12 +989,20 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">加载钱包...</translation>
     </message>
     <message>
+        <source>Missing amount</source>
+        <translation type="unfinished">找不到金额</translation>
+    </message>
+    <message>
+        <source>Missing solving data for estimating transaction size</source>
+        <translation type="unfinished">找不到用于估计交易大小的解答数据</translation>
+    </message>
+    <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
         <translation type="unfinished">-whitebind: '%s' 需要指定一个端口</translation>
     </message>
     <message>
-        <source>No proxy server specified. Use -proxy=&lt;ip&gt; or -proxy=&lt;ip:port&gt;.</source>
-        <translation type="unfinished">未指定代理服务器。请使用 -proxy=&lt;ip&gt; 或 -proxy=&lt;ip:port&gt; 。</translation>
+        <source>No addresses available</source>
+        <translation type="unfinished">没有可用的地址</translation>
     </message>
     <message>
         <source>Not enough file descriptors available.</source>
@@ -821,10 +1011,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Prune cannot be configured with a negative value.</source>
         <translation type="unfinished">不能把修剪配置成一个负数。</translation>
-    </message>
-    <message>
-        <source>Prune mode is incompatible with -coinstatsindex.</source>
-        <translation type="unfinished">区块修剪模式与 coinstatsindex 不兼容。</translation>
     </message>
     <message>
         <source>Prune mode is incompatible with -txindex.</source>
@@ -927,6 +1113,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">交易金额不不可为负数</translation>
     </message>
     <message>
+        <source>Transaction change output index out of range</source>
+        <translation type="unfinished">交易找零输出项编号超出范围</translation>
+    </message>
+    <message>
         <source>Transaction has too long of a mempool chain</source>
         <translation type="unfinished">此交易在内存池中的存在过长的链条</translation>
     </message>
@@ -935,8 +1125,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">交易必须包含至少一个收款人</translation>
     </message>
     <message>
+        <source>Transaction needs a change address, but we can't generate it.</source>
+        <translation type="unfinished">交易需要一个找零地址，但是我们无法生成它。</translation>
+    </message>
+    <message>
         <source>Transaction too large</source>
         <translation type="unfinished">交易过大</translation>
+    </message>
+    <message>
+        <source>Unable to allocate memory for -maxsigcachesize: '%s' MiB</source>
+        <translation type="unfinished">无法为 -maxsigcachesize: '%s' MiB 分配内存</translation>
     </message>
     <message>
         <source>Unable to bind to %s on this computer (bind returned error %s)</source>
@@ -951,6 +1149,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">无法创建PID文件'%s': %s</translation>
     </message>
     <message>
+        <source>Unable to find UTXO for external input</source>
+        <translation type="unfinished">无法为外部输入找到UTXO</translation>
+    </message>
+    <message>
         <source>Unable to generate initial keys</source>
         <translation type="unfinished">无法生成初始密钥</translation>
     </message>
@@ -963,8 +1165,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">无法打开%s用于写入</translation>
     </message>
     <message>
+        <source>Unable to parse -maxuploadtarget: '%s'</source>
+        <translation type="unfinished">无法解析 -maxuploadtarget: '%s'</translation>
+    </message>
+    <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
         <translation type="unfinished">无法启动HTTP服务，查看日志获取更多信息</translation>
+    </message>
+    <message>
+        <source>Unable to unload the wallet before migrating</source>
+        <translation type="unfinished">在迁移前无法卸载钱包</translation>
     </message>
     <message>
         <source>Unknown -blockfilterindex value %s.</source>
@@ -987,12 +1197,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">不明的交易规则已经激活 (versionbit %i)</translation>
     </message>
     <message>
-        <source>Unsupported logging category %s=%s.</source>
-        <translation type="unfinished">不支持的日志分类 %s=%s。</translation>
+        <source>Unsupported global logging level -loglevel=%s. Valid values: %s.</source>
+        <translation type="unfinished">不支持的全局日志等级 -loglevel=%s 。有效的数值：%s 。</translation>
     </message>
     <message>
-        <source>Upgrading UTXO database</source>
-        <translation type="unfinished">正在升级UTXO数据库</translation>
+        <source>Unsupported logging category %s=%s.</source>
+        <translation type="unfinished">不支持的日志分类 %s=%s。</translation>
     </message>
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
@@ -1060,6 +1270,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Create a new wallet</source>
         <translation type="unfinished">创建一个新的钱包</translation>
+    </message>
+    <message>
+        <source>&amp;Minimize</source>
+        <translation type="unfinished">最小化(&amp;M)</translation>
     </message>
     <message>
         <source>Wallet:</source>
@@ -1209,7 +1423,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>已处理%n个区块的交易历史。</numerusform>
         </translation>
     </message>
     <message>
@@ -1249,6 +1463,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">加载部分签名比特币交易（PSBT）</translation>
     </message>
     <message>
+        <source>Load PSBT from &amp;clipboard…</source>
+        <translation type="unfinished">从剪贴板加载PSBT(&amp;C)...</translation>
+    </message>
+    <message>
         <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
         <translation type="unfinished">从剪贴板中加载部分签名比特币交易（PSBT）</translation>
     </message>
@@ -1285,6 +1503,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">卸载钱包</translation>
     </message>
     <message>
+        <source>Restore Wallet…</source>
+        <extracomment>Name of the menu item that restores wallet from a backup file.</extracomment>
+        <translation type="unfinished">恢复钱包...</translation>
+    </message>
+    <message>
+        <source>Restore a wallet from a backup file</source>
+        <extracomment>Status tip for Restore Wallet menu item</extracomment>
+        <translation type="unfinished">从备份文件恢复钱包</translation>
+    </message>
+    <message>
         <source>Close all wallets</source>
         <translation type="unfinished">关闭所有钱包</translation>
     </message>
@@ -1309,6 +1537,26 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">没有可用的钱包</translation>
     </message>
     <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">钱包数据</translation>
+    </message>
+    <message>
+        <source>Load Wallet Backup</source>
+        <extracomment>The title for Restore Wallet File Windows</extracomment>
+        <translation type="unfinished">加载钱包备份</translation>
+    </message>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of pop-up window shown when the user is attempting to restore a wallet.</extracomment>
+        <translation type="unfinished">恢复钱包</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">钱包名称</translation>
+    </message>
+    <message>
         <source>&amp;Window</source>
         <translation type="unfinished">窗口(&amp;W)</translation>
     </message>
@@ -1324,11 +1572,19 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>%1 client</source>
         <translation type="unfinished">%1 客户端</translation>
     </message>
+    <message>
+        <source>&amp;Hide</source>
+        <translation type="unfinished">隐藏(&amp;H)</translation>
+    </message>
+    <message>
+        <source>S&amp;how</source>
+        <translation type="unfinished">显示(&amp;H)</translation>
+    </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>%n 条到比特币网络的活动连接</numerusform>
         </translation>
     </message>
     <message>
@@ -1350,6 +1606,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Enable network activity</source>
         <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
         <translation type="unfinished">启用网络活动</translation>
+    </message>
+    <message>
+        <source>Pre-syncing Headers (%1%)…</source>
+        <translation type="unfinished">预同步区块头 (%1%)…</translation>
     </message>
     <message>
         <source>Error: %1</source>
@@ -1522,6 +1782,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">复制金额(&amp;A)</translation>
     </message>
     <message>
+        <source>Copy transaction &amp;ID and output index</source>
+        <translation type="unfinished">复制交易&amp;ID和输出序号</translation>
+    </message>
+    <message>
         <source>L&amp;ock unspent</source>
         <translation type="unfinished">锁定未花费(&amp;O)</translation>
     </message>
@@ -1610,6 +1874,23 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Can't list signers</source>
         <translation type="unfinished">无法列出签名器</translation>
     </message>
+    <message>
+        <source>Too many external signers found</source>
+        <translation type="unfinished">找到的外部签名器太多</translation>
+    </message>
+</context>
+<context>
+    <name>LoadWalletsActivity</name>
+    <message>
+        <source>Load Wallets</source>
+        <extracomment>Title of progress window which is displayed when wallets are being loaded.</extracomment>
+        <translation type="unfinished">加载钱包</translation>
+    </message>
+    <message>
+        <source>Loading wallets…</source>
+        <extracomment>Descriptive text of the load wallets progress window which indicates to the user that wallets are currently being loaded.</extracomment>
+        <translation type="unfinished">加载钱包...</translation>
+    </message>
 </context>
 <context>
     <name>OpenWalletActivity</name>
@@ -1634,6 +1915,34 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
         <extracomment>Descriptive text of the open wallet progress window which indicates to the user which wallet is currently being opened.</extracomment>
         <translation type="unfinished">打开钱包&lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+</context>
+<context>
+    <name>RestoreWalletActivity</name>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of progress window which is displayed when wallets are being restored.</extracomment>
+        <translation type="unfinished">恢复钱包</translation>
+    </message>
+    <message>
+        <source>Restoring Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the restore wallets progress window which indicates to the user that wallets are currently being restored.</extracomment>
+        <translation type="unfinished">恢复钱包&lt;b&gt;%1&lt;/b&gt;…</translation>
+    </message>
+    <message>
+        <source>Restore wallet failed</source>
+        <extracomment>Title of message box which is displayed when the wallet could not be restored.</extracomment>
+        <translation type="unfinished">恢复钱包失败</translation>
+    </message>
+    <message>
+        <source>Restore wallet warning</source>
+        <extracomment>Title of message box which is displayed when the wallet is restored with some warning.</extracomment>
+        <translation type="unfinished">恢复钱包警告</translation>
+    </message>
+    <message>
+        <source>Restore wallet message</source>
+        <extracomment>Title of message box which is displayed when the wallet is successfully restored.</extracomment>
+        <translation type="unfinished">恢复钱包消息</translation>
     </message>
 </context>
 <context>
@@ -1815,13 +2124,23 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Bitcoin</source>
         <translation type="unfinished">比特币</translation>
     </message>
-    <message>
-        <source>(of %1 GB needed)</source>
-        <translation type="unfinished">(需要 %1 GB)</translation>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform>可用空间 %n GB</numerusform>
+        </translation>
     </message>
-    <message>
-        <source>(%1 GB needed for full chain)</source>
-        <translation type="unfinished">(完整区块链需要 %1 GB)</translation>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform>(需要 %n GB的空间)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform>(保存完整的链需要 %n GB)</numerusform>
+        </translation>
     </message>
     <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
@@ -1835,7 +2154,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>(足以恢复 %n 天之内的备份)</numerusform>
         </translation>
     </message>
     <message>
@@ -1867,10 +2186,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">由于这是第一次启动此程序，您可以选择%1存储数据的位置</translation>
     </message>
     <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation type="unfinished">当你单击确认后，%1 将会在 %4 启动时从  %3 中最早的交易开始，下载并处理完整的 %4 区块链 (%2GB)。</translation>
-    </message>
-    <message>
         <source>Limit block chain storage to</source>
         <translation type="unfinished">将区块链存储限制到</translation>
     </message>
@@ -1881,6 +2196,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
         <translation type="unfinished">初始化同步过程是非常吃力的，同时可能会暴露您之前没有注意到的电脑硬件问题。你每次启动%1时，它都会从之前中断的地方继续下载。</translation>
+    </message>
+    <message>
+        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2 GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
+        <translation type="unfinished">当你单击确认后，%1 将会从%4在%3年创始时最早的交易开始，下载并处理完整的 %4 区块链 (%2 GB)。</translation>
     </message>
     <message>
         <source>If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</source>
@@ -1975,6 +2294,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Unknown. Syncing Headers (%1, %2%)…</source>
         <translation type="unfinished">未知。同步区块头(%1, %2%)...</translation>
     </message>
+    <message>
+        <source>Unknown. Pre-syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">未知。预同步区块头 (%1, %2%)…</translation>
+    </message>
 </context>
 <context>
     <name>OpenURIDialog</name>
@@ -2031,6 +2354,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">窗口被关闭时最小化程序而不是退出。当此选项启用时，只有在菜单中选择“退出”时才会让程序退出。</translation>
     </message>
     <message>
+        <source>Options set in this dialog are overridden by the command line:</source>
+        <translation type="unfinished">这个对话框中的设置已被如下命令行选项覆盖:</translation>
+    </message>
+    <message>
         <source>Open the %1 configuration file from the working directory.</source>
         <translation type="unfinished">从工作目录下打开配置文件 %1。</translation>
     </message>
@@ -2059,12 +2386,42 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">警告:还原此设置需要重新下载整个区块链。</translation>
     </message>
     <message>
+        <source>Maximum database cache size. A larger cache can contribute to faster sync, after which the benefit is less pronounced for most use cases. Lowering the cache size will reduce memory usage. Unused mempool memory is shared for this cache.</source>
+        <extracomment>Tooltip text for Options window setting that sets the size of the database cache. Explains the corresponding effects of increasing/decreasing this value.</extracomment>
+        <translation type="unfinished">数据库缓存的最大大小。加大缓存有助于加快同步，但对于大多数使用场景来说，继续加大后收效会越来越不明显。降低缓存大小将会减小内存使用量。内存池中尚未被使用的那部分内存也会被共享用于这里的数据库缓存。</translation>
+    </message>
+    <message>
+        <source>Set the number of script verification threads. Negative values correspond to the number of cores you want to leave free to the system.</source>
+        <extracomment>Tooltip text for Options window setting that sets the number of script verification threads. Explains that negative values mean to leave these many cores free to the system.</extracomment>
+        <translation type="unfinished">设置脚本验证线程的数量。负值则表示你想要保留给系统的核心数量。</translation>
+    </message>
+    <message>
         <source>(0 = auto, &lt;0 = leave that many cores free)</source>
         <translation type="unfinished">(0 = 自动, &lt;0 = 保持指定数量的CPU核心空闲)</translation>
     </message>
     <message>
+        <source>This allows you or a third party tool to communicate with the node through command-line and JSON-RPC commands.</source>
+        <extracomment>Tooltip text for Options window setting that enables the RPC server.</extracomment>
+        <translation type="unfinished">这允许作为用户的你或第三方工具通过命令行和JSON-RPC命令行与节点通信。</translation>
+    </message>
+    <message>
+        <source>Enable R&amp;PC server</source>
+        <extracomment>An Options window setting to enable the RPC server.</extracomment>
+        <translation type="unfinished">启用R&amp;PC服务器</translation>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished">钱包(&amp;A)</translation>
+    </message>
+    <message>
+        <source>Whether to set subtract fee from amount as default or not.</source>
+        <extracomment>Tooltip text for Options window setting that sets subtracting the fee from a sending amount as default.</extracomment>
+        <translation type="unfinished">是否要默认从金额中减去手续费。</translation>
+    </message>
+    <message>
+        <source>Subtract &amp;fee from amount by default</source>
+        <extracomment>An Options window setting to set subtracting the fee from a sending amount as default.</extracomment>
+        <translation type="unfinished">默认从金额中减去交易手续费(&amp;F)</translation>
     </message>
     <message>
         <source>Expert</source>
@@ -2081,6 +2438,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>&amp;Spend unconfirmed change</source>
         <translation type="unfinished">动用尚未确认的找零资金(&amp;S)</translation>
+    </message>
+    <message>
+        <source>Enable &amp;PSBT controls</source>
+        <extracomment>An options window setting to enable PSBT controls.</extracomment>
+        <translation type="unfinished">启用&amp;PSBT控件</translation>
+    </message>
+    <message>
+        <source>Whether to show PSBT controls.</source>
+        <extracomment>Tooltip text for options window setting that enables PSBT controls.</extracomment>
+        <translation type="unfinished">是否要显示PSBT控件</translation>
     </message>
     <message>
         <source>External Signer (e.g. hardware wallet)</source>
@@ -2187,6 +2554,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">选择显示及发送比特币时使用的最小单位。</translation>
     </message>
     <message>
+        <source>Third-party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</source>
+        <translation type="unfinished">这个第三方网址（比如区块浏览器）会出现在交易选项卡的右键菜单中。 网址中的%s代表交易哈希。多个网址需要用竖线 | 相互分隔。</translation>
+    </message>
+    <message>
+        <source>&amp;Third-party transaction URLs</source>
+        <translation type="unfinished">第三方交易网址(&amp;T)</translation>
+    </message>
+    <message>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished">是否显示手动选币功能。</translation>
     </message>
@@ -2204,15 +2579,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>embedded "%1"</source>
-        <translation type="unfinished">嵌入了 “%1”</translation>
+        <translation type="unfinished">嵌入的 "%1"</translation>
     </message>
     <message>
         <source>closest matching "%1"</source>
         <translation type="unfinished">与 "%1" 最接近的匹配</translation>
-    </message>
-    <message>
-        <source>Options set in this dialog are overridden by the command line or in the configuration file:</source>
-        <translation type="unfinished">这个对话框中的设置已被如下命令行选项或配置文件项覆盖:</translation>
     </message>
     <message>
         <source>&amp;OK</source>
@@ -2237,14 +2608,22 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Confirm options reset</source>
+        <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
         <translation type="unfinished">确认恢复默认设置</translation>
     </message>
     <message>
         <source>Client restart required to activate changes.</source>
+        <extracomment>Text explaining that the settings changed will not come into effect until the client is restarted.</extracomment>
         <translation type="unfinished">需要重启客户端才能使更改生效。</translation>
     </message>
     <message>
+        <source>Current settings will be backed up at "%1".</source>
+        <extracomment>Text explaining to the user that the client's current settings will be backed up at a specific location. %1 is a stand-in argument for the backup location's path.</extracomment>
+        <translation type="unfinished">当前设置将会被备份到 "%1"。</translation>
+    </message>
+    <message>
         <source>Client will be shut down. Do you want to proceed?</source>
+        <extracomment>Text asking the user to confirm if they would like to proceed with a client shutdown.</extracomment>
         <translation type="unfinished">客户端即将关闭，您想继续吗？</translation>
     </message>
     <message>
@@ -2256,6 +2635,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>The configuration file is used to specify advanced user options which override GUI settings. Additionally, any command-line options will override this configuration file.</source>
         <extracomment>Explanatory text about the priority order of instructions considered by client. The order from high to low being: command-line, configuration file, GUI settings.</extracomment>
         <translation type="unfinished">配置文件可以用来设置高级选项。配置文件会覆盖设置界面窗口中的选项。此外，命令行会覆盖配置文件指定的选项。</translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation type="unfinished">继续</translation>
     </message>
     <message>
         <source>Cancel</source>
@@ -2276,6 +2659,13 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>The supplied proxy address is invalid.</source>
         <translation type="unfinished">提供的代理服务器地址无效。</translation>
+    </message>
+</context>
+<context>
+    <name>OptionsModel</name>
+    <message>
+        <source>Could not read setting "%1", %2.</source>
+        <translation type="unfinished">无法读取设置 "%1"，%2。</translation>
     </message>
 </context>
 <context>
@@ -2392,6 +2782,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">签名交易失败: %1</translation>
     </message>
     <message>
+        <source>Cannot sign inputs while wallet is locked.</source>
+        <translation type="unfinished">钱包已锁定，无法签名交易输入项。</translation>
+    </message>
+    <message>
         <source>Could not sign any more inputs.</source>
         <translation type="unfinished">没有交易输入项可供签名了。</translation>
     </message>
@@ -2465,6 +2859,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">交易仍然需要签名。</translation>
     </message>
     <message>
+        <source>(But no wallet is loaded.)</source>
+        <translation type="unfinished">(但没有加载钱包。)</translation>
+    </message>
+    <message>
         <source>(But this wallet cannot sign transactions.)</source>
         <translation type="unfinished">(但这个钱包不能签名交易)</translation>
     </message>
@@ -2527,6 +2925,11 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <source>Peer</source>
         <extracomment>Title of Peers Table column which contains a unique number used to identify a connection.</extracomment>
         <translation type="unfinished">节点</translation>
+    </message>
+    <message>
+        <source>Age</source>
+        <extracomment>Title of Peers Table column which indicates the duration (length of time) since the peer connection started.</extracomment>
+        <translation type="unfinished">连接时间</translation>
     </message>
     <message>
         <source>Direction</source>
@@ -2716,12 +3119,46 @@ If you are receiving this error you should request the merchant provide a BIP21 
         <translation type="unfinished">已同步区块</translation>
     </message>
     <message>
+        <source>Last Transaction</source>
+        <translation type="unfinished">最近交易</translation>
+    </message>
+    <message>
         <source>The mapped Autonomous System used for diversifying peer selection.</source>
         <translation type="unfinished">映射到的自治系统，被用来多样化选择节点</translation>
     </message>
     <message>
         <source>Mapped AS</source>
         <translation type="unfinished">映射到的AS</translation>
+    </message>
+    <message>
+        <source>Whether we relay addresses to this peer.</source>
+        <extracomment>Tooltip text for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
+        <translation type="unfinished">是否把地址转发给这个节点。</translation>
+    </message>
+    <message>
+        <source>Address Relay</source>
+        <extracomment>Text title for the Address Relay field in the peer details area, which displays whether we relay addresses to this peer (Yes/No).</extracomment>
+        <translation type="unfinished">地址转发</translation>
+    </message>
+    <message>
+        <source>The total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</source>
+        <extracomment>Tooltip text for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
+        <translation type="unfinished">从这个节点接收并处理过的地址总数（除去因频次限制而丢弃的那些地址）。</translation>
+    </message>
+    <message>
+        <source>The total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</source>
+        <extracomment>Tooltip text for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
+        <translation type="unfinished">从这个节点接收后又因频次限制而丢弃（未被处理）的地址总数。</translation>
+    </message>
+    <message>
+        <source>Addresses Processed</source>
+        <extracomment>Text title for the Addresses Processed field in the peer details area, which displays the total number of addresses received from this peer that were processed (excludes addresses that were dropped due to rate-limiting).</extracomment>
+        <translation type="unfinished">已处理地址</translation>
+    </message>
+    <message>
+        <source>Addresses Rate-Limited</source>
+        <extracomment>Text title for the Addresses Rate-Limited field in the peer details area, which displays the total number of addresses received from this peer that were dropped (not processed) due to rate-limiting.</extracomment>
+        <translation type="unfinished">被频率限制丢弃的地址</translation>
     </message>
     <message>
         <source>User Agent</source>
@@ -2930,6 +3367,11 @@ If you are receiving this error you should request the merchant provide a BIP21 
     <message>
         <source>1 &amp;year</source>
         <translation type="unfinished">1 年(&amp;Y)</translation>
+    </message>
+    <message>
+        <source>&amp;Copy IP/Netmask</source>
+        <extracomment>Context menu action to copy the IP/Netmask of a banned peer. IP/Netmask is the combination of a peer's IP address and its Netmask. For IP address, see: https://en.wikipedia.org/wiki/IP_address.</extracomment>
+        <translation type="unfinished">复制IP/网络掩码(&amp;C)</translation>
     </message>
     <message>
         <source>&amp;Unban</source>
@@ -3460,6 +3902,16 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
         <translation type="unfinished">请务必仔细检查您的交易请求。这会产生一个部分签名比特币交易(PSBT)，可以把保存下来或复制出去，然后就可以对它进行签名，比如用离线%1钱包，或是用兼容PSBT的硬件钱包。</translation>
     </message>
     <message>
+        <source>Do you want to create this transaction?</source>
+        <extracomment>Message displayed when attempting to create a transaction. Cautionary text to prompt the user to verify that the displayed transaction details represent the transaction the user intends to create.</extracomment>
+        <translation type="unfinished">要创建这笔交易吗？</translation>
+    </message>
+    <message>
+        <source>Please, review your transaction. You can create and send this transaction or create a Partially Signed Bitcoin Transaction (PSBT), which you can save or copy and then sign with, e.g., an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
+        <extracomment>Text to inform a user attempting to create a transaction of their current options. At this stage, a user can send their transaction or create a PSBT. This string is displayed when both private keys and PSBT controls are enabled.</extracomment>
+        <translation type="unfinished">请务必仔细检查您的交易。你可以创建并发送这笔交易；也可以创建一个“部分签名比特币交易(PSBT)”，它可以被保存下来或被复制出去，然后就可以对它进行签名，比如用离线%1钱包，或是用兼容PSBT的硬件钱包。</translation>
+    </message>
+    <message>
         <source>Please, review your transaction.</source>
         <extracomment>Text to prompt a user to review the details of the transaction they are attempting to send.</extracomment>
         <translation type="unfinished">请检查您的交易。</translation>
@@ -3512,14 +3964,10 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
         <source>A fee higher than %1 is considered an absurdly high fee.</source>
         <translation type="unfinished">超过 %1 的手续费被视为高得离谱。</translation>
     </message>
-    <message>
-        <source>Payment request expired.</source>
-        <translation type="unfinished">支付请求已过期。</translation>
-    </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>预计%n个区块内确认。</numerusform>
         </translation>
     </message>
     <message>
@@ -3594,28 +4042,12 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
         <translation type="unfinished">消息:</translation>
     </message>
     <message>
-        <source>This is an unauthenticated payment request.</source>
-        <translation type="unfinished">这是一个未经验证的支付请求。</translation>
-    </message>
-    <message>
-        <source>This is an authenticated payment request.</source>
-        <translation type="unfinished">这是一个已经验证的支付请求。</translation>
-    </message>
-    <message>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished">请为此地址输入一个标签以将它加入已用地址列表</translation>
     </message>
     <message>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished">bitcoin: URI 附带的备注信息，将会和交易一起存储，备查。 注意：该消息不会通过比特币网络传输。</translation>
-    </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">支付给:</translation>
-    </message>
-    <message>
-        <source>Memo:</source>
-        <translation type="unfinished">附言:</translation>
     </message>
 </context>
 <context>
@@ -3689,7 +4121,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     </message>
     <message>
         <source>Enter the receiver's address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack. Note that this only proves the signing party receives with the address, it cannot prove sendership of any transaction!</source>
-        <translation type="unfinished">请在下面输入接收者地址、消息（确保换行符、空格符、制表符等完全相同）和签名以验证消息。请仔细核对签名信息，以提防中间人攻击。请注意，这只是证明接收方可以用这个地址签名，它不能证明任何交易！</translation>
+        <translation type="unfinished">请在下面输入接收者地址、消息（确保换行符、空格符、制表符等完全相同）和签名以验证消息。请仔细核对签名信息，以提防中间人攻击。请注意，这只是证明接收方可以用这个地址签名，它不能证明任何交易的发送人身份！</translation>
     </message>
     <message>
         <source>The Bitcoin address the message was signed with</source>
@@ -3778,35 +4210,41 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
         <source>(press q to shutdown and continue later)</source>
         <translation type="unfinished">(按q退出并在以后继续)</translation>
     </message>
-    </context>
+    <message>
+        <source>press q to shutdown</source>
+        <translation type="unfinished">按q键关闭并退出</translation>
+    </message>
+</context>
 <context>
     <name>TransactionDesc</name>
     <message>
         <source>conflicted with a transaction with %1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that conflicts with a confirmed transaction.</extracomment>
         <translation type="unfinished">与一个有 %1 个确认的交易冲突</translation>
     </message>
     <message>
-        <source>0/unconfirmed, %1</source>
-        <translation type="unfinished">0/未确认，%1</translation>
+        <source>0/unconfirmed, in memory pool</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is in the memory pool.</extracomment>
+        <translation type="unfinished">0/未确认，在内存池中</translation>
     </message>
     <message>
-        <source>in memory pool</source>
-        <translation type="unfinished">在内存池中</translation>
-    </message>
-    <message>
-        <source>not in memory pool</source>
-        <translation type="unfinished">不在内存池中</translation>
+        <source>0/unconfirmed, not in memory pool</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that is not in the memory pool.</extracomment>
+        <translation type="unfinished">0/未确认，不在内存池中</translation>
     </message>
     <message>
         <source>abandoned</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an abandoned transaction.</extracomment>
         <translation type="unfinished">已丢弃</translation>
     </message>
     <message>
         <source>%1/unconfirmed</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
         <translation type="unfinished">%1/未确认</translation>
     </message>
     <message>
         <source>%1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
         <translation type="unfinished">%1 个确认</translation>
     </message>
     <message>
@@ -3856,7 +4294,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>在%n个区块内成熟</numerusform>
         </translation>
     </message>
     <message>
@@ -4151,6 +4589,11 @@ Note:  Since the fee is calculated on a per-byte basis, a fee rate of "100 satos
     <message>
         <source>&amp;Edit address label</source>
         <translation type="unfinished">编辑地址标签(&amp;E)</translation>
+    </message>
+    <message>
+        <source>Show in %1</source>
+        <extracomment>Transactions table context menu action to show the selected transaction in a third-party block explorer. %1 is a stand-in argument for the URL of the explorer.</extracomment>
+        <translation type="unfinished">在 %1中显示</translation>
     </message>
     <message>
         <source>Export Transaction History</source>

--- a/src/qt/locale/bitcoin_zh_HK.ts
+++ b/src/qt/locale/bitcoin_zh_HK.ts
@@ -499,6 +499,24 @@
 <context>
     <name>Intro</name>
     <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">

--- a/src/qt/locale/bitcoin_zh_TW.ts
+++ b/src/qt/locale/bitcoin_zh_TW.ts
@@ -35,7 +35,7 @@
     </message>
     <message>
         <source>&amp;Export</source>
-        <translation type="unfinished">匯出(&amp;E)</translation>
+        <translation type="unfinished">&amp;匯出</translation>
     </message>
     <message>
         <source>&amp;Delete</source>
@@ -48,6 +48,10 @@
     <message>
         <source>Choose the address to receive coins with</source>
         <translation type="unfinished">選擇要接收幣的地址</translation>
+    </message>
+    <message>
+        <source>C&amp;hoose</source>
+        <translation type="unfinished">選擇 (&amp;h)</translation>
     </message>
     <message>
         <source>Sending addresses</source>
@@ -168,7 +172,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Enter the new passphrase for the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
-        <translation type="unfinished">輸入錢包的新密碼短語。&lt;br/&gt;請使用&lt;b&gt;個或10個以上隨機字符&lt;/b&gt;或&lt;b&gt;個8個以上單詞3的密碼。</translation>
+        <translation type="unfinished">輸入錢包的新密碼短語。&lt;br/&gt;請使用&lt;b&gt;個或10個以上隨機字符&lt;/b&gt;或&lt;b&gt;個8個以上單詞&lt;/b&gt;的密碼。</translation>
     </message>
     <message>
         <source>Enter the old passphrase and new passphrase for the wallet.</source>
@@ -237,12 +241,34 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>BitcoinApplication</name>
     <message>
+        <source>Settings file %1 might be corrupt or invalid.</source>
+        <translation type="unfinished">設定檔%1可能已經失效或無效</translation>
+    </message>
+    <message>
+        <source>Runaway exception</source>
+        <translation type="unfinished">失控異常</translation>
+    </message>
+    <message>
         <source>Internal error</source>
         <translation type="unfinished">內部錯誤</translation>
     </message>
-    </context>
+    <message>
+        <source>An internal error occurred. %1 will attempt to continue safely. This is an unexpected bug which can be reported as described below.</source>
+        <translation type="unfinished">發生了內部錯誤%1 將嘗試安全地繼續。 這是一個意外錯誤，可以按如下所述進行報告。</translation>
+    </message>
+</context>
 <context>
     <name>QObject</name>
+    <message>
+        <source>Do you want to reset settings to default values, or to abort without making changes?</source>
+        <extracomment>Explanatory text shown on startup when the settings file cannot be read. Prompts user to make a choice between resetting or aborting.</extracomment>
+        <translation type="unfinished">您想將設置重置為預設值，還是在不進行更改的情況下中止？</translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. Check that settings file is writable, or try running with -nosettings.</source>
+        <extracomment>Explanatory text shown on startup when the settings file could not be written. Prompts user to check that we have the ability to write to the file. Explains that the user has the option of running without a settings file.</extracomment>
+        <translation type="unfinished">發生致命錯誤。檢查設置文件是否可寫入，或嘗試運行 -nosettings</translation>
+    </message>
     <message>
         <source>Error: Specified data directory "%1" does not exist.</source>
         <translation type="unfinished">错误：指定的数据目录“%1”不存在。</translation>
@@ -256,6 +282,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">错误：%1</translation>
     </message>
     <message>
+        <source>%1 didn't yet exit safely…</source>
+        <translation type="unfinished">%1還沒有安全退出……</translation>
+    </message>
+    <message>
         <source>unknown</source>
         <translation type="unfinished">未知</translation>
     </message>
@@ -266,6 +296,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Enter a Bitcoin address (e.g. %1)</source>
         <translation type="unfinished">輸入 比特幣地址 (比如說 %1)</translation>
+    </message>
+    <message>
+        <source>Unroutable</source>
+        <translation type="unfinished">不可路由</translation>
     </message>
     <message>
         <source>Inbound</source>
@@ -361,6 +395,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>bitcoin-core</name>
     <message>
+        <source>Settings file could not be read</source>
+        <translation type="unfinished">設定檔案無法讀取</translation>
+    </message>
+    <message>
+        <source>Settings file could not be written</source>
+        <translation type="unfinished">設定檔案無法寫入</translation>
+    </message>
+    <message>
         <source>The %s developers</source>
         <translation type="unfinished">%s 開發人員</translation>
     </message>
@@ -379,10 +421,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Error reading %s! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation type="unfinished">讀取錢包檔 %s 時發生錯誤！所有的鑰匙都正確讀取了，但是交易資料或地址簿資料可能會缺少或不正確。</translation>
-    </message>
-    <message>
-        <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
-        <translation type="unfinished">錯誤: 聽候外來連線失敗(回傳錯誤 %s)</translation>
     </message>
     <message>
         <source>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.</source>
@@ -541,10 +579,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">讀取資料庫時發生錯誤，要關閉了。</translation>
     </message>
     <message>
-        <source>Error upgrading chainstate database</source>
-        <translation type="unfinished">升級區塊鏈狀態資料庫時發生錯誤</translation>
-    </message>
-    <message>
         <source>Error: Disk space is low for %s</source>
         <translation type="unfinished">错误： %s 所在的磁盘空间低。</translation>
     </message>
@@ -561,12 +595,24 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">初始化時重新掃描錢包失敗了</translation>
     </message>
     <message>
+        <source>Fee rate (%s) is lower than the minimum fee rate setting (%s)</source>
+        <translation type="unfinished">手續費費率(%s) 低於最低費率設置（%s)</translation>
+    </message>
+    <message>
+        <source>Importing…</source>
+        <translation type="unfinished">匯入中...</translation>
+    </message>
+    <message>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation type="unfinished">創世區塊不正確或找不到。資料目錄錯了嗎？</translation>
     </message>
     <message>
         <source>Initialization sanity check failed. %s is shutting down.</source>
         <translation type="unfinished">初始化時的基本檢查失敗了。%s 就要關閉了。</translation>
+    </message>
+    <message>
+        <source>Input not found or already spent</source>
+        <translation type="unfinished">找不到交易項，或可能已經花掉了</translation>
     </message>
     <message>
         <source>Insufficient funds</source>
@@ -586,31 +632,55 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Invalid amount for -%s=&lt;amount&gt;: '%s'</source>
-        <translation type="unfinished">參數 -%s=&lt;金額&gt; 指定的金額無效: '%s'</translation>
+        <translation type="unfinished">無效金額給 -%s=&lt;amount&gt;:'%s'</translation>
     </message>
     <message>
         <source>Invalid amount for -discardfee=&lt;amount&gt;: '%s'</source>
-        <translation type="unfinished">設定 -discardfee=&lt;金額&gt; 的金額無效: '%s'</translation>
+        <translation type="unfinished">無效金額給 -丟棄費=&lt;amount&gt;; '%s' </translation>
     </message>
     <message>
         <source>Invalid amount for -fallbackfee=&lt;amount&gt;: '%s'</source>
-        <translation type="unfinished">設定 -fallbackfee=&lt;金額&gt; 的金額無效: '%s'</translation>
+        <translation type="unfinished">無效金額給 -後備費用=&lt;amount&gt;: '%s'</translation>
     </message>
     <message>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: '%s' (must be at least %s)</source>
-        <translation type="unfinished">設定 -paytxfee=&lt;金額&gt; 的金額無效: '%s' (至少要有 %s)</translation>
+        <translation type="unfinished">無效金額給 -支付費用&lt;amount&gt;:'%s' (必須至少%s)</translation>
     </message>
     <message>
         <source>Invalid netmask specified in -whitelist: '%s'</source>
         <translation type="unfinished">指定在 -whitelist 的網段無效: '%s'</translation>
     </message>
     <message>
+        <source>Loading P2P addresses…</source>
+        <translation type="unfinished">載入P2P地址中...</translation>
+    </message>
+    <message>
+        <source>Loading banlist…</source>
+        <translation type="unfinished">正在載入黑名單中...</translation>
+    </message>
+    <message>
+        <source>Loading block index…</source>
+        <translation type="unfinished">載入區塊索引中...</translation>
+    </message>
+    <message>
+        <source>Loading wallet…</source>
+        <translation type="unfinished">載入錢包中...</translation>
+    </message>
+    <message>
+        <source>Missing amount</source>
+        <translation type="unfinished">缺少金額</translation>
+    </message>
+    <message>
+        <source>Missing solving data for estimating transaction size</source>
+        <translation type="unfinished">缺少用於估計交易規模的求解數據</translation>
+    </message>
+    <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
         <translation type="unfinished">指定 -whitebind 時必須包含通訊埠: '%s'</translation>
     </message>
     <message>
-        <source>No proxy server specified. Use -proxy=&lt;ip&gt; or -proxy=&lt;ip:port&gt;.</source>
-        <translation type="unfinished">未指定代理伺服器。使用-proxy = &lt;ip&gt;或-proxy = &lt;ip:port&gt;。</translation>
+        <source>No addresses available</source>
+        <translation type="unfinished">沒有可用的地址</translation>
     </message>
     <message>
         <source>Not enough file descriptors available.</source>
@@ -625,8 +695,20 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">修剪模式和 -txindex 參數不相容。</translation>
     </message>
     <message>
+        <source>Pruning blockstore…</source>
+        <translation type="unfinished">修剪區塊資料庫中...</translation>
+    </message>
+    <message>
         <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
         <translation type="unfinished">因為系統的限制，將 -maxconnections 參數從 %d 降到了 %d</translation>
+    </message>
+    <message>
+        <source>Replaying blocks…</source>
+        <translation type="unfinished">正在對區塊進行重新計算...</translation>
+    </message>
+    <message>
+        <source>Rescanning…</source>
+        <translation type="unfinished">重新掃描中...</translation>
     </message>
     <message>
         <source>Section [%s] is not recognized.</source>
@@ -653,8 +735,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">指定的區塊目錄 "%s" 不存在。</translation>
     </message>
     <message>
+        <source>Starting network threads…</source>
+        <translation type="unfinished">正在開始網路線程...</translation>
+    </message>
+    <message>
         <source>The source code is available from %s.</source>
         <translation type="unfinished">原始碼可以在 %s 取得。</translation>
+    </message>
+    <message>
+        <source>The specified config file %s does not exist</source>
+        <translation type="unfinished">這個指定的配置檔案%s不存在</translation>
     </message>
     <message>
         <source>The transaction amount is too small to pay the fee</source>
@@ -685,12 +775,20 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">交易金額不能是負的</translation>
     </message>
     <message>
+        <source>Transaction change output index out of range</source>
+        <translation type="unfinished">交易尋找零輸出項超出範圍</translation>
+    </message>
+    <message>
         <source>Transaction has too long of a mempool chain</source>
         <translation type="unfinished">交易造成記憶池中的交易鏈太長</translation>
     </message>
     <message>
         <source>Transaction must have at least one recipient</source>
         <translation type="unfinished">交易必須至少有一個收款人</translation>
+    </message>
+    <message>
+        <source>Transaction needs a change address, but we can't generate it.</source>
+        <translation type="unfinished">需要交易一個找零地址，但是我們無法生成它。</translation>
     </message>
     <message>
         <source>Transaction too large</source>
@@ -717,6 +815,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">沒辦法產生密鑰</translation>
     </message>
     <message>
+        <source>Unable to open %s for writing</source>
+        <translation type="unfinished">無法開啟%s來寫入</translation>
+    </message>
+    <message>
+        <source>Unable to parse -maxuploadtarget: '%s'</source>
+        <translation type="unfinished">無法解析-最大上傳目標:'%s'</translation>
+    </message>
+    <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
         <translation type="unfinished">無法啟動 HTTP 伺服器。詳情請看除錯紀錄。</translation>
     </message>
@@ -737,16 +843,24 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">在 -onlynet 指定了不明的網路別: '%s'</translation>
     </message>
     <message>
+        <source>Unknown new rules activated (versionbit %i)</source>
+        <translation type="unfinished">未知的交易已經有新規則激活 (versionbit %i)</translation>
+    </message>
+    <message>
         <source>Unsupported logging category %s=%s.</source>
         <translation type="unfinished">不支援的紀錄類別 %s=%s。</translation>
     </message>
     <message>
-        <source>Upgrading UTXO database</source>
-        <translation type="unfinished">正在升級 UTXO 資料庫</translation>
-    </message>
-    <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
         <translation type="unfinished">使用者代理註解(%s)中含有不安全的字元。</translation>
+    </message>
+    <message>
+        <source>Verifying blocks…</source>
+        <translation type="unfinished">正在驗證區塊數據...</translation>
+    </message>
+    <message>
+        <source>Verifying wallet(s)…</source>
+        <translation type="unfinished">正在驗證錢包...</translation>
     </message>
     <message>
         <source>Wallet needed to be rewritten: restart %s to complete</source>
@@ -796,6 +910,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">創建一個新錢包</translation>
     </message>
     <message>
+        <source>&amp;Minimize</source>
+        <translation type="unfinished">&amp;最小化</translation>
+    </message>
+    <message>
         <source>Wallet:</source>
         <translation type="unfinished">錢包:</translation>
     </message>
@@ -829,16 +947,61 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">&amp;接收</translation>
     </message>
     <message>
+        <source>&amp;Options…</source>
+        <translation type="unfinished">&amp;選項...</translation>
+    </message>
+    <message>
+        <source>&amp;Encrypt Wallet…</source>
+        <translation type="unfinished">&amp;加密錢包...</translation>
+    </message>
+    <message>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation type="unfinished">將錢包中之密鑰加密</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet…</source>
+        <translation type="unfinished">&amp;備用錢包</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase…</source>
+        <translation type="unfinished">&amp;更改密碼短語...</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message…</source>
+        <translation type="unfinished">簽名 &amp;信息…</translation>
     </message>
     <message>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation type="unfinished">用比特幣地址簽名訊息來證明位址是你的</translation>
     </message>
     <message>
+        <source>&amp;Verify message…</source>
+        <translation type="unfinished">&amp;驗證
+訊息...</translation>
+    </message>
+    <message>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation type="unfinished">驗證訊息是用來確定訊息是用指定的比特幣地址簽名的</translation>
+    </message>
+    <message>
+        <source>&amp;Load PSBT from file…</source>
+        <translation type="unfinished">&amp;從檔案載入PSBT...</translation>
+    </message>
+    <message>
+        <source>Open &amp;URI…</source>
+        <translation type="unfinished">開啟 &amp;URI...</translation>
+    </message>
+    <message>
+        <source>Close Wallet…</source>
+        <translation type="unfinished">关钱包...</translation>
+    </message>
+    <message>
+        <source>Create Wallet…</source>
+        <translation type="unfinished">创建钱包...</translation>
+    </message>
+    <message>
+        <source>Close All Wallets…</source>
+        <translation type="unfinished">关所有钱包...</translation>
     </message>
     <message>
         <source>&amp;File</source>
@@ -855,6 +1018,30 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Tabs toolbar</source>
         <translation type="unfinished">分頁工具列</translation>
+    </message>
+    <message>
+        <source>Syncing Headers (%1%)…</source>
+        <translation type="unfinished">同步區塊頭 (%1%)…</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network…</source>
+        <translation type="unfinished">正在與網絡同步…</translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk…</source>
+        <translation type="unfinished">索引磁盤上的索引塊中...</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk…</source>
+        <translation type="unfinished">處理磁碟裡的區塊中...</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk…</source>
+        <translation type="unfinished">正在重新索引磁盤上的區塊...</translation>
+    </message>
+    <message>
+        <source>Connecting to peers…</source>
+        <translation type="unfinished">连到同行...</translation>
     </message>
     <message>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
@@ -875,12 +1062,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>已處裡%n個區塊的交易紀錄</numerusform>
         </translation>
     </message>
     <message>
         <source>%1 behind</source>
         <translation type="unfinished">落後 %1</translation>
+    </message>
+    <message>
+        <source>Catching up…</source>
+        <translation type="unfinished">赶上...</translation>
     </message>
     <message>
         <source>Last received block was generated %1 ago.</source>
@@ -909,6 +1100,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Load Partially Signed Bitcoin Transaction</source>
         <translation type="unfinished">載入部分簽名的比特幣交易</translation>
+    </message>
+    <message>
+        <source>Load PSBT from &amp;clipboard…</source>
+        <translation type="unfinished">從剪貼簿載入PSBT</translation>
     </message>
     <message>
         <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
@@ -947,6 +1142,16 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">關閉錢包</translation>
     </message>
     <message>
+        <source>Restore Wallet…</source>
+        <extracomment>Name of the menu item that restores wallet from a backup file.</extracomment>
+        <translation type="unfinished">恢復錢包...</translation>
+    </message>
+    <message>
+        <source>Restore a wallet from a backup file</source>
+        <extracomment>Status tip for Restore Wallet menu item</extracomment>
+        <translation type="unfinished">從備份檔案中恢復錢包</translation>
+    </message>
+    <message>
         <source>Close all wallets</source>
         <translation type="unfinished">關閉所有錢包</translation>
     </message>
@@ -971,8 +1176,28 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">没有可用的钱包</translation>
     </message>
     <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">錢包資料</translation>
+    </message>
+    <message>
+        <source>Load Wallet Backup</source>
+        <extracomment>The title for Restore Wallet File Windows</extracomment>
+        <translation type="unfinished">載入錢包備份</translation>
+    </message>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of pop-up window shown when the user is attempting to restore a wallet.</extracomment>
+        <translation type="unfinished">恢復錢包</translation>
+    </message>
+    <message>
+        <source>Wallet Name</source>
+        <extracomment>Label of the input field where the name of the wallet is entered.</extracomment>
+        <translation type="unfinished">錢包名稱</translation>
+    </message>
+    <message>
         <source>&amp;Window</source>
-        <translation type="unfinished">視窗(&amp;W)</translation>
+        <translation type="unfinished">&amp;視窗</translation>
     </message>
     <message>
         <source>Zoom</source>
@@ -986,12 +1211,44 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>%1 client</source>
         <translation type="unfinished">%1 客戶端</translation>
     </message>
+    <message>
+        <source>&amp;Hide</source>
+        <translation type="unfinished">&amp;躲</translation>
+    </message>
+    <message>
+        <source>S&amp;how</source>
+        <translation type="unfinished">&amp;顯示</translation>
+    </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>已處理%n個區塊的交易歷史。</numerusform>
         </translation>
+    </message>
+    <message>
+        <source>Click for more actions.</source>
+        <extracomment>A substring of the tooltip. "More actions" are available via the context menu.</extracomment>
+        <translation type="unfinished">點擊查看更多操作</translation>
+    </message>
+    <message>
+        <source>Show Peers tab</source>
+        <extracomment>A context menu item. The "Peers tab" is an element of the "Node window".</extracomment>
+        <translation type="unfinished">顯示節點選項卡</translation>
+    </message>
+    <message>
+        <source>Disable network activity</source>
+        <extracomment>A context menu item.</extracomment>
+        <translation type="unfinished">關閉網路紀錄</translation>
+    </message>
+    <message>
+        <source>Enable network activity</source>
+        <extracomment>A context menu item. The network activity was disabled previously.</extracomment>
+        <translation type="unfinished">關閉網路紀錄</translation>
+    </message>
+    <message>
+        <source>Pre-syncing Headers (%1%)…</source>
+        <translation type="unfinished">預先同步標頭(%1%)</translation>
     </message>
     <message>
         <source>Error: %1</source>
@@ -1152,6 +1409,30 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">複製金額</translation>
     </message>
     <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;复制地址</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">复制和标签</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">复制和数量</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID and output index</source>
+        <translation type="unfinished">複製交易&amp;ID與輸出序號</translation>
+    </message>
+    <message>
+        <source>L&amp;ock unspent</source>
+        <translation type="unfinished">鎖定未消費金額額</translation>
+    </message>
+    <message>
+        <source>&amp;Unlock unspent</source>
+        <translation type="unfinished">解鎖未花費金額</translation>
+    </message>
+    <message>
         <source>Copy quantity</source>
         <translation type="unfinished">複製數目</translation>
     </message>
@@ -1216,6 +1497,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">新增錢包</translation>
     </message>
     <message>
+        <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the create wallet progress window which indicates to the user which wallet is currently being created.</extracomment>
+        <translation type="unfinished">正在創建錢包&lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+    <message>
         <source>Create wallet failed</source>
         <translation type="unfinished">創建錢包失敗&lt;br&gt;</translation>
     </message>
@@ -1223,7 +1509,28 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Create wallet warning</source>
         <translation type="unfinished">產生錢包警告:</translation>
     </message>
-    </context>
+    <message>
+        <source>Can't list signers</source>
+        <translation type="unfinished">無法列出簽名器</translation>
+    </message>
+    <message>
+        <source>Too many external signers found</source>
+        <translation type="unfinished">偵測到的外接簽名器過多</translation>
+    </message>
+</context>
+<context>
+    <name>LoadWalletsActivity</name>
+    <message>
+        <source>Load Wallets</source>
+        <extracomment>Title of progress window which is displayed when wallets are being loaded.</extracomment>
+        <translation type="unfinished">載入錢包</translation>
+    </message>
+    <message>
+        <source>Loading wallets…</source>
+        <extracomment>Descriptive text of the load wallets progress window which indicates to the user that wallets are currently being loaded.</extracomment>
+        <translation type="unfinished">正在載入錢包...</translation>
+    </message>
+</context>
 <context>
     <name>OpenWalletActivity</name>
     <message>
@@ -1243,7 +1550,40 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <extracomment>Title of window indicating the progress of opening of a wallet.</extracomment>
         <translation type="unfinished">打開錢包</translation>
     </message>
-    </context>
+    <message>
+        <source>Opening Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the open wallet progress window which indicates to the user which wallet is currently being opened.</extracomment>
+        <translation type="unfinished">正在打開錢包&lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+</context>
+<context>
+    <name>RestoreWalletActivity</name>
+    <message>
+        <source>Restore Wallet</source>
+        <extracomment>Title of progress window which is displayed when wallets are being restored.</extracomment>
+        <translation type="unfinished">恢復錢包</translation>
+    </message>
+    <message>
+        <source>Restoring Wallet &lt;b&gt;%1&lt;/b&gt;…</source>
+        <extracomment>Descriptive text of the restore wallets progress window which indicates to the user that wallets are currently being restored.</extracomment>
+        <translation type="unfinished">正在恢復錢包&lt;b&gt;%1&lt;/b&gt;...</translation>
+    </message>
+    <message>
+        <source>Restore wallet failed</source>
+        <extracomment>Title of message box which is displayed when the wallet could not be restored.</extracomment>
+        <translation type="unfinished">恢復錢包失敗</translation>
+    </message>
+    <message>
+        <source>Restore wallet warning</source>
+        <extracomment>Title of message box which is displayed when the wallet is restored with some warning.</extracomment>
+        <translation type="unfinished">恢復錢包警告</translation>
+    </message>
+    <message>
+        <source>Restore wallet message</source>
+        <extracomment>Title of message box which is displayed when the wallet is successfully restored.</extracomment>
+        <translation type="unfinished">恢復錢包訊息</translation>
+    </message>
+</context>
 <context>
     <name>WalletController</name>
     <message>
@@ -1314,10 +1654,24 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">描述符錢包</translation>
     </message>
     <message>
+        <source>Use an external signing device such as a hardware wallet. Configure the external signer script in wallet preferences first.</source>
+        <translation type="unfinished">使用外接簽名裝置(例如: 實體錢包)。
+請先在設定選項中設定好外接簽名裝置。</translation>
+    </message>
+    <message>
+        <source>External signer</source>
+        <translation type="unfinished">外接簽名裝置</translation>
+    </message>
+    <message>
         <source>Create</source>
         <translation type="unfinished">產生</translation>
     </message>
-    </context>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">編譯時沒有外接簽名器支援(外接簽名必須有此功能)</translation>
+    </message>
+</context>
 <context>
     <name>EditAddressDialog</name>
     <message>
@@ -1394,6 +1748,24 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 </context>
 <context>
     <name>Intro</name>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform>%nGB可用</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform>(需要 %n GB)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform>（完整區塊鏈需要％n GB）</numerusform>
+        </translation>
+    </message>
     <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
         <translation type="unfinished">在這個目錄中至少會存放 %1 GB 的資料，並且還會隨時間增加。</translation>
@@ -1406,7 +1778,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>(sufficient to restore backups %n day(s) old)</source>
         <extracomment>Explanatory text on the capability of the current prune target.</extracomment>
         <translation type="unfinished">
-            <numerusform />
+            <numerusform>(足以恢復%n天內的備份)</numerusform>
         </translation>
     </message>
     <message>
@@ -1438,16 +1810,24 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">因為這是程式第一次啓動，你可以選擇 %1 儲存資料的地方。</translation>
     </message>
     <message>
-        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation type="unfinished">在你按下「好」之後，%1 就會開始下載並處理整個 %4 區塊鏈(大小是  %2GB)，也就是從 %3 年 %4 剛剛起步時的最初交易開始。</translation>
+        <source>Limit block chain storage to</source>
+        <translation type="unfinished">將區塊鏈儲存限制為</translation>
     </message>
     <message>
         <source>Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</source>
         <translation type="unfinished">還原此設置需要重新下載整個區塊鏈。首先下載完整的鏈，然後再修剪它是更快的。禁用某些高級功能。</translation>
     </message>
     <message>
+        <source> GB</source>
+        <translation type="unfinished">GB</translation>
+    </message>
+    <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
         <translation type="unfinished">一開始的同步作業非常的耗費資源，並且可能會暴露出之前沒被發現的電腦硬體問題。每次執行 %1 的時候都會繼續先前未完成的下載。</translation>
+    </message>
+    <message>
+        <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2 GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
+        <translation type="unfinished">當你點擊「確認」，%1會開始下載，並從%3年最早的交易，處裡整個%4區塊鏈(大小:%2GB)</translation>
     </message>
     <message>
         <source>If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</source>
@@ -1480,6 +1860,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
 <context>
     <name>ShutdownWindow</name>
     <message>
+        <source>%1 is shutting down…</source>
+        <translation type="unfinished">%1正在關機</translation>
+    </message>
+    <message>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished">在這個視窗不見以前，請不要關掉電腦。</translation>
     </message>
@@ -1501,6 +1885,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Number of blocks left</source>
         <translation type="unfinished">剩餘區塊數</translation>
+    </message>
+    <message>
+        <source>Unknown…</source>
+        <translation type="unfinished">不明...</translation>
+    </message>
+    <message>
+        <source>calculating…</source>
+        <translation type="unfinished">计算...</translation>
     </message>
     <message>
         <source>Last block time</source>
@@ -1526,7 +1918,15 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Esc</source>
         <translation type="unfinished">離開鍵</translation>
     </message>
-    </context>
+    <message>
+        <source>Unknown. Syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">不明。正在同步標頭(%1, %2%)...</translation>
+    </message>
+    <message>
+        <source>Unknown. Pre-syncing Headers (%1, %2%)…</source>
+        <translation type="unfinished">不明。正在預先同步標頭(%1, %2%)...</translation>
+    </message>
+</context>
 <context>
     <name>OpenURIDialog</name>
     <message>
@@ -1675,7 +2075,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>&amp;Window</source>
-        <translation type="unfinished">視窗(&amp;W)</translation>
+        <translation type="unfinished">&amp;視窗</translation>
     </message>
     <message>
         <source>Show only a tray icon after minimizing the window.</source>
@@ -1722,16 +2122,17 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">使用個別的SOCKS＆5代理介由Tor onion服務到達peers：</translation>
     </message>
     <message>
-        <source>Options set in this dialog are overridden by the command line or in the configuration file:</source>
-        <translation type="unfinished">这个对话框中的设置已被如下命令行选项或配置文件项覆盖：</translation>
-    </message>
-    <message>
         <source>&amp;OK</source>
         <translation type="unfinished">好(&amp;O)</translation>
     </message>
     <message>
         <source>&amp;Cancel</source>
         <translation type="unfinished">取消(&amp;C)</translation>
+    </message>
+    <message>
+        <source>Compiled without external signing support (required for external signing)</source>
+        <extracomment>"External signing" means using devices such as hardware wallets.</extracomment>
+        <translation type="unfinished">編譯時沒有外接簽名器支援(外接簽名必須有此功能)</translation>
     </message>
     <message>
         <source>default</source>
@@ -1743,14 +2144,17 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Confirm options reset</source>
+        <extracomment>Window title text of pop-up window shown when the user has chosen to reset options.</extracomment>
         <translation type="unfinished">確認重設選項</translation>
     </message>
     <message>
         <source>Client restart required to activate changes.</source>
+        <extracomment>Text explaining that the settings changed will not come into effect until the client is restarted.</extracomment>
         <translation type="unfinished">需要重新開始客戶端軟體來讓改變生效。</translation>
     </message>
     <message>
         <source>Client will be shut down. Do you want to proceed?</source>
+        <extracomment>Text asking the user to confirm if they would like to proceed with a client shutdown.</extracomment>
         <translation type="unfinished">客戶端軟體就要關掉了。繼續做下去嗎？</translation>
     </message>
     <message>
@@ -1762,6 +2166,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>The configuration file is used to specify advanced user options which override GUI settings. Additionally, any command-line options will override this configuration file.</source>
         <extracomment>Explanatory text about the priority order of instructions considered by client. The order from high to low being: command-line, configuration file, GUI settings.</extracomment>
         <translation type="unfinished">設定檔可以用來指定進階的使用選項，並且會覆蓋掉圖形介面的設定。不過，命令列的選項也會覆蓋掉設定檔中的選項。</translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation type="unfinished">继续</translation>
     </message>
     <message>
         <source>Cancel</source>
@@ -1882,6 +2290,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">複製到剪貼簿</translation>
     </message>
     <message>
+        <source>Save…</source>
+        <translation type="unfinished">拯救...</translation>
+    </message>
+    <message>
         <source>Close</source>
         <translation type="unfinished">關閉</translation>
     </message>
@@ -1988,6 +2400,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Ping</source>
         <extracomment>Title of Peers Table column which indicates the current latency of the connection with the peer.</extracomment>
         <translation type="unfinished">Ping  時間</translation>
+    </message>
+    <message>
+        <source>Peer</source>
+        <extracomment>Title of Peers Table column which contains a unique number used to identify a connection.</extracomment>
+        <translation type="unfinished">同行</translation>
     </message>
     <message>
         <source>Direction</source>
@@ -2276,6 +2693,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">去:</translation>
     </message>
     <message>
+        <source>&amp;Copy address</source>
+        <extracomment>Context menu action to copy the address of a peer.</extracomment>
+        <translation type="unfinished">&amp;复制地址</translation>
+    </message>
+    <message>
         <source>&amp;Disconnect</source>
         <translation type="unfinished">斷線(&amp;D)</translation>
     </message>
@@ -2409,6 +2831,18 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Copy &amp;URI</source>
         <translation type="unfinished">複製 &amp;URI</translation>
+    </message>
+    <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;复制地址</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">复制和标签</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">复制和数量</translation>
     </message>
     <message>
         <source>Could not unlock wallet.</source>
@@ -2740,10 +3174,6 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>A fee higher than %1 is considered an absurdly high fee.</source>
         <translation type="unfinished">高於 %1 的手續費會被認為是不合理。</translation>
     </message>
-    <message>
-        <source>Payment request expired.</source>
-        <translation type="unfinished">付款的要求過期了。</translation>
-    </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">
@@ -2822,28 +3252,12 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">訊息:</translation>
     </message>
     <message>
-        <source>This is an unauthenticated payment request.</source>
-        <translation type="unfinished">這是個沒有驗證過身份的付款要求。</translation>
-    </message>
-    <message>
-        <source>This is an authenticated payment request.</source>
-        <translation type="unfinished">這是個已經驗證過身份的付款要求。</translation>
-    </message>
-    <message>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished">請輸入這個地址的標籤，來把它加進去已使用過地址清單。</translation>
     </message>
     <message>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished">附加在 Bitcoin 付款協議的資源識別碼(URI)中的訊息，會和交易內容一起存起來，給你自己做參考。注意: 這個訊息不會送到 Bitcoin 網路上。</translation>
-    </message>
-    <message>
-        <source>Pay To:</source>
-        <translation type="unfinished">付給:</translation>
-    </message>
-    <message>
-        <source>Memo:</source>
-        <translation type="unfinished">備註:</translation>
     </message>
 </context>
 <context>
@@ -3011,30 +3425,22 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <name>TransactionDesc</name>
     <message>
         <source>conflicted with a transaction with %1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an unconfirmed transaction that conflicts with a confirmed transaction.</extracomment>
         <translation type="unfinished">跟一個目前確認 %1 次的交易互相衝突</translation>
     </message>
     <message>
-        <source>0/unconfirmed, %1</source>
-        <translation type="unfinished">0 次/未確認，%1</translation>
-    </message>
-    <message>
-        <source>in memory pool</source>
-        <translation type="unfinished">在記憶池中</translation>
-    </message>
-    <message>
-        <source>not in memory pool</source>
-        <translation type="unfinished">不在記憶池中</translation>
-    </message>
-    <message>
         <source>abandoned</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents an abandoned transaction.</extracomment>
         <translation type="unfinished">已中止</translation>
     </message>
     <message>
         <source>%1/unconfirmed</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in at least one block, but less than 6 blocks.</extracomment>
         <translation type="unfinished">%1 次/未確認</translation>
     </message>
     <message>
         <source>%1 confirmations</source>
+        <extracomment>Text explaining the current status of a transaction, shown in the status field of the details window for this transaction. This status represents a transaction confirmed in 6 or more blocks.</extracomment>
         <translation type="unfinished">確認 %1 次</translation>
     </message>
     <message>
@@ -3337,6 +3743,22 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation type="unfinished">最小金額</translation>
     </message>
     <message>
+        <source>&amp;Copy address</source>
+        <translation type="unfinished">&amp;复制地址</translation>
+    </message>
+    <message>
+        <source>Copy &amp;label</source>
+        <translation type="unfinished">复制和标签</translation>
+    </message>
+    <message>
+        <source>Copy &amp;amount</source>
+        <translation type="unfinished">复制和数量</translation>
+    </message>
+    <message>
+        <source>Copy transaction &amp;ID</source>
+        <translation type="unfinished">複製交易 &amp;ID</translation>
+    </message>
+    <message>
         <source>Export Transaction History</source>
         <translation type="unfinished">匯出交易記錄</translation>
     </message>
@@ -3497,7 +3919,7 @@ Go to File &gt; Open Wallet to load a wallet.
     <name>WalletView</name>
     <message>
         <source>&amp;Export</source>
-        <translation type="unfinished">匯出(&amp;E)</translation>
+        <translation type="unfinished">&amp;匯出</translation>
     </message>
     <message>
         <source>Export the data in the current tab to a file</source>
@@ -3506,6 +3928,11 @@ Go to File &gt; Open Wallet to load a wallet.
     <message>
         <source>Backup Wallet</source>
         <translation type="unfinished">備份錢包</translation>
+    </message>
+    <message>
+        <source>Wallet Data</source>
+        <extracomment>Name of the wallet data file format.</extracomment>
+        <translation type="unfinished">錢包資料</translation>
     </message>
     <message>
         <source>Backup Failed</source>

--- a/src/qt/locale/bitcoin_zu.ts
+++ b/src/qt/locale/bitcoin_zu.ts
@@ -2,6 +2,18 @@
 <context>
     <name>AddressBookPage</name>
     <message>
+        <source>&amp;New</source>
+        <translation type="unfinished">&amp;Okusha</translation>
+    </message>
+    <message>
+        <source>&amp;Copy</source>
+        <translation type="unfinished">&amp;Kopisha</translation>
+    </message>
+    <message>
+        <source>Receiving addresses</source>
+        <translation type="unfinished">Amakheli ukuthola</translation>
+    </message>
+    <message>
         <source>Comma separated file</source>
         <extracomment>Expanded name of the CSV file format. See: https://en.wikipedia.org/wiki/Comma-separated_values.</extracomment>
         <translation type="unfinished">Ifayela elehlukaniswe ngo khefana.</translation>
@@ -72,6 +84,13 @@
     </message>
     </context>
 <context>
+    <name>bitcoin-core</name>
+    <message>
+        <source>Error: Missing checksum</source>
+        <translation type="unfinished">Iphutha: iChecksum engekho</translation>
+    </message>
+    </context>
+<context>
     <name>BitcoinGUI</name>
     <message>
         <source>&amp;Options…</source>
@@ -112,8 +131,8 @@
         <source>%n active connection(s) to Bitcoin network.</source>
         <extracomment>A substring of the tooltip.</extracomment>
         <translation type="unfinished">
-            <numerusform />
-            <numerusform />
+            <numerusform>%n active connection(s) to Bitcoin network.</numerusform>
+            <numerusform>%n active connection(s) to Bitcoin network.</numerusform>
         </translation>
     </message>
     <message>
@@ -133,7 +152,7 @@
         <source>Can't list signers</source>
         <translation type="unfinished">Akukwazi ukwenza uhlu lwabasayini.</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>CreateWalletDialog</name>
     <message>
@@ -143,9 +162,26 @@
     </context>
 <context>
     <name>Intro</name>
-    <message>
-        <source>(of %1 GB needed)</source>
-        <translation type="unfinished">(ku %1 GB odingakalayo)</translation>
+    <message numerus="yes">
+        <source>%n GB of space available</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation type="unfinished">
+            <numerusform>(of %n GB needed)</numerusform>
+            <numerusform>(of %n GB needed)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>(%n GB needed for full chain)</source>
+        <translation type="unfinished">
+            <numerusform>(%n GB needed for full chain)</numerusform>
+            <numerusform>(%n GB needed for full chain)</numerusform>
+        </translation>
     </message>
     <message numerus="yes">
         <source>(sufficient to restore backups %n day(s) old)</source>
@@ -166,6 +202,10 @@
     </context>
 <context>
     <name>SendCoinsDialog</name>
+    <message>
+        <source>Sign failed</source>
+        <translation type="unfinished">Uphawu lwehlulekile</translation>
+    </message>
     <message numerus="yes">
         <source>Estimated to begin confirmation within %n block(s).</source>
         <translation type="unfinished">


### PR DESCRIPTION
This PR follows our [Release Process](https://github.com/bitcoin/bitcoin/blob/master/doc/release-process.md).

Required to open Transifex translations for 25.0 on 2023-03-01 as it's [planned](https://github.com/bitcoin/bitcoin/issues/26549).

**NOTE.** Translations for the following languages for the latest 24.x Transifex resource have been effectively cancelled/damaged/vandalized:
- German (de) by [nesbonk83](https://www.transifex.com/user/profile/nesbonk83/) on 2023-01-27
- Dutch (nl) by [bram00767](https://www.transifex.com/user/profile/bram00767/) on 2022-12-17
- Spanish, Mexico (es_MX) by [VCFNFT](https://www.transifex.com/user/profile/VCFNFT/) on 2022-08-08

The first commit ignores changes to translations mentioned above.