### PR TITLE
depends: fix osx build with clang 16

### DIFF
--- a/depends/hosts/darwin.mk
+++ b/depends/hosts/darwin.mk
@@ -99,8 +99,8 @@ darwin_CC=env -u C_INCLUDE_PATH -u CPLUS_INCLUDE_PATH \
             $(clang_prog) --target=$(host) -mmacosx-version-min=$(OSX_MIN_VERSION) \
               -B$(build_prefix)/bin -mlinker-version=$(LD64_VERSION) \
               -isysroot$(OSX_SDK) \
-              -Xclang -internal-externc-isystem$(clang_resource_dir)/include \
-              -Xclang -internal-externc-isystem$(OSX_SDK)/usr/include
+              -Xclang -internal-externc-isystem -Xclang $(clang_resource_dir)/include \
+              -Xclang -internal-externc-isystem -Xclang $(OSX_SDK)/usr/include
 darwin_CXX=env -u C_INCLUDE_PATH -u CPLUS_INCLUDE_PATH \
                -u OBJC_INCLUDE_PATH -u OBJCPLUS_INCLUDE_PATH -u CPATH \
                -u LIBRARY_PATH \
@@ -109,8 +109,8 @@ darwin_CXX=env -u C_INCLUDE_PATH -u CPLUS_INCLUDE_PATH \
                -isysroot$(OSX_SDK) \
                -stdlib=libc++ \
                -stdlib++-isystem$(OSX_SDK)/usr/include/c++/v1 \
-               -Xclang -internal-externc-isystem$(clang_resource_dir)/include \
-               -Xclang -internal-externc-isystem$(OSX_SDK)/usr/include
+               -Xclang -internal-externc-isystem -Xclang $(clang_resource_dir)/include \
+               -Xclang -internal-externc-isystem -Xclang $(OSX_SDK)/usr/include
 
 darwin_CFLAGS=-pipe -std=$(C_STANDARD)
 darwin_CXXFLAGS=-pipe -std=$(CXX_STANDARD)


### PR DESCRIPTION
Current build (using forced system clang as a test) results in:

> error: unknown argument: '-internal-externc-isystem/opt/clang+llvm-16.0.0-x86_64-linux-gnu-ubuntu-18.04/lib/clang/16/include'

For some reason the previous syntax worked with clang 15 and below, but clang 16 requires that the option and value are properly separated.

See [here for an example of upstream using this syntax](https://github.com/llvm/llvm-project/blob/main/clang/test/Driver/crash-report-with-asserts.c#L9).

There is no change in behavior for previous versions.

I'm seeing an additional unrelated problem with linking with system clang, but I'll PR the solution to that separately as it's not as straightforward as this.