### PR TITLE
[src/{core_read,core_write,psbt,txorphanage}.cpp] Use correct `size_type` for `std::vector` iteration

### DIFF
--- a/src/core_read.cpp
+++ b/src/core_read.cpp
@@ -105,14 +105,14 @@ static bool CheckTxScriptsSanity(const CMutableTransaction& tx)
 {
     // Check input scripts for non-coinbase txs
     if (!CTransaction(tx).IsCoinBase()) {
-        for (unsigned int i = 0; i < tx.vin.size(); i++) {
+        for (std::vector<decltype(&tx)>::size_type i = 0; i < tx.vin.size(); i++) {
             if (!tx.vin[i].scriptSig.HasValidOps() || tx.vin[i].scriptSig.size() > MAX_SCRIPT_SIZE) {
                 return false;
             }
         }
     }
     // Check output scripts
-    for (unsigned int i = 0; i < tx.vout.size(); i++) {
+    for (std::vector<decltype(&tx)>::size_type i = 0; i < tx.vout.size(); i++) {
         if (!tx.vout[i].scriptPubKey.HasValidOps() || tx.vout[i].scriptPubKey.size() > MAX_SCRIPT_SIZE) {
             return false;
         }

--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -190,7 +190,7 @@ void TxToUniv(const CTransaction& tx, const uint256& block_hash, UniValue& entry
     CAmount amt_total_in = 0;
     CAmount amt_total_out = 0;
 
-    for (unsigned int i = 0; i < tx.vin.size(); i++) {
+    for (std::vector<decltype(&tx)>::size_type i = 0; i < tx.vin.size(); i++) {
         const CTxIn& txin = tx.vin[i];
         UniValue in(UniValue::VOBJ);
         if (tx.IsCoinBase()) {
@@ -234,7 +234,7 @@ void TxToUniv(const CTransaction& tx, const uint256& block_hash, UniValue& entry
     entry.pushKV("vin", vin);
 
     UniValue vout(UniValue::VARR);
-    for (unsigned int i = 0; i < tx.vout.size(); i++) {
+    for (std::vector<decltype(&tx)>::size_type i = 0; i < tx.vout.size(); i++) {
         const CTxOut& txout = tx.vout[i];
 
         UniValue out(UniValue::VOBJ);

--- a/src/psbt.cpp
+++ b/src/psbt.cpp
@@ -27,10 +27,10 @@ bool PartiallySignedTransaction::Merge(const PartiallySignedTransaction& psbt)
         return false;
     }
 
-    for (unsigned int i = 0; i < inputs.size(); ++i) {
+    for (std::vector<decltype(inputs)>::size_type i = 0; i < inputs.size(); ++i) {
         inputs[i].Merge(psbt.inputs[i]);
     }
-    for (unsigned int i = 0; i < outputs.size(); ++i) {
+    for (std::vector<decltype(outputs)>::size_type i = 0; i < outputs.size(); ++i) {
         outputs[i].Merge(psbt.outputs[i]);
     }
     for (auto& xpub_pair : psbt.m_xpubs) {
@@ -448,7 +448,7 @@ void RemoveUnnecessaryTransactions(PartiallySignedTransaction& psbtx, const int&
     if ((sighash_type & 0x80) != SIGHASH_ANYONECANPAY) {
         // Figure out if any non_witness_utxos should be dropped
         std::vector<unsigned int> to_drop;
-        for (unsigned int i = 0; i < psbtx.inputs.size(); ++i) {
+        for (std::vector<decltype(psbtx.inputs)>::size_type i = 0; i < psbtx.inputs.size(); ++i) {
             const auto& input = psbtx.inputs.at(i);
             int wit_ver;
             std::vector<unsigned char> wit_prog;
@@ -482,7 +482,7 @@ bool FinalizePSBT(PartiallySignedTransaction& psbtx)
     //   script.
     bool complete = true;
     const PrecomputedTransactionData txdata = PrecomputePSBTData(psbtx);
-    for (unsigned int i = 0; i < psbtx.tx->vin.size(); ++i) {
+    for (std::vector<decltype(psbtx.tx->vin)>::size_type i = 0; i < psbtx.tx->vin.size(); ++i) {
         complete &= SignPSBTInput(DUMMY_SIGNING_PROVIDER, psbtx, i, &txdata, SIGHASH_ALL, nullptr, true);
     }
 
@@ -498,7 +498,7 @@ bool FinalizeAndExtractPSBT(PartiallySignedTransaction& psbtx, CMutableTransacti
     }
 
     result = *psbtx.tx;
-    for (unsigned int i = 0; i < result.vin.size(); ++i) {
+    for (std::vector<decltype(result.vin)>::size_type i = 0; i < result.vin.size(); ++i) {
         result.vin[i].scriptSig = psbtx.inputs[i].final_script_sig;
         result.vin[i].scriptWitness = psbtx.inputs[i].final_script_witness;
     }

--- a/src/txorphanage.cpp
+++ b/src/txorphanage.cpp
@@ -150,7 +150,7 @@ void TxOrphanage::AddChildrenToWorkSet(const CTransaction& tx)
     LOCK(m_mutex);
 
 
-    for (unsigned int i = 0; i < tx.vout.size(); i++) {
+    for (std::vector<decltype(&tx.vout)>::size_type i = 0; i < tx.vout.size(); i++) {
         const auto it_by_prev = m_outpoint_to_orphan_it.find(COutPoint(tx.GetHash(), i));
         if (it_by_prev != m_outpoint_to_orphan_it.end()) {
             for (const auto& elem : it_by_prev->second) {


### PR DESCRIPTION
Note that `size_t` is not always `size_type`, but I haven't replaced your other usages of `size_t` throughout the codebase (I can upon request).

Some details:
- https://en.cppreference.com/w/cpp/container/vector#Member_types
- https://www.ibm.com/docs/en/zos/2.4.0?topic=types-vectorsize-type

Further discussion:
- https://stackoverflow.com/q/17258067
- https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1428r0.pdf a dissent by Bjarne Stroustrup