### PR TITLE
blockstorage: Adjust fastprune limit if block exceeds blockfile size

### DIFF
--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -619,7 +619,18 @@ bool BlockManager::FindBlockPos(FlatFilePos& pos, unsigned int nAddSize, unsigne
 
     bool finalize_undo = false;
     if (!fKnown) {
-        while (m_blockfile_info[nFile].nSize + nAddSize >= (gArgs.GetBoolArg("-fastprune", false) ? 0x10000 /* 64kb */ : MAX_BLOCKFILE_SIZE)) {
+        unsigned int max_blockfile_size{MAX_BLOCKFILE_SIZE};
+        // Use smaller blockfiles in test-only -fastprune mode - but avoid
+        // the possibility of having a block not fit into the block file.
+        if (gArgs.GetBoolArg("-fastprune", false)) {
+            max_blockfile_size = 0x10000; // 64kiB
+            if (nAddSize >= max_blockfile_size) {
+                // dynamically adjust the blockfile size to be larger than the added size
+                max_blockfile_size = nAddSize + 1;
+            }
+        }
+        assert(nAddSize < max_blockfile_size);
+        while (m_blockfile_info[nFile].nSize + nAddSize >= max_blockfile_size) {
             // when the undo file is keeping up with the block file, we want to flush it explicitly
             // when it is lagging behind (more blocks arrive than are being connected), we let the
             // undo block write case handle it

--- a/test/functional/feature_fastprune.py
+++ b/test/functional/feature_fastprune.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+# Copyright (c) 2023 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test fastprune mode."""
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal
+)
+from test_framework.blocktools import (
+    create_block,
+    create_coinbase,
+    add_witness_commitment
+)
+from test_framework.wallet import MiniWallet
+
+
+class FeatureFastpruneTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.extra_args = [["-fastprune"]]
+
+    def run_test(self):
+        self.log.info("ensure that large blocks don't crash or freeze in -fastprune")
+        wallet = MiniWallet(self.nodes[0])
+        tx = wallet.create_self_transfer()['tx']
+        annex = [0x50]
+        for _ in range(0x10000):
+            annex.append(0xff)
+        tx.wit.vtxinwit[0].scriptWitness.stack.append(bytes(annex))
+        tip = int(self.nodes[0].getbestblockhash(), 16)
+        time = self.nodes[0].getblock(self.nodes[0].getbestblockhash())['time'] + 1
+        height = self.nodes[0].getblockcount() + 1
+        block = create_block(hashprev=tip, ntime=time, txlist=[tx], coinbase=create_coinbase(height=height))
+        add_witness_commitment(block)
+        block.solve()
+        self.nodes[0].submitblock(block.serialize().hex())
+        assert_equal(int(self.nodes[0].getbestblockhash(), 16), block.sha256)
+
+
+if __name__ == '__main__':
+    FeatureFastpruneTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -320,6 +320,7 @@ BASE_SCRIPTS = [
     'feature_includeconf.py',
     'feature_addrman.py',
     'feature_asmap.py',
+    'feature_fastprune.py',
     'mempool_unbroadcast.py',
     'mempool_compatibility.py',
     'mempool_accept_wtxid.py',


### PR DESCRIPTION
The debug-only `-fastprune` option used in several tests is not always safe to use:
If a `-fastprune` node receives a block larger than the maximum blockfile size of `64kb` bad things happen: The while loop in `BlockManager::FindBlockPos` never terminates, and the node runs oom because memory for `m_blockfile_info` is allocated in each iteration of the loop.
The same would happen if a naive user used `-fastprune` on anything other than regtest (so this can be tested by syncing on signet for example, the first block that crashes the node is at height 2232).

Change the approach by raising the blockfile size to the size of the block, if that block otherwise wouldn't fit (idea by TheCharlatan).