### PR TITLE
ci: Nuke Android APK task, Use credits for tsan

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -248,6 +248,7 @@ task:
     docker_arguments:
       CI_IMAGE_NAME_TAG: ubuntu:lunar
       FILE_ENV: "./ci/test/00_setup_env_native_tsan.sh"
+  << : *CREDITS_TEMPLATE
   env:
     << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
 
@@ -348,21 +349,3 @@ task:
     CI_USE_APT_INSTALL: "no"
     PACKAGE_MANAGER_INSTALL: "echo"  # Nothing to do
     FILE_ENV: "./ci/test/00_setup_env_mac_native_arm64.sh"
-
-task:
-  name: 'ARM64 Android APK [jammy]'
-  << : *CONTAINER_DEPENDS_TEMPLATE
-  container:
-    docker_arguments:
-      CI_IMAGE_NAME_TAG: ubuntu:jammy
-      FILE_ENV: "./ci/test/00_setup_env_android.sh"
-  << : *CREDITS_TEMPLATE
-  android_sdk_cache:
-    folder: "depends/SDKs/android"
-    fingerprint_key: "ANDROID_API_LEVEL=28 ANDROID_BUILD_TOOLS_VERSION=28.0.3 ANDROID_NDK_VERSION=23.2.8568313"
-  depends_sources_cache:
-    folder: "depends/sources"
-    fingerprint_script: git rev-parse HEAD:depends/packages
-  << : *MAIN_TEMPLATE
-  env:
-    << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV


### PR DESCRIPTION
The Android task has many issues:

* It runs into more network timeouts (intermittent failures) than other tasks
* It never failed since its introduction years ago in a scenario where all other tasks passed, thus it is useless (so far)

Fix all issues by removing the task. Note that the CI env file is kept, so anyone can still run the Android CI.

Also, use the compute credits to promote tsan, a more useful task.