### PR TITLE
Enhanced error messages for invalid network prefix during address parsing.

### DIFF
--- a/src/bech32.cpp
+++ b/src/bech32.cpp
@@ -399,27 +399,28 @@ DecodeResult Decode(const std::string& str, CharLimit limit) {
     return {result, std::move(hrp), data(values.begin(), values.end() - CHECKSUM_SIZE)};
 }
 
-/** Find index of an incorrect character in a Bech32 string. */
-std::pair<std::string, std::vector<int>> LocateErrors(const std::string& str, CharLimit limit) {
+/** Classify and locate errors in a Bech32(m) string. */
+LocateErrorsResult LocateErrors(const std::string& str, CharLimit limit)
+{
     std::vector<int> error_locations{};
 
     if (str.size() > limit) {
         error_locations.resize(str.size() - limit);
         std::iota(error_locations.begin(), error_locations.end(), static_cast<int>(limit));
-        return std::make_pair("Bech32 string too long", std::move(error_locations));
+        return {Error::TOO_LONG, std::move(error_locations)};
     }
 
-    if (!CheckCharacters(str, error_locations)){
-        return std::make_pair("Invalid character or mixed case", std::move(error_locations));
+    if (!CheckCharacters(str, error_locations)) {
+        return {Error::INVALID_CHARS_OR_MIXED_CASE, std::move(error_locations)};
     }
 
     size_t pos = str.rfind(SEPARATOR);
     if (pos == str.npos) {
-        return std::make_pair("Missing separator", std::vector<int>{});
+        return {Error::MISSING_SEPARATOR, {}};
     }
     if (pos == 0 || pos + CHECKSUM_SIZE >= str.size()) {
         error_locations.push_back(pos);
-        return std::make_pair("Invalid separator position", std::move(error_locations));
+        return {Error::INVALID_SEPARATOR_POSITION, std::move(error_locations)};
     }
 
     std::string hrp;
@@ -435,7 +436,7 @@ std::pair<std::string, std::vector<int>> LocateErrors(const std::string& str, Ch
         int8_t rev = CHARSET_REV[c];
         if (rev == -1) {
             error_locations.push_back(i);
-            return std::make_pair("Invalid Base 32 character", std::move(error_locations));
+            return {Error::INVALID_BASE32_CHAR, std::move(error_locations)};
         }
         values[i - pos - 1] = rev;
     }
@@ -556,7 +557,7 @@ std::pair<std::string, std::vector<int>> LocateErrors(const std::string& str, Ch
             }
         } else {
             // No errors
-            return std::make_pair("", std::vector<int>{});
+            return {Error::NONE, {}};
         }
 
         if (error_locations.empty() || (!possible_errors.empty() && possible_errors.size() < error_locations.size())) {
@@ -564,11 +565,11 @@ std::pair<std::string, std::vector<int>> LocateErrors(const std::string& str, Ch
             if (!error_locations.empty()) error_encoding = encoding;
         }
     }
-    std::string error_message = error_encoding == Encoding::BECH32M ? "Invalid Bech32m checksum"
-                              : error_encoding == Encoding::BECH32 ? "Invalid Bech32 checksum"
-                              : "Invalid checksum";
+    const Error error{error_encoding == Encoding::BECH32M ? Error::INVALID_BECH32M_CHECKSUM :
+                      error_encoding == Encoding::BECH32  ? Error::INVALID_BECH32_CHECKSUM :
+                                                            Error::INVALID_CHECKSUM};
 
-    return std::make_pair(error_message, std::move(error_locations));
+    return {error, std::move(error_locations)};
 }
 
 } // namespace bech32

--- a/src/bech32.h
+++ b/src/bech32.h
@@ -58,8 +58,26 @@ struct DecodeResult
 /** Decode a Bech32 or Bech32m string. */
 DecodeResult Decode(const std::string& str, CharLimit limit = CharLimit::BECH32);
 
-/** Return the positions of errors in a Bech32 string. */
-std::pair<std::string, std::vector<int>> LocateErrors(const std::string& str, CharLimit limit = CharLimit::BECH32);
+/** Error codes describing how a Bech32(m) string is invalid, as detected by LocateErrors. */
+enum class Error {
+    NONE,                        //!< No error
+    TOO_LONG,                    //!< String exceeds the character limit
+    INVALID_CHARS_OR_MIXED_CASE, //!< Invalid character(s), or mixed uppercase and lowercase
+    MISSING_SEPARATOR,           //!< No separator character present
+    INVALID_SEPARATOR_POSITION,  //!< Separator at the start, or too close to the end
+    INVALID_BASE32_CHAR,         //!< Character in the data section not in the Bech32 character set
+    INVALID_CHECKSUM,            //!< Checksum invalid under both Bech32 and Bech32m rules
+    INVALID_BECH32_CHECKSUM,     //!< Checksum invalid, fewest errors found under Bech32 rules
+    INVALID_BECH32M_CHECKSUM,    //!< Checksum invalid, fewest errors found under Bech32m rules
+};
+
+struct LocateErrorsResult {
+    Error error;                //!< The detected error; Error::NONE if there is none.
+    std::vector<int> locations; //!< Character positions of the error(s); may be empty.
+};
+
+/** Classify and locate errors in a Bech32(m) string. The caller decides how to present the error. */
+LocateErrorsResult LocateErrors(const std::string& str, CharLimit limit = CharLimit::BECH32);
 
 } // namespace bech32
 

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -180,6 +180,9 @@ public:
         base58Prefixes[EXT_PUBLIC_KEY] = {0x04, 0x88, 0xB2, 0x1E};
         base58Prefixes[EXT_SECRET_KEY] = {0x04, 0x88, 0xAD, 0xE4};
 
+        base58EncodedPrefixes[PUBKEY_ADDRESS] = {"1"};
+        base58EncodedPrefixes[SCRIPT_ADDRESS] = {"3"};
+
         bech32_hrp = "bc";
 
         vFixedSeeds = std::vector<uint8_t>(std::begin(chainparams_seed_main), std::end(chainparams_seed_main));
@@ -295,6 +298,9 @@ public:
         base58Prefixes[EXT_PUBLIC_KEY] = {0x04, 0x35, 0x87, 0xCF};
         base58Prefixes[EXT_SECRET_KEY] = {0x04, 0x35, 0x83, 0x94};
 
+        base58EncodedPrefixes[PUBKEY_ADDRESS] = {"m", "n"};
+        base58EncodedPrefixes[SCRIPT_ADDRESS] = {"2"};
+
         bech32_hrp = "tb";
 
         vFixedSeeds = std::vector<uint8_t>(std::begin(chainparams_seed_test), std::end(chainparams_seed_test));
@@ -401,6 +407,9 @@ public:
         base58Prefixes[SECRET_KEY] =     std::vector<unsigned char>(1,239);
         base58Prefixes[EXT_PUBLIC_KEY] = {0x04, 0x35, 0x87, 0xCF};
         base58Prefixes[EXT_SECRET_KEY] = {0x04, 0x35, 0x83, 0x94};
+
+        base58EncodedPrefixes[PUBKEY_ADDRESS] = {"m", "n"};
+        base58EncodedPrefixes[SCRIPT_ADDRESS] = {"2"};
 
         bech32_hrp = "tb";
 
@@ -545,6 +554,9 @@ public:
         base58Prefixes[EXT_PUBLIC_KEY] = {0x04, 0x35, 0x87, 0xCF};
         base58Prefixes[EXT_SECRET_KEY] = {0x04, 0x35, 0x83, 0x94};
 
+        base58EncodedPrefixes[PUBKEY_ADDRESS] = {"m", "n"};
+        base58EncodedPrefixes[SCRIPT_ADDRESS] = {"2"};
+
         bech32_hrp = "tb";
 
         fDefaultConsistencyChecks = false;
@@ -652,6 +664,9 @@ public:
         base58Prefixes[SECRET_KEY] =     std::vector<unsigned char>(1,239);
         base58Prefixes[EXT_PUBLIC_KEY] = {0x04, 0x35, 0x87, 0xCF};
         base58Prefixes[EXT_SECRET_KEY] = {0x04, 0x35, 0x83, 0x94};
+
+        base58EncodedPrefixes[PUBKEY_ADDRESS] = {"m", "n"};
+        base58EncodedPrefixes[SCRIPT_ADDRESS] = {"2"};
 
         bech32_hrp = "bcrt";
 

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -179,6 +179,12 @@ public:
         base58Prefixes[EXT_PUBLIC_KEY] = {0x04, 0x88, 0xB2, 0x1E};
         base58Prefixes[EXT_SECRET_KEY] = {0x04, 0x88, 0xAD, 0xE4};
 
+        base58PrefixText[PUBKEY_ADDRESS] = {"1"};
+        base58PrefixText[SCRIPT_ADDRESS] = {"3"};
+        base58PrefixText[SECRET_KEY] = {"5", "K", "L"};
+        base58PrefixText[EXT_PUBLIC_KEY] = {"xpub"};
+        base58PrefixText[EXT_SECRET_KEY] = {"xprv"};
+
         bech32_hrp = "bc";
 
         vFixedSeeds = std::vector<uint8_t>(std::begin(chainparams_seed_main), std::end(chainparams_seed_main));
@@ -293,6 +299,12 @@ public:
         base58Prefixes[EXT_PUBLIC_KEY] = {0x04, 0x35, 0x87, 0xCF};
         base58Prefixes[EXT_SECRET_KEY] = {0x04, 0x35, 0x83, 0x94};
 
+        base58PrefixText[PUBKEY_ADDRESS] = {"m", "n"};
+        base58PrefixText[SCRIPT_ADDRESS] = {"2"};
+        base58PrefixText[SECRET_KEY] = {"9", "c"};
+        base58PrefixText[EXT_PUBLIC_KEY] = {"tpub"};
+        base58PrefixText[EXT_SECRET_KEY] = {"tprv"};
+
         bech32_hrp = "tb";
 
         vFixedSeeds = std::vector<uint8_t>(std::begin(chainparams_seed_test), std::end(chainparams_seed_test));
@@ -399,6 +411,12 @@ public:
         base58Prefixes[SECRET_KEY] =     std::vector<unsigned char>(1,239);
         base58Prefixes[EXT_PUBLIC_KEY] = {0x04, 0x35, 0x87, 0xCF};
         base58Prefixes[EXT_SECRET_KEY] = {0x04, 0x35, 0x83, 0x94};
+
+        base58PrefixText[PUBKEY_ADDRESS] = {"m", "n"};
+        base58PrefixText[SCRIPT_ADDRESS] = {"2"};
+        base58PrefixText[SECRET_KEY] = {"9", "c"};
+        base58PrefixText[EXT_PUBLIC_KEY] = {"tpub"};
+        base58PrefixText[EXT_SECRET_KEY] = {"tprv"};
 
         bech32_hrp = "tb";
 
@@ -543,6 +561,12 @@ public:
         base58Prefixes[EXT_PUBLIC_KEY] = {0x04, 0x35, 0x87, 0xCF};
         base58Prefixes[EXT_SECRET_KEY] = {0x04, 0x35, 0x83, 0x94};
 
+        base58PrefixText[PUBKEY_ADDRESS] = {"m", "n"};
+        base58PrefixText[SCRIPT_ADDRESS] = {"2"};
+        base58PrefixText[SECRET_KEY] = {"9", "c"};
+        base58PrefixText[EXT_PUBLIC_KEY] = {"tpub"};
+        base58PrefixText[EXT_SECRET_KEY] = {"tprv"};
+
         bech32_hrp = "tb";
 
         fDefaultConsistencyChecks = false;
@@ -650,6 +674,12 @@ public:
         base58Prefixes[SECRET_KEY] =     std::vector<unsigned char>(1,239);
         base58Prefixes[EXT_PUBLIC_KEY] = {0x04, 0x35, 0x87, 0xCF};
         base58Prefixes[EXT_SECRET_KEY] = {0x04, 0x35, 0x83, 0x94};
+
+        base58PrefixText[PUBKEY_ADDRESS] = {"m", "n"};
+        base58PrefixText[SCRIPT_ADDRESS] = {"2"};
+        base58PrefixText[SECRET_KEY] = {"9", "c"};
+        base58PrefixText[EXT_PUBLIC_KEY] = {"tpub"};
+        base58PrefixText[EXT_SECRET_KEY] = {"tprv"};
 
         bech32_hrp = "bcrt";
 

--- a/src/kernel/chainparams.h
+++ b/src/kernel/chainparams.h
@@ -19,6 +19,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 
@@ -112,6 +113,7 @@ public:
     /** Return the list of hostnames to look up for DNS seeds */
     const std::vector<std::string>& DNSSeeds() const { return vSeeds; }
     const std::vector<unsigned char>& Base58Prefix(Base58Type type) const { return base58Prefixes[type]; }
+    const std::vector<std::string_view>& Base58EncodedPrefix(Base58Type type) const { return base58EncodedPrefixes[type]; }
     const std::string& Bech32HRP() const { return bech32_hrp; }
     const std::vector<uint8_t>& FixedSeeds() const { return vFixedSeeds; }
     const HeadersSyncParams& HeadersSync() const { return m_headers_sync_params; }
@@ -189,6 +191,7 @@ protected:
     uint64_t m_assumed_chain_state_size;
     std::vector<std::string> vSeeds;
     std::vector<unsigned char> base58Prefixes[MAX_BASE58_TYPES];
+    std::vector<std::string_view> base58EncodedPrefixes[MAX_BASE58_TYPES];
     std::string bech32_hrp;
     ChainType m_chain_type;
     CBlock genesis;

--- a/src/kernel/chainparams.h
+++ b/src/kernel/chainparams.h
@@ -112,6 +112,8 @@ public:
     /** Return the list of hostnames to look up for DNS seeds */
     const std::vector<std::string>& DNSSeeds() const { return vSeeds; }
     const std::vector<unsigned char>& Base58Prefix(Base58Type type) const { return base58Prefixes[type]; }
+    /** Human-readable leading characters (e.g. "1", "xpub") of base58-encoded strings for this role on this network. */
+    const std::vector<std::string>& Base58PrefixText(Base58Type type) const { return base58PrefixText[type]; }
     const std::string& Bech32HRP() const { return bech32_hrp; }
     const std::vector<uint8_t>& FixedSeeds() const { return vFixedSeeds; }
     const HeadersSyncParams& HeadersSync() const { return m_headers_sync_params; }
@@ -189,6 +191,7 @@ protected:
     uint64_t m_assumed_chain_state_size;
     std::vector<std::string> vSeeds;
     std::vector<unsigned char> base58Prefixes[MAX_BASE58_TYPES];
+    std::vector<std::string> base58PrefixText[MAX_BASE58_TYPES];
     std::string bech32_hrp;
     ChainType m_chain_type;
     CBlock genesis;

