### PR TITLE
depends: make fontconfig build under clang-16

### DIFF
--- a/depends/packages/fontconfig.mk
+++ b/depends/packages/fontconfig.mk
@@ -9,6 +9,7 @@ $(package)_patches=gperf_header_regen.patch
 define $(package)_set_vars
   $(package)_config_opts=--disable-docs --disable-static --disable-libxml2 --disable-iconv
   $(package)_config_opts += --disable-dependency-tracking --enable-option-checking
+  $(package)_cflags += -Wno-implicit-function-declaration
 endef
 
 define $(package)_preprocess_cmds


### PR DESCRIPTION
Use the same workaround we've applied to qrencode, and other packages. Fontconfig not building is currently a blocker for fuzz/sanitizer infra upgrades (#27298).
    
For now, this is also more straightforward than bumping the package, which introduces more complexity/usage of gperf.

Closes: #27299.