### PR TITLE
net, refactor: Privatise CNode send queue

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1300,7 +1300,7 @@ void CConnman::SocketHandlerConnected(const std::vector<CNode*>& nodes,
 
         if (sendSet) {
             // Send data
-            size_t bytes_sent = WITH_LOCK(pnode->cs_vSend, return pnode->SocketSendData());
+            size_t bytes_sent{pnode->SocketSendData()};
             if (bytes_sent) RecordBytesSent(bytes_sent);
         }
 
@@ -2770,7 +2770,7 @@ std::optional<std::pair<CNetMessage, bool>> CNode::PollMessage()
     return std::make_pair(std::move(msgs.front()), !m_msg_process_queue.empty());
 }
 
-size_t CNode::SocketSendData()
+size_t CNode::SocketSendDataInternal()
 {
     auto it = vSendMsg.begin();
     size_t nSentSize = 0;
@@ -2849,7 +2849,7 @@ size_t CNode::PushMessage(CSerializedNetMsg&& msg)
         if (msg.data.size()) vSendMsg.push_back(std::move(msg.data));
 
         // If write queue empty, attempt "optimistic write"
-        if (optimisticSend) nBytesSent = SocketSendData();
+        if (optimisticSend) nBytesSent = SocketSendDataInternal();
     }
 
     return nBytesSent;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2832,6 +2832,33 @@ size_t CNode::SocketSendData()
     return nSentSize;
 }
 
+size_t CNode::PushMessage(CSerializedNetMsg&& msg)
+{
+    // make sure we use the appropriate network transport format
+    std::vector<unsigned char> serializedHeader;
+    m_serializer->prepareForTransport(msg, serializedHeader);
+    size_t nTotalSize = msg.data.size() + serializedHeader.size();
+
+    size_t nBytesSent = 0;
+    {
+        LOCK(cs_vSend);
+        bool optimisticSend(vSendMsg.empty());
+
+        // log total amount of bytes per message type
+        AccountForSentBytes(msg.m_type, nTotalSize);
+        nSendSize += nTotalSize;
+
+        if (nSendSize > m_max_send_buf_size) fPauseSend = true;
+        vSendMsg.push_back(std::move(serializedHeader));
+        if (msg.data.size()) vSendMsg.push_back(std::move(msg.data));
+
+        // If write queue empty, attempt "optimistic write"
+        if (optimisticSend) nBytesSent = SocketSendData();
+    }
+
+    return nBytesSent;
+}
+
 bool CConnman::NodeFullyConnected(const CNode* pnode)
 {
     return pnode && pnode->fSuccessfullyConnected && !pnode->fDisconnect;
@@ -2839,44 +2866,24 @@ bool CConnman::NodeFullyConnected(const CNode* pnode)
 
 void CConnman::PushMessage(CNode* pnode, CSerializedNetMsg&& msg)
 {
-    AssertLockNotHeld(m_total_bytes_sent_mutex);
-    size_t nMessageSize = msg.data.size();
-    LogPrint(BCLog::NET, "sending %s (%d bytes) peer=%d\n", msg.m_type, nMessageSize, pnode->GetId());
+    assert(pnode);
+
+    LogPrint(BCLog::NET, "sending %s (%d bytes) peer=%d\n", msg.m_type, msg.data.size(), pnode->GetId());
     if (gArgs.GetBoolArg("-capturemessages", false)) {
         CaptureMessage(pnode->addr, msg.m_type, msg.data, /*is_incoming=*/false);
     }
 
     TRACE6(net, outbound_message,
-        pnode->GetId(),
-        pnode->m_addr_name.c_str(),
-        pnode->ConnectionTypeAsString().c_str(),
-        msg.m_type.c_str(),
-        msg.data.size(),
-        msg.data.data()
-    );
+           pnode->GetId(),
+           pnode->m_addr_name.c_str(),
+           pnode->ConnectionTypeAsString().c_str(),
+           msg.m_type.c_str(),
+           msg.data.size(),
+           msg.data.data());
 
-    // make sure we use the appropriate network transport format
-    std::vector<unsigned char> serializedHeader;
-    pnode->m_serializer->prepareForTransport(msg, serializedHeader);
-    size_t nTotalSize = nMessageSize + serializedHeader.size();
-
-    size_t nBytesSent = 0;
-    {
-        LOCK(pnode->cs_vSend);
-        bool optimisticSend(pnode->vSendMsg.empty());
-
-        //log total amount of bytes per message type
-        pnode->AccountForSentBytes(msg.m_type, nTotalSize);
-        pnode->nSendSize += nTotalSize;
-
-        if (pnode->nSendSize > nSendBufferMaxSize) pnode->fPauseSend = true;
-        pnode->vSendMsg.push_back(std::move(serializedHeader));
-        if (nMessageSize) pnode->vSendMsg.push_back(std::move(msg.data));
-
-        // If write queue empty, attempt "optimistic write"
-        if (optimisticSend) nBytesSent = pnode->SocketSendData();
+    if (auto bytes_sent = pnode->PushMessage(std::move(msg))) {
+        RecordBytesSent(bytes_sent);
     }
-    if (nBytesSent) RecordBytesSent(nBytesSent);
 }
 
 bool CConnman::ForNode(NodeId id, std::function<bool(CNode* pnode)> func)

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -576,6 +576,7 @@ CNode* CConnman::ConnectNode(CAddress addrConnect, const char *pszDest, bool fCo
                              CNodeOptions{
                                  .i2p_sam_session = std::move(i2p_transient_session),
                                  .recv_flood_size = nReceiveFloodSize,
+                                 .max_send_buf_size = nSendBufferMaxSize,
                              });
     pnode->AddRef();
 
@@ -1057,6 +1058,7 @@ void CConnman::CreateNodeFromAcceptedSocket(std::unique_ptr<Sock>&& sock,
                                  .permission_flags = permission_flags,
                                  .prefer_evict = discouraged,
                                  .recv_flood_size = nReceiveFloodSize,
+                                 .max_send_buf_size = nSendBufferMaxSize,
                              });
     pnode->AddRef();
     m_msgproc->InitializeNode(*pnode, nodeServices);
