### PR TITLE
Reduce calls to various SetNull methods

### DIFF
--- a/src/bench/duplicate_inputs.cpp
+++ b/src/bench/duplicate_inputs.cpp
@@ -33,7 +33,6 @@ static void DuplicateInputs(benchmark::Bench& bench)
 
     // Make a coinbase TX
     coinbaseTx.vin.resize(1);
-    coinbaseTx.vin[0].prevout.SetNull();
     coinbaseTx.vout.resize(1);
     coinbaseTx.vout[0].scriptPubKey = SCRIPT_PUB;
     coinbaseTx.vout[0].nValue = GetBlockSubsidy(nHeight, chainparams.GetConsensus());

--- a/src/bench/mempool_eviction.cpp
+++ b/src/bench/mempool_eviction.cpp
@@ -55,10 +55,8 @@ static void MempoolEviction(benchmark::Bench& bench)
 
     CMutableTransaction tx4 = CMutableTransaction();
     tx4.vin.resize(2);
-    tx4.vin[0].prevout.SetNull();
     tx4.vin[0].scriptSig = CScript() << OP_4;
     tx4.vin[0].scriptWitness.stack.push_back({4});
-    tx4.vin[1].prevout.SetNull();
     tx4.vin[1].scriptSig = CScript() << OP_4;
     tx4.vin[1].scriptWitness.stack.push_back({4});
     tx4.vout.resize(2);
@@ -72,7 +70,6 @@ static void MempoolEviction(benchmark::Bench& bench)
     tx5.vin[0].prevout = COutPoint(tx4.GetHash(), 0);
     tx5.vin[0].scriptSig = CScript() << OP_4;
     tx5.vin[0].scriptWitness.stack.push_back({4});
-    tx5.vin[1].prevout.SetNull();
     tx5.vin[1].scriptSig = CScript() << OP_5;
     tx5.vin[1].scriptWitness.stack.push_back({5});
     tx5.vout.resize(2);
@@ -86,7 +83,6 @@ static void MempoolEviction(benchmark::Bench& bench)
     tx6.vin[0].prevout = COutPoint(tx4.GetHash(), 1);
     tx6.vin[0].scriptSig = CScript() << OP_4;
     tx6.vin[0].scriptWitness.stack.push_back({4});
-    tx6.vin[1].prevout.SetNull();
     tx6.vin[1].scriptSig = CScript() << OP_6;
     tx6.vin[1].scriptWitness.stack.push_back({6});
     tx6.vout.resize(2);

