### PR TITLE
test: Remove windows workaround in authproxy

### DIFF
--- a/test/functional/test_framework/authproxy.py
+++ b/test/functional/test_framework/authproxy.py
@@ -39,7 +39,6 @@ from http import HTTPStatus
 import http.client
 import json
 import logging
-import os
 import socket
 import time
 import urllib.parse
@@ -100,11 +99,6 @@ class AuthServiceProxy():
                    'User-Agent': USER_AGENT,
                    'Authorization': self.__auth_header,
                    'Content-type': 'application/json'}
-        if os.name == 'nt':
-            # Windows somehow does not like to re-use connections
-            # TODO: Find out why the connection would disconnect occasionally and make it reusable on Windows
-            # Avoid "ConnectionAbortedError: [WinError 10053] An established connection was aborted by the software in your host machine"
-            self._set_conn()
         self.__conn.request(method, path, postdata, headers)
         return self._get_response()
 


### PR DESCRIPTION
I wonder if the windows issues have also been fixed by bumping the server timeout in commit 88134fcee998849d9569368d6cefbfa487dc82d1.

I guess the only way to find out and try.

Note that even with the workaround, the issue would still happen occasionally: https://github.com/bitcoin/bitcoin/issues/18623