### PR TITLE
rpc: Add test-only RPC getaddrmaninfo for new/tried table address count

### DIFF
--- a/src/test/fuzz/rpc.cpp
+++ b/src/test/fuzz/rpc.cpp
@@ -110,6 +110,7 @@ const std::vector<std::string> RPC_COMMANDS_SAFE_FOR_FUZZING{
     "generate",
     "generateblock",
     "getaddednodeinfo",
+    "getaddrmaninfo",
     "getbestblockhash",
     "getblock",
     "getblockchaininfo",

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -66,6 +66,7 @@ class NetTest(BitcoinTestFramework):
         self.test_getnodeaddresses()
         self.test_addpeeraddress()
         self.test_sendmsgtopeer()
+        self.test_getaddrmaninfo()
 
     def test_connection_count(self):
         self.log.info("Test getconnectioncount")
@@ -360,6 +361,28 @@ class NetTest(BitcoinTestFramework):
         node.sendmsgtopeer(peer_id=0, msg_type="addr", msg=zero_byte_string.hex())
         self.wait_until(lambda: len(self.nodes[0].getpeerinfo()) == 0, timeout=10)
 
+    def test_getaddrmaninfo(self):
+        self.log.info("Test getaddrmaninfo")
+        node = self.nodes[1]
+
+        self.log.debug("Test that getaddrmaninfo is a hidden RPC")
+        # It is hidden from general help, but its detailed help may be called directly.
+        assert "getaddrmaninfo" not in node.help()
+        assert "getaddrmaninfo" in node.help("getaddrmaninfo")
+
+        # current count of ipv4 addresses in addrman is {'new':1, 'tried':1}
+        self.log.info("Test that count of addresses in addrman match expected values")
+        res = node.getaddrmaninfo()
+        assert_equal(res["ipv4"]["new"], 1)
+        assert_equal(res["ipv4"]["tried"], 1)
+        assert_equal(res["ipv4"]["total"], 2)
+        assert_equal(res["all_networks"]["new"], 1)
+        assert_equal(res["all_networks"]["tried"], 1)
+        assert_equal(res["all_networks"]["total"], 2)
+        for net in ["ipv6", "onion", "i2p", "cjdns"]:
+            assert_equal(res[net]["new"], 0)
+            assert_equal(res[net]["tried"], 0)
+            assert_equal(res[net]["total"], 0)
 
 if __name__ == '__main__':
     NetTest().main()


### PR DESCRIPTION
implements https://github.com/bitcoin/bitcoin/issues/26907. split off from #26988 to keep RPC, CLI discussions separate.

This PR introduces a new RPC `getaddrmaninfo`which returns the count of addresses in the new/tried table of a node's addrman broken down by network type. This would be useful for users who want to see the distribution of addresses from different networks across new/tried table in the addrman.

```jsx
$ getaddrmaninfo

Result:
{                   (json object) json object with network type as keys
  "network" : {     (json object) The network (ipv4, ipv6, onion, i2p, cjdns)
    "new" : n,      (numeric) number of addresses in new table
    "tried" : n,    (numeric) number of addresses in tried table
    "total" : n     (numeric) total number of addresses in both new/tried tables from a network
  },
  ...
}
```

### additional context from [original PR](https://github.com/bitcoin/bitcoin/pull/26988)

1. network coverage tests were skipped because there’s a small chance that addresses from different networks could hash to the same bucket and cause count of different network addresses in the tests to fail. see https://github.com/bitcoin/bitcoin/pull/26988#discussion_r1137596851.
2. #26988 uses this RPC in -addrinfo CLI. Slight preference for keeping the RPC hidden since this info will mostly be useful to only super users. see https://github.com/bitcoin/bitcoin/pull/26988#discussion_r1173964808.