### PR TITLE
rpc: Be able to access RPC parameters by name

### DIFF
--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -320,7 +320,7 @@ public:
     {
         JSONRPCRequest req;
         req.context = m_context;
-        req.params = params;
+        req.params.received = params;
         req.strMethod = command;
         req.URI = uri;
         return ::tableRPC.execute(req);

--- a/src/qt/test/rpcnestedtests.cpp
+++ b/src/qt/test/rpcnestedtests.cpp
@@ -29,7 +29,7 @@ static RPCHelpMan rpcNestedTest_rpc()
         RPCResult{RPCResult::Type::ANY, "", ""},
         RPCExamples{""},
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue {
-            return request.params.write(0, 0);
+            return request.params.received.write(0, 0);
         },
     };
 }

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -586,7 +586,7 @@ static bool rest_chaininfo(const std::any& context, HTTPRequest* req, const std:
     case RESTResponseFormat::JSON: {
         JSONRPCRequest jsonRequest;
         jsonRequest.context = context;
-        jsonRequest.params = UniValue(UniValue::VARR);
+        jsonRequest.params.received = UniValue(UniValue::VARR);
         UniValue chainInfoObject = getblockchaininfo().HandleRequest(jsonRequest);
         std::string strJSON = chainInfoObject.write() + "\n";
         req->WriteHeader("Content-Type", "application/json");
@@ -613,7 +613,7 @@ static bool rest_deploymentinfo(const std::any& context, HTTPRequest* req, const
     case RESTResponseFormat::JSON: {
         JSONRPCRequest jsonRequest;
         jsonRequest.context = context;
-        jsonRequest.params = UniValue(UniValue::VARR);
+        jsonRequest.params.received = UniValue(UniValue::VARR);
 
         if (!hash_str.empty()) {
             uint256 hash;
@@ -627,7 +627,7 @@ static bool rest_deploymentinfo(const std::any& context, HTTPRequest* req, const
                 return RESTERR(req, HTTP_BAD_REQUEST, "Block not found");
             }
 
-            jsonRequest.params.push_back(hash_str);
+            jsonRequest.params.received.push_back(hash_str);
         }
 
         req->WriteHeader("Content-Type", "application/json");

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -628,6 +628,7 @@ static bool rest_deploymentinfo(const std::any& context, HTTPRequest* req, const
             }
 
             jsonRequest.params.received.push_back(hash_str);
+            jsonRequest.params.ProcessParameters(getdeploymentinfo().GetArgNames());
         }
 
         req->WriteHeader("Content-Type", "application/json");

--- a/src/rpc/node.cpp
+++ b/src/rpc/node.cpp
@@ -292,7 +292,7 @@ static RPCHelpMan echo(const std::string& name)
         CHECK_NONFATAL(request.params[9].get_str() != "trigger_internal_bug");
     }
 
-    return request.params;
+    return request.params.AsUniValueArray();
 },
     };
 }

--- a/src/rpc/request.cpp
+++ b/src/rpc/request.cpp
@@ -11,6 +11,7 @@
 #include <logging.h>
 #include <random.h>
 #include <rpc/protocol.h>
+#include <util/check.h>
 #include <util/fs_helpers.h>
 #include <util/strencodings.h>
 
@@ -183,9 +184,31 @@ void JSONRPCRequest::parse(const UniValue& valRequest)
     // Parse params
     const UniValue& valParams{request.find_value("params")};
     if (valParams.isArray() || valParams.isObject())
-        params = valParams;
+        params.received = valParams;
     else if (valParams.isNull())
-        params = UniValue(UniValue::VARR);
+        params.received = UniValue(UniValue::VARR);
     else
         throw JSONRPCError(RPC_INVALID_REQUEST, "Params must be an array or object");
+}
+
+const UniValue& JSONRPCRequest::JSONRPCParameters::operator[](const std::string& key) const
+{
+    return received[key];
+}
+
+const UniValue& JSONRPCRequest::JSONRPCParameters::operator[](size_t pos) const
+{
+    return received[pos];
+}
+
+size_t JSONRPCRequest::JSONRPCParameters::size() const
+{
+    return received.size();
+}
+
+UniValue JSONRPCRequest::JSONRPCParameters::AsUniValueArray() const
+{
+    // The callers of this function will always have parameter objects that are arrays
+    Assert(received.isArray());
+    return received;
 }

