### PR TITLE
ci: fix git dubious permissions error

### DIFF
--- a/ci/test/04_install.sh
+++ b/ci/test/04_install.sh
@@ -57,6 +57,9 @@ if [ -z "$DANGER_RUN_CI_ON_HOST" ]; then
   export CI_EXEC_CMD_PREFIX="docker exec ${CI_CONTAINER_ID}"
   $CI_EXEC_CMD_PREFIX rsync --archive --stats --human-readable /ci_base_install/ "${BASE_ROOT_DIR}"
   $CI_EXEC_CMD_PREFIX rsync --archive --stats --human-readable /ro_base/ "$BASE_ROOT_DIR"
+  # Fixes permission issues when there is a container UID/GID mismatch with the owner
+  # of the mounted bitcoin src dir.
+  $CI_EXEC_CMD_PREFIX git config --global --add safe.directory "*"
 else
   echo "Running on host system without docker wrapper"
   "${BASE_ROOT_DIR}/ci/test/01_base_install.sh"


### PR DESCRIPTION
fixes https://github.com/bitcoin/bitcoin/pull/27376#issuecomment-1496449588

this appears to be caused by a more recent version of git being sensitive to mismatched permissions on directories. we didn't notice this before because we were using two separate user accounts to fix up dir permissions in the container , but the second account was removed in #27376 

there might be a more elegant way to do this, but this does the trick and seems to be the way others are fixing this issue around the internets.
