### PR TITLE
init: Fixes for file descriptor accounting

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -969,7 +969,7 @@ bool AppInitParameterInteraction(const ArgsManager& args)
     }
 
     // Make sure enough file descriptors are available
-    int nBind = std::max(nUserBind, size_t(1));
+    const int nBind = std::max(nUserBind, size_t(1));
     nUserMaxConnections = args.GetIntArg("-maxconnections", DEFAULT_MAX_PEER_CONNECTIONS);
     nMaxConnections = std::max(nUserMaxConnections, 0);
 


### PR DESCRIPTION
This rebases and revises #16003 for clarity of review.

Aims to fix #18911.