--- a/src/rpc/request.h
+++ b/src/rpc/request.h
@@ -8,6 +8,7 @@
 
 #include <any>
 #include <string>
+#include <unordered_map>
 
 #include <univalue.h>
 
@@ -33,10 +34,22 @@ public:
     public:
         /** The parameters as received */
         UniValue received;
+        /** When processing the parameters, we may construct new UniValue objects which we will store here */
+        std::vector<UniValue> constructed;
+        /** Parameter name to parameter. Only provided parameters will be present. */
+        std::unordered_map<std::string, const UniValue*> named;
+        /** Parameter position to parameter.
+         * Parameters not provided at all (neither named nor positional) will be stored as nullptr,
+         * with the exception of trailing parameters (i.e. this vector never ends with nullptrs)
+         * to preserve backwards compatibility that act based on the number of specified parameters. */
+        std::vector<const UniValue*> positional;
 
-        /** Retrieve a parameter by its name */
+        /** Process the received parameters into named and positional mappings */
+        void ProcessParameters(const std::vector<std::pair<std::string, bool>>& argNames);
+
+        /** Retrieve a parameter by its name. Unknown parameters are returned as NullUniValue. */
         const UniValue& operator[](const std::string& key) const;
-        /** Retrieve a parameter by its position */
+        /** Retrieve a parameter by its position. Out of bound parameters are returned as NullUniValue */
         const UniValue& operator[](size_t pos) const;
 
         /** The number of parameters received */

--- a/src/rpc/request.h
+++ b/src/rpc/request.h
@@ -28,9 +28,27 @@ std::vector<UniValue> JSONRPCProcessBatchReply(const UniValue& in);
 class JSONRPCRequest
 {
 public:
+    class JSONRPCParameters
+    {
+    public:
+        /** The parameters as received */
+        UniValue received;
+
+        /** Retrieve a parameter by its name */
+        const UniValue& operator[](const std::string& key) const;
+        /** Retrieve a parameter by its position */
+        const UniValue& operator[](size_t pos) const;
+
+        /** The number of parameters received */
+        size_t size() const;
+
+        /** Produce a UniValue array with each argument in its expected position */
+        UniValue AsUniValueArray() const;
+    };
+
     UniValue id;
     std::string strMethod;
-    UniValue params;
+    JSONRPCParameters params;
     enum Mode { EXECUTE, GET_HELP, GET_ARGS } mode = EXECUTE;
     std::string URI;
     std::string authUser;

--- a/src/test/fuzz/rpc.cpp
+++ b/src/test/fuzz/rpc.cpp
@@ -48,7 +48,7 @@ struct RPCFuzzTestingSetup : public TestingSetup {
         request.context = &m_node;
         request.strMethod = rpc_method;
         try {
-            request.params = RPCConvertValues(rpc_method, arguments);
+            request.params.received = RPCConvertValues(rpc_method, arguments);
         } catch (const std::runtime_error&) {
             return;
         }

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -50,11 +50,11 @@ UniValue RPCTestingSetup::TransformParams(const UniValue& params, std::vector<st
 {
     UniValue transformed_params;
     CRPCTable table;
-    CRPCCommand command{"category", "method", [&](const JSONRPCRequest& request, UniValue&, bool) -> bool { transformed_params = request.params; return true; }, arg_names, /*unique_id=*/0};
+    CRPCCommand command{"category", "method", [&](const JSONRPCRequest& request, UniValue&, bool) -> bool { transformed_params = request.params.AsUniValueArray(); return true; }, arg_names, /*unique_id=*/0};
     table.appendCommand("method", &command);
     JSONRPCRequest request;
     request.strMethod = "method";
-    request.params = params;
+    request.params.received = params;
     if (RPCIsInWarmup(nullptr)) SetRPCWarmupFinished();
     table.execute(request);
     return transformed_params;
@@ -68,7 +68,7 @@ UniValue RPCTestingSetup::CallRPC(std::string args)
     JSONRPCRequest request;
     request.context = &m_node;
     request.strMethod = strMethod;
-    request.params = RPCConvertValues(strMethod, vArgs);
+    request.params.received = RPCConvertValues(strMethod, vArgs);
     if (RPCIsInWarmup(nullptr)) SetRPCWarmupFinished();
     try {
         UniValue result = tableRPC.execute(request);

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -128,7 +128,7 @@ BOOST_AUTO_TEST_CASE(rpc_namedonlyparams)
 
     // Make sure options object specified through args array conflicts.
     BOOST_CHECK_EXCEPTION(TransformParams(JSON(R"({"args": [1, 2, {"opt1": 10}], "opt2": 20})"), arg_names), UniValue,
-                          HasJSON(R"({"code":-8,"message":"Parameter options specified twice both as positional and named argument"})"));
+                          HasJSON(R"({"code":-8,"message":"Parameter options conflicts with parameter opt2"})"));
 }
 
 BOOST_AUTO_TEST_CASE(rpc_rawparams)

--- a/src/wallet/rpc/coins.cpp
+++ b/src/wallet/rpc/coins.cpp
@@ -113,7 +113,7 @@ RPCHelpMan getreceivedbyaddress()
 
     LOCK(pwallet->cs_wallet);
 
-    return ValueFromAmount(GetReceived(*pwallet, request.params, /*by_label=*/false));
+    return ValueFromAmount(GetReceived(*pwallet, request.params.AsUniValueArray(), /*by_label=*/false));
 },
     };
 }
