### PR TITLE
mempool: keep CPFP'd transactions when loading from mempool.dat

### DIFF
--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1058,17 +1058,23 @@ void CTxMemPool::TrimToSize(size_t sizelimit, std::vector<COutPoint>* pvNoSpends
 
     unsigned nTxnRemoved = 0;
     CFeeRate maxFeeRateRemoved(0);
-    while (!mapTx.empty() && DynamicMemoryUsage() > sizelimit) {
+    while (!mapTx.empty()) {
         indexed_transaction_set::index<descendant_score>::type::iterator it = mapTx.get<descendant_score>().begin();
+
+        CFeeRate removed(it->GetModFeesWithDescendants(), it->GetSizeWithDescendants());
+        // Skim away everything paying effectively zero fees, regardless of mempool size.
+        // Above that feerate, just trim until memory is within limits.
+        if (removed >= m_min_relay_feerate && DynamicMemoryUsage() <= sizelimit) break;
 
         // We set the new mempool min fee to the feerate of the removed set, plus the
         // "minimum reasonable fee rate" (ie some value under which we consider txn
         // to have 0 fee). This way, we don't allow txn to enter mempool with feerate
         // equal to txn which were removed with no block in between.
-        CFeeRate removed(it->GetModFeesWithDescendants(), it->GetSizeWithDescendants());
-        removed += m_incremental_relay_feerate;
-        trackPackageRemoved(removed);
-        maxFeeRateRemoved = std::max(maxFeeRateRemoved, removed);
+        if (removed >= m_min_relay_feerate) {
+            removed += m_incremental_relay_feerate;
+            trackPackageRemoved(removed);
+            maxFeeRateRemoved = std::max(maxFeeRateRemoved, removed);
+        }
 
         setEntries stage;
         CalculateDescendants(mapTx.project<0>(it), stage);

--- a/test/functional/mempool_limit.py
+++ b/test/functional/mempool_limit.py
@@ -13,6 +13,7 @@ from test_framework.util import (
     assert_equal,
     assert_fee_amount,
     assert_greater_than,
+    assert_greater_than_or_equal,
     assert_raises_rpc_error,
     create_lots_of_big_transactions,
     gen_return_txouts,
@@ -27,10 +28,13 @@ from test_framework.wallet import (
 class MempoolLimitTest(BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
-        self.num_nodes = 1
+        self.num_nodes = 2
         self.extra_args = [[
             "-datacarriersize=100000",
             "-maxmempool=5",
+        ],
+        [
+            "-datacarriersize=100000",
         ]]
         self.supports_cli = False
 
@@ -39,25 +43,32 @@ class MempoolLimitTest(BitcoinTestFramework):
         node = self.nodes[0]
         miniwallet = MiniWallet(node)
         relayfee = node.getnetworkinfo()['relayfee']
+        all_transactions = []
 
         self.log.info('Check that mempoolminfee is minrelaytxfee')
         assert_equal(node.getmempoolinfo()['minrelaytxfee'], Decimal('0.00001000'))
         assert_equal(node.getmempoolinfo()['mempoolminfee'], Decimal('0.00001000'))
 
+        # Batch size 1 is required to ensure every tx has a different feerate, which means the
+        # selection of transaction(s) for eviction is identical across nodes.
         tx_batch_size = 1
         num_of_batches = 75
         # Generate UTXOs to flood the mempool
         # 1 to create a tx initially that will be evicted from the mempool later
-        # 3 batches of multiple transactions with a fee rate much higher than the previous UTXO
+        # 75 transactions, each with a fee rate much higher than the previous one
         # And 1 more to verify that this tx does not get added to the mempool with a fee rate less than the mempoolminfee
         # And 2 more for the package cpfp test
+        # And 2 more for the package mempool full test
         self.generate(miniwallet, 1 + (num_of_batches * tx_batch_size) + 1 + 2)
 
         # Mine 99 blocks so that the UTXOs are allowed to be spent
         self.generate(node, COINBASE_MATURITY - 1)
+        self.disconnect_nodes(0, 1)
 
         self.log.info('Create a mempool tx that will be evicted')
-        tx_to_be_evicted_id = miniwallet.send_self_transfer(from_node=node, fee_rate=relayfee)["txid"]
+        tx_to_be_evicted = miniwallet.send_self_transfer(from_node=node, fee_rate=relayfee)
+        tx_to_be_evicted_id = tx_to_be_evicted["txid"]
+        all_transactions.append(tx_to_be_evicted["hex"])
 
         # Increase the tx fee rate to give the subsequent transactions a higher priority in the mempool
         # The tx has an approx. vsize of 65k, i.e. multiplying the previous fee rate (in sats/kvB)
@@ -67,7 +78,7 @@ class MempoolLimitTest(BitcoinTestFramework):
         self.log.info("Fill up the mempool with txs with higher fee rate")
         for batch_of_txid in range(num_of_batches):
             fee = (batch_of_txid + 1) * base_fee
-            create_lots_of_big_transactions(miniwallet, node, fee, tx_batch_size, txouts)
+            all_transactions.extend(create_lots_of_big_transactions(miniwallet, node, fee, tx_batch_size, txouts)[1])
 
         self.log.info('The tx should be evicted by now')
         # The number of transactions created should be greater than the ones present in the mempool
@@ -81,7 +92,9 @@ class MempoolLimitTest(BitcoinTestFramework):
 
         # Deliberately try to create a tx with a fee less than the minimum mempool fee to assert that it does not get added to the mempool
         self.log.info('Create a mempool tx that will not pass mempoolminfee')
-        assert_raises_rpc_error(-26, "mempool min fee not met", miniwallet.send_self_transfer, from_node=node, fee_rate=relayfee)
+        tx_below_mempoolmin = miniwallet.create_self_transfer(fee_rate=relayfee)
+        assert_raises_rpc_error(-26, "mempool min fee not met", node.sendrawtransaction, tx_below_mempoolmin["hex"])
+        all_transactions.append(tx_below_mempoolmin["hex"])
 
         self.log.info("Check that submitpackage allows cpfp of a parent below mempool min feerate")
         node = self.nodes[0]
@@ -116,6 +129,7 @@ class MempoolLimitTest(BitcoinTestFramework):
         assert_fee_amount(package_fees, package_vsize, child_result["fees"]["effective-feerate"])
         assert_equal([tx_poor["wtxid"], tx_child["tx"].getwtxid()], poor_parent_result["fees"]["effective-includes"])
         assert_equal([tx_poor["wtxid"], tx_child["tx"].getwtxid()], child_result["fees"]["effective-includes"])
+        assert_greater_than_or_equal(poor_parent_result["fees"]["effective-feerate"], Decimal("0.0002"))
 
         # The node will broadcast each transaction, still abiding by its peer's fee filter
         peer.wait_for_broadcast([tx["tx"].getwtxid() for tx in package_txns])
@@ -144,6 +158,37 @@ class MempoolLimitTest(BitcoinTestFramework):
         assert_greater_than(mempoolmin_feerate, (parent_fee) / (tx_parent_just_below["tx"].get_vsize()))
         assert_greater_than((parent_fee + child_fee) / (tx_parent_just_below["tx"].get_vsize() + tx_child_just_above["tx"].get_vsize()), mempoolmin_feerate / 1000)
         assert_raises_rpc_error(-26, "mempool full", node.submitpackage, [tx_parent_just_below["hex"], tx_child_just_above["hex"]])
+        kept_txids = set(node.getrawmempool())
+
+        self.log.info('Test restarting with smaller maxmempool persists the correct transactions.')
+        # All transactions would make it in to a default size mempool:
+        self.nodes[1].prioritisetransaction(tx_rich["txid"], 0, int(DEFAULT_FEE * COIN))
+        for txhex in all_transactions:
+            self.nodes[1].sendrawtransaction(txhex)
+        self.nodes[1].submitpackage([tx["hex"] for tx in package_txns])
+        node1_info = self.nodes[1].getmempoolinfo()
+        assert_equal(node1_info["mempoolminfee"], node1_info["minrelaytxfee"])
+        self.stop_node(1)
+        # Upon restart, the mempool min fee will rise above 1sat/vB due to the limited capacity.
+        self.restart_node(1, extra_args=["-maxmempool=5","-datacarriersize=100000"])
+        node1_info_after_restart = self.nodes[1].getmempoolinfo()
+        assert_greater_than(node1_info_after_restart["mempoolminfee"], node1_info_after_restart["minrelaytxfee"])
+        assert_equal(set(self.nodes[1].getrawmempool()), kept_txids)
+
+        txids_above_20 = set()
+        for txid in kept_txids:
+            entry = self.nodes[1].getmempoolentry(txid)
+            descendant_feerate = Decimal(entry["fees"]["descendant"] / entry["descendantsize"])
+            assert_greater_than_or_equal(descendant_feerate * 1000, node1_info_after_restart["mempoolminfee"])
+            if (descendant_feerate * 1000 >= Decimal("0.0002")):
+                txids_above_20.add(txid)
+        assert all([tx["txid"] in txids_above_20 for tx in package_txns])
+
+        self.log.info('Test restarting with higher -minrelaytxfee persists the correct transactions.')
+        self.stop_node(1)
+        self.restart_node(1, extra_args=["-minrelaytxfee=0.0002","-datacarriersize=100000"])
+        assert_equal(set(self.nodes[1].getrawmempool()), txids_above_20)
+
 
         self.log.info('Test passing a value below the minimum (5 MB) to -maxmempool throws an error')
         self.stop_node(0)

--- a/test/functional/mining_prioritisetransaction.py
+++ b/test/functional/mining_prioritisetransaction.py
@@ -152,7 +152,7 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
                 (i+1) * base_fee,
                 end_range - start_range,
                 self.txouts,
-                utxos[start_range:end_range])
+                utxos[start_range:end_range])[0]
 
         # Make sure that the size of each group of transactions exceeds
         # MAX_BLOCK_WEIGHT // 4 -- otherwise the test needs to be revised to

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -505,6 +505,7 @@ def gen_return_txouts():
 # transaction to make it large.  See gen_return_txouts() above.
 def create_lots_of_big_transactions(mini_wallet, node, fee, tx_batch_size, txouts, utxos=None):
     txids = []
+    txhex = []
     use_internal_utxos = utxos is None
     for _ in range(tx_batch_size):
         tx = mini_wallet.create_self_transfer(
@@ -512,10 +513,11 @@ def create_lots_of_big_transactions(mini_wallet, node, fee, tx_batch_size, txout
             fee=fee,
         )["tx"]
         tx.vout.extend(txouts)
+        txhex.append(tx.serialize().hex())
         res = node.testmempoolaccept([tx.serialize().hex()])[0]
         assert_equal(res['fees']['base'], fee)
         txids.append(node.sendrawtransaction(tx.serialize().hex()))
-    return txids
+    return txids, txhex
 
 
 def mine_large_block(test_framework, mini_wallet, node):


### PR DESCRIPTION
Part of v3 and package relay (see #27463).

**Problem**
When loading mempool.dat, we apply -minrelaytxfee and mempool min feerate on each transaction, meaning we'll reject transactions that may be CPFP'd by later transactions mempool.dat. Even without package relay, we can run into this problem if we are shrinking -maxmempool or raising -minrelaytxfee on a restart.

**Solution**
When loading mempool.dat, use `bypass_limits=true` and then call `TrimToSize()` at the very end.

Advantages:
- We definitely keep the "highest descendant score" transactions if mempool min feerate rises.
- It's extremely simple implementation-wise.
- It's simple to keep track of what made it in and what didn't.

Disadvantages:
- If mempool.dat is very large, we can exceed maxmempool by quite a bit.
- This won't be sufficient for ephemeral anchors (unless `bypass_limits` allows not-yet-spent anchors).
