### PR TITLE
refactor: Extract util/fs from util/system

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -154,7 +154,6 @@ BITCOIN_CORE_H = \
   deploymentstatus.h \
   external_signer.h \
   flatfile.h \
-  fs.h \
   headerssync.h \
   httprpc.h \
   httpserver.h \
@@ -285,6 +284,7 @@ BITCOIN_CORE_H = \
   util/exception.h \
   util/fastrange.h \
   util/fees.h \
+  util/fs.h \
   util/fs_helpers.h \
   util/getuniquepath.h \
   util/golombrice.h \
@@ -695,7 +695,6 @@ libbitcoin_util_a_SOURCES = \
   support/lockedpool.cpp \
   chainparamsbase.cpp \
   clientversion.cpp \
-  fs.cpp \
   logging.cpp \
   random.cpp \
   randomenv.cpp \
@@ -708,6 +707,7 @@ libbitcoin_util_a_SOURCES = \
   util/error.cpp \
   util/exception.cpp \
   util/fees.cpp \
+  util/fs.cpp \
   util/fs_helpers.cpp \
   util/getuniquepath.cpp \
   util/hasher.cpp \
@@ -910,7 +910,6 @@ libbitcoinkernel_la_SOURCES = \
   deploymentinfo.cpp \
   deploymentstatus.cpp \
   flatfile.cpp \
-  fs.cpp \
   hash.cpp \
   kernel/chain.cpp \
   kernel/checks.cpp \
@@ -953,6 +952,7 @@ libbitcoinkernel_la_SOURCES = \
   uint256.cpp \
   util/check.cpp \
   util/exception.cpp \
+  util/fs.cpp \
   util/fs_helpers.cpp \
   util/getuniquepath.cpp \
   util/hasher.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -285,6 +285,7 @@ BITCOIN_CORE_H = \
   util/exception.h \
   util/fastrange.h \
   util/fees.h \
+  util/fs_helpers.h \
   util/getuniquepath.h \
   util/golombrice.h \
   util/hash_type.h \
@@ -707,6 +708,7 @@ libbitcoin_util_a_SOURCES = \
   util/error.cpp \
   util/exception.cpp \
   util/fees.cpp \
+  util/fs_helpers.cpp \
   util/getuniquepath.cpp \
   util/hasher.cpp \
   util/sock.cpp \
@@ -951,6 +953,7 @@ libbitcoinkernel_la_SOURCES = \
   uint256.cpp \
   util/check.cpp \
   util/exception.cpp \
+  util/fs_helpers.cpp \
   util/getuniquepath.cpp \
   util/hasher.cpp \
   util/moneystr.cpp \

--- a/src/addrdb.cpp
+++ b/src/addrdb.cpp
@@ -19,6 +19,7 @@
 #include <streams.h>
 #include <tinyformat.h>
 #include <univalue.h>
+#include <util/fs_helpers.h>
 #include <util/settings.h>
 #include <util/system.h>
 #include <util/translation.h>

--- a/src/addrdb.cpp
+++ b/src/addrdb.cpp
@@ -9,7 +9,6 @@
 #include <chainparams.h>
 #include <clientversion.h>
 #include <cstdint>
-#include <fs.h>
 #include <hash.h>
 #include <logging.h>
 #include <logging/timer.h>
@@ -19,6 +18,7 @@
 #include <streams.h>
 #include <tinyformat.h>
 #include <univalue.h>
+#include <util/fs.h>
 #include <util/fs_helpers.h>
 #include <util/settings.h>
 #include <util/system.h>

--- a/src/addrdb.h
+++ b/src/addrdb.h
@@ -6,9 +6,9 @@
 #ifndef BITCOIN_ADDRDB_H
 #define BITCOIN_ADDRDB_H
 
-#include <fs.h>
 #include <net_types.h> // For banmap_t
 #include <univalue.h>
+#include <util/fs.h>
 
 #include <optional>
 #include <vector>

--- a/src/banman.h
+++ b/src/banman.h
@@ -7,9 +7,9 @@
 
 #include <addrdb.h>
 #include <common/bloom.h>
-#include <fs.h>
 #include <net_types.h> // For banmap_t
 #include <sync.h>
+#include <util/fs.h>
 
 #include <chrono>
 #include <cstdint>

--- a/src/bench/bench.cpp
+++ b/src/bench/bench.cpp
@@ -4,8 +4,8 @@
 
 #include <bench/bench.h>
 
-#include <fs.h>
 #include <test/util/setup_common.h>
+#include <util/fs.h>
 #include <util/string.h>
 
 #include <chrono>

--- a/src/bench/bench.h
+++ b/src/bench/bench.h
@@ -5,7 +5,7 @@
 #ifndef BITCOIN_BENCH_BENCH_H
 #define BITCOIN_BENCH_BENCH_H
 
-#include <fs.h>
+#include <util/fs.h>
 #include <util/macros.h>
 
 #include <chrono>

--- a/src/bench/bench_bitcoin.cpp
+++ b/src/bench/bench_bitcoin.cpp
@@ -6,7 +6,7 @@
 
 #include <clientversion.h>
 #include <crypto/sha256.h>
-#include <fs.h>
+#include <util/fs.h>
 #include <util/strencodings.h>
 #include <util/system.h>
 

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -12,7 +12,6 @@
 #include <consensus/amount.h>
 #include <consensus/consensus.h>
 #include <core_io.h>
-#include <fs.h>
 #include <key_io.h>
 #include <policy/policy.h>
 #include <primitives/transaction.h>
@@ -21,6 +20,7 @@
 #include <script/signingprovider.h>
 #include <univalue.h>
 #include <util/exception.h>
+#include <util/fs.h>
 #include <util/moneystr.h>
 #include <util/rbf.h>
 #include <util/strencodings.h>

--- a/src/common/init.cpp
+++ b/src/common/init.cpp
@@ -2,10 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <common/init.h>
 #include <chainparams.h>
-#include <fs.h>
+#include <common/init.h>
 #include <tinyformat.h>
+#include <util/fs.h>
 #include <util/system.h>
 #include <util/translation.h>
 

--- a/src/compat/assumptions.h
+++ b/src/compat/assumptions.h
@@ -8,6 +8,7 @@
 #ifndef BITCOIN_COMPAT_ASSUMPTIONS_H
 #define BITCOIN_COMPAT_ASSUMPTIONS_H
 
+#include <cstddef>
 #include <limits>
 
 // Assumption: We assume that the macro NDEBUG is not defined.

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -4,10 +4,10 @@
 
 #include <dbwrapper.h>
 
-#include <fs.h>
 #include <logging.h>
 #include <random.h>
 #include <tinyformat.h>
+#include <util/fs.h>
 #include <util/fs_helpers.h>
 #include <util/strencodings.h>
 

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -8,8 +8,8 @@
 #include <logging.h>
 #include <random.h>
 #include <tinyformat.h>
+#include <util/fs_helpers.h>
 #include <util/strencodings.h>
-#include <util/system.h>
 
 #include <algorithm>
 #include <cassert>

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -6,11 +6,11 @@
 #define BITCOIN_DBWRAPPER_H
 
 #include <clientversion.h>
-#include <fs.h>
 #include <logging.h>
 #include <serialize.h>
 #include <span.h>
 #include <streams.h>
+#include <util/fs.h>
 
 #include <cstddef>
 #include <cstdint>

--- a/src/flatfile.cpp
+++ b/src/flatfile.cpp
@@ -8,7 +8,7 @@
 #include <flatfile.h>
 #include <logging.h>
 #include <tinyformat.h>
-#include <util/system.h>
+#include <util/fs_helpers.h>
 
 FlatFileSeq::FlatFileSeq(fs::path dir, const char* prefix, size_t chunk_size) :
     m_dir(std::move(dir)),

--- a/src/flatfile.h
+++ b/src/flatfile.h
@@ -8,8 +8,8 @@
 
 #include <string>
 
-#include <fs.h>
 #include <serialize.h>
