### PR TITLE
Add support for "partial" fuzzers that indicate usefulness

### DIFF
--- a/src/test/fuzz/asmap_direct.cpp
+++ b/src/test/fuzz/asmap_direct.cpp
@@ -12,7 +12,7 @@
 
 #include <assert.h>
 
-FUZZ_TARGET(asmap_direct)
+FUZZ_PARTIAL_TARGET(asmap_direct)
 {
     // Encoding: [asmap using 1 bit / byte] 0xFF [addr using 1 bit / byte]
     std::optional<size_t> sep_pos_opt;
@@ -20,15 +20,15 @@ FUZZ_TARGET(asmap_direct)
         uint8_t x = buffer[pos];
         if ((x & 0xFE) == 0) continue;
         if (x == 0xFF) {
-            if (sep_pos_opt) return;
+            if (sep_pos_opt) return FuzzResult::UNINTERESTING;
             sep_pos_opt = pos;
         } else {
-            return;
+            return FuzzResult::UNINTERESTING;
         }
     }
-    if (!sep_pos_opt) return; // Needs exactly 1 separator
+    if (!sep_pos_opt) return FuzzResult::UNINTERESTING; // Needs exactly 1 separator
     const size_t sep_pos{sep_pos_opt.value()};
-    if (buffer.size() - sep_pos - 1 > 128) return; // At most 128 bits in IP address
+    if (buffer.size() - sep_pos - 1 > 128) return FuzzResult::UNINTERESTING; // At most 128 bits in IP address
 
     // Checks on asmap
     std::vector<bool> asmap(buffer.begin(), buffer.begin() + sep_pos);
@@ -46,4 +46,6 @@ FUZZ_TARGET(asmap_direct)
         std::vector<bool> addr(buffer.begin() + sep_pos + 1, buffer.end());
         (void)Interpret(asmap, addr);
     }
+
+    return FuzzResult::MAYBE_INTERESTING;
 }

--- a/src/test/fuzz/fuzz.h
+++ b/src/test/fuzz/fuzz.h
@@ -40,22 +40,37 @@ void FuzzFrameworkRegisterTarget(std::string_view name, TypeTestOneInput target,
 
 inline void FuzzFrameworkEmptyInitFun() {}
 
+/** Fuzz target without initialization function that always succeeds. */
 #define FUZZ_TARGET(name) \
     FUZZ_TARGET_INIT(name, FuzzFrameworkEmptyInitFun)
 
+/** Fuzz target without initialization function that returns FuzzResult. */
+#define FUZZ_PARTIAL_TARGET(name) \
+    FUZZ_PARTIAL_TARGET_INIT(name, FuzzFrameworkEmptyInitFun)
+
+/** Fuzz target with initialization function that always returns MAYBE_INTERESTING. */
 #define FUZZ_TARGET_INIT(name, init_fun) \
     FUZZ_TARGET_INIT_HIDDEN(name, init_fun, false)
 
-#define FUZZ_TARGET_INIT_HIDDEN(name, init_fun, hidden)                               \
+/** Fuzz target with initialization function that returns FuzzResult. */
+#define FUZZ_PARTIAL_TARGET_INIT(name, init_fun) \
+    FUZZ_PARTIAL_TARGET_INIT_HIDDEN(name, init_fun, false)
+
+/** Potentially hidden fuzz target with initialization that returns FuzzResult. */
+#define FUZZ_PARTIAL_TARGET_INIT_HIDDEN(name, init_fun, hidden)                       \
     FuzzResult name##_fuzz_target(FuzzBufferType);                                    \
-    void name##_fuzz_target_complete(FuzzBufferType);                                 \
     struct name##_Before_Main {                                                       \
         name##_Before_Main()                                                          \
         {                                                                             \
             FuzzFrameworkRegisterTarget(#name, name##_fuzz_target, init_fun, hidden); \
         }                                                                             \
     } const static g_##name##_before_main;                                            \
-    FuzzResult name##_fuzz_target(FuzzBufferType buffer)                              \
+    FuzzResult name##_fuzz_target(FuzzBufferType buffer)
+
+/** Potentially hidden fuzz target with initialization that always returns MAYBE_INTERESTING. */
+#define FUZZ_TARGET_INIT_HIDDEN(name, init_fun, hidden)                               \
+    void name##_fuzz_target_complete(FuzzBufferType);                                 \
+    FUZZ_PARTIAL_TARGET_INIT_HIDDEN(name, init_fun, hidden)                           \
     {                                                                                 \
         name##_fuzz_target_complete(buffer);                                          \
         return FuzzResult::MAYBE_INTERESTING;                                         \


### PR DESCRIPTION
This adds supports for fuzz targets that return a boolean: `true` is the normal case, while `false` indicates the input was uninteresting and should not under any circumstances be added to the corpus. This is intended for fuzz targets that have some early bail-out criteria, so that the fuzzer doesn't continue to iterate on them.

