### PR TITLE
test: Simplify feature_fastprune.py

### DIFF
--- a/test/functional/feature_fastprune.py
+++ b/test/functional/feature_fastprune.py
@@ -7,11 +7,6 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal
 )
-from test_framework.blocktools import (
-    create_block,
-    create_coinbase,
-    add_witness_commitment
-)
 from test_framework.wallet import MiniWallet
 
 
@@ -24,18 +19,10 @@ class FeatureFastpruneTest(BitcoinTestFramework):
         self.log.info("ensure that large blocks don't crash or freeze in -fastprune")
         wallet = MiniWallet(self.nodes[0])
         tx = wallet.create_self_transfer()['tx']
-        annex = [0x50]
-        for _ in range(0x10000):
-            annex.append(0xff)
-        tx.wit.vtxinwit[0].scriptWitness.stack.append(bytes(annex))
-        tip = int(self.nodes[0].getbestblockhash(), 16)
-        time = self.nodes[0].getblock(self.nodes[0].getbestblockhash())['time'] + 1
-        height = self.nodes[0].getblockcount() + 1
-        block = create_block(hashprev=tip, ntime=time, txlist=[tx], coinbase=create_coinbase(height=height))
-        add_witness_commitment(block)
-        block.solve()
-        self.nodes[0].submitblock(block.serialize().hex())
-        assert_equal(int(self.nodes[0].getbestblockhash(), 16), block.sha256)
+        annex = b"\x50" + b"\xff" * 0x10000
+        tx.wit.vtxinwit[0].scriptWitness.stack.append(annex)
+        self.generateblock(self.nodes[0], output="raw(55)", transactions=[tx.serialize().hex()])
+        assert_equal(self.nodes[0].getblockcount(), 201)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The goal of the test is a single regression check to see if a RPC times out. It shouldn't do more than calling the RPC (and the minimum work needed to get there).

Fix that by removing all blocktools imports and a `for` loop.