### PR TITLE
kernel:  Remove shutdown globals from kernel library

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -310,6 +310,7 @@ BITCOIN_CORE_H = \
   util/result.h \
   util/serfloat.h \
   util/settings.h \
+  util/signalinterrupt.h \
   util/sock.h \
   util/spanparsing.h \
   util/string.h \
@@ -734,6 +735,7 @@ libbitcoin_util_a_SOURCES = \
   util/rbf.cpp \
   util/readwritefile.cpp \
   util/settings.cpp \
+  util/signalinterrupt.cpp \
   util/thread.cpp \
   util/threadinterrupt.cpp \
   util/threadnames.cpp \
@@ -979,11 +981,13 @@ libbitcoinkernel_la_SOURCES = \
   util/rbf.cpp \
   util/serfloat.cpp \
   util/settings.cpp \
+  util/signalinterrupt.cpp \
   util/strencodings.cpp \
   util/string.cpp \
   util/syscall_sandbox.cpp \
   util/syserror.cpp \
   util/thread.cpp \
+  util/threadinterrupt.cpp \
   util/threadnames.cpp \
   util/time.cpp \
   util/tokenpipe.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -941,7 +941,6 @@ libbitcoinkernel_la_SOURCES = \
   logging.cpp \
   node/blockstorage.cpp \
   node/chainstate.cpp \
-  node/interface_ui.cpp \
   node/utxo_snapshot.cpp \
   policy/feerate.cpp \
   policy/fees.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -397,6 +397,7 @@ libbitcoin_node_a_SOURCES = \
   kernel/context.cpp \
   kernel/cs_main.cpp \
   kernel/mempool_persist.cpp \
+  kernel/notifications_interface.cpp \
   mapport.cpp \
   net.cpp \
   net_processing.cpp \
@@ -937,6 +938,7 @@ libbitcoinkernel_la_SOURCES = \
   kernel/context.cpp \
   kernel/cs_main.cpp \
   kernel/mempool_persist.cpp \
+  kernel/notifications_interface.cpp \
   key.cpp \
   logging.cpp \
   node/blockstorage.cpp \
@@ -960,7 +962,6 @@ libbitcoinkernel_la_SOURCES = \
   script/script_error.cpp \
   script/sigcache.cpp \
   script/standard.cpp \
-  shutdown.cpp \
   signet.cpp \
   support/cleanse.cpp \
   support/lockedpool.cpp \

--- a/src/bitcoin-chainstate.cpp
+++ b/src/bitcoin-chainstate.cpp
@@ -117,7 +117,7 @@ int main(int argc, char* argv[])
         .chainparams = chainman_opts.chainparams,
         .blocks_dir = gArgs.GetBlocksDirPath(),
     };
-    ChainstateManager chainman{chainman_opts, blockman_opts};
+    ChainstateManager chainman{kernel_context.interrupt, chainman_opts, blockman_opts};
 
     node::CacheSizes cache_sizes;
     cache_sizes.block_tree_db = 2 << 20;

--- a/src/bitcoin-chainstate.cpp
+++ b/src/bitcoin-chainstate.cpp
@@ -108,6 +108,10 @@ int main(int argc, char* argv[])
             std::cerr << "Error: " << debug_message << std::endl;
             std::cerr << (user_message.empty() ? "A fatal internal error occurred." : user_message.original) << std::endl;
         }
+        void interrupt(const kernel::InterruptReason reason) override
+        {
+            std::cout << "Received interrupt notification: " << InterruptReasonToString(reason);
+        }
     };
     auto notifications = std::make_unique<KernelNotifications>();
 

--- a/src/bitcoin-chainstate.cpp
+++ b/src/bitcoin-chainstate.cpp
@@ -103,6 +103,11 @@ int main(int argc, char* argv[])
         {
             std::cout << "Warning: " << warning.original << std::endl;
         }
+        void fatalError(const std::string& debug_message, const bilingual_str& user_message) override
+        {
+            std::cerr << "Error: " << debug_message << std::endl;
+            std::cerr << (user_message.empty() ? "A fatal internal error occurred." : user_message.original) << std::endl;
+        }
     };
     auto notifications = std::make_unique<KernelNotifications>();
 
@@ -116,6 +121,7 @@ int main(int argc, char* argv[])
     const node::BlockManager::Options blockman_opts{
         .chainparams = chainman_opts.chainparams,
         .blocks_dir = gArgs.GetBlocksDirPath(),
+        .notifications = chainman_opts.notifications,
     };
     ChainstateManager chainman{kernel_context.interrupt, chainman_opts, blockman_opts};
 

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -31,7 +31,7 @@ constexpr auto SYNC_LOG_INTERVAL{30s};
 constexpr auto SYNC_LOCATOR_WRITE_INTERVAL{30s};
 
 template <typename... Args>