@@ -154,7 +154,7 @@ RPCHelpMan getreceivedbylabel()
 
     LOCK(pwallet->cs_wallet);
 
-    return ValueFromAmount(GetReceived(*pwallet, request.params, /*by_label=*/true));
+    return ValueFromAmount(GetReceived(*pwallet, request.params.AsUniValueArray(), /*by_label=*/true));
 },
     };
 }

--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -272,32 +272,32 @@ RPCHelpMan sendtoaddress()
 
     // Wallet comments
     mapValue_t mapValue;
-    if (!request.params[2].isNull() && !request.params[2].get_str().empty())
-        mapValue["comment"] = request.params[2].get_str();
-    if (!request.params[3].isNull() && !request.params[3].get_str().empty())
-        mapValue["to"] = request.params[3].get_str();
+    if (!request.params["comment"].isNull() && !request.params["comment"].get_str().empty())
+        mapValue["comment"] = request.params["comment"].get_str();
+    if (!request.params["comment_to"].isNull() && !request.params["comment_to"].get_str().empty())
+        mapValue["to"] = request.params["comment_to"].get_str();
 
     bool fSubtractFeeFromAmount = false;
-    if (!request.params[4].isNull()) {
-        fSubtractFeeFromAmount = request.params[4].get_bool();
+    if (!request.params["subtractfeefromamount"].isNull()) {
+        fSubtractFeeFromAmount = request.params["subtractfeefromamount"].get_bool();
     }
 
     CCoinControl coin_control;
-    if (!request.params[5].isNull()) {
-        coin_control.m_signal_bip125_rbf = request.params[5].get_bool();
+    if (!request.params["replaceable"].isNull()) {
+        coin_control.m_signal_bip125_rbf = request.params["replaceable"].get_bool();
     }
 
-    coin_control.m_avoid_address_reuse = GetAvoidReuseFlag(*pwallet, request.params[8]);
+    coin_control.m_avoid_address_reuse = GetAvoidReuseFlag(*pwallet, request.params["avoid_reuse"]);
     // We also enable partial spend avoidance if reuse avoidance is set.
     coin_control.m_avoid_partial_spends |= coin_control.m_avoid_address_reuse;
 
-    SetFeeEstimateMode(*pwallet, coin_control, /*conf_target=*/request.params[6], /*estimate_mode=*/request.params[7], /*fee_rate=*/request.params[9], /*override_min_fee=*/false);
+    SetFeeEstimateMode(*pwallet, coin_control, /*conf_target=*/request.params["conf_target"], /*estimate_mode=*/request.params["estimate_mode"], /*fee_rate=*/request.params["fee_rate"], /*override_min_fee=*/false);
 
     EnsureWalletIsUnlocked(*pwallet);
 
     UniValue address_amounts(UniValue::VOBJ);
-    const std::string address = request.params[0].get_str();
-    address_amounts.pushKV(address, request.params[1]);
+    const std::string address = request.params["address"].get_str();
+    address_amounts.pushKV(address, request.params["amount"]);
     UniValue subtractFeeFromAmount(UniValue::VARR);
     if (fSubtractFeeFromAmount) {
         subtractFeeFromAmount.push_back(address);
@@ -305,7 +305,7 @@ RPCHelpMan sendtoaddress()
 
     std::vector<CRecipient> recipients;
     ParseRecipients(address_amounts, subtractFeeFromAmount, recipients);
-    const bool verbose{request.params[10].isNull() ? false : request.params[10].get_bool()};
+    const bool verbose{request.params["verbose"].isNull() ? false : request.params["verbose"].get_bool()};
 
     return SendMoney(*pwallet, coin_control, recipients, mapValue, verbose);
 },
@@ -379,29 +379,29 @@ RPCHelpMan sendmany()
 
     LOCK(pwallet->cs_wallet);
 
-    if (!request.params[0].isNull() && !request.params[0].get_str().empty()) {
+    if (!request.params["dummy"].isNull() && !request.params["dummy"].get_str().empty()) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Dummy value must be set to \"\"");
     }
-    UniValue sendTo = request.params[1].get_obj();
+    UniValue sendTo = request.params["amounts"].get_obj();
 
     mapValue_t mapValue;
-    if (!request.params[3].isNull() && !request.params[3].get_str().empty())
-        mapValue["comment"] = request.params[3].get_str();
+    if (!request.params["comment"].isNull() && !request.params["comment"].get_str().empty())
+        mapValue["comment"] = request.params["comment"].get_str();
 
     UniValue subtractFeeFromAmount(UniValue::VARR);
-    if (!request.params[4].isNull())
-        subtractFeeFromAmount = request.params[4].get_array();
+    if (!request.params["subtractfeefrom"].isNull())
+        subtractFeeFromAmount = request.params["subtractfeefrom"].get_array();
 
     CCoinControl coin_control;
-    if (!request.params[5].isNull()) {
-        coin_control.m_signal_bip125_rbf = request.params[5].get_bool();
+    if (!request.params["replaceable"].isNull()) {
+        coin_control.m_signal_bip125_rbf = request.params["replaceable"].get_bool();
     }
 
-    SetFeeEstimateMode(*pwallet, coin_control, /*conf_target=*/request.params[6], /*estimate_mode=*/request.params[7], /*fee_rate=*/request.params[8], /*override_min_fee=*/false);
+    SetFeeEstimateMode(*pwallet, coin_control, /*conf_target=*/request.params["conf_target"], /*estimate_mode=*/request.params["estimate_mode"], /*fee_rate=*/request.params["fee_rate"], /*override_min_fee=*/false);
 
     std::vector<CRecipient> recipients;
     ParseRecipients(sendTo, subtractFeeFromAmount, recipients);
-    const bool verbose{request.params[9].isNull() ? false : request.params[9].get_bool()};
+    const bool verbose{request.params["verbose"].isNull() ? false : request.params["verbose"].get_bool()};
 
     return SendMoney(*pwallet, coin_control, recipients, std::move(mapValue), verbose);
 },

--- a/src/wallet/rpc/transactions.cpp
+++ b/src/wallet/rpc/transactions.cpp
@@ -246,7 +246,7 @@ RPCHelpMan listreceivedbyaddress()
 
     LOCK(pwallet->cs_wallet);
 
-    return ListReceived(*pwallet, request.params, false, include_immature_coinbase);
+    return ListReceived(*pwallet, request.params.AsUniValueArray(), false, include_immature_coinbase);
 },
     };
 }
