### PR TITLE
lint: stop ignoring LIEF imports

### DIFF
--- a/ci/lint/04_install.sh
+++ b/ci/lint/04_install.sh
@@ -35,6 +35,7 @@ fi
 
 ${CI_RETRY_EXE} pip3 install codespell==2.2.1
 ${CI_RETRY_EXE} pip3 install flake8==5.0.4
+${CI_RETRY_EXE} pip3 install lief==0.13.1
 ${CI_RETRY_EXE} pip3 install mypy==0.971
 ${CI_RETRY_EXE} pip3 install pyzmq==24.0.1
 ${CI_RETRY_EXE} pip3 install vulture==2.6

--- a/contrib/devtools/security-check.py
+++ b/contrib/devtools/security-check.py
@@ -10,7 +10,7 @@ Otherwise the exit status will be 1 and it will log which executables failed whi
 import sys
 from typing import List
 
-import lief #type:ignore
+import lief
 
 def check_ELF_RELRO(binary) -> bool:
     '''

--- a/contrib/devtools/symbol-check.py
+++ b/contrib/devtools/symbol-check.py
@@ -13,7 +13,7 @@ Example usage:
 import sys
 from typing import List, Dict
 
-import lief #type:ignore
+import lief
 
 # Debian 10 (Buster) EOL: 2024. https://wiki.debian.org/LTS
 #

--- a/contrib/devtools/test-security-check.py
+++ b/contrib/devtools/test-security-check.py
@@ -5,7 +5,7 @@
 '''
 Test script for security-check.py
 '''
-import lief #type:ignore
+import lief
 import os
 import subprocess
 from typing import List

--- a/test/README.md
+++ b/test/README.md
@@ -331,6 +331,7 @@ Use the `-v` option for verbose output.
 | Lint test | Dependency |
 |-----------|:----------:|
 | [`lint-python.py`](lint/lint-python.py) | [flake8](https://gitlab.com/pycqa/flake8)
+| [`lint-python.py`](lint/lint-python.py) | [lief](https://github.com/lief-project/LIEF)
 | [`lint-python.py`](lint/lint-python.py) | [mypy](https://github.com/python/mypy)
 | [`lint-python.py`](lint/lint-python.py) | [pyzmq](https://github.com/zeromq/pyzmq)
 | [`lint-python-dead-code.py`](lint/lint-python-dead-code.py) | [vulture](https://github.com/jendrikseipp/vulture)

--- a/test/lint/lint-python.py
+++ b/test/lint/lint-python.py
@@ -13,7 +13,7 @@ import pkg_resources
 import subprocess
 import sys
 
-DEPS = ['flake8', 'mypy', 'pyzmq']
+DEPS = ['flake8', 'lief', 'mypy', 'pyzmq']
 MYPY_CACHE_DIR = f"{os.getenv('BASE_ROOT_DIR', '')}/test/.mypy_cache"
 
 # All .py files, except those in src/ (to exclude subtrees there)


### PR DESCRIPTION
Type stubs are now available as of 0.13.0.
See https://github.com/lief-project/LIEF/issues/650.