--- a/src/key_io.cpp
+++ b/src/key_io.cpp
@@ -185,27 +185,50 @@ CTxDestination DecodeDestination(const std::string& str, const CChainParams& par
                 std::equal(pubkey_prefix.begin(), pubkey_prefix.end(), data.begin()))) {
             error_str = "Invalid length for Base58 address (P2PKH or P2SH)";
         } else {
-            error_str = "Invalid or unsupported Base58-encoded address.";
+            std::vector<std::string_view> encoded_prefixes;
+            const std::vector<std::string_view>& pubkey_prefixes = params.Base58EncodedPrefix(CChainParams::PUBKEY_ADDRESS);
+            const std::vector<std::string_view>& script_prefixes = params.Base58EncodedPrefix(CChainParams::SCRIPT_ADDRESS);
+            encoded_prefixes.insert(encoded_prefixes.end(), script_prefixes.begin(), script_prefixes.end());
+            encoded_prefixes.insert(encoded_prefixes.end(), pubkey_prefixes.begin(), pubkey_prefixes.end());
+
+            std::string base58_address_prefixes;
+            for (size_t i = 0; i < encoded_prefixes.size(); ++i) {
+                if (i > 0) {
+                    base58_address_prefixes += (i == encoded_prefixes.size() - 1) ? ", or " : ", ";
+                }
+                base58_address_prefixes += std::string(encoded_prefixes[i]);
+            }
+            error_str = strprintf("Invalid Base58 address. Expected prefix %s", base58_address_prefixes);
         }
         return CNoDestination();
     } else {
-        // Try Base58 decoding without the checksum, using a much larger max length
-        bool is_base58 = DecodeBase58(str, data, 100);
+        std::string str_lower = ToLower(str);
+        bool is_mixed_case = (str_lower != str && ToUpper(str) != str);
+        auto [bech32_error, bech32_error_loc] = bech32::LocateErrors(str);
 
-        // Perform Bech32 error location with a larger limit to handle longer strings
-        auto res = bech32::LocateErrors(str, bech32::CharLimit(std::max(str.size(), size_t(90))));
-
-        if (!is_base58 && !res.first.empty()) {
-            // Not valid Base58 and we have a Bech32 error
-            error_str = "Bech32 address decoded with error: " + res.first;
-            if (error_locations) *error_locations = std::move(res.second);
-        } else if (is_base58) {
-            // Valid Base58 characters but invalid checksum
-            error_str = "Invalid checksum or length of Base58 address (P2PKH or P2SH)";
-        } else {
-            // Fallback error
-            error_str = "Invalid or unsupported Segwit (Bech32) or Base58 encoding.";
+        // Attempt bech32 read as lower if case is mixed, fall through if decode isn't mixed
+        if (bech32_error == "Invalid character or mixed case" && is_mixed_case) {
+            auto [bech32_encoding, _bech32_hrp, _bech32_chars] = bech32::Decode(str_lower );
+            if (bech32_encoding != bech32::Encoding::INVALID) {
+                error_str = "Bech32 address is mixed case";
+                if (error_locations) {
+                    *error_locations = std::move(bech32_error_loc);
+                }
+                return CNoDestination();
+            }
         }
+        // Try Base58 decoding without the checksum, using a much larger max length
+        if (!DecodeBase58(str, data, 100)) {
+            // If bech32 decoding failed due to invalid base32 chars, address format is ambiguous; otherwise, report bech32 error
+            bool invalidBech32Chars = (bech32_error == "Invalid Base 32 character");
+            error_str = invalidBech32Chars ? "Address is not valid Base58 or Bech32" : "Bech32 address decoded with error: " + bech32_error;
+            if (error_locations) {
+                *error_locations = std::move(bech32_error_loc);
+            }
+        } else {
+            error_str = bech32_error.find("checksum") != std::string::npos ? "Invalid checksum" : "Invalid checksum or length of Base58 address (P2PKH or P2SH)";
+        }
+
         return CNoDestination();
     }
 }

