### PR TITLE
doc: Add example of how to mix private and public keys in descriptors

### DIFF
--- a/doc/descriptors.md
+++ b/doc/descriptors.md
@@ -248,7 +248,7 @@ including private key material.
 
 For example, after importing the following 2-of-3 multisig descriptor
 into a wallet, one could use `signrawtransactionwithwallet`
-to sign a transaction with the first signature:
+to sign a transaction with the first key:
 ```
 sh(multi(2,xprv9s21Z.../84'/0'/0'/0/0,0280007cb...,033af7e98...))#lx65wk3z
 ```

--- a/doc/descriptors.md
+++ b/doc/descriptors.md
@@ -243,7 +243,18 @@ Often it is useful to communicate a description of scripts along with the
 necessary private keys. For this reason, anywhere a public key or xpub is
 supported, a private key in WIF format or xprv may be provided instead.
 This is useful when private keys are necessary for hardened derivation
-steps, or for dumping wallet descriptors including private key material.
+steps, signing transactions, or for dumping wallet descriptors
+including private key material.
+
+For example, after importing the following 2-of-3 multisig descriptor
+into a wallet, one could use `signrawtransactionwithwallet`
+to sign a transaction with the first signature:
+```
+sh(multi(2,xprv9s21Z.../84'/0'/0'/0/0,0280007cb...,033af7e98...))#lx65wk3z
+```
+Note how the first key is an xprv private key with a specific descriptor path,
+while the other two are public keys.
+
 
 ### Compatibility with old wallets
 


### PR DESCRIPTION
It took me quite a while to understand how to use both xpriv and public keys in a single descriptor. The trick was to use xprv key + derivation path. Also, it was not obvious that Bitcoin Core would figure it out and sign a multisig transaction if the xpriv is present in the descriptor. As a newbie to Bitcoin Core, I had to consult stackexchange to understand that.

Adding an example would make it easier to "gotcha" for the reader.