### PR TITLE
Relay own transactions only via short-lived Tor or I2P connections

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -451,6 +451,7 @@ private:
         if (conn_type == "block-relay-only") return "block";
         if (conn_type == "manual" || conn_type == "feeler") return conn_type;
         if (conn_type == "addr-fetch") return "addr";
+        if (conn_type == "sensitive-relay") return "srelay";
         return "";
     }
 
@@ -657,6 +658,7 @@ public:
         "           \"manual\" - peer we manually added using RPC addnode or the -addnode/-connect config options\n"
         "           \"feeler\" - short-lived connection for testing addresses\n"
         "           \"addr\"   - address fetch; short-lived connection for requesting addresses\n"
+        "           \"srelay\" - sensitive relay; short-lived connection for relaying our transactions\n"
         "  net      Network the peer connected through (\"ipv4\", \"ipv6\", \"onion\", \"i2p\", \"cjdns\", or \"npr\" (not publicly routable))\n"
         "  mping    Minimum observed ping time, in milliseconds (ms)\n"
         "  ping     Last observed ping time, in milliseconds (ms)\n"

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -182,6 +182,7 @@ const CLogCategoryDesc LogCategories[] =
     {BCLog::BLOCKSTORAGE, "blockstorage"},
     {BCLog::TXRECONCILIATION, "txreconciliation"},
     {BCLog::SCAN, "scan"},
+    {BCLog::SENSITIVE_RELAY, "sensitiverelay"},
     {BCLog::ALL, "1"},
     {BCLog::ALL, "all"},
 };
@@ -286,6 +287,8 @@ std::string LogCategoryToStr(BCLog::LogFlags category)
         return "txreconciliation";
     case BCLog::LogFlags::SCAN:
         return "scan";
+    case BCLog::LogFlags::SENSITIVE_RELAY:
+        return "sensitiverelay";
     case BCLog::LogFlags::ALL:
         return "all";
     }

--- a/src/logging.h
+++ b/src/logging.h
@@ -68,6 +68,7 @@ namespace BCLog {
         BLOCKSTORAGE = (1 << 26),
         TXRECONCILIATION = (1 << 27),
         SCAN        = (1 << 28),
+        SENSITIVE_RELAY = (1 << 29),
         ALL         = ~(uint32_t)0,
     };
     enum class Level {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1078,6 +1078,7 @@ bool CConnman::AddConnection(const std::string& address, ConnectionType conn_typ
     switch (conn_type) {
     case ConnectionType::INBOUND:
     case ConnectionType::MANUAL:
+    case ConnectionType::SENSITIVE_RELAY:
         return false;
     case ConnectionType::OUTBOUND_FULL_RELAY:
         max_connections = m_max_outbound_full_relay;
@@ -1722,6 +1723,7 @@ void CConnman::ThreadOpenConnections(const std::vector<std::string> connect)
                     // peers from addrman.
                     case ConnectionType::ADDR_FETCH:
                     case ConnectionType::FEELER:
+                    case ConnectionType::SENSITIVE_RELAY:
                         break;
                     case ConnectionType::MANUAL:
                     case ConnectionType::OUTBOUND_FULL_RELAY:

--- a/src/net.h
+++ b/src/net.h
@@ -451,6 +451,7 @@ public:
             case ConnectionType::MANUAL:
             case ConnectionType::ADDR_FETCH:
             case ConnectionType::FEELER:
+            case ConnectionType::SENSITIVE_RELAY:
                 return false;
         } // no default case, so the compiler can warn about missing cases
 
@@ -477,6 +478,10 @@ public:
         return m_conn_type == ConnectionType::ADDR_FETCH;
     }
 
+    bool IsSensitiveRelayConn() const {
+        return m_conn_type == ConnectionType::SENSITIVE_RELAY;
+    }
+
     bool IsInboundConn() const {
         return m_conn_type == ConnectionType::INBOUND;
     }
@@ -490,6 +495,7 @@ public:
             case ConnectionType::OUTBOUND_FULL_RELAY:
             case ConnectionType::BLOCK_RELAY:
             case ConnectionType::ADDR_FETCH:
+            case ConnectionType::SENSITIVE_RELAY:
                 return true;
         } // no default case, so the compiler can warn about missing cases
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1533,7 +1533,7 @@ void PeerManagerImpl::ReattemptInitialBroadcast(CScheduler& scheduler)
         CTransactionRef tx = m_mempool.get(txid);
 
         if (tx != nullptr) {
-            ScheduleTxForRelayToAll(txid, tx->GetWitnessHash());
+            ScheduleLocalTxForRelay(txid, tx->GetWitnessHash());
         } else {
             m_mempool.RemoveUnbroadcastTx(txid, true);
         }

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -22,6 +22,8 @@ static const unsigned int DEFAULT_MAX_ORPHAN_TRANSACTIONS = 100;
 static const unsigned int DEFAULT_BLOCK_RECONSTRUCTION_EXTRA_TXN = 100;
 static const bool DEFAULT_PEERBLOOMFILTERS = false;
 static const bool DEFAULT_PEERBLOCKFILTERS = false;
+/** Default for -sensitiverelayowntx. */
+static const bool DEFAULT_SENSITIVE_RELAY_OWN_TX{false};
 /** Threshold for marking a node to be discouraged, e.g. disconnected and added to the discouragement filter. */
 static const int DISCOURAGEMENT_THRESHOLD{100};
 /** Maximum number of outstanding CMPCTBLOCK requests for the same block. */

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -80,12 +80,12 @@ public:
     /** Whether this node ignores txs received over p2p. */
     virtual bool IgnoresIncomingTxs() = 0;
 
