### PR TITLE
wallet: track mempool conflicts with wallet transactions

### DIFF
--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -101,7 +101,7 @@ WalletTxStatus MakeWalletTxStatus(const CWallet& wallet, const CWalletTx& wtx)
     result.is_trusted = CachedTxIsTrusted(wallet, wtx);
     result.is_abandoned = wtx.isAbandoned();
     result.is_coinbase = wtx.IsCoinBase();
-    result.is_in_main_chain = wallet.IsTxInMainChain(wtx);
+    result.is_in_main_chain = wtx.isConfirmed();
     return result;
 }
 

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -92,7 +92,7 @@ WalletTxStatus MakeWalletTxStatus(const CWallet& wallet, const CWalletTx& wtx)
     WalletTxStatus result;
     result.block_height =
         wtx.state<TxStateConfirmed>() ? wtx.state<TxStateConfirmed>()->confirmed_block_height :
-        wtx.state<TxStateConflicted>() ? wtx.state<TxStateConflicted>()->conflicting_block_height :
+        wtx.state<TxStateBlockConflicted>() ? wtx.state<TxStateBlockConflicted>()->conflicting_block_height :
         std::numeric_limits<int>::max();
     result.blocks_to_maturity = wallet.GetTxBlocksToMaturity(wtx);
     result.depth_in_main_chain = wallet.GetTxDepthInMainChain(wtx);

