### PR TITLE
httpserver, rest: improving URI validation

### DIFF
--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -57,10 +57,10 @@ class HTTPRequest
 {
 private:
     struct evhttp_request* req;
-    bool replySent;
+    bool replySent{false};
 
 public:
-    explicit HTTPRequest(struct evhttp_request* req, bool replySent = false);
+    explicit HTTPRequest(struct evhttp_request* req);
     ~HTTPRequest();
 
     enum RequestMethod {

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -199,11 +199,7 @@ static bool rest_headers(const std::any& context,
     } else if (path.size() == 1) {
         // new path with query parameter: /rest/headers/<hash>?count=<count>
         hashStr = path[0];
-        try {
-            raw_count = req->GetQueryParameter("count").value_or("5");
-        } catch (const std::runtime_error& e) {
-            return RESTERR(req, HTTP_BAD_REQUEST, e.what());
-        }
+        raw_count = req->GetQueryParameter("count").value_or("5");
     } else {
         return RESTERR(req, HTTP_BAD_REQUEST, "Invalid URI format. Expected /rest/headers/<hash>.<ext>?count=<count>");
     }
@@ -374,11 +370,7 @@ static bool rest_filter_header(const std::any& context, HTTPRequest* req, const 
     } else if (uri_parts.size() == 2) {
         // new path with query parameter: /rest/blockfilterheaders/<filtertype>/<blockhash>?count=<count>
         raw_blockhash = uri_parts[1];
-        try {
-            raw_count = req->GetQueryParameter("count").value_or("5");
-        } catch (const std::runtime_error& e) {
-            return RESTERR(req, HTTP_BAD_REQUEST, e.what());
-        }
+        raw_count = req->GetQueryParameter("count").value_or("5");
     } else {
         return RESTERR(req, HTTP_BAD_REQUEST, "Invalid URI format. Expected /rest/blockfilterheaders/<filtertype>/<blockhash>.<ext>?count=<count>");
     }
@@ -660,20 +652,12 @@ static bool rest_mempool(const std::any& context, HTTPRequest* req, const std::s
         std::string str_json;
         if (param == "contents") {
             std::string raw_verbose;
-            try {
-                raw_verbose = req->GetQueryParameter("verbose").value_or("true");
-            } catch (const std::runtime_error& e) {
-                return RESTERR(req, HTTP_BAD_REQUEST, e.what());
-            }
+            raw_verbose = req->GetQueryParameter("verbose").value_or("true");
             if (raw_verbose != "true" && raw_verbose != "false") {
                 return RESTERR(req, HTTP_BAD_REQUEST, "The \"verbose\" query parameter must be either \"true\" or \"false\".");
             }
             std::string raw_mempool_sequence;
-            try {
-                raw_mempool_sequence = req->GetQueryParameter("mempool_sequence").value_or("false");
-            } catch (const std::runtime_error& e) {
-                return RESTERR(req, HTTP_BAD_REQUEST, e.what());
-            }
+            raw_mempool_sequence = req->GetQueryParameter("mempool_sequence").value_or("false");
             if (raw_mempool_sequence != "true" && raw_mempool_sequence != "false") {
                 return RESTERR(req, HTTP_BAD_REQUEST, "The \"mempool_sequence\" query parameter must be either \"true\" or \"false\".");
             }

--- a/src/test/fuzz/http_request.cpp
+++ b/src/test/fuzz/http_request.cpp
@@ -47,19 +47,22 @@ FUZZ_TARGET(http_request)
         return;
     }
 
-    HTTPRequest http_request{evreq, true};
-    const HTTPRequest::RequestMethod request_method = http_request.GetRequestMethod();
-    (void)RequestMethodString(request_method);
-    (void)http_request.GetURI();
-    (void)http_request.GetHeader("Host");
-    const std::string header = fuzzed_data_provider.ConsumeRandomLengthString(16);
-    (void)http_request.GetHeader(header);
-    (void)http_request.WriteHeader(header, fuzzed_data_provider.ConsumeRandomLengthString(16));
-    (void)http_request.GetHeader(header);
-    const std::string body = http_request.ReadBody();
-    assert(body.empty());
-    const CService service = http_request.GetPeer();
-    assert(service.ToStringAddrPort() == "[::]:0");
+    try {
+        HTTPRequest http_request{evreq};
+        const HTTPRequest::RequestMethod request_method = http_request.GetRequestMethod();
+        (void)RequestMethodString(request_method);
+        (void)http_request.GetURI();
+        (void)http_request.GetHeader("Host");
+        const std::string header = fuzzed_data_provider.ConsumeRandomLengthString(16);
+        (void)http_request.GetHeader(header);
+        (void)http_request.WriteHeader(header, fuzzed_data_provider.ConsumeRandomLengthString(16));
+        (void)http_request.GetHeader(header);
+        const std::string body = http_request.ReadBody();
+        assert(body.empty());
+        const CService service = http_request.GetPeer();
+        assert(service.ToStringAddrPort() == "[::]:0");
+    } catch(std::runtime_error &) {
+    }
 
     evbuffer_free(evbuf);
     evhttp_request_free(evreq);

--- a/src/test/httpserver_tests.cpp
+++ b/src/test/httpserver_tests.cpp
@@ -5,38 +5,58 @@
 #include <httpserver.h>
 #include <test/util/setup_common.h>
 
+#include <event2/http.h>
+
+#include <string>
+#include <string_view>
+
 #include <boost/test/unit_test.hpp>
 
 BOOST_FIXTURE_TEST_SUITE(httpserver_tests, BasicTestingSetup)
+
+std::optional<std::string> GetParameterFromURI(const std::string_view uri, const std::string& key){
+    auto uri_parsed{evhttp_uri_parse(uri.data())};
+    if (uri_parsed == nullptr) return std::nullopt;
+    auto param_value{GetQueryParameterFromUri(*uri_parsed, key)};
+    evhttp_uri_free(uri_parsed);
+    return param_value;
+}
+
+/** Test if query parameter exists in the provided uri. */
+bool QueryParameterExists(const std::string_view uri, const std::string& key)
+{
+    return GetParameterFromURI(uri, key).has_value();
+}
+
+/** Test if query parameter exists in the provided uri and if its value matches the expected_value. */
+bool QueryParameterEquals(const std::string_view uri, const std::string& key, const std::string_view expected_value)
+{
+    auto param_value{GetParameterFromURI(uri, key)};
+    return param_value.has_value() && *param_value == expected_value;
+}
 
 BOOST_AUTO_TEST_CASE(test_query_parameters)
 {
     std::string uri {};
 
     // No parameters
-    uri = "localhost:8080/rest/headers/someresource.json";
-    BOOST_CHECK(!GetQueryParameterFromUri(uri.c_str(), "p1").has_value());
+    BOOST_CHECK(!QueryParameterExists("localhost:8080/rest/headers/someresource.json", "p1"));
 
     // Single parameter
-    uri = "localhost:8080/rest/endpoint/someresource.json?p1=v1";
-    BOOST_CHECK_EQUAL(GetQueryParameterFromUri(uri.c_str(), "p1").value(), "v1");
-    BOOST_CHECK(!GetQueryParameterFromUri(uri.c_str(), "p2").has_value());
+    BOOST_CHECK(QueryParameterEquals("localhost:8080/rest/endpoint/someresource.json?p1=v1", "p1", "v1"));
+    BOOST_CHECK(!QueryParameterExists("localhost:8080/rest/endpoint/someresource.json?p1=v1", "p2"));
 
     // Multiple parameters
-    uri = "/rest/endpoint/someresource.json?p1=v1&p2=v2";
-    BOOST_CHECK_EQUAL(GetQueryParameterFromUri(uri.c_str(), "p1").value(), "v1");
-    BOOST_CHECK_EQUAL(GetQueryParameterFromUri(uri.c_str(), "p2").value(), "v2");
+    BOOST_CHECK(QueryParameterEquals("/rest/endpoint/someresource.json?p1=v1&p2=v2", "p1", "v1"));
+    BOOST_CHECK(QueryParameterEquals("/rest/endpoint/someresource.json?p1=v1&p2=v2", "p2", "v2"));
 
     // If the query string contains duplicate keys, the first value is returned
-    uri = "/rest/endpoint/someresource.json?p1=v1&p1=v2";
-    BOOST_CHECK_EQUAL(GetQueryParameterFromUri(uri.c_str(), "p1").value(), "v1");
+    BOOST_CHECK(QueryParameterEquals("/rest/endpoint/someresource.json?p1=v1&p1=v2", "p1", "v1"));
 
     // Invalid query string syntax is the same as not having parameters
-    uri = "/rest/endpoint/someresource.json&p1=v1&p2=v2";
-    BOOST_CHECK(!GetQueryParameterFromUri(uri.c_str(), "p1").has_value());
+    BOOST_CHECK(!QueryParameterExists("/rest/endpoint/someresource.json&p1=v1&p2=v2", "p1"));
 
-    // URI with invalid characters (%) raises a runtime error regardless of which query parameter is queried
-    uri = "/rest/endpoint/someresource.json&p1=v1&p2=v2%";
-    BOOST_CHECK_EXCEPTION(GetQueryParameterFromUri(uri.c_str(), "p1"), std::runtime_error, HasReason("URI parsing failed, it likely contained RFC 3986 invalid characters"));
+    // URI with invalid characters (%) won't return any values regardless of which query parameter is queried
+    BOOST_CHECK(!QueryParameterExists("/rest/endpoint/someresource.json&p1=v1&p2=v2%", "p1"));
 }
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR contains an isolated enhancement of the segfault bugfix https://github.com/bitcoin/bitcoin/pull/27468 (already merged), improving the way we handle the URI validation, which will be performed only once instead of on each query parameter of a rest service endpoint.