### PR TITLE
doc: update comment in policy.cpp to refer to virtual bytes

### DIFF
--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -35,7 +35,7 @@ CAmount GetDustThreshold(const CTxOut& txout, const CFeeRate& dustRelayFeeIn)
     // 182*dustRelayFee/1000 (in satoshis).
     // 546 satoshis at the default rate of 3000 sat/kvB.
     // A typical spendable segwit P2WPKH txout is 31 bytes big, and will
-    // need a CTxIn of at least 67 bytes to spend:
+    // need a CTxIn of at least 67 vbytes to spend:
     // so dust is a spendable txout less than
     // 98*dustRelayFee/1000 (in satoshis).
     // 294 satoshis at the default rate of 3000 sat/kvB.


### PR DESCRIPTION
I think this should be virtual bytes? Or maybe not
