### PR TITLE
ZMQ: Support UNIX domain sockets

### DIFF
--- a/doc/release-notes-27679.md
+++ b/doc/release-notes-27679.md
@@ -1,0 +1,2 @@
+- unix socket paths are now accepted for `-zmqpubrawblock` and `-zmqpubrawtx` with
+the format `-zmqpubrawtx=unix:/path/to/file`

--- a/src/zmq/zmqnotificationinterface.cpp
+++ b/src/zmq/zmqnotificationinterface.cpp
@@ -8,6 +8,7 @@
 #include <kernel/chain.h>
 #include <kernel/mempool_entry.h>
 #include <logging.h>
+#include <netbase.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <validationinterface.h>
@@ -57,7 +58,12 @@ std::unique_ptr<CZMQNotificationInterface> CZMQNotificationInterface::Create(std
     {
         std::string arg("-zmq" + entry.first);
         const auto& factory = entry.second;
-        for (const std::string& address : gArgs.GetArgs(arg)) {
+        for (std::string& address : gArgs.GetArgs(arg)) {
+            // libzmq uses prefix "ipc://" for UNIX domain sockets
+            if (address.substr(0, ADDR_PREFIX_UNIX.length()) == ADDR_PREFIX_UNIX) {
+                address.replace(0, ADDR_PREFIX_UNIX.length(), ADDR_PREFIX_IPC);
+            }
+
             std::unique_ptr<CZMQAbstractNotifier> notifier = factory();
             notifier->SetType(entry.first);
             notifier->SetAddress(address);

--- a/src/zmq/zmqutil.h
+++ b/src/zmq/zmqutil.h
@@ -9,4 +9,7 @@
 
 void zmqError(const std::string& str);
 
+/** Prefix for unix domain socket addresses (which are local filesystem paths) */
+const std::string ADDR_PREFIX_IPC = "ipc://"; // used by libzmq, example "ipc:///root/path/to/file"
+
 #endif // BITCOIN_ZMQ_ZMQUTIL_H

--- a/test/functional/interface_zmq.py
+++ b/test/functional/interface_zmq.py
@@ -3,7 +3,9 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test the ZMQ notification interface."""
+import os
 import struct
+import tempfile
 from time import sleep
 from io import BytesIO
 
@@ -30,7 +32,7 @@ from test_framework.util import (
 from test_framework.wallet import (
     MiniWallet,
 )
-from test_framework.netutil import test_ipv6_local
+from test_framework.netutil import test_ipv6_local, test_unix_socket
 
 
 # Test may be skipped and not have zmq installed
@@ -119,6 +121,10 @@ class ZMQTest (BitcoinTestFramework):
         self.ctx = zmq.Context()
         try:
             self.test_basic()
+            if test_unix_socket():
+                self.test_basic(unix=True)
+            else:
+                self.log.info("Skipping ipc test, because UNIX sockets are not supported.")
             self.test_sequence()
             self.test_mempool_sync()
             self.test_reorg()
@@ -139,7 +145,7 @@ class ZMQTest (BitcoinTestFramework):
                 socket.setsockopt(zmq.IPV6, 1)
             subscribers.append(ZMQSubscriber(socket, topic.encode()))
 
-        self.restart_node(0, [f"-zmqpub{topic}={address}" for topic, address in services])
+        self.restart_node(0, [f"-zmqpub{topic}={address.replace('ipc://', 'unix:')}" for topic, address in services])
 
         for i, sub in enumerate(subscribers):
             sub.socket.connect(services[i][1])
@@ -176,12 +182,19 @@ class ZMQTest (BitcoinTestFramework):
 
         return subscribers
 
-    def test_basic(self):
+    def test_basic(self, unix = False):
+        self.log.info(f"Running basic test with {'ipc' if unix else 'tcp'} protocol")
 
         # Invalid zmq arguments don't take down the node, see #17185.
         self.restart_node(0, ["-zmqpubrawtx=foo", "-zmqpubhashtx=bar"])
 
         address = f"tcp://127.0.0.1:{self.zmq_port_base}"
+
+        if unix:
+            # Use the shortest temp path possible since paths may have as little as 92-char limit
+            socket_path = tempfile.NamedTemporaryFile().name
+            address = f"ipc://{socket_path}"
+
         subs = self.setup_zmq_test([(topic, address) for topic in ["hashblock", "hashtx", "rawblock", "rawtx"]])
 
         hashblock = subs[0]
@@ -247,6 +260,8 @@ class ZMQTest (BitcoinTestFramework):
         ])
 
         assert_equal(self.nodes[1].getzmqnotifications(), [])
+        if unix:
+            os.unlink(socket_path)
 
     def test_reorg(self):
 


### PR DESCRIPTION
This is a follow-up to https://github.com/bitcoin/bitcoin/pull/27375, allowing ZMQ notifications to be published to a UNIX domain socket.

Fortunately, libzmq handles unix sockets already, all we really have to do to support it is allow the format in the actual option.

[libzmq](https://libzmq.readthedocs.io/en/latest/zmq_ipc.html) uses the prefix `ipc://` as opposed to `unix:` which is [used by Tor](https://gitlab.torproject.org/tpo/core/tor/-/blob/main/doc/man/tor.1.txt?ref_type=heads#L1475) and now also by [bitcoind](https://github.com/bitcoin/bitcoin/blob/a85e5a7c9ab75209bc88e49be6991ba0a467034e/doc/release-notes-27375.md?plain=1#L5) so we need to switch that internally.

As far as I can tell, [LND](https://github.com/lightninglabs/gozmq/blob/d20a764486bf506bc045642e455bc7f0d21b232a/zmq.go#L38) supports `ipc://` and `unix://` (notice the double slashes).

With this patch, LND can connect to bitcoind using unix sockets:


Example:

*bitcoin.conf*:
```
zmqpubrawblock=unix:/tmp/zmqsb
zmqpubrawtx=unix:/tmp/zmqst
```

*lnd.conf*:
```
bitcoind.zmqpubrawblock=ipc:///tmp/zmqsb
bitcoind.zmqpubrawtx=ipc:///tmp/zmqst
```