### PR TITLE
[NO MERGE] BIP331 Ancestor Package Relay

### DIFF
--- a/doc/release-notes-27609.md
+++ b/doc/release-notes-27609.md
@@ -1,0 +1,11 @@
+- A new RPC, `submitpackage`, has been added. It can be used to submit a list of raw hex
+  transactions to the mempool to be evaluated as a package using consensus and mempool policy rules,
+including package CPFP (allowing a child to bump a parent below the mempool minimum feerate).
+Warning: successful submission does not mean the transactions will propagate throughout the network,
+as package relay is not used.
+
+    - Not all features are available. For example, RBF is not supported and the package is limited
+      to a child with its unconfirmed parents. Refer to doc/policy/packages.md for more details on
+      package policies and limitations.
+
+    - This RPC is experimental. Its interface may change.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -225,6 +225,7 @@ BITCOIN_CORE_H = \
   node/minisketchwrapper.h \
   node/psbt.h \
   node/transaction.h \
+  node/txpackagetracker.h \
   node/txreconciliation.h \
   node/utxo_snapshot.h \
   node/validation_cache_args.h \
@@ -420,6 +421,7 @@ libbitcoin_node_a_SOURCES = \
   node/minisketchwrapper.cpp \
   node/psbt.cpp \
   node/transaction.cpp \
+  node/txpackagetracker.cpp \
   node/txreconciliation.cpp \
   node/utxo_snapshot.cpp \
   node/validation_cache_args.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -240,6 +240,7 @@ test_fuzz_fuzz_SOURCES = \
  $(FUZZ_WALLET_SRC) \
  test/fuzz/addition_overflow.cpp \
  test/fuzz/addrman.cpp \
+ test/fuzz/ancestorpackage.cpp \
  test/fuzz/asmap.cpp \
  test/fuzz/asmap_direct.cpp \
  test/fuzz/autofile.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -152,6 +152,7 @@ BITCOIN_TESTS =\
   test/translation_tests.cpp \
   test/txindex_tests.cpp \
   test/txpackage_tests.cpp \
+  test/txpackagetracker_tests.cpp \
   test/txreconciliation_tests.cpp \
   test/txrequest_tests.cpp \
   test/txvalidation_tests.cpp \

--- a/src/consensus/validation.h
+++ b/src/consensus/validation.h
@@ -54,6 +54,7 @@ enum class TxValidationResult {
     TX_CONFLICT,
     TX_MEMPOOL_POLICY,        //!< violated mempool's fee/size/descendant/RBF/etc limits
     TX_NO_MEMPOOL,            //!< this node does not have a mempool so can't validate the transaction
+    TX_LOW_FEE,               //!< fee was insufficient to meet some policy (minimum/RBF/etc)
 };
 
 /** A "reason" why a block was invalid, suitable for determining whether the

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -50,6 +50,7 @@
 #include <node/mempool_args.h>
 #include <node/mempool_persist_args.h>
 #include <node/miner.h>
+#include <node/txpackagetracker.h>
 #include <node/txreconciliation.h>
 #include <node/validation_cache_args.h>
 #include <policy/feerate.h>
@@ -496,6 +497,7 @@ void SetupServerArgs(ArgsManager& argsman)
     argsman.AddArg("-i2psam=<ip:port>", "I2P SAM proxy to reach I2P peers and accept I2P connections (default: none)", ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-i2pacceptincoming", strprintf("Whether to accept inbound I2P connections (default: %i). Ignored if -i2psam is not set. Listening for inbound I2P connections is done through the SAM proxy, not by binding to a local address and port.", DEFAULT_I2P_ACCEPT_INCOMING), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-onlynet=<net>", "Make automatic outbound connections only to network <net> (" + Join(GetNetworkNames(), ", ") + "). Inbound and manual connections are not affected by this option. It can be specified multiple times to allow multiple networks.", ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
+    argsman.AddArg("-packagerelay", strprintf("[EXPERIMENTAL] Support relaying transaction packages (default: %u)", node::DEFAULT_ENABLE_PACKAGE_RELAY), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-peerbloomfilters", strprintf("Support filtering of blocks and transaction with bloom filters (default: %u)", DEFAULT_PEERBLOOMFILTERS), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-peerblockfilters", strprintf("Serve compact block filters to peers per BIP 157 (default: %u)", DEFAULT_PEERBLOCKFILTERS), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-txreconciliation", strprintf("Enable transaction reconciliations per BIP 330 (default: %d)", DEFAULT_TXRECONCILIATION_ENABLE), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CONNECTION);
@@ -1539,10 +1541,11 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     }
 
     ChainstateManager& chainman = *Assert(node.chainman);
+    const bool enable_package_relay{gArgs.GetBoolArg("-packagerelay", node::DEFAULT_ENABLE_PACKAGE_RELAY)};
 
     assert(!node.peerman);
     node.peerman = PeerManager::make(*node.connman, *node.addrman, node.banman.get(),
-                                     chainman, *node.mempool, ignores_incoming_txs);
+                                     chainman, *node.mempool, ignores_incoming_txs, enable_package_relay);
     RegisterValidationInterface(node.peerman.get());
 
     // ********************************************************* Step 8: start indexers

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -182,6 +182,7 @@ const CLogCategoryDesc LogCategories[] =
     {BCLog::BLOCKSTORAGE, "blockstorage"},
     {BCLog::TXRECONCILIATION, "txreconciliation"},
     {BCLog::SCAN, "scan"},
+    {BCLog::TXPACKAGES, "txpackages"},
     {BCLog::ALL, "1"},
     {BCLog::ALL, "all"},
 };
@@ -286,6 +287,8 @@ std::string LogCategoryToStr(BCLog::LogFlags category)
         return "txreconciliation";
     case BCLog::LogFlags::SCAN:
         return "scan";
+    case BCLog::LogFlags::TXPACKAGES:
+        return "txpackages";
     case BCLog::LogFlags::ALL:
         return "all";
     }

--- a/src/logging.h
+++ b/src/logging.h
@@ -68,6 +68,7 @@ namespace BCLog {
         BLOCKSTORAGE = (1 << 26),
         TXRECONCILIATION = (1 << 27),
         SCAN        = (1 << 28),
+        TXPACKAGES  = (1 << 29),
         ALL         = ~(uint32_t)0,
     };
     enum class Level {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -22,6 +22,7 @@
 #include <netbase.h>
 #include <netmessagemaker.h>
 #include <node/blockstorage.h>
+#include <node/txpackagetracker.h>
 #include <node/txreconciliation.h>
 #include <policy/fees.h>
 #include <policy/policy.h>
@@ -711,6 +712,7 @@ private:
     CTxMemPool& m_mempool;
     TxRequestTracker m_txrequest GUARDED_BY(::cs_main);
     std::unique_ptr<TxReconciliationTracker> m_txreconciliation;
+    std::unique_ptr<node::TxPackageTracker> m_txpackagetracker;
 
     /** The height of the best chain */
     std::atomic<int> m_best_height{-1};
@@ -1830,6 +1832,7 @@ PeerManagerImpl::PeerManagerImpl(CConnman& connman, AddrMan& addrman,
     if (gArgs.GetBoolArg("-txreconciliation", DEFAULT_TXRECONCILIATION_ENABLE)) {
         m_txreconciliation = std::make_unique<TxReconciliationTracker>(TXRECONCILIATION_VERSION);
     }
+    m_txpackagetracker = std::make_unique<node::TxPackageTracker>();
 }
 
 void PeerManagerImpl::StartScheduledTasks(CScheduler& scheduler)

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2965,7 +2965,7 @@ bool PeerManagerImpl::ProcessOrphanTx(Peer& peer)
             LogPrint(BCLog::MEMPOOL, "   accepted orphan tx %s\n", orphanHash.ToString());
             RelayTransaction(orphanHash, porphanTx->GetWitnessHash());
             m_txpackagetracker->AddChildrenToWorkSet(*porphanTx);
-            m_txpackagetracker->EraseOrphanTx(orphanHash);
+            m_txpackagetracker->EraseOrphanTx(porphanTx->GetWitnessHash());
             for (const CTransactionRef& removedTx : result.m_replaced_transactions.value()) {
                 AddToCompactExtraTransactions(removedTx);
             }
@@ -3011,7 +3011,7 @@ bool PeerManagerImpl::ProcessOrphanTx(Peer& peer)
                     m_recent_rejects.insert(porphanTx->GetHash());
                 }
             }
-            m_txpackagetracker->EraseOrphanTx(orphanHash);
+            m_txpackagetracker->EraseOrphanTx(porphanTx->GetWitnessHash());
             return true;
         }
     }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1504,6 +1504,7 @@ void PeerManagerImpl::AddOrphanAnnouncer(NodeId nodeid, const uint256& orphan_wt
     // - "preferred": if fPreferredDownload is set (= outbound, or NetPermissionFlags::NoBan permission)
     // - "reqtime": current time plus delays for:
     //   - NONPREF_PEER_TX_DELAY for announcements from non-preferred connections
+    //   - TXID_RELAY_DELAY for txid-based parent requests while package relay peers are available
     //   - OVERLOADED_PEER_TX_DELAY for announcements from peers which have at least
     //     MAX_PEER_TX_REQUEST_IN_FLIGHT requests in flight
     //     TODO: allow peers with Relay permissions to bypass this restiction
@@ -1511,6 +1512,9 @@ void PeerManagerImpl::AddOrphanAnnouncer(NodeId nodeid, const uint256& orphan_wt
     const bool preferred = state->fPreferredDownload;
     if (!preferred) delay += NONPREF_PEER_TX_DELAY;
     const bool overloaded = m_txrequest.CountInFlight(nodeid) >= MAX_PEER_TX_REQUEST_IN_FLIGHT;
+    const auto peer_ref{GetPeerRef(nodeid)};
+    if (!peer_ref) return;
+    if (!peer_ref->m_package_relay && m_package_relay_peers > 0) delay += TXID_RELAY_DELAY;
     if (overloaded) delay += OVERLOADED_PEER_TX_DELAY;
     m_txpackagetracker->AddOrphanTx(nodeid, orphan_wtxid, tx, preferred, current_time + delay);
 }
@@ -4295,6 +4299,56 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
         return;
     }
 
+    if (msg_type == NetMsgType::ANCPKGINFO) {
+        std::vector<uint256> package_wtxids;
+        vRecv >> package_wtxids;
+        if (package_wtxids.empty()) return;
+        if (!peer->m_package_relay) {
+            LogPrint(BCLog::NET, "ancpkginfo sent in violation of protocol, disconnecting peer=%d\n", pfrom.GetId());
+            pfrom.fDisconnect = true;
+            return;
+        }
+        if (!m_txpackagetracker->PkgInfoAllowed(pfrom.GetId(), package_wtxids.back(), node::PKG_RELAY_ANCPKG)) {
+            LogPrint(BCLog::NET, "unsolicited ancpkginfo sent, disconnecting peer=%d\n", pfrom.GetId());
+            pfrom.fDisconnect = true;
+            return;
+        }
+
+        const auto& rep_wtxid{package_wtxids.back()};
+        if (package_wtxids.size() > MAX_PACKAGE_COUNT) {
+            LogPrint(BCLog::NET, "discarding package info for tx %s, too many transactions\n", rep_wtxid.ToString());
+            m_txpackagetracker->ForgetPkgInfo(pfrom.GetId(), package_wtxids.back(), node::PKG_RELAY_ANCPKG);
+            return;
+        }
+        LOCK(::cs_main);
+        if (m_chainman.ActiveChainstate().IsInitialBlockDownload()) return;
+        // We have already validated this exact set of transactions recently, so don't do it again.
+        if (m_recent_rejects_reconsiderable.contains(GetCombinedHash(package_wtxids))) {
+            LogPrint(BCLog::NET, "discarding package info for tx %s, this package has already been rejected\n",
+                     rep_wtxid.ToString());
+            m_txpackagetracker->ForgetPkgInfo(pfrom.GetId(), package_wtxids.back(), node::PKG_RELAY_ANCPKG);
+            return;
+        }
+        for (const auto& wtxid : package_wtxids) {
+            // If a transaction is in m_recent_rejects and not m_recent_rejects_reconsiderable, that
+            // means it will not become valid by adding another transaction.
+            if (m_recent_rejects.contains(wtxid)) {
+                LogPrint(BCLog::NET, "discarding package for tx %s, tx %s has already been rejected and is not eligible for reconsideration\n",
+                         rep_wtxid.ToString(), wtxid.ToString());
+                m_txpackagetracker->ForgetPkgInfo(pfrom.GetId(), package_wtxids.back(), node::PKG_RELAY_ANCPKG);
+                return;
+            }
+        }
+        // For now, just add these transactions as announcements.
+        const auto current_time{GetTime<std::chrono::microseconds>()};
+        for (const auto& wtxid : package_wtxids) {
+            AddKnownTx(*peer, wtxid);
+            if (!AlreadyHaveTx(GenTxid::Wtxid(wtxid)) && !m_chainman.ActiveChainstate().IsInitialBlockDownload()) {
+                AddTxAnnouncement(pfrom, GenTxid::Wtxid(wtxid), current_time);
+            }
+        }
+    }
+
     if (msg_type == NetMsgType::TX) {
         if (RejectIncomingTxs(pfrom)) {
             LogPrint(BCLog::NET, "transaction sent in violation of protocol peer=%d\n", pfrom.GetId());
@@ -5077,6 +5131,13 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
                     // If we receive a NOTFOUND message for a tx we requested, mark the announcement for it as
                     // completed in TxRequestTracker.
                     m_txrequest.ReceivedResponse(pfrom.GetId(), inv.hash);
+                } else if (inv.IsMsgAncPkgInfo() && m_enable_package_relay) {
+                    if (!m_txpackagetracker->PkgInfoAllowed(pfrom.GetId(), inv.hash, node::PKG_RELAY_ANCPKG)) {
+                        LogPrint(BCLog::NET, "\nUnsolicited ancpkginfo sent, disconnecting peer=%d\n", pfrom.GetId());
+                        // Unsolicited ancpkginfo or peer is not registered for package relay.
+                        pfrom.fDisconnect = true;
+                    }
+                    m_txpackagetracker->ForgetPkgInfo(pfrom.GetId(), inv.hash, node::PKG_RELAY_ANCPKG);
                 }
             }
         }
@@ -6099,7 +6160,7 @@ bool PeerManagerImpl::SendMessages(CNode* pto)
             if (AlreadyHaveTx(gtxid, /*include_orphanage=*/false)) {
                 m_txpackagetracker->FinalizeTransactions({gtxid.GetHash()}, {});
             } else {
-                vGetData.emplace_back(MSG_TX | GetFetchFlags(*peer), gtxid.GetHash());
+                vGetData.emplace_back(gtxid.IsWtxid() ? MSG_ANCPKGINFO : (MSG_TX | GetFetchFlags(*peer)), gtxid.GetHash());
                 if (vGetData.size() >= MAX_GETDATA_SZ) {
                     m_connman.PushMessage(pto, msgMaker.Make(NetMsgType::GETDATA, vGetData));
                     vGetData.clear();

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1516,6 +1516,7 @@ void PeerManagerImpl::AddOrphanAnnouncer(NodeId nodeid, const uint256& orphan_wt
     if (!peer_ref) return;
     if (!peer_ref->m_package_relay && m_package_relay_peers > 0) delay += TXID_RELAY_DELAY;
     if (overloaded) delay += OVERLOADED_PEER_TX_DELAY;
+    // Note that TxPackageTracker may also decide to delay or drop this request.
     m_txpackagetracker->AddOrphanTx(nodeid, orphan_wtxid, tx, preferred, current_time + delay);
 }
 void PeerManagerImpl::AddOrphanResolutionCandidates(const CTransactionRef& orphan, NodeId originator)

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -37,7 +37,6 @@
 #include <timedata.h>
 #include <tinyformat.h>
 #include <txmempool.h>
-#include <txorphanage.h>
 #include <txrequest.h>
 #include <util/check.h> // For NDEBUG compile time check
 #include <util/strencodings.h>
@@ -938,9 +937,6 @@ private:
     /** Number of peers from which we're downloading blocks. */
     int m_peers_downloading_from GUARDED_BY(cs_main) = 0;
 
-    /** Storage for orphan information */
-    TxOrphanage m_orphanage;
-
     void AddToCompactExtraTransactions(const CTransactionRef& tx) EXCLUSIVE_LOCKS_REQUIRED(g_msgproc_mutex);
 
     /** Orphan/conflicted/etc transactions that are kept for compact block reconstruction.
@@ -1543,7 +1539,7 @@ void PeerManagerImpl::FinalizeNode(const CNode& node)
             }
         }
     }
-    m_orphanage.EraseForPeer(nodeid);
+    m_txpackagetracker->DisconnectedPeer(nodeid);
     m_txrequest.DisconnectedPeer(nodeid);
     if (m_txreconciliation) m_txreconciliation->ForgetPeer(nodeid);
     m_num_preferred_download_peers -= state->fPreferredDownload;
@@ -1562,7 +1558,7 @@ void PeerManagerImpl::FinalizeNode(const CNode& node)
         assert(m_outbound_peers_with_protect_from_disconnect == 0);
         assert(m_wtxid_relay_peers == 0);
         assert(m_txrequest.Size() == 0);
-        assert(m_orphanage.Size() == 0);
+        assert(m_txpackagetracker->OrphanageSize() == 0);
     }
     } // cs_main
     if (node.fSuccessfullyConnected && misbehavior == 0 &&
@@ -1857,7 +1853,7 @@ void PeerManagerImpl::StartScheduledTasks(CScheduler& scheduler)
  */
 void PeerManagerImpl::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindex)
 {
-    m_orphanage.EraseForBlock(*pblock);
+    m_txpackagetracker->BlockConnected(*pblock);
     m_last_tip_update = GetTime<std::chrono::seconds>();
 
     {
@@ -2051,7 +2047,7 @@ bool PeerManagerImpl::AlreadyHaveTx(const GenTxid& gtxid)
 
     const uint256& hash = gtxid.GetHash();
 
-    if (m_orphanage.HaveTx(gtxid)) return true;
+    if (m_txpackagetracker->OrphanageHaveTx(gtxid)) return true;
 
     {
         LOCK(m_recent_confirmed_transactions_mutex);
@@ -2960,7 +2956,7 @@ bool PeerManagerImpl::ProcessOrphanTx(Peer& peer)
 
     CTransactionRef porphanTx = nullptr;
 
-    while (CTransactionRef porphanTx = m_orphanage.GetTxToReconsider(peer.m_id)) {
+    while (CTransactionRef porphanTx = m_txpackagetracker->GetTxToReconsider(peer.m_id)) {
         const MempoolAcceptResult result = m_chainman.ProcessTransaction(porphanTx);
         const TxValidationState& state = result.m_state;
         const uint256& orphanHash = porphanTx->GetHash();
@@ -2968,8 +2964,8 @@ bool PeerManagerImpl::ProcessOrphanTx(Peer& peer)
         if (result.m_result_type == MempoolAcceptResult::ResultType::VALID) {
             LogPrint(BCLog::MEMPOOL, "   accepted orphan tx %s\n", orphanHash.ToString());
             RelayTransaction(orphanHash, porphanTx->GetWitnessHash());
-            m_orphanage.AddChildrenToWorkSet(*porphanTx);
-            m_orphanage.EraseTx(orphanHash);
+            m_txpackagetracker->AddChildrenToWorkSet(*porphanTx);
+            m_txpackagetracker->EraseOrphanTx(orphanHash);
             for (const CTransactionRef& removedTx : result.m_replaced_transactions.value()) {
                 AddToCompactExtraTransactions(removedTx);
             }
@@ -3015,7 +3011,7 @@ bool PeerManagerImpl::ProcessOrphanTx(Peer& peer)
                     m_recent_rejects.insert(porphanTx->GetHash());
                 }
             }
-            m_orphanage.EraseTx(orphanHash);
+            m_txpackagetracker->EraseOrphanTx(orphanHash);
             return true;
         }
     }
@@ -4186,7 +4182,7 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
             m_txrequest.ForgetTxHash(tx.GetHash());
             m_txrequest.ForgetTxHash(tx.GetWitnessHash());
             RelayTransaction(tx.GetHash(), tx.GetWitnessHash());
-            m_orphanage.AddChildrenToWorkSet(tx);
+            m_txpackagetracker->AddChildrenToWorkSet(tx);
 
             pfrom.m_last_tx_time = GetTime<std::chrono::seconds>();
 
@@ -4233,7 +4229,7 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
                     if (!AlreadyHaveTx(gtxid)) AddTxAnnouncement(pfrom, gtxid, current_time);
                 }
 
-                if (m_orphanage.AddTx(ptx, pfrom.GetId())) {
+                if (m_txpackagetracker->OrphanageAddTx(ptx, pfrom.GetId())) {
                     AddToCompactExtraTransactions(ptx);
                 }
 
@@ -4243,7 +4239,7 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
 
                 // DoS prevention: do not allow m_orphanage to grow unbounded (see CVE-2012-3789)
                 unsigned int nMaxOrphanTx = (unsigned int)std::max((int64_t)0, gArgs.GetIntArg("-maxorphantx", DEFAULT_MAX_ORPHAN_TRANSACTIONS));
-                m_orphanage.LimitOrphans(nMaxOrphanTx);
+                m_txpackagetracker->LimitOrphans(nMaxOrphanTx);
             } else {
                 LogPrint(BCLog::MEMPOOL, "not keeping orphan with rejected parents %s\n",tx.GetHash().ToString());
                 // We will continue to reject this tx since it has rejected
@@ -5029,7 +5025,7 @@ bool PeerManagerImpl::ProcessMessages(CNode* pfrom, std::atomic<bool>& interrupt
         //  by another peer that was already processed; in that case,
         //  the extra work may not be noticed, possibly resulting in an
         //  unnecessary 100ms delay)
-        if (m_orphanage.HaveTxToReconsider(peer->m_id)) fMoreWork = true;
+        if (m_txpackagetracker->HaveTxToReconsider(peer->m_id)) fMoreWork = true;
     } catch (const std::exception& e) {
         LogPrint(BCLog::NET, "%s(%s, %u bytes): Exception '%s' (%s) caught\n", __func__, SanitizeString(msg.m_type), msg.m_message_size, e.what(), typeid(e).name());
     } catch (...) {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -675,6 +675,10 @@ private:
     void AddTxAnnouncement(const CNode& node, const GenTxid& gtxid, std::chrono::microseconds current_time)
         EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
+    /** Register with orphan TxRequestTracker that a peer may help us resolve this orphan. */
+    void AddOrphanResolutionCandidate(NodeId nodeid, const uint256& orphan_wtxid, const CTransactionRef& tx, std::chrono::microseconds current_time)
+        EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
     /** Send a version message to a peer */
     void PushNodeVersion(CNode& pnode, const Peer& peer);
 
@@ -777,7 +781,7 @@ private:
     /** Stalling timeout for blocks in IBD */
     std::atomic<std::chrono::seconds> m_block_stalling_timeout{BLOCK_STALLING_TIMEOUT_DEFAULT};
 
-    bool AlreadyHaveTx(const GenTxid& gtxid)
+    bool AlreadyHaveTx(const GenTxid& gtxid, bool include_orphanage = true)
         EXCLUSIVE_LOCKS_REQUIRED(cs_main, !m_recent_confirmed_transactions_mutex);
 
     /**
@@ -1432,6 +1436,18 @@ void PeerManagerImpl::PushNodeVersion(CNode& pnode, const Peer& peer)
     }
 }
 
+void PeerManagerImpl::AddOrphanResolutionCandidate(NodeId nodeid, const uint256& orphan_wtxid, const CTransactionRef& orphan, std::chrono::microseconds current_time)
+{
+    AssertLockHeld(::cs_main);
+    const CNodeState* state = State(nodeid);
+    // Decide the TxRequestTracker parameters for this orphan resolution:
+    // - "preferred": if fPreferredDownload is set (= outbound, or NetPermissionFlags::NoBan permission)
+    // - "reqtime": current time
+    auto delay{0us};
+    const bool preferred = state->fPreferredDownload;
+    m_txpackagetracker->AddOrphanTx(nodeid, orphan_wtxid, orphan, preferred, current_time + delay);
+}
+
 void PeerManagerImpl::AddTxAnnouncement(const CNode& node, const GenTxid& gtxid, std::chrono::microseconds current_time)
 {
     AssertLockHeld(::cs_main); // For m_txrequest
@@ -2034,7 +2050,7 @@ void PeerManagerImpl::BlockChecked(const CBlock& block, const BlockValidationSta
 //
 
 
-bool PeerManagerImpl::AlreadyHaveTx(const GenTxid& gtxid)
+bool PeerManagerImpl::AlreadyHaveTx(const GenTxid& gtxid, bool include_orphanage)
 {
     if (m_chainman.ActiveChain().Tip()->GetBlockHash() != hashRecentRejectsChainTip) {
         // If the chain tip has changed previously rejected transactions
@@ -2047,7 +2063,7 @@ bool PeerManagerImpl::AlreadyHaveTx(const GenTxid& gtxid)
 
     const uint256& hash = gtxid.GetHash();
 
-    if (m_txpackagetracker->OrphanageHaveTx(gtxid)) return true;
+    if (include_orphanage && m_txpackagetracker->OrphanageHaveTx(gtxid)) return true;
 
     {
         LOCK(m_recent_confirmed_transactions_mutex);
@@ -2969,6 +2985,7 @@ bool PeerManagerImpl::ProcessOrphanTx(Peer& peer)
             for (const CTransactionRef& removedTx : result.m_replaced_transactions.value()) {
                 AddToCompactExtraTransactions(removedTx);
             }
+            m_txpackagetracker->FinalizeTransactions({porphanTx->GetWitnessHash()}, {});
             return true;
         } else if (state.GetResult() != TxValidationResult::TX_MISSING_INPUTS) {
             if (state.IsInvalid()) {
@@ -4182,6 +4199,7 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
             m_txrequest.ForgetTxHash(tx.GetHash());
             m_txrequest.ForgetTxHash(tx.GetWitnessHash());
             RelayTransaction(tx.GetHash(), tx.GetWitnessHash());
+            m_txpackagetracker->FinalizeTransactions({tx.GetWitnessHash()}, {});
             m_txpackagetracker->AddChildrenToWorkSet(tx);
 
             pfrom.m_last_tx_time = GetTime<std::chrono::seconds>();
@@ -4198,38 +4216,20 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
         else if (state.GetResult() == TxValidationResult::TX_MISSING_INPUTS)
         {
             bool fRejectedParents = false; // It may be the case that the orphans parents have all been rejected
-
-            // Deduplicate parent txids, so that we don't have to loop over
-            // the same parent txid more than once down below.
-            std::vector<uint256> unique_parents;
-            unique_parents.reserve(tx.vin.size());
-            for (const CTxIn& txin : tx.vin) {
-                // We start with all parents, and then remove duplicates below.
-                unique_parents.push_back(txin.prevout.hash);
-            }
-            std::sort(unique_parents.begin(), unique_parents.end());
-            unique_parents.erase(std::unique(unique_parents.begin(), unique_parents.end()), unique_parents.end());
-            for (const uint256& parent_txid : unique_parents) {
+            for (const auto& input : tx.vin) {
+                const auto& parent_txid = input.prevout.hash;
+                AddKnownTx(*peer, parent_txid);
                 if (m_recent_rejects.contains(parent_txid)) {
                     fRejectedParents = true;
                     break;
                 }
             }
             if (!fRejectedParents) {
+                const bool had_before{m_txpackagetracker->OrphanageHaveTx(GenTxid::Wtxid(ptx->GetWitnessHash()))};
                 const auto current_time{GetTime<std::chrono::microseconds>()};
+                AddOrphanResolutionCandidate(pfrom.GetId(), ptx->GetWitnessHash(), ptx, current_time);
 
-                for (const uint256& parent_txid : unique_parents) {
-                    // Here, we only have the txid (and not wtxid) of the
-                    // inputs, so we only request in txid mode, even for
-                    // wtxidrelay peers.
-                    // Eventually we should replace this with an improved
-                    // protocol for getting all unconfirmed parents.
-                    const auto gtxid{GenTxid::Txid(parent_txid)};
-                    AddKnownTx(*peer, parent_txid);
-                    if (!AlreadyHaveTx(gtxid)) AddTxAnnouncement(pfrom, gtxid, current_time);
-                }
-
-                if (m_txpackagetracker->OrphanageAddTx(ptx, pfrom.GetId())) {
+                if (!had_before && m_txpackagetracker->OrphanageHaveTx(GenTxid::Wtxid(ptx->GetWitnessHash()))) {
                     AddToCompactExtraTransactions(ptx);
                 }
 
@@ -5925,6 +5925,18 @@ bool PeerManagerImpl::SendMessages(CNode* pto)
             }
         }
 
+        auto requestable_orphans = m_txpackagetracker->GetOrphanRequests(pto->GetId(), current_time);
+        for (const auto& gtxid : requestable_orphans) {
+            if (AlreadyHaveTx(gtxid, /*include_orphanage=*/false)) {
+                m_txpackagetracker->FinalizeTransactions({gtxid.GetHash()}, {});
+            } else {
+                vGetData.emplace_back(MSG_TX | GetFetchFlags(*peer), gtxid.GetHash());
+                if (vGetData.size() >= MAX_GETDATA_SZ) {
+                    m_connman.PushMessage(pto, msgMaker.Make(NetMsgType::GETDATA, vGetData));
+                    vGetData.clear();
+                }
+            }
+        }
 
         if (!vGetData.empty())
             m_connman.PushMessage(pto, msgMaker.Make(NetMsgType::GETDATA, vGetData));

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1698,6 +1698,7 @@ bool PeerManagerImpl::GetNodeStateStats(NodeId nodeid, CNodeStateStats& stats) c
         stats.m_fee_filter_received = 0;
     }
 
