### PR TITLE
ci: Add missing libclang-rt-dev package

### DIFF
--- a/ci/test/00_setup_env_native_asan.sh
+++ b/ci/test/00_setup_env_native_asan.sh
@@ -19,7 +19,7 @@ else
 fi
 
 export CONTAINER_NAME=ci_native_asan
-export PACKAGES="systemtap-sdt-dev clang llvm python3-zmq qtbase5-dev qttools5-dev-tools libevent-dev bsdmainutils libboost-dev libdb5.3++-dev libminiupnpc-dev libnatpmp-dev libzmq3-dev libqrencode-dev libsqlite3-dev ${BPFCC_PACKAGE}"
+export PACKAGES="systemtap-sdt-dev clang llvm libclang-rt-dev python3-zmq qtbase5-dev qttools5-dev-tools libevent-dev bsdmainutils libboost-dev libdb5.3++-dev libminiupnpc-dev libnatpmp-dev libzmq3-dev libqrencode-dev libsqlite3-dev ${BPFCC_PACKAGE}"
 export CI_IMAGE_NAME_TAG=ubuntu:22.04
 export NO_DEPENDS=1
 export GOAL="install"

--- a/ci/test/00_setup_env_native_fuzz.sh
+++ b/ci/test/00_setup_env_native_fuzz.sh
@@ -8,7 +8,7 @@ export LC_ALL=C.UTF-8
 
 export CI_IMAGE_NAME_TAG="ubuntu:22.04"
 export CONTAINER_NAME=ci_native_fuzz
-export PACKAGES="clang llvm python3 libevent-dev bsdmainutils libboost-dev libsqlite3-dev"
+export PACKAGES="clang llvm libclang-rt-dev python3 libevent-dev bsdmainutils libboost-dev libsqlite3-dev"
 export NO_DEPENDS=1
 export RUN_UNIT_TESTS=false
 export RUN_FUNCTIONAL_TESTS=false

--- a/ci/test/00_setup_env_native_tsan.sh
+++ b/ci/test/00_setup_env_native_tsan.sh
@@ -8,7 +8,7 @@ export LC_ALL=C.UTF-8
 
 export CONTAINER_NAME=ci_native_tsan
 export CI_IMAGE_NAME_TAG=ubuntu:22.04
-export PACKAGES="clang-13 llvm-13 libc++abi-13-dev libc++-13-dev python3-zmq"
+export PACKAGES="clang-13 llvm-13 libclang-rt-13-dev libc++abi-13-dev libc++-13-dev python3-zmq"
 export DEP_OPTS="CC=clang-13 CXX='clang++-13 -stdlib=libc++'"
 export GOAL="install"
 export BITCOIN_CONFIG="--enable-zmq CPPFLAGS='-DARENA_DEBUG -DDEBUG_LOCKORDER -DDEBUG_LOCKCONTENTION' CXXFLAGS='-g' --with-sanitizers=thread"


### PR DESCRIPTION
This is required, due to `--no-install-recommends` in `ci/test/01_base_install.sh`, I presume.

If not added, this will cause issues if the CI image is bumped, for example, to Ubuntu Lunar.

Asan Lunar:

```
configure:22272: clang++ -std=c++20 -o conftest -g -O2 -DARENA_DEBUG -DDEBUG_LOCKORDER   -fsanitize=address,integer,undefined conftest.cpp  >&5
/usr/bin/ld: cannot find /usr/lib/llvm-15/lib/clang/15.0.7/lib/linux/libclang_rt.asan_static-x86_64.a: No such file or directory
/usr/bin/ld: cannot find /usr/lib/llvm-15/lib/clang/15.0.7/lib/linux/libclang_rt.asan-x86_64.a: No such file or directory
/usr/bin/ld: cannot find /usr/lib/llvm-15/lib/clang/15.0.7/lib/linux/libclang_rt.asan_cxx-x86_64.a: No such file or directory
```

Fuzz Lunar:

```
configure:22272: clang++ -ftrivial-auto-var-init=pattern -std=c++17 -o conftest -g -O2    -fsanitize=fuzzer,address,undefined,integer conftest.cpp  >&5
/usr/bin/ld: cannot find /usr/lib/llvm-15/lib/clang/15.0.7/lib/linux/libclang_rt.fuzzer-x86_64.a: No such file or directory
/usr/bin/ld: cannot find /usr/lib/llvm-15/lib/clang/15.0.7/lib/linux/libclang_rt.asan_static-x86_64.a: No such file or directory
/usr/bin/ld: cannot find /usr/lib/llvm-15/lib/clang/15.0.7/lib/linux/libclang_rt.asan-x86_64.a: No such file or directory
/usr/bin/ld: cannot find /usr/lib/llvm-15/lib/clang/15.0.7/lib/linux/libclang_rt.asan_cxx-x86_64.a: No such file or directory
```


Tsan Lunar:

See https://github.com/bitcoin/bitcoin/pull/27298#issuecomment-1480024555