### PR TITLE
kernel: Remove args, settings, chainparams, chainparamsbase from kernel library

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -143,6 +143,7 @@ BITCOIN_CORE_H = \
   compat/compat.h \
   compat/cpuid.h \
   compat/endian.h \
+  common/settings.h \
   common/system.h \
   compressor.h \
   consensus/consensus.h \
@@ -309,7 +310,6 @@ BITCOIN_CORE_H = \
   util/readwritefile.h \
   util/result.h \
   util/serfloat.h \
-  util/settings.h \
   util/sock.h \
   util/spanparsing.h \
   util/string.h \
@@ -663,6 +663,7 @@ libbitcoin_common_a_SOURCES = \
   common/init.cpp \
   common/interfaces.cpp \
   common/run_command.cpp \
+  common/settings.cpp \
   common/system.cpp \
   compressor.cpp \
   core_read.cpp \
@@ -733,7 +734,6 @@ libbitcoin_util_a_SOURCES = \
   util/moneystr.cpp \
   util/rbf.cpp \
   util/readwritefile.cpp \
-  util/settings.cpp \
   util/thread.cpp \
   util/threadinterrupt.cpp \
   util/threadnames.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -912,12 +912,8 @@ libbitcoinkernel_la_SOURCES = \
   kernel/bitcoinkernel.cpp \
   arith_uint256.cpp \
   chain.cpp \
-  chainparamsbase.cpp \
-  chainparams.cpp \
   clientversion.cpp \
   coins.cpp \
-  common/args.cpp \
-  common/config.cpp \
   compressor.cpp \
   consensus/merkle.cpp \
   consensus/tx_check.cpp \
@@ -978,7 +974,6 @@ libbitcoinkernel_la_SOURCES = \
   util/moneystr.cpp \
   util/rbf.cpp \
   util/serfloat.cpp \
-  util/settings.cpp \
   util/strencodings.cpp \
   util/string.cpp \
   util/syscall_sandbox.cpp \

