### PR TITLE
kernel: Remove util/system from kernel library, interface_ui from validation.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -143,6 +143,7 @@ BITCOIN_CORE_H = \
   compat/compat.h \
   compat/cpuid.h \
   compat/endian.h \
+  common/system.h \
   compressor.h \
   consensus/consensus.h \
   consensus/tx_check.h \
@@ -314,7 +315,6 @@ BITCOIN_CORE_H = \
   util/string.h \
   util/syscall_sandbox.h \
   util/syserror.h \
-  util/system.h \
   util/thread.h \
   util/threadinterrupt.h \
   util/threadnames.h \
@@ -663,6 +663,7 @@ libbitcoin_common_a_SOURCES = \
   common/init.cpp \
   common/interfaces.cpp \
   common/run_command.cpp \
+  common/system.cpp \
   compressor.cpp \
   core_read.cpp \
   core_write.cpp \
@@ -728,7 +729,6 @@ libbitcoin_util_a_SOURCES = \
   util/hasher.cpp \
   util/sock.cpp \
   util/syserror.cpp \
-  util/system.cpp \
   util/message.cpp \
   util/moneystr.cpp \
   util/rbf.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -186,6 +186,7 @@ BITCOIN_CORE_H = \
   kernel/mempool_limits.h \
   kernel/mempool_options.h \
   kernel/mempool_persist.h \
+  kernel/notifications_interface.h \
   kernel/validation_cache_sizes.h \
   key.h \
   key_io.h \
@@ -214,6 +215,7 @@ BITCOIN_CORE_H = \
   node/database_args.h \
   node/eviction.h \
   node/interface_ui.h \
+  node/kernel_notifications.h \
   node/mempool_args.h \
   node/mempool_persist_args.h \
   node/miner.h \
@@ -408,6 +410,7 @@ libbitcoin_node_a_SOURCES = \
   node/eviction.cpp \
   node/interface_ui.cpp \
   node/interfaces.cpp \
+  node/kernel_notifications.cpp \
   node/mempool_args.cpp \
   node/mempool_persist_args.cpp \
   node/miner.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -297,6 +297,7 @@ BITCOIN_CORE_H = \
   util/golombrice.h \
   util/hash_type.h \
   util/hasher.h \
+  util/insert.h \
   util/macros.h \
   util/message.h \
   util/moneystr.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -280,6 +280,7 @@ BITCOIN_CORE_H = \
   txrequest.h \
   undo.h \
   util/asmap.h \
+  util/batchpriority.h \
   util/bip32.h \
   util/bitdeque.h \
   util/bytevectorhash.h \
@@ -711,6 +712,7 @@ libbitcoin_util_a_SOURCES = \
   support/cleanse.cpp \
   sync.cpp \
   util/asmap.cpp \
+  util/batchpriority.cpp \
   util/bip32.cpp \
   util/bytevectorhash.cpp \
   util/chaintype.cpp \
@@ -963,6 +965,7 @@ libbitcoinkernel_la_SOURCES = \
   txdb.cpp \
   txmempool.cpp \
   uint256.cpp \
+  util/batchpriority.cpp \
   util/chaintype.cpp \
   util/check.cpp \
   util/exception.cpp \
@@ -978,7 +981,6 @@ libbitcoinkernel_la_SOURCES = \
   util/string.cpp \
   util/syscall_sandbox.cpp \
   util/syserror.cpp \
-  util/system.cpp \
   util/thread.cpp \
   util/threadnames.cpp \
   util/time.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -279,6 +279,7 @@ BITCOIN_CORE_H = \
   txorphanage.h \
   txrequest.h \
   undo.h \
+  util/any.h \
   util/asmap.h \
   util/batchpriority.h \
   util/bip32.h \

--- a/src/banman.cpp
+++ b/src/banman.cpp
@@ -5,11 +5,11 @@
 
 #include <banman.h>
 
+#include <common/system.h>
 #include <logging.h>
 #include <netaddress.h>
 #include <node/interface_ui.h>
 #include <sync.h>
-#include <util/system.h>
 #include <util/time.h>
 #include <util/translation.h>
 

--- a/src/bench/checkqueue.cpp
+++ b/src/bench/checkqueue.cpp
@@ -4,11 +4,11 @@
 
 #include <bench/bench.h>
 #include <checkqueue.h>
+#include <common/system.h>
 #include <key.h>
 #include <prevector.h>
 #include <pubkey.h>
 #include <random.h>
-#include <util/system.h>
 
 #include <vector>
 

--- a/src/bitcoin-chainstate.cpp
+++ b/src/bitcoin-chainstate.cpp
@@ -32,6 +32,7 @@
 #include <validationinterface.h>
 
 #include <cassert>
+#include <cstdint>
 #include <filesystem>
 #include <functional>
 #include <iosfwd>
@@ -88,6 +89,10 @@ int main(int argc, char* argv[])
         void blockTip(SynchronizationState, CBlockIndex&) override
         {
             std::cout << "Block tip changed" << std::endl;
+        }
+        void headerTip(SynchronizationState, int64_t height, int64_t timestamp, bool presync) override
+        {
+            std::cout << "Header tip changed: " << height << ", " << timestamp << ", " << presync << std::endl;
         }
     };
     auto notifications = std::make_unique<KernelNotifications>();

--- a/src/bitcoin-chainstate.cpp
+++ b/src/bitcoin-chainstate.cpp
@@ -99,6 +99,10 @@ int main(int argc, char* argv[])
         {
             std::cout << "Progress: " << title.original << ", " << progress_percent << ", " << resume_possible << std::endl;
         }
+        void warning(const bilingual_str& warning) override
+        {
+            std::cout << "Warning: " << warning.original << std::endl;
+        }
     };
     auto notifications = std::make_unique<KernelNotifications>();
 

--- a/src/bitcoin-chainstate.cpp
+++ b/src/bitcoin-chainstate.cpp
@@ -37,6 +37,7 @@
 #include <functional>
 #include <iosfwd>
 #include <memory>
+#include <string>
 
 int main(int argc, char* argv[])
 {
@@ -93,6 +94,10 @@ int main(int argc, char* argv[])
         void headerTip(SynchronizationState, int64_t height, int64_t timestamp, bool presync) override
         {
             std::cout << "Header tip changed: " << height << ", " << timestamp << ", " << presync << std::endl;
+        }
+        void progress(const bilingual_str& title, int progress_percent, bool resume_possible) override
+        {
+            std::cout << "Progress: " << title.original << ", " << progress_percent << ", " << resume_possible << std::endl;
         }
     };
     auto notifications = std::make_unique<KernelNotifications>();

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -10,6 +10,7 @@
 #include <chainparamsbase.h>
 #include <clientversion.h>
 #include <common/args.h>
+#include <common/system.h>
 #include <common/url.h>
 #include <compat/compat.h>
 #include <compat/stdin.h>
@@ -23,7 +24,6 @@
 #include <util/chaintype.h>
 #include <util/exception.h>
 #include <util/strencodings.h>
-#include <util/system.h>
 #include <util/time.h>
 #include <util/translation.h>
 

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -10,6 +10,7 @@
 #include <clientversion.h>
 #include <coins.h>
 #include <common/args.h>
+#include <common/system.h>
 #include <compat/compat.h>
 #include <consensus/amount.h>
 #include <consensus/consensus.h>
@@ -27,7 +28,6 @@
 #include <util/rbf.h>
 #include <util/strencodings.h>
 #include <util/string.h>
-#include <util/system.h>
 #include <util/translation.h>
 
 #include <cstdio>

--- a/src/bitcoin-util.cpp
+++ b/src/bitcoin-util.cpp
@@ -12,11 +12,11 @@
 #include <chainparamsbase.h>
 #include <clientversion.h>
 #include <common/args.h>
