### PR TITLE
Silent Payments: send and receive

### DIFF
--- a/build_msvc/libsecp256k1/libsecp256k1.vcxproj
+++ b/build_msvc/libsecp256k1/libsecp256k1.vcxproj
@@ -14,7 +14,7 @@
   </ItemGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <PreprocessorDefinitions>ENABLE_MODULE_RECOVERY;ENABLE_MODULE_EXTRAKEYS;ENABLE_MODULE_SCHNORRSIG;ENABLE_MODULE_ELLSWIFT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>ENABLE_MODULE_ECDH;ENABLE_MODULE_RECOVERY;ENABLE_MODULE_EXTRAKEYS;ENABLE_MODULE_SCHNORRSIG;ENABLE_MODULE_ELLSWIFT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <UndefinePreprocessorDefinitions>USE_ASM_X86_64;%(UndefinePreprocessorDefinitions)</UndefinePreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\src\secp256k1;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4146;4244;4267;4334</DisableSpecificWarnings>

--- a/configure.ac
+++ b/configure.ac
@@ -1951,7 +1951,7 @@ CPPFLAGS_TEMP="$CPPFLAGS"
 unset CPPFLAGS
 CPPFLAGS="$CPPFLAGS_TEMP"
 
-ac_configure_args="${ac_configure_args} --disable-shared --with-pic --enable-benchmark=no --enable-module-recovery --disable-module-ecdh"
+ac_configure_args="${ac_configure_args} --disable-shared --with-pic --enable-benchmark=no --enable-module-recovery --enable-module-ecdh"
 AC_CONFIG_SUBDIRS([src/secp256k1])
 
 AC_OUTPUT

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -346,6 +346,7 @@ BITCOIN_CORE_H = \
   wallet/rpc/wallet.h \
   wallet/salvage.h \
   wallet/scriptpubkeyman.h \
+  wallet/silentpayments.h \
   wallet/spend.h \
   wallet/sqlite.h \
   wallet/transaction.h \
@@ -509,6 +510,7 @@ libbitcoin_wallet_a_SOURCES = \
   wallet/rpc/util.cpp \
   wallet/rpc/wallet.cpp \
   wallet/scriptpubkeyman.cpp \
+  wallet/silentpayments.cpp \
   wallet/spend.cpp \
   wallet/transaction.cpp \
   wallet/wallet.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -17,6 +17,7 @@ FUZZ_BINARY=test/fuzz/fuzz$(EXEEXT)
 JSON_TEST_FILES = \
   test/data/script_tests.json \
   test/data/bip341_wallet_vectors.json \
+  test/data/bip352_send_and_receive_vectors.json \
   test/data/base58_encode_decode.json \
   test/data/blockfilters.json \
   test/data/key_io_valid.json \
@@ -182,6 +183,7 @@ BITCOIN_TESTS += \
   wallet/test/ismine_tests.cpp \
   wallet/test/rpc_util_tests.cpp \
   wallet/test/scriptpubkeyman_tests.cpp \
+  wallet/test/silentpayment_tests.cpp \
   wallet/test/walletload_tests.cpp \
   wallet/test/group_outputs_tests.cpp
 

--- a/src/bech32.cpp
+++ b/src/bech32.cpp
@@ -370,11 +370,13 @@ std::string Encode(Encoding encoding, const std::string& hrp, const data& values
 }
 
 /** Decode a Bech32 or Bech32m string. */