+    stats.m_package_relay = peer->m_package_relay;
     stats.m_ping_wait = ping_wait;
     stats.m_addr_processed = peer->m_addr_processed.load();
     stats.m_addr_rate_limited = peer->m_addr_rate_limited.load();

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4441,7 +4441,7 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
             ProcessPackage(pfrom, std::get<node::TxPackageTracker::PackageToValidate>(result));
         } else {
             const auto& request_list{std::get<std::vector<uint256>>(result)};
-            if (!request_list.empty()) {
+            if (!request_list.empty() && request_list.size() < node::MAX_PKGTXNS_COUNT) {
                 if (m_txpackagetracker->PeerSupportsVersion(pfrom.GetId(), node::PKG_RELAY_PKGTXNS)) {
                     // If this peer supports it, request transactions in a batch so they can be
                     // submitted as a package without hitting the orphanage.

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -32,6 +32,7 @@ struct CNodeStateStats {
     std::chrono::microseconds m_ping_wait;
     std::vector<int> vHeightInFlight;
     bool m_relay_txs;
+    bool m_package_relay;
     CAmount m_fee_filter_received;
     uint64_t m_addr_processed = 0;
     uint64_t m_addr_rate_limited = 0;

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -45,7 +45,8 @@ class PeerManager : public CValidationInterface, public NetEventsInterface
 public:
     static std::unique_ptr<PeerManager> make(CConnman& connman, AddrMan& addrman,
                                              BanMan* banman, ChainstateManager& chainman,
-                                             CTxMemPool& pool, bool ignore_incoming_txs);
+                                             CTxMemPool& pool, bool ignore_incoming_txs,
+                                             bool enable_package_relay);
     virtual ~PeerManager() { }
 
     /**

--- a/src/node/txpackagetracker.cpp
+++ b/src/node/txpackagetracker.cpp
@@ -35,7 +35,6 @@ public:
     Impl() = default;
 
     // Orphanage Wrapper Functions
-    bool OrphanageAddTx(const CTransactionRef& tx, NodeId peer) { return m_orphanage.AddTx(tx, peer); }
     bool OrphanageHaveTx(const GenTxid& gtxid) { return m_orphanage.HaveTx(gtxid); }
     CTransactionRef GetTxToReconsider(NodeId peer) { return m_orphanage.GetTxToReconsider(peer); }
     int EraseOrphanTx(const uint256& txid) { return m_orphanage.EraseTx(txid); }
@@ -157,7 +156,6 @@ public:
 TxPackageTracker::TxPackageTracker() : m_impl{std::make_unique<TxPackageTracker::Impl>()} {}
 TxPackageTracker::~TxPackageTracker() = default;
 
-bool TxPackageTracker::OrphanageAddTx(const CTransactionRef& tx, NodeId peer) { return m_impl->OrphanageAddTx(tx, peer); }
 bool TxPackageTracker::OrphanageHaveTx(const GenTxid& gtxid) { return m_impl->OrphanageHaveTx(gtxid); }
 CTransactionRef TxPackageTracker::GetTxToReconsider(NodeId peer) { return m_impl->GetTxToReconsider(peer); }
 int TxPackageTracker::EraseOrphanTx(const uint256& txid) { return m_impl->EraseOrphanTx(txid); }

--- a/src/node/txpackagetracker.cpp
+++ b/src/node/txpackagetracker.cpp
@@ -39,6 +39,10 @@ class TxPackageTracker::Impl {
             return m_txrelay && m_wtxid_relay && m_sendpackages_received && m_versions_in_common != PKG_RELAY_NONE;
         }
     };
+    using PackageInfoRequestId = uint256;
+    PackageInfoRequestId GetPackageInfoRequestId(NodeId nodeid, const uint256& wtxid, uint32_t version) {
+        return (CHashWriter(SER_GETHASH, 0) << nodeid << wtxid << version).GetHash();
+    }
 
     struct PeerInfo {
         /** Whether this is an inbound peer. Affects how much of the orphanage we may protect for
@@ -62,12 +66,14 @@ class TxPackageTracker::Impl {
      * whether or not we relay packages with a peer. */
     std::map<NodeId, PeerInfo> info_per_peer GUARDED_BY(m_mutex);
 
-
     /** Tracks orphans for which we need to request ancestor information. All hashes stored are
      * wtxids, i.e., the wtxid of the orphan. However, the is_wtxid field is used to indicate
      * whether we would request the ancestor information by wtxid (via package relay) or by txid
      * (via prevouts of the missing inputs). */
     TxRequestTracker orphan_request_tracker GUARDED_BY(m_mutex);
+
+    /** Cache of package info requests sent. Used to identify unsolicited package info messages. */
+    CRollingBloomFilter packageinfo_requested GUARDED_BY(m_mutex){50000, 0.000001};
 
 public:
     Impl() = default;
@@ -158,14 +164,26 @@ public:
         // Skip if we weren't provided the tx and can't find the wtxid in the orphanage.
         if (tx == nullptr && !m_orphanage.HaveTx(GenTxid::Wtxid(wtxid))) return;
 
-        // Even though this stores the orphan wtxid, is_wtxid=false because we will be requesting the parents via txid.
-        orphan_request_tracker.ReceivedInv(nodeid, GenTxid::Txid(wtxid), is_preferred, reqtime);
+        // Skip if already requested in the (recent-ish) past.
+        if (packageinfo_requested.contains(GetPackageInfoRequestId(nodeid, wtxid, PKG_RELAY_ANCPKG))) return;
+
+        auto it_peer_info = info_per_peer.find(nodeid);
+        if (it_peer_info != info_per_peer.end() && it_peer_info->second.SupportsVersion(PKG_RELAY_ANCPKG)) {
+            // Package relay peer: is_wtxid=true because we will be requesting via ancpkginfo.
+            LogPrint(BCLog::TXPACKAGES, "\nPotential orphan resolution for %s from package relay peer=%d\n", wtxid.ToString(), nodeid);
+            orphan_request_tracker.ReceivedInv(nodeid, GenTxid::Wtxid(wtxid), is_preferred, reqtime);
+        } else {
+            // Even though this stores the orphan wtxid, is_wtxid=false because we will be requesting the parents via txid.
+            LogPrint(BCLog::TXPACKAGES, "\nPotential orphan resolution for %s from legacy peer=%d\n", wtxid.ToString(), nodeid);
+            orphan_request_tracker.ReceivedInv(nodeid, GenTxid::Txid(wtxid), is_preferred, reqtime);
+        }
 
         if (tx != nullptr) {
             m_orphanage.AddTx(tx, nodeid);
         } else {
             m_orphanage.AddTx(m_orphanage.GetTx(wtxid), nodeid);
         }
+
     }
     size_t CountInFlight(NodeId nodeid) const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
     {
@@ -195,36 +213,45 @@ public:
         }
         std::vector<GenTxid> results;
         for (const auto& gtxid : tracker_requestable) {
-            LogPrint(BCLog::TXPACKAGES, "\nResolving orphan %s, requesting by txids of parents from peer=%d\n", gtxid.GetHash().ToString(), nodeid);
-            const auto ptx = m_orphanage.GetTx(gtxid.GetHash());
-            if (!ptx) {
-                // We can't request ancpkginfo and we have no way of knowing what the missing
-                // parents are (it could also be that the orphan has already been resolved).
-                // Give up.
-                orphan_request_tracker.ForgetTxHash(gtxid.GetHash());
-                LogPrint(BCLog::TXPACKAGES, "\nForgetting orphan %s from peer=%d\n", gtxid.GetHash().ToString(), nodeid);
-                continue;
+            if (gtxid.IsWtxid()) {
+                Assume(info_per_peer.find(nodeid) != info_per_peer.end());
+                // Add the orphan's wtxid as-is.
+                LogPrint(BCLog::TXPACKAGES, "\nResolving orphan %s, requesting by ancpkginfo from peer=%d\n", gtxid.GetHash().ToString(), nodeid);
+                results.emplace_back(gtxid);
+                packageinfo_requested.insert(GetPackageInfoRequestId(nodeid, gtxid.GetHash(), PKG_RELAY_ANCPKG));
+                orphan_request_tracker.RequestedTx(nodeid, gtxid.GetHash(), current_time + ORPHAN_ANCESTOR_GETDATA_INTERVAL);
+            } else {
+                LogPrint(BCLog::TXPACKAGES, "\nResolving orphan %s, requesting by txids of parents from peer=%d\n", gtxid.GetHash().ToString(), nodeid);
+                const auto ptx = m_orphanage.GetTx(gtxid.GetHash());
+                if (!ptx) {
+                    // We can't request ancpkginfo and we have no way of knowing what the missing
+                    // parents are (it could also be that the orphan has already been resolved).
+                    // Give up.
+                    orphan_request_tracker.ForgetTxHash(gtxid.GetHash());
+                    LogPrint(BCLog::TXPACKAGES, "\nForgetting orphan %s from peer=%d\n", gtxid.GetHash().ToString(), nodeid);
+                    continue;
+                }
+                // Add the orphan's parents. Net processing will filter out what we already have.
+                // Deduplicate parent txids, so that we don't have to loop over
+                // the same parent txid more than once down below.
+                std::vector<uint256> unique_parents;
+                unique_parents.reserve(ptx->vin.size());
+                for (const auto& txin : ptx->vin) {
+                    // We start with all parents, and then remove duplicates below.
+                    unique_parents.push_back(txin.prevout.hash);
+                }
+                std::sort(unique_parents.begin(), unique_parents.end());
+                unique_parents.erase(std::unique(unique_parents.begin(), unique_parents.end()), unique_parents.end());
+                for (const auto& txid : unique_parents) {
+                    results.emplace_back(GenTxid::Txid(txid));
+                }
+                // Mark the orphan as requested. Limitation: we aren't tracking these txids in
+                // relation to the orphan's wtxid anywhere. If we get a NOTFOUND for the parent(s),
+                // we won't automatically know that it corresponds to this orphan (i.e. won't be
+                // able to call ReceivedResponse()). We will need to wait until it expires before
+                // requesting from somebody else.
+                orphan_request_tracker.RequestedTx(nodeid, gtxid.GetHash(), current_time + ORPHAN_ANCESTOR_GETDATA_INTERVAL);
             }
-            // Add the orphan's parents. Net processing will filter out what we already have.
-            // Deduplicate parent txids, so that we don't have to loop over
-            // the same parent txid more than once down below.
-            std::vector<uint256> unique_parents;
-            unique_parents.reserve(ptx->vin.size());
-            for (const auto& txin : ptx->vin) {
-                // We start with all parents, and then remove duplicates below.
-                unique_parents.push_back(txin.prevout.hash);
-            }
-            std::sort(unique_parents.begin(), unique_parents.end());
-            unique_parents.erase(std::unique(unique_parents.begin(), unique_parents.end()), unique_parents.end());
-            for (const auto& txid : unique_parents) {
-                results.emplace_back(GenTxid::Txid(txid));
-            }
-            // Mark the orphan as requested. Limitation: we aren't tracking these txids in
-            // relation to the orphan's wtxid anywhere. If we get a NOTFOUND for the parent(s),
-            // we won't automatically know that it corresponds to this orphan (i.e. won't be
-            // able to call ReceivedResponse()). We will need to wait until it expires before
-            // requesting from somebody else.
-            orphan_request_tracker.RequestedTx(nodeid, gtxid.GetHash(), current_time + ORPHAN_ANCESTOR_GETDATA_INTERVAL);
         }
         if (!results.empty()) LogPrint(BCLog::TXPACKAGES, "\nRequesting %u items from peer=%d\n", results.size(), nodeid);
         return results;
@@ -240,6 +267,31 @@ public:
             orphan_request_tracker.ForgetTxHash(wtxid);
         }
     }
+    bool PkgInfoAllowed(NodeId nodeid, const uint256& wtxid, PackageRelayVersions version) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
+    {
+        AssertLockNotHeld(m_mutex);
+        LOCK(m_mutex);
+        auto peerinfo_it = info_per_peer.find(nodeid);
+        if (peerinfo_it == info_per_peer.end()) {
+            return false;
+        } else if (!peerinfo_it->second.SupportsVersion(version)) {
+            return false;
+        }
+        if (!packageinfo_requested.contains(GetPackageInfoRequestId(nodeid, wtxid, version))) {
+            return false;
+        }
+        orphan_request_tracker.ReceivedResponse(nodeid, wtxid);
+        return true;
+    }
+    void ForgetPkgInfo(NodeId nodeid, const uint256& rep_wtxid, PackageRelayVersions pkginfo_version) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
+    {
+        AssertLockNotHeld(m_mutex);
+        LOCK(m_mutex);
+        if (pkginfo_version == PKG_RELAY_ANCPKG) {
+            orphan_request_tracker.ReceivedResponse(nodeid, rep_wtxid);
+        }
+    }
+
 };
 
 TxPackageTracker::TxPackageTracker() : m_impl{std::make_unique<TxPackageTracker::Impl>()} {}
@@ -272,5 +324,13 @@ std::vector<GenTxid> TxPackageTracker::GetOrphanRequests(NodeId nodeid, std::chr
 void TxPackageTracker::FinalizeTransactions(const std::set<uint256>& valid, const std::set<uint256>& invalid)
 {
     m_impl->FinalizeTransactions(valid, invalid);
+}
+bool TxPackageTracker::PkgInfoAllowed(NodeId nodeid, const uint256& wtxid, PackageRelayVersions version)
+{
+    return m_impl->PkgInfoAllowed(nodeid, wtxid, version);
+}
+void TxPackageTracker::ForgetPkgInfo(NodeId nodeid, const uint256& rep_wtxid, PackageRelayVersions pkginfo_version)
+{
+    m_impl->ForgetPkgInfo(nodeid, rep_wtxid, pkginfo_version);
 }
 } // namespace node

--- a/src/node/txpackagetracker.cpp
+++ b/src/node/txpackagetracker.cpp
@@ -1,0 +1,14 @@
+// Copyright (c) 2022
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <node/txpackagetracker.h>
+
+namespace node {
+class TxPackageTracker::Impl {
+};
+
+TxPackageTracker::TxPackageTracker() : m_impl{std::make_unique<TxPackageTracker::Impl>()} {}
+TxPackageTracker::~TxPackageTracker() = default;
+
+} // namespace node

--- a/src/node/txpackagetracker.cpp
+++ b/src/node/txpackagetracker.cpp
@@ -4,12 +4,33 @@
 
 #include <node/txpackagetracker.h>
 
+#include <common/bloom.h>
+#include <logging.h>
 #include <txorphanage.h>
+#include <txrequest.h>
+#include <util/hasher.h>
 
 namespace node {
+    /** How long to wait before requesting orphan ancpkginfo/parents from an additional peer.
+     * Same as GETDATA_TX_INTERVAL. */
+    static constexpr auto ORPHAN_ANCESTOR_GETDATA_INTERVAL{60s};
+
+    /** Delay to add if an orphan resolution candidate is already using a lot of memory in the
+     * orphanage. */
+    static constexpr auto ORPHANAGE_OVERLOAD_DELAY{1s};
+
 class TxPackageTracker::Impl {
     /** Manages unvalidated tx data (orphan transactions for which we are downloading ancestors). */
     TxOrphanage m_orphanage;
+
+    mutable Mutex m_mutex;
+
+    /** Tracks orphans for which we need to request ancestor information. All hashes stored are
+     * wtxids, i.e., the wtxid of the orphan. However, the is_wtxid field is used to indicate
+     * whether we would request the ancestor information by wtxid (via package relay) or by txid
+     * (via prevouts of the missing inputs). */
+    TxRequestTracker orphan_request_tracker GUARDED_BY(m_mutex);
+
 public:
     Impl() = default;
 
@@ -18,14 +39,119 @@ public:
     bool OrphanageHaveTx(const GenTxid& gtxid) { return m_orphanage.HaveTx(gtxid); }
     CTransactionRef GetTxToReconsider(NodeId peer) { return m_orphanage.GetTxToReconsider(peer); }
     int EraseOrphanTx(const uint256& txid) { return m_orphanage.EraseTx(txid); }
-    void DisconnectedPeer(NodeId peer) {
-        m_orphanage.EraseForPeer(peer);
+    void DisconnectedPeer(NodeId nodeid) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
+    {
+        AssertLockNotHeld(m_mutex);
+        LOCK(m_mutex);
+        orphan_request_tracker.DisconnectedPeer(nodeid);
+        m_orphanage.EraseForPeer(nodeid);
     }
-    void BlockConnected(const CBlock& block) { m_orphanage.EraseForBlock(block); }
+    void BlockConnected(const CBlock& block) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
+    {
+        AssertLockNotHeld(m_mutex);
+        const auto wtxids_erased{m_orphanage.EraseForBlock(block)};
+        std::set<uint256> block_wtxids;
+        std::set<uint256> conflicted_wtxids;
+        for (const CTransactionRef& ptx : block.vtx) {
+            block_wtxids.insert(ptx->GetWitnessHash());
+        }
+        for (const auto& wtxid : wtxids_erased) {
+            if (block_wtxids.count(wtxid) == 0) {
+                conflicted_wtxids.insert(wtxid);
+            }
+        }
+        FinalizeTransactions(block_wtxids, conflicted_wtxids);
+    }
     void LimitOrphans(unsigned int max_orphans) { m_orphanage.LimitOrphans(max_orphans); }
     void AddChildrenToWorkSet(const CTransaction& tx) { m_orphanage.AddChildrenToWorkSet(tx); }
     bool HaveTxToReconsider(NodeId peer) { return m_orphanage.HaveTxToReconsider(peer); }
     size_t OrphanageSize() { return m_orphanage.Size(); }
+    void AddOrphanTx(NodeId nodeid, const uint256& wtxid, const CTransactionRef& tx, bool is_preferred, std::chrono::microseconds reqtime)
+        EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
+    {
+        AssertLockNotHeld(m_mutex);
+        LOCK(m_mutex);
+        // Skip if we weren't provided the tx and can't find the wtxid in the orphanage.
+        if (tx == nullptr && !m_orphanage.HaveTx(GenTxid::Wtxid(wtxid))) return;
+
+        // Even though this stores the orphan wtxid, is_wtxid=false because we will be requesting the parents via txid.
+        orphan_request_tracker.ReceivedInv(nodeid, GenTxid::Txid(wtxid), is_preferred, reqtime);
+
+        if (tx != nullptr) {
+            m_orphanage.AddTx(tx, nodeid);
+        } else {
+            m_orphanage.AddTx(m_orphanage.GetTx(wtxid), nodeid);
+        }
+    }
+    size_t CountInFlight(NodeId nodeid) const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
+    {
+        AssertLockNotHeld(m_mutex);
+        LOCK(m_mutex);
+        auto count{orphan_request_tracker.CountInFlight(nodeid)};
+        return count;
+    }
+    size_t Count(NodeId nodeid) const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
+    {
+        AssertLockNotHeld(m_mutex);
+        LOCK(m_mutex);
+        auto count{orphan_request_tracker.Count(nodeid)};
+        return count;
+    }
+
+    std::vector<GenTxid> GetOrphanRequests(NodeId nodeid, std::chrono::microseconds current_time)
+        EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
+    {
+        AssertLockNotHeld(m_mutex);
+        LOCK(m_mutex);
+        std::vector<std::pair<NodeId, GenTxid>> expired;
+        auto tracker_requestable = orphan_request_tracker.GetRequestable(nodeid, current_time, &expired);
+        for (const auto& entry : expired) {
+            LogPrint(BCLog::TXPACKAGES, "\nTimeout of inflight %s %s from peer=%d\n", entry.second.IsWtxid() ? "ancpkginfo" : "orphan parent",
+                entry.second.GetHash().ToString(), entry.first);
+        }
+        std::vector<GenTxid> results;
+        for (const auto& gtxid : tracker_requestable) {
+            LogPrint(BCLog::TXPACKAGES, "\nResolving orphan %s, requesting by txids of parents from peer=%d\n", gtxid.GetHash().ToString(), nodeid);
+            const auto ptx = m_orphanage.GetTx(gtxid.GetHash());
+            if (!ptx) {
+                // We can't request ancpkginfo and we have no way of knowing what the missing
+                // parents are (it could also be that the orphan has already been resolved).
+                // Give up.
+                orphan_request_tracker.ForgetTxHash(gtxid.GetHash());
+                LogPrint(BCLog::TXPACKAGES, "\nForgetting orphan %s from peer=%d\n", gtxid.GetHash().ToString(), nodeid);
+                continue;
+            }
+            // Add the orphan's parents. Net processing will filter out what we already have.
+            // Deduplicate parent txids, so that we don't have to loop over
+            // the same parent txid more than once down below.
+            std::vector<uint256> unique_parents;
+            unique_parents.reserve(ptx->vin.size());
+            for (const auto& txin : ptx->vin) {
+                // We start with all parents, and then remove duplicates below.
+                unique_parents.push_back(txin.prevout.hash);
+            }
+            std::sort(unique_parents.begin(), unique_parents.end());
+            unique_parents.erase(std::unique(unique_parents.begin(), unique_parents.end()), unique_parents.end());
+            for (const auto& txid : unique_parents) {
+                results.emplace_back(GenTxid::Txid(txid));
+            }
+            // Mark the orphan as requested
+            orphan_request_tracker.RequestedTx(nodeid, gtxid.GetHash(), current_time + ORPHAN_ANCESTOR_GETDATA_INTERVAL);
+        }
+        if (!results.empty()) LogPrint(BCLog::TXPACKAGES, "\nRequesting %u items from peer=%d\n", results.size(), nodeid);
+        return results;
+    }
+    void FinalizeTransactions(const std::set<uint256>& valid, const std::set<uint256>& invalid) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
+    {
+        AssertLockNotHeld(m_mutex);
+        LOCK(m_mutex);
+        for (const auto& wtxid : valid) {
+            orphan_request_tracker.ForgetTxHash(wtxid);
+        }
+        for (const auto& wtxid : invalid) {
+            orphan_request_tracker.ForgetTxHash(wtxid);
+        }
+    }
 };
 
 TxPackageTracker::TxPackageTracker() : m_impl{std::make_unique<TxPackageTracker::Impl>()} {}
@@ -41,4 +167,17 @@ void TxPackageTracker::LimitOrphans(unsigned int max_orphans) { m_impl->LimitOrp
 void TxPackageTracker::AddChildrenToWorkSet(const CTransaction& tx) { m_impl->AddChildrenToWorkSet(tx); }
 bool TxPackageTracker::HaveTxToReconsider(NodeId peer) { return m_impl->HaveTxToReconsider(peer); }
 size_t TxPackageTracker::OrphanageSize() { return m_impl->OrphanageSize(); }
+void TxPackageTracker::AddOrphanTx(NodeId nodeid, const uint256& wtxid, const CTransactionRef& tx, bool is_preferred, std::chrono::microseconds reqtime)
+{
+    m_impl->AddOrphanTx(nodeid, wtxid, tx, is_preferred, reqtime);
+}
+size_t TxPackageTracker::CountInFlight(NodeId nodeid) const { return m_impl->CountInFlight(nodeid); }
+size_t TxPackageTracker::Count(NodeId nodeid) const { return m_impl->Count(nodeid); }
+std::vector<GenTxid> TxPackageTracker::GetOrphanRequests(NodeId nodeid, std::chrono::microseconds current_time) {
+    return m_impl->GetOrphanRequests(nodeid, current_time);
+}
+void TxPackageTracker::FinalizeTransactions(const std::set<uint256>& valid, const std::set<uint256>& invalid)
+{
+    m_impl->FinalizeTransactions(valid, invalid);
+}
 } // namespace node

--- a/src/node/txpackagetracker.cpp
+++ b/src/node/txpackagetracker.cpp
@@ -4,11 +4,41 @@
 
 #include <node/txpackagetracker.h>
 
+#include <txorphanage.h>
+
 namespace node {
 class TxPackageTracker::Impl {
+    /** Manages unvalidated tx data (orphan transactions for which we are downloading ancestors). */
+    TxOrphanage m_orphanage;
+public:
+    Impl() = default;
+
+    // Orphanage Wrapper Functions
+    bool OrphanageAddTx(const CTransactionRef& tx, NodeId peer) { return m_orphanage.AddTx(tx, peer); }
+    bool OrphanageHaveTx(const GenTxid& gtxid) { return m_orphanage.HaveTx(gtxid); }
+    CTransactionRef GetTxToReconsider(NodeId peer) { return m_orphanage.GetTxToReconsider(peer); }
+    int EraseOrphanTx(const uint256& txid) { return m_orphanage.EraseTx(txid); }
+    void DisconnectedPeer(NodeId peer) {
+        m_orphanage.EraseForPeer(peer);
+    }
+    void BlockConnected(const CBlock& block) { m_orphanage.EraseForBlock(block); }
+    void LimitOrphans(unsigned int max_orphans) { m_orphanage.LimitOrphans(max_orphans); }
+    void AddChildrenToWorkSet(const CTransaction& tx) { m_orphanage.AddChildrenToWorkSet(tx); }
+    bool HaveTxToReconsider(NodeId peer) { return m_orphanage.HaveTxToReconsider(peer); }
+    size_t OrphanageSize() { return m_orphanage.Size(); }
 };
 
 TxPackageTracker::TxPackageTracker() : m_impl{std::make_unique<TxPackageTracker::Impl>()} {}
 TxPackageTracker::~TxPackageTracker() = default;
 
+bool TxPackageTracker::OrphanageAddTx(const CTransactionRef& tx, NodeId peer) { return m_impl->OrphanageAddTx(tx, peer); }
+bool TxPackageTracker::OrphanageHaveTx(const GenTxid& gtxid) { return m_impl->OrphanageHaveTx(gtxid); }
+CTransactionRef TxPackageTracker::GetTxToReconsider(NodeId peer) { return m_impl->GetTxToReconsider(peer); }
+int TxPackageTracker::EraseOrphanTx(const uint256& txid) { return m_impl->EraseOrphanTx(txid); }
+void TxPackageTracker::DisconnectedPeer(NodeId peer) { m_impl->DisconnectedPeer(peer); }
+void TxPackageTracker::BlockConnected(const CBlock& block) { m_impl->BlockConnected(block); }
+void TxPackageTracker::LimitOrphans(unsigned int max_orphans) { m_impl->LimitOrphans(max_orphans); }
+void TxPackageTracker::AddChildrenToWorkSet(const CTransaction& tx) { m_impl->AddChildrenToWorkSet(tx); }
+bool TxPackageTracker::HaveTxToReconsider(NodeId peer) { return m_impl->HaveTxToReconsider(peer); }
+size_t TxPackageTracker::OrphanageSize() { return m_impl->OrphanageSize(); }
 } // namespace node

--- a/src/node/txpackagetracker.cpp
+++ b/src/node/txpackagetracker.cpp
@@ -134,7 +134,11 @@ public:
             for (const auto& txid : unique_parents) {
                 results.emplace_back(GenTxid::Txid(txid));
             }
-            // Mark the orphan as requested
+            // Mark the orphan as requested. Limitation: we aren't tracking these txids in
+            // relation to the orphan's wtxid anywhere. If we get a NOTFOUND for the parent(s),
+            // we won't automatically know that it corresponds to this orphan (i.e. won't be
+            // able to call ReceivedResponse()). We will need to wait until it expires before
+            // requesting from somebody else.
             orphan_request_tracker.RequestedTx(nodeid, gtxid.GetHash(), current_time + ORPHAN_ANCESTOR_GETDATA_INTERVAL);
         }
         if (!results.empty()) LogPrint(BCLog::TXPACKAGES, "\nRequesting %u items from peer=%d\n", results.size(), nodeid);

--- a/src/node/txpackagetracker.h
+++ b/src/node/txpackagetracker.h
@@ -15,6 +15,12 @@ class CBlock;
 class TxOrphanage;
 namespace node {
 static constexpr bool DEFAULT_ENABLE_PACKAGE_RELAY{false};
+static constexpr size_t MAX_PKGTXNS_COUNT{100};
+enum PackageRelayVersions : uint64_t {
+    PKG_RELAY_NONE = 0,
+    // BIP331 Ancestor Package Information
+    PKG_RELAY_ANCPKG = (1 << 0),
+};
 
 class TxPackageTracker {
     class Impl;
@@ -55,6 +61,14 @@ public:
 
     /** Return how many entries exist in the orphange */
     size_t OrphanageSize();
+
+    PackageRelayVersions GetSupportedVersions() const;
+
+    // We expect this to be called only once
+    void ReceivedVersion(NodeId nodeid);
+    void ReceivedSendpackages(NodeId nodeid, PackageRelayVersions versions);
+    // Finalize the registration state.
+    bool ReceivedVerack(NodeId nodeid, bool inbound, bool txrelay, bool wtxidrelay);
 
     /** Received an announcement from this peer for a tx we already know is an orphan; should be
      * called for every peer that announces the tx, even if they are not a package relay peer.

--- a/src/node/txpackagetracker.h
+++ b/src/node/txpackagetracker.h
@@ -100,6 +100,16 @@ public:
      * Should not be called when a tx fails validation.
      * */
     void FinalizeTransactions(const std::set<uint256>& valid, const std::set<uint256>& invalid);
+
+    /** Whether a package info message is allowed (version-agnostic):
+     * - We agreed to relay packages of this version with this peer.
+     * - We solicited this package info somewhat recently.
+     * Returns false if the message is not allowed and the peer should be disconnected. */
+    bool PkgInfoAllowed(NodeId nodeid, const uint256& wtxid, PackageRelayVersions version);
+
+    /** Record receipt of a notfound message for pkginfo. */
+    void ForgetPkgInfo(NodeId nodeid, const uint256& rep_wtxid, PackageRelayVersions pkginfo_version);
+
 };
 } // namespace node
 #endif // BITCOIN_NODE_TXPACKAGETRACKER_H

--- a/src/node/txpackagetracker.h
+++ b/src/node/txpackagetracker.h
@@ -20,8 +20,8 @@ static constexpr size_t MAX_PKGTXNS_COUNT{100};
 enum PackageRelayVersions : uint64_t {
     PKG_RELAY_NONE = 0,
     // BIP331 Ancestor Package Information
-    PKG_RELAY_ANCPKG = (1 << 0),
-    PKG_RELAY_PKGTXNS = (1 << 1),
+    PKG_RELAY_ANCPKG = (1 << 1),
+    PKG_RELAY_PKGTXNS = (1 << 0),
 };
 
 class TxPackageTracker {

--- a/src/node/txpackagetracker.h
+++ b/src/node/txpackagetracker.h
@@ -25,9 +25,6 @@ public:
     ~TxPackageTracker();
 
     // Orphanage wrapper functions
-    /** Add new tx to orphanage if it isn't already there. Returns whether the tx was added. */
-    bool OrphanageAddTx(const CTransactionRef& tx, NodeId peer);
-
     /** Check if we already have an orphan transaction (by txid or wtxid) */
     bool OrphanageHaveTx(const GenTxid& gtxid);
 

--- a/src/node/txpackagetracker.h
+++ b/src/node/txpackagetracker.h
@@ -21,6 +21,7 @@ enum PackageRelayVersions : uint64_t {
     PKG_RELAY_NONE = 0,
     // BIP331 Ancestor Package Information
     PKG_RELAY_ANCPKG = (1 << 0),
+    PKG_RELAY_PKGTXNS = (1 << 1),
 };
 
 class TxPackageTracker {
@@ -70,6 +71,9 @@ public:
     void ReceivedSendpackages(NodeId nodeid, PackageRelayVersions versions);
     // Finalize the registration state.
     bool ReceivedVerack(NodeId nodeid, bool inbound, bool txrelay, bool wtxidrelay);
+
+    /** Whether the peer supports any of these versions of package relay. */
+    bool PeerSupportsVersion(NodeId nodeid, PackageRelayVersions versions) const;
 
     /** Received an announcement from this peer for a tx we already know is an orphan; should be
      * called for every peer that announces the tx, even if they are not a package relay peer.

--- a/src/node/txpackagetracker.h
+++ b/src/node/txpackagetracker.h
@@ -11,6 +11,7 @@
 #include <map>
 #include <vector>
 
+class TxOrphanage;
 namespace node {
 static constexpr bool DEFAULT_ENABLE_PACKAGE_RELAY{false};
 
@@ -21,6 +22,42 @@ class TxPackageTracker {
 public:
     explicit TxPackageTracker();
     ~TxPackageTracker();
+
+    // Orphanage wrapper functions
+    /** Add new tx to orphanage if it isn't already there. Returns whether the tx was added. */
+    bool OrphanageAddTx(const CTransactionRef& tx, NodeId peer);
+
+    /** Check if we already have an orphan transaction (by txid or wtxid) */
+    bool OrphanageHaveTx(const GenTxid& gtxid);
+
+    /** Extract a transaction from a peer's work set
+     *  Returns nullptr if there are no transactions to work on.
+     *  Otherwise returns the transaction reference, and removes
+     *  it from the work set.
+     */
+    CTransactionRef GetTxToReconsider(NodeId peer);
+
+    /** Erase an orphan by txid */
+    int EraseOrphanTx(const uint256& txid);
+
+    /** Erase all orphans announced by a peer (eg, after that peer disconnects) */
+    void DisconnectedPeer(NodeId peer);
+
+    /** Erase all orphans included in or invalidated by a new block */
+    void BlockConnected(const CBlock& block);
+
+    /** Limit the orphanage to the given maximum */
+    void LimitOrphans(unsigned int max_orphans);
+
+    /** Add any orphans that list a particular tx as a parent into the from peer's work set */
+    void AddChildrenToWorkSet(const CTransaction& tx);
+
+    /** Does this peer have any orphans to validate? */
+    bool HaveTxToReconsider(NodeId peer);
+
+    /** Return how many entries exist in the orphange */
+    size_t OrphanageSize();
+
 };
 } // namespace node
 #endif // BITCOIN_NODE_TXPACKAGETRACKER_H

--- a/src/node/txpackagetracker.h
+++ b/src/node/txpackagetracker.h
@@ -141,6 +141,13 @@ public:
                                                                              const uint256& rep_wtxid,
                                                                              const std::vector<std::pair<uint256, bool>>& txdata_status,
                                                                              std::chrono::microseconds expiry);
+    /** Record receipt of notfound message for pkgtxns. */
+    void ReceivedNotFound(NodeId nodeid, const uint256& hash);
+
+    /** If there is a package that is missing this tx data, updates the PendingPackage and
+     * returns a PackageToValidate including the other txdata stored in the orphanage.
+     */
+    std::optional<PackageToValidate> ReceivedPkgTxns(NodeId nodeid, const std::vector<CTransactionRef>& package_txns);
 };
 } // namespace node
 #endif // BITCOIN_NODE_TXPACKAGETRACKER_H