--- a/src/wallet/receive.cpp
+++ b/src/wallet/receive.cpp
@@ -149,7 +149,7 @@ CAmount CachedTxGetImmatureCredit(const CWallet& wallet, const CWalletTx& wtx, c
 {
     AssertLockHeld(wallet.cs_wallet);
 
-    if (wallet.IsTxImmatureCoinBase(wtx) && wallet.IsTxInMainChain(wtx)) {
+    if (wallet.IsTxImmatureCoinBase(wtx) && wtx.isConfirmed()) {
         return GetCachableAmount(wallet, wtx, CWalletTx::IMMATURE_CREDIT, filter);
     }
 
@@ -256,9 +256,8 @@ bool CachedTxIsFromMe(const CWallet& wallet, const CWalletTx& wtx, const isminef
 bool CachedTxIsTrusted(const CWallet& wallet, const CWalletTx& wtx, std::set<uint256>& trusted_parents)
 {
     AssertLockHeld(wallet.cs_wallet);
-    int nDepth = wallet.GetTxDepthInMainChain(wtx);
-    if (nDepth >= 1) return true;
-    if (nDepth < 0) return false;
+    if (wtx.isConfirmed()) return true;
+    if (wtx.isBlockConflicted()) return false;
     // using wtx's cached debit
     if (!wallet.m_spend_zero_conf_change || !CachedTxIsFromMe(wallet, wtx, ISMINE_ALL)) return false;
 

--- a/src/wallet/rpc/transactions.cpp
+++ b/src/wallet/rpc/transactions.cpp
@@ -40,6 +40,10 @@ static void WalletTxToJSON(const CWallet& wallet, const CWalletTx& wtx, UniValue
     for (const uint256& conflict : wallet.GetTxConflicts(wtx))
         conflicts.push_back(conflict.GetHex());
     entry.pushKV("walletconflicts", conflicts);
+    UniValue mempool_conflicts(UniValue::VARR);
+    for (const Txid& mempool_conflict : wtx.mempool_conflicts)
+        mempool_conflicts.push_back(mempool_conflict.GetHex());
+    entry.pushKV("mempoolconflicts", mempool_conflicts);
     entry.pushKV("time", wtx.GetTxTime());
     entry.pushKV("timereceived", int64_t{wtx.nTimeReceived});
 
@@ -417,6 +421,10 @@ static std::vector<RPCResult> TransactionDescriptionString()
            }},
            {RPCResult::Type::STR_HEX, "replaced_by_txid", /*optional=*/true, "Only if 'category' is 'send'. The txid if this tx was replaced."},
            {RPCResult::Type::STR_HEX, "replaces_txid", /*optional=*/true, "Only if 'category' is 'send'. The txid if this tx replaces another."},
+           {RPCResult::Type::ARR, "mempoolconflicts", "Transactions that directly conflict with either this transaction or an ancestor transaction",
+           {
+               {RPCResult::Type::STR_HEX, "txid", "The transaction id."},
+           }},
            {RPCResult::Type::STR, "to", /*optional=*/true, "If a comment to is associated with the transaction."},
            {RPCResult::Type::NUM_TIME, "time", "The transaction time expressed in " + UNIX_EPOCH_TIME + "."},
            {RPCResult::Type::NUM_TIME, "timereceived", "The time received expressed in " + UNIX_EPOCH_TIME + "."},

--- a/src/wallet/transaction.cpp
+++ b/src/wallet/transaction.cpp
@@ -45,7 +45,7 @@ void CWalletTx::updateState(interfaces::Chain& chain)
     };
     if (auto* conf = state<TxStateConfirmed>()) {
         lookup_block(conf->confirmed_block_hash, conf->confirmed_block_height, m_state);
-    } else if (auto* conf = state<TxStateConflicted>()) {
+    } else if (auto* conf = state<TxStateBlockConflicted>()) {
         lookup_block(conf->conflicting_block_hash, conf->conflicting_block_height, m_state);
     }
 }

--- a/src/wallet/transaction.h
+++ b/src/wallet/transaction.h
@@ -48,7 +48,7 @@ struct TxStateBlockConflicted {
     int conflicting_block_height;
 
     explicit TxStateBlockConflicted(const uint256& block_hash, int height) : conflicting_block_hash(block_hash), conflicting_block_height(height) {}
-    std::string toString() const { return strprintf("Conflicted (block=%s, height=%i)", conflicting_block_hash.ToString(), conflicting_block_height); }
+    std::string toString() const { return strprintf("BlockConflicted (block=%s, height=%i)", conflicting_block_hash.ToString(), conflicting_block_height); }
 };
 
 //! State of transaction not confirmed or conflicting with a known block and
@@ -258,6 +258,14 @@ public:
     CTransactionRef tx;
     TxState m_state;
 
+    // Set of mempool transactions that conflict
+    // directly with the transaction, or that conflict
+    // with an ancestor transaction. This set will be
+    // empty if state is InMempool or Confirmed, but
+    // can be nonempty if state is Inactive or
+    // BlockConflicted.
+    std::set<Txid> mempool_conflicts;
+
     template<typename Stream>
     void Serialize(Stream& s) const
     {
@@ -335,9 +343,10 @@ public:
     void updateState(interfaces::Chain& chain);
 
     bool isAbandoned() const { return state<TxStateInactive>() && state<TxStateInactive>()->abandoned; }
+    bool isMempoolConflicted() const { return !mempool_conflicts.empty(); }
     bool isBlockConflicted() const { return state<TxStateBlockConflicted>(); }
     bool isInactive() const { return state<TxStateInactive>(); }
-    bool isUnconfirmed() const { return !isAbandoned() && !isBlockConflicted() && !isConfirmed(); }
+    bool isUnconfirmed() const { return !isAbandoned() && !isBlockConflicted() && !isMempoolConflicted() && !isConfirmed(); }
     bool isConfirmed() const { return state<TxStateConfirmed>(); }
     const Txid& GetHash() const LIFETIMEBOUND { return tx->GetHash(); }
     const Wtxid& GetWitnessHash() const LIFETIMEBOUND { return tx->GetWitnessHash(); }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -752,8 +752,8 @@ bool CWallet::IsSpent(const COutPoint& outpoint) const
         const uint256& wtxid = it->second;
         const auto mit = mapWallet.find(wtxid);
         if (mit != mapWallet.end()) {
-            int depth = GetTxDepthInMainChain(mit->second);
-            if (depth > 0  || (depth == 0 && !mit->second.isAbandoned()))
+            const auto& wtx = mit->second;
+            if (!wtx.isAbandoned() && !wtx.isBlockConflicted())
                 return true; // Spent
         }
     }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -515,11 +515,6 @@ public:
      * referenced in transaction, and might cause assert failures.
      */
     int GetTxDepthInMainChain(const CWalletTx& wtx) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
-    bool IsTxInMainChain(const CWalletTx& wtx) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet)
-    {
-        AssertLockHeld(cs_wallet);
-        return GetTxDepthInMainChain(wtx) > 0;
-    }
 
     /**
      * @return number of blocks to maturity for this transaction:

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -364,6 +364,7 @@ private:
 
     /** Mark a transaction (and its in-wallet descendants) as a particular tx state. */
     void RecursiveUpdateTxState(const uint256& tx_hash, const TryUpdatingStateFn& try_updating_state) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    void RecursiveUpdateTxState(WalletBatch* batch, const uint256& tx_hash, const TryUpdatingStateFn& try_updating_state) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     /** Mark a transaction's inputs dirty, thus forcing the outputs to be recomputed */
     void MarkInputsDirty(const CTransactionRef& tx) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);

