### PR TITLE
[23.x] Additional backports for 23.x

### DIFF
--- a/depends/packages/bdb.mk
+++ b/depends/packages/bdb.mk
@@ -14,7 +14,7 @@ $(package)_config_opts_freebsd=--with-pic
 $(package)_config_opts_netbsd=--with-pic
 $(package)_config_opts_openbsd=--with-pic
 $(package)_config_opts_android=--with-pic
-$(package)_cflags+=-Wno-error=implicit-function-declaration
+$(package)_cflags+=-Wno-error=implicit-function-declaration -Wno-error=format-security
 $(package)_cxxflags+=-std=c++17
 $(package)_cppflags_mingw32=-DUNICODE -D_UNICODE
 endef

--- a/depends/packages/bdb.mk
+++ b/depends/packages/bdb.mk
@@ -14,7 +14,7 @@ $(package)_config_opts_freebsd=--with-pic
 $(package)_config_opts_netbsd=--with-pic
 $(package)_config_opts_openbsd=--with-pic
 $(package)_config_opts_android=--with-pic
-$(package)_cflags+=-Wno-error=implicit-function-declaration -Wno-error=format-security
+$(package)_cflags+=-Wno-error=implicit-function-declaration -Wno-error=format-security -Wno-error=implicit-int
 $(package)_cxxflags+=-std=c++17
 $(package)_cppflags_mingw32=-DUNICODE -D_UNICODE
 endef

--- a/depends/packages/libxkbcommon.mk
+++ b/depends/packages/libxkbcommon.mk
@@ -5,9 +5,14 @@ $(package)_file_name=$(package)-$($(package)_version).tar.xz
 $(package)_sha256_hash=60ddcff932b7fd352752d51a5c4f04f3d0403230a584df9a2e0d5ed87c486c8b
 $(package)_dependencies=libxcb
 
+# This package explicitly enables -Werror=array-bounds, which causes build failures
+# with GCC 12.1+. Work around that by turning errors back into warnings.
+# This workaround would be dropped if the package was updated, as that would require
+# a different build system (Meson)
 define $(package)_set_vars
 $(package)_config_opts = --enable-option-checking --disable-dependency-tracking
 $(package)_config_opts += --disable-static --disable-docs
+$(package)_cflags += -Wno-error=array-bounds
 endef
 
 define $(package)_preprocess_cmds


### PR DESCRIPTION
Any further backports for 23.x. Currently:
* 1bdbbbdc46c4e50bf07bc362e7e391ea1a53ea2f from https://github.com/bitcoin/bitcoin/pull/25436 - which fixes building QT in depends with GCC > 12.1
* https://github.com/bitcoin/bitcoin/pull/25763/
* https://github.com/bitcoin/bitcoin/pull/27462