--- a/src/node/txpackagetracker.h
+++ b/src/node/txpackagetracker.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_NODE_TXPACKAGETRACKER_H
+#define BITCOIN_NODE_TXPACKAGETRACKER_H
+
+#include <net.h>
+
+#include <cstdint>
+#include <map>
+#include <vector>
+
+namespace node {
+static constexpr bool DEFAULT_ENABLE_PACKAGE_RELAY{false};
+
+class TxPackageTracker {
+    class Impl;
+    const std::unique_ptr<Impl> m_impl;
+
+public:
+    explicit TxPackageTracker();
+    ~TxPackageTracker();
+};
+} // namespace node
+#endif // BITCOIN_NODE_TXPACKAGETRACKER_H

--- a/src/policy/packages.cpp
+++ b/src/policy/packages.cpp
@@ -51,7 +51,7 @@ bool IsConsistent(const Package& txns)
     return true;
 }
 
-bool IsPackageWellFormed(const Package& txns, PackageValidationState& state)
+bool IsPackageWellFormed(const Package& txns, PackageValidationState& state, bool require_sorted)
 {
     const unsigned int package_count = txns.size();
 
@@ -70,7 +70,7 @@ bool IsPackageWellFormed(const Package& txns, PackageValidationState& state)
     // An unsorted package will fail anyway on missing-inputs, but it's better to quit earlier and
     // fail on something less ambiguous (missing-inputs could also be an orphan or trying to
     // spend nonexistent coins).
-    if (!IsSorted(txns)) return state.Invalid(PackageValidationResult::PCKG_POLICY, "package-not-sorted");
+    if (require_sorted && !IsSorted(txns)) return state.Invalid(PackageValidationResult::PCKG_POLICY, "package-not-sorted");
     if (!IsConsistent(txns)) return state.Invalid(PackageValidationResult::PCKG_POLICY, "conflict-in-package");
     return true;
 }

--- a/src/policy/packages.cpp
+++ b/src/policy/packages.cpp
@@ -15,6 +15,43 @@
 #include <numeric>
 #include <unordered_set>
 
+bool IsSorted(const Package& txns)
+{
+    std::unordered_set<uint256, SaltedTxidHasher> later_txids;
+    std::transform(txns.cbegin(), txns.cend(), std::inserter(later_txids, later_txids.end()),
+                   [](const auto& tx) { return tx->GetHash(); });
+    for (const auto& tx : txns) {
+        for (const auto& input : tx->vin) {
+            if (later_txids.find(input.prevout.hash) != later_txids.end()) {
+                // The parent is a subsequent transaction in the package.
+                return false;
+            }
+        }
+        later_txids.erase(tx->GetHash());
+    }
+    return true;
+}
+
+bool IsConsistent(const Package& txns)
+{
+    // Don't allow any conflicting transactions, i.e. spending the same inputs, in a package.
+    std::unordered_set<COutPoint, SaltedOutpointHasher> inputs_seen;
+    for (const auto& tx : txns) {
+        for (const auto& input : tx->vin) {
+            if (inputs_seen.find(input.prevout) != inputs_seen.end()) {
+                // This input is also present in another tx in the package.
+                return false;
+            }
+        }
+        // Batch-add all the inputs for a tx at a time. If we added them 1 at a time, we could
+        // catch duplicate inputs within a single tx.  This is a more severe, consensus error,
+        // and we want to report that from CheckTransaction instead.
+        std::transform(tx->vin.cbegin(), tx->vin.cend(), std::inserter(inputs_seen, inputs_seen.end()),
+                       [](const auto& input) { return input.prevout; });
+    }
+    return true;
+}
+
 bool CheckPackage(const Package& txns, PackageValidationState& state)
 {
     const unsigned int package_count = txns.size();
@@ -34,34 +71,8 @@ bool CheckPackage(const Package& txns, PackageValidationState& state)
     // An unsorted package will fail anyway on missing-inputs, but it's better to quit earlier and
     // fail on something less ambiguous (missing-inputs could also be an orphan or trying to
     // spend nonexistent coins).
-    std::unordered_set<uint256, SaltedTxidHasher> later_txids;
-    std::transform(txns.cbegin(), txns.cend(), std::inserter(later_txids, later_txids.end()),
-                   [](const auto& tx) { return tx->GetHash(); });
-    for (const auto& tx : txns) {
-        for (const auto& input : tx->vin) {
-            if (later_txids.find(input.prevout.hash) != later_txids.end()) {
-                // The parent is a subsequent transaction in the package.
-                return state.Invalid(PackageValidationResult::PCKG_POLICY, "package-not-sorted");
-            }
-        }
-        later_txids.erase(tx->GetHash());
-    }
-
-    // Don't allow any conflicting transactions, i.e. spending the same inputs, in a package.
-    std::unordered_set<COutPoint, SaltedOutpointHasher> inputs_seen;
-    for (const auto& tx : txns) {
-        for (const auto& input : tx->vin) {
-            if (inputs_seen.find(input.prevout) != inputs_seen.end()) {
-                // This input is also present in another tx in the package.
-                return state.Invalid(PackageValidationResult::PCKG_POLICY, "conflict-in-package");
-            }
-        }
-        // Batch-add all the inputs for a tx at a time. If we added them 1 at a time, we could
-        // catch duplicate inputs within a single tx.  This is a more severe, consensus error,
-        // and we want to report that from CheckTransaction instead.
-        std::transform(tx->vin.cbegin(), tx->vin.cend(), std::inserter(inputs_seen, inputs_seen.end()),
-                       [](const auto& input) { return input.prevout; });
-    }
+    if (!IsSorted(txns)) return state.Invalid(PackageValidationResult::PCKG_POLICY, "package-not-sorted");
+    if (!IsConsistent(txns)) return state.Invalid(PackageValidationResult::PCKG_POLICY, "conflict-in-package");
     return true;
 }
 

--- a/src/policy/packages.cpp
+++ b/src/policy/packages.cpp
@@ -5,7 +5,7 @@
 #include <policy/packages.h>
 #include <policy/policy.h>
 #include <primitives/transaction.h>
-#include <uint256.h>
+#include <util/check.h>
 #include <util/hasher.h>
 
 #include <algorithm>
@@ -13,7 +13,6 @@
 #include <iterator>
 #include <memory>
 #include <numeric>
-#include <unordered_set>
 
 bool IsSorted(const Package& txns)
 {
@@ -60,7 +59,7 @@ bool IsPackageWellFormed(const Package& txns, PackageValidationState& state)
         return state.Invalid(PackageValidationResult::PCKG_POLICY, "package-too-many-transactions");
     }
 
-    const int64_t total_size = std::accumulate(txns.cbegin(), txns.cend(), 0,
+    const int64_t total_size = std::accumulate(txns.cbegin(), txns.cend(), int64_t{0},
                                [](int64_t sum, const auto& tx) { return sum + GetVirtualTransactionSize(*tx); });
     // If the package only contains 1 tx, it's better to report the policy violation on individual tx size.
     if (package_count > 1 && total_size > MAX_PACKAGE_SIZE * 1000) {
@@ -91,4 +90,93 @@ bool IsChildWithParents(const Package& package)
     // Every transaction must be a parent of the last transaction in the package.
     return std::all_of(package.cbegin(), package.cend() - 1,
                        [&input_txids](const auto& ptx) { return input_txids.count(ptx->GetHash()) > 0; });
+}
+
+// Calculates curr_tx's in-package ancestor set. If the tx spends another tx in the package, calls
+// visit() for that transaction first, since any transaction's ancestor set includes its parents'
+// ancestor sets. Transaction dependency cycles are not possible without breaking sha256 and
+// duplicate transactions were checked in the AncestorPackage() ctor, so this won't recurse infinitely.
+// After this function returns, curr_tx is guaranteed to be in the ancestor_subsets map.
+void AncestorPackage::visit(const CTransactionRef& curr_tx)
+{
+    const uint256& curr_txid = curr_tx->GetHash();
+    if (ancestor_subsets.count(curr_txid) > 0) return;
+    std::set<uint256> my_ancestors;
+    my_ancestors.insert(curr_txid);
+    for (const auto& input : curr_tx->vin) {
+        auto parent_tx = txid_to_tx.find(input.prevout.hash);
+        if (parent_tx == txid_to_tx.end()) continue;
+        if (ancestor_subsets.count(parent_tx->first) == 0) {
+            visit(parent_tx->second);
+        }
+        auto parent_ancestor_set = ancestor_subsets.find(parent_tx->first);
+        my_ancestors.insert(parent_ancestor_set->second.cbegin(), parent_ancestor_set->second.cend());
+    }
+    ancestor_subsets.insert(std::make_pair(curr_txid, my_ancestors));
+}
+
+AncestorPackage::AncestorPackage(const Package& txns_in)
+{
+    // Duplicate transactions are not allowed, as they will result in infinite visit() recursion.
+    Assume(IsConsistent(txns_in));
+    if (txns_in.empty() || !IsConsistent(txns_in)) return;
+    // Populate txid_to_tx for quick lookup
+    std::transform(txns_in.cbegin(), txns_in.cend(), std::inserter(txid_to_tx, txid_to_tx.end()),
+            [](const auto& tx) { return std::make_pair(tx->GetHash(), tx); });
+    // DFS-based algorithm to sort transactions by ancestor count and populate ancestor_subsets cache.
+    // Best case runtime is if the package is already sorted and no recursive calls happen.
+    // Exclusion from ancestor_subsets is equivalent to not yet being fully processed.
+    size_t i{0};
+    while (ancestor_subsets.size() < txns_in.size() && i < txns_in.size()) {
+        const auto& tx = txns_in[i];
+        if (ancestor_subsets.count(tx->GetHash()) == 0) visit(tx);
+        Assume(ancestor_subsets.count(tx->GetHash()) == 1);
+        ++i;
+    }
+    txns = txns_in;
+    // Sort by the number of in-package ancestors.
+    std::sort(txns.begin(), txns.end(), [&](const CTransactionRef& a, const CTransactionRef& b) -> bool {
+        auto a_ancestors = ancestor_subsets.find(a->GetHash());
+        auto b_ancestors = ancestor_subsets.find(b->GetHash());
+        return a_ancestors->second.size() < b_ancestors->second.size();
+    });
+    Assume(IsSorted(txns));
+    Assume(ancestor_subsets.find(txns.back()->GetHash()) != ancestor_subsets.end());
+    is_ancestor_package = ancestor_subsets.find(txns.back()->GetHash())->second.size() == txns.size();
+}
+
+std::optional<std::vector<CTransactionRef>> AncestorPackage::GetAncestorSet(const CTransactionRef& tx)
+{
+    auto ancestor_set = ancestor_subsets.find(tx->GetHash());
+    if (ancestor_set == ancestor_subsets.end()) return std::nullopt;
+    std::vector<CTransactionRef> result;
+    for (const auto& txid : ancestor_set->second) {
+        if (banned_txns.find(txid) != banned_txns.end()) {
+            return std::nullopt;
+        }
+    }
+    result.reserve(ancestor_set->second.size());
+    for (const auto& txid : ancestor_set->second) {
+        auto it = txid_to_tx.find(txid);
+        if (excluded_txns.find(txid) == excluded_txns.end()) {
+            result.push_back(it->second);
+        }
+    }
+    std::sort(result.begin(), result.end(), [&](const CTransactionRef& a, const CTransactionRef& b) -> bool {
+        auto a_ancestors = ancestor_subsets.find(a->GetHash());
+        auto b_ancestors = ancestor_subsets.find(b->GetHash());
+        return a_ancestors->second.size() < b_ancestors->second.size();
+    });
+    return result;
+}
+
+void AncestorPackage::Exclude(const CTransactionRef& transaction)
+{
+    if (ancestor_subsets.count(transaction->GetHash()) == 0) return;
+    excluded_txns.insert(transaction->GetHash());
+}
+void AncestorPackage::Ban(const CTransactionRef& transaction)
+{
+    if (ancestor_subsets.count(transaction->GetHash()) == 0) return;
+    banned_txns.insert(transaction->GetHash());
 }

--- a/src/policy/packages.cpp
+++ b/src/policy/packages.cpp
@@ -52,7 +52,7 @@ bool IsConsistent(const Package& txns)
     return true;
 }
 
-bool CheckPackage(const Package& txns, PackageValidationState& state)
+bool IsPackageWellFormed(const Package& txns, PackageValidationState& state)
 {
     const unsigned int package_count = txns.size();
 

--- a/src/policy/packages.cpp
+++ b/src/policy/packages.cpp
@@ -180,3 +180,17 @@ void AncestorPackage::Ban(const CTransactionRef& transaction)
     if (ancestor_subsets.count(transaction->GetHash()) == 0) return;
     banned_txns.insert(transaction->GetHash());
 }
+
+uint256 GetCombinedHash(const std::vector<uint256>& wtxids)
+{
+    std::vector<uint256> wtxids_copy(wtxids.cbegin(), wtxids.cend());
+    std::sort(wtxids_copy.begin(), wtxids_copy.end());
+    return (HashWriter() << wtxids_copy).GetHash();
+}
+uint256 GetPackageHash(const std::vector<CTransactionRef>& transactions)
+{
+    std::vector<uint256> wtxids_copy;
+    std::transform(transactions.cbegin(), transactions.cend(), std::back_inserter(wtxids_copy),
+        [](const auto& tx){ return tx->GetWitnessHash(); });
+    return GetCombinedHash(wtxids_copy);
+}

