### PR TITLE
test: refactor: introduce `generate_keypair` helper with WIF support

### DIFF
--- a/test/functional/feature_assumevalid.py
+++ b/test/functional/feature_assumevalid.py
@@ -35,7 +35,6 @@ from test_framework.blocktools import (
     create_block,
     create_coinbase,
 )
-from test_framework.key import ECKey
 from test_framework.messages import (
     CBlockHeader,
     COutPoint,
@@ -46,9 +45,13 @@ from test_framework.messages import (
     msg_headers,
 )
 from test_framework.p2p import P2PInterface
-from test_framework.script import (CScript, OP_TRUE)
+from test_framework.script import (
+    CScript,
+    OP_TRUE,
+)
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
+from test_framework.wallet_util import generate_keypair
 
 
 class BaseNode(P2PInterface):
@@ -90,9 +93,7 @@ class AssumeValidTest(BitcoinTestFramework):
         self.blocks = []
 
         # Get a pubkey for the coinbase TXO
-        coinbase_key = ECKey()
-        coinbase_key.generate()
-        coinbase_pubkey = coinbase_key.get_pubkey().get_bytes()
+        _, coinbase_pubkey = generate_keypair()
 
         # Create the first block with a coinbase output to our key
         height = 1

--- a/test/functional/feature_block.py
+++ b/test/functional/feature_block.py
@@ -14,7 +14,6 @@ from test_framework.blocktools import (
     get_legacy_sigopcount_block,
     MAX_BLOCK_SIGOPS,
 )
-from test_framework.key import ECKey
 from test_framework.messages import (
     CBlock,
     COIN,
@@ -55,6 +54,7 @@ from test_framework.util import (
     assert_equal,
     assert_greater_than,
 )
+from test_framework.wallet_util import generate_keypair
 from data import invalid_txs
 
 
@@ -98,9 +98,7 @@ class FullBlockTest(BitcoinTestFramework):
         self.bootstrap_p2p()  # Add one p2p connection to the node
 
         self.block_heights = {}
-        self.coinbase_key = ECKey()
-        self.coinbase_key.generate()
-        self.coinbase_pubkey = self.coinbase_key.get_pubkey().get_bytes()
+        self.coinbase_key, self.coinbase_pubkey = generate_keypair()
         self.tip = None
         self.blocks = {}
         self.genesis_hash = int(self.nodes[0].getbestblockhash(), 16)

--- a/test/functional/feature_nulldummy.py
+++ b/test/functional/feature_nulldummy.py
@@ -35,8 +35,7 @@ from test_framework.util import (
     assert_raises_rpc_error,
 )
 from test_framework.wallet import getnewdestination
-from test_framework.key import ECKey
-from test_framework.wallet_util import bytes_to_wif
+from test_framework.wallet_util import generate_keypair
 
 NULLDUMMY_ERROR = "non-mandatory-script-verify-flag (Dummy CHECKMULTISIG argument must be zero)"
 
@@ -71,12 +70,9 @@ class NULLDUMMYTest(BitcoinTestFramework):
         return tx_from_hex(signedtx["hex"])
 
     def run_test(self):
-        eckey = ECKey()
-        eckey.generate()
-        self.privkey = bytes_to_wif(eckey.get_bytes())
-        self.pubkey = eckey.get_pubkey().get_bytes().hex()
-        cms = self.nodes[0].createmultisig(1, [self.pubkey])
-        wms = self.nodes[0].createmultisig(1, [self.pubkey], 'p2sh-segwit')
+        self.privkey, self.pubkey = generate_keypair(wif=True)
+        cms = self.nodes[0].createmultisig(1, [self.pubkey.hex()])
+        wms = self.nodes[0].createmultisig(1, [self.pubkey.hex()], 'p2sh-segwit')
         self.ms_address = cms["address"]
         ms_unlock_details = {"scriptPubKey": address_to_scriptpubkey(self.ms_address).hex(),
                              "redeemScript": cms["redeemScript"]}

--- a/test/functional/feature_taproot.py
+++ b/test/functional/feature_taproot.py
@@ -97,6 +97,7 @@ from test_framework.util import (
     assert_equal,
     random_bytes,
 )
+from test_framework.wallet_util import generate_keypair
 from test_framework.key import (
     generate_privkey,
     compute_xonly_pubkey,
@@ -1186,11 +1187,8 @@ def spenders_taproot_active():
 
     # Also add a few legacy spends into the mix, so that transactions which combine taproot and pre-taproot spends get tested too.
     for compressed in [False, True]:
-        eckey1 = ECKey()
-        eckey1.set(generate_privkey(), compressed)
-        pubkey1 = eckey1.get_pubkey().get_bytes()
-        eckey2 = ECKey()
-        eckey2.set(generate_privkey(), compressed)
+        eckey1, pubkey1 = generate_keypair(compressed=compressed)
+        eckey2, _ = generate_keypair(compressed=compressed)
         for p2sh in [False, True]:
             for witv0 in [False, True]:
                 for hashtype in VALID_SIGHASHES_ECDSA + [random.randrange(0x04, 0x80), random.randrange(0x84, 0x100)]:

--- a/test/functional/mempool_accept.py
+++ b/test/functional/mempool_accept.py
@@ -9,7 +9,6 @@ from decimal import Decimal
 import math
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.key import ECKey
 from test_framework.messages import (
     MAX_BIP125_RBF_SEQUENCE,
     COIN,
@@ -44,6 +43,7 @@ from test_framework.util import (
     assert_raises_rpc_error,
 )
 from test_framework.wallet import MiniWallet
+from test_framework.wallet_util import generate_keypair
 
 
 class MempoolAcceptanceTest(BitcoinTestFramework):
@@ -283,9 +283,7 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
             rawtxs=[tx.serialize().hex()],
         )
         tx = tx_from_hex(raw_tx_reference)
-        key = ECKey()
-        key.generate()
-        pubkey = key.get_pubkey().get_bytes()
+        _, pubkey = generate_keypair()
         tx.vout[0].scriptPubKey = keys_to_multisig_script([pubkey] * 3, k=2)  # Some bare multisig script (2-of-3)
         self.check_mempool_result(
             result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject-reason': 'bare-multisig'}],

--- a/test/functional/mempool_dust.py
+++ b/test/functional/mempool_dust.py
@@ -5,7 +5,6 @@
 """Test dust limit mempool policy (`-dustrelayfee` parameter)"""
 from decimal import Decimal
 
-from test_framework.key import ECKey
 from test_framework.messages import (
     COIN,
     CTxOut,
@@ -32,6 +31,7 @@ from test_framework.util import (
     get_fee,
 )
 from test_framework.wallet import MiniWallet
+from test_framework.wallet_util import generate_keypair
 
 
 DUST_RELAY_TX_FEE = 3000  # default setting [sat/kvB]
@@ -74,11 +74,8 @@ class DustRelayFeeTest(BitcoinTestFramework):
         self.wallet = MiniWallet(self.nodes[0])
 
         # prepare output scripts of each standard type
-        key = ECKey()
-        key.generate(compressed=False)
-        uncompressed_pubkey = key.get_pubkey().get_bytes()
-        key.generate(compressed=True)
-        pubkey = key.get_pubkey().get_bytes()
+        _, uncompressed_pubkey = generate_keypair(compressed=False)
+        _, pubkey = generate_keypair(compressed=True)
 
         output_scripts = (
             (key_to_p2pk_script(uncompressed_pubkey),          "P2PK (uncompressed)"),

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -14,7 +14,6 @@ from test_framework.blocktools import (
     create_block,
     create_coinbase,
 )
-from test_framework.key import ECKey
 from test_framework.messages import (
     MAX_BIP125_RBF_SEQUENCE,
     CBlockHeader,
@@ -89,6 +88,7 @@ from test_framework.util import (
     assert_raises_rpc_error,
 )
 from test_framework.wallet import MiniWallet
+from test_framework.wallet_util import generate_keypair
 
 
 MAX_SIGOP_COST = 80000
@@ -1448,9 +1448,7 @@ class SegWitTest(BitcoinTestFramework):
 
         # Segwit transactions using uncompressed pubkeys are not accepted
         # under default policy, but should still pass consensus.
-        key = ECKey()
-        key.generate(False)
-        pubkey = key.get_pubkey().get_bytes()
+        key, pubkey = generate_keypair(compressed=False)
         assert_equal(len(pubkey), 65)  # This should be an uncompressed pubkey
 
         utxo = self.utxo.pop(0)
@@ -1544,11 +1542,7 @@ class SegWitTest(BitcoinTestFramework):
 
     @subtest
     def test_signature_version_1(self):
-
-        key = ECKey()
-        key.generate()
-        pubkey = key.get_pubkey().get_bytes()
-
+        key, pubkey = generate_keypair()
         witness_script = key_to_p2pk_script(pubkey)
         script_pubkey = script_to_p2wsh_script(witness_script)
 

--- a/test/functional/rpc_createmultisig.py
+++ b/test/functional/rpc_createmultisig.py
@@ -12,13 +12,13 @@ from test_framework.address import address_to_scriptpubkey
 from test_framework.blocktools import COINBASE_MATURITY
 from test_framework.authproxy import JSONRPCException
 from test_framework.descriptors import descsum_create, drop_origins
-from test_framework.key import ECPubKey, ECKey
+from test_framework.key import ECPubKey
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_raises_rpc_error,
     assert_equal,
 )
-from test_framework.wallet_util import bytes_to_wif
+from test_framework.wallet_util import generate_keypair
 from test_framework.wallet import (
     MiniWallet,
     getnewdestination,
@@ -38,10 +38,9 @@ class RpcCreateMultiSigTest(BitcoinTestFramework):
         self.priv = []
         node0, node1, node2 = self.nodes
         for _ in range(self.nkeys):
-            k = ECKey()
-            k.generate()
-            self.pub.append(k.get_pubkey().get_bytes().hex())
-            self.priv.append(bytes_to_wif(k.get_bytes(), k.is_compressed))
+            privkey, pubkey = generate_keypair(wif=True)
+            self.pub.append(pubkey.hex())
+            self.priv.append(privkey)
         if self.is_bdb_compiled():
             self.final = node2.getnewaddress()
         else:

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -8,7 +8,7 @@ from decimal import Decimal
 from itertools import product
 
 from test_framework.descriptors import descsum_create
-from test_framework.key import ECKey, H_POINT
+from test_framework.key import H_POINT
 from test_framework.messages import (
     COutPoint,
     CTransaction,
@@ -43,8 +43,8 @@ from test_framework.util import (
     random_bytes,
 )
 from test_framework.wallet_util import (
-    bytes_to_wif,
-    get_generate_key
+    generate_keypair,
+    get_generate_key,
 )
 
 import json
@@ -710,9 +710,7 @@ class PSBTTest(BitcoinTestFramework):
 
         self.log.info("Test that we can fund psbts with external inputs specified")
 
-        eckey = ECKey()
-        eckey.generate()
-        privkey = bytes_to_wif(eckey.get_bytes())
+        privkey, _ = generate_keypair(wif=True)
 
         self.nodes[1].createwallet("extfund")
         wallet = self.nodes[1].get_wallet_rpc("extfund")
@@ -825,11 +823,9 @@ class PSBTTest(BitcoinTestFramework):
         self.nodes[1].createwallet(wallet_name="scriptwatchonly", disable_private_keys=True)
         watchonly = self.nodes[1].get_wallet_rpc("scriptwatchonly")
 
-        eckey = ECKey()
-        eckey.generate()
-        privkey = bytes_to_wif(eckey.get_bytes())
+        privkey, pubkey = generate_keypair(wif=True)
 
-        desc = descsum_create("wsh(pkh({}))".format(eckey.get_pubkey().get_bytes().hex()))
+        desc = descsum_create("wsh(pkh({}))".format(pubkey.hex()))
         if self.options.descriptors:
             res = watchonly.importdescriptors([{"desc": desc, "timestamp": "now"}])
         else:
@@ -846,11 +842,9 @@ class PSBTTest(BitcoinTestFramework):
 
         # Same test but for taproot
         if self.options.descriptors:
-            eckey = ECKey()
-            eckey.generate()
-            privkey = bytes_to_wif(eckey.get_bytes())
+            privkey, pubkey = generate_keypair(wif=True)
 
-            desc = descsum_create("tr({},pk({}))".format(H_POINT, eckey.get_pubkey().get_bytes().hex()))
+            desc = descsum_create("tr({},pk({}))".format(H_POINT, pubkey.hex()))
             res = watchonly.importdescriptors([{"desc": desc, "timestamp": "now"}])
             assert res[0]["success"]
             addr = self.nodes[0].deriveaddresses(desc)[0]

--- a/test/functional/rpc_signrawtransactionwithkey.py
+++ b/test/functional/rpc_signrawtransactionwithkey.py
@@ -11,7 +11,6 @@ from test_framework.address import (
     address_to_scriptpubkey,
     script_to_p2sh,
 )
-from test_framework.key import ECKey
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
@@ -23,15 +22,15 @@ from test_framework.script_util import (
     script_to_p2sh_p2wsh_script,
     script_to_p2wsh_script,
 )
+from test_framework.wallet import (
+    getnewdestination,
+)
 from test_framework.wallet_util import (
-    bytes_to_wif,
+    generate_keypair,
 )
 
 from decimal import (
     Decimal,
-)
-from test_framework.wallet import (
-    getnewdestination,
 )
 
 
@@ -80,11 +79,8 @@ class SignRawTransactionWithKeyTest(BitcoinTestFramework):
     def witness_script_test(self):
         self.log.info("Test signing transaction to P2SH-P2WSH addresses without wallet")
         # Create a new P2SH-P2WSH 1-of-1 multisig address:
-        eckey = ECKey()
-        eckey.generate()
-        embedded_privkey = bytes_to_wif(eckey.get_bytes())
-        embedded_pubkey = eckey.get_pubkey().get_bytes().hex()
-        p2sh_p2wsh_address = self.nodes[1].createmultisig(1, [embedded_pubkey], "p2sh-segwit")
+        embedded_privkey, embedded_pubkey = generate_keypair(wif=True)
+        p2sh_p2wsh_address = self.nodes[1].createmultisig(1, [embedded_pubkey.hex()], "p2sh-segwit")
         # send transaction to P2SH-P2WSH 1-of-1 multisig address
         self.block_hash = self.generate(self.nodes[0], COINBASE_MATURITY + 1)
         self.blk_idx = 0
@@ -109,10 +105,7 @@ class SignRawTransactionWithKeyTest(BitcoinTestFramework):
 
     def verify_txn_with_witness_script(self, tx_type):
         self.log.info("Test with a {} script as the witnessScript".format(tx_type))
-        eckey = ECKey()
-        eckey.generate()
-        embedded_privkey = bytes_to_wif(eckey.get_bytes())
-        embedded_pubkey = eckey.get_pubkey().get_bytes().hex()
+        embedded_privkey, embedded_pubkey = generate_keypair(wif=True)
         witness_script = {
             'P2PKH': key_to_p2pkh_script(embedded_pubkey).hex(),
             'P2PK': key_to_p2pk_script(embedded_pubkey).hex()

--- a/test/functional/test_framework/wallet.py
+++ b/test/functional/test_framework/wallet.py
@@ -20,6 +20,7 @@ from test_framework.address import (
     key_to_p2wpkh,
     output_key_to_p2tr,
 )
+from test_framework.blocktools import COINBASE_MATURITY
 from test_framework.descriptors import descsum_create
 from test_framework.key import (
     ECKey,
@@ -53,7 +54,7 @@ from test_framework.util import (
     assert_equal,
     assert_greater_than_or_equal,
 )
-from test_framework.blocktools import COINBASE_MATURITY
+from test_framework.wallet_util import generate_keypair
 
 DEFAULT_FEE = Decimal("0.0001")
 
@@ -395,9 +396,7 @@ def getnewdestination(address_type='bech32m'):
        'legacy', 'p2sh-segwit', 'bech32' and 'bech32m'. Can be used when a random
        destination is needed, but no compiled wallet is available (e.g. as
        replacement to the getnewaddress/getaddressinfo RPCs)."""
-    key = ECKey()
-    key.generate()
-    pubkey = key.get_pubkey().get_bytes()
+    key, pubkey = generate_keypair()
     if address_type == 'legacy':
         scriptpubkey = key_to_p2pkh_script(pubkey)
         address = key_to_p2pkh(pubkey)

--- a/test/functional/test_framework/wallet_util.py
+++ b/test/functional/test_framework/wallet_util.py
@@ -63,12 +63,9 @@ def get_generate_key():
     """Generate a fresh key
 
     Returns a named tuple of privkey, pubkey and all address and scripts."""
-    eckey = ECKey()
-    eckey.generate()
-    privkey = bytes_to_wif(eckey.get_bytes())
-    pubkey = eckey.get_pubkey().get_bytes().hex()
+    privkey, pubkey = generate_keypair(wif=True)
     return Key(privkey=privkey,
-               pubkey=pubkey,
+               pubkey=pubkey.hex(),
                p2pkh_script=key_to_p2pkh_script(pubkey).hex(),
                p2pkh_addr=key_to_p2pkh(pubkey),
                p2wpkh_script=key_to_p2wpkh_script(pubkey).hex(),
@@ -114,8 +111,14 @@ def bytes_to_wif(b, compressed=True):
         b += b'\x01'
     return byte_to_base58(b, 239)
 
-def generate_wif_key():
-    # Makes a WIF privkey for imports
-    k = ECKey()
-    k.generate()
-    return bytes_to_wif(k.get_bytes(), k.is_compressed)
+def generate_keypair(compressed=True, wif=False):
+    """Generate a new random keypair and return the corresponding ECKey /
+    bytes objects. The private key can also be provided as WIF (wallet
+    import format) string instead, which is often useful for wallet RPC
+    interaction."""
+    privkey = ECKey()
+    privkey.generate(compressed)
+    pubkey = privkey.get_pubkey().get_bytes()
+    if wif:
+        privkey = bytes_to_wif(privkey.get_bytes(), compressed)
+    return privkey, pubkey

--- a/test/functional/wallet_blank.py
+++ b/test/functional/wallet_blank.py
@@ -10,11 +10,10 @@ from test_framework.address import (
     ADDRESS_BCRT1_UNSPENDABLE,
     ADDRESS_BCRT1_UNSPENDABLE_DESCRIPTOR,
 )
-from test_framework.key import ECKey
 from test_framework.util import (
     assert_equal,
 )
-from test_framework.wallet_util import bytes_to_wif
+from test_framework.wallet_util import generate_keypair
 
 
 class WalletBlankTest(BitcoinTestFramework):
@@ -50,10 +49,8 @@ class WalletBlankTest(BitcoinTestFramework):
             assert_equal(info["descriptors"], False)
             assert_equal(info["blank"], True)
 
-            eckey = ECKey()
-            eckey.generate(compressed=comp)
-
-            wallet.importpubkey(eckey.get_pubkey().get_bytes().hex())
+            _, pubkey = generate_keypair(compressed=comp)
+            wallet.importpubkey(pubkey.hex())
             assert_equal(wallet.getwalletinfo()["blank"], False)
 
     def test_importprivkey(self):
@@ -67,10 +64,7 @@ class WalletBlankTest(BitcoinTestFramework):
             assert_equal(info["descriptors"], False)
             assert_equal(info["blank"], True)
 
-            eckey = ECKey()
-            eckey.generate(compressed=comp)
-            wif = bytes_to_wif(eckey.get_bytes(), eckey.is_compressed)
-
+            wif, _ = generate_keypair(compressed=comp, wif=True)
             wallet.importprivkey(wif)
             assert_equal(wallet.getwalletinfo()["blank"], False)
 

--- a/test/functional/wallet_createwallet.py
+++ b/test/functional/wallet_createwallet.py
@@ -7,13 +7,13 @@
 
 from test_framework.address import key_to_p2wpkh
 from test_framework.descriptors import descsum_create
-from test_framework.key import ECKey
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
 )
-from test_framework.wallet_util import bytes_to_wif, generate_wif_key
+from test_framework.wallet_util import generate_keypair
+
 
 EMPTY_PASSPHRASE_MSG = "Empty string given as passphrase, wallet will not be encrypted."
 LEGACY_WALLET_MSG = "Wallet created successfully. The legacy wallet type is being deprecated and support for creating and opening legacy wallets will be removed in the future."
@@ -50,14 +50,12 @@ class CreateWalletTest(BitcoinTestFramework):
         w1.importpubkey(w0.getaddressinfo(address1)['pubkey'])
 
         self.log.info('Test that private keys cannot be imported')
-        eckey = ECKey()
-        eckey.generate()
-        privkey = bytes_to_wif(eckey.get_bytes())
+        privkey, pubkey = generate_keypair(wif=True)
         assert_raises_rpc_error(-4, 'Cannot import private keys to a wallet with private keys disabled', w1.importprivkey, privkey)
         if self.options.descriptors:
             result = w1.importdescriptors([{'desc': descsum_create('wpkh(' + privkey + ')'), 'timestamp': 'now'}])
         else:
-            result = w1.importmulti([{'scriptPubKey': {'address': key_to_p2wpkh(eckey.get_pubkey().get_bytes())}, 'timestamp': 'now', 'keys': [privkey]}])
+            result = w1.importmulti([{'scriptPubKey': {'address': key_to_p2wpkh(pubkey)}, 'timestamp': 'now', 'keys': [privkey]}])
         assert not result[0]['success']
         assert 'warnings' not in result[0]
         assert_equal(result[0]['error']['code'], -4)
@@ -77,7 +75,7 @@ class CreateWalletTest(BitcoinTestFramework):
         assert_raises_rpc_error(-4, "Error: This wallet has no available keys", w3.getnewaddress)
         assert_raises_rpc_error(-4, "Error: This wallet has no available keys", w3.getrawchangeaddress)
         # Import private key
-        w3.importprivkey(generate_wif_key())
+        w3.importprivkey(generate_keypair(wif=True)[0])
         # Imported private keys are currently ignored by the keypool
         assert_equal(w3.getwalletinfo()['keypoolsize'], 0)
         assert_raises_rpc_error(-4, "Error: This wallet has no available keys", w3.getnewaddress)

--- a/test/functional/wallet_fundrawtransaction.py
+++ b/test/functional/wallet_fundrawtransaction.py
@@ -10,7 +10,6 @@ from itertools import product
 from math import ceil
 
 from test_framework.descriptors import descsum_create
-from test_framework.key import ECKey
 from test_framework.messages import (
     COIN,
 )
@@ -25,7 +24,7 @@ from test_framework.util import (
     count_bytes,
     find_vout_for_address,
 )
-from test_framework.wallet_util import bytes_to_wif
+from test_framework.wallet_util import generate_keypair
 
 ERR_NOT_ENOUGH_PRESET_INPUTS = "The preselected coins total amount does not cover the transaction target. " \
                                "Please allow other inputs to be automatically selected or include more coins manually"
@@ -999,11 +998,7 @@ class RawTransactionsTest(BitcoinTestFramework):
 
     def test_external_inputs(self):
         self.log.info("Test funding with external inputs")
-
-        eckey = ECKey()
-        eckey.generate()
-        privkey = bytes_to_wif(eckey.get_bytes())
-
+        privkey, _ = generate_keypair(wif=True)
         self.nodes[2].createwallet("extfund")
         wallet = self.nodes[2].get_wallet_rpc("extfund")
 

--- a/test/functional/wallet_importprunedfunds.py
+++ b/test/functional/wallet_importprunedfunds.py
@@ -7,7 +7,6 @@ from decimal import Decimal
 
 from test_framework.address import key_to_p2wpkh
 from test_framework.blocktools import COINBASE_MATURITY
-from test_framework.key import ECKey
 from test_framework.messages import (
     CMerkleBlock,
     from_hex,
@@ -17,7 +16,7 @@ from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
 )
-from test_framework.wallet_util import bytes_to_wif
+from test_framework.wallet_util import generate_keypair
 
 
 class ImportPrunedFundsTest(BitcoinTestFramework):
@@ -40,10 +39,8 @@ class ImportPrunedFundsTest(BitcoinTestFramework):
         # pubkey
         address2 = self.nodes[0].getnewaddress()
         # privkey
-        eckey = ECKey()
-        eckey.generate()
-        address3_privkey = bytes_to_wif(eckey.get_bytes())
-        address3 = key_to_p2wpkh(eckey.get_pubkey().get_bytes())
+        address3_privkey, address3_pubkey = generate_keypair(wif=True)
+        address3 = key_to_p2wpkh(address3_pubkey)
         self.nodes[0].importprivkey(address3_privkey)
 
         # Check only one address

--- a/test/functional/wallet_listsinceblock.py
+++ b/test/functional/wallet_listsinceblock.py
@@ -7,7 +7,6 @@
 from test_framework.address import key_to_p2wpkh
 from test_framework.blocktools import COINBASE_MATURITY
 from test_framework.descriptors import descsum_create
-from test_framework.key import ECKey
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.messages import MAX_BIP125_RBF_SEQUENCE
 from test_framework.util import (
@@ -15,7 +14,7 @@ from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
 )
-from test_framework.wallet_util import bytes_to_wif
+from test_framework.wallet_util import generate_keypair
 
 from decimal import Decimal
 
@@ -202,10 +201,8 @@ class ListSinceBlockTest(BitcoinTestFramework):
         self.sync_all()
 
         # share utxo between nodes[1] and nodes[2]
-        eckey = ECKey()
-        eckey.generate()
-        privkey = bytes_to_wif(eckey.get_bytes())
-        address = key_to_p2wpkh(eckey.get_pubkey().get_bytes())
+        privkey, pubkey = generate_keypair(wif=True)
+        address = key_to_p2wpkh(pubkey)
         self.nodes[2].sendtoaddress(address, 10)
         self.generate(self.nodes[2], 6)
         self.nodes[2].importprivkey(privkey)

--- a/test/functional/wallet_send.py
+++ b/test/functional/wallet_send.py
@@ -9,7 +9,6 @@ from itertools import product
 
 from test_framework.authproxy import JSONRPCException
 from test_framework.descriptors import descsum_create
-from test_framework.key import ECKey
 from test_framework.messages import (
     ser_compact_size,
     WITNESS_SCALE_FACTOR,
@@ -22,7 +21,8 @@ from test_framework.util import (
     assert_raises_rpc_error,
     count_bytes,
 )
-from test_framework.wallet_util import bytes_to_wif
+from test_framework.wallet_util import generate_keypair
+
 
 class WalletSendTest(BitcoinTestFramework):
     def add_options(self, parser):
@@ -500,9 +500,7 @@ class WalletSendTest(BitcoinTestFramework):
         assert res["complete"]
 
         self.log.info("External outputs")
-        eckey = ECKey()
-        eckey.generate()
-        privkey = bytes_to_wif(eckey.get_bytes())
+        privkey, _ = generate_keypair(wif=True)
 
         self.nodes[1].createwallet("extsend")
         ext_wallet = self.nodes[1].get_wallet_rpc("extsend")


### PR DESCRIPTION
In functional tests it is a quite common scenario to generate fresh elliptic curve keypairs, which is currently a bit cumbersome as it involves multiple steps, e.g.:

    privkey = ECKey()
    privkey.generate()
    privkey_wif = bytes_to_wif(privkey.get_bytes())
    pubkey = privkey.get_pubkey().get_bytes()

Simplify this by providing a new `generate_keypair` helper function that returns the private key either as `ECKey` object or as WIF-string (depending on the boolean `wif` parameter) and the public key as byte-string; these formats are what we mostly need (currently we don't use `ECPubKey` objects from generated keypairs anywhere).

With this, most of the affected code blocks following the pattern above can be replaced by one-liners, e.g.:

    privkey, pubkey = generate_keypair(wif=True)

Note that after this commit, the only direct uses of `ECKey` remain in situations where we want to set the private key explicitly, e.g. in MiniWallet (test/functional/test_framework/wallet.py) or the test for the signet miner script (test/functional/tool_signet_miner.py).