### PR TITLE
Blocking arguments -nohelp, -noh, and -no?

### DIFF
--- a/src/common/args.cpp
+++ b/src/common/args.cpp
@@ -581,10 +581,10 @@ void ArgsManager::AddArg(const std::string& name, const std::string& help, unsig
     }
 }
 
-void ArgsManager::AddHiddenArgs(const std::vector<std::string>& names)
+void ArgsManager::AddHiddenArgs(const std::vector<std::string>& names, unsigned int flags)
 {
     for (const std::string& name : names) {
-        AddArg(name, "", ArgsManager::ALLOW_ANY, OptionsCategory::HIDDEN);
+        AddArg(name, "", flags, OptionsCategory::HIDDEN);
     }
 }
 
@@ -664,8 +664,8 @@ bool HelpRequested(const ArgsManager& args)
 
 void SetupHelpOptions(ArgsManager& args)
 {
-    args.AddArg("-?", "Print this help message and exit", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
-    args.AddHiddenArgs({"-h", "-help"});
+    args.AddArg("-?", "Print this help message and exit", ArgsManager::DISALLOW_NEGATION, OptionsCategory::OPTIONS);
+    args.AddHiddenArgs({"-h", "-help"}, ArgsManager::DISALLOW_NEGATION);
 }
 
 static const int screenWidth = 79;

--- a/src/common/args.h
+++ b/src/common/args.h
@@ -351,7 +351,7 @@ protected:
     /**
      * Add many hidden arguments
      */
-    void AddHiddenArgs(const std::vector<std::string>& args);
+    void AddHiddenArgs(const std::vector<std::string>& args, unsigned int flags = ArgsManager::ALLOW_ANY);
 
     /**
      * Clear available arguments


### PR DESCRIPTION
The three arguments -nohelp, -noh, and -no? were previously silently accepted and interpreted as -help, -h, and -? respectively. As negating these arguments is meaningless, this is now blocked and properly communicated to the user, resulting in e.g.:

> Error parsing command line arguments: Negating of -help is meaningless and therefore forbidden

Not that anyone ever complained about this. I just noticed this oddity while looking through the code.