### PR TITLE
Add public Boost headers explicitly

### DIFF
--- a/src/node/miner.h
+++ b/src/node/miner.h
@@ -14,7 +14,10 @@
 #include <optional>
 #include <stdint.h>
 
+#include <boost/multi_index/identity.hpp>
+#include <boost/multi_index/indexed_by.hpp>
 #include <boost/multi_index/ordered_index.hpp>
+#include <boost/multi_index/tag.hpp>
 #include <boost/multi_index_container.hpp>
 
 class ArgsManager;

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -33,8 +33,11 @@
 #include <util/result.h>
 
 #include <boost/multi_index/hashed_index.hpp>
+#include <boost/multi_index/identity.hpp>
+#include <boost/multi_index/indexed_by.hpp>
 #include <boost/multi_index/ordered_index.hpp>
 #include <boost/multi_index/sequenced_index.hpp>
+#include <boost/multi_index/tag.hpp>
 #include <boost/multi_index_container.hpp>
 
 class CBlockIndex;

--- a/src/txrequest.cpp
+++ b/src/txrequest.cpp
@@ -10,8 +10,12 @@
 #include <random.h>
 #include <uint256.h>
 
-#include <boost/multi_index_container.hpp>
+#include <boost/multi_index/indexed_by.hpp>
 #include <boost/multi_index/ordered_index.hpp>
+#include <boost/multi_index/sequenced_index.hpp>
+#include <boost/multi_index/tag.hpp>
+#include <boost/multi_index_container.hpp>
+#include <boost/tuple/tuple.hpp>
 
 #include <chrono>
 #include <unordered_map>

--- a/src/wallet/test/coinselector_tests.cpp
+++ b/src/wallet/test/coinselector_tests.cpp
@@ -432,7 +432,7 @@ BOOST_AUTO_TEST_CASE(bnb_search_test)
         CAmount selection_target = 16 * CENT;
         const auto& no_res = SelectCoinsBnB(GroupCoins(available_coins.All(), /*subtract_fee_outputs*/true),
                                             selection_target, /*cost_of_change=*/0, MAX_STANDARD_TX_WEIGHT);
-        BOOST_ASSERT(!no_res);
+        BOOST_REQUIRE(!no_res);
         BOOST_CHECK(util::ErrorString(no_res).original.find("The inputs size exceeds the maximum weight") != std::string::npos);
 
         // Now add same coin value with a good size and check that it gets selected

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -938,11 +938,10 @@ BOOST_FIXTURE_TEST_CASE(wallet_sync_tx_invalid_state_test, TestingSetup)
     }
 
     // Add tx to wallet
-    const auto& op_dest = wallet.GetNewDestination(OutputType::BECH32M, "");
-    BOOST_ASSERT(op_dest);
+    const auto op_dest{*Assert(wallet.GetNewDestination(OutputType::BECH32M, ""))};
 
     CMutableTransaction mtx;
-    mtx.vout.push_back({COIN, GetScriptForDestination(*op_dest)});
+    mtx.vout.push_back({COIN, GetScriptForDestination(op_dest)});
     mtx.vin.push_back(CTxIn(g_insecure_rand_ctx.rand256(), 0));
     const auto& tx_id_to_spend = wallet.AddToWallet(MakeTransactionRef(mtx), TxStateInMempool{})->GetHash();
 

--- a/src/wallet/test/walletdb_tests.cpp
+++ b/src/wallet/test/walletdb_tests.cpp
@@ -39,7 +39,7 @@ BOOST_AUTO_TEST_CASE(walletdb_read_write_deadlock)
         DatabaseStatus status;
         bilingual_str error_string;
         std::unique_ptr<WalletDatabase> db = MakeDatabase(m_path_root / strprintf("wallet_%d_.dat", db_format).c_str(), options, status, error_string);
-        BOOST_ASSERT(status == DatabaseStatus::SUCCESS);
+        BOOST_CHECK_EQUAL(status, DatabaseStatus::SUCCESS);
 
         std::shared_ptr<CWallet> wallet(new CWallet(m_node.chain.get(), "", std::move(db)));
         wallet->m_keypool_size = 4;

--- a/src/wallet/test/walletload_tests.cpp
+++ b/src/wallet/test/walletload_tests.cpp
@@ -169,7 +169,7 @@ BOOST_FIXTURE_TEST_CASE(wallet_load_ckey, TestingSetup)
         // Fourth test case:
         // Verify that loading up a 'ckey' with an invalid pubkey throws an error
         CPubKey invalid_key;
-        BOOST_ASSERT(!invalid_key.IsValid());
+        BOOST_CHECK(!invalid_key.IsValid());
         SerializeData key = MakeSerializeData(DBKeys::CRYPTED_KEY, invalid_key);
         records[key] = ckey_record_value;
 

--- a/test/lint/lint-includes.py
+++ b/test/lint/lint-includes.py
@@ -23,15 +23,20 @@ EXCLUDED_DIRS = ["src/leveldb/",
 
 EXPECTED_BOOST_INCLUDES = ["boost/date_time/posix_time/posix_time.hpp",
                            "boost/multi_index/hashed_index.hpp",
+                           "boost/multi_index/identity.hpp",
+                           "boost/multi_index/indexed_by.hpp",
                            "boost/multi_index/ordered_index.hpp",
                            "boost/multi_index/sequenced_index.hpp",
+                           "boost/multi_index/tag.hpp",
                            "boost/multi_index_container.hpp",
                            "boost/process.hpp",
                            "boost/signals2/connection.hpp",
                            "boost/signals2/optional_last_value.hpp",
                            "boost/signals2/signal.hpp",
                            "boost/test/included/unit_test.hpp",
-                           "boost/test/unit_test.hpp"]
+                           "boost/test/unit_test.hpp",
+                           "boost/tuple/tuple.hpp",
+                          ]
 
 
 def get_toplevel():


### PR DESCRIPTION
To check symbols in the code base, run:
```
git grep boost::multi_index::identity
git grep boost::multi_index::indexed_by
git grep boost::multi_index::tag
git grep boost::make_tuple
```

Hoping on the absence of conflicts with top-prio PRs :)