### PR TITLE
build: Bump minimum supported Clang to clang-10

### DIFF
--- a/build-aux/m4/l_filesystem.m4
+++ b/build-aux/m4/l_filesystem.m4
@@ -3,7 +3,6 @@ dnl Distributed under the MIT software license, see the accompanying
 dnl file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 # GCC 8.1 and earlier requires -lstdc++fs
-# Clang 8.0.0 (libc++) and earlier requires -lc++fs
 
 m4_define([_CHECK_FILESYSTEM_testbody], [[
   #include <filesystem>
@@ -26,20 +25,12 @@ AC_DEFUN([CHECK_FILESYSTEM], [
       AC_MSG_RESULT([yes])
     ],[
       AC_MSG_RESULT([no])
-      SAVED_LIBS="$LIBS"
-      LIBS="$SAVED_LIBS -lstdc++fs"
+      LIBS="$LIBS -lstdc++fs"
       AC_MSG_CHECKING([whether std::filesystem needs -lstdc++fs])
       AC_LINK_IFELSE([AC_LANG_SOURCE([_CHECK_FILESYSTEM_testbody])],[
           AC_MSG_RESULT([yes])
         ],[
-          AC_MSG_RESULT([no])
-          AC_MSG_CHECKING([whether std::filesystem needs -lc++fs])
-          LIBS="$SAVED_LIBS -lc++fs"
-          AC_LINK_IFELSE([AC_LANG_SOURCE([_CHECK_FILESYSTEM_testbody])],[
-            AC_MSG_RESULT([yes])
-        ],[
             AC_MSG_FAILURE([cannot figure out how to use std::filesystem])
-          ])
         ])
     ])
 

--- a/ci/test/00_setup_env_native_nowallet_libbitcoinkernel.sh
+++ b/ci/test/00_setup_env_native_nowallet_libbitcoinkernel.sh
@@ -12,5 +12,4 @@ export CI_IMAGE_NAME_TAG="ubuntu:20.04"
 export PACKAGES="python3-zmq clang-10 llvm-10 libc++abi-10-dev libc++-10-dev"
 export DEP_OPTS="NO_WALLET=1 CC=clang-10 CXX='clang++-10 -stdlib=libc++'"
 export GOAL="install"
-export NO_WERROR=1
 export BITCOIN_CONFIG="--enable-reduce-exports --enable-experimental-util-chainstate --with-experimental-kernel-lib --enable-shared"

--- a/ci/test/00_setup_env_native_nowallet_libbitcoinkernel.sh
+++ b/ci/test/00_setup_env_native_nowallet_libbitcoinkernel.sh
@@ -8,9 +8,9 @@ export LC_ALL=C.UTF-8
 
 export CONTAINER_NAME=ci_native_nowallet_libbitcoinkernel
 export CI_IMAGE_NAME_TAG="ubuntu:20.04"
-# Use minimum supported python3.8 and clang-8, see doc/dependencies.md
-export PACKAGES="python3-zmq clang-8 llvm-8 libc++abi-8-dev libc++-8-dev"
-export DEP_OPTS="NO_WALLET=1 CC=clang-8 CXX='clang++-8 -stdlib=libc++'"
+# Use minimum supported python3.8 and clang-10, see doc/dependencies.md
+export PACKAGES="python3-zmq clang-10 llvm-10 libc++abi-10-dev libc++-10-dev"
+export DEP_OPTS="NO_WALLET=1 CC=clang-10 CXX='clang++-10 -stdlib=libc++'"
 export GOAL="install"
 export NO_WERROR=1
-export BITCOIN_CONFIG="--enable-reduce-exports CC=clang-8 CXX='clang++-8 -stdlib=libc++' --enable-experimental-util-chainstate --with-experimental-kernel-lib --enable-shared"
+export BITCOIN_CONFIG="--enable-reduce-exports --enable-experimental-util-chainstate --with-experimental-kernel-lib --enable-shared"

--- a/ci/test/06_script_b.sh
+++ b/ci/test/06_script_b.sh
@@ -52,9 +52,6 @@ fi
 
 if [ -z "$NO_DEPENDS" ]; then
   if [[ $CI_IMAGE_NAME_TAG == *centos* ]]; then
-    # CentOS has problems building the depends if the config shell is not explicitly set
-    # (i.e. for libevent a Makefile with an empty SHELL variable is generated, leading to
-    #  an error as the first command is executed)
     SHELL_OPTS="LC_ALL=en_US.UTF-8 CONFIG_SHELL=/bin/dash"
   else
     SHELL_OPTS="CONFIG_SHELL="

--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -8,7 +8,7 @@ You can find installation instructions in the `build-*.md` file for your platfor
 | --- | --- |
 | [Autoconf](https://www.gnu.org/software/autoconf/) | [2.69](https://github.com/bitcoin/bitcoin/pull/17769) |
 | [Automake](https://www.gnu.org/software/automake/) | [1.13](https://github.com/bitcoin/bitcoin/pull/18290) |
-| [Clang](https://clang.llvm.org) | [8.0](https://github.com/bitcoin/bitcoin/pull/24164) |
+| [Clang](https://clang.llvm.org) | [10.0](https://github.com/bitcoin/bitcoin/pull/27682) |
 | [GCC](https://gcc.gnu.org) | [8.1](https://github.com/bitcoin/bitcoin/pull/23060) |
 | [Python](https://www.python.org) (scripts, tests) | [3.8](https://github.com/bitcoin/bitcoin/pull/27483) |
 | [systemtap](https://sourceware.org/systemtap/) ([tracing](tracing.md))| N/A |


### PR DESCRIPTION
It doesn't make sense to support a minimum clang version that is difficult to install on all supported operating systems, which generally ship a later version:

* Ubuntu Focal 20.04: https://packages.ubuntu.com/focal/clang-10 and https://packages.ubuntu.com/focal/clang-12
* Debian Bullseye: https://packages.debian.org/bullseye/clang-13
* CentOS 8 Stream: All Clang versions from 11.0 to 15.0

Also, it allows to drop build code, which means it won't waste review when rolling over into cmake (`cmake/module/CheckStdFilesystem.cmake`).

