### PR TITLE
test: remove `GetRNGState` lsan suppression

### DIFF
--- a/test/sanitizer_suppressions/lsan
+++ b/test/sanitizer_suppressions/lsan
@@ -1,5 +1,2 @@
 # Suppress warnings triggered in dependencies
 leak:libQt5Widgets
-
-# false-positive due to use of secure_allocator<>
-leak:GetRNGState


### PR DESCRIPTION
I am no-longer seeing this, testing with the native_asan job over `x86_64` (Ubuntu 22.04) and `aarch64` (Fedora 37). 

Can anyone recreate the false-positive?