### PR TITLE
Remove now-unnecessary poll, fcntl includes from net(base).cpp

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -37,16 +37,10 @@
 
 #ifdef WIN32
 #include <string.h>
-#else
-#include <fcntl.h>
 #endif
 
 #if HAVE_DECL_GETIFADDRS && HAVE_DECL_FREEIFADDRS
 #include <ifaddrs.h>
-#endif
-
-#ifdef USE_POLL
-#include <poll.h>
 #endif
 
 #include <algorithm>

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -21,14 +21,6 @@
 #include <limits>
 #include <memory>
 
-#ifndef WIN32
-#include <fcntl.h>
-#endif
-
-#ifdef USE_POLL
-#include <poll.h>
-#endif
-
 // Settings
 static GlobalMutex g_proxyinfo_mutex;
 static Proxy proxyInfo[NET_MAX] GUARDED_BY(g_proxyinfo_mutex);


### PR DESCRIPTION
As far as I can tell, the code calling for these includes was removed in:
6e68ccbefea6509c61fc4405a391a517c6057bb0 #24356
82d360b5a88d9057b6c09b61cd69e426c7a2412d #21387