### PR TITLE
depends: Boost 1.82.0

### DIFF
--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -1,8 +1,8 @@
 package=boost
-$(package)_version=1.81.0
+$(package)_version=1.82.0
 $(package)_download_path=https://boostorg.jfrog.io/artifactory/main/release/$($(package)_version)/source/
 $(package)_file_name=boost_$(subst .,_,$($(package)_version)).tar.bz2
-$(package)_sha256_hash=71feeed900fbccca04a3b4f2f84a7c217186f28a940ed8b7ed4725986baf99fa
+$(package)_sha256_hash=a6e1ab9b0860e6a2881dd7b21fe9f737a095e5f33a3a874afc6a345228597ee6
 
 define $(package)_stage_cmds
   mkdir -p $($(package)_staging_prefix_dir)/include && \

--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -17,7 +17,7 @@ You can find installation instructions in the `build-*.md` file for your platfor
 
 | Dependency | Releases | Version used | Minimum required | Runtime |
 | --- | --- | --- | --- | --- |
-| [Boost](../depends/packages/boost.mk) | [link](https://www.boost.org/users/download/) | [1.81.0](https://github.com/bitcoin/bitcoin/pull/26557) | [1.64.0](https://github.com/bitcoin/bitcoin/pull/22320) | No |
+| [Boost](../depends/packages/boost.mk) | [link](https://www.boost.org/users/download/) | [1.82.0](https://github.com/bitcoin/bitcoin/pull/27671) | [1.64.0](https://github.com/bitcoin/bitcoin/pull/22320) | No |
 | [libevent](../depends/packages/libevent.mk) | [link](https://github.com/libevent/libevent/releases) | [2.1.12-stable](https://github.com/bitcoin/bitcoin/pull/21991) | [2.1.8](https://github.com/bitcoin/bitcoin/pull/24681) | No |
 | glibc | [link](https://www.gnu.org/software/libc/) | N/A | [2.27](https://github.com/bitcoin/bitcoin/pull/27029) | Yes |
 | Linux Kernel | [link](https://www.kernel.org/) | N/A | 3.2.0 | Yes |


### PR DESCRIPTION
https://www.boost.org/users/history/version_1_82_0.html

Relevant changelogs:

https://github.com/boostorg/core/compare/boost-1.81.0...boost-1.82.0

https://github.com/boostorg/multi_index/compare/boost-1.81.0...boost-1.82.0

https://github.com/boostorg/test/compare/boost-1.81.0...boost-1.82.0

https://github.com/boostorg/process/compare/boost-1.81.0...boost-1.82.0

Other modules, i.e date_time, signals2, etc, had no changes.