### PR TITLE
rpc, net: add erlay status in `getpeerinfo`

### DIFF
--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -36,6 +36,7 @@ struct CNodeStateStats {
     uint64_t m_addr_processed = 0;
     uint64_t m_addr_rate_limited = 0;
     bool m_addr_relay_enabled{false};
+    bool m_tx_reconciliation{false};
     ServiceFlags their_services;
     int64_t presync_height{-1};
 };

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -116,6 +116,7 @@ static RPCHelpMan getpeerinfo()
                         {RPCResult::Type::STR, "SERVICE_NAME", "the service name if it is recognised"}
                     }},
                     {RPCResult::Type::BOOL, "relaytxes", "Whether we relay transactions to this peer"},
+                    {RPCResult::Type::BOOL, "tx_reconciliation", "Whether peer supports tx reconciliation"},
                     {RPCResult::Type::NUM_TIME, "lastsend", "The " + UNIX_EPOCH_TIME + " of the last send"},
                     {RPCResult::Type::NUM_TIME, "lastrecv", "The " + UNIX_EPOCH_TIME + " of the last receive"},
                     {RPCResult::Type::NUM_TIME, "last_transaction", "The " + UNIX_EPOCH_TIME + " of the last valid transaction received from this peer"},
@@ -210,6 +211,7 @@ static RPCHelpMan getpeerinfo()
         obj.pushKV("services", strprintf("%016x", services));
         obj.pushKV("servicesnames", GetServicesNames(services));
         obj.pushKV("relaytxes", statestats.m_relay_txs);
+        obj.pushKV("tx_reconciliation", statestats.m_tx_reconciliation);
         obj.pushKV("lastsend", count_seconds(stats.m_last_send));
         obj.pushKV("lastrecv", count_seconds(stats.m_last_recv));
         obj.pushKV("last_transaction", count_seconds(stats.m_last_tx_time));

--- a/test/functional/p2p_sendtxrcncl.py
+++ b/test/functional/p2p_sendtxrcncl.py
@@ -63,10 +63,16 @@ def create_sendtxrcncl_msg():
 
 class SendTxRcnclTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.num_nodes = 1
-        self.extra_args = [['-txreconciliation']]
+        self.num_nodes = 2
+        self.extra_args = [['-txreconciliation'], ["-txreconciliation"]]
 
     def run_test(self):
+        # Check both nodes successfully registered tx reconciliation support
+        self.log.info("Test the getpeerinfo `tx_reconciliation` field")
+        for node in self.nodes:
+            peerinfo = node.getpeerinfo()
+            assert_equal(peerinfo[0]['tx_reconciliation'], True)
+
         # Check everything concerning *sending* SENDTXRCNCL
         # First, *sending* to *inbound*.
         self.log.info('SENDTXRCNCL sent to an inbound')

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -145,6 +145,7 @@ class NetTest(BitcoinTestFramework):
                 "synced_blocks": -1,
                 "synced_headers": -1,
                 "timeoffset": 0,
+                "tx_reconciliation": False,
                 "version": 0,
             },
         )


### PR DESCRIPTION
Fixes #26602

Adds `m_tx_reconciliation` in `Peer` struct
to know whether the peer supports Erlay and
exposes it in `getpeerinfo` rpc.