### PR TITLE
Update chainparams for 25.x

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -93,8 +93,8 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nTimeout = 1628640000; // August 11th, 2021
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].min_activation_height = 709632; // Approximately November 12th, 2021
 
-        consensus.nMinimumChainWork = uint256S("0x00000000000000000000000000000000000000003404ba0801921119f903495e");
-        consensus.defaultAssumeValid = uint256S("0x00000000000000000009c97098b5295f7e5f183ac811fb5d1534040adb93cabd"); // 751565
+        consensus.nMinimumChainWork = uint256S("0x00000000000000000000000000000000000000004200315292c8bdc13e546bdc");
+        consensus.defaultAssumeValid = uint256S("0x00000000000000000001ab5cdb8f56ebc12419a1c12a528f576c535e976ae5e9"); // 779756
 
         /**
          * The message start string is designed to be unlikely to occur in normal data.
@@ -107,7 +107,7 @@ public:
         pchMessageStart[3] = 0xd9;
         nDefaultPort = 8333;
         nPruneAfterHeight = 100000;
-        m_assumed_blockchain_size = 496;
+        m_assumed_blockchain_size = 543;
         m_assumed_chain_state_size = 6;
 
         genesis = CreateGenesisBlock(1231006505, 2083236893, 0x1d00ffff, 1, 50 * COIN);
@@ -168,10 +168,10 @@ public:
         };
 
         chainTxData = ChainTxData{
-            // Data from RPC: getchaintxstats 4096 00000000000000000009c97098b5295f7e5f183ac811fb5d1534040adb93cabd
-            .nTime    = 1661697692,
-            .nTxCount = 760120522,
-            .dTxRate  = 2.925802860942233,
+            // Data from RPC: getchaintxstats 4096 00000000000000000001ab5cdb8f56ebc12419a1c12a528f576c535e976ae5e9
+            .nTime    = 1678203665,
+            .nTxCount = 811834437,
+            .dTxRate  = 3.521413854206197,
         };
     }
 };
@@ -213,8 +213,8 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nTimeout = 1628640000; // August 11th, 2021
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].min_activation_height = 0; // No activation delay
 
-        consensus.nMinimumChainWork = uint256S("0x00000000000000000000000000000000000000000000076f6e7cbd0beade5d20");
-        consensus.defaultAssumeValid = uint256S("0x0000000000000004877fa2d36316398528de4f347df2f8a96f76613a298ce060"); // 2344474
+        consensus.nMinimumChainWork = uint256S("0x0000000000000000000000000000000000000000000009187b7c3b56dbc42a6f");
+        consensus.defaultAssumeValid = uint256S("0x0000000000000011687aa6730b65137ca2549024b71bfda69d9eaf5eb7336749"); // 2423291
 
         pchMessageStart[0] = 0x0b;
         pchMessageStart[1] = 0x11;
@@ -264,10 +264,10 @@ public:
         };
 
         chainTxData = ChainTxData{
-            // Data from RPC: getchaintxstats 4096 0000000000000004877fa2d36316398528de4f347df2f8a96f76613a298ce060
-            .nTime    = 1661705221,
-            .nTxCount = 63531852,
-            .dTxRate  = 0.1079119341520164,
+            // Data from RPC: getchaintxstats 4096 0000000000000011687aa6730b65137ca2549024b71bfda69d9eaf5eb7336749
+            .nTime    = 1678204040,
+            .nTxCount = 65041246,
+            .dTxRate  = 0.06820774626044654,
         };
     }
 };
@@ -289,15 +289,15 @@ public:
             vSeeds.emplace_back("178.128.221.177");
             vSeeds.emplace_back("v7ajjeirttkbnt32wpy3c6w3emwnfr3fkla7hpxcfokr3ysd3kqtzmqd.onion:38333");
 
-            consensus.nMinimumChainWork = uint256S("0x000000000000000000000000000000000000000000000000000001291fc22898");
-            consensus.defaultAssumeValid = uint256S("0x000000d1a0e224fa4679d2fb2187ba55431c284fa1b74cbc8cfda866fd4d2c09"); // 105495
+            consensus.nMinimumChainWork = uint256S("0x0000000000000000000000000000000000000000000000000000017aeaa97dea");
+            consensus.defaultAssumeValid = uint256S("0x0000001681c52f68f3b148a931574d23a54153231d4a6a0161799950e2453d97"); // 133021
             m_assumed_blockchain_size = 1;
             m_assumed_chain_state_size = 0;
             chainTxData = ChainTxData{
                 // Data from RPC: getchaintxstats 4096 000000d1a0e224fa4679d2fb2187ba55431c284fa1b74cbc8cfda866fd4d2c09
-                .nTime    = 1661702566,
-                .nTxCount = 1903567,
-                .dTxRate  = 0.02336701143027275,
+                .nTime    = 1678203585,
+                .nTxCount = 2207891,
+                .dTxRate  = 0.007109003813377025,
             };
         } else {
             const auto signet_challenge = args.GetArgs("-signetchallenge");


### PR DESCRIPTION

Update chain parameters for upcoming major release. See [doc/release-process.md](https://github.com/bitcoin/bitcoin/blob/master/doc/release-process.md) for review instructions.  Followed instructions from #24418 closely as well.

- `m_assumed_blockchain_size`, `m_assumed_chain_state_size`:

mainnet
```
.bitcoin$ du -h --exclude=signet --exclude=testnet3 .
0       ./wallets
117M    ./blocks/index
489G    ./blocks
4.9G    ./chainstate
494G    .
.bitcoin$ python3
Python 3.11.1 (main, Jan  6 2023, 00:00:00) [GCC 12.2.1 20221121 (Red Hat 12.2.1-4)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> 494*1.1
543.4000000000001
>>> 5*1.1
5.5
```

testnet3 (no changes needed to params)
```
.bitcoin$ du -h testnet3/
0       testnet3/wallets
648M    testnet3/blocks/index
31G     testnet3/blocks
1.4G    testnet3/chainstate
33G     testnet3/
.bitcoin$ python3
Python 3.11.1 (main, Jan  6 2023, 00:00:00) [GCC 12.2.1 20221121 (Red Hat 12.2.1-4)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> 33*1.1
36.300000000000004
>>> 1.4*1.1
1.5
```

signet (no changes needed to params)
```
.bitcoin$ du -h signet/
0       signet/wallets
19M     signet/blocks/index
714M    signet/blocks
16K     signet/chainstate
755M    signet/

```


- `chainTxData`:

mainnet
```
$ bitcoin-cli getbestblockhash
00000000000000000001ab5cdb8f56ebc12419a1c12a528f576c535e976ae5e9

$ bitcoin-cli getchaintxstats 4096 00000000000000000001ab5cdb8f56ebc12419a1c12a528f576c535e976ae5e9
{
  "time": 1678203665,
  "txcount": 811834437,
  "window_final_block_hash": "00000000000000000001ab5cdb8f56ebc12419a1c12a528f576c535e976ae5e9",
  "window_final_block_height": 779756,
  "window_block_count": 4096,
  "window_tx_count": 8082254,
  "window_interval": 2295173,
  "txrate": 3.521413854206197
}
```

testnet
```
bitcoin-cli -testnet getbestblockhash
0000000000000011687aa6730b65137ca2549024b71bfda69d9eaf5eb7336749[

bitcoin-cli -testnet getchaintxstats 4096 0000000000000011687aa6730b65137ca2549024b71bfda69d9eaf5eb7336749
{
  "time": 1678204040,
  "txcount": 65041246,
  "window_final_block_hash": "0000000000000011687aa6730b65137ca2549024b71bfda69d9eaf5eb7336749",
  "window_final_block_height": 2423291,
  "window_block_count": 4096,
  "window_tx_count": 166030,
  "window_interval": 2434181,
  "txrate": 0.06820774626044654
}
```

signet
```
$ bitcoin-cli -signet getbestblockhash
0000001681c52f68f3b148a931574d23a54153231d4a6a0161799950e2453d97

$ bitcoin-cli -signet getchaintxstats 4096 0000001681c52f68f3b148a931574d23a54153231d4a6a0161799950e2453d97
{
  "time": 1678203585,
  "txcount": 2207891,
  "window_final_block_hash": "0000001681c52f68f3b148a931574d23a54153231d4a6a0161799950e2453d97",
  "window_final_block_height": 133021,
  "window_block_count": 4096,
  "window_tx_count": 18193,
  "window_interval": 2559149,
  "txrate": 0.007109003813377025
}
```


- `nMinimumChainWork`, `defaultAssumeValid`:

mainnet
```
$ bitcoin-cli getblockheader 00000000000000000001ab5cdb8f56ebc12419a1c12a528f576c535e976ae5e9
{
  "hash": "00000000000000000001ab5cdb8f56ebc12419a1c12a528f576c535e976ae5e9",
  "confirmations": 2,
  "height": 779756,
  "version": 722239488,
  "versionHex": "2b0c8000",
  "merkleroot": "12b126d43ec53fc50c3e5bd38d0849f765463be5ba0f3b113a837acc3dc9c73c",
  "time": 1678203665,
  "mediantime": 1678201388,
  "nonce": 1118234730,
  "bits": "170689a3",
  "difficulty": 43053844193928.45,
  "chainwork": "00000000000000000000000000000000000000004200315292c8bdc13e546bdc",
  "nTx": 3502,
  "previousblockhash": "00000000000000000000f94f67e1da0927aa6c1327953513841ab9dbf4e221a6",
  "nextblockhash": "000000000000000000060227179ffe953752753c2fc4e81b48f576227bc556bf"
}
```

testnet
```
$ bitcoin-cli -testnet getblockheader 0000000000000011687aa6730b65137ca2549024b71bfda69d9eaf5eb7336749
{
  "hash": "0000000000000011687aa6730b65137ca2549024b71bfda69d9eaf5eb7336749",
  "confirmations": 1,
  "height": 2423291,
  "version": 538968064,
  "versionHex": "20200000",
  "merkleroot": "737a77e585b97bfb118fe55ba23a80e47da6798c58800c7824a061cb5f96fc7b",
  "time": 1678204040,
  "mediantime": 1678201426,
  "nonce": 2256300948,
  "bits": "192a0b9d",
  "difficulty": 102149233.8892645,
  "chainwork": "0000000000000000000000000000000000000000000009187b7c3b56dbc42a6f",
  "nTx": 53,
  "previousblockhash": "00000000000000137f3c43f8d2da8028c441d61717146786ca3ed3e203ad2e17"
}
```

signet
```
$ bitcoin-cli -signet getblockheader 0000001681c52f68f3b148a931574d23a54153231d4a6a0161799950e2453d97
{
  "hash": "0000001681c52f68f3b148a931574d23a54153231d4a6a0161799950e2453d97",
  "confirmations": 1,
  "height": 133021,
  "version": 536870912,
  "versionHex": "20000000",
  "merkleroot": "93393537b960a7f66952ac890d28edf8544ad03ef5c31d75a829c849e424bae8",
  "time": 1678203585,
  "mediantime": 1678201021,
  "nonce": 18855356,
  "bits": "1e01562c",
  "difficulty": 0.002922463283140783,
  "chainwork": "0000000000000000000000000000000000000000000000000000017aeaa97dea",
  "nTx": 1,
  "previousblockhash": "00000120da11e3c849cbca953bb92f5b24539ad9a8476217f82b7633a5bbe9b1"
}
```




