### PR TITLE
util: add missing include and fix function signature

### DIFF
--- a/src/util/readwritefile.cpp
+++ b/src/util/readwritefile.cpp
@@ -3,6 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/readwritefile.h>
+
 #include <fs.h>
 
 #include <algorithm>
@@ -11,7 +13,7 @@
 #include <string>
 #include <utility>
 
-std::pair<bool,std::string> ReadBinaryFile(const fs::path &filename, size_t maxsize=std::numeric_limits<size_t>::max())
+std::pair<bool,std::string> ReadBinaryFile(const fs::path &filename, size_t maxsize)
 {
     FILE *f = fsbridge::fopen(filename, "rb");
     if (f == nullptr)


### PR DESCRIPTION
ping hebasto 

Discovered while testing pre-compiled header support with CMake: https://github.com/theuni/bitcoin/commits/cmake-pch-poc. Compilation of that branch fails without this fix and succeeds with it.

Similar to the fix in #27144.

The problem of having a default argument in the definition was masked by the missing include. Using PCH forces that include, so we end up with the compiler error we should've been getting all along.