@@ -2783,6 +2785,7 @@ CNode::CNode(NodeId idIn,
       id{idIn},
       nLocalHostNonce{nLocalHostNonceIn},
       m_recv_flood_size{node_opts.recv_flood_size},
+      m_max_send_buf_size{node_opts.max_send_buf_size},
       m_i2p_sam_session{std::move(node_opts.i2p_sam_session)}
 {
     if (inbound_onion) assert(conn_type_in == ConnectionType::INBOUND);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1177,11 +1177,7 @@ Sock::EventsPerSock CConnman::GenerateWaitSockets(Span<CNode* const> nodes)
         //   blocking here.
 
         bool select_recv = !pnode->fPauseRecv;
-        bool select_send;
-        {
-            LOCK(pnode->cs_vSend);
-            select_send = !pnode->vSendMsg.empty();
-        }
+        bool select_send{!pnode->IsSendQueueEmpty()};
 
         LOCK(pnode->m_sock_mutex);
         if (!pnode->m_sock) {

--- a/src/net.h
+++ b/src/net.h
@@ -447,6 +447,11 @@ public:
         return WITH_LOCK(cs_vSend, return vSendMsg.empty());
     }
 
+    void TestOnlyClearSendQueue() EXCLUSIVE_LOCKS_REQUIRED(!cs_vSend)
+    {
+        WITH_LOCK(cs_vSend, vSendMsg.clear());
+    }
+
     /** Account for the total size of a sent message in the per msg type connection stats. */
     void AccountForSentBytes(const std::string& msg_type, size_t sent_bytes)
         EXCLUSIVE_LOCKS_REQUIRED(cs_vSend)

--- a/src/net.h
+++ b/src/net.h
@@ -434,6 +434,8 @@ public:
     std::optional<std::pair<CNetMessage, bool>> PollMessage()
         EXCLUSIVE_LOCKS_REQUIRED(!m_msg_process_queue_mutex);
 
+    size_t SocketSendData() EXCLUSIVE_LOCKS_REQUIRED(cs_vSend, !m_sock_mutex);
+
     /** Account for the total size of a sent message in the per msg type connection stats. */
     void AccountForSentBytes(const std::string& msg_type, size_t sent_bytes)
         EXCLUSIVE_LOCKS_REQUIRED(cs_vSend)
@@ -992,7 +994,6 @@ private:
 
     NodeId GetNewNodeId();
 
-    size_t SocketSendData(CNode& node) const EXCLUSIVE_LOCKS_REQUIRED(node.cs_vSend);
     void DumpAddresses();
 
     // Network stats

--- a/src/net.h
+++ b/src/net.h
@@ -434,7 +434,10 @@ public:
     std::optional<std::pair<CNetMessage, bool>> PollMessage()
         EXCLUSIVE_LOCKS_REQUIRED(!m_msg_process_queue_mutex);
 
-    size_t SocketSendData() EXCLUSIVE_LOCKS_REQUIRED(cs_vSend, !m_sock_mutex);
+    size_t SocketSendData() EXCLUSIVE_LOCKS_REQUIRED(!cs_vSend, !m_sock_mutex)
+    {
+        return WITH_LOCK(cs_vSend, return SocketSendDataInternal());
+    }
 
     size_t PushMessage(CSerializedNetMsg&& msg)
         EXCLUSIVE_LOCKS_REQUIRED(!cs_vSend, !m_sock_mutex);
@@ -660,6 +663,8 @@ private:
      * Otherwise this unique_ptr is empty.
      */
     std::unique_ptr<i2p::sam::Session> m_i2p_sam_session GUARDED_BY(m_sock_mutex);
+
+    size_t SocketSendDataInternal() EXCLUSIVE_LOCKS_REQUIRED(cs_vSend, !m_sock_mutex);
 };
 
 /**

--- a/src/net.h
+++ b/src/net.h
@@ -373,13 +373,6 @@ public:
      */
     std::shared_ptr<Sock> m_sock GUARDED_BY(m_sock_mutex);
 
-    /** Total size of all vSendMsg entries */
-    size_t nSendSize GUARDED_BY(cs_vSend){0};
-    /** Offset inside the first vSendMsg already sent */
-    size_t nSendOffset GUARDED_BY(cs_vSend){0};
-    uint64_t nSendBytes GUARDED_BY(cs_vSend){0};
-    std::deque<std::vector<unsigned char>> vSendMsg GUARDED_BY(cs_vSend);
-    mutable Mutex cs_vSend;
     Mutex m_sock_mutex;
     Mutex cs_vRecv;
 
@@ -649,6 +642,14 @@ private:
     Mutex m_msg_process_queue_mutex;
     std::list<CNetMessage> m_msg_process_queue GUARDED_BY(m_msg_process_queue_mutex);
     size_t m_msg_process_queue_size GUARDED_BY(m_msg_process_queue_mutex){0};
+
+    /** Total size of all vSendMsg entries */
+    size_t nSendSize GUARDED_BY(cs_vSend){0};
+    /** Offset inside the first vSendMsg already sent */
+    size_t nSendOffset GUARDED_BY(cs_vSend){0};
+    uint64_t nSendBytes GUARDED_BY(cs_vSend){0};
+    std::deque<std::vector<unsigned char>> vSendMsg GUARDED_BY(cs_vSend);
+    mutable Mutex cs_vSend;
 
     // Our address, as reported by the peer
     CService addrLocal GUARDED_BY(m_addr_local_mutex);

--- a/src/net.h
+++ b/src/net.h
@@ -379,7 +379,7 @@ public:
     size_t nSendOffset GUARDED_BY(cs_vSend){0};
     uint64_t nSendBytes GUARDED_BY(cs_vSend){0};
     std::deque<std::vector<unsigned char>> vSendMsg GUARDED_BY(cs_vSend);
-    Mutex cs_vSend;
+    mutable Mutex cs_vSend;
     Mutex m_sock_mutex;
     Mutex cs_vRecv;
 
@@ -438,6 +438,11 @@ public:
 
     size_t PushMessage(CSerializedNetMsg&& msg)
         EXCLUSIVE_LOCKS_REQUIRED(!cs_vSend, !m_sock_mutex);
+
+    bool IsSendQueueEmpty() const EXCLUSIVE_LOCKS_REQUIRED(!cs_vSend)
+    {
+        return WITH_LOCK(cs_vSend, return vSendMsg.empty());
+    }
 
     /** Account for the total size of a sent message in the per msg type connection stats. */
     void AccountForSentBytes(const std::string& msg_type, size_t sent_bytes)

--- a/src/net.h
+++ b/src/net.h
@@ -436,6 +436,9 @@ public:
 
     size_t SocketSendData() EXCLUSIVE_LOCKS_REQUIRED(cs_vSend, !m_sock_mutex);
 
+    size_t PushMessage(CSerializedNetMsg&& msg)
+        EXCLUSIVE_LOCKS_REQUIRED(!cs_vSend, !m_sock_mutex);
+
     /** Account for the total size of a sent message in the per msg type connection stats. */
     void AccountForSentBytes(const std::string& msg_type, size_t sent_bytes)
         EXCLUSIVE_LOCKS_REQUIRED(cs_vSend)

--- a/src/net.h
+++ b/src/net.h
@@ -351,6 +351,7 @@ struct CNodeOptions
     std::unique_ptr<i2p::sam::Session> i2p_sam_session = nullptr;
     bool prefer_evict = false;
     size_t recv_flood_size{DEFAULT_MAXRECEIVEBUFFER * 1000};
+    size_t max_send_buf_size{DEFAULT_MAXSENDBUFFER * 1000};
 };
 
 /** Information about a peer */
