### PR TITLE
ci: Fix "Number of CPUs" output

### DIFF
--- a/ci/test/06_script_b.sh
+++ b/ci/test/06_script_b.sh
@@ -13,7 +13,7 @@ if [ "$CI_OS_NAME" == "macos" ]; then
   echo "Number of CPUs: $(sysctl -n hw.logicalcpu)"
 else
   free -m -h
-  echo "Number of CPUs \(nproc\):" \$\(nproc\)
+  echo "Number of CPUs (nproc): $(nproc)"
   lscpu | grep Endian
 fi
 echo "Free disk space:"


### PR DESCRIPTION
This PR is a follow-up to https://github.com/bitcoin/bitcoin/pull/27616:

- on [master](https://api.cirrus-ci.com/v1/task/5809898840129536/logs/ci.log):
```
Number of CPUs \(nproc\): $(nproc)
```

- this [PR](https://api.cirrus-ci.com/v1/task/6495994095861760/logs/ci.log):
```
Number of CPUs (nproc): 32
```