### PR TITLE
test: add ripemd160 to test framework modules list

### DIFF
--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -69,11 +69,14 @@ if os.name != 'nt' or sys.getwindowsversion() >= (10, 0, 14393): #type:ignore
 TEST_EXIT_PASSED = 0
 TEST_EXIT_SKIPPED = 77
 
+# List of framework modules containing unit tests. Should be kept in sync with
+# the output of `git grep unittest.TestCase ./test/functional/test_framework`
 TEST_FRAMEWORK_MODULES = [
     "address",
     "blocktools",
     "muhash",
     "key",
+    "ripemd160",
     "script",
     "segwit_addr",
     "util",


### PR DESCRIPTION
Currently test runner doesn't execute the unit tests of the ripemd160 module, so add it to the list. All other framework modules that contain unit tests are included, as can be easily checked via
`$ git grep unittest.TestCase ./test/functional/test_framework/`

This is a late follow-up to PR #23716 (commit ad3e9e1f214d739e098c6ebbd300da5df1026a44).