### PR TITLE
build: Fix shared lib linking for darwin with lld

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -83,6 +83,16 @@ case $host in
      lt_cv_prog_compiler_pic="-DPIC"
      lt_cv_prog_compiler_pic_CXX="-DPIC"
   ;;
+  *darwin*)
+     dnl Because it prints a verbose warning, lld fails the following check
+     dnl for "-Wl,-single_module" from libtool.m4:
+     dnl   # If there is a non-empty error log, and "single_module"
+     dnl   # appears in it, assume the flag caused a linker warning
+     dnl "-single_module" works fine on ld64 and lld, so just bypass the test.
+     dnl Failure to set this to "yes" causes libtool to use a very broken
+     dnl link-line for shared libs.
+     lt_cv_apple_cc_single_mod="yes"
+  ;;
 esac
 
 AC_ARG_WITH([seccomp],

--- a/configure.ac
+++ b/configure.ac
@@ -70,11 +70,12 @@ else
 fi
 AC_PROG_CXX
 
-dnl By default, libtool for mingw refuses to link static libs into a dll for
-dnl fear of mixing pic/non-pic objects, and import/export complications. Since
-dnl we have those under control, re-enable that functionality.
+dnl libtool overrides
 case $host in
   *mingw*)
+     dnl By default, libtool for mingw refuses to link static libs into a dll for
+     dnl fear of mixing pic/non-pic objects, and import/export complications. Since
+     dnl we have those under control, re-enable that functionality.
      lt_cv_deplibs_check_method="pass_all"
 
      dnl Remove unwanted -DDLL_EXPORT from these variables.


### PR DESCRIPTION
Solves one of the last remaining blockers for #21778. Fixes lld linking shared libs for macos via libtool.

lld fails one of libtool's earliest checks [because it happens to output a warning that contains a specific string](https://git.savannah.gnu.org/cgit/libtool.git/tree/m4/libtool.m4#n999):


>     # If there is a non-empty error log, and "single_module"
>     # appears in it, assume the flag caused a linker warning

And here is the test being run:
> x86_64-apple-darwin-ld: warning: Option `-single_module' is deprecated in ld64:
> x86_64-apple-darwin-ld: warning: Unnecessary option: this is already the default

Because the warning is printed the test fails. So libtool falls back to a very primitive and broken link-line for shared libs.

Arguably this should be worked-around in upstream lld by changing the warning string, as otherwise every libtool project will fail to link with it.

Like many other libtool hacks, the solution is to simply disable the check and hard-code the answer we know to be correct.