### PR TITLE
build: remove ancient unused define

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1767,7 +1767,7 @@ else
     use_upnp=yes
     AC_DEFINE([USE_UPNP], [1], [Define to 1 if UPnP support should be compiled in.])
     if test "$TARGET_OS" = "windows"; then
-      MINIUPNPC_CPPFLAGS="$MINIUPNPC_CPPFLAGS -DSTATICLIB -DMINIUPNP_STATICLIB"
+      MINIUPNPC_CPPFLAGS="$MINIUPNPC_CPPFLAGS -DMINIUPNP_STATICLIB"
     fi
   else
     AC_MSG_RESULT([no])


### PR DESCRIPTION
The generic define was removed in [upstream miniupnpc in 2014](https://github.com/miniupnp/miniupnp/commit/f6774e33169b3101c3a242984510c9b6da033e26).

Noticed while reviewing hebasto's new CMake buildsystem: https://github.com/hebasto/bitcoin/pull/12#discussion_r1156267350.