### PR TITLE
ci: Prune dangling images on RESTART_CI_DOCKER_BEFORE_RUN

### DIFF
--- a/ci/test/04_install.sh
+++ b/ci/test/04_install.sh
@@ -43,6 +43,8 @@ if [ -z "$DANGER_RUN_CI_ON_HOST" ]; then
   if [ -n "${RESTART_CI_DOCKER_BEFORE_RUN}" ] ; then
     echo "Restart docker before run to stop and clear all containers started with --rm"
     systemctl restart docker
+    echo "Prune all dangling images"
+    docker image prune --force
   fi
 
   # shellcheck disable=SC2086

--- a/ci/test/04_install.sh
+++ b/ci/test/04_install.sh
@@ -42,7 +42,7 @@ if [ -z "$DANGER_RUN_CI_ON_HOST" ]; then
 
   if [ -n "${RESTART_CI_DOCKER_BEFORE_RUN}" ] ; then
     echo "Restart docker before run to stop and clear all containers started with --rm"
-    systemctl restart docker
+    podman container kill --all  # Similar to "systemctl restart docker"
     echo "Prune all dangling images"
     docker image prune --force
   fi


### PR DESCRIPTION
This should prevent the persistent workers from running out of disk space. Containers are already removed, but not images. This is required since CI images are built and cached.