+#include <util/fs.h>
 
 struct FlatFilePos
 {

--- a/src/i2p.cpp
+++ b/src/i2p.cpp
@@ -6,13 +6,13 @@
 #include <compat/compat.h>
 #include <compat/endian.h>
 #include <crypto/sha256.h>
-#include <fs.h>
 #include <i2p.h>
 #include <logging.h>
 #include <netaddress.h>
 #include <netbase.h>
 #include <random.h>
 #include <tinyformat.h>
+#include <util/fs.h>
 #include <util/readwritefile.h>
 #include <util/sock.h>
 #include <util/spanparsing.h>

--- a/src/i2p.h
+++ b/src/i2p.h
@@ -6,9 +6,9 @@
 #define BITCOIN_I2P_H
 
 #include <compat/compat.h>
-#include <fs.h>
 #include <netaddress.h>
 #include <sync.h>
+#include <util/fs.h>
 #include <util/sock.h>
 #include <util/threadinterrupt.h>
 

--- a/src/index/blockfilterindex.cpp
+++ b/src/index/blockfilterindex.cpp
@@ -8,6 +8,7 @@
 #include <hash.h>
 #include <index/blockfilterindex.h>
 #include <node/blockstorage.h>
+#include <util/fs_helpers.h>
 #include <util/system.h>
 #include <validation.h>
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -70,6 +70,7 @@
 #include <txmempool.h>
 #include <util/asmap.h>
 #include <util/check.h>
+#include <util/fs_helpers.h>
 #include <util/moneystr.h>
 #include <util/strencodings.h>
 #include <util/string.h>

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -20,7 +20,6 @@
 #include <chainparams.h>
 #include <consensus/amount.h>
 #include <deploymentstatus.h>
-#include <fs.h>
 #include <hash.h>
 #include <httprpc.h>
 #include <httpserver.h>
@@ -70,6 +69,7 @@
 #include <txmempool.h>
 #include <util/asmap.h>
 #include <util/check.h>
+#include <util/fs.h>
 #include <util/fs_helpers.h>
 #include <util/moneystr.h>
 #include <util/strencodings.h>

--- a/src/init/common.cpp
+++ b/src/init/common.cpp
@@ -11,6 +11,7 @@
 #include <logging.h>
 #include <node/interface_ui.h>
 #include <tinyformat.h>
+#include <util/fs_helpers.h>
 #include <util/string.h>
 #include <util/system.h>
 #include <util/time.h>

--- a/src/init/common.cpp
+++ b/src/init/common.cpp
@@ -7,10 +7,10 @@
 #endif
 
 #include <clientversion.h>
-#include <fs.h>
 #include <logging.h>
 #include <node/interface_ui.h>
 #include <tinyformat.h>
+#include <util/fs.h>
 #include <util/fs_helpers.h>
 #include <util/string.h>
 #include <util/system.h>

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -6,11 +6,11 @@
 #define BITCOIN_INTERFACES_WALLET_H
 
 #include <consensus/amount.h>
-#include <fs.h>
 #include <interfaces/chain.h>          // For ChainClient
 #include <pubkey.h>                    // For CKeyID and CScriptID (definitions needed in CTxDestination instantiation)
 #include <script/standard.h>           // For CTxDestination
 #include <support/allocators/secure.h> // For SecureString
+#include <util/fs.h>
 #include <util/message.h>
 #include <util/result.h>
 #include <util/ui_change_type.h>

--- a/src/ipc/interfaces.cpp
+++ b/src/ipc/interfaces.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <fs.h>
 #include <interfaces/init.h>
 #include <interfaces/ipc.h>
 #include <ipc/capnp/protocol.h>
@@ -10,6 +9,7 @@
 #include <ipc/protocol.h>
 #include <logging.h>
 #include <tinyformat.h>
+#include <util/fs.h>
 #include <util/system.h>
 
 #include <cstdio>

--- a/src/ipc/process.cpp
+++ b/src/ipc/process.cpp
@@ -2,11 +2,11 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <fs.h>
 #include <ipc/process.h>
 #include <ipc/protocol.h>
 #include <mp/util.h>
 #include <tinyformat.h>
+#include <util/fs.h>
 #include <util/strencodings.h>
 
 #include <cstdint>

--- a/src/ipc/process.h
+++ b/src/ipc/process.h
@@ -5,6 +5,8 @@
 #ifndef BITCOIN_IPC_PROCESS_H
 #define BITCOIN_IPC_PROCESS_H
 
+#include <fs.h>
+
 #include <memory>
 #include <string>
 

--- a/src/ipc/process.h
+++ b/src/ipc/process.h
@@ -5,7 +5,7 @@
 #ifndef BITCOIN_IPC_PROCESS_H
 #define BITCOIN_IPC_PROCESS_H
 
-#include <fs.h>
+#include <util/fs.h>
 
 #include <memory>
 #include <string>

--- a/src/kernel/mempool_persist.cpp
+++ b/src/kernel/mempool_persist.cpp
@@ -15,7 +15,7 @@
 #include <sync.h>
 #include <txmempool.h>
 #include <uint256.h>
-#include <util/system.h>
+#include <util/fs_helpers.h>
 #include <util/time.h>
 #include <validation.h>
 

--- a/src/kernel/mempool_persist.cpp
+++ b/src/kernel/mempool_persist.cpp
@@ -6,7 +6,6 @@
 
 #include <clientversion.h>
 #include <consensus/amount.h>
-#include <fs.h>
 #include <logging.h>
 #include <primitives/transaction.h>
 #include <serialize.h>
@@ -15,6 +14,7 @@
 #include <sync.h>
 #include <txmempool.h>
 #include <uint256.h>
+#include <util/fs.h>
 #include <util/fs_helpers.h>
 #include <util/time.h>
 #include <validation.h>

--- a/src/kernel/mempool_persist.h
+++ b/src/kernel/mempool_persist.h
@@ -5,7 +5,7 @@
 #ifndef BITCOIN_KERNEL_MEMPOOL_PERSIST_H
 #define BITCOIN_KERNEL_MEMPOOL_PERSIST_H
 
-#include <fs.h>
+#include <util/fs.h>
 
 class Chainstate;
 class CTxMemPool;

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <fs.h>
 #include <logging.h>
+#include <util/fs.h>
 #include <util/string.h>
 #include <util/threadnames.h>
 #include <util/time.h>

--- a/src/logging.h
+++ b/src/logging.h
@@ -6,9 +6,9 @@
 #ifndef BITCOIN_LOGGING_H
 #define BITCOIN_LOGGING_H
 
-#include <fs.h>
 #include <threadsafety.h>
 #include <tinyformat.h>
+#include <util/fs.h>
 #include <util/string.h>
 
 #include <atomic>

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -16,7 +16,6 @@
 #include <compat/compat.h>
 #include <consensus/consensus.h>
 #include <crypto/sha256.h>
-#include <fs.h>
 #include <i2p.h>
 #include <logging.h>
 #include <net_permissions.h>
@@ -27,6 +26,7 @@
 #include <protocol.h>
 #include <random.h>
 #include <scheduler.h>
+#include <util/fs.h>
 #include <util/sock.h>
 #include <util/strencodings.h>
 #include <util/syscall_sandbox.h>

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -8,7 +8,6 @@
 #include <clientversion.h>
 #include <consensus/validation.h>
 #include <flatfile.h>
-#include <fs.h>
 #include <hash.h>
 #include <logging.h>
 #include <kernel/chainparams.h>
@@ -18,6 +17,7 @@
 #include <signet.h>
 #include <streams.h>
 #include <undo.h>
+#include <util/fs.h>
 #include <util/syscall_sandbox.h>
 #include <util/system.h>
 #include <validation.h>

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -7,12 +7,12 @@
 
 #include <attributes.h>
 #include <chain.h>
-#include <fs.h>
 #include <kernel/blockmanager_opts.h>
 #include <kernel/cs_main.h>
 #include <protocol.h>
 #include <sync.h>
 #include <txdb.h>
+#include <util/fs.h>
 
 #include <atomic>
 #include <cstdint>

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -16,7 +16,7 @@
 #include <tinyformat.h>
 #include <txdb.h>
 #include <uint256.h>
-#include <fs.h>
+#include <util/fs.h>
 #include <util/time.h>
 #include <util/translation.h>
 #include <validation.h>

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -16,6 +16,7 @@
 #include <tinyformat.h>
 #include <txdb.h>
 #include <uint256.h>
+#include <fs.h>
 #include <util/time.h>
 #include <util/translation.h>
 #include <validation.h>

--- a/src/node/mempool_persist_args.cpp
+++ b/src/node/mempool_persist_args.cpp
@@ -4,7 +4,7 @@
 
 #include <node/mempool_persist_args.h>
 
-#include <fs.h>
+#include <util/fs.h>
 #include <util/system.h>
 #include <validation.h>
 

--- a/src/node/mempool_persist_args.h
+++ b/src/node/mempool_persist_args.h
@@ -5,7 +5,7 @@
 #ifndef BITCOIN_NODE_MEMPOOL_PERSIST_ARGS_H
 #define BITCOIN_NODE_MEMPOOL_PERSIST_ARGS_H
 
-#include <fs.h>
+#include <util/fs.h>
 
 class ArgsManager;
 

--- a/src/node/utxo_snapshot.cpp
+++ b/src/node/utxo_snapshot.cpp
@@ -4,13 +4,13 @@
 
 #include <node/utxo_snapshot.h>
 
-#include <fs.h>
 #include <logging.h>
 #include <streams.h>
 #include <sync.h>
 #include <tinyformat.h>
 #include <txdb.h>
 #include <uint256.h>
+#include <util/fs.h>
 #include <util/system.h>
 #include <validation.h>
 

--- a/src/node/utxo_snapshot.h
+++ b/src/node/utxo_snapshot.h
@@ -6,11 +6,11 @@
 #ifndef BITCOIN_NODE_UTXO_SNAPSHOT_H
 #define BITCOIN_NODE_UTXO_SNAPSHOT_H
 
-#include <fs.h>
 #include <kernel/cs_main.h>
 #include <serialize.h>
 #include <sync.h>
 #include <uint256.h>
+#include <util/fs.h>
 
 #include <cstdint>
 #include <optional>

--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -7,7 +7,6 @@
 
 #include <clientversion.h>
 #include <consensus/amount.h>
-#include <fs.h>
 #include <kernel/mempool_entry.h>
 #include <logging.h>
 #include <policy/feerate.h>
@@ -18,6 +17,7 @@
 #include <sync.h>
 #include <tinyformat.h>
 #include <uint256.h>
+#include <util/fs.h>
 #include <util/serfloat.h>
 #include <util/system.h>
 #include <util/time.h>

--- a/src/policy/fees.h
+++ b/src/policy/fees.h
@@ -6,12 +6,12 @@
 #define BITCOIN_POLICY_FEES_H
 
 #include <consensus/amount.h>
-#include <fs.h>
 #include <policy/feerate.h>
 #include <random.h>
 #include <sync.h>
 #include <threadsafety.h>
 #include <uint256.h>
+#include <util/fs.h>
 
 #include <array>
 #include <map>

--- a/src/policy/fees_args.h
+++ b/src/policy/fees_args.h
@@ -5,7 +5,7 @@
 #ifndef BITCOIN_POLICY_FEES_ARGS_H
 #define BITCOIN_POLICY_FEES_ARGS_H
 
-#include <fs.h>
+#include <util/fs.h>
 
 class ArgsManager;
 

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -21,6 +21,7 @@
 #include <script/script.h>
 #include <script/standard.h>
 #include <util/exception.h>
+#include <util/fs_helpers.h>
 #include <util/system.h>
 #include <util/time.h>
 

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -12,7 +12,6 @@
 
 #include <base58.h>
 #include <chainparams.h>
-#include <fs.h>
 #include <interfaces/node.h>
 #include <key_io.h>
 #include <policy/policy.h>
@@ -21,6 +20,7 @@
 #include <script/script.h>
 #include <script/standard.h>
 #include <util/exception.h>
+#include <util/fs.h>
 #include <util/fs_helpers.h>
 #include <util/system.h>
 #include <util/time.h>

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -6,10 +6,10 @@
 #define BITCOIN_QT_GUIUTIL_H
 
 #include <consensus/amount.h>
-#include <fs.h>
 #include <net.h>
 #include <netaddress.h>
 #include <util/check.h>
+#include <util/fs.h>
 
 #include <QApplication>
 #include <QEvent>

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -16,6 +16,7 @@
 #include <qt/optionsmodel.h>
 
 #include <interfaces/node.h>
+#include <util/fs_helpers.h>
 #include <util/system.h>
 #include <validation.h>
 

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -7,9 +7,9 @@
 #endif
 
 #include <chainparams.h>
-#include <fs.h>
 #include <qt/intro.h>
 #include <qt/forms/ui_intro.h>
+#include <util/fs.h>
 
 #include <qt/guiconstants.h>
 #include <qt/guiutil.h>

--- a/src/qt/psbtoperationsdialog.cpp
+++ b/src/qt/psbtoperationsdialog.cpp
@@ -5,7 +5,6 @@
 #include <qt/psbtoperationsdialog.h>
 
 #include <core_io.h>
-#include <fs.h>
 #include <interfaces/node.h>
 #include <key_io.h>
 #include <node/psbt.h>
@@ -14,6 +13,7 @@
 #include <qt/forms/ui_psbtoperationsdialog.h>
 #include <qt/guiutil.h>
 #include <qt/optionsmodel.h>
+#include <util/fs.h>
 #include <util/strencodings.h>
 
 #include <fstream>

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -4,7 +4,6 @@
 
 #include <qt/walletframe.h>
 
-#include <fs.h>
 #include <node/interface_ui.h>
 #include <psbt.h>
 #include <qt/guiutil.h>
@@ -12,6 +11,7 @@
 #include <qt/psbtoperationsdialog.h>
 #include <qt/walletmodel.h>
 #include <qt/walletview.h>
+#include <util/fs.h>
 #include <util/fs_helpers.h>
 
 #include <cassert>

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -12,7 +12,7 @@
 #include <qt/psbtoperationsdialog.h>
 #include <qt/walletmodel.h>
 #include <qt/walletview.h>
-#include <util/system.h>
+#include <util/fs_helpers.h>
 
 #include <cassert>
 #include <fstream>

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -15,7 +15,6 @@
 #include <core_io.h>
 #include <deploymentinfo.h>
 #include <deploymentstatus.h>
-#include <fs.h>
 #include <hash.h>
 #include <index/blockfilterindex.h>
 #include <index/coinstatsindex.h>
@@ -39,6 +38,7 @@
 #include <undo.h>
 #include <univalue.h>
 #include <util/check.h>
+#include <util/fs.h>
 #include <util/strencodings.h>
 #include <util/system.h>
 #include <util/translation.h>

--- a/src/rpc/blockchain.h
+++ b/src/rpc/blockchain.h
@@ -7,9 +7,9 @@
 
 #include <consensus/amount.h>
 #include <core_io.h>
-#include <fs.h>
 #include <streams.h>
 #include <sync.h>
+#include <util/fs.h>
 #include <validation.h>
 
 #include <any>

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -9,7 +9,6 @@
 
 #include <chainparams.h>
 #include <core_io.h>
-#include <fs.h>
 #include <kernel/mempool_entry.h>
 #include <node/mempool_persist_args.h>
 #include <policy/rbf.h>
@@ -21,6 +20,7 @@
 #include <script/standard.h>
 #include <txmempool.h>
 #include <univalue.h>
+#include <util/fs.h>
 #include <util/moneystr.h>
 #include <util/time.h>
 

--- a/src/rpc/request.cpp
+++ b/src/rpc/request.cpp
@@ -5,7 +5,7 @@
 
 #include <rpc/request.h>
 
-#include <fs.h>
+#include <util/fs.h>
 
 #include <random.h>
 #include <rpc/protocol.h>

--- a/src/rpc/request.cpp
+++ b/src/rpc/request.cpp
@@ -9,8 +9,9 @@
 
 #include <random.h>
 #include <rpc/protocol.h>
-#include <util/system.h>
+#include <util/fs_helpers.h>
 #include <util/strencodings.h>
+#include <util/system.h>
 
 #include <fstream>
 #include <stdexcept>

--- a/src/test/argsman_tests.cpp
+++ b/src/test/argsman_tests.cpp
@@ -2,14 +2,14 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/system.h>
-#include <fs.h>
 #include <sync.h>
 #include <test/util/logging.h>
 #include <test/util/setup_common.h>
 #include <test/util/str.h>
-#include <util/strencodings.h>
 #include <univalue.h>
+#include <util/fs.h>
+#include <util/strencodings.h>
+#include <util/system.h>
 
 #include <array>
 #include <optional>

--- a/src/test/fs_tests.cpp
+++ b/src/test/fs_tests.cpp
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 //
-#include <fs.h>
 #include <test/util/setup_common.h>
+#include <util/fs.h>
 #include <util/fs_helpers.h>
 #include <util/getuniquepath.h>
 

--- a/src/test/fs_tests.cpp
+++ b/src/test/fs_tests.cpp
@@ -4,7 +4,7 @@
 //
 #include <fs.h>
 #include <test/util/setup_common.h>
-#include <util/system.h>
+#include <util/fs_helpers.h>
 #include <util/getuniquepath.h>
 
 #include <boost/test/unit_test.hpp>

--- a/src/test/fuzz/banman.cpp
+++ b/src/test/fuzz/banman.cpp
@@ -3,13 +3,13 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <banman.h>
-#include <fs.h>
 #include <netaddress.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/fuzz/util/net.h>
 #include <test/util/setup_common.h>
+#include <util/fs.h>
 #include <util/readwritefile.h>
 #include <util/system.h>
 

--- a/src/test/fuzz/fuzz.cpp
+++ b/src/test/fuzz/fuzz.cpp
@@ -4,11 +4,11 @@
 
 #include <test/fuzz/fuzz.h>
 
-#include <fs.h>
 #include <netaddress.h>
 #include <netbase.h>
 #include <test/util/setup_common.h>
 #include <util/check.h>
+#include <util/fs.h>
 #include <util/sock.h>
 #include <util/time.h>
 

--- a/src/test/fuzz/utxo_snapshot.cpp
+++ b/src/test/fuzz/utxo_snapshot.cpp
@@ -4,13 +4,13 @@
 
 #include <chainparams.h>
 #include <consensus/validation.h>
-#include <fs.h>
 #include <node/utxo_snapshot.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/util/mining.h>
 #include <test/util/setup_common.h>
+#include <util/fs.h>
 #include <validation.h>
 #include <validationinterface.h>
 

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -6,7 +6,6 @@
 #include <test/data/bip341_wallet_vectors.json.h>
 
 #include <core_io.h>
-#include <fs.h>
 #include <key.h>
 #include <rpc/util.h>
 #include <script/script.h>
@@ -19,6 +18,7 @@
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <test/util/transaction_utils.h>
+#include <util/fs.h>
 #include <util/strencodings.h>
 #include <util/system.h>
 

--- a/src/test/settings_tests.cpp
+++ b/src/test/settings_tests.cpp
@@ -4,9 +4,9 @@
 
 #include <util/settings.h>
 
-#include <fs.h>
 #include <test/util/setup_common.h>
 #include <test/util/str.h>
+#include <util/fs.h>
 
 
 #include <boost/test/unit_test.hpp>

--- a/src/test/streams_tests.cpp
+++ b/src/test/streams_tests.cpp
@@ -2,10 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <fs.h>
 #include <streams.h>
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
+#include <util/fs.h>
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/util/chainstate.h
+++ b/src/test/util/chainstate.h
@@ -6,12 +6,12 @@
 #define BITCOIN_TEST_UTIL_CHAINSTATE_H
 
 #include <clientversion.h>
-#include <fs.h>
 #include <logging.h>
 #include <node/context.h>
 #include <node/utxo_snapshot.h>
 #include <rpc/blockchain.h>
 #include <test/util/setup_common.h>
+#include <util/fs.h>
 #include <validation.h>
 
 #include <univalue.h>

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -6,7 +6,6 @@
 #define BITCOIN_TEST_UTIL_SETUP_COMMON_H
 
 #include <chainparamsbase.h>
-#include <fs.h>
 #include <key.h>
 #include <node/caches.h>
 #include <node/context.h>
@@ -15,6 +14,7 @@
 #include <random.h>
 #include <stdexcept>
 #include <util/check.h>
+#include <util/fs.h>
 #include <util/string.h>
 #include <util/system.h>
 #include <util/vector.h>

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -3,7 +3,6 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <clientversion.h>
-#include <fs.h>
 #include <hash.h> // For Hash()
 #include <key.h>  // For CKey
 #include <sync.h>
@@ -11,6 +10,7 @@
 #include <test/util/setup_common.h>
 #include <uint256.h>
 #include <util/bitdeque.h>
+#include <util/fs.h>
 #include <util/fs_helpers.h>
 #include <util/getuniquepath.h>
 #include <util/message.h> // For MessageSign(), MessageVerify(), MESSAGE_MAGIC

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -2,8 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/system.h>
-
 #include <clientversion.h>
 #include <fs.h>
 #include <hash.h> // For Hash()
@@ -12,6 +10,8 @@
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <uint256.h>
+#include <util/bitdeque.h>
+#include <util/fs_helpers.h>
 #include <util/getuniquepath.h>
 #include <util/message.h> // For MessageSign(), MessageVerify(), MESSAGE_MAGIC
 #include <util/moneystr.h>
@@ -22,7 +22,6 @@
 #include <util/string.h>
 #include <util/time.h>
 #include <util/vector.h>
-#include <util/bitdeque.h>
 
 #include <array>
 #include <cmath>

--- a/src/torcontrol.h
+++ b/src/torcontrol.h
@@ -8,8 +8,8 @@
 #ifndef BITCOIN_TORCONTROL_H
 #define BITCOIN_TORCONTROL_H
 
-#include <fs.h>
 #include <netaddress.h>
+#include <util/fs.h>
 
 #include <boost/signals2/signal.hpp>
 

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -10,7 +10,7 @@
 #include <dbwrapper.h>
 #include <kernel/cs_main.h>
 #include <sync.h>
-#include <fs.h>
+#include <util/fs.h>
 
 #include <memory>
 #include <optional>

--- a/src/util/asmap.cpp
+++ b/src/util/asmap.cpp
@@ -6,10 +6,10 @@
 
 #include <clientversion.h>
 #include <crypto/common.h>
-#include <fs.h>
 #include <logging.h>
 #include <serialize.h>
 #include <streams.h>
+#include <util/fs.h>
 
 #include <algorithm>
 #include <cassert>

--- a/src/util/asmap.h
+++ b/src/util/asmap.h
@@ -5,7 +5,7 @@
 #ifndef BITCOIN_UTIL_ASMAP_H
 #define BITCOIN_UTIL_ASMAP_H
 
-#include <fs.h>
+#include <util/fs.h>
 
 #include <cstdint>
 #include <vector>

--- a/src/util/fs.cpp
+++ b/src/util/fs.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <fs.h>
+#include <util/fs.h>
 #include <util/syserror.h>
 
 #ifndef WIN32

--- a/src/util/fs.h
+++ b/src/util/fs.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_FS_H
-#define BITCOIN_FS_H
+#ifndef BITCOIN_UTIL_FS_H
+#define BITCOIN_UTIL_FS_H
 
 #include <tinyformat.h>
 
@@ -248,4 +248,4 @@ template<> inline void formatValue(std::ostream&, const char*, const char*, int,
 template<> inline void formatValue(std::ostream&, const char*, const char*, int, const fs::path&) = delete;
 } // namespace tinyformat
 
-#endif // BITCOIN_FS_H
+#endif // BITCOIN_UTIL_FS_H

--- a/src/util/fs_helpers.cpp
+++ b/src/util/fs_helpers.cpp
@@ -9,10 +9,10 @@
 #include <config/bitcoin-config.h>
 #endif
 
-#include <fs.h>
 #include <logging.h>
 #include <sync.h>
 #include <tinyformat.h>
+#include <util/fs.h>
 #include <util/getuniquepath.h>
 
 #include <cerrno>

--- a/src/util/fs_helpers.cpp
+++ b/src/util/fs_helpers.cpp
@@ -1,0 +1,295 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <util/fs_helpers.h>
+
+#if defined(HAVE_CONFIG_H)
+#include <config/bitcoin-config.h>
+#endif
+
+#include <fs.h>
+#include <logging.h>
+#include <sync.h>
+#include <tinyformat.h>
+#include <util/getuniquepath.h>
+
+#include <cerrno>
+#include <filesystem>
+#include <fstream>
+#include <map>
+#include <memory>
+#include <string>
+#include <system_error>
+#include <utility>
+
+#ifndef WIN32
+// for posix_fallocate, in configure.ac we check if it is present after this
+#ifdef __linux__
+
+#ifdef _POSIX_C_SOURCE
+#undef _POSIX_C_SOURCE
+#endif
+
+#define _POSIX_C_SOURCE 200112L
+
+#endif // __linux__
+
+#include <fcntl.h>
+#include <sys/resource.h>
+#include <unistd.h>
+#else
+#include <io.h> /* For _get_osfhandle, _chsize */
+#include <shlobj.h> /* For SHGetSpecialFolderPathW */
+#endif // WIN32
+
+/** Mutex to protect dir_locks. */
+static GlobalMutex cs_dir_locks;
+/** A map that contains all the currently held directory locks. After
+ * successful locking, these will be held here until the global destructor
+ * cleans them up and thus automatically unlocks them, or ReleaseDirectoryLocks
+ * is called.
+ */
+static std::map<std::string, std::unique_ptr<fsbridge::FileLock>> dir_locks GUARDED_BY(cs_dir_locks);
+
+bool LockDirectory(const fs::path& directory, const fs::path& lockfile_name, bool probe_only)
+{
+    LOCK(cs_dir_locks);
+    fs::path pathLockFile = directory / lockfile_name;
+
+    // If a lock for this directory already exists in the map, don't try to re-lock it
+    if (dir_locks.count(fs::PathToString(pathLockFile))) {
+        return true;
+    }
+
+    // Create empty lock file if it doesn't exist.
+    FILE* file = fsbridge::fopen(pathLockFile, "a");
+    if (file) fclose(file);
+    auto lock = std::make_unique<fsbridge::FileLock>(pathLockFile);
+    if (!lock->TryLock()) {
+        return error("Error while attempting to lock directory %s: %s", fs::PathToString(directory), lock->GetReason());
+    }
+    if (!probe_only) {
+        // Lock successful and we're not just probing, put it into the map
+        dir_locks.emplace(fs::PathToString(pathLockFile), std::move(lock));
+    }
+    return true;
+}
+
+void UnlockDirectory(const fs::path& directory, const fs::path& lockfile_name)
+{
+    LOCK(cs_dir_locks);
+    dir_locks.erase(fs::PathToString(directory / lockfile_name));
+}
+
+void ReleaseDirectoryLocks()
+{
+    LOCK(cs_dir_locks);
+    dir_locks.clear();
+}
+
+bool DirIsWritable(const fs::path& directory)
+{
+    fs::path tmpFile = GetUniquePath(directory);
+
+    FILE* file = fsbridge::fopen(tmpFile, "a");
+    if (!file) return false;
+
+    fclose(file);
+    remove(tmpFile);
+
+    return true;
+}
+
+bool CheckDiskSpace(const fs::path& dir, uint64_t additional_bytes)
+{
+    constexpr uint64_t min_disk_space = 52428800; // 50 MiB
+
+    uint64_t free_bytes_available = fs::space(dir).available;
+    return free_bytes_available >= min_disk_space + additional_bytes;
+}
+
+std::streampos GetFileSize(const char* path, std::streamsize max)
+{
+    std::ifstream file{path, std::ios::binary};
+    file.ignore(max);
+    return file.gcount();
+}
+
+bool FileCommit(FILE* file)
+{
+    if (fflush(file) != 0) { // harmless if redundantly called
+        LogPrintf("%s: fflush failed: %d\n", __func__, errno);
+        return false;
+    }
+#ifdef WIN32
+    HANDLE hFile = (HANDLE)_get_osfhandle(_fileno(file));
+    if (FlushFileBuffers(hFile) == 0) {
+        LogPrintf("%s: FlushFileBuffers failed: %d\n", __func__, GetLastError());
+        return false;
+    }
+#elif defined(MAC_OSX) && defined(F_FULLFSYNC)
+    if (fcntl(fileno(file), F_FULLFSYNC, 0) == -1) { // Manpage says "value other than -1" is returned on success
+        LogPrintf("%s: fcntl F_FULLFSYNC failed: %d\n", __func__, errno);
+        return false;
+    }
+#elif HAVE_FDATASYNC
+    if (fdatasync(fileno(file)) != 0 && errno != EINVAL) { // Ignore EINVAL for filesystems that don't support sync
+        LogPrintf("%s: fdatasync failed: %d\n", __func__, errno);
+        return false;
+    }
+#else
+    if (fsync(fileno(file)) != 0 && errno != EINVAL) {
+        LogPrintf("%s: fsync failed: %d\n", __func__, errno);
+        return false;
+    }
+#endif
+    return true;
+}
+
+void DirectoryCommit(const fs::path& dirname)
+{
+#ifndef WIN32
+    FILE* file = fsbridge::fopen(dirname, "r");
+    if (file) {
+        fsync(fileno(file));
+        fclose(file);
+    }
+#endif
+}
+
+bool TruncateFile(FILE* file, unsigned int length)
+{
+#if defined(WIN32)
+    return _chsize(_fileno(file), length) == 0;
+#else
+    return ftruncate(fileno(file), length) == 0;
+#endif
+}
+
+/**
+ * this function tries to raise the file descriptor limit to the requested number.
+ * It returns the actual file descriptor limit (which may be more or less than nMinFD)
+ */
+int RaiseFileDescriptorLimit(int nMinFD)
+{
+#if defined(WIN32)
+    return 2048;
+#else
+    struct rlimit limitFD;
+    if (getrlimit(RLIMIT_NOFILE, &limitFD) != -1) {
+        if (limitFD.rlim_cur < (rlim_t)nMinFD) {
+            limitFD.rlim_cur = nMinFD;
+            if (limitFD.rlim_cur > limitFD.rlim_max)
+                limitFD.rlim_cur = limitFD.rlim_max;
+            setrlimit(RLIMIT_NOFILE, &limitFD);
+            getrlimit(RLIMIT_NOFILE, &limitFD);
+        }
+        return limitFD.rlim_cur;
+    }
+    return nMinFD; // getrlimit failed, assume it's fine
+#endif
+}
+
+/**
+ * this function tries to make a particular range of a file allocated (corresponding to disk space)
+ * it is advisory, and the range specified in the arguments will never contain live data
+ */
+void AllocateFileRange(FILE* file, unsigned int offset, unsigned int length)
+{
+#if defined(WIN32)
+    // Windows-specific version
+    HANDLE hFile = (HANDLE)_get_osfhandle(_fileno(file));
+    LARGE_INTEGER nFileSize;
+    int64_t nEndPos = (int64_t)offset + length;
+    nFileSize.u.LowPart = nEndPos & 0xFFFFFFFF;
+    nFileSize.u.HighPart = nEndPos >> 32;
+    SetFilePointerEx(hFile, nFileSize, 0, FILE_BEGIN);
+    SetEndOfFile(hFile);
+#elif defined(MAC_OSX)
+    // OSX specific version
+    // NOTE: Contrary to other OS versions, the OSX version assumes that
+    // NOTE: offset is the size of the file.
+    fstore_t fst;
+    fst.fst_flags = F_ALLOCATECONTIG;
+    fst.fst_posmode = F_PEOFPOSMODE;
+    fst.fst_offset = 0;
+    fst.fst_length = length; // mac os fst_length takes the # of free bytes to allocate, not desired file size
+    fst.fst_bytesalloc = 0;
+    if (fcntl(fileno(file), F_PREALLOCATE, &fst) == -1) {
+        fst.fst_flags = F_ALLOCATEALL;
+        fcntl(fileno(file), F_PREALLOCATE, &fst);
+    }
+    ftruncate(fileno(file), static_cast<off_t>(offset) + length);
+#else
+#if defined(HAVE_POSIX_FALLOCATE)
+    // Version using posix_fallocate
+    off_t nEndPos = (off_t)offset + length;
+    if (0 == posix_fallocate(fileno(file), 0, nEndPos)) return;
+#endif
+    // Fallback version
+    // TODO: just write one byte per block
+    static const char buf[65536] = {};
+    if (fseek(file, offset, SEEK_SET)) {
+        return;
+    }
+    while (length > 0) {
+        unsigned int now = 65536;
+        if (length < now)
+            now = length;
+        fwrite(buf, 1, now, file); // allowed to fail; this function is advisory anyway
+        length -= now;
+    }
+#endif
+}
+
+#ifdef WIN32
+fs::path GetSpecialFolderPath(int nFolder, bool fCreate)
+{
+    WCHAR pszPath[MAX_PATH] = L"";
+
+    if (SHGetSpecialFolderPathW(nullptr, pszPath, nFolder, fCreate)) {
+        return fs::path(pszPath);
+    }
+
+    LogPrintf("SHGetSpecialFolderPathW() failed, could not obtain requested path.\n");
+    return fs::path("");
+}
+#endif
+
+bool RenameOver(fs::path src, fs::path dest)
+{
+#ifdef __MINGW64__
+    // This is a workaround for a bug in libstdc++ which
+    // implements std::filesystem::rename with _wrename function.
+    // This bug has been fixed in upstream:
+    //  - GCC 10.3: 8dd1c1085587c9f8a21bb5e588dfe1e8cdbba79e
+    //  - GCC 11.1: 1dfd95f0a0ca1d9e6cbc00e6cbfd1fa20a98f312
+    // For more details see the commits mentioned above.
+    return MoveFileExW(src.wstring().c_str(), dest.wstring().c_str(),
+                       MOVEFILE_REPLACE_EXISTING) != 0;
+#else
+    std::error_code error;
+    fs::rename(src, dest, error);
+    return !error;
+#endif
+}
+
+/**
+ * Ignores exceptions thrown by create_directories if the requested directory exists.
+ * Specifically handles case where path p exists, but it wasn't possible for the user to
+ * write to the parent directory.
+ */
+bool TryCreateDirectories(const fs::path& p)
+{
+    try {
+        return fs::create_directories(p);
+    } catch (const fs::filesystem_error&) {
+        if (!fs::exists(p) || !fs::is_directory(p))
+            throw;
+    }
+
+    // create_directories didn't create the directory, it had to have existed already
+    return false;
+}

--- a/src/util/fs_helpers.h
+++ b/src/util/fs_helpers.h
@@ -6,7 +6,7 @@
 #ifndef BITCOIN_UTIL_FS_HELPERS_H
 #define BITCOIN_UTIL_FS_HELPERS_H
 
-#include <fs.h>
+#include <util/fs.h>
 
 #include <cstdint>
 #include <cstdio>

--- a/src/util/fs_helpers.h
+++ b/src/util/fs_helpers.h
@@ -1,0 +1,63 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_UTIL_FS_HELPERS_H
+#define BITCOIN_UTIL_FS_HELPERS_H
+
+#include <fs.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <iosfwd>
+#include <limits>
+
+/**
+ * Ensure file contents are fully committed to disk, using a platform-specific
+ * feature analogous to fsync().
+ */
+bool FileCommit(FILE* file);
+
+/**
+ * Sync directory contents. This is required on some environments to ensure that
+ * newly created files are committed to disk.
+ */
+void DirectoryCommit(const fs::path& dirname);
+
+bool TruncateFile(FILE* file, unsigned int length);
+int RaiseFileDescriptorLimit(int nMinFD);
+void AllocateFileRange(FILE* file, unsigned int offset, unsigned int length);
+
+/**
+ * Rename src to dest.
+ * @return true if the rename was successful.
+ */
+[[nodiscard]] bool RenameOver(fs::path src, fs::path dest);
+
+bool LockDirectory(const fs::path& directory, const fs::path& lockfile_name, bool probe_only = false);
+void UnlockDirectory(const fs::path& directory, const fs::path& lockfile_name);
+bool DirIsWritable(const fs::path& directory);
+bool CheckDiskSpace(const fs::path& dir, uint64_t additional_bytes = 0);
+
+/** Get the size of a file by scanning it.
+ *
+ * @param[in] path The file path
+ * @param[in] max Stop seeking beyond this limit
+ * @return The file size or max
+ */
+std::streampos GetFileSize(const char* path, std::streamsize max = std::numeric_limits<std::streamsize>::max());
+
+/** Release all directory locks. This is used for unit testing only, at runtime
+ * the global destructor will take care of the locks.
+ */
+void ReleaseDirectoryLocks();
+
+bool TryCreateDirectories(const fs::path& p);
+fs::path GetDefaultDataDir();
+
+#ifdef WIN32
+fs::path GetSpecialFolderPath(int nFolder, bool fCreate = true);
+#endif
+
+#endif // BITCOIN_UTIL_FS_HELPERS_H

--- a/src/util/getuniquepath.cpp
+++ b/src/util/getuniquepath.cpp
@@ -3,7 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <random.h>
-#include <fs.h>
+#include <util/fs.h>
 #include <util/strencodings.h>
 
 fs::path GetUniquePath(const fs::path& base)

--- a/src/util/getuniquepath.h
+++ b/src/util/getuniquepath.h
@@ -5,7 +5,7 @@
 #ifndef BITCOIN_UTIL_GETUNIQUEPATH_H
 #define BITCOIN_UTIL_GETUNIQUEPATH_H
 
-#include <fs.h>
+#include <util/fs.h>
 
 /**
  * Helper function for getting a unique path

--- a/src/util/readwritefile.cpp
+++ b/src/util/readwritefile.cpp
@@ -5,7 +5,7 @@
 
 #include <util/readwritefile.h>
 
-#include <fs.h>
+#include <util/fs.h>
 
 #include <algorithm>
 #include <cstdio>

--- a/src/util/readwritefile.h
+++ b/src/util/readwritefile.h
@@ -5,7 +5,7 @@
 #ifndef BITCOIN_UTIL_READWRITEFILE_H
 #define BITCOIN_UTIL_READWRITEFILE_H
 
-#include <fs.h>
+#include <util/fs.h>
 
 #include <limits>
 #include <string>

--- a/src/util/settings.cpp
+++ b/src/util/settings.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <fs.h>
+#include <util/fs.h>
 #include <util/settings.h>
 
 #include <tinyformat.h>

--- a/src/util/settings.h
+++ b/src/util/settings.h
@@ -5,7 +5,7 @@
 #ifndef BITCOIN_UTIL_SETTINGS_H
 #define BITCOIN_UTIL_SETTINGS_H
 
-#include <fs.h>
+#include <util/fs.h>
 
 #include <map>
 #include <string>

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -6,9 +6,9 @@
 #include <util/system.h>
 
 #include <chainparamsbase.h>
-#include <fs.h>
 #include <sync.h>
 #include <util/check.h>
+#include <util/fs.h>
 #include <util/fs_helpers.h>
 #include <util/getuniquepath.h>
 #include <util/strencodings.h>

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -9,6 +9,7 @@
 #include <fs.h>
 #include <sync.h>
 #include <util/check.h>
+#include <util/fs_helpers.h>
 #include <util/getuniquepath.h>
 #include <util/strencodings.h>
 #include <util/string.h>
@@ -22,17 +23,6 @@
 #endif
 
 #ifndef WIN32
-// for posix_fallocate, in configure.ac we check if it is present after this
-#ifdef __linux__
-
-#ifdef _POSIX_C_SOURCE
-#undef _POSIX_C_SOURCE
-#endif
-
-#define _POSIX_C_SOURCE 200112L
-
-#endif // __linux__
-
 #include <algorithm>
 #include <cassert>
 #include <fcntl.h>
@@ -44,7 +34,6 @@
 
 #include <codecvt>
 
-#include <io.h> /* for _commit */
 #include <shellapi.h>
 #include <shlobj.h>
 #endif
@@ -71,78 +60,6 @@ const char * const BITCOIN_CONF_FILENAME = "bitcoin.conf";
 const char * const BITCOIN_SETTINGS_FILENAME = "settings.json";
 
 ArgsManager gArgs;
-
-/** Mutex to protect dir_locks. */
-static GlobalMutex cs_dir_locks;
-/** A map that contains all the currently held directory locks. After
- * successful locking, these will be held here until the global destructor
- * cleans them up and thus automatically unlocks them, or ReleaseDirectoryLocks
- * is called.
- */
-static std::map<std::string, std::unique_ptr<fsbridge::FileLock>> dir_locks GUARDED_BY(cs_dir_locks);
-
-bool LockDirectory(const fs::path& directory, const fs::path& lockfile_name, bool probe_only)
-{
-    LOCK(cs_dir_locks);
-    fs::path pathLockFile = directory / lockfile_name;
-
-    // If a lock for this directory already exists in the map, don't try to re-lock it
-    if (dir_locks.count(fs::PathToString(pathLockFile))) {
-        return true;
-    }
-
-    // Create empty lock file if it doesn't exist.
-    FILE* file = fsbridge::fopen(pathLockFile, "a");
-    if (file) fclose(file);
-    auto lock = std::make_unique<fsbridge::FileLock>(pathLockFile);
-    if (!lock->TryLock()) {
-        return error("Error while attempting to lock directory %s: %s", fs::PathToString(directory), lock->GetReason());
-    }
-    if (!probe_only) {
-        // Lock successful and we're not just probing, put it into the map
-        dir_locks.emplace(fs::PathToString(pathLockFile), std::move(lock));
-    }
-    return true;
-}
-
-void UnlockDirectory(const fs::path& directory, const fs::path& lockfile_name)
-{
-    LOCK(cs_dir_locks);
-    dir_locks.erase(fs::PathToString(directory / lockfile_name));
-}
-
-void ReleaseDirectoryLocks()
-{
-    LOCK(cs_dir_locks);
-    dir_locks.clear();
-}
-
-bool DirIsWritable(const fs::path& directory)
-{
-    fs::path tmpFile = GetUniquePath(directory);
-
-    FILE* file = fsbridge::fopen(tmpFile, "a");
-    if (!file) return false;
-
-    fclose(file);
-    remove(tmpFile);
-
-    return true;
-}
-
-bool CheckDiskSpace(const fs::path& dir, uint64_t additional_bytes)
-{
-    constexpr uint64_t min_disk_space = 52428800; // 50 MiB
-
-    uint64_t free_bytes_available = fs::space(dir).available;
-    return free_bytes_available >= min_disk_space + additional_bytes;
-}
-
-std::streampos GetFileSize(const char* path, std::streamsize max) {
-    std::ifstream file{path, std::ios::binary};
-    file.ignore(max);
-    return file.gcount();
-}
 
 /**
  * Interpret a string argument as a boolean.
@@ -1091,182 +1008,6 @@ void ArgsManager::LogArgs() const
     logArgsPrefix("Command-line arg:", "", m_settings.command_line_options);
 }
 
-bool RenameOver(fs::path src, fs::path dest)
-{
-#ifdef __MINGW64__
-    // This is a workaround for a bug in libstdc++ which
-    // implements std::filesystem::rename with _wrename function.
-    // This bug has been fixed in upstream:
-    //  - GCC 10.3: 8dd1c1085587c9f8a21bb5e588dfe1e8cdbba79e
-    //  - GCC 11.1: 1dfd95f0a0ca1d9e6cbc00e6cbfd1fa20a98f312
-    // For more details see the commits mentioned above.
-    return MoveFileExW(src.wstring().c_str(), dest.wstring().c_str(),
-                       MOVEFILE_REPLACE_EXISTING) != 0;
-#else
-    std::error_code error;
-    fs::rename(src, dest, error);
-    return !error;
-#endif
-}
-
-/**
- * Ignores exceptions thrown by create_directories if the requested directory exists.
- * Specifically handles case where path p exists, but it wasn't possible for the user to
- * write to the parent directory.
- */
-bool TryCreateDirectories(const fs::path& p)
-{
-    try
-    {
-        return fs::create_directories(p);
-    } catch (const fs::filesystem_error&) {
-        if (!fs::exists(p) || !fs::is_directory(p))
-            throw;
-    }
-
-    // create_directories didn't create the directory, it had to have existed already
-    return false;
-}
-
-bool FileCommit(FILE *file)
-{
-    if (fflush(file) != 0) { // harmless if redundantly called
-        LogPrintf("%s: fflush failed: %d\n", __func__, errno);
-        return false;
-    }
-#ifdef WIN32
-    HANDLE hFile = (HANDLE)_get_osfhandle(_fileno(file));
-    if (FlushFileBuffers(hFile) == 0) {
-        LogPrintf("%s: FlushFileBuffers failed: %d\n", __func__, GetLastError());
-        return false;
-    }
-#elif defined(MAC_OSX) && defined(F_FULLFSYNC)
-    if (fcntl(fileno(file), F_FULLFSYNC, 0) == -1) { // Manpage says "value other than -1" is returned on success
-        LogPrintf("%s: fcntl F_FULLFSYNC failed: %d\n", __func__, errno);
-        return false;
-    }
-#elif HAVE_FDATASYNC
-    if (fdatasync(fileno(file)) != 0 && errno != EINVAL) { // Ignore EINVAL for filesystems that don't support sync
-        LogPrintf("%s: fdatasync failed: %d\n", __func__, errno);
-        return false;
-    }
-#else
-    if (fsync(fileno(file)) != 0 && errno != EINVAL) {
-        LogPrintf("%s: fsync failed: %d\n", __func__, errno);
-        return false;
-    }
-#endif
-    return true;
-}
-
-void DirectoryCommit(const fs::path &dirname)
-{
-#ifndef WIN32
-    FILE* file = fsbridge::fopen(dirname, "r");
-    if (file) {
-        fsync(fileno(file));
-        fclose(file);
-    }
-#endif
-}
-
-bool TruncateFile(FILE *file, unsigned int length) {
-#if defined(WIN32)
-    return _chsize(_fileno(file), length) == 0;
-#else
-    return ftruncate(fileno(file), length) == 0;
-#endif
-}
-
-/**
- * this function tries to raise the file descriptor limit to the requested number.
- * It returns the actual file descriptor limit (which may be more or less than nMinFD)
- */
-int RaiseFileDescriptorLimit(int nMinFD) {
-#if defined(WIN32)
-    return 2048;
-#else
-    struct rlimit limitFD;
-    if (getrlimit(RLIMIT_NOFILE, &limitFD) != -1) {
-        if (limitFD.rlim_cur < (rlim_t)nMinFD) {
-            limitFD.rlim_cur = nMinFD;
-            if (limitFD.rlim_cur > limitFD.rlim_max)
-                limitFD.rlim_cur = limitFD.rlim_max;
-            setrlimit(RLIMIT_NOFILE, &limitFD);
-            getrlimit(RLIMIT_NOFILE, &limitFD);
-        }
-        return limitFD.rlim_cur;
-    }
-    return nMinFD; // getrlimit failed, assume it's fine
-#endif
-}
-
-/**
- * this function tries to make a particular range of a file allocated (corresponding to disk space)
- * it is advisory, and the range specified in the arguments will never contain live data
- */
-void AllocateFileRange(FILE *file, unsigned int offset, unsigned int length) {
-#if defined(WIN32)
-    // Windows-specific version
-    HANDLE hFile = (HANDLE)_get_osfhandle(_fileno(file));
-    LARGE_INTEGER nFileSize;
-    int64_t nEndPos = (int64_t)offset + length;
-    nFileSize.u.LowPart = nEndPos & 0xFFFFFFFF;
-    nFileSize.u.HighPart = nEndPos >> 32;
-    SetFilePointerEx(hFile, nFileSize, 0, FILE_BEGIN);
-    SetEndOfFile(hFile);
-#elif defined(MAC_OSX)
-    // OSX specific version
-    // NOTE: Contrary to other OS versions, the OSX version assumes that
-    // NOTE: offset is the size of the file.
-    fstore_t fst;
-    fst.fst_flags = F_ALLOCATECONTIG;
-    fst.fst_posmode = F_PEOFPOSMODE;
-    fst.fst_offset = 0;
-    fst.fst_length = length; // mac os fst_length takes the # of free bytes to allocate, not desired file size
-    fst.fst_bytesalloc = 0;
-    if (fcntl(fileno(file), F_PREALLOCATE, &fst) == -1) {
-        fst.fst_flags = F_ALLOCATEALL;
-        fcntl(fileno(file), F_PREALLOCATE, &fst);
-    }
-    ftruncate(fileno(file), static_cast<off_t>(offset) + length);
-#else
-    #if defined(HAVE_POSIX_FALLOCATE)
-    // Version using posix_fallocate
-    off_t nEndPos = (off_t)offset + length;
-    if (0 == posix_fallocate(fileno(file), 0, nEndPos)) return;
-    #endif
-    // Fallback version
-    // TODO: just write one byte per block
-    static const char buf[65536] = {};
-    if (fseek(file, offset, SEEK_SET)) {
-        return;
-    }
-    while (length > 0) {
-        unsigned int now = 65536;
-        if (length < now)
-            now = length;
-        fwrite(buf, 1, now, file); // allowed to fail; this function is advisory anyway
-        length -= now;
-    }
-#endif
-}
-
-#ifdef WIN32
-fs::path GetSpecialFolderPath(int nFolder, bool fCreate)
-{
-    WCHAR pszPath[MAX_PATH] = L"";
-
-    if(SHGetSpecialFolderPathW(nullptr, pszPath, nFolder, fCreate))
-    {
-        return fs::path(pszPath);
-    }
-
-    LogPrintf("SHGetSpecialFolderPathW() failed, could not obtain requested path.\n");
-    return fs::path("");
-}
-#endif
-
 #ifndef WIN32
 std::string ShellEscape(const std::string& arg)
 {
@@ -1289,7 +1030,6 @@ void runCommand(const std::string& strCommand)
         LogPrintf("runCommand error: system(%s) returned %d\n", strCommand, nErr);
 }
 #endif
-
 
 void SetupEnvironment()
 {

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -42,55 +42,9 @@ extern const char * const BITCOIN_SETTINGS_FILENAME;
 
 void SetupEnvironment();
 bool SetupNetworking();
-
-/**
- * Ensure file contents are fully committed to disk, using a platform-specific
- * feature analogous to fsync().
- */
-bool FileCommit(FILE *file);
-
-/**
- * Sync directory contents. This is required on some environments to ensure that
- * newly created files are committed to disk.
- */
-void DirectoryCommit(const fs::path &dirname);
-
-bool TruncateFile(FILE *file, unsigned int length);
-int RaiseFileDescriptorLimit(int nMinFD);
-void AllocateFileRange(FILE *file, unsigned int offset, unsigned int length);
-
-/**
- * Rename src to dest.
- * @return true if the rename was successful.
- */
-[[nodiscard]] bool RenameOver(fs::path src, fs::path dest);
-
-bool LockDirectory(const fs::path& directory, const fs::path& lockfile_name, bool probe_only=false);
-void UnlockDirectory(const fs::path& directory, const fs::path& lockfile_name);
-bool DirIsWritable(const fs::path& directory);
-bool CheckDiskSpace(const fs::path& dir, uint64_t additional_bytes = 0);
-
-/** Get the size of a file by scanning it.
- *
- * @param[in] path The file path
- * @param[in] max Stop seeking beyond this limit
- * @return The file size or max
- */
-std::streampos GetFileSize(const char* path, std::streamsize max = std::numeric_limits<std::streamsize>::max());
-
-/** Release all directory locks. This is used for unit testing only, at runtime
- * the global destructor will take care of the locks.
- */
-void ReleaseDirectoryLocks();
-
-bool TryCreateDirectories(const fs::path& p);
-fs::path GetDefaultDataDir();
 // Return true if -datadir option points to a valid directory or is not specified.
 bool CheckDataDirOption(const ArgsManager& args);
 fs::path GetConfigFile(const ArgsManager& args, const fs::path& configuration_file_path);
-#ifdef WIN32
-fs::path GetSpecialFolderPath(int nFolder, bool fCreate = true);
-#endif
 #ifndef WIN32
 std::string ShellEscape(const std::string& arg);
 #endif

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -14,11 +14,11 @@
 #include <config/bitcoin-config.h>
 #endif
 
-#include <compat/compat.h>
 #include <compat/assumptions.h>
-#include <fs.h>
+#include <compat/compat.h>
 #include <logging.h>
 #include <sync.h>
+#include <util/fs.h>
 #include <util/settings.h>
 #include <util/time.h>
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -19,7 +19,6 @@
 #include <consensus/validation.h>
 #include <cuckoocache.h>
 #include <flatfile.h>
-#include <fs.h>
 #include <hash.h>
 #include <kernel/chainparams.h>
 #include <kernel/mempool_entry.h>
@@ -46,6 +45,7 @@
 #include <uint256.h>
 #include <undo.h>
 #include <util/check.h> // For NDEBUG compile time check
+#include <util/fs.h>
 #include <util/fs_helpers.h>
 #include <util/hasher.h>
 #include <util/moneystr.h>

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -46,6 +46,7 @@
 #include <uint256.h>
 #include <undo.h>
 #include <util/check.h> // For NDEBUG compile time check
+#include <util/fs_helpers.h>
 #include <util/hasher.h>
 #include <util/moneystr.h>
 #include <util/rbf.h>

--- a/src/validation.h
+++ b/src/validation.h
@@ -15,7 +15,6 @@
 #include <chain.h>
 #include <consensus/amount.h>
 #include <deploymentstatus.h>
-#include <fs.h>
 #include <kernel/chainparams.h>
 #include <kernel/chainstatemanager_opts.h>
 #include <kernel/cs_main.h> // IWYU pragma: export
@@ -30,6 +29,7 @@
 #include <txmempool.h> // For CTxMemPool::cs
 #include <uint256.h>
 #include <util/check.h>
+#include <util/fs.h>
 #include <util/hasher.h>
 #include <util/translation.h>
 #include <versionbits.h>

--- a/src/wallet/bdb.cpp
+++ b/src/wallet/bdb.cpp
@@ -4,7 +4,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <compat/compat.h>
-#include <fs.h>
+#include <util/fs.h>
 #include <wallet/bdb.h>
 #include <wallet/db.h>
 

--- a/src/wallet/bdb.cpp
+++ b/src/wallet/bdb.cpp
@@ -9,6 +9,7 @@
 #include <wallet/db.h>
 
 #include <util/check.h>
+#include <util/fs_helpers.h>
 #include <util/strencodings.h>
 #include <util/translation.h>
 

--- a/src/wallet/bdb.h
+++ b/src/wallet/bdb.h
@@ -7,9 +7,9 @@
 #define BITCOIN_WALLET_BDB_H
 
 #include <clientversion.h>
-#include <fs.h>
 #include <serialize.h>
 #include <streams.h>
+#include <util/fs.h>
 #include <util/system.h>
 #include <wallet/db.h>
 

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -4,8 +4,8 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chainparams.h>
-#include <fs.h>
 #include <logging.h>
+#include <util/fs.h>
 #include <util/system.h>
 #include <wallet/db.h>
 

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -7,9 +7,9 @@
 #define BITCOIN_WALLET_DB_H
 
 #include <clientversion.h>
-#include <fs.h>
 #include <streams.h>
 #include <support/allocators/secure.h>
+#include <util/fs.h>
 
 #include <atomic>
 #include <memory>

--- a/src/wallet/dump.cpp
+++ b/src/wallet/dump.cpp
@@ -4,7 +4,7 @@
 
 #include <wallet/dump.h>
 
-#include <fs.h>
+#include <util/fs.h>
 #include <util/system.h>
 #include <util/translation.h>
 #include <wallet/wallet.h>

--- a/src/wallet/dump.h
+++ b/src/wallet/dump.h
@@ -5,7 +5,7 @@
 #ifndef BITCOIN_WALLET_DUMP_H
 #define BITCOIN_WALLET_DUMP_H
 
-#include <fs.h>
+#include <util/fs.h>
 
 #include <string>
 #include <vector>

--- a/src/wallet/load.cpp
+++ b/src/wallet/load.cpp
@@ -5,10 +5,10 @@
 
 #include <wallet/load.h>
 
-#include <fs.h>
 #include <interfaces/chain.h>
 #include <scheduler.h>
 #include <util/check.h>
+#include <util/fs.h>
 #include <util/string.h>
 #include <util/system.h>
 #include <util/translation.h>

--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -5,7 +5,6 @@
 #include <chain.h>
 #include <clientversion.h>
 #include <core_io.h>
-#include <fs.h>
 #include <hash.h>
 #include <interfaces/chain.h>
 #include <key_io.h>
@@ -17,6 +16,7 @@
 #include <sync.h>
 #include <uint256.h>
 #include <util/bip32.h>
+#include <util/fs.h>
 #include <util/time.h>
 #include <util/translation.h>
 #include <wallet/rpc/util.h>

--- a/src/wallet/salvage.cpp
+++ b/src/wallet/salvage.cpp
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <fs.h>
 #include <streams.h>
+#include <util/fs.h>
 #include <util/translation.h>
 #include <wallet/bdb.h>
 #include <wallet/salvage.h>

--- a/src/wallet/salvage.h
+++ b/src/wallet/salvage.h
@@ -6,8 +6,8 @@
 #ifndef BITCOIN_WALLET_SALVAGE_H
 #define BITCOIN_WALLET_SALVAGE_H
 
-#include <fs.h>
 #include <streams.h>
+#include <util/fs.h>
 
 class ArgsManager;
 struct bilingual_str;

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -8,8 +8,8 @@
 #include <crypto/common.h>
 #include <logging.h>
 #include <sync.h>
+#include <util/fs_helpers.h>
 #include <util/strencodings.h>
-#include <util/system.h>
 #include <util/translation.h>
 #include <wallet/db.h>
 

--- a/src/wallet/test/db_tests.cpp
+++ b/src/wallet/test/db_tests.cpp
@@ -4,8 +4,8 @@
 
 #include <boost/test/unit_test.hpp>
 
-#include <fs.h>
 #include <test/util/setup_common.h>
+#include <util/fs.h>
 #include <wallet/bdb.h>
 
 #include <fstream>

--- a/src/wallet/test/init_test_fixture.cpp
+++ b/src/wallet/test/init_test_fixture.cpp
@@ -2,9 +2,9 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <fs.h>
 #include <univalue.h>
 #include <util/check.h>
+#include <util/fs.h>
 #include <util/system.h>
 
 #include <fstream>

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -32,6 +32,7 @@
 #include <util/check.h>
 #include <util/error.h>
 #include <util/fees.h>
+#include <util/fs_helpers.h>
 #include <util/moneystr.h>
 #include <util/rbf.h>
 #include <util/string.h>
@@ -39,8 +40,8 @@
 #include <util/translation.h>
 #include <wallet/coincontrol.h>
 #include <wallet/context.h>
-#include <wallet/fees.h>
 #include <wallet/external_signer_scriptpubkeyman.h>
+#include <wallet/fees.h>
 
 #include <univalue.h>
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -11,7 +11,6 @@
 #include <consensus/consensus.h>
 #include <consensus/validation.h>
 #include <external_signer.h>
-#include <fs.h>
 #include <interfaces/chain.h>
 #include <interfaces/wallet.h>
 #include <key.h>
@@ -32,6 +31,7 @@
 #include <util/check.h>
 #include <util/error.h>
 #include <util/fees.h>
+#include <util/fs.h>
 #include <util/fs_helpers.h>
 #include <util/moneystr.h>
 #include <util/rbf.h>

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -7,7 +7,6 @@
 #define BITCOIN_WALLET_WALLET_H
 
 #include <consensus/amount.h>
-#include <fs.h>
 #include <interfaces/chain.h>
 #include <interfaces/handler.h>
 #include <logging.h>
@@ -15,6 +14,7 @@
 #include <policy/feerate.h>
 #include <psbt.h>
 #include <tinyformat.h>
+#include <util/fs.h>
 #include <util/hasher.h>
 #include <util/message.h>
 #include <util/result.h>

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -5,12 +5,12 @@
 
 #include <wallet/walletdb.h>
 
-#include <fs.h>
 #include <key_io.h>
 #include <protocol.h>
 #include <serialize.h>
 #include <sync.h>
 #include <util/bip32.h>
+#include <util/fs.h>
 #include <util/system.h>
 #include <util/time.h>
 #include <util/translation.h>

--- a/src/wallet/wallettool.cpp
+++ b/src/wallet/wallettool.cpp
@@ -8,7 +8,7 @@
 
 #include <wallet/wallettool.h>
 
-#include <fs.h>
+#include <util/fs.h>
 #include <util/system.h>
 #include <util/translation.h>
 #include <wallet/dump.h>

--- a/src/wallet/walletutil.h
+++ b/src/wallet/walletutil.h
@@ -5,8 +5,8 @@
 #ifndef BITCOIN_WALLET_WALLETUTIL_H
 #define BITCOIN_WALLET_WALLETUTIL_H
 
-#include <fs.h>
 #include <script/descriptor.h>
+#include <util/fs.h>
 
 #include <vector>
 


### PR DESCRIPTION
This pull request is part of the `libbitcoinkernel` project https://github.com/bitcoin/bitcoin/issues/24303 https://github.com/bitcoin/bitcoin/projects/18 and more specifically its "Step 2: Decouple most non-consensus code from libbitcoinkernel". This commit was originally authored by empact and is taken from its parent PR #25152.

#### Context

There is an ongoing effort to decouple the `ArgsManager` used for command line parsing user-provided arguments from the libbitcoinkernel library (https://github.com/bitcoin/bitcoin/pull/25290, https://github.com/bitcoin/bitcoin/pull/25487, https://github.com/bitcoin/bitcoin/pull/25527, https://github.com/bitcoin/bitcoin/pull/25862, https://github.com/bitcoin/bitcoin/pull/26177, and https://github.com/bitcoin/bitcoin/pull/27125). The `ArgsManager` is defined in `system.h`. A similar pull request extracting functionality from `system.h` has been merged in https://github.com/bitcoin/bitcoin/pull/27238.

#### Changes

Next to providing better code organization, this PR removes some reliance of the tree of libbitcoinkernel header includes on `system.h` (and thus the `ArgsManager` definition) by moving filesystem related functions out of the `system.*` files. 

There is already a pair of `fs.h` / `fs.cpp` in the top-level `src/` directory. They were not combined with the files introduced here, to keep the patch cleaner and more importantly because they are often included without the utility functions. The new files are therefore named `fs_helpers` and the existing `fs` files are moved into the util directory.

Further commits splitting more functionality out of `system.h` are still in #25152 and will be submitted in separate PRs once this PR has been processed.