--- a/src/policy/packages.cpp
+++ b/src/policy/packages.cpp
@@ -185,7 +185,7 @@ uint256 GetCombinedHash(const std::vector<uint256>& wtxids)
 {
     std::vector<uint256> wtxids_copy(wtxids.cbegin(), wtxids.cend());
     std::sort(wtxids_copy.begin(), wtxids_copy.end());
-    return (HashWriter() << wtxids_copy).GetHash();
+    return (HashWriter() << wtxids_copy).GetSHA256();
 }
 uint256 GetPackageHash(const std::vector<CTransactionRef>& transactions)
 {

--- a/src/policy/packages.h
+++ b/src/policy/packages.h
@@ -9,8 +9,11 @@
 #include <consensus/validation.h>
 #include <policy/policy.h>
 #include <primitives/transaction.h>
+#include <uint256.h>
+#include <util/hasher.h>
 
 #include <cstdint>
+#include <unordered_set>
 #include <vector>
 
 /** Default maximum number of transactions in a package. */
@@ -73,4 +76,60 @@ bool IsPackageWellFormed(const Package& txns, PackageValidationState& state);
  */
 bool IsChildWithParents(const Package& package);
 
+/** A potential BIP331 Ancestor Package, i.e. one transaction with its set of ancestors.
+ * This class does not have any knowledge of chainstate, so it cannot determine whether all
+ * unconfirmed ancestors are present. Its constructor accepts any list of transactions that
+ * IsConsistent(), sorts them topologically (accessible through Txns()), and determines whether it
+ * IsAncestorPackage(). GetAncestorSet() can be used to get a transaction's "subpackage," i.e.
+ * ancestor set within the package. Exclude() should be called when a transaction is in
+ * the mempool so that it can be excluded from other transactions' subpackages. Ban() should be
+ * called when a transaction is invalid and all of its descendants should be considered invalid as
+ * well; GetAncestorSet() will then return std::nullopt for those descendants.
+ * */
+class AncestorPackage
+{
+    /** Whether txns contains a connected package in which all transactions are ancestors of the
+     * last transaction. This object is not aware of chainstate. So if txns only includes a
+     * grandparent and not the "connecting" parent, this will (incorrectly) determine that the
+     * grandparent is not an ancestor.
+     * */
+    bool is_ancestor_package{false};
+    /** Transactions sorted topologically (see IsSorted()). */
+    Package txns;
+    /** Map from txid to transaction for quick lookup. */
+    std::map<uint256, CTransactionRef> txid_to_tx;
+    /** Cache of the in-package ancestors for each transaction, indexed by txid. */
+    std::map<uint256, std::set<uint256>> ancestor_subsets;
+    /** Txids of transactions to exclude when returning ancestor subsets.*/
+    std::unordered_set<uint256, SaltedTxidHasher> excluded_txns;
+    /** Txids of transactions that are banned. Return nullopt from GetAncestorSet() if it contains
+     * any of these transactions.*/
+    std::unordered_set<uint256, SaltedTxidHasher> banned_txns;
+
+    /** Helper function for recursively constructing ancestor caches in ctor. */
+    void visit(const CTransactionRef&);
+public:
+    /** Constructs ancestor package, sorting the transactions topologically and constructing the
+     * txid_to_tx and ancestor_subsets maps. It is ok if the input txns is not sorted.
+     * Expects:
+     * - No duplicate transactions.
+     * - No conflicts between transactions.
+     * - txns is of reasonable size (e.g. below MAX_PACKAGE_COUNT) to limit recursion depth
+     */
+    AncestorPackage(const Package& txns);
+
+    bool IsAncestorPackage() const { return is_ancestor_package; }
+    /** Returns the transactions, in ascending order of number of in-package ancestors. */
+    Package Txns() const { return txns; }
+    /** Get the ancestor subpackage for a tx, sorted so that ancestors appear before descendants.
+     * The list includes the tx. If this transaction is not part of this package or it depends on a
+     * Banned tx, returns std::nullopt. If one or more ancestors have been Excluded, they will not
+     * appear in the result. */
+    std::optional<std::vector<CTransactionRef>> GetAncestorSet(const CTransactionRef& tx);
+    /** From now on, exclude this tx from any result in GetAncestorSet(). Does not affect Txns(). */
+    void Exclude(const CTransactionRef& transaction);
+    /** Mark a transaction as "banned." From now on, if this transaction is present in the ancestor
+     * set, GetAncestorSet() should return std::nullopt for that tx. Does not affect Txns(). */
+    void Ban(const CTransactionRef& transaction);
+};
 #endif // BITCOIN_POLICY_PACKAGES_H

--- a/src/policy/packages.h
+++ b/src/policy/packages.h
@@ -65,7 +65,7 @@ bool IsConsistent(const Package& txns);
  * 3. If any dependencies exist between transactions, parents must appear before children.
  * 4. Transactions cannot conflict, i.e., spend the same inputs.
  */
-bool CheckPackage(const Package& txns, PackageValidationState& state);
+bool IsPackageWellFormed(const Package& txns, PackageValidationState& state);
 
 /** Context-free check that a package is exactly one child and its parents; not all parents need to
  * be present, but the package must not contain any transactions that are not the child's parents.

--- a/src/policy/packages.h
+++ b/src/policy/packages.h
@@ -68,7 +68,7 @@ bool IsConsistent(const Package& txns);
  * 3. If any dependencies exist between transactions, parents must appear before children.
  * 4. Transactions cannot conflict, i.e., spend the same inputs.
  */
-bool IsPackageWellFormed(const Package& txns, PackageValidationState& state);
+bool IsPackageWellFormed(const Package& txns, PackageValidationState& state, bool require_sorted);
 
 /** Context-free check that a package is exactly one child and its parents; not all parents need to
  * be present, but the package must not contain any transactions that are not the child's parents.

--- a/src/policy/packages.h
+++ b/src/policy/packages.h
@@ -45,6 +45,20 @@ using Package = std::vector<CTransactionRef>;
 
 class PackageValidationState : public ValidationState<PackageValidationResult> {};
 
+/** If any direct dependencies exist between transactions (i.e. a child spending the output of a
+ * parent), checks that all parents appear somewhere in the list before their respective children.
+ * This function cannot detect indirect dependencies (e.g. a transaction's grandparent if its parent
+ * is not present).
+ * @returns true if sorted. False if any tx spends the output of a tx that appears later in txns.
+ */
+bool IsSorted(const Package& txns);
+
+/** Checks that none of the transactions conflict, i.e., spend the same prevout. Consequently also
+ * checks that there are no duplicate transactions.
+ * @returns true if there are no conflicts. False if any two transactions spend the same prevout.
+ * */
+bool IsConsistent(const Package& txns);
+
 /** Context-free package policy checks:
  * 1. The number of transactions cannot exceed MAX_PACKAGE_COUNT.
  * 2. The total virtual size cannot exceed MAX_PACKAGE_SIZE.

--- a/src/policy/packages.h
+++ b/src/policy/packages.h
@@ -132,4 +132,11 @@ public:
      * set, GetAncestorSet() should return std::nullopt for that tx. Does not affect Txns(). */
     void Ban(const CTransactionRef& transaction);
 };
+
+
+/** Get the hash of these wtxids, concatenated in lexicographical order. */
+uint256 GetCombinedHash(const std::vector<uint256>& wtxids);
+/** Get the hash of these transactions' wtxids, concatenated in lexicographical order. */
+uint256 GetPackageHash(const std::vector<CTransactionRef>& transactions);
+
 #endif // BITCOIN_POLICY_PACKAGES_H

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -48,6 +48,7 @@ const char *CFCHECKPT="cfcheckpt";
 const char *WTXIDRELAY="wtxidrelay";
 const char *SENDTXRCNCL="sendtxrcncl";
 const char *SENDPACKAGES="sendpackages";
+const char *ANCPKGINFO="ancpkginfo";
 } // namespace NetMsgType
 
 /** All known message types. Keep this in the same order as the list of
@@ -90,6 +91,7 @@ const static std::string allNetMessageTypes[] = {
     NetMsgType::WTXIDRELAY,
     NetMsgType::SENDTXRCNCL,
     NetMsgType::SENDPACKAGES,
+    NetMsgType::ANCPKGINFO,
 };
 const static std::vector<std::string> allNetMessageTypesVec(std::begin(allNetMessageTypes), std::end(allNetMessageTypes));
 
@@ -168,6 +170,7 @@ std::string CInv::GetCommand() const
     case MSG_BLOCK:          return cmd.append(NetMsgType::BLOCK);
     case MSG_FILTERED_BLOCK: return cmd.append(NetMsgType::MERKLEBLOCK);
     case MSG_CMPCT_BLOCK:    return cmd.append(NetMsgType::CMPCTBLOCK);
+    case MSG_ANCPKGINFO:     return cmd.append(NetMsgType::ANCPKGINFO);
     default:
         throw std::out_of_range(strprintf("CInv::GetCommand(): type=%d unknown type", type));
     }
@@ -223,6 +226,6 @@ std::vector<std::string> serviceFlagsToStr(uint64_t flags)
 
 GenTxid ToGenTxid(const CInv& inv)
 {
-    assert(inv.IsGenTxMsg());
-    return inv.IsMsgWtx() ? GenTxid::Wtxid(inv.hash) : GenTxid::Txid(inv.hash);
+    assert(inv.IsGenTxMsg() || inv.IsMsgAncPkgInfo());
+    return (inv.IsMsgWtx() || inv.IsMsgAncPkgInfo()) ? GenTxid::Wtxid(inv.hash) : GenTxid::Txid(inv.hash);
 }

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -49,6 +49,8 @@ const char *WTXIDRELAY="wtxidrelay";
 const char *SENDTXRCNCL="sendtxrcncl";
 const char *SENDPACKAGES="sendpackages";
 const char *ANCPKGINFO="ancpkginfo";
+const char *GETPKGTXNS="getpkgtxns";
+const char *PKGTXNS="pkgtxns";
 } // namespace NetMsgType
 
 /** All known message types. Keep this in the same order as the list of
@@ -92,6 +94,8 @@ const static std::string allNetMessageTypes[] = {
     NetMsgType::SENDTXRCNCL,
     NetMsgType::SENDPACKAGES,
     NetMsgType::ANCPKGINFO,
+    NetMsgType::GETPKGTXNS,
+    NetMsgType::PKGTXNS,
 };
 const static std::vector<std::string> allNetMessageTypesVec(std::begin(allNetMessageTypes), std::end(allNetMessageTypes));
 

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -47,6 +47,7 @@ const char *GETCFCHECKPT="getcfcheckpt";
 const char *CFCHECKPT="cfcheckpt";
 const char *WTXIDRELAY="wtxidrelay";
 const char *SENDTXRCNCL="sendtxrcncl";
+const char *SENDPACKAGES="sendpackages";
 } // namespace NetMsgType
 
 /** All known message types. Keep this in the same order as the list of
@@ -88,6 +89,7 @@ const static std::string allNetMessageTypes[] = {
     NetMsgType::CFCHECKPT,
     NetMsgType::WTXIDRELAY,
     NetMsgType::SENDTXRCNCL,
+    NetMsgType::SENDPACKAGES,
 };
 const static std::vector<std::string> allNetMessageTypesVec(std::begin(allNetMessageTypes), std::end(allNetMessageTypes));
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -265,6 +265,10 @@ extern const char* WTXIDRELAY;
  * txreconciliation, as described by BIP 330.
  */
 extern const char* SENDTXRCNCL;
+/**
+ * Indicates that a node wants to relay packages, described in BIP 331.
+ */
+extern const char* SENDPACKAGES;
 }; // namespace NetMsgType
 
 /* Get a vector of all valid message types (see above) */

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -269,6 +269,8 @@ extern const char* SENDTXRCNCL;
  * Indicates that a node wants to relay packages, described in BIP 331.
  */
 extern const char* SENDPACKAGES;
+/** List of wtxids corresponding to a transaction's ancestor package. */
+extern const char* ANCPKGINFO;
 }; // namespace NetMsgType
 
 /* Get a vector of all valid message types (see above) */
@@ -474,6 +476,7 @@ enum GetDataMsg : uint32_t {
     // MSG_FILTERED_WITNESS_BLOCK is defined in BIP144 as reserved for future
     // use and remains unused.
     // MSG_FILTERED_WITNESS_BLOCK = MSG_FILTERED_BLOCK | MSG_WITNESS_FLAG,
+    MSG_ANCPKGINFO = 7,                              //!< Defined in BIP331
 };
 
 /** inv message data */
@@ -497,6 +500,7 @@ public:
     bool IsMsgFilteredBlk() const { return type == MSG_FILTERED_BLOCK; }
     bool IsMsgCmpctBlk() const { return type == MSG_CMPCT_BLOCK; }
     bool IsMsgWitnessBlk() const { return type == MSG_WITNESS_BLOCK; }
+    bool IsMsgAncPkgInfo() const { return type == MSG_ANCPKGINFO; }
 
     // Combined-message helper methods
     bool IsGenTxMsg() const

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -271,6 +271,14 @@ extern const char* SENDTXRCNCL;
 extern const char* SENDPACKAGES;
 /** List of wtxids corresponding to a transaction's ancestor package. */
 extern const char* ANCPKGINFO;
+/**
+ * Requests all or none of a list of transactions, specified by wtxid.
+ */
+extern const char* GETPKGTXNS;
+/**
+ * List of transactions.
+ */
+extern const char* PKGTXNS;
 }; // namespace NetMsgType
 
 /* Get a vector of all valid message types (see above) */
@@ -476,6 +484,7 @@ enum GetDataMsg : uint32_t {
     // MSG_FILTERED_WITNESS_BLOCK is defined in BIP144 as reserved for future
     // use and remains unused.
     // MSG_FILTERED_WITNESS_BLOCK = MSG_FILTERED_BLOCK | MSG_WITNESS_FLAG,
+    MSG_PKGTXNS = 6,                                 //!< Defined in BIP331
     MSG_ANCPKGINFO = 7,                              //!< Defined in BIP331
 };
 
@@ -501,6 +510,7 @@ public:
     bool IsMsgCmpctBlk() const { return type == MSG_CMPCT_BLOCK; }
     bool IsMsgWitnessBlk() const { return type == MSG_WITNESS_BLOCK; }
     bool IsMsgAncPkgInfo() const { return type == MSG_ANCPKGINFO; }
+    bool IsMsgPkgTxns() const { return type == MSG_PKGTXNS; }
 
     // Combined-message helper methods
     bool IsGenTxMsg() const

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -759,11 +759,10 @@ static RPCHelpMan savemempool()
 static RPCHelpMan submitpackage()
 {
     return RPCHelpMan{"submitpackage",
-        "Submit a package of raw transactions (serialized, hex-encoded) to local node (-regtest only).\n"
+        "Submit a package of raw transactions (serialized, hex-encoded) to local node.\n"
         "The package will be validated according to consensus and mempool policy rules. If all transactions pass, they will be accepted to mempool.\n"
         "This RPC is experimental and the interface may be unstable. Refer to doc/policy/packages.md for documentation on package policies.\n"
-        "Warning: until package relay is in use, successful submission does not mean the transaction will propagate to other nodes on the network.\n"
-        "Currently, each transaction is broadcasted individually after submission, which means they must meet other nodes' feerate requirements alone.\n"
+        "Warning: successful submission does not mean the transactions will propagate throughout the network.\n"
         ,
         {
             {"package", RPCArg::Type::ARR, RPCArg::Optional::NO, "An array of raw transactions.",
@@ -802,9 +801,6 @@ static RPCHelpMan submitpackage()
         },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
         {
-            if (!Params().IsMockableChain()) {
-                throw std::runtime_error("submitpackage is for regression testing (-regtest mode) only");
-            }
             const UniValue raw_transactions = request.params[0].get_array();
             if (raw_transactions.size() < 1 || raw_transactions.size() > MAX_PACKAGE_COUNT) {
                 throw JSONRPCError(RPC_INVALID_PARAMETER,
@@ -922,7 +918,7 @@ void RegisterMempoolRPCCommands(CRPCTable& t)
         {"blockchain", &getmempoolinfo},
         {"blockchain", &getrawmempool},
         {"blockchain", &savemempool},
-        {"hidden", &submitpackage},
+        {"rawtransactions", &submitpackage},
     };
     for (const auto& c : commands) {
         t.appendCommand(c.name, &c);

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -116,6 +116,7 @@ static RPCHelpMan getpeerinfo()
                         {RPCResult::Type::STR, "SERVICE_NAME", "the service name if it is recognised"}
                     }},
                     {RPCResult::Type::BOOL, "relaytxes", "Whether we relay transactions to this peer"},
+                    {RPCResult::Type::BOOL, "relaytxpackages", "Whether we relay packages with this peer"},
                     {RPCResult::Type::NUM_TIME, "lastsend", "The " + UNIX_EPOCH_TIME + " of the last send"},
                     {RPCResult::Type::NUM_TIME, "lastrecv", "The " + UNIX_EPOCH_TIME + " of the last receive"},
                     {RPCResult::Type::NUM_TIME, "last_transaction", "The " + UNIX_EPOCH_TIME + " of the last valid transaction received from this peer"},
@@ -244,6 +245,7 @@ static RPCHelpMan getpeerinfo()
             heights.push_back(height);
         }
         obj.pushKV("inflight", heights);
+        obj.pushKV("relaytxpackages", statestats.m_package_relay);
         obj.pushKV("addr_relay_enabled", statestats.m_addr_relay_enabled);
         obj.pushKV("addr_processed", statestats.m_addr_processed);
         obj.pushKV("addr_rate_limited", statestats.m_addr_rate_limited);

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -132,7 +132,7 @@ BOOST_AUTO_TEST_CASE(stale_tip_peer_management)
     NodeId id{0};
     auto connman = std::make_unique<ConnmanTestMsg>(0x1337, 0x1337, *m_node.addrman, *m_node.netgroupman);
     auto peerLogic = PeerManager::make(*connman, *m_node.addrman, nullptr,
-                                       *m_node.chainman, *m_node.mempool, false);
+                                       *m_node.chainman, *m_node.mempool, false, false);
 
     constexpr int max_outbound_full_relay = MAX_OUTBOUND_FULL_RELAY_CONNECTIONS;
     CConnman::Options options;
@@ -209,7 +209,7 @@ BOOST_AUTO_TEST_CASE(block_relay_only_eviction)
     NodeId id{0};
     auto connman = std::make_unique<ConnmanTestMsg>(0x1337, 0x1337, *m_node.addrman, *m_node.netgroupman);
     auto peerLogic = PeerManager::make(*connman, *m_node.addrman, nullptr,
-                                       *m_node.chainman, *m_node.mempool, false);
+                                       *m_node.chainman, *m_node.mempool, false, false);
 
     constexpr int max_outbound_block_relay{MAX_BLOCK_RELAY_ONLY_CONNECTIONS};
     constexpr int64_t MINIMUM_CONNECT_TIME{30};
@@ -273,7 +273,7 @@ BOOST_AUTO_TEST_CASE(peer_discouragement)
     auto banman = std::make_unique<BanMan>(m_args.GetDataDirBase() / "banlist", nullptr, DEFAULT_MISBEHAVING_BANTIME);
     auto connman = std::make_unique<ConnmanTestMsg>(0x1337, 0x1337, *m_node.addrman, *m_node.netgroupman);
     auto peerLogic = PeerManager::make(*connman, *m_node.addrman, banman.get(),
-                                       *m_node.chainman, *m_node.mempool, false);
+                                       *m_node.chainman, *m_node.mempool, false, false);
 
     CNetAddr tor_netaddr;
     BOOST_REQUIRE(
@@ -376,7 +376,7 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
     auto banman = std::make_unique<BanMan>(m_args.GetDataDirBase() / "banlist", nullptr, DEFAULT_MISBEHAVING_BANTIME);
     auto connman = std::make_unique<CConnman>(0x1337, 0x1337, *m_node.addrman, *m_node.netgroupman);
     auto peerLogic = PeerManager::make(*connman, *m_node.addrman, banman.get(),
-                                       *m_node.chainman, *m_node.mempool, false);
+                                       *m_node.chainman, *m_node.mempool, false, false);
 
     banman->ClearBanned();
     int64_t nStartTime = GetTime();

--- a/src/test/fuzz/ancestorpackage.cpp
+++ b/src/test/fuzz/ancestorpackage.cpp
@@ -1,0 +1,55 @@
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+#include <test/util/script.h>
+#include <test/util/setup_common.h>
+
+#include <policy/packages.h>
+
+#include <set>
+#include <vector>
+
+namespace {
+FUZZ_TARGET(ancestorpackage)
+{
+    FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
+    std::vector<CTransactionRef> txns_in;
+    // Avoid repeat coins, as they may cause transactions to conflict
+    std::set<COutPoint> available_coins;
+    for (auto i{0}; i < 100; ++i) {
+        if (auto mtx{ConsumeDeserializable<CMutableTransaction>(fuzzed_data_provider)}) {
+            available_coins.insert(COutPoint{MakeTransactionRef(*mtx)->GetHash(), 0});
+        }
+    }
+    LIMITED_WHILE(!available_coins.empty(), 50)
+    {
+        CMutableTransaction mtx = CMutableTransaction();
+        const size_t num_inputs = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(1, available_coins.size());
+        const size_t num_outputs = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(1, 50);
+        for (size_t n{0}; n < num_inputs; ++n) {
+            auto prevout = available_coins.begin();
+            mtx.vin.push_back(CTxIn(*prevout, CScript()));
+            available_coins.erase(prevout);
+        }
+        for (uint32_t n{0}; n < num_outputs; ++n) {
+            mtx.vout.push_back(CTxOut(100, P2WSH_OP_TRUE));
+        }
+        CTransactionRef tx = MakeTransactionRef(mtx);
+        txns_in.push_back(tx);
+        // Make outputs available to spend
+        for (uint32_t n{0}; n < num_outputs; ++n) {
+            COutPoint new_coin{tx->GetHash(), n};
+            if (fuzzed_data_provider.ConsumeBool()) {
+                available_coins.insert(new_coin);
+            }
+        }
+    }
+    AncestorPackage packageified(txns_in);
+    assert(IsSorted(packageified.Txns()));
+    if (packageified.IsAncestorPackage()) {
+        for (const auto& tx : packageified.Txns()) {
+            assert(IsSorted(*packageified.GetAncestorSet(tx)));
+        }
+    }
+}
+} // namespace

--- a/src/test/txpackage_tests.cpp
+++ b/src/test/txpackage_tests.cpp
@@ -48,7 +48,7 @@ BOOST_FIXTURE_TEST_CASE(package_sanitization_tests, TestChain100Setup)
         package_too_many.emplace_back(create_placeholder_tx(1, 1));
     }
     PackageValidationState state_too_many;
-    BOOST_CHECK(!CheckPackage(package_too_many, state_too_many));
+    BOOST_CHECK(!IsPackageWellFormed(package_too_many, state_too_many));
     BOOST_CHECK_EQUAL(state_too_many.GetResult(), PackageValidationResult::PCKG_POLICY);
     BOOST_CHECK_EQUAL(state_too_many.GetRejectReason(), "package-too-many-transactions");
 
@@ -63,7 +63,7 @@ BOOST_FIXTURE_TEST_CASE(package_sanitization_tests, TestChain100Setup)
     }
     BOOST_CHECK(package_too_large.size() <= MAX_PACKAGE_COUNT);
     PackageValidationState state_too_large;
-    BOOST_CHECK(!CheckPackage(package_too_large, state_too_large));
+    BOOST_CHECK(!IsPackageWellFormed(package_too_large, state_too_large));
     BOOST_CHECK_EQUAL(state_too_large.GetResult(), PackageValidationResult::PCKG_POLICY);
     BOOST_CHECK_EQUAL(state_too_large.GetRejectReason(), "package-too-large");
 }
@@ -147,8 +147,8 @@ BOOST_FIXTURE_TEST_CASE(noncontextual_package_tests, TestChain100Setup)
         CTransactionRef tx_child = MakeTransactionRef(mtx_child);
 
         PackageValidationState state;
-        BOOST_CHECK(CheckPackage({tx_parent, tx_child}, state));
-        BOOST_CHECK(!CheckPackage({tx_child, tx_parent}, state));
+        BOOST_CHECK(IsPackageWellFormed({tx_parent, tx_child}, state));
+        BOOST_CHECK(!IsPackageWellFormed({tx_child, tx_parent}, state));
         BOOST_CHECK_EQUAL(state.GetResult(), PackageValidationResult::PCKG_POLICY);
         BOOST_CHECK_EQUAL(state.GetRejectReason(), "package-not-sorted");
         BOOST_CHECK(IsChildWithParents({tx_parent, tx_child}));
@@ -175,7 +175,7 @@ BOOST_FIXTURE_TEST_CASE(noncontextual_package_tests, TestChain100Setup)
         package.push_back(MakeTransactionRef(child));
 
         PackageValidationState state;
-        BOOST_CHECK(CheckPackage(package, state));
+        BOOST_CHECK(IsPackageWellFormed(package, state));
         BOOST_CHECK(IsChildWithParents(package));
 
         package.erase(package.begin());
@@ -211,8 +211,8 @@ BOOST_FIXTURE_TEST_CASE(noncontextual_package_tests, TestChain100Setup)
         BOOST_CHECK(IsChildWithParents({tx_parent, tx_parent_also_child, tx_child}));
         // IsChildWithParents does not detect unsorted parents.
         BOOST_CHECK(IsChildWithParents({tx_parent_also_child, tx_parent, tx_child}));
-        BOOST_CHECK(CheckPackage({tx_parent, tx_parent_also_child, tx_child}, state));
-        BOOST_CHECK(!CheckPackage({tx_parent_also_child, tx_parent, tx_child}, state));
+        BOOST_CHECK(IsPackageWellFormed({tx_parent, tx_parent_also_child, tx_child}, state));
+        BOOST_CHECK(!IsPackageWellFormed({tx_parent_also_child, tx_parent, tx_child}, state));
         BOOST_CHECK_EQUAL(state.GetResult(), PackageValidationResult::PCKG_POLICY);
         BOOST_CHECK_EQUAL(state.GetRejectReason(), "package-not-sorted");
     }

--- a/src/test/txpackage_tests.cpp
+++ b/src/test/txpackage_tests.cpp
@@ -908,18 +908,20 @@ BOOST_FIXTURE_TEST_CASE(package_cpfp_tests, TestChain100Setup)
         expected_pool_size += 1;
         BOOST_CHECK_MESSAGE(submit_rich_parent.m_state.IsInvalid(), "Package validation unexpectedly succeeded");
 
-        // The child would have been validated on its own and failed, then submitted as a "package" of 1.
+        // The child would have been validated on its own and failed.
         BOOST_CHECK_EQUAL(submit_rich_parent.m_state.GetResult(), PackageValidationResult::PCKG_TX);
         BOOST_CHECK_EQUAL(submit_rich_parent.m_state.GetRejectReason(), "transaction failed");
 
         auto it_parent = submit_rich_parent.m_tx_results.find(tx_parent_rich->GetWitnessHash());
+        auto it_child = submit_rich_parent.m_tx_results.find(tx_child_poor->GetWitnessHash());
         BOOST_CHECK(it_parent != submit_rich_parent.m_tx_results.end());
+        BOOST_CHECK(it_child != submit_rich_parent.m_tx_results.end());
         BOOST_CHECK(it_parent->second.m_result_type == MempoolAcceptResult::ResultType::VALID);
+        BOOST_CHECK(it_child->second.m_result_type == MempoolAcceptResult::ResultType::INVALID);
         BOOST_CHECK(it_parent->second.m_state.GetRejectReason() == "");
         BOOST_CHECK_MESSAGE(it_parent->second.m_base_fees.value() == high_parent_fee,
                 strprintf("rich parent: expected fee %s, got %s", high_parent_fee, it_parent->second.m_base_fees.value()));
         BOOST_CHECK(it_parent->second.m_effective_feerate == CFeeRate(high_parent_fee, GetVirtualTransactionSize(*tx_parent_rich)));
-        auto it_child = submit_rich_parent.m_tx_results.find(tx_child_poor->GetWitnessHash());
         BOOST_CHECK(it_child != submit_rich_parent.m_tx_results.end());
         BOOST_CHECK_EQUAL(it_child->second.m_result_type, MempoolAcceptResult::ResultType::INVALID);
         BOOST_CHECK_EQUAL(it_child->second.m_state.GetResult(), TxValidationResult::TX_MEMPOOL_POLICY);

--- a/src/test/txpackage_tests.cpp
+++ b/src/test/txpackage_tests.cpp
@@ -450,7 +450,56 @@ BOOST_FIXTURE_TEST_CASE(package_submission_tests, TestChain100Setup)
         BOOST_CHECK_EQUAL(it_parent->second.m_state.GetResult(), TxValidationResult::TX_WITNESS_MUTATED);
         BOOST_CHECK_EQUAL(it_parent->second.m_state.GetRejectReason(), "bad-witness-nonstandard");
         BOOST_CHECK_EQUAL(it_child->second.m_state.GetResult(), TxValidationResult::TX_MISSING_INPUTS);
