### PR TITLE
refactor: Split logging utilities from system.h

### DIFF
--- a/ci/test/06_script_b.sh
+++ b/ci/test/06_script_b.sh
@@ -69,6 +69,7 @@ if [ "${RUN_TIDY}" = "true" ]; then
           " src/util/bytevectorhash.cpp"\
           " src/util/check.cpp"\
           " src/util/error.cpp"\
+          " src/util/exception.cpp"\
           " src/util/getuniquepath.cpp"\
           " src/util/hasher.cpp"\
           " src/util/message.cpp"\

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -279,6 +279,7 @@ BITCOIN_CORE_H = \
   util/check.h \
   util/epochguard.h \
   util/error.h \
+  util/exception.h \
   util/fastrange.h \
   util/fees.h \
   util/getuniquepath.h \
@@ -699,6 +700,7 @@ libbitcoin_util_a_SOURCES = \
   util/bytevectorhash.cpp \
   util/check.cpp \
   util/error.cpp \
+  util/exception.cpp \
   util/fees.cpp \
   util/getuniquepath.cpp \
   util/hasher.cpp \
@@ -942,6 +944,7 @@ libbitcoinkernel_la_SOURCES = \
   txmempool.cpp \
   uint256.cpp \
   util/check.cpp \
+  util/exception.cpp \
   util/getuniquepath.cpp \
   util/hasher.cpp \
   util/moneystr.cpp \

--- a/src/addrdb.cpp
+++ b/src/addrdb.cpp
@@ -11,6 +11,7 @@
 #include <cstdint>
 #include <fs.h>
 #include <hash.h>
+#include <logging.h>
 #include <logging/timer.h>
 #include <netbase.h>
 #include <netgroup.h>

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -19,6 +19,7 @@
 #include <rpc/request.h>
 #include <tinyformat.h>
 #include <univalue.h>
+#include <util/exception.h>
 #include <util/strencodings.h>
 #include <util/system.h>
 #include <util/translation.h>

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -12,14 +12,15 @@
 #include <consensus/amount.h>
 #include <consensus/consensus.h>
 #include <core_io.h>
-#include <key_io.h>
 #include <fs.h>
+#include <key_io.h>
 #include <policy/policy.h>
 #include <primitives/transaction.h>
 #include <script/script.h>
 #include <script/sign.h>
 #include <script/signingprovider.h>
 #include <univalue.h>
+#include <util/exception.h>
 #include <util/moneystr.h>
 #include <util/rbf.h>
 #include <util/strencodings.h>

--- a/src/bitcoin-util.cpp
+++ b/src/bitcoin-util.cpp
@@ -14,6 +14,7 @@
 #include <compat/compat.h>
 #include <core_io.h>
 #include <streams.h>
+#include <util/exception.h>
 #include <util/system.h>
 #include <util/translation.h>
 #include <version.h>

--- a/src/bitcoin-wallet.cpp
+++ b/src/bitcoin-wallet.cpp
@@ -16,6 +16,7 @@
 #include <logging.h>
 #include <pubkey.h>
 #include <tinyformat.h>
+#include <util/exception.h>
 #include <util/system.h>
 #include <util/translation.h>
 #include <wallet/wallettool.h>

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -20,6 +20,7 @@
 #include <noui.h>
 #include <shutdown.h>
 #include <util/check.h>
+#include <util/exception.h>
 #include <util/strencodings.h>
 #include <util/syscall_sandbox.h>
 #include <util/syserror.h>

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -6,6 +6,7 @@
 #include <index/base.h>
 #include <interfaces/chain.h>
 #include <kernel/chain.h>
+#include <logging.h>
 #include <node/blockstorage.h>
 #include <node/context.h>
 #include <node/database_args.h>

--- a/src/index/coinstatsindex.cpp
+++ b/src/index/coinstatsindex.cpp
@@ -7,6 +7,7 @@
 #include <crypto/muhash.h>
 #include <index/coinstatsindex.h>
 #include <kernel/coinstats.h>
+#include <logging.h>
 #include <node/blockstorage.h>
 #include <serialize.h>
 #include <txdb.h>

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -5,6 +5,7 @@
 #include <index/txindex.h>
 
 #include <index/disktxpos.h>
+#include <logging.h>
 #include <node/blockstorage.h>
 #include <util/system.h>
 #include <validation.h>

--- a/src/kernel/coinstats.cpp
+++ b/src/kernel/coinstats.cpp
@@ -8,6 +8,7 @@
 #include <coins.h>
 #include <crypto/muhash.h>
 #include <hash.h>