-DecodeResult Decode(const std::string& str) {
+DecodeResult Decode(const std::string& str, bool silent) {
+    std::size_t max_size = silent ? 1024 : 90;
+
     std::vector<int> errors;
     if (!CheckCharacters(str, errors)) return {};
     size_t pos = str.rfind('1');
-    if (str.size() > 90 || pos == str.npos || pos == 0 || pos + 7 > str.size()) {
+    if (str.size() > max_size || pos == str.npos || pos == 0 || pos + 7 > str.size()) {
         return {};
     }
     data values(str.size() - 1 - pos);

--- a/src/bech32.h
+++ b/src/bech32.h
@@ -43,7 +43,7 @@ struct DecodeResult
 };
 
 /** Decode a Bech32 or Bech32m string. */
-DecodeResult Decode(const std::string& str);
+DecodeResult Decode(const std::string& str, bool silent = false);
 
 /** Return the positions of errors in a Bech32 string. */
 std::pair<std::string, std::vector<int>> LocateErrors(const std::string& str);

--- a/src/bench/wallet_create_tx.cpp
+++ b/src/bench/wallet_create_tx.cpp
@@ -126,7 +126,7 @@ static void WalletCreateTx(benchmark::Bench& bench, const OutputType output_type
 
     // If automatic coin selection is enabled, add the value of another UTXO to the target
     if (coin_control.m_allow_other_inputs) target += 50 * COIN;
-    std::vector<wallet::CRecipient> recipients = {{dest, target, true}};
+    std::vector<wallet::Destination> recipients = {wallet::CRecipient{dest, target, true}};
 
     bench.epochIterations(5).run([&] {
         LOCK(wallet.cs_wallet);

--- a/src/hash.h
+++ b/src/hash.h
@@ -108,6 +108,10 @@ public:
     {
         ctx.Write(UCharCast(src.data()), src.size());
     }
+    void write(Span<const unsigned char> src)
+    {
+        ctx.Write(src.data(), src.size());
+    }
 
     /** Compute the double-SHA256 hash of all data written to this object.
      *

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -157,6 +157,7 @@ public:
     //! Return whether node has the block and optionally return block metadata
     //! or contents.
     virtual bool findBlock(const uint256& hash, const FoundBlock& block={}) = 0;
+    virtual bool getUndoBlock(const uint256& block_hash, CBlockUndo& blockUndo) = 0;
 
     //! Find first block in the chain with timestamp >= the given time
     //! and height >= than the given height, return false if there is no block

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -38,9 +38,10 @@ class CWallet;
 enum class AddressPurpose;
 enum isminetype : unsigned int;
 struct CRecipient;
+struct V0SilentPaymentDestination;
 struct WalletContext;
 using isminefilter = std::underlying_type<isminetype>::type;
-using Destination = std::variant<CRecipient>;
+using Destination = std::variant<CRecipient, V0SilentPaymentDestination>;
 } // namespace wallet
 
 namespace interfaces {

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -40,6 +40,7 @@ enum isminetype : unsigned int;
 struct CRecipient;
 struct WalletContext;
 using isminefilter = std::underlying_type<isminetype>::type;
+using Destination = std::variant<CRecipient>;
 } // namespace wallet
 
 namespace interfaces {
@@ -140,7 +141,7 @@ public:
     virtual void listLockedCoins(std::vector<COutPoint>& outputs) = 0;
 
     //! Create transaction.
-    virtual util::Result<CTransactionRef> createTransaction(const std::vector<wallet::CRecipient>& recipients,
+    virtual util::Result<CTransactionRef> createTransaction(const std::vector<wallet::Destination>& recipients,
         const wallet::CCoinControl& coin_control,
         bool sign,
         int& change_pos,

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -147,6 +147,7 @@ public:
         base58Prefixes[EXT_SECRET_KEY] = {0x04, 0x88, 0xAD, 0xE4};
 
         bech32_hrp = "bc";
+        silent_payment_hrp = "sp";
 
         vFixedSeeds = std::vector<uint8_t>(std::begin(chainparams_seed_main), std::end(chainparams_seed_main));
 
@@ -255,6 +256,7 @@ public:
         base58Prefixes[EXT_SECRET_KEY] = {0x04, 0x35, 0x83, 0x94};
 
         bech32_hrp = "tb";
+        silent_payment_hrp = "tsp";
 
         vFixedSeeds = std::vector<uint8_t>(std::begin(chainparams_seed_test), std::end(chainparams_seed_test));
 
@@ -380,6 +382,7 @@ public:
         base58Prefixes[EXT_SECRET_KEY] = {0x04, 0x35, 0x83, 0x94};
 
         bech32_hrp = "tb";
+        silent_payment_hrp = "tsp";
 
         fDefaultConsistencyChecks = false;
         fRequireStandard = true;
@@ -508,6 +511,7 @@ public:
         base58Prefixes[EXT_SECRET_KEY] = {0x04, 0x35, 0x83, 0x94};
 
         bech32_hrp = "bcrt";
+        silent_payment_hrp = "sprt";
     }
 };
 

--- a/src/kernel/chainparams.h
+++ b/src/kernel/chainparams.h
@@ -123,6 +123,7 @@ public:
     const std::vector<std::string>& DNSSeeds() const { return vSeeds; }
     const std::vector<unsigned char>& Base58Prefix(Base58Type type) const { return base58Prefixes[type]; }
     const std::string& Bech32HRP() const { return bech32_hrp; }
+    const std::string& SilentPaymentHRP() const { return silent_payment_hrp; }
     const std::vector<uint8_t>& FixedSeeds() const { return vFixedSeeds; }
     const CCheckpointData& Checkpoints() const { return checkpointData; }
 
@@ -175,6 +176,7 @@ protected:
     std::vector<std::string> vSeeds;
     std::vector<unsigned char> base58Prefixes[MAX_BASE58_TYPES];
     std::string bech32_hrp;
+    std::string silent_payment_hrp;
     ChainType m_chain_type;
     CBlock genesis;
     std::vector<uint8_t> vFixedSeeds;

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -190,6 +190,24 @@ CKey CKey::AddTweak(const unsigned char *tweak32) const
     return new_seckey;
 }
 
+bool CKey::ApplyTapTweak(const uint256* merkle_root, CKey& key) const
+{
+    secp256k1_keypair keypair;
+    if (!secp256k1_keypair_create(secp256k1_context_sign, &keypair, begin())) return false;
+
+    secp256k1_xonly_pubkey pubkey;
+    if (!secp256k1_keypair_xonly_pub(secp256k1_context_sign, &pubkey, nullptr, &keypair)) return false;
+    unsigned char pubkey_bytes[32];
+    if (!secp256k1_xonly_pubkey_serialize(secp256k1_context_sign, pubkey_bytes, &pubkey)) return false;
+    uint256 tweak = XOnlyPubKey(pubkey_bytes).ComputeTapTweakHash(merkle_root->IsNull() ? nullptr : merkle_root);
+    if (!secp256k1_keypair_xonly_tweak_add(secp256k1_context_static, &keypair, tweak.data())) return false;
+
+    unsigned char tweaked_secret_key[32];
+    if (!secp256k1_keypair_sec(secp256k1_context_sign, tweaked_secret_key, &keypair)) return false;
+    key.Set(std::begin(tweaked_secret_key), std::end(tweaked_secret_key), true);
+    return key.IsValid();
+}
+
 CKey CKey::MultiplyTweak(const unsigned char *tweak32) const
 {
     assert(fValid);

--- a/src/key.h
+++ b/src/key.h
@@ -107,6 +107,20 @@ public:
     //! Negate private key
     bool Negate();
 
+    //! Tweak a secret key by adding a scalar value to it.
+    //
+    CKey AddTweak(const unsigned char *tweak32) const;
+
+    //! Tweak a secret key by multiplying it by a scalar value.
+    CKey MultiplyTweak(const unsigned char *tweak32) const;
+
+    /**
+     * Compute a public key via ECDH for Silent Payments.
+     * This returns the un-hashed ECDH result and should not be used
+     * outside of silent payments
+     */
+    CPubKey SilentPaymentECDH(const CPubKey& pubkey) const;
+
     /**
      * Convert the private key to a CPrivKey (serialized OpenSSL private key data).
      * This is expensive.

--- a/src/key.h
+++ b/src/key.h
@@ -110,6 +110,7 @@ public:
     //! Tweak a secret key by adding a scalar value to it.
     //
     CKey AddTweak(const unsigned char *tweak32) const;
+    bool ApplyTapTweak(const uint256*, CKey&) const;
 
     //! Tweak a secret key by multiplying it by a scalar value.
     CKey MultiplyTweak(const unsigned char *tweak32) const;

--- a/src/key_io.cpp
+++ b/src/key_io.cpp
@@ -341,3 +341,21 @@ std::vector<unsigned char> DecodeSilentAddress(const std::string& str)
     if ((version == 0 && silent_payment_data.size() != SILENT_PAYMENT_V0_DATA_SIZE) || silent_payment_data.size() < SILENT_PAYMENT_V0_DATA_SIZE) return {};
     return silent_payment_data;
 }
+
+std::string EncodeSilentDestination(const CPubKey& scan_pubkey, const CPubKey& spend_pubkey)
+{
+    // The data_in is scan_pubkey + spend_pubkey
+    std::vector<unsigned char> data_in = {};
+    // Set 0 as the silent payments version
+    std::vector<unsigned char> data_out = {0};
+
+    data_in.insert(data_in.end(), scan_pubkey.begin(), scan_pubkey.end());
+    data_in.insert(data_in.end(), spend_pubkey.begin(), spend_pubkey.end());
+
+    ConvertBits<8, 5, true>([&](unsigned char c) { data_out.push_back(c); }, data_in.begin(), data_in.end());
+
+    std::string hrp = Params().SilentPaymentHRP();
+
+    return bech32::Encode(bech32::Encoding::BECH32M, hrp, data_out);
+}
+

--- a/src/key_io.h
+++ b/src/key_io.h
@@ -27,6 +27,7 @@ CTxDestination DecodeDestination(const std::string& str, std::string& error_msg,
 
 std::pair<CPubKey, CPubKey> DecodeSilentData(const std::vector<unsigned char>& data);
 std::vector<unsigned char> DecodeSilentAddress(const std::string& str);
+std::string EncodeSilentDestination(const CPubKey& scan_pubkey, const CPubKey& spend_pubkey);
 
 bool IsValidDestinationString(const std::string& str);
 bool IsValidDestinationString(const std::string& str, const CChainParams& params);

--- a/src/key_io.h
+++ b/src/key_io.h
@@ -24,6 +24,10 @@ std::string EncodeExtPubKey(const CExtPubKey& extpubkey);
 std::string EncodeDestination(const CTxDestination& dest);
 CTxDestination DecodeDestination(const std::string& str);
 CTxDestination DecodeDestination(const std::string& str, std::string& error_msg, std::vector<int>* error_locations = nullptr);
+
+std::pair<CPubKey, CPubKey> DecodeSilentData(const std::vector<unsigned char>& data);
+std::vector<unsigned char> DecodeSilentAddress(const std::string& str);
+
 bool IsValidDestinationString(const std::string& str);
 bool IsValidDestinationString(const std::string& str, const CChainParams& params);
 

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -563,6 +563,13 @@ public:
         WAIT_LOCK(cs_main, lock);
         return FillBlock(chainman().m_blockman.LookupBlockIndex(hash), block, lock, chainman().ActiveChain(), chainman().m_blockman);
     }
+    bool getUndoBlock(const uint256& block_hash, CBlockUndo& undoBlock) override
+    {
+        WAIT_LOCK(cs_main, lock);
+        const CBlockIndex* pindex{chainman().m_blockman.LookupBlockIndex(block_hash)};
+        if (!chainman().m_blockman.UndoReadFromDisk(undoBlock, *pindex)) return false;
+        return true;
+    }
     bool findFirstBlockWithTimeAndHeight(int64_t min_time, int min_height, const FoundBlock& block) override
     {
         WAIT_LOCK(cs_main, lock);

--- a/src/outputtype.cpp
+++ b/src/outputtype.cpp
@@ -20,6 +20,7 @@ static const std::string OUTPUT_TYPE_STRING_LEGACY = "legacy";
 static const std::string OUTPUT_TYPE_STRING_P2SH_SEGWIT = "p2sh-segwit";
 static const std::string OUTPUT_TYPE_STRING_BECH32 = "bech32";
 static const std::string OUTPUT_TYPE_STRING_BECH32M = "bech32m";
+static const std::string OUTPUT_TYPE_STRING_SILENT_PAYMENT = "silent-payment";
 static const std::string OUTPUT_TYPE_STRING_UNKNOWN = "unknown";
 
 std::optional<OutputType> ParseOutputType(const std::string& type)
@@ -32,6 +33,8 @@ std::optional<OutputType> ParseOutputType(const std::string& type)
         return OutputType::BECH32;
     } else if (type == OUTPUT_TYPE_STRING_BECH32M) {
         return OutputType::BECH32M;
+    } else if (type == OUTPUT_TYPE_STRING_SILENT_PAYMENT) {
+        return OutputType::SILENT_PAYMENT;
     }
     return std::nullopt;
 }
@@ -43,6 +46,7 @@ const std::string& FormatOutputType(OutputType type)
     case OutputType::P2SH_SEGWIT: return OUTPUT_TYPE_STRING_P2SH_SEGWIT;
     case OutputType::BECH32: return OUTPUT_TYPE_STRING_BECH32;
     case OutputType::BECH32M: return OUTPUT_TYPE_STRING_BECH32M;
+    case OutputType::SILENT_PAYMENT: return OUTPUT_TYPE_STRING_SILENT_PAYMENT;
     case OutputType::UNKNOWN: return OUTPUT_TYPE_STRING_UNKNOWN;
     } // no default case, so the compiler can warn about missing cases
     assert(false);
@@ -64,7 +68,8 @@ CTxDestination GetDestinationForKey(const CPubKey& key, OutputType type)
         }
     }
     case OutputType::BECH32M:
-    case OutputType::UNKNOWN: {} // This function should never be used with BECH32M or UNKNOWN, so let it assert
+    case OutputType::SILENT_PAYMENT:
+    case OutputType::UNKNOWN: {} // This function should never be used with BECH32M, SILENT_PAYMENT, or UNKNOWN so let it assert
     } // no default case, so the compiler can warn about missing cases
     assert(false);
 }
@@ -103,7 +108,8 @@ CTxDestination AddAndGetDestinationForScript(FillableSigningProvider& keystore, 
         }
     }
     case OutputType::BECH32M:
-    case OutputType::UNKNOWN: {} // This function should not be used for BECH32M or UNKNOWN, so let it assert
+    case OutputType::SILENT_PAYMENT:
+    case OutputType::UNKNOWN: {} // This function should not be used for BECH32M, SILENT_PAYMENT, or UNKNOWN so let it assert
     } // no default case, so the compiler can warn about missing cases
     assert(false);
 }

--- a/src/outputtype.h
+++ b/src/outputtype.h
@@ -19,6 +19,7 @@ enum class OutputType {
     P2SH_SEGWIT,
     BECH32,
     BECH32M,
+    SILENT_PAYMENT,
     UNKNOWN,
 };
 
@@ -27,6 +28,7 @@ static constexpr auto OUTPUT_TYPES = std::array{
     OutputType::P2SH_SEGWIT,
     OutputType::BECH32,
     OutputType::BECH32M,
+    OutputType::SILENT_PAYMENT,
 };
 
 std::optional<OutputType> ParseOutputType(const std::string& str);

--- a/src/pubkey.h
+++ b/src/pubkey.h
@@ -211,6 +211,12 @@ public:
      */
     static bool CheckLowS(const std::vector<unsigned char>& vchSig);
 
+    //! Add a number of public keys together.
+    static CPubKey Combine(std::vector<CPubKey> pubkeys);
+
+    /** Tweak a public key by adding the generator multiplied with tweak32 to it. */
+    CPubKey AddTweak(const unsigned char *tweak32) const;
+
     //! Recover a public key from a compact signature.
     bool RecoverCompact(const uint256& hash, const std::vector<unsigned char>& vchSig);
 
@@ -271,6 +277,7 @@ public:
     /** Construct a Taproot tweaked output point with this point as internal key. */
     std::optional<std::pair<XOnlyPubKey, bool>> CreateTapTweak(const uint256* merkle_root) const;
 
+
     /** Returns a list of CKeyIDs for the CPubKeys that could have been used to create this XOnlyPubKey.
      * This is needed for key lookups since keys are indexed by CKeyID.
      */
@@ -286,6 +293,13 @@ public:
     bool operator==(const XOnlyPubKey& other) const { return m_keydata == other.m_keydata; }
     bool operator!=(const XOnlyPubKey& other) const { return m_keydata != other.m_keydata; }
     bool operator<(const XOnlyPubKey& other) const { return m_keydata < other.m_keydata; }
+
+    CPubKey ConvertToCompressedPubKey(bool even = true) const
+    {
+        std::vector<unsigned char> vch(std::begin(m_keydata), std::end(m_keydata));
+        vch.insert(vch.begin(), even ? 2 : 3);
+        return CPubKey(vch.begin(), vch.end());
+    }
 
     //! Implement serialization without length prefixes since it is a fixed length
     SERIALIZE_METHODS(XOnlyPubKey, obj) { READWRITE(obj.m_keydata); }

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -26,7 +26,8 @@
 #include <psbt.h>
 #include <util/translation.h>
 #include <wallet/coincontrol.h>
-#include <wallet/wallet.h> // for CRecipient
+#include <wallet/types.h> // for Destination, CRecipient
+#include <wallet/wallet.h>
 
 #include <stdint.h>
 #include <functional>
@@ -38,6 +39,7 @@
 
 using wallet::CCoinControl;
 using wallet::CRecipient;
+using wallet::Destination;
 using wallet::DEFAULT_DISABLE_WALLET;
 
 WalletModel::WalletModel(std::unique_ptr<interfaces::Wallet> wallet, ClientModel& client_model, const PlatformStyle *platformStyle, QObject *parent) :
@@ -160,7 +162,7 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
     CAmount total = 0;
     bool fSubtractFeeFromAmount = false;
     QList<SendCoinsRecipient> recipients = transaction.getRecipients();
-    std::vector<CRecipient> vecSend;
+    std::vector<Destination> vecSend;
 
     if(recipients.empty())
     {

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -289,6 +289,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "createwallet", 5, "descriptors"},
     { "createwallet", 6, "load_on_startup"},
     { "createwallet", 7, "external_signer"},
+    { "createwallet", 8, "silent_payment"},
     { "restorewallet", 2, "load_on_startup"},
     { "loadwallet", 1, "load_on_startup"},
     { "unloadwallet", 1, "load_on_startup"},

--- a/src/test/data/bip352_send_and_receive_vectors.json
+++ b/src/test/data/bip352_send_and_receive_vectors.json
@@ -1,0 +1,1743 @@
+[
+    {
+        "comment": "Simple send: two inputs",
+        "sending": [
+            {
+                "given": {
+                    "outpoints": [
+                        [
+                            "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
+                            0
+                        ],
+                        [
+                            "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
+                            0
+                        ]
+                    ],
+                    "input_priv_keys": [
+                        [
+                            "eadc78165ff1f8ea94ad7cfdc54990738a4c53f6e0507b42154201b8e5dff3b1",
+                            false
+                        ],
+                        [
+                            "93f5ed907ad5b2bdbbdcb5d9116ebc0a4e1f92f910d5260237fa45a9408aad16",
+                            false
+                        ]
+                    ],
+                    "recipients": [
+                        [
+                            "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv",
+                            1.0
+                        ]
+                    ]
+                },
+                "expected": {
+                    "outputs": [
+                        [
+                            "39a1e5ff6206cd316151b9b34cee4f80bb48ce61adee0a12ce7ff05ea436a1d9",
+                            1.0
+                        ]
+                    ]
+                }
+            }
+        ],
+        "receiving": [
+            {
+                "supports_labels": false,
+                "given": {
+                    "outpoints": [
+                        [
+                            "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
+                            0
+                        ],
+                        [
+                            "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
+                            0
+                        ]
+                    ],
+                    "input_pub_keys": [
+                        "025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
+                        "03bd85685d03d111699b15d046319febe77f8de5286e9e512703cdee1bf3be3792"
+                    ],
+                    "bip32_seed": "f00dbabe",
+                    "scan_priv_key": "0f694e068028a717f8af6b9411f9a133dd3565258714cc226594b34db90c1f2c",
+                    "spend_priv_key": "9d6ad855ce3417ef84e836892e5a56392bfba05fa5d97ccea30e266f540e08b3",
+                    "labels": {},
+                    "outputs": [
+                        "39a1e5ff6206cd316151b9b34cee4f80bb48ce61adee0a12ce7ff05ea436a1d9"
+                    ]
+                },
+                "expected": {
+                    "addresses": [
+                        "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv"
+                    ],
+                    "outputs": [
+                        {
+                            "pub_key": "39a1e5ff6206cd316151b9b34cee4f80bb48ce61adee0a12ce7ff05ea436a1d9",
+                            "priv_key_tweak": "8e4bbee712779f746337cadf39e8b1eab8e8869dd40f2e3a7281113e858ffc0b",
+                            "signature": "e18fe06280456ed533808606f73e0d46dea49f90751078d127379a8e176a6e56bb1e86f4ca3522a58e760a4ea68e6f3a26b24dcbcb9c614d4d5d2bce9bf956bf"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    {
+        "comment": "Simple send: two inputs, order reversed",
+        "sending": [
+            {
+                "given": {
+                    "outpoints": [
+                        [
+                            "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
+                            0
+                        ],
+                        [
+                            "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
+                            0
+                        ]
+                    ],
+                    "input_priv_keys": [
+                        [
+                            "eadc78165ff1f8ea94ad7cfdc54990738a4c53f6e0507b42154201b8e5dff3b1",
+                            false
+                        ],
+                        [
+                            "93f5ed907ad5b2bdbbdcb5d9116ebc0a4e1f92f910d5260237fa45a9408aad16",
+                            false
+                        ]
+                    ],
+                    "recipients": [
+                        [
+                            "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv",
+                            1.0
+                        ]
+                    ]
+                },
+                "expected": {
+                    "outputs": [
+                        [
+                            "39a1e5ff6206cd316151b9b34cee4f80bb48ce61adee0a12ce7ff05ea436a1d9",
+                            1.0
+                        ]
+                    ]
+                }
+            }
+        ],
+        "receiving": [
+            {
+                "supports_labels": false,
+                "given": {
+                    "outpoints": [
+                        [
+                            "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
+                            0
+                        ],
+                        [
+                            "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
+                            0
+                        ]
+                    ],
+                    "input_pub_keys": [
+                        "025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
+                        "03bd85685d03d111699b15d046319febe77f8de5286e9e512703cdee1bf3be3792"
+                    ],
+                    "bip32_seed": "f00dbabe",
+                    "scan_priv_key": "0f694e068028a717f8af6b9411f9a133dd3565258714cc226594b34db90c1f2c",
+                    "spend_priv_key": "9d6ad855ce3417ef84e836892e5a56392bfba05fa5d97ccea30e266f540e08b3",
+                    "labels": {},
+                    "outputs": [
+                        "39a1e5ff6206cd316151b9b34cee4f80bb48ce61adee0a12ce7ff05ea436a1d9"
+                    ]
+                },
+                "expected": {
+                    "addresses": [
+                        "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv"
+                    ],
+                    "outputs": [
+                        {
+                            "pub_key": "39a1e5ff6206cd316151b9b34cee4f80bb48ce61adee0a12ce7ff05ea436a1d9",
+                            "priv_key_tweak": "8e4bbee712779f746337cadf39e8b1eab8e8869dd40f2e3a7281113e858ffc0b",
+                            "signature": "e18fe06280456ed533808606f73e0d46dea49f90751078d127379a8e176a6e56bb1e86f4ca3522a58e760a4ea68e6f3a26b24dcbcb9c614d4d5d2bce9bf956bf"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    {
+        "comment": "Simple send: two inputs from the same transaction",
+        "sending": [
+            {
+                "given": {
+                    "outpoints": [
+                        [
+                            "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
+                            3
+                        ],
+                        [
+                            "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
+                            7
+                        ]
+                    ],
+                    "input_priv_keys": [
+                        [
+                            "eadc78165ff1f8ea94ad7cfdc54990738a4c53f6e0507b42154201b8e5dff3b1",
+                            false
+                        ],
+                        [
+                            "93f5ed907ad5b2bdbbdcb5d9116ebc0a4e1f92f910d5260237fa45a9408aad16",
+                            false
+                        ]
+                    ],
+                    "recipients": [
+                        [
+                            "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv",
+                            1.0
+                        ]
+                    ]
+                },
+                "expected": {
+                    "outputs": [
+                        [
+                            "162f2298705b3ddca01ce1d214eedff439df3927582938d08e29e464908db00b",
+                            1.0
+                        ]
+                    ]
+                }
+            }
+        ],
+        "receiving": [
+            {
+                "supports_labels": false,
+                "given": {
+                    "outpoints": [
+                        [
+                            "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
+                            3
+                        ],
+                        [
+                            "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
+                            7
+                        ]
+                    ],
+                    "input_pub_keys": [
+                        "025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
+                        "03bd85685d03d111699b15d046319febe77f8de5286e9e512703cdee1bf3be3792"
+                    ],
+                    "bip32_seed": "f00dbabe",
+                    "scan_priv_key": "0f694e068028a717f8af6b9411f9a133dd3565258714cc226594b34db90c1f2c",
+                    "spend_priv_key": "9d6ad855ce3417ef84e836892e5a56392bfba05fa5d97ccea30e266f540e08b3",
+                    "labels": {},
+                    "outputs": [
+                        "162f2298705b3ddca01ce1d214eedff439df3927582938d08e29e464908db00b"
+                    ]
+                },
+                "expected": {
+                    "addresses": [
+                        "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv"
+                    ],
+                    "outputs": [
+                        {
+                            "pub_key": "162f2298705b3ddca01ce1d214eedff439df3927582938d08e29e464908db00b",
+                            "priv_key_tweak": "f06d8d90561bdbc3e511c3bec7355ad3c858aaf38a132c772d6cd82ec04102ac",
+                            "signature": "4c900d573964d31953acdaedbcbb7866fedbdc215417adfd4173073f86179cad5903ae64490629fae610bf879263c3b9f5c7e6ec1b32a159e2d2e60a16d36597"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    {
+        "comment": "Simple send: two inputs from the same transaction, order reversed",
+        "sending": [
+            {
+                "given": {
+                    "outpoints": [
+                        [
+                            "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
+                            7
+                        ],
+                        [
+                            "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
+                            3
+                        ]
+                    ],
+                    "input_priv_keys": [
+                        [
+                            "eadc78165ff1f8ea94ad7cfdc54990738a4c53f6e0507b42154201b8e5dff3b1",
+                            false
+                        ],
+                        [
+                            "93f5ed907ad5b2bdbbdcb5d9116ebc0a4e1f92f910d5260237fa45a9408aad16",
+                            false
+                        ]
+                    ],
+                    "recipients": [
+                        [
+                            "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv",
+                            1.0
+                        ]
+                    ]
+                },
+                "expected": {
+                    "outputs": [
+                        [
+                            "d9ede52f7e1e64e36ccf895ca0250daad96b174987079c903519b17852b21a3f",
+                            1.0
+                        ]
+                    ]
+                }
+            }
+        ],
+        "receiving": [
+            {
+                "supports_labels": false,
+                "given": {
+                    "outpoints": [
+                        [
+                            "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
+                            7
+                        ],
+                        [
+                            "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
+                            3
+                        ]
+                    ],
+                    "input_pub_keys": [
+                        "025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
+                        "03bd85685d03d111699b15d046319febe77f8de5286e9e512703cdee1bf3be3792"
+                    ],
+                    "bip32_seed": "f00dbabe",
+                    "scan_priv_key": "0f694e068028a717f8af6b9411f9a133dd3565258714cc226594b34db90c1f2c",
+                    "spend_priv_key": "9d6ad855ce3417ef84e836892e5a56392bfba05fa5d97ccea30e266f540e08b3",
+                    "labels": {},
+                    "outputs": [
+                        "d9ede52f7e1e64e36ccf895ca0250daad96b174987079c903519b17852b21a3f"
+                    ]
+                },
+                "expected": {
+                    "addresses": [
+                        "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv"
+                    ],
+                    "outputs": [
+                        {
+                            "pub_key": "d9ede52f7e1e64e36ccf895ca0250daad96b174987079c903519b17852b21a3f",
+                            "priv_key_tweak": "44b827516c2128287b1d571add7cfeb42f122e86bc40b4eb2b21ac144607fdb2",
+                            "signature": "1bdb32461dd502ee9c19c7dff5f3801a26c2bc0ffe6f34671053ef7083ea0d5adca6036564252a76e427555deb17edd6f801d45cd7b830d7e3003eb3c8c85263"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    {
+        "comment": "Single recipient: multiple UTXOs from the same public key",
+        "sending": [
+            {
+                "given": {
+                    "outpoints": [
+                        [
+                            "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
+                            0
+                        ],
+                        [
+                            "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
+                            0
+                        ]
+                    ],
+                    "input_priv_keys": [
+                        [
+                            "eadc78165ff1f8ea94ad7cfdc54990738a4c53f6e0507b42154201b8e5dff3b1",
+                            false
+                        ],
+                        [
+                            "eadc78165ff1f8ea94ad7cfdc54990738a4c53f6e0507b42154201b8e5dff3b1",
+                            false
+                        ]
+                    ],
+                    "recipients": [
+                        [
+                            "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv",
+                            1.0
+                        ]
+                    ]
+                },
+                "expected": {
+                    "outputs": [
+                        [
+                            "0aafdcdb5893ae813299b16eea75f34ec16653ac39171da04d7c4e6d2e09ab8e",
+                            1.0
+                        ]
+                    ]
+                }
+            }
+        ],
+        "receiving": [
+            {
+                "supports_labels": false,
+                "given": {
+                    "outpoints": [
+                        [
+                            "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
+                            0
+                        ],
+                        [
+                            "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
+                            0
+                        ]
+                    ],
+                    "input_pub_keys": [
+                        "025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
+                        "025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5"
+                    ],
+                    "bip32_seed": "f00dbabe",
+                    "scan_priv_key": "0f694e068028a717f8af6b9411f9a133dd3565258714cc226594b34db90c1f2c",
+                    "spend_priv_key": "9d6ad855ce3417ef84e836892e5a56392bfba05fa5d97ccea30e266f540e08b3",
+                    "labels": {},
+                    "outputs": [
+                        "0aafdcdb5893ae813299b16eea75f34ec16653ac39171da04d7c4e6d2e09ab8e"
+                    ]
+                },
+                "expected": {
+                    "addresses": [
+                        "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv"
+                    ],
+                    "outputs": [
+                        {
+                            "pub_key": "0aafdcdb5893ae813299b16eea75f34ec16653ac39171da04d7c4e6d2e09ab8e",
+                            "priv_key_tweak": "bf7336bdc02f624715aab385cc62b71f6f494bf8a7dd0fd621cfd365039c39d1",
+                            "signature": "e00ba3406cea12127896fbc198a9da889a4afcf3d66e46b3df0e7bb36de400a109442e5bbd005c3cc5ae30ae7d235ea111475ad621e1e2c27374fda906521c69"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    {
+        "comment": "Single recipient: taproot only inputs with even y-values",
+        "sending": [
+            {
+                "given": {
+                    "outpoints": [
+                        [
+                            "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
+                            0
+                        ],
+                        [
+                            "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
+                            0
+                        ]
+                    ],
+                    "input_priv_keys": [
+                        [
+                            "eadc78165ff1f8ea94ad7cfdc54990738a4c53f6e0507b42154201b8e5dff3b1",
+                            true
+                        ],
+                        [
+                            "fc8716a97a48ba9a05a98ae47b5cd201a25a7fd5d8b73c203c5f7b6b6b3b6ad7",
+                            true
+                        ]
+                    ],
+                    "recipients": [
+                        [
+                            "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv",
+                            1.0
+                        ]
+                    ]
+                },
+                "expected": {
+                    "outputs": [
+                        [
+                            "15d1dfe4403791509cf47f073be2eb3277decabe90da395e63b1f49a09fe965e",
+                            1.0
+                        ]
+                    ]
+                }
+            }
+        ],
+        "receiving": [
+            {
+                "supports_labels": false,
+                "given": {
+                    "outpoints": [
+                        [
+                            "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
+                            0
+                        ],
+                        [
+                            "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
+                            0
+                        ]
+                    ],
+                    "input_pub_keys": [
+                        "5a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
+                        "782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338"
+                    ],
+                    "bip32_seed": "f00dbabe",
+                    "scan_priv_key": "0f694e068028a717f8af6b9411f9a133dd3565258714cc226594b34db90c1f2c",
+                    "spend_priv_key": "9d6ad855ce3417ef84e836892e5a56392bfba05fa5d97ccea30e266f540e08b3",
+                    "labels": {},
+                    "outputs": [
+                        "15d1dfe4403791509cf47f073be2eb3277decabe90da395e63b1f49a09fe965e"
+                    ]
+                },
+                "expected": {
+                    "addresses": [
+                        "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv"
+                    ],
+                    "outputs": [
+                        {
+                            "pub_key": "15d1dfe4403791509cf47f073be2eb3277decabe90da395e63b1f49a09fe965e",
+                            "priv_key_tweak": "0734de077e436e8f6f125e16287cb60dead8ebddc8532be3589ba27156f1add2",
+                            "signature": "d743170ded6bc695f2997caed9886deb7ddc2e0e11d5f1493d6d7e498e8686f94c393c5d20eceb700a4c2035271196897a83fe1658414c38da07e0e4af00fd0a"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    {
+        "comment": "Single recipient: taproot only with mixed even/odd y-values",
+        "sending": [
+            {
+                "given": {
+                    "outpoints": [
+                        [
+                            "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
+                            0
+                        ],
+                        [
+                            "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
+                            0
+                        ]
+                    ],
+                    "input_priv_keys": [
+                        [
+                            "eadc78165ff1f8ea94ad7cfdc54990738a4c53f6e0507b42154201b8e5dff3b1",
+                            true
+                        ],
+                        [
+                            "0378e95685b74565fa56751b84a32dfd18545d10d691641b8372e32164fad66a",
+                            true
+                        ]
+                    ],
+                    "recipients": [
+                        [
+                            "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv",
+                            1.0
+                        ]
+                    ]
+                },
+                "expected": {
+                    "outputs": [
+                        [
+                            "15d1dfe4403791509cf47f073be2eb3277decabe90da395e63b1f49a09fe965e",
+                            1.0
+                        ]
+                    ]
+                }
+            }
+        ],
+        "receiving": [
+            {
+                "supports_labels": false,
+                "given": {
+                    "outpoints": [
+                        [
+                            "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
+                            0
+                        ],
+                        [
+                            "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
+                            0
+                        ]
+                    ],
+                    "input_pub_keys": [
+                        "5a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
+                        "782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338"
+                    ],
+                    "bip32_seed": "f00dbabe",
+                    "scan_priv_key": "0f694e068028a717f8af6b9411f9a133dd3565258714cc226594b34db90c1f2c",
+                    "spend_priv_key": "9d6ad855ce3417ef84e836892e5a56392bfba05fa5d97ccea30e266f540e08b3",
+                    "labels": {},
+                    "outputs": [
+                        "15d1dfe4403791509cf47f073be2eb3277decabe90da395e63b1f49a09fe965e"
+                    ]
+                },
+                "expected": {
+                    "addresses": [
+                        "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv"
+                    ],
+                    "outputs": [
+                        {
+                            "pub_key": "15d1dfe4403791509cf47f073be2eb3277decabe90da395e63b1f49a09fe965e",
+                            "priv_key_tweak": "0734de077e436e8f6f125e16287cb60dead8ebddc8532be3589ba27156f1add2",
+                            "signature": "d743170ded6bc695f2997caed9886deb7ddc2e0e11d5f1493d6d7e498e8686f94c393c5d20eceb700a4c2035271196897a83fe1658414c38da07e0e4af00fd0a"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    {
+        "comment": "Single recipient: taproot input with even y-value and non-taproot input",
+        "sending": [
+            {
+                "given": {
+                    "outpoints": [
+                        [
+                            "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
+                            0
+                        ],
+                        [
+                            "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
+                            0
+                        ]
+                    ],
+                    "input_priv_keys": [
+                        [
+                            "eadc78165ff1f8ea94ad7cfdc54990738a4c53f6e0507b42154201b8e5dff3b1",
+                            true
+                        ],
+                        [
+                            "8d4751f6e8a3586880fb66c19ae277969bd5aa06f61c4ee2f1e2486efdf666d3",
+                            false
+                        ]
+                    ],
+                    "recipients": [
+                        [
+                            "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv",
+                            1.0
+                        ]
+                    ]
+                },
+                "expected": {
+                    "outputs": [
+                        [
+                            "2b4ff8e5bc608cbdd12117171e7d265b6882ad597559caf67b5ecfaf15301dd0",
+                            1.0
+                        ]
+                    ]
+                }
+            }
+        ],
+        "receiving": [
+            {
+                "supports_labels": false,
+                "given": {
+                    "outpoints": [
+                        [
+                            "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
+                            0
+                        ],
+                        [
+                            "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
+                            0
+                        ]
+                    ],
+                    "input_pub_keys": [
+                        "5a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
+                        "03e0ec4f64b3fa2e463ccfcf4e856e37d5e1e20275bc89ec1def9eb098eff1f85d"
+                    ],
+                    "bip32_seed": "f00dbabe",
+                    "scan_priv_key": "0f694e068028a717f8af6b9411f9a133dd3565258714cc226594b34db90c1f2c",
+                    "spend_priv_key": "9d6ad855ce3417ef84e836892e5a56392bfba05fa5d97ccea30e266f540e08b3",
+                    "labels": {},
+                    "outputs": [
+                        "2b4ff8e5bc608cbdd12117171e7d265b6882ad597559caf67b5ecfaf15301dd0"
+                    ]
+                },
+                "expected": {
+                    "addresses": [
+                        "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv"
+                    ],
+                    "outputs": [
+                        {
+                            "pub_key": "2b4ff8e5bc608cbdd12117171e7d265b6882ad597559caf67b5ecfaf15301dd0",
+                            "priv_key_tweak": "17d93733d2acd8388279c24dc4413483802378c99f266f5961ac3338c5146861",
+                            "signature": "7f8f909460c0357a2c1c784e92967e888c6b63ff799db3ce22e8acc715a42ab9177b9db2237d76db60e72bc30c827008266062506cd57f93f9b872529bd50376"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    {
+        "comment": "Single recipient: taproot input with odd y-value and non-taproot input",
+        "sending": [
+            {
+                "given": {
+                    "outpoints": [
+                        [
+                            "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
+                            0
+                        ],
+                        [
+                            "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
+                            0
+                        ]
+                    ],
+                    "input_priv_keys": [
+                        [
+                            "0378e95685b74565fa56751b84a32dfd18545d10d691641b8372e32164fad66a",
+                            true
+                        ],
+                        [
+                            "8d4751f6e8a3586880fb66c19ae277969bd5aa06f61c4ee2f1e2486efdf666d3",
+                            false
+                        ]
+                    ],
+                    "recipients": [
+                        [
+                            "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv",
+                            1.0
+                        ]
+                    ]
+                },
+                "expected": {
+                    "outputs": [
+                        [
+                            "75f501f319db549aaa613717bd7af44da566d4d859b67fe436946564fafc47a3",
+                            1.0
+                        ]
+                    ]
+                }
+            }
+        ],
+        "receiving": [
+            {
+                "supports_labels": false,
+                "given": {
+                    "outpoints": [
+                        [
+                            "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
+                            0
+                        ],
+                        [
+                            "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
+                            0
+                        ]
+                    ],
+                    "input_pub_keys": [
+                        "782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338",
+                        "03e0ec4f64b3fa2e463ccfcf4e856e37d5e1e20275bc89ec1def9eb098eff1f85d"
+                    ],
+                    "bip32_seed": "f00dbabe",
+                    "scan_priv_key": "0f694e068028a717f8af6b9411f9a133dd3565258714cc226594b34db90c1f2c",
+                    "spend_priv_key": "9d6ad855ce3417ef84e836892e5a56392bfba05fa5d97ccea30e266f540e08b3",
+                    "labels": {},
+                    "outputs": [
+                        "75f501f319db549aaa613717bd7af44da566d4d859b67fe436946564fafc47a3"
+                    ]
+                },
+                "expected": {
+                    "addresses": [
+                        "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv"
+                    ],
+                    "outputs": [
+                        {
+                            "pub_key": "75f501f319db549aaa613717bd7af44da566d4d859b67fe436946564fafc47a3",
+                            "priv_key_tweak": "619a5a59a16d4a8e857ef48e63ef7c8195c858191d4e826205e8438ab70d059e",
+                            "signature": "ba2e40de3b3acbc97d282f2d09b9c79936de109710e8d4139409964346f1221c3d4c823a1ee0a946f98b0ce644d136fbc5ea22cd73736fe05475174b25c01e62"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    {
+        "comment": "Multiple outputs: multiple outputs, same recipient",
+        "sending": [
+            {
+                "given": {
+                    "outpoints": [
+                        [
+                            "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
+                            0
+                        ],
+                        [
+                            "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
+                            0
+                        ]
+                    ],
+                    "input_priv_keys": [
+                        [
+                            "eadc78165ff1f8ea94ad7cfdc54990738a4c53f6e0507b42154201b8e5dff3b1",
+                            false
+                        ],
+                        [
+                            "0378e95685b74565fa56751b84a32dfd18545d10d691641b8372e32164fad66a",
+                            false
+                        ]
+                    ],
+                    "recipients": [
+                        [
+                            "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv",
+                            2.0
+                        ],
+                        [
+                            "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv",
+                            3.0
+                        ]
+                    ]
+                },
+                "expected": {
+                    "outputs": [
+                        [
+                            "64f1c7e8992352d18cdbca600b9e1c3a6025050d56a3e1cc833222e4f3b59e18",
+                            2.0
+                        ],
+                        [
+                            "0a48c6ccc1d516e8244dc0153dc88db45f8f264357667c2057a29ca3c2445d09",
+                            3.0
+                        ]
+                    ]
+                }
+            }
+        ],
+        "receiving": [
+            {
+                "supports_labels": false,
+                "given": {
+                    "outpoints": [
+                        [
+                            "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
+                            0
+                        ],
+                        [
+                            "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
+                            0
+                        ]
+                    ],
+                    "input_pub_keys": [
+                        "025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
+                        "03782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338"
+                    ],
+                    "bip32_seed": "f00dbabe",
+                    "scan_priv_key": "0f694e068028a717f8af6b9411f9a133dd3565258714cc226594b34db90c1f2c",
+                    "spend_priv_key": "9d6ad855ce3417ef84e836892e5a56392bfba05fa5d97ccea30e266f540e08b3",
+                    "labels": {},
+                    "outputs": [
+                        "64f1c7e8992352d18cdbca600b9e1c3a6025050d56a3e1cc833222e4f3b59e18",
+                        "0a48c6ccc1d516e8244dc0153dc88db45f8f264357667c2057a29ca3c2445d09",
+                        "c58e121044b23cba9b4695052229a9fd9e044b579f92864eb886ae7c99b021c9",
+                        "4b15b75f3f184328c4a2f7c79357481ed06cf3b6f95512d5ed946fdc0b60d62b"
+                    ]
+                },
+                "expected": {
+                    "addresses": [
+                        "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv"
+                    ],
+                    "outputs": [
+                        {
+                            "pub_key": "64f1c7e8992352d18cdbca600b9e1c3a6025050d56a3e1cc833222e4f3b59e18",
+                            "priv_key_tweak": "96439446f13ddaab2c5bc5a59a08992fd9d33bf8563c8a1b362730f4dc022e30",
+                            "signature": "3f6226feb9e4cafc0bdab8c9cfe085885308f3708c222bcec6cf26467685d897f51597abe39d1d279708e63513c7be23daed78607a98837060950493de188645"
+                        },
+                        {
+                            "pub_key": "0a48c6ccc1d516e8244dc0153dc88db45f8f264357667c2057a29ca3c2445d09",
+                            "priv_key_tweak": "d39df91bd0e7825bfa1d30096febc5bf6fa7da79d7f25b7b4bea9538cc9a9f7f",
+                            "signature": "be5f139f6eaad2d5eb75c6e307defb29925e16d55dbbc12872b0ab6aca38959c0c6a8f3f72bf82e3deb226cb539e117f9db4b04a5efb4e2eb01a86374f5baa12"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    {
+        "comment": "Multiple outputs: multiple outputs, multiple recipients",
+        "sending": [
+            {
+                "given": {
+                    "outpoints": [
+                        [
+                            "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
+                            0
+                        ],
+                        [
+                            "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
+                            0
+                        ]
+                    ],
+                    "input_priv_keys": [
+                        [
+                            "eadc78165ff1f8ea94ad7cfdc54990738a4c53f6e0507b42154201b8e5dff3b1",
+                            false
+                        ],
+                        [
+                            "0378e95685b74565fa56751b84a32dfd18545d10d691641b8372e32164fad66a",
+                            false
+                        ]
+                    ],
+                    "recipients": [
+                        [
+                            "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv",
+                            2.0
+                        ],
+                        [
+                            "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv",
+                            3.0
+                        ],
+                        [
+                            "sp1qqgrz6j0lcqnc04vxccydl0kpsj4frfje0ktmgcl2t346hkw30226xqupawdf48k8882j0strrvcmgg2kdawz53a54dd376ngdhak364hzcmynqtn",
+                            4.0
+                        ],
+                        [
+                            "sp1qqgrz6j0lcqnc04vxccydl0kpsj4frfje0ktmgcl2t346hkw30226xqupawdf48k8882j0strrvcmgg2kdawz53a54dd376ngdhak364hzcmynqtn",
+                            5.0
+                        ]
+                    ]
+                },
+                "expected": {
+                    "outputs": [
+                        [
+                            "64f1c7e8992352d18cdbca600b9e1c3a6025050d56a3e1cc833222e4f3b59e18",
+                            2.0
+                        ],
+                        [
+                            "0a48c6ccc1d516e8244dc0153dc88db45f8f264357667c2057a29ca3c2445d09",
+                            3.0
+                        ],
+                        [
+                            "c58e121044b23cba9b4695052229a9fd9e044b579f92864eb886ae7c99b021c9",
+                            4.0
+                        ],
+                        [
+                            "4b15b75f3f184328c4a2f7c79357481ed06cf3b6f95512d5ed946fdc0b60d62b",
+                            5.0
+                        ]
+                    ]
+                }
+            }
+        ],
+        "receiving": [
+            {
+                "supports_labels": false,
+                "given": {
+                    "outpoints": [
+                        [
+                            "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
+                            0
+                        ],
+                        [
+                            "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
+                            0
+                        ]
+                    ],
+                    "input_pub_keys": [
+                        "025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
+                        "03782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338"
+                    ],
+                    "bip32_seed": "f00dbabe",
+                    "scan_priv_key": "0f694e068028a717f8af6b9411f9a133dd3565258714cc226594b34db90c1f2c",
+                    "spend_priv_key": "9d6ad855ce3417ef84e836892e5a56392bfba05fa5d97ccea30e266f540e08b3",
+                    "labels": {},
+                    "outputs": [
+                        "64f1c7e8992352d18cdbca600b9e1c3a6025050d56a3e1cc833222e4f3b59e18",
+                        "0a48c6ccc1d516e8244dc0153dc88db45f8f264357667c2057a29ca3c2445d09",
+                        "c58e121044b23cba9b4695052229a9fd9e044b579f92864eb886ae7c99b021c9",
+                        "4b15b75f3f184328c4a2f7c79357481ed06cf3b6f95512d5ed946fdc0b60d62b"
+                    ]
+                },
+                "expected": {
+                    "addresses": [
+                        "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv"
+                    ],
+                    "outputs": [
+                        {
+                            "pub_key": "64f1c7e8992352d18cdbca600b9e1c3a6025050d56a3e1cc833222e4f3b59e18",
+                            "priv_key_tweak": "96439446f13ddaab2c5bc5a59a08992fd9d33bf8563c8a1b362730f4dc022e30",
+                            "signature": "3f6226feb9e4cafc0bdab8c9cfe085885308f3708c222bcec6cf26467685d897f51597abe39d1d279708e63513c7be23daed78607a98837060950493de188645"
+                        },
+                        {
+                            "pub_key": "0a48c6ccc1d516e8244dc0153dc88db45f8f264357667c2057a29ca3c2445d09",
+                            "priv_key_tweak": "d39df91bd0e7825bfa1d30096febc5bf6fa7da79d7f25b7b4bea9538cc9a9f7f",
+                            "signature": "be5f139f6eaad2d5eb75c6e307defb29925e16d55dbbc12872b0ab6aca38959c0c6a8f3f72bf82e3deb226cb539e117f9db4b04a5efb4e2eb01a86374f5baa12"
+                        }
+                    ]
+                }
+            },
+            {
+                "supports_labels": false,
+                "given": {
+                    "outpoints": [
+                        [
+                            "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
+                            0
+                        ],
+                        [
+                            "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
+                            0
+                        ]
+                    ],
+                    "input_pub_keys": [
+                        "025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
+                        "03782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338"
+                    ],
+                    "bip32_seed": "decafbad",
+                    "scan_priv_key": "060b751d7892149006ed7b98606955a29fe284a1e900070c0971f5fb93dbf422",
+                    "spend_priv_key": "9902c3c56e84002a7cd410113a9ab21d142be7f53cf5200720bb01314c5eb920",
+                    "labels": {},
+                    "outputs": [
+                        "64f1c7e8992352d18cdbca600b9e1c3a6025050d56a3e1cc833222e4f3b59e18",
+                        "0a48c6ccc1d516e8244dc0153dc88db45f8f264357667c2057a29ca3c2445d09",
+                        "c58e121044b23cba9b4695052229a9fd9e044b579f92864eb886ae7c99b021c9",
+                        "4b15b75f3f184328c4a2f7c79357481ed06cf3b6f95512d5ed946fdc0b60d62b"
+                    ]
+                },
+                "expected": {
+                    "addresses": [
+                        "sp1qqgrz6j0lcqnc04vxccydl0kpsj4frfje0ktmgcl2t346hkw30226xqupawdf48k8882j0strrvcmgg2kdawz53a54dd376ngdhak364hzcmynqtn"
+                    ],
+                    "outputs": [
+                        {
+                            "pub_key": "c58e121044b23cba9b4695052229a9fd9e044b579f92864eb886ae7c99b021c9",
+                            "priv_key_tweak": "567710d07bdaacc8de3f1cec467bcb162ed7daa6b901b59af257bcd7e39dffcf",
+                            "signature": "d675fd6f55f42b61c8797c80d46048cfca5125bcef06e3a0ff555ace0e8f6d84da9b6f473b559376afd5ee11dc63c4415dc565f8272d2b673d39759f29c0d56a"
+                        },
+                        {
+                            "pub_key": "4b15b75f3f184328c4a2f7c79357481ed06cf3b6f95512d5ed946fdc0b60d62b",
+                            "priv_key_tweak": "25dd11163a9a2853709c4c837aafb3347e2eaa875cf4c5170e2a3663879f4c58",
+                            "signature": "ab872ee64623cf1ddb646c65159c09bc69cd64c6b60767a94934e12ec074f0fa7c9e4cc6a9bca2ec6592e4d64636a07fcfd71c622619c3bf46c5a2816aeb3456"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    {
+        "comment": "Receiving with labels: label with even parity",
+        "sending": [
+            {
+                "given": {
+                    "outpoints": [
+                        [
+                            "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
+                            0
+                        ],
+                        [
+                            "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
+                            0
+                        ]
+                    ],
+                    "input_priv_keys": [
+                        [
+                            "eadc78165ff1f8ea94ad7cfdc54990738a4c53f6e0507b42154201b8e5dff3b1",
+                            false
+                        ],
+                        [
+                            "0378e95685b74565fa56751b84a32dfd18545d10d691641b8372e32164fad66a",
+                            false
+                        ]
+                    ],
+                    "recipients": [
+                        [
+                            "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqhmem6grvs4nacsu0v5v5mjs934j7qfgkdkj8c95gyuru3tjpulvcwky2dz",
+                            1.0
+                        ]
+                    ]
+                },
+                "expected": {
+                    "outputs": [
+                        [
+                            "2cbceeab2a4982841eb7dc34b8b4f19c04bf3bc083ebf984f5664366778eb50f",
+                            1.0
+                        ]
+                    ]
+                }
+            }
+        ],
+        "receiving": [
+            {
+                "supports_labels": true,
+                "given": {
+                    "outpoints": [
+                        [
+                            "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
+                            0
+                        ],
+                        [
+                            "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
+                            0
+                        ]
+                    ],
+                    "input_pub_keys": [
+                        "025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
+                        "03782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338"
+                    ],
+                    "bip32_seed": "f00dbabe",
+                    "scan_priv_key": "0f694e068028a717f8af6b9411f9a133dd3565258714cc226594b34db90c1f2c",
+                    "spend_priv_key": "9d6ad855ce3417ef84e836892e5a56392bfba05fa5d97ccea30e266f540e08b3",
+                    "labels": {
+                        "02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5": "0000000000000000000000000000000000000000000000000000000000000002",
+                        "02f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9": "0000000000000000000000000000000000000000000000000000000000000003",
+                        "03348b4f5feb64b557dac8cfa10044bdc2094fca9147163bf514f68687e0d1dba6": "00000000000000000000000000000000000000000000000000000000000f4779"
+                    },
+                    "outputs": [
+                        "2cbceeab2a4982841eb7dc34b8b4f19c04bf3bc083ebf984f5664366778eb50f"
+                    ]
+                },
+                "expected": {
+                    "addresses": [
+                        "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv",
+                        "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqhmem6grvs4nacsu0v5v5mjs934j7qfgkdkj8c95gyuru3tjpulvcwky2dz",
+                        "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqc389f45lq7jyqt8jxq6fkskfukr2tlruf6w8cpcx2krntwe4fr9ykagp3j",
+                        "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgq4umqa5feskydh9xadc9jlc22c89tu0apcv72u2vkuwtsrgzf0uesq45zq9"
+                    ],
+                    "outputs": [
+                        {
+                            "pub_key": "2cbceeab2a4982841eb7dc34b8b4f19c04bf3bc083ebf984f5664366778eb50f",
+                            "priv_key_tweak": "96439446f13ddaab2c5bc5a59a08992fd9d33bf8563c8a1b362730f4dc022e32",
+                            "signature": "0fa1b43afde9a03901dda91a0bd66fc82b6452c14a20718dc87dc70d4cedd9aeadf7c4c96116b8053c4aa113e26cea2fb64f8c408a8e8bc6e4fc9f6a06672b95"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    {
+        "comment": "Receiving with labels: label with odd parity",
+        "sending": [
+            {
+                "given": {
+                    "outpoints": [
+                        [
+                            "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
+                            0
+                        ],
+                        [
+                            "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
+                            0
+                        ]
+                    ],
+                    "input_priv_keys": [
+                        [
+                            "eadc78165ff1f8ea94ad7cfdc54990738a4c53f6e0507b42154201b8e5dff3b1",
+                            false
+                        ],
+                        [
+                            "0378e95685b74565fa56751b84a32dfd18545d10d691641b8372e32164fad66a",
+                            false
+                        ]
+                    ],
+                    "recipients": [
+                        [
+                            "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqc389f45lq7jyqt8jxq6fkskfukr2tlruf6w8cpcx2krntwe4fr9ykagp3j",
+                            1.0
+                        ]
+                    ]
+                },
+                "expected": {
+                    "outputs": [
+                        [
+                            "6b4455de119f51bf4d4a12dea555f14a5dc2c1369af5fba4871c5367264c028d",
+                            1.0
+                        ]
+                    ]
+                }
+            }
+        ],
+        "receiving": [
+            {
+                "supports_labels": true,
+                "given": {
+                    "outpoints": [
+                        [
+                            "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
+                            0
+                        ],
+                        [
+                            "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
+                            0
+                        ]
+                    ],
+                    "input_pub_keys": [
+                        "025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
+                        "03782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338"
+                    ],
+                    "bip32_seed": "f00dbabe",
+                    "scan_priv_key": "0f694e068028a717f8af6b9411f9a133dd3565258714cc226594b34db90c1f2c",
+                    "spend_priv_key": "9d6ad855ce3417ef84e836892e5a56392bfba05fa5d97ccea30e266f540e08b3",
+                    "labels": {
+                        "02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5": "0000000000000000000000000000000000000000000000000000000000000002",
+                        "02f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9": "0000000000000000000000000000000000000000000000000000000000000003",
+                        "03348b4f5feb64b557dac8cfa10044bdc2094fca9147163bf514f68687e0d1dba6": "00000000000000000000000000000000000000000000000000000000000f4779"
+                    },
+                    "outputs": [
+                        "6b4455de119f51bf4d4a12dea555f14a5dc2c1369af5fba4871c5367264c028d"
+                    ]
+                },
+                "expected": {
+                    "addresses": [
+                        "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv",
+                        "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqhmem6grvs4nacsu0v5v5mjs934j7qfgkdkj8c95gyuru3tjpulvcwky2dz",
+                        "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqc389f45lq7jyqt8jxq6fkskfukr2tlruf6w8cpcx2krntwe4fr9ykagp3j",
+                        "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgq4umqa5feskydh9xadc9jlc22c89tu0apcv72u2vkuwtsrgzf0uesq45zq9"
+                    ],
+                    "outputs": [
+                        {
+                            "pub_key": "6b4455de119f51bf4d4a12dea555f14a5dc2c1369af5fba4871c5367264c028d",
+                            "priv_key_tweak": "96439446f13ddaab2c5bc5a59a08992fd9d33bf8563c8a1b362730f4dc022e33",
+                            "signature": "b4ea01f7f47bcdf131b5a3aa3a1c848faae75e661d63bfff84c230bcc96313d0b443b9b3a76718a7474d51994395739bc6041caabe98133e3697412e07e19c0a"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    {
+        "comment": "Receiving with labels: large label integer",
+        "sending": [
+            {
+                "given": {
+                    "outpoints": [
+                        [
+                            "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
+                            0
+                        ],
+                        [
+                            "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
+                            0
+                        ]
+                    ],
+                    "input_priv_keys": [
+                        [
+                            "eadc78165ff1f8ea94ad7cfdc54990738a4c53f6e0507b42154201b8e5dff3b1",
+                            false
+                        ],
+                        [
+                            "0378e95685b74565fa56751b84a32dfd18545d10d691641b8372e32164fad66a",
+                            false
+                        ]
+                    ],
+                    "recipients": [
+                        [
+                            "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgq4umqa5feskydh9xadc9jlc22c89tu0apcv72u2vkuwtsrgzf0uesq45zq9",
+                            1.0
+                        ]
+                    ]
+                },
+                "expected": {
+                    "outputs": [
+                        [
+                            "c3473bfcbe5e4d20d0790ae91f1b339bc15b46de64ca068d140118d0e325b849",
+                            1.0
+                        ]
+                    ]
+                }
+            }
+        ],
+        "receiving": [
+            {
+                "supports_labels": true,
+                "given": {
+                    "outpoints": [
+                        [
+                            "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
+                            0
+                        ],
+                        [
+                            "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
+                            0
+                        ]
+                    ],
+                    "input_pub_keys": [
+                        "025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
+                        "03782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338"
+                    ],
+                    "bip32_seed": "f00dbabe",
+                    "scan_priv_key": "0f694e068028a717f8af6b9411f9a133dd3565258714cc226594b34db90c1f2c",
+                    "spend_priv_key": "9d6ad855ce3417ef84e836892e5a56392bfba05fa5d97ccea30e266f540e08b3",
+                    "labels": {
+                        "02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5": "0000000000000000000000000000000000000000000000000000000000000002",
+                        "02f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9": "0000000000000000000000000000000000000000000000000000000000000003",
+                        "03348b4f5feb64b557dac8cfa10044bdc2094fca9147163bf514f68687e0d1dba6": "00000000000000000000000000000000000000000000000000000000000f4779"
+                    },
+                    "outputs": [
+                        "c3473bfcbe5e4d20d0790ae91f1b339bc15b46de64ca068d140118d0e325b849"
+                    ]
+                },
+                "expected": {
+                    "addresses": [
+                        "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv",
+                        "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqhmem6grvs4nacsu0v5v5mjs934j7qfgkdkj8c95gyuru3tjpulvcwky2dz",
+                        "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqc389f45lq7jyqt8jxq6fkskfukr2tlruf6w8cpcx2krntwe4fr9ykagp3j",
+                        "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgq4umqa5feskydh9xadc9jlc22c89tu0apcv72u2vkuwtsrgzf0uesq45zq9"
+                    ],
+                    "outputs": [
+                        {
+                            "pub_key": "c3473bfcbe5e4d20d0790ae91f1b339bc15b46de64ca068d140118d0e325b849",
+                            "priv_key_tweak": "96439446f13ddaab2c5bc5a59a08992fd9d33bf8563c8a1b362730f4dc1175a9",
+                            "signature": "ab9f3684cb497951fd013444d35909ed10669691d9fa3ac0be57f874a4df9f43c67647c9f17528110d2df0ce41dd3c05c04f4624629f8758fff1060049dc7d6b"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    {
+        "comment": "Multiple outputs with labels: un-labeled and labeled address; same recipient",
+        "sending": [
+            {
+                "given": {
+                    "outpoints": [
+                        [
+                            "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
+                            0
+                        ],
+                        [
+                            "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
+                            0
+                        ]
+                    ],
+                    "input_priv_keys": [
+                        [
+                            "eadc78165ff1f8ea94ad7cfdc54990738a4c53f6e0507b42154201b8e5dff3b1",
+                            false
+                        ],
+                        [
+                            "0378e95685b74565fa56751b84a32dfd18545d10d691641b8372e32164fad66a",
+                            false
+                        ]
+                    ],
+                    "recipients": [
+                        [
+                            "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv",
+                            1.0
+                        ],
+                        [
+                            "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqah4hxfsjdwyaeel4g8x2npkj7qlvf2692l5760z5ut0ggnlrhdzsy3cvsj",
+                            2.0
+                        ]
+                    ]
+                },
+                "expected": {
+                    "outputs": [
+                        [
+                            "64f1c7e8992352d18cdbca600b9e1c3a6025050d56a3e1cc833222e4f3b59e18",
+                            1.0
+                        ],
+                        [
+                            "7956317130124c32afd07b3f2432a3e92c1447cf58da95491a307ae3d564535e",
+                            2.0
+                        ]
+                    ]
+                }
+            }
+        ],
+        "receiving": [
+            {
+                "supports_labels": true,
+                "given": {
+                    "outpoints": [
+                        [
+                            "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
+                            0
+                        ],
+                        [
+                            "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
+                            0
+                        ]
+                    ],
+                    "input_pub_keys": [
+                        "025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
+                        "03782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338"
+                    ],
+                    "bip32_seed": "f00dbabe",
+                    "scan_priv_key": "0f694e068028a717f8af6b9411f9a133dd3565258714cc226594b34db90c1f2c",
+                    "spend_priv_key": "9d6ad855ce3417ef84e836892e5a56392bfba05fa5d97ccea30e266f540e08b3",
+                    "labels": {
+                        "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798": "0000000000000000000000000000000000000000000000000000000000000001"
+                    },
+                    "outputs": [
+                        "64f1c7e8992352d18cdbca600b9e1c3a6025050d56a3e1cc833222e4f3b59e18",
+                        "7956317130124c32afd07b3f2432a3e92c1447cf58da95491a307ae3d564535e"
+                    ]
+                },
+                "expected": {
+                    "addresses": [
+                        "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv",
+                        "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqah4hxfsjdwyaeel4g8x2npkj7qlvf2692l5760z5ut0ggnlrhdzsy3cvsj"
+                    ],
+                    "outputs": [
+                        {
+                            "pub_key": "64f1c7e8992352d18cdbca600b9e1c3a6025050d56a3e1cc833222e4f3b59e18",
+                            "priv_key_tweak": "96439446f13ddaab2c5bc5a59a08992fd9d33bf8563c8a1b362730f4dc022e30",
+                            "signature": "3f6226feb9e4cafc0bdab8c9cfe085885308f3708c222bcec6cf26467685d897f51597abe39d1d279708e63513c7be23daed78607a98837060950493de188645"
+                        },
+                        {
+                            "pub_key": "7956317130124c32afd07b3f2432a3e92c1447cf58da95491a307ae3d564535e",
+                            "priv_key_tweak": "d39df91bd0e7825bfa1d30096febc5bf6fa7da79d7f25b7b4bea9538cc9a9f80",
+                            "signature": "567f0d4d914456141ca83fe89e99f008c1f7ab9e9a65d4a60162840824737407acbaa61d7efa1a6af5d6439d213187e2f76696bb657dc709a0077bbf3b40e2f2"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    {
+        "comment": "Multiple outputs with labels: multiple outputs for labeled address; same recipient",
+        "sending": [
+            {
+                "given": {
+                    "outpoints": [
+                        [
+                            "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
+                            0
+                        ],
+                        [
+                            "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
+                            0
+                        ]
+                    ],
+                    "input_priv_keys": [
+                        [
+                            "eadc78165ff1f8ea94ad7cfdc54990738a4c53f6e0507b42154201b8e5dff3b1",
+                            false
+                        ],
+                        [
+                            "0378e95685b74565fa56751b84a32dfd18545d10d691641b8372e32164fad66a",
+                            false
+                        ]
+                    ],
+                    "recipients": [
+                        [
+                            "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqah4hxfsjdwyaeel4g8x2npkj7qlvf2692l5760z5ut0ggnlrhdzsy3cvsj",
+                            3.0
+                        ],
+                        [
+                            "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqah4hxfsjdwyaeel4g8x2npkj7qlvf2692l5760z5ut0ggnlrhdzsy3cvsj",
+                            4.0
+                        ]
+                    ]
+                },
+                "expected": {
+                    "outputs": [
+                        [
+                            "8890c19f005d6f6add5fef92d37ac6b161b7fdd5c1aef6eed1d32be3f216ac4c",
+                            3.0
+                        ],
+                        [
+                            "7956317130124c32afd07b3f2432a3e92c1447cf58da95491a307ae3d564535e",
+                            4.0
+                        ]
+                    ]
+                }
+            }
+        ],
+        "receiving": [
+            {
+                "supports_labels": true,
+                "given": {
+                    "outpoints": [
+                        [
+                            "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
+                            0
+                        ],
+                        [
+                            "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
+                            0
+                        ]
+                    ],
+                    "input_pub_keys": [
+                        "025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
+                        "03782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338"
+                    ],
+                    "bip32_seed": "f00dbabe",
+                    "scan_priv_key": "0f694e068028a717f8af6b9411f9a133dd3565258714cc226594b34db90c1f2c",
+                    "spend_priv_key": "9d6ad855ce3417ef84e836892e5a56392bfba05fa5d97ccea30e266f540e08b3",
+                    "labels": {
+                        "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798": "0000000000000000000000000000000000000000000000000000000000000001"
+                    },
+                    "outputs": [
+                        "8890c19f005d6f6add5fef92d37ac6b161b7fdd5c1aef6eed1d32be3f216ac4c",
+                        "7956317130124c32afd07b3f2432a3e92c1447cf58da95491a307ae3d564535e"
+                    ]
+                },
+                "expected": {
+                    "addresses": [
+                        "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv",
+                        "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqah4hxfsjdwyaeel4g8x2npkj7qlvf2692l5760z5ut0ggnlrhdzsy3cvsj"
+                    ],
+                    "outputs": [
+                        {
+                            "pub_key": "8890c19f005d6f6add5fef92d37ac6b161b7fdd5c1aef6eed1d32be3f216ac4c",
+                            "priv_key_tweak": "96439446f13ddaab2c5bc5a59a08992fd9d33bf8563c8a1b362730f4dc022e31",
+                            "signature": "f0eb3b826553709356c351e1ced49a72900f261be18e64914c3c694af94595a4a80417ecbf5e86fde8b08e451fb42ec36b7a9d733eb42f92206f4f6c78da66bb"
+                        },
+                        {
+                            "pub_key": "7956317130124c32afd07b3f2432a3e92c1447cf58da95491a307ae3d564535e",
+                            "priv_key_tweak": "d39df91bd0e7825bfa1d30096febc5bf6fa7da79d7f25b7b4bea9538cc9a9f80",
+                            "signature": "567f0d4d914456141ca83fe89e99f008c1f7ab9e9a65d4a60162840824737407acbaa61d7efa1a6af5d6439d213187e2f76696bb657dc709a0077bbf3b40e2f2"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    {
+        "comment": "Multiple outputs with labels: un-labeled, labeled, and multiple outputs for labeled address; multiple recipients",
+        "sending": [
+            {
+                "given": {
+                    "outpoints": [
+                        [
+                            "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
+                            0
+                        ],
+                        [
+                            "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
+                            0
+                        ]
+                    ],
+                    "input_priv_keys": [
+                        [
+                            "eadc78165ff1f8ea94ad7cfdc54990738a4c53f6e0507b42154201b8e5dff3b1",
+                            false
+                        ],
+                        [
+                            "0378e95685b74565fa56751b84a32dfd18545d10d691641b8372e32164fad66a",
+                            false
+                        ]
+                    ],
+                    "recipients": [
+                        [
+                            "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv",
+                            5.0
+                        ],
+                        [
+                            "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqah4hxfsjdwyaeel4g8x2npkj7qlvf2692l5760z5ut0ggnlrhdzsy3cvsj",
+                            6.0
+                        ],
+                        [
+                            "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgq562yg7htxyg8eq60rl37uul37jy62apnf5ru62uef0eajpdfrnp5cmqndj",
+                            7.0
+                        ],
+                        [
+                            "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgq562yg7htxyg8eq60rl37uul37jy62apnf5ru62uef0eajpdfrnp5cmqndj",
+                            8.0
+                        ]
+                    ]
+                },
+                "expected": {
+                    "outputs": [
+                        [
+                            "64f1c7e8992352d18cdbca600b9e1c3a6025050d56a3e1cc833222e4f3b59e18",
+                            5.0
+                        ],
+                        [
+                            "7956317130124c32afd07b3f2432a3e92c1447cf58da95491a307ae3d564535e",
+                            6.0
+                        ],
+                        [
+                            "1b90a42136fef9ff2ca192abffc7be4536dc83d4e61cf18ae078f7e92b297cce",
+                            7.0
+                        ],
+                        [
+                            "87a82600c08a255bc97d172e10816e322967eed6a77c9f37dd926492d7fdc106",
+                            8.0
+                        ]
+                    ]
+                }
+            }
+        ],
+        "receiving": [
+            {
+                "supports_labels": true,
+                "given": {
+                    "outpoints": [
+                        [
+                            "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
+                            0
+                        ],
+                        [
+                            "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
+                            0
+                        ]
+                    ],
+                    "input_pub_keys": [
+                        "025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
+                        "03782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338"
+                    ],
+                    "bip32_seed": "f00dbabe",
+                    "scan_priv_key": "0f694e068028a717f8af6b9411f9a133dd3565258714cc226594b34db90c1f2c",
+                    "spend_priv_key": "9d6ad855ce3417ef84e836892e5a56392bfba05fa5d97ccea30e266f540e08b3",
+                    "labels": {
+                        "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798": "0000000000000000000000000000000000000000000000000000000000000001",
+                        "02db0c51cc634a4096374b0b895584a3ca2fb3bea4fd0ee2361f8db63a650fcee6": "0000000000000000000000000000000000000000000000000000000000000539"
+                    },
+                    "outputs": [
+                        "64f1c7e8992352d18cdbca600b9e1c3a6025050d56a3e1cc833222e4f3b59e18",
+                        "7956317130124c32afd07b3f2432a3e92c1447cf58da95491a307ae3d564535e",
+                        "1b90a42136fef9ff2ca192abffc7be4536dc83d4e61cf18ae078f7e92b297cce",
+                        "87a82600c08a255bc97d172e10816e322967eed6a77c9f37dd926492d7fdc106"
+                    ]
+                },
+                "expected": {
+                    "addresses": [
+                        "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv",
+                        "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqah4hxfsjdwyaeel4g8x2npkj7qlvf2692l5760z5ut0ggnlrhdzsy3cvsj",
+                        "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgq562yg7htxyg8eq60rl37uul37jy62apnf5ru62uef0eajpdfrnp5cmqndj"
+                    ],
+                    "outputs": [
+                        {
+                            "pub_key": "64f1c7e8992352d18cdbca600b9e1c3a6025050d56a3e1cc833222e4f3b59e18",
+                            "priv_key_tweak": "96439446f13ddaab2c5bc5a59a08992fd9d33bf8563c8a1b362730f4dc022e30",
+                            "signature": "3f6226feb9e4cafc0bdab8c9cfe085885308f3708c222bcec6cf26467685d897f51597abe39d1d279708e63513c7be23daed78607a98837060950493de188645"
+                        },
+                        {
+                            "pub_key": "7956317130124c32afd07b3f2432a3e92c1447cf58da95491a307ae3d564535e",
+                            "priv_key_tweak": "d39df91bd0e7825bfa1d30096febc5bf6fa7da79d7f25b7b4bea9538cc9a9f80",
+                            "signature": "567f0d4d914456141ca83fe89e99f008c1f7ab9e9a65d4a60162840824737407acbaa61d7efa1a6af5d6439d213187e2f76696bb657dc709a0077bbf3b40e2f2"
+                        },
+                        {
+                            "pub_key": "1b90a42136fef9ff2ca192abffc7be4536dc83d4e61cf18ae078f7e92b297cce",
+                            "priv_key_tweak": "255a912ad6cdebc0842d49fd9f7b2d81ee37d66c62839879371b699010f78ef1",
+                            "signature": "aa4cc7be2d90f30984d93535058f4894a6e0c7698deaaef179eda55724cc214e8e6ed055d437f1bf37c8c5c5431dad5080d03200cdd861a5b5e3855515e15d61"
+                        },
+                        {
+                            "pub_key": "87a82600c08a255bc97d172e10816e322967eed6a77c9f37dd926492d7fdc106",
+                            "priv_key_tweak": "d7535d792cb1388ab0b3bd5ff57337436d62f7719c1796beb5d80ab2fa34f307",
+                            "signature": "d68d0005118fcaae6d970925b452d038a03fda40d50aa9d6d3b4aff8189f226c71428838eadaf55662048f549bc7b19380438f09df9344eff30b96497b6aafa3"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    {
+        "comment": "Single recipient: use silent payments for sender change",
+        "sending": [
+            {
+                "given": {
+                    "outpoints": [
+                        [
+                            "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
+                            0
+                        ],
+                        [
+                            "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
+                            0
+                        ]
+                    ],
+                    "input_priv_keys": [
+                        [
+                            "eadc78165ff1f8ea94ad7cfdc54990738a4c53f6e0507b42154201b8e5dff3b1",
+                            false
+                        ],
+                        [
+                            "0378e95685b74565fa56751b84a32dfd18545d10d691641b8372e32164fad66a",
+                            false
+                        ]
+                    ],
+                    "recipients": [
+                        [
+                            "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv",
+                            1.0
+                        ],
+                        [
+                            "sp1qqw6vczcfpdh5nf5y2ky99kmqae0tr30hgdfg88parz50cp80wd2wqqll5497pp2gcr4cmq0v5nv07x8u5jswmf8ap2q0kxmx8628mkqanyu63ck8",
+                            2.0
+                        ]
+                    ]
+                },
+                "expected": {
+                    "outputs": [
+                        [
+                            "64f1c7e8992352d18cdbca600b9e1c3a6025050d56a3e1cc833222e4f3b59e18",
+                            1.0
+                        ],
+                        [
+                            "0050c52a32566c0dfb517e473c68fedce4bd4543d219348d3bbdceeeb5755e34",
+                            2.0
+                        ]
+                    ]
+                }
+            }
+        ],
+        "receiving": [
+            {
+                "supports_labels": true,
+                "given": {
+                    "outpoints": [
+                        [
+                            "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
+                            0
+                        ],
+                        [
+                            "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
+                            0
+                        ]
+                    ],
+                    "input_pub_keys": [
+                        "025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
+                        "03782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338"
+                    ],
+                    "bip32_seed": "deadbeef",
+                    "scan_priv_key": "11b7a82e06ca2648d5fded2366478078ec4fc9dc1d8ff487518226f229d768fd",
+                    "spend_priv_key": "b8f87388cbb41934c50daca018901b00070a5ff6cc25a7e9e716a9d5b9e4d664",
+                    "labels": {
+                        "02295dc38e877b754c0d0ed767434f1572cf34a82ccc06ffea1d9e04f1f7878e1a": "91cb04398a508c9d995ff4a18e5eae24d5e9488309f189120a3fdbb977978c46"
+                    },
+                    "outputs": [
+                        "64f1c7e8992352d18cdbca600b9e1c3a6025050d56a3e1cc833222e4f3b59e18",
+                        "0050c52a32566c0dfb517e473c68fedce4bd4543d219348d3bbdceeeb5755e34"
+                    ]
+                },
+                "expected": {
+                    "addresses": [
+                        "sp1qqw6vczcfpdh5nf5y2ky99kmqae0tr30hgdfg88parz50cp80wd2wqqauj52ymtc4xdkmx3tgyhrsemg2g3303xk2gtzfy8h8ejet8fz8jcw23zua",
+                        "sp1qqw6vczcfpdh5nf5y2ky99kmqae0tr30hgdfg88parz50cp80wd2wqqll5497pp2gcr4cmq0v5nv07x8u5jswmf8ap2q0kxmx8628mkqanyu63ck8"
+                    ],
+                    "outputs": [
+                        {
+                            "pub_key": "0050c52a32566c0dfb517e473c68fedce4bd4543d219348d3bbdceeeb5755e34",
+                            "priv_key_tweak": "2e9c2a37cfa7827907d36357f0632d258dbd14b3a7854937ecf732fb6acefdc8",
+                            "signature": "6ba068ee36454c5ff002082578e234917de9e384df739c43a8b7c4cce58724cba4479191cf972b235bc4bb6c2a8d6081650d1d5ba043b59bd51d6ac15d55b396"
+                        }
+                    ]
+                }
+            },
+            {
+                "supports_labels": false,
+                "given": {
+                    "outpoints": [
+                        [
+                            "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
+                            0
+                        ],
+                        [
+                            "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
+                            0
+                        ]
+                    ],
+                    "input_pub_keys": [
+                        "025a1e61f898173040e20616d43e9f496fba90338a39faa1ed98fcbaeee4dd9be5",
+                        "03782eeb913431ca6e9b8c2fd80a5f72ed2024ef72a3c6fb10263c379937323338"
+                    ],
+                    "bip32_seed": "f00dbabe",
+                    "scan_priv_key": "0f694e068028a717f8af6b9411f9a133dd3565258714cc226594b34db90c1f2c",
+                    "spend_priv_key": "9d6ad855ce3417ef84e836892e5a56392bfba05fa5d97ccea30e266f540e08b3",
+                    "labels": {},
+                    "outputs": [
+                        "64f1c7e8992352d18cdbca600b9e1c3a6025050d56a3e1cc833222e4f3b59e18",
+                        "0050c52a32566c0dfb517e473c68fedce4bd4543d219348d3bbdceeeb5755e34"
+                    ]
+                },
+                "expected": {
+                    "addresses": [
+                        "sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv"
+                    ],
+                    "outputs": [
+                        {
+                            "pub_key": "64f1c7e8992352d18cdbca600b9e1c3a6025050d56a3e1cc833222e4f3b59e18",
+                            "priv_key_tweak": "96439446f13ddaab2c5bc5a59a08992fd9d33bf8563c8a1b362730f4dc022e30",
+                            "signature": "3f6226feb9e4cafc0bdab8c9cfe085885308f3708c222bcec6cf26467685d897f51597abe39d1d279708e63513c7be23daed78607a98837060950493de188645"
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+]

--- a/src/wallet/coincontrol.h
+++ b/src/wallet/coincontrol.h
@@ -42,6 +42,8 @@ public:
     bool fAllowWatchOnly = false;
     //! Override automatic min/max checks on fee, m_feerate must be set if true
     bool fOverrideFeeRate = false;
+    //! True if we are doing coin selection to fund a silent payment transaction
+    bool m_silent_payment = false;
     //! Override the wallet's m_pay_tx_fee if set
     std::optional<CFeeRate> m_feerate;
     //! Override the default confirmation target if set

--- a/src/wallet/feebumper.cpp
+++ b/src/wallet/feebumper.cpp
@@ -242,7 +242,7 @@ Result CreateRateBumpTransaction(CWallet& wallet, const uint256& txid, const CCo
     // Fill in recipients (and preserve a single change key if there
     // is one). If outputs vector is non-empty, replace original
     // outputs with its contents, otherwise use original outputs.
-    std::vector<CRecipient> recipients;
+    std::vector<Destination> recipients;
     CAmount new_outputs_value = 0;
     const auto& txouts = outputs.empty() ? wtx.tx->vout : outputs;
     for (size_t i = 0; i < txouts.size(); ++i) {

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -272,7 +272,7 @@ public:
         LOCK(m_wallet->cs_wallet);
         return m_wallet->ListLockedCoins(outputs);
     }
-    util::Result<CTransactionRef> createTransaction(const std::vector<CRecipient>& recipients,
+    util::Result<CTransactionRef> createTransaction(const std::vector<Destination>& recipients,
         const CCoinControl& coin_control,
         bool sign,
         int& change_pos,

--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -1496,17 +1496,12 @@ static UniValue ProcessDescriptorImport(CWallet& wallet, const UniValue& data, c
                 }
             }
         }
-	// Can only have sp at the top level
-	bool isSP = (descriptor.rfind("sp(", 0) == 0);
+        // Can only have sp at the top level
+        bool is_silent_payment_desc = (descriptor.rfind("sp(", 0) == 0);
 
         // Active descriptors must be ranged
-        if (active && !parsed_desc->IsRange()) {
+        if (active && !parsed_desc->IsRange() && !is_silent_payment_desc) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Active descriptors must be ranged");
-        }
-
-        if (isSP && data.exists("next_index"))
-        {
-            next_index = data["next_index"].getInt<int64_t>();
         }
 
         // Ranged descriptors should not have a label
@@ -1585,6 +1580,10 @@ static UniValue ProcessDescriptorImport(CWallet& wallet, const UniValue& data, c
             if (w_desc.descriptor->GetOutputType()) {
                 wallet.DeactivateScriptPubKeyMan(spk_manager->GetID(), *w_desc.descriptor->GetOutputType(), internal);
             }
+        }
+
+        if (is_silent_payment_desc && !wallet.IsWalletFlagSet(WALLET_FLAG_SILENT_PAYMENT)) {
+            wallet.SetWalletFlag(WALLET_FLAG_SILENT_PAYMENT);
         }
 
         result.pushKV("success", UniValue(true));

--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -1496,10 +1496,17 @@ static UniValue ProcessDescriptorImport(CWallet& wallet, const UniValue& data, c
                 }
             }
         }
+	// Can only have sp at the top level
+	bool isSP = (descriptor.rfind("sp(", 0) == 0);
 
         // Active descriptors must be ranged
         if (active && !parsed_desc->IsRange()) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Active descriptors must be ranged");
+        }
+
+        if (isSP && data.exists("next_index"))
+        {
+            next_index = data["next_index"].getInt<int64_t>();
         }
 
         // Ranged descriptors should not have a label
@@ -1846,6 +1853,9 @@ RPCHelpMan listdescriptors()
             spk.pushKV("range", range);
             spk.pushKV("next", info.next_index);
             spk.pushKV("next_index", info.next_index);
+        }
+        if (info.descriptor.rfind("sp(", 0) == 0) {
+            spk.pushKV("next", info.next_index);
         }
         descriptors.push_back(spk);
     }

--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -23,7 +23,7 @@
 
 
 namespace wallet {
-static void ParseRecipients(const UniValue& address_amounts, const UniValue& subtract_fee_outputs, std::vector<CRecipient>& recipients)
+static void ParseRecipients(const UniValue& address_amounts, const UniValue& subtract_fee_outputs, std::vector<Destination>& recipients)
 {
     std::set<CTxDestination> destinations;
     int i = 0;
@@ -141,7 +141,7 @@ static void PreventOutdatedOptions(const UniValue& options)
     }
 }
 
-UniValue SendMoney(CWallet& wallet, const CCoinControl &coin_control, std::vector<CRecipient> &recipients, mapValue_t map_value, bool verbose)
+UniValue SendMoney(CWallet& wallet, const CCoinControl &coin_control, std::vector<Destination> &recipients, mapValue_t map_value, bool verbose)
 {
     EnsureWalletIsUnlocked(wallet);
 
@@ -302,7 +302,7 @@ RPCHelpMan sendtoaddress()
         subtractFeeFromAmount.push_back(address);
     }
 
-    std::vector<CRecipient> recipients;
+    std::vector<Destination> recipients;
     ParseRecipients(address_amounts, subtractFeeFromAmount, recipients);
     const bool verbose{request.params[10].isNull() ? false : request.params[10].get_bool()};
 
@@ -398,7 +398,7 @@ RPCHelpMan sendmany()
 
     SetFeeEstimateMode(*pwallet, coin_control, /*conf_target=*/request.params[6], /*estimate_mode=*/request.params[7], /*fee_rate=*/request.params[8], /*override_min_fee=*/false);
 
-    std::vector<CRecipient> recipients;
+    std::vector<Destination> recipients;
     ParseRecipients(sendTo, subtractFeeFromAmount, recipients);
     const bool verbose{request.params[9].isNull() ? false : request.params[9].get_bool()};
 

--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -311,6 +311,10 @@ RPCHelpMan sendtoaddress()
 
     std::vector<Destination> recipients;
     ParseRecipients(address_amounts, subtractFeeFromAmount, recipients);
+    auto it = std::find_if(recipients.begin(), recipients.end(), [](const auto& r) { return std::holds_alternative<V0SilentPaymentDestination>(r); });
+    if (it != recipients.end())
+        coin_control.m_silent_payment = true;
+
     const bool verbose{request.params[10].isNull() ? false : request.params[10].get_bool()};
 
     return SendMoney(*pwallet, coin_control, recipients, mapValue, verbose);
@@ -407,6 +411,9 @@ RPCHelpMan sendmany()
 
     std::vector<Destination> recipients;
     ParseRecipients(sendTo, subtractFeeFromAmount, recipients);
+    auto it = std::find_if(recipients.begin(), recipients.end(), [](const auto& r) { return std::holds_alternative<V0SilentPaymentDestination>(r); });
+    if (it != recipients.end())
+        coin_control.m_silent_payment = true;
     const bool verbose{request.params[9].isNull() ? false : request.params[9].get_bool()};
 
     return SendMoney(*pwallet, coin_control, recipients, std::move(mapValue), verbose);

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -27,6 +27,10 @@ static const std::map<uint64_t, std::string> WALLET_FLAG_CAVEATS{
      "You need to rescan the blockchain in order to correctly mark used "
      "destinations in the past. Until this is done, some destinations may "
      "be considered unused, even if the opposite is the case."},
+    {WALLET_FLAG_SILENT_PAYMENT,
+     "By enabling this flag, the wallet will start to check for silent transactions. "
+     "For previous transactions, a rescan is required."
+     "This flag increases wallet rescan time."},
 };
 
 /** Checks if a CKey is in the given CWallet compressed or otherwise*/
@@ -69,6 +73,7 @@ static RPCHelpMan getwalletinfo()
                         {RPCResult::Type::BOOL, "descriptors", "whether this wallet uses descriptors for scriptPubKey management"},
                         {RPCResult::Type::BOOL, "external_signer", "whether this wallet is configured to use an external signer such as a hardware wallet"},
                         {RPCResult::Type::BOOL, "blank", "Whether this wallet intentionally does not contain any keys, scripts, or descriptors"},
+                        {RPCResult::Type::BOOL, "silent_payment", "whether this supports silent payments"},
                         RESULT_LAST_PROCESSED_BLOCK,
                     }},
                 },
@@ -132,6 +137,7 @@ static RPCHelpMan getwalletinfo()
     obj.pushKV("descriptors", pwallet->IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS));
     obj.pushKV("external_signer", pwallet->IsWalletFlagSet(WALLET_FLAG_EXTERNAL_SIGNER));
     obj.pushKV("blank", pwallet->IsWalletFlagSet(WALLET_FLAG_BLANK_WALLET));
+    obj.pushKV("silent_payment", pwallet->IsWalletFlagSet(WALLET_FLAG_SILENT_PAYMENT));
 
     AppendLastProcessedBlock(obj, *pwallet);
     return obj;

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -828,6 +828,8 @@ RPCHelpMan keypoolrefill();
 RPCHelpMan newkeypool();
 RPCHelpMan getaddressesbylabel();
 RPCHelpMan listlabels();
+RPCHelpMan getsilentaddress();
+RPCHelpMan decodesilentaddress();
 #ifdef ENABLE_EXTERNAL_SIGNER
 RPCHelpMan walletdisplayaddress();
 #endif // ENABLE_EXTERNAL_SIGNER
@@ -911,6 +913,8 @@ Span<const CRPCCommand> GetWalletRPCCommands()
         {"wallet", &getrawchangeaddress},
         {"wallet", &getreceivedbyaddress},
         {"wallet", &getreceivedbylabel},
+        {"wallet", &getsilentaddress},
+        {"wallet", &decodesilentaddress},
         {"wallet", &gettransaction},
         {"wallet", &getunconfirmedbalance},
         {"wallet", &getbalances},

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -2847,4 +2847,17 @@ bool DescriptorScriptPubKeyMan::CanUpdateToWalletDescriptor(const WalletDescript
 
     return true;
 }
+
+std::vector<CKey> DescriptorScriptPubKeyMan::VerifySilentPaymentAddress(
+    std::vector<XOnlyPubKey>& tx_output_pub_keys,
+    const CPubKey& sender_pub_key,
+    const std::vector<COutPoint>& tx_outpoints)
+{
+    LOCK(cs_desc_man);
+    std::vector<CKey> raw_tr_keys;
+    LoadSilentRecipient();
+    assert(m_silent_recipient != nullptr);
+    m_silent_recipient->ComputeECDHSharedSecret(sender_pub_key, tx_outpoints);
+    return m_silent_recipient->ScanTxOutputs(tx_output_pub_keys);
+}
 } // namespace wallet

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -2282,6 +2282,9 @@ bool DescriptorScriptPubKeyMan::SetupDescriptorGeneration(const CExtKey& master_
         desc_prefix = "tr(" + xpub + "/86h";
         break;
     }
+    case OutputType::SILENT_PAYMENT:
+        // We don't have a descriptor for silent payments defined yet,
+        // so let this fall through as an unknown
     case OutputType::UNKNOWN: {
         // We should never have a DescriptorScriptPubKeyMan for an UNKNOWN OutputType,
         // so if we get to this point something is wrong

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -2282,9 +2282,23 @@ bool DescriptorScriptPubKeyMan::SetupDescriptorGeneration(const CExtKey& master_
         desc_prefix = "tr(" + xpub + "/86h";
         break;
     }
-    case OutputType::SILENT_PAYMENT:
-        // We don't have a descriptor for silent payments defined yet,
-        // so let this fall through as an unknown
+    case OutputType::SILENT_PAYMENT: {
+        // Mainnet derives at 0', testnet and regtest derive at 1'
+        std::string coin_type;
+        if (Params().IsTestChain()) {
+            coin_type = "/1h";
+        } else {
+            coin_type = "/0h";
+        }
+        std::string purpose = "/352h";
+        std::string account = "/0h";
+        // Following BIP44 - m/purpose/coin_type/account/
+        std::string root = xpub + purpose + coin_type + account;
+        std::string scan_key = root + "/1h/0";
+        std::string spend_key = root + "/0h/0";
+        desc_prefix = "sp(" + scan_key + "," + spend_key + ")";
+        break;
+    }
     case OutputType::UNKNOWN: {
         // We should never have a DescriptorScriptPubKeyMan for an UNKNOWN OutputType,
         // so if we get to this point something is wrong

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -2635,6 +2635,32 @@ bool DescriptorScriptPubKeyMan::AddCryptedKey(const CKeyID& key_id, const CPubKe
     return true;
 }
 
+std::pair<CKey,bool> DescriptorScriptPubKeyMan::GetPrivKeyForSilentPayment(const CScript& scriptPubKey) const
+{
+    std::vector<std::vector<unsigned char>> solutions;
+    TxoutType whichType = Solver(scriptPubKey, solutions);
+    if (whichType == TxoutType::NONSTANDARD || whichType == TxoutType::MULTISIG || whichType == TxoutType::WITNESS_UNKNOWN ) return {};
+    std::unique_ptr<FlatSigningProvider> coin_keys = GetSigningProvider(scriptPubKey, true);
+    if (!coin_keys || coin_keys->keys.size() != 1) return {};
+    const auto& [_, key] = *coin_keys->keys.begin();
+    (void) _;
+
+    if (whichType == TxoutType::WITNESS_V1_TAPROOT) {
+        auto pubKeyFromScriptPubKey = XOnlyPubKey(solutions[0]);
+        // this means it is a "rawtr" output
+        if (XOnlyPubKey(key.GetPubKey()) == pubKeyFromScriptPubKey) return {key, true};
+
+        // Otherwise, tweak with the merkle root
+        TaprootSpendData spenddata;
+        coin_keys->GetTaprootSpendData(pubKeyFromScriptPubKey, spenddata);
+        CKey tweaked_key;
+        if(!key.ApplyTapTweak(&spenddata.merkle_root, tweaked_key)) return {};
+        if (XOnlyPubKey(tweaked_key.GetPubKey()) ==  pubKeyFromScriptPubKey) return {tweaked_key, true};
+        return {};
+    }
+    return {key, false};
+}
+
 bool DescriptorScriptPubKeyMan::HasWalletDescriptor(const WalletDescriptor& desc) const
 {
     LOCK(cs_desc_man);

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -670,6 +670,8 @@ public:
     bool GetDescriptorString(std::string& out, const bool priv) const;
 
     void UpgradeDescriptorCache();
+
+    std::vector<CKey> VerifySilentPaymentAddress(std::vector<XOnlyPubKey>& txOutputPubKeys, const CPubKey& senderPubKey, const std::vector<COutPoint>& tx_outpoints);
 };
 
 /** struct containing information needed for migrating legacy wallets to descriptor wallets */

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -15,6 +15,7 @@
 #include <util/result.h>
 #include <util/time.h>
 #include <wallet/crypter.h>
+#include <wallet/silentpayments.h>
 #include <wallet/types.h>
 #include <wallet/walletdb.h>
 #include <wallet/walletutil.h>
@@ -561,6 +562,8 @@ private:
     KeyMap m_map_keys GUARDED_BY(cs_desc_man);
     CryptedKeyMap m_map_crypted_keys GUARDED_BY(cs_desc_man);
 
+    std::unique_ptr<Recipient> m_silent_recipient{nullptr};
+
     //! keeps track of whether Unlock has run a thorough check before
     bool m_decryption_thoroughly_checked = false;
 
@@ -595,8 +598,10 @@ public:
         {}
 
     mutable RecursiveMutex cs_desc_man;
+    void LoadSilentRecipient();
 
     util::Result<CTxDestination> GetNewDestination(const OutputType type) override;
+    util::Result<std::pair<CPubKey,CPubKey>> GetSilentAddress();
     isminetype IsMine(const CScript& script) const override;
 
     bool CheckDecryptionKey(const CKeyingMaterial& master_key, bool accept_no_keys = false) override;

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -649,6 +649,8 @@ public:
     bool AddKey(const CKeyID& key_id, const CKey& key);
     bool AddCryptedKey(const CKeyID& key_id, const CPubKey& pubkey, const std::vector<unsigned char>& crypted_key);
 
+    std::pair<CKey,bool> GetPrivKeyForSilentPayment(const CScript& scriptPubKey) const;
+
     bool HasWalletDescriptor(const WalletDescriptor& desc) const;
     void UpdateWalletDescriptor(WalletDescriptor& descriptor);
     bool CanUpdateToWalletDescriptor(const WalletDescriptor& descriptor, std::string& error);

--- a/src/wallet/silentpayments.cpp
+++ b/src/wallet/silentpayments.cpp
@@ -1,0 +1,179 @@
+#include <wallet/silentpayments.h>
+#include <arith_uint256.h>
+#include <coins.h>
+#include <crypto/common.h>
+#include <crypto/hmac_sha512.h>
+#include <key_io.h>
+#include <undo.h>
+#include <logging.h>
+
+namespace wallet {
+
+Recipient::Recipient(const CKey& scan_seckey, const CKey& spend_seckey)
+{
+    m_scan_seckey = scan_seckey;
+    m_scan_pubkey = CPubKey{m_scan_seckey.GetPubKey()};
+    m_spend_seckey = spend_seckey;
+    m_spend_pubkey = CPubKey{m_spend_seckey.GetPubKey()};
+}
+
+void Recipient::ComputeECDHSharedSecret(const CPubKey& sender_public_key, const std::vector<COutPoint>& tx_outpoints)
+{
+    const auto& outpoint_hash = HashOutpoints(tx_outpoints);
+    auto tweaked_scan_seckey = m_scan_seckey.MultiplyTweak(outpoint_hash.begin());
+    CPubKey result = tweaked_scan_seckey.SilentPaymentECDH(sender_public_key);
+
+    m_ecdh_pubkey = result;
+    assert(m_ecdh_pubkey.IsValid());
+}
+
+std::pair<CKey,CPubKey> Recipient::CreateOutput(const uint32_t output_index) const
+{
+    HashWriter h;
+    h.write(Span{m_ecdh_pubkey});
+    unsigned char num[4];
+    WriteBE32(num, output_index);
+    h << num;
+    uint256 shared_secret = h.GetSHA256();
+
+    const auto& result_pubkey{m_spend_pubkey.AddTweak(shared_secret.begin())};
+    const auto& result_seckey{m_spend_seckey.AddTweak(shared_secret.begin())};
+
+    return {result_seckey, result_pubkey};
+}
+
+std::pair<CPubKey,CPubKey> Recipient::GetAddress() const
+{
+    return {m_scan_pubkey, m_spend_pubkey};
+}
+
+std::vector<CKey> Recipient::ScanTxOutputs(std::vector<XOnlyPubKey> output_pub_keys)
+{
+    // Because a sender can create multiple outputs for us, we first check the outputs vector for an output with
+    // output index 0. If we find it, we remove it from the vector and then iterate over the vector again looking for
+    // an output with index 1, and so on until one of the following happens:
+    //
+    //     1. We have determined all outputs belong to us (the vector is empty)
+    //     2. We have passed over the vector and found no outputs belonging to us
+    //
+
+    // The ECDH shared secret must be set before we start scanning
+    assert(m_ecdh_pubkey.IsValid());
+
+    bool removed;
+    uint32_t output_index{0};
+    std::vector<CKey> raw_tr_keys;
+    do {
+        // We haven't removed anything yet on this pass and if we don't remove anything, we didn't find
+        // any silent payment outputs and should stop checking
+        removed = false;
+        std::pair<CKey, CPubKey> tweakResult = CreateOutput(output_index);
+        const CKey& silent_payment_priv_key = tweakResult.first;
+        const XOnlyPubKey& silent_payment_pub_key = XOnlyPubKey{tweakResult.second};
+        output_pub_keys.erase(std::remove_if(output_pub_keys.begin(), output_pub_keys.end(), [&](auto outputPubKey) {
+            if (silent_payment_pub_key == outputPubKey) {
+                // Since we found an output, we need to increment the output index and check the vector again
+                raw_tr_keys.emplace_back(silent_payment_priv_key);
+                removed = true;
+                output_index++;
+                // Return true so that this output pubkey is removed the from vector and not checked again
+                return true;
+            }
+            return false;
+        }), output_pub_keys.end());
+    } while (!output_pub_keys.empty() && removed);
+    return raw_tr_keys;
+}
+
+Sender::Sender(const CKey& scalar_ecdh_input, const SilentPaymentRecipient& recipient)
+{
+    m_ecdh_pubkey = scalar_ecdh_input.SilentPaymentECDH(recipient.m_scan_pubkey);
+    m_recipient = recipient;
+}
+
+CPubKey Sender::CreateOutput(const CPubKey& spend_pubkey, const uint32_t output_index) const
+{
+    HashWriter h;
+    h.write(Span{m_ecdh_pubkey});
+    unsigned char num[4];
+    WriteBE32(num, output_index);
+    h << num;
+    uint256 shared_secret = h.GetSHA256();
+    return spend_pubkey.AddTweak(shared_secret.begin());
+}
+
+std::vector<wallet::CRecipient> Sender::GenerateRecipientScriptPubKeys() const
+{
+    int n = 0;
+    std::vector<wallet::CRecipient> spks;
+    for (const auto& pair : m_recipient.m_outputs) {
+        XOnlyPubKey output_pubkey = XOnlyPubKey{CreateOutput(pair.first, n)};
+        auto tap = WitnessV1Taproot(output_pubkey);
+        CScript spk = GetScriptForDestination(tap);
+        spks.push_back(wallet::CRecipient{spk, pair.second, false});
+        n++;
+    }
+    return spks;
+}
+
+CKey SumInputPrivKeys(const std::vector<std::pair<CKey, bool>>& sender_secret_keys)
+{
+    const auto& [seckey, is_taproot] = sender_secret_keys.at(0);
+    CKey sum_seckey{seckey};
+    if (is_taproot && sum_seckey.GetPubKey()[0] == 3) {
+        sum_seckey.Negate();
+    }
+    if (sender_secret_keys.size() > 1) {
+        for (size_t i = 1; i < sender_secret_keys.size(); i++) {
+            const auto& [sender_seckey, sender_is_taproot] = sender_secret_keys.at(i);
+            auto temp_key{sender_seckey};
+            if (sender_is_taproot && sender_seckey.GetPubKey()[0] == 3) {
+                temp_key.Negate();
+            }
+            sum_seckey = sum_seckey.AddTweak(temp_key.begin());
+        }
+    }
+    return sum_seckey;
+}
+
+CKey PrepareScalarECDHInput(const std::vector<std::pair<CKey, bool>>& sender_secret_keys, const std::vector<COutPoint>& tx_outpoints)
+{
+    CKey sum_input_secret_keys = SumInputPrivKeys(sender_secret_keys);
+    uint256 outpoints_hash = HashOutpoints(tx_outpoints);
+    return sum_input_secret_keys.MultiplyTweak(outpoints_hash.begin());
+}
+
+std::vector<SilentPaymentRecipient> GroupSilentPaymentAddresses(const std::vector<wallet::V0SilentPaymentDestination>& silent_payment_destinations)
+{
+    std::map<CPubKey, std::vector<std::pair<CPubKey, CAmount>>> recipient_groups;
+    std::vector<SilentPaymentRecipient> recipients;
+    for (const auto& destination : silent_payment_destinations) {
+        recipient_groups[destination.m_scan_pubkey].emplace_back(destination.m_spend_pubkey, destination.m_amount);
+    }
+    for (const auto& pair : recipient_groups) {
+        SilentPaymentRecipient recipient{pair.first};
+        for (const auto& output : pair.second) {
+            recipient.m_outputs.push_back(output);
+        }
+        recipients.push_back(recipient);
+    }
+    return recipients;
+}
+
+uint256 HashOutpoints(const std::vector<COutPoint>& tx_outpoints)
+{
+
+    // Make a local copy of the outpoints so we can sort them before hashing.
+    // This is to ensure the sender and receiver deterministically arrive at the same outpoint hash,
+    // regardless of how the outpoints are ordered in the transaction.
+
+    std::vector<COutPoint> outpoints{tx_outpoints};
+    std::sort(outpoints.begin(), outpoints.end());
+
+    HashWriter h;
+    for (const auto& outpoint: outpoints) {
+        h << outpoint;
+    }
+    return h.GetSHA256();
+}
+}

--- a/src/wallet/silentpayments.h
+++ b/src/wallet/silentpayments.h
@@ -1,0 +1,49 @@
+#ifndef BITCOIN_WALLET_SILENTPAYMENTS_H
+#define BITCOIN_WALLET_SILENTPAYMENTS_H
+
+#include <coins.h>
+#include <key_io.h>
+#include <undo.h>
+#include <wallet/types.h>
+
+namespace wallet {
+class Recipient {
+    protected:
+        CKey m_scan_seckey;
+        CKey m_spend_seckey;
+        CPubKey m_scan_pubkey;
+        CPubKey m_spend_pubkey;
+        CPubKey m_ecdh_pubkey;
+
+    public:
+        Recipient(const CKey& scan_seckey, const CKey& spend_seckey);
+        void ComputeECDHSharedSecret(const CPubKey& sender_public_key, const std::vector<COutPoint>& tx_outpoints);
+        std::pair<CKey,CPubKey> CreateOutput(const uint32_t output_index) const;
+        std::pair<CPubKey,CPubKey> GetAddress() const;
+        std::vector<CKey> ScanTxOutputs(std::vector<XOnlyPubKey> output_pub_keys);
+};
+
+struct SilentPaymentRecipient
+{
+    CPubKey m_scan_pubkey;
+    std::vector<std::pair<CPubKey, CAmount>> m_outputs;
+    SilentPaymentRecipient() {};
+    SilentPaymentRecipient(CPubKey scan_pubkey) : m_scan_pubkey(scan_pubkey) {};
+};
+
+class Sender {
+    protected:
+        CPubKey m_ecdh_pubkey;
+        SilentPaymentRecipient m_recipient;
+        CPubKey CreateOutput(const CPubKey& spend_pubkey, const uint32_t output_index) const;
+
+    public:
+        Sender(const CKey& scalar_ecdh_input, const SilentPaymentRecipient& recipient);
+        std::vector<wallet::CRecipient> GenerateRecipientScriptPubKeys() const;
+};  // class Sender
+
+uint256 HashOutpoints(const std::vector<COutPoint>& tx_outpoints);
+std::vector<SilentPaymentRecipient> GroupSilentPaymentAddresses(const std::vector<V0SilentPaymentDestination>& silent_payment_addresses);
+CKey PrepareScalarECDHInput(const std::vector<std::pair<CKey, bool>>& sender_secret_keys, const std::vector<COutPoint>& tx_outpoints);
+} // namespace wallet
+#endif // BITCOIN_WALLET_SILENTPAYMENTS_H

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -194,6 +194,21 @@ util::Result<PreSelectedInputs> FetchSelectedInputs(const CWallet& wallet, const
             return util::Error{strprintf(_("Not solvable pre-selected input %s"), outpoint.ToString())}; // Not solvable, can't estimate size for fee
         }
 
+        if (coin_control.m_silent_payment) {
+            std::vector<std::vector<uint8_t>> solutions;
+            TxoutType type = Solver(txout.scriptPubKey, solutions);
+            if (type == TxoutType::WITNESS_UNKNOWN) {
+                return util::Error{strprintf(_("%s has an unknown witness version and cannot be used in a silent payment transaction"), outpoint.ToString())};
+            } else if (type == TxoutType::WITNESS_V1_TAPROOT) {
+                std::unique_ptr<SigningProvider> provider = wallet.GetSolvingProvider(txout.scriptPubKey);
+                TaprootSpendData spenddata;
+                if (provider->GetTaprootSpendData(XOnlyPubKey(solutions[0]), spenddata)) {
+                    if (!spenddata.scripts.empty())
+                        return util::Error{strprintf(_("Found script data for %s. Only key path spends are allowed when funding a silent payment, please choose a different input"), outpoint.ToString())};
+                }
+            }
+        }
+
         /* Set some defaults for depth, spendable, solvable, safe, time, and from_me as these don't matter for preset inputs since no selection is being done. */
         COutput output(outpoint, txout, /*depth=*/ 0, input_bytes, /*spendable=*/ true, /*solvable=*/ true, /*safe=*/ true, /*time=*/ 0, /*from_me=*/ false, coin_selection_params.m_effective_feerate);
         result.Insert(output, coin_selection_params.m_subtract_fee_outputs);
@@ -215,6 +230,7 @@ CoinsResult AvailableCoins(const CWallet& wallet,
     const int min_depth = {coinControl ? coinControl->m_min_depth : DEFAULT_MIN_DEPTH};
     const int max_depth = {coinControl ? coinControl->m_max_depth : DEFAULT_MAX_DEPTH};
     const bool only_safe = {coinControl ? !coinControl->m_include_unsafe_inputs : true};
+    const bool silent_payment = {coinControl ? coinControl->m_silent_payment : false};
     const bool can_grind_r = wallet.CanGrindR();
 
     std::set<uint256> trusted_parents;
@@ -328,6 +344,19 @@ CoinsResult AvailableCoins(const CWallet& wallet,
                 if (!provider->GetCScript(CScriptID(uint160(script_solutions[0])), script)) continue;
                 type = Solver(script, script_solutions);
                 is_from_p2sh = true;
+            }
+
+            // Very unlikely we'd be spending a witness unknown output, but if we are trying to pay a
+            // silent payments v0 address, this can't be included
+            if (silent_payment && type == TxoutType::WITNESS_UNKNOWN) continue;
+            if (silent_payment && type == TxoutType::WITNESS_V1_TAPROOT) {
+                TaprootSpendData spenddata;
+                // If we have scriptpath spend data for the taproot output, just skip it for now. Only keypath
+                // spends can be used with silent payments and at this point we don't know if the keypath or script path is going to be used
+                // so if there's even a chance the script path will be used, better to skip the output for now
+                if (provider->GetTaprootSpendData(XOnlyPubKey(script_solutions[0]), spenddata)) {
+                    if (!spenddata.scripts.empty()) continue;
+                }
             }
 
             result.Add(GetOutputType(type, is_from_p2sh),

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -908,6 +908,24 @@ std::vector<CRecipient> CreateSilentPaymentOutputs(
     return outputs;
 }
 
+std::pair<std::vector<CRecipient>, std::vector<V0SilentPaymentDestination>> SeparateDestinations(std::vector<Destination> destinations)
+{
+    std::vector<CRecipient> recipients;
+    std::vector<V0SilentPaymentDestination> silent_payment_destinations;
+    recipients.reserve(destinations.size());
+    silent_payment_destinations.reserve(destinations.size());
+    for (const auto& var : destinations) {
+        std::visit([&](auto&& arg) {
+            using T = std::decay_t<decltype(arg)>;
+            if constexpr (std::is_same_v<T, CRecipient>)
+                recipients.push_back(arg);
+            else if constexpr (std::is_same_v<T, V0SilentPaymentDestination>)
+                silent_payment_destinations.push_back(arg);
+        }, var);
+    }
+    return {recipients, silent_payment_destinations};
+}
+
 static util::Result<CreatedTransactionResult> CreateTransactionInternal(
         CWallet& wallet,
         const std::vector<Destination>& vecSend,

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -819,6 +819,50 @@ static void DiscourageFeeSniping(CMutableTransaction& tx, FastRandomContext& rng
     }
 }
 
+bool IsInputForSharedSecretDerivation(const CScript& input, const CWallet& wallet)
+{
+    std::vector<std::vector<unsigned char>> solutions;
+    TxoutType type = Solver(input, solutions);
+
+    switch (type) {
+        // First check the conditional inputs: P2TR and P2SH
+        case TxoutType::SCRIPTHASH:
+            {
+                // Only P2SH-P2WPKH is supported. If it is any other type of P2SH, skip the input
+                // To determine if this input is a P2SH-P2WPKH, get the redeemScript and check the
+                // TxOutType. If we can't get the reedeemScript, we have know way of knowing what type
+                // the P2SH is, and don't have access to the spending data, anyways.
+                std::unique_ptr<SigningProvider> provider = wallet.GetSolvingProvider(input);
+                CScript script;
+                if (!provider->GetCScript(CScriptID(uint160(solutions[0])), script)) return false;
+                type = Solver(script, solutions);
+                if (type == TxoutType::WITNESS_V0_KEYHASH) return true;
+                return false;
+            }
+        case TxoutType::WITNESS_V1_TAPROOT:
+            {
+                // TODO: If the outer public key is H (the NUMS point defined in the BIP), skip the input
+                // if (pubkey == H) return false;
+                return true;
+            }
+        case TxoutType::PUBKEYHASH:
+        case TxoutType::WITNESS_V0_KEYHASH: { return true; }
+        // For all the rest, these can be included as inputs but
+        // are not used when deriving the shared secret
+        case TxoutType::WITNESS_V0_SCRIPTHASH:
+        case TxoutType::MULTISIG:
+        case TxoutType::PUBKEY:
+        case TxoutType::NONSTANDARD:
+        case TxoutType::NULL_DATA: { return false; }
+        case TxoutType::WITNESS_UNKNOWN:
+            // This should never happen, as this step takes place after coin selection
+            // and this input would have been filtered out during coin selection.
+            assert(false);
+    }
+    // No default case so the compiler can warn us if we've missed something
+    assert(false);
+}
+
 static util::Result<CreatedTransactionResult> CreateTransactionInternal(
         CWallet& wallet,
         const std::vector<Destination>& vecSend,

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -840,6 +840,8 @@ static util::Result<CreatedTransactionResult> CreateTransactionInternal(
 
     // Set the long term feerate estimate to the wallet's consolidate feerate
     coin_selection_params.m_long_term_feerate = wallet.m_consolidate_feerate;
+    // Static vsize overhead + outputs vsize. 4 nVersion, 4 nLocktime, 1 input count, 1 witness overhead (dummy, flag, stack size)
+    coin_selection_params.tx_noinputs_size = 10 + GetSizeOfCompactSize(vecSend.size()); // bytes for output count
 
     CAmount recipients_sum = 0;
     const OutputType change_type = wallet.TransactionChangeType(coin_control.m_change_type ? *coin_control.m_change_type : wallet.m_default_change_type, vecSend);
@@ -852,6 +854,9 @@ static util::Result<CreatedTransactionResult> CreateTransactionInternal(
             outputs_to_subtract_fee_from++;
             coin_selection_params.m_subtract_fee_outputs = true;
         }
+
+        // Include the fee cost for outputs.
+        coin_selection_params.tx_noinputs_size += GetSerializeSizeFromDestination(recipient);
     }
 
     // Create change script that will be used if we need change
@@ -930,8 +935,6 @@ static util::Result<CreatedTransactionResult> CreateTransactionInternal(
     const auto change_spend_fee = coin_selection_params.m_discard_feerate.GetFee(coin_selection_params.change_spend_size);
     coin_selection_params.min_viable_change = std::max(change_spend_fee + 1, dust);
 
-    // Static vsize overhead + outputs vsize. 4 nVersion, 4 nLocktime, 1 input count, 1 witness overhead (dummy, flag, stack size)
-    coin_selection_params.tx_noinputs_size = 10 + GetSizeOfCompactSize(vecSend.size()); // bytes for output count
 
     // vouts to the payees
     for (const auto& destination : vecSend)
@@ -945,9 +948,6 @@ static util::Result<CreatedTransactionResult> CreateTransactionInternal(
             }
             txNew.vout.push_back(txout);
         }
-
-        // Include the fee cost for outputs.
-        coin_selection_params.tx_noinputs_size += GetSerializeSizeFromDestination(destination);
     }
 
     // Include the fees for things that aren't inputs, excluding the change output

--- a/src/wallet/spend.h
+++ b/src/wallet/spend.h
@@ -216,7 +216,7 @@ struct CreatedTransactionResult
  * selected by SelectCoins(); Also create the change output, when needed
  * @note passing change_pos as -1 will result in setting a random position
  */
-util::Result<CreatedTransactionResult> CreateTransaction(CWallet& wallet, const std::vector<CRecipient>& vecSend, int change_pos, const CCoinControl& coin_control, bool sign = true);
+util::Result<CreatedTransactionResult> CreateTransaction(CWallet& wallet, const std::vector<Destination>& vecSend, int change_pos, const CCoinControl& coin_control, bool sign = true);
 
 /**
  * Insert additional inputs into the transaction by

--- a/src/wallet/test/silentpayment_tests.cpp
+++ b/src/wallet/test/silentpayment_tests.cpp
@@ -1,0 +1,167 @@
+#include <wallet/silentpayments.h>
+#include <test/data/bip352_send_and_receive_vectors.json.h>
+
+#include <test/util/setup_common.h>
+#include <hash.h>
+
+#include <boost/test/unit_test.hpp>
+#include <test/util/json.h>
+#include <vector>
+#include <util/bip32.h>
+
+namespace wallet {
+BOOST_FIXTURE_TEST_SUITE(silentpayment_tests, BasicTestingSetup)
+
+CKey ParseHexToCKey(std::string hex) {
+    CKey output;
+    auto hex_data = ParseHex(hex);
+    output.Set(hex_data.begin(), hex_data.end(), true);
+    return output;
+};
+
+CKey GetKeyFromBIP32Path(std::vector<std::byte> seed, std::vector<uint32_t> path)
+{
+    CExtKey key_parent, key_child;
+    key_parent.SetSeed(seed);
+    for (auto index : path) {
+        BOOST_CHECK(key_parent.Derive(key_child, index));
+        std::swap(key_parent, key_child);
+    }
+    return key_parent.key;
+}
+
+class TestSender: public Sender {
+    public:
+        TestSender(const CKey scalar_ecdh_input, SilentPaymentRecipient& recipient) :
+            Sender(scalar_ecdh_input, recipient) {}
+        CPubKey GetSharedSecret() {
+            return m_ecdh_pubkey;
+    }
+};
+
+BOOST_AUTO_TEST_CASE(bip352_send_and_receive_test_vectors)
+{
+    UniValue tests;
+    tests.read(json_tests::bip352_send_and_receive_vectors);
+
+    for (const auto& vec : tests.getValues()) {
+        // run sending tests
+        BOOST_TEST_MESSAGE(vec["comment"].get_str());
+        for (const auto& sender : vec["sending"].getValues()) {
+            const auto& given = sender["given"];
+            const auto& expected = sender["expected"];
+
+            std::vector<COutPoint> outpoints;
+            for (const auto& outpoint : sender["given"]["outpoints"].getValues()) {
+                outpoints.emplace_back(uint256S(outpoint[0].get_str()), outpoint[1].getInt<uint32_t>());
+            }
+
+            std::vector<std::pair<CKey, bool>> sender_secret_keys;
+            for (const auto& key : given["input_priv_keys"].getValues()) {
+                sender_secret_keys.emplace_back(ParseHexToCKey(key[0].get_str()), key[1].get_bool());
+            }
+            std::vector<V0SilentPaymentDestination> silent_payment_addresses;
+            for (const auto& recipient : given["recipients"].getValues()) {
+                std::string silent_payment_address = recipient[0].get_str();
+                CAmount amount = recipient[1].get_real() * COIN;
+                const auto&[scan_pubkey, spend_pubkey] = DecodeSilentData(DecodeSilentAddress(silent_payment_address));
+                silent_payment_addresses.push_back(V0SilentPaymentDestination{scan_pubkey, spend_pubkey, amount});
+            }
+
+            // silent payments logic
+            std::vector<SilentPaymentRecipient> groups = GroupSilentPaymentAddresses(silent_payment_addresses);
+            CKey scalar_ecdh_input = PrepareScalarECDHInput(sender_secret_keys, outpoints);
+
+            std::vector<CRecipient> spks;
+            for (const auto& recipient : groups) {
+                Sender sender{scalar_ecdh_input, recipient};
+                std::vector<CRecipient> recipient_spks = sender.GenerateRecipientScriptPubKeys();
+                spks.insert(spks.end(), recipient_spks.begin(), recipient_spks.end());
+            }
+
+            std::vector<CRecipient> expected_spks;
+            for (const auto& recipient : expected["outputs"].getValues()) {
+                std::string pubkey_hex = recipient[0].get_str();
+                CAmount amount = recipient[1].get_real() * COIN;
+                auto tap = WitnessV1Taproot(XOnlyPubKey(ParseHex(pubkey_hex)));
+                CScript spk = GetScriptForDestination(tap);
+                expected_spks.push_back(CRecipient{spk, amount, false});
+            }
+
+            BOOST_CHECK(spks.size() == expected_spks.size());
+            for (const auto& spk : spks) {
+                BOOST_CHECK(std::find(expected_spks.begin(), expected_spks.end(), spk) != expected_spks.end());
+            }
+        }
+
+        // Test receiving
+        for (const auto& recipient : vec["receiving"].getValues()) {
+            // TODO: implement labels for Bitcoin Core, until then skip the receiving with labels tests
+            if (recipient["supports_labels"].get_bool()) {
+                BOOST_TEST_MESSAGE("Labels not implemented; skipping..");
+                continue;
+            }
+
+            const auto& given = recipient["given"];
+            const auto& expected = recipient["expected"];
+
+            std::vector<COutPoint> outpoints;
+            for (const auto& outpoint : recipient["given"]["outpoints"].getValues()) {
+                outpoints.emplace_back(uint256S(outpoint[0].get_str()), outpoint[1].getInt<uint32_t>());
+            }
+
+            std::vector<CPubKey> input_pub_keys;
+            for (const auto& pubkey : given["input_pub_keys"].getValues()) {
+                // All pubkeys must be in compressed format
+                auto pubkey_bytes = ParseHex(pubkey.get_str());
+                if (pubkey_bytes.size() == 32) {
+                    // XOnlyPubKeys are always even
+                    pubkey_bytes.insert(pubkey_bytes.begin(), 2);
+                }
+                input_pub_keys.emplace_back(pubkey_bytes);
+            }
+            std::vector<XOnlyPubKey> output_pub_keys;
+            for (const auto& pubkey : given["outputs"].getValues()) {
+                output_pub_keys.emplace_back(ParseHex(pubkey.get_str()));
+            }
+
+            std::string hex_str = given["bip32_seed"].get_str();
+            std::vector<std::byte> seed{ParseHex<std::byte>(hex_str)};
+            std::vector<uint32_t> scan_keypath;
+            BOOST_CHECK(ParseHDKeypath("m/352'/0'/0'/1'/0", scan_keypath));
+            std::vector<uint32_t> spend_keypath;
+            BOOST_CHECK(ParseHDKeypath("m/352'/0'/0'/0'/0", spend_keypath));
+            CKey scan_priv_key = GetKeyFromBIP32Path(seed, scan_keypath);
+            CKey spend_priv_key = GetKeyFromBIP32Path(seed, spend_keypath);
+
+            // Scanning
+            Recipient scanner{scan_priv_key, spend_priv_key};
+            CPubKey sum_input_pub_keys = CPubKey::Combine(input_pub_keys);
+
+            const auto expected_addresses = expected["addresses"].getValues();
+            // We know there is only one address, but if we support labels, this could be multiple addresses
+            // TODO: update this to handle multiple addresses
+            std::string expected_address = expected_addresses[0].get_str();
+            const auto key_pair = scanner.GetAddress();
+            BOOST_CHECK(EncodeSilentDestination(key_pair.first, key_pair.second) == expected_address);
+            scanner.ComputeECDHSharedSecret(sum_input_pub_keys, outpoints);
+            std::vector<CKey> found_priv_keys = scanner.ScanTxOutputs(output_pub_keys);
+
+            std::vector<XOnlyPubKey> expected_outputs;
+            for (const auto& output : expected["outputs"].getValues()) {
+                std::string pubkey_hex = output["pub_key"].get_str();
+                const auto pubkey = XOnlyPubKey(ParseHex(pubkey_hex));
+                expected_outputs.push_back(pubkey);
+            }
+            std::vector<XOnlyPubKey> outputs;
+            for (const auto& privkey : found_priv_keys) {
+                const auto& pubkey = privkey.GetPubKey();
+                BOOST_CHECK(privkey.VerifyPubKey(pubkey));
+                outputs.push_back(XOnlyPubKey{pubkey});
+            }
+            BOOST_CHECK(outputs == expected_outputs);
+        }
+    }
+}
+BOOST_AUTO_TEST_SUITE_END()
+} // namespace wallet

--- a/src/wallet/test/spend_tests.cpp
+++ b/src/wallet/test/spend_tests.cpp
@@ -128,7 +128,7 @@ BOOST_FIXTURE_TEST_CASE(wallet_duplicated_preset_inputs_test, TestChain100Setup)
 
     // Try to create a tx that spends more than what preset inputs + wallet selected inputs are covering for.
     // The wallet can cover up to 200 BTC, and the tx target is 299 BTC.
-    std::vector<CRecipient> recipients = {{GetScriptForDestination(*Assert(wallet->GetNewDestination(OutputType::BECH32, "dummy"))),
+    std::vector<Destination> recipients = {CRecipient{GetScriptForDestination(*Assert(wallet->GetNewDestination(OutputType::BECH32, "dummy"))),
                                            /*nAmount=*/299 * COIN, /*fSubtractFeeFromAmount=*/true}};
     CCoinControl coin_control;
     coin_control.m_allow_other_inputs = true;
@@ -152,7 +152,7 @@ BOOST_FIXTURE_TEST_CASE(wallet_duplicated_preset_inputs_test, TestChain100Setup)
     BOOST_CHECK(!res_tx.has_value());
 
     // Second case, don't use 'subtract_fee_from_outputs'.
-    recipients[0].fSubtractFeeFromAmount = false;
+    std::get<wallet::CRecipient>(recipients[0]).fSubtractFeeFromAmount = false;
     res_tx = CreateTransaction(*wallet, recipients, /*change_pos*/-1, coin_control);
     BOOST_CHECK(!res_tx.has_value());
 }

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -671,7 +671,7 @@ BOOST_FIXTURE_TEST_CASE(BasicOutputTypesTest, ListCoinsTest)
     //   2. One UTXO from the change, due to payment address matching logic
 
     for (const auto& out_type : OUTPUT_TYPES) {
-        if (out_type == OutputType::UNKNOWN) continue;
+        if (out_type == OutputType::UNKNOWN || out_type == OutputType::SILENT_PAYMENT) continue;
         expected_coins_sizes[out_type] = 2U;
         TestCoinsResult(*this, out_type, 1 * COIN, expected_coins_sizes);
     }

--- a/src/wallet/types.h
+++ b/src/wallet/types.h
@@ -69,6 +69,11 @@ struct CRecipient
     CScript scriptPubKey;
     CAmount nAmount;
     bool fSubtractFeeFromAmount;
+
+    friend bool operator==(const CRecipient& a, const CRecipient& b)
+    {
+        return a.scriptPubKey == b.scriptPubKey && a.nAmount == b.nAmount;
+    }
 };
 
 struct V0SilentPaymentDestination

--- a/src/wallet/types.h
+++ b/src/wallet/types.h
@@ -14,6 +14,7 @@
 #define BITCOIN_WALLET_TYPES_H
 
 #include <type_traits>
+#include <pubkey.h>
 
 namespace wallet {
 /**
@@ -61,6 +62,20 @@ enum class AddressPurpose {
     RECEIVE,
     SEND,
     REFUND, //!< Never set in current code may be present in older wallet databases
+};
+
+struct CRecipient
+{
+    CScript scriptPubKey;
+    CAmount nAmount;
+    bool fSubtractFeeFromAmount;
+};
+
+struct V0SilentPaymentDestination
+{
+    CPubKey m_scan_pubkey;
+    CPubKey m_spend_pubkey;
+    CAmount m_amount;
 };
 } // namespace wallet
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -53,7 +53,6 @@
 using interfaces::FoundBlock;
 
 namespace wallet {
-
 bool AddWalletSetting(interfaces::Chain& chain, const std::string& wallet_name)
 {
     common::SettingsValue setting_value = chain.getRwSetting("wallet");

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2272,6 +2272,7 @@ OutputType CWallet::TransactionChangeType(const std::optional<OutputType>& chang
 
     for (const auto& recipient : vecSend) {
         if (std::holds_alternative<V0SilentPaymentDestination>(recipient)) {
+            any_tr = true;
             continue;
         }
         std::vector<std::vector<uint8_t>> dummy;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -336,7 +336,7 @@ std::shared_ptr<CWallet> LoadWallet(WalletContext& context, const std::string& n
     return wallet;
 }
 
-std::shared_ptr<CWallet> CreateWallet(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error, std::vector<bilingual_str>& warnings)
+std::shared_ptr<CWallet> CreateWallet(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error, std::vector<bilingual_str>& warnings, const bool silent_payment)
 {
     uint64_t wallet_creation_flags = options.create_flags;
     const SecureString& passphrase = options.create_passphrase;
@@ -372,6 +372,26 @@ std::shared_ptr<CWallet> CreateWallet(WalletContext& context, const std::string&
         return nullptr;
     }
 
+    // silent payment validations
+    if ((wallet_creation_flags & WALLET_FLAG_DISABLE_PRIVATE_KEYS) && (wallet_creation_flags & WALLET_FLAG_SILENT_PAYMENT)) {
+        error = Untranslated("Silent payments require the ability to store private keys.") + error;
+        status = DatabaseStatus::FAILED_VERIFY;
+        return nullptr;
+    }
+
+    if ((wallet_creation_flags & WALLET_FLAG_SILENT_PAYMENT) && !(wallet_creation_flags & WALLET_FLAG_DESCRIPTORS)) {
+        error = Untranslated("Only descriptor wallets support silent payments.") + error;
+        status = DatabaseStatus::FAILED_VERIFY;
+        return nullptr;
+    }
+
+    if (!passphrase.empty() && (wallet_creation_flags & WALLET_FLAG_SILENT_PAYMENT)) {
+        error = Untranslated("Silent payment verification requires access to private keys. Cannot be used with encrypted wallets.")  + error;
+        status = DatabaseStatus::FAILED_VERIFY;
+        return nullptr;
+    }
+    // end - silent payment validations
+
     // Wallet::Verify will check if we're trying to create a wallet with a duplicate name.
     std::unique_ptr<WalletDatabase> database = MakeWalletDatabase(name, options, status, error);
     if (!database) {
@@ -382,7 +402,7 @@ std::shared_ptr<CWallet> CreateWallet(WalletContext& context, const std::string&
 
     // Make the wallet
     context.chain->initMessage(_("Loading wallet…").translated);
-    std::shared_ptr<CWallet> wallet = CWallet::Create(context, name, std::move(database), wallet_creation_flags, error, warnings);
+    std::shared_ptr<CWallet> wallet = CWallet::Create(context, name, std::move(database), wallet_creation_flags, error, warnings, silent_payment);
     if (!wallet) {
         error = Untranslated("Wallet creation failed.") + Untranslated(" ") + error;
         status = DatabaseStatus::FAILED_CREATE;
@@ -2507,8 +2527,10 @@ bool CWallet::TopUpKeyPool(unsigned int kpSize)
     return res;
 }
 
-util::Result<CTxDestination> CWallet::GetNewDestination(const OutputType type, const std::string label)
+util::Result<CTxDestination> CWallet::GetNewDestination(const OutputType& type, const std::string& label)
 {
+    assert(type != OutputType::SILENT_PAYMENT);
+
     LOCK(cs_wallet);
     auto spk_man = GetScriptPubKeyMan(type, /*internal=*/false);
     if (!spk_man) {
@@ -2521,6 +2543,32 @@ util::Result<CTxDestination> CWallet::GetNewDestination(const OutputType type, c
     }
 
     return op_dest;
+}
+
+util::Result<std::string>  CWallet::GetSilentDestination()
+{
+    LOCK(cs_wallet);
+
+    auto spk_man = GetScriptPubKeyMan(OutputType::SILENT_PAYMENT, false /* internal */);
+    if (!spk_man) {
+        return util::Error{strprintf(_("Error: No %s addresses available."), FormatOutputType(OutputType::SILENT_PAYMENT))};
+    }
+
+    const auto desc_spkm{dynamic_cast<DescriptorScriptPubKeyMan*>(spk_man)};
+    assert(desc_spkm);
+    const auto result{desc_spkm->GetSilentAddress()};
+    if (!result) {
+        return util::Error{util::ErrorString(result)};
+    }
+
+    auto const& [scan_pubkey, spend_pubkey] = result.value();
+
+    if(!scan_pubkey.IsFullyValid() || !spend_pubkey.IsFullyValid()) {
+        return util::Error{_("Invalid scan or spend key.")};
+    }
+
+    const auto silent_address = EncodeSilentDestination(scan_pubkey, spend_pubkey);
+    return silent_address;
 }
 
 util::Result<CTxDestination> CWallet::GetNewChangeDestination(const OutputType type)
@@ -2913,7 +2961,7 @@ std::unique_ptr<WalletDatabase> MakeWalletDatabase(const std::string& name, cons
     return MakeDatabase(wallet_path, options, status, error_string);
 }
 
-std::shared_ptr<CWallet> CWallet::Create(WalletContext& context, const std::string& name, std::unique_ptr<WalletDatabase> database, uint64_t wallet_creation_flags, bilingual_str& error, std::vector<bilingual_str>& warnings)
+std::shared_ptr<CWallet> CWallet::Create(WalletContext& context, const std::string& name, std::unique_ptr<WalletDatabase> database, uint64_t wallet_creation_flags, bilingual_str& error, std::vector<bilingual_str>& warnings, const bool silent_payment)
 {
     interfaces::Chain* chain = context.chain;
     ArgsManager& args = *Assert(context.args);
@@ -2990,7 +3038,7 @@ std::shared_ptr<CWallet> CWallet::Create(WalletContext& context, const std::stri
         if ((wallet_creation_flags & WALLET_FLAG_EXTERNAL_SIGNER) || !(wallet_creation_flags & (WALLET_FLAG_DISABLE_PRIVATE_KEYS | WALLET_FLAG_BLANK_WALLET))) {
             LOCK(walletInstance->cs_wallet);
             if (walletInstance->IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS)) {
-                walletInstance->SetupDescriptorScriptPubKeyMans();
+                walletInstance->SetupDescriptorScriptPubKeyMans(silent_payment);
                 // SetupDescriptorScriptPubKeyMans already calls SetupGeneration for us so we don't need to call SetupGeneration separately
             } else {
                 // Legacy wallets need SetupGeneration here.
@@ -3620,13 +3668,13 @@ void CWallet::LoadDescriptorScriptPubKeyMan(uint256 id, WalletDescriptor& desc)
     }
 }
 
-void CWallet::SetupDescriptorScriptPubKeyMans(const CExtKey& master_key)
+void CWallet::SetupDescriptorScriptPubKeyMans(const CExtKey& master_key, bool silent_payment)
 {
     AssertLockHeld(cs_wallet);
 
     for (bool internal : {false, true}) {
         for (OutputType t : OUTPUT_TYPES) {
-            if (t == OutputType::SILENT_PAYMENT) continue;
+            if (t == OutputType::SILENT_PAYMENT && (!silent_payment || IsCrypted() || internal)) continue;
             auto spk_manager = std::unique_ptr<DescriptorScriptPubKeyMan>(new DescriptorScriptPubKeyMan(*this, m_keypool_size));
             if (IsCrypted()) {
                 if (IsLocked()) {
@@ -3644,7 +3692,7 @@ void CWallet::SetupDescriptorScriptPubKeyMans(const CExtKey& master_key)
     }
 }
 
-void CWallet::SetupDescriptorScriptPubKeyMans()
+void CWallet::SetupDescriptorScriptPubKeyMans(bool silent_payment)
 {
     AssertLockHeld(cs_wallet);
 
@@ -3659,7 +3707,7 @@ void CWallet::SetupDescriptorScriptPubKeyMans()
         CExtKey master_key;
         master_key.SetSeed(seed_key);
 
-        SetupDescriptorScriptPubKeyMans(master_key);
+        SetupDescriptorScriptPubKeyMans(master_key, silent_payment);
     } else {
         ExternalSigner signer = ExternalSignerScriptPubKeyMan::GetExternalSigner();
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3530,6 +3530,25 @@ std::vector<WalletDescriptor> CWallet::GetWalletDescriptors(const CScript& scrip
     return descs;
 }
 
+util::Result<WalletDescriptor> CWallet::GetWalletDescriptor(const OutputType type, const bool internal) const
+{
+    LOCK(cs_wallet);
+    auto spk_man = GetScriptPubKeyMan(type, false /* internal */);
+
+    if (!spk_man) {
+        return util::Error{strprintf(_("Error: No %s addresses available."), FormatOutputType(type))};
+    }
+
+    const auto desc_spk_man = dynamic_cast<DescriptorScriptPubKeyMan*>(spk_man);
+
+    if (!desc_spk_man) {
+        return util::Error{strprintf(_("Error: No descriptor scriptpubkeymanager for this output type"))};
+    }
+
+    LOCK(desc_spk_man->cs_desc_man);
+    return desc_spk_man->GetWalletDescriptor();
+}
+
 LegacyScriptPubKeyMan* CWallet::GetLegacyScriptPubKeyMan() const
 {
     if (IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS)) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3608,6 +3608,7 @@ void CWallet::SetupDescriptorScriptPubKeyMans(const CExtKey& master_key)
 
     for (bool internal : {false, true}) {
         for (OutputType t : OUTPUT_TYPES) {
+            if (t == OutputType::SILENT_PAYMENT) continue;
             auto spk_manager = std::unique_ptr<DescriptorScriptPubKeyMan>(new DescriptorScriptPubKeyMan(*this, m_keypool_size));
             if (IsCrypted()) {
                 if (IsLocked()) {

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -131,10 +131,12 @@ static constexpr uint64_t KNOWN_WALLET_FLAGS =
     |   WALLET_FLAG_LAST_HARDENED_XPUB_CACHED
     |   WALLET_FLAG_DISABLE_PRIVATE_KEYS
     |   WALLET_FLAG_DESCRIPTORS
-    |   WALLET_FLAG_EXTERNAL_SIGNER;
+    |   WALLET_FLAG_EXTERNAL_SIGNER
+    |   WALLET_FLAG_SILENT_PAYMENT;
 
 static constexpr uint64_t MUTABLE_WALLET_FLAGS =
-        WALLET_FLAG_AVOID_REUSE;
+        WALLET_FLAG_AVOID_REUSE
+    |   WALLET_FLAG_SILENT_PAYMENT;
 
 static const std::map<std::string,WalletFlags> WALLET_FLAG_MAP{
     {"avoid_reuse", WALLET_FLAG_AVOID_REUSE},
@@ -143,7 +145,8 @@ static const std::map<std::string,WalletFlags> WALLET_FLAG_MAP{
     {"last_hardened_xpub_cached", WALLET_FLAG_LAST_HARDENED_XPUB_CACHED},
     {"disable_private_keys", WALLET_FLAG_DISABLE_PRIVATE_KEYS},
     {"descriptor_wallet", WALLET_FLAG_DESCRIPTORS},
-    {"external_signer", WALLET_FLAG_EXTERNAL_SIGNER}
+    {"external_signer", WALLET_FLAG_EXTERNAL_SIGNER},
+    {"silent_payment", WALLET_FLAG_SILENT_PAYMENT}
 };
 
 /** A wrapper to reserve an address from a wallet

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -262,13 +262,6 @@ inline std::optional<AddressPurpose> PurposeFromString(std::string_view s)
     return {};
 }
 
-struct CRecipient
-{
-    CScript scriptPubKey;
-    CAmount nAmount;
-    bool fSubtractFeeFromAmount;
-};
-
 class WalletRescanReserver; //forward declarations for ScanForWalletTransactions/RescanFromTime
 /**
  * A CWallet maintains a set of transactions and balances, and provides the ability to create new transactions.

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -262,7 +262,7 @@ inline std::optional<AddressPurpose> PurposeFromString(std::string_view s)
     return {};
 }
 
-using Destination = std::variant<CRecipient>;
+using Destination = std::variant<CRecipient, V0SilentPaymentDestination>;
 
 CAmount GetAmountFromDestination(const Destination& destination);
 bool GetSubtractFeeFromAmountFromDestination(const Destination& destination);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -262,6 +262,12 @@ inline std::optional<AddressPurpose> PurposeFromString(std::string_view s)
     return {};
 }
 
+using Destination = std::variant<CRecipient>;
+
+CAmount GetAmountFromDestination(const Destination& destination);
+bool GetSubtractFeeFromAmountFromDestination(const Destination& destination);
+size_t GetSerializeSizeFromDestination(const Destination& destination);
+
 class WalletRescanReserver; //forward declarations for ScanForWalletTransactions/RescanFromTime
 /**
  * A CWallet maintains a set of transactions and balances, and provides the ability to create new transactions.
@@ -596,7 +602,7 @@ public:
     bool ShouldResend() const;
     void ResubmitWalletTransactions(bool relay, bool force);
 
-    OutputType TransactionChangeType(const std::optional<OutputType>& change_type, const std::vector<CRecipient>& vecSend) const;
+    OutputType TransactionChangeType(const std::optional<OutputType>& change_type, const std::vector<Destination>& vecSend) const;
 
     /** Fetch the inputs and sign with SIGHASH_ALL. */
     bool SignTransaction(CMutableTransaction& tx) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -921,6 +921,9 @@ public:
     //! Get the wallet descriptors for a script.
     std::vector<WalletDescriptor> GetWalletDescriptors(const CScript& script) const;
 
+    //! Get the wallet descriptor for an output type.
+    util::Result<WalletDescriptor> GetWalletDescriptor(const OutputType type, const bool internal) const;
+
     //! Get the LegacyScriptPubKeyMan which is used for all types, internal, and external.
     LegacyScriptPubKeyMan* GetLegacyScriptPubKeyMan() const;
     LegacyScriptPubKeyMan* GetOrCreateLegacyScriptPubKeyMan();

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -315,6 +315,11 @@ private:
     void AddToSpends(const COutPoint& outpoint, const uint256& wtxid, WalletBatch* batch = nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     void AddToSpends(const CWalletTx& wtx, WalletBatch* batch = nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
+    void AddSilentScriptPubKey(const CTransaction& tx, const SyncTxState& state, bool rescanning_old_block, const std::vector<CKey>& rawTrKeys) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+
+    /** Detect if a transaction is a silent payment that belongs to wallet and in that case add it **/
+    bool VerifySilentPayment(const CTransaction& tx, std::vector<CKey>& rawTrKeys, const std::map<uint256, CPubKey>& tweakData) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+
     /**
      * Add a transaction to the wallet, or update it.  confirm.block_* should
      * be set when the transaction was known to be included in a block.  When
@@ -331,7 +336,9 @@ private:
      * Should be called with rescanning_old_block set to true, if the transaction is
      * not discovered in real time, but during a rescan of old blocks.
      */
-    bool AddToWalletIfInvolvingMe(const CTransactionRef& tx, const SyncTxState& state, bool fUpdate, bool rescanning_old_block) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    bool AddToWalletIfInvolvingMe(const CTransactionRef& tx, const SyncTxState& state, const std::map<uint256, CPubKey>& tweakData, bool fUpdate, bool rescanning_old_block, bool taproot_active) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+
+    Coin FindPreviousCoin(const CTxIn& txin) const;
 
     /** Mark a transaction (and its in-wallet descendants) as conflicting with a particular block. */
     void MarkConflicted(const uint256& hashBlock, int conflicting_height, const uint256& hashTx);
@@ -348,7 +355,7 @@ private:
 
     void SyncMetaData(std::pair<TxSpends::iterator, TxSpends::iterator>) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
-    void SyncTransaction(const CTransactionRef& tx, const SyncTxState& state, bool update_tx = true, bool rescanning_old_block = false) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    void SyncTransaction(const CTransactionRef& tx, const SyncTxState& state, const std::map<uint256, CPubKey>& tweakData = {}, bool update_tx = true, bool rescanning_old_block = false, bool taproot_active = true) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     /** WalletFlags set on this wallet. */
     std::atomic<uint64_t> m_wallet_flags{0};
@@ -1011,8 +1018,10 @@ public:
 
     //! Whether the (external) signer performs R-value signature grinding
     bool CanGrindR() const;
+    std::map<uint256, CPubKey> GetSilentPaymentKeysPerBlock(const uint256& block_hash, const std::vector<CTransactionRef> vtx);
 };
 
+std::map<uint256, CPubKey> GetSilentPaymentKeys(const uint256& block_hash, const CBlockUndo& blockUndo, const std::vector<CTransactionRef> vtx);
 /**
  * Called periodically by the schedule thread. Prompts individual wallets to resend
  * their transactions. Actual rebroadcast schedule is managed by the wallets themselves.
@@ -1061,6 +1070,8 @@ public:
         }
     }
 };
+
+CPubKey SumInputPubKeys(const CTransaction &tx, const std::vector<Coin>& coins);
 
 //! Add wallet name to persistent configuration so it will be loaded on startup.
 bool AddWalletSetting(interfaces::Chain& chain, const std::string& wallet_name);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -69,7 +69,7 @@ std::vector<std::shared_ptr<CWallet>> GetWallets(WalletContext& context);
 std::shared_ptr<CWallet> GetDefaultWallet(WalletContext& context, size_t& count);
 std::shared_ptr<CWallet> GetWallet(WalletContext& context, const std::string& name);
 std::shared_ptr<CWallet> LoadWallet(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, const DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error, std::vector<bilingual_str>& warnings);
-std::shared_ptr<CWallet> CreateWallet(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error, std::vector<bilingual_str>& warnings);
+std::shared_ptr<CWallet> CreateWallet(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error, std::vector<bilingual_str>& warnings, const bool silent_payment = false);
 std::shared_ptr<CWallet> RestoreWallet(WalletContext& context, const fs::path& backup_file, const std::string& wallet_name, std::optional<bool> load_on_start, DatabaseStatus& status, bilingual_str& error, std::vector<bilingual_str>& warnings);
 std::unique_ptr<interfaces::Handler> HandleLoadWallet(WalletContext& context, LoadWalletFn load_wallet);
 void NotifyWalletLoaded(WalletContext& context, const std::shared_ptr<CWallet>& wallet);
@@ -741,7 +741,8 @@ public:
      */
     void MarkDestinationsDirty(const std::set<CTxDestination>& destinations) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
-    util::Result<CTxDestination> GetNewDestination(const OutputType type, const std::string label);
+    util::Result<CTxDestination> GetNewDestination(const OutputType& type, const std::string& label);
+    util::Result<std::string> GetSilentDestination();
     util::Result<CTxDestination> GetNewChangeDestination(const OutputType type);
 
     isminetype IsMine(const CTxDestination& dest) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
@@ -841,7 +842,7 @@ public:
     bool MarkReplaced(const uint256& originalHash, const uint256& newHash);
 
     /* Initializes the wallet, returns a new CWallet instance or a null pointer in case of an error */
-    static std::shared_ptr<CWallet> Create(WalletContext& context, const std::string& name, std::unique_ptr<WalletDatabase> database, uint64_t wallet_creation_flags, bilingual_str& error, std::vector<bilingual_str>& warnings);
+    static std::shared_ptr<CWallet> Create(WalletContext& context, const std::string& name, std::unique_ptr<WalletDatabase> database, uint64_t wallet_creation_flags, bilingual_str& error, std::vector<bilingual_str>& warnings, const bool silent_payment = false);
 
     /**
      * Wallet post-init setup
@@ -980,8 +981,8 @@ public:
     void DeactivateScriptPubKeyMan(uint256 id, OutputType type, bool internal);
 
     //! Create new DescriptorScriptPubKeyMans and add them to the wallet
-    void SetupDescriptorScriptPubKeyMans(const CExtKey& master_key) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
-    void SetupDescriptorScriptPubKeyMans() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    void SetupDescriptorScriptPubKeyMans(const CExtKey& master_key, bool silent_payment = false) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    void SetupDescriptorScriptPubKeyMans(bool silent_payment = false) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     //! Return the DescriptorScriptPubKeyMan for a WalletDescriptor if it is already in the wallet
     DescriptorScriptPubKeyMan* GetDescriptorScriptPubKeyMan(const WalletDescriptor& desc) const;

--- a/src/wallet/walletutil.h
+++ b/src/wallet/walletutil.h
@@ -75,6 +75,10 @@ enum WalletFlags : uint64_t {
 
     //! Indicates that the wallet needs an external signer
     WALLET_FLAG_EXTERNAL_SIGNER = (1ULL << 35),
+
+    //! Indicates that the wallet supports Silent Payments
+    //! This means a more complex scanning logic
+    WALLET_FLAG_SILENT_PAYMENT = (1ULL << 36),
 };
 
 //! Get the path of the wallet directory.

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -793,10 +793,10 @@ class RPCOverloadWrapper():
     def createwallet_passthrough(self, *args, **kwargs):
         return self.__getattr__("createwallet")(*args, **kwargs)
 
-    def createwallet(self, wallet_name, disable_private_keys=None, blank=None, passphrase='', avoid_reuse=None, descriptors=None, load_on_startup=None, external_signer=None):
+    def createwallet(self, wallet_name, disable_private_keys=None, blank=None, passphrase='', avoid_reuse=None, descriptors=None, load_on_startup=None, external_signer=None, silent_payment=None):
         if descriptors is None:
             descriptors = self.descriptors
-        return self.__getattr__('createwallet')(wallet_name, disable_private_keys, blank, passphrase, avoid_reuse, descriptors, load_on_startup, external_signer)
+        return self.__getattr__('createwallet')(wallet_name, disable_private_keys, blank, passphrase, avoid_reuse, descriptors, load_on_startup, external_signer, silent_payment)
 
     def importprivkey(self, privkey, label=None, rescan=None):
         wallet_info = self.getwalletinfo()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -104,6 +104,7 @@ BASE_SCRIPTS = [
     'feature_maxuploadtarget.py',
     'mempool_updatefromblock.py',
     'mempool_persist.py --descriptors',
+    'wallet_silentpayments_receiving.py',
     # vv Tests less than 60s vv
     'rpc_psbt.py --legacy-wallet',
     'rpc_psbt.py --descriptors',

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -146,6 +146,7 @@ BASE_SCRIPTS = [
     'wallet_listtransactions.py --legacy-wallet',
     'wallet_listtransactions.py --descriptors',
     # vv Tests less than 30s vv
+    'wallet_silentpayments_sending.py',
     'p2p_invalid_messages.py',
     'rpc_createmultisig.py',
     'p2p_timeouts.py',

--- a/test/functional/wallet_silentpayments_receiving.py
+++ b/test/functional/wallet_silentpayments_receiving.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.descriptors import descsum_create
+
+
+class SilentTransactioTest(BitcoinTestFramework):
+    def add_options(self, parser):
+        self.add_wallet_options(parser)
+
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 3
+        self.extra_args = [[], ["-txindex=1"], []]
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+        self.skip_if_no_sqlite()
+
+    def init_wallet(self, *, node):
+        pass
+
+    def create_silent_payments_wallet(self):
+
+        self.nodes[0].createwallet(wallet_name='sp', descriptors=True, silent_payment=True, blank=True)
+        sp_wallet = self.nodes[0].get_wallet_rpc('sp')
+        desc_str = "sp(cN6fC62XuB4gv3tu4tFnwtd72jTfT7Mezzhn7b8GSZKHTHZiBegX,cSrhaUv9F9pKyW812V4M2mcf5awrwFYX8RWUfcd9xqk2Co6Rr2bh)"
+        desc = [{"desc": descsum_create(desc_str), "active": True, "timestamp": "now", "internal": False}]
+        sp_wallet.importdescriptors(desc)
+        assert sp_wallet.getsilentaddress()["address"] == "sprt1qqfwvnptdd7ph2dgwzguh3k4vyqxzvr94kkhgxyrv4wgysnwd3l8nvq3qhnavtwv7qjk35pkalvqkacf4sfsf6c9k9y0f35q6n0y6zmyk6smx9ad8"
+
+    def run_test(self):
+        self.create_silent_payments_wallet()
+
+
+if __name__ == '__main__':
+    SilentTransactioTest().main()

--- a/test/functional/wallet_silentpayments_sending.py
+++ b/test/functional/wallet_silentpayments_sending.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+from test_framework.address import address_to_scriptpubkey
+from test_framework.blocktools import COINBASE_MATURITY
+from test_framework.descriptors import descsum_create
+from test_framework.messages import COIN
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_raises_rpc_error
+from test_framework.wallet import MiniWallet
+
+SILENT_PAYMENT_ADDRESS="sprt1qqtzwfsu4f34wejks0nxwzed3zq6vh53cg2rnxj9w6ncyrmy95dxx7qnvd47fskn470t9tl4z8a8nul5k3fztquqp4fjrarl7d5lphu7rk52s4hsp"
+
+
+class SilentTransactioTest(BitcoinTestFramework):
+    def add_options(self, parser):
+        self.add_wallet_options(parser)
+
+    def set_test_params(self):
+        self.num_nodes = 3
+        self.extra_args = [[], ["-txindex=1"], []]
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+        self.skip_if_no_sqlite()
+
+    def init_wallet(self, *, node):
+        pass
+
+    def watch_only_wallet_send(self):
+        self.log.info("Testing if a watch only wallet is not able to send silent transaction")
+        self.nodes[0].createwallet(wallet_name='watch_only_wallet', descriptors=True, disable_private_keys=True, blank=True)
+        watch_only_wallet = self.nodes[0].get_wallet_rpc('watch_only_wallet')
+        desc_import = [{
+            "desc": descsum_create("wpkh(tpubD6NzVbkrYhZ4YNXVQbNhMK1WqguFsUXceaVJKbmno2aZ3B6QfbMeraaYvnBSGpV3vxLyTTK9DYT1yoEck4XUScMzXoQ2U2oSmE2JyMedq3H/0/*)"),
+            "timestamp": "now",
+            "internal": False,
+            "active": True,
+            "keypool": True,
+            "range": [0, 100],
+            "watchonly": True,
+        }]
+        watch_only_wallet.importdescriptors(desc_import)
+        self.generatetoaddress(self.nodes[0], COINBASE_MATURITY + 10, watch_only_wallet.getnewaddress())
+        self.log.info("Watch-only wallets cannot send coins using silent_payment option")
+        assert_raises_rpc_error(
+                -4,
+                "Silent payments require access to private keys to build transactions.",
+                watch_only_wallet.sendtoaddress,
+                SILENT_PAYMENT_ADDRESS,
+                21,
+        )
+
+    def encrypted_wallet_send(self):
+        self.log.info("Testing if encrypted SP wallet")
+        self.nodes[0].createwallet(wallet_name='encrypted_wallet', descriptors=True, passphrase='passphrase')
+        encrypted_wallet = self.nodes[0].get_wallet_rpc('encrypted_wallet')
+        self.generatetoaddress(self.nodes[0], COINBASE_MATURITY + 10, encrypted_wallet.getnewaddress())
+        self.log.info("encrypted wallets must be able to send coins after decryption")
+        outputs = [{"bcrt1pk0yzk76w2p55ykyjyfeq99td069c257se9nwugl7cl5geadq944spyc330": 15}]
+
+        # send RPC can be run without decrypting the wallet and it must generate a incomplete PSBT
+        tx = encrypted_wallet.send(outputs=outputs, options={"add_to_wallet": False})
+        assert not tx['complete']
+
+        # but when silent_payment option is enabled, wallet must be decrypted
+        assert_raises_rpc_error(
+                -13,
+                "Please enter the wallet passphrase with walletpassphrase first.",
+                encrypted_wallet.sendtoaddress,
+                SILENT_PAYMENT_ADDRESS,
+                21,
+        )
+
+        encrypted_wallet.walletpassphrase('passphrase', 20)
+        txid = encrypted_wallet.sendtoaddress(
+            address=SILENT_PAYMENT_ADDRESS,
+            amount=21,
+        )
+        assert txid
+
+    def test_simple_send(self):
+        self.log.info("Testing a simple send")
+        self.nodes[0].createwallet(wallet_name="simple_send")
+        simple_send = self.nodes[0].get_wallet_rpc("simple_send")
+        self.generatetoaddress(self.nodes[0], COINBASE_MATURITY + 10, simple_send.getnewaddress())
+        txid = simple_send.sendtoaddress(
+            address=SILENT_PAYMENT_ADDRESS,
+            amount=21,
+        )
+        assert txid
+
+    def test_deterministic_send(self):
+
+        # set up and fund the funder wallet. we will use this wallet to create UTXOs
+        # at specific addresses in the sending wallet
+        # using miniwallet for determinism
+        funder = MiniWallet(self.nodes[0])
+
+        # set up the sender wallet
+        xprv1 = 'tprv8ZgxMBicQKsPevADjDCWsa6DfhkVXicu8NQUzfibwX2MexVwW4tCec5mXdCW8kJwkzBRRmAay1KZya4WsehVvjTGVW6JLqiqd8DdZ4xSg52'
+        descriptor = {"desc": descsum_create("wpkh(" + xprv1 + "/0h/0h/*h)"),
+                              "timestamp": "now",
+                              "active": True,
+                      }
+        self.nodes[1].createwallet("sending_wallet", descriptors=True)
+        sender = self.nodes[1].get_wallet_rpc("sending_wallet")
+        sender.importdescriptors([descriptor])
+
+        # fund the sender wallet with two utxos and mine a block
+        address_one = sender.getnewaddress()
+        address_two = sender.getnewaddress()
+        funder.send_to(from_node=self.nodes[0], scriptPubKey=address_to_scriptpubkey(address_one), amount=10 * COIN)
+        funder.send_to(from_node=self.nodes[0], scriptPubKey=address_to_scriptpubkey(address_two), amount=10 * COIN)
+        self.generate(self.nodes[0], 1)
+
+        # recipient address: generated with wallet seed hex `f00dbabe`
+        silent_payment_address = "sprt1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xcrdz399"
+        amount = 15.0
+        txid = sender.sendtoaddress(address=silent_payment_address, amount=amount)
+        tx = sender.getrawtransaction(txid, True)
+        for output in tx["vout"]:
+            if output["value"] == amount:
+                assert output["scriptPubKey"]["address"] == "bcrt1p5num3dvry0ffusg3s7v2j5fy025p95jtn6js65jlruwc69r9je2s6qfsj7"
+                break
+        else:
+            assert False
+
+    def test_address_reuse(self):
+        self.nodes[0].createwallet(wallet_name=f'miner_wallet', descriptors=True)
+        miner_wallet = self.nodes[0].get_wallet_rpc(f'miner_wallet')
+        self.generatetoaddress(self.nodes[0], COINBASE_MATURITY + 10, miner_wallet.getnewaddress())
+
+        self.nodes[0].createwallet(wallet_name=f'sender_wallet', descriptors=True)
+        sender_wallet = self.nodes[0].get_wallet_rpc(f'sender_wallet')
+        sender_address = sender_wallet.getnewaddress()
+
+        miner_wallet.send(outputs=[{sender_address: 5}])
+        miner_wallet.send(outputs=[{sender_address: 7}])
+
+        self.generate(self.nodes[0], 8, sync_fun=self.no_op)
+
+        silent_payment_address = "sprt1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xcrdz399"
+        txid1 = sender_wallet.sendtoaddress(address=silent_payment_address, amount=4)
+        txid2 = sender_wallet.sendtoaddress(address=silent_payment_address, amount=6)
+
+        output1 = ""
+        output2 = ""
+        for output in sender_wallet.getrawtransaction(txid1, True)["vout"]:
+            if output["value"] == 4.0:
+                output1 = output["scriptPubKey"]["address"]
+
+        for output in sender_wallet.getrawtransaction(txid2, True)["vout"]:
+            if output["value"] == 6.0:
+                output2 = output["scriptPubKey"]["address"]
+
+        assert output1 != output2
+
+    def run_test(self):
+        self.watch_only_wallet_send()
+        self.encrypted_wallet_send()
+        self.test_simple_send()
+        self.test_deterministic_send()
+        self.test_address_reuse()
+
+
+if __name__ == '__main__':
+    SilentTransactioTest().main()


### PR DESCRIPTION
## For reviewers

In an attempt to make reviewing a bit more sane, I'm breaking this up into a few smaller PRs, but will keep this one open as the parent PR and keep it rebased on the child PRs. The main purpose of having this PR is to track progress on child PRs and also have an easy way to compile `bitcoind` with both send and receive support for testing. Additionally, I'll be adding more functional tests to this PR since it's much easier to test when `bitcoind` can both send and receive.

## PRs

- [ ] https://github.com/bitcoin/bitcoin/pull/28122
  - Implements the logic from BIP352 without any wallet code. This PR adds the necessary cryptographic functions and implements the logic needed for sending and scanning. This PR also includes the test vectors from the BIP as unit tests. Both the send and receive PRs have this as a dependency. In terms of priority, this PR should be reviewed first
- [ ] https://github.com/bitcoin/bitcoin/pull/28201
  - Implements sending in the Bitcoin Core wallet. This PR allows a wallet to send to a silent payment address, regardless of whether or not the wallet can receive silent payments
  - Ready for review, but marked as a draft until dependencies are merged
- [ ] https://github.com/bitcoin/bitcoin/pull/28202
  - Implements receiving in the Bitcoin Core wallet. This PR allows a wallet to generate silent payment addresses and scan for silent payments, regardless of whether or not the wallet can send to a silent payment address
  - Ready for review but marked as a draft until dependencies are merged

For the silent payments specification, see https://github.com/bitcoin/bips/pull/1458

## Overall

This PR implements the full silent payments scheme: sending and receiving. The following items are not covered in this PR and are intended for follow-up PRs:

* Adding labels for the receiver wallet
* Full RPC coverage (only `sendtoaddress` and `sendmany` are covered in this PR)
* Light client support (vending the tweak data per block, either in an index or to serve to indexer, such as electrum server)
* Add benchmarks to validate that there are no DoS concerns for doing silent payment verification for transactions in the mempool
* External signer support (dependent on hardware wallets supporting silent payments)
* More unit / functional test coverage

## Major changes

This PR is a continuation of the work done in https://github.com/bitcoin/bitcoin/pull/24897. Below is a summary of the major changes:

* Remove labels
  * The original draft included labels, but this has been deferred for a later PR. Labels are not necessary for sending and receiving and there are still some open questions on how best to implement them in Bitcoin Core. Labels can also be added at any point by the receiver without requiring any changes from the sender
* Remove indexes
  * In the original draft, indexes were used when scanning for silent payments and when doing wallet rescans. This has been removed in favor of using `rev*.dat` files for rescanning. It may make sense to add an index in the future, but for the purpose of vending tweak data to light clients, which is still an open question
* Update to implement the most current version of BIP352
  * Since the original draft, there have been a few changes in the BIP which are reflected in the current PR. Most notably, using 33-byte compressed keys for the silent payment address (as opposed to X-only keys in the original draft) 

It may be helpful for context to read through the discussions on #24897 , but ongoing review should happen in the relevant child PRs listed above.