### PR TITLE
test: refactor: replace unnecessary `BytesIO` uses

### DIFF
--- a/test/functional/feature_taproot.py
+++ b/test/functional/feature_taproot.py
@@ -19,6 +19,7 @@ from test_framework.messages import (
     CTxInWitness,
     CTxOut,
     SEQUENCE_FINAL,
+    tx_from_hex,
 )
 from test_framework.script import (
     ANNEX_TAG,
@@ -109,7 +110,6 @@ from test_framework.address import (
     program_to_witness,
 )
 from collections import OrderedDict, namedtuple
-from io import BytesIO
 import json
 import hashlib
 import os
@@ -1386,8 +1386,7 @@ class TaprootTest(BitcoinTestFramework):
             # Add change
             fund_tx.vout.append(CTxOut(balance - 10000, random.choice(host_spks)))
             # Ask the wallet to sign
-            ss = BytesIO(bytes.fromhex(node.signrawtransactionwithwallet(fund_tx.serialize().hex())["hex"]))
-            fund_tx.deserialize(ss)
+            fund_tx = tx_from_hex(node.signrawtransactionwithwallet(fund_tx.serialize().hex())["hex"])
             # Construct UTXOData entries
             fund_tx.rehash()
             for i in range(count_this_tx):

--- a/test/functional/interface_rest.py
+++ b/test/functional/interface_rest.py
@@ -7,9 +7,7 @@
 from decimal import Decimal
 from enum import Enum
 import http.client
-from io import BytesIO
 import json
-from struct import pack, unpack
 import typing
 import urllib.parse
 
@@ -160,12 +158,11 @@ class RESTTest (BitcoinTestFramework):
         bin_request = b'\x01\x02'
         for txid, n in [spending, spent]:
             bin_request += bytes.fromhex(txid)
-            bin_request += pack("i", n)
+            bin_request += n.to_bytes(4, 'little')
 
         bin_response = self.test_rest_request("/getutxos", http_method='POST', req_type=ReqType.BIN, body=bin_request, ret_type=RetType.BYTES)
-        output = BytesIO(bin_response)
-        chain_height, = unpack("<i", output.read(4))
-        response_hash = output.read(32)[::-1].hex()
+        chain_height = int.from_bytes(bin_response[0:4], 'little')
+        response_hash = bin_response[4:36][::-1].hex()
 
         assert_equal(bb_hash, response_hash)  # check if getutxo's chaintip during calculation was fine
         assert_equal(chain_height, 201)  # chain height must be 201 (pre-mined chain [200] + generated block [1])

--- a/test/functional/interface_zmq.py
+++ b/test/functional/interface_zmq.py
@@ -4,6 +4,7 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test the ZMQ notification interface."""
 import struct
+from time import sleep
 
 from test_framework.address import (
     ADDRESS_BCRT1_P2WSH_OP_TRUE,
@@ -16,8 +17,8 @@ from test_framework.blocktools import (
 )
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.messages import (
-    CTransaction,
     hash256,
+    tx_from_hex,
 )
 from test_framework.util import (
     assert_equal,
@@ -28,8 +29,7 @@ from test_framework.wallet import (
     MiniWallet,
 )
 from test_framework.netutil import test_ipv6_local
-from io import BytesIO
-from time import sleep
+
 
 # Test may be skipped and not have zmq installed
 try:
@@ -198,9 +198,7 @@ class ZMQTest (BitcoinTestFramework):
             txid = hashtx.receive()
 
             # Should receive the coinbase raw transaction.
-            hex = rawtx.receive()
-            tx = CTransaction()
-            tx.deserialize(BytesIO(hex))
+            tx = tx_from_hex(rawtx.receive().hex())
             tx.calc_sha256()
             assert_equal(tx.hash, txid.hex())
 


### PR DESCRIPTION
Rather than needing to create intermediate stream variables, we can use helper functions like `tx_from_hex` instead or access the result directly, leading both to increased readability and less code.