### PR TITLE
p2p: Unconditionally return when compact block status == READ_STATUS_FAILED

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4365,11 +4365,11 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
                         std::vector<CInv> vInv(1);
                         vInv[0] = CInv(MSG_BLOCK | GetFetchFlags(*peer), blockhash);
                         m_connman.PushMessage(&pfrom, msgMaker.Make(NetMsgType::GETDATA, vInv));
-                        return;
                     } else {
                         // Give up for this peer and wait for other peer(s)
                         RemoveBlockRequest(pindex->GetBlockHash(), pfrom.GetId());
                     }
+                    return;
                 }
 
                 BlockTransactionsRequest req;


### PR DESCRIPTION
Fixes https://github.com/bitcoin/bitcoin/pull/27626#discussion_r1204491894 which would have resulted in wasted bandwidth every once in a while.