### PR TITLE
refactor: Replace GetTimeMicros by SystemClock

### DIFF
--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -349,11 +349,12 @@ std::string BCLog::Logger::LogTimestampStr(const std::string& str)
         return str;
 
     if (m_started_new_line) {
-        int64_t nTimeMicros = GetTimeMicros();
-        strStamped = FormatISO8601DateTime(nTimeMicros/1000000);
+        const auto now{SystemClock::now()};
+        const auto now_seconds{std::chrono::time_point_cast<std::chrono::seconds>(now)};
+        strStamped = FormatISO8601DateTime(TicksSinceEpoch<std::chrono::seconds>(now_seconds));
         if (m_log_time_micros) {
             strStamped.pop_back();
-            strStamped += strprintf(".%06dZ", nTimeMicros%1000000);
+            strStamped += strprintf(".%06dZ", Ticks<std::chrono::microseconds>(now - now_seconds));
         }
         std::chrono::seconds mocktime = GetMockTime();
         if (mocktime > 0s) {

--- a/src/util/time.cpp
+++ b/src/util/time.cpp
@@ -107,11 +107,6 @@ int64_t GetTimeMillis()
     return int64_t{GetSystemTime<std::chrono::milliseconds>().count()};
 }
 
-int64_t GetTimeMicros()
-{
-    return int64_t{GetSystemTime<std::chrono::microseconds>().count()};
-}
-
 int64_t GetTime() { return GetTime<std::chrono::seconds>().count(); }
 
 std::string FormatISO8601DateTime(int64_t nTime) {

--- a/src/util/time.h
+++ b/src/util/time.h
@@ -29,6 +29,8 @@ using SteadySeconds = std::chrono::time_point<std::chrono::steady_clock, std::ch
 using SteadyMilliseconds = std::chrono::time_point<std::chrono::steady_clock, std::chrono::milliseconds>;
 using SteadyMicroseconds = std::chrono::time_point<std::chrono::steady_clock, std::chrono::microseconds>;
 
+using SystemClock = std::chrono::system_clock;
+
 void UninterruptibleSleep(const std::chrono::microseconds& n);
 
 /**
@@ -63,16 +65,14 @@ using MillisecondsDouble = std::chrono::duration<double, std::chrono::millisecon
  * DEPRECATED
  * Use either ClockType::now() or Now<TimePointType>() if a cast is needed.
  * ClockType is
- * - std::chrono::steady_clock for steady time
- * - std::chrono::system_clock for system time
- * - NodeClock                 for mockable system time
+ * - SteadyClock/std::chrono::steady_clock for steady time
+ * - SystemClock/std::chrono::system_clock for system time
+ * - NodeClock                             for mockable system time
  */
 int64_t GetTime();
 
 /** Returns the system time (not mockable) */
 int64_t GetTimeMillis();
-/** Returns the system time (not mockable) */
-int64_t GetTimeMicros();
 
 /**
  * DEPRECATED


### PR DESCRIPTION
It is unclear from the name that `GetTimeMicros` returns the system time. Also, it is not using the type-safe `std::chrono` types.

Fix both issues by replacing it with `SystemClock` in the only place it is used.

This refactor should not change behavior.