-        BOOST_CHECK_EQUAL(it_child->second.m_state.GetRejectReason(), "bad-txns-inputs-missingorspent");
+        BOOST_CHECK_EQUAL(it_child->second.m_state.GetRejectReason(), "invalid-tx-dependency");
+    }
+
+    // Check that validation isn't quitting *too* early.
+    // This package has a child with 2 parents. Parent1 has a consensus issue, while Parent2 is
+    // valid and has a high feerate (can be accepted by itself). Parent1 and the child would be
+    // rejected, and Parent2 should be accepted. Otherwise, anybody could censor a transaction like
+    // Parent2 by broadcasting it in a package similar to this one.
+    {
+        // premature coinbase spend (consensus error)
+        auto tx_parent1_bad{MakeTransactionRef(CreateValidMempoolTransaction(/*input_transaction=*/m_coinbase_txns[99],
+                                                                             /*input_vout=*/0,
+                                                                             /*input_height=*/102,
+                                                                             /*input_signing_key=*/coinbaseKey,
+                                                                             /*output_destination=*/parent_locking_script,
+                                                                             /*output_amount=*/ 24 * COIN,
+                                                                             /*submit=*/false))};
+        auto tx_parent2_good{MakeTransactionRef(CreateValidMempoolTransaction(/*input_transaction=*/m_coinbase_txns[50],
+                                                                             /*input_vout=*/0,
+                                                                             /*input_height=*/102,
+                                                                             /*input_signing_key=*/coinbaseKey,
+                                                                             /*output_destination=*/parent_locking_script,
+                                                                             /*output_amount=*/ 24 * COIN,
+                                                                             /*submit=*/false))};
+        auto tx_child_quit_early{MakeTransactionRef(CreateValidMempoolTransaction(/*input_transactions=*/{tx_parent1_bad, tx_parent2_good},
+                                                                                  /*inputs=*/{COutPoint{tx_parent1_bad->GetHash(), 0},
+                                                                                              COutPoint{tx_parent2_good->GetHash(), 0}},
+                                                                                  /*input_height=*/102,
+                                                                                  /*input_signing_keys=*/{parent_key},
+                                                                                  /*outputs=*/{CTxOut{23*COIN, child_locking_script}},
+                                                                                  /*submit=*/false))};
+        Package package_quit_too_early{tx_parent1_bad, tx_parent2_good, tx_child_quit_early};
+        auto result_quit_too_early = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                       package_quit_too_early, /*test_accept=*/ false);
+        expected_pool_size += 1;
+        BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
+        BOOST_CHECK(result_quit_too_early.m_state.IsInvalid());
+        BOOST_CHECK_EQUAL(result_quit_too_early.m_state.GetResult(), PackageValidationResult::PCKG_TX);
+        BOOST_CHECK_EQUAL(result_quit_too_early.m_tx_results.size(), 3);
+        BOOST_CHECK(m_node.mempool->exists(GenTxid::Txid(tx_parent2_good->GetHash())));
+        BOOST_CHECK(!m_node.mempool->exists(GenTxid::Txid(tx_parent1_bad->GetHash())));
+        BOOST_CHECK(!m_node.mempool->exists(GenTxid::Txid(tx_child_quit_early->GetHash())));
+        auto it_parent1 = result_quit_too_early.m_tx_results.find(tx_parent1_bad->GetWitnessHash());
+        auto it_parent2 = result_quit_too_early.m_tx_results.find(tx_parent2_good->GetWitnessHash());
+        auto it_child = result_quit_too_early.m_tx_results.find(tx_child_quit_early->GetWitnessHash());
+        BOOST_CHECK(it_parent1->second.m_state.IsInvalid());
+        BOOST_CHECK_EQUAL(it_parent1->second.m_state.GetResult(), TxValidationResult::TX_PREMATURE_SPEND);
+        BOOST_CHECK_MESSAGE(it_parent2->second.m_state.IsValid(), "parent2 error: " << it_parent2->second.m_state.GetRejectReason());
+        BOOST_CHECK(it_child->second.m_state.IsInvalid());
+        BOOST_CHECK_EQUAL(it_child->second.m_state.GetResult(), TxValidationResult::TX_MISSING_INPUTS);
     }
 
     // Child with missing parent.

--- a/src/test/txpackage_tests.cpp
+++ b/src/test/txpackage_tests.cpp
@@ -962,7 +962,7 @@ BOOST_FIXTURE_TEST_CASE(package_cpfp_tests, TestChain100Setup)
         BOOST_CHECK_EQUAL(submit_cpfp_deprio.m_state.GetResult(), PackageValidationResult::PCKG_TX);
         BOOST_CHECK(submit_cpfp_deprio.m_state.IsInvalid());
         BOOST_CHECK_EQUAL(submit_cpfp_deprio.m_tx_results.find(tx_parent->GetWitnessHash())->second.m_state.GetResult(),
-                          TxValidationResult::TX_MEMPOOL_POLICY);
+                          TxValidationResult::TX_LOW_FEE);
         BOOST_CHECK_EQUAL(submit_cpfp_deprio.m_tx_results.find(tx_child->GetWitnessHash())->second.m_state.GetResult(),
                           TxValidationResult::TX_MISSING_INPUTS);
         BOOST_CHECK(submit_cpfp_deprio.m_tx_results.find(tx_parent->GetWitnessHash())->second.m_state.GetRejectReason() == "min relay fee not met");
@@ -1114,7 +1114,7 @@ BOOST_FIXTURE_TEST_CASE(package_cpfp_tests, TestChain100Setup)
         BOOST_CHECK(it_parent->second.m_effective_feerate == CFeeRate(high_parent_fee, GetVirtualTransactionSize(*tx_parent_rich)));
         BOOST_CHECK(it_child != submit_rich_parent.m_tx_results.end());
         BOOST_CHECK_EQUAL(it_child->second.m_result_type, MempoolAcceptResult::ResultType::INVALID);
-        BOOST_CHECK_EQUAL(it_child->second.m_state.GetResult(), TxValidationResult::TX_MEMPOOL_POLICY);
+        BOOST_CHECK_EQUAL(it_child->second.m_state.GetResult(), TxValidationResult::TX_LOW_FEE);
         BOOST_CHECK(it_child->second.m_state.GetRejectReason() == "min relay fee not met");
 
         BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);

--- a/src/test/txpackage_tests.cpp
+++ b/src/test/txpackage_tests.cpp
@@ -293,16 +293,27 @@ BOOST_FIXTURE_TEST_CASE(noncontextual_package_tests, TestChain100Setup)
         BOOST_CHECK_EQUAL(state.GetResult(), PackageValidationResult::PCKG_POLICY);
         BOOST_CHECK_EQUAL(state.GetRejectReason(), "package-not-sorted");
         BOOST_CHECK(IsChildWithParents({tx_parent, tx_child}));
+        BOOST_CHECK_EQUAL(GetPackageHash({tx_child}), GetCombinedHash({tx_child->GetWitnessHash()}));
+        BOOST_CHECK_EQUAL(GetPackageHash({tx_child, tx_parent}), GetPackageHash({tx_parent, tx_child}));
+        BOOST_CHECK_EQUAL(GetCombinedHash({tx_parent->GetWitnessHash(), tx_child->GetWitnessHash()}),
+                          GetCombinedHash({tx_child->GetWitnessHash(), tx_parent->GetWitnessHash()}));
+        BOOST_CHECK_EQUAL(GetCombinedHash({tx_parent->GetWitnessHash(), tx_child->GetWitnessHash()}),
+                          GetPackageHash({tx_parent, tx_child}));
+        BOOST_CHECK(GetPackageHash({tx_parent}) != GetPackageHash({tx_child}));
+        BOOST_CHECK(GetPackageHash({tx_child, tx_child}) != GetPackageHash({tx_child}));
+        BOOST_CHECK(GetPackageHash({tx_child, tx_parent}) != GetPackageHash({tx_child, tx_child}));
     }
 
     // 24 Parents and 1 Child
     {
         Package package;
+        std::vector<uint256> package_wtxids;
         CMutableTransaction child;
         for (int i{0}; i < 24; ++i) {
             auto parent = MakeTransactionRef(CreateValidMempoolTransaction(m_coinbase_txns[i + 1],
                                              0, 0, coinbaseKey, spk, CAmount(48 * COIN), false));
             package.emplace_back(parent);
+            package_wtxids.emplace_back(parent->GetWitnessHash());
             child.vin.push_back(CTxIn(COutPoint(parent->GetHash(), 0)));
         }
         child.vout.push_back(CTxOut(47 * COIN, spk2));
@@ -313,7 +324,10 @@ BOOST_FIXTURE_TEST_CASE(noncontextual_package_tests, TestChain100Setup)
         // The parents can be in any order.
         FastRandomContext rng;
         Shuffle(package.begin(), package.end(), rng);
-        package.push_back(MakeTransactionRef(child));
+        auto tx_child = MakeTransactionRef(child);
+        package.emplace_back(tx_child);
+        package_wtxids.push_back(tx_child->GetWitnessHash());
+        BOOST_CHECK_EQUAL(GetCombinedHash(package_wtxids), GetPackageHash(package));
 
         PackageValidationState state;
         BOOST_CHECK(IsPackageWellFormed(package, state, /*require_sorted=*/true));
@@ -694,6 +708,8 @@ BOOST_FIXTURE_TEST_CASE(package_witness_swap_tests, TestChain100Setup)
     BOOST_CHECK_EQUAL(ptx_child1->GetHash(), ptx_child2->GetHash());
     // child1 and child2 have different wtxids
     BOOST_CHECK(ptx_child1->GetWitnessHash() != ptx_child2->GetWitnessHash());
+    // package1 and package2 have different packageids
+    BOOST_CHECK(GetPackageHash({ptx_parent, ptx_child1}) != GetPackageHash({ptx_parent, ptx_child2}));
 
     // Try submitting Package1{parent, child1} and Package2{parent, child2} where the children are
     // same-txid-different-witness.
@@ -760,7 +776,7 @@ BOOST_FIXTURE_TEST_CASE(package_witness_swap_tests, TestChain100Setup)
                                                         /*output_destination=*/grandchild_locking_script,
                                                         /*output_amount=*/CAmount(47 * COIN), /*submit=*/false);
     CTransactionRef ptx_grandchild = MakeTransactionRef(mtx_grandchild);
-
+    BOOST_CHECK(GetPackageHash({ptx_child1, ptx_grandchild}) != GetPackageHash({ptx_child2, ptx_grandchild}));
     // We already submitted child1 above.
     {
         const auto submit_spend_ignored = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,

--- a/src/test/txpackagetracker_tests.cpp
+++ b/src/test/txpackagetracker_tests.cpp
@@ -1,0 +1,49 @@
+// Copyright (c) 2021-2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <node/txpackagetracker.h>
+#include <txorphanage.h>
+
+#include <test/util/setup_common.h>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(txpackagetracker_tests, BasicTestingSetup)
+BOOST_AUTO_TEST_CASE(pkginfo)
+{
+    TxOrphanage orphanage;
+    node::TxPackageTracker tracker;
+
+    // Peer 0: successful handshake
+    NodeId peer = 0;
+    tracker.ReceivedVersion(peer);
+    tracker.ReceivedSendpackages(peer, node::PKG_RELAY_ANCPKG);
+    BOOST_CHECK(tracker.ReceivedVerack(peer, /*inbound`*/ true, /*txrelay=*/true, /*wtxidrelay=*/true));
+
+    // Peer 1: unsupported version(s)
+    const node::PackageRelayVersions unsupported_package_type{1ULL << 43};
+    peer = 1;
+    tracker.ReceivedVersion(peer);
+    tracker.ReceivedSendpackages(peer, unsupported_package_type);
+    BOOST_CHECK(!tracker.ReceivedVerack(peer, /*inbound`*/ true, /*txrelay=*/true, /*wtxidrelay=*/true));
+
+    // Peer 2: no wtxidrelay
+    peer = 2;
+    tracker.ReceivedVersion(peer);
+    tracker.ReceivedSendpackages(peer, node::PKG_RELAY_ANCPKG);
+    BOOST_CHECK(!tracker.ReceivedVerack(peer, /*inbound`*/ true, /*txrelay=*/true, /*wtxidrelay=*/false));
+
+    // Peer 3: fRelay=false
+    peer = 3;
+    tracker.ReceivedVersion(peer);
+    tracker.ReceivedSendpackages(peer, node::PKG_RELAY_ANCPKG);
+    BOOST_CHECK(!tracker.ReceivedVerack(peer, /*inbound`*/ true, /*txrelay=*/false, /*wtxidrelay=*/true));
+
+    for (NodeId i{0}; i < peer + 1; ++i) {
+        BOOST_CHECK_EQUAL(tracker.Count(i), 0);
+        BOOST_CHECK_EQUAL(tracker.CountInFlight(i), 0);
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/txpackagetracker_tests.cpp
+++ b/src/test/txpackagetracker_tests.cpp
@@ -116,6 +116,78 @@ BOOST_AUTO_TEST_CASE(pkginfo)
     BOOST_CHECK_EQUAL(peer4_requests_later.size(), 2);
     // This counts as 1 in-flight request
     BOOST_CHECK_EQUAL(tracker.CountInFlight(4), 1);
+
+    // peer0 is allowed to send ancpkginfo for orphan0, but not for any other tx or version
+    BOOST_CHECK(tracker.PkgInfoAllowed(/*nodeid=*/0, orphan0->GetWitnessHash(), node::PKG_RELAY_ANCPKG));
+    BOOST_CHECK(!tracker.PkgInfoAllowed(/*nodeid=*/0, orphan0->GetWitnessHash(), unsupported_package_type));
+    BOOST_CHECK(!tracker.PkgInfoAllowed(/*nodeid=*/0, orphan1->GetWitnessHash(), node::PKG_RELAY_ANCPKG));
+    // No other peers are allowed to send ancpkginfo (they disconnected or aren't registered for it)
+    BOOST_CHECK(!tracker.PkgInfoAllowed(/*nodeid=*/1, orphan1->GetWitnessHash(), node::PKG_RELAY_ANCPKG));
+    BOOST_CHECK(!tracker.PkgInfoAllowed(/*nodeid=*/2, orphan1->GetWitnessHash(), node::PKG_RELAY_ANCPKG));
+    BOOST_CHECK(!tracker.PkgInfoAllowed(/*nodeid=*/3, orphan2->GetWitnessHash(), node::PKG_RELAY_ANCPKG));
+    BOOST_CHECK(!tracker.PkgInfoAllowed(/*nodeid=*/4, orphan2->GetWitnessHash(), node::PKG_RELAY_ANCPKG));
+
+    // After receiving ancpkginfo, a second ancpkginfo is not allowed
+    const auto missing_wtxid{det_rand.rand256()};
+    std::vector<std::pair<uint256, bool>> txdata_status;
+    txdata_status.emplace_back(missing_wtxid, true);
+    txdata_status.emplace_back(orphan0->GetWitnessHash(), false);
+    const auto ancpkginfo_result = tracker.ReceivedAncPkgInfo(/*nodeid=*/0, orphan0->GetWitnessHash(), txdata_status,
+                                            current_time + 100s);
+    BOOST_CHECK_EQUAL(std::get<std::vector<uint256>>(ancpkginfo_result).size(), 1);
+    BOOST_CHECK_EQUAL(std::get<std::vector<uint256>>(ancpkginfo_result).front(), missing_wtxid);
+    BOOST_CHECK(!tracker.PkgInfoAllowed(/*nodeid=*/0, orphan0->GetWitnessHash(), node::PKG_RELAY_ANCPKG));
+}
+void RegisterPeerForAncestorPackages(node::TxPackageTracker& tracker, NodeId peer)
+{
+    tracker.ReceivedVersion(peer);
+    tracker.ReceivedSendpackages(peer, node::PKG_RELAY_ANCPKG);
+    tracker.ReceivedVerack(peer, true, true, true);
+}
+BOOST_AUTO_TEST_CASE(txdata_download)
+{
+    FastRandomContext det_rand{true};
+    node::TxPackageTracker tracker;
+
+    // 2 parents 1 child
+    const auto tx_parent1 = make_tx({COutPoint{det_rand.rand256(), 0}}, 1);
+    const auto tx_parent2 = make_tx({COutPoint{det_rand.rand256(), 0}}, 1);
+    const auto tx_child = make_tx({COutPoint{tx_parent1->GetHash(), 0}, COutPoint{tx_parent2->GetHash(), 0}}, 1);
+    const Package package_2p1c{tx_parent1, tx_parent2, tx_child};
+
+    const auto current_time{GetTime<std::chrono::microseconds>()};
+    {
+    NodeId peer = 0;
+    RegisterPeerForAncestorPackages(tracker, peer);
+
+    tracker.AddOrphanTx(peer, tx_child->GetWitnessHash(), tx_child, /*is_preferred=*/true, current_time);
+    const auto requests = tracker.GetOrphanRequests(peer, current_time + 1s);
+    BOOST_CHECK_EQUAL(1, requests.size());
+    BOOST_CHECK(tracker.PkgInfoAllowed(peer, tx_child->GetWitnessHash(), node::PKG_RELAY_ANCPKG));
+
+    const std::vector<uint256> missing_wtxids{tx_parent1->GetWitnessHash(), tx_parent2->GetWitnessHash()};
+    std::vector<std::pair<uint256, bool>> txdata_status;
+    txdata_status.emplace_back(tx_parent1->GetWitnessHash(), true);
+    txdata_status.emplace_back(tx_parent2->GetWitnessHash(), true);
+    txdata_status.emplace_back(tx_child->GetWitnessHash(), false);
+    const auto ancpkginfo_result = tracker.ReceivedAncPkgInfo(peer, tx_child->GetWitnessHash(), txdata_status,
+                                            current_time + 100s);
+    const auto request_list = std::get<std::vector<uint256>>(ancpkginfo_result);
+    BOOST_CHECK(std::find(request_list.cbegin(), request_list.cend(), tx_parent1->GetWitnessHash()) != request_list.end());
+    BOOST_CHECK(std::find(request_list.cbegin(), request_list.cend(), tx_parent2->GetWitnessHash()) != request_list.end());
+
+    // Nodeid and exact missing transactions must match.
+    BOOST_CHECK(!tracker.ReceivedPkgTxns(peer, {tx_parent1}).has_value());
+    BOOST_CHECK(!tracker.ReceivedPkgTxns(peer, {tx_parent2}).has_value());
+    BOOST_CHECK(!tracker.ReceivedPkgTxns(2, {tx_parent1, tx_parent2}).has_value());
+
+    const auto validate_2p1c = tracker.ReceivedPkgTxns(peer, {tx_parent1, tx_parent2});
+    BOOST_CHECK(validate_2p1c.has_value());
+    BOOST_CHECK_EQUAL(validate_2p1c.value().m_info_provider, peer);
+    BOOST_CHECK_EQUAL(validate_2p1c->m_rep_wtxid, tx_child->GetWitnessHash());
+    BOOST_CHECK_EQUAL(validate_2p1c->m_pkginfo_hash, GetPackageHash(package_2p1c));
+    BOOST_CHECK(validate_2p1c->m_unvalidated_txns == package_2p1c);
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/txpackagetracker_tests.cpp
+++ b/src/test/txpackagetracker_tests.cpp
@@ -3,16 +3,36 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <node/txpackagetracker.h>
+#include <random.h>
 #include <txorphanage.h>
 
 #include <test/util/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
 
+static inline CTransactionRef make_tx(const std::vector<COutPoint>& inputs, size_t num_outputs)
+{
+    CMutableTransaction tx = CMutableTransaction();
+    tx.vin.resize(inputs.size());
+    tx.vout.resize(num_outputs);
+    for (size_t i = 0; i < inputs.size(); ++i) {
+        tx.vin[i].prevout = inputs[i];
+        // Add a witness so wtxid != txid
+        CScriptWitness witness;
+        witness.stack.push_back(std::vector<unsigned char>(i + 10));
+        tx.vin[i].scriptWitness = witness;
+    }
+    for (size_t i = 0; i < num_outputs; ++i) {
+        tx.vout[i].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
+        tx.vout[i].nValue = COIN;
+    }
+    return MakeTransactionRef(tx);
+}
+
 BOOST_FIXTURE_TEST_SUITE(txpackagetracker_tests, BasicTestingSetup)
 BOOST_AUTO_TEST_CASE(pkginfo)
 {
-    TxOrphanage orphanage;
+    FastRandomContext det_rand{true};
     node::TxPackageTracker tracker;
 
     // Peer 0: successful handshake
@@ -44,6 +64,58 @@ BOOST_AUTO_TEST_CASE(pkginfo)
         BOOST_CHECK_EQUAL(tracker.Count(i), 0);
         BOOST_CHECK_EQUAL(tracker.CountInFlight(i), 0);
     }
+
+    const auto current_time{GetTime<std::chrono::microseconds>()};
+    const auto orphan0 = make_tx({COutPoint{det_rand.rand256(), 0}}, 1);
+    const auto wtxid_parent1 = det_rand.rand256();
+    const auto orphan1 = make_tx({COutPoint{wtxid_parent1, 0}, COutPoint{wtxid_parent1, 1}}, 1);
+    const auto orphan2 = make_tx({COutPoint{det_rand.rand256(), 0}, COutPoint{det_rand.rand256(), 0}}, 1);
+    tracker.AddOrphanTx(/*nodeid=*/0, orphan0->GetWitnessHash(), orphan0, /*is_preferred=*/false, current_time);
+    tracker.AddOrphanTx(/*nodeid=*/1, orphan1->GetWitnessHash(), orphan1, /*is_preferred=*/false, current_time);
+    tracker.AddOrphanTx(/*nodeid=*/1, orphan0->GetWitnessHash(), orphan0, /*is_preferred=*/false, current_time + 10s);
+    tracker.AddOrphanTx(/*nodeid=*/2, orphan1->GetWitnessHash(), orphan1, /*is_preferred=*/false, current_time + 5s);
+    tracker.AddOrphanTx(/*nodeid=*/3, orphan2->GetWitnessHash(), orphan2, /*is_preferred=*/true, current_time + 5s);
+    tracker.AddOrphanTx(/*nodeid=*/4, orphan2->GetWitnessHash(), orphan2, /*is_preferred=*/false, current_time + 9s);
+    BOOST_CHECK_EQUAL(tracker.Count(0), 1);
+    BOOST_CHECK_EQUAL(tracker.Count(1), 2);
+    BOOST_CHECK_EQUAL(tracker.Count(2), 1);
+    BOOST_CHECK_EQUAL(tracker.Count(3), 1);
+    BOOST_CHECK_EQUAL(tracker.Count(4), 1);
+    const auto peer0_requests = tracker.GetOrphanRequests(/*nodeid=*/0, current_time + 1s);
+    const auto peer1_requests = tracker.GetOrphanRequests(/*nodeid=*/1, current_time + 1s);
+    const auto peer2_requests = tracker.GetOrphanRequests(/*nodeid=*/2, current_time + 1s);
+    const auto peer3_requests = tracker.GetOrphanRequests(/*nodeid=*/3, current_time);
+    const auto peer4_requests = tracker.GetOrphanRequests(/*nodeid=*/4, current_time);
+    BOOST_CHECK_EQUAL(peer0_requests.size(), 1);
+    BOOST_CHECK(peer0_requests.front().IsWtxid());
+    BOOST_CHECK_EQUAL(peer0_requests.front().GetHash(), orphan0->GetWitnessHash());
+    BOOST_CHECK_EQUAL(peer1_requests.size(), 1);
+    BOOST_CHECK_EQUAL(peer1_requests.front().GetHash(), wtxid_parent1);
+    BOOST_CHECK(!peer1_requests.front().IsWtxid());
+    BOOST_CHECK(peer2_requests.empty());
+    BOOST_CHECK(peer3_requests.empty());
+    BOOST_CHECK(peer4_requests.empty());
+    BOOST_CHECK_EQUAL(tracker.CountInFlight(0), 1);
+    BOOST_CHECK_EQUAL(tracker.CountInFlight(1), 1);
+    BOOST_CHECK_EQUAL(tracker.Count(1), 2);
+    BOOST_CHECK_EQUAL(tracker.CountInFlight(2), 0);
+    BOOST_CHECK_EQUAL(tracker.CountInFlight(3), 0);
+    BOOST_CHECK_EQUAL(tracker.CountInFlight(4), 0);
+    // After peer1 disconnects, request from peer2
+    tracker.DisconnectedPeer(1);
+    // After peer3 disconnects, request from peer4
+    tracker.DisconnectedPeer(3);
+    BOOST_CHECK_EQUAL(tracker.Count(3), 0);
+    BOOST_CHECK_EQUAL(tracker.CountInFlight(3), 0);
+    const auto peer2_requests_later = tracker.GetOrphanRequests(/*nodeid=*/2, current_time + 5s);
+    // 2 inputs but only 1 unique parent
+    BOOST_CHECK_EQUAL(peer2_requests_later.size(), 1);
+    BOOST_CHECK(!peer2_requests_later.front().IsWtxid());
+    BOOST_CHECK_EQUAL(peer2_requests_later.front().GetHash(), wtxid_parent1);
+    const auto peer4_requests_later = tracker.GetOrphanRequests(/*nodeid=*/4, current_time + 9s);
+    BOOST_CHECK_EQUAL(peer4_requests_later.size(), 2);
+    // This counts as 1 in-flight request
+    BOOST_CHECK_EQUAL(tracker.CountInFlight(4), 1);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -271,7 +271,7 @@ TestingSetup::TestingSetup(
     m_node.connman = std::make_unique<ConnmanTestMsg>(0x1337, 0x1337, *m_node.addrman, *m_node.netgroupman); // Deterministic randomness for tests.
     m_node.peerman = PeerManager::make(*m_node.connman, *m_node.addrman,
                                        m_node.banman.get(), *m_node.chainman,
-                                       *m_node.mempool, false);
+                                       *m_node.mempool, false, false);
     {
         CConnman::Options options;
         options.m_msgproc = m_node.peerman.get();

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -157,6 +157,23 @@ struct TestChain100Setup : public TestingSetup {
     /**
      * Create a transaction and submit to the mempool.
      *
+     * @param input_transactions   The transactions to spend
+     * @param input_height         The height of the block that included the input transactions.
+     * @param inputs               Outpoints with which to construct transaction vin.
+     * @param input_signing_keys   The keys to spend the input transactions.
+     * @param outputs              Transaction vout.
+     * @param submit               Whether or not to submit to mempool
+     */
+    CMutableTransaction CreateValidMempoolTransaction(const std::vector<CTransactionRef>& input_transactions,
+                                                      const std::vector<COutPoint>& inputs,
+                                                      int input_height,
+                                                      const std::vector<CKey>& input_signing_keys,
+                                                      const std::vector<CTxOut>& outputs,
+                                                      bool submit = true);
+
+    /**
+     * Create a transaction and submit to the mempool.
+     *
      * @param input_transaction  The transaction to spend
      * @param input_vout         The vout to spend from the input_transaction
      * @param input_height       The height of the block that included the input_transaction
@@ -166,7 +183,7 @@ struct TestChain100Setup : public TestingSetup {
      * @param submit             Whether or not to submit to mempool
      */
     CMutableTransaction CreateValidMempoolTransaction(CTransactionRef input_transaction,
-                                                      int input_vout,
+                                                      uint32_t input_vout,
                                                       int input_height,
                                                       CKey input_signing_key,
                                                       CScript output_destination,

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -710,6 +710,11 @@ public:
     TxMempoolInfo info(const GenTxid& gtxid) const;
     std::vector<TxMempoolInfo> infoAll() const;
 
+    /** Get the minimum base feerate between this entry and its parents (ignoring prioritisation).
+     * returns std::nullopt if the entry doesn't exist
+     * returns the tx's own feerate if it doesn't have any parents */
+    std::optional<CFeeRate> MinimumFeerateWithParents(const GenTxid& gtxid) const;
+
     size_t DynamicMemoryUsage() const;
 
     /** Adds a transaction to the unbroadcast set */

--- a/src/txorphanage.cpp
+++ b/src/txorphanage.cpp
@@ -214,7 +214,7 @@ bool TxOrphanage::HaveTxToReconsider(NodeId peer)
     return false;
 }
 
-void TxOrphanage::EraseForBlock(const CBlock& block)
+std::vector<uint256> TxOrphanage::EraseForBlock(const CBlock& block)
 {
     LOCK(m_mutex);
 
@@ -243,4 +243,5 @@ void TxOrphanage::EraseForBlock(const CBlock& block)
         }
         LogPrint(BCLog::MEMPOOL, "Erased %d orphan tx included or conflicted by block\n", nErased);
     }
+    return vOrphanErase;
 }

--- a/src/txorphanage.cpp
+++ b/src/txorphanage.cpp
@@ -35,7 +35,7 @@ bool TxOrphanage::AddTx(const CTransactionRef& tx, NodeId peer)
     unsigned int sz = GetTransactionWeight(*tx);
     if (sz > MAX_STANDARD_TX_WEIGHT)
     {
-        LogPrint(BCLog::MEMPOOL, "ignoring large orphan tx (size: %u, hash: %s)\n", sz, hash.ToString());
+        LogPrint(BCLog::TXPACKAGES, "ignoring large orphan tx (size: %u, hash: %s)\n", sz, hash.ToString());
         return false;
     }
 
@@ -48,7 +48,7 @@ bool TxOrphanage::AddTx(const CTransactionRef& tx, NodeId peer)
         m_outpoint_to_orphan_it[txin.prevout].insert(ret.first);
     }
 
-    LogPrint(BCLog::MEMPOOL, "stored orphan tx %s (mapsz %u outsz %u)\n", hash.ToString(),
+    LogPrint(BCLog::TXPACKAGES, "stored orphan tx %s (mapsz %u outsz %u)\n", hash.ToString(),
              m_orphans.size(), m_outpoint_to_orphan_it.size());
     return true;
 }
@@ -114,7 +114,7 @@ void TxOrphanage::EraseForPeer(NodeId peer)
             nErased += EraseTxNoLock(maybeErase->second.tx->GetWitnessHash());
         }
     }
-    if (nErased > 0) LogPrint(BCLog::MEMPOOL, "Erased %d orphan tx from peer=%d\n", nErased, peer);
+    if (nErased > 0) LogPrint(BCLog::TXPACKAGES, "Erased %d orphan tx from peer=%d\n", nErased, peer);
 }
 
 void TxOrphanage::LimitOrphans(unsigned int max_orphans)
