### PR TITLE
#24049 Issue: Update nScore datatype

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -176,7 +176,7 @@ extern bool fListen;
 extern std::string strSubVersion;
 
 struct LocalServiceInfo {
-    int nScore;
+    int64_t nScore;
     uint16_t nPort;
 };
 


### PR DESCRIPTION
I had just changed the datatype of nScore from int to int64_t as the issue suggest.