### PR TITLE
build, qt: Fix handling of `CXX=clang++` when building `qt` package

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -161,9 +161,15 @@ $(package)_config_opts_linux += -dbus-runtime
 ifneq ($(LTO),)
 $(package)_config_opts_linux += -ltcg
 endif
-$(package)_config_opts_linux += -platform linux-g++ -xplatform bitcoin-linux-g++
-ifneq (,$(findstring -stdlib=libc++,$($(1)_cxx)))
-$(package)_config_opts_x86_64_linux = -xplatform linux-clang-libc++
+
+ifneq (,$(findstring clang,$($(package)_cxx)))
+  ifneq (,$(findstring -stdlib=libc++,$($(package)_cxx)))
+    $(package)_config_opts_linux += -platform linux-clang-libc++ -xplatform linux-clang-libc++
+  else
+    $(package)_config_opts_linux += -platform linux-clang -xplatform linux-clang
+  endif
+else
+  $(package)_config_opts_linux += -platform linux-g++ -xplatform bitcoin-linux-g++
 endif
 
 $(package)_config_opts_mingw32 = -no-opengl


### PR DESCRIPTION
On the master branch (f380bb93e854b24cec4ef020235340f5186deded):
```
$ cd depends
$ make qt CC=clang CXX=clang++
...
Project ERROR: failed to parse default search paths from compiler output
make: *** [funcs.mk:292: /home/hebasto/git/bitcoin/depends/x86_64-pc-linux-gnu/.qt_stamp_configured] Error 3
```

Fixes https://github.com/bitcoin/bitcoin/pull/27301#issuecomment-1479622034.

