### PR TITLE
refactor: Drop no longer used `CNetMsgMaker` instances

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2439,8 +2439,6 @@ arith_uint256 PeerManagerImpl::GetAntiDoSWorkThreshold()
 void PeerManagerImpl::HandleFewUnconnectingHeaders(CNode& pfrom, Peer& peer,
         const std::vector<CBlockHeader>& headers)
 {
-    const CNetMsgMaker msgMaker(pfrom.GetCommonVersion());
-
     LOCK(cs_main);
     CNodeState *nodestate = State(pfrom.GetId());
 
@@ -4938,7 +4936,6 @@ void PeerManagerImpl::ConsiderEviction(CNode& pto, Peer& peer, std::chrono::seco
     AssertLockHeld(cs_main);
 
     CNodeState &state = *State(pto.GetId());
-    const CNetMsgMaker msgMaker(pto.GetCommonVersion());
 
     if (!state.m_chain_sync.m_protect && pto.IsOutboundOrBlockRelayConn() && state.fSyncStarted) {
         // This is an outbound peer subject to disconnection if they don't


### PR DESCRIPTION
The removed lines have been unused since the https://github.com/bitcoin/bitcoin/commit/abf5d16c24cb08b0451bdbd4d1de63a12930e8f5 commit from https://github.com/bitcoin/bitcoin/pull/25454.