### PR TITLE
logging: accept "none" as argument for rpc logging

### DIFF
--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -151,6 +151,7 @@ const CLogCategoryDesc LogCategories[] =
 {
     {BCLog::NONE, "0"},
     {BCLog::NONE, ""},
+    {BCLog::NONE, "none"},
     {BCLog::NET, "net"},
     {BCLog::TOR, "tor"},
     {BCLog::MEMPOOL, "mempool"},

--- a/test/functional/rpc_misc.py
+++ b/test/functional/rpc_misc.py
@@ -72,6 +72,18 @@ class RpcMiscTest(BitcoinTestFramework):
         logging_help = self.nodes[0].help('logging')
         assert f"valid logging categories are: {categories}" in logging_help
 
+        # Test aliases for logging all or none
+        def check_all(include, exclude, expected):
+            res = node.logging([include], [exclude])
+            for key in res:
+                assert_equal(res[key], expected)
+        check_all("1", "0", True)
+        check_all("0", "1", False)
+        check_all("all", "none", True)
+        check_all("none", "all", False)
+        check_all("all", "none", True) # repeated case to reset for next line
+        check_all("", "all", False)
+
         self.log.info("test echoipc (testing spawned process in multiprocess build)")
         assert_equal(node.echoipc("hello"), "hello")
 


### PR DESCRIPTION
The help message for rpc `logging` includes:

```
In addition, the following are available as category names with special meanings:
  - "all",  "1" : represent all logging categories.
  - "none", "0" : even if other logging categories are specified, ignore all of them.
```

However "none" is not currently recognized:

```
$ bitcoin/src/bitcoin-cli logging "[\"none\"]"
error code: -8
error message:
unknown logging category none
```

This patch adds the string "none" to match the help instructions.