@@ -140,7 +140,7 @@ void TxOrphanage::LimitOrphans(unsigned int max_orphans)
         }
         // Sweep again 5 minutes after the next entry that expires in order to batch the linear scan.
         nNextSweep = nMinExpTime + ORPHAN_TX_EXPIRE_INTERVAL;
-        if (nErased > 0) LogPrint(BCLog::MEMPOOL, "Erased %d orphan tx due to expiration\n", nErased);
+        if (nErased > 0) LogPrint(BCLog::TXPACKAGES, "Erased %d orphan tx due to expiration\n", nErased);
     }
     FastRandomContext rng;
     while (m_orphans.size() > max_orphans)
@@ -150,7 +150,7 @@ void TxOrphanage::LimitOrphans(unsigned int max_orphans)
         EraseTxNoLock(m_orphan_list[randompos]->second.tx->GetWitnessHash());
         ++nEvicted;
     }
-    if (nEvicted > 0) LogPrint(BCLog::MEMPOOL, "orphanage overflow, removed %u tx\n", nEvicted);
+    if (nEvicted > 0) LogPrint(BCLog::TXPACKAGES, "orphanage overflow, removed %u tx\n", nEvicted);
 }
 
 void TxOrphanage::AddChildrenToWorkSet(const CTransaction& tx)
@@ -241,7 +241,7 @@ std::vector<uint256> TxOrphanage::EraseForBlock(const CBlock& block)
         for (const uint256& orphanHash : vOrphanErase) {
             nErased += EraseTxNoLock(orphanHash);
         }
-        LogPrint(BCLog::MEMPOOL, "Erased %d orphan tx included or conflicted by block\n", nErased);
+        LogPrint(BCLog::TXPACKAGES, "Erased %d orphan tx included or conflicted by block\n", nErased);
     }
     return vOrphanErase;
 }

--- a/src/txorphanage.h
+++ b/src/txorphanage.h
@@ -72,6 +72,13 @@ public:
         LOCK(m_mutex);
         return m_total_orphan_bytes;
     }
+    size_t BytesFromPeer(NodeId peer) const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
+    {
+        LOCK(m_mutex);
+        auto peer_bytes_it = m_peer_bytes_used.find(peer);
+        return peer_bytes_it == m_peer_bytes_used.end() ? 0 : peer_bytes_it->second;
+    }
+
 protected:
     size_t m_total_orphan_bytes{0};
 
@@ -113,6 +120,9 @@ protected:
     /** Index from wtxid into the m_orphans to lookup orphan
      *  transactions using their witness ids. */
     std::map<uint256, OrphanMap::iterator> m_wtxid_to_orphan_it GUARDED_BY(m_mutex);
+
+    /** Map from nodeid to the amount of orphans provided by this peer, in bytes. */
+    std::map<NodeId, size_t> m_peer_bytes_used GUARDED_BY(m_mutex);
 
     /** Erase an orphan by txid */
     int EraseTxNoLock(const uint256& txid) EXCLUSIVE_LOCKS_REQUIRED(m_mutex);

--- a/src/txorphanage.h
+++ b/src/txorphanage.h
@@ -42,8 +42,8 @@ public:
     /** Erase all orphans announced by a peer (eg, after that peer disconnects) */
     void EraseForPeer(NodeId peer) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
-    /** Erase all orphans included in or invalidated by a new block */
-    void EraseForBlock(const CBlock& block) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+    /** Erase all orphans included in or invalidated by a new block. Returns wtxids of erased txns. */
+    std::vector<uint256> EraseForBlock(const CBlock& block) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /** Limit the orphanage to the given maximum */
     void LimitOrphans(unsigned int max_orphans) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);

--- a/src/txorphanage.h
+++ b/src/txorphanage.h
@@ -23,6 +23,9 @@ public:
     /** Add a new orphan transaction */
     bool AddTx(const CTransactionRef& tx, NodeId peer) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
+    /** Get orphan transaction by wtxid. Returns nullptr if we don't have it anymore. */
+    CTransactionRef GetTx(const uint256& wtxid) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
     /** Check if we already have an orphan transaction (by txid or wtxid) */
     bool HaveTx(const GenTxid& gtxid) const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
@@ -33,8 +36,8 @@ public:
      */
     CTransactionRef GetTxToReconsider(NodeId peer) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
-    /** Erase an orphan by txid */
-    int EraseTx(const uint256& txid) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+    /** Erase an orphan by wtxid */
+    int EraseTx(const uint256& wtxid) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /** Erase all orphans announced by a peer (eg, after that peer disconnects) */
     void EraseForPeer(NodeId peer) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);

--- a/src/txorphanage.h
+++ b/src/txorphanage.h
@@ -6,12 +6,16 @@
 #define BITCOIN_TXORPHANAGE_H
 
 #include <net.h>
+#include <policy/policy.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <sync.h>
 
 #include <map>
 #include <set>
+
+/** Maximum total size of orphan transactions stored, in bytes. */
+static constexpr size_t MAX_ORPHAN_TOTAL_SIZE{100 * MAX_STANDARD_TX_WEIGHT};
 
 /** A class to track orphan transactions (failed on TX_MISSING_INPUTS)
  * Since we cannot distinguish orphans from bad transactions with
@@ -61,7 +65,16 @@ public:
         return m_orphans.size();
     }
 
+    /** Return total memory usage of the transactions stored. Does not include overhead of
+     * m_orphans, m_peer_work_set, etc. */
+    size_t TotalOrphanBytes() const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
+    {
+        LOCK(m_mutex);
+        return m_total_orphan_bytes;
+    }
 protected:
+    size_t m_total_orphan_bytes{0};
+
     /** Guards orphan transactions */
     mutable Mutex m_mutex;
 

--- a/src/txorphanage.h
+++ b/src/txorphanage.h
@@ -50,7 +50,12 @@ public:
     /** Erase all orphans included in or invalidated by a new block. Returns wtxids of erased txns. */
     std::vector<uint256> EraseForBlock(const CBlock& block) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
-    /** Limit the orphanage to the given maximum */
+    /** Limit the orphanage to the given maximum. Delete orphans whose expiry has been reached.
+     * The maximum does not apply to protected transactions, i.e., LimitOrphans(100) ensures
+     * that the number of non-protected orphan entries does not exceed 100. Afterward, Size() may
+     * return a number greater than 100.  It is the caller's responsibility to ensure that not too
+     * many orphans are protected.
+     */
     void LimitOrphans(unsigned int max_orphans) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /** Add any orphans that list a particular tx as a parent into the from peer's work set */
@@ -65,6 +70,16 @@ public:
         LOCK(m_mutex);
         return m_orphans.size();
     }
+    /** Protect an orphan from eviction from the orphanage getting full. The orphan may still be
+     * removed due to expiry. If the orphan is already protected (by any peer), nothing happens.
+     */
+    void ProtectOrphan(const uint256& wtxid) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
+    /** Remove protection of an orphan. If the orphan is nonexistent or not protected, nothing happens. */
+    void UndoProtectOrphan(const uint256& wtxid) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
+    /** Return number of protected entries in the orphanage. */
+    size_t NumProtected() const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /** Return total memory usage of the transactions stored. Does not include overhead of
      * m_orphans, m_peer_work_set, etc. */
@@ -86,6 +101,7 @@ public:
 
 protected:
     size_t m_total_orphan_bytes{0};
+    size_t m_total_protected_orphan_bytes{0};
 
     /** Guards orphan transactions */
     mutable Mutex m_mutex;
@@ -93,7 +109,9 @@ protected:
     struct OrphanTx {
         CTransactionRef tx;
         int64_t nTimeExpire;
-        size_t list_pos;
+        /** If >= 0: position in m_orphan_list.
+         *  If  < 0: number of protections on this orphan (multiplied by -1). */
+        int32_t list_pos;
         std::set<NodeId> announcers;
     };
 

--- a/src/txrequest.cpp
+++ b/src/txrequest.cpp
@@ -577,6 +577,17 @@ public:
         }
     }
 
+    std::vector<NodeId> GetCandidatePeers(const uint256& txhash) const
+    {
+        std::vector<NodeId> result_peers;
+        auto it = m_index.get<ByTxHash>().lower_bound(ByTxHashView{txhash, State::CANDIDATE_DELAYED, 0});
+        while (it != m_index.get<ByTxHash>().end() && it->m_txhash == txhash) {
+            if (it->GetState() != State::COMPLETED) result_peers.push_back(it->m_peer);
+            ++it;
+        }
+        return result_peers;
+    }
+
     void ReceivedInv(NodeId peer, const GenTxid& gtxid, bool preferred,
         std::chrono::microseconds reqtime)
     {
@@ -671,6 +682,21 @@ public:
         });
     }
 
