### PR TITLE
test: fix intermittent issue in `feature_bip68_sequence`

### DIFF
--- a/test/functional/interface_usdt_mempool.py
+++ b/test/functional/interface_usdt_mempool.py
@@ -173,6 +173,7 @@ class MempoolTracepointTest(BitcoinTestFramework):
 
         self.log.info("Ensuring mempool:added event was handled successfully...")
         assert_equal(EXPECTED_ADDED_EVENTS, handled_added_events)
+        self.generate(self.wallet, 1)
 
     def removed_test(self):
         """Expire a transaction from the mempool and make sure the tracepoint returns
@@ -223,6 +224,7 @@ class MempoolTracepointTest(BitcoinTestFramework):
 
         self.log.info("Ensuring mempool:removed event was handled successfully...")
         assert_equal(EXPECTED_REMOVED_EVENTS, handled_removed_events)
+        self.generate(self.wallet, 1)
 
     def replaced_test(self):
         """Replace one and two transactions in the mempool and make sure the tracepoint
@@ -280,6 +282,7 @@ class MempoolTracepointTest(BitcoinTestFramework):
 
         self.log.info("Ensuring mempool:replaced event was handled successfully...")
         assert_equal(EXPECTED_REPLACED_EVENTS, handled_replaced_events)
+        self.generate(self.wallet, 1)
 
     def rejected_test(self):
         """Create an invalid transaction and make sure the tracepoint returns
@@ -321,6 +324,7 @@ class MempoolTracepointTest(BitcoinTestFramework):
 
         self.log.info("Ensuring mempool:rejected event was handled successfully...")
         assert_equal(EXPECTED_REJECTED_EVENTS, handled_rejected_events)
+        self.generate(self.wallet, 1)
 
     def run_test(self):
         """Tests the mempool:added, mempool:removed, mempool:replaced,

--- a/test/functional/mempool_compatibility.py
+++ b/test/functional/mempool_compatibility.py
@@ -47,12 +47,12 @@ class MempoolCompatibilityTest(BitcoinTestFramework):
         # unbroadcasted_tx won't pass old_node's `MemPoolAccept::PreChecks`.
         self.connect_nodes(0, 1)
         self.sync_blocks()
-        self.stop_node(1)
 
         self.log.info("Add a transaction to mempool on old node and shutdown")
         old_tx_hash = new_wallet.send_self_transfer(from_node=old_node)["txid"]
         assert old_tx_hash in old_node.getrawmempool()
         self.stop_node(0)
+        self.stop_node(1)
 
         self.log.info("Move mempool.dat from old to new node")
         old_node_mempool = os.path.join(old_node.datadir, self.chain, 'mempool.dat')

--- a/test/functional/mempool_package_limits.py
+++ b/test/functional/mempool_package_limits.py
@@ -46,8 +46,7 @@ class MempoolPackageLimitsTest(BitcoinTestFramework):
     def run_test(self):
         self.wallet = MiniWallet(self.nodes[0])
         # Add enough mature utxos to the wallet so that all txs spend confirmed coins.
-        self.generate(self.wallet, 35)
-        self.generate(self.nodes[0], COINBASE_MATURITY)
+        self.generate(self.wallet, COINBASE_MATURITY + 35)
 
         self.test_chain_limits()
         self.test_desc_count_limits()

--- a/test/functional/mempool_persist.py
+++ b/test/functional/mempool_persist.py
@@ -191,6 +191,7 @@ class MempoolPersistTest(BitcoinTestFramework):
     def test_persist_unbroadcast(self):
         node0 = self.nodes[0]
         self.start_node(0)
+        self.start_node(2)
 
         # clear out mempool
         self.generate(node0, 1, sync_fun=self.no_op)

--- a/test/functional/test_framework/wallet.py
+++ b/test/functional/test_framework/wallet.py
@@ -218,10 +218,12 @@ class MiniWallet:
         txid: get the first utxo we find from a specific transaction
         """
         self._utxos = sorted(self._utxos, key=lambda k: (k['value'], -k['height']))  # Put the largest utxo last
+        blocks_height = self._test_node.getblockchaininfo()['blocks']
+        mature_coins = list(filter(lambda utxo: not utxo['coinbase'] or COINBASE_MATURITY - 1 <= blocks_height - utxo['height'], self._utxos))
         if txid:
             utxo_filter: Any = filter(lambda utxo: txid == utxo['txid'], self._utxos)
         else:
-            utxo_filter = reversed(self._utxos)  # By default the largest utxo
+            utxo_filter = reversed(mature_coins)  # By default the largest utxo
         if vout is not None:
             utxo_filter = filter(lambda utxo: vout == utxo['vout'], utxo_filter)
         index = self._utxos.index(next(utxo_filter))

--- a/test/functional/test_framework/wallet.py
+++ b/test/functional/test_framework/wallet.py
@@ -235,7 +235,8 @@ class MiniWallet:
     def get_utxos(self, *, include_immature_coinbase=False, mark_as_spent=True):
         """Returns the list of all utxos and optionally mark them as spent"""
         if not include_immature_coinbase:
-            utxo_filter = filter(lambda utxo: not utxo['coinbase'] or COINBASE_MATURITY <= utxo['confirmations'], self._utxos)
+            blocks_height = self._test_node.getblockchaininfo()['blocks']
+            utxo_filter = filter(lambda utxo: not utxo['coinbase'] or COINBASE_MATURITY - 1 <= blocks_height - utxo['height'], self._utxos)
         else:
             utxo_filter = self._utxos
         utxos = deepcopy(list(utxo_filter))


### PR DESCRIPTION
Fixes #27129

To avoid `bad-txns-premature-spend-of-coinbase` error,
when getting a utxo (using `get_utxo`) to create a new
transaction `get_utxo` shouldn't return (if possible)
by default immature coinbase.

