### PR TITLE
ci: Remove unused errtrace trap ERR

### DIFF
--- a/ci/test/06_script_b.sh
+++ b/ci/test/06_script_b.sh
@@ -104,9 +104,6 @@ cd "${BASE_BUILD_DIR}/bitcoin-$HOST"
 
 bash -c "./configure --cache-file=../config.cache $BITCOIN_CONFIG_ALL $BITCOIN_CONFIG" || ( (cat config.log) && false)
 
-set -o errtrace
-trap 'bash -c "cat ${BASE_SCRATCH_DIR}/sanitizer-output/* 2> /dev/null"' ERR
-
 if [[ ${USE_MEMORY_SANITIZER} == "true" ]]; then
   # MemorySanitizer (MSAN) does not support tracking memory initialization done by
   # using the Linux getrandom syscall. Avoid using getrandom by undefining


### PR DESCRIPTION
This was added in commit 069752b72613b772a9536a3e7f15fa75097f2946, presumably at a time when the functional tests wouldn't capture stderr.

Now that all tests capture and print stderr on failure, it can be removed. Reference:

* Unit tests capture via `2>&1`:

https://github.com/bitcoin/bitcoin/blob/d7700d3a26478d9b1648463c188648c7047b1c60/src/Makefile.test.include#L421

* Functional tests capture as well:

https://github.com/bitcoin/bitcoin/blob/d7700d3a26478d9b1648463c188648c7047b1c60/test/functional/test_framework/test_node.py#L356