### PR TITLE
util: Use steady clock in SeedStrengthen, FindBestImplementation, FlushStateToDisk

### DIFF
--- a/ci/test/06_script_b.sh
+++ b/ci/test/06_script_b.sh
@@ -50,12 +50,14 @@ if [ "${RUN_TIDY}" = "true" ]; then
           " src/node/chainstate.cpp"\
           " src/node/chainstatemanager_args.cpp"\
           " src/node/mempool_args.cpp"\
+          " src/node/minisketchwrapper.cpp"\
           " src/node/utxo_snapshot.cpp"\
           " src/node/validation_cache_args.cpp"\
           " src/policy/feerate.cpp"\
           " src/policy/packages.cpp"\
           " src/policy/settings.cpp"\
           " src/primitives/transaction.cpp"\
+          " src/random.cpp"\
           " src/rpc/fees.cpp"\
           " src/rpc/signmessage.cpp"\
           " src/test/fuzz/txorphan.cpp"\

--- a/src/node/minisketchwrapper.cpp
+++ b/src/node/minisketchwrapper.cpp
@@ -23,17 +23,17 @@ static constexpr uint32_t BITS = 32;
 
 uint32_t FindBestImplementation()
 {
-    std::optional<std::pair<int64_t, uint32_t>> best;
+    std::optional<std::pair<SteadyClock::duration, uint32_t>> best;
 
     uint32_t max_impl = Minisketch::MaxImplementation();
     for (uint32_t impl = 0; impl <= max_impl; ++impl) {
-        std::vector<int64_t> benches;
+        std::vector<SteadyClock::duration> benches;
         uint64_t offset = 0;
         /* Run a little benchmark with capacity 32, adding 184 entries, and decoding 11 of them once. */
         for (int b = 0; b < 11; ++b) {
             if (!Minisketch::ImplementationSupported(BITS, impl)) break;
             Minisketch sketch(BITS, impl, 32);
-            auto start = GetTimeMicros();
+            auto start = SteadyClock::now();
             for (uint64_t e = 0; e < 100; ++e) {
                 sketch.Add(e*1337 + b*13337 + offset);
             }
@@ -41,7 +41,7 @@ uint32_t FindBestImplementation()
                 sketch.Add(e*1337 + b*13337 + offset);
             }
             offset += (*sketch.Decode(32))[0];
-            auto stop = GetTimeMicros();
+            auto stop = SteadyClock::now();
             benches.push_back(stop - start);
         }
         /* Remember which implementation has the best median benchmark time. */

--- a/src/util/time.h
+++ b/src/util/time.h
@@ -8,7 +8,7 @@
 
 #include <compat/compat.h>
 
-#include <chrono>
+#include <chrono> // IWYU pragma: export
 #include <cstdint>
 #include <string>
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2478,12 +2478,12 @@ bool Chainstate::FlushStateToDisk(
                 }
             }
         }
-        const auto nNow = GetTime<std::chrono::microseconds>();
+        const auto nNow{SteadyClock::now()};
         // Avoid writing/flushing immediately after startup.
-        if (m_last_write.count() == 0) {
+        if (m_last_write == decltype(m_last_write){}) {
             m_last_write = nNow;
         }
-        if (m_last_flush.count() == 0) {
+        if (m_last_flush == decltype(m_last_flush){}) {
             m_last_flush = nNow;
         }
         // The cache is large and we're within 10% and 10 MiB of the limit, but we have time now (not in the middle of a block processing).
@@ -2544,7 +2544,7 @@ bool Chainstate::FlushStateToDisk(
             m_last_flush = nNow;
             full_flush_completed = true;
             TRACE5(utxocache, flush,
-                   (int64_t)(GetTimeMicros() - nNow.count()), // in microseconds (µs)
+                   int64_t{Ticks<std::chrono::microseconds>(SteadyClock::now() - nNow)},
                    (uint32_t)mode,
                    (uint64_t)coins_count,
                    (uint64_t)coins_mem_usage,

--- a/src/validation.h
+++ b/src/validation.h
@@ -785,8 +785,8 @@ private:
     void UpdateTip(const CBlockIndex* pindexNew)
         EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
-    std::chrono::microseconds m_last_write{0};
-    std::chrono::microseconds m_last_flush{0};
+    SteadyClock::time_point m_last_write{};
+    SteadyClock::time_point m_last_flush{};
 
     friend ChainstateManager;
 };


### PR DESCRIPTION
There may be a theoretical deadlock for the duration of the offset when the system clock is adjusted into a past time while executing `SeedStrengthen`.

Fix this by using steady clock.

Do the same in `FindBestImplementation`, which shouldn't be affected, because it discards outlier measurements. However, doing the same there for consistency seems fine.

Do the same in `FlushStateToDisk`, which should make the flushes more steady, if the system clock is adjusted by a large offset.