### PR TITLE
init: deduplicate added connections

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1837,6 +1837,12 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         const auto connect = args.GetArgs("-connect");
         if (connect.size() != 1 || connect[0] != "0") {
             connOptions.m_specified_outgoing = connect;
+            // De-duplicate -addnode and -connect hosts. Prefer -connect
+            connOptions.m_added_nodes.erase(
+                std::remove_if(connOptions.m_added_nodes.begin(), connOptions.m_added_nodes.end(), [&](const std::string& node) {
+                    return std::find(connOptions.m_specified_outgoing.begin(), connOptions.m_specified_outgoing.end(), node) != connOptions.m_specified_outgoing.end();
+                }),
+                connOptions.m_added_nodes.end());
         }
         if (!connOptions.m_specified_outgoing.empty() && !connOptions.vSeedNodes.empty()) {
             LogPrintf("-seednode is ignored when -connect is used\n");


### PR DESCRIPTION
Fixes #5299

Previously connections may be added to both `m_added_nodes` (via `-addnode`) and `m_specified_outgoing` (via `-connect`) if duplicated in config.

During init this can see duplicate connections made to the same outbound node as `ThreadOpenConnections` and `ThreadOpenAddedConnections` will both try to make the same connection at the same time.

Deduplicate the two vectors as a basic sanity check before starting connection manager.