### PR TITLE
fuzz: wallet, add target for `fees`

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -195,6 +195,7 @@ endif
 
 FUZZ_WALLET_SRC = \
  wallet/test/fuzz/coinselection.cpp \
+ wallet/test/fuzz/fees.cpp \
  wallet/test/fuzz/parse_iso8601.cpp
 
 if USE_SQLITE

--- a/src/wallet/test/fuzz/fees.cpp
+++ b/src/wallet/test/fuzz/fees.cpp
@@ -1,0 +1,68 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+#include <test/util/setup_common.h>
+#include <wallet/coincontrol.h>
+#include <wallet/fees.h>
+#include <wallet/wallet.h>
+#include <wallet/test/util.h>
+#include <validation.h>
+
+namespace wallet {
+namespace {
+const TestingSetup* g_setup;
+static std::unique_ptr<CWallet> g_wallet_ptr;
+
+void initialize_setup()
+{
+    static const auto testing_setup = MakeNoLogFileContext<const TestingSetup>();
+    g_setup = testing_setup.get();
+    const auto& node{g_setup->m_node};
+    g_wallet_ptr = std::make_unique<CWallet>(node.chain.get(), "", CreateMockableWalletDatabase());
+}
+
+FUZZ_TARGET_INIT(wallet_fees, initialize_setup)
+{
+    FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
+    const auto& node{g_setup->m_node};
+    Chainstate* chainstate = &node.chainman->ActiveChainstate();
+    CWallet& wallet = *g_wallet_ptr;
+    {
+        LOCK(wallet.cs_wallet);
+        wallet.SetLastBlockProcessed(chainstate->m_chain.Height(), chainstate->m_chain.Tip()->GetBlockHash());
+    }
+
+    if (fuzzed_data_provider.ConsumeBool()) {
+        wallet.m_discard_rate = CFeeRate{ConsumeMoney(fuzzed_data_provider, /*max=*/COIN)};
+    }
+    (void)GetDiscardRate(wallet);
+
+    const auto tx_bytes{fuzzed_data_provider.ConsumeIntegral<unsigned int>()};
+
+    if (fuzzed_data_provider.ConsumeBool()) {
+        wallet.m_pay_tx_fee = CFeeRate{ConsumeMoney(fuzzed_data_provider, /*max=*/COIN)};
+        wallet.m_min_fee = CFeeRate{ConsumeMoney(fuzzed_data_provider, /*max=*/COIN)};
+    }
+
+    (void)GetRequiredFee(wallet, tx_bytes);
+    (void)GetRequiredFeeRate(wallet);
+
+    CCoinControl coin_control;
+    if (fuzzed_data_provider.ConsumeBool()) {
+        coin_control.m_feerate = CFeeRate{ConsumeMoney(fuzzed_data_provider, /*max=*/COIN)};
+    }
+    if (fuzzed_data_provider.ConsumeBool()) {
+        coin_control.m_confirm_target = fuzzed_data_provider.ConsumeIntegral<unsigned int>();
+    }
+
+    FeeCalculation fee_calculation;
+    FeeCalculation* maybe_fee_calculation{fuzzed_data_provider.ConsumeBool() ? nullptr : &fee_calculation};
+    (void)GetMinimumFeeRate(wallet, coin_control, maybe_fee_calculation);
+    (void)GetMinimumFee(wallet, tx_bytes, coin_control, maybe_fee_calculation);
+}
+} // namespace
+} // namespace wallet


### PR DESCRIPTION
This PR adds fuzz coverage for `wallet/fees`. Some functions may use or not (non default) values from `wallet`, `CCoinControl` or `FeeCalculation`. So the logic is to make the test sometimes fill up some attributes and others no.

Obs: As soon as this PR gets some reviews, I can open the proper PR to `qa-assets` as well.