@@ -623,6 +624,8 @@ private:
     std::atomic<int> m_greatest_common_version{INIT_PROTO_VERSION};
 
     const size_t m_recv_flood_size;
+    const size_t m_max_send_buf_size;
+
     std::list<CNetMessage> vRecvMsg; // Used only by SocketHandler thread
 
     Mutex m_msg_process_queue_mutex;

--- a/src/qt/peertablemodel.cpp
+++ b/src/qt/peertablemodel.cpp
@@ -84,7 +84,7 @@ QVariant PeerTableModel::data(const QModelIndex& index, int role) const
         case Ping:
             return GUIUtil::formatPingTime(rec->nodeStats.m_min_ping_time);
         case Sent:
-            return GUIUtil::formatBytes(rec->nodeStats.nSendBytes);
+            return GUIUtil::formatBytes(rec->nodeStats.m_send_bytes);
         case Received:
             return GUIUtil::formatBytes(rec->nodeStats.nRecvBytes);
         case Subversion:

--- a/src/qt/peertablesortproxy.cpp
+++ b/src/qt/peertablesortproxy.cpp
@@ -37,7 +37,7 @@ bool PeerTableSortProxy::lessThan(const QModelIndex& left_index, const QModelInd
     case PeerTableModel::Ping:
         return left_stats.m_min_ping_time < right_stats.m_min_ping_time;
     case PeerTableModel::Sent:
-        return left_stats.nSendBytes < right_stats.nSendBytes;
+        return left_stats.m_send_bytes < right_stats.m_send_bytes;
     case PeerTableModel::Received:
         return left_stats.nRecvBytes < right_stats.nRecvBytes;
     case PeerTableModel::Subversion:

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -1173,7 +1173,7 @@ void RPCConsole::updateDetailWidget()
     ui->peerLastTx->setText(TimeDurationField(time_now, stats->nodeStats.m_last_tx_time));
     ui->peerLastSend->setText(TimeDurationField(time_now, stats->nodeStats.m_last_send));
     ui->peerLastRecv->setText(TimeDurationField(time_now, stats->nodeStats.m_last_recv));
-    ui->peerBytesSent->setText(GUIUtil::formatBytes(stats->nodeStats.nSendBytes));
+    ui->peerBytesSent->setText(GUIUtil::formatBytes(stats->nodeStats.m_send_bytes));
     ui->peerBytesRecv->setText(GUIUtil::formatBytes(stats->nodeStats.nRecvBytes));
     ui->peerPingTime->setText(GUIUtil::formatPingTime(stats->nodeStats.m_last_ping_time));
     ui->peerMinPing->setText(GUIUtil::formatPingTime(stats->nodeStats.m_min_ping_time));

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -213,7 +213,7 @@ static RPCHelpMan getpeerinfo()
         obj.pushKV("lastrecv", count_seconds(stats.m_last_recv));
         obj.pushKV("last_transaction", count_seconds(stats.m_last_tx_time));
         obj.pushKV("last_block", count_seconds(stats.m_last_block_time));
-        obj.pushKV("bytessent", stats.nSendBytes);
+        obj.pushKV("bytessent", stats.m_send_bytes);
         obj.pushKV("bytesrecv", stats.nRecvBytes);
         obj.pushKV("conntime", count_seconds(stats.m_connected));
         obj.pushKV("timeoffset", stats.nTimeOffset);

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -86,8 +86,7 @@ BOOST_AUTO_TEST_CASE(outbound_slow_chain_eviction)
 
     {
         BOOST_CHECK(!dummyNode1.IsSendQueueEmpty());
-        LOCK(dummyNode1.cs_vSend);
-        dummyNode1.vSendMsg.clear();
+        dummyNode1.TestOnlyClearSendQueue();
     }
 
     int64_t nStartTime = GetTime();

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -85,8 +85,8 @@ BOOST_AUTO_TEST_CASE(outbound_slow_chain_eviction)
     BOOST_CHECK(peerman.SendMessages(&dummyNode1)); // should result in getheaders
 
     {
+        BOOST_CHECK(!dummyNode1.IsSendQueueEmpty());
         LOCK(dummyNode1.cs_vSend);
-        BOOST_CHECK(dummyNode1.vSendMsg.size() > 0);
         dummyNode1.vSendMsg.clear();
     }
 
@@ -94,10 +94,7 @@ BOOST_AUTO_TEST_CASE(outbound_slow_chain_eviction)
     // Wait 21 minutes
     SetMockTime(nStartTime+21*60);
     BOOST_CHECK(peerman.SendMessages(&dummyNode1)); // should result in getheaders
-    {
-        LOCK(dummyNode1.cs_vSend);
-        BOOST_CHECK(dummyNode1.vSendMsg.size() > 0);
-    }
+    BOOST_CHECK(!dummyNode1.IsSendQueueEmpty());
     // Wait 3 more minutes
     SetMockTime(nStartTime+24*60);
     BOOST_CHECK(peerman.SendMessages(&dummyNode1)); // should result in disconnect


### PR DESCRIPTION
The send queue members on `CNode` should not be part of the public interface. This PR makes all of them private and creates a clear interface for the send queue.

The interface after this PR consists of:
* `CNode::PushMessage` for appending a message onto the send queue
* `CNode::SocketSendData` for pushing as many messages from the send queue as possible onto the wire
* `CNode::IsSendQueueEmpty` for checking if the send queue is empty
* (`CNode::TestOnlyClearSendQueue` a test-only utility for clearing the send queue)