--- a/test/functional/wallet_abandonconflict.py
+++ b/test/functional/wallet_abandonconflict.py
@@ -232,7 +232,11 @@ class AbandonConflictTest(BitcoinTestFramework):
         balance = newbalance
 
         # Invalidate the block with the double spend. B & C's 10 BTC outputs should no longer be available
-        self.nodes[0].invalidateblock(self.nodes[0].getbestblockhash())
+        blk = self.nodes[0].getbestblockhash()
+        # mine 10 blocks so that when the blk is invalidated, the transactions are not
+        # returned to the mempool
+        self.generate(self.nodes[1], 10)
+        self.nodes[0].invalidateblock(blk)
         assert_equal(alice.gettransaction(txAB1)["confirmations"], 0)
         newbalance = alice.getbalance()
         assert_equal(newbalance, balance - Decimal("20"))

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -679,7 +679,7 @@ class WalletTest(BitcoinTestFramework):
                                  "category": baz["category"],
                                  "vout":     baz["vout"]}
         expected_fields = frozenset({'amount', 'bip125-replaceable', 'confirmations', 'details', 'fee',
-                                     'hex', 'lastprocessedblock', 'time', 'timereceived', 'trusted', 'txid', 'wtxid', 'walletconflicts'})
+                                     'hex', 'lastprocessedblock', 'time', 'timereceived', 'trusted', 'txid', 'wtxid', 'walletconflicts', 'mempoolconflicts'})
         verbose_field = "decoded"
         expected_verbose_fields = expected_fields | {verbose_field}
 

--- a/test/functional/wallet_conflicts.py
+++ b/test/functional/wallet_conflicts.py
@@ -9,6 +9,7 @@ Test that wallet correctly tracks transactions that have been conflicted by bloc
 
 from decimal import Decimal
 
+from test_framework.blocktools import COINBASE_MATURITY
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
         assert_equal,
@@ -28,6 +29,20 @@ class TxConflicts(BitcoinTestFramework):
         return next(tx_out["vout"] for tx_out in self.nodes[0].gettransaction(from_tx_id)["details"] if tx_out["amount"] == Decimal(f"{search_value}"))
 
     def run_test(self):
+        """
+        The following tests check the behavior of the wallet when
+        transaction conflicts are created. These conflicts are created
+        using raw transaction RPCs that double-spend UTXOs and have more
+        fees, replacing the original transaction.
+        """
+
+        self.test_block_conflicts()
+        self.generatetoaddress(self.nodes[0], COINBASE_MATURITY + 7, self.nodes[2].getnewaddress())
+        self.test_mempool_conflict()
+        self.test_mempool_and_block_conflicts()
+        self.test_descendants_with_mempool_conflicts()
+
+    def test_block_conflicts(self):
         self.log.info("Send tx from which to conflict outputs later")
         txid_conflict_from_1 = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), Decimal("10"))
         txid_conflict_from_2 = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), Decimal("10"))
