### PR TITLE
ci: Check for `git` before its usage

### DIFF
--- a/ci/test/01_base_install.sh
+++ b/ci/test/01_base_install.sh
@@ -8,7 +8,7 @@ export LC_ALL=C.UTF-8
 
 CFG_DONE="ci.base-install-done"  # Use a global git setting to remember whether this script ran to avoid running it twice
 
-if [ "$(git config --global ${CFG_DONE})" == "true" ]; then
+if [ "$(command -v git)" ] && [ "$(git config --global ${CFG_DONE})" == "true" ]; then
   echo "Skip base install"
   exit 0
 fi


### PR DESCRIPTION
Fixes https://cirrus-ci.com/task/6690296436621312.

https://api.cirrus-ci.com/v1/task/6690296436621312/logs/build.log:
```
./ci/test/01_base_install.sh: line 11: git: command not found
```