### PR TITLE
Renamed UniValue::__pushKV to UniValue::pushKVEnd.

### DIFF
--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -115,7 +115,7 @@ bool WriteSettings(const fs::path& path,
 {
     SettingsValue out(SettingsValue::VOBJ);
     for (const auto& value : values) {
-        out.__pushKV(value.first, value.second);
+        out.pushKVEnd(value.first, value.second);
     }
     std::ofstream file;
     file.open(path);

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -371,10 +371,10 @@ UniValue RPCConvertNamedValues(const std::string &strMethod, const std::vector<s
     }
 
     if (!positional_args.empty()) {
-        // Use __pushKV instead of pushKV to avoid overwriting an explicit
+        // Use pushKVEnd instead of pushKV to avoid overwriting an explicit
         // "args" value with an implicit one. Let the RPC server handle the
         // request as given.
-        params.__pushKV("args", positional_args);
+        params.pushKVEnd("args", positional_args);
     }
 
     return params;

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -351,8 +351,8 @@ UniValue MempoolToJSON(const CTxMemPool& pool, bool verbose, bool include_mempoo
             entryToJSON(pool, info, e);
             // Mempool has unique entries so there is no advantage in using
             // UniValue::pushKV, which checks if the key already exists in O(N).
-            // UniValue::__pushKV is used instead which currently is O(1).
-            o.__pushKV(hash.ToString(), info);
+            // UniValue::pushKVEnd is used instead which currently is O(1).
+            o.pushKVEnd(hash.ToString(), info);
         }
         return o;
     } else {

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -437,7 +437,7 @@ static inline JSONRPCRequest transformNamedArguments(const JSONRPCRequest& in, c
                 if (options.exists(fr->first)) {
                     throw JSONRPCError(RPC_INVALID_PARAMETER, "Parameter " + fr->first + " specified multiple times");
                 }
-                options.__pushKV(fr->first, *fr->second);
+                options.pushKVEnd(fr->first, *fr->second);
                 argsIn.erase(fr);
             }
             continue;

--- a/src/support/allocators/secure.h
+++ b/src/support/allocators/secure.h
@@ -32,9 +32,9 @@ struct secure_allocator : public std::allocator<T> {
     {
     }
     ~secure_allocator() noexcept {}
-    template <typename _Other>
+    template <typename Other>
     struct rebind {
-        typedef secure_allocator<_Other> other;
+        typedef secure_allocator<Other> other;
     };
 
     T* allocate(std::size_t n, const void* hint = nullptr)

--- a/src/support/allocators/zeroafterfree.h
+++ b/src/support/allocators/zeroafterfree.h
@@ -27,9 +27,9 @@ struct zero_after_free_allocator : public std::allocator<T> {
     {
     }
     ~zero_after_free_allocator() noexcept {}
-    template <typename _Other>
+    template <typename Other>
     struct rebind {
-        typedef zero_after_free_allocator<_Other> other;
+        typedef zero_after_free_allocator<Other> other;
     };
 
     void deallocate(T* p, std::size_t n)

--- a/src/test/settings_tests.cpp
+++ b/src/test/settings_tests.cpp
@@ -35,7 +35,7 @@ inline std::ostream& operator<<(std::ostream& os, const common::SettingsValue& v
 inline std::ostream& operator<<(std::ostream& os, const std::pair<std::string, common::SettingsValue>& kv)
 {
     common::SettingsValue out(common::SettingsValue::VOBJ);
-    out.__pushKV(kv.first, kv.second);
+    out.pushKVEnd(kv.first, kv.second);
     os << out.write();
     return os;
 }

--- a/src/txorphanage.h
+++ b/src/txorphanage.h
@@ -99,7 +99,7 @@ protected:
     std::map<uint256, OrphanMap::iterator> m_wtxid_to_orphan_it GUARDED_BY(m_mutex);
 
     /** Erase an orphan by txid */
-    int _EraseTx(const uint256& txid) EXCLUSIVE_LOCKS_REQUIRED(m_mutex);
+    int EraseTxNoLock(const uint256& txid) EXCLUSIVE_LOCKS_REQUIRED(m_mutex);
 };
 
 #endif // BITCOIN_TXORPHANAGE_H

--- a/src/univalue/include/univalue.h
+++ b/src/univalue/include/univalue.h
@@ -87,7 +87,7 @@ public:
     template <class It>
     void push_backV(It first, It last);
 
-    void __pushKV(std::string key, UniValue val);
+    void pushKVEnd(std::string key, UniValue val);
     void pushKV(std::string key, UniValue val);
     void pushKVs(UniValue obj);
 

--- a/src/univalue/lib/univalue.cpp
+++ b/src/univalue/lib/univalue.cpp
@@ -115,7 +115,7 @@ void UniValue::push_backV(const std::vector<UniValue>& vec)
     values.insert(values.end(), vec.begin(), vec.end());
 }
 
-void UniValue::__pushKV(std::string key, UniValue val)
+void UniValue::pushKVEnd(std::string key, UniValue val)
 {
     checkType(VOBJ);
 
@@ -131,7 +131,7 @@ void UniValue::pushKV(std::string key, UniValue val)
     if (findKey(key, idx))
         values[idx] = std::move(val);
     else
-        __pushKV(std::move(key), std::move(val));
+        pushKVEnd(std::move(key), std::move(val));
 }
 
 void UniValue::pushKVs(UniValue obj)
@@ -140,7 +140,7 @@ void UniValue::pushKVs(UniValue obj)
     obj.checkType(VOBJ);
 
     for (size_t i = 0; i < obj.keys.size(); i++)
-        __pushKV(std::move(obj.keys.at(i)), std::move(obj.values.at(i)));
+        pushKVEnd(std::move(obj.keys.at(i)), std::move(obj.values.at(i)));
 }
 
 void UniValue::getObjMap(std::map<std::string,UniValue>& kv) const

--- a/src/univalue/test/object.cpp
+++ b/src/univalue/test/object.cpp
@@ -86,7 +86,7 @@ void univalue_push_throw()
     UniValue j;
     BOOST_CHECK_THROW(j.push_back(1), std::runtime_error);
     BOOST_CHECK_THROW(j.push_backV({1}), std::runtime_error);
-    BOOST_CHECK_THROW(j.__pushKV("k", 1), std::runtime_error);
+    BOOST_CHECK_THROW(j.pushKVEnd("k", 1), std::runtime_error);
     BOOST_CHECK_THROW(j.pushKV("k", 1), std::runtime_error);
     BOOST_CHECK_THROW(j.pushKVs({}), std::runtime_error);
 }
@@ -364,7 +364,7 @@ void univalue_object()
     obj.setObject();
     UniValue uv;
     uv.setInt(42);
-    obj.__pushKV("age", uv);
+    obj.pushKVEnd("age", uv);
     BOOST_CHECK_EQUAL(obj.size(), 1);
     BOOST_CHECK_EQUAL(obj["age"].getValStr(), "42");
 

--- a/src/wallet/rpc/addresses.cpp
+++ b/src/wallet/rpc/addresses.cpp
@@ -677,11 +677,11 @@ RPCHelpMan getaddressesbylabel()
             CHECK_NONFATAL(unique);
             // UniValue::pushKV checks if the key exists in O(N)
             // and since duplicate addresses are unexpected (checked with
-            // std::set in O(log(N))), UniValue::__pushKV is used instead,
+            // std::set in O(log(N))), UniValue::pushKVEnd is used instead,
             // which currently is O(1).
             UniValue value(UniValue::VOBJ);
             value.pushKV("purpose", _purpose ? PurposeToString(*_purpose) : "unknown");
-            ret.__pushKV(address, value);
+            ret.pushKVEnd(address, value);
         }
     });
 


### PR DESCRIPTION
Any identifier starting with 2 _ is reserved for the compiler and thus must not be used.

See: https://stackoverflow.com/a/228797/7130273