### PR TITLE
ci: Add test coverage job

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -317,6 +317,19 @@ task:
     << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
 
 task:
+  name: 'code coverage [jammy]'
+  << : *GLOBAL_TASK_TEMPLATE
+  container:
+    cpu: 4
+    docker_arguments:
+      CI_IMAGE_NAME_TAG: ubuntu:jammy
+      FILE_ENV: "./ci/test/00_setup_env_native_coverage.sh"
+  env:
+    << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
+    MAKEJOBS: "-j4"
+    CODECOV_TOKEN: ENCRYPTED[!ecde4475f93a3607c87a3abaea30a6692c19c658e1b924130ad15b317e44d5f1abdd596984036eada4eeded24384cbd2!]
+
+task:
   name: 'macOS 10.15 [gui, no tests] [focal]'
   << : *CONTAINER_DEPENDS_TEMPLATE
   container:

--- a/Makefile.am
+++ b/Makefile.am
@@ -197,7 +197,6 @@ baseline_filtered.info: baseline.info
 fuzz.info: baseline_filtered.info
 	@TIMEOUT=15 test/fuzz/test_runner.py $(DIR_FUZZ_SEED_CORPUS) -l DEBUG
 	$(LCOV) -c $(LCOV_OPTS) -d $(abs_builddir)/src --t fuzz-tests -o $@
-	$(LCOV) -z $(LCOV_OPTS) -d $(abs_builddir)/src
 
 fuzz_filtered.info: fuzz.info
 	$(abs_builddir)/contrib/filter-lcov.py $(LCOV_FILTER_PATTERN) $< $@
@@ -206,7 +205,6 @@ fuzz_filtered.info: fuzz.info
 test_bitcoin.info: baseline_filtered.info
 	$(MAKE) -C src/ check
 	$(LCOV) -c $(LCOV_OPTS) -d $(abs_builddir)/src -t test_bitcoin -o $@
-	$(LCOV) -z $(LCOV_OPTS) -d $(abs_builddir)/src
 
 test_bitcoin_filtered.info: test_bitcoin.info
 	$(abs_builddir)/contrib/filter-lcov.py $(LCOV_FILTER_PATTERN) $< $@
@@ -215,7 +213,6 @@ test_bitcoin_filtered.info: test_bitcoin.info
 functional_test.info: test_bitcoin_filtered.info
 	@TIMEOUT=15 test/functional/test_runner.py $(EXTENDED_FUNCTIONAL_TESTS)
 	$(LCOV) -c $(LCOV_OPTS) -d $(abs_builddir)/src --t functional-tests -o $@
-	$(LCOV) -z $(LCOV_OPTS) -d $(abs_builddir)/src
 
 functional_test_filtered.info: functional_test.info
 	$(abs_builddir)/contrib/filter-lcov.py $(LCOV_FILTER_PATTERN) $< $@

--- a/Makefile.am
+++ b/Makefile.am
@@ -211,7 +211,7 @@ test_bitcoin_filtered.info: test_bitcoin.info
 	$(LCOV) -a $@ $(LCOV_OPTS) -o $@
 
 functional_test.info: test_bitcoin_filtered.info
-	@TIMEOUT=15 test/functional/test_runner.py $(EXTENDED_FUNCTIONAL_TESTS)
+	@TIMEOUT=15 test/functional/test_runner.py $(TEST_RUNNER_ARGS)
 	$(LCOV) -c $(LCOV_OPTS) -d $(abs_builddir)/src --t functional-tests -o $@
 
 functional_test_filtered.info: functional_test.info

