### PR TITLE
system: cache config file path before potentially updating datadir

### DIFF
--- a/src/util/system.h
+++ b/src/util/system.h
@@ -199,6 +199,7 @@ protected:
     mutable fs::path m_cached_blocks_path GUARDED_BY(cs_args);
     mutable fs::path m_cached_datadir_path GUARDED_BY(cs_args);
     mutable fs::path m_cached_network_datadir_path GUARDED_BY(cs_args);
+    mutable fs::path m_cached_config_file_path GUARDED_BY(cs_args);
 
     [[nodiscard]] bool ReadConfigStream(std::istream& stream, const std::string& filepath, std::string& error, bool ignore_invalid_keys = false);
 

--- a/test/functional/feature_config_args.py
+++ b/test/functional/feature_config_args.py
@@ -324,6 +324,10 @@ class ConfArgsTest(BitcoinTestFramework):
         self.start_node(0, [f'-conf={conf_file}'])
         self.stop_node(0)
         assert os.path.exists(os.path.join(new_data_dir, self.chain, 'blocks'))
+        # Can not use assert_debug_log() with the custom datadir
+        with open(os.path.join(new_data_dir, "regtest", "debug.log"), encoding='utf-8') as dl:
+            log = dl.read()
+            assert f'Config file: {conf_file}' in log
 
         # Ensure command line argument overrides datadir in conf
         os.mkdir(new_data_dir_2)


### PR DESCRIPTION
Closes https://github.com/bitcoin/bitcoin/issues/19990

Fixes an issue where a `bitcoin.conf` file that contains a `datadir=` setting would be incorrectly reported in the logs (see examples below). This fix is implemented by caching the path to the conf file before setting `datadir`.

## Master

```
Default data directory /Users/matthewzipkin/Library/Application Support/Bitcoin
Using data directory /tmp/bcdata/regtest
Config file: /tmp/bcdata/bitcoin.conf (not found, skipping)
Config file arg: blocksdir="/tmp/blocks"
Config file arg: datadir="/tmp/bcdata"
Command-line arg: regtest=""
```

## Branch

```
Default data directory /Users/matthewzipkin/Library/Application Support/Bitcoin
Using data directory /tmp/bcdata/regtest
Config file: /Users/matthewzipkin/Library/Application Support/Bitcoin/bitcoin.conf
Config file arg: blocksdir="/tmp/blocks"
Config file arg: datadir="/tmp/bcdata"
Config file arg: prune="10000"
Command-line arg: regtest=""
```

See also https://github.com/bitcoin/bitcoin/issues/27246 and https://github.com/bitcoin/bitcoin/pull/27302