@@ -291,7 +291,7 @@ RPCHelpMan listreceivedbylabel()
 
     LOCK(pwallet->cs_wallet);
 
-    return ListReceived(*pwallet, request.params, true, include_immature_coinbase);
+    return ListReceived(*pwallet, request.params.AsUniValueArray(), true, include_immature_coinbase);
 },
     };
 }

--- a/src/wallet/rpc/transactions.cpp
+++ b/src/wallet/rpc/transactions.cpp
@@ -609,8 +609,8 @@ RPCHelpMan listsinceblock()
     isminefilter filter = ISMINE_SPENDABLE;
 
     uint256 blockId;
-    if (!request.params[0].isNull() && !request.params[0].get_str().empty()) {
-        blockId = ParseHashV(request.params[0], "blockhash");
+    if (!request.params["blockhash"].isNull() && !request.params["blockhash"].get_str().empty()) {
+        blockId = ParseHashV(request.params["blockhash"], "blockhash");
         height = int{};
         altheight = int{};
         if (!wallet.chain().findCommonAncestor(blockId, wallet.GetLastBlockHash(), /*ancestor_out=*/FoundBlock().height(*height), /*block1_out=*/FoundBlock().height(*altheight))) {
@@ -618,24 +618,24 @@ RPCHelpMan listsinceblock()
         }
     }
 
-    if (!request.params[1].isNull()) {
-        target_confirms = request.params[1].getInt<int>();
+    if (!request.params["target_confirmations"].isNull()) {
+        target_confirms = request.params["target_confirmations"].getInt<int>();
 
         if (target_confirms < 1) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter");
         }
     }
 
-    if (ParseIncludeWatchonly(request.params[2], wallet)) {
+    if (ParseIncludeWatchonly(request.params["include_watchonly"], wallet)) {
         filter |= ISMINE_WATCH_ONLY;
     }
 
-    bool include_removed = (request.params[3].isNull() || request.params[3].get_bool());
-    bool include_change = (!request.params[4].isNull() && request.params[4].get_bool());
+    bool include_removed = (request.params["include_removed"].isNull() || request.params["include_removed"].get_bool());
+    bool include_change = (!request.params["include_change"].isNull() && request.params["include_change"].get_bool());
 
     // Only set it if 'label' was provided.
     std::optional<std::string> filter_label;
-    if (!request.params[5].isNull()) filter_label.emplace(LabelFromValue(request.params[5]));
+    if (!request.params["label"].isNull()) filter_label.emplace(LabelFromValue(request.params["label"]));
 
     int depth = height ? wallet.GetLastBlockHeight() + 1 - *height : -1;
 

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -368,25 +368,25 @@ static RPCHelpMan createwallet()
 {
     WalletContext& context = EnsureWalletContext(request.context);
     uint64_t flags = 0;
-    if (!request.params[1].isNull() && request.params[1].get_bool()) {
+    if (!request.params["disable_private_keys"].isNull() && request.params["disable_private_keys"].get_bool()) {
         flags |= WALLET_FLAG_DISABLE_PRIVATE_KEYS;
     }
 
-    if (!request.params[2].isNull() && request.params[2].get_bool()) {
+    if (!request.params["blank"].isNull() && request.params["blank"].get_bool()) {
         flags |= WALLET_FLAG_BLANK_WALLET;
     }
     SecureString passphrase;
     passphrase.reserve(100);
     std::vector<bilingual_str> warnings;
-    if (!request.params[3].isNull()) {
-        passphrase = std::string_view{request.params[3].get_str()};
+    if (!request.params["passphrase"].isNull()) {
+        passphrase = std::string_view{request.params["passphrase"].get_str()};
         if (passphrase.empty()) {
             // Empty string means unencrypted
             warnings.emplace_back(Untranslated("Empty string given as passphrase, wallet will not be encrypted."));
         }
     }
 
-    if (!request.params[4].isNull() && request.params[4].get_bool()) {
+    if (!request.params["avoid_reuse"].isNull() && request.params["avoid_reuse"].get_bool()) {
         flags |= WALLET_FLAG_AVOID_REUSE;
     }
     if (self.Arg<bool>(5)) {
@@ -400,7 +400,7 @@ static RPCHelpMan createwallet()
                                                  " In this release it can be re-enabled temporarily with the -deprecatedrpc=create_bdb setting.");
         }
     }
-    if (!request.params[7].isNull() && request.params[7].get_bool()) {
+    if (!request.params["external_signer"].isNull() && request.params["external_signer"].get_bool()) {
 #ifdef ENABLE_EXTERNAL_SIGNER
         flags |= WALLET_FLAG_EXTERNAL_SIGNER;
 #else
@@ -421,8 +421,8 @@ static RPCHelpMan createwallet()
     options.create_flags = flags;
     options.create_passphrase = passphrase;
     bilingual_str error;
-    std::optional<bool> load_on_start = request.params[6].isNull() ? std::nullopt : std::optional<bool>(request.params[6].get_bool());
-    const std::shared_ptr<CWallet> wallet = CreateWallet(context, request.params[0].get_str(), load_on_start, options, status, error, warnings);
+    std::optional<bool> load_on_start = request.params["load_on_startup"].isNull() ? std::nullopt : std::optional<bool>(request.params["load_on_startup"].get_bool());
+    const std::shared_ptr<CWallet> wallet = CreateWallet(context, request.params["wallet_name"].get_str(), load_on_start, options, status, error, warnings);
     if (!wallet) {
         RPCErrorCode code = status == DatabaseStatus::FAILED_ENCRYPT ? RPC_WALLET_ENCRYPTION_FAILED : RPC_WALLET_ERROR;
         throw JSONRPCError(code, error.original);

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -241,6 +241,7 @@ BOOST_FIXTURE_TEST_CASE(importmulti_rescan, TestChain100Setup)
         request.context = &context;
         request.params.received.setArray();
         request.params.received.push_back(keys);
+        request.params.ProcessParameters(importmulti().GetArgNames());
 
         UniValue response = importmulti().HandleRequest(request);
         BOOST_CHECK_EQUAL(response.write(),
@@ -296,6 +297,7 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
         request.context = &context;
         request.params.received.setArray();
         request.params.received.push_back(backup_file);
+        request.params.ProcessParameters(dumpwallet().GetArgNames());
 
         wallet::dumpwallet().HandleRequest(request);
         RemoveWallet(context, wallet, /* load_on_start= */ std::nullopt);
@@ -314,6 +316,7 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
         request.context = &context;
         request.params.received.setArray();
         request.params.received.push_back(backup_file);
+        request.params.ProcessParameters(importwallet().GetArgNames());
         AddWallet(context, wallet);
         LOCK(Assert(m_node.chainman)->GetMutex());
         wallet->SetLastBlockProcessed(m_node.chainman->ActiveChain().Height(), m_node.chainman->ActiveChain().Tip()->GetBlockHash());

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -239,8 +239,8 @@ BOOST_FIXTURE_TEST_CASE(importmulti_rescan, TestChain100Setup)
         keys.push_back(key);
         JSONRPCRequest request;
         request.context = &context;
-        request.params.setArray();
-        request.params.push_back(keys);
+        request.params.received.setArray();
+        request.params.received.push_back(keys);
 
         UniValue response = importmulti().HandleRequest(request);
         BOOST_CHECK_EQUAL(response.write(),
@@ -294,8 +294,8 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
         }
         JSONRPCRequest request;
         request.context = &context;
-        request.params.setArray();
-        request.params.push_back(backup_file);
+        request.params.received.setArray();
+        request.params.received.push_back(backup_file);
 
         wallet::dumpwallet().HandleRequest(request);
         RemoveWallet(context, wallet, /* load_on_start= */ std::nullopt);
@@ -312,8 +312,8 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
         context.args = &m_args;
         JSONRPCRequest request;
         request.context = &context;
-        request.params.setArray();
-        request.params.push_back(backup_file);
+        request.params.received.setArray();
+        request.params.received.push_back(backup_file);
         AddWallet(context, wallet);
         LOCK(Assert(m_node.chainman)->GetMutex());
         wallet->SetLastBlockProcessed(m_node.chainman->ActiveChain().Height(), m_node.chainman->ActiveChain().Tip()->GetBlockHash());


### PR DESCRIPTION
Although we accept named RPC parameters, we still access the parameters by position within the RPC implementations. This PR makes it possible to access these parameters directly by name. This is achieved by holding the parameters in a separate `JSONRPCParameters` class which contains mappings from both name to value, and position to value. Two `operator[]` methods are implemented which can accept both strings and ints. This allows for backwards compatibility, while also allowing for future implementation to access the parameters by name.

The processing of named arguments ends up being entirely overhauled in order to be able to store the mappings to the parameters.

Based on #26485 to avoid conflicting with it.