### PR TITLE
test: Drop `deadlock:libdb` TSan suppression

### DIFF
--- a/test/sanitizer_suppressions/tsan
+++ b/test/sanitizer_suppressions/tsan
@@ -25,7 +25,6 @@ race:src/qt/test/*
 deadlock:src/qt/test/*
 
 # External libraries
-deadlock:libdb
 race:libzmq
 
 # Intermittent issues


### PR DESCRIPTION
I'm not able to reproduce the TSan's "lock-order-inversion (potential deadlock)" warning for `libdb` for `24.x`, `25.x` and master branches neither in CI nor in different local environments (Ubuntu, Fedora).

If Tsan complains again, we can obtain a call stack from TSan, and this change can be easily reverted back.

Noticed while reviewing https://github.com/bitcoin/bitcoin/pull/27556.