+#include <common/system.h>
 #include <compat/compat.h>
 #include <core_io.h>
 #include <streams.h>
 #include <util/exception.h>
-#include <util/system.h>
 #include <util/translation.h>
 #include <version.h>
 

--- a/src/bitcoin-wallet.cpp
+++ b/src/bitcoin-wallet.cpp
@@ -10,6 +10,7 @@
 #include <chainparamsbase.h>
 #include <clientversion.h>
 #include <common/args.h>
+#include <common/system.h>
 #include <common/url.h>
 #include <compat/compat.h>
 #include <interfaces/init.h>
@@ -18,7 +19,6 @@
 #include <pubkey.h>
 #include <tinyformat.h>
 #include <util/exception.h>
-#include <util/system.h>
 #include <util/translation.h>
 #include <wallet/wallettool.h>
 

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -11,6 +11,7 @@
 #include <clientversion.h>
 #include <common/args.h>
 #include <common/init.h>
+#include <common/system.h>
 #include <common/url.h>
 #include <compat/compat.h>
 #include <init.h>
@@ -25,7 +26,6 @@
 #include <util/strencodings.h>
 #include <util/syscall_sandbox.h>
 #include <util/syserror.h>
-#include <util/system.h>
 #include <util/threadnames.h>
 #include <util/tokenpipe.h>
 #include <util/translation.h>

--- a/src/blockencodings.cpp
+++ b/src/blockencodings.cpp
@@ -3,16 +3,16 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <blockencodings.h>
+#include <chainparams.h>
+#include <common/system.h>
 #include <consensus/consensus.h>
 #include <consensus/validation.h>
-#include <chainparams.h>
 #include <crypto/sha256.h>
 #include <crypto/siphash.h>
 #include <random.h>
 #include <streams.h>
 #include <txmempool.h>
 #include <validation.h>
-#include <util/system.h>
 
 #include <unordered_map>
 

--- a/src/common/system.cpp
+++ b/src/common/system.cpp
@@ -3,7 +3,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/system.h>
+#include <common/system.h>
 
 #include <logging.h>
 #include <util/string.h>

--- a/src/common/system.h
+++ b/src/common/system.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_UTIL_SYSTEM_H
-#define BITCOIN_UTIL_SYSTEM_H
+#ifndef BITCOIN_COMMON_SYSTEM_H
+#define BITCOIN_COMMON_SYSTEM_H
 
 #if defined(HAVE_CONFIG_H)
 #include <config/bitcoin-config.h>
@@ -35,4 +35,4 @@ void runCommand(const std::string& strCommand);
  */
 int GetNumCores();
 
-#endif // BITCOIN_UTIL_SYSTEM_H
+#endif // BITCOIN_COMMON_SYSTEM_H

--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -4,6 +4,7 @@
 
 #include <core_io.h>
 
+#include <common/system.h>
 #include <consensus/amount.h>
 #include <consensus/consensus.h>
 #include <consensus/validation.h>
@@ -17,7 +18,6 @@
 #include <univalue.h>
 #include <util/check.h>
 #include <util/strencodings.h>
-#include <util/system.h>
 
 #include <map>
 #include <string>

--- a/src/external_signer.h
+++ b/src/external_signer.h
@@ -5,8 +5,8 @@
 #ifndef BITCOIN_EXTERNAL_SIGNER_H
 #define BITCOIN_EXTERNAL_SIGNER_H
 
+#include <common/system.h>
 #include <univalue.h>
-#include <util/system.h>
 
 #include <string>
 #include <vector>

--- a/src/i2p.cpp
+++ b/src/i2p.cpp
@@ -336,7 +336,7 @@ void Session::GenerateAndSavePrivateKey(const Sock& sock)
 {
     DestGenerate(sock);
 
-    // umask is set to 0077 in util/system.cpp, which is ok.
+    // umask is set to 0077 in common/system.cpp, which is ok.
     if (!WriteBinaryFile(m_private_key_file,
                          std::string(m_private_key.begin(), m_private_key.end()))) {
         throw std::runtime_error(

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -45,6 +45,7 @@
 #include <node/chainstatemanager_args.h>
 #include <node/context.h>
 #include <node/interface_ui.h>
+#include <node/kernel_notifications.h>
 #include <node/mempool_args.h>
 #include <node/mempool_persist_args.h>
 #include <node/miner.h>
@@ -124,6 +125,7 @@ using node::DEFAULT_PERSIST_MEMPOOL;
 using node::DEFAULT_PRINTPRIORITY;
 using node::fReindex;
 using node::g_indexes_ready_to_sync;
+using node::KernelNotifications;
 using node::LoadChainstate;
 using node::MempoolPath;
 using node::NodeContext;
@@ -1019,9 +1021,11 @@ bool AppInitParameterInteraction(const ArgsManager& args, bool use_syscall_sandb
 
     // Also report errors from parsing before daemonization
     {
+        KernelNotifications notifications{};
         ChainstateManager::Options chainman_opts_dummy{
             .chainparams = chainparams,
             .datadir = args.GetDataDirNet(),
+            .notifications = notifications,
         };
         if (const auto error{ApplyArgsManOptions(args, chainman_opts_dummy)}) {
             return InitError(*error);
@@ -1427,12 +1431,14 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 
     // ********************************************************* Step 7: load block chain
 
+    node.notifications = std::make_unique<KernelNotifications>();
     fReindex = args.GetBoolArg("-reindex", false);
     bool fReindexChainState = args.GetBoolArg("-reindex-chainstate", false);
     ChainstateManager::Options chainman_opts{
         .chainparams = chainparams,
         .datadir = args.GetDataDirNet(),
         .adjusted_time_callback = GetAdjustedTime,
+        .notifications = *node.notifications,
     };
     Assert(!ApplyArgsManOptions(args, chainman_opts)); // no error can happen, already checked in AppInitParameterInteraction
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -20,6 +20,7 @@
 #include <chainparams.h>
 #include <chainparamsbase.h>
 #include <common/args.h>
+#include <common/system.h>
 #include <consensus/amount.h>
 #include <deploymentstatus.h>
 #include <hash.h>
@@ -80,7 +81,6 @@
 #include <util/string.h>
 #include <util/syscall_sandbox.h>
 #include <util/syserror.h>
-#include <util/system.h>
 #include <util/thread.h>
 #include <util/threadnames.h>
 #include <util/translation.h>

--- a/src/ipc/interfaces.cpp
+++ b/src/ipc/interfaces.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <common/system.h>
 #include <interfaces/init.h>
 #include <interfaces/ipc.h>
 #include <ipc/capnp/protocol.h>
@@ -10,7 +11,6 @@
 #include <logging.h>
 #include <tinyformat.h>
 #include <util/fs.h>
-#include <util/system.h>
 
 #include <cstdio>
 #include <cstdlib>

--- a/src/kernel/chainstatemanager_opts.h
+++ b/src/kernel/chainstatemanager_opts.h
@@ -5,6 +5,8 @@
 #ifndef BITCOIN_KERNEL_CHAINSTATEMANAGER_OPTS_H
 #define BITCOIN_KERNEL_CHAINSTATEMANAGER_OPTS_H
 
+#include <kernel/notifications_interface.h>
+
 #include <arith_uint256.h>
 #include <dbwrapper.h>
 #include <txdb.h>
@@ -42,6 +44,7 @@ struct ChainstateManagerOpts {
     DBOptions block_tree_db{};
     DBOptions coins_db{};
     CoinsViewOptions coins_view{};
+    Notifications& notifications;
 };
 
 } // namespace kernel

--- a/src/kernel/notifications_interface.h
+++ b/src/kernel/notifications_interface.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_KERNEL_NOTIFICATIONS_INTERFACE_H
+#define BITCOIN_KERNEL_NOTIFICATIONS_INTERFACE_H
+
+class CBlockIndex;
+enum class SynchronizationState;
+
+namespace kernel {
+
+/**
+ * A base class defining functions for notifying about certain kernel
+ * events.
+ */
+class Notifications
+{
+public:
+    virtual ~Notifications(){};
+
+    virtual void blockTip(SynchronizationState state, CBlockIndex& index) {}
+};
+} // namespace kernel
+
+#endif // BITCOIN_KERNEL_NOTIFICATIONS_INTERFACE_H

--- a/src/kernel/notifications_interface.h
+++ b/src/kernel/notifications_interface.h
@@ -5,6 +5,8 @@
 #ifndef BITCOIN_KERNEL_NOTIFICATIONS_INTERFACE_H
 #define BITCOIN_KERNEL_NOTIFICATIONS_INTERFACE_H
 
+#include <cstdint>
+
 class CBlockIndex;
 enum class SynchronizationState;
 
@@ -20,6 +22,7 @@ public:
     virtual ~Notifications(){};
 
     virtual void blockTip(SynchronizationState state, CBlockIndex& index) {}
+    virtual void headerTip(SynchronizationState state, int64_t height, int64_t timestamp, bool presync) {}
 };
 } // namespace kernel
 

--- a/src/kernel/notifications_interface.h
+++ b/src/kernel/notifications_interface.h
@@ -6,9 +6,11 @@
 #define BITCOIN_KERNEL_NOTIFICATIONS_INTERFACE_H
 
 #include <cstdint>
+#include <string>
 
 class CBlockIndex;
 enum class SynchronizationState;
+struct bilingual_str;
 
 namespace kernel {
 
@@ -23,6 +25,7 @@ public:
 
     virtual void blockTip(SynchronizationState state, CBlockIndex& index) {}
     virtual void headerTip(SynchronizationState state, int64_t height, int64_t timestamp, bool presync) {}
+    virtual void progress(const bilingual_str& title, int progress_percent, bool resume_possible) {}
 };
 } // namespace kernel
 

--- a/src/kernel/notifications_interface.h
+++ b/src/kernel/notifications_interface.h
@@ -26,6 +26,7 @@ public:
     virtual void blockTip(SynchronizationState state, CBlockIndex& index) {}
     virtual void headerTip(SynchronizationState state, int64_t height, int64_t timestamp, bool presync) {}
     virtual void progress(const bilingual_str& title, int progress_percent, bool resume_possible) {}
+    virtual void warning(const bilingual_str& warning) {}
 };
 } // namespace kernel
 

