### PR TITLE
fuzz: Fix mini_miner_selection running out of coin

### DIFF
--- a/src/test/fuzz/mini_miner.cpp
+++ b/src/test/fuzz/mini_miner.cpp
@@ -118,10 +118,11 @@ FUZZ_TARGET_INIT(mini_miner_selection, initialize_miner)
     LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 100)
     {
         CMutableTransaction mtx = CMutableTransaction();
-        const size_t num_inputs = 2;
+        assert(!available_coins.empty());
+        const size_t num_inputs = std::min(size_t{2}, available_coins.size());
         const size_t num_outputs = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(2, 5);
         for (size_t n{0}; n < num_inputs; ++n) {
-            auto prevout = available_coins.front();
+            auto prevout = available_coins.at(0);
             mtx.vin.push_back(CTxIn(prevout, CScript()));
             available_coins.pop_front();
         }


### PR DESCRIPTION
Fixes a bug in the mini_miner_selection fuzz test found by fuzzing: It was possible for the mini_miner_selection fuzz test to generated transactions that created fewer new outputs than the two inputs they each spent. If the fuzz seed did so consistently, eventually it would cause a `pop_front()` on an empty available_coins which resulted in undefined behavior.

Fixed per belt-suspender approach:
- assert that available_coins is not empty before generating tx
- generate at least two coins per new tx
- allow building tx with a single input if only one coin is available