### PR TITLE
miniscript: explicit cast instead of comparing integers of different signs

### DIFF
--- a/src/script/miniscript.h
+++ b/src/script/miniscript.h
@@ -1194,7 +1194,7 @@ public:
                 case Fragment::OR_I:
                     return subs[0] || subs[1];
                 case Fragment::THRESH:
-                    return std::count(subs.begin(), subs.end(), true) >= node.k;
+                    return static_cast<uint32_t>(std::count(subs.begin(), subs.end(), true)) >= node.k;
                 default: // wrappers
                     assert(subs.size() == 1);
                     return subs[0];


### PR DESCRIPTION
Fixes #27381