### PR TITLE
test: wallet_create_tx.py fix race

### DIFF
--- a/test/functional/wallet_create_tx.py
+++ b/test/functional/wallet_create_tx.py
@@ -92,6 +92,7 @@ class CreateTxWalletTest(BitcoinTestFramework):
         txid = tx_data['txid']
         vout = 1
 
+        self.nodes[0].syncwithvalidationinterfacequeue()
         options = {"change_position": 0, "add_inputs": False}
         for i in range(1, 25):
             options['inputs'] = [{'txid': txid, 'vout': vout}]


### PR DESCRIPTION
Fixes #27316

Because wallets are internally synchronized through the validation interface,
and the interface dispatches events on a worker thread, it is possible for a
transaction created by the first wallet to not arrive to the second wallet
before the second wallet attempts to use one of its outputs. This is because
we do not wait for the `BroadcastTransaction` callback during the wallet's
"submit to mempool" process. To address this in the tests, we need to
manually sync the validation queue.