--- a/src/bench/wallet_create_tx.cpp
+++ b/src/bench/wallet_create_tx.cpp
@@ -44,7 +44,6 @@ void generateFakeBlock(const CChainParams& params,
     CBlock block;
     CMutableTransaction coinbase_tx;
     coinbase_tx.vin.resize(1);
-    coinbase_tx.vin[0].prevout.SetNull();
     coinbase_tx.vout.resize(2);
     coinbase_tx.vout[0].scriptPubKey = coinbase_out_script;
     coinbase_tx.vout[0].nValue = 49 * COIN;

--- a/src/chain.h
+++ b/src/chain.h
@@ -42,13 +42,13 @@ static constexpr int64_t MAX_BLOCK_TIME_GAP = 90 * 60;
 class CBlockFileInfo
 {
 public:
-    unsigned int nBlocks;      //!< number of blocks stored in file
-    unsigned int nSize;        //!< number of used bytes of block file
-    unsigned int nUndoSize;    //!< number of used bytes in the undo file
-    unsigned int nHeightFirst; //!< lowest height of block in file
-    unsigned int nHeightLast;  //!< highest height of block in file
-    uint64_t nTimeFirst;       //!< earliest time of block in file
-    uint64_t nTimeLast;        //!< latest time of block in file
+    unsigned int nBlocks{};      //!< number of blocks stored in file
+    unsigned int nSize{};        //!< number of used bytes of block file
+    unsigned int nUndoSize{};    //!< number of used bytes in the undo file
+    unsigned int nHeightFirst{}; //!< lowest height of block in file
+    unsigned int nHeightLast{};  //!< highest height of block in file
+    uint64_t nTimeFirst{};       //!< earliest time of block in file
+    uint64_t nTimeLast{};        //!< latest time of block in file
 
     SERIALIZE_METHODS(CBlockFileInfo, obj)
     {
@@ -72,10 +72,7 @@ public:
         nTimeLast = 0;
     }
 
-    CBlockFileInfo()
-    {
-        SetNull();
-    }
+    CBlockFileInfo() = default;
 
     std::string ToString() const;
 

--- a/src/consensus/merkle.cpp
+++ b/src/consensus/merkle.cpp
@@ -76,7 +76,7 @@ uint256 BlockWitnessMerkleRoot(const CBlock& block, bool* mutated)
 {
     std::vector<uint256> leaves;
     leaves.resize(block.vtx.size());
-    leaves[0].SetNull(); // The witness hash of the coinbase is 0.
+    // The witness hash of the coinbase (leaves[0]) is 0.
     for (size_t s = 1; s < block.vtx.size(); s++) {
         leaves[s] = block.vtx[s]->GetWitnessHash();
     }

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -41,7 +41,6 @@ static CBlock CreateGenesisBlock(const char* pszTimestamp, const CScript& genesi
     genesis.nNonce   = nNonce;
     genesis.nVersion = nVersion;
     genesis.vtx.push_back(MakeTransactionRef(std::move(txNew)));
-    genesis.hashPrevBlock.SetNull();
     genesis.hashMerkleRoot = BlockMerkleRoot(genesis);
     return genesis;
 }

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -150,7 +150,6 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     // Create coinbase transaction.
     CMutableTransaction coinbaseTx;
     coinbaseTx.vin.resize(1);
-    coinbaseTx.vin[0].prevout.SetNull();
     coinbaseTx.vout.resize(1);
     coinbaseTx.vout[0].scriptPubKey = scriptPubKeyIn;
     coinbaseTx.vout[0].nValue = nFees + GetBlockSubsidy(nHeight, chainparams.GetConsensus());

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -22,17 +22,14 @@ class CBlockHeader
 {
 public:
     // header
-    int32_t nVersion;
+    int32_t nVersion{};
     uint256 hashPrevBlock;
     uint256 hashMerkleRoot;
-    uint32_t nTime;
-    uint32_t nBits;
-    uint32_t nNonce;
+    uint32_t nTime{};
+    uint32_t nBits{};
+    uint32_t nNonce{};
 
-    CBlockHeader()
-    {
-        SetNull();
-    }
+    CBlockHeader() = default;
 
     SERIALIZE_METHODS(CBlockHeader, obj) { READWRITE(obj.nVersion, obj.hashPrevBlock, obj.hashMerkleRoot, obj.nTime, obj.nBits, obj.nNonce); }
 
@@ -72,16 +69,12 @@ public:
     std::vector<CTransactionRef> vtx;
 
     // memory only
-    mutable bool fChecked;
+    mutable bool fChecked{};
 
-    CBlock()
-    {
-        SetNull();
-    }
+    CBlock() = default;
 
     CBlock(const CBlockHeader &header)
     {
-        SetNull();
         *(static_cast<CBlockHeader*>(this)) = header;
     }
 

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -139,12 +139,6 @@ void SetServiceFlagsIBDCache(bool state) {
     g_initial_block_download_completed = state;
 }
 
-CInv::CInv()
-{
-    type = 0;
-    hash.SetNull();
-}
-
 CInv::CInv(uint32_t typeIn, const uint256& hashIn) : type(typeIn), hash(hashIn) {}
 
 bool operator<(const CInv& a, const CInv& b)

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -477,7 +477,7 @@ enum GetDataMsg : uint32_t {
 class CInv
 {
 public:
-    CInv();
+    CInv() = default;
     CInv(uint32_t typeIn, const uint256& hashIn);
 
     SERIALIZE_METHODS(CInv, obj) { READWRITE(obj.type, obj.hash); }
@@ -505,7 +505,7 @@ public:
         return type == MSG_BLOCK || type == MSG_FILTERED_BLOCK || type == MSG_CMPCT_BLOCK || type == MSG_WITNESS_BLOCK;
     }
 
-    uint32_t type;
+    uint32_t type{};
     uint256 hash;
 };
 

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -482,9 +482,7 @@ BOOST_AUTO_TEST_CASE(MempoolSizeLimitTest)
 
     CMutableTransaction tx4 = CMutableTransaction();
     tx4.vin.resize(2);
-    tx4.vin[0].prevout.SetNull();
     tx4.vin[0].scriptSig = CScript() << OP_4;
-    tx4.vin[1].prevout.SetNull();
     tx4.vin[1].scriptSig = CScript() << OP_4;
     tx4.vout.resize(2);
     tx4.vout[0].scriptPubKey = CScript() << OP_4 << OP_EQUAL;
@@ -496,7 +494,6 @@ BOOST_AUTO_TEST_CASE(MempoolSizeLimitTest)
     tx5.vin.resize(2);
     tx5.vin[0].prevout = COutPoint(tx4.GetHash(), 0);
     tx5.vin[0].scriptSig = CScript() << OP_4;
-    tx5.vin[1].prevout.SetNull();
     tx5.vin[1].scriptSig = CScript() << OP_5;
     tx5.vout.resize(2);
     tx5.vout[0].scriptPubKey = CScript() << OP_5 << OP_EQUAL;
@@ -508,7 +505,6 @@ BOOST_AUTO_TEST_CASE(MempoolSizeLimitTest)
     tx6.vin.resize(2);
     tx6.vin[0].prevout = COutPoint(tx4.GetHash(), 1);
     tx6.vin[0].scriptSig = CScript() << OP_4;
-    tx6.vin[1].prevout.SetNull();
     tx6.vin[1].scriptSig = CScript() << OP_6;
     tx6.vout.resize(2);
     tx6.vout[0].scriptPubKey = CScript() << OP_6 << OP_EQUAL;

--- a/src/test/merkle_tests.cpp
+++ b/src/test/merkle_tests.cpp
@@ -342,7 +342,6 @@ BOOST_AUTO_TEST_CASE(merkle_test_BlockWitness)
 
     std::vector<uint256> hashes;
     hashes.resize(block.vtx.size());
-    hashes[0].SetNull();
     hashes[1] = block.vtx[1]->GetHash();
 
     uint256 merkleRootofHashes = ComputeMerkleRoot(hashes);

--- a/src/test/sigopcount_tests.cpp
+++ b/src/test/sigopcount_tests.cpp
@@ -87,7 +87,6 @@ static void BuildTxs(CMutableTransaction& spendingTx, CCoinsViewCache& coins, CM
 {
     creationTx.nVersion = 1;
     creationTx.vin.resize(1);
-    creationTx.vin[0].prevout.SetNull();
     creationTx.vin[0].scriptSig = CScript();
     creationTx.vout.resize(1);
     creationTx.vout[0].nValue = 1;

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -413,7 +413,6 @@ static void CreateCreditAndSpend(const FillableSigningProvider& keystore, const 
     CMutableTransaction outputm;
     outputm.nVersion = 1;
     outputm.vin.resize(1);
-    outputm.vin[0].prevout.SetNull();
     outputm.vin[0].scriptSig = CScript();
     outputm.vout.resize(1);
     outputm.vout[0].nValue = 1;

--- a/src/test/util/mining.cpp
+++ b/src/test/util/mining.cpp
@@ -36,7 +36,6 @@ std::vector<std::shared_ptr<CBlock>> CreateBlockChain(size_t total_height, const
 
         CMutableTransaction coinbase_tx;
         coinbase_tx.vin.resize(1);
-        coinbase_tx.vin[0].prevout.SetNull();
         coinbase_tx.vout.resize(1);
         coinbase_tx.vout[0].scriptPubKey = P2WSH_OP_TRUE;
         coinbase_tx.vout[0].nValue = GetBlockSubsidy(height + 1, params.GetConsensus());

--- a/src/test/util/transaction_utils.cpp
+++ b/src/test/util/transaction_utils.cpp
@@ -13,7 +13,6 @@ CMutableTransaction BuildCreditingTransaction(const CScript& scriptPubKey, int n
     txCredit.nLockTime = 0;
     txCredit.vin.resize(1);
     txCredit.vout.resize(1);
-    txCredit.vin[0].prevout.SetNull();
     txCredit.vin[0].scriptSig = CScript() << CScriptNum(0) << CScriptNum(0);
     txCredit.vin[0].nSequence = CTxIn::SEQUENCE_FINAL;
     txCredit.vout[0].scriptPubKey = scriptPubKey;

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -22,12 +22,12 @@ class base_blob
 {
 protected:
     static constexpr int WIDTH = BITS / 8;
-    std::array<uint8_t, WIDTH> m_data;
+    std::array<uint8_t, WIDTH> m_data{};
     static_assert(WIDTH == sizeof(m_data), "Sanity check");
 
 public:
-    /* construct 0 value by default */
-    constexpr base_blob() : m_data() {}
+    /* construct by default */
+    constexpr base_blob() = default;
 
     /* constructor for constants between 1 and 255 */
     constexpr explicit base_blob(uint8_t v) : m_data{v} {}


### PR DESCRIPTION
This PR aims to defaults initialise various class members and make redundant several calls to SetNull methods for those classes. This makes the default constructor for a few classes without any other constructors redundant as well but rather than remove them I'll created them with default in case of compiler complaints.

- Default initialise m_data member in base_blob which makes calls to SetNull on uint256 redundant, create  base_blob() with default rather than remove in case of compiler complaints.
- Default initialise members in CBlockFileInfo and remove constructor which called SetNull, create  CBlockFileInfo() with default.
- Default initialise members of CBlockHeader and remove constructor which called SetNull, create  CBlockHeader() with default.
- Default initialise fChecked member of CBlock and remove constructor which called SetNull as CBlockHeader no longer requires this call and the vtx member will already be clear. Create  CBlock() with default.
- Default initialise type in CInv and remove constructor which set type and called SetNull on the hash member. Create  CInv() with default.