### PR TITLE
log: Check that the timestamp string is non-empty to avoid undefined behavior

### DIFF
--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -352,7 +352,7 @@ std::string BCLog::Logger::LogTimestampStr(const std::string& str)
         const auto now{SystemClock::now()};
         const auto now_seconds{std::chrono::time_point_cast<std::chrono::seconds>(now)};
         strStamped = FormatISO8601DateTime(TicksSinceEpoch<std::chrono::seconds>(now_seconds));
-        if (m_log_time_micros) {
+        if (m_log_time_micros && !strStamped.empty()) {
             strStamped.pop_back();
             strStamped += strprintf(".%06dZ", Ticks<std::chrono::microseconds>(now - now_seconds));
         }


### PR DESCRIPTION
Follow-up to https://github.com/bitcoin/bitcoin/pull/27233

The current `FormatISO8601DateTime` function will return an empty string if it encounters an error when converting the `int64_t` seconds-since-epoch to a formatted date time. In the unlikely case that happens, here `strStamped.pop_back()` would be undefined behavior.
