### PR TITLE
ci: Use Cirrus CI dockerfile env

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -210,6 +210,7 @@ task:
     docker_arguments:
       CI_IMAGE_NAME_TAG: ubuntu:jammy
       FILE_ENV: "./ci/test/00_setup_env_win64.sh"
+  << : *CREDITS_TEMPLATE
   env:
     << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
 
@@ -308,6 +309,7 @@ task:
     docker_arguments:
       CI_IMAGE_NAME_TAG: debian:buster
       FILE_ENV: "./ci/test/00_setup_env_native_nowallet_libbitcoinkernel.sh"
+  << : *CREDITS_TEMPLATE
   env:
     << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
 
@@ -318,6 +320,7 @@ task:
     docker_arguments:
       CI_IMAGE_NAME_TAG: ubuntu:focal
       FILE_ENV: "./ci/test/00_setup_env_mac.sh"
+  << : *CREDITS_TEMPLATE
   macos_sdk_cache:
     folder: "depends/SDKs/$MACOS_SDK"
     fingerprint_key: "$MACOS_SDK"
@@ -350,6 +353,7 @@ task:
     docker_arguments:
       CI_IMAGE_NAME_TAG: ubuntu:jammy
       FILE_ENV: "./ci/test/00_setup_env_android.sh"
+  << : *CREDITS_TEMPLATE
   android_sdk_cache:
     folder: "depends/SDKs/android"
     fingerprint_key: "ANDROID_API_LEVEL=28 ANDROID_BUILD_TOOLS_VERSION=28.0.3 ANDROID_NDK_VERSION=23.2.8568313"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -47,6 +47,7 @@ container_depends_template: &CONTAINER_DEPENDS_TEMPLATE
     cpu: 2
     greedy: true
     memory: 8G  # Set to 8GB to avoid OOM. https://cirrus-ci.org/guide/linux/#linux-containers
+    dockerfile: ci/test_imagefile  # https://cirrus-ci.org/guide/docker-builder-vm/#dockerfile-as-a-ci-environment
   depends_built_cache:
     folder: "depends/built"
     fingerprint_script: echo $CIRRUS_TASK_NAME $(git rev-parse HEAD:depends)
@@ -83,14 +84,15 @@ task:
   name: 'tidy [lunar]'
   << : *GLOBAL_TASK_TEMPLATE
   container:
-    image: ubuntu:lunar
     cpu: 2
     memory: 5G
+    docker_arguments:
+      CI_IMAGE_NAME_TAG: ubuntu:lunar
+      FILE_ENV: "./ci/test/00_setup_env_native_tidy.sh"
   # For faster CI feedback, immediately schedule the linters
   << : *CREDITS_TEMPLATE
   env:
     << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
-    FILE_ENV: "./ci/test/00_setup_env_native_tidy.sh"
 
 task:
   name: "Win64 native [vs2022]"
@@ -195,6 +197,7 @@ task:
     image: debian:bullseye
     cpu: 2
     memory: 8G
+    # docker_arguments:  # Can use dockerfile after https://github.com/cirruslabs/cirrus-ci-docs/issues/1154
   env:
     << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
     FILE_ENV: "./ci/test/00_setup_env_arm.sh"
@@ -204,22 +207,24 @@ task:
   name: 'Win64 [unit tests, no gui tests, no boost::process, no functional tests] [jammy]'
   << : *GLOBAL_TASK_TEMPLATE
   container:
-    image: ubuntu:jammy
+    docker_arguments:
+      CI_IMAGE_NAME_TAG: ubuntu:jammy
+      FILE_ENV: "./ci/test/00_setup_env_win64.sh"
   env:
     << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
-    FILE_ENV: "./ci/test/00_setup_env_win64.sh"
 
 task:
   name: '32-bit + dash [gui] [CentOS 8]'
   << : *GLOBAL_TASK_TEMPLATE
   container:
-    image: quay.io/centos/centos:stream8
+    docker_arguments:
+      CI_IMAGE_NAME_TAG: quay.io/centos/centos:stream8
+      FILE_ENV: "./ci/test/00_setup_env_i686_centos.sh"
   # For faster CI feedback, immediately schedule one task that runs all tests
   << : *CREDITS_TEMPLATE
   env:
     << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
     PACKAGE_MANAGER_INSTALL: "yum install -y"
-    FILE_ENV: "./ci/test/00_setup_env_i686_centos.sh"
 
 task:
   name: '[previous releases, uses qt5 dev package and some depends packages, DEBUG] [unsigned char] [buster]'
@@ -235,21 +240,23 @@ task:
   name: '[TSan, depends, gui] [lunar]'
   << : *GLOBAL_TASK_TEMPLATE
   container:
-    image: ubuntu:lunar
     cpu: 6  # Increase CPU and Memory to avoid timeout
     memory: 24G
+    docker_arguments:
+      CI_IMAGE_NAME_TAG: ubuntu:lunar
+      FILE_ENV: "./ci/test/00_setup_env_native_tsan.sh"
   env:
     << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
-    FILE_ENV: "./ci/test/00_setup_env_native_tsan.sh"
 
 task:
   name: '[MSan, depends] [lunar]'
   << : *GLOBAL_TASK_TEMPLATE
   container:
-    image: ubuntu:lunar
+    docker_arguments:
+      CI_IMAGE_NAME_TAG: ubuntu:lunar
+      FILE_ENV: "./ci/test/00_setup_env_native_msan.sh"
   env:
     << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
-    FILE_ENV: "./ci/test/00_setup_env_native_msan.sh"
     MAKEJOBS: "-j4"  # Avoid excessive memory use due to MSan
 
 task:
