### PR TITLE
fuzz: Change LIMIT_TO_MESSAGE_TYPE from a compile-time to a run-time setting

### DIFF
--- a/src/test/fuzz/process_message.cpp
+++ b/src/test/fuzz/process_message.cpp
@@ -2,15 +2,16 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <banman.h>
-#include <chainparams.h>
 #include <consensus/consensus.h>
 #include <net.h>
 #include <net_processing.h>
+#include <primitives/transaction.h>
 #include <protocol.h>
-#include <scheduler.h>
 #include <script/script.h>
+#include <serialize.h>
+#include <span.h>
 #include <streams.h>
+#include <sync.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
@@ -20,42 +21,32 @@
 #include <test/util/setup_common.h>
 #include <test/util/validation.h>
 #include <util/chaintype.h>
+#include <util/check.h>
+#include <util/time.h>
+#include <validation.h>
 #include <validationinterface.h>
 #include <version.h>
 
+
 #include <atomic>
-#include <cassert>
-#include <chrono>
-#include <cstdint>
-#include <iosfwd>
+#include <cstdlib>
 #include <iostream>
 #include <memory>
 #include <string>
+#include <string_view>
+#include <vector>
 
 namespace {
 const TestingSetup* g_setup;
+std::string_view LIMIT_TO_MESSAGE_TYPE{};
 } // namespace
-
-size_t& GetNumMsgTypes()
-{
-    static size_t g_num_msg_types{0};
-    return g_num_msg_types;
-}
-#define FUZZ_TARGET_MSG(msg_type)                                            \
-    struct msg_type##_Count_Before_Main {                                    \
-        msg_type##_Count_Before_Main()                                       \
-        {                                                                    \
-            ++GetNumMsgTypes();                                              \
-        }                                                                    \
-    } const static g_##msg_type##_count_before_main;                         \
-    FUZZ_TARGET_INIT(process_message_##msg_type, initialize_process_message) \
-    {                                                                        \
-        fuzz_target(buffer, #msg_type);                                      \
-    }
 
 void initialize_process_message()
 {
-    Assert(GetNumMsgTypes() == getAllNetMessageTypes().size()); // If this fails, add or remove the message type below
+    if (const auto val{std::getenv("LIMIT_TO_MESSAGE_TYPE")}) {
+        LIMIT_TO_MESSAGE_TYPE = val;
+        Assert(std::count(getAllNetMessageTypes().begin(), getAllNetMessageTypes().end(), LIMIT_TO_MESSAGE_TYPE)); // Unknown message type passed
+    }
 
     static const auto testing_setup = MakeNoLogFileContext<const TestingSetup>(
             /*chain_type=*/ChainType::REGTEST,
@@ -67,7 +58,7 @@ void initialize_process_message()
     SyncWithValidationInterfaceQueue();
 }
 
-void fuzz_target(FuzzBufferType buffer, const std::string& LIMIT_TO_MESSAGE_TYPE)
+FUZZ_TARGET_INIT(process_message, initialize_process_message)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
 
@@ -101,40 +92,3 @@ void fuzz_target(FuzzBufferType buffer, const std::string& LIMIT_TO_MESSAGE_TYPE
     SyncWithValidationInterfaceQueue();
     g_setup->m_node.connman->StopNodes();
 }
-
-FUZZ_TARGET_INIT(process_message, initialize_process_message) { fuzz_target(buffer, ""); }
-FUZZ_TARGET_MSG(addr);
-FUZZ_TARGET_MSG(addrv2);
-FUZZ_TARGET_MSG(block);
-FUZZ_TARGET_MSG(blocktxn);
-FUZZ_TARGET_MSG(cfcheckpt);
-FUZZ_TARGET_MSG(cfheaders);
-FUZZ_TARGET_MSG(cfilter);
-FUZZ_TARGET_MSG(cmpctblock);
-FUZZ_TARGET_MSG(feefilter);
-FUZZ_TARGET_MSG(filteradd);
-FUZZ_TARGET_MSG(filterclear);
-FUZZ_TARGET_MSG(filterload);
-FUZZ_TARGET_MSG(getaddr);
-FUZZ_TARGET_MSG(getblocks);
-FUZZ_TARGET_MSG(getblocktxn);
-FUZZ_TARGET_MSG(getcfcheckpt);
-FUZZ_TARGET_MSG(getcfheaders);
-FUZZ_TARGET_MSG(getcfilters);
-FUZZ_TARGET_MSG(getdata);
-FUZZ_TARGET_MSG(getheaders);
-FUZZ_TARGET_MSG(headers);
-FUZZ_TARGET_MSG(inv);
-FUZZ_TARGET_MSG(mempool);
-FUZZ_TARGET_MSG(merkleblock);
-FUZZ_TARGET_MSG(notfound);
-FUZZ_TARGET_MSG(ping);
-FUZZ_TARGET_MSG(pong);
-FUZZ_TARGET_MSG(sendaddrv2);
-FUZZ_TARGET_MSG(sendcmpct);
-FUZZ_TARGET_MSG(sendheaders);
-FUZZ_TARGET_MSG(sendtxrcncl);
-FUZZ_TARGET_MSG(tx);
-FUZZ_TARGET_MSG(verack);
-FUZZ_TARGET_MSG(version);
-FUZZ_TARGET_MSG(wtxidrelay);

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -8,7 +8,7 @@
 #include <common/args.h>
 #include <key.h>
 #include <node/caches.h>
-#include <node/context.h>
+#include <node/context.h> // IWYU pragma: export
 #include <primitives/transaction.h>
 #include <pubkey.h>
 #include <random.h>


### PR DESCRIPTION
The `process_message_${msg_type}` fuzz targets have many issues:

* In a context where each fuzz target must be a separate binary, this bloats the storage requirements by the number of message types.
* The qa-assets repo for fuzz inputs also bloats, because each input in the type specific folder (`./process_message_${msg_type}`) is accompanied by a similar input in the general folder (`./process_message`) or a in another specific folder. The size seems to be ~3GB for the sum of all folders vs 0.3GB for the general folder.
* Handling of different folders for each message type and one general folder for all message types (and unknown message types) is undocumented and unclear. Cross-pollination is encouraged, I guess, but who does it?
* It is unclear if the fuzz target has any value at all, given that any bug that is found here should also be found by the `process_messages` fuzz target, and historically always has been? So maybe it can even be removed completely in the future?
* (minor nit): When adding a new message type, the message type has to be added to this fuzz target as well.

Fix all issues by turning the compile-time setting into a run-time setting, thus removing the extra executables and fuzz folders. The same approach is also taken by the `rpc` fuzz target.

If someone wants to limit their fuzzing to a specific message type, they can still do it. For example,

```
LIMIT_TO_MESSAGE_TYPE=inv FUZZ=process_message ./src/test/fuzz/fuzz