### PR TITLE
wallet: fix deadlock in bdb read write operation

### DIFF
--- a/src/wallet/bdb.h
+++ b/src/wallet/bdb.h
@@ -192,7 +192,7 @@ private:
     Dbc* m_cursor;
 
 public:
-    explicit BerkeleyCursor(BerkeleyDatabase& database, BerkeleyBatch* batch=nullptr);
+    explicit BerkeleyCursor(BerkeleyDatabase& database, const BerkeleyBatch& batch);
     ~BerkeleyCursor() override;
 
     Status Next(DataStream& key, DataStream& value) override;

--- a/src/wallet/test/util.h
+++ b/src/wallet/test/util.h
@@ -22,6 +22,15 @@ namespace wallet {
 class CWallet;
 class WalletDatabase;
 
+static const DatabaseFormat DATABASE_FORMATS[] = {
+#ifdef USE_SQLITE
+       DatabaseFormat::SQLITE,
+#endif
+#ifdef USE_BDB
+       DatabaseFormat::BERKELEY,
+#endif
+};
+
 std::unique_ptr<CWallet> CreateSyncedWallet(interfaces::Chain& chain, CChain& cchain, const CKey& key);
 
 // Creates a copy of the provided database

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -426,15 +426,6 @@ BOOST_AUTO_TEST_CASE(ComputeTimeSmart)
     BOOST_CHECK_EQUAL(AddTx(*m_node.chainman, m_wallet, 5, 50, 600), 300);
 }
 
-static const DatabaseFormat DATABASE_FORMATS[] = {
-#ifdef USE_SQLITE
-    DatabaseFormat::SQLITE,
-#endif
-#ifdef USE_BDB
-    DatabaseFormat::BERKELEY,
-#endif
-};
-
 void TestLoadWallet(const std::string& name, DatabaseFormat format, std::function<void(std::shared_ptr<CWallet>)> f)
 {
     node::NodeContext node;

--- a/src/wallet/test/walletdb_tests.cpp
+++ b/src/wallet/test/walletdb_tests.cpp
@@ -6,6 +6,8 @@
 #include <clientversion.h>
 #include <streams.h>
 #include <uint256.h>
+#include <wallet/test/util.h>
+#include <wallet/wallet.h>
 
 #include <boost/test/unit_test.hpp>
 
@@ -25,6 +27,32 @@ BOOST_AUTO_TEST_CASE(walletdb_readkeyvalue)
     CDataStream ssValue(SER_DISK, CLIENT_VERSION);
     uint256 dummy;
     BOOST_CHECK_THROW(ssValue >> dummy, std::ios_base::failure);
+}
+
+BOOST_AUTO_TEST_CASE(walletdb_read_write_deadlock)
+{
+    // Exercises a db read write operation that shouldn't deadlock.
+    for (const DatabaseFormat& db_format : DATABASE_FORMATS) {
+        // Context setup
+        DatabaseOptions options;
+        options.require_format = db_format;
+        DatabaseStatus status;
+        bilingual_str error_string;
+        std::unique_ptr<WalletDatabase> db = MakeDatabase(m_path_root / strprintf("wallet_%d_.dat", db_format).c_str(), options, status, error_string);
+        BOOST_ASSERT(status == DatabaseStatus::SUCCESS);
+
+        std::shared_ptr<CWallet> wallet(new CWallet(m_node.chain.get(), "", std::move(db)));
+        wallet->m_keypool_size = 4;
+
+        // Create legacy spkm
+        LOCK(wallet->cs_wallet);
+        auto legacy_spkm = wallet->GetOrCreateLegacyScriptPubKeyMan();
+        BOOST_CHECK(legacy_spkm->SetupGeneration(true));
+        wallet->Flush();
+
+        // Now delete all records, which performs a read write operation.
+        BOOST_CHECK(wallet->GetLegacyScriptPubKeyMan()->DeleteRecords());
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Basically, with bdb, we can't make a write operation while we are traversing the db with the same db handler. These two operations are performed in different txn contexts and cause a deadlock.

Added coverage by using `EraseRecords()` which is the simplest function that executes this process.

To replicate it, need bdb support and drop the first commit. The test will run forever.