@@ -274,38 +281,43 @@ task:
   name: '[fuzzer,address,undefined,integer, no depends] [lunar]'
   << : *GLOBAL_TASK_TEMPLATE
   container:
-    image: ubuntu:lunar
     cpu: 4  # Increase CPU and memory to avoid timeout
     memory: 16G
+    docker_arguments:
+      CI_IMAGE_NAME_TAG: ubuntu:lunar
+      FILE_ENV: "./ci/test/00_setup_env_native_fuzz.sh"
   env:
     << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
-    FILE_ENV: "./ci/test/00_setup_env_native_fuzz.sh"
 
 task:
   name: '[multiprocess, i686, DEBUG] [focal]'
   << : *GLOBAL_TASK_TEMPLATE
   container:
-    image: ubuntu:focal
     cpu: 4
     memory: 16G  # The default memory is sometimes just a bit too small, so double everything
+    docker_arguments:
+      CI_IMAGE_NAME_TAG: ubuntu:focal
+      FILE_ENV: "./ci/test/00_setup_env_i686_multiprocess.sh"
   env:
     << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
-    FILE_ENV: "./ci/test/00_setup_env_i686_multiprocess.sh"
 
 task:
   name: '[no wallet, libbitcoinkernel] [buster]'
   << : *GLOBAL_TASK_TEMPLATE
   container:
-    image: debian:buster
+    docker_arguments:
+      CI_IMAGE_NAME_TAG: debian:buster
+      FILE_ENV: "./ci/test/00_setup_env_native_nowallet_libbitcoinkernel.sh"
   env:
     << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
-    FILE_ENV: "./ci/test/00_setup_env_native_nowallet_libbitcoinkernel.sh"
 
 task:
   name: 'macOS 10.15 [gui, no tests] [focal]'
   << : *CONTAINER_DEPENDS_TEMPLATE
   container:
-    image: ubuntu:focal
+    docker_arguments:
+      CI_IMAGE_NAME_TAG: ubuntu:focal
+      FILE_ENV: "./ci/test/00_setup_env_mac.sh"
   macos_sdk_cache:
     folder: "depends/SDKs/$MACOS_SDK"
     fingerprint_key: "$MACOS_SDK"
@@ -313,7 +325,6 @@ task:
   env:
     MACOS_SDK: "Xcode-12.2-12B45b-extracted-SDK-with-libcxx-headers"
     << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
-    FILE_ENV: "./ci/test/00_setup_env_mac.sh"
 
 task:
   name: 'macOS 13 native arm64 [gui, sqlite only] [no depends]'
@@ -336,7 +347,9 @@ task:
   name: 'ARM64 Android APK [jammy]'
   << : *CONTAINER_DEPENDS_TEMPLATE
   container:
-    image: ubuntu:jammy
+    docker_arguments:
+      CI_IMAGE_NAME_TAG: ubuntu:jammy
+      FILE_ENV: "./ci/test/00_setup_env_android.sh"
   android_sdk_cache:
     folder: "depends/SDKs/android"
     fingerprint_key: "ANDROID_API_LEVEL=28 ANDROID_BUILD_TOOLS_VERSION=28.0.3 ANDROID_NDK_VERSION=23.2.8568313"
@@ -346,4 +359,3 @@ task:
   << : *MAIN_TEMPLATE
   env:
     << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
-    FILE_ENV: "./ci/test/00_setup_env_android.sh"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -303,11 +303,11 @@ task:
     << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
 
 task:
-  name: '[no wallet, libbitcoinkernel] [buster]'
+  name: '[no wallet, libbitcoinkernel] [focal]'
   << : *GLOBAL_TASK_TEMPLATE
   container:
     docker_arguments:
-      CI_IMAGE_NAME_TAG: debian:buster
+      CI_IMAGE_NAME_TAG: ubuntu:focal
       FILE_ENV: "./ci/test/00_setup_env_native_nowallet_libbitcoinkernel.sh"
   << : *CREDITS_TEMPLATE
   env:

--- a/ci/test/00_setup_env_native_nowallet_libbitcoinkernel.sh
+++ b/ci/test/00_setup_env_native_nowallet_libbitcoinkernel.sh
@@ -7,10 +7,9 @@
 export LC_ALL=C.UTF-8
 
 export CONTAINER_NAME=ci_native_nowallet_libbitcoinkernel
-export CI_IMAGE_NAME_TAG=debian:buster
-# Use minimum supported python3.7 and clang-8, see doc/dependencies.md
-export PACKAGES="-t buster-backports python3-zmq clang-8 llvm-8 libc++abi-8-dev libc++-8-dev"
-export APPEND_APT_SOURCES_LIST="deb http://deb.debian.org/debian buster-backports main"
+export CI_IMAGE_NAME_TAG=ubuntu:focal
+# Use minimum supported python3.7 (or python3.8, as best-effort) and clang-8, see doc/dependencies.md
+export PACKAGES="python3-zmq clang-8 llvm-8 libc++abi-8-dev libc++-8-dev"
 export DEP_OPTS="NO_WALLET=1 CC=clang-8 CXX='clang++-8 -stdlib=libc++'"
 export GOAL="install"
 export NO_WERROR=1


### PR DESCRIPTION
Currently the CI env has many intermittent issues:

* The Ubuntu package servers are frequently down
* Occasionally other stuff is down, such as dnf, pip, or the android sdk
* Installing packages is slower than downloading them, at least on Cirrus, which has a fast download speed

Fix all issues by using the Cirrus CI dockerfile env.