### PR TITLE
doc: clarify full Xcode download is not needed

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -24,6 +24,9 @@ To install, run the following command from your terminal:
 xcode-select --install
 ```
 
+The above command should work on a fresh macOS installation. It is not necessary
+to download and install the full Xcode suite from the App Store.
+
 Upon running the command, you should see a popup appear.
 Click on `Install` to continue the installation process.
 


### PR DESCRIPTION
Some people keep thinking that you need to download the full 4GB of Xcode before running `xcode-select`. However `xcode-select` is already present on any freshly installed macOS. 