--- a/src/mapport.cpp
+++ b/src/mapport.cpp
@@ -9,12 +9,12 @@
 #include <mapport.h>
 
 #include <clientversion.h>
+#include <common/system.h>
 #include <logging.h>
 #include <net.h>
 #include <netaddress.h>
 #include <netbase.h>
 #include <util/syscall_sandbox.h>
-#include <util/system.h>
 #include <util/thread.h>
 #include <util/threadinterrupt.h>
 

--- a/src/net_permissions.cpp
+++ b/src/net_permissions.cpp
@@ -2,10 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <common/system.h>
 #include <net_permissions.h>
 #include <netbase.h>
 #include <util/error.h>
-#include <util/system.h>
 #include <util/translation.h>
 
 const std::vector<std::string> NET_PERMISSIONS_DOC{

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -20,7 +20,6 @@
 #include <util/batchpriority.h>
 #include <util/fs.h>
 #include <util/syscall_sandbox.h>
-#include <util/system.h>
 #include <validation.h>
 
 #include <map>

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -17,6 +17,7 @@
 #include <signet.h>
 #include <streams.h>
 #include <undo.h>
+#include <util/batchpriority.h>
 #include <util/fs.h>
 #include <util/syscall_sandbox.h>
 #include <util/system.h>

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -253,7 +253,7 @@ ChainstateLoadResult VerifyLoadedChainstate(ChainstateManager& chainman, const C
                                                          "Only rebuild the block database if you are sure that your computer's date and time are correct")};
             }
 
-            VerifyDBResult result = CVerifyDB().VerifyDB(
+            VerifyDBResult result = CVerifyDB(chainman.GetNotifications()).VerifyDB(
                 *chainstate, chainman.GetConsensus(), chainstate->CoinsDB(),
                 options.check_level,
                 options.check_blocks);

--- a/src/node/context.cpp
+++ b/src/node/context.cpp
@@ -11,6 +11,7 @@
 #include <net.h>
 #include <net_processing.h>
 #include <netgroup.h>
+#include <node/kernel_notifications.h>
 #include <policy/fees.h>
 #include <scheduler.h>
 #include <txmempool.h>

--- a/src/node/context.h
+++ b/src/node/context.h
@@ -30,6 +30,8 @@ class WalletLoader;
 } // namespace interfaces
 
 namespace node {
+class KernelNotifications;
+
 //! NodeContext struct containing references to chain state and connection
 //! state.
 //!
@@ -62,6 +64,7 @@ struct NodeContext {
     interfaces::WalletLoader* wallet_loader{nullptr};
     std::unique_ptr<CScheduler> scheduler;
     std::function<void()> rpc_interruption_point = [] {};
+    std::unique_ptr<KernelNotifications> notifications;
 
     //! Declare default constructor and destructor that are not inline, so code
     //! instantiating the NodeContext struct doesn't need to #include class

--- a/src/node/kernel_notifications.cpp
+++ b/src/node/kernel_notifications.cpp
@@ -13,4 +13,9 @@ void KernelNotifications::blockTip(SynchronizationState state, CBlockIndex& inde
     uiInterface.NotifyBlockTip(state, &index);
 }
 
+void KernelNotifications::headerTip(SynchronizationState state, int64_t height, int64_t timestamp, bool presync)
+{
+    uiInterface.NotifyHeaderTip(state, height, timestamp, presync);
+}
+
 } // namespace node

--- a/src/node/kernel_notifications.cpp
+++ b/src/node/kernel_notifications.cpp
@@ -1,0 +1,16 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <node/kernel_notifications.h>
+
+#include <node/interface_ui.h>
+
+namespace node {
+
+void KernelNotifications::blockTip(SynchronizationState state, CBlockIndex& index)
+{
+    uiInterface.NotifyBlockTip(state, &index);
+}
+
+} // namespace node

--- a/src/node/kernel_notifications.cpp
+++ b/src/node/kernel_notifications.cpp
@@ -9,10 +9,10 @@
 #endif
 
 #include <common/args.h>
+#include <common/system.h>
 #include <node/interface_ui.h>
 #include <util/strencodings.h>
 #include <util/string.h>
-#include <util/system.h>
 #include <util/translation.h>
 #include <warnings.h>
 

--- a/src/node/kernel_notifications.cpp
+++ b/src/node/kernel_notifications.cpp
@@ -5,6 +5,7 @@
 #include <node/kernel_notifications.h>
 
 #include <node/interface_ui.h>
+#include <util/translation.h>
 
 namespace node {
 
@@ -16,6 +17,11 @@ void KernelNotifications::blockTip(SynchronizationState state, CBlockIndex& inde
 void KernelNotifications::headerTip(SynchronizationState state, int64_t height, int64_t timestamp, bool presync)
 {
     uiInterface.NotifyHeaderTip(state, height, timestamp, presync);
+}
+
+void KernelNotifications::progress(const bilingual_str& title, int progress_percent, bool resume_possible)
+{
+    uiInterface.ShowProgress(title.translated, progress_percent, resume_possible);
 }
 
 } // namespace node

--- a/src/node/kernel_notifications.cpp
+++ b/src/node/kernel_notifications.cpp
@@ -4,8 +4,51 @@
 
 #include <node/kernel_notifications.h>
 
+#if defined(HAVE_CONFIG_H)
+#include <config/bitcoin-config.h>
+#endif
+
+#include <common/args.h>
 #include <node/interface_ui.h>
+#include <util/strencodings.h>
+#include <util/string.h>
+#include <util/system.h>
 #include <util/translation.h>
+#include <warnings.h>
+
+#include <cstdint>
+#include <string>
+#include <thread>
+
+static void AlertNotify(const std::string& strMessage)
+{
+    uiInterface.NotifyAlertChanged();
+#if HAVE_SYSTEM
+    std::string strCmd = gArgs.GetArg("-alertnotify", "");
+    if (strCmd.empty()) return;
+
+    // Alert text should be plain ascii coming from a trusted source, but to
+    // be safe we first strip anything not in safeChars, then add single quotes around
+    // the whole string before passing it to the shell:
+    std::string singleQuote("'");
+    std::string safeStatus = SanitizeString(strMessage);
+    safeStatus = singleQuote+safeStatus+singleQuote;
+    ReplaceAll(strCmd, "%s", safeStatus);
+
+    std::thread t(runCommand, strCmd);
+    t.detach(); // thread runs free
+#endif
+}
+
+static void DoWarning(const bilingual_str& warning)
+{
+    static bool fWarned = false;
+    SetMiscWarning(warning);
+    if (!fWarned) {
+        AlertNotify(warning.original);
+        fWarned = true;
+    }
+}
 
 namespace node {
 
@@ -22,6 +65,11 @@ void KernelNotifications::headerTip(SynchronizationState state, int64_t height, 
 void KernelNotifications::progress(const bilingual_str& title, int progress_percent, bool resume_possible)
 {
     uiInterface.ShowProgress(title.translated, progress_percent, resume_possible);
+}
+
+void KernelNotifications::warning(const bilingual_str& warning)
+{
+    DoWarning(warning);
 }
 
 } // namespace node

--- a/src/node/kernel_notifications.h
+++ b/src/node/kernel_notifications.h
@@ -1,0 +1,21 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_NODE_KERNEL_NOTIFICATIONS_H
+#define BITCOIN_NODE_KERNEL_NOTIFICATIONS_H
+
+#include <kernel/notifications_interface.h>
+
+class CBlockIndex;
+enum class SynchronizationState;
+
+namespace node {
+class KernelNotifications : public kernel::Notifications
+{
+public:
+    void blockTip(SynchronizationState state, CBlockIndex& index) override;
+};
+} // namespace node
+
+#endif // BITCOIN_NODE_KERNEL_NOTIFICATIONS_H

--- a/src/node/kernel_notifications.h
+++ b/src/node/kernel_notifications.h
@@ -7,6 +7,8 @@
 
 #include <kernel/notifications_interface.h>
 
+#include <cstdint>
+
 class CBlockIndex;
 enum class SynchronizationState;
 
@@ -15,6 +17,8 @@ class KernelNotifications : public kernel::Notifications
 {
 public:
     void blockTip(SynchronizationState state, CBlockIndex& index) override;
+
+    void headerTip(SynchronizationState state, int64_t height, int64_t timestamp, bool presync) override;
 };
 } // namespace node
 

--- a/src/node/kernel_notifications.h
+++ b/src/node/kernel_notifications.h
@@ -23,6 +23,8 @@ public:
     void headerTip(SynchronizationState state, int64_t height, int64_t timestamp, bool presync) override;
 
     void progress(const bilingual_str& title, int progress_percent, bool resume_possible) override;
+
+    void warning(const bilingual_str& warning) override;
 };
 } // namespace node
 

