### PR TITLE
net, refactor: extract Network and BIP155Network logic to node/network

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -224,6 +224,7 @@ BITCOIN_CORE_H = \
   node/miner.h \
   node/mini_miner.h \
   node/minisketchwrapper.h \
+  node/network.h \
   node/peerman_args.h \
   node/psbt.h \
   node/transaction.h \
@@ -422,6 +423,7 @@ libbitcoin_node_a_SOURCES = \
   node/miner.cpp \
   node/mini_miner.cpp \
   node/minisketchwrapper.cpp \
+  node/network.cpp \
   node/peerman_args.cpp \
   node/psbt.cpp \
   node/transaction.cpp \

--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -10,6 +10,8 @@
 #include <logging.h>
 #include <logging/timer.h>
 #include <netaddress.h>
+#include <netgroup.h>
+#include <node/network.h>
 #include <protocol.h>
 #include <random.h>
 #include <serialize.h>

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -6,25 +6,28 @@
 #ifndef BITCOIN_ADDRMAN_H
 #define BITCOIN_ADDRMAN_H
 
-#include <netaddress.h>
-#include <netgroup.h>
-#include <protocol.h>
-#include <streams.h>
+#include <node/network.h>
 #include <util/time.h>
 
 #include <cstdint>
+#include <ios>
 #include <memory>
 #include <optional>
 #include <utility>
 #include <vector>
+
+class AddrManImpl;
+class CAddress;
+class CNetAddr;
+class CService;
+class NetGroupManager;
+enum ServiceFlags : uint64_t;
 
 class InvalidAddrManVersionError : public std::ios_base::failure
 {
 public:
     InvalidAddrManVersionError(std::string msg) : std::ios_base::failure(msg) { }
 };
-
-class AddrManImpl;
 
 /** Default for -checkaddrman */
 static constexpr int32_t DEFAULT_ADDRMAN_CONSISTENCY_CHECKS{0};

--- a/src/addrman_impl.h
+++ b/src/addrman_impl.h
@@ -8,6 +8,7 @@
 #include <logging.h>
 #include <logging/timer.h>
 #include <netaddress.h>
+#include <node/network.h>
 #include <protocol.h>
 #include <serialize.h>
 #include <sync.h>

--- a/src/bench/addrman.cpp
+++ b/src/bench/addrman.cpp
@@ -6,6 +6,7 @@
 #include <bench/bench.h>
 #include <netbase.h>
 #include <netgroup.h>
+#include <protocol.h>
 #include <random.h>
 #include <util/check.h>
 #include <util/time.h>

--- a/src/bench/peer_eviction.cpp
+++ b/src/bench/peer_eviction.cpp
@@ -5,6 +5,7 @@
 #include <bench/bench.h>
 #include <net.h>
 #include <netaddress.h>
+#include <node/network.h>
 #include <random.h>
 #include <test/util/net.h>
 #include <test/util/setup_common.h>

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -59,7 +59,6 @@ static constexpr int DEFAULT_WAIT_CLIENT_TIMEOUT = 0;
 static const bool DEFAULT_NAMED=false;
 static const int CONTINUE_EXECUTION=-1;
 static constexpr int8_t UNKNOWN_NETWORK{-1};
-// See GetNetworkName() in netbase.cpp
 static constexpr std::array NETWORKS{"not_publicly_routable", "ipv4", "ipv6", "onion", "i2p", "cjdns", "internal"};
 static constexpr std::array NETWORK_SHORT_NAMES{"npr", "ipv4", "ipv6", "onion", "i2p", "cjdns", "int"};
 static constexpr std::array UNREACHABLE_NETWORK_IDS{/*not_publicly_routable*/0, /*internal*/6};

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -50,6 +50,7 @@
 #include <node/mempool_args.h>
 #include <node/mempool_persist_args.h>
 #include <node/miner.h>
+#include <node/network.h>
 #include <node/peerman_args.h>
 #include <node/validation_cache_args.h>
 #include <policy/feerate.h>

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -9,8 +9,8 @@
 #include <consensus/amount.h>          // For CAmount
 #include <net.h>                       // For NodeId
 #include <net_types.h>                 // For banmap_t
-#include <netaddress.h>                // For Network
 #include <netbase.h>                   // For ConnectionDirection
+#include <node/network.h>
 #include <support/allocators/secure.h> // For SecureString
 #include <util/translation.h>
 

--- a/src/kernel/chainparams.h
+++ b/src/kernel/chainparams.h
@@ -8,6 +8,7 @@
 
 #include <consensus/params.h>
 #include <netaddress.h>
