### PR TITLE
net: call getaddrinfo() in detachable thread to prevent stalling

### DIFF
--- a/src/netbase.h
+++ b/src/netbase.h
@@ -96,6 +96,20 @@ bool SetNameProxy(const Proxy &addrProxy);
 bool HaveNameProxy();
 bool GetNameProxy(Proxy &nameProxyOut);
 
+struct GAIRequest
+{
+    std::atomic<bool> complete{false};
+    bool allow_lookup{false};
+    const std::string name;
+    std::vector<CNetAddr>* vAddr;
+
+    GAIRequest(bool allow_lookup, const std::string name, std::vector<CNetAddr>* vAddr) :
+        allow_lookup(allow_lookup), name(name), vAddr(vAddr) {}
+};
+
+using AsyncGAIFn = std::function<void(std::shared_ptr<GAIRequest> req)>;
+extern AsyncGAIFn g_async_gai;
+
 using DNSLookupFn = std::function<std::vector<CNetAddr>(const std::string&, bool)>;
 extern DNSLookupFn g_dns_lookup;
 


### PR DESCRIPTION
Closes https://github.com/bitcoin/bitcoin/issues/16778
Replaces https://github.com/bitcoin/bitcoin/pull/27505

The library call `getaddrinfo()` has no internal timeout and depending on the user's system may wait indefinitely for a response when looking up a hostname in the DNS. By making that call in a separate thread, we can abandon it completely after some timeout (currently in this PR, 2 seconds).

TODO:

- [ ] We could make the polling loop interruptible but I'm not sure the best approach to that, since these functions don't live in a class with a flag like interruptNet


