### PR TITLE
depends, doc: Document `NO_USDT` option

### DIFF
--- a/depends/README.md
+++ b/depends/README.md
@@ -107,7 +107,8 @@ The following can be set when running make: `make FOO=bar`
 - `NO_BDB`: Don't download/build/cache BerkeleyDB
 - `NO_SQLITE`: Don't download/build/cache SQLite
 - `NO_UPNP`: Don't download/build/cache packages needed for enabling UPnP
-- `NO_NATPMP`: Don't download/build/cache packages needed for enabling NAT-PMP</dd>
+- `NO_NATPMP`: Don't download/build/cache packages needed for enabling NAT-PMP
+- `NO_USDT`: Don't download/build/cache packages needed for enabling USDT tracepoints
 - `ALLOW_HOST_PACKAGES`: Packages that are missed in dependencies (due to `NO_*` option or
   build script logic) are searched for among the host system packages using
   `pkg-config`. It allows building with packages of other (newer) versions


### PR DESCRIPTION
A follow-up for https://github.com/bitcoin/bitcoin/pull/23724.

This also removes a stray `</dd>` from the `NO_NATPMP` docs.