+#include <node/network.h>
 #include <primitives/block.h>
 #include <protocol.h>
 #include <uint256.h>

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -22,8 +22,11 @@
 #include <net_permissions.h>
 #include <netaddress.h>
 #include <netbase.h>
+#include <netgroup.h>
+#include <node/connection_types.h>
 #include <node/eviction.h>
 #include <node/interface_ui.h>
+#include <node/network.h>
 #include <protocol.h>
 #include <random.h>
 #include <scheduler.h>

--- a/src/net.h
+++ b/src/net.h
@@ -16,8 +16,7 @@
 #include <i2p.h>
 #include <net_permissions.h>
 #include <netaddress.h>
-#include <netbase.h>
-#include <netgroup.h>
+#include <node/network.h>
 #include <policy/feerate.h>
 #include <protocol.h>
 #include <random.h>
@@ -47,6 +46,8 @@ class AddrMan;
 class BanMan;
 class CNode;
 class CScheduler;
+class NetGroupManager;
+enum class ConnectionDirection;
 struct bilingual_str;
 
 /** Default for -whitelistrelay. */
@@ -101,7 +102,6 @@ struct AddedNodeInfo
     bool fInbound;
 };
 
-class CNodeStats;
 class CClientUIInterface;
 
 struct CSerializedNetMsg {

--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -8,6 +8,7 @@
 #include <crypto/common.h>
 #include <crypto/sha3.h>
 #include <hash.h>
+#include <node/network.h>
 #include <prevector.h>
 #include <tinyformat.h>
 #include <util/strencodings.h>

--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -24,7 +24,7 @@
 bool CNetAddr::SetNetFromBIP155Network(uint8_t possible_bip155_net, size_t address_size)
 {
     switch (possible_bip155_net) {
-    case BIP155Network::IPV4:
+    case static_cast<uint8_t>(BIP155Network::IPV4):
         if (address_size == ADDR_IPV4_SIZE) {
             m_net = NET_IPV4;
             return true;
@@ -32,7 +32,7 @@ bool CNetAddr::SetNetFromBIP155Network(uint8_t possible_bip155_net, size_t addre
         throw std::ios_base::failure(
             strprintf("BIP155 IPv4 address with length %u (should be %u)", address_size,
                       ADDR_IPV4_SIZE));
-    case BIP155Network::IPV6:
+    case static_cast<uint8_t>(BIP155Network::IPV6):
         if (address_size == ADDR_IPV6_SIZE) {
             m_net = NET_IPV6;
             return true;
@@ -40,7 +40,7 @@ bool CNetAddr::SetNetFromBIP155Network(uint8_t possible_bip155_net, size_t addre
         throw std::ios_base::failure(
             strprintf("BIP155 IPv6 address with length %u (should be %u)", address_size,
                       ADDR_IPV6_SIZE));
-    case BIP155Network::TORV3:
+    case static_cast<uint8_t>(BIP155Network::TORV3):
         if (address_size == ADDR_TORV3_SIZE) {
             m_net = NET_ONION;
             return true;
@@ -48,7 +48,7 @@ bool CNetAddr::SetNetFromBIP155Network(uint8_t possible_bip155_net, size_t addre
         throw std::ios_base::failure(
             strprintf("BIP155 TORv3 address with length %u (should be %u)", address_size,
                       ADDR_TORV3_SIZE));
-    case BIP155Network::I2P:
+    case static_cast<uint8_t>(BIP155Network::I2P):
         if (address_size == ADDR_I2P_SIZE) {
             m_net = NET_I2P;
             return true;
@@ -56,7 +56,7 @@ bool CNetAddr::SetNetFromBIP155Network(uint8_t possible_bip155_net, size_t addre
         throw std::ios_base::failure(
             strprintf("BIP155 I2P address with length %u (should be %u)", address_size,
                       ADDR_I2P_SIZE));
-    case BIP155Network::CJDNS:
+    case static_cast<uint8_t>(BIP155Network::CJDNS):
         if (address_size == ADDR_CJDNS_SIZE) {
             m_net = NET_CJDNS;
             return true;

--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -21,28 +21,6 @@
 #include <iterator>
 #include <tuple>
 
-CNetAddr::BIP155Network CNetAddr::GetBIP155Network() const
-{
-    switch (m_net) {
-    case NET_IPV4:
-        return BIP155Network::IPV4;
-    case NET_IPV6:
-        return BIP155Network::IPV6;
-    case NET_ONION:
-        return BIP155Network::TORV3;
-    case NET_I2P:
-        return BIP155Network::I2P;
-    case NET_CJDNS:
-        return BIP155Network::CJDNS;
-    case NET_INTERNAL:   // should have been handled before calling this function
-    case NET_UNROUTABLE: // m_net is never and should not be set to NET_UNROUTABLE
-    case NET_MAX:        // m_net is never and should not be set to NET_MAX
-        assert(false);
-    } // no default case, so the compiler can warn about missing cases
-
-    assert(false);
-}
-
 bool CNetAddr::SetNetFromBIP155Network(uint8_t possible_bip155_net, size_t address_size)
 {
     switch (possible_bip155_net) {

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -233,18 +233,6 @@ private:
     bool SetI2P(const std::string& addr);
 
     /**
-     * BIP155 network ids recognized by this software.
-     */
-    enum BIP155Network : uint8_t {
-        IPV4 = 1,
-        IPV6 = 2,
-        TORV2 = 3,
-        TORV3 = 4,
-        I2P = 5,
-        CJDNS = 6,
-    };
-
-    /**
      * Size of CNetAddr when serialized as ADDRv1 (pre-BIP155) (in bytes).
      */
     static constexpr size_t V1_SERIALIZATION_SIZE = ADDR_IPV6_SIZE;
@@ -255,13 +243,6 @@ private:
      * when serialized.
      */
     static constexpr size_t MAX_ADDRV2_SIZE = 512;
-
-    /**
-     * Get the BIP155 network id of this address.
-     * Must not be called for IsInternal() objects.
-     * @returns BIP155 network id, except TORV2 which is no longer supported.
-     */
-    BIP155Network GetBIP155Network() const;
 
     /**
      * Set `m_net` from the provided BIP155 network id and size after validation.
@@ -337,7 +318,7 @@ private:
             return;
         }
 
-        s << static_cast<uint8_t>(GetBIP155Network());
+        s << static_cast<uint8_t>(GetBIP155Network(m_net));
         s << m_addr;
     }
 

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -11,6 +11,7 @@
 
 #include <compat/compat.h>
 #include <crypto/siphash.h>
+#include <node/network.h>
 #include <prevector.h>
 #include <random.h>
 #include <serialize.h>
@@ -31,42 +32,6 @@
  * or with `SERIALIZE_TRANSACTION_NO_WITNESS`.
  */
 static constexpr int ADDRV2_FORMAT = 0x20000000;
-
-/**
- * A network type.
- * @note An address may belong to more than one network, for example `10.0.0.1`
- * belongs to both `NET_UNROUTABLE` and `NET_IPV4`.
- * Keep these sequential starting from 0 and `NET_MAX` as the last entry.
- * We have loops like `for (int i = 0; i < NET_MAX; ++i)` that expect to iterate
- * over all enum values and also `GetExtNetwork()` "extends" this enum by
- * introducing standalone constants starting from `NET_MAX`.
- */
-enum Network {
-    /// Addresses from these networks are not publicly routable on the global Internet.
-    NET_UNROUTABLE = 0,
-
-    /// IPv4
-    NET_IPV4,
-
-    /// IPv6
-    NET_IPV6,
-
-    /// TOR (v2 or v3)
-    NET_ONION,
-
-    /// I2P
-    NET_I2P,
-
-    /// CJDNS
-    NET_CJDNS,
-
-    /// A set of addresses that represent the hash of a string or FQDN. We use
-    /// them in AddrMan to keep track of which DNS seeds were used.
-    NET_INTERNAL,
-
-    /// Dummy value to indicate the number of NET_* constants.
-    NET_MAX,
-};
 
 /// Prefix of an IPv6 address when it contains an embedded IPv4 address.
 /// Used when (un)serializing addresses in ADDRv1 format (pre-BIP155).

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -194,7 +194,7 @@ enum SOCKS5Reply: uint8_t {
 };
 
 /** Values defined for ATYPE in RFC1928 */
-enum SOCKS5Atyp: uint8_t {
+enum class SOCKS5Atyp : uint8_t {
     IPV4 = 0x01,
     DOMAINNAME = 0x03,
     IPV6 = 0x04,
@@ -343,7 +343,7 @@ bool Socks5(const std::string& strDest, uint16_t port, const ProxyCredentials* a
     vSocks5.push_back(SOCKSVersion::SOCKS5); // VER protocol version
     vSocks5.push_back(SOCKS5Command::CONNECT); // CMD CONNECT
     vSocks5.push_back(0x00); // RSV Reserved must be 0
-    vSocks5.push_back(SOCKS5Atyp::DOMAINNAME); // ATYP DOMAINNAME
+    vSocks5.push_back(static_cast<uint8_t>(SOCKS5Atyp::DOMAINNAME)); // ATYP DOMAINNAME
     vSocks5.push_back(strDest.size()); // Length<=255 is checked at beginning of function
     vSocks5.insert(vSocks5.end(), strDest.begin(), strDest.end());
     vSocks5.push_back((port >> 8) & 0xFF);
@@ -377,9 +377,9 @@ bool Socks5(const std::string& strDest, uint16_t port, const ProxyCredentials* a
     uint8_t pchRet3[256];
     switch (pchRet2[3])
     {
-        case SOCKS5Atyp::IPV4: recvr = InterruptibleRecv(pchRet3, 4, g_socks5_recv_timeout, sock); break;
-        case SOCKS5Atyp::IPV6: recvr = InterruptibleRecv(pchRet3, 16, g_socks5_recv_timeout, sock); break;
-        case SOCKS5Atyp::DOMAINNAME:
+        case static_cast<uint8_t>(SOCKS5Atyp::IPV4): recvr = InterruptibleRecv(pchRet3, 4, g_socks5_recv_timeout, sock); break;
+        case static_cast<uint8_t>(SOCKS5Atyp::IPV6): recvr = InterruptibleRecv(pchRet3, 16, g_socks5_recv_timeout, sock); break;
+        case static_cast<uint8_t>(SOCKS5Atyp::DOMAINNAME):
         {
             recvr = InterruptibleRecv(pchRet3, 1, g_socks5_recv_timeout, sock);
             if (recvr != IntrRecvError::OK) {

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -7,6 +7,7 @@
 
 #include <compat/compat.h>
 #include <logging.h>
+#include <node/network.h>
 #include <sync.h>
 #include <tinyformat.h>
 #include <util/sock.h>
@@ -75,54 +76,6 @@ std::vector<CNetAddr> WrappedGetAddrInfo(const std::string& name, bool allow_loo
 }
 
 DNSLookupFn g_dns_lookup{WrappedGetAddrInfo};
-
-enum Network ParseNetwork(const std::string& net_in) {
-    std::string net = ToLower(net_in);
-    if (net == "ipv4") return NET_IPV4;
-    if (net == "ipv6") return NET_IPV6;
-    if (net == "onion") return NET_ONION;
-    if (net == "tor") {
-        LogPrintf("Warning: net name 'tor' is deprecated and will be removed in the future. You should use 'onion' instead.\n");
-        return NET_ONION;
-    }
-    if (net == "i2p") {
-        return NET_I2P;
-    }
-    if (net == "cjdns") {
-        return NET_CJDNS;
-    }
-    return NET_UNROUTABLE;
-}
-
-std::string GetNetworkName(enum Network net)
-{
-    switch (net) {
-    case NET_UNROUTABLE: return "not_publicly_routable";
-    case NET_IPV4: return "ipv4";
-    case NET_IPV6: return "ipv6";
-    case NET_ONION: return "onion";
-    case NET_I2P: return "i2p";
-    case NET_CJDNS: return "cjdns";
-    case NET_INTERNAL: return "internal";
-    case NET_MAX: assert(false);
-    } // no default case, so the compiler can warn about missing cases
-
-    assert(false);
-}
-
-std::vector<std::string> GetNetworkNames(bool append_unroutable)
-{
-    std::vector<std::string> names;
-    for (int n = 0; n < NET_MAX; ++n) {
-        const enum Network network{static_cast<Network>(n)};
-        if (network == NET_UNROUTABLE || network == NET_INTERNAL) continue;
-        names.emplace_back(GetNetworkName(network));
-    }
-    if (append_unroutable) {
-        names.emplace_back(GetNetworkName(NET_UNROUTABLE));
-    }
-    return names;
-}
 
 static std::vector<CNetAddr> LookupIntern(const std::string& name, unsigned int nMaxSolutions, bool fAllowLookup, DNSLookupFn dns_lookup_function)
 {

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -11,6 +11,7 @@
 
 #include <compat/compat.h>
 #include <netaddress.h>
+#include <node/network.h>
 #include <serialize.h>
 #include <util/sock.h>
 
@@ -69,10 +70,6 @@ struct ProxyCredentials
  */
 std::vector<CNetAddr> WrappedGetAddrInfo(const std::string& name, bool allow_lookup);
 
-enum Network ParseNetwork(const std::string& net);
-std::string GetNetworkName(enum Network net);
-/** Return a vector of publicly routable Network names; optionally append NET_UNROUTABLE. */
-std::vector<std::string> GetNetworkNames(bool append_unroutable = false);
 bool SetProxy(enum Network net, const Proxy &addrProxy);
 bool GetProxy(enum Network net, Proxy &proxyInfoOut);
 bool IsProxy(const CNetAddr &addr);

--- a/src/netgroup.cpp
+++ b/src/netgroup.cpp
@@ -4,6 +4,9 @@
 
 #include <netgroup.h>
 
+#include <netaddress.h>
+#include <node/network.h>
+
 #include <hash.h>
 #include <util/asmap.h>
 

--- a/src/netgroup.h
+++ b/src/netgroup.h
@@ -5,10 +5,11 @@
 #ifndef BITCOIN_NETGROUP_H
 #define BITCOIN_NETGROUP_H
 
-#include <netaddress.h>
 #include <uint256.h>
 
 #include <vector>
+
+class CNetAddr;
 
 /**
  * Netgroup manager

--- a/src/node/eviction.cpp
+++ b/src/node/eviction.cpp
@@ -4,8 +4,12 @@
 
 #include <node/eviction.h>
 
+#include <node/connection_types.h>
+#include <node/network.h>
+
 #include <algorithm>
 #include <array>
+#include <cassert>
 #include <chrono>
 #include <cstdint>
 #include <functional>

--- a/src/node/eviction.h
+++ b/src/node/eviction.h
@@ -5,13 +5,14 @@
 #ifndef BITCOIN_NODE_EVICTION_H
 #define BITCOIN_NODE_EVICTION_H
 
-#include <node/connection_types.h>
-#include <net_permissions.h>
+#include <node/network.h>
 
 #include <chrono>
 #include <cstdint>
 #include <optional>
 #include <vector>
+
+enum class ConnectionType;
 
 typedef int64_t NodeId;
 

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <addrdb.h>
 #include <banman.h>
 #include <blockfilter.h>
 #include <chain.h>
@@ -21,12 +20,12 @@
 #include <mapport.h>
 #include <net.h>
 #include <net_processing.h>
-#include <netaddress.h>
 #include <netbase.h>
 #include <node/blockstorage.h>
 #include <node/coin.h>
 #include <node/context.h>
 #include <node/interface_ui.h>
+#include <node/network.h>
 #include <node/transaction.h>
 #include <policy/feerate.h>
 #include <policy/fees.h>
@@ -59,6 +58,9 @@
 #include <utility>
 
 #include <boost/signals2/signal.hpp>
+
+class CNetAddr;
+class CSubNet;
 
 using interfaces::BlockTip;
 using interfaces::Chain;

--- a/src/node/network.cpp
+++ b/src/node/network.cpp
@@ -1,0 +1,58 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <node/network.h>
+
+#include <logging.h>
+#include <util/strencodings.h>
+
+#include <algorithm>
+#include <cassert>
+#include <string>
+#include <vector>
+
+enum Network ParseNetwork(const std::string& net_in)
+{
+    const std::string net{ToLower(net_in)};
+    if (net == "ipv4") return NET_IPV4;
+    if (net == "ipv6") return NET_IPV6;
+    if (net == "onion") return NET_ONION;
+    if (net == "tor") {
+        LogPrintf("Warning: net name 'tor' is deprecated and will be removed in the future. You should use 'onion' instead.\n");
+        return NET_ONION;
+    }
+    if (net == "i2p") return NET_I2P;
+    if (net == "cjdns") return NET_CJDNS;
+    return NET_UNROUTABLE;
+}
+
+std::string GetNetworkName(enum Network net)
+{
+    switch (net) {
+    case NET_UNROUTABLE: return "not_publicly_routable";
+    case NET_IPV4: return "ipv4";
+    case NET_IPV6: return "ipv6";
+    case NET_ONION: return "onion";
+    case NET_I2P: return "i2p";
+    case NET_CJDNS: return "cjdns";
+    case NET_INTERNAL: return "internal";
+    case NET_MAX: assert(false);
+    } // no default case, so the compiler can warn about missing cases
+
+    assert(false);
+}
+
+std::vector<std::string> GetNetworkNames(bool append_unroutable)
+{
+    std::vector<std::string> names;
+    for (int n = 0; n < NET_MAX; ++n) {
+        const enum Network network{static_cast<Network>(n)};
+        if (network == NET_UNROUTABLE || network == NET_INTERNAL) continue;
+        names.emplace_back(GetNetworkName(network));
+    }
+    if (append_unroutable) {
+        names.emplace_back(GetNetworkName(NET_UNROUTABLE));
+    }
+    return names;
+}

--- a/src/node/network.cpp
+++ b/src/node/network.cpp
@@ -12,6 +12,28 @@
 #include <string>
 #include <vector>
 
+BIP155Network GetBIP155Network(Network net)
+{
+    switch (net) {
+    case NET_IPV4:
+        return BIP155Network::IPV4;
+    case NET_IPV6:
+        return BIP155Network::IPV6;
+    case NET_ONION:
+        return BIP155Network::TORV3;
+    case NET_I2P:
+        return BIP155Network::I2P;
+    case NET_CJDNS:
+        return BIP155Network::CJDNS;
+    case NET_INTERNAL:   // should have been handled before calling this function
+    case NET_UNROUTABLE: // should never be NET_UNROUTABLE
+    case NET_MAX:        // should never be NET_MAX
+        assert(false);
+    } // no default case, so the compiler can warn about missing cases
+
+    assert(false);
+}
+
 enum Network ParseNetwork(const std::string& net_in)
 {
     const std::string net{ToLower(net_in)};

--- a/src/node/network.h
+++ b/src/node/network.h
@@ -45,6 +45,25 @@ enum Network {
     NET_MAX,
 };
 
+/**
+ * BIP155 network ids recognized by this software.
+ */
+enum BIP155Network : uint8_t {
+    IPV4 = 1,
+    IPV6 = 2,
+    TORV2 = 3,
+    TORV3 = 4,
+    I2P = 5,
+    CJDNS = 6,
+};
+
+/**
+ * Get the BIP155 network id of a network.
+ * Must not be called for IsInternal() objects.
+ * @returns BIP155 network id, except TORV2 which is no longer supported.
+ */
+BIP155Network GetBIP155Network(Network net);
+
 enum Network ParseNetwork(const std::string& net_in);
 
 std::string GetNetworkName(enum Network net);

--- a/src/node/network.h
+++ b/src/node/network.h
@@ -1,0 +1,55 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_NODE_NETWORK_H
+#define BITCOIN_NODE_NETWORK_H
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+/**
+ * A network type.
+ * @note An address may belong to more than one network, for example `10.0.0.1`
+ * belongs to both `NET_UNROUTABLE` and `NET_IPV4`.
+ * Keep these sequential starting from 0 and `NET_MAX` as the last entry.
+ * We have loops like `for (int i = 0; i < NET_MAX; ++i)` that expect to iterate
+ * over all enum values and also `GetExtNetwork()` "extends" this enum by
+ * introducing standalone constants starting from `NET_MAX`.
+ */
+enum Network {
+    /// Addresses from these networks are not publicly routable on the global Internet.
+    NET_UNROUTABLE = 0,
+
+    /// IPv4
+    NET_IPV4,
+
+    /// IPv6
+    NET_IPV6,
+
+    /// TOR (v2 or v3)
+    NET_ONION,
+
+    /// I2P
+    NET_I2P,
+
+    /// CJDNS
+    NET_CJDNS,
+
+    /// A set of addresses that represent the hash of a string or FQDN. We use
+    /// them in AddrMan to keep track of which DNS seeds were used.
+    NET_INTERNAL,
+
+    /// Dummy value to indicate the number of NET_* constants.
+    NET_MAX,
+};
+
+enum Network ParseNetwork(const std::string& net_in);
+
+std::string GetNetworkName(enum Network net);
+
+/** Return a vector of publicly routable Network names; optionally append NET_UNROUTABLE. */
+std::vector<std::string> GetNetworkNames(bool append_unroutable = false);
+
+#endif // BITCOIN_NODE_NETWORK_H

--- a/src/node/network.h
+++ b/src/node/network.h
@@ -62,13 +62,13 @@ enum class BIP155Network : uint8_t {
  * Must not be called for IsInternal() objects.
  * @returns BIP155 network id, except TORV2 which is no longer supported.
  */
-BIP155Network GetBIP155Network(Network net);
+[[nodiscard]] BIP155Network GetBIP155Network(Network net);
 
-enum Network ParseNetwork(const std::string& net_in);
+[[nodiscard]] enum Network ParseNetwork(const std::string& net_in);
 
-std::string GetNetworkName(enum Network net);
+[[nodiscard]] std::string GetNetworkName(enum Network net);
 
 /** Return a vector of publicly routable Network names; optionally append NET_UNROUTABLE. */
-std::vector<std::string> GetNetworkNames(bool append_unroutable = false);
+[[nodiscard]] std::vector<std::string> GetNetworkNames(bool append_unroutable = false);
 
 #endif // BITCOIN_NODE_NETWORK_H

--- a/src/node/network.h
+++ b/src/node/network.h
@@ -48,7 +48,7 @@ enum Network {
 /**
  * BIP155 network ids recognized by this software.
  */
-enum BIP155Network : uint8_t {
+enum class BIP155Network : uint8_t {
     IPV4 = 1,
     IPV6 = 2,
     TORV2 = 3,

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -17,6 +17,7 @@
 #include <interfaces/node.h>
 #include <net.h>
 #include <netbase.h>
+#include <node/network.h>
 #include <util/threadnames.h>
 #include <util/time.h>
 #include <validation.h>

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -16,6 +16,8 @@
 #include <interfaces/node.h>
 #include <key_io.h>
 #include <logging.h>
+#include <node/connection_types.h>
+#include <node/network.h>
 #include <policy/policy.h>
 #include <primitives/transaction.h>
 #include <protocol.h>

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -6,8 +6,7 @@
 #define BITCOIN_QT_GUIUTIL_H
 
 #include <consensus/amount.h>
-#include <net.h>
-#include <netaddress.h>
+#include <node/network.h>
 #include <util/check.h>
 #include <util/fs.h>
 
@@ -30,6 +29,7 @@
 class PlatformStyle;
 class QValidatedLineEdit;
 class SendCoinsRecipient;
+enum class ConnectionType;
 
 namespace interfaces
 {

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -18,6 +18,7 @@
 #include <common/system.h>
 #include <interfaces/node.h>
 #include <netbase.h>
+#include <node/network.h>
 #include <txdb.h>
 #include <validation.h>
 

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -13,6 +13,7 @@
 #include <qt/walletview.h>
 #include <util/fs.h>
 #include <util/fs_helpers.h>
+#include <util/strencodings.h>
 
 #include <cassert>
 #include <fstream>

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -16,6 +16,7 @@
 #include <deploymentstatus.h>
 #include <key_io.h>
 #include <net.h>
+#include <netbase.h>
 #include <node/context.h>
 #include <node/miner.h>
 #include <pow.h>

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -14,6 +14,7 @@
 #include <net_types.h> // For banmap_t
 #include <netbase.h>
 #include <node/context.h>
+#include <node/network.h>
 #include <policy/settings.h>
 #include <rpc/blockchain.h>
 #include <rpc/protocol.h>

--- a/src/test/addrman_tests.cpp
+++ b/src/test/addrman_tests.cpp
@@ -9,6 +9,8 @@
 #include <clientversion.h>
 #include <hash.h>
 #include <netbase.h>
+#include <netgroup.h>
+#include <node/network.h>
 #include <random.h>
 #include <test/data/asmap.raw.h>
 #include <test/util/setup_common.h>

--- a/src/test/fuzz/addrman.cpp
+++ b/src/test/fuzz/addrman.cpp
@@ -69,12 +69,13 @@ CNetAddr RandAddr(FuzzedDataProvider& fuzzed_data_provider, FastRandomContext& f
     if (fuzzed_data_provider.remaining_bytes() > 1 && fuzzed_data_provider.ConsumeBool()) {
         addr = ConsumeNetAddr(fuzzed_data_provider);
     } else {
-        // The networks [1..6] correspond to CNetAddr::BIP155Network (private).
-        static const std::map<uint8_t, uint8_t> net_len_map = {{1, ADDR_IPV4_SIZE},
-                                                               {2, ADDR_IPV6_SIZE},
-                                                               {4, ADDR_TORV3_SIZE},
-                                                               {5, ADDR_I2P_SIZE},
-                                                               {6, ADDR_CJDNS_SIZE}};
+        static const std::map<uint8_t, uint8_t> net_len_map = {
+            {static_cast<uint8_t>(BIP155Network::IPV4), ADDR_IPV4_SIZE},
+            {static_cast<uint8_t>(BIP155Network::IPV6), ADDR_IPV6_SIZE},
+            {static_cast<uint8_t>(BIP155Network::TORV3), ADDR_TORV3_SIZE},
+            {static_cast<uint8_t>(BIP155Network::I2P), ADDR_I2P_SIZE},
+            {static_cast<uint8_t>(BIP155Network::CJDNS), ADDR_CJDNS_SIZE},
+        };
         uint8_t net = fast_random_context.randrange(5) + 1; // [1..5]
         if (net == 3) {
             net = 6;

--- a/src/test/fuzz/addrman.cpp
+++ b/src/test/fuzz/addrman.cpp
@@ -8,6 +8,8 @@
 #include <chainparams.h>
 #include <common/args.h>
 #include <merkleblock.h>
+#include <netgroup.h>
+#include <node/network.h>
 #include <random.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>

--- a/src/test/fuzz/connman.cpp
+++ b/src/test/fuzz/connman.cpp
@@ -6,7 +6,7 @@
 #include <chainparams.h>
 #include <common/args.h>
 #include <net.h>
-#include <netaddress.h>
+#include <netbase.h>
 #include <protocol.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>

--- a/src/test/fuzz/netaddress.cpp
+++ b/src/test/fuzz/netaddress.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <netaddress.h>
+#include <node/network.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util/net.h>

--- a/src/test/fuzz/string.cpp
+++ b/src/test/fuzz/string.cpp
@@ -8,7 +8,7 @@
 #include <common/settings.h>
 #include <common/system.h>
 #include <common/url.h>
-#include <netbase.h>
+#include <node/network.h>
 #include <outputtype.h>
 #include <rpc/client.h>
 #include <rpc/request.h>

--- a/src/test/fuzz/util/net.cpp
+++ b/src/test/fuzz/util/net.cpp
@@ -6,6 +6,7 @@
 
 #include <compat/compat.h>
 #include <netaddress.h>
+#include <node/network.h>
 #include <protocol.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/util.h>

--- a/src/test/i2p_tests.cpp
+++ b/src/test/i2p_tests.cpp
@@ -6,6 +6,7 @@
 #include <i2p.h>
 #include <logging.h>
 #include <netaddress.h>
+#include <netbase.h>
 #include <test/util/logging.h>
 #include <test/util/net.h>
 #include <test/util/setup_common.h>

--- a/src/test/net_peer_eviction_tests.cpp
+++ b/src/test/net_peer_eviction_tests.cpp
@@ -4,6 +4,7 @@
 
 #include <netaddress.h>
 #include <net.h>
+#include <node/network.h>
 #include <test/util/net.h>
 #include <test/util/setup_common.h>
 

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -12,6 +12,7 @@
 #include <netaddress.h>
 #include <netbase.h>
 #include <netmessagemaker.h>
+#include <node/network.h>
 #include <serialize.h>
 #include <span.h>
 #include <streams.h>

--- a/src/test/netbase_tests.cpp
+++ b/src/test/netbase_tests.cpp
@@ -6,6 +6,7 @@
 #include <netaddress.h>
 #include <netbase.h>
 #include <netgroup.h>
+#include <node/network.h>
 #include <protocol.h>
 #include <serialize.h>
 #include <streams.h>

--- a/src/test/util/net.cpp
+++ b/src/test/util/net.cpp
@@ -7,6 +7,7 @@
 #include <chainparams.h>
 #include <node/eviction.h>
 #include <net.h>
+#include <netaddress.h>
 #include <net_processing.h>
 #include <netmessagemaker.h>
 #include <span.h>

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -7,8 +7,8 @@
 
 #include <compat/compat.h>
 #include <node/eviction.h>
-#include <netaddress.h>
 #include <net.h>
+#include <node/network.h>
 #include <util/sock.h>
 
 #include <array>

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -20,6 +20,7 @@
 #include <interfaces/chain.h>
 #include <kernel/mempool_entry.h>
 #include <net.h>
+#include <netgroup.h>
 #include <net_processing.h>
 #include <node/blockstorage.h>
 #include <node/chainstate.h>

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -14,6 +14,7 @@
 #include <net.h>
 #include <netaddress.h>
 #include <netbase.h>
+#include <node/network.h>
 #include <util/readwritefile.h>
 #include <util/strencodings.h>
 #include <util/thread.h>


### PR DESCRIPTION
This extracts the `Network` and `BIP155Network` logic to `node/network`.  The code has been living between `netaddress` and `netbase` and some compilation units include these large files when they only need a `Network` enum or related method.  Separating the code to a standalone unit in `node` improves code separation and helps with using only what is needed.

I verified the `include` headers with https://cirrus-ci.com/task/6749578737745920 generated by https://github.com/bitcoin/bitcoin/pull/27385/commits/8f647a65d3484c7acd2d97f4b055c582d7734b6f while this was in draft and carefully narrowed them down to the most relevant ones.

Possible todos for a follow-up: upgrade `Network` to an `enum class`, e.g. `NET_I2P` becomes `Network::I2P` and https://github.com/bitcoin/bitcoin/pull/27385/commits/5cfa3fb8b5815aaf96483a63526e5f0bf3c0a06b.