+#include <logging.h>
 #include <node/blockstorage.h>
 #include <primitives/transaction.h>
 #include <script/script.h>
@@ -19,7 +20,6 @@
 #include <uint256.h>
 #include <util/check.h>
 #include <util/overflow.h>
-#include <util/system.h>
 #include <validation.h>
 #include <version.h>
 

--- a/src/logging.h
+++ b/src/logging.h
@@ -257,4 +257,11 @@ static inline void LogPrintf_(const std::string& logging_function, const std::st
         }                                                 \
     } while (0)
 
+template <typename... Args>
+bool error(const char* fmt, const Args&... args)
+{
+    LogPrintf("ERROR: %s\n", tfm::format(fmt, args...));
+    return false;
+}
+
 #endif // BITCOIN_LOGGING_H

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -16,12 +16,13 @@
 #include <compat/compat.h>
 #include <consensus/consensus.h>
 #include <crypto/sha256.h>
-#include <node/eviction.h>
 #include <fs.h>
 #include <i2p.h>
+#include <logging.h>
 #include <net_permissions.h>
 #include <netaddress.h>
 #include <netbase.h>
+#include <node/eviction.h>
 #include <node/interface_ui.h>
 #include <protocol.h>
 #include <random.h>

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -6,12 +6,12 @@
 #include <netbase.h>
 
 #include <compat/compat.h>
+#include <logging.h>
 #include <sync.h>
 #include <tinyformat.h>
 #include <util/sock.h>
 #include <util/strencodings.h>
 #include <util/string.h>
-#include <util/system.h>
 #include <util/time.h>
 
 #include <atomic>

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -11,6 +11,7 @@
 #include <flatfile.h>
 #include <fs.h>
 #include <hash.h>
+#include <logging.h>
 #include <pow.h>
 #include <reverse_iterator.h>
 #include <shutdown.h>

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -29,6 +29,7 @@
 #include <qt/utilitydialog.h>
 #include <qt/winshutdownmonitor.h>
 #include <uint256.h>
+#include <util/exception.h>
 #include <util/string.h>
 #include <util/system.h>
 #include <util/threadnames.h>

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -20,6 +20,7 @@
 #include <protocol.h>
 #include <script/script.h>
 #include <script/standard.h>
+#include <util/exception.h>
 #include <util/system.h>
 #include <util/time.h>
 

--- a/src/qt/initexecutor.cpp
+++ b/src/qt/initexecutor.cpp
@@ -5,7 +5,7 @@
 #include <qt/initexecutor.h>
 
 #include <interfaces/node.h>
-#include <util/system.h>
+#include <util/exception.h>
 #include <util/threadnames.h>
 
 #include <exception>

--- a/src/script/signingprovider.cpp
+++ b/src/script/signingprovider.cpp
@@ -7,7 +7,7 @@
 #include <script/signingprovider.h>
 #include <script/standard.h>
 
-#include <util/system.h>
+#include <logging.h>
 
 const SigningProvider& DUMMY_SIGNING_PROVIDER = SigningProvider();
 

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -6,11 +6,11 @@
 #include <txdb.h>
 
 #include <chain.h>
+#include <logging.h>
 #include <pow.h>
 #include <random.h>
 #include <shutdown.h>
 #include <uint256.h>
-#include <util/system.h>
 #include <util/translation.h>
 #include <util/vector.h>
 

--- a/src/util/exception.cpp
+++ b/src/util/exception.cpp
@@ -1,0 +1,41 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <util/exception.h>
+
+#include <logging.h>
+#include <tinyformat.h>
+
+#include <exception>
+#include <iostream>
+#include <string>
+#include <typeinfo>
+
+#ifdef WIN32
+#include <windows.h>
+#endif // WIN32
+
+static std::string FormatException(const std::exception* pex, std::string_view thread_name)
+{
+#ifdef WIN32
+    char pszModule[MAX_PATH] = "";
+    GetModuleFileNameA(nullptr, pszModule, sizeof(pszModule));
+#else
+    const char* pszModule = "bitcoin";
+#endif
+    if (pex)
+        return strprintf(
+            "EXCEPTION: %s       \n%s       \n%s in %s       \n", typeid(*pex).name(), pex->what(), pszModule, thread_name);
+    else
+        return strprintf(
+            "UNKNOWN EXCEPTION       \n%s in %s       \n", pszModule, thread_name);
+}
+
+void PrintExceptionContinue(const std::exception* pex, std::string_view thread_name)
+{
+    std::string message = FormatException(pex, thread_name);
+    LogPrintf("\n\n************************\n%s\n", message);
+    tfm::format(std::cerr, "\n\n************************\n%s\n", message);
+}

