### PR TITLE
refactor: Move chain names to the util library

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -278,6 +278,7 @@ BITCOIN_CORE_H = \
   util/bip32.h \
   util/bitdeque.h \
   util/bytevectorhash.h \
+  util/chainname.h \
   util/check.h \
   util/epochguard.h \
   util/error.h \
@@ -703,6 +704,7 @@ libbitcoin_util_a_SOURCES = \
   util/asmap.cpp \
   util/bip32.cpp \
   util/bytevectorhash.cpp \
+  util/chainname.cpp \
   util/check.cpp \
   util/error.cpp \
   util/exception.cpp \
@@ -950,6 +952,7 @@ libbitcoinkernel_la_SOURCES = \
   txdb.cpp \
   txmempool.cpp \
   uint256.cpp \
+  util/chainname.cpp \
   util/check.cpp \
   util/exception.cpp \
   util/fs.cpp \

--- a/src/bench/checkblock.cpp
+++ b/src/bench/checkblock.cpp
@@ -8,6 +8,7 @@
 #include <chainparams.h>
 #include <consensus/validation.h>
 #include <streams.h>
+#include <util/chainname.h>
 #include <util/system.h>
 #include <validation.h>
 

--- a/src/bench/checkblock.cpp
+++ b/src/bench/checkblock.cpp
@@ -37,7 +37,7 @@ static void DeserializeAndCheckBlockTest(benchmark::Bench& bench)
     stream.write({&a, 1}); // Prevent compaction
 
     ArgsManager bench_args;
