### PR TITLE
refactor: Use ChainType enum exhaustively

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -434,9 +434,10 @@ private:
             return " signet";
         case ChainType::REGTEST:
             return " regtest";
-        default:
+        case ChainType::MAIN:
             return "";
         }
+        assert(false);
     }
     std::string PingTimeToString(double seconds) const
     {

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -117,7 +117,7 @@ std::unique_ptr<const CChainParams> CreateChainParams(const ArgsManager& args, c
         return CChainParams::RegTest(opts);
     }
     }
-    throw std::invalid_argument(strprintf("%s: Invalid ChainType value", __func__));
+    assert(false);
 }
 
 void SelectParams(const ChainType chain)

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -25,8 +25,6 @@ class ArgsManager;
 
 /**
  * Creates and returns a std::unique_ptr<CChainParams> of the chosen chain.
- * @returns a CChainParams* of the chosen chain.
- * @throws a std::runtime_error if the chain is not supported.
  */
 std::unique_ptr<const CChainParams> CreateChainParams(const ArgsManager& args, const ChainType chain);
 
@@ -37,8 +35,7 @@ std::unique_ptr<const CChainParams> CreateChainParams(const ArgsManager& args, c
 const CChainParams &Params();
 
 /**
- * Sets the params returned by Params() to those for the given chain name.
- * @throws std::runtime_error when the chain is not supported.
+ * Sets the params returned by Params() to those for the given chain type.
  */
 void SelectParams(const ChainType chain);
 

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -48,7 +48,7 @@ std::unique_ptr<CBaseChainParams> CreateBaseChainParams(const ChainType chain)
     case ChainType::REGTEST:
         return std::make_unique<CBaseChainParams>("regtest", 18443, 18445);
     }
-    throw std::invalid_argument(strprintf("%s: Invalid ChainType value", __func__));
+    assert(false);
 }
 
 void SelectBaseParams(const ChainType chain)

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -35,8 +35,6 @@ private:
 
 /**
  * Creates and returns a std::unique_ptr<CBaseChainParams> of the chosen chain.
- * @returns a CBaseChainParams* of the chosen chain.
- * @throws a std::runtime_error if the chain is not supported.
  */
 std::unique_ptr<CBaseChainParams> CreateBaseChainParams(const ChainType chain);
 

--- a/src/common/args.h
+++ b/src/common/args.h
@@ -325,14 +325,14 @@ protected:
     void ForceSetArg(const std::string& strArg, const std::string& strValue);
 
     /**
-     * Returns the appropriate chain name from the program arguments.
+     * Returns the appropriate chain type from the program arguments.
      * @return ChainType::MAIN by default; raises runtime error if an invalid
      * combination, or unknown chain is given.
      */
     ChainType GetChainType() const;
 
     /**
-     * Returns the appropriate chain name string from the program arguments.
+     * Returns the appropriate chain type string from the program arguments.
      * @return ChainType::MAIN string by default; raises runtime error if an
      * invalid combination is given.
      */
@@ -423,7 +423,7 @@ private:
 
     /**
      * Return -regtest/-signet/-testnet/-chain= setting as a ChainType enum if a
-     * recognized chain name was set, or as a string if an unrecognized chain
+     * recognized chain type was set, or as a string if an unrecognized chain
      * name was set. Raise an exception if an invalid combination of flags was
      * provided.
      */

--- a/src/test/argsman_tests.cpp
+++ b/src/test/argsman_tests.cpp
@@ -255,7 +255,7 @@ BOOST_AUTO_TEST_CASE(util_ParseInvalidParameters)
     BOOST_CHECK(!test.ParseParameters(2, (char**)argv, error));
     BOOST_CHECK_EQUAL(error, "Invalid parameter -unregistered");
 
-    // Make sure registered parameters prefixed with a chain name trigger errors.
+    // Make sure registered parameters prefixed with a chain type trigger errors.
     // (Previously, they were accepted and ignored.)
     argv[1] = "-test.registered";
     BOOST_CHECK(!test.ParseParameters(2, (char**)argv, error));


### PR DESCRIPTION
This is a follow up of https://github.com/bitcoin/bitcoin/pull/27491, more concretely https://github.com/bitcoin/bitcoin/pull/27491#discussion_r1188847896, for not using default cases (as per the style guide), and https://github.com/bitcoin/bitcoin/pull/27491#discussion_r1188852707 and https://github.com/bitcoin/bitcoin/pull/27491#discussion_r1188851857 for avoiding dead code.
