### PR TITLE
net: Add new permission `forceinbound` to evict a random unprotected connection if all slots are otherwise full

### DIFF
--- a/doc/release-notes-27600.md
+++ b/doc/release-notes-27600.md
@@ -8,4 +8,4 @@ P2P
   slots are full. This is achieved by attempting to force the eviction of a random,
   inbound, otherwise unprotected peer. Because this permission can be exploited
   to disrupt existing connections, a maximum of 8 forced inbound peers are allowed
-  simultaneously. (#27600)
+  simultaneously. RPC `getpeerinfo` will also now indicate `forced_inbound`. (#27600)

--- a/doc/release-notes-27600.md
+++ b/doc/release-notes-27600.md
@@ -1,0 +1,10 @@
+P2P
+---
+
+- A new net permission `forceinbound` (set with `-whitelist=forceinbound@...`
+  or `-whitebind=forceinbound@...`) is introduced that extends `noban` permissions.
+  Inbound connections from hosts protected by `forceinbound` will now be more
+  likely to connect even if `maxconnections` is reached and the node's inbound
+  slots are full. This is achieved by attempting to force the eviction of a random,
+  inbound, otherwise unprotected peer. Because this permission can be exploited
+  to disrupt existing connections, it should be used only with limited ranges.

--- a/doc/release-notes-27600.md
+++ b/doc/release-notes-27600.md
@@ -7,4 +7,5 @@ P2P
   likely to connect even if `maxconnections` is reached and the node's inbound
   slots are full. This is achieved by attempting to force the eviction of a random,
   inbound, otherwise unprotected peer. Because this permission can be exploited
-  to disrupt existing connections, it should be used only with limited ranges.
+  to disrupt existing connections, a maximum of 8 forced inbound peers are allowed
+  simultaneously. (#27600)

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -627,6 +627,7 @@ void CNode::CopyStats(CNodeStats& stats)
         if (info.session_id) stats.m_session_id = HexStr(*info.session_id);
     }
     X(m_permission_flags);
+    X(m_forced_inbound);
 
     X(m_last_ping_time);
     X(m_min_ping_time);

--- a/src/net.h
+++ b/src/net.h
@@ -226,6 +226,8 @@ public:
     TransportProtocolType m_transport_type;
     /** BIP324 session id string in hex, if any. */
     std::string m_session_id;
+    /** whether this peer forced its connection by evicting another */
+    bool m_forced_inbound;
 };
 
 

--- a/src/net.h
+++ b/src/net.h
@@ -87,6 +87,8 @@ static const bool DEFAULT_BLOCKSONLY = false;
 static const int64_t DEFAULT_PEER_CONNECT_TIMEOUT = 60;
 /** Number of file descriptors required for message capture **/
 static const int NUM_FDS_MESSAGE_CAPTURE = 1;
+/** Maximum number of forced inbound connections **/
+static const int MAX_FORCED_INBOUND_CONNECTIONS{8};
 
 static constexpr bool DEFAULT_FORCEDNSSEED{false};
 static constexpr bool DEFAULT_DNSSEED{true};
@@ -675,6 +677,8 @@ struct CNodeOptions
     NetPermissionFlags permission_flags = NetPermissionFlags::None;
     std::unique_ptr<i2p::sam::Session> i2p_sam_session = nullptr;
     bool prefer_evict = false;
+    // True if ForceInbound connection required evicting a peer
+    bool forced_inbound{false};
     size_t recv_flood_size{DEFAULT_MAXRECEIVEBUFFER * 1000};
     bool use_v2transport = false;
 };
@@ -733,6 +737,7 @@ public:
      */
     std::string cleanSubVer GUARDED_BY(m_subver_mutex){};
     const bool m_prefer_evict{false}; // This peer is preferred for eviction.
+    const bool m_forced_inbound{false}; // This peer forced an inbound connection
     bool HasPermission(NetPermissionFlags permission) const {
         return NetPermissions::HasFlag(m_permission_flags, permission);
     }

