### PR TITLE
Fixes compile errors in MSVC build #27332

### DIFF
--- a/build_msvc/vcpkg.json
+++ b/build_msvc/vcpkg.json
@@ -13,5 +13,12 @@
       "features": ["thread"]
     },
     "zeromq"
+  ],
+  "builtin-baseline": "f14984af3738e69f197bf0e647a8dca12de92996",
+  "overrides": [
+    {
+      "name": "libevent",
+      "version": "2.1.12#7"
+    }
   ]
 }


### PR DESCRIPTION
This PR is designed to address the issue https://github.com/bitcoin/bitcoin/issues/27332. The MSVC build is failing because of two bugs in how the build is configured.

The issue
====

When running `msbuild build_msvc\bitcoin.sln -property:Configuration=Release -maxCpuCount -verbosity:minima`l the build fails with following two errors.

* `C:\Users\e0\Documents\GitHub\bitcoin\src\httpserver.cpp(637,9): error C2664: 'void evhttp_connection_get_peer(evhttp_connection *,const char **,uint16_t *)': cannot convert argument 2 from 'char **' to 'const char **' [C:\Users\e0\Documents\GitHub\bitcoin\build_msvc\libbitcoin_node\libbitcoin_node .vcxproj]`

This error is occurs because bitcoin is using the wrong function signature for `evhttp_connection_get_peer` in libevent. In automake builds, configure.ac inspects the version of libevent it is building against and then defines `HAVE_EVHTTP_CONNECTION_GET_PEER_CONST_CHAR` to flag the source code to use the correct signature. In MSVC build there does not appear to be a mechanism to do this. So it uses the wrong signature and fails. See the PR https://github.com/bitcoin/bitcoin/pull/23607 for when this logic was added to automake builds.

* `event.lib(evutil_rand.c.obj) : error LNK2019: unresolved external symbol BCryptGenRandom referenced in function arc4_seed [C:\Users\e0\Documents\GitHub\bitcoin\build_msvc\bitcoin-cli\bitcoin-cli.vcxproj]
C:\Users\e0\Documents\GitHub\bitcoin\build_msvc\x64\Release\bitcoin-cli.exe : fatal error LNK1120: 1 unresolved externals [C:\Users\e0\Documents\GitHub\bitcoin\build_msvc\bitcoin-cli\bitcoin-cli.vcxproj]`

This error is caused by msbuild not being able to find the library bcrypt.lib because it has not been configured to use bcrypt.lib. 

Fixes (Initially Proposed)
====
**Edit:** This bug was solved using an alternative fix documented below as Fixes (Actual)

While for automake builds a macro is being define to configure the current function signature for `evhttp_connection_get_peer` in libevent, this macro is not being defined for MSVC builds.

1.  This PR addresses this issue by assuming more recent version of libevent is installed and always defining `HAVE_EVHTTP_CONNECTION_GET_PEER_CONST_CHAR`. This logic is more brittle the automake logic, but someone following the MSVC build instructions should only get the more recent version of libevent.

2. This PR fixes the bcrypt.lib errors this by setting this library as a dependency in build_msvc/common.init.vcxproj.in.

Fixes (Actual)
====

* This PR Pin the version of libevent to an older version which uses the older function signature and does not require bcrypt as a separate dependency.

If at some point we have not moved to CMake and we wish upgrade libevent we need to perform the actions in Fixes (Initially Proposed). However it is likely Bitcoin will be on CMake before that is neccessary.


