### PR TITLE
guix: use python-minimal (3.9)

### DIFF
--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -598,7 +598,7 @@ inspecting signatures in Mach-O binaries.")
         gcc-toolchain-10
         (list gcc-toolchain-10 "static")
         ;; Scripting
-        python-3
+        python-minimal ;; (3.9)
         ;; Git
         git-minimal
         ;; Tests


### PR DESCRIPTION
This further minifies the Guix release build environment.