### PR TITLE
msvc: Provide `ObjectFileName` explicitly

### DIFF
--- a/build_msvc/test_bitcoin-qt/test_bitcoin-qt.vcxproj
+++ b/build_msvc/test_bitcoin-qt/test_bitcoin-qt.vcxproj
@@ -10,14 +10,18 @@
   <ItemGroup>
     <ClCompile Include="..\..\src\init\bitcoin-qt.cpp" />
     <ClCompile Include="..\..\src\test\util\setup_common.cpp" />
-    <ClCompile Include="..\..\src\wallet\test\util.cpp" />
+    <ClCompile Include="..\..\src\wallet\test\util.cpp">
+      <ObjectFileName>$(IntDir)wallet_test_util.obj</ObjectFileName>
+    </ClCompile>
     <ClCompile Include="..\..\src\qt\test\addressbooktests.cpp" />
     <ClCompile Include="..\..\src\qt\test\apptests.cpp" />
     <ClCompile Include="..\..\src\qt\test\optiontests.cpp" />
     <ClCompile Include="..\..\src\qt\test\rpcnestedtests.cpp" />
     <ClCompile Include="..\..\src\qt\test\test_main.cpp" />
     <ClCompile Include="..\..\src\qt\test\uritests.cpp" />
-    <ClCompile Include="..\..\src\qt\test\util.cpp" />
+    <ClCompile Include="..\..\src\qt\test\util.cpp">
+      <ObjectFileName>$(IntDir)qt_test_util.obj</ObjectFileName>
+    </ClCompile>
     <ClCompile Include="..\..\src\qt\test\wallettests.cpp" />
     <ClCompile Include="..\..\src\wallet\test\wallet_test_fixture.cpp" />
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_addressbooktests.cpp" />


### PR DESCRIPTION
This PR is a follow-up to https://github.com/bitcoin/bitcoin/pull/26715.

Fixes intermittent MSVC link [errors](https://cirrus-ci.com/task/6646912535756800).