--- a/src/key_io.cpp
+++ b/src/key_io.cpp
@@ -84,15 +84,85 @@ public:
 
 CTxDestination DecodeDestination(const std::string& str, const CChainParams& params, std::string& error_str, std::vector<int>* error_locations)
 {
-    std::vector<unsigned char> data;
-    uint160 hash;
     error_str = "";
+    std::vector<unsigned char> data, bech32_data;
+    auto [bech32_encoding, bech32_hrp, bech32_chars] = bech32::Decode(str);
 
-    // Note this will be false if it is a valid Bech32 address for a different network
-    bool is_bech32 = (ToLower(str.substr(0, params.Bech32HRP().size())) == params.Bech32HRP());
+    if (bech32_encoding == bech32::Encoding::BECH32 || bech32_encoding == bech32::Encoding::BECH32M) {
+        if (bech32_chars.empty()) {
+            error_str = "Empty Bech32 data section";
+            return CNoDestination();
+        }
+        // Bech32 decoding
+        if (bech32_hrp != params.Bech32HRP()) {
+            error_str = strprintf("Invalid or unsupported prefix for Segwit (Bech32) address (expected %s, got %s)", params.Bech32HRP(), bech32_hrp);
+            return CNoDestination();
+        }
+        int version = bech32_chars[0]; // The first 5 bit symbol is the witness version (0-16)
+        if (version == 0 && bech32_encoding != bech32::Encoding::BECH32) {
+            error_str = "Version 0 witness address must use Bech32 checksum";
+            return CNoDestination();
+        }
+        if (version != 0 && bech32_encoding != bech32::Encoding::BECH32M) {
+            error_str = "Version 1+ witness address must use Bech32m checksum";
+            return CNoDestination();
+        }
+        // The rest of the symbols are converted witness program bytes.
+        bech32_data.reserve(((bech32_chars.size() - 1) * 5) / 8);
+        if (ConvertBits<5, 8, false>([&](unsigned char c) { bech32_data.push_back(c); }, bech32_chars.begin() + 1, bech32_chars.end())) {
 
-    if (!is_bech32 && DecodeBase58Check(str, data, 21)) {
-        // base58-encoded Bitcoin addresses.
+            std::string_view byte_str{bech32_data.size() == 1 ? "byte" : "bytes"};
+
+            if (version == 0) {
+                {
+                    WitnessV0KeyHash keyid;
+                    if (bech32_data.size() == keyid.size()) {
+                        std::copy(bech32_data.begin(), bech32_data.end(), keyid.begin());
+                        return keyid;
+                    }
+                }
+                {
+                    WitnessV0ScriptHash scriptid;
+                    if (bech32_data.size() == scriptid.size()) {
+                        std::copy(bech32_data.begin(), bech32_data.end(), scriptid.begin());
+                        return scriptid;
+                    }
+                }
+
+                error_str = strprintf("Invalid SegWit v0 address program size (%d %s), per BIP141", bech32_data.size(), byte_str);
+                return CNoDestination();
+            }
+
+            if (version == 1 && bech32_data.size() == WITNESS_V1_TAPROOT_SIZE) {
+                static_assert(WITNESS_V1_TAPROOT_SIZE == WitnessV1Taproot::size());
+                WitnessV1Taproot tap;
+                std::copy(bech32_data.begin(), bech32_data.end(), tap.begin());
+                return tap;
+            }
+
+            if (CScript::IsPayToAnchor(version, bech32_data)) {
+                return PayToAnchor();
+            }
+
+            if (version > 16) {
+                error_str = "Invalid Bech32 address witness version";
+                return CNoDestination();
+            }
+
+            if (bech32_data.size() < 2 || bech32_data.size() > BECH32_WITNESS_PROG_MAX_LEN) {
+                error_str = strprintf("Invalid Bech32 address program size (%d %s)", bech32_data.size(), byte_str);
+                return CNoDestination();
+            }
+
+            return WitnessUnknown{version, bech32_data};
+        } else {
+            error_str = strprintf("Invalid padding in Bech32 data section");
+            return CNoDestination();
+        }
+    }
+
+    if (DecodeBase58Check(str, data, 21)) {
+        uint160 hash;        // base58-encoded Bitcoin addresses.
         // Public-key-hash-addresses have version 0 (or 111 testnet).
         // The data vector contains RIPEMD160(SHA256(pubkey)), where pubkey is the serialized public key.
         const std::vector<unsigned char>& pubkey_prefix = params.Base58Prefix(CChainParams::PUBKEY_ADDRESS);
@@ -118,96 +188,26 @@ CTxDestination DecodeDestination(const std::string& str, const CChainParams& par
             error_str = "Invalid or unsupported Base58-encoded address.";
         }
         return CNoDestination();
-    } else if (!is_bech32) {
+    } else {
         // Try Base58 decoding without the checksum, using a much larger max length
-        if (!DecodeBase58(str, data, 100)) {
-            error_str = "Invalid or unsupported Segwit (Bech32) or Base58 encoding.";
-        } else {
+        bool is_base58 = DecodeBase58(str, data, 100);
+
+        // Perform Bech32 error location with a larger limit to handle longer strings
+        auto res = bech32::LocateErrors(str, bech32::CharLimit(std::max(str.size(), size_t(90))));
+
+        if (!is_base58 && !res.first.empty()) {
+            // Not valid Base58 and we have a Bech32 error
+            error_str = "Bech32 address decoded with error: " + res.first;
+            if (error_locations) *error_locations = std::move(res.second);
+        } else if (is_base58) {
+            // Valid Base58 characters but invalid checksum
             error_str = "Invalid checksum or length of Base58 address (P2PKH or P2SH)";
+        } else {
+            // Fallback error
+            error_str = "Invalid or unsupported Segwit (Bech32) or Base58 encoding.";
         }
         return CNoDestination();
     }
-
-    data.clear();
-    const auto dec = bech32::Decode(str);
-    if (dec.encoding == bech32::Encoding::BECH32 || dec.encoding == bech32::Encoding::BECH32M) {
-        if (dec.data.empty()) {
-            error_str = "Empty Bech32 data section";
-            return CNoDestination();
-        }
-        // Bech32 decoding
-        if (dec.hrp != params.Bech32HRP()) {
-            error_str = strprintf("Invalid or unsupported prefix for Segwit (Bech32) address (expected %s, got %s).", params.Bech32HRP(), dec.hrp);
-            return CNoDestination();
-        }
-        int version = dec.data[0]; // The first 5 bit symbol is the witness version (0-16)
-        if (version == 0 && dec.encoding != bech32::Encoding::BECH32) {
-            error_str = "Version 0 witness address must use Bech32 checksum";
-            return CNoDestination();
-        }
-        if (version != 0 && dec.encoding != bech32::Encoding::BECH32M) {
-            error_str = "Version 1+ witness address must use Bech32m checksum";
-            return CNoDestination();
-        }
-        // The rest of the symbols are converted witness program bytes.
-        data.reserve(((dec.data.size() - 1) * 5) / 8);
-        if (ConvertBits<5, 8, false>([&](unsigned char c) { data.push_back(c); }, dec.data.begin() + 1, dec.data.end())) {
-
-            std::string_view byte_str{data.size() == 1 ? "byte" : "bytes"};
-
-            if (version == 0) {
-                {
-                    WitnessV0KeyHash keyid;
-                    if (data.size() == keyid.size()) {
-                        std::copy(data.begin(), data.end(), keyid.begin());
-                        return keyid;
-                    }
-                }
-                {
-                    WitnessV0ScriptHash scriptid;
-                    if (data.size() == scriptid.size()) {
-                        std::copy(data.begin(), data.end(), scriptid.begin());
-                        return scriptid;
-                    }
-                }
-
-                error_str = strprintf("Invalid Bech32 v0 address program size (%d %s), per BIP141", data.size(), byte_str);
-                return CNoDestination();
-            }
-
-            if (version == 1 && data.size() == WITNESS_V1_TAPROOT_SIZE) {
-                static_assert(WITNESS_V1_TAPROOT_SIZE == WitnessV1Taproot::size());
-                WitnessV1Taproot tap;
-                std::copy(data.begin(), data.end(), tap.begin());
-                return tap;
-            }
-
-            if (CScript::IsPayToAnchor(version, data)) {
-                return PayToAnchor();
-            }
-
-            if (version > 16) {
-                error_str = "Invalid Bech32 address witness version";
-                return CNoDestination();
-            }
-
-            if (data.size() < 2 || data.size() > BECH32_WITNESS_PROG_MAX_LEN) {
-                error_str = strprintf("Invalid Bech32 address program size (%d %s)", data.size(), byte_str);
-                return CNoDestination();
-            }
-
-            return WitnessUnknown{version, data};
-        } else {
-            error_str = strprintf("Invalid padding in Bech32 data section");
-            return CNoDestination();
-        }
-    }
-
-    // Perform Bech32 error location
-    auto res = bech32::LocateErrors(str);
-    error_str = res.first;
-    if (error_locations) *error_locations = std::move(res.second);
-    return CNoDestination();
 }
 } // namespace
 

--- a/src/key_io.cpp
+++ b/src/key_io.cpp
@@ -209,20 +209,12 @@ CTxDestination DecodeDestination(const std::string& str, const CChainParams& par
 {
     error_str = "";
 
-    // Note this will be false if it is a valid Bech32 address for a different network
-    const bool is_bech32 = (ToLower(str.substr(0, params.Bech32HRP().size())) == params.Bech32HRP());
-
-    if (is_bech32) {
-        const auto dec = bech32::Decode(str);
-        if (dec.encoding == bech32::Encoding::BECH32 || dec.encoding == bech32::Encoding::BECH32M) {
-            return DecodeBech32Destination(dec, params, error_str);
-        }
-
-        // Perform Bech32 error location
-        auto [error, locations] = bech32::LocateErrors(str);
-        error_str = Bech32ErrorMessage(error);
-        if (error_locations) *error_locations = std::move(locations);
-        return CNoDestination();
+    // Try Bech32(m) first: checking the prefix before decoding would misroute valid
+    // Bech32 addresses for other networks to the Base58 decoder, producing the
+    // misleading "Invalid or unsupported Segwit (Bech32) or Base58 encoding." error.
+    const auto dec = bech32::Decode(str);
+    if (dec.encoding == bech32::Encoding::BECH32 || dec.encoding == bech32::Encoding::BECH32M) {
+        return DecodeBech32Destination(dec, params, error_str);
     }
 
     std::vector<unsigned char> data;
@@ -230,11 +222,20 @@ CTxDestination DecodeDestination(const std::string& str, const CChainParams& par
         return DecodeBase58Destination(data, params, error_str);
     }
 
-    // Try Base58 decoding without the checksum, using a much larger max length
-    if (!DecodeBase58(str, data, 100)) {
-        error_str = "Invalid or unsupported Segwit (Bech32) or Base58 encoding.";
-    } else {
+    // Neither Bech32 nor Base58Check decoding succeeded. Unless the input already rules
+    // out Bech32 (invalid character or mixed case), report the specific Bech32 error.
+    // Otherwise, try Base58 decoding without the checksum, using a much larger max length.
+    // Strings beyond the 90-character BIP173 limit cannot be Bech32 addresses, so if one
+    // still raw-decodes as Base58 (e.g. an extended key), report the Base58 error.
+    auto [error, locations] = bech32::LocateErrors(str);
+    const bool is_base58{DecodeBase58(str, data, 100)};
+    const bool maybe_bech32{error != bech32::Error::INVALID_CHARS_OR_MIXED_CASE &&
+                            !(error == bech32::Error::TOO_LONG && is_base58)};
+    if (!maybe_bech32 && is_base58) {
         error_str = "Invalid checksum or length of Base58 address (P2PKH or P2SH)";
+    } else {
+        error_str = Bech32ErrorMessage(error);
+        if (error_locations) *error_locations = std::move(locations);
     }
     return CNoDestination();
 }

--- a/src/key_io.cpp
+++ b/src/key_io.cpp
@@ -140,7 +140,7 @@ CTxDestination DecodeBech32Destination(const bech32::DecodeResult& dec, const CC
     }
     // Bech32 decoding
     if (dec.hrp != params.Bech32HRP()) {
-        error_str = strprintf("Invalid or unsupported prefix for Segwit (Bech32) address (expected %s, got %s).", params.Bech32HRP(), dec.hrp);
+        error_str = strprintf("Invalid or unsupported prefix for Segwit (Bech32) address (expected %s, got %s)", params.Bech32HRP(), dec.hrp);
         return CNoDestination();
     }
     int version = dec.data[0]; // The first 5 bit symbol is the witness version (0-16)
@@ -173,7 +173,7 @@ CTxDestination DecodeBech32Destination(const bech32::DecodeResult& dec, const CC
                 }
             }
 
-            error_str = strprintf("Invalid Bech32 v0 address program size (%d %s), per BIP141", data.size(), byte_str);
+            error_str = strprintf("Invalid SegWit v0 address program size (%d %s), per BIP141", data.size(), byte_str);
             return CNoDestination();
         }
 
@@ -233,18 +233,23 @@ CTxDestination DecodeDestination(const std::string& str, const CChainParams& par
     }
 
     // Neither Bech32 nor Base58Check decoding succeeded. Unless the input already rules
-    // out Bech32 (invalid character or mixed case), report the specific Bech32 error.
-    // Otherwise, try Base58 decoding without the checksum, using a much larger max length.
-    // Strings beyond the 90-character BIP173 limit cannot be Bech32 addresses, so if one
-    // still raw-decodes as Base58 (e.g. an extended key), report the Base58 error.
+    // out Bech32 (invalid character or mixed case), report the specific Bech32 error and
+    // its locations. Otherwise, the Base58 checksum or length must be wrong if the string
+    // still raw-decodes as Base58; if not, the format is ambiguous. Strings beyond the
+    // 90-character BIP173 limit cannot be Bech32 addresses, so one that still raw-decodes
+    // as Base58 (e.g. an extended key) is diagnosed as Base58 even though LocateErrors
+    // reports it as too long.
     auto [error, locations] = bech32::LocateErrors(str);
     const bool is_base58{DecodeBase58(str, data, 100)};
     const bool maybe_bech32{error != bech32::Error::INVALID_CHARS_OR_MIXED_CASE &&
                             !(error == bech32::Error::TOO_LONG && is_base58)};
-    if (!maybe_bech32 && is_base58) {
+    if (maybe_bech32) {
+        error_str = "Bech32 address decoded with error: " + Bech32ErrorMessage(error);
+        if (error_locations) *error_locations = std::move(locations);
+    } else if (is_base58) {
         error_str = "Invalid checksum or length of Base58 address (P2PKH or P2SH)";
     } else {
-        error_str = Bech32ErrorMessage(error);
+        error_str = "Address is not valid Base58 or Bech32";
         if (error_locations) *error_locations = std::move(locations);
     }
     return CNoDestination();

--- a/src/key_io.cpp
+++ b/src/key_io.cpp
@@ -82,6 +82,23 @@ public:
     std::string operator()(const PubKeyDestination& pk) const { return {}; }
 };
 
+/** Translate a Bech32 decoding error code into a user-facing message. */
+std::string Bech32ErrorMessage(bech32::Error error)
+{
+    switch (error) {
+    case bech32::Error::NONE: return "";
+    case bech32::Error::TOO_LONG: return "Bech32 string too long";
+    case bech32::Error::INVALID_CHARS_OR_MIXED_CASE: return "Invalid character or mixed case";
+    case bech32::Error::MISSING_SEPARATOR: return "Missing separator";
+    case bech32::Error::INVALID_SEPARATOR_POSITION: return "Invalid separator position";
+    case bech32::Error::INVALID_BASE32_CHAR: return "Invalid Base 32 character";
+    case bech32::Error::INVALID_CHECKSUM: return "Invalid checksum";
+    case bech32::Error::INVALID_BECH32_CHECKSUM: return "Invalid Bech32 checksum";
+    case bech32::Error::INVALID_BECH32M_CHECKSUM: return "Invalid Bech32m checksum";
+    }
+    assert(false);
+}
+
 CTxDestination DecodeDestination(const std::string& str, const CChainParams& params, std::string& error_str, std::vector<int>* error_locations)
 {
     std::vector<unsigned char> data;
@@ -204,9 +221,9 @@ CTxDestination DecodeDestination(const std::string& str, const CChainParams& par
     }
 
     // Perform Bech32 error location
-    auto res = bech32::LocateErrors(str);
-    error_str = res.first;
-    if (error_locations) *error_locations = std::move(res.second);
+    auto [error, locations] = bech32::LocateErrors(str);
+    error_str = Bech32ErrorMessage(error);
+    if (error_locations) *error_locations = std::move(locations);
     return CNoDestination();
 }
 } // namespace

--- a/src/key_io.cpp
+++ b/src/key_io.cpp
@@ -212,8 +212,18 @@ CTxDestination DecodeDestination(const std::string& str, const CChainParams& par
     // Try Bech32(m) first: checking the prefix before decoding would misroute valid
     // Bech32 addresses for other networks to the Base58 decoder, producing the
     // misleading "Invalid or unsupported Segwit (Bech32) or Base58 encoding." error.
-    const auto dec = bech32::Decode(str);
+    // Decode a lowercased copy so that mixed-case input (which is invalid) can be
+    // diagnosed without decoding twice; all-lowercase and all-uppercase are both valid.
+    const std::string lower_str{ToLower(str)};
+    const auto dec = bech32::Decode(lower_str);
     if (dec.encoding == bech32::Encoding::BECH32 || dec.encoding == bech32::Encoding::BECH32M) {
+        const bool has_upper{std::ranges::any_of(str, [](char c) { return c >= 'A' && c <= 'Z'; })};
+        const bool has_lower{std::ranges::any_of(str, [](char c) { return c >= 'a' && c <= 'z'; })};
+        if (has_upper && has_lower) {
+            error_str = "Bech32 address is mixed case";
+            if (error_locations) *error_locations = bech32::LocateErrors(str).locations;
+            return CNoDestination();
+        }
         return DecodeBech32Destination(dec, params, error_str);
     }
 

--- a/src/key_io.cpp
+++ b/src/key_io.cpp
@@ -99,131 +99,143 @@ std::string Bech32ErrorMessage(bech32::Error error)
     assert(false);
 }
 
-CTxDestination DecodeDestination(const std::string& str, const CChainParams& params, std::string& error_str, std::vector<int>* error_locations)
+CTxDestination DecodeBase58Destination(const std::vector<unsigned char>& data, const CChainParams& params, std::string& error_str)
+{
+    uint160 hash;
+    // base58-encoded Bitcoin addresses.
+    // Public-key-hash-addresses have version 0 (or 111 testnet).
+    // The data vector contains RIPEMD160(SHA256(pubkey)), where pubkey is the serialized public key.
+    const std::vector<unsigned char>& pubkey_prefix = params.Base58Prefix(CChainParams::PUBKEY_ADDRESS);
+    if (data.size() == hash.size() + pubkey_prefix.size() && std::equal(pubkey_prefix.begin(), pubkey_prefix.end(), data.begin())) {
+        std::copy(data.begin() + pubkey_prefix.size(), data.end(), hash.begin());
+        return PKHash(hash);
+    }
+    // Script-hash-addresses have version 5 (or 196 testnet).
+    // The data vector contains RIPEMD160(SHA256(cscript)), where cscript is the serialized redemption script.
+    const std::vector<unsigned char>& script_prefix = params.Base58Prefix(CChainParams::SCRIPT_ADDRESS);
+    if (data.size() == hash.size() + script_prefix.size() && std::equal(script_prefix.begin(), script_prefix.end(), data.begin())) {
+        std::copy(data.begin() + script_prefix.size(), data.end(), hash.begin());
+        return ScriptHash(hash);
+    }
+
+    // If the prefix of data matches either the script or pubkey prefix, the length must have been wrong
+    if ((data.size() >= script_prefix.size() &&
+         std::equal(script_prefix.begin(), script_prefix.end(), data.begin())) ||
+        (data.size() >= pubkey_prefix.size() &&
+         std::equal(pubkey_prefix.begin(), pubkey_prefix.end(), data.begin()))) {
+        error_str = "Invalid length for Base58 address (P2PKH or P2SH)";
+    } else {
+        error_str = "Invalid or unsupported Base58-encoded address.";
+    }
+    return CNoDestination();
+}
+
+CTxDestination DecodeBech32Destination(const bech32::DecodeResult& dec, const CChainParams& params, std::string& error_str)
 {
     std::vector<unsigned char> data;
-    uint160 hash;
+
+    if (dec.data.empty()) {
+        error_str = "Empty Bech32 data section";
+        return CNoDestination();
+    }
+    // Bech32 decoding
+    if (dec.hrp != params.Bech32HRP()) {
+        error_str = strprintf("Invalid or unsupported prefix for Segwit (Bech32) address (expected %s, got %s).", params.Bech32HRP(), dec.hrp);
+        return CNoDestination();
+    }
+    int version = dec.data[0]; // The first 5 bit symbol is the witness version (0-16)
+    if (version == 0 && dec.encoding != bech32::Encoding::BECH32) {
+        error_str = "Version 0 witness address must use Bech32 checksum";
+        return CNoDestination();
+    }
+    if (version != 0 && dec.encoding != bech32::Encoding::BECH32M) {
+        error_str = "Version 1+ witness address must use Bech32m checksum";
+        return CNoDestination();
+    }
+    // The rest of the symbols are converted witness program bytes.
+    data.reserve(((dec.data.size() - 1) * 5) / 8);
+    if (ConvertBits<5, 8, false>([&](unsigned char c) { data.push_back(c); }, dec.data.begin() + 1, dec.data.end())) {
+        std::string_view byte_str{data.size() == 1 ? "byte" : "bytes"};
+
+        if (version == 0) {
+            {
+                WitnessV0KeyHash keyid;
+                if (data.size() == keyid.size()) {
+                    std::copy(data.begin(), data.end(), keyid.begin());
+                    return keyid;
+                }
+            }
+            {
+                WitnessV0ScriptHash scriptid;
+                if (data.size() == scriptid.size()) {
+                    std::copy(data.begin(), data.end(), scriptid.begin());
+                    return scriptid;
+                }
+            }
+
+            error_str = strprintf("Invalid Bech32 v0 address program size (%d %s), per BIP141", data.size(), byte_str);
+            return CNoDestination();
+        }
+
+        if (version == 1 && data.size() == WITNESS_V1_TAPROOT_SIZE) {
+            static_assert(WITNESS_V1_TAPROOT_SIZE == WitnessV1Taproot::size());
+            WitnessV1Taproot tap;
+            std::copy(data.begin(), data.end(), tap.begin());
+            return tap;
+        }
+
+        if (CScript::IsPayToAnchor(version, data)) {
+            return PayToAnchor();
+        }
+
+        if (version > 16) {
+            error_str = "Invalid Bech32 address witness version";
+            return CNoDestination();
+        }
+
+        if (data.size() < 2 || data.size() > BECH32_WITNESS_PROG_MAX_LEN) {
+            error_str = strprintf("Invalid Bech32 address program size (%d %s)", data.size(), byte_str);
+            return CNoDestination();
+        }
+
+        return WitnessUnknown{version, data};
+    } else {
+        error_str = strprintf("Invalid padding in Bech32 data section");
+        return CNoDestination();
+    }
+}
+
+CTxDestination DecodeDestination(const std::string& str, const CChainParams& params, std::string& error_str, std::vector<int>* error_locations)
+{
     error_str = "";
 
     // Note this will be false if it is a valid Bech32 address for a different network
-    bool is_bech32 = (ToLower(str.substr(0, params.Bech32HRP().size())) == params.Bech32HRP());
+    const bool is_bech32 = (ToLower(str.substr(0, params.Bech32HRP().size())) == params.Bech32HRP());
 
-    if (!is_bech32 && DecodeBase58Check(str, data, 21)) {
-        // base58-encoded Bitcoin addresses.
-        // Public-key-hash-addresses have version 0 (or 111 testnet).
-        // The data vector contains RIPEMD160(SHA256(pubkey)), where pubkey is the serialized public key.
-        const std::vector<unsigned char>& pubkey_prefix = params.Base58Prefix(CChainParams::PUBKEY_ADDRESS);
-        if (data.size() == hash.size() + pubkey_prefix.size() && std::equal(pubkey_prefix.begin(), pubkey_prefix.end(), data.begin())) {
-            std::copy(data.begin() + pubkey_prefix.size(), data.end(), hash.begin());
-            return PKHash(hash);
-        }
-        // Script-hash-addresses have version 5 (or 196 testnet).
-        // The data vector contains RIPEMD160(SHA256(cscript)), where cscript is the serialized redemption script.
-        const std::vector<unsigned char>& script_prefix = params.Base58Prefix(CChainParams::SCRIPT_ADDRESS);
-        if (data.size() == hash.size() + script_prefix.size() && std::equal(script_prefix.begin(), script_prefix.end(), data.begin())) {
-            std::copy(data.begin() + script_prefix.size(), data.end(), hash.begin());
-            return ScriptHash(hash);
+    if (is_bech32) {
+        const auto dec = bech32::Decode(str);
+        if (dec.encoding == bech32::Encoding::BECH32 || dec.encoding == bech32::Encoding::BECH32M) {
+            return DecodeBech32Destination(dec, params, error_str);
         }
 
-        // If the prefix of data matches either the script or pubkey prefix, the length must have been wrong
-        if ((data.size() >= script_prefix.size() &&
-                std::equal(script_prefix.begin(), script_prefix.end(), data.begin())) ||
-            (data.size() >= pubkey_prefix.size() &&
-                std::equal(pubkey_prefix.begin(), pubkey_prefix.end(), data.begin()))) {
-            error_str = "Invalid length for Base58 address (P2PKH or P2SH)";
-        } else {
-            error_str = "Invalid or unsupported Base58-encoded address.";
-        }
-        return CNoDestination();
-    } else if (!is_bech32) {
-        // Try Base58 decoding without the checksum, using a much larger max length
-        if (!DecodeBase58(str, data, 100)) {
-            error_str = "Invalid or unsupported Segwit (Bech32) or Base58 encoding.";
-        } else {
-            error_str = "Invalid checksum or length of Base58 address (P2PKH or P2SH)";
-        }
+        // Perform Bech32 error location
+        auto [error, locations] = bech32::LocateErrors(str);
+        error_str = Bech32ErrorMessage(error);
+        if (error_locations) *error_locations = std::move(locations);
         return CNoDestination();
     }
 
-    data.clear();
-    const auto dec = bech32::Decode(str);
-    if (dec.encoding == bech32::Encoding::BECH32 || dec.encoding == bech32::Encoding::BECH32M) {
-        if (dec.data.empty()) {
-            error_str = "Empty Bech32 data section";
-            return CNoDestination();
-        }
-        // Bech32 decoding
-        if (dec.hrp != params.Bech32HRP()) {
-            error_str = strprintf("Invalid or unsupported prefix for Segwit (Bech32) address (expected %s, got %s).", params.Bech32HRP(), dec.hrp);
-            return CNoDestination();
-        }
-        int version = dec.data[0]; // The first 5 bit symbol is the witness version (0-16)
-        if (version == 0 && dec.encoding != bech32::Encoding::BECH32) {
-            error_str = "Version 0 witness address must use Bech32 checksum";
-            return CNoDestination();
-        }
-        if (version != 0 && dec.encoding != bech32::Encoding::BECH32M) {
-            error_str = "Version 1+ witness address must use Bech32m checksum";
-            return CNoDestination();
-        }
-        // The rest of the symbols are converted witness program bytes.
-        data.reserve(((dec.data.size() - 1) * 5) / 8);
-        if (ConvertBits<5, 8, false>([&](unsigned char c) { data.push_back(c); }, dec.data.begin() + 1, dec.data.end())) {
-
-            std::string_view byte_str{data.size() == 1 ? "byte" : "bytes"};
-
-            if (version == 0) {
-                {
-                    WitnessV0KeyHash keyid;
-                    if (data.size() == keyid.size()) {
-                        std::copy(data.begin(), data.end(), keyid.begin());
-                        return keyid;
-                    }
-                }
-                {
-                    WitnessV0ScriptHash scriptid;
-                    if (data.size() == scriptid.size()) {
-                        std::copy(data.begin(), data.end(), scriptid.begin());
-                        return scriptid;
-                    }
-                }
-
-                error_str = strprintf("Invalid Bech32 v0 address program size (%d %s), per BIP141", data.size(), byte_str);
-                return CNoDestination();
-            }
-
-            if (version == 1 && data.size() == WITNESS_V1_TAPROOT_SIZE) {
-                static_assert(WITNESS_V1_TAPROOT_SIZE == WitnessV1Taproot::size());
-                WitnessV1Taproot tap;
-                std::copy(data.begin(), data.end(), tap.begin());
-                return tap;
-            }
-
-            if (CScript::IsPayToAnchor(version, data)) {
-                return PayToAnchor();
-            }
-
-            if (version > 16) {
-                error_str = "Invalid Bech32 address witness version";
-                return CNoDestination();
-            }
-
-            if (data.size() < 2 || data.size() > BECH32_WITNESS_PROG_MAX_LEN) {
-                error_str = strprintf("Invalid Bech32 address program size (%d %s)", data.size(), byte_str);
-                return CNoDestination();
-            }
-
-            return WitnessUnknown{version, data};
-        } else {
-            error_str = strprintf("Invalid padding in Bech32 data section");
-            return CNoDestination();
-        }
+    std::vector<unsigned char> data;
+    if (DecodeBase58Check(str, data, 21)) {
+        return DecodeBase58Destination(data, params, error_str);
     }
 
-    // Perform Bech32 error location
-    auto [error, locations] = bech32::LocateErrors(str);
-    error_str = Bech32ErrorMessage(error);
-    if (error_locations) *error_locations = std::move(locations);
+    // Try Base58 decoding without the checksum, using a much larger max length
+    if (!DecodeBase58(str, data, 100)) {
+        error_str = "Invalid or unsupported Segwit (Bech32) or Base58 encoding.";
+    } else {
+        error_str = "Invalid checksum or length of Base58 address (P2PKH or P2SH)";
+    }
     return CNoDestination();
 }
 } // namespace

--- a/src/key_io.cpp
+++ b/src/key_io.cpp
@@ -11,6 +11,8 @@
 #include <tinyformat.h>
 #include <util/overflow.h>
 #include <util/strencodings.h>
+#include <util/string.h>
+#include <util/vector.h>
 
 #include <algorithm>
 #include <cassert>
@@ -125,7 +127,11 @@ CTxDestination DecodeBase58Destination(const std::vector<unsigned char>& data, c
          std::equal(pubkey_prefix.begin(), pubkey_prefix.end(), data.begin()))) {
         error_str = "Invalid length for Base58 address (P2PKH or P2SH)";
     } else {
-        error_str = "Invalid or unsupported Base58-encoded address.";
+        auto prefixes{Cat(params.Base58PrefixText(CChainParams::SCRIPT_ADDRESS),
+                          params.Base58PrefixText(CChainParams::PUBKEY_ADDRESS))};
+        const std::string last{std::move(prefixes.back())};
+        prefixes.pop_back();
+        error_str = strprintf("Invalid Base58 address. Expected prefix %s or %s", util::Join(prefixes, ", "), last);
     }
     return CNoDestination();
 }

--- a/src/test/bech32_tests.cpp
+++ b/src/test/bech32_tests.cpp
@@ -72,23 +72,23 @@ BOOST_AUTO_TEST_CASE(bech32_testvectors_invalid)
         "abcdef1qpzrz9x8gf2tvdw0s3jn54khce6mua7lmqqqxw",
         "test1zg69w7y6hn0aqy352euf40x77qddq3dc",
     };