--- a/src/node/kernel_notifications.h
+++ b/src/node/kernel_notifications.h
@@ -8,9 +8,11 @@
 #include <kernel/notifications_interface.h>
 
 #include <cstdint>
+#include <string>
 
 class CBlockIndex;
 enum class SynchronizationState;
+struct bilingual_str;
 
 namespace node {
 class KernelNotifications : public kernel::Notifications
@@ -19,6 +21,8 @@ public:
     void blockTip(SynchronizationState state, CBlockIndex& index) override;
 
     void headerTip(SynchronizationState state, int64_t height, int64_t timestamp, bool presync) override;
+
+    void progress(const bilingual_str& title, int progress_percent, bool resume_possible) override;
 };
 } // namespace node
 

--- a/src/node/txreconciliation.cpp
+++ b/src/node/txreconciliation.cpp
@@ -4,9 +4,9 @@
 
 #include <node/txreconciliation.h>
 
+#include <common/system.h>
 #include <logging.h>
 #include <util/check.h>
-#include <util/system.h>
 
 #include <unordered_map>
 #include <variant>

--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -6,6 +6,7 @@
 #include <policy/fees.h>
 
 #include <clientversion.h>
+#include <common/system.h>
 #include <consensus/amount.h>
 #include <kernel/mempool_entry.h>
 #include <logging.h>
@@ -19,7 +20,6 @@
 #include <uint256.h>
 #include <util/fs.h>
 #include <util/serfloat.h>
-#include <util/system.h>
 #include <util/time.h>
 
 #include <algorithm>

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -5,7 +5,7 @@
 
 #include <protocol.h>
 
-#include <util/system.h>
+#include <common/system.h>
 
 #include <atomic>
 

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -11,6 +11,7 @@
 #include <chainparams.h>
 #include <common/args.h>
 #include <common/init.h>
+#include <common/system.h>
 #include <init.h>
 #include <interfaces/handler.h>
 #include <interfaces/init.h>
@@ -32,7 +33,6 @@
 #include <uint256.h>
 #include <util/exception.h>
 #include <util/string.h>
-#include <util/system.h>
 #include <util/threadnames.h>
 #include <util/translation.h>
 #include <validation.h>

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -30,15 +30,16 @@
 #include <qt/macdockiconhandler.h>
 #endif
 
-#include <functional>
 #include <chain.h>
 #include <chainparams.h>
+#include <common/system.h>
 #include <interfaces/handler.h>
 #include <interfaces/node.h>
 #include <node/interface_ui.h>
-#include <util/system.h>
 #include <util/translation.h>
 #include <validation.h>
+
+#include <functional>
 
 #include <QAction>
 #include <QActionGroup>

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -12,11 +12,11 @@
 
 #include <clientversion.h>
 #include <common/args.h>
+#include <common/system.h>
 #include <interfaces/handler.h>
 #include <interfaces/node.h>
 #include <net.h>
 #include <netbase.h>
-#include <util/system.h>
 #include <util/threadnames.h>
 #include <util/time.h>
 #include <validation.h>

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -15,11 +15,11 @@
 #include <qt/guiutil.h>
 #include <qt/optionsmodel.h>
 
+#include <common/system.h>
 #include <interfaces/node.h>
-#include <validation.h> // for DEFAULT_SCRIPTCHECK_THREADS and MAX_SCRIPTCHECK_THREADS
 #include <netbase.h>
-#include <txdb.h> // for -dbcache defaults
-#include <util/system.h>
+#include <txdb.h>
+#include <validation.h>
 
 #include <chrono>
 

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -10,6 +10,7 @@
 #include <qt/forms/ui_debugwindow.h>
 
 #include <chainparams.h>
+#include <common/system.h>
 #include <interfaces/node.h>
 #include <qt/bantablemodel.h>
 #include <qt/clientmodel.h>
@@ -21,7 +22,6 @@
 #include <rpc/server.h>
 #include <util/strencodings.h>
 #include <util/string.h>
-#include <util/system.h>
 #include <util/threadnames.h>
 
 #include <univalue.h>

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -9,13 +9,13 @@
 #include <qt/splashscreen.h>
 
 #include <clientversion.h>
