### PR TITLE
ci: Use clang-15 in "tidy" task

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -80,10 +80,10 @@ task:
     << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
 
 task:
-  name: 'tidy [jammy]'
+  name: 'tidy [bookworm]'
   << : *GLOBAL_TASK_TEMPLATE
   container:
-    image: ubuntu:jammy
+    image: debian:bookworm
     cpu: 2
     memory: 5G
   # For faster CI feedback, immediately schedule the linters

--- a/ci/test/00_setup_env_native_tidy.sh
+++ b/ci/test/00_setup_env_native_tidy.sh
@@ -6,14 +6,14 @@
 
 export LC_ALL=C.UTF-8
 
-export CI_IMAGE_NAME_TAG="ubuntu:22.04"
+export CI_IMAGE_NAME_TAG="debian:bookworm"
 export CONTAINER_NAME=ci_native_tidy
-export PACKAGES="clang libclang-dev llvm-dev clang-tidy bear cmake libevent-dev libboost-dev libminiupnpc-dev libnatpmp-dev libzmq3-dev systemtap-sdt-dev libqt5gui5 libqt5core5a libqt5dbus5 qttools5-dev qttools5-dev-tools libqrencode-dev libsqlite3-dev libdb++-dev"
+export PACKAGES="clang-15 libclang-15-dev llvm-15-dev clang-tidy-15 bear cmake libevent-dev libboost-dev libminiupnpc-dev libnatpmp-dev libzmq3-dev systemtap-sdt-dev libqt5gui5 libqt5core5a libqt5dbus5 qttools5-dev qttools5-dev-tools libqrencode-dev libsqlite3-dev libdb++-dev"
 export NO_DEPENDS=1
 export RUN_UNIT_TESTS=false
 export RUN_FUNCTIONAL_TESTS=false
 export RUN_FUZZ_TESTS=false
 export RUN_TIDY=true
 export GOAL="install"
-export BITCOIN_CONFIG="CC=clang CXX=clang++ --with-incompatible-bdb --disable-hardening CFLAGS='-O0 -g0' CXXFLAGS='-O0 -g0'"
+export BITCOIN_CONFIG="CC=clang-15 CXX=clang++-15 --with-incompatible-bdb --disable-hardening CFLAGS='-O0 -g0' CXXFLAGS='-O0 -g0'"
 export CCACHE_SIZE=200M

--- a/ci/test/04_install.sh
+++ b/ci/test/04_install.sh
@@ -135,8 +135,8 @@ if [[ "${RUN_TIDY}" == "true" ]]; then
   export DIR_IWYU="${BASE_SCRATCH_DIR}/iwyu"
   if [ ! -d "${DIR_IWYU}" ]; then
     CI_EXEC "mkdir -p ${DIR_IWYU}/build/"
-    CI_EXEC "git clone --depth=1 https://github.com/include-what-you-use/include-what-you-use -b clang_14 ${DIR_IWYU}/include-what-you-use"
-    CI_EXEC "cd ${DIR_IWYU}/build && cmake -G 'Unix Makefiles' -DCMAKE_PREFIX_PATH=/usr/lib/llvm-14 ../include-what-you-use"
+    CI_EXEC "git clone --depth=1 https://github.com/include-what-you-use/include-what-you-use -b clang_15 ${DIR_IWYU}/include-what-you-use"
+    CI_EXEC "cd ${DIR_IWYU}/build && cmake -G 'Unix Makefiles' -DCMAKE_PREFIX_PATH=/usr/lib/llvm-15 ../include-what-you-use"
     CI_EXEC_ROOT "cd ${DIR_IWYU}/build && make install $MAKEJOBS"
   fi
 fi

--- a/ci/test/06_script_b.sh
+++ b/ci/test/06_script_b.sh
@@ -39,7 +39,7 @@ fi
 if [ "${RUN_TIDY}" = "true" ]; then
   set -eo pipefail
   export P_CI_DIR="${BASE_BUILD_DIR}/bitcoin-$HOST/src/"
-  ( CI_EXEC run-clang-tidy -quiet "${MAKEJOBS}" ) | grep -C5 "error"
+  ( CI_EXEC run-clang-tidy-15 -quiet "${MAKEJOBS}" ) | grep -C5 "error"
   export P_CI_DIR="${BASE_BUILD_DIR}/bitcoin-$HOST/"
   CI_EXEC "python3 ${DIR_IWYU}/include-what-you-use/iwyu_tool.py"\
           " src/common/init.cpp"\


### PR DESCRIPTION
Newer tools usually are better in terms of features and bug fixes.

Requested in https://github.com/bitcoin/bitcoin/pull/26642#issuecomment-1440230390.

Split from https://github.com/bitcoin/bitcoin/pull/26766.