### PR TITLE
wallet: allow importing descriptors that have no xprivs, even in a privkey-enabled wallet

### DIFF
--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -1536,9 +1536,6 @@ static UniValue ProcessDescriptorImport(CWallet& wallet, const UniValue& data, c
 
         // If private keys are enabled, check some things.
         if (!wallet.IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS)) {
-           if (keys.keys.empty()) {
-                throw JSONRPCError(RPC_WALLET_ERROR, "Cannot import descriptor without private keys to a wallet with private keys enabled");
-           }
            if (!have_all_privkeys) {
                warnings.push_back("Not all private keys provided. Some wallet functionality may return unexpected errors");
            }

--- a/test/functional/wallet_importdescriptors.py
+++ b/test/functional/wallet_importdescriptors.py
@@ -207,15 +207,6 @@ class ImportDescriptorsTest(BitcoinTestFramework):
                               error_code=-8,
                               error_message='Ranged descriptors should not have a label')
 
-        self.log.info("Private keys required for private keys enabled wallet")
-        self.test_importdesc({"desc":descsum_create(desc),
-                              "timestamp": "now",
-                              "range": [0, 100]},
-                              success=False,
-                              error_code=-4,
-                              error_message='Cannot import descriptor without private keys to a wallet with private keys enabled',
-                              wallet=wpriv)
-
         self.log.info("Ranged descriptor import should warn without a specified range")
         self.test_importdesc({"desc": descsum_create(desc),
                                "timestamp": "now"},


### PR DESCRIPTION
Importing pubkey-only descriptors works fine as long as the wallet already has the required privkeys.

Happy to add whatever tests people advise me to.

Fixes #27336

**Edit** Never mind -- we can update balances but not sign coins. More work needs to be done to support this.