### PR TITLE
net: use interruptible async getaddrinfo wrapper from libevent for DNS

### DIFF
--- a/src/netbase.h
+++ b/src/netbase.h
@@ -65,9 +65,15 @@ struct ProxyCredentials
 };
 
 /**
- * Wrapper for getaddrinfo(3). Do not use directly: call Lookup/LookupHost/LookupNumeric/LookupSubNet.
+ * Async wrapper for getaddrinfo(3) provided by libevent. Do not use directly: call Lookup/LookupHost/LookupNumeric/LookupSubNet.
  */
-std::vector<CNetAddr> WrappedGetAddrInfo(const std::string& name, bool allow_lookup);
+std::vector<CNetAddr> DNSResolveAsync(const std::string& name, bool allow_lookup);
+
+struct DNSResolveResponse
+{
+    bool complete;
+    std::vector<CNetAddr>* vAddr;
+};
 
 enum Network ParseNetwork(const std::string& net);
 std::string GetNetworkName(enum Network net);

--- a/src/support/events.h
+++ b/src/support/events.h
@@ -8,6 +8,7 @@
 #include <ios>
 #include <memory>
 
+#include <event2/dns.h>
 #include <event2/event.h>
 #include <event2/http.h>
 
@@ -26,6 +27,16 @@ MAKE_RAII(event);
 MAKE_RAII(evhttp);
 MAKE_RAII(evhttp_request);
 MAKE_RAII(evhttp_connection);
+
+struct evdns_base_deleter {
+    void operator()(struct evdns_base* ob) {
+        // If the 'fail_requests' option is enabled, all active requests will return
+        // an empty result with the error flag set to DNS_ERR_SHUTDOWN. Otherwise,
+        // the requests will be silently discarded.
+        evdns_base_free(ob, /*fail_requests=*/0);
+    }
+};
+typedef std::unique_ptr<struct evdns_base, evdns_base_deleter> raii_evdns_base;
 
 inline raii_event_base obtain_event_base() {
     auto result = raii_event_base(event_base_new());
@@ -50,6 +61,13 @@ inline raii_evhttp_connection obtain_evhttp_connection_base(struct event_base* b
     auto result = raii_evhttp_connection(evhttp_connection_base_new(base, nullptr, host.c_str(), port));
     if (!result.get())
         throw std::runtime_error("create connection failed");
+    return result;
+}
+
+inline raii_evdns_base obtain_evdns_base(struct event_base* base) {
+    auto result = raii_evdns_base(evdns_base_new(base, /*initialize=*/1));
+    if (!result.get())
+        throw std::runtime_error("cannot create evdns_base");
     return result;
 }
 

--- a/src/test/fuzz/fuzz.cpp
+++ b/src/test/fuzz/fuzz.cpp
@@ -74,7 +74,7 @@ void initialize()
         if (allow_lookup) {
             std::terminate();
         }
-        return WrappedGetAddrInfo(name, false);
+        return DNSResolveAsync(name, false);
     };
 
     bool should_abort{false};

--- a/src/test/netbase_tests.cpp
+++ b/src/test/netbase_tests.cpp
@@ -158,6 +158,14 @@ BOOST_AUTO_TEST_CASE(embedded_test)
     BOOST_CHECK_EQUAL(addr1.ToStringAddr(), addr2.ToStringAddr());
 }
 
+BOOST_AUTO_TEST_CASE(dns_lookup)
+{
+    CNetAddr addr;
+    bool ret = LookupHost("nic.com", addr, /*fAllowLookup=*/true);
+    BOOST_CHECK(ret);
+    BOOST_CHECK(addr.IsRoutable());
+}
+
 BOOST_AUTO_TEST_CASE(subnet_test)
 {
 


### PR DESCRIPTION
Closes https://github.com/bitcoin/bitcoin/issues/16778

Bitcoin uses `getaddrinfo` to make DNS requests for DNS seed servers and for adding peers with `-addnode`, `-seednode` and `-connect`. Depending on the platform this can be clunky and a system issue could prevent name resolution from completing at all, blocking the thread and in some cases preventing a clean shutdown.

An attempt was made to switch to the asynchronous `getaddrinfo_a` in https://github.com/bitcoin/bitcoin/pull/4421 but that was reverted in https://github.com/bitcoin/bitcoin/pull/9229 after discovering that function has a segfault!

Taking BlueMatt's suggestion in https://github.com/bitcoin/bitcoin/pull/10215#issue-221886328, this PR modifies our `g_dns_lookup` function to use `evdns_getaddrinfo()` from [libevent](https://libevent.org/libevent-book/Ref9_dns.html). This is an asynchronous function but I've implemented it in a polling loop so it still blocks -- but now will timeout after 2 seconds.

TODO:
- [ ] We could make the polling loop interruptible but I'm not sure the best approach to that, since these functions don't live in a class with a flag like `interruptNet` 
- [ ] Is it possible to add functional tests that mess with DNS? Probably not.
- [ ] The unit test I added makes a live DNS request for `nic.com` that test will fail the platform has no DNS

Future work:
- libevent has more low-level DNS functions as well, we could ultimately use those to (for example) request `TXT` records with onion addresses from our DNS seeders

