### PR TITLE
Avoiding unnecessary std::string copy in ArgsManager::GetPathArg argument list

### DIFF
--- a/src/common/args.cpp
+++ b/src/common/args.cpp
@@ -268,7 +268,7 @@ std::optional<unsigned int> ArgsManager::GetArgFlags(const std::string& name) co
     return std::nullopt;
 }
 
-fs::path ArgsManager::GetPathArg(std::string arg, const fs::path& default_value) const
+fs::path ArgsManager::GetPathArg(const std::string& arg, const fs::path& default_value) const
 {
     if (IsArgNegated(arg)) return fs::path{};
     std::string path_str = GetArg(arg, "");

--- a/src/common/args.h
+++ b/src/common/args.h
@@ -280,7 +280,7 @@ protected:
      * for examples or implementation for details). If argument is empty or not
      * set, default_value is returned unchanged.
      */
-    fs::path GetPathArg(std::string arg, const fs::path& default_value = {}) const;
+    fs::path GetPathArg(const std::string& arg, const fs::path& default_value = {}) const;
 
     /**
      * Return integer argument or default value


### PR DESCRIPTION
Please note, this is my first contribution to Bitcoin Core. I am not sure where the line of "significantly improving developer experience" is drawn, but this at least removes a warning from some static code checkers.