--- a/ci/test/00_setup_env_native_coverage.sh
+++ b/ci/test/00_setup_env_native_coverage.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2023 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C.UTF-8
+
+export CONTAINER_NAME=ci_native_coverage
+export CI_IMAGE_NAME_TAG="ubuntu:23.04"
+export PACKAGES="gcc g++ git python3-zmq libevent-dev libboost-dev libdb5.3++-dev libsqlite3-dev libminiupnpc-dev libzmq3-dev lcov build-essential libtool autotools-dev automake pkg-config bsdmainutils bsdextrautils libxml2-dev python3-pip python3-dev ccache"
+export DEP_OPTS="NO_QT=1 NO_NATPMP=1 NO_UPNP=1 NO_ZMQ=1 NO_USDT=1"
+export RUN_UNIT_TESTS="false"
+export RUN_FUNCTIONAL_TESTS="false"
+export RUN_COVERAGE="true"
+export UPLOAD_COVERAGE="true"
+export TEST_RUNNER_ARGS="--timeout-factor=10 --exclude=feature_dbcrash $MAKEJOBS"
+export GOAL="install"
+export NO_WERROR=1
+export DOWNLOAD_PREVIOUS_RELEASES="true"
+export BDB_PREFIX="/tmp/cirrus-ci-build/depends/x86_64-pc-linux-gnu"
+export BITCOIN_CONFIG="--disable-fuzz --enable-fuzz-binary=no --with-gui=no --disable-bench BDB_LIBS=\"-L${BDB_PREFIX}/lib -ldb_cxx-4.8\" BDB_CFLAGS=\"-I${BDB_PREFIX}/include\" --enable-lcov"

--- a/ci/test/06_script_b.sh
+++ b/ci/test/06_script_b.sh
@@ -173,3 +173,15 @@ fi
 if [ "$RUN_FUZZ_TESTS" = "true" ]; then
   bash -c "LD_LIBRARY_PATH=${DEPENDS_DIR}/${HOST}/lib test/fuzz/test_runner.py ${FUZZ_TESTS_CONFIG} $MAKEJOBS -l DEBUG ${DIR_FUZZ_IN}"
 fi
+
+if [ "$RUN_COVERAGE" = "true" ]; then
+  make cov
+  geninfo . -b src -o coverage.info
+  if [ "$UPLOAD_COVERAGE" = "true" ]; then
+    if [ ! -f codecov ]; then
+      curl -Os https://uploader.codecov.io/latest/linux/codecov
+      chmod +x codecov
+    fi
+    ./codecov -t "$CODECOV_TOKEN"
+  fi
+fi

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: false

--- a/configure.ac
+++ b/configure.ac
@@ -198,11 +198,6 @@ AC_ARG_ENABLE(bench,
     [use_bench=$enableval],
     [use_bench=yes])
 
-AC_ARG_ENABLE([extended-functional-tests],
-    AS_HELP_STRING([--enable-extended-functional-tests],[enable expensive functional tests when using lcov (default no)]),
-    [use_extended_functional_tests=$enableval],
-    [use_extended_functional_tests=no])
-
 AC_ARG_ENABLE([fuzz],
     AS_HELP_STRING([--enable-fuzz],
     [build for fuzzing (default no). enabling this will disable all other targets and override --{enable,disable}-fuzz-binary]),
@@ -840,10 +835,6 @@ case $host in
      TARGET_OS=linux
      ;;
 esac
-
-if test "$use_extended_functional_tests" != "no"; then
-  AC_SUBST(EXTENDED_FUNCTIONAL_TESTS, --extended)
-fi
 
 if test "$use_lcov" = "yes"; then
   if test "$LCOV" = ""; then


### PR DESCRIPTION
This PR adds a new Cirrus job that generates test coverage reports for all pull requests and master using [Codecov](https://about.codecov.io/). It is free for open-source projects.
We can now quickly determine whether a feature that a pull request adds is properly tested.

I've ran a few tests on my own fork, you can check it out here: https://app.codecov.io/gh/aureleoules/bitcoin and a test pull request: https://app.codecov.io/gh/aureleoules/bitcoin/pull/5.

Codecov has a nice feature that highlights the untested chunks of code directly in the GitHub's "Files changed" tab of a pull request. See for example https://github.com/aureleoules/bitcoin/pull/5/files.

<details>
<summary>Example</summary>

![image](https://user-images.githubusercontent.com/22493292/235375705-61d33a36-e96c-42d1-864c-09c594638144.png)

</details>


It can also generate a GitHub comment with a brief summary of the coverage: https://github.com/aureleoules/bitcoin/pull/5#issuecomment-1528823591.
Though, that may be undesirable considering Drahtbot already comments on pulls. It can be turned off.

<details>
<summary>Example</summary>

![image](https://user-images.githubusercontent.com/22493292/235375727-4f68a46b-f524-4a3a-ba65-f477b3f114d7.png)

</details>

These are the permissions Codecov needs to work:
![image](https://user-images.githubusercontent.com/22493292/235375827-017ab26a-1931-4fea-8615-5bbed52342db.png)


19212b413e518908fa73147b665d8599b7a2f016 also fixes #26736.