### PR TITLE
test: Remove modinv python util helper function

### DIFF
--- a/test/functional/test_framework/key.py
+++ b/test/functional/test_framework/key.py
@@ -13,8 +13,6 @@ import os
 import random
 import unittest
 
-from .util import modinv
-
 # Point with no known discrete log.
 H_POINT = "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0"
 
@@ -78,7 +76,7 @@ class EllipticCurve:
         x1, y1, z1 = p1
         if z1 == 0:
             return None
-        inv = modinv(z1, self.p)
+        inv = pow(z1, -1, self.p)
         inv_2 = (inv**2) % self.p
         inv_3 = (inv_2 * inv) % self.p
         return ((inv_2 * x1) % self.p, (inv_3 * y1) % self.p, 1)
@@ -319,7 +317,7 @@ class ECPubKey():
         z = int.from_bytes(msg, 'big')
 
         # Run verifier algorithm on r, s
-        w = modinv(s, SECP256K1_ORDER)
+        w = pow(s, -1, SECP256K1_ORDER)
         u1 = z*w % SECP256K1_ORDER
         u2 = r*w % SECP256K1_ORDER
         R = SECP256K1.affine(SECP256K1.mul([(SECP256K1_G, u1), (self.p, u2)]))
@@ -397,7 +395,7 @@ class ECKey():
             k = random.randrange(1, SECP256K1_ORDER)
         R = SECP256K1.affine(SECP256K1.mul([(SECP256K1_G, k)]))
         r = R[0] % SECP256K1_ORDER
-        s = (modinv(k, SECP256K1_ORDER) * (z + self.secret * r)) % SECP256K1_ORDER
+        s = (pow(k, -1, SECP256K1_ORDER) * (z + self.secret * r)) % SECP256K1_ORDER
         if low_s and s > SECP256K1_ORDER_HALF:
             s = SECP256K1_ORDER - s
         # Represent in DER format. The byte representations of r and s have

--- a/test/functional/test_framework/muhash.py
+++ b/test/functional/test_framework/muhash.py
@@ -6,8 +6,6 @@
 import hashlib
 import unittest
 
-from .util import modinv
-
 def rot32(v, bits):
     """Rotate the 32-bit value v left by bits bits."""
     bits %= 32  # Make sure the term below does not throw an exception
@@ -88,7 +86,7 @@ class MuHash3072:
 
     def digest(self):
         """Extract the final hash. Does not modify this object."""
-        val = (self.numerator * modinv(self.denominator, self.MODULUS)) % self.MODULUS
+        val = (self.numerator * pow(self.denominator, -1, self.MODULUS)) % self.MODULUS
         bytes384 = val.to_bytes(384, 'little')
         return hashlib.sha256(bytes384).digest()
 

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -15,7 +15,6 @@ import os
 import random
 import re
 import time
-import unittest
 
 from . import coverage
 from .authproxy import AuthServiceProxy, JSONRPCException
@@ -537,22 +536,3 @@ def find_vout_for_address(node, txid, addr):
         if addr == tx["vout"][i]["scriptPubKey"]["address"]:
             return i
     raise RuntimeError("Vout not found for address: txid=%s, addr=%s" % (txid, addr))
-
-def modinv(a, n):
-    """Compute the modular inverse of a modulo n using the extended Euclidean
-    Algorithm. See https://en.wikipedia.org/wiki/Extended_Euclidean_algorithm#Modular_integers.
-    """
-    return pow(a, -1, n)
-
-class TestFrameworkUtil(unittest.TestCase):
-    def test_modinv(self):
-        test_vectors = [
-            [7, 11],
-            [11, 29],
-            [90, 13],
-            [1891, 3797],
-            [6003722857, 77695236973],
-        ]
-
-        for a, n in test_vectors:
-            self.assertEqual(modinv(a, n), pow(a, n-2, n))


### PR DESCRIPTION
Since #27483 was merged the `modinv()` body is just one line calling pythons own implementation of `pow()`. We can just remove the function as it doesn't seem to add any value. Additionally the comment in the function is now outdated and the test is only testing two ways of doing modular inverse but both using python's `pow()` function.