### PR TITLE
test: handle failed `assert_equal()` assertions in bcc callback functions

### DIFF
--- a/test/functional/interface_usdt_net.py
+++ b/test/functional/interface_usdt_net.py
@@ -116,13 +116,10 @@ class NetTracepointTest(BitcoinTestFramework):
                          fn_name="trace_outbound_message")
         bpf = BPF(text=net_tracepoints_program, usdt_contexts=[ctx], debug=0)
 
-        # The handle_* function is a ctypes callback function called from C. When
-        # we assert in the handle_* function, the AssertError doesn't propagate
-        # back to Python. The exception is ignored. We manually count and assert
-        # that the handle_* functions succeeded.
         EXPECTED_INOUTBOUND_VERSION_MSG = 1
         checked_inbound_version_msg = 0
         checked_outbound_version_msg = 0
+        events = []
 
         def check_p2p_message(event, inbound):
             nonlocal checked_inbound_version_msg, checked_outbound_version_msg
@@ -142,12 +139,13 @@ class NetTracepointTest(BitcoinTestFramework):
                     checked_outbound_version_msg += 1
 
         def handle_inbound(_, data, __):
+            nonlocal events
             event = ctypes.cast(data, ctypes.POINTER(P2PMessage)).contents
-            check_p2p_message(event, True)
+            events.append((event, True))
 
         def handle_outbound(_, data, __):
             event = ctypes.cast(data, ctypes.POINTER(P2PMessage)).contents
-            check_p2p_message(event, False)
+            events.append((event, False))
 
         bpf["inbound_messages"].open_perf_buffer(handle_inbound)
         bpf["outbound_messages"].open_perf_buffer(handle_outbound)
@@ -158,11 +156,14 @@ class NetTracepointTest(BitcoinTestFramework):
         bpf.perf_buffer_poll(timeout=200)
 
         self.log.info(
-            "check that we got both an inbound and outbound version message")
+            "check receipt and content of in- and outbound version messages")
+        for event, inbound in events:
+            check_p2p_message(event, inbound)
         assert_equal(EXPECTED_INOUTBOUND_VERSION_MSG,
                      checked_inbound_version_msg)
         assert_equal(EXPECTED_INOUTBOUND_VERSION_MSG,
                      checked_outbound_version_msg)
+
 
         bpf.cleanup()
 

--- a/test/functional/interface_usdt_utxocache.py
+++ b/test/functional/interface_usdt_utxocache.py
@@ -188,13 +188,16 @@ class UTXOCacheTracepointTest(BitcoinTestFramework):
             nonlocal handle_uncache_succeeds
             event = ctypes.cast(data, ctypes.POINTER(UTXOCacheChange)).contents
             self.log.info(f"handle_utxocache_uncache(): {event}")
-            assert_equal(block_1_coinbase_txid, bytes(event.txid[::-1]).hex())
-            assert_equal(0, event.index)  # prevout index
-            assert_equal(EARLY_BLOCK_HEIGHT, event.height)
-            assert_equal(50 * COIN, event.value)
-            assert_equal(True, event.is_coinbase)
-
-            handle_uncache_succeeds += 1
+            try:
+                assert_equal(block_1_coinbase_txid, bytes(event.txid[::-1]).hex())
+                assert_equal(0, event.index)  # prevout index
+                assert_equal(EARLY_BLOCK_HEIGHT, event.height)
+                assert_equal(50 * COIN, event.value)
+                assert_equal(True, event.is_coinbase)
+            except AssertionError:
+                self.log.exception("Assertion failed")
+            else:
+                handle_uncache_succeeds += 1
 
         bpf["utxocache_uncache"].open_perf_buffer(handle_utxocache_uncache)
 
@@ -260,24 +263,32 @@ class UTXOCacheTracepointTest(BitcoinTestFramework):
             event = ctypes.cast(data, ctypes.POINTER(UTXOCacheChange)).contents
             self.log.info(f"handle_utxocache_add(): {event}")
             add = expected_utxocache_adds.pop(0)
-            assert_equal(add["txid"], bytes(event.txid[::-1]).hex())
-            assert_equal(add["index"], event.index)
-            assert_equal(add["height"], event.height)
-            assert_equal(add["value"], event.value)
-            assert_equal(add["is_coinbase"], event.is_coinbase)
-            handle_add_succeeds += 1
+            try:
+                assert_equal(add["txid"], bytes(event.txid[::-1]).hex())
+                assert_equal(add["index"], event.index)
+                assert_equal(add["height"], event.height)
+                assert_equal(add["value"], event.value)
+                assert_equal(add["is_coinbase"], event.is_coinbase)
+            except AssertionError:
+                self.log.exception("Assertion failed")
+            else:
+                handle_add_succeeds += 1
 
         def handle_utxocache_spent(_, data, __):
             nonlocal handle_spent_succeeds
             event = ctypes.cast(data, ctypes.POINTER(UTXOCacheChange)).contents
             self.log.info(f"handle_utxocache_spent(): {event}")
             spent = expected_utxocache_spents.pop(0)
-            assert_equal(spent["txid"], bytes(event.txid[::-1]).hex())
-            assert_equal(spent["index"], event.index)
-            assert_equal(spent["height"], event.height)
-            assert_equal(spent["value"], event.value)
-            assert_equal(spent["is_coinbase"], event.is_coinbase)
-            handle_spent_succeeds += 1
+            try:
+                assert_equal(spent["txid"], bytes(event.txid[::-1]).hex())
+                assert_equal(spent["index"], event.index)
+                assert_equal(spent["height"], event.height)
+                assert_equal(spent["value"], event.value)
+                assert_equal(spent["is_coinbase"], event.is_coinbase)
+            except AssertionError:
+                self.log.exception("Assertion failed")
+            else:
+                handle_spent_succeeds += 1
 
         bpf["utxocache_add"].open_perf_buffer(handle_utxocache_add)
         bpf["utxocache_spent"].open_perf_buffer(handle_utxocache_spent)

