### PR TITLE
bugfix: Properly handle "unknown" Address Type

### DIFF
--- a/src/outputtype.cpp
+++ b/src/outputtype.cpp
@@ -32,8 +32,6 @@ std::optional<OutputType> ParseOutputType(const std::string& type)
         return OutputType::BECH32;
     } else if (type == OUTPUT_TYPE_STRING_BECH32M) {
         return OutputType::BECH32M;
-    } else if (type == OUTPUT_TYPE_STRING_UNKNOWN) {
-        return OutputType::UNKNOWN;
     }
     return std::nullopt;
 }


### PR DESCRIPTION
Fixes https://github.com/bitcoin/bitcoin/issues/27472 by also handling at the relevant places the case where ParseOutputType returns `OutputType::UNKNOWN`, and not just when it returns `std::nullopt`.