### PR TITLE
fuzz: fix wallet notifications.cpp

### DIFF
--- a/src/wallet/test/fuzz/notifications.cpp
+++ b/src/wallet/test/fuzz/notifications.cpp
@@ -141,6 +141,10 @@ FUZZ_TARGET_INIT(wallet_notifications, initialize_setup)
                 info.prev_hash = &block.hashPrevBlock;
                 info.height = chain.size();
                 info.data = &block;
+                // Ensure that no blocks are skipped by the wallet by setting the chain's accumulated
+                // time to the maximum value. This ensures that the wallet's birth time is always
+                // earlier than this maximum time.
+                info.chain_time_max = std::numeric_limits<unsigned int>::max();
                 a.wallet->blockConnected(info);
                 b.wallet->blockConnected(info);
                 // Store the coins for the next block


### PR DESCRIPTION
Fixing https://github.com/bitcoin/bitcoin/pull/27469#issuecomment-1568815816.

As the fuzzing test requires all blocks to be scanned by the wallet
(because it is asserting the wallet balance at the end), we need to
ensure that no blocks are skipped by the recently added wallet
birth time functionality.

This just means setting the chain accumulated time to the maximum
value, so the wallet birth time is always below it, and the block is
always processed by the wallet.