### PR TITLE
test: Make `util/test_runner.py` honor `BITCOINUTIL` and `BITCOINTX`

### DIFF
--- a/test/util/test_runner.py
+++ b/test/util/test_runner.py
@@ -74,6 +74,11 @@ def bctest(testDir, testObj, buildenv):
     """
     # Get the exec names and arguments
     execprog = os.path.join(buildenv["BUILDDIR"], "src", testObj["exec"] + buildenv["EXEEXT"])
+    if testObj["exec"] == "./bitcoin-util":
+        execprog = os.getenv("BITCOINUTIL", default=execprog)
+    elif testObj["exec"] == "./bitcoin-tx":
+        execprog = os.getenv("BITCOINTX", default=execprog)
+
     execargs = testObj['args']
     execrun = [execprog] + execargs
 


### PR DESCRIPTION
This PR is a continuation of changes to our testing frameworks (https://github.com/bitcoin/bitcoin/pull/27554, https://github.com/bitcoin/bitcoin/pull/27561) that allow them to work correctly in a multi-config build environment that is possible for [upcoming](https://github.com/bitcoin/bitcoin/pull/25797) CMake-based build system. That means that built for different configurations binaries (e.g., "Debug" and "Release") can coexist in separated directories.

The commit has been pulled from https://github.com/hebasto/bitcoin/pull/15 and it seems [useful](https://github.com/hebasto/bitcoin/pull/15#discussion_r1200251404) by itself as:
> I believe the rationale for allowing to drop in the executables via env var is to allow to test the guix-produced, or other third-party-produced executables...

The current implementation of the `test/functional/test_framework/test_framework.py` script uses the same approach: https://github.com/bitcoin/bitcoin/blob/09351f51d279612973ecd76811dc075dff08209f/test/functional/test_framework/test_framework.py#L231-L246