-    /** Relay transaction to all peers. */
-    virtual void RelayTransaction(const uint256& txid, const uint256& wtxid) = 0;
+    /** Schedule a transaction to be relayed to all peers at a later time. */
+    virtual void ScheduleTxForRelayToAll(const uint256& txid, const uint256& wtxid) = 0;
 
     /**
      * Schedule a local transaction to be relayed. This is done asynchronously
-     * either via short-lived privacy connections or via `RelayTransaction()`.
+     * either via short-lived privacy connections or via `ScheduleTxForRelayToAll()`.
      */
     virtual void ScheduleLocalTxForRelay(const uint256& txid, const uint256& wtxid) = 0;
 

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -54,6 +54,7 @@ public:
         uint32_t max_orphan_txs{DEFAULT_MAX_ORPHAN_TRANSACTIONS};
         size_t max_extra_txs{DEFAULT_BLOCK_RECONSTRUCTION_EXTRA_TXN};
         bool capture_messages{false};
+        bool sensitiverelayowntx{DEFAULT_SENSITIVE_RELAY_OWN_TX};
     };
 
     static std::unique_ptr<PeerManager> make(CConnman& connman, AddrMan& addrman,
@@ -81,6 +82,12 @@ public:
 
     /** Relay transaction to all peers. */
     virtual void RelayTransaction(const uint256& txid, const uint256& wtxid) = 0;
+
+    /**
+     * Schedule a local transaction to be relayed. This is done asynchronously
+     * either via short-lived privacy connections or via `RelayTransaction()`.
+     */
+    virtual void ScheduleLocalTxForRelay(const uint256& txid, const uint256& wtxid) = 0;
 
     /** Send ping message to all peers */
     virtual void SendPings() = 0;

--- a/src/node/connection_types.cpp
+++ b/src/node/connection_types.cpp
@@ -20,6 +20,8 @@ std::string ConnectionTypeAsString(ConnectionType conn_type)
         return "block-relay-only";
     case ConnectionType::ADDR_FETCH:
         return "addr-fetch";
+    case ConnectionType::SENSITIVE_RELAY:
+        return "sensitive-relay";
     } // no default case, so the compiler can warn about missing cases
 
     assert(false);

--- a/src/node/connection_types.h
+++ b/src/node/connection_types.h
@@ -74,6 +74,13 @@ enum class ConnectionType {
      * AddrMan is empty.
      */
     ADDR_FETCH,
+
+    /**
+     * Sensitive-relay connections are short-lived and only opened to
+     * privacy networks (Tor, I2P) for relaying sensitive data (like our
+     * own transactions) and closed afterwards.
+     */
+    SENSITIVE_RELAY,
 };
 
 /** Convert ConnectionType enum to a string value */

--- a/src/node/peerman_args.cpp
+++ b/src/node/peerman_args.cpp
@@ -20,6 +20,8 @@ void ApplyArgsManOptions(const ArgsManager& argsman, PeerManager::Options& optio
     if (auto value{argsman.GetBoolArg("-capturemessages")}) options.capture_messages = *value;
 
     if (auto value{argsman.GetBoolArg("-blocksonly")}) options.ignore_incoming_txs = *value;
+
+    if (auto value{argsman.GetBoolArg("-sensitiverelayowntx")}) options.sensitiverelayowntx = *value;
 }
 
 } // namespace node

--- a/src/node/transaction.cpp
+++ b/src/node/transaction.cpp
@@ -116,7 +116,7 @@ TransactionError BroadcastTransaction(NodeContext& node, const CTransactionRef t
     }
 
     if (relay) {
-        node.peerman->ScheduleTxForRelayToAll(txid, wtxid);
+        node.peerman->ScheduleLocalTxForRelay(txid, wtxid);
     }
 
     return TransactionError::OK;

--- a/src/node/transaction.cpp
+++ b/src/node/transaction.cpp
@@ -116,7 +116,7 @@ TransactionError BroadcastTransaction(NodeContext& node, const CTransactionRef t
     }
 
     if (relay) {
-        node.peerman->RelayTransaction(txid, wtxid);
+        node.peerman->ScheduleTxForRelayToAll(txid, wtxid);
     }
 
     return TransactionError::OK;

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -717,6 +717,8 @@ QString ConnectionTypeToQString(ConnectionType conn_type, bool prepend_direction
     case ConnectionType::FEELER: return prefix + QObject::tr("Feeler");
     //: Short-lived peer connection type that solicits known addresses from a peer.
     case ConnectionType::ADDR_FETCH: return prefix + QObject::tr("Address Fetch");
+    //: Short-lived peer connection type that is used for relaying sensitive data.
+    case ConnectionType::SENSITIVE_RELAY: return prefix + QObject::tr("Sensitive Relay");
     } // no default case, so the compiler can warn about missing cases
     assert(false);
 }

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -513,7 +513,10 @@ RPCConsole::RPCConsole(interfaces::Node& node, const PlatformStyle *_platformSty
         tr("Outbound Feeler: short-lived, for testing addresses"),
         /*: Explanatory text for a short-lived outbound peer connection that is used
             to request addresses from a peer. */
-        tr("Outbound Address Fetch: short-lived, for soliciting addresses")};
+        tr("Outbound Address Fetch: short-lived, for soliciting addresses"),
+        /*: Explanatory text for a short-lived outbound peer connection that is used
+            to relay our transactions. */
+        tr("Sensitive Relay: short-lived, for relaying our transactions")};
     const QString list{"<ul><li>" + Join(CONNECTION_TYPE_DOC, QString("</li><li>")) + "</li></ul>"};
     ui->peerConnectionTypeLabel->setToolTip(ui->peerConnectionTypeLabel->toolTip().arg(list));
     const QString hb_list{"<ul><li>\""

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -334,7 +334,7 @@ static void entryToJSON(const CTxMemPool& pool, UniValue& info, const CTxMemPool
     }
 
     info.pushKV("bip125-replaceable", rbfStatus);
-    info.pushKV("unbroadcast", pool.IsUnbroadcastTx(tx.GetHash()));
+    info.pushKV("unbroadcast", pool.IsUnbroadcastTx(GenTxid::Txid(tx.GetHash())));
 }
 
 UniValue MempoolToJSON(const CTxMemPool& pool, bool verbose, bool include_mempool_sequence)

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -42,7 +42,8 @@ const std::vector<std::string> CONNECTION_TYPE_DOC{
         "inbound (initiated by the peer)",
         "manual (added via addnode RPC or -addnode/-connect configuration options)",
         "addr-fetch (short-lived automatic connection for soliciting addresses)",
-        "feeler (short-lived automatic connection for testing addresses)"
+        "feeler (short-lived automatic connection for testing addresses)",
+        "sensitive-relay (short-lived automatic connection for relaying our transactions)"
 };
 
 static RPCHelpMan getconnectioncount()

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1003,13 +1003,15 @@ size_t CTxMemPool::DynamicMemoryUsage() const {
     return memusage::MallocUsage(sizeof(CTxMemPoolEntry) + 15 * sizeof(void*)) * mapTx.size() + memusage::DynamicUsage(mapNextTx) + memusage::DynamicUsage(mapDeltas) + memusage::DynamicUsage(vTxHashes) + cachedInnerUsage;
 }
 