--- a/src/net.h
+++ b/src/net.h
@@ -1333,7 +1333,14 @@ private:
      */
     bool AlreadyConnectedToAddress(const CAddress& addr);
 
-    bool AttemptToEvictConnection();
+    /**
+     * Attempt to disconnect a connected peer.
+     * Used to make room for new inbound connections, returns true if successful.
+     * @param[in] force     Try to evict a random inbound ban-able peer if
+     *                      all connections are otherwise protected.
+     */
+    bool AttemptToEvictConnection(bool force);
+
     CNode* ConnectNode(CAddress addrConnect, const char *pszDest, bool fCountFailure, ConnectionType conn_type, bool use_v2transport) EXCLUSIVE_LOCKS_REQUIRED(!m_unused_i2p_sessions_mutex);
     void AddWhitelistPermissionFlags(NetPermissionFlags& flags, const CNetAddr &addr) const;
 

--- a/src/net_permissions.cpp
+++ b/src/net_permissions.cpp
@@ -15,7 +15,8 @@ const std::vector<std::string> NET_PERMISSIONS_DOC{
     "relay (relay even in -blocksonly mode, and unlimited transaction announcements)",
     "mempool (allow requesting BIP35 mempool contents)",
     "download (allow getheaders during IBD, no disconnect after maxuploadtarget limit)",
-    "addr (responses to GETADDR avoid hitting the cache and contain random records with the most up-to-date info)"
+    "addr (responses to GETADDR avoid hitting the cache and contain random records with the most up-to-date info)",
+    "forceinbound (when connections are full, attempt to evict a random unprotected inbound peer to open a slot; implies noban)"
 };
 
 namespace {
@@ -52,6 +53,7 @@ bool TryParsePermissionFlags(const std::string& str, NetPermissionFlags& output,
             else if (permission == "all") NetPermissions::AddFlag(flags, NetPermissionFlags::All);
             else if (permission == "relay") NetPermissions::AddFlag(flags, NetPermissionFlags::Relay);
             else if (permission == "addr") NetPermissions::AddFlag(flags, NetPermissionFlags::Addr);
+            else if (permission == "forceinbound") NetPermissions::AddFlag(flags, NetPermissionFlags::ForceInbound);
             else if (permission.length() == 0); // Allow empty entries
             else {
                 error = strprintf(_("Invalid P2P permission: '%s'"), permission);

--- a/src/net_permissions.h
+++ b/src/net_permissions.h
@@ -34,11 +34,14 @@ enum class NetPermissionFlags : uint32_t {
     // Can request addrs without hitting a privacy-preserving cache, and send us
     // unlimited amounts of addrs.
     Addr = (1U << 7),
+    // Try harder to evict an existing connection if needed to open
+    // an inbound slot from this peer
+    ForceInbound = (1U << 8) | NoBan,
 
     // True if the user did not specifically set fine-grained permissions with
     // the -whitebind or -whitelist configuration options.
     Implicit = (1U << 31),
-    All = BloomFilter | ForceRelay | Relay | NoBan | Mempool | Download | Addr,
+    All = BloomFilter | ForceRelay | Relay | NoBan | Mempool | Download | Addr | ForceInbound,
 };
 static inline constexpr NetPermissionFlags operator|(NetPermissionFlags a, NetPermissionFlags b)
 {

--- a/src/node/eviction.h
+++ b/src/node/eviction.h
@@ -38,8 +38,12 @@ struct NodeEvictionCandidate {
  * fixed numbers of desirable peers per various criteria, followed by (mostly)
  * ratios of desirable or disadvantaged peers. If any eviction candidates
  * remain, the selection logic chooses a peer to evict.
+ * @param[in]   force   Attempt to evict a random peer if no candidates
+ *                      are available among inbound no-ban connections.
+ *                      (see CConman::AttemptToEvictConnection())
+ *                      Default: false
  */
-[[nodiscard]] std::optional<NodeId> SelectNodeToEvict(std::vector<NodeEvictionCandidate>&& vEvictionCandidates);
+[[nodiscard]] std::optional<NodeId> SelectNodeToEvict(std::vector<NodeEvictionCandidate>&& vEvictionCandidates, bool force = false);
 
 /** Protect desirable or disadvantaged inbound peers from eviction by ratio.
  *

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -167,6 +167,7 @@ static RPCHelpMan getpeerinfo()
                     {
                         {RPCResult::Type::STR, "permission_type", Join(NET_PERMISSIONS_DOC, ",\n") + ".\n"},
                     }},
+                    {RPCResult::Type::BOOL, "forced_inbound", "Whether this peer forced a connection by evicting another."},
                     {RPCResult::Type::NUM, "minfeefilter", "The minimum fee rate for transactions this peer accepts"},
                     {RPCResult::Type::OBJ_DYN, "bytessent_per_msg", "",
                     {
@@ -274,6 +275,7 @@ static RPCHelpMan getpeerinfo()
             permissions.push_back(permission);
         }
         obj.pushKV("permissions", permissions);
+        obj.pushKV("forced_inbound", stats.m_forced_inbound);
         obj.pushKV("minfeefilter", ValueFromAmount(statestats.m_fee_filter_received));
 
         UniValue sendPerMsgType(UniValue::VOBJ);

--- a/src/test/fuzz/node_eviction.cpp
+++ b/src/test/fuzz/node_eviction.cpp
@@ -40,7 +40,7 @@ FUZZ_TARGET(node_eviction)
     // Make a copy since eviction_candidates may be in some valid but otherwise
     // indeterminate state after the SelectNodeToEvict(&&) call.
     const std::vector<NodeEvictionCandidate> eviction_candidates_copy = eviction_candidates;
-    const std::optional<NodeId> node_to_evict = SelectNodeToEvict(std::move(eviction_candidates));
+    const std::optional<NodeId> node_to_evict = SelectNodeToEvict(std::move(eviction_candidates), /*force=*/fuzzed_data_provider.ConsumeBool());
     if (node_to_evict) {
         assert(std::any_of(eviction_candidates_copy.begin(), eviction_candidates_copy.end(), [&node_to_evict](const NodeEvictionCandidate& eviction_candidate) { return *node_to_evict == eviction_candidate.id; }));
     }

--- a/src/test/net_peer_eviction_tests.cpp
+++ b/src/test/net_peer_eviction_tests.cpp
@@ -573,7 +573,7 @@ BOOST_AUTO_TEST_CASE(peer_protection_test)
 bool IsEvicted(std::vector<NodeEvictionCandidate> candidates, const std::unordered_set<NodeId>& node_ids, FastRandomContext& random_context)
 {
     Shuffle(candidates.begin(), candidates.end(), random_context);
-    const std::optional<NodeId> evicted_node_id = SelectNodeToEvict(std::move(candidates));
+    const std::optional<NodeId> evicted_node_id = SelectNodeToEvict(std::move(candidates), /*force=*/false);
     if (!evicted_node_id) {
         return false;
     }
@@ -666,14 +666,14 @@ BOOST_AUTO_TEST_CASE(peer_eviction_test)
         // four peers by net group, eight by lowest ping time, four by last time of novel tx, up to eight non-tx-relay
         // peers by last novel block time, and four more peers by last novel block time.
         if (number_of_nodes >= 29) {
-            BOOST_CHECK(SelectNodeToEvict(GetRandomNodeEvictionCandidates(number_of_nodes, random_context)));
+            BOOST_CHECK(SelectNodeToEvict(GetRandomNodeEvictionCandidates(number_of_nodes, random_context), /*force=*/false));
         }
 
         // No eviction is expected given <= 20 random eviction candidates. The eviction logic protects at least
         // four peers by net group, eight by lowest ping time, four by last time of novel tx and four peers by last
         // novel block time.
         if (number_of_nodes <= 20) {
-            BOOST_CHECK(!SelectNodeToEvict(GetRandomNodeEvictionCandidates(number_of_nodes, random_context)));
+            BOOST_CHECK(!SelectNodeToEvict(GetRandomNodeEvictionCandidates(number_of_nodes, random_context), /*force=*/false));
         }
 
         // Cases left to test:

--- a/test/functional/p2p_eviction.py
+++ b/test/functional/p2p_eviction.py
@@ -123,15 +123,18 @@ class P2PEvict(BitcoinTestFramework):
         assert evicted_peers[0] not in protected_peers
 
         self.log.info("Test that whitebind inbounds get extra eviction power")
-        # Only allow 1 inbound connection, but set whitebind
-        self.restart_node(0, extra_args=['-maxconnections=12', '-whitebind=127.0.0.1:30201', '-whitebind=forceinbound@127.0.0.1:30202'])
-        self.log.debug("Connect 1 peer")
-        node.add_p2p_connection(P2PInterface())
+        # Allow 10 inbound connections, set whitebind and forceinbound
+        self.restart_node(0, extra_args=['-maxconnections=21', '-whitebind=127.0.0.1:30201', '-whitebind=forceinbound@127.0.0.1:30202'])
+        self.log.debug("Fill connections with unprivileged peers")
+        for i in range(10):
+            node.add_p2p_connection(P2PInterface())
 
         # Create a peer that expects to be rejected
         class RejectedPeer(P2PInterface):
             def connection_lost(self, exc):
                 return
+
+        allowed_peers = []
 
         self.log.debug("Generic inbound gets rejected when full")
         with node.assert_debug_log(["failed to find an eviction candidate - connection dropped (full)"]):
@@ -142,20 +145,24 @@ class P2PEvict(BitcoinTestFramework):
             node.add_p2p_connection(RejectedPeer(), wait_for_verack=False, dstport=30201)
 
         self.log.debug("ForceInbound whitebind inbound gets connected, even when full")
-        allowed_peer = node.add_p2p_connection(P2PInterface(), dstport=30202)
+        allowed_peers.append(node.add_p2p_connection(P2PInterface(), dstport=30202))
 
-        assert_equal(len(node.getpeerinfo()), 1)
+        assert_equal(len(node.getpeerinfo()), 10)
 
         self.log.debug("Generic inbound gets rejected when whitebind peer is filling inbound slot")
         with node.assert_debug_log(["failed to find an eviction candidate - connection dropped (full)"]):
             node.add_p2p_connection(RejectedPeer(), wait_for_verack=False)
 
-        self.log.debug("ForceInbound whitebind inbound gets rejected when another whitebind peer is filling inbound slot")
-        with node.assert_debug_log(["failed to find an eviction candidate - connection dropped (full)"]):
+        self.log.debug("Fill force_inbound slots")
+        for i in range(7):
+            allowed_peers.append(node.add_p2p_connection(P2PInterface(), dstport=30202))
+
+        self.log.debug("ForceInbound gets rejected after 8 evictions")
+        with node.assert_debug_log([f"dropped (too many forced inbound)"]):
             node.add_p2p_connection(RejectedPeer(), dstport=30202, wait_for_verack=False)
 
-        assert_equal(len(node.getpeerinfo()), 1)
-        assert allowed_peer.is_connected
+        assert_equal(len(node.getpeerinfo()), 10)
+        assert [peer.is_connected for peer in allowed_peers]
 
 if __name__ == '__main__':
     P2PEvict().main()

--- a/test/functional/p2p_eviction.py
+++ b/test/functional/p2p_eviction.py
@@ -147,7 +147,13 @@ class P2PEvict(BitcoinTestFramework):
         self.log.debug("ForceInbound whitebind inbound gets connected, even when full")
         allowed_peers.append(node.add_p2p_connection(P2PInterface(), dstport=30202))
 
-        assert_equal(len(node.getpeerinfo()), 10)
+        peerinfo = node.getpeerinfo()
+        assert_equal(len(peerinfo), 10)
+        for peer in peerinfo:
+            if "30202" in peer["addrbind"]:
+                assert peer["forced_inbound"]
+            else:
+                assert not peer["forced_inbound"]
 
         self.log.debug("Generic inbound gets rejected when whitebind peer is filling inbound slot")
         with node.assert_debug_log(["failed to find an eviction candidate - connection dropped (full)"]):

--- a/test/functional/p2p_eviction.py
+++ b/test/functional/p2p_eviction.py
@@ -122,6 +122,40 @@ class P2PEvict(BitcoinTestFramework):
         self.log.debug("{} protected peers: {}".format(len(protected_peers), protected_peers))
         assert evicted_peers[0] not in protected_peers
 
+        self.log.info("Test that whitebind inbounds get extra eviction power")
+        # Only allow 1 inbound connection, but set whitebind
+        self.restart_node(0, extra_args=['-maxconnections=12', '-whitebind=127.0.0.1:30201', '-whitebind=forceinbound@127.0.0.1:30202'])
+        self.log.debug("Connect 1 peer")
+        node.add_p2p_connection(P2PInterface())
+
+        # Create a peer that expects to be rejected
+        class RejectedPeer(P2PInterface):
+            def connection_lost(self, exc):
+                return
+
+        self.log.debug("Generic inbound gets rejected when full")
+        with node.assert_debug_log(["failed to find an eviction candidate - connection dropped (full)"]):
+            node.add_p2p_connection(RejectedPeer(), wait_for_verack=False)
+
+        self.log.debug("Default whitebind inbound gets rejected, even when full")
+        with node.assert_debug_log(["failed to find an eviction candidate - connection dropped (full)"]):
+            node.add_p2p_connection(RejectedPeer(), wait_for_verack=False, dstport=30201)
+
+        self.log.debug("ForceInbound whitebind inbound gets connected, even when full")
+        allowed_peer = node.add_p2p_connection(P2PInterface(), dstport=30202)
+
+        assert_equal(len(node.getpeerinfo()), 1)
+
+        self.log.debug("Generic inbound gets rejected when whitebind peer is filling inbound slot")
+        with node.assert_debug_log(["failed to find an eviction candidate - connection dropped (full)"]):
+            node.add_p2p_connection(RejectedPeer(), wait_for_verack=False)
+
+        self.log.debug("ForceInbound whitebind inbound gets rejected when another whitebind peer is filling inbound slot")
+        with node.assert_debug_log(["failed to find an eviction candidate - connection dropped (full)"]):
+            node.add_p2p_connection(RejectedPeer(), dstport=30202, wait_for_verack=False)
+
+        assert_equal(len(node.getpeerinfo()), 1)
+        assert allowed_peer.is_connected
 
 if __name__ == '__main__':
     P2PEvict().main()

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -140,6 +140,7 @@ class NetTest(BitcoinTestFramework):
                 "minfeefilter": Decimal("0E-8"),
                 "network": "not_publicly_routable",
                 "permissions": [],
+                "forced_inbound": False,
                 "presynced_headers": -1,
                 "relaytxes": False,
                 "services": "0000000000000000",


### PR DESCRIPTION
Closes https://github.com/bitcoin/bitcoin/issues/8798

Use case: I run a full node that accepts inbound connections and have a `whitebind` setting so my personal light client can always connect, even when `maxconnections` (and particularly all inbound slots) is already full.

Currently when connections are full, if we receive an inbound peer request, we look for a current connection to evict so the new peer can have a slot. To find an evict-able peer we go through all our peers and "protect" multiple categories of peers, then we evict the "worst" peer that is left unprotected. If there are no peers left to evict, the inbound connection is denied.

With this PR, if the inbound connection has `forceinbound` permission we start the eviction process by first protecting all `noban` and outbound connections, then selecting one of the remaining peers (if any) at random. Then we loop through all our current connections, removing protected peers from the evict-able list. If we end up protecting all our remaining connections, the randomly chosen peer is evicted.

`forceinbound` implies `noban` permission.

All outbound and `noban` connections remain protected from eviction.