### PR TITLE
fuzz: Print error message when FUZZ is missing

### DIFF
--- a/ci/test/06_script_b.sh
+++ b/ci/test/06_script_b.sh
@@ -24,6 +24,11 @@ if [ "$RUN_FUZZ_TESTS" = "true" ]; then
   if [ ! -d "$DIR_FUZZ_IN" ]; then
     git clone --depth=1 https://github.com/bitcoin-core/qa-assets "${DIR_QA_ASSETS}"
   fi
+  (
+    cd "${DIR_QA_ASSETS}"
+    echo "Using qa-assets repo from commit ..."
+    git log -1
+  )
 elif [ "$RUN_UNIT_TESTS" = "true" ] || [ "$RUN_UNIT_TESTS_SEQUENTIAL" = "true" ]; then
   export DIR_UNIT_TEST_DATA=${DIR_QA_ASSETS}/unit_test_data/
   if [ ! -d "$DIR_UNIT_TEST_DATA" ]; then

--- a/src/test/fuzz/fuzz.cpp
+++ b/src/test/fuzz/fuzz.cpp
@@ -14,14 +14,19 @@
 
 #include <csignal>
 #include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <exception>
 #include <fstream>
 #include <functional>
+#include <iostream>
 #include <map>
 #include <memory>
 #include <string>
 #include <tuple>
 #include <unistd.h>
+#include <utility>
 #include <vector>
 
 const std::function<void(const std::string&)> G_TEST_LOG_FUN{};
@@ -77,13 +82,13 @@ void initialize()
         return WrappedGetAddrInfo(name, false);
     };
 
-    bool should_abort{false};
+    bool should_exit{false};
     if (std::getenv("PRINT_ALL_FUZZ_TARGETS_AND_ABORT")) {
         for (const auto& t : FuzzTargets()) {
             if (std::get<2>(t.second)) continue;
             std::cout << t.first << std::endl;
         }
-        should_abort = true;
+        should_exit = true;
     }
     if (const char* out_path = std::getenv("WRITE_ALL_FUZZ_TARGETS_AND_ABORT")) {
         std::cout << "Writing all fuzz target names to '" << out_path << "'." << std::endl;
@@ -92,13 +97,23 @@ void initialize()
             if (std::get<2>(t.second)) continue;
             out_stream << t.first << std::endl;
         }
-        should_abort = true;
+        should_exit= true;
     }
-    Assert(!should_abort);
-    g_fuzz_target = Assert(std::getenv("FUZZ"));
+    if (should_exit){
+        std::exit(EXIT_SUCCESS);
+    }
+    if (const auto* env_fuzz{std::getenv("FUZZ")}) {
+        // To allow for easier fuzz executable binary modification,
+        static std::string g_copy{env_fuzz}; // create copy to avoid compiler optimizations, and
+        g_fuzz_target = g_copy.c_str();      // strip string after the first null-char.
+    } else {
+        std::cerr << "Must select fuzz target with the FUZZ env var." << std::endl;
+        std::cerr << "Hint: Set the PRINT_ALL_FUZZ_TARGETS_AND_ABORT=1 env var to see all compiled targets." << std::endl;
+        std::exit(EXIT_FAILURE);
+    }
     const auto it = FuzzTargets().find(g_fuzz_target);
     if (it == FuzzTargets().end()) {
-        std::cerr << "No fuzzer for " << g_fuzz_target << "." << std::endl;
+        std::cerr << "No fuzz target compiled for " << g_fuzz_target << "." << std::endl;
         std::exit(EXIT_FAILURE);
     }
     Assert(!g_test_one_input);

--- a/src/util/fs.h
+++ b/src/util/fs.h
@@ -8,7 +8,7 @@
 #include <tinyformat.h>
 
 #include <cstdio>
-#include <filesystem>
+#include <filesystem> // IWYU pragma: export
 #include <functional>
 #include <iomanip>
 #include <ios>


### PR DESCRIPTION
Some trivial UX improvements.

* Change the exit code for `PRINT_ALL_FUZZ_TARGETS_AND_ABORT` and `WRITE_ALL_FUZZ_TARGETS_AND_ABORT` to `EXIT_SUCCESS` instead of `Aborted (core dumped)`.
* Print readable error message when `FUZZ` is missing instead of `Aborted (core dumped)`.
* Clarify that a fuzz target needs to be compiled into the executable.