-void CTxMemPool::RemoveUnbroadcastTx(const uint256& txid, const bool unchecked) {
+bool CTxMemPool::RemoveUnbroadcastTx(const uint256& txid, const bool unchecked) {
     LOCK(cs);
 
     if (m_unbroadcast_txids.erase(txid))
     {
         LogPrint(BCLog::MEMPOOL, "Removed %i from set of unbroadcast txns%s\n", txid.GetHex(), (unchecked ? " before confirmation that txn was sent out" : ""));
+        return true;
     }
+    return false;
 }
 
 bool CTxMemPool::IsUnbroadcastTx(const GenTxid& gtxid) const

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1012,6 +1012,26 @@ void CTxMemPool::RemoveUnbroadcastTx(const uint256& txid, const bool unchecked) 
     }
 }
 
+bool CTxMemPool::IsUnbroadcastTx(const GenTxid& gtxid) const
+{
+    AssertLockHeld(cs);
+    uint256 txid;
+    if (gtxid.IsWtxid()) { // m_unbroadcast_txids is by txid (not wtxid), get the txid from wtxid.
+        auto it = get_iter_from_wtxid(gtxid.GetHash());
+        if (it == mapTx.end()) {
+            return false;
+        }
+        auto tx = it->GetSharedTx();
+        if (tx.get() == nullptr) {
+            return false;
+        }
+        txid = tx->GetHash();
+    } else {
+        txid = gtxid.GetHash();
+    }
+    return m_unbroadcast_txids.count(txid) > 0;
+}
+
 void CTxMemPool::RemoveStaged(setEntries &stage, bool updateDescendants, MemPoolRemovalReason reason) {
     AssertLockHeld(cs);
     UpdateForRemoveFromMempool(stage, updateDescendants);

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -721,8 +721,11 @@ public:
         if (exists(GenTxid::Txid(txid))) m_unbroadcast_txids.insert(txid);
     };
 
-    /** Removes a transaction from the unbroadcast set */
-    void RemoveUnbroadcastTx(const uint256& txid, const bool unchecked = false);
+    /**
+     * Removes a transaction from the unbroadcast set.
+     * @return true if the transaction was in the unbroadcast set and was removed.
+     */
+    bool RemoveUnbroadcastTx(const uint256& txid, const bool unchecked = false);
 
     /** Returns transactions in unbroadcast set */
     std::set<uint256> GetUnbroadcastTxs() const

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -731,12 +731,8 @@ public:
         return m_unbroadcast_txids;
     }
 
-    /** Returns whether a txid is in the unbroadcast set */
-    bool IsUnbroadcastTx(const uint256& txid) const EXCLUSIVE_LOCKS_REQUIRED(cs)
-    {
-        AssertLockHeld(cs);
-        return m_unbroadcast_txids.count(txid) != 0;
-    }
+    /** Returns whether a transaction is in the unbroadcast set. */
+    bool IsUnbroadcastTx(const GenTxid& gtxid) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /** Guards this internal counter for external reporting */
     uint64_t GetAndIncrementSequence() const EXCLUSIVE_LOCKS_REQUIRED(cs) {

--- a/test/functional/feature_config_args.py
+++ b/test/functional/feature_config_args.py
@@ -322,6 +322,24 @@ class ConfArgsTest(BitcoinTestFramework):
                     unexpected_msgs=seednode_ignored):
                 self.restart_node(0, extra_args=[connect_arg, '-seednode=fakeaddress2'])
 
+    def test_sensitiverelayowntx(self):
+        self.log.info("Test that an invalid usage of -sensitiverelayowntx throws an init error")
+        self.stop_node(0)
+        args_errors = {
+            "Sensitive relay of own transactions requested (-sensitiverelayowntx), "
+            "but none of Tor or I2P networks is reachable":
+            ["-sensitiverelayowntx"],
+
+            "Sensitive relay of own transactions requested (-sensitiverelayowntx), "
+            "but -connect is also configured. They are incompatible because the "
+            "sensitive relay needs to open a new connection to a randomly chosen "
+            "Tor or I2P peer" :
+            # -onion= makes the Tor network reachable
+            ["-sensitiverelayowntx", "-connect=127.0.0.1:8333", "-onion=127.0.0.1:9050"]
+        }
+        for msg, args in args_errors.items():
+            self.nodes[0].assert_start_raises_init_error(extra_args=args, expected_msg=f"Error: {msg}")
+
     def test_ignored_conf(self):
         self.log.info('Test error is triggered when the datadir in use contains a bitcoin.conf file that would be ignored '
                       'because a conflicting -conf file argument is passed.')
