### PR TITLE
build: ignore common editor files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,8 +95,10 @@ Makefile
 src/qt/bitcoin-qt
 Bitcoin-Qt.app
 
-# Qt Creator
+# Editors
 Makefile.am.user
+.vscode
+.idea
 
 # Unit-tests
 Makefile.test


### PR DESCRIPTION
Add IntelliJ and Visual Studio Code editor files to .gitignore. Small QOL change :)