+    void ResetRequestTimeout(NodeId peer, const uint256& txhash, std::chrono::microseconds new_expiry)
+    {
+        auto it = m_index.get<ByPeer>().find(ByPeerView{peer, false, txhash});
+        if (it == m_index.get<ByPeer>().end()) {
+            it = m_index.get<ByPeer>().find(ByPeerView{peer, true, txhash});
+        }
+        if (it == m_index.get<ByPeer>().end() || (it->GetState() != State::REQUESTED)) {
+            // There is no REQUESTED announcement tracked for this peer, so we have nothing to do.
+            return;
+        }
+        Modify<ByPeer>(it, [new_expiry](Announcement& ann) {
+            ann.m_time = new_expiry;
+        });
+    }
+
     void ReceivedResponse(NodeId peer, const uint256& txhash)
     {
         // We need to search the ByPeer index for both (peer, false, txhash) and (peer, true, txhash).
@@ -724,6 +750,7 @@ size_t TxRequestTracker::CountInFlight(NodeId peer) const { return m_impl->Count
 size_t TxRequestTracker::CountCandidates(NodeId peer) const { return m_impl->CountCandidates(peer); }
 size_t TxRequestTracker::Count(NodeId peer) const { return m_impl->Count(peer); }
 size_t TxRequestTracker::Size() const { return m_impl->Size(); }
+std::vector<NodeId> TxRequestTracker::GetCandidatePeers(const uint256& txhash) const { return m_impl->GetCandidatePeers(txhash); }
 void TxRequestTracker::SanityCheck() const { m_impl->SanityCheck(); }
 
 void TxRequestTracker::PostGetRequestableSanityCheck(std::chrono::microseconds now) const
@@ -740,6 +767,11 @@ void TxRequestTracker::ReceivedInv(NodeId peer, const GenTxid& gtxid, bool prefe
 void TxRequestTracker::RequestedTx(NodeId peer, const uint256& txhash, std::chrono::microseconds expiry)
 {
     m_impl->RequestedTx(peer, txhash, expiry);
+}
+
+void TxRequestTracker::ResetRequestTimeout(NodeId peer, const uint256& txhash, std::chrono::microseconds new_expiry)
+{
+    m_impl->ResetRequestTimeout(peer, txhash, new_expiry);
 }
 
 void TxRequestTracker::ReceivedResponse(NodeId peer, const uint256& txhash)

--- a/src/txrequest.h
+++ b/src/txrequest.h
@@ -173,6 +173,12 @@ public:
      */
     void RequestedTx(NodeId peer, const uint256& txhash, std::chrono::microseconds expiry);
 
+    /** For some already REQUESTED announcement, reset the expiry.
+     *
+     * If no REQUESTED announcement for the provided peer and txhash exists, this call has no effect.
+     */
+    void ResetRequestTimeout(NodeId peer, const uint256& txhash, std::chrono::microseconds new_expiry);
+
     /** Converts a CANDIDATE or REQUESTED announcement to a COMPLETED one. If no such announcement exists for the
      *  provided peer and txhash, nothing happens.
      *
@@ -194,6 +200,9 @@ public:
 
     /** Count how many announcements are being tracked in total across all peers and transaction hashes. */
     size_t Size() const;
+
+    /** For some tx hash (either txid or wtxid), return all peers with non-COMPLETED announcements. */
+    std::vector<NodeId> GetCandidatePeers(const uint256& txhash) const;
 
     /** Access to the internal priority computation (testing only) */
     uint64_t ComputePriority(const uint256& txhash, NodeId peer, bool preferred) const;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -572,7 +572,7 @@ public:
      * Handle any list of transactions sensibly, even if unsorted. If not a well-formed
      * AncestorPackage, transactions will not be validated or submitted.
      */
-    PackageMempoolAcceptResult AcceptPackage(const Package& package, ATMPArgs& args) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    PackageMempoolAcceptResult AcceptAncestorPackage(const Package& package, ATMPArgs& args) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 private:
     // All the intermediate state that gets passed between the various levels
@@ -1378,7 +1378,7 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptPackageWrappingSingle(const std:
     return PackageMempoolAcceptResult(package_state_wrapped, {{tx->GetWitnessHash(), single_res}});
 }
 
-PackageMempoolAcceptResult MemPoolAccept::AcceptPackage(const Package& package, ATMPArgs& args)
+PackageMempoolAcceptResult MemPoolAccept::AcceptAncestorPackage(const Package& package, ATMPArgs& args)
 {
     AssertLockHeld(cs_main);
     // Used if returning a PackageMempoolAcceptResult directly from this function.
@@ -1579,7 +1579,7 @@ PackageMempoolAcceptResult ProcessNewPackage(Chainstate& active_chainstate, CTxM
             return MemPoolAccept(pool, active_chainstate).AcceptMultipleTransactions(package, args);
         } else {
             auto args = MemPoolAccept::ATMPArgs::PackageChildWithParents(chainparams, GetTime(), coins_to_uncache);
-            return MemPoolAccept(pool, active_chainstate).AcceptPackage(package, args);
+            return MemPoolAccept(pool, active_chainstate).AcceptAncestorPackage(package, args);
         }
     }();
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1257,7 +1257,7 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptMultipleTransactions(const std::
 
     // These context-free package limits can be done before taking the mempool lock.
     PackageValidationState package_state;
-    if (!CheckPackage(txns, package_state)) return PackageMempoolAcceptResult(package_state, {});
+    if (!IsPackageWellFormed(txns, package_state)) return PackageMempoolAcceptResult(package_state, {});
 
     std::vector<Workspace> workspaces{};
     workspaces.reserve(txns.size());
@@ -1380,7 +1380,7 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptPackage(const Package& package, 
     // transactions and thus won't return any MempoolAcceptResults, just a package-wide error.
 
     // Context-free package checks.
-    if (!CheckPackage(package, package_state_quit_early)) return PackageMempoolAcceptResult(package_state_quit_early, {});
+    if (!IsPackageWellFormed(package, package_state_quit_early)) return PackageMempoolAcceptResult(package_state_quit_early, {});
 
     // All transactions in the package must be a parent of the last transaction. This is just an
     // opportunity for us to fail fast on a context-free check without taking the mempool lock.

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -555,6 +555,20 @@ public:
     PackageMempoolAcceptResult AcceptMultipleTransactions(const std::vector<CTransactionRef>& txns, ATMPArgs& args) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     /**
+     * Multiple transaction acceptance for transactions guaranteed to be an ancestor package and a CPFP.
+     * If only 1 transaction exists in subpackage, calls AcceptSingleTransaction() with adjusted
+     * ATMPArgs to avoid additional package policy restrictions like PackageMempoolChecks() and
+     * disabled RBF. Also creates a PackageMempoolAcceptResult wrapping the result.
+     * If multiple transactions exist in subpackage, calls AcceptMultipleTransactions() with the
+     * provided ATMPArgs. AcceptMultipleTransactions may quit early when a transaction fails, and
+     * thus not return a result for the "representative tx." If this happens, its result is filled
+     * in with TX_MISSING_INPUTS. This is correct since all other transactions must be an ancestor
+     * of the representative tx.
+    */
+    PackageMempoolAcceptResult AcceptPackageWrappingSingle(const std::vector<CTransactionRef>& subpackage, ATMPArgs& args)
+        EXCLUSIVE_LOCKS_REQUIRED(cs_main, m_pool.cs);
+
+    /**
      * Package (more specific than just multiple transactions) acceptance. Package must be a child
      * with all of its unconfirmed parents, and topologically sorted.
      */
@@ -1332,6 +1346,30 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptMultipleTransactions(const std::
     return PackageMempoolAcceptResult(package_state, std::move(results));
 }
 
+PackageMempoolAcceptResult MemPoolAccept::AcceptPackageWrappingSingle(const std::vector<CTransactionRef>& subpackage, ATMPArgs& args)
+{
+    ATMPArgs single_args = ATMPArgs::SingleInPackageAccept(args);
+    AssertLockHeld(::cs_main);
+    AssertLockHeld(m_pool.cs);
+    if (subpackage.size() > 1) {
+        const auto& rep_wtxid{subpackage.back()->GetWitnessHash()};
+        auto subpackage_result{AcceptMultipleTransactions(subpackage, args)};
+        if (subpackage_result.m_tx_results.count(rep_wtxid) == 0) {
+            TxValidationState tx_state_inferred;
+            tx_state_inferred.Invalid(TxValidationResult::TX_MISSING_INPUTS, "invalid-tx-dependency");
+            subpackage_result.m_tx_results.emplace(rep_wtxid, MempoolAcceptResult::Failure(tx_state_inferred));
+        }
+        return subpackage_result;
+    }
+    const auto& tx = subpackage.front();
+    const auto single_res = AcceptSingleTransaction(tx, single_args);
+    PackageValidationState package_state_wrapped;
+    if (single_res.m_result_type != MempoolAcceptResult::ResultType::VALID) {
+        package_state_wrapped.Invalid(PackageValidationResult::PCKG_TX, "transaction failed");
+    }
+    return PackageMempoolAcceptResult(package_state_wrapped, {{tx->GetWitnessHash(), single_res}});
+}
+
 PackageMempoolAcceptResult MemPoolAccept::AcceptPackage(const Package& package, ATMPArgs& args)
 {
     AssertLockHeld(cs_main);
@@ -1470,7 +1508,7 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptPackage(const Package& package, 
     }
     // Validate the (deduplicated) transactions as a package. Note that submission_result has its
     // own PackageValidationState; package_state_quit_early is unused past this point.
-    auto submission_result = AcceptMultipleTransactions(txns_package_eval, args);
+    auto submission_result = AcceptPackageWrappingSingle(txns_package_eval, args);
     // Include already-in-mempool transaction results in the final result.
     for (const auto& [wtxid, mempoolaccept_res] : results_final) {
         Assume(submission_result.m_tx_results.emplace(wtxid, mempoolaccept_res).second);
@@ -1478,7 +1516,7 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptPackage(const Package& package, 
     }
     if (submission_result.m_state.GetResult() == PackageValidationResult::PCKG_TX) {
         // Package validation failed because one or more transactions failed. Provide a result for
-        // each transaction; if AcceptMultipleTransactions() didn't return a result for a tx,
+        // each transaction; if a transaction doesn't have an entry in submission_result,
         // include the previous individual failure reason.
         submission_result.m_tx_results.insert(individual_results_nonfinal.cbegin(),
                                               individual_results_nonfinal.cend());

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1389,10 +1389,7 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptPackage(const Package& package, 
         return PackageMempoolAcceptResult(package_state_quit_early, {});
     }
 
-    // IsChildWithParents() guarantees the package is > 1 transactions.
-    assert(package.size() > 1);
-    // The package must be 1 child with all of its unconfirmed parents. The package is expected to
-    // be sorted, so the last transaction is the child.
+    AncestorPackage packageified(package);
     const auto& child = package.back();
     std::unordered_set<uint256, SaltedTxidHasher> unconfirmed_parent_txids;
     std::transform(package.cbegin(), package.cend() - 1,
@@ -1444,7 +1441,7 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptPackage(const Package& package, 
     std::map<uint256, MempoolAcceptResult> individual_results_nonfinal;
     bool quit_early{false};
     std::vector<CTransactionRef> txns_package_eval;
-    for (const auto& tx : package) {
+    for (const auto& tx : packageified.Txns()) {
         const auto& wtxid = tx->GetWitnessHash();
         const auto& txid = tx->GetHash();
         // There are 3 possibilities: already in mempool, same-txid-diff-wtxid already in mempool,
@@ -1455,6 +1452,7 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptPackage(const Package& package, 
             auto iter = m_pool.GetIter(txid);
             assert(iter != std::nullopt);
             results_final.emplace(wtxid, MempoolAcceptResult::MempoolTx(iter.value()->GetTxSize(), iter.value()->GetFee()));
+            packageified.Exclude(tx);
         } else if (m_pool.exists(GenTxid::Txid(txid))) {
             // Transaction with the same non-witness data but different witness (same txid,
             // different wtxid) already exists in the mempool.
@@ -1467,8 +1465,23 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptPackage(const Package& package, 
             assert(iter != std::nullopt);
             // Provide the wtxid of the mempool tx so that the caller can look it up in the mempool.
             results_final.emplace(wtxid, MempoolAcceptResult::MempoolTxDifferentWitness(iter.value()->GetTx().GetWitnessHash()));
+            packageified.Exclude(tx);
         } else {
             // Transaction does not already exist in the mempool.
+            const auto subpackage = packageified.GetAncestorSet(tx);
+            if (!subpackage) {
+                Assume(quit_early);
+                // This transaction depends on a tx we will definitely not accept (failed for a
+                // non-policy and non-missing-inputs reason). We already know that this transaction
+                // will be invalid for at least one reason, i.e. a missing input. To minimize the
+                // amount of repeated work, don't validate this tx. Just return missing inputs.
+                TxValidationState tx_state_quit_early;
+                tx_state_quit_early.Invalid(TxValidationResult::TX_MISSING_INPUTS, "invalid-tx-dependency");
+                results_final.emplace(wtxid, MempoolAcceptResult::Failure(tx_state_quit_early));
+                // Don't quit too early. Other transactions may not necessarily depend on the same
+                // parent, and should still be considered.
+                continue;
+            }
             // Try submitting the transaction on its own.
             const auto single_res = AcceptSingleTransaction(tx, single_args);
             if (single_res.m_result_type == MempoolAcceptResult::ResultType::VALID) {
@@ -1476,20 +1489,18 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptPackage(const Package& package, 
                 // in package validation, because its fees should only be "used" once.
                 assert(m_pool.exists(GenTxid::Wtxid(wtxid)));
                 results_final.emplace(wtxid, single_res);
+                packageified.Exclude(tx);
             } else if (single_res.m_state.GetResult() != TxValidationResult::TX_MEMPOOL_POLICY &&
                        single_res.m_state.GetResult() != TxValidationResult::TX_MISSING_INPUTS) {
                 // Package validation policy only differs from individual policy in its evaluation
                 // of feerate. For example, if a transaction fails here due to violation of a
                 // consensus rule, the result will not change when it is submitted as part of a
-                // package. To minimize the amount of repeated work, unless the transaction fails
-                // due to feerate or missing inputs (its parent is a previous transaction in the
-                // package that failed due to feerate), don't run package validation. Note that this
-                // decision might not make sense if different types of packages are allowed in the
-                // future.  Continue individually validating the rest of the transactions, because
-                // some of them may still be valid.
+                // package. Tell the AncestorPackage that subsequent transactions depending on this one
+                // should be skipped.
                 quit_early = true;
                 package_state_quit_early.Invalid(PackageValidationResult::PCKG_TX, "transaction failed");
-                individual_results_nonfinal.emplace(wtxid, single_res);
+                results_final.emplace(wtxid, single_res);
+                packageified.Ban(tx);
             } else {
                 individual_results_nonfinal.emplace(wtxid, single_res);
                 txns_package_eval.push_back(tx);
@@ -1499,6 +1510,7 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptPackage(const Package& package, 
 
     // Quit early because package validation won't change the result or the entire package has
     // already been submitted.
+    // If txns_package_eval is empty, all transactions have already passed.
     if (quit_early || txns_package_eval.empty()) {
         for (const auto& [wtxid, mempoolaccept_res] : individual_results_nonfinal) {
             Assume(results_final.emplace(wtxid, mempoolaccept_res).second);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1482,6 +1482,12 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptPackage(const Package& package, 
                 // parent, and should still be considered.
                 continue;
             }
+            if (wtxid == child->GetWitnessHash() && !quit_early) {
+                Assume(tx == package.back());
+                txns_package_eval.push_back(tx);
+                // Unless we're quitting early, validate the child outside of this loop.
+                break;
+            }
             // Try submitting the transaction on its own.
             const auto single_res = AcceptSingleTransaction(tx, single_args);
             if (single_res.m_result_type == MempoolAcceptResult::ResultType::VALID) {

--- a/test/functional/p2p_orphan_handling.py
+++ b/test/functional/p2p_orphan_handling.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+# Copyright (c) 2022 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""
+"""
+
+import random
+import time
+
+from test_framework.messages import (
+    CInv,
+    COutPoint,
+    CTransaction,
+    CTxIn,
+    CTxInWitness,
+    CTxOut,
+    MSG_WITNESS_TX,
+    MSG_WTX,
+    msg_inv,
+    msg_tx,
+)
+from test_framework.p2p import (
+    NONPREF_PEER_TX_DELAY,
+    ORPHAN_ANCESTOR_GETDATA_INTERVAL,
+    OVERLOADED_PEER_TX_DELAY,
+    p2p_lock,
+    P2PTxInvStore,
+    TXID_RELAY_DELAY,
+)
+from test_framework.script import (
+    CScript,
+    OP_NOP,
+    OP_RETURN,
+)
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.wallet import (
+    MiniWallet,
+)
+
+# Time to fastforward (using setmocktime) before waiting for the node to send getdata(tx) in response
+# to an inv(tx), in seconds. This delay includes all possible delays + 1, so it should only be used
+# when the value of the delay is not interesting. If we want to test that the node waits x seconds
+# for one peer and y seconds for another, use specific values instead.
+TXREQUEST_TIME_SKIP = NONPREF_PEER_TX_DELAY + TXID_RELAY_DELAY + OVERLOADED_PEER_TX_DELAY + 1
+
+# Time to fastfoward (using setmocktime) in between subtests to ensure they do not interfere with
+# one another, in seconds. Equal to 12 hours, which is enough to expire anything that may exist
+# (though nothing should since state should be cleared) in p2p data structures.
+LONG_TIME_SKIP = 12 * 60 * 60
+
+def cleanup(func):
+    def wrapper(self):
+        try:
+            func(self)
+        finally:
+            # Clear mempool
+            self.generate(self.nodes[0], 1)
+            self.nodes[0].disconnect_p2ps()
+            self.mocktime += LONG_TIME_SKIP
+            self.nodes[0].setmocktime(self.mocktime)
+    return wrapper
+
+class PeerTxRelayer(P2PTxInvStore):
+    def __init__(self):
+        super().__init__()
+        self._tx_received = []
+        self._getdata_received = []
+
+    @property
+    def tx_received(self):
+        with p2p_lock:
+            return self._tx_received
+
+    @property
+    def getdata_received(self):
+        with p2p_lock:
+            return self._getdata_received
+
+    def on_tx(self, message):
+        self._tx_received.append(message)
+
+    def on_getdata(self, message):
+        self._getdata_received.append(message)
+
+    def wait_for_getdata_txids(self, txids):
+        def test_function():
+            last_getdata = self.last_message.get('getdata')
+            if not last_getdata:
+                return False
+            return all([item.type == MSG_WITNESS_TX and item.hash in txids for item in last_getdata.inv])
+        self.wait_until(test_function, timeout=10)
+
+class OrphanHandlingTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.extra_args = [[]]
+        self.mocktime = int(time.time())
+
+    def create_package(self):
+        """Create package with 1 parent and 1 child, normal fees (no cpfp).
+        """
+        parent = self.wallet.create_self_transfer()
+        child = self.wallet.create_self_transfer(utxo_to_spend=parent['new_utxo'])
+        orphan_wtxid = child["tx"].getwtxid()
+        orphan_tx = child["tx"]
+        parent_tx = parent["tx"]
+        return orphan_wtxid, orphan_tx, parent_tx
+
+    def create_large_orphan(self):
+        """Create huge orphan transaction"""
+        tx = CTransaction()
+        # Nonexistent UTXO
+        tx.vin = [CTxIn(COutPoint(random.randrange(1 << 256), random.randrange(1, 100)))]
+        tx.wit.vtxinwit = [CTxInWitness()]
+        tx.wit.vtxinwit[0].scriptWitness.stack = [CScript([OP_NOP] * 390000)]
+        tx.vout = [CTxOut(100, CScript([OP_RETURN, b'a' * 20]))]
+        return tx
+
+    def fastforward(self, seconds):
+        """Convenience helper function to fast-forward, so we don't need to keep track of the
+        starting time when we call setmocktime."""
+        self.mocktime += seconds
+        self.nodes[0].setmocktime(self.mocktime)
+
+    @cleanup
+    def test_orphan_handling_prefer_outbound(self):
+        self.log.info("Test that the node prefers requesting from outbound peers")
+        node = self.nodes[0]
+        orphan_wtxid, orphan_tx, parent_tx = self.create_package()
+        orphan_inv = CInv(t=MSG_WTX, h=int(orphan_wtxid, 16))
+
+        peer_inbound = node.add_p2p_connection(PeerTxRelayer())
+        peer_inbound.send_and_ping(msg_inv([orphan_inv]))
+        self.fastforward(TXREQUEST_TIME_SKIP)
+        peer_inbound.wait_for_getdata([int(orphan_wtxid, 16)])
+
+        # Both peers send invs for the orphan, so the node an expect both to know its ancestors.
+        peer_outbound = node.add_outbound_p2p_connection(PeerTxRelayer(), p2p_idx=1)
+        peer_outbound.send_and_ping(msg_inv([orphan_inv]))
+
+        # The outbound peer should be preferred for getting orphan parents
+        peer_inbound.send_and_ping(msg_tx(orphan_tx))
+        peer_outbound.wait_for_getdata_txids([int(parent_tx.rehash(), 16)])
+        # There should be no request to the inbound peer
+        outbound_getdata_received = peer_outbound.getdata_received.pop()
+        assert outbound_getdata_received not in peer_inbound.getdata_received
+
+        self.log.info("Test that, if the preferred peer doesn't respond, the node sends another request")
+        self.fastforward(ORPHAN_ANCESTOR_GETDATA_INTERVAL)
+        peer_inbound.sync_with_ping()
+        peer_inbound.wait_for_getdata_txids([int(parent_tx.rehash(), 16)])
+
+    @cleanup
+    def test_announcers_before_and_after(self):
+        self.log.info("Test that the node uses all peers who announced the tx prior to realizing it's an orphan")
+        node = self.nodes[0]
+        orphan_wtxid, orphan_tx, parent_tx = self.create_package()
+        orphan_inv = CInv(t=MSG_WTX, h=int(orphan_wtxid, 16))
+
+        # Announces before tx is sent, disconnects while node is requesting parents
+        peer_early_disconnected = node.add_outbound_p2p_connection(PeerTxRelayer(), p2p_idx=2)
+        # Announces before tx is sent, doesn't respond to parent request
+        peer_early_unresponsive = node.add_p2p_connection(PeerTxRelayer())
+
+        # Announces after tx is sent
+        peer_late_announcer = node.add_p2p_connection(PeerTxRelayer())
+
+        # Both peers send invs for the orphan, so the node an expect both to know its ancestors.
+        peer_early_disconnected.send_and_ping(msg_inv([orphan_inv]))
+        self.fastforward(TXREQUEST_TIME_SKIP)
+        peer_early_disconnected.wait_for_getdata([int(orphan_wtxid, 16)])
+        peer_early_unresponsive.send_and_ping(msg_inv([orphan_inv]))
+        peer_early_disconnected.send_and_ping(msg_tx(orphan_tx))
+        self.fastforward(NONPREF_PEER_TX_DELAY)
+
+        # Peer disconnects before responding to request
+        peer_early_disconnected.wait_for_getdata_txids([int(parent_tx.rehash(), 16)])
+        peer_early_disconnected.peer_disconnect()
+        peer_early_unresponsive.wait_for_getdata_txids([int(parent_tx.rehash(), 16)])
+
+        self.log.info("Test that the node uses peers who announce the tx after realizing it's an orphan")
+        peer_late_announcer.send_and_ping(msg_inv([orphan_inv]))
+        self.fastforward(ORPHAN_ANCESTOR_GETDATA_INTERVAL)
+        peer_early_unresponsive.sync_with_ping()
+        peer_late_announcer.wait_for_getdata_txids([int(parent_tx.rehash(), 16)])
+
+
+    def run_test(self):
+        self.wallet = MiniWallet(self.nodes[0])
+        self.generate(self.wallet, 160)
+        self.test_orphan_handling_prefer_outbound()
+        self.test_announcers_before_and_after()
+
+
+if __name__ == '__main__':
+    OrphanHandlingTest().main()

--- a/test/functional/p2p_package_relay.py
+++ b/test/functional/p2p_package_relay.py
@@ -72,6 +72,7 @@ class PackageRelayTest(BitcoinTestFramework):
         assert_equal(node.getpeerinfo()[0]["bytesrecv_per_msg"]["sendpackages"], 32)
         assert_equal(node.getpeerinfo()[0]["bytessent_per_msg"]["sendpackages"], 32)
         assert_equal(peer_normal.sendpackages_received, [PKG_RELAY_ANCPKG])
+        assert node.getpeerinfo()[0]["relaytxpackages"]
         node.disconnect_p2ps()
 
         self.log.info("Test sendpackages without wtxid relay")
@@ -80,6 +81,7 @@ class PackageRelayTest(BitcoinTestFramework):
         assert_equal(node.getpeerinfo()[0]["bytesrecv_per_msg"]["sendpackages"], 32)
         assert_equal(node.getpeerinfo()[0]["bytessent_per_msg"]["sendpackages"], 32)
         assert_equal(peer_no_wtxidrelay.sendpackages_received, [PKG_RELAY_ANCPKG])
+        assert not node.getpeerinfo()[0]["relaytxpackages"]
         node.disconnect_p2ps()
 
         self.log.info("Test sendpackages is sent even so")
@@ -89,6 +91,7 @@ class PackageRelayTest(BitcoinTestFramework):
         assert_equal(node.getpeerinfo()[0]["bytessent_per_msg"]["sendpackages"], 32)
         assert "sendpackages" not in node.getpeerinfo()[0]["bytesrecv_per_msg"]
         assert_equal(peer_no_sendpackages.sendpackages_received, [PKG_RELAY_ANCPKG])
+        assert not node.getpeerinfo()[0]["relaytxpackages"]
         node.disconnect_p2ps()
 
         self.log.info("Test disconnection if sendpackages is sent after version handshake")

--- a/test/functional/p2p_package_relay.py
+++ b/test/functional/p2p_package_relay.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+# Copyright (c) 2022 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test package relay messages"""
+
+import time
+
+from test_framework.messages import (
+    msg_sendpackages,
+    msg_verack,
+    msg_wtxidrelay,
+    PKG_RELAY_ANCPKG,
+)
+from test_framework.p2p import (
+    p2p_lock,
+    P2PTxInvStore,
+)
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+)
+
+def cleanup(func):
+    def wrapper(self):
+        assert len(self.nodes[0].getpeerinfo()) == 0
+        assert len(self.nodes[0].getrawmempool()) == 0
+        try:
+            func(self)
+        finally:
+            # Clear mempool
+            self.generate(self.nodes[0], 1)
+            self.nodes[0].disconnect_p2ps()
+    return wrapper
+
+class PackageRelayer(P2PTxInvStore):
+    def __init__(self, send_sendpackages=True, send_wtxidrelay=True):
+        super().__init__()
+        # List versions of each sendpackages received
+        self._sendpackages_received = []
+        self._send_sendpackages = send_sendpackages
+        self._send_wtxidrelay = send_wtxidrelay
+
+    @property
+    def sendpackages_received(self):
+        with p2p_lock:
+            return self._sendpackages_received
+
+    def on_version(self, message):
+        if self._send_wtxidrelay:
+            self.send_message(msg_wtxidrelay())
+        if self._send_sendpackages:
+            sendpackages_message = msg_sendpackages()
+            sendpackages_message.versions = PKG_RELAY_ANCPKG
+            self.send_message(sendpackages_message)
+        self.send_message(msg_verack())
+        self.nServices = message.nServices
+
+    def on_sendpackages(self, message):
+        self._sendpackages_received.append(message.versions)
+
+class PackageRelayTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.extra_args = [["-packagerelay=1"]]
+
+    @cleanup
+    def test_sendpackages(self):
+        self.log.info("Test sendpackages during version handshake")
+        node = self.nodes[0]
+        peer_normal = node.add_p2p_connection(PackageRelayer())
+        assert_equal(node.getpeerinfo()[0]["bytesrecv_per_msg"]["sendpackages"], 32)
+        assert_equal(node.getpeerinfo()[0]["bytessent_per_msg"]["sendpackages"], 32)
+        assert_equal(peer_normal.sendpackages_received, [PKG_RELAY_ANCPKG])
+        node.disconnect_p2ps()
+
+        self.log.info("Test sendpackages without wtxid relay")
+        node = self.nodes[0]
+        peer_no_wtxidrelay = node.add_p2p_connection(PackageRelayer(send_wtxidrelay=False))
+        assert_equal(node.getpeerinfo()[0]["bytesrecv_per_msg"]["sendpackages"], 32)
+        assert_equal(node.getpeerinfo()[0]["bytessent_per_msg"]["sendpackages"], 32)
+        assert_equal(peer_no_wtxidrelay.sendpackages_received, [PKG_RELAY_ANCPKG])
+        node.disconnect_p2ps()
+
+        self.log.info("Test sendpackages is sent even so")
+        node = self.nodes[0]
+        peer_no_sendpackages = node.add_p2p_connection(PackageRelayer(send_sendpackages=False))
+        # Sendpackages should still be sent
+        assert_equal(node.getpeerinfo()[0]["bytessent_per_msg"]["sendpackages"], 32)
+        assert "sendpackages" not in node.getpeerinfo()[0]["bytesrecv_per_msg"]
+        assert_equal(peer_no_sendpackages.sendpackages_received, [PKG_RELAY_ANCPKG])
+        node.disconnect_p2ps()
+
+        self.log.info("Test disconnection if sendpackages is sent after version handshake")
+        peer_sendpackages_after_verack = node.add_p2p_connection(P2PTxInvStore())
+        sendpackages_message = msg_sendpackages()
+        sendpackages_message.versions = PKG_RELAY_ANCPKG
+        peer_sendpackages_after_verack.send_message(sendpackages_message)
+        peer_sendpackages_after_verack.wait_for_disconnect()
+
+    def run_test(self):
+        self.test_sendpackages()
+
+if __name__ == '__main__':
+    PackageRelayTest().main()

--- a/test/functional/p2p_package_relay.py
+++ b/test/functional/p2p_package_relay.py
@@ -7,19 +7,44 @@
 import time
 
 from test_framework.messages import (
+    CInv,
+    MSG_ANCPKGINFO,
+    MSG_WTX,
+    msg_getdata,
     msg_sendpackages,
     msg_verack,
     msg_wtxidrelay,
     PKG_RELAY_ANCPKG,
 )
 from test_framework.p2p import (
+    NONPREF_PEER_TX_DELAY,
+    OVERLOADED_PEER_TX_DELAY,
     p2p_lock,
     P2PTxInvStore,
+    TXID_RELAY_DELAY,
+    UNCONDITIONAL_RELAY_DELAY,
 )
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
+    assert_greater_than_or_equal,
 )
+from test_framework.wallet import (
+    COIN,
+    DEFAULT_FEE,
+    MiniWallet,
+)
+
+# Time to fastforward (using setmocktime) before waiting for the node to send getdata(tx) in response
+# to an inv(tx), in seconds. This delay includes all possible delays + 1, so it should only be used
+# when the value of the delay is not interesting. If we want to test that the node waits x seconds
+# for one peer and y seconds for another, use specific values instead.
+TXREQUEST_TIME_SKIP = NONPREF_PEER_TX_DELAY + TXID_RELAY_DELAY + OVERLOADED_PEER_TX_DELAY + 1
+
+# Time to fastfoward (using setmocktime) in between subtests to ensure they do not interfere with
+# one another, in seconds. Equal to 12 hours, which is enough to expire anything that may exist
+# (though nothing should since state should be cleared) in p2p data structures.
+LONG_TIME_SKIP = 12 * 60 * 60
 
 def cleanup(func):
     def wrapper(self):
@@ -31,6 +56,8 @@ def cleanup(func):
             # Clear mempool
             self.generate(self.nodes[0], 1)
             self.nodes[0].disconnect_p2ps()
+            self.mocktime += LONG_TIME_SKIP
+            self.nodes[0].setmocktime(self.mocktime)
     return wrapper
 
 class PackageRelayer(P2PTxInvStore):
@@ -40,11 +67,23 @@ class PackageRelayer(P2PTxInvStore):
         self._sendpackages_received = []
         self._send_sendpackages = send_sendpackages
         self._send_wtxidrelay = send_wtxidrelay
+        self._ancpkginfo_received = []
+        self._tx_received = []
 
     @property
     def sendpackages_received(self):
         with p2p_lock:
             return self._sendpackages_received
+
+    @property
+    def ancpkginfo_received(self):
+        with p2p_lock:
+            return self._ancpkginfo_received
+
+    @property
+    def tx_received(self):
+        with p2p_lock:
+            return self._tx_received
 
     def on_version(self, message):
         if self._send_wtxidrelay:
@@ -59,10 +98,41 @@ class PackageRelayer(P2PTxInvStore):
     def on_sendpackages(self, message):
         self._sendpackages_received.append(message.versions)
 
+    def on_ancpkginfo(self, message):
+        self._ancpkginfo_received.append(message.wtxids)
+
+    def on_tx(self, message):
+        self._tx_received.append(message)
+
 class PackageRelayTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
         self.extra_args = [["-packagerelay=1"]]
+        self.mocktime = int(time.time())
+
+    def create_package(self, cpfp=True):
+        """Create package with these transactions:
+        - Parent 1: fee=default
+        - Parent 2: fee=0 if cpfp, else default
+        - Child:    fee=high
+        """
+        parent1 = self.wallet.create_self_transfer()
+        parent2 = self.wallet.create_self_transfer(fee_rate=0, fee=0) if cpfp else self.wallet.create_self_transfer()
+        child = self.wallet.create_self_transfer_multi(
+            utxos_to_spend=[parent1['new_utxo'], parent2["new_utxo"]],
+            num_outputs=1,
+            fee_per_output=int(DEFAULT_FEE * COIN)
+        )
+        package_hex = [parent1["hex"], parent2["hex"], child["hex"]]
+        package_txns = [parent1["tx"], parent2["tx"], child["tx"]]
+        package_wtxids = [tx.getwtxid() for tx in package_txns]
+        return package_hex, package_txns, package_wtxids
+
+    def fastforward(self, seconds):
+        """Convenience helper function to fast-forward, so we don't need to keep track of the
+        starting time when we call setmocktime."""
+        self.mocktime += seconds
+        self.nodes[0].setmocktime(self.mocktime)
 
     @cleanup
     def test_sendpackages(self):
@@ -101,8 +171,44 @@ class PackageRelayTest(BitcoinTestFramework):
         peer_sendpackages_after_verack.send_message(sendpackages_message)
         peer_sendpackages_after_verack.wait_for_disconnect()
 
+    @cleanup
+    def test_ancpkginfo_requests(self):
+        node = self.nodes[0]
+        peer_info_requester = node.add_p2p_connection(PackageRelayer())
+        package_hex, package_txns, package_wtxids = self.create_package(cpfp=False)
+        node.submitpackage(package_hex)
+        assert_equal(node.getmempoolentry(package_txns[-1].rehash())["ancestorcount"], 3)
+
+        self.log.info("Test that ancpkginfo requests for unannounced transactions are ignored until UNCONDITIONAL_RELAY_DELAY elapses")
+        tx_request = msg_getdata([CInv(t=MSG_WTX, h=int(package_wtxids[-1], 16))])
+        peer_info_requester.send_and_ping(tx_request)
+        assert not peer_info_requester.tx_received
+        child_ancpkginfo_request = msg_getdata([CInv(t=MSG_ANCPKGINFO, h=int(package_wtxids[-1], 16))])
+        peer_info_requester.send_and_ping(child_ancpkginfo_request)
+        assert not peer_info_requester.ancpkginfo_received
+
+        self.fastforward(UNCONDITIONAL_RELAY_DELAY)
+        peer_info_requester.send_and_ping(tx_request)
+        assert_greater_than_or_equal(len(peer_info_requester.tx_received), 1)
+
+        self.log.info("Test that node responds to ancpkginfo request with ancestor package wtxids")
+        peer_info_requester.send_and_ping(child_ancpkginfo_request)
+        assert_greater_than_or_equal(len(peer_info_requester.ancpkginfo_received), 1)
+        last_ancpkginfo_received = peer_info_requester.ancpkginfo_received.pop()
+        assert all([int(wtxid, 16) in last_ancpkginfo_received for wtxid in package_wtxids])
+        # When a tx has no unconfirmed ancestors, ancpkginfo just contains its own wtxid
+        for i in range(len(package_txns) - 1):
+            parent_ancpkginfo_request = msg_getdata([CInv(t=MSG_ANCPKGINFO, h=int(package_wtxids[i], 16))])
+            peer_info_requester.send_and_ping(parent_ancpkginfo_request)
+            assert_equal([int(package_wtxids[i], 16)], peer_info_requester.ancpkginfo_received.pop())
+
     def run_test(self):
+        self.wallet = MiniWallet(self.nodes[0])
+        self.generate(self.wallet, 160)
+
         self.test_sendpackages()
+        self.test_ancpkginfo_requests()
+
 
 if __name__ == '__main__':
     PackageRelayTest().main()

--- a/test/functional/p2p_package_relay.py
+++ b/test/functional/p2p_package_relay.py
@@ -2,16 +2,25 @@
 # Copyright (c) 2022 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Test package relay messages"""
+"""
+Test package relay messages and net processing logic on a singular node.
+This has its own test because it requires lots of setmocktimeing and that's hard to coordinate
+across multiple nodes.
+"""
 
 import time
 
 from test_framework.messages import (
     CInv,
     MSG_ANCPKGINFO,
+    MSG_WITNESS_TX,
     MSG_WTX,
+    msg_ancpkginfo,
     msg_getdata,
+    msg_inv,
+    msg_notfound,
     msg_sendpackages,
+    msg_tx,
     msg_verack,
     msg_wtxidrelay,
     PKG_RELAY_ANCPKG,
@@ -19,6 +28,7 @@ from test_framework.messages import (
 from test_framework.p2p import (
     NONPREF_PEER_TX_DELAY,
     OVERLOADED_PEER_TX_DELAY,
+    ORPHAN_ANCESTOR_GETDATA_INTERVAL,
     p2p_lock,
     P2PTxInvStore,
     TXID_RELAY_DELAY,
@@ -69,6 +79,7 @@ class PackageRelayer(P2PTxInvStore):
         self._send_wtxidrelay = send_wtxidrelay
         self._ancpkginfo_received = []
         self._tx_received = []
+        self._getdata_received = []
 
     @property
     def sendpackages_received(self):
@@ -84,6 +95,11 @@ class PackageRelayer(P2PTxInvStore):
     def tx_received(self):
         with p2p_lock:
             return self._tx_received
+
+    @property
+    def getdata_received(self):
+        with p2p_lock:
+            return self._getdata_received
 
     def on_version(self, message):
         if self._send_wtxidrelay:
@@ -103,6 +119,25 @@ class PackageRelayer(P2PTxInvStore):
 
     def on_tx(self, message):
         self._tx_received.append(message)
+
+    def on_getdata(self, message):
+        self._getdata_received.append(message)
+
+    def wait_for_getancpkginfo(self, wtxid16):
+        def test_function():
+            last_getdata = self.last_message.get('getdata')
+            if not last_getdata:
+                return False
+            return last_getdata.inv[0].hash == wtxid16 and last_getdata.inv[0].type == MSG_ANCPKGINFO
+        self.wait_until(test_function, timeout=10)
+
+    def wait_for_getdata_txids(self, txids):
+        def test_function():
+            last_getdata = self.last_message.get('getdata')
+            if not last_getdata:
+                return False
+            return all([item.type == MSG_WITNESS_TX and item.hash in txids for item in last_getdata.inv])
+        self.wait_until(test_function, timeout=10)
 
 class PackageRelayTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -189,7 +224,7 @@ class PackageRelayTest(BitcoinTestFramework):
 
         self.fastforward(UNCONDITIONAL_RELAY_DELAY)
         peer_info_requester.send_and_ping(tx_request)
-        assert_greater_than_or_equal(len(peer_info_requester.tx_received), 1)
+        peer_info_requester.wait_for_tx(package_txns[-1].rehash())
 
         self.log.info("Test that node responds to ancpkginfo request with ancestor package wtxids")
         peer_info_requester.send_and_ping(child_ancpkginfo_request)
@@ -202,12 +237,182 @@ class PackageRelayTest(BitcoinTestFramework):
             peer_info_requester.send_and_ping(parent_ancpkginfo_request)
             assert_equal([int(package_wtxids[i], 16)], peer_info_requester.ancpkginfo_received.pop())
 
+    @cleanup
+    def test_orphan_get_ancpkginfo(self):
+        self.log.info("Test that nodes deal with orphans by requesting ancestor package info")
+        node = self.nodes[0]
+        package_hex, package_txns, package_wtxids = self.create_package()
+        orphan_tx = package_txns[-1]
+        orphan_wtxid = package_wtxids[-1]
+
+        peer_package_relayer = node.add_p2p_connection(PackageRelayer())
+        orphan_inv = CInv(t=MSG_WTX, h=int(orphan_wtxid, 16))
+        peer_package_relayer.send_and_ping(msg_inv([orphan_inv]))
+        self.fastforward(NONPREF_PEER_TX_DELAY + 1)
+        peer_package_relayer.wait_for_getdata([int(orphan_wtxid, 16)])
+        peer_package_relayer.send_and_ping(msg_tx(orphan_tx))
+
+        self.fastforward(NONPREF_PEER_TX_DELAY + 1)
+        peer_package_relayer.sync_with_ping()
+        peer_package_relayer.wait_for_getancpkginfo(int(orphan_wtxid, 16))
+        peer_package_relayer.send_and_ping(msg_ancpkginfo([int(wtxid, 16) for wtxid in package_wtxids]))
+        self.wait_until(lambda: "ancpkginfo" in node.getpeerinfo()[0]["bytesrecv_per_msg"])
+
+    @cleanup
+    def test_orphan_handling_prefer_outbound(self):
+        self.log.info("Test that the node uses all announcers as potential candidates for orphan handling")
+        node = self.nodes[0]
+        package_hex, package_txns, package_wtxids = self.create_package()
+        orphan_tx = package_txns[-1]
+        orphan_wtxid = package_wtxids[-1]
+        orphan_inv = CInv(t=MSG_WTX, h=int(orphan_wtxid, 16))
+
+        peer_inbound = node.add_p2p_connection(PackageRelayer())
+        peer_outbound = node.add_outbound_p2p_connection(PackageRelayer(), p2p_idx=1)
+
+        peer_inbound.send_and_ping(msg_inv([orphan_inv]))
+        self.fastforward(NONPREF_PEER_TX_DELAY + 1)
+        peer_inbound.wait_for_getdata([int(orphan_wtxid, 16)])
+        # Both send invs for the orphan, so the node an expect both to know its ancestors.
+        peer_outbound.send_and_ping(msg_inv([orphan_inv]))
+        peer_inbound.send_and_ping(msg_tx(orphan_tx))
+        self.fastforward(NONPREF_PEER_TX_DELAY)
+
+        self.log.info("Test that the node prefers requesting ancpkginfo from outbound peers")
+        # The outbound peer should be preferred for getting ancpkginfo
+        peer_outbound.wait_for_getancpkginfo(int(orphan_wtxid, 16))
+        # There should be no request to the inbound peer
+        ancpkginfo_request = peer_outbound.getdata_received.pop()
+        assert ancpkginfo_request not in peer_inbound.getdata_received
+
+        self.log.info("Test that, if the preferred peer doesn't respond, the node sends another request")
+        self.fastforward(ORPHAN_ANCESTOR_GETDATA_INTERVAL)
+        peer_inbound.sync_with_ping()
+        peer_inbound.wait_for_getancpkginfo(int(orphan_wtxid, 16))
+
+    @cleanup
+    def test_orphan_handling_prefer_ancpkginfo(self):
+        node = self.nodes[0]
+        package_hex, package_txns, package_wtxids = self.create_package()
+        orphan_tx = package_txns[-1]
+        orphan_wtxid = package_wtxids[-1]
+        orphan_inv = CInv(t=MSG_WTX, h=int(orphan_wtxid, 16))
+
+        peer_legacy = node.add_p2p_connection(PackageRelayer(send_sendpackages=False))
+        peer_package_relay = node.add_p2p_connection(PackageRelayer())
+        assert not node.getpeerinfo()[0]["relaytxpackages"]
+        assert node.getpeerinfo()[1]["relaytxpackages"]
+
+        peer_legacy.send_and_ping(msg_inv([orphan_inv]))
+        self.fastforward(TXREQUEST_TIME_SKIP)
+        peer_legacy.wait_for_getdata([int(orphan_wtxid, 16)])
+        # Both send invs for the orphan, so the node can expect both to know its ancestors.
+        peer_package_relay.send_and_ping(msg_inv([orphan_inv]))
+        peer_legacy.send_and_ping(msg_tx(orphan_tx))
+
+        # Tx is an orphan. The package relay peer is preferred for orphan resolution.
+        nonpackage_prev_getdata = len(peer_legacy.getdata_received)
+        self.fastforward(NONPREF_PEER_TX_DELAY)
+        peer_package_relay.sync_with_ping()
+        peer_legacy.sync_with_ping()
+        peer_package_relay.wait_for_getancpkginfo(int(orphan_wtxid, 16))
+        # The legacy peer should not have received any request.
+        assert_equal(nonpackage_prev_getdata, len(peer_legacy.getdata_received))
+
+        self.log.info("Test that, if the package relay peer doesn't respond, node falls back to parent txids")
+        self.fastforward(ORPHAN_ANCESTOR_GETDATA_INTERVAL)
+        peer_legacy.wait_for_getdata_txids([int(tx.rehash(), 16) for tx in package_txns[:-1]])
+
+    @cleanup
+    def test_orphan_announcer_memory(self):
+        self.log.info("Test that the node remembers who announced orphan transactions")
+        node = self.nodes[0]
+        package_hex, package_txns, package_wtxids = self.create_package()
+        orphan_tx = package_txns[-1]
+        orphan_wtxid = package_wtxids[-1]
+        orphan_inv = CInv(t=MSG_WTX, h=int(orphan_wtxid, 16))
+
+        # Original announcer of orphan
+        peer_package_relay1 = node.add_outbound_p2p_connection(PackageRelayer(), p2p_idx=2)
+        # Sends an inv for the orphan before the node requests orphan tx data.
+        # Preferred for orphan handling over peer3 because it's an outbound connection.
+        peer_package_relay2 = node.add_p2p_connection(PackageRelayer())
+        # Sends an inv for the orphan while the node is requesting ancpkginfo
+        peer_package_relay3 = node.add_p2p_connection(PackageRelayer())
+
+        peer_package_relay1.send_and_ping(msg_inv([orphan_inv]))
+        self.fastforward(NONPREF_PEER_TX_DELAY + 1)
+        peer_package_relay1.wait_for_getdata([int(orphan_wtxid, 16)])
+
+        # Both send invs for the orphan, so the node an expect both to know its ancestors.
+        peer_package_relay2.send_and_ping(msg_inv([orphan_inv]))
+        peer_package_relay1.send_and_ping(msg_tx(orphan_tx))
+
+        peer2_prev_getdata = len(peer_package_relay2.getdata_received)
+        peer3_prev_getdata = len(peer_package_relay3.getdata_received)
+        self.fastforward(NONPREF_PEER_TX_DELAY)
+        peer_package_relay1.wait_for_getancpkginfo(int(orphan_wtxid, 16))
+        peer_package_relay3.send_and_ping(msg_inv([orphan_inv]))
+        # Peers 2 and 3 should not have received any getdata
+        # Not for tx data of the orphan, not for ancpkginfo, and not for parent txids
+        assert_equal(peer2_prev_getdata, len(peer_package_relay2.getdata_received))
+        assert_equal(peer3_prev_getdata, len(peer_package_relay3.getdata_received))
+
+        self.log.info("Test that the node requests ancpkginfo from a different peer upon receiving notfound")
+        orphan_ancpkginfo_notfound = msg_notfound(vec=[CInv(MSG_ANCPKGINFO, int(orphan_wtxid, 16))])
+        peer_package_relay1.send_and_ping(orphan_ancpkginfo_notfound)
+        self.fastforward(1)
+        # Node should try again from peer2
+        peer_package_relay2.wait_for_getancpkginfo(int(orphan_wtxid, 16))
+
+        self.log.info("Test that the node requests ancpkginfo from a different peer if peer disconnects")
+        # Peer 2 disconnected before responding
+        peer_package_relay2.peer_disconnect()
+        self.fastforward(1)
+        peer_package_relay3.sync_with_ping()
+        peer_package_relay3.wait_for_getancpkginfo(int(orphan_wtxid, 16))
+
+    @cleanup
+    def test_ancpkginfo_received(self):
+        node = self.nodes[0]
+        parent1 = self.wallet.create_self_transfer()
+        parent2 = self.wallet.create_self_transfer()
+        child = self.wallet.create_self_transfer_multi(
+            utxos_to_spend=[parent1['new_utxo'], parent2["new_utxo"]],
+            num_outputs=1,
+            fee_per_output=int(DEFAULT_FEE * COIN)
+        )
+        package_txns = [parent1["tx"], parent2["tx"], child["tx"]]
+        package_wtxids = [tx.getwtxid() for tx in package_txns]
+        ancpkginfo_message = msg_ancpkginfo([int(wtxid, 16) for wtxid in package_wtxids])
+
+        self.log.info("Test that unsolicited ancpkginfo results in disconnection")
+        peer1 = node.add_p2p_connection(PackageRelayer())
+        peer1.send_message(ancpkginfo_message)
+        peer1.wait_for_disconnect()
+
+        self.log.info("Test that peer uses ancpkginfo to request orphan's ancestors")
+        orphan_inv = CInv(t=MSG_WTX, h=int(package_wtxids[-1], 16))
+        peer2 = node.add_p2p_connection(PackageRelayer())
+        peer2.send_and_ping(msg_inv([orphan_inv]))
+        self.fastforward(NONPREF_PEER_TX_DELAY + 1)
+        peer2.wait_for_getdata([int(package_wtxids[-1], 16)])
+        peer2.send_and_ping(msg_tx(package_txns[-1]))
+        self.fastforward(NONPREF_PEER_TX_DELAY + 1)
+        peer2.wait_for_getancpkginfo(int(package_wtxids[-1], 16))
+        peer2.send_and_ping(ancpkginfo_message)
+
     def run_test(self):
         self.wallet = MiniWallet(self.nodes[0])
         self.generate(self.wallet, 160)
 
         self.test_sendpackages()
         self.test_ancpkginfo_requests()
+        self.test_orphan_get_ancpkginfo()
+        self.test_orphan_handling_prefer_outbound()
+        self.test_orphan_handling_prefer_ancpkginfo()
+        self.test_orphan_announcer_memory()
+        self.test_ancpkginfo_received()
 
 
 if __name__ == '__main__':

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -2058,7 +2058,7 @@ class SegWitTest(BitcoinTestFramework):
         test_transaction_acceptance(self.nodes[0], self.wtx_node, tx2, with_witness=True, accepted=False)
 
         # Expect a request for parent (tx) by txid despite use of WTX peer
-        self.wtx_node.wait_for_getdata([tx.sha256], 60)
+        self.wtx_node.wait_for_getdata([tx.sha256], 65)
         with p2p_lock:
             lgd = self.wtx_node.lastgetdata[:]
         assert_equal(lgd, [CInv(MSG_WITNESS_TX, tx.sha256)])

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -129,6 +129,7 @@ class NetTest(BitcoinTestFramework):
                 "id": no_version_peer_id,
                 "inbound": True,
                 "inflight": [],
+                "relaytxpackages" : False,
                 "last_block": 0,
                 "last_transaction": 0,
                 "lastrecv": 0,

--- a/test/functional/rpc_packages.py
+++ b/test/functional/rpc_packages.py
@@ -17,7 +17,6 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     assert_fee_amount,
-    assert_raises_rpc_error,
 )
 from test_framework.wallet import (
     DEFAULT_FEE,
@@ -325,17 +324,13 @@ class RPCPackagesTest(BitcoinTestFramework):
         self.generate(node, 1)
 
     def test_submitpackage(self):
-        node = self.nodes[0]
-
         self.log.info("Submitpackage valid packages with 1 child and some number of parents")
         for num_parents in [1, 2, 24]:
             self.test_submit_child_with_parents(num_parents, False)
             self.test_submit_child_with_parents(num_parents, True)
-
-        self.log.info("Submitpackage only allows packages of 1 child with its parents")
-        # Chain of 3 transactions has too many generations
+        self.log.info("Submitpackage with a 25-generation chain")
         chain_hex = [t["hex"] for t in self.wallet.create_self_transfer_chain(chain_length=25)]
-        assert_raises_rpc_error(-25, "not-child-with-parents", node.submitpackage, chain_hex)
+        self.nodes[0].submitpackage(chain_hex)
 
 
 if __name__ == "__main__":

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -73,6 +73,8 @@ MAX_OP_RETURN_RELAY = 83
 
 DEFAULT_MEMPOOL_EXPIRY_HOURS = 336  # hours
 
+PKG_RELAY_ANCPKG = 1
+
 def sha256(s):
     return hashlib.sha256(s).digest()
 
@@ -1852,3 +1854,21 @@ class msg_sendtxrcncl:
     def __repr__(self):
         return "msg_sendtxrcncl(version=%lu, salt=%lu)" %\
             (self.version, self.salt)
+
+class msg_sendpackages:
+    __slots__ = ("versions")
+    msgtype = b"sendpackages"
+
+    def __init__(self):
+        self.versions = 0
+
+    def deserialize(self, f):
+        self.versions = struct.unpack("<Q", f.read(8))[0]
+
+    def serialize(self):
+        r = b""
+        r += struct.pack("<Q", self.versions)
+        return r
+
+    def __repr__(self):
+        return "msg_sendpackages(versions={})".format(self.versions)

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -77,6 +77,7 @@ MAX_OP_RETURN_RELAY = 83
 DEFAULT_MEMPOOL_EXPIRY_HOURS = 336  # hours
 
 PKG_RELAY_ANCPKG = 1
+PKG_RELAY_PKGTXNS = 1 << 1
 
 def sha256(s):
     return hashlib.sha256(s).digest()

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -76,8 +76,8 @@ MAX_OP_RETURN_RELAY = 83
 
 DEFAULT_MEMPOOL_EXPIRY_HOURS = 336  # hours
 
-PKG_RELAY_ANCPKG = 1
-PKG_RELAY_PKGTXNS = 1 << 1
+PKG_RELAY_ANCPKG = 1 << 1
+PKG_RELAY_PKGTXNS = 1 << 0
 
 def sha256(s):
     return hashlib.sha256(s).digest()

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -60,6 +60,7 @@ MSG_WTX = 5
 MSG_WITNESS_FLAG = 1 << 30
 MSG_TYPE_MASK = 0xffffffff >> 2
 MSG_WITNESS_TX = MSG_TX | MSG_WITNESS_FLAG
+MSG_ANCPKGINFO = 7
 
 FILTER_TYPE_BASIC = 0
 
@@ -334,6 +335,7 @@ class CInv:
         MSG_FILTERED_BLOCK: "filtered Block",
         MSG_CMPCT_BLOCK: "CompactBlock",
         MSG_WTX: "WTX",
+        MSG_ANCPKGINFO: "ancpkginfo",
     }
 
     def __init__(self, t=0, h=0):
@@ -1872,3 +1874,21 @@ class msg_sendpackages:
 
     def __repr__(self):
         return "msg_sendpackages(versions={})".format(self.versions)
+
+class msg_ancpkginfo:
+    __slots__ = ("wtxids")
+    msgtype = b"ancpkginfo"
+
+    def __init__(self, wtxids=None):
+        self.wtxids = wtxids if wtxids is not None else []
+
+    def deserialize(self, f):
+        self.wtxids = deser_uint256_vector(f)
+
+    def serialize(self):
+        r = b""
+        r += ser_uint256_vector(self.wtxids)
+        return r
+
+    def __repr__(self):
+        return "msg_ancpkginfo(wtxids=%s)" % (self.wtxids)

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -1942,7 +1942,7 @@ def get_combined_hash(package_wtxids):
     def uint256_lexico(a):
         return ser_uint256(a)
     wtxids_copy.sort(key=uint256_lexico)
-    return uint256_from_str(hash256(ser_uint256_vector(wtxids_copy)))
+    return uint256_from_str(sha256(ser_uint256_vector(wtxids_copy)))
 
 def get_package_hash(package_txns):
     # There should never be duplicate hashes
@@ -1959,11 +1959,11 @@ class TestFrameworkMessages(unittest.TestCase):
         assert zero < one
         assert one < two
         assert two < eff
-        hash_0 = uint256_from_str(hash256(ser_uint256_vector([zero])))
-        hash_01 = uint256_from_str(hash256(ser_uint256_vector([zero, one])))
-        hash_12 = uint256_from_str(hash256(ser_uint256_vector([one, two])))
-        hash_012 = uint256_from_str(hash256(ser_uint256_vector([zero, one, two])))
-        hash_012f = uint256_from_str(hash256(ser_uint256_vector([zero, one, two, eff])))
+        hash_0 = uint256_from_str(sha256(ser_uint256_vector([zero])))
+        hash_01 = uint256_from_str(sha256(ser_uint256_vector([zero, one])))
+        hash_12 = uint256_from_str(sha256(ser_uint256_vector([one, two])))
+        hash_012 = uint256_from_str(sha256(ser_uint256_vector([zero, one, two])))
+        hash_012f = uint256_from_str(sha256(ser_uint256_vector([zero, one, two, eff])))
         assert_equal(hash_0, get_combined_hash([zero]))
         assert_equal(hash_01, get_combined_hash([one, zero]))
         assert_equal(hash_12, get_combined_hash([two, one]))

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -62,6 +62,7 @@ from test_framework.messages import (
     msg_sendaddrv2,
     msg_sendcmpct,
     msg_sendheaders,
+    msg_sendpackages,
     msg_sendtxrcncl,
     msg_tx,
     MSG_TX,
@@ -133,6 +134,7 @@ MESSAGEMAP = {
     b"sendaddrv2": msg_sendaddrv2,
     b"sendcmpct": msg_sendcmpct,
     b"sendheaders": msg_sendheaders,
+    b"sendpackages": msg_sendpackages,
     b"sendtxrcncl": msg_sendtxrcncl,
     b"tx": msg_tx,
     b"verack": msg_verack,
@@ -429,6 +431,7 @@ class P2PInterface(P2PConnection):
     def on_sendaddrv2(self, message): pass
     def on_sendcmpct(self, message): pass
     def on_sendheaders(self, message): pass
+    def on_sendpackages(self, message): pass
     def on_sendtxrcncl(self, message): pass
     def on_tx(self, message): pass
     def on_wtxidrelay(self, message): pass

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -53,11 +53,13 @@ from test_framework.messages import (
     msg_getcfilters,
     msg_getdata,
     msg_getheaders,
+    msg_getpkgtxns,
     msg_headers,
     msg_inv,
     msg_mempool,
     msg_merkleblock,
     msg_notfound,
+    msg_pkgtxns,
     msg_ping,
     msg_pong,
     msg_sendaddrv2,
@@ -128,11 +130,13 @@ MESSAGEMAP = {
     b"getcfilters": msg_getcfilters,
     b"getdata": msg_getdata,
     b"getheaders": msg_getheaders,
+    b"getpkgtxns": msg_getpkgtxns,
     b"headers": msg_headers,
     b"inv": msg_inv,
     b"mempool": msg_mempool,
     b"merkleblock": msg_merkleblock,
     b"notfound": msg_notfound,
+    b"pkgtxns": msg_pkgtxns,
     b"ping": msg_ping,
     b"pong": msg_pong,
     b"sendaddrv2": msg_sendaddrv2,
@@ -427,10 +431,12 @@ class P2PInterface(P2PConnection):
     def on_getblocktxn(self, message): pass
     def on_getdata(self, message): pass
     def on_getheaders(self, message): pass
+    def on_getpkgtxns(self, message): pass
     def on_headers(self, message): pass
     def on_mempool(self, message): pass
     def on_merkleblock(self, message): pass
     def on_notfound(self, message): pass
+    def on_pkgtxns(self, message): pass
     def on_pong(self, message): pass
     def on_sendaddrv2(self, message): pass
     def on_sendcmpct(self, message): pass
@@ -789,6 +795,7 @@ class P2PDataStore(P2PInterface):
                 # Check that none of the txs are now in the mempool
                 for tx in txs:
                     assert tx.hash not in raw_mempool, "{} tx found in mempool".format(tx.hash)
+
 
 class P2PTxInvStore(P2PInterface):
     """A P2PInterface which stores a count of how many times each txid has been announced."""

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -33,6 +33,7 @@ from test_framework.messages import (
     MAX_HEADERS_RESULTS,
     msg_addr,
     msg_addrv2,
+    msg_ancpkginfo,
     msg_block,
     MSG_BLOCK,
     msg_blocktxn,
@@ -102,10 +103,13 @@ TXID_RELAY_DELAY = 2
 ORPHAN_ANCESTOR_GETDATA_INTERVAL = 60
 # How long a transaction has to be in the mempool before it can unconditionally be relayed
 UNCONDITIONAL_RELAY_DELAY = 120
+# Delay for requesting transactions if the peer has MAX_PEER_TX_REQUEST_IN_FLIGHT or more requests
+OVERLOADED_PEER_TX_DELAY = 2
 
 MESSAGEMAP = {
     b"addr": msg_addr,
     b"addrv2": msg_addrv2,
+    b"ancpkginfo": msg_ancpkginfo,
     b"block": msg_block,
     b"blocktxn": msg_blocktxn,
     b"cfcheckpt": msg_cfcheckpt,

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -107,6 +107,8 @@ ORPHAN_ANCESTOR_GETDATA_INTERVAL = 60
 UNCONDITIONAL_RELAY_DELAY = 120
 # Delay for requesting transactions if the peer has MAX_PEER_TX_REQUEST_IN_FLIGHT or more requests
 OVERLOADED_PEER_TX_DELAY = 2
+# Delay for requesting transactions if the peer cannot protect this orphan
+ORPHANAGE_OVERLOAD_DELAY = 1
 
 MESSAGEMAP = {
     b"addr": msg_addr,

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -95,6 +95,12 @@ P2P_SUBVERSION = "/python-p2p-tester:0.0.3/"
 P2P_VERSION_RELAY = 1
 # Delay after receiving a tx inv before requesting transactions from non-preferred peers, in seconds
 NONPREF_PEER_TX_DELAY = 2
+# Delay for requesting transactions via txids if we have wtxid-relaying peers, in seconds
+TXID_RELAY_DELAY = 2
+# Wait time before orphan request expires, in seconds
+ORPHAN_ANCESTOR_GETDATA_INTERVAL = 60
+# How long a transaction has to be in the mempool before it can unconditionally be relayed
+UNCONDITIONAL_RELAY_DELAY = 120
 
 MESSAGEMAP = {
     b"addr": msg_addr,

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -122,6 +122,7 @@ BASE_SCRIPTS = [
     'feature_abortnode.py',
     'wallet_address_types.py --legacy-wallet',
     'wallet_address_types.py --descriptors',
+    'p2p_orphan_handling.py',
     'wallet_basic.py --legacy-wallet',
     'wallet_basic.py --descriptors',
     'feature_maxtipage.py',

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -188,6 +188,7 @@ BASE_SCRIPTS = [
     'wallet_txn_clone.py --segwit',
     'rpc_getchaintips.py',
     'rpc_misc.py',
+    'p2p_package_relay.py',
     'interface_rest.py',
     'mempool_spend_coinbase.py',
     'wallet_avoid_mixing_output_types.py --descriptors',

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -77,6 +77,7 @@ TEST_FRAMEWORK_MODULES = [
     "ellswift",
     "key",
     "muhash",
+    "messages",
     "ripemd160",
     "script",
     "segwit_addr",


### PR DESCRIPTION
**WORK IN PROGRESS.** Please do not run it for any use other than testing.
  
This PR is not meant for merge. This branch exists to help reviewers see what package relay would look like all together. I will open separate PRs for these components and expect to add more tests, docs, and polish along the way. This PR contains all of the functionality built in a linear manner. However, since there are pieces in various areas of the codebase and they can make progress in parallel, commits don't necessarily need to be merged in this order.

**See #27463 for what PR(s) are open for review right now.**

## Note to Reviewers

The major purpose of this PR is to solicit "approach" review.

This is a large project, and the first few p2p commits essentially define the interface. I'd like to get rough consensus on approach before we start looking at code details and merging PRs, because I believe it will help us "get useful stuff in" faster and avoid premature optimizations.

Here are some questions I hope are answered before we try to merge anything (originally https://github.com/bitcoin/bitcoin/pull/27742#issuecomment-1572205313):

1. Does the proposed protocol look sound?
2. Are these 3 milestones appropriate?
3. Is there important functionality that is in the "todo improvements" section but should be included in one of the 3 milestones? Alternatively, is there not-that-important stuff in the milestones that we should defer until later?
4. Does it make sense to have this PeerManager <-> TxDownloadMan interface?

Comments about naming, typos, code details, etc. are also appreciated but please note I may wait until their respective PRs are open to incorporate your comments. Thank you for your patience.

### Design Docs

BIP: https://github.com/bitcoin/bips/pull/1382
Orphanage changes: https://gist.github.com/glozow/7c0ff639f996e660146314edffa6f06c

## Project Structure

### 3 Major Milestones

This project is split into 3 milestones, each of which gives us something useful.

1. Modularize and improve orphan-handling (also some refactoring).
	- Introduce a `TxDownloadManager` class, responsible for downloading transactions that have been announced to us.
	- Use all announcers as potential candidates for resolving an orphan. Add a `TxRequestTracker` Orphan Request Tracker which helps track orphans we need to resolve. Preferentially request orphan resolution from outbounds, preferred relay, etc., over inbounds.

2. When package relay peers are available, use `ancpkginfo` instead of missing parents when handling orphans.
	- Add `sendpackages` negotiation logic.
	- Add a separate rejections filter for transactions that are eligible for reconsideration when validated together as a package, so that children of low-feerate transactions are still considered.
	- Send `getdata(MSG_ANCPKGINFO)` to package relay peers for orphan resolution. Use `ancpkginfo` to request missing ancestors through normal individual transaction relay.

3. Download and validate ancestor packages using `getpkgtxns` and `pkgtxns`.
	- Add support for `getpkgtxns` and `pkgtxns`. Send a `pkgtxns` using the list of missing transactions from `ancpkginfo`.
	- Ensure we can process "normal" orphans even if a peer is trying to overwhelm/churn our orphanage. Do this by "opportunistically" protecting orphans from random eviction if they were sent by package relay peers, and redownloading orphans if we cannot afford to protect them. Each peer is allocated a certain amount of orphans they can protect at a time ("token bucket" style but the number of tokens is static for now). Outbound peers get more than inbounds.
	- If a transaction's parent(s) are below the fee filter, don't announce it (save the bandwidth of legacy nodes).

###  Todo improvements 
These could be added to the milestones or deferred until basic functionality is deployed.
- Store orphans serialized instead of as CTransactionRefs to significantly reduce their memory usage.
- Perhaps try to keep orphans in disk and/or process them asynchronously, given the incredibly DoSable nature of orphan handling.
- Dynamically allocate tokens for orphan protection. For example, if a long-standing inbound peer continuously provides good packages for orphans, they should have more tokens. If a peer is obviously serving us garbage, reduce their tokens.
- Detect when we have received all the transactions for a package, regardless of how (individual or block or other), and return `PackageToValidate`  in `GetTxToReconsider`.
- New format for mempool.dat, packages instead of transactions.