@@ -377,6 +395,7 @@ class ConfArgsTest(BitcoinTestFramework):
         self.test_seed_peers()
         self.test_networkactive()
         self.test_connect_with_seednode()
+        self.test_sensitiverelayowntx()
 
         self.test_config_file_parser()
         self.test_config_file_log()

--- a/test/functional/p2p_local_tx_relay.py
+++ b/test/functional/p2p_local_tx_relay.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017-2023 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""
+Test how locally submitted transactions are sent to the network when sensitive relay is used.
+
+The topology in the test is:
+
+Bitcoin Core (node0)
+               ^   v       The default full-outbound + block-only connections
+               |   |       (MAX_OUTBOUND_FULL_RELAY_CONNECTIONS + MAX_BLOCK_RELAY_ONLY_CONNECTIONS):
+               |   |
+               |   *-----> SOCKS5 Proxy ---> P2PInterface (self.socks5_server.conf.destinations[0]["node"])
+               |   |
+               |   *-----> SOCKS5 Proxy ---> P2PInterface (self.socks5_server.conf.destinations[1]["node"])
+               |   ...
+               |   |       The sensitive relay TX recipients
+               |   |       (SENSITIVE_RELAY_NUM_BROADCAST_PER_TX)
+               |   |       plus maybe some feeler or extra block only connections:
+               |   |
+               |   *-----> SOCKS5 Proxy ---> Bitcoin Core (node1) (self.socks5_server.conf.destinations[i]["node"] is None)
+               |   |                          ^
+               |   |                          *----< P2PInterface (far_observer) (to check Bitcoin Core relays the tx)
+               |   |
+               |   *-----> SOCKS5 Proxy ---> P2PInterface (self.socks5_server.conf.destinations[i + 1]["node"])
+               |   ...
+               |
+               *---------< P2PDataStore (observer_inbound)
+"""
+
+from test_framework.p2p import (
+    P2PDataStore,
+    P2PInterface,
+    P2P_SERVICES,
+    P2P_VERSION,
+)
+from test_framework.messages import (
+    CAddress,
+    CInv,
+    MSG_WTX,
+    msg_getdata,
+    msg_inv,
+    msg_mempool,
+)
+from test_framework.socks5 import (
+    Socks5Configuration,
+    Socks5Server,
+)
+from test_framework.test_framework import (
+    BitcoinTestFramework,
+)
+from test_framework.util import (
+    MAX_NODES,
+    assert_equal,
+    p2p_port,
+)
+from test_framework.wallet import (
+    MiniWallet,
+)
+
+MAX_OUTBOUND_FULL_RELAY_CONNECTIONS = 8
+MAX_BLOCK_RELAY_ONLY_CONNECTIONS = 2
+NUM_INITIAL_CONNECTIONS = MAX_OUTBOUND_FULL_RELAY_CONNECTIONS + MAX_BLOCK_RELAY_ONLY_CONNECTIONS
+SENSITIVE_RELAY_NUM_BROADCAST_PER_TX = 5
+
+# Fill addrman with these addresses. Must have enough Tor addresses, so that even
+# if all 10 default connections are opened to a Tor address (!?) there must be more
+# for sensitive relays.
+addresses = [
+    "1.65.195.98",
+    "2.59.236.56",
+    "2.83.114.20",
+    "2.248.194.16",
+    "5.2.154.6",
+    "5.101.140.30",
+    "5.128.87.126",
+    "5.144.21.49",
+    "5.172.132.104",
+    "5.188.62.18",
+    "5.200.2.180",
+    "8.129.184.255",
+    "8.209.105.138",
+    "12.34.98.148",
+    "14.199.102.151",
+    "18.27.79.17",
+    "18.27.124.231",
+    "18.216.249.151",
+    "23.88.155.58",
+    "23.93.101.158",
+    "[2001:19f0:1000:1db3:5400:4ff:fe56:5a8d]",
+    "[2001:19f0:5:24da:3eec:efff:feb9:f36e]",
+    "[2001:19f0:5:24da::]",
+    "[2001:19f0:5:4535:3eec:efff:feb9:87e4]",
+    "[2001:19f0:5:4535::]",
+    "[2001:1bc0:c1::2000]",
+    "[2001:1c04:4008:6300:8a5f:2678:114b:a660]",
+    "[2001:41d0:203:3739::]",
+    "[2001:41d0:203:8f49::]",
+    "[2001:41d0:203:bb0a::]",
+    "[2001:41d0:2:bf8f::]",
+    "[2001:41d0:303:de8b::]",
+    "[2001:41d0:403:3d61::]",
+    "[2001:41d0:405:9600::]",
+    "[2001:41d0:8:ed7f::1]",
+    "[2001:41d0:a:69a2::1]",
+    "[2001:41f0::62:6974:636f:696e]",
+    "[2001:470:1b62::]",
+    "[2001:470:1f05:43b:2831:8530:7179:5864]",
+    "[2001:470:1f09:b14::11]",
+    "2bqghnldu6mcug4pikzprwhtjjnsyederctvci6klcwzepnjd46ikjyd.onion",
+    "4lr3w2iyyl5u5l6tosizclykf5v3smqroqdn2i4h3kq6pfbbjb2xytad.onion",
+    "5g72ppm3krkorsfopcm2bi7wlv4ohhs4u4mlseymasn7g7zhdcyjpfid.onion",
+    "5sbmcl4m5api5tqafi4gcckrn3y52sz5mskxf3t6iw4bp7erwiptrgqd.onion",
+    "776aegl7tfhg6oiqqy76jnwrwbvcytsx2qegcgh2mjqujll4376ohlid.onion",
+    "77mdte42srl42shdh2mhtjr7nf7dmedqrw6bkcdekhdvmnld6ojyyiad.onion",
+    "azbpsh4arqlm6442wfimy7qr65bmha2zhgjg7wbaji6vvaug53hur2qd.onion",
+    "b64xcbleqmwgq2u46bh4hegnlrzzvxntyzbmucn3zt7cssm7y4ubv3id.onion",
+    "bsqbtcparrfihlwolt4xgjbf4cgqckvrvsfyvy6vhiqrnh4w6ghixoid.onion",
+    "bsqbtctulf2g4jtjsdfgl2ed7qs6zz5wqx27qnyiik7laockryvszqqd.onion",
+    "cwi3ekrwhig47dhhzfenr5hbvckj7fzaojygvazi2lucsenwbzwoyiqd.onion",
+    "devinbtcmwkuitvxl3tfi5of4zau46ymeannkjv6fpnylkgf3q5fa3id.onion",
+    "devinbtctu7uctl7hly2juu3thbgeivfnvw3ckj3phy6nyvpnx66yeyd.onion",
+    "devinbtcyk643iruzfpaxw3on2jket7rbjmwygm42dmdyub3ietrbmid.onion",
+    "dtql5vci4iaml4anmueftqr7bfgzqlauzfy4rc2tfgulldd3ekyijjyd.onion",
+    "emzybtc25oddoa2prol2znpz2axnrg6k77xwgirmhv7igoiucddsxiad.onion",
+    "emzybtc3ewh7zihpkdvuwlgxrhzcxy2p5fvjggp7ngjbxcytxvt4rjid.onion",
+    "emzybtc454ewbviqnmgtgx3rgublsgkk23r4onbhidcv36wremue4kqd.onion",
+    "emzybtc5bnpb2o6gh54oquiox54o4r7yn4a2wiiwzrjonlouaibm2zid.onion",
+    "fpz6r5ppsakkwypjcglz6gcnwt7ytfhxskkfhzu62tnylcknh3eq6pad.onion",
+    "255fhcp6ajvftnyo7bwz3an3t4a4brhopm3bamyh2iu5r3gnr2rq.b32.i2p",
+    "27yrtht5b5bzom2w5ajb27najuqvuydtzb7bavlak25wkufec5mq.b32.i2p",
+    "3gocb7wc4zvbmmebktet7gujccuux4ifk3kqilnxnj5wpdpqx2hq.b32.i2p",
+    "4fcc23wt3hyjk3csfzcdyjz5pcwg5dzhdqgma6bch2qyiakcbboa.b32.i2p",
+    "4osyqeknhx5qf3a73jeimexwclmt42cju6xdp7icja4ixxguu2hq.b32.i2p",
+    "4umsi4nlmgyp4rckosg4vegd2ysljvid47zu7pqsollkaszcbpqq.b32.i2p",
+    "6j2ezegd3e2e2x3o3pox335f5vxfthrrigkdrbgfbdjchm5h4awa.b32.i2p",
+    "6n36ljyr55szci5ygidmxqer64qr24f4qmnymnbvgehz7qinxnla.b32.i2p",
+    "72yjs6mvlby3ky6mgpvvlemmwq5pfcznrzd34jkhclgrishqdxva.b32.i2p",
+    "a5qsnv3maw77mlmmzlcglu6twje6ttctd3fhpbfwcbpmewx6fczq.b32.i2p",
+    "aovep2pco7v2k4rheofrgytbgk23eg22dczpsjqgqtxcqqvmxk6a.b32.i2p",
+    "bitcoi656nll5hu6u7ddzrmzysdtwtnzcnrjd4rfdqbeey7dmn5a.b32.i2p",
+    "brifkruhlkgrj65hffybrjrjqcgdgqs2r7siizb5b2232nruik3a.b32.i2p",
+    "c4gfnttsuwqomiygupdqqqyy5y5emnk5c73hrfvatri67prd7vyq.b32.i2p",
+    "day3hgxyrtwjslt54sikevbhxxs4qzo7d6vi72ipmscqtq3qmijq.b32.i2p",
+    "du5kydummi23bjfp6bd7owsvrijgt7zhvxmz5h5f5spcioeoetwq.b32.i2p",
+    "e55k6wu46rzp4pg5pk5npgbr3zz45bc3ihtzu2xcye5vwnzdy7pq.b32.i2p",
+    "eciohu5nq7vsvwjjc52epskuk75d24iccgzmhbzrwonw6lx4gdva.b32.i2p",
+    "ejlnngarmhqvune74ko7kk55xtgbz5i5ncs4vmnvjpy3l7y63xaa.b32.i2p",
+    "fhzlp3xroabohnmjonu5iqazwhlbbwh5cpujvw2azcu3srqdceja.b32.i2p",
+    "[fc32:17ea:e415:c3bf:9808:149d:b5a2:c9aa]",
+    "[fcc7:be49:ccd1:dc91:3125:f0da:457d:8ce]",
+    "[fcdc:73ae:b1a9:1bf8:d4c2:811:a4c7:c34e]",
+]
+
+class P2PLocalTxRelay(BitcoinTestFramework):
+    def set_test_params(self):
+        self.disable_autoconnect = False
+        self.num_nodes = 2
+
+    def setup_nodes(self):
+        # Start a SOCKS5 proxy server.
+        socks5_server_config = Socks5Configuration()
+        # self.nodes[0] listens on p2p_port(0),
+        # self.nodes[1] listens on p2p_port(1),
+        # thus we tell the SOCKS5 server to listen on p2p_port(self.num_nodes (which is 2))
+        socks5_server_config.addr = ("127.0.0.1", p2p_port(self.num_nodes))
+        socks5_server_config.unauth = True
+        socks5_server_config.auth = True
+
+        self.socks5_server = Socks5Server(socks5_server_config)
+        self.socks5_server.start()
+
+        ports_base = p2p_port(MAX_NODES) + 15000
+
+        for i in range(NUM_INITIAL_CONNECTIONS + SENSITIVE_RELAY_NUM_BROADCAST_PER_TX + 2): # Add 2 because one feeler and one extra block relay connections may sneak in between the sensitive relay connections.
+            if i == NUM_INITIAL_CONNECTIONS:
+                # Instruct the SOCKS5 server to redirect the first sensitive relay connection from nodes[0] to nodes[1]
+                self.socks5_server.conf.destinations.append({
+                    "listen_addr": "127.0.0.1", # nodes[1] listen address
+                    "listen_port": p2p_port(1), # nodes[1] listen port
+                    "node": None,
+                    "requested_to_addr": None,
+                })
+            else:
+                # Create a Python P2P listening node and add it to self.socks5_server.conf.destinations[]
+                listener = P2PInterface()
+                listener.peer_connect_helper(dstaddr="0.0.0.0", dstport=0, net=self.chain, timeout_factor=self.options.timeout_factor)
+                listener.peer_connect_send_version(services=P2P_SERVICES)
+                self.network_thread.listen(
+                    p2p=listener,
+                    # Instruct the SOCKS5 server to redirect a connection to this Python P2P listener.
+                    callback=lambda addr, port: self.socks5_server.conf.destinations.append({
+                        "listen_addr": addr,
+                        "listen_port": port,
+                        "node": None,
+                        "requested_to_addr": None,
+                    }),
+                    addr="127.0.0.1",
+                    port=ports_base + i)
+                # Wait until the callback has been called and it has done append().
+                self.wait_until(lambda: len(self.socks5_server.conf.destinations) == i + 1)
+
+                self.socks5_server.conf.destinations[i]["node"] = listener
+
+        self.extra_args = [
+            [
+                "-peerbloomfilters", # needed to test replies to MEMPOOL
+                "-cjdnsreachable", # needed to be able to add CJDNS addresses to addrman (otherwise they are unroutable).
+                "-sensitiverelayowntx",
+                f"-proxy={socks5_server_config.addr[0]}:{socks5_server_config.addr[1]}",
+            ],
+            [
+                "-connect=0",
+                f"-bind=127.0.0.1:{p2p_port(1)}=onion", # consider all incoming as coming from Tor
+            ],
+        ]
+        super().setup_nodes()
+
+    def setup_network(self):
+        self.setup_nodes()
+
+    def run_test(self):
+        node0 = self.nodes[0]
+
+        observer_inbound = node0.add_p2p_connection(P2PDataStore())
+
+        # Fill node0's addrman.
+        for addr in addresses:
+            res = node0.addpeeraddress(address=addr, port=8333, tried=False)
+            if res["success"]:
+                self.log.debug(f"Added {addr} to node0's addrman")
+            else:
+                self.log.debug(f"Could not add {addr} to node0's addrman (collision?)")
+
+        self.wait_until(lambda: self.socks5_server.conf.destinations_used == NUM_INITIAL_CONNECTIONS)
+
+        node1 = self.nodes[1]
+        far_observer = node1.add_p2p_connection(P2PInterface())
+        assert_equal(len(node1.getrawmempool()), 0)
+
+        # The next opened connections should be "sensitive relay" for sending the transaction.
+
+        miniwallet = MiniWallet(node0)
+        tx = miniwallet.send_self_transfer(from_node=node0)
+        self.log.info(f"Created transaction txid={tx['txid']}")
+
+        self.log.debug(f"Inspecting outbound connection i={NUM_INITIAL_CONNECTIONS}")
+        self.wait_until(lambda: len(node1.getrawmempool()) > 0)
+        far_observer.wait_for_tx(tx["txid"])
+        self.log.debug(f"Outbound connection i={NUM_INITIAL_CONNECTIONS} another bitcoind further relayed the transaction")
+
+        num_sensitive_relay_opened = 1 # already 1 connection to node1, confirmed by far_observer getting the tx
+        for i in range(NUM_INITIAL_CONNECTIONS + 1, len(self.socks5_server.conf.destinations)):
+            self.log.debug(f"Inspecting outbound connection i={i}")
+            # At this point the connection may not yet have been established (A),
+            # may be active (B), or may have already been closed (C).
+            peer = self.socks5_server.conf.destinations[i]["node"]
+            peer.wait_until(lambda: peer.message_count["version"] == 1, check_connected=False)
+            # Now it is either (B) or (C).
+            requested_to_addr = self.socks5_server.conf.destinations[i]["requested_to_addr"]
+            if peer.last_message["version"].nServices != 0:
+                self.log.debug(f"Outbound connection i={i} to {requested_to_addr} not a sensitive relay, ignoring it (maybe feeler or extra block only)")
+                continue
+            self.log.debug(f"Outbound connection i={i} to {requested_to_addr} must be a sensitive relay, checking it")
+            assert requested_to_addr.endswith(".onion")
+            peer.wait_for_disconnect()
+            # Now it is (C).
+            assert_equal(peer.message_count, {
+                "version": 1,
+                "verack": 1,
+                "tx": 1,
+                "ping": 1
+            })
+            dummy_address = CAddress()
+            dummy_address.nServices = 0
+            assert_equal(peer.last_message["version"].nVersion, P2P_VERSION)
+            assert_equal(peer.last_message["version"].nServices, 0)
+            assert_equal(peer.last_message["version"].nTime, 0)
+            assert_equal(peer.last_message["version"].addrTo, dummy_address)
+            assert_equal(peer.last_message["version"].addrFrom, dummy_address)
+            assert_equal(peer.last_message["version"].strSubVer, "/pynode:0.0.1/")
+            assert_equal(peer.last_message["version"].nStartingHeight, 0)
+            assert_equal(peer.last_message["version"].relay, 0)
+            assert_equal(peer.last_message["tx"].tx.rehash(), tx["txid"])
+            self.log.debug(f"Outbound connection i={i} is proper sensitive relay, test ok")
+            num_sensitive_relay_opened += 1
+            if num_sensitive_relay_opened == SENSITIVE_RELAY_NUM_BROADCAST_PER_TX:
+                break
+        assert_equal(num_sensitive_relay_opened, SENSITIVE_RELAY_NUM_BROADCAST_PER_TX)
+
+        wtxid_int = int(tx["wtxid"], 16)
+        inv = CInv(MSG_WTX, wtxid_int)
+
+        observer_outbound = self.socks5_server.conf.destinations[0]["node"]
+
+        self.log.info("Checking that the node hides the transaction from GETDATA requests")
+        for observer in [observer_inbound, observer_outbound]:
+            observer.last_message.pop("notfound", None)
+            observer.send_message(msg_getdata([inv]))
+            observer.wait_until(lambda: "notfound" in observer.last_message)
+            assert "tx" not in observer.last_message
+
+        self.log.info("Checking that the node hides the transaction from MEMPOOL requests")
+        msg = f"Omitting INV for unbroadcast transaction (txid={tx['txid']}) from MEMPOOL reply".encode("utf-8")
+        for observer in [observer_inbound, observer_outbound]:
+            with node0.wait_for_debug_log([msg]):
+                observer.send_message(msg_mempool())
+            assert "tx" not in observer.last_message
+
+        self.log.info("Sending INV from an observer and waiting for GETDATA from node")
+        observer_inbound.tx_store[wtxid_int] = tx["tx"]
+        msg = f"Received own transaction (txid={tx['txid']}) from the network".encode("utf-8")
+        with node0.wait_for_debug_log(expected_msgs=[msg]):
+            observer_inbound.send_message(msg_inv([inv]))
+
+        self.log.info("Waiting for normal broadcast to another observer")
+        observer_outbound.wait_for_inv([inv])
+
+
+if __name__ == "__main__":
+    P2PLocalTxRelay().main()

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -197,7 +197,12 @@ class P2PConnection(asyncio.Protocol):
     def connection_made(self, transport):
         """asyncio callback when a connection is opened."""
         assert not self._transport
-        logger.debug("Connected & Listening: %s:%d" % (self.dstaddr, self.dstport))
+        info = transport.get_extra_info("socket")
+        us = info.getsockname()
+        them = info.getpeername()
+        logger.debug(f"Connected: us={us[0]}:{us[1]}, them={them[0]}:{them[1]}")
+        self.dstaddr = them[0]
+        self.dstport = them[1]
         self._transport = transport
         if self.on_connection_send_msg:
             self.send_message(self.on_connection_send_msg)

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -668,12 +668,13 @@ class P2PDataStore(P2PInterface):
         self.getdata_requests = []
 
     def on_getdata(self, message):
-        """Check for the tx/block in our stores and if found, reply with an inv message."""
+        """Check for the tx/block in our stores and if found, reply with MSG_TX or MSG_BLOCK."""
         for inv in message.inv:
             self.getdata_requests.append(inv.hash)
-            if (inv.type & MSG_TYPE_MASK) == MSG_TX and inv.hash in self.tx_store.keys():
+            invtype = inv.type & MSG_TYPE_MASK
+            if (invtype == MSG_TX or invtype == MSG_WTX) and inv.hash in self.tx_store.keys():
                 self.send_message(msg_tx(self.tx_store[inv.hash]))
-            elif (inv.type & MSG_TYPE_MASK) == MSG_BLOCK and inv.hash in self.block_store.keys():
+            elif invtype == MSG_BLOCK and inv.hash in self.block_store.keys():
                 self.send_message(msg_block(self.block_store[inv.hash]))
             else:
                 logger.debug('getdata message type {} received.'.format(hex(inv.type)))

--- a/test/functional/test_framework/socks5.py
+++ b/test/functional/test_framework/socks5.py
@@ -4,6 +4,7 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Dummy Socks5 server for testing."""
 
