### PR TITLE
test: fix intermittent error in getblockfrompeer.py

### DIFF
--- a/test/functional/rpc_getblockfrompeer.py
+++ b/test/functional/rpc_getblockfrompeer.py
@@ -117,9 +117,11 @@ class GetBlockFromPeerTest(BitcoinTestFramework):
         assert_raises_rpc_error(-1, error_msg, self.nodes[1].getblockfrompeer, blockhash, node1_interface_id)
 
         self.log.info("Connect pruned node")
-        # We need to generate more blocks to be able to prune
         self.connect_nodes(0, 2)
         pruned_node = self.nodes[2]
+        self.sync_blocks([self.nodes[0], pruned_node])
+
+        # We need to generate more blocks to be able to prune
         self.generate(self.nodes[0], 400, sync_fun=self.no_op)
         self.sync_blocks([self.nodes[0], pruned_node])
         pruneheight = pruned_node.pruneblockchain(300)


### PR DESCRIPTION
This adds an additional `sync_blocks` call, fixing an intermittent error caused by blocks arriving out of order due to how compact block relay may revert to headers processing when the tip hasn't caught up, and resulting in slightly different pruning behavior. 
Making sure that all blocks from the previous tests are synced before generating more blocks makes this impossible.

See https://github.com/bitcoin/bitcoin/issues/27749#issuecomment-1566354933 and https://github.com/bitcoin/bitcoin/issues/27749#issuecomment-1566554075 for a more detailed analysis.

#27770 is a more long-term approach to avoid having to deal with magic pruneheight numbers in the first place, but that PR introduces a new RPC and needs more discussion.

Fixes #27749.