@@ -122,6 +137,273 @@ class TxConflicts(BitcoinTestFramework):
         former_conflicted = self.nodes[0].gettransaction(txid_AB_parent)
         assert_equal(former_conflicted["confirmations"], 1)
         assert_equal(former_conflicted["blockheight"], 217)
+
+    def test_mempool_conflict(self):
+        self.nodes[0].createwallet("alice")
+        alice = self.nodes[0].get_wallet_rpc("alice")
+
+        bob = self.nodes[1]
+
+        self.nodes[2].send(outputs=[{alice.getnewaddress() : 25} for _ in range(3)])
+        self.generate(self.nodes[2], 1)
+
+        self.log.info("Test a scenario where a transaction has a mempool conflict")
+
+        unspents = alice.listunspent()
+        assert_equal(len(unspents), 3)
+        assert all([tx["amount"] == 25 for tx in unspents])
+
+        # tx1 spends unspent[0] and unspent[1]
+        raw_tx = alice.createrawtransaction(inputs=[unspents[0], unspents[1]], outputs=[{bob.getnewaddress() : 49.9999}])
+        tx1 = alice.signrawtransactionwithwallet(raw_tx)['hex']
+
+        # tx2 spends unspent[1] and unspent[2], conflicts with tx1
+        raw_tx = alice.createrawtransaction(inputs=[unspents[1], unspents[2]], outputs=[{bob.getnewaddress() : 49.99}])
+        tx2 = alice.signrawtransactionwithwallet(raw_tx)['hex']
+
+        # tx3 spends unspent[2], conflicts with tx2
+        raw_tx = alice.createrawtransaction(inputs=[unspents[2]], outputs=[{bob.getnewaddress() : 24.9899}])
+        tx3 = alice.signrawtransactionwithwallet(raw_tx)['hex']
+
+        # broadcast tx1
+        tx1_txid = alice.sendrawtransaction(tx1)
+
+        assert_equal(alice.listunspent(), [unspents[2]])
+        assert_equal(alice.getbalance(), 25)
+
+        # broadcast tx2, replaces tx1 in mempool
+        tx2_txid = alice.sendrawtransaction(tx2)
+
+        # Check that unspent[0] is still not available because the wallet does not know that the tx spending it has a mempool conflicted
+        assert_equal(alice.listunspent(), [])
+        assert_equal(alice.getbalance(), 0)
+
+        self.log.info("Test scenario where a mempool conflict is removed")
+
+        # broadcast tx3, replaces tx2 in mempool
+        # Now that tx1's conflict has been removed, tx1 is now
+        # not conflicted, and instead is inactive until it is
+        # rebroadcasted. Now unspent[0] is not available, because
+        # tx1 is no longer conflicted.
+        alice.sendrawtransaction(tx3)
+
+        assert tx1_txid not in self.nodes[0].getrawmempool()
+
+        # now all of alice's outputs should be considered spent
+        # unspent[0]: spent by inactive tx1
+        # unspent[1]: spent by inactive tx1
+        # unspent[2]: spent by active tx3
+        assert_equal(alice.listunspent(), [])
+        assert_equal(alice.getbalance(), 0)
+
+        # Clean up for next test
+        bob.sendall([self.nodes[2].getnewaddress()])
+        self.generate(self.nodes[2], 1)
+
+        alice.unloadwallet()
+
+    def test_mempool_and_block_conflicts(self):
+        self.nodes[0].createwallet("alice_2")
+        alice = self.nodes[0].get_wallet_rpc("alice_2")
+        bob = self.nodes[1]
+
+        self.nodes[2].send(outputs=[{alice.getnewaddress() : 25} for _ in range(3)])
+        self.generate(self.nodes[2], 1)
+
+        self.log.info("Test a scenario where a transaction has both a block conflict and a mempool conflict")
+        unspents = [{"txid" : element["txid"], "vout" : element["vout"]} for element in alice.listunspent()]
+
+        assert_equal(bob.getbalances()["mine"]["untrusted_pending"], 0)
+
+        # alice and bob nodes are disconnected so that transactions can be
+        # created by alice, but broadcasted from bob so that alice's wallet
+        # doesn't know about them
+        self.disconnect_nodes(0, 1)
+
+        # Sends funds to bob
+        raw_tx = alice.createrawtransaction(inputs=[unspents[0]], outputs=[{bob.getnewaddress() : 24.99999}])
+        raw_tx1 = alice.signrawtransactionwithwallet(raw_tx)['hex']
+        tx1_txid = bob.sendrawtransaction(raw_tx1) # broadcast original tx spending unspents[0] only to bob
+
+        # create a conflict to previous tx (also spends unspents[0]), but don't broadcast, sends funds back to alice
+        raw_tx = alice.createrawtransaction(inputs=[unspents[0], unspents[2]], outputs=[{alice.getnewaddress() : 49.999}])
+        tx1_conflict = alice.signrawtransactionwithwallet(raw_tx)['hex']
+
+        # Sends funds to bob
+        raw_tx = alice.createrawtransaction(inputs=[unspents[1]], outputs=[{bob.getnewaddress() : 24.9999}])
+        raw_tx2 = alice.signrawtransactionwithwallet(raw_tx)['hex']
+        tx2_txid = bob.sendrawtransaction(raw_tx2) # broadcast another original tx spending unspents[1] only to bob
+
+        # create a conflict to previous tx (also spends unspents[1]), but don't broadcast, sends funds to alice
+        raw_tx = alice.createrawtransaction(inputs=[unspents[1]], outputs=[{alice.getnewaddress() : 24.9999}])
+        tx2_conflict = alice.signrawtransactionwithwallet(raw_tx)['hex']
+
+        bob_unspents = [{"txid" : element, "vout" : 0} for element in [tx1_txid, tx2_txid]]
+
+        # tx1 and tx2 are now in bob's mempool, and they are unconflicted, so bob has these funds
+        assert_equal(bob.getbalances()["mine"]["untrusted_pending"], Decimal("49.99989000"))
+
+        # spend both of bob's unspents, child tx of tx1 and tx2
+        raw_tx = bob.createrawtransaction(inputs=[bob_unspents[0], bob_unspents[1]], outputs=[{bob.getnewaddress() : 49.999}])
+        raw_tx3 = bob.signrawtransactionwithwallet(raw_tx)['hex']
+        tx3_txid = bob.sendrawtransaction(raw_tx3) # broadcast tx only to bob
+
+        # alice knows about 0 txs, bob knows about 3
+        assert_equal(len(alice.getrawmempool()), 0)
+        assert_equal(len(bob.getrawmempool()), 3)
+
+        assert_equal(bob.getbalances()["mine"]["untrusted_pending"], Decimal("49.99900000"))
+
+        # bob broadcasts tx_1 conflict
+        tx1_conflict_txid = bob.sendrawtransaction(tx1_conflict)
+        assert_equal(len(alice.getrawmempool()), 0)
+        assert_equal(len(bob.getrawmempool()), 2) # tx1_conflict kicks out both tx1, and its child tx3
+
+        assert tx2_txid in bob.getrawmempool()
+        assert tx1_conflict_txid in bob.getrawmempool()
+
+        # check that the tx2 unspent is still not available because the wallet does not know that the tx spending it has a mempool conflict
+        assert_equal(bob.getbalances()["mine"]["untrusted_pending"], 0)
+
+        # we will be disconnecting this block in the future
+        alice.sendrawtransaction(tx2_conflict)
+        assert_equal(len(alice.getrawmempool()), 1) # currently alice's mempool is only aware of tx2_conflict
+        # 11 blocks are mined so that when they are invalidated, tx_2
+        # does not get put back into the mempool
+        blk = self.generate(self.nodes[0], 11, sync_fun=self.no_op)[0]
+        assert_equal(len(alice.getrawmempool()), 0) # tx2_conflict is now mined
+
+        self.connect_nodes(0, 1)
+        self.sync_blocks()
+        assert_equal(alice.getbestblockhash(), bob.getbestblockhash())
+
+        # now that tx2 has a block conflict, tx1_conflict should be the only tx in bob's mempool
+        assert tx1_conflict_txid in bob.getrawmempool()
+        assert_equal(len(bob.getrawmempool()), 1)
+
+        # tx3 should now also be block-conflicted by tx2_conflict
+        assert_equal(bob.gettransaction(tx3_txid)["confirmations"], -11)
+        # bob has no pending funds, since tx1, tx2, and tx3 are all conflicted
+        assert_equal(bob.getbalances()["mine"]["untrusted_pending"], 0)
+        bob.invalidateblock(blk) # remove tx2_conflict
+        # bob should still have no pending funds because tx1 and tx3 are still conflicted, and tx2 has not been re-broadcast
+        assert_equal(bob.getbalances()["mine"]["untrusted_pending"], 0)
+        assert_equal(len(bob.getrawmempool()), 1)
+        # check that tx3 is no longer block-conflicted
+        assert_equal(bob.gettransaction(tx3_txid)["confirmations"], 0)
+
+        bob.sendrawtransaction(raw_tx2)
+        assert_equal(bob.getbalances()["mine"]["untrusted_pending"], 0)
+
+        # create a conflict to previous tx (also spends unspents[2]), but don't broadcast, sends funds back to alice
+        raw_tx = alice.createrawtransaction(inputs=[unspents[2]], outputs=[{alice.getnewaddress() : 24.99}])
+        tx1_conflict_conflict = alice.signrawtransactionwithwallet(raw_tx)['hex']
+
+        bob.sendrawtransaction(tx1_conflict_conflict) # kick tx1_conflict out of the mempool
+        bob.sendrawtransaction(raw_tx1) #re-broadcast tx1 because it is no longer conflicted
+
+        # Now bob has no pending funds because tx1 and tx2 are spent by tx3, which hasn't been re-broadcast yet
+        assert_equal(bob.getbalances()["mine"]["untrusted_pending"], 0)
+
+        bob.sendrawtransaction(raw_tx3)
+        assert_equal(len(bob.getrawmempool()), 4) # The mempool contains: tx1, tx2, tx1_conflict_conflict, tx3
+        assert_equal(bob.getbalances()["mine"]["untrusted_pending"], Decimal("49.99900000"))
+
+        # Clean up for next test
+        bob.reconsiderblock(blk)
+        assert_equal(alice.getbestblockhash(), bob.getbestblockhash())
+        self.sync_mempools()
+        self.generate(self.nodes[2], 1)
+
+        alice.unloadwallet()
+
+    def test_descendants_with_mempool_conflicts(self):
+        self.nodes[0].createwallet("alice_3")
+        alice = self.nodes[0].get_wallet_rpc("alice_3")
+
+        self.nodes[2].send(outputs=[{alice.getnewaddress() : 25} for _ in range(2)])
+        self.generate(self.nodes[2], 1)
+
+        self.nodes[1].createwallet("bob_1")
+        bob = self.nodes[1].get_wallet_rpc("bob_1")
+
+        self.nodes[2].createwallet("carol")
+        carol = self.nodes[2].get_wallet_rpc("carol")
+
+        self.log.info("Test a scenario where a transaction's parent has a mempool conflict")
+
+        unspents = alice.listunspent()
+        assert_equal(len(unspents), 2)
+        assert all([tx["amount"] == 25 for tx in unspents])
+
+        assert_equal(alice.getrawmempool(), [])
+
+        # Alice spends first utxo to bob in tx1
+        raw_tx = alice.createrawtransaction(inputs=[unspents[0]], outputs=[{bob.getnewaddress() : 24.9999}])
+        tx1 = alice.signrawtransactionwithwallet(raw_tx)['hex']
+        tx1_txid = alice.sendrawtransaction(tx1)
+
+        self.sync_mempools()
+
+        assert_equal(alice.getbalance(), 25)
+        assert_equal(bob.getbalances()["mine"]["untrusted_pending"], Decimal("24.99990000"))
+
+        raw_tx = bob.createrawtransaction(inputs=[bob.listunspent(minconf=0)[0]], outputs=[{carol.getnewaddress() : 24.999}])
+        # Bob creates a child to tx1
+        tx1_child = bob.signrawtransactionwithwallet(raw_tx)['hex']
+        tx1_child_txid = bob.sendrawtransaction(tx1_child)
+
+        self.sync_mempools()
+
+        # Currently neither tx1 nor tx1_child should have any conflicts
+        assert tx1_txid in bob.getrawmempool()
+        assert tx1_child_txid in bob.getrawmempool()
+        assert_equal(len(bob.getrawmempool()), 2)
+
+        assert_equal(bob.getbalances()["mine"]["untrusted_pending"], 0)
+        assert_equal(carol.getbalances()["mine"]["untrusted_pending"], Decimal("24.99900000"))
+
+        # Alice spends first unspent again, conflicting with tx1
+        raw_tx = alice.createrawtransaction(inputs=[unspents[0], unspents[1]], outputs=[{carol.getnewaddress() : 49.99}])
+        tx1_conflict = alice.signrawtransactionwithwallet(raw_tx)['hex']
+        tx1_conflict_txid = alice.sendrawtransaction(tx1_conflict)
+
+        self.sync_mempools()
+
+        assert_equal(bob.getbalances()["mine"]["untrusted_pending"], 0)
+        assert_equal(carol.getbalances()["mine"]["untrusted_pending"], Decimal("49.99000000"))
+
+        assert tx1_txid not in bob.getrawmempool()
+        assert tx1_child_txid not in bob.getrawmempool()
+        assert tx1_conflict_txid in bob.getrawmempool()
+        assert_equal(len(bob.getrawmempool()), 1)
+
+        # Now create a conflict to tx1_conflict, so that it gets kicked out of the mempool
+        raw_tx = alice.createrawtransaction(inputs=[unspents[1]], outputs=[{carol.getnewaddress() : 24.9895}])
+        tx1_conflict_conflict = alice.signrawtransactionwithwallet(raw_tx)['hex']
+        tx1_conflict_conflict_txid = alice.sendrawtransaction(tx1_conflict_conflict)
+
+        self.sync_mempools()
+
+        # Both tx1 and tx1_child are still not in the mempool because they have not be re-broadcasted
+        assert tx1_txid not in bob.getrawmempool()
+        assert tx1_child_txid not in bob.getrawmempool()
+        assert tx1_conflict_txid not in bob.getrawmempool()
+        assert tx1_conflict_conflict_txid in bob.getrawmempool()
+        assert_equal(len(bob.getrawmempool()), 1)
+
+        assert_equal(alice.getbalance(), 0)
+        assert_equal(bob.getbalances()["mine"]["untrusted_pending"], 0)
+        assert_equal(carol.getbalances()["mine"]["untrusted_pending"], Decimal("24.98950000"))
+
+        # Both tx1 and tx1_child can now be re-broadcasted
+        bob.sendrawtransaction(tx1)
+        bob.sendrawtransaction(tx1_child)
+        assert_equal(len(bob.getrawmempool()), 3)
+
+        alice.unloadwallet()
+        bob.unloadwallet()
+        carol.unloadwallet()
 
 if __name__ == '__main__':
     TxConflicts().main()


### PR DESCRIPTION
The `mempool_conflicts` variable is added to `CWalletTx`, it is a set of txids of txs in the mempool conflicting with the wallet tx or a wallet tx's parent. This PR only changes how mempool-conflicted txs are dealt with in memory.

`IsSpent` now returns false for an output being spent by a mempool conflicted transaction where it previously returned true.

A txid is added to `mempool_conflicts` during  `transactionAddedToMempool`. A txid is removed from `mempool_conflicts` during  `transactionRemovedFromMempool`.

This PR also adds a `mempoolconflicts` field to the `gettransaction` wallet RPC result.

Builds on #27145
Second attempt at #18600