### PR TITLE
test: fix `feature_addrman.py` on big-endian systems

### DIFF
--- a/test/functional/feature_addrman.py
+++ b/test/functional/feature_addrman.py
@@ -32,12 +32,12 @@ def serialize_addrman(
     r += struct.pack("B", format)
     r += struct.pack("B", INCOMPATIBILITY_BASE + lowest_compatible)
     r += ser_uint256(bucket_key)
-    r += struct.pack("i", len_new or len(new))
-    r += struct.pack("i", len_tried or len(tried))
+    r += struct.pack("<i", len_new or len(new))
+    r += struct.pack("<i", len_tried or len(tried))
     ADDRMAN_NEW_BUCKET_COUNT = 1 << 10
-    r += struct.pack("i", ADDRMAN_NEW_BUCKET_COUNT ^ (1 << 30))
+    r += struct.pack("<i", ADDRMAN_NEW_BUCKET_COUNT ^ (1 << 30))
     for _ in range(ADDRMAN_NEW_BUCKET_COUNT):
-        r += struct.pack("i", 0)
+        r += struct.pack("<i", 0)
     checksum = hash256(r)
     r += mock_checksum or checksum
     return r


### PR DESCRIPTION
The test `feature_addrman.py` currently serializes the addrdb without specifying endianness for `int`s, so the machine's native byte order is used (see https://docs.python.org/3/library/struct.html#byte-order-size-and-alignment) and the generated `peers.dat` would be invalid on big-endian systems (our internal (de)serializers always use little-endian, see `ser_{read,write}data32`). Fix this by explicitly specifying little-endian serialization via the `<` character in `struct.pack(...)`.

This is not detected by CI as we unfortunately don't run functional tests on big-endian systems there (I think we definitely should!).