+import select
 import socket
 import threading
 import queue
@@ -41,6 +42,16 @@ class Socks5Configuration():
         self.unauth = False  # Support unauthenticated
         self.auth = False  # Support authentication
         self.keep_alive = False  # Do not automatically close connections
+        # An array of objects like:
+        # {
+        #     "listen_addr": "127.0.0.1"
+        #     "listen_port": 28276
+        #     "node": python_p2p_node,
+        #     "requested_to_addr": "the_client_asked_to_connect_to_this_addr.onion",
+        # }
+        # Redirect the i'th connection to destinations[i] listen_addr:listen_port
+        self.destinations = []
+        self.destinations_used = 0
 
 class Socks5Command():
     """Information about an incoming socks5 command."""
@@ -117,6 +128,33 @@ class Socks5Connection():
             cmdin = Socks5Command(cmd, atyp, addr, port, username, password)
             self.serv.queue.put(cmdin)
             logger.debug('Proxy: %s', cmdin)
+
+            num_destinations = len(self.serv.conf.destinations)
+            if self.serv.conf.destinations_used < num_destinations:
+                dest = self.serv.conf.destinations[self.serv.conf.destinations_used]
+                dest["requested_to_addr"] = addr.decode("utf-8")
+                self.serv.conf.destinations_used += 1
+                with socket.create_connection((dest["listen_addr"], dest["listen_port"])) as conn_to:
+                    self.conn.setblocking(False)
+                    conn_to.setblocking(False)
+                    sockets = [self.conn, conn_to]
+                    done = False
+                    while not done:
+                        rlist, _, xlist = select.select(sockets, [], sockets)
+                        if len(xlist) > 0:
+                            raise IOError("Exceptional condition on socket")
+                        for s in rlist:
+                            data = s.recv(4096)
+                            if data is None or len(data) == 0:
+                                done = True
+                                break
+                            if s == self.conn:
+                                conn_to.sendall(data)
+                            else:
+                                self.conn.sendall(data)
+            elif num_destinations > 0:
+                logger.warning(f"It was requested to redirect the first {num_destinations} connections to the SOCKS5 proxy. Closing subsequent connection without redirecting it.")
+
             # Fall through to disconnect
         except Exception as e:
             logger.exception("socks5 request handling failed.")

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -304,6 +304,7 @@ BASE_SCRIPTS = [
     'rpc_dumptxoutset.py',
     'feature_minchainwork.py',
     'rpc_estimatefee.py',
+    'p2p_local_tx_relay.py',
     'rpc_getblockstats.py',
     'feature_bind_port_externalip.py',
     'wallet_create_tx.py --legacy-wallet',


### PR DESCRIPTION
To improve privacy, relay locally submitted transactions (from the wallet or via RPC) to the P2P network only via Tor or I2P short-lived connections.

* Introduce a new connection type for relaying sensitive data (our own transactions) with the following properties:
  * started whenever there are local unbroadcast transactions to be sent
  * only opened to Tor or I2P peers
  * opened regardless of max connections limits
  * after handshake is completed one local transaction is pushed to the peer and the connection is closed
  * ignore all incoming messages after handshake is completed

* Relay locally submitted transactions (from the wallet or via RPC) using this new mechanism, to a few Tor or I2P peers.

* Hide those transactions from `GETDATA` and `MEMPOOL` requests, as if we don't have them.

* Once we get an `INV` from somebody, request the transaction with `GETDATA`, as if we didn't have it before.

* After we receive the full transaction as a `TX` message, in reply to our `GETDATA` request, only then consider the transaction has propagated through the network and remove it from the unbroadcast list.

* `INV` it to others as a result of the `TX` message we get, like what we do with transactions that are not ours.

The messages exchange should look like this:

```
tx-sender >--- connect -------> tx-recipient
tx-sender >--- VERSION -------> tx-recipient
tx-sender <--- VERSION -------< tx-recipient
tx-sender <--- WTXIDRELAY ----< tx-recipient (maybe) 
tx-sender <--- SENDADDRV2 ----< tx-recipient (maybe) 
tx-sender <--- SENDTXRCNCL ---< tx-recipient (maybe) 
tx-sender <--- VERACK --------< tx-recipient
tx-sender >--- VERACK --------> tx-recipient
tx-sender >--- TX ------------> tx-recipient
tx-sender >--- PING ----------> tx-recipient
tx-sender <--- PONG ----------< tx-recipient
tx-sender disconnects
```

Whenever a new local transaction is received (from the wallet or RPC), the node will send it to 5 (`SENSITIVE_RELAY_NUM_BROADCAST_PER_TX`) recipients right away. If after 10-15 mins we still have not heard anything about the transaction from the network, then it will be sent to 5 more peers (see `PeerManagerImpl::ReattemptInitialBroadcast()`).

A few considerations:
* The short-lived sensitive relay connections are very cheap and fast wrt network traffic. It is expected that some of those peers will blackhole the transaction. Just one honest/proper peer is enough for successful propagation.
* The peers that receive the transaction could deduce that this is initial transaction broadcast from the transaction originator. This is ok, they can't identify the sender.

TODO:
* [x] Disable if `-connect` is used or Tor and I2P are not reachable.
* [x] Use I2P transient connections even if listening on I2P.
* [x] Do something with the user-agent string (could reveal identity if it has been personalized) and make sure no identifying information in the `VERSION` message. Done: took the [suggestion below](https://github.com/bitcoin/bitcoin/pull/27509#issuecomment-1517896418).
* [x] Improve the condition when we consider the transaction seen by the network: right now a single INV from somebody suffices (this is still an improvement over `master` which is ok right after pushing the tx to a peer). We could wait for more than one INV, from peers that we have selected (outbound) and that are specifically not the ones we broadcasted to (via short-lived connection). Edit: One `INV` should be enough because after that we broadcast the transaction to everybody we are connected to (like if it is not ours).
* [ ] Idea: start with one connection per transaction (not 5 as it is now), optimistically assuming it will be sufficient. (numbers are examples) After 1 minute, if still not received from the network, try 2 connections, after a few minutes try more. If still unsuccessful after 10 minutes, then fall back to the old mechanism.

This is supposed to address:
https://github.com/bitcoin/bitcoin/issues/3828
https://github.com/bitcoin/bitcoin/issues/14692
https://github.com/bitcoin/bitcoin/issues/19042
https://github.com/bitcoin/bitcoin/issues/24557
https://github.com/bitcoin/bitcoin/issues/25450
