### PR TITLE
wallet: Add tracing for sqlite statements

### DIFF
--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -34,6 +34,21 @@ static void ErrorLogCallback(void* arg, int code, const char* msg)
     LogPrintf("SQLite Error. Code: %d. Message: %s\n", code, msg);
 }
 
+static int TraceSqlCallback(unsigned code, void* context, void* param1, void* param2)
+{
+    auto* db = static_cast<SQLiteDatabase*>(context);
+    if (code == SQLITE_TRACE_STMT) {
+        auto* stmt = static_cast<sqlite3_stmt*>(param1);
+        // To be conservative and avoid leaking potentially secret information
+        // in the log file, only expand statements that query the database, not
+        // statements that update the database.
+        char* expanded{sqlite3_stmt_readonly(stmt) ? sqlite3_expanded_sql(stmt) : nullptr};
+        LogPrintf("[%s] SQLite Statement: %s\n", db->Filename(), expanded ? expanded : sqlite3_sql(stmt));
+        if (expanded) sqlite3_free(expanded);
+    }
+    return SQLITE_OK;
+}
+
 static bool BindBlobToStatement(sqlite3_stmt* stmt,
                                 int index,
                                 Span<const std::byte> blob,
@@ -234,6 +249,13 @@ void SQLiteDatabase::Open()
         ret = sqlite3_extended_result_codes(m_db, 1);
         if (ret != SQLITE_OK) {
             throw std::runtime_error(strprintf("SQLiteDatabase: Failed to enable extended result codes: %s\n", sqlite3_errstr(ret)));
+        }
+        // Trace SQL statements if tracing is enabled with -debug=walletdb -loglevel=walletdb:trace
+        if (LogAcceptCategory(BCLog::WALLETDB, BCLog::Level::Trace)) {
+           ret = sqlite3_trace_v2(m_db, SQLITE_TRACE_STMT, TraceSqlCallback, this);
+           if (ret != SQLITE_OK) {
+               LogPrintf("Failed to enable SQL tracing for %s\n", Filename());
+           }
         }
     }
 


### PR DESCRIPTION
I found sqlite tracing was useful for debugging a test in #27790, and thought it might be helpful in other contexts too, so this PR adds an option to enable it. Tracing is still disabled by default and only shown with `-debug=walletdb -loglevel=walletdb:trace` options.