### PR TITLE
Added clangd .cache and compile_commands.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,7 @@ dist/
 /guix-build-*
 
 /ci/scratch/
+
+# clangd
+.cache/
+compile_commands.json


### PR DESCRIPTION
Added cause these were always getting created whenever I was using clangd in the project