### PR TITLE
system: allow GUI to initialize default data dir

### DIFF
--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -260,8 +260,8 @@ bool Intro::showIfNeeded(bool& did_show_intro, int64_t& prune_MiB)
      * override -datadir in the bitcoin.conf file in the default data directory
      * (to be consistent with bitcoind behavior)
      */
-    if(dataDir != GUIUtil::getDefaultDataDirectory()) {
-        gArgs.SoftSetArg("-datadir", fs::PathToString(GUIUtil::QStringToPath(dataDir))); // use OS locale for path setting
+    if (dataDir != GUIUtil::getDefaultDataDirectory()) {
+        gArgs.InitDefaultDataDir(GUIUtil::QStringToPath(dataDir));
     }
     return true;
 }

--- a/src/qt/test/optiontests.h
+++ b/src/qt/test/optiontests.h
@@ -23,6 +23,7 @@ private Q_SLOTS:
     void integerGetArgBug();
     void parametersInteraction();
     void extractFilter();
+    void initDataDir();
 
 private:
     interfaces::Node& m_node;

--- a/src/test/argsman_tests.cpp
+++ b/src/test/argsman_tests.cpp
@@ -1040,4 +1040,25 @@ BOOST_AUTO_TEST_CASE(util_ReadWriteSettings)
     }
 }
 
+BOOST_AUTO_TEST_CASE(util_InitDefaultDataDir)
+{
+    TestArgsManager args;
+    fs::path config_location = m_path_root / "config-file-only";
+    fs::path datadir_location = m_path_root / "preferred-location";
+    fs::create_directory(config_location);
+    fs::create_directory(datadir_location);
+
+    args.AddArg("-datadir", "", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    // GUI loads user preferences from QSettings
+    args.InitDefaultDataDir(config_location);
+    // InitConfig reads config file at the QSettings strDataDir location
+    std::string conf = "datadir=";
+    conf += fs::PathToString(datadir_location);
+    args.ReadConfigString(conf.c_str());
+
+    fs::path actual_datadir = args.GetDataDirNet();
+    BOOST_CHECK(actual_datadir == datadir_location);
+}
+
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -428,7 +428,7 @@ const fs::path& ArgsManager::GetDataDir(bool net_specific) const
             return path;
         }
     } else {
-        path = GetDefaultDataDir();
+        path = m_init_default_datadir_path.empty() ? GetDefaultDataDir() : m_init_default_datadir_path;
     }
 
     if (net_specific && !BaseParams().DataDir().empty()) {
@@ -436,6 +436,13 @@ const fs::path& ArgsManager::GetDataDir(bool net_specific) const
     }
 
     return path;
+}
+
+void ArgsManager::InitDefaultDataDir(const fs::path path)
+{
+    LOCK(cs_args);
+    if (m_init_default_datadir_path.empty())
+        m_init_default_datadir_path = path;
 }
 
 void ArgsManager::ClearPathCache()

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -199,6 +199,7 @@ protected:
     mutable fs::path m_cached_blocks_path GUARDED_BY(cs_args);
     mutable fs::path m_cached_datadir_path GUARDED_BY(cs_args);
     mutable fs::path m_cached_network_datadir_path GUARDED_BY(cs_args);
+    mutable fs::path m_init_default_datadir_path GUARDED_BY(cs_args);
 
     [[nodiscard]] bool ReadConfigStream(std::istream& stream, const std::string& filepath, std::string& error, bool ignore_invalid_keys = false);
 
@@ -287,6 +288,13 @@ protected:
      * @return Absolute path on success, otherwise an empty path when a non-directory path would be returned
      */
     const fs::path& GetDataDirNet() const { return GetDataDir(true); }
+
+    /**
+     * Sets the initial default data dir path, unless it has already been set.
+     * Intended for use only by the GUI before config file is parsed.
+     *
+     */
+    void InitDefaultDataDir(const fs::path path);
 
     /**
      * Clear cached directory paths


### PR DESCRIPTION
closes #27246

Replaces a `SoftSetArg()` called by the GUI before parsing `bitcoin.conf` with a new method `InitDefaultDataDir()`. This allows the GUI to look for the conf file in a user-specified, non-default location and still parse a `datadir=` setting from that file. Adds unit tests for argsman and also for Qt and its QSettings.