-    static const std::pair<std::string, std::vector<int>> ERRORS[] = {
-        {"Invalid character or mixed case", {0}},
-        {"Invalid character or mixed case", {0}},
-        {"Invalid character or mixed case", {0}},
-        {"Bech32 string too long", {90}},
-        {"Missing separator", {}},
-        {"Invalid separator position", {0}},
-        {"Invalid Base 32 character", {2}},
-        {"Invalid separator position", {2}},
-        {"Invalid character or mixed case", {8}},
-        {"Invalid checksum", {}}, // The checksum is calculated using the uppercase form so the entire string is invalid, not just a few characters
-        {"Invalid separator position", {0}},
-        {"Invalid separator position", {0}},
-        {"Invalid character or mixed case", {3, 4, 5, 7}},
-        {"Invalid character or mixed case", {3}},
-        {"Invalid Bech32 checksum", {11}},
-        {"Invalid Bech32 checksum", {9, 16}},
+    static const std::pair<bech32::Error, std::vector<int>> ERRORS[] = {
+        {bech32::Error::INVALID_CHARS_OR_MIXED_CASE, {0}},
+        {bech32::Error::INVALID_CHARS_OR_MIXED_CASE, {0}},
+        {bech32::Error::INVALID_CHARS_OR_MIXED_CASE, {0}},
+        {bech32::Error::TOO_LONG, {90}},
+        {bech32::Error::MISSING_SEPARATOR, {}},
+        {bech32::Error::INVALID_SEPARATOR_POSITION, {0}},
+        {bech32::Error::INVALID_BASE32_CHAR, {2}},
+        {bech32::Error::INVALID_SEPARATOR_POSITION, {2}},
+        {bech32::Error::INVALID_CHARS_OR_MIXED_CASE, {8}},
+        {bech32::Error::INVALID_CHECKSUM, {}}, // The checksum is calculated using the uppercase form so the entire string is invalid, not just a few characters
+        {bech32::Error::INVALID_SEPARATOR_POSITION, {0}},
+        {bech32::Error::INVALID_SEPARATOR_POSITION, {0}},
+        {bech32::Error::INVALID_CHARS_OR_MIXED_CASE, {3, 4, 5, 7}},
+        {bech32::Error::INVALID_CHARS_OR_MIXED_CASE, {3}},
+        {bech32::Error::INVALID_BECH32_CHECKSUM, {11}},
+        {bech32::Error::INVALID_BECH32_CHECKSUM, {9, 16}},
     };
     static_assert(std::size(CASES) == std::size(ERRORS), "Bech32 CASES and ERRORS should have the same length");
 
@@ -97,8 +97,8 @@ BOOST_AUTO_TEST_CASE(bech32_testvectors_invalid)
         const auto& err = ERRORS[i];
         const auto dec = bech32::Decode(str);
         BOOST_CHECK(dec.encoding == bech32::Encoding::INVALID);
-        auto [error, error_locations] = bech32::LocateErrors(str);
-        BOOST_CHECK_EQUAL(err.first, error);
+        const auto [error, error_locations] = bech32::LocateErrors(str);
+        BOOST_CHECK(err.first == error);
         BOOST_CHECK(err.second == error_locations);
         i++;
     }
@@ -124,23 +124,23 @@ BOOST_AUTO_TEST_CASE(bech32m_testvectors_invalid)
         "abcdef1l7aum6echk45nj2s0wdvt2fg8x9yrzpqzd3ryx",
         "test1zg69v7y60n00qy352euf40x77qcusag6",
     };
-    static const std::pair<std::string, std::vector<int>> ERRORS[] = {
-        {"Invalid character or mixed case", {0}},
-        {"Invalid character or mixed case", {0}},
-        {"Invalid character or mixed case", {0}},
-        {"Bech32 string too long", {90}},
-        {"Missing separator", {}},
-        {"Invalid separator position", {0}},
-        {"Invalid Base 32 character", {2}},
-        {"Invalid Base 32 character", {3}},
-        {"Invalid separator position", {2}},
-        {"Invalid Base 32 character", {8}},
-        {"Invalid Base 32 character", {7}},
-        {"Invalid checksum", {}},
-        {"Invalid separator position", {0}},
-        {"Invalid separator position", {0}},
-        {"Invalid Bech32m checksum", {21}},
-        {"Invalid Bech32m checksum", {13, 32}},
+    static const std::pair<bech32::Error, std::vector<int>> ERRORS[] = {
+        {bech32::Error::INVALID_CHARS_OR_MIXED_CASE, {0}},
+        {bech32::Error::INVALID_CHARS_OR_MIXED_CASE, {0}},
+        {bech32::Error::INVALID_CHARS_OR_MIXED_CASE, {0}},
+        {bech32::Error::TOO_LONG, {90}},
+        {bech32::Error::MISSING_SEPARATOR, {}},
+        {bech32::Error::INVALID_SEPARATOR_POSITION, {0}},
+        {bech32::Error::INVALID_BASE32_CHAR, {2}},
+        {bech32::Error::INVALID_BASE32_CHAR, {3}},
+        {bech32::Error::INVALID_SEPARATOR_POSITION, {2}},
+        {bech32::Error::INVALID_BASE32_CHAR, {8}},
+        {bech32::Error::INVALID_BASE32_CHAR, {7}},
+        {bech32::Error::INVALID_CHECKSUM, {}},
+        {bech32::Error::INVALID_SEPARATOR_POSITION, {0}},
+        {bech32::Error::INVALID_SEPARATOR_POSITION, {0}},
+        {bech32::Error::INVALID_BECH32M_CHECKSUM, {21}},
+        {bech32::Error::INVALID_BECH32M_CHECKSUM, {13, 32}},
     };
     static_assert(std::size(CASES) == std::size(ERRORS), "Bech32m CASES and ERRORS should have the same length");
 
@@ -149,8 +149,8 @@ BOOST_AUTO_TEST_CASE(bech32m_testvectors_invalid)
         const auto& err = ERRORS[i];
         const auto dec = bech32::Decode(str);
         BOOST_CHECK(dec.encoding == bech32::Encoding::INVALID);
-        auto [error, error_locations] = bech32::LocateErrors(str);
-        BOOST_CHECK_EQUAL(err.first, error);
+        const auto [error, error_locations] = bech32::LocateErrors(str);
+        BOOST_CHECK(err.first == error);
         BOOST_CHECK(err.second == error_locations);
         i++;
     }

--- a/src/test/key_io_tests.cpp
+++ b/src/test/key_io_tests.cpp
@@ -2,12 +2,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <test/data/key_io_invalid.json.h>
-#include <test/data/key_io_valid.json.h>
-
+#include <kernel/chainparams.h>
 #include <key.h>
 #include <key_io.h>
 #include <script/script.h>
+#include <test/data/key_io_invalid.json.h>
+#include <test/data/key_io_valid.json.h>
 #include <test/util/json.h>
 #include <test/util/setup_common.h>
 #include <univalue.h>
@@ -17,6 +17,8 @@
 #include <boost/test/unit_test.hpp>
 
 #include <algorithm>
+#include <array>
+#include <utility>
 
 BOOST_FIXTURE_TEST_SUITE(key_io_tests, BasicTestingSetup)
 
@@ -145,6 +147,38 @@ BOOST_AUTO_TEST_CASE(key_io_invalid)
             BOOST_CHECK_MESSAGE(!privkey.IsValid(), "IsValid privkey in mainnet:" + strTest);
         }
     }
+}
+
+// Goal: check that each network's human-readable base58 prefixes match what
+// user-facing error messages (e.g. in DecodeDestination) will reference.
+BOOST_AUTO_TEST_CASE(base58_prefix_text)
+{
+    using Entry = std::pair<CChainParams::Base58Type, std::vector<std::string>>;
+    using Prefixes = std::array<Entry, CChainParams::MAX_BASE58_TYPES>;
+
+    const Prefixes mainnet{{{CChainParams::PUBKEY_ADDRESS, {"1"}},
+                            {CChainParams::SCRIPT_ADDRESS, {"3"}},
+                            {CChainParams::SECRET_KEY, {"5", "K", "L"}},
+                            {CChainParams::EXT_PUBLIC_KEY, {"xpub"}},
+                            {CChainParams::EXT_SECRET_KEY, {"xprv"}}}};
+    const Prefixes testnet{{{CChainParams::PUBKEY_ADDRESS, {"m", "n"}},
+                            {CChainParams::SCRIPT_ADDRESS, {"2"}},
+                            {CChainParams::SECRET_KEY, {"9", "c"}},
+                            {CChainParams::EXT_PUBLIC_KEY, {"tpub"}},
+                            {CChainParams::EXT_SECRET_KEY, {"tprv"}}}};
+
+    const auto check{[](const CChainParams& params, const Prefixes& expected) {
+        for (const auto& [type, values] : expected) {
+            const auto& actual{params.Base58PrefixText(type)};
+            BOOST_CHECK_EQUAL_COLLECTIONS(actual.begin(), actual.end(), values.begin(), values.end());
+        }
+    }};
+
+    check(*CChainParams::Main(), mainnet);
+    check(*CChainParams::TestNet(), testnet);
+    check(*CChainParams::TestNet4(), testnet);
+    check(*CChainParams::SigNet(), testnet);
+    check(*CChainParams::RegTest(), testnet);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/functional/data/rpc_validateaddress.json
+++ b/test/functional/data/rpc_validateaddress.json
@@ -1,0 +1,252 @@
+{
+  "invalid": {
+    "mainnet": [
+      {
+        "address": "tc1qw508d6qejxtdg4y5r3zarvary0c5xw7kg3g4ty",
+        "error": "Invalid or unsupported prefix for Segwit (Bech32) address (expected bc, got tc)",
+        "error_locations": [],
+        "comment": "Invalid hrp"
+      },
+      {
+        "address": "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t5",
+        "error": "Bech32 address decoded with error: Invalid Bech32 checksum",
+        "error_locations": [41],
+        "comment": null
+      },
+      {
+        "address": "BC13W508D6QEJXTDG4Y5R3ZARVARY0C5XW7KN40WF2",
+        "error": "Version 1+ witness address must use Bech32m checksum",
+        "error_locations": [],
+        "comment": null
+      },
+      {
+        "address": "bc1rw5uspcuh",
+        "error": "Version 1+ witness address must use Bech32m checksum",
+        "error_locations": [],
+        "comment": "Invalid program length"
+      },
+      {
+        "address": "bc10w508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kw5rljs90",
+        "error": "Version 1+ witness address must use Bech32m checksum",
+        "error_locations": [],
+        "comment": "Invalid program length"
+      },
+      {
+        "address": "BC1QR508D6QEJXTDG4Y5R3ZARVARYV98GJ9P",
+        "error": "Invalid SegWit v0 address program size (16 bytes), per BIP141",
+        "error_locations": [],
+        "comment": null
+      },
+      {
+        "address": "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sL5k7",
+        "error": "Bech32 address decoded with error: Invalid character or mixed case",
+        "error_locations": [58],
+        "comment": "tb1, Mixed case"
+      },
+      {
+        "address": "BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3t4",
+        "error": "Bech32 address decoded with error: Invalid character or mixed case",
+        "error_locations": [40],
+        "comment": "bc1, Mixed case, not in BIP 173 test vectors"
+      },
+      {
+        "address": "bc1zw508d6qejxtdg4y5r3zarvaryvqyzf3du",
+        "error": "Version 1+ witness address must use Bech32m checksum",
+        "error_locations": [],
+        "comment": "Wrong padding"
+      },
+      {
+        "address": "bc1qfysxzmfq2phhyarvv9hxgtjgdajxcw3fpkpph893lw",
+        "error": "Invalid padding in Bech32 data section",
+        "error_locations": [],
+        "comment": "tb1, Non-zero padding in 8-to-5 conversion"
+      },
+      {
+        "address": "bc1gmk9yu",
+        "error": "Empty Bech32 data section",
+        "error_locations": [],
+        "comment": null
+      },
+      {
+        "address": "tc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vq5zuyut",
+        "error": "Invalid or unsupported prefix for Segwit (Bech32) address (expected bc, got tc)",
+        "error_locations": [],
+        "comment": "Invalid human-readable part"
+      },
+      {
+        "address": "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqh2y7hd",
+        "error": "Version 1+ witness address must use Bech32m checksum",
+        "error_locations": [],
+        "comment": "Invalid checksum (Bech32 instead of Bech32m)"
+      },
+      {
+        "address": "BC1PFYSXZMFQ2PHHYARVV9HXGTJGFAZYCWJYPQQQF9ZLQ6",
+        "error": "Version 1+ witness address must use Bech32m checksum",
+        "error_locations": [],
+        "comment": "Invalid checksum (Bech32 instead of Bech32m)"
+      },
+      {
+        "address": "bc1qfysxzmfq2phhyarvv9hxgtjgfazycwjypqqqfm706a",
+        "error": "Version 0 witness address must use Bech32 checksum",
+        "error_locations": [],
+        "comment": "Invalid checksum (Bech32m instead of Bech32)"
+      },
+      {
+        "address": "Address is not valid Base58 or Bech32 ",
+        "error": "Bech32 address decoded with error: Invalid character or mixed case",
+        "error_locations": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 22, 23, 24, 27, 28, 29, 30, 32, 33, 34, 37],
+        "comment": "Invalid character in checksum"
+      },
+      {
+        "address": "BC130XLXVLHEMJA6C4DQV22UAPCTQUPFHLXM9H8Z3K2E72Q4K9HCZ7VQ7ZWS8R",
+        "error": "Invalid Bech32 address witness version",
+        "error_locations": [],
+        "comment": null
+      },
+      {
+        "address": "bc1pw5dgrnzv",
+        "error": "Invalid Bech32 address program size (1 byte)",
+        "error_locations": [],
+        "comment": null
+      },
+      {
+        "address": "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7v8n0nx0muaewav253zgeav",
+        "error": "Invalid Bech32 address program size (41 bytes)",
+        "error_locations": [],
+        "comment": null
+      },
+      {
+        "address": "BC1QR508D6QEJXTDG4Y5R3ZARVARYV98GJ9P",
+        "error": "Invalid SegWit v0 address program size (16 bytes), per BIP141",
+        "error_locations": [],
+        "comment": null
+      },
+      {
+        "address": "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7v07qwwzcrf",
+        "error": "Invalid padding in Bech32 data section",
+        "error_locations": [],
+        "comment": "zero padding of more than 4 bits"
+      },
+      {
+        "address": "bc1gmk9yu",
+        "error": "Empty Bech32 data section",
+        "error_locations": [],
+        "comment": null
+      }
+    ],
+    "signet": [
+      {
+        "address": "tc1qw508d6qejxtdg4y5r3zarvary0c5xw7kg3g4ty",
+        "error": "Invalid or unsupported prefix for Segwit (Bech32) address (expected tb, got tc)",
+        "error_locations": [],
+        "comment": "Invalid hrp"
+      },
+      {
+        "address": "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3pjxtptv",
+        "error": "Invalid padding in Bech32 data section",
+        "error_locations": [],
+        "comment": "tb1, Non-zero padding in 8-to-5 conversion"
+      },
+      {
+        "address": "tb1z0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqglt7rf",
+        "error": "Version 1+ witness address must use Bech32m checksum",
+        "error_locations": [],
+        "comment": "tb1, Invalid checksum (Bech32 instead of Bech32m)"
+      },
+      {
+        "address": "tb1q0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vq24jc47",
+        "error": "Version 0 witness address must use Bech32 checksum",
+        "error_locations": [],
+        "comment": "tb1, Invalid checksum (Bech32m instead of Bech32)"
+      },
+      {
+        "address": "tb1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vq47Zagq",
+        "error": "Bech32 address decoded with error: Invalid character or mixed case",
+        "error_locations": [58],
+        "comment": "tb1, Mixed case"
+      },
+      {
+        "address": "tb1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vpggkg4j",
+        "error": "Invalid padding in Bech32 data section",
+        "error_locations": [],
+        "comment": "tb1, Non-zero padding in 8-to-5 conversion"
+      }
+    ]
+  },
+  "valid": {
+    "mainnet": [
+      {
+        "address": "BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4",
+        "scriptPubKey": "0014751e76e8199196d454941c45d1b3a323f1433bd6",
+        "comment": null
+      },
+      {
+        "address": "bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3",
+        "scriptPubKey": "00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262",
+        "comment": null
+      },
+      {
+        "address": "bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kt5nd6y",
+        "scriptPubKey": "5128751e76e8199196d454941c45d1b3a323f1433bd6751e76e8199196d454941c45d1b3a323f1433bd6",
+        "comment": null
+      },
+      {
+        "address": "BC1SW50QGDZ25J",
+        "scriptPubKey": "6002751e",
+        "comment": null
+      },
+      {
+        "address": "bc1zw508d6qejxtdg4y5r3zarvaryvaxxpcs",
+        "scriptPubKey": "5210751e76e8199196d454941c45d1b3a323",
+        "comment": null
+      },
+      {
+        "address": "bc1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvses5wp4dt",
+        "scriptPubKey": "0020000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433",
+        "comment": null
+      },
+      {
+        "address": "bc1pqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvses7epu4h",
+        "scriptPubKey": "5120000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433",
+        "comment": null
+      },
+      {
+        "address": "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj0",
+        "scriptPubKey": "512079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+        "comment": null
+      },
+      {
+        "address": "bc1pfeessrawgf",
+        "scriptPubKey": "51024e73",
+        "comment": "PayToAnchor(P2A)"
+      }
+    ],
+    "signet": [
+      {
+        "address": "tb1pfees9rn5nz",
+        "scriptPubKey": "51024e73",
+        "comment": "PayToAnchor(P2A)"
+      },
+      {
+        "address": "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7",
+        "scriptPubKey": "00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262",
+        "comment": null
+      },
+      {
+        "address": "tb1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesrxh6hy",
+        "scriptPubKey": "0020000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433",
+        "comment": null
+      },
+      {
+        "address": "tb1pqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesf3hn0c",
+        "scriptPubKey": "5120000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433",
+        "comment": null
+      },
+      {
+        "address": "tb1pqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesf3hn0c",
+        "scriptPubKey": "5120000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433",
+        "comment": null
+      }
+    ]
+  }
+}

