### PR TITLE
ci: bump lint task to bookworm for git v2.38

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -61,10 +61,10 @@ compute_credits_template: &CREDITS_TEMPLATE
   use_compute_credits: $CIRRUS_REPO_FULL_NAME == 'bitcoin/bitcoin' && $CIRRUS_PR != ""
 
 task:
-  name: 'lint [jammy]'
+  name: 'lint [bookworm]'
   << : *BASE_TEMPLATE
   container:
-    image: ubuntu:jammy
+    image: debian:bookworm
     cpu: 1
     memory: 1G
   # For faster CI feedback, immediately schedule the linters


### PR DESCRIPTION
Since 5497c14, verify-commits.py uses `git merge-tree` which requires git v2.38 or later. Fix the lint jobs on master (e.g. https://cirrus-ci.com/task/4971007513985024).
