### PR TITLE
doc: remove Tor link & generalize onion getnodeaddresses RPC

### DIFF
--- a/doc/cjdns.md
+++ b/doc/cjdns.md
@@ -112,5 +112,4 @@ There are several ways to see your CJDNS address in Bitcoin Core:
 To see which CJDNS peers your node is connected to, use `bitcoin-cli -netinfo 4`
 or the `getpeerinfo` RPC (i.e. `bitcoin-cli getpeerinfo`).
 
-To see which CJDNS addresses your node knows, use the `getnodeaddresses 0 cjdns`
-RPC.
+You can use the `getnodeaddresses` RPC to fetch a number of CJDNS peers known to your node; run `bitcoin-cli help getnodeaddresses` for details.

--- a/doc/i2p.md
+++ b/doc/i2p.md
@@ -111,8 +111,7 @@ incoming I2P connections (`-i2pacceptincoming`):
 To see which I2P peers your node is connected to, use `bitcoin-cli -netinfo 4`
 or the `getpeerinfo` RPC (e.g. `bitcoin-cli getpeerinfo`).
 
-To see which I2P addresses your node knows, use the `getnodeaddresses 0 i2p`
-RPC.
+You can use the `getnodeaddresses` RPC to fetch a number of I2P peers known to your node; run `bitcoin-cli help getnodeaddresses` for details.
 
 ## Compatibility
 

--- a/doc/tor.md
+++ b/doc/tor.md
@@ -2,9 +2,7 @@
 
 It is possible to run Bitcoin Core as a Tor onion service, and connect to such services.
 
-The following directions assume you have a Tor proxy running on port 9050. Many distributions default to having a SOCKS proxy listening on port 9050, but others may not. In particular, the Tor Browser Bundle defaults to listening on port 9150. See [Tor Project FAQ:TBBSocksPort](https://www.torproject.org/docs/faq.html.en#TBBSocksPort) for how to properly
-configure Tor.
-
+The following directions assume you have a Tor proxy running on port 9050. Many distributions default to having a SOCKS proxy listening on port 9050, but others may not. In particular, the Tor Browser Bundle defaults to listening on port 9150.
 ## Compatibility
 
 - Starting with version 22.0, Bitcoin Core only supports Tor version 3 hidden
@@ -27,8 +25,7 @@ CLI `-addrinfo` returns the number of addresses known to your node per
 network. This can be useful to see how many onion peers your node knows,
 e.g. for `-onlynet=onion`.
 
-To fetch a number of onion addresses that your node knows, for example seven
-addresses, use the `getnodeaddresses 7 onion` RPC.
+You can use the `getnodeaddresses` RPC to fetch a number of onion peers known to your node; run `bitcoin-cli help getnodeaddresses` for details.
 
 ## 1. Run Bitcoin Core behind a Tor proxy
 


### PR DESCRIPTION
- remove broken link about how to properly configure tor
- generalize getnodeaddresses RPC in doc