--- a/test/functional/data/rpc_validateaddress.json
+++ b/test/functional/data/rpc_validateaddress.json
@@ -39,13 +39,13 @@
       },
       {
         "address": "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sL5k7",
-        "error": "Bech32 address decoded with error: Invalid character or mixed case",
+        "error": "Bech32 address is mixed case",
         "error_locations": [58],
         "comment": "tb1, Mixed case"
       },
       {
         "address": "BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3t4",
-        "error": "Bech32 address decoded with error: Invalid character or mixed case",
+        "error": "Bech32 address is mixed case",
         "error_locations": [40],
         "comment": "bc1, Mixed case, not in BIP 173 test vectors"
       },
@@ -161,7 +161,7 @@
       },
       {
         "address": "tb1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vq47Zagq",
-        "error": "Bech32 address decoded with error: Invalid character or mixed case",
+        "error": "Bech32 address is mixed case",
         "error_locations": [58],
         "comment": "tb1, Mixed case"
       },

--- a/test/functional/data/rpc_validateaddress.json
+++ b/test/functional/data/rpc_validateaddress.json
@@ -1,0 +1,245 @@
+{
+  "invalid": {
+    "mainnet": [
+      {
+        "address": "tc1qw508d6qejxtdg4y5r3zarvary0c5xw7kg3g4ty",
+        "error": "Invalid or unsupported prefix for Segwit (Bech32) address (expected bc, got tc)",
+        "error_locations": [],
+        "comment": "Invalid hrp"
+      },
+      {
+        "address": "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t5",
+        "error": "Bech32 address decoded with error: Invalid Bech32 checksum",
+        "error_locations": [
+          41
+        ]
+      },
+      {
+        "address": "BC13W508D6QEJXTDG4Y5R3ZARVARY0C5XW7KN40WF2",
+        "error": "Version 1+ witness address must use Bech32m checksum",
+        "error_locations": []
+      },
+      {
+        "address": "bc1rw5uspcuh",
+        "error": "Version 1+ witness address must use Bech32m checksum",
+        "error_locations": [],
+        "comment": "Invalid program length"
+      },
+      {
+        "address": "bc10w508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kw5rljs90",
+        "error": "Version 1+ witness address must use Bech32m checksum",
+        "error_locations": [],
+        "comment": "Invalid program length"
+      },
+      {
+        "address": "BC1QR508D6QEJXTDG4Y5R3ZARVARYV98GJ9P",
+        "error": "Invalid SegWit v0 address program size (16 bytes), per BIP141",
+        "error_locations": []
+      },
+      {
+        "address": "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sL5k7",
+        "error": "Bech32 address is mixed case",
+        "error_locations": [
+          58
+        ],
+        "comment": "tb1, Mixed case"
+      },
+      {
+        "address": "BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3t4",
+        "error": "Bech32 address is mixed case",
+        "error_locations": [
+          40
+        ],
+        "comment": "bc1, Mixed case, not in BIP 173 test vectors"
+      },
+      {
+        "address": "bc1zw508d6qejxtdg4y5r3zarvaryvqyzf3du",
+        "error": "Version 1+ witness address must use Bech32m checksum",
+        "error_locations": [],
+        "comment": "Wrong padding"
+      },
+      {
+        "address": "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3pjxtptv",
+        "error": "Invalid or unsupported prefix for Segwit (Bech32) address (expected bc, got tb)",
+        "error_locations": [],
+        "comment": "tb1, Non-zero padding in 8-to-5 conversion"
+      },
+      {
+        "address": "bc1gmk9yu",
+        "error": "Empty Bech32 data section",
+        "error_locations": []
+      },
+      {
+        "address": "tc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vq5zuyut",
+        "error": "Invalid or unsupported prefix for Segwit (Bech32) address (expected bc, got tc)",
+        "error_locations": [],
+        "comment": "Invalid human-readable part"
+      },
+      {
+        "address": "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqh2y7hd",
+        "error": "Version 1+ witness address must use Bech32m checksum",
+        "error_locations": [],
+        "comment": "Invalid checksum (Bech32 instead of Bech32m)"
+      },
+      {
+        "address": "tb1z0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqglt7rf",
+        "error": "Invalid or unsupported prefix for Segwit (Bech32) address (expected bc, got tb)",
+        "error_locations": [],
+        "comment": "tb1, Invalid checksum (Bech32 instead of Bech32m)"
+      },
+      {
+        "address": "BC1S0XLXVLHEMJA6C4DQV22UAPCTQUPFHLXM9H8Z3K2E72Q4K9HCZ7VQ54WELL",
+        "error": "Version 1+ witness address must use Bech32m checksum",
+        "error_locations": [],
+        "comment": "Invalid checksum (Bech32 instead of Bech32m)"
+      },
+      {
+        "address": "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kemeawh",
+        "error": "Version 0 witness address must use Bech32 checksum",
+        "error_locations": [],
+        "comment": "Invalid checksum (Bech32m instead of Bech32)"
+      },
+      {
+        "address": "tb1q0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vq24jc47",
+        "error": "Invalid or unsupported prefix for Segwit (Bech32) address (expected bc, got tb)",
+        "error_locations": [],
+        "comment": "tb1, Invalid checksum (Bech32m instead of Bech32)"
+      },
+      {
+        "address": "bc1p38j9r5y49hruaue7wxjce0updqjuyyx0kh56v8s25huc6995vvpql3jow4",
+        "error": "Bech32 address decoded with error: Invalid Base 32 character",
+        "error_locations": [
+          59
+        ],
+        "comment": "Invalid character in checksum"
+      },
+      {
+        "address": "BC130XLXVLHEMJA6C4DQV22UAPCTQUPFHLXM9H8Z3K2E72Q4K9HCZ7VQ7ZWS8R",
+        "error": "Invalid Bech32 address witness version",
+        "error_locations": []
+      },
+      {
+        "address": "bc1pw5dgrnzv",
+        "error": "Invalid Bech32 address program size (1 byte)",
+        "error_locations": []
+      },
+      {
+        "address": "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7v8n0nx0muaewav253zgeav",
+        "error": "Invalid Bech32 address program size (41 bytes)",
+        "error_locations": []
+      },
+      {
+        "address": "tb1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vq47Zagq",
+        "error": "Bech32 address is mixed case",
+        "error_locations": [
+          58
+        ],
+        "comment": "tb1, Mixed case"
+      },
+      {
+        "address": "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7v07qwwzcrf",
+        "error": "Invalid padding in Bech32 data section",
+        "error_locations": [],
+        "comment": "zero padding of more than 4 bits"
+      },
+      {
+        "address": "tb1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vpggkg4j",
+        "error": "Invalid or unsupported prefix for Segwit (Bech32) address (expected bc, got tb)",
+        "error_locations": [],
+        "comment": "tb1, Non-zero padding in 8-to-5 conversion"
+      }
+    ],
+    "signet": [
+      {
+        "address": "tc1qw508d6qejxtdg4y5r3zarvary0c5xw7kg3g4ty",
+        "error": "Invalid or unsupported prefix for Segwit (Bech32) address (expected tb, got tc)",
+        "error_locations": [],
+        "comment": "Invalid hrp"
+      },
+      {
+        "address": "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3pjxtptv",
+        "error": "Invalid padding in Bech32 data section",
+        "error_locations": [],
+        "comment": "Non-zero padding in 8-to-5 conversion"
+      },
+      {
+        "address": "tb1z0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqglt7rf",
+        "error": "Version 1+ witness address must use Bech32m checksum",
+        "error_locations": [],
+        "comment": "Invalid checksum (Bech32 instead of Bech32m)"
+      },
+      {
+        "address": "tb1q0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vq24jc47",
+        "error": "Version 0 witness address must use Bech32 checksum",
+        "error_locations": [],
+        "comment": "Invalid checksum (Bech32m instead of Bech32)"
+      },
+      {
+        "address": "tb1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vpggkg4j",
+        "error": "Invalid padding in Bech32 data section",
+        "error_locations": [],
+        "comment": "Non-zero padding in 8-to-5 conversion"
+      }
+    ]
+  },
+  "valid": {
+    "mainnet": [
+      {
+        "address": "BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4",
+        "scriptPubKey": "0014751e76e8199196d454941c45d1b3a323f1433bd6"
+      },
+      {
+        "address": "bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3",
+        "scriptPubKey": "00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262"
+      },
+      {
+        "address": "bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kt5nd6y",
+        "scriptPubKey": "5128751e76e8199196d454941c45d1b3a323f1433bd6751e76e8199196d454941c45d1b3a323f1433bd6"
+      },
+      {
+        "address": "BC1SW50QGDZ25J",
+        "scriptPubKey": "6002751e"
+      },
+      {
+        "address": "bc1zw508d6qejxtdg4y5r3zarvaryvaxxpcs",
+        "scriptPubKey": "5210751e76e8199196d454941c45d1b3a323"
+      },
+      {
+        "address": "bc1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvses5wp4dt",
+        "scriptPubKey": "0020000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433"
+      },
+      {
+        "address": "bc1pqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvses7epu4h",
+        "scriptPubKey": "5120000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433"
+      },
+      {
+        "address": "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj0",
+        "scriptPubKey": "512079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+      },
+      {
+        "address": "bc1pfeessrawgf",
+        "scriptPubKey": "51024e73",
+        "comment": "PayToAnchor(P2A)"
+      }
+    ],
+    "signet": [
+      {
+        "address": "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7",
+        "scriptPubKey": "00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262"
+      },
+      {
+        "address": "tb1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesrxh6hy",
+        "scriptPubKey": "0020000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433"
+      },
+      {
+        "address": "tb1pqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesf3hn0c",
+        "scriptPubKey": "5120000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433"
+      },
+      {
+        "address": "tb1pfees9rn5nz",
+        "scriptPubKey": "51024e73",
+        "comment": "PayToAnchor(P2A)"
+      }
+    ]
+  }
+}

--- a/test/functional/rpc_invalid_address_message.py
+++ b/test/functional/rpc_invalid_address_message.py
@@ -63,19 +63,19 @@ class InvalidAddressErrorMessageTest(BitcoinTestFramework):
     def test_validateaddress(self):
         # Invalid Bech32
         self.check_invalid(BECH32_INVALID_SIZE, "Invalid Bech32 address program size (41 bytes)")
-        self.check_invalid(BECH32_INVALID_PREFIX, 'Invalid or unsupported Segwit (Bech32) or Base58 encoding.')
+        self.check_invalid(BECH32_INVALID_PREFIX, 'Invalid or unsupported prefix for Segwit (Bech32) address (expected bcrt, got bc)')
         self.check_invalid(BECH32_INVALID_BECH32, 'Version 1+ witness address must use Bech32m checksum')
         self.check_invalid(BECH32_INVALID_BECH32M, 'Version 0 witness address must use Bech32 checksum')
         self.check_invalid(BECH32_INVALID_VERSION, 'Invalid Bech32 address witness version')
-        self.check_invalid(BECH32_INVALID_V0_SIZE, "Invalid Bech32 v0 address program size (21 bytes), per BIP141")
-        self.check_invalid(BECH32_TOO_LONG, 'Bech32 string too long', list(range(90, 108)))
-        self.check_invalid(BECH32_ONE_ERROR, 'Invalid Bech32 checksum', [9])
-        self.check_invalid(BECH32_TWO_ERRORS, 'Invalid Bech32 checksum', [22, 43])
-        self.check_invalid(BECH32_ONE_ERROR_CAPITALS, 'Invalid Bech32 checksum', [38])
-        self.check_invalid(BECH32_NO_SEPARATOR, 'Missing separator')
-        self.check_invalid(BECH32_INVALID_CHAR, 'Invalid Base 32 character', [8])
-        self.check_invalid(BECH32_MULTISIG_TWO_ERRORS, 'Invalid Bech32 checksum', [19, 30])
-        self.check_invalid(BECH32_WRONG_VERSION, 'Invalid Bech32 checksum', [5])
+        self.check_invalid(BECH32_INVALID_V0_SIZE, "Invalid SegWit v0 address program size (21 bytes), per BIP141")
+        self.check_invalid(BECH32_TOO_LONG, 'Bech32 address decoded with error: Invalid checksum', [])
+        self.check_invalid(BECH32_ONE_ERROR, 'Bech32 address decoded with error: Invalid Bech32 checksum', [9])
+        self.check_invalid(BECH32_TWO_ERRORS, 'Bech32 address decoded with error: Invalid Bech32 checksum', [22, 43])
+        self.check_invalid(BECH32_ONE_ERROR_CAPITALS, 'Invalid checksum or length of Base58 address (P2PKH or P2SH)', [])
+        self.check_invalid(BECH32_NO_SEPARATOR, 'Bech32 address decoded with error: Missing separator')
+        self.check_invalid(BECH32_INVALID_CHAR, 'Bech32 address decoded with error: Invalid Base 32 character', [8])
+        self.check_invalid(BECH32_MULTISIG_TWO_ERRORS, 'Bech32 address decoded with error: Invalid Bech32 checksum', [19, 30])
+        self.check_invalid(BECH32_WRONG_VERSION, 'Bech32 address decoded with error: Invalid Bech32 checksum', [5])
 
         # Valid Bech32
         self.check_valid(BECH32_VALID)
@@ -85,15 +85,15 @@ class InvalidAddressErrorMessageTest(BitcoinTestFramework):
 
         # Invalid Base58
         self.check_invalid(BASE58_INVALID_PREFIX, 'Invalid or unsupported Base58-encoded address.')
-        self.check_invalid(BASE58_INVALID_CHECKSUM, 'Invalid checksum or length of Base58 address (P2PKH or P2SH)')
-        self.check_invalid(BASE58_INVALID_LENGTH, 'Invalid checksum or length of Base58 address (P2PKH or P2SH)')
+        self.check_invalid(BASE58_INVALID_CHECKSUM, 'Invalid checksum or length of Base58 address (P2PKH or P2SH)', [])
+        self.check_invalid(BASE58_INVALID_LENGTH, 'Invalid checksum or length of Base58 address (P2PKH or P2SH)', [])
 
         # Valid Base58
         self.check_valid(BASE58_VALID)
 
         # Invalid address format
-        self.check_invalid(INVALID_ADDRESS, 'Invalid or unsupported Segwit (Bech32) or Base58 encoding.')
-        self.check_invalid(INVALID_ADDRESS_2, 'Invalid or unsupported Segwit (Bech32) or Base58 encoding.')
+        self.check_invalid(INVALID_ADDRESS, 'Bech32 address decoded with error: Invalid separator position', [14])
+        self.check_invalid(INVALID_ADDRESS_2, 'Bech32 address decoded with error: Invalid separator position', [0])
 
         node = self.nodes[0]
 
@@ -108,9 +108,9 @@ class InvalidAddressErrorMessageTest(BitcoinTestFramework):
         node = self.nodes[0]
 
         assert_raises_rpc_error(-5, "Invalid Bech32 address program size (41 bytes)", node.getaddressinfo, BECH32_INVALID_SIZE)
-        assert_raises_rpc_error(-5, "Invalid or unsupported Segwit (Bech32) or Base58 encoding.", node.getaddressinfo, BECH32_INVALID_PREFIX)
+        assert_raises_rpc_error(-5, "Invalid or unsupported prefix for Segwit (Bech32) address (expected bcrt, got bc)", node.getaddressinfo, BECH32_INVALID_PREFIX)
         assert_raises_rpc_error(-5, "Invalid or unsupported Base58-encoded address.", node.getaddressinfo, BASE58_INVALID_PREFIX)
-        assert_raises_rpc_error(-5, "Invalid or unsupported Segwit (Bech32) or Base58 encoding.", node.getaddressinfo, INVALID_ADDRESS)
+        assert_raises_rpc_error(-5, "Bech32 address decoded with error: Invalid separator position", node.getaddressinfo, INVALID_ADDRESS)
         assert "isscript" not in node.getaddressinfo(BECH32_VALID_UNKNOWN_WITNESS)
 
     def run_test(self):

--- a/test/functional/rpc_invalid_address_message.py
+++ b/test/functional/rpc_invalid_address_message.py
@@ -68,12 +68,12 @@ class InvalidAddressErrorMessageTest(BitcoinTestFramework):
         self.check_invalid(BECH32_INVALID_BECH32M, 'Version 0 witness address must use Bech32 checksum')
         self.check_invalid(BECH32_INVALID_VERSION, 'Invalid Bech32 address witness version')
         self.check_invalid(BECH32_INVALID_V0_SIZE, "Invalid SegWit v0 address program size (21 bytes), per BIP141")
-        self.check_invalid(BECH32_TOO_LONG, 'Bech32 address decoded with error: Invalid checksum', [])
+        self.check_invalid(BECH32_TOO_LONG, 'Bech32 address decoded with error: Bech32 string too long', list(range(90, 108)))
         self.check_invalid(BECH32_ONE_ERROR, 'Bech32 address decoded with error: Invalid Bech32 checksum', [9])
         self.check_invalid(BECH32_TWO_ERRORS, 'Bech32 address decoded with error: Invalid Bech32 checksum', [22, 43])
-        self.check_invalid(BECH32_ONE_ERROR_CAPITALS, 'Invalid checksum or length of Base58 address (P2PKH or P2SH)', [])
+        self.check_invalid(BECH32_ONE_ERROR_CAPITALS, "Invalid checksum")
         self.check_invalid(BECH32_NO_SEPARATOR, 'Bech32 address decoded with error: Missing separator')
-        self.check_invalid(BECH32_INVALID_CHAR, 'Bech32 address decoded with error: Invalid Base 32 character', [8])
+        self.check_invalid(BECH32_INVALID_CHAR, 'Address is not valid Base58 or Bech32', [8])
         self.check_invalid(BECH32_MULTISIG_TWO_ERRORS, 'Bech32 address decoded with error: Invalid Bech32 checksum', [19, 30])
         self.check_invalid(BECH32_WRONG_VERSION, 'Bech32 address decoded with error: Invalid Bech32 checksum', [5])
 
@@ -84,9 +84,9 @@ class InvalidAddressErrorMessageTest(BitcoinTestFramework):
         self.check_valid(BECH32_VALID_MULTISIG)
 
         # Invalid Base58
-        self.check_invalid(BASE58_INVALID_PREFIX, 'Invalid or unsupported Base58-encoded address.')
-        self.check_invalid(BASE58_INVALID_CHECKSUM, 'Invalid checksum or length of Base58 address (P2PKH or P2SH)', [])
-        self.check_invalid(BASE58_INVALID_LENGTH, 'Invalid checksum or length of Base58 address (P2PKH or P2SH)', [])
+        self.check_invalid(BASE58_INVALID_PREFIX, 'Invalid Base58 address. Expected prefix 2, m, or n')
+        self.check_invalid(BASE58_INVALID_CHECKSUM, 'Invalid checksum or length of Base58 address (P2PKH or P2SH)')
+        self.check_invalid(BASE58_INVALID_LENGTH, 'Invalid checksum or length of Base58 address (P2PKH or P2SH)')
 
         # Valid Base58
         self.check_valid(BASE58_VALID)
@@ -109,7 +109,7 @@ class InvalidAddressErrorMessageTest(BitcoinTestFramework):
 
         assert_raises_rpc_error(-5, "Invalid Bech32 address program size (41 bytes)", node.getaddressinfo, BECH32_INVALID_SIZE)
         assert_raises_rpc_error(-5, "Invalid or unsupported prefix for Segwit (Bech32) address (expected bcrt, got bc)", node.getaddressinfo, BECH32_INVALID_PREFIX)
-        assert_raises_rpc_error(-5, "Invalid or unsupported Base58-encoded address.", node.getaddressinfo, BASE58_INVALID_PREFIX)
+        assert_raises_rpc_error(-5, "Invalid Base58 address. Expected prefix 2, m, or n", node.getaddressinfo, BASE58_INVALID_PREFIX)
         assert_raises_rpc_error(-5, "Bech32 address decoded with error: Invalid separator position", node.getaddressinfo, INVALID_ADDRESS)
         assert "isscript" not in node.getaddressinfo(BECH32_VALID_UNKNOWN_WITNESS)
 

--- a/test/functional/rpc_invalid_address_message.py
+++ b/test/functional/rpc_invalid_address_message.py
@@ -66,19 +66,19 @@ class InvalidAddressErrorMessageTest(BitcoinTestFramework):
     def test_validateaddress(self):
         # Invalid Bech32
         self.check_invalid(BECH32_INVALID_SIZE, "Invalid Bech32 address program size (41 bytes)")
-        self.check_invalid(BECH32_INVALID_PREFIX, 'Invalid or unsupported prefix for Segwit (Bech32) address (expected bcrt, got bc).')
+        self.check_invalid(BECH32_INVALID_PREFIX, 'Invalid or unsupported prefix for Segwit (Bech32) address (expected bcrt, got bc)')
         self.check_invalid(BECH32_INVALID_BECH32, 'Version 1+ witness address must use Bech32m checksum')
         self.check_invalid(BECH32_INVALID_BECH32M, 'Version 0 witness address must use Bech32 checksum')
         self.check_invalid(BECH32_INVALID_VERSION, 'Invalid Bech32 address witness version')
-        self.check_invalid(BECH32_INVALID_V0_SIZE, "Invalid Bech32 v0 address program size (21 bytes), per BIP141")
-        self.check_invalid(BECH32_TOO_LONG, 'Bech32 string too long', list(range(90, 108)))
-        self.check_invalid(BECH32_ONE_ERROR, 'Invalid Bech32 checksum', [9])
-        self.check_invalid(BECH32_TWO_ERRORS, 'Invalid Bech32 checksum', [22, 43])
-        self.check_invalid(BECH32_ONE_ERROR_CAPITALS, 'Invalid Bech32 checksum', [38])
-        self.check_invalid(BECH32_NO_SEPARATOR, 'Missing separator')
-        self.check_invalid(BECH32_INVALID_CHAR, 'Invalid Base 32 character', [8])
-        self.check_invalid(BECH32_MULTISIG_TWO_ERRORS, 'Invalid Bech32 checksum', [19, 30])
-        self.check_invalid(BECH32_WRONG_VERSION, 'Invalid Bech32 checksum', [5])
+        self.check_invalid(BECH32_INVALID_V0_SIZE, "Invalid SegWit v0 address program size (21 bytes), per BIP141")
+        self.check_invalid(BECH32_TOO_LONG, 'Bech32 address decoded with error: Bech32 string too long', list(range(90, 108)))
+        self.check_invalid(BECH32_ONE_ERROR, 'Bech32 address decoded with error: Invalid Bech32 checksum', [9])
+        self.check_invalid(BECH32_TWO_ERRORS, 'Bech32 address decoded with error: Invalid Bech32 checksum', [22, 43])
+        self.check_invalid(BECH32_ONE_ERROR_CAPITALS, 'Bech32 address decoded with error: Invalid Bech32 checksum', [38])
+        self.check_invalid(BECH32_NO_SEPARATOR, 'Bech32 address decoded with error: Missing separator')
+        self.check_invalid(BECH32_INVALID_CHAR, 'Bech32 address decoded with error: Invalid Base 32 character', [8])
+        self.check_invalid(BECH32_MULTISIG_TWO_ERRORS, 'Bech32 address decoded with error: Invalid Bech32 checksum', [19, 30])
+        self.check_invalid(BECH32_WRONG_VERSION, 'Bech32 address decoded with error: Invalid Bech32 checksum', [5])
 
         # Valid Bech32
         self.check_valid(BECH32_VALID)
@@ -96,8 +96,8 @@ class InvalidAddressErrorMessageTest(BitcoinTestFramework):
         self.check_valid(BASE58_VALID)
 
         # Invalid address format
-        self.check_invalid(INVALID_ADDRESS, 'Invalid separator position', [14])
-        self.check_invalid(INVALID_ADDRESS_2, 'Invalid separator position', [0])
+        self.check_invalid(INVALID_ADDRESS, 'Bech32 address decoded with error: Invalid separator position', [14])
+        self.check_invalid(INVALID_ADDRESS_2, 'Bech32 address decoded with error: Invalid separator position', [0])
 
         node = self.nodes[0]
 
@@ -112,9 +112,9 @@ class InvalidAddressErrorMessageTest(BitcoinTestFramework):
         node = self.nodes[0]
 
         assert_raises_rpc_error(-5, "Invalid Bech32 address program size (41 bytes)", node.getaddressinfo, BECH32_INVALID_SIZE)
-        assert_raises_rpc_error(-5, "Invalid or unsupported prefix for Segwit (Bech32) address (expected bcrt, got bc).", node.getaddressinfo, BECH32_INVALID_PREFIX)
+        assert_raises_rpc_error(-5, "Invalid or unsupported prefix for Segwit (Bech32) address (expected bcrt, got bc)", node.getaddressinfo, BECH32_INVALID_PREFIX)
         assert_raises_rpc_error(-5, "Invalid or unsupported Base58-encoded address.", node.getaddressinfo, BASE58_INVALID_PREFIX)
-        assert_raises_rpc_error(-5, "Invalid separator position", node.getaddressinfo, INVALID_ADDRESS)
+        assert_raises_rpc_error(-5, "Bech32 address decoded with error: Invalid separator position", node.getaddressinfo, INVALID_ADDRESS)
         assert "isscript" not in node.getaddressinfo(BECH32_VALID_UNKNOWN_WITNESS)
 
     def run_test(self):

--- a/test/functional/rpc_invalid_address_message.py
+++ b/test/functional/rpc_invalid_address_message.py
@@ -87,7 +87,7 @@ class InvalidAddressErrorMessageTest(BitcoinTestFramework):
         self.check_valid(BECH32_VALID_MULTISIG)
 
         # Invalid Base58
-        self.check_invalid(BASE58_INVALID_PREFIX, 'Invalid or unsupported Base58-encoded address.')
+        self.check_invalid(BASE58_INVALID_PREFIX, 'Invalid Base58 address. Expected prefix 2, m or n')
         self.check_invalid(BASE58_INVALID_CHECKSUM, 'Invalid checksum or length of Base58 address (P2PKH or P2SH)')
         self.check_invalid(BASE58_INVALID_LENGTH, 'Invalid checksum or length of Base58 address (P2PKH or P2SH)')
         self.check_invalid(BASE58_OVER_BECH32_LIMIT, 'Invalid checksum or length of Base58 address (P2PKH or P2SH)')
@@ -113,7 +113,7 @@ class InvalidAddressErrorMessageTest(BitcoinTestFramework):
 
         assert_raises_rpc_error(-5, "Invalid Bech32 address program size (41 bytes)", node.getaddressinfo, BECH32_INVALID_SIZE)
         assert_raises_rpc_error(-5, "Invalid or unsupported prefix for Segwit (Bech32) address (expected bcrt, got bc)", node.getaddressinfo, BECH32_INVALID_PREFIX)
-        assert_raises_rpc_error(-5, "Invalid or unsupported Base58-encoded address.", node.getaddressinfo, BASE58_INVALID_PREFIX)
+        assert_raises_rpc_error(-5, "Invalid Base58 address. Expected prefix 2, m or n", node.getaddressinfo, BASE58_INVALID_PREFIX)
         assert_raises_rpc_error(-5, "Bech32 address decoded with error: Invalid separator position", node.getaddressinfo, INVALID_ADDRESS)
         assert "isscript" not in node.getaddressinfo(BECH32_VALID_UNKNOWN_WITNESS)
 

--- a/test/functional/rpc_invalid_address_message.py
+++ b/test/functional/rpc_invalid_address_message.py
@@ -35,6 +35,9 @@ BASE58_VALID = 'mipcBbFg9gMiCh81Kj8tqqdgoZub1ZJRfn'
 BASE58_INVALID_PREFIX = '17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYhem'
 BASE58_INVALID_CHECKSUM = 'mipcBbFg9gMiCh81Kj8tqqdgoZub1ZJJfn'
 BASE58_INVALID_LENGTH = '2VKf7XKMrp4bVNVmuRbyCewkP8FhGLP2E54LHDPakr9Sq5mtU2'
+# Exceeds the 90-character Bech32 limit (BIP173), so it is diagnosed as Base58
+# rather than reported as a Bech32 length error.
+BASE58_OVER_BECH32_LIMIT = '1' * 100
 
 INVALID_ADDRESS = 'asfah14i8fajz0123f'
 INVALID_ADDRESS_2 = '1q049ldschfnwystcqnsvyfpj23mpsg3jcedq9xv'
@@ -63,7 +66,7 @@ class InvalidAddressErrorMessageTest(BitcoinTestFramework):
     def test_validateaddress(self):
         # Invalid Bech32
         self.check_invalid(BECH32_INVALID_SIZE, "Invalid Bech32 address program size (41 bytes)")
-        self.check_invalid(BECH32_INVALID_PREFIX, 'Invalid or unsupported Segwit (Bech32) or Base58 encoding.')
+        self.check_invalid(BECH32_INVALID_PREFIX, 'Invalid or unsupported prefix for Segwit (Bech32) address (expected bcrt, got bc).')
         self.check_invalid(BECH32_INVALID_BECH32, 'Version 1+ witness address must use Bech32m checksum')
         self.check_invalid(BECH32_INVALID_BECH32M, 'Version 0 witness address must use Bech32 checksum')
         self.check_invalid(BECH32_INVALID_VERSION, 'Invalid Bech32 address witness version')
@@ -87,13 +90,14 @@ class InvalidAddressErrorMessageTest(BitcoinTestFramework):
         self.check_invalid(BASE58_INVALID_PREFIX, 'Invalid or unsupported Base58-encoded address.')
         self.check_invalid(BASE58_INVALID_CHECKSUM, 'Invalid checksum or length of Base58 address (P2PKH or P2SH)')
         self.check_invalid(BASE58_INVALID_LENGTH, 'Invalid checksum or length of Base58 address (P2PKH or P2SH)')
+        self.check_invalid(BASE58_OVER_BECH32_LIMIT, 'Invalid checksum or length of Base58 address (P2PKH or P2SH)')
 
         # Valid Base58
         self.check_valid(BASE58_VALID)
 
         # Invalid address format
-        self.check_invalid(INVALID_ADDRESS, 'Invalid or unsupported Segwit (Bech32) or Base58 encoding.')
-        self.check_invalid(INVALID_ADDRESS_2, 'Invalid or unsupported Segwit (Bech32) or Base58 encoding.')
+        self.check_invalid(INVALID_ADDRESS, 'Invalid separator position', [14])
+        self.check_invalid(INVALID_ADDRESS_2, 'Invalid separator position', [0])
 
         node = self.nodes[0]
 
@@ -108,9 +112,9 @@ class InvalidAddressErrorMessageTest(BitcoinTestFramework):
         node = self.nodes[0]
 
         assert_raises_rpc_error(-5, "Invalid Bech32 address program size (41 bytes)", node.getaddressinfo, BECH32_INVALID_SIZE)
-        assert_raises_rpc_error(-5, "Invalid or unsupported Segwit (Bech32) or Base58 encoding.", node.getaddressinfo, BECH32_INVALID_PREFIX)
+        assert_raises_rpc_error(-5, "Invalid or unsupported prefix for Segwit (Bech32) address (expected bcrt, got bc).", node.getaddressinfo, BECH32_INVALID_PREFIX)
         assert_raises_rpc_error(-5, "Invalid or unsupported Base58-encoded address.", node.getaddressinfo, BASE58_INVALID_PREFIX)
-        assert_raises_rpc_error(-5, "Invalid or unsupported Segwit (Bech32) or Base58 encoding.", node.getaddressinfo, INVALID_ADDRESS)
+        assert_raises_rpc_error(-5, "Invalid separator position", node.getaddressinfo, INVALID_ADDRESS)
         assert "isscript" not in node.getaddressinfo(BECH32_VALID_UNKNOWN_WITNESS)
 
     def run_test(self):

--- a/test/functional/rpc_validateaddress.py
+++ b/test/functional/rpc_validateaddress.py
@@ -4,182 +4,20 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test validateaddress for main chain"""
 
-from test_framework.test_framework import BitcoinTestFramework
+import json
+import os
 
+from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
 
-INVALID_DATA = [
-    # BIP 173
-    (
-        "tc1qw508d6qejxtdg4y5r3zarvary0c5xw7kg3g4ty",
-        "Invalid or unsupported Segwit (Bech32) or Base58 encoding.",  # Invalid hrp
-        [],
-    ),
-    ("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t5", "Invalid Bech32 checksum", [41]),
-    (
-        "BC13W508D6QEJXTDG4Y5R3ZARVARY0C5XW7KN40WF2",
-        "Version 1+ witness address must use Bech32m checksum",
-        [],
-    ),
-    (
-        "bc1rw5uspcuh",
-        "Version 1+ witness address must use Bech32m checksum",  # Invalid program length
-        [],
-    ),
-    (
-        "bc10w508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kw5rljs90",
-        "Version 1+ witness address must use Bech32m checksum",  # Invalid program length
-        [],
-    ),
-    (
-        "BC1QR508D6QEJXTDG4Y5R3ZARVARYV98GJ9P",
-        "Invalid Bech32 v0 address program size (16 bytes), per BIP141",
-        [],
-    ),
-    (
-        "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sL5k7",
-        "Invalid or unsupported Segwit (Bech32) or Base58 encoding.",  # tb1, Mixed case
-        [],
-    ),
-    (
-        "BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3t4",
-        "Invalid character or mixed case",  # bc1, Mixed case, not in BIP 173 test vectors
-        [40],
-    ),
-    (
-        "bc1zw508d6qejxtdg4y5r3zarvaryvqyzf3du",
-        "Version 1+ witness address must use Bech32m checksum",  # Wrong padding
-        [],
-    ),
-    (
-        "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3pjxtptv",
-        "Invalid or unsupported Segwit (Bech32) or Base58 encoding.",  # tb1, Non-zero padding in 8-to-5 conversion
-        [],
-    ),
-    ("bc1gmk9yu", "Empty Bech32 data section", []),
-    # BIP 350
-    (
-        "tc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vq5zuyut",
-        "Invalid or unsupported Segwit (Bech32) or Base58 encoding.",  # Invalid human-readable part
-        [],
-    ),
-    (
-        "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqh2y7hd",
-        "Version 1+ witness address must use Bech32m checksum",  # Invalid checksum (Bech32 instead of Bech32m)
-        [],
-    ),
-    (
-        "tb1z0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqglt7rf",
-        "Invalid or unsupported Segwit (Bech32) or Base58 encoding.",  # tb1, Invalid checksum (Bech32 instead of Bech32m)
-        [],
-    ),
-    (
-        "BC1S0XLXVLHEMJA6C4DQV22UAPCTQUPFHLXM9H8Z3K2E72Q4K9HCZ7VQ54WELL",
-        "Version 1+ witness address must use Bech32m checksum",  # Invalid checksum (Bech32 instead of Bech32m)
-        [],
-    ),
-    (
-        "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kemeawh",
-        "Version 0 witness address must use Bech32 checksum",  # Invalid checksum (Bech32m instead of Bech32)
-        [],
-    ),
-    (
-        "tb1q0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vq24jc47",
-        "Invalid or unsupported Segwit (Bech32) or Base58 encoding.",  # tb1, Invalid checksum (Bech32m instead of Bech32)
-        [],
-    ),
-    (
-        "bc1p38j9r5y49hruaue7wxjce0updqjuyyx0kh56v8s25huc6995vvpql3jow4",
-        "Invalid Base 32 character",  # Invalid character in checksum
-        [59],
-    ),
-    (
-        "BC130XLXVLHEMJA6C4DQV22UAPCTQUPFHLXM9H8Z3K2E72Q4K9HCZ7VQ7ZWS8R",
-        "Invalid Bech32 address witness version",
-        [],
-    ),
-    ("bc1pw5dgrnzv", "Invalid Bech32 address program size (1 byte)", []),
-    (
-        "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7v8n0nx0muaewav253zgeav",
-        "Invalid Bech32 address program size (41 bytes)",
-        [],
-    ),
-    (
-        "BC1QR508D6QEJXTDG4Y5R3ZARVARYV98GJ9P",
-        "Invalid Bech32 v0 address program size (16 bytes), per BIP141",
-        [],
-    ),
-    (
-        "tb1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vq47Zagq",
-        "Invalid or unsupported Segwit (Bech32) or Base58 encoding.",  # tb1, Mixed case
-        [],
-    ),
-    (
-        "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7v07qwwzcrf",
-        "Invalid padding in Bech32 data section",  # zero padding of more than 4 bits
-        [],
-    ),
-    (
-        "tb1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vpggkg4j",
-        "Invalid or unsupported Segwit (Bech32) or Base58 encoding.",  # tb1, Non-zero padding in 8-to-5 conversion
-        [],
-    ),
-    ("bc1gmk9yu", "Empty Bech32 data section", []),
-]
-VALID_DATA = [
-    # BIP 350
-    (
-        "BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4",
-        "0014751e76e8199196d454941c45d1b3a323f1433bd6",
-    ),
-    # (
-    #   "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7",
-    #   "00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262",
-    # ),
-    (
-        "bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3",
-        "00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262",
-    ),
-    (
-        "bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kt5nd6y",
-        "5128751e76e8199196d454941c45d1b3a323f1433bd6751e76e8199196d454941c45d1b3a323f1433bd6",
-    ),
-    ("BC1SW50QGDZ25J", "6002751e"),
-    ("bc1zw508d6qejxtdg4y5r3zarvaryvaxxpcs", "5210751e76e8199196d454941c45d1b3a323"),
-    # (
-    #   "tb1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesrxh6hy",
-    #   "0020000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433",
-    # ),
-    (
-        "bc1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvses5wp4dt",
-        "0020000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433",
-    ),
-    # (
-    #   "tb1pqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesf3hn0c",
-    #   "5120000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433",
-    # ),
-    (
-        "bc1pqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvses7epu4h",
-        "5120000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433",
-    ),
-    (
-        "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj0",
-        "512079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
-    ),
-    # PayToAnchor(P2A)
-    (
-        "bc1pfeessrawgf",
-        "51024e73",
-    ),
-]
-
+TESTSDIR = os.path.dirname(os.path.realpath(__file__))
 
 class ValidateAddressMainTest(BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
-        self.chain = ""  # main
+        self.chain = "signet"
         self.num_nodes = 1
-        self.extra_args = [["-prune=899"]] * self.num_nodes
+        self.extra_args = [["-prune=899", "-signet"]]
 
     def check_valid(self, addr, spk):
         info = self.nodes[0].validateaddress(addr)
@@ -194,15 +32,33 @@ class ValidateAddressMainTest(BitcoinTestFramework):
         assert_equal(res["error"], error_str)
         assert_equal(res["error_locations"], error_locations)
 
-    def test_validateaddress(self):
-        for (addr, error, locs) in INVALID_DATA:
-            self.check_invalid(addr, error, locs)
-        for (addr, spk) in VALID_DATA:
-            self.check_valid(addr, spk)
+    def load_test_data(self, filename):
+        with open(filename, 'r', encoding='utf-8') as f:
+            return json.load(f)
+
+    def test_validateaddress_signet(self, test_data):
+        for entry in test_data["invalid"]["signet"]:
+            self.check_invalid(entry["address"], entry["error"], entry["error_locations"])
+        for entry in test_data["valid"]["signet"]:
+            self.check_valid(entry["address"], entry["scriptPubKey"])
+
+    def test_validateaddress_mainnet(self, test_data):
+        for entry in test_data["invalid"]["mainnet"]:
+            self.check_invalid(entry["address"], entry["error"], entry["error_locations"])
+        for entry in test_data["valid"]["mainnet"]:
+            self.check_valid(entry["address"], entry["scriptPubKey"])
 
     def run_test(self):
-        self.test_validateaddress()
+        test_data = self.load_test_data(os.path.join(TESTSDIR, "data", "rpc_validateaddress.json"))
 
+        self.test_validateaddress_signet(test_data)
+        self.stop_nodes()
+        self.nodes.clear()
+        self.chain = ""
+        self.extra_args = [["-prune=899"]]
+        self.setup_chain()
+        self.setup_network()
+        self.test_validateaddress_mainnet(test_data)
 
 if __name__ == "__main__":
     ValidateAddressMainTest(__file__).main()

--- a/test/functional/rpc_validateaddress.py
+++ b/test/functional/rpc_validateaddress.py
@@ -2,184 +2,23 @@
 # Copyright (c) 2023-present The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Test validateaddress for main chain"""
+"""Test validateaddress across networks (signet and mainnet)"""
+
+import json
+import os
 
 from test_framework.test_framework import BitcoinTestFramework
-
 from test_framework.util import assert_equal
 
-INVALID_DATA = [
-    # BIP 173
-    (
-        "tc1qw508d6qejxtdg4y5r3zarvary0c5xw7kg3g4ty",
-        "Invalid or unsupported prefix for Segwit (Bech32) address (expected bc, got tc)",  # Invalid hrp
-        [],
-    ),
-    ("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t5", "Bech32 address decoded with error: Invalid Bech32 checksum", [41]),
-    (
-        "BC13W508D6QEJXTDG4Y5R3ZARVARY0C5XW7KN40WF2",
-        "Version 1+ witness address must use Bech32m checksum",
-        [],
-    ),
-    (
-        "bc1rw5uspcuh",
-        "Version 1+ witness address must use Bech32m checksum",  # Invalid program length
-        [],
-    ),
-    (
-        "bc10w508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kw5rljs90",
-        "Version 1+ witness address must use Bech32m checksum",  # Invalid program length
-        [],
-    ),
-    (
-        "BC1QR508D6QEJXTDG4Y5R3ZARVARYV98GJ9P",
-        "Invalid SegWit v0 address program size (16 bytes), per BIP141",
-        [],
-    ),
-    (
-        "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sL5k7",
-        "Bech32 address is mixed case",  # tb1, Mixed case
-        [58],
-    ),
-    (
-        "BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3t4",
-        "Bech32 address is mixed case",  # bc1, Mixed case, not in BIP 173 test vectors
-        [40],
-    ),
-    (
-        "bc1zw508d6qejxtdg4y5r3zarvaryvqyzf3du",
-        "Version 1+ witness address must use Bech32m checksum",  # Wrong padding
-        [],
-    ),
-    (
-        "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3pjxtptv",
-        "Invalid or unsupported prefix for Segwit (Bech32) address (expected bc, got tb)",  # tb1, Non-zero padding in 8-to-5 conversion
-        [],
-    ),
-    ("bc1gmk9yu", "Empty Bech32 data section", []),
-    # BIP 350
-    (
-        "tc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vq5zuyut",
-        "Invalid or unsupported prefix for Segwit (Bech32) address (expected bc, got tc)",  # Invalid human-readable part
-        [],
-    ),
-    (
-        "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqh2y7hd",
-        "Version 1+ witness address must use Bech32m checksum",  # Invalid checksum (Bech32 instead of Bech32m)
-        [],
-    ),
-    (
-        "tb1z0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqglt7rf",
-        "Invalid or unsupported prefix for Segwit (Bech32) address (expected bc, got tb)",  # tb1, Invalid checksum (Bech32 instead of Bech32m)
-        [],
-    ),
-    (
-        "BC1S0XLXVLHEMJA6C4DQV22UAPCTQUPFHLXM9H8Z3K2E72Q4K9HCZ7VQ54WELL",
-        "Version 1+ witness address must use Bech32m checksum",  # Invalid checksum (Bech32 instead of Bech32m)
-        [],
-    ),
-    (
-        "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kemeawh",
-        "Version 0 witness address must use Bech32 checksum",  # Invalid checksum (Bech32m instead of Bech32)
-        [],
-    ),
-    (
-        "tb1q0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vq24jc47",
-        "Invalid or unsupported prefix for Segwit (Bech32) address (expected bc, got tb)",  # tb1, Invalid checksum (Bech32m instead of Bech32)
-        [],
-    ),
-    (
-        "bc1p38j9r5y49hruaue7wxjce0updqjuyyx0kh56v8s25huc6995vvpql3jow4",
-        "Bech32 address decoded with error: Invalid Base 32 character",  # Invalid character in checksum
-        [59],
-    ),
-    (
-        "BC130XLXVLHEMJA6C4DQV22UAPCTQUPFHLXM9H8Z3K2E72Q4K9HCZ7VQ7ZWS8R",
-        "Invalid Bech32 address witness version",
-        [],
-    ),
-    ("bc1pw5dgrnzv", "Invalid Bech32 address program size (1 byte)", []),
-    (
-        "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7v8n0nx0muaewav253zgeav",
-        "Invalid Bech32 address program size (41 bytes)",
-        [],
-    ),
-    (
-        "BC1QR508D6QEJXTDG4Y5R3ZARVARYV98GJ9P",
-        "Invalid SegWit v0 address program size (16 bytes), per BIP141",
-        [],
-    ),
-    (
-        "tb1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vq47Zagq",
-        "Bech32 address is mixed case",  # tb1, Mixed case
-        [58],
-    ),
-    (
-        "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7v07qwwzcrf",
-        "Invalid padding in Bech32 data section",  # zero padding of more than 4 bits
-        [],
-    ),
-    (
-        "tb1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vpggkg4j",
-        "Invalid or unsupported prefix for Segwit (Bech32) address (expected bc, got tb)",  # tb1, Non-zero padding in 8-to-5 conversion
-        [],
-    ),
-    ("bc1gmk9yu", "Empty Bech32 data section", []),
-]
-VALID_DATA = [
-    # BIP 350
-    (
-        "BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4",
-        "0014751e76e8199196d454941c45d1b3a323f1433bd6",
-    ),
-    # (
-    #   "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7",
-    #   "00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262",
-    # ),
-    (
-        "bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3",
-        "00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262",
-    ),
-    (
-        "bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kt5nd6y",
-        "5128751e76e8199196d454941c45d1b3a323f1433bd6751e76e8199196d454941c45d1b3a323f1433bd6",
-    ),
-    ("BC1SW50QGDZ25J", "6002751e"),
-    ("bc1zw508d6qejxtdg4y5r3zarvaryvaxxpcs", "5210751e76e8199196d454941c45d1b3a323"),
-    # (
-    #   "tb1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesrxh6hy",
-    #   "0020000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433",
-    # ),
-    (
-        "bc1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvses5wp4dt",
-        "0020000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433",
-    ),
-    # (
-    #   "tb1pqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesf3hn0c",
-    #   "5120000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433",
-    # ),
-    (
-        "bc1pqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvses7epu4h",
-        "5120000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433",
-    ),
-    (
-        "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj0",
-        "512079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
-    ),
-    # PayToAnchor(P2A)
-    (
-        "bc1pfeessrawgf",
-        "51024e73",
-    ),
-]
+TEST_DATA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), "data", "rpc_validateaddress.json")
 
 
-class ValidateAddressMainTest(BitcoinTestFramework):
+class ValidateAddressTest(BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
-        self.chain = ""  # main
+        self.chain = "signet"
         self.num_nodes = 1
-        self.extra_args = [["-prune=899"]] * self.num_nodes
+        self.extra_args = [["-prune=899"]]
 
     def check_valid(self, addr, spk):
         info = self.nodes[0].validateaddress(addr)
@@ -194,15 +33,28 @@ class ValidateAddressMainTest(BitcoinTestFramework):
         assert_equal(res["error"], error_str)
         assert_equal(res["error_locations"], error_locations)
 
-    def test_validateaddress(self):
-        for (addr, error, locs) in INVALID_DATA:
-            self.check_invalid(addr, error, locs)
-        for (addr, spk) in VALID_DATA:
-            self.check_valid(addr, spk)
+    def test_validateaddress_on_network(self, test_data, network_name):
+        self.log.info(f"Testing validateaddress on {network_name}")
+        for entry in test_data["invalid"][network_name]:
+            self.check_invalid(entry["address"], entry["error"], entry["error_locations"])
+        for entry in test_data["valid"][network_name]:
+            self.check_valid(entry["address"], entry["scriptPubKey"])
 
     def run_test(self):
-        self.test_validateaddress()
+        with open(TEST_DATA_PATH, encoding="utf-8") as f:
+            test_data = json.load(f)
+
+        self.test_validateaddress_on_network(test_data, "signet")
+
+        self.log.info("Restarting node on mainnet")
+        self.stop_nodes()
+        self.nodes.clear()
+        self.chain = ""
+        self.extra_args = [["-prune=899"]]
+        self.setup_chain()
+        self.setup_network()
+        self.test_validateaddress_on_network(test_data, "mainnet")
 
 
 if __name__ == "__main__":
-    ValidateAddressMainTest(__file__).main()
+    ValidateAddressTest(__file__).main()

--- a/test/functional/rpc_validateaddress.py
+++ b/test/functional/rpc_validateaddress.py
@@ -12,10 +12,10 @@ INVALID_DATA = [
     # BIP 173
     (
         "tc1qw508d6qejxtdg4y5r3zarvary0c5xw7kg3g4ty",
-        "Invalid or unsupported prefix for Segwit (Bech32) address (expected bc, got tc).",  # Invalid hrp
+        "Invalid or unsupported prefix for Segwit (Bech32) address (expected bc, got tc)",  # Invalid hrp
         [],
     ),
-    ("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t5", "Invalid Bech32 checksum", [41]),
+    ("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t5", "Bech32 address decoded with error: Invalid Bech32 checksum", [41]),
     (
         "BC13W508D6QEJXTDG4Y5R3ZARVARY0C5XW7KN40WF2",
         "Version 1+ witness address must use Bech32m checksum",
@@ -33,7 +33,7 @@ INVALID_DATA = [
     ),
     (
         "BC1QR508D6QEJXTDG4Y5R3ZARVARYV98GJ9P",
-        "Invalid Bech32 v0 address program size (16 bytes), per BIP141",
+        "Invalid SegWit v0 address program size (16 bytes), per BIP141",
         [],
     ),
     (
@@ -53,14 +53,14 @@ INVALID_DATA = [
     ),
     (
         "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3pjxtptv",
-        "Invalid or unsupported prefix for Segwit (Bech32) address (expected bc, got tb).",  # tb1, Non-zero padding in 8-to-5 conversion
+        "Invalid or unsupported prefix for Segwit (Bech32) address (expected bc, got tb)",  # tb1, Non-zero padding in 8-to-5 conversion
         [],
     ),
     ("bc1gmk9yu", "Empty Bech32 data section", []),
     # BIP 350
     (
         "tc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vq5zuyut",
-        "Invalid or unsupported prefix for Segwit (Bech32) address (expected bc, got tc).",  # Invalid human-readable part
+        "Invalid or unsupported prefix for Segwit (Bech32) address (expected bc, got tc)",  # Invalid human-readable part
         [],
     ),
     (
@@ -70,7 +70,7 @@ INVALID_DATA = [
     ),
     (
         "tb1z0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqglt7rf",
-        "Invalid or unsupported prefix for Segwit (Bech32) address (expected bc, got tb).",  # tb1, Invalid checksum (Bech32 instead of Bech32m)
+        "Invalid or unsupported prefix for Segwit (Bech32) address (expected bc, got tb)",  # tb1, Invalid checksum (Bech32 instead of Bech32m)
         [],
     ),
     (
@@ -85,12 +85,12 @@ INVALID_DATA = [
     ),
     (
         "tb1q0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vq24jc47",
-        "Invalid or unsupported prefix for Segwit (Bech32) address (expected bc, got tb).",  # tb1, Invalid checksum (Bech32m instead of Bech32)
+        "Invalid or unsupported prefix for Segwit (Bech32) address (expected bc, got tb)",  # tb1, Invalid checksum (Bech32m instead of Bech32)
         [],
     ),
     (
         "bc1p38j9r5y49hruaue7wxjce0updqjuyyx0kh56v8s25huc6995vvpql3jow4",
-        "Invalid Base 32 character",  # Invalid character in checksum
+        "Bech32 address decoded with error: Invalid Base 32 character",  # Invalid character in checksum
         [59],
     ),
     (
@@ -106,7 +106,7 @@ INVALID_DATA = [
     ),
     (
         "BC1QR508D6QEJXTDG4Y5R3ZARVARYV98GJ9P",
-        "Invalid Bech32 v0 address program size (16 bytes), per BIP141",
+        "Invalid SegWit v0 address program size (16 bytes), per BIP141",
         [],
     ),
     (
@@ -121,7 +121,7 @@ INVALID_DATA = [
     ),
     (
         "tb1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vpggkg4j",
-        "Invalid or unsupported prefix for Segwit (Bech32) address (expected bc, got tb).",  # tb1, Non-zero padding in 8-to-5 conversion
+        "Invalid or unsupported prefix for Segwit (Bech32) address (expected bc, got tb)",  # tb1, Non-zero padding in 8-to-5 conversion
         [],
     ),
     ("bc1gmk9yu", "Empty Bech32 data section", []),

--- a/test/functional/rpc_validateaddress.py
+++ b/test/functional/rpc_validateaddress.py
@@ -12,7 +12,7 @@ INVALID_DATA = [
     # BIP 173
     (
         "tc1qw508d6qejxtdg4y5r3zarvary0c5xw7kg3g4ty",
-        "Invalid or unsupported Segwit (Bech32) or Base58 encoding.",  # Invalid hrp
+        "Invalid or unsupported prefix for Segwit (Bech32) address (expected bc, got tc).",  # Invalid hrp
         [],
     ),
     ("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t5", "Invalid Bech32 checksum", [41]),
@@ -38,8 +38,8 @@ INVALID_DATA = [
     ),
     (
         "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sL5k7",
-        "Invalid or unsupported Segwit (Bech32) or Base58 encoding.",  # tb1, Mixed case
-        [],
+        "Invalid character or mixed case",  # tb1, Mixed case
+        [58],
     ),
     (
         "BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3t4",
@@ -53,14 +53,14 @@ INVALID_DATA = [
     ),
     (
         "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3pjxtptv",
-        "Invalid or unsupported Segwit (Bech32) or Base58 encoding.",  # tb1, Non-zero padding in 8-to-5 conversion
+        "Invalid or unsupported prefix for Segwit (Bech32) address (expected bc, got tb).",  # tb1, Non-zero padding in 8-to-5 conversion
         [],
     ),
     ("bc1gmk9yu", "Empty Bech32 data section", []),
     # BIP 350
     (
         "tc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vq5zuyut",
-        "Invalid or unsupported Segwit (Bech32) or Base58 encoding.",  # Invalid human-readable part
+        "Invalid or unsupported prefix for Segwit (Bech32) address (expected bc, got tc).",  # Invalid human-readable part
         [],
     ),
     (
@@ -70,7 +70,7 @@ INVALID_DATA = [
     ),
     (
         "tb1z0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqglt7rf",
-        "Invalid or unsupported Segwit (Bech32) or Base58 encoding.",  # tb1, Invalid checksum (Bech32 instead of Bech32m)
+        "Invalid or unsupported prefix for Segwit (Bech32) address (expected bc, got tb).",  # tb1, Invalid checksum (Bech32 instead of Bech32m)
         [],
     ),
     (
@@ -85,7 +85,7 @@ INVALID_DATA = [
     ),
     (
         "tb1q0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vq24jc47",
-        "Invalid or unsupported Segwit (Bech32) or Base58 encoding.",  # tb1, Invalid checksum (Bech32m instead of Bech32)
+        "Invalid or unsupported prefix for Segwit (Bech32) address (expected bc, got tb).",  # tb1, Invalid checksum (Bech32m instead of Bech32)
         [],
     ),
     (
@@ -111,8 +111,8 @@ INVALID_DATA = [
     ),
     (
         "tb1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vq47Zagq",
-        "Invalid or unsupported Segwit (Bech32) or Base58 encoding.",  # tb1, Mixed case
-        [],
+        "Invalid character or mixed case",  # tb1, Mixed case
+        [58],
     ),
     (
         "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7v07qwwzcrf",
@@ -121,7 +121,7 @@ INVALID_DATA = [
     ),
     (
         "tb1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vpggkg4j",
-        "Invalid or unsupported Segwit (Bech32) or Base58 encoding.",  # tb1, Non-zero padding in 8-to-5 conversion
+        "Invalid or unsupported prefix for Segwit (Bech32) address (expected bc, got tb).",  # tb1, Non-zero padding in 8-to-5 conversion
         [],
     ),
     ("bc1gmk9yu", "Empty Bech32 data section", []),

--- a/test/functional/rpc_validateaddress.py
+++ b/test/functional/rpc_validateaddress.py
@@ -38,12 +38,12 @@ INVALID_DATA = [
     ),
     (
         "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sL5k7",
-        "Invalid character or mixed case",  # tb1, Mixed case
+        "Bech32 address is mixed case",  # tb1, Mixed case
         [58],
     ),
     (
         "BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3t4",
-        "Invalid character or mixed case",  # bc1, Mixed case, not in BIP 173 test vectors
+        "Bech32 address is mixed case",  # bc1, Mixed case, not in BIP 173 test vectors
         [40],
     ),
     (
@@ -111,7 +111,7 @@ INVALID_DATA = [
     ),
     (
         "tb1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vq47Zagq",
-        "Invalid character or mixed case",  # tb1, Mixed case
+        "Bech32 address is mixed case",  # tb1, Mixed case
         [58],
     ),
     (

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -527,7 +527,7 @@ class WalletTest(BitcoinTestFramework):
         assert_equal(total_txs, len(self.nodes[0].listtransactions("*", 99999)))
 
         # Test getaddressinfo on external address. Note that these addresses are taken from disablewallet.py
-        assert_raises_rpc_error(-5, "Invalid or unsupported Base58-encoded address.", self.nodes[0].getaddressinfo, "3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy")
+        assert_raises_rpc_error(-5, "Invalid Base58 address. Expected prefix 2, m, or n", self.nodes[0].getaddressinfo, "3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy")
         address_info = self.nodes[0].getaddressinfo("mneYUmWYsuk7kySiURxCi3AGxrAqZxLgPZ")
         assert_equal(address_info['address'], "mneYUmWYsuk7kySiURxCi3AGxrAqZxLgPZ")
         assert_equal(address_info["scriptPubKey"], "76a9144e3854046c7bd1594ac904e4793b6a45b36dea0988ac")

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -527,7 +527,7 @@ class WalletTest(BitcoinTestFramework):
         assert_equal(total_txs, len(self.nodes[0].listtransactions("*", 99999)))
 
         # Test getaddressinfo on external address. Note that these addresses are taken from disablewallet.py
-        assert_raises_rpc_error(-5, "Invalid or unsupported Base58-encoded address.", self.nodes[0].getaddressinfo, "3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy")
+        assert_raises_rpc_error(-5, "Invalid Base58 address. Expected prefix 2, m or n", self.nodes[0].getaddressinfo, "3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy")
         address_info = self.nodes[0].getaddressinfo("mneYUmWYsuk7kySiURxCi3AGxrAqZxLgPZ")
         assert_equal(address_info['address'], "mneYUmWYsuk7kySiURxCi3AGxrAqZxLgPZ")
         assert_equal(address_info["scriptPubKey"], "76a9144e3854046c7bd1594ac904e4793b6a45b36dea0988ac")


### PR DESCRIPTION
# Improve Address Decoding Error Messages

Fixes #26290.

## Issue

`DecodeDestination` gives misleading errors when a user inputs a valid address for the wrong network (e.g. a signet address while running on mainnet). Because the Bech32-vs-Base58 dispatch guessed the encoding from the address prefix, a valid Bech32 address for a different network fell through to the Base58 path and reported "Invalid or unsupported Segwit (Bech32) or Base58 encoding."

## Approach

- **Decode first, then validate**: the input is decoded with `bech32::Decode()` upfront (on a lowercased copy, so mixed-case input can be diagnosed explicitly without decoding twice) instead of prefix-guessing. Valid Bech32 addresses for other networks now reach the HRP check and report the expected and actual prefix. Malformed input is diagnosed by the most specific applicable decoder.
- **Separated helpers**: `DecodeDestination` is split into `DecodeBech32Destination()` / `DecodeBase58Destination()`; pure moves/refactors are in their own commits, separate from behavior changes.
- **Structured Bech32 errors**: `bech32::LocateErrors()` now returns a `bech32::Error` code plus locations instead of a message string; `key_io` maps codes to user-facing messages via `Bech32ErrorMessage()`.
- **Network-aware Base58 errors**: expected human-readable prefixes (e.g. "1", "3") come from a new `CChainParams::Base58PrefixText()` table populated for every network and `Base58Type`.

## Error message changes

| Scenario | Previous | New |
|----------|----------|-----|
| Bech32 address for another network | "Invalid or unsupported Segwit (Bech32) or Base58 encoding." | "Invalid or unsupported prefix for Segwit (Bech32) address (expected bc, got tb)" |
| Mixed-case Bech32 string | "Invalid character or mixed case" | "Bech32 address is mixed case" (with offending character positions) |
| Bech32 checksum/format errors | bare message from `LocateErrors` | "Bech32 address decoded with error: …" |
| Base58 address with another network's version bytes | "Invalid or unsupported Base58-encoded address." | "Invalid Base58 address. Expected prefix 3 or 1" |
| Base58 checksum/length failure | "Invalid or unsupported Segwit (Bech32) or Base58 encoding." | "Invalid checksum or length of Base58 address (P2PKH or P2SH)" |
| Input that is neither | "Invalid or unsupported Segwit (Bech32) or Base58 encoding." | "Address is not valid Base58 or Bech32" |

Consistency: the trailing period was dropped from the wrong-network prefix message, and the witness program size error now says "SegWit v0" instead of "Bech32 v0" (the version is a SegWit concept, not an encoding one).

## Tests

- `test/functional/data/rpc_validateaddress.json`: new data file with test vectors keyed by network; `rpc_validateaddress.py` runs them on both signet and mainnet (restarting the node in between), re-enabling the `tb1` BIP 173/350 vectors that were commented out in #27727 and dropping duplicates.
- `rpc_invalid_address_message.py` and `wallet_basic.py` updated for the new messages.
- New `key_io` unit test checking `Base58PrefixText()` on all networks; `bech32` unit tests updated for the error-code enum.
