### PR TITLE
wallet: don't duplicate change output if already exist

### DIFF
--- a/src/bench/coin_selection.cpp
+++ b/src/bench/coin_selection.cpp
@@ -69,7 +69,6 @@ static void CoinSelection(benchmark::Bench& bench)
     const CoinSelectionParams coin_selection_params{
         rand,
         /*change_output_size=*/ 34,
-        /*change_spend_size=*/ 148,
         /*min_change_target=*/ CHANGE_LOWER,
         /*effective_feerate=*/ CFeeRate(0),
         /*long_term_feerate=*/ CFeeRate(0),

--- a/src/bench/coin_selection.cpp
+++ b/src/bench/coin_selection.cpp
@@ -72,7 +72,6 @@ static void CoinSelection(benchmark::Bench& bench)
         /*min_change_target=*/ CHANGE_LOWER,
         /*effective_feerate=*/ CFeeRate(0),
         /*long_term_feerate=*/ CFeeRate(0),
-        /*discard_feerate=*/ CFeeRate(0),
         /*tx_noinputs_size=*/ 0,
         /*avoid_partial=*/ false,
     };

--- a/src/wallet/coinselection.h
+++ b/src/wallet/coinselection.h
@@ -125,8 +125,6 @@ struct CoinSelectionParams {
     FastRandomContext& rng_fast;
     /** Size of a change output in bytes, determined by the output type. */
     size_t change_output_size = 0;
-    /** Size of the input to spend a change output in virtual bytes. */
-    size_t change_spend_size = 0;
     /** Mininmum change to target in Knapsack solver: select coins to cover the payment and
      * at least this value of change. */
     CAmount m_min_change_target{0};
@@ -160,12 +158,11 @@ struct CoinSelectionParams {
      */
     bool m_include_unsafe_inputs = false;
 
-    CoinSelectionParams(FastRandomContext& rng_fast, size_t change_output_size, size_t change_spend_size,
+    CoinSelectionParams(FastRandomContext& rng_fast, size_t change_output_size,
                         CAmount min_change_target, CFeeRate effective_feerate,
                         CFeeRate long_term_feerate, CFeeRate discard_feerate, size_t tx_noinputs_size, bool avoid_partial)
         : rng_fast{rng_fast},
           change_output_size(change_output_size),
-          change_spend_size(change_spend_size),
           m_min_change_target(min_change_target),
           m_effective_feerate(effective_feerate),
           m_long_term_feerate(long_term_feerate),

--- a/src/wallet/coinselection.h
+++ b/src/wallet/coinselection.h
@@ -280,13 +280,14 @@ typedef std::map<CoinEligibilityFilter, OutputGroupTypeMap> FilteredOutputGroups
  *
  * @param[in] inputs The selected inputs
  * @param[in] change_cost The cost of creating change and spending it in the future.
- *                        Only used if there is change, in which case it must be positive.
- *                        Must be 0 if there is no change.
+ *                        Only used if there is change, in which case it must be positive, or 0 for an already covered
+ *                        change cost (e.g. existent change output).
+ *                        Must be std::nullopt if there is no change.
  * @param[in] target The amount targeted by the coin selection algorithm.
  * @param[in] use_effective_value Whether to use the input's effective value (when true) or the real value (when false).
  * @return The waste
  */
-[[nodiscard]] CAmount GetSelectionWaste(const std::set<std::shared_ptr<COutput>>& inputs, CAmount change_cost, CAmount target, bool use_effective_value = true);
+[[nodiscard]] CAmount GetSelectionWaste(const std::set<std::shared_ptr<COutput>>& inputs, std::optional<CAmount> change_cost, CAmount target, bool use_effective_value = true);
 
 
 /** Choose a random change target for each transaction to make it harder to fingerprint the Core

--- a/src/wallet/coinselection.h
+++ b/src/wallet/coinselection.h
@@ -141,8 +141,6 @@ struct CoinSelectionParams {
     /** The feerate estimate used to estimate an upper bound on what should be sufficient to spend
      * the change output sometime in the future. */
     CFeeRate m_long_term_feerate;
-    /** If the cost to spend a change output at the discard feerate exceeds its value, drop it to fees. */
-    CFeeRate m_discard_feerate;
     /** Size of the transaction before coin selection, consisting of the header and recipient
      * output(s), excluding the inputs and change output(s). */
     size_t tx_noinputs_size = 0;
@@ -160,13 +158,12 @@ struct CoinSelectionParams {
 
     CoinSelectionParams(FastRandomContext& rng_fast, size_t change_output_size,
                         CAmount min_change_target, CFeeRate effective_feerate,
-                        CFeeRate long_term_feerate, CFeeRate discard_feerate, size_t tx_noinputs_size, bool avoid_partial)
+                        CFeeRate long_term_feerate, size_t tx_noinputs_size, bool avoid_partial)
         : rng_fast{rng_fast},
           change_output_size(change_output_size),
           m_min_change_target(min_change_target),
           m_effective_feerate(effective_feerate),
           m_long_term_feerate(long_term_feerate),
-          m_discard_feerate(discard_feerate),
           tx_noinputs_size(tx_noinputs_size),
           m_avoid_partial_spends(avoid_partial)
     {

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -946,8 +946,10 @@ static util::Result<CreatedTransactionResult> CreateTransactionInternal(
         return util::Error{strprintf(_("Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable %s."), "-fallbackfee")};
     }
 
-    // Set the 'change' related coin selection params
-    ComputeChangeParams(coin_selection_params, wallet, scriptChange, recipients_sum, vecSend.size());
+    // Only compute 'change' params when we might produce a change output
+    if (!existent_change_out_index) {
+        ComputeChangeParams(coin_selection_params, wallet, scriptChange, recipients_sum, vecSend.size());
+    }
 
     // Static vsize overhead + outputs vsize. 4 nVersion, 4 nLocktime, 1 input count, 1 witness overhead (dummy, flag, stack size)
     coin_selection_params.tx_noinputs_size = 10 + GetSizeOfCompactSize(vecSend.size()); // bytes for output count

--- a/src/wallet/test/coinselector_tests.cpp
+++ b/src/wallet/test/coinselector_tests.cpp
@@ -162,7 +162,6 @@ inline std::vector<OutputGroup>& KnapsackGroupOutputs(const CoinsResult& availab
     CoinSelectionParams coin_selection_params{
         rand,
         /*change_output_size=*/ 0,
-        /*change_spend_size=*/ 0,
         /*min_change_target=*/ CENT,
         /*effective_feerate=*/ CFeeRate(0),
         /*long_term_feerate=*/ CFeeRate(0),
@@ -307,7 +306,6 @@ BOOST_AUTO_TEST_CASE(bnb_search_test)
     CoinSelectionParams coin_selection_params_bnb{
         rand,
         /*change_output_size=*/ 31,
-        /*change_spend_size=*/ 68,
         /*min_change_target=*/ 0,
         /*effective_feerate=*/ CFeeRate(3000),
         /*long_term_feerate=*/ CFeeRate(1000),
@@ -315,9 +313,10 @@ BOOST_AUTO_TEST_CASE(bnb_search_test)
         /*tx_noinputs_size=*/ 0,
         /*avoid_partial=*/ false,
     };
+    uint32_t change_spend_size = 68;
     coin_selection_params_bnb.m_change_fee = coin_selection_params_bnb.m_effective_feerate.GetFee(coin_selection_params_bnb.change_output_size);
-    coin_selection_params_bnb.m_cost_of_change = coin_selection_params_bnb.m_effective_feerate.GetFee(coin_selection_params_bnb.change_spend_size) + coin_selection_params_bnb.m_change_fee;
-    coin_selection_params_bnb.min_viable_change = coin_selection_params_bnb.m_effective_feerate.GetFee(coin_selection_params_bnb.change_spend_size);
+    coin_selection_params_bnb.m_cost_of_change = coin_selection_params_bnb.m_effective_feerate.GetFee(change_spend_size) + coin_selection_params_bnb.m_change_fee;
+    coin_selection_params_bnb.min_viable_change = coin_selection_params_bnb.m_effective_feerate.GetFee(change_spend_size);
     coin_selection_params_bnb.m_subtract_fee_outputs = true;
 
     {
@@ -808,7 +807,6 @@ BOOST_AUTO_TEST_CASE(SelectCoins_test)
         CoinSelectionParams cs_params{
             rand,
             /*change_output_size=*/ 34,
-            /*change_spend_size=*/ 148,
             /*min_change_target=*/ CENT,
             /*effective_feerate=*/ CFeeRate(0),
             /*long_term_feerate=*/ CFeeRate(0),
@@ -982,7 +980,6 @@ BOOST_AUTO_TEST_CASE(srd_tests)
     CoinSelectionParams dummy_params{ // Only used to provide the 'avoid_partial' flag.
             rand,
             /*change_output_size=*/34,
-            /*change_spend_size=*/68,
             /*min_change_target=*/CENT,
             /*effective_feerate=*/CFeeRate(0),
             /*long_term_feerate=*/CFeeRate(0),
@@ -1077,7 +1074,6 @@ BOOST_AUTO_TEST_CASE(check_max_weight)
     CoinSelectionParams cs_params{
         rand,
         /*change_output_size=*/34,
-        /*change_spend_size=*/68,
         /*min_change_target=*/CENT,
         /*effective_feerate=*/CFeeRate(0),
         /*long_term_feerate=*/CFeeRate(0),
@@ -1182,7 +1178,6 @@ BOOST_AUTO_TEST_CASE(SelectCoins_effective_value_test)
     CoinSelectionParams cs_params{
         rand,
         /*change_output_size=*/34,
-        /*change_spend_size=*/148,
         /*min_change_target=*/1000,
         /*effective_feerate=*/CFeeRate(3000),
         /*long_term_feerate=*/CFeeRate(1000),

--- a/src/wallet/test/coinselector_tests.cpp
+++ b/src/wallet/test/coinselector_tests.cpp
@@ -165,7 +165,6 @@ inline std::vector<OutputGroup>& KnapsackGroupOutputs(const CoinsResult& availab
         /*min_change_target=*/ CENT,
         /*effective_feerate=*/ CFeeRate(0),
         /*long_term_feerate=*/ CFeeRate(0),
-        /*discard_feerate=*/ CFeeRate(0),
         /*tx_noinputs_size=*/ 0,
         /*avoid_partial=*/ false,
     };
@@ -309,7 +308,6 @@ BOOST_AUTO_TEST_CASE(bnb_search_test)
         /*min_change_target=*/ 0,
         /*effective_feerate=*/ CFeeRate(3000),
         /*long_term_feerate=*/ CFeeRate(1000),
-        /*discard_feerate=*/ CFeeRate(1000),
         /*tx_noinputs_size=*/ 0,
         /*avoid_partial=*/ false,
     };
@@ -810,7 +808,6 @@ BOOST_AUTO_TEST_CASE(SelectCoins_test)
             /*min_change_target=*/ CENT,
             /*effective_feerate=*/ CFeeRate(0),
             /*long_term_feerate=*/ CFeeRate(0),
-            /*discard_feerate=*/ CFeeRate(0),
             /*tx_noinputs_size=*/ 0,
             /*avoid_partial=*/ false,
         };
@@ -983,7 +980,6 @@ BOOST_AUTO_TEST_CASE(srd_tests)
             /*min_change_target=*/CENT,
             /*effective_feerate=*/CFeeRate(0),
             /*long_term_feerate=*/CFeeRate(0),
-            /*discard_feerate=*/CFeeRate(0),
             /*tx_noinputs_size=*/10 + 34, // static header size + output size
             /*avoid_partial=*/false,
     };
@@ -1077,7 +1073,6 @@ BOOST_AUTO_TEST_CASE(check_max_weight)
         /*min_change_target=*/CENT,
         /*effective_feerate=*/CFeeRate(0),
         /*long_term_feerate=*/CFeeRate(0),
-        /*discard_feerate=*/CFeeRate(0),
         /*tx_noinputs_size=*/10 + 34, // static header size + output size
         /*avoid_partial=*/false,
     };
@@ -1181,7 +1176,6 @@ BOOST_AUTO_TEST_CASE(SelectCoins_effective_value_test)
         /*min_change_target=*/1000,
         /*effective_feerate=*/CFeeRate(3000),
         /*long_term_feerate=*/CFeeRate(1000),
-        /*discard_feerate=*/CFeeRate(1000),
         /*tx_noinputs_size=*/0,
         /*avoid_partial=*/false,
     };

--- a/src/wallet/test/fuzz/coinselection.cpp
+++ b/src/wallet/test/fuzz/coinselection.cpp
@@ -99,8 +99,8 @@ FUZZ_TARGET(coinselection)
     coin_params.change_output_size = fuzzed_data_provider.ConsumeIntegralInRange<int>(10, 1000);
     coin_params.m_change_fee = effective_fee_rate.GetFee(coin_params.change_output_size);
     coin_params.m_discard_feerate = discard_fee_rate;
-    coin_params.change_spend_size = fuzzed_data_provider.ConsumeIntegralInRange<int>(41, 1000);
-    coin_params.m_cost_of_change = coin_params.m_change_fee + coin_params.m_discard_feerate.GetFee(coin_params.change_spend_size);
+    CAmount change_spend_size = fuzzed_data_provider.ConsumeIntegralInRange<int>(41, 1000);
+    coin_params.m_cost_of_change = coin_params.m_change_fee + coin_params.m_discard_feerate.GetFee(change_spend_size);
 
     int next_locktime{0};
     CAmount total_balance{CreateCoins(fuzzed_data_provider, utxo_pool, coin_params, next_locktime)};

--- a/src/wallet/test/fuzz/coinselection.cpp
+++ b/src/wallet/test/fuzz/coinselection.cpp
@@ -98,9 +98,8 @@ FUZZ_TARGET(coinselection)
     coin_params.min_viable_change = min_viable_change;
     coin_params.change_output_size = fuzzed_data_provider.ConsumeIntegralInRange<int>(10, 1000);
     coin_params.m_change_fee = effective_fee_rate.GetFee(coin_params.change_output_size);
-    coin_params.m_discard_feerate = discard_fee_rate;
     CAmount change_spend_size = fuzzed_data_provider.ConsumeIntegralInRange<int>(41, 1000);
-    coin_params.m_cost_of_change = coin_params.m_change_fee + coin_params.m_discard_feerate.GetFee(change_spend_size);
+    coin_params.m_cost_of_change = coin_params.m_change_fee + discard_fee_rate.GetFee(change_spend_size);
 
     int next_locktime{0};
     CAmount total_balance{CreateCoins(fuzzed_data_provider, utxo_pool, coin_params, next_locktime)};

--- a/src/wallet/test/group_outputs_tests.cpp
+++ b/src/wallet/test/group_outputs_tests.cpp
@@ -67,7 +67,6 @@ static void addCoin(CoinsResult& coins,
             /*min_change_target=*/ CENT,
             /*effective_feerate=*/ CFeeRate(0),
             /*long_term_feerate=*/ CFeeRate(0),
-            /*discard_feerate=*/ CFeeRate(0),
             /*tx_noinputs_size=*/ 0,
             /*avoid_partial=*/ avoid_partial_spends,
     };

--- a/src/wallet/test/group_outputs_tests.cpp
+++ b/src/wallet/test/group_outputs_tests.cpp
@@ -64,7 +64,6 @@ static void addCoin(CoinsResult& coins,
     return CoinSelectionParams{
             rand,
             /*change_output_size=*/ 0,
-            /*change_spend_size=*/ 0,
             /*min_change_target=*/ CENT,
             /*effective_feerate=*/ CFeeRate(0),
             /*long_term_feerate=*/ CFeeRate(0),


### PR DESCRIPTION
If the transaction includes an output that goes to the custom change
address (`CoinControl::destChange`), the transaction creation process
should avoid creating duplicate outputs to the same address.

Instead, it should reuse the existing output to prevent revealing which
address is the change address, which could compromise privacy.

This will also be useful to make other wallet processes less confusing
and error-prone. For instance, within the bumpfee functionality, we
manually extract the change recipient from the transaction before calling
'CreateTransaction' to ensure that the change output is not duplicated.

Side note:
This is something that will be using for the #26732 rework.