### PR TITLE
test: fix intermittent failure in ChainStateManager tests

### DIFF
--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -367,10 +367,13 @@ struct SnapshotTestSetup : TestChain100Setup {
 
         BOOST_TEST_MESSAGE("Simulating node restart");
         {
-            LOCK(::cs_main);
             for (Chainstate* cs : chainman.GetAll()) {
+                LOCK(::cs_main);
                 cs->ForceFlushStateToDisk();
             }
+            // Process all callbacks referring to the old manager before wiping it.
+            SyncWithValidationInterfaceQueue();
+            LOCK(::cs_main);
             chainman.ResetChainstates();
             BOOST_CHECK_EQUAL(chainman.GetAll().size(), 0);
             const ChainstateManager::Options chainman_opts{


### PR DESCRIPTION
Before wiping a `ChainStateManager` and creating a new one, the `validationinterface` queue should be emptied to avoid the possibility of accessing deleted memory.
This could lead to very rare CI failures reported in #26613 and #27320 (see [here](https://github.com/bitcoin/bitcoin/issues/27320#issuecomment-1485694691) for a more detailed explanation).

Fixes #27320