### PR TITLE
Ignore datacarrier limits for dataless OP_RETURN outputs

### DIFF
--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -83,7 +83,9 @@ bool IsStandard(const CScript& scriptPubKey, const std::optional<unsigned>& max_
         if (m < 1 || m > n)
             return false;
     } else if (whichType == TxoutType::NULL_DATA) {
-        if (!max_datacarrier_bytes || scriptPubKey.size() > *max_datacarrier_bytes) {
+        // An empty OP_RETURN output doesn't carry any data, so don't apply the
+        // data carrier size limit to it.
+        if (scriptPubKey.size() > 1 && (!max_datacarrier_bytes || scriptPubKey.size() > *max_datacarrier_bytes)) {
             return false;
         }
     }

--- a/test/functional/mempool_datacarrier.py
+++ b/test/functional/mempool_datacarrier.py
@@ -31,7 +31,10 @@ class DataCarrierTest(BitcoinTestFramework):
 
     def test_null_data_transaction(self, node: TestNode, data: bytes, success: bool) -> None:
         tx = self.wallet.create_self_transfer(fee_rate=0)["tx"]
-        tx.vout.append(CTxOut(nValue=0, scriptPubKey=CScript([OP_RETURN, data])))
+        if data is None:
+            tx.vout.append(CTxOut(nValue=0, scriptPubKey=CScript([OP_RETURN])))
+        else:
+            tx.vout.append(CTxOut(nValue=0, scriptPubKey=CScript([OP_RETURN, data])))
         tx.vout[0].nValue -= tx.get_vsize()  # simply pay 1sat/vbyte fee
 
         tx_hex = tx.serialize().hex()
@@ -64,6 +67,12 @@ class DataCarrierTest(BitcoinTestFramework):
 
         self.log.info("Testing a null data transaction with a size smaller than accepted by -datacarriersize.")
         self.test_null_data_transaction(node=self.nodes[2], data=small_data, success=True)
+
+        # Should be accepted by all nodes
+        self.log.info("Testing a bare op_return transaction containing no data.")
+        self.test_null_data_transaction(node=self.nodes[0], data=None, success=True)
+        self.test_null_data_transaction(node=self.nodes[1], data=None, success=True)
+        self.test_null_data_transaction(node=self.nodes[2], data=None, success=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
They don't carry any data, so the -datacarrier/-datacarriersize options should not apply to them. Previously a transaction containing an OP_RETURN without data would be rejected if datacarrier was set to false, or the datacarriersize was set to zero.