-    const auto chainParams = CreateChainParams(bench_args, CBaseChainParams::MAIN);
+    const auto chainParams = CreateChainParams(bench_args, chainname::MAIN);
 
     bench.unit("block").run([&] {
         CBlock block; // Note that CBlock caches its checked state, so we need to recreate it here

--- a/src/bench/load_external.cpp
+++ b/src/bench/load_external.cpp
@@ -6,6 +6,7 @@
 #include <bench/data.h>
 #include <chainparams.h>
 #include <test/util/setup_common.h>
+#include <util/chainname.h>
 #include <validation.h>
 
 /**

--- a/src/bench/load_external.cpp
+++ b/src/bench/load_external.cpp
@@ -23,7 +23,7 @@
  */
 static void LoadExternalBlockFile(benchmark::Bench& bench)
 {
-    const auto testing_setup{MakeNoLogFileContext<const TestingSetup>(CBaseChainParams::MAIN)};
+    const auto testing_setup{MakeNoLogFileContext<const TestingSetup>(chainname::MAIN)};
 
     // Create a single block as in the blocks files (magic bytes, block size,
     // block data) as a stream object.

--- a/src/bench/logging.cpp
+++ b/src/bench/logging.cpp
@@ -19,7 +19,7 @@ static void Logging(benchmark::Bench& bench, const std::vector<const char*>& ext
     LogInstance().DisableCategory(BCLog::LogFlags::ALL);
 
     TestingSetup test_setup{
-        CBaseChainParams::REGTEST,
+        chainname::REGTEST,
         extra_args,
     };
 

--- a/src/bench/logging.cpp
+++ b/src/bench/logging.cpp
@@ -5,6 +5,7 @@
 #include <bench/bench.h>
 #include <logging.h>
 #include <test/util/setup_common.h>
+#include <util/chainname.h>
 
 // All but 2 of the benchmarks should have roughly similar performance:
 //

--- a/src/bench/mempool_stress.cpp
+++ b/src/bench/mempool_stress.cpp
@@ -7,6 +7,7 @@
 #include <policy/policy.h>
 #include <test/util/setup_common.h>
 #include <txmempool.h>
+#include <util/chainname.h>
 #include <validation.h>
 
 #include <vector>

--- a/src/bench/mempool_stress.cpp
+++ b/src/bench/mempool_stress.cpp
@@ -89,7 +89,7 @@ static void ComplexMemPool(benchmark::Bench& bench)
         childTxs = static_cast<int>(bench.complexityN());
     }
     std::vector<CTransactionRef> ordered_coins = CreateOrderedCoins(det_rand, childTxs, /*min_ancestors=*/1);
-    const auto testing_setup = MakeNoLogFileContext<const TestingSetup>(CBaseChainParams::MAIN);
+    const auto testing_setup = MakeNoLogFileContext<const TestingSetup>(chainname::MAIN);
     CTxMemPool& pool = *testing_setup.get()->m_node.mempool;
     LOCK2(cs_main, pool.cs);
     bench.run([&]() NO_THREAD_SAFETY_ANALYSIS {
@@ -104,7 +104,7 @@ static void ComplexMemPool(benchmark::Bench& bench)
 static void MempoolCheck(benchmark::Bench& bench)
 {
     FastRandomContext det_rand{true};
-    auto testing_setup = MakeNoLogFileContext<TestChain100Setup>(CBaseChainParams::REGTEST, {"-checkmempool=1"});
+    auto testing_setup = MakeNoLogFileContext<TestChain100Setup>(chainname::REGTEST, {"-checkmempool=1"});
     CTxMemPool& pool = *testing_setup.get()->m_node.mempool;
     LOCK2(cs_main, pool.cs);
     testing_setup->PopulateMempool(det_rand, 400, true);

--- a/src/bench/rpc_blockchain.cpp
+++ b/src/bench/rpc_blockchain.cpp
@@ -8,6 +8,7 @@
 #include <rpc/blockchain.h>
 #include <streams.h>
 #include <test/util/setup_common.h>
+#include <util/chainname.h>
 #include <validation.h>
 
 #include <univalue.h>

--- a/src/bench/rpc_blockchain.cpp
+++ b/src/bench/rpc_blockchain.cpp
@@ -16,7 +16,7 @@
 namespace {
 
 struct TestBlockAndIndex {
-    const std::unique_ptr<const TestingSetup> testing_setup{MakeNoLogFileContext<const TestingSetup>(CBaseChainParams::MAIN)};
+    const std::unique_ptr<const TestingSetup> testing_setup{MakeNoLogFileContext<const TestingSetup>(chainname::MAIN)};
     CBlock block{};
     uint256 blockHash{};
     CBlockIndex blockindex{};

--- a/src/bench/rpc_mempool.cpp
+++ b/src/bench/rpc_mempool.cpp
@@ -3,7 +3,6 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <bench/bench.h>
-#include <chainparamsbase.h>
 #include <kernel/cs_main.h>
 #include <kernel/mempool_entry.h>
 #include <rpc/mempool.h>

--- a/src/bench/rpc_mempool.cpp
+++ b/src/bench/rpc_mempool.cpp
@@ -22,7 +22,7 @@ static void AddTx(const CTransactionRef& tx, const CAmount& fee, CTxMemPool& poo
 
 static void RpcMempool(benchmark::Bench& bench)
 {
-    const auto testing_setup = MakeNoLogFileContext<const ChainTestingSetup>(CBaseChainParams::MAIN);
+    const auto testing_setup = MakeNoLogFileContext<const ChainTestingSetup>(chainname::MAIN);
     CTxMemPool& pool = *Assert(testing_setup->m_node.mempool);
     LOCK2(cs_main, pool.cs);
 

--- a/src/bench/rpc_mempool.cpp
+++ b/src/bench/rpc_mempool.cpp
@@ -9,6 +9,7 @@
 #include <rpc/mempool.h>
 #include <test/util/setup_common.h>
 #include <txmempool.h>
+#include <util/chainname.h>
 
 #include <univalue.h>
 

--- a/src/bitcoin-chainstate.cpp
+++ b/src/bitcoin-chainstate.cpp
@@ -15,6 +15,7 @@
 #include <kernel/checks.h>
 #include <kernel/context.h>
 #include <kernel/validation_cache_sizes.h>
+#include <util/chainname.h>
 
 #include <chainparams.h>
 #include <consensus/validation.h>

--- a/src/bitcoin-chainstate.cpp
+++ b/src/bitcoin-chainstate.cpp
@@ -53,7 +53,7 @@ int main(int argc, char* argv[])
 
 
     // SETUP: Misc Globals
-    SelectParams(CBaseChainParams::MAIN);
+    SelectParams(chainname::MAIN);
     auto chainparams = CChainParams::Main();
 
     kernel::Context kernel_context{};

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -19,6 +19,7 @@
 #include <rpc/request.h>
 #include <tinyformat.h>
 #include <univalue.h>
+#include <util/chainname.h>
 #include <util/exception.h>
 #include <util/strencodings.h>
 #include <util/system.h>

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -72,10 +72,10 @@ static void SetupCliArgs(ArgsManager& argsman)
 {
     SetupHelpOptions(argsman);
 
-    const auto defaultBaseParams = CreateBaseChainParams(CBaseChainParams::MAIN);
-    const auto testnetBaseParams = CreateBaseChainParams(CBaseChainParams::TESTNET);
-    const auto signetBaseParams = CreateBaseChainParams(CBaseChainParams::SIGNET);
-    const auto regtestBaseParams = CreateBaseChainParams(CBaseChainParams::REGTEST);
+    const auto defaultBaseParams = CreateBaseChainParams(chainname::MAIN);
+    const auto testnetBaseParams = CreateBaseChainParams(chainname::TESTNET);
+    const auto signetBaseParams = CreateBaseChainParams(chainname::SIGNET);
+    const auto regtestBaseParams = CreateBaseChainParams(chainname::REGTEST);
 
     argsman.AddArg("-version", "Print version and exit", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-conf=<file>", strprintf("Specify configuration file. Relative paths will be prefixed by datadir location. (default: %s)", BITCOIN_CONF_FILENAME), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
@@ -425,9 +425,9 @@ private:
     std::vector<Peer> m_peers;
     std::string ChainToString() const
     {
-        if (gArgs.GetChainName() == CBaseChainParams::TESTNET) return " testnet";
-        if (gArgs.GetChainName() == CBaseChainParams::SIGNET) return " signet";
-        if (gArgs.GetChainName() == CBaseChainParams::REGTEST) return " regtest";
+        if (gArgs.GetChainName() == chainname::TESTNET) return " testnet";
+        if (gArgs.GetChainName() == chainname::SIGNET) return " signet";
+        if (gArgs.GetChainName() == chainname::REGTEST) return " regtest";
         return "";
     }
     std::string PingTimeToString(double seconds) const

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -6,6 +6,7 @@
 #include <config/bitcoin-config.h>
 #endif
 
+#include <chainparamsbase.h>
 #include <clientversion.h>
 #include <coins.h>
 #include <compat/compat.h>

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -5,11 +5,13 @@
 
 #include <chainparams.h>
 
+#include <chainparamsbase.h>
 #include <chainparamsseeds.h>
 #include <consensus/merkle.h>
 #include <deploymentinfo.h>
 #include <hash.h> // for signet block challenge hash
 #include <script/interpreter.h>
+#include <util/chainname.h>
 #include <util/string.h>
 #include <util/system.h>
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -100,15 +100,15 @@ const CChainParams &Params() {
 
 std::unique_ptr<const CChainParams> CreateChainParams(const ArgsManager& args, const std::string& chain)
 {
-    if (chain == CBaseChainParams::MAIN) {
+    if (chain == chainname::MAIN) {
         return CChainParams::Main();
-    } else if (chain == CBaseChainParams::TESTNET) {
+    } else if (chain == chainname::TESTNET) {
         return CChainParams::TestNet();
-    } else if (chain == CBaseChainParams::SIGNET) {
+    } else if (chain == chainname::SIGNET) {
         auto opts = CChainParams::SigNetOptions{};
         ReadSigNetArgs(args, opts);
         return CChainParams::SigNet(opts);
-    } else if (chain == CBaseChainParams::REGTEST) {
+    } else if (chain == chainname::REGTEST) {
         auto opts = CChainParams::RegTestOptions{};
         ReadRegTestArgs(args, opts);
         return CChainParams::RegTest(opts);

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -8,7 +8,6 @@
 
 #include <kernel/chainparams.h>
 
-#include <chainparamsbase.h>
 #include <consensus/params.h>
 #include <netaddress.h>
 #include <primitives/block.h>

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -21,6 +21,8 @@
 #include <unordered_map>
 #include <vector>
 
+class ArgsManager;
+
 /**
  * Creates and returns a std::unique_ptr<CChainParams> of the chosen chain.
  * @returns a CChainParams* of the chosen chain.

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -6,6 +6,7 @@
 #include <chainparamsbase.h>
 
 #include <tinyformat.h>
+#include <util/chainname.h>
 #include <util/system.h>
 
 #include <assert.h>

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -11,11 +11,6 @@
 
 #include <assert.h>
 
-const std::string CBaseChainParams::MAIN = "main";
-const std::string CBaseChainParams::TESTNET = "test";
-const std::string CBaseChainParams::SIGNET = "signet";
-const std::string CBaseChainParams::REGTEST = "regtest";
-
 void SetupChainParamsBaseOptions(ArgsManager& argsman)
 {
     argsman.AddArg("-chain=<chain>", "Use the chain <chain> (default: main). Allowed values: main, test, signet, regtest", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
@@ -43,13 +38,13 @@ const CBaseChainParams& BaseParams()
  */
 std::unique_ptr<CBaseChainParams> CreateBaseChainParams(const std::string& chain)
 {
-    if (chain == CBaseChainParams::MAIN) {
+    if (chain == chainname::MAIN) {
         return std::make_unique<CBaseChainParams>("", 8332, 8334);
-    } else if (chain == CBaseChainParams::TESTNET) {
+    } else if (chain == chainname::TESTNET) {
         return std::make_unique<CBaseChainParams>("testnet3", 18332, 18334);
-    } else if (chain == CBaseChainParams::SIGNET) {
+    } else if (chain == chainname::SIGNET) {
         return std::make_unique<CBaseChainParams>("signet", 38332, 38334);
-    } else if (chain == CBaseChainParams::REGTEST) {
+    } else if (chain == chainname::REGTEST) {
         return std::make_unique<CBaseChainParams>("regtest", 18443, 18445);
     }
     throw std::runtime_error(strprintf("%s: Unknown chain %s.", __func__, chain));

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -17,14 +17,6 @@ class ArgsManager;
 class CBaseChainParams
 {
 public:
-    ///@{
-    /** Chain name strings */
-    static const std::string MAIN;
-    static const std::string TESTNET;
-    static const std::string SIGNET;
-    static const std::string REGTEST;
-    ///@}
-
     const std::string& DataDir() const { return strDataDir; }
     uint16_t RPCPort() const { return m_rpc_port; }
     uint16_t OnionServiceTargetPort() const { return m_onion_service_target_port; }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -18,6 +18,7 @@
 #include <blockfilter.h>
 #include <chain.h>
 #include <chainparams.h>
+#include <chainparamsbase.h>
 #include <consensus/amount.h>
 #include <deploymentstatus.h>
 #include <hash.h>
@@ -68,6 +69,7 @@
 #include <txdb.h>
 #include <txmempool.h>
 #include <util/asmap.h>
+#include <util/chainname.h>
 #include <util/check.h>
 #include <util/fs.h>
 #include <util/fs_helpers.h>

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -409,14 +409,14 @@ void SetupServerArgs(ArgsManager& argsman)
 
     init::AddLoggingArgs(argsman);
 
-    const auto defaultBaseParams = CreateBaseChainParams(CBaseChainParams::MAIN);
-    const auto testnetBaseParams = CreateBaseChainParams(CBaseChainParams::TESTNET);
-    const auto signetBaseParams = CreateBaseChainParams(CBaseChainParams::SIGNET);
-    const auto regtestBaseParams = CreateBaseChainParams(CBaseChainParams::REGTEST);
-    const auto defaultChainParams = CreateChainParams(argsman, CBaseChainParams::MAIN);
-    const auto testnetChainParams = CreateChainParams(argsman, CBaseChainParams::TESTNET);
-    const auto signetChainParams = CreateChainParams(argsman, CBaseChainParams::SIGNET);
-    const auto regtestChainParams = CreateChainParams(argsman, CBaseChainParams::REGTEST);
+    const auto defaultBaseParams = CreateBaseChainParams(chainname::MAIN);
+    const auto testnetBaseParams = CreateBaseChainParams(chainname::TESTNET);
+    const auto signetBaseParams = CreateBaseChainParams(chainname::SIGNET);
+    const auto regtestBaseParams = CreateBaseChainParams(chainname::REGTEST);
+    const auto defaultChainParams = CreateChainParams(argsman, chainname::MAIN);
+    const auto testnetChainParams = CreateChainParams(argsman, chainname::TESTNET);
+    const auto signetChainParams = CreateChainParams(argsman, chainname::SIGNET);
+    const auto regtestChainParams = CreateChainParams(argsman, chainname::REGTEST);
 
     // Hidden Options
     std::vector<std::string> hidden_args = {
@@ -847,7 +847,7 @@ bool AppInitParameterInteraction(const ArgsManager& args, bool use_syscall_sandb
     // specified in default section of config file, but not overridden
     // on the command line or in this network's section of the config file.
     std::string network = args.GetChainName();
-    if (network == CBaseChainParams::SIGNET) {
+    if (network == chainname::SIGNET) {
         LogPrintf("Signet derived magic (message start): %s\n", HexStr(chainparams.MessageStart()));
     }
     bilingual_str errors;

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -5,18 +5,19 @@
 
 #include <kernel/chainparams.h>
 
+#include <chainparamsbase.h>
 #include <chainparamsseeds.h>
 #include <consensus/amount.h>
 #include <consensus/merkle.h>
 #include <consensus/params.h>
 #include <hash.h>
-#include <chainparamsbase.h>
 #include <logging.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <script/interpreter.h>
 #include <script/script.h>
 #include <uint256.h>
+#include <util/chainname.h>
 #include <util/strencodings.h>
 
 #include <algorithm>

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -5,7 +5,6 @@
 
 #include <kernel/chainparams.h>
 
-#include <chainparamsbase.h>
 #include <chainparamsseeds.h>
 #include <consensus/amount.h>
 #include <consensus/merkle.h>

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -71,7 +71,7 @@ static CBlock CreateGenesisBlock(uint32_t nTime, uint32_t nNonce, uint32_t nBits
 class CMainParams : public CChainParams {
 public:
     CMainParams() {
-        strNetworkID = CBaseChainParams::MAIN;
+        strNetworkID = chainname::MAIN;
         consensus.signet_blocks = false;
         consensus.signet_challenge.clear();
         consensus.nSubsidyHalvingInterval = 210000;
@@ -193,7 +193,7 @@ public:
 class CTestNetParams : public CChainParams {
 public:
     CTestNetParams() {
-        strNetworkID = CBaseChainParams::TESTNET;
+        strNetworkID = chainname::TESTNET;
         consensus.signet_blocks = false;
         consensus.signet_challenge.clear();
         consensus.nSubsidyHalvingInterval = 210000;
@@ -329,7 +329,7 @@ public:
             vSeeds = *options.seeds;
         }
 
-        strNetworkID = CBaseChainParams::SIGNET;
+        strNetworkID = chainname::SIGNET;
         consensus.signet_blocks = true;
         consensus.signet_challenge.assign(bin.begin(), bin.end());
         consensus.nSubsidyHalvingInterval = 210000;
@@ -398,7 +398,7 @@ class CRegTestParams : public CChainParams
 public:
     explicit CRegTestParams(const RegTestOptions& opts)
     {
-        strNetworkID =  CBaseChainParams::REGTEST;
+        strNetworkID =  chainname::REGTEST;
         consensus.signet_blocks = false;
         consensus.signet_challenge.clear();
         consensus.nSubsidyHalvingInterval = 150;

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -504,9 +504,9 @@ bool LabelOutOfFocusEventFilter::eventFilter(QObject* watched, QEvent* event)
 fs::path static StartupShortcutPath()
 {
     std::string chain = gArgs.GetChainName();
-    if (chain == CBaseChainParams::MAIN)
+    if (chain == chainname::MAIN)
         return GetSpecialFolderPath(CSIDL_STARTUP) / "Bitcoin.lnk";
-    if (chain == CBaseChainParams::TESTNET) // Remove this special case when CBaseChainParams::TESTNET = "testnet4"
+    if (chain == chainname::TESTNET) // Remove this special case when chainname::TESTNET = "testnet4"
         return GetSpecialFolderPath(CSIDL_STARTUP) / "Bitcoin (testnet).lnk";
     return GetSpecialFolderPath(CSIDL_STARTUP) / fs::u8path(strprintf("Bitcoin (%s).lnk", chain));
 }
@@ -587,7 +587,7 @@ fs::path static GetAutostartDir()
 fs::path static GetAutostartFilePath()
 {
     std::string chain = gArgs.GetChainName();
-    if (chain == CBaseChainParams::MAIN)
+    if (chain == chainname::MAIN)
         return GetAutostartDir() / "bitcoin.desktop";
     return GetAutostartDir() / fs::u8path(strprintf("bitcoin-%s.desktop", chain));
 }
@@ -633,7 +633,7 @@ bool SetStartOnSystemStartup(bool fAutoStart)
         // Write a bitcoin.desktop file to the autostart directory:
         optionFile << "[Desktop Entry]\n";
         optionFile << "Type=Application\n";
-        if (chain == CBaseChainParams::MAIN)
+        if (chain == chainname::MAIN)
             optionFile << "Name=Bitcoin\n";
         else
             optionFile << strprintf("Name=Bitcoin (%s)\n", chain);

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -19,6 +19,7 @@
 #include <protocol.h>
 #include <script/script.h>
 #include <script/standard.h>
+#include <util/chainname.h>
 #include <util/exception.h>
 #include <util/fs.h>
 #include <util/fs_helpers.h>

--- a/src/qt/networkstyle.cpp
+++ b/src/qt/networkstyle.cpp
@@ -6,7 +6,6 @@
 
 #include <qt/guiconstants.h>
 
-#include <chainparamsbase.h>
 #include <tinyformat.h>
 #include <util/chainname.h>
 

--- a/src/qt/networkstyle.cpp
+++ b/src/qt/networkstyle.cpp
@@ -8,6 +8,7 @@
 
 #include <chainparamsbase.h>
 #include <tinyformat.h>
+#include <util/chainname.h>
 
 #include <QApplication>
 

--- a/src/qt/networkstyle.cpp
+++ b/src/qt/networkstyle.cpp
@@ -80,7 +80,7 @@ NetworkStyle::NetworkStyle(const QString &_appName, const int iconColorHueShift,
 
 const NetworkStyle* NetworkStyle::instantiate(const std::string& networkId)
 {
-    std::string titleAddText = networkId == CBaseChainParams::MAIN ? "" : strprintf("[%s]", networkId);
+    std::string titleAddText = networkId == chainname::MAIN ? "" : strprintf("[%s]", networkId);
     for (const auto& network_style : network_styles) {
         if (networkId == network_style.networkId) {
             return new NetworkStyle(

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -14,6 +14,7 @@
 #include <qt/test/rpcnestedtests.h>
 #include <qt/test/uritests.h>
 #include <test/util/setup_common.h>
+#include <util/chainname.h>
 
 #ifdef ENABLE_WALLET
 #include <qt/test/addressbooktests.h>

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -58,7 +58,7 @@ int main(int argc, char* argv[])
     //
     // All tests must use their own testing setup (if needed).
     fs::create_directories([] {
-        BasicTestingSetup dummy{CBaseChainParams::REGTEST};
+        BasicTestingSetup dummy{chainname::REGTEST};
         return gArgs.GetDataDirNet() / "blocks";
     }());
 

--- a/src/rpc/external_signer.cpp
+++ b/src/rpc/external_signer.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <chainparamsbase.h>
 #include <external_signer.h>
 #include <rpc/server.h>
 #include <rpc/util.h>

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -355,7 +355,7 @@ static RPCHelpMan addconnection()
         },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
-    if (Params().NetworkIDString() != CBaseChainParams::REGTEST) {
+    if (Params().NetworkIDString() != chainname::REGTEST) {
         throw std::runtime_error("addconnection is for regression testing (-regtest mode) only.");
     }
 

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -21,6 +21,7 @@
 #include <rpc/util.h>
 #include <sync.h>
 #include <timedata.h>
+#include <util/chainname.h>
 #include <util/strencodings.h>
 #include <util/string.h>
 #include <util/time.h>

--- a/src/test/argsman_tests.cpp
+++ b/src/test/argsman_tests.cpp
@@ -7,6 +7,7 @@
 #include <test/util/setup_common.h>
 #include <test/util/str.h>
 #include <univalue.h>
+#include <util/chainname.h>
 #include <util/fs.h>
 #include <util/strencodings.h>
 #include <util/system.h>

--- a/src/test/argsman_tests.cpp
+++ b/src/test/argsman_tests.cpp
@@ -581,7 +581,7 @@ BOOST_AUTO_TEST_CASE(util_ReadConfigStream)
     test_args.SetNetworkOnlyArg("-ccc");
     test_args.SetNetworkOnlyArg("-h");
 
-    test_args.SelectConfigNetwork(CBaseChainParams::MAIN);
+    test_args.SelectConfigNetwork(chainname::MAIN);
     BOOST_CHECK(test_args.GetArg("-d", "xxx") == "e");
     BOOST_CHECK(test_args.GetArgs("-ccc").size() == 2);
     BOOST_CHECK(test_args.GetArg("-h", "xxx") == "0");
@@ -756,8 +756,8 @@ struct ArgsMergeTestingSetup : public BasicTestingSetup {
             ForEachNoDup(conf_actions, SET, SECTION_NEGATE, [&] {
                 for (bool soft_set : {false, true}) {
                     for (bool force_set : {false, true}) {
-                        for (const std::string& section : {CBaseChainParams::MAIN, CBaseChainParams::TESTNET, CBaseChainParams::SIGNET}) {
-                            for (const std::string& network : {CBaseChainParams::MAIN, CBaseChainParams::TESTNET, CBaseChainParams::SIGNET}) {
+                        for (const std::string& section : {chainname::MAIN, chainname::TESTNET, chainname::SIGNET}) {
+                            for (const std::string& network : {chainname::MAIN, chainname::TESTNET, chainname::SIGNET}) {
                                 for (bool net_specific : {false, true}) {
                                     fn(arg_actions, conf_actions, soft_set, force_set, section, network, net_specific);
                                 }

--- a/src/test/blockmanager_tests.cpp
+++ b/src/test/blockmanager_tests.cpp
@@ -5,6 +5,7 @@
 #include <chainparams.h>
 #include <node/blockstorage.h>
 #include <node/context.h>
+#include <util/chainname.h>
 #include <validation.h>
 
 #include <boost/test/unit_test.hpp>

--- a/src/test/blockmanager_tests.cpp
+++ b/src/test/blockmanager_tests.cpp
@@ -21,7 +21,7 @@ BOOST_FIXTURE_TEST_SUITE(blockmanager_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(blockmanager_find_block_pos)
 {
-    const auto params {CreateChainParams(ArgsManager{}, CBaseChainParams::MAIN)};
+    const auto params {CreateChainParams(ArgsManager{}, chainname::MAIN)};
     BlockManager blockman{{}};
     CChain chain {};
     // simulate adding a genesis block normally

--- a/src/test/checkqueue_tests.cpp
+++ b/src/test/checkqueue_tests.cpp
@@ -28,9 +28,9 @@
 struct NoLockLoggingTestingSetup : public TestingSetup {
     NoLockLoggingTestingSetup()
 #ifdef DEBUG_LOCKCONTENTION
-        : TestingSetup{CBaseChainParams::MAIN, /*extra_args=*/{"-debugexclude=lock"}} {}
+        : TestingSetup{chainname::MAIN, /*extra_args=*/{"-debugexclude=lock"}} {}
 #else
-        : TestingSetup{CBaseChainParams::MAIN} {}
+        : TestingSetup{chainname::MAIN} {}
 #endif
 };
 

--- a/src/test/checkqueue_tests.cpp
+++ b/src/test/checkqueue_tests.cpp
@@ -6,6 +6,7 @@
 #include <sync.h>
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
+#include <util/chainname.h>
 #include <util/system.h>
 #include <util/time.h>
 

--- a/src/test/fuzz/addrman.cpp
+++ b/src/test/fuzz/addrman.cpp
@@ -35,7 +35,7 @@ int32_t GetCheckRatio()
 
 void initialize_addrman()
 {
-    static const auto testing_setup = MakeNoLogFileContext<>(CBaseChainParams::REGTEST);
+    static const auto testing_setup = MakeNoLogFileContext<>(chainname::REGTEST);
     g_setup = testing_setup.get();
 }
 

--- a/src/test/fuzz/addrman.cpp
+++ b/src/test/fuzz/addrman.cpp
@@ -15,6 +15,7 @@
 #include <test/util/setup_common.h>
 #include <time.h>
 #include <util/asmap.h>
+#include <util/chainname.h>
 #include <util/system.h>
 
 #include <cassert>

--- a/src/test/fuzz/block.cpp
+++ b/src/test/fuzz/block.cpp
@@ -11,6 +11,7 @@
 #include <pubkey.h>
 #include <streams.h>
 #include <test/fuzz/fuzz.h>
+#include <util/chainname.h>
 #include <validation.h>
 #include <version.h>
 

--- a/src/test/fuzz/block.cpp
+++ b/src/test/fuzz/block.cpp
@@ -20,7 +20,7 @@
 
 void initialize_block()
 {
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(chainname::REGTEST);
 }
 
 FUZZ_TARGET_INIT(block, initialize_block)

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -3,7 +3,6 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chainparams.h>
-#include <chainparamsbase.h>
 #include <coins.h>
 #include <consensus/amount.h>
 #include <consensus/tx_check.h>

--- a/src/test/fuzz/connman.cpp
+++ b/src/test/fuzz/connman.cpp
@@ -4,7 +4,6 @@
 
 #include <addrman.h>
 #include <chainparams.h>
-#include <chainparamsbase.h>
 #include <net.h>
 #include <netaddress.h>
 #include <protocol.h>

--- a/src/test/fuzz/descriptor_parse.cpp
+++ b/src/test/fuzz/descriptor_parse.cpp
@@ -6,6 +6,7 @@
 #include <pubkey.h>
 #include <script/descriptor.h>
 #include <test/fuzz/fuzz.h>
+#include <util/chainname.h>
 
 void initialize_descriptor_parse()
 {

--- a/src/test/fuzz/descriptor_parse.cpp
+++ b/src/test/fuzz/descriptor_parse.cpp
@@ -11,7 +11,7 @@
 void initialize_descriptor_parse()
 {
     ECC_Start();
-    SelectParams(CBaseChainParams::MAIN);
+    SelectParams(chainname::MAIN);
 }
 
 FUZZ_TARGET_INIT(descriptor_parse, initialize_descriptor_parse)

--- a/src/test/fuzz/integer.cpp
+++ b/src/test/fuzz/integer.cpp
@@ -42,7 +42,7 @@
 
 void initialize_integer()
 {
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(chainname::REGTEST);
 }
 
 FUZZ_TARGET_INIT(integer, initialize_integer)

--- a/src/test/fuzz/integer.cpp
+++ b/src/test/fuzz/integer.cpp
@@ -25,6 +25,7 @@
 #include <test/fuzz/util.h>
 #include <uint256.h>
 #include <univalue.h>
+#include <util/chainname.h>
 #include <util/check.h>
 #include <util/moneystr.h>
 #include <util/overflow.h>

--- a/src/test/fuzz/key.cpp
+++ b/src/test/fuzz/key.cpp
@@ -3,7 +3,6 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chainparams.h>
-#include <chainparamsbase.h>
 #include <key.h>
 #include <key_io.h>
 #include <outputtype.h>

--- a/src/test/fuzz/key.cpp
+++ b/src/test/fuzz/key.cpp
@@ -29,7 +29,7 @@
 void initialize_key()
 {
     ECC_Start();
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(chainname::REGTEST);
 }
 
 FUZZ_TARGET_INIT(key, initialize_key)

--- a/src/test/fuzz/key.cpp
+++ b/src/test/fuzz/key.cpp
@@ -17,6 +17,7 @@
 #include <script/standard.h>
 #include <streams.h>
 #include <test/fuzz/fuzz.h>
+#include <util/chainname.h>
 #include <util/strencodings.h>
 
 #include <cassert>

--- a/src/test/fuzz/key_io.cpp
+++ b/src/test/fuzz/key_io.cpp
@@ -5,6 +5,7 @@
 #include <chainparams.h>
 #include <key_io.h>
 #include <test/fuzz/fuzz.h>
+#include <util/chainname.h>
 
 #include <cassert>
 #include <cstdint>

--- a/src/test/fuzz/key_io.cpp
+++ b/src/test/fuzz/key_io.cpp
@@ -15,7 +15,7 @@
 void initialize_key_io()
 {
     ECC_Start();
-    SelectParams(CBaseChainParams::MAIN);
+    SelectParams(chainname::MAIN);
 }
 
 FUZZ_TARGET_INIT(key_io, initialize_key_io)

--- a/src/test/fuzz/message.cpp
+++ b/src/test/fuzz/message.cpp
@@ -20,7 +20,7 @@
 void initialize_message()
 {
     ECC_Start();
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(chainname::REGTEST);
 }
 
 FUZZ_TARGET_INIT(message, initialize_message)

--- a/src/test/fuzz/message.cpp
+++ b/src/test/fuzz/message.cpp
@@ -7,6 +7,7 @@
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
+#include <util/chainname.h>
 #include <util/message.h>
 #include <util/strencodings.h>
 

--- a/src/test/fuzz/net.cpp
+++ b/src/test/fuzz/net.cpp
@@ -3,7 +3,6 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chainparams.h>
-#include <chainparamsbase.h>
 #include <net.h>
 #include <net_permissions.h>
 #include <netaddress.h>

--- a/src/test/fuzz/net.cpp
+++ b/src/test/fuzz/net.cpp
@@ -16,6 +16,7 @@
 #include <test/util/net.h>
 #include <test/util/setup_common.h>
 #include <util/asmap.h>
+#include <util/chainname.h>
 
 #include <cstdint>
 #include <optional>

--- a/src/test/fuzz/net.cpp
+++ b/src/test/fuzz/net.cpp
@@ -25,7 +25,7 @@
 
 void initialize_net()
 {
-    static const auto testing_setup = MakeNoLogFileContext<>(CBaseChainParams::MAIN);
+    static const auto testing_setup = MakeNoLogFileContext<>(chainname::MAIN);
 }
 
 FUZZ_TARGET_INIT(net, initialize_net)

--- a/src/test/fuzz/p2p_transport_serialization.cpp
+++ b/src/test/fuzz/p2p_transport_serialization.cpp
@@ -19,7 +19,7 @@
 
 void initialize_p2p_transport_serialization()
 {
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(chainname::REGTEST);
 }
 
 FUZZ_TARGET_INIT(p2p_transport_serialization, initialize_p2p_transport_serialization)

--- a/src/test/fuzz/p2p_transport_serialization.cpp
+++ b/src/test/fuzz/p2p_transport_serialization.cpp
@@ -9,6 +9,7 @@
 #include <protocol.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
+#include <util/chainname.h>
 
 #include <cassert>
 #include <cstdint>

--- a/src/test/fuzz/parse_univalue.cpp
+++ b/src/test/fuzz/parse_univalue.cpp
@@ -7,6 +7,7 @@
 #include <rpc/client.h>
 #include <rpc/util.h>
 #include <test/fuzz/fuzz.h>
+#include <util/chainname.h>
 
 #include <limits>
 #include <string>

--- a/src/test/fuzz/parse_univalue.cpp
+++ b/src/test/fuzz/parse_univalue.cpp
@@ -14,7 +14,7 @@
 
 void initialize_parse_univalue()
 {
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(chainname::REGTEST);
 }
 
 FUZZ_TARGET_INIT(parse_univalue, initialize_parse_univalue)

--- a/src/test/fuzz/pow.cpp
+++ b/src/test/fuzz/pow.cpp
@@ -9,6 +9,7 @@
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
+#include <util/chainname.h>
 #include <util/check.h>
 #include <util/overflow.h>
 

--- a/src/test/fuzz/pow.cpp
+++ b/src/test/fuzz/pow.cpp
@@ -20,7 +20,7 @@
 
 void initialize_pow()
 {
-    SelectParams(CBaseChainParams::MAIN);
+    SelectParams(chainname::MAIN);
 }
 
 FUZZ_TARGET_INIT(pow, initialize_pow)

--- a/src/test/fuzz/process_message.cpp
+++ b/src/test/fuzz/process_message.cpp
@@ -58,7 +58,7 @@ void initialize_process_message()
     Assert(GetNumMsgTypes() == getAllNetMessageTypes().size()); // If this fails, add or remove the message type below
 
     static const auto testing_setup = MakeNoLogFileContext<const TestingSetup>(
-            /*chain_name=*/CBaseChainParams::REGTEST,
+            /*chain_name=*/chainname::REGTEST,
             /*extra_args=*/{"-txreconciliation"});
     g_setup = testing_setup.get();
     for (int i = 0; i < 2 * COINBASE_MATURITY; i++) {

--- a/src/test/fuzz/process_message.cpp
+++ b/src/test/fuzz/process_message.cpp
@@ -19,6 +19,7 @@
 #include <test/util/net.h>
 #include <test/util/setup_common.h>
 #include <test/util/validation.h>
+#include <util/chainname.h>
 #include <validationinterface.h>
 #include <version.h>
 

--- a/src/test/fuzz/process_messages.cpp
+++ b/src/test/fuzz/process_messages.cpp
@@ -24,7 +24,7 @@ const TestingSetup* g_setup;
 void initialize_process_messages()
 {
     static const auto testing_setup = MakeNoLogFileContext<const TestingSetup>(
-            /*chain_name=*/CBaseChainParams::REGTEST,
+            /*chain_name=*/chainname::REGTEST,
             /*extra_args=*/{"-txreconciliation"});
     g_setup = testing_setup.get();
     for (int i = 0; i < 2 * COINBASE_MATURITY; i++) {

--- a/src/test/fuzz/script.cpp
+++ b/src/test/fuzz/script.cpp
@@ -22,6 +22,7 @@
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <univalue.h>
+#include <util/chainname.h>
 
 #include <algorithm>
 #include <cassert>

--- a/src/test/fuzz/script.cpp
+++ b/src/test/fuzz/script.cpp
@@ -33,7 +33,7 @@
 
 void initialize_script()
 {
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(chainname::REGTEST);
 }
 
 FUZZ_TARGET_INIT(script, initialize_script)

--- a/src/test/fuzz/script_format.cpp
+++ b/src/test/fuzz/script_format.cpp
@@ -11,6 +11,7 @@
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <univalue.h>
+#include <util/chainname.h>
 
 void initialize_script_format()
 {

--- a/src/test/fuzz/script_format.cpp
+++ b/src/test/fuzz/script_format.cpp
@@ -15,7 +15,7 @@
 
 void initialize_script_format()
 {
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(chainname::REGTEST);
 }
 
 FUZZ_TARGET_INIT(script_format, initialize_script_format)

--- a/src/test/fuzz/script_sigcache.cpp
+++ b/src/test/fuzz/script_sigcache.cpp
@@ -3,7 +3,6 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chainparams.h>
-#include <chainparamsbase.h>
 #include <key.h>
 #include <pubkey.h>
 #include <script/sigcache.h>

--- a/src/test/fuzz/script_sign.cpp
+++ b/src/test/fuzz/script_sign.cpp
@@ -3,7 +3,6 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chainparams.h>
-#include <chainparamsbase.h>
 #include <key.h>
 #include <psbt.h>
 #include <pubkey.h>

--- a/src/test/fuzz/script_sign.cpp
+++ b/src/test/fuzz/script_sign.cpp
@@ -14,6 +14,7 @@
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
+#include <util/chainname.h>
 #include <util/translation.h>
 
 #include <cassert>

--- a/src/test/fuzz/script_sign.cpp
+++ b/src/test/fuzz/script_sign.cpp
@@ -28,7 +28,7 @@
 void initialize_script_sign()
 {
     ECC_Start();
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(chainname::REGTEST);
 }
 
 FUZZ_TARGET_INIT(script_sign, initialize_script_sign)

--- a/src/test/fuzz/signet.cpp
+++ b/src/test/fuzz/signet.cpp
@@ -11,6 +11,7 @@
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <test/util/setup_common.h>
+#include <util/chainname.h>
 
 #include <cstdint>
 #include <optional>

--- a/src/test/fuzz/signet.cpp
+++ b/src/test/fuzz/signet.cpp
@@ -19,7 +19,7 @@
 
 void initialize_signet()
 {
-    static const auto testing_setup = MakeNoLogFileContext<>(CBaseChainParams::SIGNET);
+    static const auto testing_setup = MakeNoLogFileContext<>(chainname::SIGNET);
 }
 
 FUZZ_TARGET_INIT(signet, initialize_signet)

--- a/src/test/fuzz/transaction.cpp
+++ b/src/test/fuzz/transaction.cpp
@@ -24,7 +24,7 @@
 
 void initialize_transaction()
 {
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(chainname::REGTEST);
 }
 
 FUZZ_TARGET_INIT(transaction, initialize_transaction)

--- a/src/test/fuzz/transaction.cpp
+++ b/src/test/fuzz/transaction.cpp
@@ -15,6 +15,7 @@
 #include <streams.h>
 #include <test/fuzz/fuzz.h>
 #include <univalue.h>
+#include <util/chainname.h>
 #include <util/rbf.h>
 #include <validation.h>
 #include <version.h>

--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -6,7 +6,6 @@
 #define BITCOIN_TEST_FUZZ_UTIL_H
 
 #include <arith_uint256.h>
-#include <chainparamsbase.h>
 #include <coins.h>
 #include <compat/compat.h>
 #include <consensus/amount.h>

--- a/src/test/fuzz/utxo_snapshot.cpp
+++ b/src/test/fuzz/utxo_snapshot.cpp
@@ -23,7 +23,7 @@ const std::vector<std::shared_ptr<CBlock>>* g_chain;
 
 void initialize_chain()
 {
-    const auto params{CreateChainParams(ArgsManager{}, CBaseChainParams::REGTEST)};
+    const auto params{CreateChainParams(ArgsManager{}, chainname::REGTEST)};
     static const auto chain{CreateBlockChain(2 * COINBASE_MATURITY, *params)};
     g_chain = &chain;
 }

--- a/src/test/fuzz/utxo_snapshot.cpp
+++ b/src/test/fuzz/utxo_snapshot.cpp
@@ -10,6 +10,7 @@
 #include <test/fuzz/util.h>
 #include <test/util/mining.h>
 #include <test/util/setup_common.h>
+#include <util/chainname.h>
 #include <util/fs.h>
 #include <validation.h>
 #include <validationinterface.h>

--- a/src/test/fuzz/validation_load_mempool.cpp
+++ b/src/test/fuzz/validation_load_mempool.cpp
@@ -4,7 +4,6 @@
 
 #include <kernel/mempool_persist.h>
 
-#include <chainparamsbase.h>
 #include <node/mempool_args.h>
 #include <node/mempool_persist_args.h>
 #include <test/fuzz/FuzzedDataProvider.h>

--- a/src/test/fuzz/versionbits.cpp
+++ b/src/test/fuzz/versionbits.cpp
@@ -105,7 +105,7 @@ std::unique_ptr<const CChainParams> g_params;
 void initialize()
 {
     // this is actually comparatively slow, so only do it once
-    g_params = CreateChainParams(ArgsManager{}, CBaseChainParams::MAIN);
+    g_params = CreateChainParams(ArgsManager{}, chainname::MAIN);
     assert(g_params != nullptr);
 }
 

--- a/src/test/fuzz/versionbits.cpp
+++ b/src/test/fuzz/versionbits.cpp
@@ -6,6 +6,7 @@
 #include <chainparams.h>
 #include <consensus/params.h>
 #include <primitives/block.h>
+#include <util/chainname.h>
 #include <util/system.h>
 #include <versionbits.h>
 

--- a/src/test/key_io_tests.cpp
+++ b/src/test/key_io_tests.cpp
@@ -25,7 +25,7 @@ BOOST_AUTO_TEST_CASE(key_io_valid_parse)
     UniValue tests = read_json(std::string(json_tests::key_io_valid, json_tests::key_io_valid + sizeof(json_tests::key_io_valid)));
     CKey privkey;
     CTxDestination destination;
-    SelectParams(CBaseChainParams::MAIN);
+    SelectParams(chainname::MAIN);
 
     for (unsigned int idx = 0; idx < tests.size(); idx++) {
         const UniValue& test = tests[idx];
@@ -114,7 +114,7 @@ BOOST_AUTO_TEST_CASE(key_io_valid_gen)
         }
     }
 
-    SelectParams(CBaseChainParams::MAIN);
+    SelectParams(chainname::MAIN);
 }
 
 
@@ -136,7 +136,7 @@ BOOST_AUTO_TEST_CASE(key_io_invalid)
         std::string exp_base58string = test[0].get_str();
 
         // must be invalid as public and as private key
-        for (const auto& chain : { CBaseChainParams::MAIN, CBaseChainParams::TESTNET, CBaseChainParams::SIGNET, CBaseChainParams::REGTEST }) {
+        for (const auto& chain : { chainname::MAIN, chainname::TESTNET, chainname::SIGNET, chainname::REGTEST }) {
             SelectParams(chain);
             destination = DecodeDestination(exp_base58string);
             BOOST_CHECK_MESSAGE(!IsValidDestination(destination), "IsValid pubkey in mainnet:" + strTest);

--- a/src/test/key_io_tests.cpp
+++ b/src/test/key_io_tests.cpp
@@ -10,6 +10,7 @@
 #include <script/script.h>
 #include <test/util/json.h>
 #include <test/util/setup_common.h>
+#include <util/chainname.h>
 #include <util/strencodings.h>
 
 #include <boost/test/unit_test.hpp>

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -16,7 +16,7 @@ BOOST_FIXTURE_TEST_SUITE(pow_tests, BasicTestingSetup)
 /* Test calculation of next difficulty target with no constraints applying */
 BOOST_AUTO_TEST_CASE(get_next_work)
 {
-    const auto chainParams = CreateChainParams(*m_node.args, CBaseChainParams::MAIN);
+    const auto chainParams = CreateChainParams(*m_node.args, chainname::MAIN);
     int64_t nLastRetargetTime = 1261130161; // Block #30240
     CBlockIndex pindexLast;
     pindexLast.nHeight = 32255;
@@ -35,7 +35,7 @@ BOOST_AUTO_TEST_CASE(get_next_work)
 /* Test the constraint on the upper bound for next work */
 BOOST_AUTO_TEST_CASE(get_next_work_pow_limit)
 {
-    const auto chainParams = CreateChainParams(*m_node.args, CBaseChainParams::MAIN);
+    const auto chainParams = CreateChainParams(*m_node.args, chainname::MAIN);
     int64_t nLastRetargetTime = 1231006505; // Block #0
     CBlockIndex pindexLast;
     pindexLast.nHeight = 2015;
@@ -49,7 +49,7 @@ BOOST_AUTO_TEST_CASE(get_next_work_pow_limit)
 /* Test the constraint on the lower bound for actual time taken */
 BOOST_AUTO_TEST_CASE(get_next_work_lower_limit_actual)
 {
-    const auto chainParams = CreateChainParams(*m_node.args, CBaseChainParams::MAIN);
+    const auto chainParams = CreateChainParams(*m_node.args, chainname::MAIN);
     int64_t nLastRetargetTime = 1279008237; // Block #66528
     CBlockIndex pindexLast;
     pindexLast.nHeight = 68543;
@@ -66,7 +66,7 @@ BOOST_AUTO_TEST_CASE(get_next_work_lower_limit_actual)
 /* Test the constraint on the upper bound for actual time taken */
 BOOST_AUTO_TEST_CASE(get_next_work_upper_limit_actual)
 {
-    const auto chainParams = CreateChainParams(*m_node.args, CBaseChainParams::MAIN);
+    const auto chainParams = CreateChainParams(*m_node.args, chainname::MAIN);
     int64_t nLastRetargetTime = 1263163443; // NOTE: Not an actual block time
     CBlockIndex pindexLast;
     pindexLast.nHeight = 46367;
@@ -82,7 +82,7 @@ BOOST_AUTO_TEST_CASE(get_next_work_upper_limit_actual)
 
 BOOST_AUTO_TEST_CASE(CheckProofOfWork_test_negative_target)
 {
-    const auto consensus = CreateChainParams(*m_node.args, CBaseChainParams::MAIN)->GetConsensus();
+    const auto consensus = CreateChainParams(*m_node.args, chainname::MAIN)->GetConsensus();
     uint256 hash;
     unsigned int nBits;
     nBits = UintToArith256(consensus.powLimit).GetCompact(true);
@@ -92,7 +92,7 @@ BOOST_AUTO_TEST_CASE(CheckProofOfWork_test_negative_target)
 
 BOOST_AUTO_TEST_CASE(CheckProofOfWork_test_overflow_target)
 {
-    const auto consensus = CreateChainParams(*m_node.args, CBaseChainParams::MAIN)->GetConsensus();
+    const auto consensus = CreateChainParams(*m_node.args, chainname::MAIN)->GetConsensus();
     uint256 hash;
     unsigned int nBits{~0x00800000U};
     hash.SetHex("0x1");
@@ -101,7 +101,7 @@ BOOST_AUTO_TEST_CASE(CheckProofOfWork_test_overflow_target)
 
 BOOST_AUTO_TEST_CASE(CheckProofOfWork_test_too_easy_target)
 {
-    const auto consensus = CreateChainParams(*m_node.args, CBaseChainParams::MAIN)->GetConsensus();
+    const auto consensus = CreateChainParams(*m_node.args, chainname::MAIN)->GetConsensus();
     uint256 hash;
     unsigned int nBits;
     arith_uint256 nBits_arith = UintToArith256(consensus.powLimit);
@@ -113,7 +113,7 @@ BOOST_AUTO_TEST_CASE(CheckProofOfWork_test_too_easy_target)
 
 BOOST_AUTO_TEST_CASE(CheckProofOfWork_test_biger_hash_than_target)
 {
-    const auto consensus = CreateChainParams(*m_node.args, CBaseChainParams::MAIN)->GetConsensus();
+    const auto consensus = CreateChainParams(*m_node.args, chainname::MAIN)->GetConsensus();
     uint256 hash;
     unsigned int nBits;
     arith_uint256 hash_arith = UintToArith256(consensus.powLimit);
@@ -125,7 +125,7 @@ BOOST_AUTO_TEST_CASE(CheckProofOfWork_test_biger_hash_than_target)
 
 BOOST_AUTO_TEST_CASE(CheckProofOfWork_test_zero_target)
 {
-    const auto consensus = CreateChainParams(*m_node.args, CBaseChainParams::MAIN)->GetConsensus();
+    const auto consensus = CreateChainParams(*m_node.args, chainname::MAIN)->GetConsensus();
     uint256 hash;
     unsigned int nBits;
     arith_uint256 hash_arith{0};
@@ -136,7 +136,7 @@ BOOST_AUTO_TEST_CASE(CheckProofOfWork_test_zero_target)
 
 BOOST_AUTO_TEST_CASE(GetBlockProofEquivalentTime_test)
 {
-    const auto chainParams = CreateChainParams(*m_node.args, CBaseChainParams::MAIN);
+    const auto chainParams = CreateChainParams(*m_node.args, chainname::MAIN);
     std::vector<CBlockIndex> blocks(10000);
     for (int i = 0; i < 10000; i++) {
         blocks[i].pprev = i ? &blocks[i - 1] : nullptr;
@@ -185,22 +185,22 @@ void sanity_check_chainparams(const ArgsManager& args, std::string chainName)
 
 BOOST_AUTO_TEST_CASE(ChainParams_MAIN_sanity)
 {
-    sanity_check_chainparams(*m_node.args, CBaseChainParams::MAIN);
+    sanity_check_chainparams(*m_node.args, chainname::MAIN);
 }
 
 BOOST_AUTO_TEST_CASE(ChainParams_REGTEST_sanity)
 {
-    sanity_check_chainparams(*m_node.args, CBaseChainParams::REGTEST);
+    sanity_check_chainparams(*m_node.args, chainname::REGTEST);
 }
 
 BOOST_AUTO_TEST_CASE(ChainParams_TESTNET_sanity)
 {
-    sanity_check_chainparams(*m_node.args, CBaseChainParams::TESTNET);
+    sanity_check_chainparams(*m_node.args, chainname::TESTNET);
 }
 
 BOOST_AUTO_TEST_CASE(ChainParams_SIGNET_sanity)
 {
-    sanity_check_chainparams(*m_node.args, CBaseChainParams::SIGNET);
+    sanity_check_chainparams(*m_node.args, chainname::SIGNET);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -7,6 +7,7 @@
 #include <pow.h>
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
+#include <util/chainname.h>
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/settings_tests.cpp
+++ b/src/test/settings_tests.cpp
@@ -6,11 +6,11 @@
 
 #include <test/util/setup_common.h>
 #include <test/util/str.h>
-#include <util/fs.h>
-
 
 #include <boost/test/unit_test.hpp>
 #include <univalue.h>
+#include <util/chainname.h>
+#include <util/fs.h>
 #include <util/strencodings.h>
 #include <util/string.h>
 #include <util/system.h>

--- a/src/test/settings_tests.cpp
+++ b/src/test/settings_tests.cpp
@@ -190,7 +190,7 @@ BOOST_FIXTURE_TEST_CASE(Merge, MergeTestingSetup)
         if (!out_file) throw std::system_error(errno, std::generic_category(), "fopen failed");
     }
 
-    const std::string& network = CBaseChainParams::MAIN;
+    const std::string& network = chainname::MAIN;
     ForEachMergeSetup([&](const ActionList& arg_actions, const ActionList& conf_actions, bool force_set,
                           bool ignore_default_section_config) {
         std::string desc;

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -9,6 +9,7 @@
 #include <script/standard.h>
 #include <test/util/setup_common.h>
 #include <txmempool.h>
+#include <util/chainname.h>
 #include <validation.h>
 
 #include <boost/test/unit_test.hpp>

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -16,7 +16,7 @@
 
 struct Dersig100Setup : public TestChain100Setup {
     Dersig100Setup()
-        : TestChain100Setup{CBaseChainParams::REGTEST, {"-testactivationheight=dersig@102"}} {}
+        : TestChain100Setup{chainname::REGTEST, {"-testactivationheight=dersig@102"}} {}
 };
 
 bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -42,6 +42,7 @@
 #include <timedata.h>
 #include <txdb.h>
 #include <txmempool.h>
+#include <util/chainname.h>
 #include <util/strencodings.h>
 #include <util/string.h>
 #include <util/thread.h>

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -272,7 +272,7 @@ TestChain100Setup::TestChain100Setup(
         const std::vector<const char*>& extra_args,
         const bool coins_db_in_memory,
         const bool block_tree_db_in_memory)
-    : TestingSetup{CBaseChainParams::REGTEST, extra_args, coins_db_in_memory, block_tree_db_in_memory}
+    : TestingSetup{chainname::REGTEST, extra_args, coins_db_in_memory, block_tree_db_in_memory}
 {
     SetMockTime(1598887952);
     constexpr std::array<unsigned char, 32> vchKey = {

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -5,7 +5,6 @@
 #ifndef BITCOIN_TEST_UTIL_SETUP_COMMON_H
 #define BITCOIN_TEST_UTIL_SETUP_COMMON_H
 
-#include <chainparamsbase.h>
 #include <key.h>
 #include <node/caches.h>
 #include <node/context.h>

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -13,6 +13,7 @@
 #include <pubkey.h>
 #include <random.h>
 #include <stdexcept>
+#include <util/chainname.h>
 #include <util/check.h>
 #include <util/fs.h>
 #include <util/string.h>

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -80,7 +80,7 @@ static constexpr CAmount CENT{1000000};
 struct BasicTestingSetup {
     node::NodeContext m_node; // keep as first member to be destructed last
 
-    explicit BasicTestingSetup(const std::string& chainName = CBaseChainParams::MAIN, const std::vector<const char*>& extra_args = {});
+    explicit BasicTestingSetup(const std::string& chainName = chainname::MAIN, const std::vector<const char*>& extra_args = {});
     ~BasicTestingSetup();
 
     const fs::path m_path_root;
@@ -94,7 +94,7 @@ struct BasicTestingSetup {
 struct ChainTestingSetup : public BasicTestingSetup {
     node::CacheSizes m_cache_sizes{};
 
-    explicit ChainTestingSetup(const std::string& chainName = CBaseChainParams::MAIN, const std::vector<const char*>& extra_args = {});
+    explicit ChainTestingSetup(const std::string& chainName = chainname::MAIN, const std::vector<const char*>& extra_args = {});
     ~ChainTestingSetup();
 };
 
@@ -107,7 +107,7 @@ struct TestingSetup : public ChainTestingSetup {
     void LoadVerifyActivateChainstate();
 
     explicit TestingSetup(
-        const std::string& chainName = CBaseChainParams::MAIN,
+        const std::string& chainName = chainname::MAIN,
         const std::vector<const char*>& extra_args = {},
         const bool coins_db_in_memory = true,
         const bool block_tree_db_in_memory = true);
@@ -116,7 +116,7 @@ struct TestingSetup : public ChainTestingSetup {
 /** Identical to TestingSetup, but chain set to regtest */
 struct RegTestingSetup : public TestingSetup {
     RegTestingSetup()
-        : TestingSetup{CBaseChainParams::REGTEST} {}
+        : TestingSetup{chainname::REGTEST} {}
 };
 
 class CBlock;
@@ -128,7 +128,7 @@ class CScript;
  */
 struct TestChain100Setup : public TestingSetup {
     TestChain100Setup(
-        const std::string& chain_name = CBaseChainParams::REGTEST,
+        const std::string& chain_name = chainname::REGTEST,
         const std::vector<const char*>& extra_args = {},
         const bool coins_db_in_memory = true,
         const bool block_tree_db_in_memory = true);
@@ -195,7 +195,7 @@ struct TestChain100Setup : public TestingSetup {
  * be used in "hot loops", for example fuzzing or benchmarking.
  */
 template <class T = const BasicTestingSetup>
-std::unique_ptr<T> MakeNoLogFileContext(const std::string& chain_name = CBaseChainParams::REGTEST, const std::vector<const char*>& extra_args = {})
+std::unique_ptr<T> MakeNoLogFileContext(const std::string& chain_name = chainname::REGTEST, const std::vector<const char*>& extra_args = {})
 {
     const std::vector<const char*> arguments = Cat(
         {

--- a/src/test/validation_tests.cpp
+++ b/src/test/validation_tests.cpp
@@ -7,6 +7,7 @@
 #include <net.h>
 #include <signet.h>
 #include <uint256.h>
+#include <util/chainname.h>
 #include <validation.h>
 
 #include <test/util/setup_common.h>

--- a/src/test/validation_tests.cpp
+++ b/src/test/validation_tests.cpp
@@ -42,7 +42,7 @@ static void TestBlockSubsidyHalvings(int nSubsidyHalvingInterval)
 
 BOOST_AUTO_TEST_CASE(block_subsidy_test)
 {
-    const auto chainParams = CreateChainParams(*m_node.args, CBaseChainParams::MAIN);
+    const auto chainParams = CreateChainParams(*m_node.args, chainname::MAIN);
     TestBlockSubsidyHalvings(chainParams->GetConsensus()); // As in main
     TestBlockSubsidyHalvings(150); // As in regtest
     TestBlockSubsidyHalvings(1000); // Just another interval
@@ -50,7 +50,7 @@ BOOST_AUTO_TEST_CASE(block_subsidy_test)
 
 BOOST_AUTO_TEST_CASE(subsidy_limit_test)
 {
-    const auto chainParams = CreateChainParams(*m_node.args, CBaseChainParams::MAIN);
+    const auto chainParams = CreateChainParams(*m_node.args, chainname::MAIN);
     CAmount nSum = 0;
     for (int nHeight = 0; nHeight < 14000000; nHeight += 1000) {
         CAmount nSubsidy = GetBlockSubsidy(nHeight, chainParams->GetConsensus());
@@ -65,7 +65,7 @@ BOOST_AUTO_TEST_CASE(signet_parse_tests)
 {
     ArgsManager signet_argsman;
     signet_argsman.ForceSetArg("-signetchallenge", "51"); // set challenge to OP_TRUE
-    const auto signet_params = CreateChainParams(signet_argsman, CBaseChainParams::SIGNET);
+    const auto signet_params = CreateChainParams(signet_argsman, chainname::SIGNET);
     CBlock block;
     BOOST_CHECK(signet_params->GetConsensus().signet_challenge == std::vector<uint8_t>{OP_TRUE});
     CScript challenge{OP_TRUE};
@@ -125,7 +125,7 @@ BOOST_AUTO_TEST_CASE(signet_parse_tests)
 //! Test retrieval of valid assumeutxo values.
 BOOST_AUTO_TEST_CASE(test_assumeutxo)
 {
-    const auto params = CreateChainParams(*m_node.args, CBaseChainParams::REGTEST);
+    const auto params = CreateChainParams(*m_node.args, chainname::REGTEST);
 
     // These heights don't have assumeutxo configurations associated, per the contents
     // of chainparams.cpp.

--- a/src/test/versionbits_tests.cpp
+++ b/src/test/versionbits_tests.cpp
@@ -419,7 +419,7 @@ BOOST_AUTO_TEST_CASE(versionbits_computeblockversion)
 
     // check that any deployment on any chain can conceivably reach both
     // ACTIVE and FAILED states in roughly the way we expect
-    for (const auto& chain_name : {CBaseChainParams::MAIN, CBaseChainParams::TESTNET, CBaseChainParams::SIGNET, CBaseChainParams::REGTEST}) {
+    for (const auto& chain_name : {chainname::MAIN, chainname::TESTNET, chainname::SIGNET, chainname::REGTEST}) {
         const auto chainParams = CreateChainParams(*m_node.args, chain_name);
         uint32_t chain_all_vbits{0};
         for (int i = 0; i < (int)Consensus::MAX_VERSION_BITS_DEPLOYMENTS; ++i) {
@@ -441,7 +441,7 @@ BOOST_AUTO_TEST_CASE(versionbits_computeblockversion)
         // deployment that's not always/never active
         ArgsManager args;
         args.ForceSetArg("-vbparams", "testdummy:1199145601:1230767999"); // January 1, 2008 - December 31, 2008
-        const auto chainParams = CreateChainParams(args, CBaseChainParams::REGTEST);
+        const auto chainParams = CreateChainParams(args, chainname::REGTEST);
         check_computeblockversion(vbcache, chainParams->GetConsensus(), Consensus::DEPLOYMENT_TESTDUMMY);
     }
 
@@ -451,7 +451,7 @@ BOOST_AUTO_TEST_CASE(versionbits_computeblockversion)
         // live deployment
         ArgsManager args;
         args.ForceSetArg("-vbparams", "testdummy:1199145601:1230767999:403200"); // January 1, 2008 - December 31, 2008, min act height 403200
-        const auto chainParams = CreateChainParams(args, CBaseChainParams::REGTEST);
+        const auto chainParams = CreateChainParams(args, chainname::REGTEST);
         check_computeblockversion(vbcache, chainParams->GetConsensus(), Consensus::DEPLOYMENT_TESTDUMMY);
     }
 }

--- a/src/test/versionbits_tests.cpp
+++ b/src/test/versionbits_tests.cpp
@@ -7,6 +7,7 @@
 #include <consensus/params.h>
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
+#include <util/chainname.h>
 #include <versionbits.h>
 
 #include <boost/test/unit_test.hpp>

--- a/src/util/chainname.cpp
+++ b/src/util/chainname.cpp
@@ -1,0 +1,14 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <util/chainname.h>
+
+#include <chainparamsbase.h>
+
+#include <string>
+
+const std::string chainname::MAIN{CBaseChainParams::MAIN};
+const std::string chainname::TESTNET{CBaseChainParams::TESTNET};
+const std::string chainname::SIGNET{CBaseChainParams::SIGNET};
+const std::string chainname::REGTEST{CBaseChainParams::REGTEST};

--- a/src/util/chainname.cpp
+++ b/src/util/chainname.cpp
@@ -4,11 +4,9 @@
 
 #include <util/chainname.h>
 
-#include <chainparamsbase.h>
-
 #include <string>
 
-const std::string chainname::MAIN{CBaseChainParams::MAIN};
-const std::string chainname::TESTNET{CBaseChainParams::TESTNET};
-const std::string chainname::SIGNET{CBaseChainParams::SIGNET};
-const std::string chainname::REGTEST{CBaseChainParams::REGTEST};
+const std::string chainname::MAIN{"main"};
+const std::string chainname::TESTNET{"test"};
+const std::string chainname::SIGNET{"signet"};
+const std::string chainname::REGTEST{"regtest"};

--- a/src/util/chainname.h
+++ b/src/util/chainname.h
@@ -1,0 +1,17 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_UTIL_CHAINNAME_H
+#define BITCOIN_UTIL_CHAINNAME_H
+
+#include <string>
+
+namespace chainname {
+extern const std::string MAIN;
+extern const std::string TESTNET;
+extern const std::string SIGNET;
+extern const std::string REGTEST;
+} // namespace chainname
+
+#endif // BITCOIN_UTIL_CHAINNAME_H

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -170,7 +170,7 @@ std::set<std::string> ArgsManager::GetUnsuitableSectionOnlyArgs() const
     if (m_network.empty()) return std::set<std::string> {};
 
     // if it's okay to use the default section for this network, don't worry
-    if (m_network == CBaseChainParams::MAIN) return std::set<std::string> {};
+    if (m_network == chainname::MAIN) return std::set<std::string> {};
 
     for (const auto& arg : m_network_only_args) {
         if (OnlyHasDefaultSectionSetting(m_settings, m_network, SettingName(arg))) {
@@ -184,10 +184,10 @@ std::list<SectionInfo> ArgsManager::GetUnrecognizedSections() const
 {
     // Section names to be recognized in the config file.
     static const std::set<std::string> available_sections{
-        CBaseChainParams::REGTEST,
-        CBaseChainParams::SIGNET,
-        CBaseChainParams::TESTNET,
-        CBaseChainParams::MAIN
+        chainname::REGTEST,
+        chainname::SIGNET,
+        chainname::TESTNET,
+        chainname::MAIN
     };
 
     LOCK(cs_args);
@@ -951,19 +951,19 @@ std::string ArgsManager::GetChainName() const
         throw std::runtime_error("Invalid combination of -regtest, -signet, -testnet and -chain. Can use at most one.");
     }
     if (fRegTest)
-        return CBaseChainParams::REGTEST;
+        return chainname::REGTEST;
     if (fSigNet) {
-        return CBaseChainParams::SIGNET;
+        return chainname::SIGNET;
     }
     if (fTestNet)
-        return CBaseChainParams::TESTNET;
+        return chainname::TESTNET;
 
-    return GetArg("-chain", CBaseChainParams::MAIN);
+    return GetArg("-chain", chainname::MAIN);
 }
 
 bool ArgsManager::UseDefaultSection(const std::string& arg) const
 {
-    return m_network == CBaseChainParams::MAIN || m_network_only_args.count(arg) == 0;
+    return m_network == chainname::MAIN || m_network_only_args.count(arg) == 0;
 }
 
 util::SettingsValue ArgsManager::GetSetting(const std::string& arg) const

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -7,6 +7,7 @@
 
 #include <chainparamsbase.h>
 #include <sync.h>
+#include <util/chainname.h>
 #include <util/check.h>
 #include <util/fs.h>
 #include <util/fs_helpers.h>

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -338,7 +338,7 @@ protected:
 
     /**
      * Returns the appropriate chain name from the program arguments.
-     * @return CBaseChainParams::MAIN by default; raises runtime error if an invalid combination is given.
+     * @return chainname::MAIN by default; raises runtime error if an invalid combination is given.
      */
     std::string GetChainName() const;
 

--- a/src/wallet/test/init_test_fixture.h
+++ b/src/wallet/test/init_test_fixture.h
@@ -14,7 +14,7 @@
 
 namespace wallet {
 struct InitWalletDirTestingSetup: public BasicTestingSetup {
-    explicit InitWalletDirTestingSetup(const std::string& chainName = CBaseChainParams::MAIN);
+    explicit InitWalletDirTestingSetup(const std::string& chainName = chainname::MAIN);
     ~InitWalletDirTestingSetup();
     void SetWalletDir(const fs::path& walletdir_path);
 

--- a/src/wallet/test/init_test_fixture.h
+++ b/src/wallet/test/init_test_fixture.h
@@ -9,6 +9,7 @@
 #include <interfaces/wallet.h>
 #include <node/context.h>
 #include <test/util/setup_common.h>
+#include <util/chainname.h>
 
 
 namespace wallet {

--- a/src/wallet/test/wallet_test_fixture.h
+++ b/src/wallet/test/wallet_test_fixture.h
@@ -10,6 +10,7 @@
 #include <interfaces/chain.h>
 #include <interfaces/wallet.h>
 #include <node/context.h>
+#include <util/chainname.h>
 #include <util/check.h>
 #include <wallet/wallet.h>
 

--- a/src/wallet/test/wallet_test_fixture.h
+++ b/src/wallet/test/wallet_test_fixture.h
@@ -20,7 +20,7 @@ namespace wallet {
 /** Testing setup and teardown for wallet.
  */
 struct WalletTestingSetup : public TestingSetup {
-    explicit WalletTestingSetup(const std::string& chainName = CBaseChainParams::MAIN);
+    explicit WalletTestingSetup(const std::string& chainName = chainname::MAIN);
     ~WalletTestingSetup();
 
     std::unique_ptr<interfaces::WalletLoader> m_wallet_loader;


### PR DESCRIPTION
This pull request is part of the `libbitcoinkernel` project https://github.com/bitcoin/bitcoin/issues/24303 https://github.com/bitcoin/bitcoin/projects/18 and more specifically its "Step 2: Decouple most non-consensus code from libbitcoinkernel". It is also a follow up to #26177.

The code move of the chain name constants out of the `chainparamsbase` to their own separate header allows the kernel `chainparams` to no longer include `chainparamsbase`. The `chainparamsbase` contain references to the `ArgsManager` and networking related options that should not belong to the kernel library.

The commits are split up to accommodate scripted diffs.