### PR TITLE
ci: use clang-16 in tidy task

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -80,10 +80,10 @@ task:
     << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
 
 task:
-  name: 'tidy [bookworm]'
+  name: 'tidy [lunar]'
   << : *GLOBAL_TASK_TEMPLATE
   container:
-    image: debian:bookworm
+    image: ubuntu:lunar
     cpu: 2
     memory: 5G
   # For faster CI feedback, immediately schedule the linters

--- a/ci/test/00_setup_env_native_tidy.sh
+++ b/ci/test/00_setup_env_native_tidy.sh
@@ -6,14 +6,14 @@
 
 export LC_ALL=C.UTF-8
 
-export CI_IMAGE_NAME_TAG="debian:bookworm"
+export CI_IMAGE_NAME_TAG="ubuntu:lunar" # Version 23.04 will reach EOL in Jan 2024, and can be replaced by "ubuntu:24.04" (or anything else that ships the wanted clang version).
 export CONTAINER_NAME=ci_native_tidy
-export PACKAGES="clang-15 libclang-15-dev llvm-15-dev clang-tidy-15 bear cmake libevent-dev libboost-dev libminiupnpc-dev libnatpmp-dev libzmq3-dev systemtap-sdt-dev libqt5gui5 libqt5core5a libqt5dbus5 qttools5-dev qttools5-dev-tools libqrencode-dev libsqlite3-dev libdb++-dev"
+export PACKAGES="clang-16 libclang-16-dev llvm-16-dev libomp-16-dev clang-tidy-16 bear cmake libevent-dev libboost-dev libminiupnpc-dev libnatpmp-dev libzmq3-dev systemtap-sdt-dev libqt5gui5 libqt5core5a libqt5dbus5 qttools5-dev qttools5-dev-tools libqrencode-dev libsqlite3-dev libdb++-dev"
 export NO_DEPENDS=1
 export RUN_UNIT_TESTS=false
 export RUN_FUNCTIONAL_TESTS=false
 export RUN_FUZZ_TESTS=false
 export RUN_TIDY=true
 export GOAL="install"
-export BITCOIN_CONFIG="CC=clang-15 CXX=clang++-15 --with-incompatible-bdb --disable-hardening CFLAGS='-O0 -g0' CXXFLAGS='-O0 -g0'"
+export BITCOIN_CONFIG="CC=clang-16 CXX=clang++-16 --with-incompatible-bdb --disable-hardening CFLAGS='-O0 -g0' CXXFLAGS='-O0 -g0 -I/usr/lib/llvm-16/lib/clang/16/include'"
 export CCACHE_SIZE=200M

--- a/ci/test/01_base_install.sh
+++ b/ci/test/01_base_install.sh
@@ -52,10 +52,9 @@ fi
 
 if [[ "${RUN_TIDY}" == "true" ]]; then
   if [ ! -d "${DIR_IWYU}" ]; then
-    mkdir -p "${DIR_IWYU}"/build/
-    git clone --depth=1 https://github.com/include-what-you-use/include-what-you-use -b clang_15 "${DIR_IWYU}"/include-what-you-use
-    cd "${DIR_IWYU}"/build && cmake -G 'Unix Makefiles' -DCMAKE_PREFIX_PATH=/usr/lib/llvm-15 ../include-what-you-use
-    cd "${DIR_IWYU}"/build && make install "$MAKEJOBS"
+    git clone --depth=1 https://github.com/include-what-you-use/include-what-you-use -b clang_16 "${DIR_IWYU}"/include-what-you-use
+    cmake -B "${DIR_IWYU}"/build/ -G 'Unix Makefiles' -DCMAKE_PREFIX_PATH=/usr/lib/llvm-16 -S "${DIR_IWYU}"/include-what-you-use
+    make -C "${DIR_IWYU}"/build/ install "$MAKEJOBS"
   fi
 fi
 

--- a/ci/test/06_script_b.sh
+++ b/ci/test/06_script_b.sh
@@ -39,7 +39,7 @@ fi
 if [ "${RUN_TIDY}" = "true" ]; then
   set -eo pipefail
   export P_CI_DIR="${BASE_BUILD_DIR}/bitcoin-$HOST/src/"
-  ( CI_EXEC run-clang-tidy-15 -quiet "${MAKEJOBS}" ) | grep -C5 "error"
+  ( CI_EXEC run-clang-tidy-16 -quiet "${MAKEJOBS}" ) | grep -C5 "error"
   export P_CI_DIR="${BASE_BUILD_DIR}/bitcoin-$HOST/"
   CI_EXEC "python3 ${DIR_IWYU}/include-what-you-use/iwyu_tool.py"\
           " src/common/init.cpp"\

--- a/src/test/fuzz/miniscript.cpp
+++ b/src/test/fuzz/miniscript.cpp
@@ -248,8 +248,6 @@ using Fragment = miniscript::Fragment;
 using NodeRef = miniscript::NodeRef<CPubKey>;
 using Node = miniscript::Node<CPubKey>;
 using Type = miniscript::Type;
-// https://github.com/llvm/llvm-project/issues/53444
-// NOLINTNEXTLINE(misc-unused-using-decls)
 using miniscript::operator"" _mst;
 
 //! Construct a miniscript node as a shared_ptr.

--- a/src/test/miniscript_tests.cpp
+++ b/src/test/miniscript_tests.cpp
@@ -241,8 +241,6 @@ const KeyConverter CONVERTER{};
 
 using Fragment = miniscript::Fragment;
 using NodeRef = miniscript::NodeRef<CPubKey>;
-// https://github.com/llvm/llvm-project/issues/53444
-// NOLINTNEXTLINE(misc-unused-using-decls)
 using miniscript::operator"" _mst;
 using Node = miniscript::Node<CPubKey>;
 


### PR DESCRIPTION
Follow up to https://github.com/bitcoin/bitcoin/pull/27311#issuecomment-1481020371, as IWYU now has a [clang_16 branch](https://github.com/include-what-you-use/include-what-you-use/tree/clang_16).

This also removes some workarounds for (now fixed) clang-tidy issues, and simplifies the IWYU install steps.