--- a/src/addrdb.cpp
+++ b/src/addrdb.cpp
@@ -132,7 +132,7 @@ CBanDB::CBanDB(fs::path ban_list_path)
 bool CBanDB::Write(const banmap_t& banSet)
 {
     std::vector<std::string> errors;
-    if (util::WriteSettings(m_banlist_json, {{JSON_KEY, BanMapToJson(banSet)}}, errors)) {
+    if (common::WriteSettings(m_banlist_json, {{JSON_KEY, BanMapToJson(banSet)}}, errors)) {
         return true;
     }
 
@@ -152,10 +152,10 @@ bool CBanDB::Read(banmap_t& banSet)
         return false;
     }
 
-    std::map<std::string, util::SettingsValue> settings;
+    std::map<std::string, common::SettingsValue> settings;
     std::vector<std::string> errors;
 
-    if (!util::ReadSettings(m_banlist_json, settings, errors)) {
+    if (!common::ReadSettings(m_banlist_json, settings, errors)) {
         for (const auto& err : errors) {
             LogPrintf("Cannot load banlist %s: %s\n", fs::PathToString(m_banlist_json), err);
         }

--- a/src/addrdb.cpp
+++ b/src/addrdb.cpp
@@ -9,6 +9,7 @@
 #include <chainparams.h>
 #include <clientversion.h>
 #include <common/args.h>
+#include <common/settings.h>
 #include <cstdint>
 #include <hash.h>
 #include <logging.h>
@@ -21,7 +22,6 @@
 #include <univalue.h>
 #include <util/fs.h>
 #include <util/fs_helpers.h>
-#include <util/settings.h>
 #include <util/translation.h>
 
 namespace {

--- a/src/common/args.cpp
+++ b/src/common/args.cpp
@@ -104,7 +104,7 @@ KeyInfo InterpretKey(std::string key)
  * @return parsed settings value if it is valid, otherwise nullopt accompanied
  * by a descriptive error string
  */
-std::optional<util::SettingsValue> InterpretValue(const KeyInfo& key, const std::string* value,
+std::optional<common::SettingsValue> InterpretValue(const KeyInfo& key, const std::string* value,
                                                   unsigned int flags, std::string& error)
 {
     // Return negated settings as false values.
@@ -238,15 +238,15 @@ bool ArgsManager::ParseParameters(int argc, const char* const argv[], std::strin
             return false;
         }
 
-        std::optional<util::SettingsValue> value = InterpretValue(keyinfo, val ? &*val : nullptr, *flags, error);
+        std::optional<common::SettingsValue> value = InterpretValue(keyinfo, val ? &*val : nullptr, *flags, error);
         if (!value) return false;
 
         m_settings.command_line_options[keyinfo.name].push_back(*value);
     }
 
     // we do not allow -includeconf from command line, only -noincludeconf
-    if (auto* includes = util::FindKey(m_settings.command_line_options, "includeconf")) {
-        const util::SettingsSpan values{*includes};
+    if (auto* includes = common::FindKey(m_settings.command_line_options, "includeconf")) {
+        const common::SettingsSpan values{*includes};
         // Range may be empty if -noincludeconf was passed
         if (!values.empty()) {
             error = "-includeconf cannot be used from commandline; -includeconf=" + values.begin()->write();
@@ -361,7 +361,7 @@ std::optional<const ArgsManager::Command> ArgsManager::GetCommand() const
 std::vector<std::string> ArgsManager::GetArgs(const std::string& strArg) const
 {
     std::vector<std::string> result;
-    for (const util::SettingsValue& value : GetSettingsList(strArg)) {
+    for (const common::SettingsValue& value : GetSettingsList(strArg)) {
         result.push_back(value.isFalse() ? "0" : value.isTrue() ? "1" : value.get_str());
     }
     return result;
@@ -408,7 +408,7 @@ bool ArgsManager::ReadSettingsFile(std::vector<std::string>* errors)
     LOCK(cs_args);
     m_settings.rw_settings.clear();
     std::vector<std::string> read_errors;
-    if (!util::ReadSettings(path, m_settings.rw_settings, read_errors)) {
+    if (!common::ReadSettings(path, m_settings.rw_settings, read_errors)) {
         SaveErrors(read_errors, errors);
         return false;
     }
@@ -430,7 +430,7 @@ bool ArgsManager::WriteSettingsFile(std::vector<std::string>* errors, bool backu
 
     LOCK(cs_args);
     std::vector<std::string> write_errors;
-    if (!util::WriteSettings(path_tmp, m_settings.rw_settings, write_errors)) {
+    if (!common::WriteSettings(path_tmp, m_settings.rw_settings, write_errors)) {
         SaveErrors(write_errors, errors);
         return false;
     }
@@ -441,10 +441,10 @@ bool ArgsManager::WriteSettingsFile(std::vector<std::string>* errors, bool backu
     return true;
 }
 
-util::SettingsValue ArgsManager::GetPersistentSetting(const std::string& name) const
+common::SettingsValue ArgsManager::GetPersistentSetting(const std::string& name) const
 {
     LOCK(cs_args);
-    return util::GetSetting(m_settings, m_network, name, !UseDefaultSection("-" + name),
+    return common::GetSetting(m_settings, m_network, name, !UseDefaultSection("-" + name),
         /*ignore_nonpersistent=*/true, /*get_chain_type=*/false);
 }
 
@@ -460,11 +460,11 @@ std::string ArgsManager::GetArg(const std::string& strArg, const std::string& st
 
 std::optional<std::string> ArgsManager::GetArg(const std::string& strArg) const
 {
-    const util::SettingsValue value = GetSetting(strArg);
+    const common::SettingsValue value = GetSetting(strArg);
     return SettingToString(value);
 }
 
-std::optional<std::string> SettingToString(const util::SettingsValue& value)
+std::optional<std::string> SettingToString(const common::SettingsValue& value)
 {
     if (value.isNull()) return std::nullopt;
     if (value.isFalse()) return "0";
@@ -473,7 +473,7 @@ std::optional<std::string> SettingToString(const util::SettingsValue& value)
     return value.get_str();
 }
 
-std::string SettingToString(const util::SettingsValue& value, const std::string& strDefault)
+std::string SettingToString(const common::SettingsValue& value, const std::string& strDefault)
 {
     return SettingToString(value).value_or(strDefault);
 }
@@ -485,11 +485,11 @@ int64_t ArgsManager::GetIntArg(const std::string& strArg, int64_t nDefault) cons
 
 std::optional<int64_t> ArgsManager::GetIntArg(const std::string& strArg) const
 {
-    const util::SettingsValue value = GetSetting(strArg);
+    const common::SettingsValue value = GetSetting(strArg);
     return SettingToInt(value);
 }
 
-std::optional<int64_t> SettingToInt(const util::SettingsValue& value)
+std::optional<int64_t> SettingToInt(const common::SettingsValue& value)
 {
     if (value.isNull()) return std::nullopt;
     if (value.isFalse()) return 0;
@@ -498,7 +498,7 @@ std::optional<int64_t> SettingToInt(const util::SettingsValue& value)
     return LocaleIndependentAtoi<int64_t>(value.get_str());
 }
 
-int64_t SettingToInt(const util::SettingsValue& value, int64_t nDefault)
+int64_t SettingToInt(const common::SettingsValue& value, int64_t nDefault)
 {
     return SettingToInt(value).value_or(nDefault);
 }
@@ -510,18 +510,18 @@ bool ArgsManager::GetBoolArg(const std::string& strArg, bool fDefault) const
 
 std::optional<bool> ArgsManager::GetBoolArg(const std::string& strArg) const
 {
-    const util::SettingsValue value = GetSetting(strArg);
+    const common::SettingsValue value = GetSetting(strArg);
     return SettingToBool(value);
 }
 
-std::optional<bool> SettingToBool(const util::SettingsValue& value)
+std::optional<bool> SettingToBool(const common::SettingsValue& value)
 {
     if (value.isNull()) return std::nullopt;
     if (value.isBool()) return value.get_bool();
     return InterpretBool(value.get_str());
 }
 
-bool SettingToBool(const util::SettingsValue& value, bool fDefault)
+bool SettingToBool(const common::SettingsValue& value, bool fDefault)
 {
     return SettingToBool(value).value_or(fDefault);
 }
@@ -738,7 +738,7 @@ std::variant<ChainType, std::string> ArgsManager::GetChainArg() const
 {
     auto get_net = [&](const std::string& arg) {
         LOCK(cs_args);
-        util::SettingsValue value = util::GetSetting(m_settings, /* section= */ "", SettingName(arg),
+        common::SettingsValue value = common::GetSetting(m_settings, /* section= */ "", SettingName(arg),
             /* ignore_default_section_config= */ false,
             /*ignore_nonpersistent=*/false,
             /* get_chain_type= */ true);
@@ -769,24 +769,24 @@ bool ArgsManager::UseDefaultSection(const std::string& arg) const
     return m_network == ChainTypeToString(ChainType::MAIN) || m_network_only_args.count(arg) == 0;
 }
 
-util::SettingsValue ArgsManager::GetSetting(const std::string& arg) const
+common::SettingsValue ArgsManager::GetSetting(const std::string& arg) const
 {
     LOCK(cs_args);
-    return util::GetSetting(
+    return common::GetSetting(
         m_settings, m_network, SettingName(arg), !UseDefaultSection(arg),
         /*ignore_nonpersistent=*/false, /*get_chain_type=*/false);
 }
 
-std::vector<util::SettingsValue> ArgsManager::GetSettingsList(const std::string& arg) const
+std::vector<common::SettingsValue> ArgsManager::GetSettingsList(const std::string& arg) const
 {
     LOCK(cs_args);
-    return util::GetSettingsList(m_settings, m_network, SettingName(arg), !UseDefaultSection(arg));
+    return common::GetSettingsList(m_settings, m_network, SettingName(arg), !UseDefaultSection(arg));
 }
 
 void ArgsManager::logArgsPrefix(
     const std::string& prefix,
     const std::string& section,
-    const std::map<std::string, std::vector<util::SettingsValue>>& args) const
+    const std::map<std::string, std::vector<common::SettingsValue>>& args) const
 {
     std::string section_str = section.empty() ? "" : "[" + section + "] ";
     for (const auto& arg : args) {

--- a/src/common/args.cpp
+++ b/src/common/args.cpp
@@ -6,6 +6,7 @@
 #include <common/args.h>
 
 #include <chainparamsbase.h>
+#include <common/settings.h>
 #include <logging.h>
 #include <sync.h>
 #include <tinyformat.h>
@@ -14,7 +15,6 @@
 #include <util/check.h>
 #include <util/fs.h>
 #include <util/fs_helpers.h>
-#include <util/settings.h>
 #include <util/strencodings.h>
 
 #ifdef WIN32

--- a/src/common/args.h
+++ b/src/common/args.h
@@ -5,11 +5,11 @@
 #ifndef BITCOIN_COMMON_ARGS_H
 #define BITCOIN_COMMON_ARGS_H
 
+#include <common/settings.h>
 #include <compat/compat.h>
 #include <sync.h>
 #include <util/chaintype.h>
 #include <util/fs.h>
-#include <util/settings.h>
 
 #include <iosfwd>
 #include <list>

--- a/src/common/args.h
+++ b/src/common/args.h
@@ -75,7 +75,7 @@ struct KeyInfo {
 
 KeyInfo InterpretKey(std::string key);
 
-std::optional<util::SettingsValue> InterpretValue(const KeyInfo& key, const std::string* value,
+std::optional<common::SettingsValue> InterpretValue(const KeyInfo& key, const std::string* value,
                                                          unsigned int flags, std::string& error);
 
 struct SectionInfo {
@@ -84,14 +84,14 @@ struct SectionInfo {
     int m_line;
 };
 
-std::string SettingToString(const util::SettingsValue&, const std::string&);
-std::optional<std::string> SettingToString(const util::SettingsValue&);
+std::string SettingToString(const common::SettingsValue&, const std::string&);
+std::optional<std::string> SettingToString(const common::SettingsValue&);
 
-int64_t SettingToInt(const util::SettingsValue&, int64_t);
-std::optional<int64_t> SettingToInt(const util::SettingsValue&);
+int64_t SettingToInt(const common::SettingsValue&, int64_t);
+std::optional<int64_t> SettingToInt(const common::SettingsValue&);
 
-bool SettingToBool(const util::SettingsValue&, bool);
-std::optional<bool> SettingToBool(const util::SettingsValue&);
+bool SettingToBool(const common::SettingsValue&, bool);
+std::optional<bool> SettingToBool(const common::SettingsValue&);
 
 class ArgsManager
 {
@@ -130,7 +130,7 @@ protected:
     };
 
     mutable RecursiveMutex cs_args;
-    util::Settings m_settings GUARDED_BY(cs_args);
+    common::Settings m_settings GUARDED_BY(cs_args);
     std::vector<std::string> m_command GUARDED_BY(cs_args);
     std::string m_network GUARDED_BY(cs_args);
     std::set<std::string> m_network_only_args GUARDED_BY(cs_args);
@@ -159,12 +159,12 @@ protected:
      * false if "-nosetting" argument was passed, and a string if a "-setting=value"
      * argument was passed.
      */
-    util::SettingsValue GetSetting(const std::string& arg) const;
+    common::SettingsValue GetSetting(const std::string& arg) const;
 
     /**
      * Get list of setting values.
      */
-    std::vector<util::SettingsValue> GetSettingsList(const std::string& arg) const;
+    std::vector<common::SettingsValue> GetSettingsList(const std::string& arg) const;
 
     ArgsManager();
     ~ArgsManager();
@@ -394,7 +394,7 @@ protected:
      * Get current setting from config file or read/write settings file,
      * ignoring nonpersistent command line or forced settings values.
      */
-    util::SettingsValue GetPersistentSetting(const std::string& name) const;
+    common::SettingsValue GetPersistentSetting(const std::string& name) const;
 
     /**
      * Access settings with lock held.
@@ -433,7 +433,7 @@ private:
     void logArgsPrefix(
         const std::string& prefix,
         const std::string& section,
-        const std::map<std::string, std::vector<util::SettingsValue>>& args) const;
+        const std::map<std::string, std::vector<common::SettingsValue>>& args) const;
 };
 
 extern ArgsManager gArgs;

--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -4,13 +4,13 @@
 
 #include <common/args.h>
 
+#include <common/settings.h>
 #include <logging.h>
 #include <sync.h>
 #include <tinyformat.h>
 #include <univalue.h>
 #include <util/chaintype.h>
 #include <util/fs.h>
-#include <util/settings.h>
 #include <util/string.h>
 
 #include <algorithm>

--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -98,7 +98,7 @@ bool ArgsManager::ReadConfigStream(std::istream& stream, const std::string& file
         std::optional<unsigned int> flags = GetArgFlags('-' + key.name);
         if (!IsConfSupported(key, error)) return false;
         if (flags) {
-            std::optional<util::SettingsValue> value = InterpretValue(key, &option.second, *flags, error);
+            std::optional<common::SettingsValue> value = InterpretValue(key, &option.second, *flags, error);
             if (!value) {
                 return false;
             }
@@ -142,9 +142,9 @@ bool ArgsManager::ReadConfigFiles(std::string& error, bool ignore_invalid_keys)
         bool use_conf_file{true};
         {
             LOCK(cs_args);
-            if (auto* includes = util::FindKey(m_settings.command_line_options, "includeconf")) {
+            if (auto* includes = common::FindKey(m_settings.command_line_options, "includeconf")) {
                 // ParseParameters() fails if a non-negated -includeconf is passed on the command-line
-                assert(util::SettingsSpan(*includes).last_negated());
+                assert(common::SettingsSpan(*includes).last_negated());
                 use_conf_file = false;
             }
         }
@@ -155,9 +155,9 @@ bool ArgsManager::ReadConfigFiles(std::string& error, bool ignore_invalid_keys)
             auto add_includes = [&](const std::string& network, size_t skip = 0) {
                 size_t num_values = 0;
                 LOCK(cs_args);
-                if (auto* section = util::FindKey(m_settings.ro_config, network)) {
-                    if (auto* values = util::FindKey(*section, "includeconf")) {
-                        for (size_t i = std::max(skip, util::SettingsSpan(*values).negated()); i < values->size(); ++i) {
+                if (auto* section = common::FindKey(m_settings.ro_config, network)) {
+                    if (auto* values = common::FindKey(*section, "includeconf")) {
+                        for (size_t i = std::max(skip, common::SettingsSpan(*values).negated()); i < values->size(); ++i) {
                             conf_file_names.push_back((*values)[i].get_str());
                         }
                         num_values = values->size();

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -2,15 +2,18 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/fs.h>
-#include <util/settings.h>
+#include <common/settings.h>
 
 #include <tinyformat.h>
 #include <univalue.h>
+#include <util/fs.h>
 
+#include <algorithm>
 #include <fstream>
+#include <iterator>
 #include <map>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace util {

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -16,7 +16,7 @@
 #include <utility>
 #include <vector>
 
-namespace util {
+namespace common {
 namespace {
 
 enum class Source {
@@ -258,4 +258,4 @@ size_t SettingsSpan::negated() const
     return 0;
 }
 
-} // namespace util
+} // namespace common

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -14,7 +14,7 @@
 
 class UniValue;
 
-namespace util {
+namespace common {
 
 //! Settings value type (string/integer/boolean/null variant).
 //!
@@ -110,6 +110,6 @@ auto FindKey(Map&& map, Key&& key) -> decltype(&map.at(key))
     return it == map.end() ? nullptr : &it->second;
 }
 
-} // namespace util
+} // namespace common
 
 #endif // BITCOIN_COMMON_SETTINGS_H

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -2,11 +2,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_UTIL_SETTINGS_H
-#define BITCOIN_UTIL_SETTINGS_H
+#ifndef BITCOIN_COMMON_SETTINGS_H
+#define BITCOIN_COMMON_SETTINGS_H
 
 #include <util/fs.h>
 
+#include <cstddef>
 #include <map>
 #include <string>
 #include <vector>
@@ -111,4 +112,4 @@ auto FindKey(Map&& map, Key&& key) -> decltype(&map.at(key))
 
 } // namespace util
 
-#endif // BITCOIN_UTIL_SETTINGS_H
+#endif // BITCOIN_COMMON_SETTINGS_H

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -300,17 +300,17 @@ public:
     virtual int rpcSerializationFlags() = 0;
 
     //! Get settings value.
-    virtual util::SettingsValue getSetting(const std::string& arg) = 0;
+    virtual common::SettingsValue getSetting(const std::string& arg) = 0;
 
     //! Get list of settings values.
-    virtual std::vector<util::SettingsValue> getSettingsList(const std::string& arg) = 0;
+    virtual std::vector<common::SettingsValue> getSettingsList(const std::string& arg) = 0;
 
     //! Return <datadir>/settings.json setting value.
-    virtual util::SettingsValue getRwSetting(const std::string& name) = 0;
+    virtual common::SettingsValue getRwSetting(const std::string& name) = 0;
 
     //! Write a setting to <datadir>/settings.json. Optionally just update the
     //! setting in memory and do not write the file.
-    virtual bool updateRwSetting(const std::string& name, const util::SettingsValue& value, bool write=true) = 0;
+    virtual bool updateRwSetting(const std::string& name, const common::SettingsValue& value, bool write=true) = 0;
 
     //! Synchronously send transactionAddedToMempool notifications about all
     //! current mempool transactions to the specified handler and return after

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -6,8 +6,8 @@
 #define BITCOIN_INTERFACES_CHAIN_H
 
 #include <blockfilter.h>
+#include <common/settings.h>
 #include <primitives/transaction.h> // For CTransactionRef
-#include <util/settings.h>          // For util::SettingsValue
 
 #include <functional>
 #include <memory>

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -5,13 +5,13 @@
 #ifndef BITCOIN_INTERFACES_NODE_H
 #define BITCOIN_INTERFACES_NODE_H
 
+#include <common/settings.h>
 #include <consensus/amount.h>          // For CAmount
 #include <net.h>                       // For NodeId
 #include <net_types.h>                 // For banmap_t
 #include <netaddress.h>                // For Network
 #include <netbase.h>                   // For ConnectionDirection
 #include <support/allocators/secure.h> // For SecureString
-#include <util/settings.h>             // For util::SettingsValue
 #include <util/translation.h>
 
 #include <functional>

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -103,14 +103,14 @@ public:
     virtual bool isSettingIgnored(const std::string& name) = 0;
 
     //! Return setting value from <datadir>/settings.json or bitcoin.conf.
-    virtual util::SettingsValue getPersistentSetting(const std::string& name) = 0;
+    virtual common::SettingsValue getPersistentSetting(const std::string& name) = 0;
 
     //! Update a setting in <datadir>/settings.json.
-    virtual void updateRwSetting(const std::string& name, const util::SettingsValue& value) = 0;
+    virtual void updateRwSetting(const std::string& name, const common::SettingsValue& value) = 0;
 
     //! Force a setting value to be applied, overriding any other configuration
     //! source, but not being persisted.
-    virtual void forceSetting(const std::string& name, const util::SettingsValue& value) = 0;
+    virtual void forceSetting(const std::string& name, const common::SettingsValue& value) = 0;
 
     //! Clear all settings in <datadir>/settings.json and store a backup of
     //! previous settings in <datadir>/settings.json.bak.

--- a/src/kernel/chainstatemanager_opts.h
+++ b/src/kernel/chainstatemanager_opts.h
@@ -21,6 +21,7 @@ class CChainParams;
 
 static constexpr bool DEFAULT_CHECKPOINTS_ENABLED{true};
 static constexpr auto DEFAULT_MAX_TIP_AGE{24h};
+static constexpr int DEFAULT_STOPATHEIGHT{0};
 
 namespace kernel {
 
@@ -45,6 +46,7 @@ struct ChainstateManagerOpts {
     DBOptions coins_db{};
     CoinsViewOptions coins_view{};
     Notifications& notifications;
+    int stop_at_height{DEFAULT_STOPATHEIGHT};
 };
 
 } // namespace kernel

--- a/src/node/chainstatemanager_args.cpp
+++ b/src/node/chainstatemanager_args.cpp
@@ -37,6 +37,8 @@ util::Result<void> ApplyArgsManOptions(const ArgsManager& args, ChainstateManage
 
     if (auto value{args.GetIntArg("-maxtipage")}) opts.max_tip_age = std::chrono::seconds{*value};
 
+    if (auto value{args.GetIntArg("-stopatheight")}) opts.stop_at_height = *value;
+
     ReadDatabaseArgs(args, opts.block_tree_db);
     ReadDatabaseArgs(args, opts.coins_db);
     ReadCoinsViewArgs(args, opts.coins_view);

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -125,17 +125,17 @@ public:
     bool isSettingIgnored(const std::string& name) override
     {
         bool ignored = false;
-        args().LockSettings([&](util::Settings& settings) {
-            if (auto* options = util::FindKey(settings.command_line_options, name)) {
+        args().LockSettings([&](common::Settings& settings) {
+            if (auto* options = common::FindKey(settings.command_line_options, name)) {
                 ignored = !options->empty();
             }
         });
         return ignored;
     }
-    util::SettingsValue getPersistentSetting(const std::string& name) override { return args().GetPersistentSetting(name); }
-    void updateRwSetting(const std::string& name, const util::SettingsValue& value) override
+    common::SettingsValue getPersistentSetting(const std::string& name) override { return args().GetPersistentSetting(name); }
+    void updateRwSetting(const std::string& name, const common::SettingsValue& value) override
     {
-        args().LockSettings([&](util::Settings& settings) {
+        args().LockSettings([&](common::Settings& settings) {
             if (value.isNull()) {
                 settings.rw_settings.erase(name);
             } else {
@@ -144,9 +144,9 @@ public:
         });
         args().WriteSettingsFile();
     }
-    void forceSetting(const std::string& name, const util::SettingsValue& value) override
+    void forceSetting(const std::string& name, const common::SettingsValue& value) override
     {
-        args().LockSettings([&](util::Settings& settings) {
+        args().LockSettings([&](common::Settings& settings) {
             if (value.isNull()) {
                 settings.forced_settings.erase(name);
             } else {
@@ -157,7 +157,7 @@ public:
     void resetSettings() override
     {
         args().WriteSettingsFile(/*errors=*/nullptr, /*backup=*/true);
-        args().LockSettings([&](util::Settings& settings) {
+        args().LockSettings([&](common::Settings& settings) {
             settings.rw_settings.clear();
         });
         args().WriteSettingsFile();
@@ -744,27 +744,27 @@ public:
         RPCRunLater(name, std::move(fn), seconds);
     }
     int rpcSerializationFlags() override { return RPCSerializationFlags(); }
-    util::SettingsValue getSetting(const std::string& name) override
+    common::SettingsValue getSetting(const std::string& name) override
     {
         return args().GetSetting(name);
     }
-    std::vector<util::SettingsValue> getSettingsList(const std::string& name) override
+    std::vector<common::SettingsValue> getSettingsList(const std::string& name) override
     {
         return args().GetSettingsList(name);
     }
-    util::SettingsValue getRwSetting(const std::string& name) override
+    common::SettingsValue getRwSetting(const std::string& name) override
     {
-        util::SettingsValue result;
-        args().LockSettings([&](const util::Settings& settings) {
-            if (const util::SettingsValue* value = util::FindKey(settings.rw_settings, name)) {
+        common::SettingsValue result;
+        args().LockSettings([&](const common::Settings& settings) {
+            if (const common::SettingsValue* value = common::FindKey(settings.rw_settings, name)) {
                 result = *value;
             }
         });
         return result;
     }
-    bool updateRwSetting(const std::string& name, const util::SettingsValue& value, bool write) override
+    bool updateRwSetting(const std::string& name, const common::SettingsValue& value, bool write) override
     {
-        args().LockSettings([&](util::Settings& settings) {
+        args().LockSettings([&](common::Settings& settings) {
             if (value.isNull()) {
                 settings.rw_settings.erase(name);
             } else {

--- a/src/node/utxo_snapshot.cpp
+++ b/src/node/utxo_snapshot.cpp
@@ -4,7 +4,6 @@
 
 #include <node/utxo_snapshot.h>
 
-#include <common/args.h>
 #include <logging.h>
 #include <streams.h>
 #include <sync.h>
@@ -82,10 +81,10 @@ std::optional<uint256> ReadSnapshotBaseBlockhash(fs::path chaindir)
     return base_blockhash;
 }
 
-std::optional<fs::path> FindSnapshotChainstateDir()
+std::optional<fs::path> FindSnapshotChainstateDir(const fs::path& data_dir)
 {
     fs::path possible_dir =
-        gArgs.GetDataDirNet() / fs::u8path(strprintf("chainstate%s", SNAPSHOT_CHAINSTATE_SUFFIX));
+        data_dir / fs::u8path(strprintf("chainstate%s", SNAPSHOT_CHAINSTATE_SUFFIX));
 
     if (fs::exists(possible_dir)) {
         return possible_dir;

--- a/src/node/utxo_snapshot.h
+++ b/src/node/utxo_snapshot.h
@@ -67,7 +67,7 @@ constexpr std::string_view SNAPSHOT_CHAINSTATE_SUFFIX = "_snapshot";
 
 
 //! Return a path to the snapshot-based chainstate dir, if one exists.
-std::optional<fs::path> FindSnapshotChainstateDir();
+std::optional<fs::path> FindSnapshotChainstateDir(const fs::path& data_dir);
 
 } // namespace node
 

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -60,7 +60,7 @@ static const char* SettingName(OptionsModel::OptionID option)
 }
 
 /** Call node.updateRwSetting() with Bitcoin 22.x workaround. */
-static void UpdateRwSetting(interfaces::Node& node, OptionsModel::OptionID option, const std::string& suffix, const util::SettingsValue& value)
+static void UpdateRwSetting(interfaces::Node& node, OptionsModel::OptionID option, const std::string& suffix, const common::SettingsValue& value)
 {
     if (value.isNum() &&
         (option == OptionsModel::DatabaseCache ||
@@ -81,14 +81,14 @@ static void UpdateRwSetting(interfaces::Node& node, OptionsModel::OptionID optio
 }
 
 //! Convert enabled/size values to bitcoin -prune setting.
-static util::SettingsValue PruneSetting(bool prune_enabled, int prune_size_gb)
+static common::SettingsValue PruneSetting(bool prune_enabled, int prune_size_gb)
 {
     assert(!prune_enabled || prune_size_gb >= 1); // PruneSizeGB and ParsePruneSizeGB never return less
     return prune_enabled ? PruneGBtoMiB(prune_size_gb) : 0;
 }
 
 //! Get pruning enabled value to show in GUI from bitcoin -prune setting.
-static bool PruneEnabled(const util::SettingsValue& prune_setting)
+static bool PruneEnabled(const common::SettingsValue& prune_setting)
 {
     // -prune=1 setting is manual pruning mode, so disabled for purposes of the gui
     return SettingToInt(prune_setting, 0) > 1;
@@ -96,7 +96,7 @@ static bool PruneEnabled(const util::SettingsValue& prune_setting)
 
 //! Get pruning size value to show in GUI from bitcoin -prune setting. If
 //! pruning is not enabled, just show default recommended pruning size (2GB).
-static int PruneSizeGB(const util::SettingsValue& prune_setting)
+static int PruneSizeGB(const common::SettingsValue& prune_setting)
 {
     int value = SettingToInt(prune_setting, 0);
     return value > 1 ? PruneMiBtoGB(value) : DEFAULT_PRUNE_TARGET_GB;
@@ -311,8 +311,8 @@ static QString GetDefaultProxyAddress()
 
 void OptionsModel::SetPruneTargetGB(int prune_target_gb)
 {
-    const util::SettingsValue cur_value = node().getPersistentSetting("prune");
-    const util::SettingsValue new_value = PruneSetting(prune_target_gb > 0, prune_target_gb);
+    const common::SettingsValue cur_value = node().getPersistentSetting("prune");
+    const common::SettingsValue new_value = PruneSetting(prune_target_gb > 0, prune_target_gb);
 
     // Force setting to take effect. It is still safe to change the value at
     // this point because this function is only called after the intro screen is
@@ -331,7 +331,7 @@ void OptionsModel::SetPruneTargetGB(int prune_target_gb)
 
     // Keep previous pruning size, if pruning was disabled.
     if (PruneEnabled(cur_value)) {
-        UpdateRwSetting(node(), Prune, "-prev", PruneEnabled(new_value) ? util::SettingsValue{} : cur_value);
+        UpdateRwSetting(node(), Prune, "-prev", PruneEnabled(new_value) ? common::SettingsValue{} : cur_value);
     }
 }
 
@@ -457,7 +457,7 @@ QVariant OptionsModel::getOption(OptionID option, const std::string& suffix) con
 bool OptionsModel::setOption(OptionID option, const QVariant& value, const std::string& suffix)
 {
     auto changed = [&] { return value.isValid() && value != getOption(option, suffix); };
-    auto update = [&](const util::SettingsValue& value) { return UpdateRwSetting(node(), option, suffix, value); };
+    auto update = [&](const common::SettingsValue& value) { return UpdateRwSetting(node(), option, suffix, value); };
 
     bool successful = true; /* set to false on parse error */
     QSettings settings;

--- a/src/qt/test/optiontests.cpp
+++ b/src/qt/test/optiontests.cpp
@@ -18,13 +18,13 @@
 
 OptionTests::OptionTests(interfaces::Node& node) : m_node(node)
 {
-    gArgs.LockSettings([&](util::Settings& s) { m_previous_settings = s; });
+    gArgs.LockSettings([&](common::Settings& s) { m_previous_settings = s; });
 }
 
 void OptionTests::init()
 {
     // reset args
-    gArgs.LockSettings([&](util::Settings& s) { s = m_previous_settings; });
+    gArgs.LockSettings([&](common::Settings& s) { s = m_previous_settings; });
     gArgs.ClearPathCache();
 }
 
@@ -76,14 +76,14 @@ void OptionTests::integerGetArgBug()
     // Test regression https://github.com/bitcoin/bitcoin/issues/24457. Ensure
     // that setting integer prune value doesn't cause an exception to be thrown
     // in the OptionsModel constructor
-    gArgs.LockSettings([&](util::Settings& settings) {
+    gArgs.LockSettings([&](common::Settings& settings) {
         settings.forced_settings.erase("prune");
         settings.rw_settings["prune"] = 3814;
     });
     gArgs.WriteSettingsFile();
     bilingual_str error;
     QVERIFY(OptionsModel{m_node}.Init(error));
-    gArgs.LockSettings([&](util::Settings& settings) {
+    gArgs.LockSettings([&](common::Settings& settings) {
         settings.rw_settings.erase("prune");
     });
     gArgs.WriteSettingsFile();
@@ -95,7 +95,7 @@ void OptionTests::parametersInteraction()
     // It was fixed via https://github.com/bitcoin-core/gui/pull/568.
     // With fListen=false in ~/.config/Bitcoin/Bitcoin-Qt.conf and all else left as default,
     // bitcoin-qt should set both -listen and -listenonion to false and start successfully.
-    gArgs.LockSettings([&](util::Settings& s) {
+    gArgs.LockSettings([&](common::Settings& s) {
         s.forced_settings.erase("listen");
         s.forced_settings.erase("listenonion");
     });

--- a/src/qt/test/optiontests.h
+++ b/src/qt/test/optiontests.h
@@ -26,7 +26,7 @@ private Q_SLOTS:
 
 private:
     interfaces::Node& m_node;
-    util::Settings m_previous_settings;
+    common::Settings m_previous_settings;
 };
 
 #endif // BITCOIN_QT_TEST_OPTIONTESTS_H

--- a/src/qt/test/optiontests.h
+++ b/src/qt/test/optiontests.h
@@ -5,9 +5,9 @@
 #ifndef BITCOIN_QT_TEST_OPTIONTESTS_H
 #define BITCOIN_QT_TEST_OPTIONTESTS_H
 
+#include <common/settings.h>
 #include <qt/optionsmodel.h>
 #include <univalue.h>
-#include <util/settings.h>
 
 #include <QObject>
 

--- a/src/test/argsman_tests.cpp
+++ b/src/test/argsman_tests.cpp
@@ -85,7 +85,7 @@ class CheckValueTest : public TestChain100Setup
 {
 public:
     struct Expect {
-        util::SettingsValue setting;
+        common::SettingsValue setting;
         bool default_string = false;
         bool default_int = false;
         bool default_bool = false;
@@ -95,7 +95,7 @@ public:
         std::optional<std::vector<std::string>> list_value;
         const char* error = nullptr;
 
-        explicit Expect(util::SettingsValue s) : setting(std::move(s)) {}
+        explicit Expect(common::SettingsValue s) : setting(std::move(s)) {}
         Expect& DefaultString() { default_string = true; return *this; }
         Expect& DefaultInt() { default_int = true; return *this; }
         Expect& DefaultBool() { default_bool = true; return *this; }
@@ -1022,14 +1022,14 @@ BOOST_AUTO_TEST_CASE(util_ReadWriteSettings)
     // Test writing setting.
     TestArgsManager args1;
     args1.ForceSetArg("-datadir", fs::PathToString(m_path_root));
-    args1.LockSettings([&](util::Settings& settings) { settings.rw_settings["name"] = "value"; });
+    args1.LockSettings([&](common::Settings& settings) { settings.rw_settings["name"] = "value"; });
     args1.WriteSettingsFile();
 
     // Test reading setting.
     TestArgsManager args2;
     args2.ForceSetArg("-datadir", fs::PathToString(m_path_root));
     args2.ReadSettingsFile();
-    args2.LockSettings([&](util::Settings& settings) { BOOST_CHECK_EQUAL(settings.rw_settings["name"].get_str(), "value"); });
+    args2.LockSettings([&](common::Settings& settings) { BOOST_CHECK_EQUAL(settings.rw_settings["name"].get_str(), "value"); });
 
     // Test error logging, and remove previously written setting.
     {

--- a/src/test/fuzz/string.cpp
+++ b/src/test/fuzz/string.cpp
@@ -63,7 +63,7 @@ FUZZ_TARGET(string)
     (void)IsDeprecatedRPCEnabled(random_string_1);
     (void)Join(random_string_vector, random_string_1);
     (void)JSONRPCError(fuzzed_data_provider.ConsumeIntegral<int>(), random_string_1);
-    const util::Settings settings;
+    const common::Settings settings;
     (void)OnlyHasDefaultSectionSetting(settings, random_string_1, random_string_2);
     (void)ParseNetwork(random_string_1);
     try {

--- a/src/test/fuzz/string.cpp
+++ b/src/test/fuzz/string.cpp
@@ -5,6 +5,7 @@
 #include <blockfilter.h>
 #include <clientversion.h>
 #include <common/args.h>
+#include <common/settings.h>
 #include <common/system.h>
 #include <common/url.h>
 #include <netbase.h>
@@ -22,7 +23,6 @@
 #include <test/fuzz/util.h>
 #include <util/error.h>
 #include <util/fees.h>
-#include <util/settings.h>
 #include <util/strencodings.h>
 #include <util/string.h>
 #include <util/translation.h>

--- a/src/test/getarg_tests.cpp
+++ b/src/test/getarg_tests.cpp
@@ -3,10 +3,10 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <common/args.h>
+#include <common/settings.h>
 #include <logging.h>
 #include <test/util/setup_common.h>
 #include <univalue.h>
-#include <util/settings.h>
 #include <util/strencodings.h>
 
 #include <limits>

--- a/src/test/getarg_tests.cpp
+++ b/src/test/getarg_tests.cpp
@@ -57,8 +57,8 @@ BOOST_AUTO_TEST_CASE(setting_args)
     ArgsManager args;
     SetupArgs(args, {{"-foo", ArgsManager::ALLOW_ANY}});
 
-    auto set_foo = [&](const util::SettingsValue& value) {
-      args.LockSettings([&](util::Settings& settings) {
+    auto set_foo = [&](const common::SettingsValue& value) {
+      args.LockSettings([&](common::Settings& settings) {
         settings.rw_settings["foo"] = value;
       });
     };

--- a/src/test/settings_tests.cpp
+++ b/src/test/settings_tests.cpp
@@ -21,20 +21,20 @@
 #include <system_error>
 #include <vector>
 
-inline bool operator==(const util::SettingsValue& a, const util::SettingsValue& b)
+inline bool operator==(const common::SettingsValue& a, const common::SettingsValue& b)
 {
     return a.write() == b.write();
 }
 
-inline std::ostream& operator<<(std::ostream& os, const util::SettingsValue& value)
+inline std::ostream& operator<<(std::ostream& os, const common::SettingsValue& value)
 {
     os << value.write();
     return os;
 }
 
-inline std::ostream& operator<<(std::ostream& os, const std::pair<std::string, util::SettingsValue>& kv)
+inline std::ostream& operator<<(std::ostream& os, const std::pair<std::string, common::SettingsValue>& kv)
 {
-    util::SettingsValue out(util::SettingsValue::VOBJ);
+    common::SettingsValue out(common::SettingsValue::VOBJ);
     out.__pushKV(kv.first, kv.second);
     os << out.write();
     return os;
@@ -60,7 +60,7 @@ BOOST_AUTO_TEST_CASE(ReadWrite)
         "null": null
     })");
 
-    std::map<std::string, util::SettingsValue> expected{
+    std::map<std::string, common::SettingsValue> expected{
         {"string", "string"},
         {"num", 5},
         {"bool", true},
@@ -68,15 +68,15 @@ BOOST_AUTO_TEST_CASE(ReadWrite)
     };
 
     // Check file read.
-    std::map<std::string, util::SettingsValue> values;
+    std::map<std::string, common::SettingsValue> values;
     std::vector<std::string> errors;
-    BOOST_CHECK(util::ReadSettings(path, values, errors));
+    BOOST_CHECK(common::ReadSettings(path, values, errors));
     BOOST_CHECK_EQUAL_COLLECTIONS(values.begin(), values.end(), expected.begin(), expected.end());
     BOOST_CHECK(errors.empty());
 
     // Check no errors if file doesn't exist.
     fs::remove(path);
-    BOOST_CHECK(util::ReadSettings(path, values, errors));
+    BOOST_CHECK(common::ReadSettings(path, values, errors));
     BOOST_CHECK(values.empty());
     BOOST_CHECK(errors.empty());
 
@@ -85,29 +85,29 @@ BOOST_AUTO_TEST_CASE(ReadWrite)
         "dupe": "string",
         "dupe": "dupe"
     })");
-    BOOST_CHECK(!util::ReadSettings(path, values, errors));
+    BOOST_CHECK(!common::ReadSettings(path, values, errors));
     std::vector<std::string> dup_keys = {strprintf("Found duplicate key dupe in settings file %s", fs::PathToString(path))};
     BOOST_CHECK_EQUAL_COLLECTIONS(errors.begin(), errors.end(), dup_keys.begin(), dup_keys.end());
     BOOST_CHECK(values.empty());
 
     // Check non-kv json files not allowed
     WriteText(path, R"("non-kv")");
-    BOOST_CHECK(!util::ReadSettings(path, values, errors));
+    BOOST_CHECK(!common::ReadSettings(path, values, errors));
     std::vector<std::string> non_kv = {strprintf("Found non-object value \"non-kv\" in settings file %s", fs::PathToString(path))};
     BOOST_CHECK_EQUAL_COLLECTIONS(errors.begin(), errors.end(), non_kv.begin(), non_kv.end());
 
     // Check invalid json not allowed
     WriteText(path, R"(invalid json)");
-    BOOST_CHECK(!util::ReadSettings(path, values, errors));
+    BOOST_CHECK(!common::ReadSettings(path, values, errors));
     std::vector<std::string> fail_parse = {strprintf("Unable to parse settings file %s", fs::PathToString(path))};
     BOOST_CHECK_EQUAL_COLLECTIONS(errors.begin(), errors.end(), fail_parse.begin(), fail_parse.end());
 }
 
 //! Check settings struct contents against expected json strings.
-static void CheckValues(const util::Settings& settings, const std::string& single_val, const std::string& list_val)
+static void CheckValues(const common::Settings& settings, const std::string& single_val, const std::string& list_val)
 {
-    util::SettingsValue single_value = GetSetting(settings, "section", "name", false, false, false);
-    util::SettingsValue list_value(util::SettingsValue::VARR);
+    common::SettingsValue single_value = GetSetting(settings, "section", "name", false, false, false);
+    common::SettingsValue list_value(common::SettingsValue::VARR);
     for (const auto& item : GetSettingsList(settings, "section", "name", false)) {
         list_value.push_back(item);
     }
@@ -118,7 +118,7 @@ static void CheckValues(const util::Settings& settings, const std::string& singl
 // Simple settings merge test case.
 BOOST_AUTO_TEST_CASE(Simple)
 {
-    util::Settings settings;
+    common::Settings settings;
     settings.command_line_options["name"].push_back("val1");
     settings.command_line_options["name"].push_back("val2");
     settings.ro_config["section"]["name"].push_back(2);
@@ -126,7 +126,7 @@ BOOST_AUTO_TEST_CASE(Simple)
     // The last given arg takes precedence when specified via commandline.
     CheckValues(settings, R"("val2")", R"(["val1","val2",2])");
 
-    util::Settings settings2;
+    common::Settings settings2;
     settings2.ro_config["section"]["name"].push_back("val2");
     settings2.ro_config["section"]["name"].push_back("val3");
 
@@ -140,7 +140,7 @@ BOOST_AUTO_TEST_CASE(Simple)
 // its default value.
 BOOST_AUTO_TEST_CASE(NullOverride)
 {
-    util::Settings settings;
+    common::Settings settings;
     settings.command_line_options["name"].push_back("value");
     BOOST_CHECK_EQUAL(R"("value")", GetSetting(settings, "section", "name", false, false, false).write().c_str());
     settings.forced_settings["name"] = {};
@@ -195,11 +195,11 @@ BOOST_FIXTURE_TEST_CASE(Merge, MergeTestingSetup)
                           bool ignore_default_section_config) {
         std::string desc;
         int value_suffix = 0;
-        util::Settings settings;
+        common::Settings settings;
 
         const std::string& name = ignore_default_section_config ? "wallet" : "server";
         auto push_values = [&](Action action, const char* value_prefix, const std::string& name_prefix,
-                               std::vector<util::SettingsValue>& dest) {
+                               std::vector<common::SettingsValue>& dest) {
             if (action == SET || action == SECTION_SET) {
                 for (int i = 0; i < 2; ++i) {
                     dest.push_back(value_prefix + ToString(++value_suffix));

--- a/src/test/settings_tests.cpp
+++ b/src/test/settings_tests.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/settings.h>
+#include <common/settings.h>
 
 #include <test/util/setup_common.h>
 #include <test/util/str.h>

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -184,7 +184,7 @@ struct SnapshotTestSetup : TestChain100Setup {
         {
             LOCK(::cs_main);
             BOOST_CHECK(!chainman.IsSnapshotValidated());
-            BOOST_CHECK(!node::FindSnapshotChainstateDir());
+            BOOST_CHECK(!node::FindSnapshotChainstateDir(m_args.GetDataDirNet()));
         }
 
         size_t initial_size;
@@ -234,7 +234,7 @@ struct SnapshotTestSetup : TestChain100Setup {
                 auto_infile >> coin;
         }));
 
-        BOOST_CHECK(!node::FindSnapshotChainstateDir());
+        BOOST_CHECK(!node::FindSnapshotChainstateDir(m_args.GetDataDirNet()));
 
         BOOST_REQUIRE(!CreateAndActivateUTXOSnapshot(
             this, [](AutoFile& auto_infile, SnapshotMetadata& metadata) {
@@ -258,7 +258,7 @@ struct SnapshotTestSetup : TestChain100Setup {
         }));
 
         BOOST_REQUIRE(CreateAndActivateUTXOSnapshot(this));
-        BOOST_CHECK(fs::exists(*node::FindSnapshotChainstateDir()));
+        BOOST_CHECK(fs::exists(*node::FindSnapshotChainstateDir(m_args.GetDataDirNet())));
 
         // Ensure our active chain is the snapshot chainstate.
         BOOST_CHECK(!chainman.ActiveChainstate().m_from_snapshot_blockhash->IsNull());
@@ -271,7 +271,7 @@ struct SnapshotTestSetup : TestChain100Setup {
         {
             LOCK(::cs_main);
 
-            fs::path found = *node::FindSnapshotChainstateDir();
+            fs::path found = *node::FindSnapshotChainstateDir(m_args.GetDataDirNet());
 
             // Note: WriteSnapshotBaseBlockhash() is implicitly tested above.
             BOOST_CHECK_EQUAL(
@@ -491,7 +491,7 @@ BOOST_FIXTURE_TEST_CASE(chainstatemanager_snapshot_init, SnapshotTestSetup)
 
     this->SetupSnapshot();
 
-    fs::path snapshot_chainstate_dir = *node::FindSnapshotChainstateDir();
+    fs::path snapshot_chainstate_dir = *node::FindSnapshotChainstateDir(m_args.GetDataDirNet());
     BOOST_CHECK(fs::exists(snapshot_chainstate_dir));
     BOOST_CHECK_EQUAL(snapshot_chainstate_dir, gArgs.GetDataDirNet() / "chainstate_snapshot");
 
@@ -565,7 +565,7 @@ BOOST_FIXTURE_TEST_CASE(chainstatemanager_snapshot_completion, SnapshotTestSetup
     SnapshotCompletionResult res;
     auto mock_shutdown = [](bilingual_str msg) {};
 
-    fs::path snapshot_chainstate_dir = *node::FindSnapshotChainstateDir();
+    fs::path snapshot_chainstate_dir = *node::FindSnapshotChainstateDir(m_args.GetDataDirNet());
     BOOST_CHECK(fs::exists(snapshot_chainstate_dir));
     BOOST_CHECK_EQUAL(snapshot_chainstate_dir, gArgs.GetDataDirNet() / "chainstate_snapshot");
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -11,7 +11,6 @@
 #include <arith_uint256.h>
 #include <chain.h>
 #include <checkqueue.h>
-#include <common/args.h>
 #include <consensus/amount.h>
 #include <consensus/consensus.h>
 #include <consensus/merkle.h>
@@ -2500,7 +2499,7 @@ bool Chainstate::FlushStateToDisk(
         // Write blocks and block index to disk.
         if (fDoFullFlush || fPeriodicWrite) {
             // Ensure we can write block index
-            if (!CheckDiskSpace(gArgs.GetBlocksDirPath())) {
+            if (!CheckDiskSpace(m_blockman.m_opts.blocks_dir)) {
                 return AbortNode(state, "Disk space is too low!", _("Disk space is too low!"));
             }
             {
@@ -2536,7 +2535,7 @@ bool Chainstate::FlushStateToDisk(
             // twice (once in the log, and once in the tables). This is already
             // an overestimation, as most will delete an existing entry or
             // overwrite one. Still, use a conservative safety factor of 2.
-            if (!CheckDiskSpace(gArgs.GetDataDirNet(), 48 * 2 * 2 * CoinsTip().GetCacheSize())) {
+            if (!CheckDiskSpace(m_chainman.m_options.datadir, 48 * 2 * 2 * CoinsTip().GetCacheSize())) {
                 return AbortNode(state, "Disk space is too low!", _("Disk space is too low!"));
             }
             // Flush the chainstate (which may refer to block index entries).

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5107,7 +5107,7 @@ bool ChainstateManager::ActivateSnapshot(
 
         // PopulateAndValidateSnapshot can return (in error) before the leveldb datadir
         // has been created, so only attempt removal if we got that far.
-        if (auto snapshot_datadir = node::FindSnapshotChainstateDir()) {
+        if (auto snapshot_datadir = node::FindSnapshotChainstateDir(m_options.datadir)) {
             // We have to destruct leveldb::DB in order to release the db lock, otherwise
             // DestroyDB() (in DeleteCoinsDBFromDisk()) will fail. See `leveldb::~DBImpl()`.
             // Destructing the chainstate (and so resetting the coinsviews object) does this.
@@ -5597,7 +5597,7 @@ ChainstateManager::~ChainstateManager()
 bool ChainstateManager::DetectSnapshotChainstate(CTxMemPool* mempool)
 {
     assert(!m_snapshot_chainstate);
-    std::optional<fs::path> path = node::FindSnapshotChainstateDir();
+    std::optional<fs::path> path = node::FindSnapshotChainstateDir(m_options.datadir);
     if (!path) {
         return false;
     }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3104,7 +3104,6 @@ bool Chainstate::ActivateBestChain(BlockValidationState& state, std::shared_ptr<
 
     CBlockIndex *pindexMostWork = nullptr;
     CBlockIndex *pindexNewTip = nullptr;
-    int nStopAtHeight = gArgs.GetIntArg("-stopatheight", DEFAULT_STOPATHEIGHT);
     do {
         // Block until the validation queue drains. This should largely
         // never happen in normal operation, however may happen during
@@ -3179,7 +3178,7 @@ bool Chainstate::ActivateBestChain(BlockValidationState& state, std::shared_ptr<
         }
         // When we reach this point, we switched to a new tip (stored in pindexNewTip).
 
-        if (nStopAtHeight && pindexNewTip && pindexNewTip->nHeight >= nStopAtHeight) StartShutdown();
+        if (m_chainman.StopAtHeight() && pindexNewTip && pindexNewTip->nHeight >= m_chainman.StopAtHeight()) StartShutdown();
 
         if (WITH_LOCK(::cs_main, return m_disabled)) {
             // Background chainstate has reached the snapshot base block, so exit.

--- a/src/validation.h
+++ b/src/validation.h
@@ -65,8 +65,6 @@ struct Params;
 static const int MAX_SCRIPTCHECK_THREADS = 15;
 /** -par default (number of script-checking threads, 0 = auto) */
 static const int DEFAULT_SCRIPTCHECK_THREADS = 0;
-/** Default for -stopatheight */
-static const int DEFAULT_STOPATHEIGHT = 0;
 /** Block files containing a block-height within MIN_BLOCKS_TO_KEEP of ActiveChain().Tip() will not be pruned. */
 static const unsigned int MIN_BLOCKS_TO_KEEP = 288;
 static const signed int DEFAULT_CHECKBLOCKS = 6;
@@ -960,6 +958,7 @@ public:
     const arith_uint256& MinimumChainWork() const { return *Assert(m_options.minimum_chain_work); }
     const uint256& AssumedValidBlock() const { return *Assert(m_options.assumed_valid_block); }
     kernel::Notifications& GetNotifications() const { return m_options.notifications; };
+    int StopAtHeight() const { return m_options.stop_at_height; };
 
     /**
      * Alias for ::cs_main.

--- a/src/wallet/load.cpp
+++ b/src/wallet/load.cpp
@@ -62,7 +62,7 @@ bool VerifyWallets(WalletContext& context)
         options.require_existing = true;
         options.verify = false;
         if (MakeWalletDatabase("", options, status, error_string)) {
-            util::SettingsValue wallets(util::SettingsValue::VARR);
+            common::SettingsValue wallets(common::SettingsValue::VARR);
             wallets.push_back(""); // Default wallet name is ""
             // Pass write=false because no need to write file and probably
             // better not to. If unnamed wallet needs to be added next startup

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -56,9 +56,9 @@ namespace wallet {
 
 bool AddWalletSetting(interfaces::Chain& chain, const std::string& wallet_name)
 {
-    util::SettingsValue setting_value = chain.getRwSetting("wallet");
+    common::SettingsValue setting_value = chain.getRwSetting("wallet");
     if (!setting_value.isArray()) setting_value.setArray();
-    for (const util::SettingsValue& value : setting_value.getValues()) {
+    for (const common::SettingsValue& value : setting_value.getValues()) {
         if (value.isStr() && value.get_str() == wallet_name) return true;
     }
     setting_value.push_back(wallet_name);
@@ -67,10 +67,10 @@ bool AddWalletSetting(interfaces::Chain& chain, const std::string& wallet_name)
 
 bool RemoveWalletSetting(interfaces::Chain& chain, const std::string& wallet_name)
 {
-    util::SettingsValue setting_value = chain.getRwSetting("wallet");
+    common::SettingsValue setting_value = chain.getRwSetting("wallet");
     if (!setting_value.isArray()) return true;
-    util::SettingsValue new_value(util::SettingsValue::VARR);
-    for (const util::SettingsValue& value : setting_value.getValues()) {
+    common::SettingsValue new_value(common::SettingsValue::VARR);
+    for (const common::SettingsValue& value : setting_value.getValues()) {
         if (!value.isStr() || value.get_str() != wallet_name) new_value.push_back(value);
     }
     if (new_value.size() == setting_value.size()) return true;
@@ -2832,7 +2832,7 @@ bool CWallet::SetAddressPreviouslySpent(WalletBatch& batch, const CTxDestination
         return false;
 
     if (!used) {
-        if (auto* data{util::FindKey(m_address_book, dest)}) data->previously_spent = false;
+        if (auto* data{common::FindKey(m_address_book, dest)}) data->previously_spent = false;
         return batch.WriteAddressPreviouslySpent(dest, false);
     }
 
@@ -2852,7 +2852,7 @@ void CWallet::LoadAddressReceiveRequest(const CTxDestination& dest, const std::s
 
 bool CWallet::IsAddressPreviouslySpent(const CTxDestination& dest) const
 {
-    if (auto* data{util::FindKey(m_address_book, dest)}) return data->previously_spent;
+    if (auto* data{common::FindKey(m_address_book, dest)}) return data->previously_spent;
     return false;
 }
 


### PR DESCRIPTION
This pull request is part of the `libbitcoinkernel` project https://github.com/bitcoin/bitcoin/issues/27587 https://github.com/bitcoin/bitcoin/projects/18 and more specifically its "Step 2: Decouple most non-consensus code from libbitcoinkernel".

---

This completes the removal of the node's chainparams, chainparamsbase, args and settings files and their respective classes from the kernel library. This is the last pull request in a long series working towards decoupling the `ArgsManager` and the `gArgs` global from kernel code. These prior pull requests are: https://github.com/bitcoin/bitcoin/pull/26177 https://github.com/bitcoin/bitcoin/pull/27125 https://github.com/bitcoin/bitcoin/pull/25527 https://github.com/bitcoin/bitcoin/pull/25487 https://github.com/bitcoin/bitcoin/pull/25290

