### PR TITLE
init: add MALLOC_ARENA_MAX=1 to systemd

### DIFF
--- a/contrib/init/bitcoind.service
+++ b/contrib/init/bitcoind.service
@@ -23,6 +23,9 @@ ExecStart=/usr/bin/bitcoind -daemonwait \
                             -conf=/etc/bitcoin/bitcoin.conf \
                             -datadir=/var/lib/bitcoind
 
+# Avoid excessive memory usage by bitcoind
+Environment="MALLOC_ARENA_MAX=1"
+
 # Make sure the config directory is readable by the service user
 PermissionsStartOnly=true
 ExecStartPre=/bin/chgrp bitcoin /etc/bitcoin


### PR DESCRIPTION
This adds the MALLOC_ARENA_MAX=1 environment variable as suggested in https://github.com/bitcoin/bitcoin/blob/master/doc/reduce-memory.md#linux-specific to the systemd service file definition.

Without this env var, memory usage can grow significantly especially when rpcthreads is increased above its default value.

Closes https://github.com/bitcoin/bitcoin/issues/24542.

I have tested this change myself with positive results after dealing with memory consumption issues for a long time using systemd on a 8GB RAM raspi4. I figure a similar change may be desirable for the OpenRC and CentOS init files, but I don't have a way to test them and I'm not even exactly sure how environment variables should be added there (via export statements?).