### PR TITLE
ci: Remove second user account

### DIFF
--- a/ci/test/05_before_script.sh
+++ b/ci/test/05_before_script.sh
@@ -11,7 +11,6 @@ if [ "$CI_OS_NAME" == "macos" ]; then
   echo > "${HOME}/Library/Application Support/Bitcoin"
 else
   CI_EXEC echo \> \$HOME/.bitcoin
-  CI_EXEC_ROOT echo \> \$HOME/.bitcoin
 fi
 
 if [ -z "$NO_DEPENDS" ]; then


### PR DESCRIPTION
The rationale for the second (nonroot) account no longer applies. See also https://github.com/bitcoin/bitcoin/pull/27333#discussion_r1148898438