### PR TITLE
validation: implement MaybeInvalidateFork() and call from rpc getchaintips

### DIFF
--- a/src/validation.h
+++ b/src/validation.h
@@ -767,6 +767,14 @@ public:
         return m_mempool ? &m_mempool->cs : nullptr;
     }
 
+    /**
+     * Walks up the chain of ancestors of pindex until either:
+     *  - Hitting an orphan header (return true)
+     *  - Hitting the active chain (return true)
+     *  - Hitting a CBlockIndex marked as invalid (mark all descendants as INVALID_CHILD, return false)
+     */
+    bool MaybeInvalidateFork(CBlockIndex* pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+
 private:
     bool ActivateBestChainStep(BlockValidationState& state, CBlockIndex* pindexMostWork, const std::shared_ptr<const CBlock>& pblock, bool& fInvalidFound, ConnectTrace& connectTrace) EXCLUSIVE_LOCKS_REQUIRED(cs_main, m_mempool->cs);
     bool ConnectTip(BlockValidationState& state, CBlockIndex* pindexNew, const std::shared_ptr<const CBlock>& pblock, ConnectTrace& connectTrace, DisconnectedBlockTransactions& disconnectpool) EXCLUSIVE_LOCKS_REQUIRED(cs_main, m_mempool->cs);

--- a/test/functional/rpc_getchaintips_invalid.py
+++ b/test/functional/rpc_getchaintips_invalid.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+# Copyright (c) 2023 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test the getchaintips RPC when a block is invalid.
+
+- pregenerate blocks
+- start fresh node, send headers
+- malleate one block to invalidate it
+- getchaintips should have labeled the invalid chain
+"""
+
+from test_framework.blocktools import (
+    create_block,
+    create_coinbase
+)
+from test_framework.messages import (
+    CTransaction,
+    COutPoint,
+    CTxIn,
+    CTxOut
+)
+from test_framework.p2p import P2PDataStore
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+
+class GetChainTipsInvalidTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+
+    def run_test(self):
+        node = self.nodes[0]
+        peer = P2PDataStore()
+
+        # Generate 20 blocks from genesis
+        best_hash = node.getbestblockhash()
+        best_block = node.getblock(best_hash)
+        height = best_block["height"] + 1
+        block_time = best_block["time"] + 1
+        tip = int(best_hash, 16)
+        block_hashes = []
+
+        # Create tx that is invalid only "in context"
+        # The node will download the block and won't mark it invalid until ConnectBlock()
+        invalid_tx = CTransaction()
+        invalid_tx.vin.append(CTxIn(COutPoint(0xdeadbeef, 0), b"", 0xffffffff))
+        invalid_tx.vout.append(CTxOut(0, b""))
+
+        msgs = []
+        for _ in range(20):
+            block = create_block(tip, create_coinbase(height), block_time)
+            # Make this block invalid by inserting 0-input tx
+            if height == 11:
+                block.vtx.append(invalid_tx)
+                block.hashMerkleRoot = block.calc_merkle_root()
+                block.calc_sha256()
+            block.solve()
+            tip = block.sha256
+            if height == 11:
+                msgs.append(f"Found invalid chain branch ancestor hash={hex(tip)[2:]}")
+            if height > 11:
+                msgs.append(f"Invalidating child hash={hex(tip)[2:]}")
+            height += 1
+            block_time += 1
+            # python node blockstore
+            peer.block_store[tip] = block
+            peer.last_block_hash = tip
+            # ordered list of block hashes
+            block_hashes.append(tip)
+
+        # Child headers not marked as invalid yet
+        with node.assert_debug_log(expected_msgs=[], unexpected_msgs=msgs):
+            # Connect node to peer
+            node.add_p2p_connection(peer, wait_for_verack=False)
+            # bad block, bye bye
+            peer.wait_for_disconnect()
+            assert_equal(node.getblockcount(), 10)
+
+        # This RPC marks the invalid children
+        with node.assert_debug_log(expected_msgs=msgs):
+            tips = node.getchaintips()
+            assert_equal(len(tips), 2)
+            a = next(tip for tip in tips if tip["height"] == 10)
+            b = next(tip for tip in tips if tip["height"] == 20)
+            assert a and b
+            assert_equal(a["status"], "active")
+            assert_equal(int(a["hash"], 16), block_hashes[9]) # last valid block
+            assert_equal(b["status"], "invalid")  # not "headers-only"
+            assert_equal(int(b["hash"], 16), tip) # last received block
+
+        # Restart node and check again
+        self.restart_node(0)
+        tips = node.getchaintips()
+        assert_equal(len(tips), 2)
+
+        c = next(tip for tip in tips if tip["height"] == 10)
+        d = next(tip for tip in tips if tip["height"] == 20)
+        assert c and d
+        assert_equal(c["status"], "active")
+        assert_equal(int(c["hash"], 16), block_hashes[9]) # last valid block
+        assert_equal(d["status"], "invalid")
+        assert_equal(int(d["hash"], 16), tip) # last received block
+
+if __name__ == '__main__':
+    GetChainTipsInvalidTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -180,6 +180,7 @@ BASE_SCRIPTS = [
     'wallet_txn_clone.py',
     'wallet_txn_clone.py --segwit',
     'rpc_getchaintips.py',
+    'rpc_getchaintips_invalid.py',
     'rpc_misc.py',
     'interface_rest.py',
     'mempool_spend_coinbase.py',


### PR DESCRIPTION
Closes https://github.com/bitcoin/bitcoin/issues/8050

If we discover an invalid block on a blockchain branch with otherwise valid headers, all the child headers can be marked as INVALID_CHILD. When invalidating mainchain blocks we can easily mark all the invalid children but on a headers-only branch we just stop on the invalid block and search for the next best tip and branch to validate. On restart, during `LoadBlockIndex()` we iterate through all the headers we know about sorted by height, and that is when we normally mark these child-headers of invalid ancestors with `INVALID_CHILD`.

Issue #8050 illustrates a discrepancy where a headers-only branch is not marked as invalid until the node is restarted. What we do in this PR is check for invalid ancestors while we are scanning the block index for chain tips during `rpc getchaintips` itself.

I had to remove a bunch of `const` qualifiers from `getchaintips` which makes me think that modifying the block index during an RPC is just bad separation of concerns -- but it is a solution! 
