### PR TITLE
guix: import/sync python-lief (0.12.3) package definition from upstream

### DIFF
--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -210,6 +210,7 @@ chain for " target " development."))
 
 ;; Our python-lief package can be removed once we are using
 ;; guix 83bfdb409787cb2737e68b093a319b247b7858e6 or later.
+;; Note we currently use cmake-minimal.
 (define-public python-lief
   (package
     (name "python-lief")
@@ -224,7 +225,7 @@ chain for " target " development."))
                (base32
                 "11i6hqmcjh56y554kqhl61698n9v66j2qk1c1g63mv2w07h2z661"))))
     (build-system python-build-system)
-    (native-inputs (list cmake))
+    (native-inputs (list cmake-minimal))
     (arguments
      (list
       #:tests? #f                  ;needs network


### PR DESCRIPTION
Update to version 0.12.3.
Retain our PPC64 patch.
Mention when we can drop our local definition.

Also switch to using cmake-minimal (see #27172), which fixes atleast one build failure I've seen on aarch64, where cmake dependencies fail to build. Fix that by using the cmake without all the dependencies we don't actually need:
```bash
The following derivations will be built:
  /gnu/store/7qqvqq2g7l5ylrjv0gn6zha565a12kar-python-lief-0.12.1.drv
  /gnu/store/f9zwh1ldy63ga0i5w6cbbqlj6sfq226j-cmake-3.21.4.drv
  /gnu/store/3wg6ya847id503m5izhzhn1qqs464lfk-python-sphinx-4.2.0.drv

building /gnu/store/3wg6ya847id503m5izhzhn1qqs464lfk-python-sphinx-4.2.0.drv...
/ 'check' phasenote: keeping build directory `/tmp/guix-build-python-sphinx-4.2.0.drv-5'
builder for `/gnu/store/3wg6ya847id503m5izhzhn1qqs464lfk-python-sphinx-4.2.0.drv' failed with exit code 1
build of /gnu/store/3wg6ya847id503m5izhzhn1qqs464lfk-python-sphinx-4.2.0.drv failed
View build log at '/var/log/guix/drvs/3w/g6ya847id503m5izhzhn1qqs464lfk-python-sphinx-4.2.0.drv.gz'.
cannot build derivation `/gnu/store/f9zwh1ldy63ga0i5w6cbbqlj6sfq226j-cmake-3.21.4.drv': 1 dependencies couldn't be built
cannot build derivation `/gnu/store/7qqvqq2g7l5ylrjv0gn6zha565a12kar-python-lief-0.12.1.drv': 1 dependencies couldn't be built
guix environment: error: build of `/gnu/store/7qqvqq2g7l5ylrjv0gn6zha565a12kar-python-lief-0.12.1.drv' failed
```