### PR TITLE
wallet: bugfix, 'AvailableCoins' invalid output type set for raw PK outputs

### DIFF
--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -149,6 +149,7 @@ static OutputType GetOutputType(TxoutType type, bool is_from_p2sh)
             else return OutputType::BECH32;
         case TxoutType::SCRIPTHASH:
         case TxoutType::PUBKEYHASH:
+        case TxoutType::PUBKEY:
             return OutputType::LEGACY;
         default:
             return OutputType::UNKNOWN;

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -641,12 +641,11 @@ BOOST_FIXTURE_TEST_CASE(BasicOutputTypesTest, ListCoinsTest)
     std::map<OutputType, size_t> expected_coins_sizes;
     for (const auto& out_type : OUTPUT_TYPES) { expected_coins_sizes[out_type] = 0U; }
 
-    // Verify our wallet has one usable coinbase UTXO before starting
-    // This UTXO is a P2PK, so it should show up in the Other bucket
-    expected_coins_sizes[OutputType::UNKNOWN] = 1U;
+    // The wallet starts with one spendable P2PK coinbase UTXO.
+    expected_coins_sizes[OutputType::LEGACY] = 1U;
     CoinsResult available_coins = WITH_LOCK(wallet->cs_wallet, return AvailableCoins(*wallet));
-    BOOST_CHECK_EQUAL(available_coins.Size(), expected_coins_sizes[OutputType::UNKNOWN]);
-    BOOST_CHECK_EQUAL(available_coins.coins[OutputType::UNKNOWN].size(), expected_coins_sizes[OutputType::UNKNOWN]);
+    BOOST_CHECK_EQUAL(available_coins.Size(), expected_coins_sizes[OutputType::LEGACY]);
+    BOOST_CHECK_EQUAL(available_coins.coins[OutputType::LEGACY].size(), expected_coins_sizes[OutputType::LEGACY]);
 
     // We will create a self transfer for each of the OutputTypes and
     // verify it is put in the correct bucket after running GetAvailablecoins
@@ -656,8 +655,7 @@ BOOST_FIXTURE_TEST_CASE(BasicOutputTypesTest, ListCoinsTest)
     //   2. One UTXO from the change, due to payment address matching logic
 
     for (const auto& out_type : OUTPUT_TYPES) {
-        if (out_type == OutputType::UNKNOWN) continue;
-        expected_coins_sizes[out_type] = 2U;
+        expected_coins_sizes[out_type] += 2U;
         TestCoinsResult(*this, out_type, 1 * COIN, expected_coins_sizes);
     }
 }


### PR DESCRIPTION
`AvailableCoins` sets raw pubkey outputs with an `OutputType::UNKNOWN` type instead of `OutputType::LEGACY`.

Gladly, no type unknown outputs are skipped during coin selection, nor anything different is done with them.
It is just an inconsistency.