### PR TITLE
doc: update OpenBSD build docs for 7.3 (external signer support available)

### DIFF
--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -1,6 +1,6 @@
 # OpenBSD Build Guide
 
-**Updated for OpenBSD [7.1](https://www.openbsd.org/71.html)**
+**Updated for OpenBSD [7.3](https://www.openbsd.org/73.html)**
 
 This guide describes how to build bitcoind, command-line utilities, and GUI on OpenBSD.
 
@@ -79,10 +79,6 @@ export AUTOMAKE_VERSION=1.16
 ```
 
 ### 1. Configuration
-
-Note that external signer support is currently not available on OpenBSD, since
-the used header-only library Boost.Process fails to compile (certain system
-calls and preprocessor defines like `waitid()` and `WEXITED` are missing).
 
 There are many ways to configure Bitcoin Core, here are a few common examples:
 


### PR DESCRIPTION
With OpenBSD 7.3, the waitid(2) system call is implemented (see https://github.com/openbsd/src/commit/8112871f19bbd25e86c93d0f901071ca2335a352, first mentioned kernel improvement at https://www.openbsd.org/73.html).

This means Boost.Process finally doesn't fail to compile anymore and we can remove the build hint about missing external signer support. Tested on my amd64 machine by reconfiguring / rebuilding master branch and successfully running the functional test wallet_signer.py. :heavy_check_mark: 