### PR TITLE
Inscriptions option

### DIFF
--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -479,6 +479,14 @@ bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& 
                     return set_error(serror, SCRIPT_ERR_MINIMALDATA);
                 }
                 stack.push_back(vchPushValue);
+                if ((flags & SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_NOPS) && opcode == OP_FALSE) {
+                    auto pc_tmp = pc;
+                    opcodetype next_opcode;
+                    valtype dummy_data;
+                    if (script.GetOp(pc_tmp, next_opcode, dummy_data) && next_opcode == OP_IF) {
+                        return set_error(serror, SCRIPT_ERR_DISCOURAGE_UPGRADABLE_NOPS);
+                    }
+                }
             } else if (fExec || (OP_IF <= opcode && opcode <= OP_ENDIF))
             switch (opcode)
             {


### PR DESCRIPTION
There has been a lot of spam on bitcoin for several months now, it is urgent to do something to stop the spam of Inscriptions  on the chain. A whole bunch of shitcoins arrived because of brc-20 and strips the least informed bitcoiners on these topics. a lot of bitcoiners praise the assets of bitcoin such as the fact that it is a hard currency unlike shitcoins so why let this thing proliferate on the chain?

I hope that the developers will not just refuse this request and especially that they will take a little of their time to make this code optional for example with an `Inscription=0` in the file `bitcoin.conf`