### PR TITLE
Avoid lock order inversion in `Chainstate::ConnectTip` function

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1978,7 +1978,7 @@ void PeerManagerImpl::BlockChecked(const CBlock& block, const BlockValidationSta
     if (state.IsInvalid() &&
         it != mapBlockSource.end() &&
         State(it->second.first)) {
-            MaybePunishNodeForBlock(/*nodeid=*/ it->second.first, state, /*via_compact_block=*/ !it->second.second);
+            (void)std::async(std::launch::async, &PeerManagerImpl::MaybePunishNodeForBlock, this, /*nodeid=*/it->second.first, state, /*via_compact_block=*/!it->second.second, "");
     }
     // Check that:
     // 1. The block is valid

--- a/test/sanitizer_suppressions/tsan
+++ b/test/sanitizer_suppressions/tsan
@@ -12,11 +12,6 @@ race:DatabaseBatch
 race:zmq::*
 race:bitcoin-qt
 
-# deadlock (TODO fix)
-# To reproduce, see:
-# https://github.com/bitcoin/bitcoin/issues/19303#issuecomment-1514926359
-deadlock:Chainstate::ConnectTip
-
 # Intentional deadlock in tests
 deadlock:sync_tests::potential_deadlock_detected
 


### PR DESCRIPTION
Due to the synchronous call of `CValidationInterface::BlockChecked` a lock order inversion [happens](https://github.com/bitcoin/bitcoin/issues/19303#issuecomment-1514928912):
```
PeerManagerImpl::m_peer_mutex
  |
  V
Peer::TxRelay::m_tx_inventory_mutex
  |
  V
CTxMemPool::cs
  |
  V
PeerManagerImpl::m_peer_mutex
```

This PR breaks the last link.

The other possible solution is to move `CValidationInterface::BlockChecked` to a background thread (see https://github.com/bitcoin/bitcoin/pull/18963). But this PR is much simpler.

I cannot see any drawbacks of calling `MaybePunishNodeForBlock` asynchronously. Other opinions are welcome.