### PR TITLE
guix: combine and document `enable_werror`

### DIFF
--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -150,7 +150,7 @@ chain for " target " development."))
                                        #:key
                                        (base-gcc-for-libc base-gcc)
                                        (base-kernel-headers base-linux-kernel-headers)
-                                       (base-libc (hardened-glibc (make-glibc-without-werror glibc-2.27)))
+                                       (base-libc (hardened-glibc glibc-2.27))
                                        (base-gcc (make-gcc-rpath-link (hardened-gcc base-gcc))))
   "Convenience wrapper around MAKE-CROSS-TOOLCHAIN with default values
 desirable for building Bitcoin Core release binaries."
@@ -530,15 +530,16 @@ and endian independent.")
 inspecting signatures in Mach-O binaries.")
       (license license:expat))))
 
-(define (make-glibc-without-werror glibc)
-  (package-with-extra-configure-variable glibc "enable_werror" "no"))
-
 ;; https://www.gnu.org/software/libc/manual/html_node/Configuring-and-compiling.html
+;; We don't use --disable-werror directly, as that would be passed through to bash,
+;; and cause it's build to fail.
 (define (hardened-glibc glibc)
   (package-with-extra-configure-variable (
-    package-with-extra-configure-variable glibc
-    "--enable-stack-protector" "all")
-    "--enable-bind-now" "yes"))
+    package-with-extra-configure-variable (
+      package-with-extra-configure-variable glibc
+      "enable_werror" "no")
+      "--enable-stack-protector" "all")
+      "--enable-bind-now" "yes"))
 
 (define-public glibc-2.27
   (package


### PR DESCRIPTION
Combine into `hardened-glibc`.
Document why we don't use `--disable-werror` directly.

https://www.gnu.org/software/libc/manual/html_node/Configuring-and-compiling.html
> By default, the GNU C Library is built with -Werror. If you wish
> to build without this option (for example, if building with a
> newer version of GCC than this version of the GNU C Library was
> tested with, so new warnings cause the build with -Werror to fail),
> you can configure with --disable-werror.