-static void FatalError(const char* fmt, const Args&... args)
+static void FatalErrorf(const char* fmt, const Args&... args)
 {
     std::string strMessage = tfm::format(fmt, args...);
     SetMiscWarning(Untranslated(strMessage));
@@ -196,7 +196,7 @@ void BaseIndex::ThreadSync()
                     break;
                 }
                 if (pindex_next->pprev != pindex && !Rewind(pindex, pindex_next->pprev)) {
-                    FatalError("%s: Failed to rewind index %s to a previous chain tip",
+                    FatalErrorf("%s: Failed to rewind index %s to a previous chain tip",
                                __func__, GetName());
                     return;
                 }
@@ -220,14 +220,14 @@ void BaseIndex::ThreadSync()
             CBlock block;
             interfaces::BlockInfo block_info = kernel::MakeBlockInfo(pindex);
             if (!m_chainstate->m_blockman.ReadBlockFromDisk(block, *pindex)) {
-                FatalError("%s: Failed to read block %s from disk",
+                FatalErrorf("%s: Failed to read block %s from disk",
                            __func__, pindex->GetBlockHash().ToString());
                 return;
             } else {
                 block_info.data = &block;
             }
             if (!CustomAppend(block_info)) {
-                FatalError("%s: Failed to write block %s to index database",
+                FatalErrorf("%s: Failed to write block %s to index database",
                            __func__, pindex->GetBlockHash().ToString());
                 return;
             }
@@ -293,7 +293,7 @@ void BaseIndex::BlockConnected(const std::shared_ptr<const CBlock>& block, const
     const CBlockIndex* best_block_index = m_best_block_index.load();
     if (!best_block_index) {
         if (pindex->nHeight != 0) {
-            FatalError("%s: First block connected is not the genesis block (height=%d)",
+            FatalErrorf("%s: First block connected is not the genesis block (height=%d)",
                        __func__, pindex->nHeight);
             return;
         }
@@ -311,7 +311,7 @@ void BaseIndex::BlockConnected(const std::shared_ptr<const CBlock>& block, const
             return;
         }
         if (best_block_index != pindex->pprev && !Rewind(best_block_index, pindex->pprev)) {
-            FatalError("%s: Failed to rewind index %s to a previous chain tip",
+            FatalErrorf("%s: Failed to rewind index %s to a previous chain tip",
                        __func__, GetName());
             return;
         }
@@ -324,7 +324,7 @@ void BaseIndex::BlockConnected(const std::shared_ptr<const CBlock>& block, const
         // processed, and the index object being safe to delete.
         SetBestBlockIndex(pindex);
     } else {
-        FatalError("%s: Failed to write block %s to index",
+        FatalErrorf("%s: Failed to write block %s to index",
                    __func__, pindex->GetBlockHash().ToString());
         return;
     }
@@ -344,7 +344,7 @@ void BaseIndex::ChainStateFlushed(const CBlockLocator& locator)
     }
 
     if (!locator_tip_index) {
-        FatalError("%s: First block (hash=%s) in locator was not found",
+        FatalErrorf("%s: First block (hash=%s) in locator was not found",
                    __func__, locator_tip_hash.ToString());
         return;
     }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1485,7 +1485,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     for (bool fLoaded = false; !fLoaded && !ShutdownRequested();) {
         node.mempool = std::make_unique<CTxMemPool>(mempool_opts);
 
-        node.chainman = std::make_unique<ChainstateManager>(chainman_opts, blockman_opts);
+        node.chainman = std::make_unique<ChainstateManager>(node.kernel->interrupt, chainman_opts, blockman_opts);
         ChainstateManager& chainman = *node.chainman;
 
         node::ChainstateLoadOptions options;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1032,6 +1032,7 @@ bool AppInitParameterInteraction(const ArgsManager& args, bool use_syscall_sandb
         BlockManager::Options blockman_opts_dummy{
             .chainparams = chainman_opts_dummy.chainparams,
             .blocks_dir = args.GetBlocksDirPath(),
+            .notifications = chainman_opts_dummy.notifications,
         };
         auto blockman_result{ApplyArgsManOptions(args, blockman_opts_dummy)};
         if (!blockman_result) {
@@ -1446,6 +1447,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     BlockManager::Options blockman_opts{
         .chainparams = chainman_opts.chainparams,
         .blocks_dir = args.GetBlocksDirPath(),
+        .notifications = chainman_opts.notifications,
     };
     Assert(ApplyArgsManOptions(args, blockman_opts)); // no error can happen, already checked in AppInitParameterInteraction
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -814,9 +814,6 @@ bool AppInitBasicSetup(const ArgsManager& args)
     // Enable heap terminate-on-corruption
     HeapSetInformation(nullptr, HeapEnableTerminationOnCorruption, nullptr, 0);
 #endif
-    if (!InitShutdownState()) {
-        return InitError(Untranslated("Initializing wait-for-shutdown state failed."));
-    }
 
     if (!SetupNetworking()) {
         return InitError(Untranslated("Initializing networking failed."));

--- a/src/kernel/blockmanager_opts.h
+++ b/src/kernel/blockmanager_opts.h
@@ -5,6 +5,7 @@
 #ifndef BITCOIN_KERNEL_BLOCKMANAGER_OPTS_H
 #define BITCOIN_KERNEL_BLOCKMANAGER_OPTS_H
 
+#include <kernel/notifications_interface.h>
 #include <util/fs.h>
 
 #include <cstdint>
@@ -25,6 +26,8 @@ struct BlockManagerOpts {
     bool fast_prune{false};
     bool stop_after_block_import{DEFAULT_STOPAFTERBLOCKIMPORT};
     const fs::path blocks_dir;
+    Notifications& notifications;
+    mutable bool interrupt_on_fatal_error{true};
 };
 
 } // namespace kernel

--- a/src/kernel/chainstatemanager_opts.h
+++ b/src/kernel/chainstatemanager_opts.h
@@ -46,6 +46,7 @@ struct ChainstateManagerOpts {
     CoinsViewOptions coins_view{};
     Notifications& notifications;
     mutable bool interrupt_on_fatal_error{true};
+    mutable bool interrupt_on_condition{true};
 };
 
 } // namespace kernel

--- a/src/kernel/chainstatemanager_opts.h
+++ b/src/kernel/chainstatemanager_opts.h
@@ -45,6 +45,7 @@ struct ChainstateManagerOpts {
     DBOptions coins_db{};
     CoinsViewOptions coins_view{};
     Notifications& notifications;
+    mutable bool interrupt_on_fatal_error{true};
 };
 
 } // namespace kernel

--- a/src/kernel/context.cpp
+++ b/src/kernel/context.cpp
@@ -14,9 +14,12 @@
 
 
 namespace kernel {
+Context* g_context;
 
 Context::Context()
 {
+    assert(!g_context);
+    g_context = this;
     std::string sha256_algo = SHA256AutoDetect();
     LogPrintf("Using the '%s' SHA256 implementation\n", sha256_algo);
     RandomInit();
@@ -26,6 +29,8 @@ Context::Context()
 Context::~Context()
 {
     ECC_Stop();
+    assert(g_context);
+    g_context = nullptr;
 }
 
 } // namespace kernel

--- a/src/kernel/context.h
+++ b/src/kernel/context.h
@@ -5,6 +5,8 @@
 #ifndef BITCOIN_KERNEL_CONTEXT_H
 #define BITCOIN_KERNEL_CONTEXT_H
 
+#include <util/signalinterrupt.h>
+
 #include <memory>
 
 namespace kernel {
@@ -16,12 +18,24 @@ namespace kernel {
 //! State stored directly in this struct should be simple. More complex state
 //! should be stored to std::unique_ptr members pointing to opaque types.
 struct Context {
+    //! Interrupt functionality that can be used to stop long-running kernel operations.
+    util::SignalInterrupt interrupt;
+
     //! Declare default constructor and destructor that are not inline, so code
     //! instantiating the kernel::Context struct doesn't need to #include class
     //! definitions for all the unique_ptr members.
     Context();
     ~Context();
 };
+
+//! Global pointer to kernel::Context for legacy code. New code should avoid
+//! using this, and require state it needs to be passed to it directly.
+//!
+//! Having this pointer is useful because it allows state be moved out of global
+//! variables into the kernel::Context struct before all global references to
+//! that state are removed. This allows the global references to be removed
+//! incrementally, instead of all at once.
+extern Context* g_context;
 } // namespace kernel
 
 #endif // BITCOIN_KERNEL_CONTEXT_H

--- a/src/kernel/mempool_persist.cpp
+++ b/src/kernel/mempool_persist.cpp
@@ -9,13 +9,13 @@
 #include <logging.h>
 #include <primitives/transaction.h>
 #include <serialize.h>
-#include <shutdown.h>
 #include <streams.h>
 #include <sync.h>
 #include <txmempool.h>
 #include <uint256.h>
 #include <util/fs.h>
 #include <util/fs_helpers.h>
+#include <util/signalinterrupt.h>
 #include <util/time.h>
 #include <validation.h>
 
@@ -95,7 +95,7 @@ bool LoadMempool(CTxMemPool& pool, const fs::path& load_path, Chainstate& active
             } else {
                 ++expired;
             }
-            if (ShutdownRequested())
+            if (active_chainstate.m_chainman.m_interrupt)
                 return false;
         }
         std::map<uint256, CAmount> mapDeltas;

--- a/src/kernel/notifications_interface.cpp
+++ b/src/kernel/notifications_interface.cpp
@@ -1,0 +1,23 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <kernel/notifications_interface.h>
+
+#include <cassert>
+#include <string>
+
+namespace kernel {
+
+std::string InterruptReasonToString(InterruptReason reason)
+{
+    switch (reason) {
+    case InterruptReason::StopAfterBlockImport:
+        return "Stopping after block import.";
+    case InterruptReason::StopAtHeight:
+        return "Reached block height specified by stop at height.";
+    } // no default case, so the compiler can warn about missing cases
+    assert(false);
+}
+
+} // namespace kernel

--- a/src/kernel/notifications_interface.h
+++ b/src/kernel/notifications_interface.h
@@ -5,12 +5,13 @@
 #ifndef BITCOIN_KERNEL_NOTIFICATIONS_INTERFACE_H
 #define BITCOIN_KERNEL_NOTIFICATIONS_INTERFACE_H
 
+#include <util/translation.h>
+
 #include <cstdint>
 #include <string>
 
 class CBlockIndex;
 enum class SynchronizationState;
-struct bilingual_str;
 
 namespace kernel {
 
@@ -27,6 +28,12 @@ public:
     virtual void headerTip(SynchronizationState state, int64_t height, int64_t timestamp, bool presync) {}
     virtual void progress(const bilingual_str& title, int progress_percent, bool resume_possible) {}
     virtual void warning(const bilingual_str& warning) {}
+
+    //! The fatal error notification is sent to notify the user and start
+    //! shutting down if an error happens in kernel code that can't be recovered
+    //! from. After this notification is sent, whatever function triggered the
+    //! error should also return an error code or raise an exception.
+    virtual void fatalError(const std::string& debug_message, const bilingual_str& user_message = {}) {}
 };
 } // namespace kernel
 

--- a/src/kernel/notifications_interface.h
+++ b/src/kernel/notifications_interface.h
@@ -15,6 +15,13 @@ enum class SynchronizationState;
 
 namespace kernel {
 
+enum class InterruptReason {
+    StopAtHeight,
+    StopAfterBlockImport,
+};
+
+std::string InterruptReasonToString(InterruptReason reason);
+
 /**
  * A base class defining functions for notifying about certain kernel
  * events.
@@ -34,6 +41,7 @@ public:
     //! from. After this notification is sent, whatever function triggered the
     //! error should also return an error code or raise an exception.
     virtual void fatalError(const std::string& debug_message, const bilingual_str& user_message = {}) {}
+    virtual void interrupt(const InterruptReason reason) {}
 };
 } // namespace kernel
 

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -13,12 +13,12 @@
 #include <logging.h>
 #include <pow.h>
 #include <reverse_iterator.h>
-#include <shutdown.h>
 #include <signet.h>
 #include <streams.h>
 #include <undo.h>
 #include <util/batchpriority.h>
 #include <util/fs.h>
+#include <util/signalinterrupt.h>
 #include <util/syscall_sandbox.h>
 #include <validation.h>
 
@@ -251,7 +251,8 @@ CBlockIndex* BlockManager::InsertBlockIndex(const uint256& hash)
 
 bool BlockManager::LoadBlockIndex()
 {
-    if (!m_block_tree_db->LoadBlockIndexGuts(GetConsensus(), [this](const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(cs_main) { return this->InsertBlockIndex(hash); })) {
+    if (!m_block_tree_db->LoadBlockIndexGuts(
+            GetConsensus(), [this](const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(cs_main) { return this->InsertBlockIndex(hash); }, m_interrupt)) {
         return false;
     }
 
@@ -261,7 +262,7 @@ bool BlockManager::LoadBlockIndex()
               CBlockIndexHeightOnlyComparator());
 
     for (CBlockIndex* pindex : vSortedByHeight) {
-        if (ShutdownRequested()) return false;
+        if (m_interrupt) return false;
         pindex->nChainWork = (pindex->pprev ? pindex->pprev->nChainWork : 0) + GetBlockProof(*pindex);
         pindex->nTimeMax = (pindex->pprev ? std::max(pindex->pprev->nTimeMax, pindex->nTime) : pindex->nTime);
 
@@ -892,8 +893,8 @@ void ThreadImport(ChainstateManager& chainman, std::vector<fs::path> vImportFile
                 }
                 LogPrintf("Reindexing block file blk%05u.dat...\n", (unsigned int)nFile);
                 chainman.ActiveChainstate().LoadExternalBlockFile(file, &pos, &blocks_with_unknown_parent);
-                if (ShutdownRequested()) {
-                    LogPrintf("Shutdown requested. Exit %s\n", __func__);
+                if (chainman.m_interrupt) {
+                    LogPrintf("Interrupt requested. Exit %s\n", __func__);
                     return;
                 }
                 nFile++;
@@ -911,8 +912,8 @@ void ThreadImport(ChainstateManager& chainman, std::vector<fs::path> vImportFile
             if (file) {
                 LogPrintf("Importing blocks file %s...\n", fs::PathToString(path));
                 chainman.ActiveChainstate().LoadExternalBlockFile(file);
-                if (ShutdownRequested()) {
-                    LogPrintf("Shutdown requested. Exit %s\n", __func__);
+                if (chainman.m_interrupt) {
+                    LogPrintf("Interrupt requested. Exit %s\n", __func__);
                     return;
                 }
             } else {

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -940,8 +940,7 @@ void ThreadImport(ChainstateManager& chainman, std::vector<fs::path> vImportFile
         for (Chainstate* chainstate : WITH_LOCK(::cs_main, return chainman.GetAll())) {
             BlockValidationState state;
             if (!chainstate->ActivateBestChain(state, nullptr)) {
-                LogPrintf("Failed to connect best block (%s)\n", state.ToString());
-                StartShutdown();
+                chainman.FatalError(strprintf("Failed to connect best block (%s)\n", state.ToString()));
                 return;
             }
         }

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -529,7 +529,8 @@ bool BlockManager::FlushUndoFile(int block_file, bool finalize)
 {
     FlatFilePos undo_pos_old(block_file, m_blockfile_info[block_file].nUndoSize);
     if (!UndoFileSeq().Flush(undo_pos_old, finalize)) {
-        return AbortNode("Flushing undo file to disk failed. This is likely the result of an I/O error.");
+        m_opts.notifications.fatalError("Flushing undo file to disk failed. This is likely the result of an I/O error.");
+        return false;
     }
     return true;
 }
@@ -549,7 +550,8 @@ bool BlockManager::FlushBlockFile(bool fFinalize, bool finalize_undo)
 
     FlatFilePos block_pos_old(m_last_blockfile, m_blockfile_info[m_last_blockfile].nSize);
     if (!BlockFileSeq().Flush(block_pos_old, fFinalize)) {
-        return AbortNode("Flushing block file to disk failed. This is likely the result of an I/O error.");
+        m_opts.notifications.fatalError("Flushing block file to disk failed. This is likely the result of an I/O error.");
+        return false;
     }
     // we do not always flush the undo file, as the chain tip may be lagging behind the incoming blocks,
     // e.g. during IBD or a sync after a node going offline
@@ -666,7 +668,8 @@ bool BlockManager::FindBlockPos(FlatFilePos& pos, unsigned int nAddSize, unsigne
         bool out_of_space;
         size_t bytes_allocated = BlockFileSeq().Allocate(pos, nAddSize, out_of_space);
         if (out_of_space) {
-            return AbortNode("Disk space is too low!", _("Disk space is too low!"));
+            m_opts.notifications.fatalError("Disk space is too low!", _("Disk space is too low!"));
+            return false;
         }
         if (bytes_allocated != 0 && IsPruneMode()) {
             m_check_for_pruning = true;
@@ -690,7 +693,7 @@ bool BlockManager::FindUndoPos(BlockValidationState& state, int nFile, FlatFileP
     bool out_of_space;
     size_t bytes_allocated = UndoFileSeq().Allocate(pos, nAddSize, out_of_space);
     if (out_of_space) {
-        return AbortNode(state, "Disk space is too low!", _("Disk space is too low!"));
+        return FatalError(m_opts.interrupt_on_fatal_error, m_interrupt, m_opts.notifications, state, "Disk space is too low!", _("Disk space is too low!"));
     }
     if (bytes_allocated != 0 && IsPruneMode()) {
         m_check_for_pruning = true;
@@ -732,7 +735,7 @@ bool BlockManager::WriteUndoDataForBlock(const CBlockUndo& blockundo, BlockValid
             return error("ConnectBlock(): FindUndoPos failed");
         }
         if (!UndoWriteToDisk(blockundo, _pos, block.pprev->GetBlockHash(), GetParams().MessageStart())) {
-            return AbortNode(state, "Failed to write undo data");
+            return FatalError(m_opts.interrupt_on_fatal_error, m_interrupt, m_opts.notifications, state, "Failed to write undo data");
         }
         // rev files are written in block height order, whereas blk files are written as blocks come in (often out of order)
         // we want to flush the rev (undo) file once we've written the last block, which is indicated by the last height
@@ -852,7 +855,7 @@ FlatFilePos BlockManager::SaveBlockToDisk(const CBlock& block, int nHeight, CCha
     }
     if (!position_known) {
         if (!WriteBlockToDisk(block, blockPos, GetParams().MessageStart())) {
-            AbortNode("Failed to write block");
+            m_opts.notifications.fatalError("Failed to write block");
             return FlatFilePos();
         }
     }

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -10,6 +10,7 @@
 #include <flatfile.h>
 #include <hash.h>
 #include <kernel/chainparams.h>
+#include <kernel/notifications_interface.h>
 #include <logging.h>
 #include <pow.h>
 #include <reverse_iterator.h>
@@ -24,6 +25,8 @@
 
 #include <map>
 #include <unordered_map>
+
+using kernel::InterruptReason;
 
 namespace node {
 std::atomic_bool fReindex(false);
@@ -947,7 +950,7 @@ void ThreadImport(ChainstateManager& chainman, std::vector<fs::path> vImportFile
 
         if (chainman.m_blockman.StopAfterBlockImport()) {
             LogPrintf("Stopping after block import\n");
-            StartShutdown();
+            chainman.Interrupt(InterruptReason::StopAfterBlockImport);
             return;
         }
     } // End scope of ImportingNow

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -33,6 +33,9 @@ struct FlatFilePos;
 namespace Consensus {
 struct Params;
 }
+namespace util {
+class SignalInterrupt;
+} // namespace util
 
 namespace node {
 
@@ -153,10 +156,12 @@ private:
 public:
     using Options = kernel::BlockManagerOpts;
 
-    explicit BlockManager(Options opts)
+    explicit BlockManager(const util::SignalInterrupt& interrupt, Options opts)
         : m_prune_mode{opts.prune_target > 0},
-          m_opts{std::move(opts)} {};
+          m_opts{std::move(opts)},
+          m_interrupt{interrupt} {};
 
+    const util::SignalInterrupt& m_interrupt;
     std::atomic<bool> m_importing{false};
 
     BlockMap m_block_index GUARDED_BY(cs_main);

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -93,9 +93,9 @@ private:
      */
     bool LoadBlockIndex()
         EXCLUSIVE_LOCKS_REQUIRED(cs_main);
-    void FlushBlockFile(bool fFinalize = false, bool finalize_undo = false);
-    void FlushUndoFile(int block_file, bool finalize = false);
-    bool FindBlockPos(FlatFilePos& pos, unsigned int nAddSize, unsigned int nHeight, CChain& active_chain, uint64_t nTime, bool fKnown);
+    [[nodiscard]] bool FlushBlockFile(bool fFinalize = false, bool finalize_undo = false);
+    [[nodiscard]] bool FlushUndoFile(int block_file, bool finalize = false);
+    [[nodiscard]] bool FindBlockPos(FlatFilePos& pos, unsigned int nAddSize, unsigned int nHeight, CChain& active_chain, uint64_t nTime, bool fKnown);
     bool FindUndoPos(BlockValidationState& state, int nFile, FlatFilePos& pos, unsigned int nAddSize);
 
     FlatFileSeq BlockFileSeq() const;
@@ -199,7 +199,7 @@ public:
     /** Get block file info entry for one block file */
     CBlockFileInfo* GetBlockFileInfo(size_t n);
 
-    bool WriteUndoDataForBlock(const CBlockUndo& blockundo, BlockValidationState& state, CBlockIndex& block)
+    [[nodiscard]] bool WriteUndoDataForBlock(const CBlockUndo& blockundo, BlockValidationState& state, CBlockIndex& block)
         EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     /** Store block on disk. If dbp is not nullptr, then it provides the known position of the block within a block file on disk. */

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -156,12 +156,12 @@ private:
 public:
     using Options = kernel::BlockManagerOpts;
 
-    explicit BlockManager(const util::SignalInterrupt& interrupt, Options opts)
+    explicit BlockManager(util::SignalInterrupt& interrupt, Options opts)
         : m_prune_mode{opts.prune_target > 0},
           m_opts{std::move(opts)},
           m_interrupt{interrupt} {};
 
-    const util::SignalInterrupt& m_interrupt;
+    util::SignalInterrupt& m_interrupt;
     std::atomic<bool> m_importing{false};
 
     BlockMap m_block_index GUARDED_BY(cs_main);

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -207,7 +207,7 @@ ChainstateLoadResult LoadChainstate(ChainstateManager& chainman, const CacheSize
     } else if (snapshot_completion == SnapshotCompletionResult::SUCCESS) {
         LogPrintf("[snapshot] cleaning up unneeded background chainstate, then reinitializing\n");
         if (!chainman.ValidatedSnapshotCleanup()) {
-            AbortNode("Background chainstate cleanup failed unexpectedly.");
+            chainman.FatalError("Background chainstate cleanup failed unexpectedly.");
         }
 
         // Because ValidatedSnapshotCleanup() has torn down chainstates with

--- a/src/node/kernel_notifications.cpp
+++ b/src/node/kernel_notifications.cpp
@@ -10,6 +10,7 @@
 
 #include <common/args.h>
 #include <common/system.h>
+#include <logging.h>
 #include <node/interface_ui.h>
 #include <util/strencodings.h>
 #include <util/string.h>
@@ -70,6 +71,13 @@ void KernelNotifications::progress(const bilingual_str& title, int progress_perc
 void KernelNotifications::warning(const bilingual_str& warning)
 {
     DoWarning(warning);
+}
+
+void KernelNotifications::fatalError(const std::string& debug_message, const bilingual_str& user_message)
+{
+    SetMiscWarning(Untranslated(debug_message));
+    LogPrintf("*** %s\n", debug_message);
+    InitError(user_message.empty() ? _("A fatal internal error occurred, see debug.log for details") : user_message);
 }
 
 } // namespace node

--- a/src/node/kernel_notifications.cpp
+++ b/src/node/kernel_notifications.cpp
@@ -10,6 +10,7 @@
 
 #include <common/args.h>
 #include <common/system.h>
+#include <kernel/notifications_interface.h>
 #include <logging.h>
 #include <node/interface_ui.h>
 #include <util/strencodings.h>
@@ -78,6 +79,11 @@ void KernelNotifications::fatalError(const std::string& debug_message, const bil
     SetMiscWarning(Untranslated(debug_message));
     LogPrintf("*** %s\n", debug_message);
     InitError(user_message.empty() ? _("A fatal internal error occurred, see debug.log for details") : user_message);
+}
+
+void KernelNotifications::interrupt(const kernel::InterruptReason reason)
+{
+    LogPrintf("Starting shutdown: %s\n", InterruptReasonToString(reason));
 }
 
 } // namespace node

--- a/src/node/kernel_notifications.h
+++ b/src/node/kernel_notifications.h
@@ -25,6 +25,8 @@ public:
     void progress(const bilingual_str& title, int progress_percent, bool resume_possible) override;
 
     void warning(const bilingual_str& warning) override;
+
+    void fatalError(const std::string& debug_message, const bilingual_str& user_message = {}) override;
 };
 } // namespace node
 

--- a/src/node/kernel_notifications.h
+++ b/src/node/kernel_notifications.h
@@ -27,6 +27,8 @@ public:
     void warning(const bilingual_str& warning) override;
 
     void fatalError(const std::string& debug_message, const bilingual_str& user_message = {}) override;
+
+    void interrupt(const kernel::InterruptReason reason) override;
 };
 } // namespace node
 

--- a/src/qt/test/apptests.cpp
+++ b/src/qt/test/apptests.cpp
@@ -86,7 +86,6 @@ void AppTests::appTests()
 
     // Reset global state to avoid interfering with later tests.
     LogInstance().DisconnectTestLogger();
-    AbortShutdown();
 }
 
 //! Entry point for BitcoinGUI tests.

--- a/src/shutdown.cpp
+++ b/src/shutdown.cpp
@@ -9,16 +9,15 @@
 #include <config/bitcoin-config.h>
 #endif
 
+#include <kernel/context.h>
 #include <logging.h>
 #include <node/interface_ui.h>
-#include <util/tokenpipe.h>
+#include <util/check.h>
+#include <util/signalinterrupt.h>
 #include <warnings.h>
 
 #include <assert.h>
-#include <atomic>
-#ifdef WIN32
-#include <condition_variable>
-#endif
+#include <optional>
 
 bool AbortNode(const std::string& strMessage, bilingual_str user_message)
 {
@@ -32,75 +31,32 @@ bool AbortNode(const std::string& strMessage, bilingual_str user_message)
     return false;
 }
 
-static std::atomic<bool> fRequestShutdown(false);
-#ifdef WIN32
-/** On windows it is possible to simply use a condition variable. */
-std::mutex g_shutdown_mutex;
-std::condition_variable g_shutdown_cv;
-#else
-/** On UNIX-like operating systems use the self-pipe trick.
- */
-static TokenPipeEnd g_shutdown_r;
-static TokenPipeEnd g_shutdown_w;
-#endif
-
-bool InitShutdownState()
-{
-#ifndef WIN32
-    std::optional<TokenPipe> pipe = TokenPipe::Make();
-    if (!pipe) return false;
-    g_shutdown_r = pipe->TakeReadEnd();
-    g_shutdown_w = pipe->TakeWriteEnd();
-#endif
-    return true;
-}
-
 void StartShutdown()
 {
-#ifdef WIN32
-    std::unique_lock<std::mutex> lk(g_shutdown_mutex);
-    fRequestShutdown = true;
-    g_shutdown_cv.notify_one();
-#else
-    // This must be reentrant and safe for calling in a signal handler, so using a condition variable is not safe.
-    // Make sure that the token is only written once even if multiple threads call this concurrently or in
-    // case of a reentrant signal.
-    if (!fRequestShutdown.exchange(true)) {
-        // Write an arbitrary byte to the write end of the shutdown pipe.
-        int res = g_shutdown_w.TokenWrite('x');
-        if (res != 0) {
-            LogPrintf("Sending shutdown token failed\n");
-            assert(0);
-        }
+    try {
+        Assert(kernel::g_context)->interrupt();
+    } catch (const std::system_error&) {
+        LogPrintf("Sending shutdown token failed\n");
+        assert(0);
     }
-#endif
 }
 
 void AbortShutdown()
 {
-    if (fRequestShutdown) {
-        // Cancel existing shutdown by waiting for it, this will reset condition flags and remove
-        // the shutdown token from the pipe.
-        WaitForShutdown();
-    }
-    fRequestShutdown = false;
+    Assert(kernel::g_context)->interrupt.reset();
 }
 
 bool ShutdownRequested()
 {
-    return fRequestShutdown;
+    return bool{Assert(kernel::g_context)->interrupt};
 }
 
 void WaitForShutdown()
 {
-#ifdef WIN32
-    std::unique_lock<std::mutex> lk(g_shutdown_mutex);
-    g_shutdown_cv.wait(lk, [] { return fRequestShutdown.load(); });
-#else
-    int res = g_shutdown_r.TokenRead();
-    if (res != 'x') {
+    try {
+        Assert(kernel::g_context)->interrupt.sleep();
+    } catch (const std::system_error&) {
         LogPrintf("Reading shutdown token failed\n");
         assert(0);
     }
-#endif
 }

--- a/src/shutdown.cpp
+++ b/src/shutdown.cpp
@@ -11,25 +11,11 @@
 
 #include <kernel/context.h>
 #include <logging.h>
-#include <node/interface_ui.h>
 #include <util/check.h>
 #include <util/signalinterrupt.h>
-#include <warnings.h>
 
 #include <assert.h>
 #include <optional>
-
-bool AbortNode(const std::string& strMessage, bilingual_str user_message)
-{
-    SetMiscWarning(Untranslated(strMessage));
-    LogPrintf("*** %s\n", strMessage);
-    if (user_message.empty()) {
-        user_message = _("A fatal internal error occurred, see debug.log for details");
-    }
-    InitError(user_message);
-    StartShutdown();
-    return false;
-}
 
 void StartShutdown()
 {

--- a/src/shutdown.h
+++ b/src/shutdown.h
@@ -11,11 +11,6 @@
 /** Abort with a message */
 bool AbortNode(const std::string& strMessage, bilingual_str user_message = bilingual_str{});
 
-/** Initialize shutdown state. This must be called before using either StartShutdown(),
- * AbortShutdown() or WaitForShutdown(). Calling ShutdownRequested() is always safe.
- */
-bool InitShutdownState();
-
 /** Request shutdown of the application. */
 void StartShutdown();
 

--- a/src/shutdown.h
+++ b/src/shutdown.h
@@ -6,11 +6,6 @@
 #ifndef BITCOIN_SHUTDOWN_H
 #define BITCOIN_SHUTDOWN_H
 
-#include <util/translation.h> // For bilingual_str
-
-/** Abort with a message */
-bool AbortNode(const std::string& strMessage, bilingual_str user_message = bilingual_str{});
-
 /** Request shutdown of the application. */
 void StartShutdown();
 

--- a/src/test/blockmanager_tests.cpp
+++ b/src/test/blockmanager_tests.cpp
@@ -25,7 +25,7 @@ BOOST_AUTO_TEST_CASE(blockmanager_find_block_pos)
         .chainparams = *params,
         .blocks_dir = m_args.GetBlocksDirPath(),
     };
-    BlockManager blockman{blockman_opts};
+    BlockManager blockman{m_node.kernel->interrupt, blockman_opts};
     CChain chain {};
     // simulate adding a genesis block normally
     BOOST_CHECK_EQUAL(blockman.SaveBlockToDisk(params->GenesisBlock(), 0, chain, nullptr).nPos, BLOCK_SERIALIZATION_HEADER_SIZE);

--- a/src/test/blockmanager_tests.cpp
+++ b/src/test/blockmanager_tests.cpp
@@ -5,14 +5,16 @@
 #include <chainparams.h>
 #include <node/blockstorage.h>
 #include <node/context.h>
+#include <node/kernel_notifications.h>
 #include <util/chaintype.h>
 #include <validation.h>
 
 #include <boost/test/unit_test.hpp>
 #include <test/util/setup_common.h>
 
-using node::BlockManager;
 using node::BLOCK_SERIALIZATION_HEADER_SIZE;
+using node::BlockManager;
+using node::KernelNotifications;
 using node::MAX_BLOCKFILE_SIZE;
 
 // use BasicTestingSetup here for the data directory configuration, setup, and cleanup
@@ -21,9 +23,11 @@ BOOST_FIXTURE_TEST_SUITE(blockmanager_tests, BasicTestingSetup)
 BOOST_AUTO_TEST_CASE(blockmanager_find_block_pos)
 {
     const auto params {CreateChainParams(ArgsManager{}, ChainType::MAIN)};
+    KernelNotifications notifications{};
     const BlockManager::Options blockman_opts{
         .chainparams = *params,
         .blocks_dir = m_args.GetBlocksDirPath(),
+        .notifications = notifications,
     };
     BlockManager blockman{m_node.kernel->interrupt, blockman_opts};
     CChain chain {};

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -197,7 +197,7 @@ ChainTestingSetup::ChainTestingSetup(const ChainType chainType, const std::vecto
         .chainparams = chainman_opts.chainparams,
         .blocks_dir = m_args.GetBlocksDirPath(),
     };
-    m_node.chainman = std::make_unique<ChainstateManager>(chainman_opts, blockman_opts);
+    m_node.chainman = std::make_unique<ChainstateManager>(m_node.kernel->interrupt, chainman_opts, blockman_opts);
     m_node.chainman->m_blockman.m_block_tree_db = std::make_unique<CBlockTreeDB>(DBParams{
         .path = m_args.GetDataDirNet() / "blocks" / "index",
         .cache_bytes = static_cast<size_t>(m_cache_sizes.block_tree_db),

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -196,6 +196,7 @@ ChainTestingSetup::ChainTestingSetup(const ChainType chainType, const std::vecto
     const BlockManager::Options blockman_opts{
         .chainparams = chainman_opts.chainparams,
         .blocks_dir = m_args.GetBlocksDirPath(),
+        .notifications = chainman_opts.notifications,
     };
     m_node.chainman = std::make_unique<ChainstateManager>(m_node.kernel->interrupt, chainman_opts, blockman_opts);
     m_node.chainman->m_blockman.m_block_tree_db = std::make_unique<CBlockTreeDB>(DBParams{

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -393,7 +393,7 @@ struct SnapshotTestSetup : TestChain100Setup {
             // For robustness, ensure the old manager is destroyed before creating a
             // new one.
             m_node.chainman.reset();
-            m_node.chainman = std::make_unique<ChainstateManager>(chainman_opts, blockman_opts);
+            m_node.chainman = std::make_unique<ChainstateManager>(m_node.kernel->interrupt, chainman_opts, blockman_opts);
         }
         return *Assert(m_node.chainman);
     }

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -9,8 +9,8 @@
 #include <logging.h>
 #include <pow.h>
 #include <random.h>
-#include <shutdown.h>
 #include <uint256.h>
+#include <util/signalinterrupt.h>
 #include <util/translation.h>
 #include <util/vector.h>
 
@@ -291,7 +291,7 @@ bool CBlockTreeDB::ReadFlag(const std::string &name, bool &fValue) {
     return true;
 }
 
-bool CBlockTreeDB::LoadBlockIndexGuts(const Consensus::Params& consensusParams, std::function<CBlockIndex*(const uint256&)> insertBlockIndex)
+bool CBlockTreeDB::LoadBlockIndexGuts(const Consensus::Params& consensusParams, std::function<CBlockIndex*(const uint256&)> insertBlockIndex, const util::SignalInterrupt& interrupt)
 {
     AssertLockHeld(::cs_main);
     std::unique_ptr<CDBIterator> pcursor(NewIterator());
@@ -299,7 +299,7 @@ bool CBlockTreeDB::LoadBlockIndexGuts(const Consensus::Params& consensusParams, 
 
     // Load m_block_index
     while (pcursor->Valid()) {
-        if (ShutdownRequested()) return false;
+        if (interrupt) return false;
         std::pair<uint8_t, uint256> key;
         if (pcursor->GetKey(key) && key.first == DB_BLOCK_INDEX) {
             CDiskBlockIndex diskindex;

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -29,6 +29,9 @@ class uint256;
 namespace Consensus {
 struct Params;
 };
+namespace util {
+class SignalInterrupt;
+} // namespace util
 
 //! -dbcache default (MiB)
 static const int64_t nDefaultDbCache = 450;
@@ -98,7 +101,7 @@ public:
     void ReadReindexing(bool &fReindexing);
     bool WriteFlag(const std::string &name, bool fValue);
     bool ReadFlag(const std::string &name, bool &fValue);
-    bool LoadBlockIndexGuts(const Consensus::Params& consensusParams, std::function<CBlockIndex*(const uint256&)> insertBlockIndex)
+    bool LoadBlockIndexGuts(const Consensus::Params& consensusParams, std::function<CBlockIndex*(const uint256&)> insertBlockIndex, const util::SignalInterrupt& interrupt)
         EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 };
 

--- a/src/util/signalinterrupt.cpp
+++ b/src/util/signalinterrupt.cpp
@@ -1,0 +1,74 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <util/signalinterrupt.h>
+
+#ifdef WIN32
+#include <mutex>
+#else
+#include <util/tokenpipe.h>
+#endif
+
+#include <ios>
+#include <optional>
+
+namespace util {
+
+SignalInterrupt::SignalInterrupt() : m_flag{false}
+{
+#ifndef WIN32
+    std::optional<TokenPipe> pipe = TokenPipe::Make();
+    if (!pipe) throw std::ios_base::failure("Could not create TokenPipe");
+    m_pipe_r = pipe->TakeReadEnd();
+    m_pipe_w = pipe->TakeWriteEnd();
+#endif
+}
+
+SignalInterrupt::operator bool() const
+{
+    return m_flag.load(std::memory_order_acquire);
+}
+
+void SignalInterrupt::reset()
+{
+    // Cancel existing interrupt by waiting for it, this will reset condition flags and remove
+    // the token from the pipe.
+    if (*this) sleep();
+    m_flag.store(false, std::memory_order_release);
+}
+
+void SignalInterrupt::operator()()
+{
+#ifdef WIN32
+    std::unique_lock<std::mutex> lk(m_sleep_mutex);
+    m_flag.store(true, std::memory_order_release);
+    m_sleep_cv.notify_one();
+#else
+    // This must be reentrant and safe for calling in a signal handler, so using a condition variable is not safe.
+    // Make sure that the token is only written once even if multiple threads call this concurrently or in
+    // case of a reentrant signal.
+    if (!m_flag.exchange(true)) {
+        // Write an arbitrary byte to the write end of the pipe.
+        int res = m_pipe_w.TokenWrite('x');
+        if (res != 0) {
+            throw std::ios_base::failure("Could not write interrupt token");
+        }
+    }
+#endif
+}
+
+void SignalInterrupt::sleep()
+{
+#ifdef WIN32
+    std::unique_lock<std::mutex> lk(m_sleep_mutex);
+    m_sleep_cv.wait(lk, [this] { return m_flag.load(); });
+#else
+    int res = m_pipe_r.TokenRead();
+    if (res != 'x') {
+        throw std::ios_base::failure("Did not read expected interrupt token");
+    }
+#endif
+}
+
+} // namespace util

--- a/src/util/signalinterrupt.h
+++ b/src/util/signalinterrupt.h
@@ -1,0 +1,51 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_UTIL_SIGNALINTERRUPT_H
+#define BITCOIN_UTIL_SIGNALINTERRUPT_H
+
+#ifdef WIN32
+#include <condition_variable>
+#include <mutex>
+#else
+#include <util/tokenpipe.h>
+#endif
+
+#include <atomic>
+
+namespace util {
+/**
+ * Helper class that allows manages an interrupt flag, and allows a thread or
+ * signal to interrupt another thread.
+ *
+ * This class is safe to be used in a signal handler. If sending an interrupt
+ * from a signal handler is not neccessary, the more lightweight \ref
+ * CThreadInterrupt class can be used instead.
+ */
+
+class SignalInterrupt
+{
+public:
+    SignalInterrupt();
+    explicit operator bool() const;
+    void operator()();
+    void reset();
+    void sleep();
+
+private:
+    std::atomic<bool> m_flag;
+
+#ifndef WIN32
+    // On UNIX-like operating systems use the self-pipe trick.
+    TokenPipeEnd m_pipe_r;
+    TokenPipeEnd m_pipe_w;
+#else
+    // On windows use a condition variable, since we don't have any signals there
+    std::mutex m_sleep_mutex;
+    std::condition_variable m_sleep_cv;
+#endif
+};
+} // namespace util
+
+#endif // BITCOIN_UTIL_SIGNALINTERRUPT_H

--- a/src/util/threadinterrupt.h
+++ b/src/util/threadinterrupt.h
@@ -16,6 +16,11 @@
     A helper class for interruptible sleeps. Calling operator() will interrupt
     any current sleep, and after that point operator bool() will return true
     until reset.
+
+    This class should not be used in a signal handler. If sending an interrupt
+    from a signal handler is neccessary, the \ref SignalInterrupt class can be
+    used instead.
+
 */
 class CThreadInterrupt
 {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2508,7 +2508,9 @@ bool Chainstate::FlushStateToDisk(
                 LOG_TIME_MILLIS_WITH_CATEGORY("write block and undo data to disk", BCLog::BENCH);
 
                 // First make sure all block and undo data is flushed to disk.
-                m_blockman.FlushBlockFile();
+                if (!m_blockman.FlushBlockFile()) {
+                    return false;
+                }
             }
 
             // Then update all block file information (which may refer to block and undo files).

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1843,10 +1843,29 @@ bool CheckInputScripts(const CTransaction& tx, TxValidationState& state,
     return true;
 }
 
-bool AbortNode(BlockValidationState& state, const std::string& strMessage, const bilingual_str& userMessage)
+bool FatalError(bool interrupt_on_fatal_error, util::SignalInterrupt& interrupt, Notifications& notifications, BlockValidationState& state, const std::string& strMessage, const bilingual_str& userMessage)
 {
-    AbortNode(strMessage, userMessage);
+    FatalError(interrupt_on_fatal_error, interrupt, notifications, strMessage, userMessage);
     return state.Error(strMessage);
+}
+
+bool FatalError(bool interrupt_on_fatal_error, util::SignalInterrupt& interrupt, Notifications& notifications, const std::string& strMessage, const bilingual_str& userMessage)
+{
+    if (interrupt_on_fatal_error) {
+        interrupt();
+    }
+    notifications.fatalError(strMessage, userMessage);
+    return false;
+}
+
+bool ChainstateManager::FatalError(BlockValidationState& state, const std::string& strMessage, const bilingual_str& userMessage)
+{
+    return ::FatalError(InterruptOnFatalError(), m_interrupt, GetNotifications(), state, strMessage, userMessage);
+}
+
+bool ChainstateManager::FatalError(const std::string& strMessage, const bilingual_str& userMessage)
+{
+    return ::FatalError(InterruptOnFatalError(), m_interrupt, GetNotifications(), strMessage, userMessage);
 }
 
 /**
@@ -2082,7 +2101,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
             // We don't write down blocks to disk if they may have been
             // corrupted, so this should be impossible unless we're having hardware
             // problems.
-            return AbortNode(state, "Corrupt block found indicating potential hardware failure; shutting down");
+            return m_chainman.FatalError(state, "Corrupt block found indicating potential hardware failure; shutting down");
         }
         return error("%s: Consensus::CheckBlock: %s", __func__, state.ToString());
     }
@@ -2502,7 +2521,7 @@ bool Chainstate::FlushStateToDisk(
         if (fDoFullFlush || fPeriodicWrite) {
             // Ensure we can write block index
             if (!CheckDiskSpace(gArgs.GetBlocksDirPath())) {
-                return AbortNode(state, "Disk space is too low!", _("Disk space is too low!"));
+                return m_chainman.FatalError(state, "Disk space is too low!", _("Disk space is too low!"));
             }
             {
                 LOG_TIME_MILLIS_WITH_CATEGORY("write block and undo data to disk", BCLog::BENCH);
@@ -2518,7 +2537,7 @@ bool Chainstate::FlushStateToDisk(
                 LOG_TIME_MILLIS_WITH_CATEGORY("write block index to disk", BCLog::BENCH);
 
                 if (!m_blockman.WriteBlockIndexDB()) {
-                    return AbortNode(state, "Failed to write to block index database");
+                    return m_chainman.FatalError(state, "Failed to write to block index database");
                 }
             }
             // Finally remove any pruned files
@@ -2540,11 +2559,11 @@ bool Chainstate::FlushStateToDisk(
             // an overestimation, as most will delete an existing entry or
             // overwrite one. Still, use a conservative safety factor of 2.
             if (!CheckDiskSpace(gArgs.GetDataDirNet(), 48 * 2 * 2 * CoinsTip().GetCacheSize())) {
-                return AbortNode(state, "Disk space is too low!", _("Disk space is too low!"));
+                return m_chainman.FatalError(state, "Disk space is too low!", _("Disk space is too low!"));
             }
             // Flush the chainstate (which may refer to block index entries).
             if (!CoinsTip().Flush())
-                return AbortNode(state, "Failed to write to coin database");
+                return m_chainman.FatalError(state, "Failed to write to coin database");
             m_last_flush = nNow;
             full_flush_completed = true;
             TRACE5(utxocache, flush,
@@ -2560,7 +2579,7 @@ bool Chainstate::FlushStateToDisk(
         GetMainSignals().ChainStateFlushed(m_chain.GetLocator());
     }
     } catch (const std::runtime_error& e) {
-        return AbortNode(state, std::string("System error while flushing: ") + e.what());
+        return m_chainman.FatalError(state, std::string("System error while flushing: ") + e.what());
     }
     return true;
 }
@@ -2796,7 +2815,7 @@ bool Chainstate::ConnectTip(BlockValidationState& state, CBlockIndex* pindexNew,
     if (!pblock) {
         std::shared_ptr<CBlock> pblockNew = std::make_shared<CBlock>();
         if (!m_blockman.ReadBlockFromDisk(*pblockNew, *pindexNew)) {
-            return AbortNode(state, "Failed to read block");
+            return FatalError(m_chainman.InterruptOnFatalError(), m_chainman.m_interrupt, m_chainman.GetNotifications(), state, "Failed to read block");
         }
         pthisBlock = pblockNew;
     } else {
@@ -2979,7 +2998,7 @@ bool Chainstate::ActivateBestChainStep(BlockValidationState& state, CBlockIndex*
             // If we're unable to disconnect a block during normal operation,
             // then that is a failure of our local system -- we should abort
             // rather than stay on a less work chain.
-            AbortNode(state, "Failed to disconnect block; see debug.log for details");
+            m_chainman.FatalError(state, "Failed to disconnect block; see debug.log for details");
             return false;
         }
         fBlocksDisconnected = true;
@@ -3975,7 +3994,7 @@ bool Chainstate::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, BlockV
         }
         ReceivedBlockTransactions(block, pindex, blockPos);
     } catch (const std::runtime_error& e) {
-        return AbortNode(state, std::string("System error: ") + e.what());
+        return m_chainman.FatalError(state, std::string("System error: ") + e.what());
     }
 
     FlushStateToDisk(state, FlushStateMode::NONE);
@@ -4666,7 +4685,7 @@ void Chainstate::LoadExternalBlockFile(
             }
         }
     } catch (const std::runtime_error& e) {
-        AbortNode(std::string("System error: ") + e.what());
+        m_chainman.FatalError(std::string("System error: ") + e.what());
     }
     LogPrintf("Loaded %i blocks from external file in %dms\n", nLoaded, Ticks<std::chrono::milliseconds>(SteadyClock::now() - start));
 }
@@ -5118,7 +5137,7 @@ bool ChainstateManager::ActivateSnapshot(
             snapshot_chainstate.reset();
             bool removed = DeleteCoinsDBFromDisk(*snapshot_datadir, /*is_snapshot=*/true);
             if (!removed) {
-                AbortNode(strprintf("Failed to remove snapshot chainstate dir (%s). "
+                FatalError(strprintf("Failed to remove snapshot chainstate dir (%s). "
                     "Manually remove it before restarting.\n", fs::PathToString(*snapshot_datadir)));
             }
         }
@@ -5383,8 +5402,7 @@ bool ChainstateManager::PopulateAndValidateSnapshot(
 //      through IsUsable() checks, or
 //
 //  (ii) giving each chainstate its own lock instead of using cs_main for everything.
-SnapshotCompletionResult ChainstateManager::MaybeCompleteSnapshotValidation(
-      std::function<void(bilingual_str)> shutdown_fnc)
+SnapshotCompletionResult ChainstateManager::MaybeCompleteSnapshotValidation()
 {
     AssertLockHeld(cs_main);
     if (m_ibd_chainstate.get() == &this->ActiveChainstate() ||
@@ -5433,7 +5451,7 @@ SnapshotCompletionResult ChainstateManager::MaybeCompleteSnapshotValidation(
 
         m_snapshot_chainstate->InvalidateCoinsDBOnDisk();
 
-        shutdown_fnc(user_error);
+        FatalError(user_error.original, user_error);
     };
 
     if (index_new.GetBlockHash() != snapshot_blockhash) {
@@ -5668,7 +5686,7 @@ void Chainstate::InvalidateCoinsDBOnDisk()
 
         LogPrintf("%s: error renaming file '%s' -> '%s': %s\n",
                 __func__, src_str, dest_str, e.what());
-        AbortNode(strprintf(
+        m_chainman.FatalError(strprintf(
             "Rename of '%s' -> '%s' failed. "
             "You should resolve this by manually moving or deleting the invalid "
             "snapshot directory %s, otherwise you will encounter the same error again "
@@ -5734,13 +5752,13 @@ bool ChainstateManager::ValidatedSnapshotCleanup()
 
     fs::path tmp_old{ibd_chainstate_path + "_todelete"};
 
-    auto rename_failed_abort = [](
+    auto rename_failed_abort = [this](
                                    fs::path p_old,
                                    fs::path p_new,
                                    const fs::filesystem_error& err) {
         LogPrintf("%s: error renaming file (%s): %s\n",
                 __func__, fs::PathToString(p_old), err.what());
-        AbortNode(strprintf(
+        FatalError(strprintf(
             "Rename of '%s' -> '%s' failed. "
             "Cannot clean up the background chainstate leveldb directory.",
             fs::PathToString(p_old), fs::PathToString(p_new)));
@@ -5765,7 +5783,7 @@ bool ChainstateManager::ValidatedSnapshotCleanup()
     }
 
     if (!DeleteCoinsDBFromDisk(tmp_old, /*is_snapshot=*/false)) {
-        // No need to AbortNode because once the unneeded bg chainstate data is
+        // No need to FatalError because once the unneeded bg chainstate data is
         // moved, it will not interfere with subsequent initialization.
         LogPrintf("Deletion of %s failed. Please remove it manually, as the " /* Continued */
                   "directory is now unnecessary.\n",

--- a/src/validation.h
+++ b/src/validation.h
@@ -60,6 +60,9 @@ class SnapshotMetadata;
 namespace Consensus {
 struct Params;
 } // namespace Consensus
+namespace util {
+class SignalInterrupt;
+} // namespace util
 
 /** Maximum number of dedicated script-checking threads allowed */
 static const int MAX_SCRIPTCHECK_THREADS = 15;
@@ -952,7 +955,7 @@ private:
 public:
     using Options = kernel::ChainstateManagerOpts;
 
-    explicit ChainstateManager(Options options, node::BlockManager::Options blockman_options);
+    explicit ChainstateManager(util::SignalInterrupt& interrupt, Options options, node::BlockManager::Options blockman_options);
 
     const CChainParams& GetParams() const { return m_options.chainparams; }
     const Consensus::Params& GetConsensus() const { return m_options.chainparams.GetConsensus(); }
@@ -974,6 +977,7 @@ public:
      */
     RecursiveMutex& GetMutex() const LOCK_RETURNED(::cs_main) { return ::cs_main; }
 
+    util::SignalInterrupt& m_interrupt;
     const Options m_options;
     std::thread m_load_block;
     //! A single BlockManager instance is shared across each constructed

--- a/src/validation.h
+++ b/src/validation.h
@@ -106,7 +106,8 @@ void StopScriptCheckWorkerThreads();
 
 CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams);
 
-bool AbortNode(BlockValidationState& state, const std::string& strMessage, const bilingual_str& userMessage = bilingual_str{});
+bool FatalError(bool interrupt_on_fatal_error, util::SignalInterrupt& interrupt, kernel::Notifications& notifications, BlockValidationState& state, const std::string& strMessage, const bilingual_str& userMessage = {});
+bool FatalError(bool interrupt_on_fatal_error, util::SignalInterrupt& interrupt, kernel::Notifications& notifications, const std::string& strMessage, const bilingual_str& userMessage = {});
 
 /** Guess verification progress (as a fraction between 0.0=genesis and 1.0=current tip). */
 double GuessVerificationProgress(const ChainTxData& data, const CBlockIndex* pindex);
@@ -963,6 +964,10 @@ public:
     const arith_uint256& MinimumChainWork() const { return *Assert(m_options.minimum_chain_work); }
     const uint256& AssumedValidBlock() const { return *Assert(m_options.assumed_valid_block); }
     kernel::Notifications& GetNotifications() const { return m_options.notifications; };
+    bool InterruptOnFatalError() const { return m_options.interrupt_on_fatal_error; };
+
+    bool FatalError(BlockValidationState& state, const std::string& strMessage, const bilingual_str& userMessage = {});
+    bool FatalError(const std::string& strMessage, const bilingual_str& userMessage = {});
 
     /**
      * Alias for ::cs_main.
@@ -1048,10 +1053,7 @@ public:
     //! If the coins match (expected), then mark the validation chainstate for
     //! deletion and continue using the snapshot chainstate as active.
     //! Otherwise, revert to using the ibd chainstate and shutdown.
-    SnapshotCompletionResult MaybeCompleteSnapshotValidation(
-        std::function<void(bilingual_str)> shutdown_fnc =
-            [](bilingual_str msg) { AbortNode(msg.original, msg); })
-        EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    SnapshotCompletionResult MaybeCompleteSnapshotValidation() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     //! The most-work chain.
     Chainstate& ActiveChainstate() const;

--- a/src/validation.h
+++ b/src/validation.h
@@ -23,7 +23,6 @@
 #include <policy/packages.h>
 #include <policy/policy.h>
 #include <script/script_error.h>
-#include <shutdown.h>
 #include <sync.h>
 #include <txdb.h>
 #include <txmempool.h> // For CTxMemPool::cs
@@ -965,9 +964,12 @@ public:
     const uint256& AssumedValidBlock() const { return *Assert(m_options.assumed_valid_block); }
     kernel::Notifications& GetNotifications() const { return m_options.notifications; };
     bool InterruptOnFatalError() const { return m_options.interrupt_on_fatal_error; };
+    bool InterruptOnCondition() const { return m_options.interrupt_on_condition; };
 
     bool FatalError(BlockValidationState& state, const std::string& strMessage, const bilingual_str& userMessage = {});
     bool FatalError(const std::string& strMessage, const bilingual_str& userMessage = {});
+
+    void Interrupt(kernel::InterruptReason reason);
 
     /**
      * Alias for ::cs_main.

--- a/test/lint/lint-format-strings.py
+++ b/test/lint/lint-format-strings.py
@@ -16,7 +16,7 @@ import re
 import sys
 
 FUNCTION_NAMES_AND_NUMBER_OF_LEADING_ARGUMENTS = [
-    'FatalError,0',
+    'FatalErrorf,0',
     'fprintf,1',
     'tfm::format,1',  # Assuming tfm::::format(std::ostream&, ...
     'LogConnectFailure,1',

--- a/test/lint/run-lint-format-strings.py
+++ b/test/lint/run-lint-format-strings.py
@@ -14,7 +14,7 @@ import sys
 
 FALSE_POSITIVES = [
     ("src/dbwrapper.cpp", "vsnprintf(p, limit - p, format, backup_ap)"),
-    ("src/index/base.cpp", "FatalError(const char* fmt, const Args&... args)"),
+    ("src/index/base.cpp", "FatalErrorf(const char* fmt, const Args&... args)"),
     ("src/netbase.cpp", "LogConnectFailure(bool manual_connection, const char* fmt, const Args&... args)"),
     ("src/clientversion.cpp", "strprintf(_(COPYRIGHT_HOLDERS).translated, COPYRIGHT_HOLDERS_SUBSTITUTION)"),
     ("src/test/translation_tests.cpp", "strprintf(format, arg)"),


### PR DESCRIPTION
This pull request is part of the `libbitcoinkernel` project https://github.com/bitcoin/bitcoin/issues/27587 https://github.com/orgs/bitcoin/projects/3 and more specifically its "Step 2: Decouple most non-consensus code from libbitcoinkernel".

---

This removes the shutdown files from the kernel library. As a standalone library the libbitcoinkernel should not have to rely on code that accesses shutdown state through a global. Instead, replace it with an interrupt class that is owned by the kernel context. Additionally this moves the remaining usages of the `uiInterface` out of the kernel code. The process of moving the `uiInterface` out of the kernel was started in https://github.com/bitcoin/bitcoin/pull/27636.

The approach taken here uses the notification interface to externalize the existing shutdown code from the kernel library. The `SignalInterrupt` kernel context member is passed by reference to the `ChainstateManager` to allow for the termination of long-running kernel functions and sending interrupt signals.
