### PR TITLE
fuzz: Remove legacy int parse fuzz tests

### DIFF
--- a/ci/test/06_script_b.sh
+++ b/ci/test/06_script_b.sh
@@ -61,6 +61,7 @@ if [ "${RUN_TIDY}" = "true" ]; then
           " src/random.cpp"\
           " src/rpc/fees.cpp"\
           " src/rpc/signmessage.cpp"\
+          " src/test/fuzz/string.cpp"\
           " src/test/fuzz/txorphan.cpp"\
           " src/test/fuzz/util/"\
           " src/test/util/coins.cpp"\

--- a/test/lint/lint-locale-dependence.py
+++ b/test/lint/lint-locale-dependence.py
@@ -44,8 +44,6 @@ from subprocess import check_output, CalledProcessError
 KNOWN_VIOLATIONS = [
     "src/dbwrapper.cpp:.*vsnprintf",
     "src/test/fuzz/locale.cpp:.*setlocale",
-    "src/test/fuzz/string.cpp:.*strtol",
-    "src/test/fuzz/string.cpp:.*strtoul",
     "src/test/util_tests.cpp:.*strtoll",
     "src/wallet/bdb.cpp:.*DbEnv::strerror",  # False positive
     "src/util/syserror.cpp:.*strerror",      # Outside this function use `SysErrorString`


### PR DESCRIPTION
The fuzz tests checked that the result of the new function was equal to the legacy function. (Side note: The checks were incomplete, as evident by the follow-up fix in commit b5c9bb5cb9f4a8db57b33ef7399310c7d6de5822).

Given that they haven't found any issues in years (beside missing the above issue, that they couldn't catch), it seems time to remove them.

They may come in handy in the rare case that someone would want to modify `LocaleIndependentAtoi()` or `Parse*Int*()`, however that seems unlikely. Also, appropriate checks can be added then.