### PR TITLE
Move IsDeprecatedRPCEnabled to rpc/util, rm redundant rpcEnableDeprecated

### DIFF
--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -104,9 +104,9 @@ struct BlockInfo {
 //!   communicate with each other without going through the node
 //!   (https://github.com/bitcoin/bitcoin/pull/15288#discussion_r253321096).
 //!
-//! * The handleRpc, registerRpcs, rpcEnableDeprecated methods and other RPC
-//!   methods can go away if wallets listen for HTTP requests on their own
-//!   ports instead of registering to handle requests on the node HTTP port.
+//! * The handleRpc and registerRpcs methods and other RPC methods can go away
+//!   if wallets listen for HTTP requests on their own ports instead of
+//!   registering to handle requests on the node HTTP port.
 //!
 //! * Move fee estimation queries to an asynchronous interface and let the
 //!   wallet cache it, fee estimation being driven by node mempool, wallet
@@ -286,9 +286,6 @@ public:
     //! Register handler for RPC. Command is not copied, so reference
     //! needs to remain valid until Handler is disconnected.
     virtual std::unique_ptr<Handler> handleRpc(const CRPCCommand& command) = 0;
-
-    //! Check if deprecated RPC is enabled.
-    virtual bool rpcEnableDeprecated(const std::string& method) = 0;
 
     //! Run function after given number of seconds. Cancel any previous calls with same name.
     virtual void rpcRunLater(const std::string& name, std::function<void()> fn, int64_t seconds) = 0;

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -738,7 +738,6 @@ public:
     {
         return std::make_unique<RpcHandlerImpl>(command);
     }
-    bool rpcEnableDeprecated(const std::string& method) override { return IsDeprecatedRPCEnabled(method); }
     void rpcRunLater(const std::string& name, std::function<void()> fn, int64_t seconds) override
     {
         RPCRunLater(name, std::move(fn), seconds);

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -349,13 +349,6 @@ bool RPCIsInWarmup(std::string *outStatus)
     return fRPCInWarmup;
 }
 
-bool IsDeprecatedRPCEnabled(const std::string& method)
-{
-    const std::vector<std::string> enabled_methods = gArgs.GetArgs("-deprecatedrpc");
-
-    return find(enabled_methods.begin(), enabled_methods.end(), method) != enabled_methods.end();
-}
-
 static UniValue JSONRPCExecOne(JSONRPCRequest jreq, const UniValue& req)
 {
     UniValue rpc_result(UniValue::VOBJ);

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -165,8 +165,6 @@ public:
     bool removeCommand(const std::string& name, const CRPCCommand* pcmd);
 };
 
-bool IsDeprecatedRPCEnabled(const std::string& method);
-
 extern CRPCTable tableRPC;
 
 void StartRPC();

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -1197,3 +1197,10 @@ void PushWarnings(const std::vector<bilingual_str>& warnings, UniValue& obj)
     if (warnings.empty()) return;
     obj.pushKV("warnings", BilingualStringsToUniValue(warnings));
 }
+
+bool IsDeprecatedRPCEnabled(const std::string& method)
+{
+    const std::vector<std::string> enabled_methods = gArgs.GetArgs("-deprecatedrpc");
+
+    return find(enabled_methods.begin(), enabled_methods.end(), method) != enabled_methods.end();
+}

--- a/src/rpc/util.h
+++ b/src/rpc/util.h
@@ -390,4 +390,6 @@ private:
 void PushWarnings(const UniValue& warnings, UniValue& obj);
 void PushWarnings(const std::vector<bilingual_str>& warnings, UniValue& obj);
 
+bool IsDeprecatedRPCEnabled(const std::string& method);
+
 #endif // BITCOIN_RPC_UTIL_H

--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -1937,7 +1937,7 @@ RPCHelpMan restorewallet()
 
     UniValue obj(UniValue::VOBJ);
     obj.pushKV("name", wallet->GetName());
-    if (wallet->chain().rpcEnableDeprecated("walletwarningfield")) {
+    if (IsDeprecatedRPCEnabled("walletwarningfield")) {
         obj.pushKV("warning", Join(warnings, Untranslated("\n")).original);
     }
     PushWarnings(warnings, obj);

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -253,7 +253,7 @@ static RPCHelpMan loadwallet()
 
     UniValue obj(UniValue::VOBJ);
     obj.pushKV("name", wallet->GetName());
-    if (wallet->chain().rpcEnableDeprecated("walletwarningfield")) {
+    if (IsDeprecatedRPCEnabled("walletwarningfield")) {
         obj.pushKV("warning", Join(warnings, Untranslated("\n")).original);
     }
     PushWarnings(warnings, obj);
@@ -425,7 +425,7 @@ static RPCHelpMan createwallet()
 
     UniValue obj(UniValue::VOBJ);
     obj.pushKV("name", wallet->GetName());
-    if (wallet->chain().rpcEnableDeprecated("walletwarningfield")) {
+    if (IsDeprecatedRPCEnabled("walletwarningfield")) {
         obj.pushKV("warning", Join(warnings, Untranslated("\n")).original);
     }
     PushWarnings(warnings, obj);
@@ -488,7 +488,7 @@ static RPCHelpMan unloadwallet()
         }
     }
     UniValue result(UniValue::VOBJ);
-    if (wallet->chain().rpcEnableDeprecated("walletwarningfield")) {
+    if (IsDeprecatedRPCEnabled("walletwarningfield")) {
         result.pushKV("warning", Join(warnings, Untranslated("\n")).original);
     }
     PushWarnings(warnings, result);


### PR DESCRIPTION
CI builds currently fail when `IsDeprecatedRPCEnabled()` is called from wallet RPCs with "Undefined reference to IsDeprecatedRPCEnabled in libbitcoin_wallet".

Fix the issue by moving `IsDeprecatedRPCEnabled()` from `rpc/server` to `rpc/util`, thereby moving it from `node` to `common` to be picked up by libbitcoin_wallet (see `doc/design/librairies.md` and `src/Makefile.am`).

This move allows us to drop the redundant `rpcEnableDeprecated()` method. Per the comment in `src/interfaces/chain.h::L107` from #15639 we would like to remove these, and this function doesn't seem constrained by the mentioned HTTP port requirement, nor needed if `IsDeprecatedRPCEnabled` is in `common` rather than `node`. 

This allows having only one call for this functionality and avoids developer confusion and head-scratching. 

If it is preferred to keep all of them, this pull could alternatively document the use of these different methods for future developers doing a deprecation.