### PR TITLE
Prevent file descriptor exhaustion from too many RPC calls

### DIFF
--- a/doc/JSON-RPC-interface.md
+++ b/doc/JSON-RPC-interface.md
@@ -188,11 +188,8 @@ this RPC may not yet be reflected as such in this RPC response.
 
 ## Limitations
 
-There is a known issue in the JSON-RPC interface that can cause a node to crash if
-too many http connections are being opened at the same time because the system runs
-out of available file descriptors. To prevent this from happening you might
-want to increase the number of maximum allowed file descriptors in your system
-and try to prevent opening too many connections to your JSON-RPC interface at the
-same time if this is under your control. It is hard to give general advice
-since this depends on your system but if you make several hundred requests at
-once you are definitely at risk of encountering this issue.
+When too many connections are opened quickly the interface will start to
+respond with 503 Service Unavailable to prevent a crash from running out of file
+descriptors. To prevent this from happening you should try to prevent opening
+too many connections to the interface at the same time, for example
+by throttling your request rate.

--- a/doc/REST-interface.md
+++ b/doc/REST-interface.md
@@ -15,14 +15,11 @@ apply.
 Limitations
 -----------
 
-There is a known issue in the REST interface that can cause a node to crash if
-too many http connections are being opened at the same time because the system runs
-out of available file descriptors. To prevent this from happening you might
-want to increase the number of maximum allowed file descriptors in your system
-and try to prevent opening too many connections to your rest interface at the
-same time if this is under your control. It is hard to give general advice
-since this depends on your system but if you make several hundred requests at
-once you are definitely at risk of encountering this issue.
+When too many connections are opened quickly the interface will start to
+respond with 503 Service Unavailable to prevent a crash from running out of file
+descriptors. To prevent this from happening you should try to prevent opening
+too many connections to the interface at the same time, for example
+by throttling your request rate.
 
 Supported API
 -------------

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -465,6 +465,15 @@ bool InitHTTPServer(const util::SignalInterrupt& interrupt)
     int workQueueDepth = std::max((long)gArgs.GetIntArg("-rpcworkqueue", DEFAULT_HTTP_WORKQUEUE), 1L);
     LogDebug(BCLog::HTTP, "creating work queue of depth %d\n", workQueueDepth);
 
+#if LIBEVENT_VERSION_NUMBER >= 0x02020001
+    if (event_get_version_number() >= 0x02020001) {
+        // Limit the maximum number of open connections to prevent exhausting
+        // the file descriptor limit. When the http server gets overwhelmed it
+        // will respond with 503 Service Unavailable.
+        evhttp_set_max_connections(http, workQueueDepth * 2);
+    }
+#endif
+
     g_work_queue = std::make_unique<WorkQueue<HTTPClosure>>(workQueueDepth);
     // transfer ownership to eventBase/HTTP via .release()
     eventBase = base_ctr.release();


### PR DESCRIPTION
Fixes #11368

This requires libevent 2.2.1 which so far was only [released in alpha](https://github.com/libevent/libevent/releases/tag/release-2.2.1-alpha).

For more context see specifically https://github.com/bitcoin/bitcoin/issues/11368#issuecomment-632717903, this uses the feature mentioned there as libevent#592.