### PR TITLE
Allow configuring target block time for a signet

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -27,6 +27,15 @@ void ReadSigNetArgs(const ArgsManager& args, CChainParams::SigNetOptions& option
         }
         options.challenge.emplace(ParseHex(signet_challenge[0]));
     }
+    if (const auto signetblocktime{args.GetIntArg("-signetblocktime")}) {
+        if (!args.IsArgSet("-signetchallenge")) {
+            throw std::runtime_error("-signetblocktime cannot be set without -signetchallenge");
+        }
+        if (*signetblocktime <= 0) {
+            throw std::runtime_error("-signetblocktime must be greater than 0");
+        }
+        options.pow_target_spacing = *signetblocktime;
+    }
 }
 
 void ReadRegTestArgs(const ArgsManager& args, CChainParams::RegTestOptions& options)

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -25,6 +25,7 @@ void SetupChainParamsBaseOptions(ArgsManager& argsman)
     argsman.AddArg("-vbparams=deployment:start:end[:min_activation_height]", "Use given start/end times and min_activation_height for specified version bits deployment (regtest-only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
     argsman.AddArg("-signet", "Use the signet chain. Equivalent to -chain=signet. Note that the network is defined by the -signetchallenge parameter", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
     argsman.AddArg("-signetchallenge", "Blocks must satisfy the given script to be considered valid (only for signet networks; defaults to the global default signet test network challenge)", ArgsManager::ALLOW_ANY | ArgsManager::DISALLOW_NEGATION, OptionsCategory::CHAINPARAMS);
+    argsman.AddArg("-signetblocktime", "Difficulty adjustment will target a block time of the given amount in seconds (only for custom signet networks, must have -signetchallenge set; defaults to 10 minutes)", ArgsManager::ALLOW_ANY | ArgsManager::DISALLOW_NEGATION, OptionsCategory::CHAINPARAMS);
     argsman.AddArg("-signetseednode", "Specify a seed node for the signet network, in the hostname[:port] format, e.g. sig.net:1234 (may be used multiple times to specify multiple seed nodes; defaults to the global default signet test network seed node(s))", ArgsManager::ALLOW_ANY | ArgsManager::DISALLOW_NEGATION, OptionsCategory::CHAINPARAMS);
 }
 

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -339,7 +339,7 @@ public:
         consensus.CSVHeight = 1;
         consensus.SegwitHeight = 1;
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
-        consensus.nPowTargetSpacing = 10 * 60;
+        consensus.nPowTargetSpacing = options.pow_target_spacing;
         consensus.fPowAllowMinDifficultyBlocks = false;
         consensus.fPowNoRetargeting = false;
         consensus.nRuleChangeActivationThreshold = 1815; // 90% of 2016

--- a/src/kernel/chainparams.h
+++ b/src/kernel/chainparams.h
@@ -135,6 +135,7 @@ public:
     struct SigNetOptions {
         std::optional<std::vector<uint8_t>> challenge{};
         std::optional<std::vector<std::string>> seeds{};
+        int64_t pow_target_spacing{10 * 60};
     };
 
     /**


### PR DESCRIPTION
This pull request introduces the ability to configure the block time of a custom Bitcoin signet network, allowing people to have a signet that is easier to test with. The change helps to improve the flexibility of signet, making it more useful for diverse testing purposes. For example, I am trying to setup a signet with a 30 second block time and this caused a bunch of difficulty adjustments to happen making the network inconsistent. Regtest isn't a real viable alternative to me here because we would like defaults to use our custom signet if configured, without hindering of local regtest development.