### PR TITLE
rpc: getblockfrompeer, introduce fetch from "any" functionality

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -800,6 +800,22 @@ public:
         }
     };
 
+    /**
+     * Loop over nodes until the provided 'func(node)' return false.
+     * @param[in] func the stop function.
+     * @param[in] random_access whether nodes should be accessed in-order or shuffled first.
+     */
+    void ForEachNodeContinueIf(const std::function<bool(CNode*)>& func, bool random_access = false)
+    {
+        LOCK(m_nodes_mutex);
+        std::vector<CNode*> nodes = m_nodes;
+        if (random_access) Shuffle(nodes.begin(), nodes.end(), FastRandomContext());
+        for (auto&& node : nodes) {
+            if (NodeFullyConnected(node))
+                if (!func(node)) break;
+        }
+    };
+
     // Addrman functions
     /**
      * Return all or many randomly selected addresses, optionally by network.

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -52,11 +52,11 @@ public:
     /**
      * Attempt to manually fetch block from a given peer. We must already have the header.
      *
-     * @param[in]  peer_id      The peer id
+     * @param[in]  op_peer_id   The peer id (std::nullopt is equivalent to "any peer")
      * @param[in]  block_index  The blockindex
      * @returns the peer id if a request was successfully made, otherwise an error message
      */
-    virtual util::Result<NodeId> FetchBlock(NodeId peer_id, const CBlockIndex& block_index) = 0;
+    virtual util::Result<NodeId> FetchBlock(std::optional<NodeId> op_peer_id, const CBlockIndex& block_index) = 0;
 
     /** Begin running background tasks, should only be called once */
     virtual void StartScheduledTasks(CScheduler& scheduler) = 0;

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -7,6 +7,7 @@
 #define BITCOIN_NET_PROCESSING_H
 
 #include <net.h>
+#include <util/result.h>
 #include <validationinterface.h>
 
 class AddrMan;
@@ -53,9 +54,9 @@ public:
      *
      * @param[in]  peer_id      The peer id
      * @param[in]  block_index  The blockindex
-     * @returns std::nullopt if a request was successfully made, otherwise an error message
+     * @returns the peer id if a request was successfully made, otherwise an error message
      */
-    virtual std::optional<std::string> FetchBlock(NodeId peer_id, const CBlockIndex& block_index) = 0;
+    virtual util::Result<NodeId> FetchBlock(NodeId peer_id, const CBlockIndex& block_index) = 0;
 
     /** Begin running background tasks, should only be called once */
     virtual void StartScheduledTasks(CScheduler& scheduler) = 0;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -432,12 +432,16 @@ static RPCHelpMan getblockfrompeer()
         "Peers generally ignore requests for a stale block that they never fully verified, or one that is more than a month old.\n"
         "When a peer does not respond with a block, we will disconnect.\n"
         "Note: The block could be re-pruned as soon as it is received.\n\n"
