### PR TITLE
refactor: Remove unused GetTimeMillis

### DIFF
--- a/src/bench/util_time.cpp
+++ b/src/bench/util_time.cpp
@@ -32,7 +32,7 @@ static void BenchTimeMillis(benchmark::Bench& bench)
 static void BenchTimeMillisSys(benchmark::Bench& bench)
 {
     bench.run([&] {
-        (void)GetTimeMillis();
+        (void)TicksSinceEpoch<std::chrono::milliseconds>(SystemClock::now());
     });
 }
 

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -512,15 +512,15 @@ static RPCHelpMan getaddednodeinfo()
 static RPCHelpMan getnettotals()
 {
     return RPCHelpMan{"getnettotals",
-                "\nReturns information about network traffic, including bytes in, bytes out,\n"
-                "and current time.\n",
-                {},
+        "Returns information about network traffic, including bytes in, bytes out,\n"
+        "and current system time.",
+        {},
                 RPCResult{
                    RPCResult::Type::OBJ, "", "",
                    {
                        {RPCResult::Type::NUM, "totalbytesrecv", "Total bytes received"},
                        {RPCResult::Type::NUM, "totalbytessent", "Total bytes sent"},
-                       {RPCResult::Type::NUM_TIME, "timemillis", "Current " + UNIX_EPOCH_TIME + " in milliseconds"},
+                       {RPCResult::Type::NUM_TIME, "timemillis", "Current system " + UNIX_EPOCH_TIME + " in milliseconds"},
                        {RPCResult::Type::OBJ, "uploadtarget", "",
                        {
                            {RPCResult::Type::NUM, "timeframe", "Length of the measuring timeframe in seconds"},
@@ -544,7 +544,7 @@ static RPCHelpMan getnettotals()
     UniValue obj(UniValue::VOBJ);
     obj.pushKV("totalbytesrecv", connman.GetTotalBytesRecv());
     obj.pushKV("totalbytessent", connman.GetTotalBytesSent());
-    obj.pushKV("timemillis", GetTimeMillis());
+    obj.pushKV("timemillis", TicksSinceEpoch<std::chrono::milliseconds>(SystemClock::now()));
 
     UniValue outboundLimit(UniValue::VOBJ);
     outboundLimit.pushKV("timeframe", count_seconds(connman.GetMaxOutboundTimeframe()));

--- a/src/util/time.cpp
+++ b/src/util/time.cpp
@@ -78,14 +78,6 @@ NodeClock::time_point NodeClock::now() noexcept
     return time_point{ret};
 };
 
-template <typename T>
-static T GetSystemTime()
-{
-    const auto now = std::chrono::duration_cast<T>(std::chrono::system_clock::now().time_since_epoch());
-    assert(now.count() > 0);
-    return now;
-}
-
 void SetMockTime(int64_t nMockTimeIn)
 {
     Assert(nMockTimeIn >= 0);
@@ -100,11 +92,6 @@ void SetMockTime(std::chrono::seconds mock_time_in)
 std::chrono::seconds GetMockTime()
 {
     return std::chrono::seconds(nMockTime.load(std::memory_order_relaxed));
-}
-
-int64_t GetTimeMillis()
-{
-    return int64_t{GetSystemTime<std::chrono::milliseconds>().count()};
 }
 
 int64_t GetTime() { return GetTime<std::chrono::seconds>().count(); }

--- a/src/util/time.h
+++ b/src/util/time.h
@@ -71,9 +71,6 @@ using MillisecondsDouble = std::chrono::duration<double, std::chrono::millisecon
  */
 int64_t GetTime();
 
-/** Returns the system time (not mockable) */
-int64_t GetTimeMillis();
-
 /**
  * DEPRECATED
  * Use SetMockTime with chrono type


### PR DESCRIPTION
The function is unused, not type-safe, and does not denote the underlying clock type. So remove it.