Guix builds:
```
daa94946aae7d4826d6f329337791a6bda0f01ac73f27003d1677dc8de031071  guix-build-25e8fe70c6e6/output/aarch64-linux-gnu/SHA256SUMS.part
38e9dcb99e329ad02837fd08559a8408bd7ba698f65163d0834d52dc9eefceae  guix-build-25e8fe70c6e6/output/aarch64-linux-gnu/bitcoin-25e8fe70c6e6-aarch64-linux-gnu-debug.tar.gz
36d48b93724b112e5553a8d048c79df0532da6d271598a105038c6a5dfbce630  guix-build-25e8fe70c6e6/output/aarch64-linux-gnu/bitcoin-25e8fe70c6e6-aarch64-linux-gnu.tar.gz
6fe9697b6c73f75b1d1ce1bf89176e4afb77a0f876cfbf72b1298660c8060c17  guix-build-25e8fe70c6e6/output/arm-linux-gnueabihf/SHA256SUMS.part
dffe564732625f7697274f5cec89c4340327fd3094c6e22dcda39edce064b249  guix-build-25e8fe70c6e6/output/arm-linux-gnueabihf/bitcoin-25e8fe70c6e6-arm-linux-gnueabihf-debug.tar.gz
d2fe5bb056b5d12363b2b7a2bf6dca95f2fc3734b61c770fe4919ecbf6570338  guix-build-25e8fe70c6e6/output/arm-linux-gnueabihf/bitcoin-25e8fe70c6e6-arm-linux-gnueabihf.tar.gz
ea63144558e7f9546b771f04fec5d59814d6dc5159fdc82c6da960fdf3de328f  guix-build-25e8fe70c6e6/output/arm64-apple-darwin/SHA256SUMS.part
579d33fb5d53789849551b25de0323714fe7d282b7506d1bcdb96690dc357911  guix-build-25e8fe70c6e6/output/arm64-apple-darwin/bitcoin-25e8fe70c6e6-arm64-apple-darwin-unsigned.dmg
439628b325a72806d2a598c9c40811f9506b3d0ca3cd56ac327ed7f25d018f22  guix-build-25e8fe70c6e6/output/arm64-apple-darwin/bitcoin-25e8fe70c6e6-arm64-apple-darwin-unsigned.tar.gz
8434b75c17c3e3fae9f28cfa8236191134327118c83e603783d700b0ebcf07a6  guix-build-25e8fe70c6e6/output/arm64-apple-darwin/bitcoin-25e8fe70c6e6-arm64-apple-darwin.tar.gz
61dc9b083d63fc955f4c064348d9c49937e6cc0e969c48538b60281e0824a0f4  guix-build-25e8fe70c6e6/output/dist-archive/bitcoin-25e8fe70c6e6.tar.gz
e31df50d868ec4ab6ecbd35ca0057a053eedd474dcc9c6287e4d225e8c0e8bee  guix-build-25e8fe70c6e6/output/powerpc64-linux-gnu/SHA256SUMS.part
086cabfda322c5f86c128d52212ccc7276a4f6273d6acaedd949634bd211f8f4  guix-build-25e8fe70c6e6/output/powerpc64-linux-gnu/bitcoin-25e8fe70c6e6-powerpc64-linux-gnu-debug.tar.gz
a245643fdad052b7fcc798bd1b7760540dcf47c54a9cdcc1e2f6bdb1fcc3f206  guix-build-25e8fe70c6e6/output/powerpc64-linux-gnu/bitcoin-25e8fe70c6e6-powerpc64-linux-gnu.tar.gz
cf8f81932f8132bc26f10599cd318310b6207aea9e31a1ac41393ffc7df51801  guix-build-25e8fe70c6e6/output/powerpc64le-linux-gnu/SHA256SUMS.part
f2fee686528ef507b5de03eb7f74f4d8a6d32338dbd7c6758795c963c6e9ce41  guix-build-25e8fe70c6e6/output/powerpc64le-linux-gnu/bitcoin-25e8fe70c6e6-powerpc64le-linux-gnu-debug.tar.gz
84a3b3c3b76eff95f8a6f49d1e4a3c7922722c1a202d982e9e4b83f9797d1e8d  guix-build-25e8fe70c6e6/output/powerpc64le-linux-gnu/bitcoin-25e8fe70c6e6-powerpc64le-linux-gnu.tar.gz
42b8d6fa5756e200fcd99fdad07186437403ec85098d6d3d3246d7750b6f8361  guix-build-25e8fe70c6e6/output/riscv64-linux-gnu/SHA256SUMS.part
0e588eb81dfc7dcc472b9ea18825a6dee5967dd7f5a0f90a59d0ea2ac54bac8d  guix-build-25e8fe70c6e6/output/riscv64-linux-gnu/bitcoin-25e8fe70c6e6-riscv64-linux-gnu-debug.tar.gz
6afcc482debcec8d3a7e32ca1216bfcd9ad4f653ace88ef39113f38bfb76e447  guix-build-25e8fe70c6e6/output/riscv64-linux-gnu/bitcoin-25e8fe70c6e6-riscv64-linux-gnu.tar.gz
f58997be8b2dde088c80534977ad26c485c687a1e55783131da259d35b477e81  guix-build-25e8fe70c6e6/output/x86_64-apple-darwin/SHA256SUMS.part
e7e17caa9035ba92216b591c9225b72316a65b1b6f68c85f85831d4c067e8d14  guix-build-25e8fe70c6e6/output/x86_64-apple-darwin/bitcoin-25e8fe70c6e6-x86_64-apple-darwin-unsigned.dmg
21df826825dd3b737f373513974e5e075470b6372b5ef00f0bfb69eaa806837c  guix-build-25e8fe70c6e6/output/x86_64-apple-darwin/bitcoin-25e8fe70c6e6-x86_64-apple-darwin-unsigned.tar.gz
81544073e667222d60591316571444b19c72be5b2e41007098b17a45e63c9691  guix-build-25e8fe70c6e6/output/x86_64-apple-darwin/bitcoin-25e8fe70c6e6-x86_64-apple-darwin.tar.gz
b1e644cc1ce3ba5bb91ca9fa22bd7abf25b2b537c9f041416555eb4327fb6a7b  guix-build-25e8fe70c6e6/output/x86_64-linux-gnu/SHA256SUMS.part
6942721e65ae40604e83957d19b12a6d320fa5676a5668e890db13a7b2df5102  guix-build-25e8fe70c6e6/output/x86_64-linux-gnu/bitcoin-25e8fe70c6e6-x86_64-linux-gnu-debug.tar.gz
c0596a5625d8cd2daf3c361290be6fc58642293d44944c10fde38bff203d1225  guix-build-25e8fe70c6e6/output/x86_64-linux-gnu/bitcoin-25e8fe70c6e6-x86_64-linux-gnu.tar.gz
ebc7bab758d37dc7a16154d24b2335aa1d261345f94eeab1ed2664bc8679f2f0  guix-build-25e8fe70c6e6/output/x86_64-w64-mingw32/SHA256SUMS.part
38f31a70a630bf9db2616eb6732635d6b9e929ebe79a5e75c0179a5dfd9c076f  guix-build-25e8fe70c6e6/output/x86_64-w64-mingw32/bitcoin-25e8fe70c6e6-win64-debug.zip
b84591a290e8d1d246eb56f29125bedd7b0e66eeeb875dee9c377c16ba3f7029  guix-build-25e8fe70c6e6/output/x86_64-w64-mingw32/bitcoin-25e8fe70c6e6-win64-setup-unsigned.exe
f3b50aee206c012c663d758d5a31d0efa7186805b70c8ec79962e1d7f977de6b  guix-build-25e8fe70c6e6/output/x86_64-w64-mingw32/bitcoin-25e8fe70c6e6-win64-unsigned.tar.gz
6d7da31b00adc5005a42983c3444f44ac13a1e0028f1db7ba07d253baf40bf9e  guix-build-25e8fe70c6e6/output/x86_64-w64-mingw32/bitcoin-25e8fe70c6e6-win64.zip
```