+#include <common/system.h>
 #include <interfaces/handler.h>
 #include <interfaces/node.h>
 #include <interfaces/wallet.h>
 #include <qt/guiutil.h>
 #include <qt/networkstyle.h>
 #include <qt/walletmodel.h>
-#include <util/system.h>
 #include <util/translation.h>
 
 #include <functional>

--- a/src/qt/test/rpcnestedtests.cpp
+++ b/src/qt/test/rpcnestedtests.cpp
@@ -4,12 +4,12 @@
 
 #include <qt/test/rpcnestedtests.h>
 
+#include <common/system.h>
 #include <interfaces/node.h>
-#include <rpc/server.h>
 #include <qt/rpcconsole.h>
+#include <rpc/server.h>
 #include <test/util/setup_common.h>
 #include <univalue.h>
-#include <util/system.h>
 
 #include <QTest>
 

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -13,12 +13,12 @@
 #include <qt/paymentserver.h>
 #include <qt/transactionrecord.h>
 
+#include <common/system.h>
 #include <consensus/consensus.h>
 #include <interfaces/node.h>
 #include <interfaces/wallet.h>
 #include <key_io.h>
 #include <policy/policy.h>
-#include <util/system.h>
 #include <validation.h>
 #include <wallet/types.h>
 

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -24,8 +24,8 @@
 #include <streams.h>
 #include <sync.h>
 #include <txmempool.h>
+#include <util/any.h>
 #include <util/check.h>
-#include <util/system.h>
 #include <validation.h>
 #include <version.h>
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1123,7 +1123,7 @@ static RPCHelpMan verifychain()
     LOCK(cs_main);
 
     Chainstate& active_chainstate = chainman.ActiveChainstate();
-    return CVerifyDB().VerifyDB(
+    return CVerifyDB(chainman.GetNotifications()).VerifyDB(
                active_chainstate, chainman.GetParams().GetConsensus(), active_chainstate.CoinsTip(), check_level, check_depth) == VerifyDBResult::SUCCESS;
 },
     };

--- a/src/rpc/external_signer.cpp
+++ b/src/rpc/external_signer.cpp
@@ -3,12 +3,12 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <common/args.h>
+#include <common/system.h>
 #include <external_signer.h>
 #include <rpc/protocol.h>
 #include <rpc/server.h>
 #include <rpc/util.h>
 #include <util/strencodings.h>
-#include <util/system.h>
 
 #include <string>
 #include <vector>

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -5,6 +5,7 @@
 
 #include <chain.h>
 #include <chainparams.h>
+#include <common/system.h>
 #include <consensus/amount.h>
 #include <consensus/consensus.h>
 #include <consensus/merkle.h>
@@ -32,7 +33,6 @@
 #include <univalue.h>
 #include <util/strencodings.h>
 #include <util/string.h>
-#include <util/system.h>
 #include <util/translation.h>
 #include <validation.h>
 #include <validationinterface.h>

--- a/src/rpc/node.cpp
+++ b/src/rpc/node.cpp
@@ -19,9 +19,9 @@
 #include <rpc/util.h>
 #include <scheduler.h>
 #include <univalue.h>
+#include <util/any.h>
 #include <util/check.h>
 #include <util/syscall_sandbox.h>
-#include <util/system.h>
 
 #include <stdint.h>
 #ifdef HAVE_MALLOC_INFO

--- a/src/rpc/request.cpp
+++ b/src/rpc/request.cpp
@@ -88,7 +88,7 @@ bool GenerateAuthCookie(std::string *cookie_out)
     std::string cookie = COOKIEAUTH_USER + ":" + HexStr(rand_pwd);
 
     /** the umask determines what permissions are used to create this file -
-     * these are set to 0077 in util/system.cpp.
+     * these are set to 0077 in common/system.cpp.
      */
     std::ofstream file;
     fs::path filepath_tmp = GetAuthCookieFile(true);

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -6,13 +6,13 @@
 #include <rpc/server.h>
 
 #include <common/args.h>
+#include <common/system.h>
 #include <logging.h>
 #include <rpc/util.h>
 #include <shutdown.h>
 #include <sync.h>
 #include <util/strencodings.h>
 #include <util/string.h>
-#include <util/system.h>
 #include <util/time.h>
 
 #include <boost/signals2/signal.hpp>

--- a/src/rpc/server_util.cpp
+++ b/src/rpc/server_util.cpp
@@ -11,7 +11,7 @@
 #include <rpc/protocol.h>
 #include <rpc/request.h>
 #include <txmempool.h>
-#include <util/system.h>
+#include <util/any.h>
 #include <validation.h>
 
 #include <any>

--- a/src/script/sigcache.cpp
+++ b/src/script/sigcache.cpp
@@ -5,11 +5,11 @@
 
 #include <script/sigcache.h>
 
+#include <common/system.h>
 #include <logging.h>
 #include <pubkey.h>
 #include <random.h>
 #include <uint256.h>
-#include <util/system.h>
 
 #include <cuckoocache.h>
 

--- a/src/signet.cpp
+++ b/src/signet.cpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <vector>
 
+#include <common/system.h>
 #include <consensus/merkle.h>
 #include <consensus/params.h>
 #include <consensus/validation.h>
@@ -22,7 +23,6 @@
 #include <streams.h>
 #include <uint256.h>
 #include <util/strencodings.h>
-#include <util/system.h>
 
 static constexpr uint8_t SIGNET_HEADER[4] = {0xec, 0xc7, 0xda, 0xa2};
 

--- a/src/test/allocator_tests.cpp
+++ b/src/test/allocator_tests.cpp
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <common/system.h>
 #include <support/lockedpool.h>
-#include <util/system.h>
 
 #include <limits>
 #include <memory>

--- a/src/test/bloom_tests.cpp
+++ b/src/test/bloom_tests.cpp
@@ -5,6 +5,7 @@
 #include <common/bloom.h>
 
 #include <clientversion.h>
+#include <common/system.h>
 #include <key.h>
 #include <key_io.h>
 #include <merkleblock.h>
@@ -16,7 +17,6 @@
 #include <test/util/setup_common.h>
 #include <uint256.h>
 #include <util/strencodings.h>
-#include <util/system.h>
 
 #include <vector>
 

--- a/src/test/fuzz/integer.cpp
+++ b/src/test/fuzz/integer.cpp
@@ -4,6 +4,7 @@
 
 #include <arith_uint256.h>
 #include <common/args.h>
+#include <common/system.h>
 #include <compressor.h>
 #include <consensus/amount.h>
 #include <consensus/merkle.h>
@@ -32,7 +33,6 @@
 #include <util/overflow.h>
 #include <util/strencodings.h>
 #include <util/string.h>
-#include <util/system.h>
 #include <version.h>
 
 #include <cassert>

--- a/src/test/fuzz/string.cpp
+++ b/src/test/fuzz/string.cpp
@@ -5,6 +5,7 @@
 #include <blockfilter.h>
 #include <clientversion.h>
 #include <common/args.h>
+#include <common/system.h>
 #include <common/url.h>
 #include <netbase.h>
 #include <outputtype.h>
@@ -24,7 +25,6 @@
 #include <util/settings.h>
 #include <util/strencodings.h>
 #include <util/string.h>
-#include <util/system.h>
 #include <util/translation.h>
 
 #include <cassert>

