### PR TITLE
Sanitizing ports of -rpcconnect and -rpcport.

### DIFF
--- a/src/util/strencodings.cpp
+++ b/src/util/strencodings.cpp
@@ -98,7 +98,7 @@ std::optional<std::vector<Byte>> TryParseHex(std::string_view str)
 template std::optional<std::vector<std::byte>> TryParseHex(std::string_view);
 template std::optional<std::vector<uint8_t>> TryParseHex(std::string_view);
 
-bool SplitHostPort(std::string_view in, uint16_t& portOut, std::string& hostOut)
+bool SplitHostPort(std::string_view in, uint16_t& portOut, std::string& hostOut, bool* cPortOut)
 {
     bool valid = false;
     size_t colon = in.find_last_of(':');
@@ -106,12 +106,14 @@ bool SplitHostPort(std::string_view in, uint16_t& portOut, std::string& hostOut)
     bool fHaveColon = colon != in.npos;
     bool fBracketed = fHaveColon && (in[0] == '[' && in[colon - 1] == ']'); // if there is a colon, and in[0]=='[', colon is not 0, so in[colon-1] is safe
     bool fMultiColon{fHaveColon && colon != 0 && (in.find_last_of(':', colon - 1) != in.npos)};
+    if (cPortOut) *cPortOut = false;
     if (fHaveColon && (colon == 0 || fBracketed || !fMultiColon)) {
         uint16_t n;
         if (ParseUInt16(in.substr(colon + 1), &n)) {
             in = in.substr(0, colon);
             portOut = n;
             valid = (portOut != 0);
+            if (cPortOut) *cPortOut = valid;
         }
     } else {
         valid = true;

--- a/src/util/strencodings.h
+++ b/src/util/strencodings.h
@@ -101,9 +101,10 @@ std::string EncodeBase32(std::string_view str, bool pad = true);
  * @param[in] in        The socket address string to split.
  * @param[out] portOut  Port-portion of the input, if found and parsable.
  * @param[out] hostOut  Host-portion of the input, if found.
+ * @param[out] cPortOut Ignored on nullptr. True if port-portion found and parsable, otherwise false.
  * @return              true if port-portion is absent or within its allowed range, otherwise false
  */
-bool SplitHostPort(std::string_view in, uint16_t& portOut, std::string& hostOut);
+bool SplitHostPort(std::string_view in, uint16_t& portOut, std::string& hostOut, bool* cPortOut = nullptr);
 
 // LocaleIndependentAtoi is provided for backwards compatibility reasons.
 //


### PR DESCRIPTION
Previously, if they contained malformed ports they were silently interpreted as value%0xffff. Illegal ports now lead to an error. Additionally, if rpcconnect has a port and rpcport is set, a useful warning is now printed.
