### PR TITLE
wallet: Turn `destdata` entries into  `CAddressBookData` fields

### DIFF
--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -121,7 +121,7 @@ public:
     virtual std::vector<std::string> getAddressReceiveRequests() = 0;
 
     //! Save or remove receive request.
-    virtual bool setAddressReceiveRequest(const CTxDestination& dest, const std::string& id, const std::string& value) = 0;
+    virtual bool setAddressReceiveRequest(const CTxDestination& dest, int64_t id, const std::string& value) = 0;
 
     //! Display address on external signer
     virtual bool displayAddress(const CTxDestination& dest) = 0;

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -120,7 +120,10 @@ public:
     //! Get receive requests.
     virtual std::vector<std::string> getAddressReceiveRequests() = 0;
 
-    //! Save or remove receive request.
+    //! Remove receive request.
+    virtual bool removeAddressReceiveRequest(const CTxDestination& dest, int64_t id) = 0;
+
+    //! Save receive request.
     virtual bool setAddressReceiveRequest(const CTxDestination& dest, int64_t id, const std::string& value) = 0;
 
     //! Display address on external signer

--- a/src/qt/recentrequeststablemodel.cpp
+++ b/src/qt/recentrequeststablemodel.cpp
@@ -149,7 +149,7 @@ bool RecentRequestsTableModel::removeRows(int row, int count, const QModelIndex 
         for (int i = 0; i < count; ++i)
         {
             const RecentRequestEntry* rec = &list[row+i];
-            if (!walletModel->wallet().setAddressReceiveRequest(DecodeDestination(rec->recipient.address.toStdString()), ToString(rec->id), ""))
+            if (!walletModel->wallet().setAddressReceiveRequest(DecodeDestination(rec->recipient.address.toStdString()), rec->id, ""))
                 return false;
         }
 
@@ -178,7 +178,7 @@ void RecentRequestsTableModel::addNewRequest(const SendCoinsRecipient &recipient
     DataStream ss{};
     ss << newEntry;
 
-    if (!walletModel->wallet().setAddressReceiveRequest(DecodeDestination(recipient.address.toStdString()), ToString(newEntry.id), ss.str()))
+    if (!walletModel->wallet().setAddressReceiveRequest(DecodeDestination(recipient.address.toStdString()), newEntry.id, ss.str()))
         return;
 
     addNewRequest(newEntry);

--- a/src/qt/recentrequeststablemodel.cpp
+++ b/src/qt/recentrequeststablemodel.cpp
@@ -149,7 +149,7 @@ bool RecentRequestsTableModel::removeRows(int row, int count, const QModelIndex 
         for (int i = 0; i < count; ++i)
         {
             const RecentRequestEntry* rec = &list[row+i];
-            if (!walletModel->wallet().setAddressReceiveRequest(DecodeDestination(rec->recipient.address.toStdString()), rec->id, ""))
+            if (!walletModel->wallet().removeAddressReceiveRequest(DecodeDestination(rec->recipient.address.toStdString()), rec->id))
                 return false;
         }
 

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -219,6 +219,11 @@ public:
         LOCK(m_wallet->cs_wallet);
         return m_wallet->GetAddressReceiveRequests();
     }
+    bool removeAddressReceiveRequest(const CTxDestination& dest, int64_t id) override {
+        LOCK(m_wallet->cs_wallet);
+        WalletBatch batch{m_wallet->GetDatabase()};
+        return m_wallet->RemoveAddressReceiveRequest(batch, dest, id);
+    }
     bool setAddressReceiveRequest(const CTxDestination& dest, int64_t id, const std::string& value) override {
         LOCK(m_wallet->cs_wallet);
         WalletBatch batch{m_wallet->GetDatabase()};

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -219,7 +219,7 @@ public:
         LOCK(m_wallet->cs_wallet);
         return m_wallet->GetAddressReceiveRequests();
     }
-    bool setAddressReceiveRequest(const CTxDestination& dest, const std::string& id, const std::string& value) override {
+    bool setAddressReceiveRequest(const CTxDestination& dest, int64_t id, const std::string& value) override {
         LOCK(m_wallet->cs_wallet);
         WalletBatch batch{m_wallet->GetDatabase()};
         return m_wallet->SetAddressReceiveRequest(batch, dest, id, value);

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -433,13 +433,19 @@ BOOST_AUTO_TEST_CASE(LoadReceiveRequests)
     LOCK(m_wallet.cs_wallet);
     WalletBatch batch{m_wallet.GetDatabase()};
     m_wallet.SetAddressUsed(batch, dest, true);
-    m_wallet.SetAddressReceiveRequest(batch, dest, 0, "val_rr0");
-    m_wallet.SetAddressReceiveRequest(batch, dest, 1, "val_rr1");
+    BOOST_CHECK(m_wallet.SetAddressReceiveRequest(batch, dest, 0, "val_rr0"));
+    BOOST_CHECK(!m_wallet.SetAddressReceiveRequest(batch, dest, 1, "val_rr1"));
 
     auto values = m_wallet.GetAddressReceiveRequests();
-    BOOST_CHECK_EQUAL(values.size(), 2U);
+    BOOST_CHECK_EQUAL(values.size(), 1U);
     BOOST_CHECK_EQUAL(values[0], "val_rr0");
-    BOOST_CHECK_EQUAL(values[1], "val_rr1");
+
+    m_wallet.RemoveAddressReceiveRequest(batch, dest, 0);
+
+    BOOST_CHECK(m_wallet.SetAddressReceiveRequest(batch, dest, 1, "val_rr1"));
+    values = m_wallet.GetAddressReceiveRequests();
+    BOOST_CHECK_EQUAL(values.size(), 1U);
+    BOOST_CHECK_EQUAL(values[0], "val_rr1");
 }
 
 // Test some watch-only LegacyScriptPubKeyMan methods by the procedure of loading (LoadWatchOnly),

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -433,8 +433,8 @@ BOOST_AUTO_TEST_CASE(LoadReceiveRequests)
     LOCK(m_wallet.cs_wallet);
     WalletBatch batch{m_wallet.GetDatabase()};
     m_wallet.SetAddressUsed(batch, dest, true);
-    m_wallet.SetAddressReceiveRequest(batch, dest, "0", "val_rr0");
-    m_wallet.SetAddressReceiveRequest(batch, dest, "1", "val_rr1");
+    m_wallet.SetAddressReceiveRequest(batch, dest, 0, "val_rr0");
+    m_wallet.SetAddressReceiveRequest(batch, dest, 1, "val_rr1");
 
     auto values = m_wallet.GetAddressReceiveRequests();
     BOOST_CHECK_EQUAL(values.size(), 2U);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2888,24 +2888,17 @@ std::vector<std::string> CWallet::GetAddressReceiveRequests() const
     return values;
 }
 
+bool CWallet::RemoveAddressReceiveRequest(WalletBatch& batch, const CTxDestination& dest, int64_t id) {
+    CAddressBookData& entry = m_address_book.at(dest);
+    entry.RemoveReceiveRequest(id);
+    return batch.EraseDestData(EncodeDestination(dest), "rr" + ToString(id));
+}
+
 bool CWallet::SetAddressReceiveRequest(WalletBatch& batch, const CTxDestination& dest, int64_t id, const std::string& value)
 {
-    const std::string key{"rr" + ToString(id)}; // "rr" prefix = "receive request" in destdata
     CAddressBookData& data = m_address_book.at(dest);
-    if (value.empty()) {
-        if (!data.RemoveReceiveRequest(id)) {
-            return false;
-        }
-        if (!batch.EraseDestData(EncodeDestination(dest), key)) {
-            return false;
-        }
-    } else {
-        data.SetReceiveRequest(id, value);
-        if (!batch.WriteDestData(EncodeDestination(dest), key, value)) {
-            return false;
-        }
-    }
-    return true;
+    data.SetReceiveRequest(id, value);
+    return batch.WriteDestData(EncodeDestination(dest), "rr" + ToString(id), value);
 }
 
 std::unique_ptr<WalletDatabase> MakeWalletDatabase(const std::string& name, const DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error_string)

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -204,8 +204,12 @@ public:
 class CAddressBookData
 {
 private:
+    //! The address is a change addres
     bool m_change{true};
+    //! The label
     std::string m_label;
+    //! This address has been used in a transaction input
+    bool m_input_used{false};
 public:
     std::string purpose;
 
@@ -220,6 +224,9 @@ public:
         m_change = false;
         m_label = label;
     }
+
+    bool GetInputUsed() const { return m_input_used; }
+    void SetInputUsed(bool value) { m_input_used = value; }
 };
 
 struct CRecipient

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -217,9 +217,6 @@ public:
 
     CAddressBookData() : purpose("unknown") {}
 
-    typedef std::map<std::string, std::string> StringMap;
-    StringMap destdata;
-
     bool IsChange() const { return m_change; }
     const std::string& GetLabel() const { return m_label; }
     void SetLabel(const std::string& label) {

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -210,6 +210,8 @@ private:
     std::string m_label;
     //! This address has been used in a transaction input
     bool m_input_used{false};
+    //! Receive Request data sent by the GUI
+    std::map<int64_t, std::string> m_receive_requests;
 public:
     std::string purpose;
 
@@ -227,6 +229,10 @@ public:
 
     bool GetInputUsed() const { return m_input_used; }
     void SetInputUsed(bool value) { m_input_used = value; }
+
+    const std::map<int64_t, std::string> GetReceiveRequests() const { return m_receive_requests; }
+    void SetReceiveRequest(int64_t id, const std::string& request) { m_receive_requests[id] = request; }
+    bool RemoveReceiveRequest(int64_t id) { return m_receive_requests.erase(id); }
 };
 
 struct CRecipient
@@ -721,7 +727,7 @@ public:
     bool SetAddressUsed(WalletBatch& batch, const CTxDestination& dest, bool used) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     std::vector<std::string> GetAddressReceiveRequests() const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
-    bool SetAddressReceiveRequest(WalletBatch& batch, const CTxDestination& dest, const std::string& id, const std::string& value) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    bool SetAddressReceiveRequest(WalletBatch& batch, const CTxDestination& dest, int64_t id, const std::string& value) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     unsigned int GetKeyPoolSize() const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -727,6 +727,7 @@ public:
     bool SetAddressUsed(WalletBatch& batch, const CTxDestination& dest, bool used) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     std::vector<std::string> GetAddressReceiveRequests() const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    bool RemoveAddressReceiveRequest(WalletBatch& batch, const CTxDestination& dest, int64_t id) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     bool SetAddressReceiveRequest(WalletBatch& batch, const CTxDestination& dest, int64_t id, const std::string& value) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     unsigned int GetKeyPoolSize() const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -211,7 +211,7 @@ private:
     //! This address has been used in a transaction input
     bool m_input_used{false};
     //! Receive Request data sent by the GUI
-    std::map<int64_t, std::string> m_receive_requests;
+    std::optional<std::pair<int64_t, std::string>> m_receive_request;
 public:
     std::string purpose;
 
@@ -227,9 +227,9 @@ public:
     bool GetInputUsed() const { return m_input_used; }
     void SetInputUsed(bool value) { m_input_used = value; }
 
-    const std::map<int64_t, std::string> GetReceiveRequests() const { return m_receive_requests; }
-    void SetReceiveRequest(int64_t id, const std::string& request) { m_receive_requests[id] = request; }
-    bool RemoveReceiveRequest(int64_t id) { return m_receive_requests.erase(id); }
+    const std::optional<std::pair<int64_t, std::string>>& GetReceiveRequest() const { return m_receive_request; }
+    void SetReceiveRequest(int64_t id, const std::string& request) { m_receive_request.emplace(id, request); }
+    void RemoveReceiveRequest() { m_receive_request.reset(); }
 };
 
 struct CRecipient


### PR DESCRIPTION
`destdata` is a generic strings map in `CAddressBookEntry`. It is opaque and thus hard to know what is actually being stored in a `CAddressBookEntry`. It is a map with fixed fields, but these are not documented nor are they immediately obvious when looking at the class definition. This PR changes those to be member variables inside of `CAddressBookEntry` to make it easier to understand what kind of data is being stored.