### PR TITLE
Refactor: Remove unused FlatFilePos::SetNull

### DIFF
--- a/src/flatfile.h
+++ b/src/flatfile.h
@@ -13,12 +13,12 @@
 
 struct FlatFilePos
 {
-    int nFile;
-    unsigned int nPos;
+    int nFile{-1};
+    unsigned int nPos{0};
 
     SERIALIZE_METHODS(FlatFilePos, obj) { READWRITE(VARINT_MODE(obj.nFile, VarIntMode::NONNEGATIVE_SIGNED), VARINT(obj.nPos)); }
 
-    FlatFilePos() : nFile(-1), nPos(0) {}
+    FlatFilePos() {}
 
     FlatFilePos(int nFileIn, unsigned int nPosIn) :
         nFile(nFileIn),
@@ -33,7 +33,6 @@ struct FlatFilePos
         return !(a == b);
     }
 
-    void SetNull() { nFile = -1; nPos = 0; }
     bool IsNull() const { return (nFile == -1); }
 
     std::string ToString() const;

--- a/src/index/disktxpos.h
+++ b/src/index/disktxpos.h
@@ -10,7 +10,7 @@
 
 struct CDiskTxPos : public FlatFilePos
 {
-    unsigned int nTxOffset; // after header
+    unsigned int nTxOffset{0}; // after header
 
     SERIALIZE_METHODS(CDiskTxPos, obj)
     {
@@ -21,15 +21,7 @@ struct CDiskTxPos : public FlatFilePos
     CDiskTxPos(const FlatFilePos &blockIn, unsigned int nTxOffsetIn) : FlatFilePos(blockIn.nFile, blockIn.nPos), nTxOffset(nTxOffsetIn) {
     }
 
-    CDiskTxPos() {
-        SetNull();
-    }
-
-    void SetNull() {
-        FlatFilePos::SetNull();
-        nTxOffset = 0;
-    }
+    CDiskTxPos() {}
 };
-
 
 #endif // BITCOIN_INDEX_DISKTXPOS_H

--- a/src/test/flatfile_tests.cpp
+++ b/src/test/flatfile_tests.cpp
@@ -23,6 +23,9 @@ BOOST_AUTO_TEST_CASE(flatfile_filename)
 
     FlatFileSeq seq2(data_dir / "a", "b", 16 * 1024);
     BOOST_CHECK_EQUAL(seq2.FileName(pos), data_dir / "a" / "b00456.dat");
+
+    // Check default constructor IsNull
+    assert(FlatFilePos{}.IsNull());
 }
 
 BOOST_AUTO_TEST_CASE(flatfile_open)

--- a/src/test/fuzz/flatfile.cpp
+++ b/src/test/fuzz/flatfile.cpp
@@ -25,6 +25,4 @@ FUZZ_TARGET(flatfile)
         assert((*flat_file_pos == *another_flat_file_pos) != (*flat_file_pos != *another_flat_file_pos));
     }
     (void)flat_file_pos->ToString();
-    flat_file_pos->SetNull();
-    assert(flat_file_pos->IsNull());
 }


### PR DESCRIPTION
This is unused outside of tests and the default constructor. With C++11, it can be replaced by C++11 member initializers in the default constructor.

Beside removing unused code, this also makes it less fragile in light of uninitialized memory. (See also https://github.com/bitcoin/bitcoin/pull/26296#issuecomment-1477801767)

If new code needs to set this to null, it can use `std::optional`, or in the worst case re-introduce this method.