--- a/test/functional/interface_usdt_validation.py
+++ b/test/functional/interface_usdt_validation.py
@@ -85,13 +85,10 @@ class ValidationTracepointTest(BitcoinTestFramework):
                     self.sigops,
                     self.duration)
 
-        # The handle_* function is a ctypes callback function called from C. When
-        # we assert in the handle_* function, the AssertError doesn't propagate
-        # back to Python. The exception is ignored. We manually count and assert
-        # that the handle_* functions succeeded.
         BLOCKS_EXPECTED = 2
         blocks_checked = 0
         expected_blocks = dict()
+        events = []
 
         self.log.info("hook into the validation:block_connected tracepoint")
         ctx = USDT(pid=self.nodes[0].process.pid)
@@ -101,19 +98,10 @@ class ValidationTracepointTest(BitcoinTestFramework):
                   usdt_contexts=[ctx], debug=0)
 
         def handle_blockconnected(_, data, __):
-            nonlocal expected_blocks, blocks_checked
+            nonlocal events, blocks_checked
             event = ctypes.cast(data, ctypes.POINTER(Block)).contents
             self.log.info(f"handle_blockconnected(): {event}")
-            block_hash = bytes(event.hash[::-1]).hex()
-            block = expected_blocks[block_hash]
-            assert_equal(block["hash"], block_hash)
-            assert_equal(block["height"], event.height)
-            assert_equal(len(block["tx"]), event.transactions)
-            assert_equal(len([tx["vin"] for tx in block["tx"]]), event.inputs)
-            assert_equal(0, event.sigops)  # no sigops in coinbase tx
-            # only plausibility checks
-            assert event.duration > 0
-            del expected_blocks[block_hash]
+            events.append(event)
             blocks_checked += 1
 
         bpf["block_connected"].open_perf_buffer(
@@ -126,11 +114,23 @@ class ValidationTracepointTest(BitcoinTestFramework):
             expected_blocks[block_hash] = self.nodes[0].getblock(block_hash, 2)
 
         bpf.perf_buffer_poll(timeout=200)
-        bpf.cleanup()
 
-        self.log.info(f"check that we traced {BLOCKS_EXPECTED} blocks")
+        self.log.info(f"check that we correctly traced {BLOCKS_EXPECTED} blocks")
+        for event in events:
+            block_hash = bytes(event.hash[::-1]).hex()
+            block = expected_blocks[block_hash]
+            assert_equal(block["hash"], block_hash)
+            assert_equal(block["height"], event.height)
+            assert_equal(len(block["tx"]), event.transactions)
+            assert_equal(len([tx["vin"] for tx in block["tx"]]), event.inputs)
+            assert_equal(0, event.sigops)  # no sigops in coinbase tx
+            # only plausibility checks
+            assert event.duration > 0
+            del expected_blocks[block_hash]
         assert_equal(BLOCKS_EXPECTED, blocks_checked)
         assert_equal(0, len(expected_blocks))
+
+        bpf.cleanup()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Address #27380 (and similar future issues) by handling failed `assert_equal()` assertions in bcc callback functions   

### Problem

Exceptions are not propagated in ctype callback functions used by bcc. This means an AssertionError exception raised by `assert_equal()` to signal a failed assertion is not getting caught and properly logged. Instead, the error is logged to stdout and execution of the callback stops.

The current workaround to check whether all `assert_equal()` assertions in a callback succeeded is to increment a success counter after the assertions (which only gets incremented if none exception is raised and stops execution). Then, outside the callback, the success counter can be used to check whether a callback executed successfully.

One issue with the described workaround is that when an exception occurs, there is no way of telling which of the `assert_equal()` statements caused the exception; moreover, there is no way of inspecting how the pieces of data that got compared in `assert_equal()` differed (often a crucial clue when debugging what went wrong).

This problem is happening in #27380: Sporadically, in the `mempool:rejected` test, execution does not reach the end of the callback function and the success counter is not incremented. Thus, the test fails when comparing the counter to its expected value of one. Without knowing which of the asserts failed any why it failed, this issue is hard to debug.

### Solution

Two fixes come to mind. The first involves having the callback function make event data accessible outside the callback and inspecting the event using `assert_equal()` outside the callback. This solution still requires a counter in the callback in order  to tell whether a callback was actually executed or if instead the call to perf_buffer_poll() timed out.

The second fix entails wrapping all relevant `assert_equal()` statements inside callback functions into try-catch blocks and manually logging AssertionErrors. While not as elegant in terms of design, this approach can be more pragmatic for more complex tests (e.g., ones involving multiple events, events of different types, or the order of events).

The solution proposed here is to select the most pragmatic fix on a case-by-case basis: Tests in `interface_usdt_net.py`, `interface_usdt_mempool.py` and `interface_usdt_validation.py` have been refactored to use the first approach, while the second approach was chosen for `interface_usdt_utxocache.py` (partly to provide a reference for the second approach, but mainly because the utxocache tests are the most intricate tests, and refactoring them to use the first approach would negatively impact their readability). Lastly, `interface_usdt_coinselection.py` was kept unchanged because it does not use `assert_equal()` statements inside callback functions.
