### PR TITLE
test: Add test to check tx in the last block can be downloaded

### DIFF
--- a/test/functional/p2p_leak_tx.py
+++ b/test/functional/p2p_leak_tx.py
@@ -23,16 +23,19 @@ class P2PLeakTxTest(BitcoinTestFramework):
         self.num_nodes = 1
 
     def run_test(self):
-        gen_node = self.nodes[0]  # The block and tx generating node
-        miniwallet = MiniWallet(gen_node)
+        self.gen_node = self.nodes[0]  # The block and tx generating node
+        self.miniwallet = MiniWallet(self.gen_node)
 
+        self.test_notfound_on_unannounced_tx()
+
+    def test_notfound_on_unannounced_tx(self):
         inbound_peer = self.nodes[0].add_p2p_connection(P2PNode())  # An "attacking" inbound peer
 
         MAX_REPEATS = 100
         self.log.info("Running test up to {} times.".format(MAX_REPEATS))
         for i in range(MAX_REPEATS):
             self.log.info('Run repeat {}'.format(i + 1))
-            txid = miniwallet.send_self_transfer(from_node=gen_node)['wtxid']
+            txid = self.miniwallet.send_self_transfer(from_node=self.gen_node)["wtxid"]
 
             want_tx = msg_getdata()
             want_tx.inv.append(CInv(t=MSG_TX, h=int(txid, 16)))

--- a/test/functional/p2p_leak_tx.py
+++ b/test/functional/p2p_leak_tx.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2017-2021 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Test that we don't leak txs to inbound peers that we haven't yet announced to"""
+"""Test transaction upload"""
 
 from test_framework.messages import msg_getdata, CInv, MSG_TX
 from test_framework.p2p import p2p_lock, P2PDataStore
@@ -26,10 +26,28 @@ class P2PLeakTxTest(BitcoinTestFramework):
         self.gen_node = self.nodes[0]  # The block and tx generating node
         self.miniwallet = MiniWallet(self.gen_node)
 
+        self.test_tx_in_block()
         self.test_notfound_on_unannounced_tx()
 
+    def test_tx_in_block(self):
+        self.log.info("Check that a transaction in the last block is uploaded (beneficial for compact block relay)")
+        inbound_peer = self.gen_node.add_p2p_connection(P2PNode())
+
+        self.log.debug("Generate transaction and block")
+        inbound_peer.last_message.pop("inv", None)
+        wtxid = self.miniwallet.send_self_transfer(from_node=self.gen_node)["wtxid"]
+        inbound_peer.wait_until(lambda: "inv" in inbound_peer.last_message and inbound_peer.last_message.get("inv").inv[0].hash == int(wtxid, 16))
+        want_tx = msg_getdata(inv=inbound_peer.last_message.get("inv").inv)
+        self.generate(self.gen_node, 1)
+
+        self.log.debug("Request transaction")
+        inbound_peer.last_message.pop("tx", None)
+        inbound_peer.send_and_ping(want_tx)
+        assert_equal(inbound_peer.last_message.get("tx").tx.getwtxid(), wtxid)
+
     def test_notfound_on_unannounced_tx(self):
-        inbound_peer = self.nodes[0].add_p2p_connection(P2PNode())  # An "attacking" inbound peer
+        self.log.info("Check that we don't leak txs to inbound peers that we haven't yet announced to")
+        inbound_peer = self.gen_node.add_p2p_connection(P2PNode())  # An "attacking" inbound peer
 
         MAX_REPEATS = 100
         self.log.info("Running test up to {} times.".format(MAX_REPEATS))


### PR DESCRIPTION
If a peer received an `inv` about a transaction, which was included in a block before receiving the corresponding `getdata`, it can be beneficial to send this transaction to the peer to aid compact block relay.

Add a test for this to avoid breaking it in the future.