### PR TITLE
util: generalize accounting of system-allocated memory in pool resource

### DIFF
--- a/src/memusage.h
+++ b/src/memusage.h
@@ -176,14 +176,7 @@ static inline size_t DynamicUsage(const std::unordered_map<Key,
                                                                          MAX_BLOCK_SIZE_BYTES,
                                                                          ALIGN_BYTES>>& m)
 {
-    auto* pool_resource = m.get_allocator().resource();
-
-    // The allocated chunks are stored in a std::list. Size per node should
-    // therefore be 3 pointers: next, previous, and a pointer to the chunk.
-    size_t estimated_list_node_size = MallocUsage(sizeof(void*) * 3);
-    size_t usage_resource = estimated_list_node_size * pool_resource->NumAllocatedChunks();
-    size_t usage_chunks = MallocUsage(pool_resource->ChunkSizeBytes()) * pool_resource->NumAllocatedChunks();
-    return usage_resource + usage_chunks + MallocUsage(sizeof(void*) * m.bucket_count());
+    return m.get_allocator().resource()->MemoryUsage();
 }
 
 } // namespace memusage

--- a/src/test/util/poolresourcetester.h
+++ b/src/test/util/poolresourcetester.h
@@ -124,6 +124,12 @@ public:
         assert(chunk_it == chunks.end());
         assert(chunk_size_remaining == 0);
     }
+
+    template <std::size_t MAX_BLOCK_SIZE_BYTES, std::size_t ALIGN_BYTES>
+    static size_t GetSystemAllocBytes(const PoolResource<MAX_BLOCK_SIZE_BYTES, ALIGN_BYTES>& resource)
+    {
+        return resource.m_system_alloc_bytes;
+    }
 };
 
 #endif // BITCOIN_TEST_UTIL_POOLRESOURCETESTER_H


### PR DESCRIPTION
Follow-on to PR #25325, "Add pool based memory resource"

The `DynamicUsage()` function for the version of `unordered_map` that uses the `PoolAllocator` returns a close approximation of the amount of physical memory used by the map. (This is the map used for the dbcache.) It accounts for several of the allocator's internal data structures, such as the memory chunks and the freelist. It also includes the `unordered_map`'s bucket array (vector), which is a bit out of place because the rest of the pool allocator doesn't know or make any assumption about the type of container that the pool allocator is being used for, namely, currently only `std::unordered_map`.

This change could prevent a possible future pool memory usage calculation error, although it would likely be a small error: If the pool is configured with a large `MAX_BLOCK_SIZE_BYTES`, it could turn out that the size of the bucket array is small enough to be allocated by the resource allocator; it would then be double-counted.

Another aspect of the pool allocator that this PR improves is a refactor of the pool allocator's `DynamicUsage()` implementation, to move details about the pool allocator's internal data structures out of `memusage.h`, which is a general source file, to the allocator's `pool.h`.