--- a/src/util/exception.h
+++ b/src/util/exception.h
@@ -1,0 +1,14 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_UTIL_EXCEPTION_H
+#define BITCOIN_UTIL_EXCEPTION_H
+
+#include <exception>
+#include <string_view>
+
+void PrintExceptionContinue(const std::exception* pex, std::string_view thread_name);
+
+#endif // BITCOIN_UTIL_EXCEPTION_H

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -792,29 +792,6 @@ std::string HelpMessageOpt(const std::string &option, const std::string &message
            std::string("\n\n");
 }
 
-static std::string FormatException(const std::exception* pex, std::string_view thread_name)
-{
-#ifdef WIN32
-    char pszModule[MAX_PATH] = "";
-    GetModuleFileNameA(nullptr, pszModule, sizeof(pszModule));
-#else
-    const char* pszModule = "bitcoin";
-#endif
-    if (pex)
-        return strprintf(
-            "EXCEPTION: %s       \n%s       \n%s in %s       \n", typeid(*pex).name(), pex->what(), pszModule, thread_name);
-    else
-        return strprintf(
-            "UNKNOWN EXCEPTION       \n%s in %s       \n", pszModule, thread_name);
-}
-
-void PrintExceptionContinue(const std::exception* pex, std::string_view thread_name)
-{
-    std::string message = FormatException(pex, thread_name);
-    LogPrintf("\n\n************************\n%s\n", message);
-    tfm::format(std::cerr, "\n\n************************\n%s\n", message);
-}
-
 fs::path GetDefaultDataDir()
 {
     // Windows: C:\Users\Username\AppData\Roaming\Bitcoin

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -19,12 +19,10 @@
 #include <fs.h>
 #include <logging.h>
 #include <sync.h>
-#include <tinyformat.h>
 #include <util/settings.h>
 #include <util/time.h>
 
 #include <any>
-#include <exception>
 #include <map>
 #include <optional>
 #include <set>
@@ -51,8 +49,6 @@ bool error(const char* fmt, const Args&... args)
     LogPrintf("ERROR: %s\n", tfm::format(fmt, args...));
     return false;
 }
-
-void PrintExceptionContinue(const std::exception* pex, std::string_view thread_name);
 
 /**
  * Ensure file contents are fully committed to disk, using a platform-specific

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -43,13 +43,6 @@ extern const char * const BITCOIN_SETTINGS_FILENAME;
 void SetupEnvironment();
 bool SetupNetworking();
 
-template<typename... Args>
-bool error(const char* fmt, const Args&... args)
-{
-    LogPrintf("ERROR: %s\n", tfm::format(fmt, args...));
-    return false;
-}
-
 /**
  * Ensure file contents are fully committed to disk, using a platform-specific
  * feature analogous to fsync().

--- a/src/util/thread.cpp
+++ b/src/util/thread.cpp
@@ -5,7 +5,7 @@
 #include <util/thread.h>
 
 #include <logging.h>
-#include <util/system.h>
+#include <util/exception.h>
 #include <util/threadnames.h>
 
 #include <exception>


### PR DESCRIPTION
This pull request is part of the `libbitcoinkernel` project https://github.com/bitcoin/bitcoin/issues/24303 https://github.com/bitcoin/bitcoin/projects/18 and more specifically its "Step 2: Decouple most non-consensus code from libbitcoinkernel". These commits were originally authored by empact and are taken from their parent PR #25152.

#### Context

There is an ongoing effort to decouple the `ArgsManager` used for command line parsing user-provided arguments from the libbitcoinkernel library (https://github.com/bitcoin/bitcoin/pull/25290, https://github.com/bitcoin/bitcoin/pull/25487, https://github.com/bitcoin/bitcoin/pull/25527, https://github.com/bitcoin/bitcoin/pull/25862, https://github.com/bitcoin/bitcoin/pull/26177, and https://github.com/bitcoin/bitcoin/pull/27125). The `ArgsManager` is defined in `system.h`.

#### Changes

Next to providing better code organization, this PR removes some reliance of the tree of libbitcoinkernel header includes on `system.h` (and thus the `ArgsManager` definition) by moving some logging functions out of the `system.*` files.

Further commits splitting more functionality out of `system.h` are still in #25152 and will be submitted in separate PRs once this PR has been processed.