--- a/src/test/fuzz/system.cpp
+++ b/src/test/fuzz/system.cpp
@@ -55,7 +55,7 @@ FUZZ_TARGET_INIT(system, initialize_system)
             [&] {
                 const OptionsCategory options_category = fuzzed_data_provider.PickValueInArray<OptionsCategory>({OptionsCategory::OPTIONS, OptionsCategory::CONNECTION, OptionsCategory::WALLET, OptionsCategory::WALLET_DEBUG_TEST, OptionsCategory::ZMQ, OptionsCategory::DEBUG_TEST, OptionsCategory::CHAINPARAMS, OptionsCategory::NODE_RELAY, OptionsCategory::BLOCK_CREATION, OptionsCategory::RPC, OptionsCategory::GUI, OptionsCategory::COMMANDS, OptionsCategory::REGISTER_COMMANDS, OptionsCategory::HIDDEN});
                 // Avoid hitting:
-                // util/system.cpp:425: void ArgsManager::AddArg(const std::string &, const std::string &, unsigned int, const OptionsCategory &): Assertion `ret.second' failed.
+                // common/args.cpp:563: void ArgsManager::AddArg(const std::string &, const std::string &, unsigned int, const OptionsCategory &): Assertion `ret.second' failed.
                 const std::string argument_name = GetArgumentName(fuzzed_data_provider.ConsumeRandomLengthString(16));
                 if (args_manager.GetArgFlags(argument_name) != std::nullopt) {
                     return;
@@ -64,7 +64,7 @@ FUZZ_TARGET_INIT(system, initialize_system)
             },
             [&] {
                 // Avoid hitting:
-                // util/system.cpp:425: void ArgsManager::AddArg(const std::string &, const std::string &, unsigned int, const OptionsCategory &): Assertion `ret.second' failed.
+                // common/args.cpp:563: void ArgsManager::AddArg(const std::string &, const std::string &, unsigned int, const OptionsCategory &): Assertion `ret.second' failed.
                 const std::vector<std::string> names = ConsumeRandomLengthStringVector(fuzzed_data_provider);
                 std::vector<std::string> hidden_arguments;
                 for (const std::string& name : names) {

--- a/src/test/key_tests.cpp
+++ b/src/test/key_tests.cpp
@@ -4,6 +4,7 @@
 
 #include <key.h>
 
+#include <common/system.h>
 #include <key_io.h>
 #include <streams.h>
 #include <test/util/random.h>
@@ -11,7 +12,6 @@
 #include <uint256.h>
 #include <util/strencodings.h>
 #include <util/string.h>
-#include <util/system.h>
 
 #include <string>
 #include <vector>

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -2,10 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <common/system.h>
 #include <policy/policy.h>
 #include <test/util/txmempool.h>
 #include <txmempool.h>
-#include <util/system.h>
 #include <util/time.h>
 
 #include <test/util/setup_common.h>

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <coins.h>
+#include <common/system.h>
 #include <consensus/consensus.h>
 #include <consensus/merkle.h>
 #include <consensus/tx_verify.h>
@@ -15,7 +16,6 @@
 #include <txmempool.h>
 #include <uint256.h>
 #include <util/strencodings.h>
-#include <util/system.h>
 #include <util/time.h>
 #include <validation.h>
 #include <versionbits.h>

--- a/src/test/miniminer_tests.cpp
+++ b/src/test/miniminer_tests.cpp
@@ -3,7 +3,6 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #include <node/mini_miner.h>
 #include <txmempool.h>
-#include <util/system.h>
 #include <util/time.h>
 
 #include <test/util/setup_common.h>

--- a/src/test/rbf_tests.cpp
+++ b/src/test/rbf_tests.cpp
@@ -1,11 +1,11 @@
 // Copyright (c) 2021-2022 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#include <common/system.h>
 #include <policy/rbf.h>
 #include <random.h>
 #include <test/util/txmempool.h>
 #include <txmempool.h>
-#include <util/system.h>
 #include <util/time.h>
 
 #include <test/util/setup_common.h>

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -5,6 +5,7 @@
 #include <test/data/script_tests.json.h>
 #include <test/data/bip341_wallet_vectors.json.h>
 
+#include <common/system.h>
 #include <core_io.h>
 #include <key.h>
 #include <rpc/util.h>
@@ -20,7 +21,6 @@
 #include <test/util/transaction_utils.h>
 #include <util/fs.h>
 #include <util/strencodings.h>
-#include <util/system.h>
 
 #if defined(HAVE_CONSENSUS_LIB)
 #include <script/bitcoinconsensus.h>

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <common/system.h>
 #include <consensus/tx_check.h>
 #include <consensus/validation.h>
 #include <hash.h>
@@ -14,7 +15,6 @@
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <util/strencodings.h>
-#include <util/system.h>
 #include <version.h>
 
 #include <iostream>

--- a/src/test/sock_tests.cpp
+++ b/src/test/sock_tests.cpp
@@ -2,10 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <common/system.h>
 #include <compat/compat.h>
 #include <test/util/setup_common.h>
 #include <util/sock.h>
-#include <util/system.h>
 #include <util/threadinterrupt.h>
 
 #include <boost/test/unit_test.hpp>

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -9,6 +9,7 @@
 #include <addrman.h>
 #include <banman.h>
 #include <chainparams.h>
+#include <common/system.h>
 #include <common/url.h>
 #include <consensus/consensus.h>
 #include <consensus/params.h>
@@ -46,7 +47,6 @@
 #include <util/chaintype.h>
 #include <util/strencodings.h>
 #include <util/string.h>
-#include <util/system.h>
 #include <util/thread.h>
 #include <util/threadnames.h>
 #include <util/time.h>

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -23,6 +23,7 @@
 #include <node/blockstorage.h>
 #include <node/chainstate.h>
 #include <node/context.h>
+#include <node/kernel_notifications.h>
 #include <node/mempool_args.h>
 #include <node/miner.h>
 #include <node/validation_cache_args.h>
@@ -64,6 +65,7 @@ using node::ApplyArgsManOptions;
 using node::BlockAssembler;
 using node::BlockManager;
 using node::CalculateCacheSizes;
+using node::KernelNotifications;
 using node::LoadChainstate;
 using node::RegenerateCommitments;
 using node::VerifyLoadedChainstate;
@@ -182,11 +184,14 @@ ChainTestingSetup::ChainTestingSetup(const ChainType chainType, const std::vecto
 
     m_cache_sizes = CalculateCacheSizes(m_args);
 
+    m_node.notifications = std::make_unique<KernelNotifications>();
+
     const ChainstateManager::Options chainman_opts{
         .chainparams = chainparams,
         .datadir = m_args.GetDataDirNet(),
         .adjusted_time_callback = GetAdjustedTime,
         .check_block_index = true,
+        .notifications = *m_node.notifications,
     };
     const BlockManager::Options blockman_opts{
         .chainparams = chainman_opts.chainparams,

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -1687,7 +1687,7 @@ BOOST_AUTO_TEST_CASE(message_hash)
 
 BOOST_AUTO_TEST_CASE(remove_prefix)
 {
-    BOOST_CHECK_EQUAL(RemovePrefix("./util/system.h", "./"), "util/system.h");
+    BOOST_CHECK_EQUAL(RemovePrefix("./common/system.h", "./"), "common/system.h");
     BOOST_CHECK_EQUAL(RemovePrefixView("foo", "foo"), "");
     BOOST_CHECK_EQUAL(RemovePrefix("foo", "fo"), "o");
     BOOST_CHECK_EQUAL(RemovePrefixView("foo", "f"), "oo");

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -4,6 +4,7 @@
 //
 #include <chainparams.h>
 #include <consensus/validation.h>
+#include <node/kernel_notifications.h>
 #include <node/utxo_snapshot.h>
 #include <random.h>
 #include <rpc/blockchain.h>
@@ -23,6 +24,7 @@
 #include <boost/test/unit_test.hpp>
 
 using node::BlockManager;
+using node::KernelNotifications;
 using node::SnapshotMetadata;
 
 BOOST_FIXTURE_TEST_SUITE(validation_chainstatemanager_tests, ChainTestingSetup)
@@ -377,10 +379,12 @@ struct SnapshotTestSetup : TestChain100Setup {
             LOCK(::cs_main);
             chainman.ResetChainstates();
             BOOST_CHECK_EQUAL(chainman.GetAll().size(), 0);
+            m_node.notifications = std::make_unique<KernelNotifications>();
             const ChainstateManager::Options chainman_opts{
                 .chainparams = ::Params(),
                 .datadir = m_args.GetDataDirNet(),
                 .adjusted_time_callback = GetAdjustedTime,
+                .notifications = *m_node.notifications,
             };
             const BlockManager::Options blockman_opts{
                 .chainparams = chainman_opts.chainparams,

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -7,6 +7,7 @@
 
 #include <chain.h>
 #include <coins.h>
+#include <common/system.h>
 #include <consensus/consensus.h>
 #include <consensus/tx_verify.h>
 #include <consensus/validation.h>
@@ -19,7 +20,6 @@
 #include <util/moneystr.h>
 #include <util/overflow.h>
 #include <util/result.h>
-#include <util/system.h>
 #include <util/time.h>
 #include <util/trace.h>
 #include <util/translation.h>

--- a/src/util/any.h
+++ b/src/util/any.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_UTIL_ANY_H
+#define BITCOIN_UTIL_ANY_H
+
+#include <any>
+
+namespace util {
+
+/**
+ * Helper function to access the contained object of a std::any instance.
+ * Returns a pointer to the object if passed instance has a value and the type
+ * matches, nullptr otherwise.
+ */
+template<typename T>
+T* AnyPtr(const std::any& any) noexcept
+{
+    T* const* ptr = std::any_cast<T*>(&any);
+    return ptr ? *ptr : nullptr;
+}
+
+} // namespace util
+
+#endif // BITCOIN_UTIL_ANY_H

--- a/src/util/batchpriority.cpp
+++ b/src/util/batchpriority.cpp
@@ -1,0 +1,26 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <logging.h>
+#include <util/syserror.h>
+
+#if (defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__DragonFly__))
+#include <pthread.h>
+#include <pthread_np.h>
+#endif
+
+#ifndef WIN32
+#include <sched.h>
+#endif
+
+void ScheduleBatchPriority()
+{
+#ifdef SCHED_BATCH
+    const static sched_param param{};
+    const int rc = pthread_setschedparam(pthread_self(), SCHED_BATCH, &param);
+    if (rc != 0) {
+        LogPrintf("Failed to pthread_setschedparam: %s\n", SysErrorString(rc));
+    }
+#endif
+}

--- a/src/util/batchpriority.h
+++ b/src/util/batchpriority.h
@@ -1,0 +1,15 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_UTIL_BATCHPRIORITY_H
+#define BITCOIN_UTIL_BATCHPRIORITY_H
+
+/**
+ * On platforms that support it, tell the kernel the calling thread is
+ * CPU-intensive and non-interactive. See SCHED_BATCH in sched(7) for details.
+ *
+ */
+void ScheduleBatchPriority();
+
+#endif // BITCOIN_UTIL_BATCHPRIORITY_H

--- a/src/util/insert.h
+++ b/src/util/insert.h
@@ -1,0 +1,24 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_UTIL_INSERT_H
+#define BITCOIN_UTIL_INSERT_H
+
+#include <set>
+
+namespace util {
+
+//! Simplification of std insertion
+template <typename Tdst, typename Tsrc>
+inline void insert(Tdst& dst, const Tsrc& src) {
+    dst.insert(dst.begin(), src.begin(), src.end());
+}
+template <typename TsetT, typename Tsrc>
+inline void insert(std::set<TsetT>& dst, const Tsrc& src) {
+    dst.insert(src.begin(), src.end());
+}
+
+} // namespace util
+
+#endif // BITCOIN_UTIL_INSERT_H

--- a/src/util/sock.cpp
+++ b/src/util/sock.cpp
@@ -2,12 +2,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <common/system.h>
 #include <compat/compat.h>
 #include <logging.h>
 #include <tinyformat.h>
 #include <util/sock.h>
 #include <util/syserror.h>
-#include <util/system.h>
 #include <util/threadinterrupt.h>
 #include <util/time.h>
 

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -7,16 +7,9 @@
 
 #include <logging.h>
 #include <util/string.h>
-#include <util/syserror.h>
 #include <util/time.h>
 
-#if (defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__DragonFly__))
-#include <pthread.h>
-#include <pthread_np.h>
-#endif
-
 #ifndef WIN32
-#include <sched.h>
 #include <sys/stat.h>
 #else
 #include <codecvt>
@@ -111,15 +104,4 @@ int GetNumCores()
 int64_t GetStartupTime()
 {
     return nStartupTime;
-}
-
-void ScheduleBatchPriority()
-{
-#ifdef SCHED_BATCH
-    const static sched_param param{};
-    const int rc = pthread_setschedparam(pthread_self(), SCHED_BATCH, &param);
-    if (rc != 0) {
-        LogPrintf("Failed to pthread_setschedparam: %s\n", SysErrorString(rc));
-    }
-#endif
 }

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -36,13 +36,6 @@ void runCommand(const std::string& strCommand);
  */
 int GetNumCores();
 
-/**
- * On platforms that support it, tell the kernel the calling thread is
- * CPU-intensive and non-interactive. See SCHED_BATCH in sched(7) for details.
- *
- */
-void ScheduleBatchPriority();
-
 namespace util {
 
 //! Simplification of std insertion

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -38,16 +38,6 @@ int GetNumCores();
 
 namespace util {
 
-//! Simplification of std insertion
-template <typename Tdst, typename Tsrc>
-inline void insert(Tdst& dst, const Tsrc& src) {
-    dst.insert(dst.begin(), src.begin(), src.end());
-}
-template <typename TsetT, typename Tsrc>
-inline void insert(std::set<TsetT>& dst, const Tsrc& src) {
-    dst.insert(src.begin(), src.end());
-}
-
 /**
  * Helper function to access the contained object of a std::any instance.
  * Returns a pointer to the object if passed instance has a value and the type

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -13,7 +13,6 @@
 #include <compat/assumptions.h>
 #include <compat/compat.h>
 
-#include <any>
 #include <set>
 #include <stdint.h>
 #include <string>
@@ -35,21 +34,5 @@ void runCommand(const std::string& strCommand);
  * @note This does count virtual cores, such as those provided by HyperThreading.
  */
 int GetNumCores();
-
-namespace util {
-
-/**
- * Helper function to access the contained object of a std::any instance.
- * Returns a pointer to the object if passed instance has a value and the type
- * matches, nullptr otherwise.
- */
-template<typename T>
-T* AnyPtr(const std::any& any) noexcept
-{
-    T* const* ptr = std::any_cast<T*>(&any);
-    return ptr ? *ptr : nullptr;
-}
-
-} // namespace util
 
 #endif // BITCOIN_UTIL_SYSTEM_H

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3206,7 +3206,7 @@ bool Chainstate::ActivateBestChain(BlockValidationState& state, std::shared_ptr<
                 GetMainSignals().UpdatedBlockTip(pindexNewTip, pindexFork, fInitialDownload);
 
                 // Always notify the UI if a new block tip was connected
-                uiInterface.NotifyBlockTip(GetSynchronizationState(fInitialDownload), pindexNewTip);
+                m_chainman.GetNotifications().blockTip(GetSynchronizationState(fInitialDownload), *pindexNewTip);
             }
         }
         // When we reach this point, we switched to a new tip (stored in pindexNewTip).
@@ -3403,7 +3403,7 @@ bool Chainstate::InvalidateBlock(BlockValidationState& state, CBlockIndex* pinde
 
     // Only notify about a new block tip if the active chain was modified.
     if (pindex_was_in_chain) {
-        uiInterface.NotifyBlockTip(GetSynchronizationState(IsInitialBlockDownload()), to_mark_failed->pprev);
+        m_chainman.GetNotifications().blockTip(GetSynchronizationState(IsInitialBlockDownload()), *to_mark_failed->pprev);
     }
     return true;
 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3097,7 +3097,7 @@ static bool NotifyHeaderTip(Chainstate& chainstate) LOCKS_EXCLUDED(cs_main) {
     }
     // Send block tip changed notifications without cs_main
     if (fNotify) {
-        uiInterface.NotifyHeaderTip(GetSynchronizationState(fInitialBlockDownload), pindexHeader->nHeight, pindexHeader->nTime, false);
+        chainstate.m_chainman.GetNotifications().headerTip(GetSynchronizationState(fInitialBlockDownload), pindexHeader->nHeight, pindexHeader->nTime, false);
     }
     return fNotify;
 }
@@ -3920,7 +3920,7 @@ void ChainstateManager::ReportHeadersPresync(const arith_uint256& work, int64_t 
         m_last_presync_update = now;
     }
     bool initial_download = chainstate.IsInitialBlockDownload();
-    uiInterface.NotifyHeaderTip(GetSynchronizationState(initial_download), height, timestamp, /*presync=*/true);
+    GetNotifications().headerTip(GetSynchronizationState(initial_download), height, timestamp, /*presync=*/true);
     if (initial_download) {
         const int64_t blocks_left{(GetTime() - timestamp) / GetConsensus().nPowTargetSpacing};
         const double progress{100.0 * height / (height + blocks_left)};

--- a/src/validation.h
+++ b/src/validation.h
@@ -955,6 +955,7 @@ public:
     bool ShouldCheckBlockIndex() const { return *Assert(m_options.check_block_index); }
     const arith_uint256& MinimumChainWork() const { return *Assert(m_options.minimum_chain_work); }
     const uint256& AssumedValidBlock() const { return *Assert(m_options.assumed_valid_block); }
+    kernel::Notifications& GetNotifications() const { return m_options.notifications; };
 
     /**
      * Alias for ::cs_main.

--- a/src/validation.h
+++ b/src/validation.h
@@ -364,9 +364,13 @@ enum class VerifyDBResult {
 };
 
 /** RAII wrapper for VerifyDB: Verify consistency of the block and coin databases */
-class CVerifyDB {
+class CVerifyDB
+{
+private:
+    kernel::Notifications& m_notifications;
+
 public:
-    CVerifyDB();
+    explicit CVerifyDB(kernel::Notifications& notifications);
     ~CVerifyDB();
     [[nodiscard]] VerifyDBResult VerifyDB(
         Chainstate& chainstate,

--- a/src/wallet/bdb.h
+++ b/src/wallet/bdb.h
@@ -7,10 +7,10 @@
 #define BITCOIN_WALLET_BDB_H
 
 #include <clientversion.h>
+#include <common/system.h>
 #include <serialize.h>
 #include <streams.h>
 #include <util/fs.h>
-#include <util/system.h>
 #include <wallet/db.h>
 
 #include <atomic>

--- a/src/wallet/coinselection.cpp
+++ b/src/wallet/coinselection.cpp
@@ -4,13 +4,13 @@
 
 #include <wallet/coinselection.h>
 
+#include <common/system.h>
 #include <consensus/amount.h>
 #include <consensus/consensus.h>
 #include <logging.h>
 #include <policy/feerate.h>
 #include <util/check.h>
 #include <util/moneystr.h>
-#include <util/system.h>
 
 #include <numeric>
 #include <optional>

--- a/src/wallet/coinselection.h
+++ b/src/wallet/coinselection.h
@@ -11,8 +11,8 @@
 #include <policy/feerate.h>
 #include <primitives/transaction.h>
 #include <random.h>
-#include <util/system.h>
 #include <util/check.h>
+#include <util/insert.h>
 #include <util/result.h>
 
 #include <optional>

--- a/src/wallet/crypter.cpp
+++ b/src/wallet/crypter.cpp
@@ -4,9 +4,9 @@
 
 #include <wallet/crypter.h>
 
+#include <common/system.h>
 #include <crypto/aes.h>
 #include <crypto/sha512.h>
-#include <util/system.h>
 
 #include <vector>
 

--- a/src/wallet/external_signer_scriptpubkeyman.cpp
+++ b/src/wallet/external_signer_scriptpubkeyman.cpp
@@ -4,8 +4,8 @@
 
 #include <chainparams.h>
 #include <common/args.h>
+#include <common/system.h>
 #include <external_signer.h>
-#include <util/system.h>
 #include <wallet/external_signer_scriptpubkeyman.h>
 
 #include <iostream>

--- a/src/wallet/feebumper.cpp
+++ b/src/wallet/feebumper.cpp
@@ -2,13 +2,13 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <common/system.h>
 #include <consensus/validation.h>
 #include <interfaces/chain.h>
 #include <policy/fees.h>
 #include <policy/policy.h>
 #include <util/moneystr.h>
 #include <util/rbf.h>
-#include <util/system.h>
 #include <util/translation.h>
 #include <wallet/coincontrol.h>
 #include <wallet/feebumper.h>

--- a/src/wallet/rpc/util.cpp
+++ b/src/wallet/rpc/util.cpp
@@ -6,7 +6,7 @@
 
 #include <common/url.h>
 #include <rpc/util.h>
-#include <util/system.h>
+#include <util/any.h>
 #include <util/translation.h>
 #include <wallet/context.h>
 #include <wallet/wallet.h>

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <common/args.h>
+#include <common/system.h>
 #include <consensus/amount.h>
 #include <consensus/validation.h>
 #include <interfaces/chain.h>
@@ -15,7 +16,6 @@
 #include <util/fees.h>
 #include <util/moneystr.h>
 #include <util/rbf.h>
-#include <util/system.h>
 #include <util/trace.h>
 #include <util/translation.h>
 #include <wallet/coincontrol.h>

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -5,13 +5,13 @@
 
 #include <wallet/walletdb.h>
 
+#include <common/system.h>
 #include <key_io.h>
 #include <protocol.h>
 #include <serialize.h>
 #include <sync.h>
 #include <util/bip32.h>
 #include <util/fs.h>
-#include <util/system.h>
 #include <util/time.h>
 #include <util/translation.h>
 #ifdef USE_BDB

--- a/src/warnings.cpp
+++ b/src/warnings.cpp
@@ -5,9 +5,9 @@
 
 #include <warnings.h>
 
+#include <common/system.h>
 #include <sync.h>
 #include <util/string.h>
-#include <util/system.h>
 #include <util/translation.h>
 
 #include <vector>


### PR DESCRIPTION
This pull request is part of the `libbitcoinkernel` project https://github.com/bitcoin/bitcoin/issues/27587 https://github.com/bitcoin/bitcoin/projects/18 and more specifically its "Step 2: Decouple most non-consensus code from libbitcoinkernel".

---

It removes the kernel library's dependency on `util/system` and `interface_ui`. `util/system` contains networking and shell-related code that should not be part of the kernel library. The following pull requests prepared `util/system` for this final step: https://github.com/bitcoin/bitcoin/pull/27419 https://github.com/bitcoin/bitcoin/pull/27254 https://github.com/bitcoin/bitcoin/pull/27238.

`interface_ui` defines functions for a more general node interface and has a dependency on `boost/signals2`. After applying the patches from this pull request, the kernel's reliance on boost is down to `boost::multiindex`.

The approach implemented here introduces some indirection, which makes the code a bit harder to read. Any suggestions for improving or reworking this pull request to make it more concise, or even reworking it into a more proper interface, are appreciated.