### PR TITLE
valgrind: remove libsecp256k1 suppression

### DIFF
--- a/contrib/valgrind.supp
+++ b/contrib/valgrind.supp
@@ -99,14 +99,6 @@
    fun:_Z11LogInstancev
 }
 {
-   Suppress secp256k1_context_create still reachable memory warning
-   Memcheck:Leak
-   match-leak-kinds: reachable
-   fun:malloc
-   ...
-   fun:secp256k1_context_create
-}
-{
    Suppress BCLog::Logger::StartLogging() still reachable memory warning
    Memcheck:Leak
    match-leak-kinds: reachable


### PR DESCRIPTION
I am no-longer been able to recreate this issue, atleast after the most recent libsecp256k1 changes. Can someone else confirm?