### PR TITLE
fuzz: net, add `recv_flood_size`, `prefer_evict` in `ConsumeNode`

### DIFF
--- a/src/test/fuzz/net.cpp
+++ b/src/test/fuzz/net.cpp
@@ -76,4 +76,5 @@ FUZZ_TARGET_INIT(net, initialize_net)
     const NetPermissionFlags net_permission_flags = ConsumeWeakEnum(fuzzed_data_provider, ALL_NET_PERMISSION_FLAGS);
     (void)node.HasPermission(net_permission_flags);
     (void)node.ConnectedThroughNetwork();
+    (void)node.MarkReceivedMsgsForProcessing();
 }

--- a/src/test/fuzz/util/net.h
+++ b/src/test/fuzz/util/net.h
@@ -110,6 +110,7 @@ auto ConsumeNode(FuzzedDataProvider& fuzzed_data_provider, const std::optional<N
     const ConnectionType conn_type = fuzzed_data_provider.PickValueInArray(ALL_CONNECTION_TYPES);
     const bool inbound_onion{conn_type == ConnectionType::INBOUND ? fuzzed_data_provider.ConsumeBool() : false};
     NetPermissionFlags permission_flags = ConsumeWeakEnum(fuzzed_data_provider, ALL_NET_PERMISSION_FLAGS);
+    const size_t recv_flood_size = fuzzed_data_provider.ConsumeIntegral<size_t>();
     if constexpr (ReturnUniquePtr) {
         return std::make_unique<CNode>(node_id,
                                        sock,
@@ -120,7 +121,10 @@ auto ConsumeNode(FuzzedDataProvider& fuzzed_data_provider, const std::optional<N
                                        addr_name,
                                        conn_type,
                                        inbound_onion,
-                                       CNodeOptions{ .permission_flags = permission_flags });
+                                       CNodeOptions{
+                                           .permission_flags = permission_flags,
+                                           .recv_flood_size = recv_flood_size,
+                                       });
     } else {
         return CNode{node_id,
                      sock,
@@ -131,7 +135,10 @@ auto ConsumeNode(FuzzedDataProvider& fuzzed_data_provider, const std::optional<N
                      addr_name,
                      conn_type,
                      inbound_onion,
-                     CNodeOptions{ .permission_flags = permission_flags }};
+                     CNodeOptions{
+                         .permission_flags = permission_flags,
+                         .recv_flood_size = recv_flood_size,
+                     }};
     }
 }
 inline std::unique_ptr<CNode> ConsumeNodeAsUniquePtr(FuzzedDataProvider& fdp, const std::optional<NodeId>& node_id_in = std::nullopt) { return ConsumeNode<true>(fdp, node_id_in); }


### PR DESCRIPTION
This PR adds `recv_flood_size` and `prefer_evict` in `CNodeOptions` when creating a new CNode in `ConsumeNode`. I noticed they were missing while working on an improvement for net fuzzing. 

Checked that #27324 added `recv_flood_size` into `CNodeOptions` and #25962 added`prefer_evict`.