-        "Returns an empty JSON object if the request was successfully scheduled.",
+        "Returns the peer id we are requesting the block from if the request was successfully scheduled.",
         {
             {"blockhash", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The block hash to try to fetch"},
             {"peer_id", RPCArg::Type::NUM, RPCArg::Optional::NO, "The peer to fetch it from (see getpeerinfo for peer IDs)"},
         },
-        RPCResult{RPCResult::Type::OBJ, "", /*optional=*/false, "", {}},
+        RPCResult{
+            RPCResult::Type::OBJ, "", "",
+            {
+                {RPCResult::Type::NUM, "peer_id", "The id of the peer from where the block is being fetched"},
+            }},
         RPCExamples{
             HelpExampleCli("getblockfrompeer", "\"00000000c937983704a73af28acdec37b049d214adbda81d7e2a3dd146f6ed09\" 0")
             + HelpExampleRpc("getblockfrompeer", "\"00000000c937983704a73af28acdec37b049d214adbda81d7e2a3dd146f6ed09\" 0")
@@ -468,10 +472,14 @@ static RPCHelpMan getblockfrompeer()
         throw JSONRPCError(RPC_MISC_ERROR, "Block already downloaded");
     }
 
-    if (const auto err{peerman.FetchBlock(peer_id, *index)}) {
-        throw JSONRPCError(RPC_MISC_ERROR, err.value());
+    if (const auto& op_res{peerman.FetchBlock(peer_id, *index)}) {
+        UniValue ret(UniValue::VOBJ);
+        ret.pushKV("peer_id", *op_res);
+        return ret;
+    } else {
+        // Error out
+        throw JSONRPCError(RPC_MISC_ERROR, util::ErrorString(op_res).original);
     }
-    return UniValue::VOBJ;
 },
     };
 }

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -435,7 +435,8 @@ static RPCHelpMan getblockfrompeer()
         "Returns the peer id we are requesting the block from if the request was successfully scheduled.",
         {
             {"blockhash", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The block hash to try to fetch"},
-            {"peer_id", RPCArg::Type::NUM, RPCArg::Optional::NO, "The peer to fetch it from (see getpeerinfo for peer IDs)"},
+            {"peer_id", RPCArg::Type::NUM, RPCArg::Optional::OMITTED, "The peer to fetch it from (see getpeerinfo for peer IDs). "
+                                                                      "If omitted, the node will fetch the block from any available peer."},
         },
         RPCResult{
             RPCResult::Type::OBJ, "", "",
@@ -453,7 +454,7 @@ static RPCHelpMan getblockfrompeer()
     PeerManager& peerman = EnsurePeerman(node);
 
     const uint256& block_hash{ParseHashV(request.params[0], "blockhash")};
-    const NodeId peer_id{request.params[1].getInt<int64_t>()};
+    const std::optional<NodeId> peer_id = request.params[1].isNull() ? std::nullopt : std::make_optional(request.params[1].getInt<int64_t>());
 
     const CBlockIndex* const index = WITH_LOCK(cs_main, return chainman.m_blockman.LookupBlockIndex(block_hash););
 

--- a/src/util/result.h
+++ b/src/util/result.h
@@ -16,6 +16,10 @@ struct Error {
     bilingual_str message;
 };
 
+static inline Error ErrorUntranslated(const std::string& err) {
+    return Error{Untranslated(err)};
+}
+
 //! The util::Result class provides a standard way for functions to return
 //! either error messages or result values.
 //!

--- a/test/functional/rpc_getblockfrompeer.py
+++ b/test/functional/rpc_getblockfrompeer.py
@@ -88,7 +88,7 @@ class GetBlockFromPeerTest(BitcoinTestFramework):
         self.log.info("Successful fetch")
         result = self.nodes[0].getblockfrompeer(short_tip, peer_0_peer_1_id)
         self.wait_until(lambda: self.check_for_block(node=0, hash=short_tip), timeout=1)
-        assert_equal(result, {})
+        assert_equal(result["peer_id"], peer_0_peer_1_id)
 
         self.log.info("Don't fetch blocks we already have")
         assert_raises_rpc_error(-1, "Block already downloaded", self.nodes[0].getblockfrompeer, short_tip, peer_0_peer_1_id)
@@ -137,7 +137,7 @@ class GetBlockFromPeerTest(BitcoinTestFramework):
         pruned_node_peer_0_id = peers[0]["id"]
         result = pruned_node.getblockfrompeer(pruned_block, pruned_node_peer_0_id)
         self.wait_until(lambda: self.check_for_block(node=2, hash=pruned_block), timeout=1)
-        assert_equal(result, {})
+        assert_equal(result["peer_id"], pruned_node_peer_0_id)
 
         self.log.info("Fetched block persists after next pruning event")
         self.generate(self.nodes[0], 250, sync_fun=self.no_op)

--- a/test/functional/rpc_getblockfrompeer.py
+++ b/test/functional/rpc_getblockfrompeer.py
@@ -10,6 +10,7 @@ from test_framework.messages import (
     from_hex,
     msg_headers,
     NODE_WITNESS,
+    NODE_NETWORK_LIMITED
 )
 from test_framework.p2p import (
     P2P_SERVICES,
@@ -151,6 +152,19 @@ class GetBlockFromPeerTest(BitcoinTestFramework):
         pruneheight += 250
         assert_equal(pruned_node.pruneblockchain(1000), pruneheight)
         assert_raises_rpc_error(-1, "Block not available (pruned data)", pruned_node.getblock, pruned_block)
+
+        ######################################################
+        # Test reject fetching old block from a limited peer #
+        ######################################################
+
+        self.log.info("Test reject fetching old block from limited peer")
+        pruned_node.add_p2p_connection(P2PInterface(), services=NODE_NETWORK_LIMITED | NODE_WITNESS)
+        limited_peer_id = next(peer for peer in pruned_node.getpeerinfo() if peer["servicesnames"] == ['WITNESS', 'NETWORK_LIMITED'])["id"]
+
+        pruned_block_10 = self.nodes[0].getblockhash(10)
+        assert_raises_rpc_error(-1, "Cannot fetch old block from a limited peer", pruned_node.getblockfrompeer, pruned_block_10, limited_peer_id)
+
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Coming from #27652. Implementing the first part of it.

The idea is to let users call `getblockfrompeer` without providing any peer id.
The node will internally select one peer at random and make the `getdata` request.

This also fixes a bug where the user is allowed to call `getblockfrompeer` providing
an id of a peer that signals a "limited" service. As limited peers cannot provide historical
blocks, it is not correct to allow the user to do that.