### PR TITLE
net: introduce block tracker to retry to download blocks after failure

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -105,6 +105,7 @@ add_library(bitcoin_common STATIC EXCLUDE_FROM_ALL
   addresstype.cpp
   base58.cpp
   bech32.cpp
+  blockrequesttracker.cpp
   chainparams.cpp
   chainparamsbase.cpp
   coins.cpp

--- a/src/blockrequesttracker.cpp
+++ b/src/blockrequesttracker.cpp
@@ -1,0 +1,90 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+#include <blockrequesttracker.h>
+
+template <typename T, typename V>
+static bool Contain(const T& t, const V& value) { return std::find(t.begin(), t.end(), value) != t.end(); }
+
+bool BlockRequestTracker::track(const uint256& block_hash, std::optional<NodeId> peer_id)
+{
+    LOCK(cs_block_tracker);
+    auto it = m_tracked_blocks.emplace(block_hash, BlockRequest{});
+    if (!it.second) return false; // block already tracked
+
+    if (peer_id) {
+        // Add in-flight request
+        BlockRequest& req = it.first->second;
+        if (std::find(req.in_flight.begin(), req.in_flight.end(), *peer_id) != req.in_flight.end()) {
+            return false; // Already existent request
+        }
+        req.in_flight.emplace_back(*peer_id);
+    } else {
+        // Add block to pending list
+        m_pending.emplace_back(it.first);
+    }
+    return true;
+}
+
+void BlockRequestTracker::untrack_internal(const uint256& block_hash)
+{
+    auto it = m_tracked_blocks.find(block_hash);
+    if (it == m_tracked_blocks.end()) return;
+    auto pending_it = std::remove(m_pending.begin(), m_pending.end(), it);
+    if (pending_it != m_pending.end()) m_pending.erase(pending_it);
+    m_tracked_blocks.erase(it);
+}
+
+void BlockRequestTracker::untrack(const uint256& block_hash)
+{
+    LOCK(cs_block_tracker);
+    untrack_internal(block_hash);
+}
+
+void BlockRequestTracker::untrack_request(NodeId peer_id, const uint256& block_hash)
+{
+    LOCK(cs_block_tracker);
+    // Get tracked block request
+    const auto& it = m_tracked_blocks.find(block_hash);
+    if (it == m_tracked_blocks.end()) return;
+
+    // Check if we were waiting for this peer
+    BlockRequest& request = it->second;
+    auto remove_it = std::remove(request.in_flight.begin(), request.in_flight.end(), peer_id);
+    if (remove_it == request.in_flight.end()) return;
+
+    // Clear request
+    request.in_flight.erase(remove_it);
+
+    // And add it to the pending vector if there are no other inflight request for this block
+    if (request.in_flight.empty() && !Contain(m_pending, it)) {
+        m_pending.emplace_back(it);
+    }
+}
+
+void BlockRequestTracker::for_pending(NodeId peer_id, const std::function<ForPendingStatus(const uint256&)>& check)
+{
+    LOCK(cs_block_tracker);
+
+    for (auto it = m_pending.begin(); it != m_pending.end();) {
+        const auto& pending = *it;
+        switch(check(pending->first)) {
+            case ForPendingStatus::POP: {
+                BlockRequest& request = pending->second;
+                request.in_flight.emplace_back(peer_id);
+                it = m_pending.erase(it);
+                break;
+            }
+            case ForPendingStatus::SKIP:
+                ++it;
+                break;
+            case ForPendingStatus::STOP:
+                return;
+            case ForPendingStatus::CANCEL:
+                untrack_internal(pending->first);
+                ++it;
+                break;
+        }
+    }
+}

--- a/src/blockrequesttracker.h
+++ b/src/blockrequesttracker.h
@@ -1,0 +1,71 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_BLOCKREQUESTTRACKER_H
+#define BITCOIN_BLOCKREQUESTTRACKER_H
+
+#include <chain.h>
+#include <net.h>
+#include <serialize.h>
+#include <util/hasher.h>
+
+#include <list>
+
+/**
+ * Structure in charge of tracking single blocks download progress.
+ * For now, only used to track blocks that aren't part of the automatic download process.
+ */
+class BlockRequestTracker
+{
+private:
+    struct BlockRequest {
+        // The in-flight request vector (preserving insertion order).
+        // Could be empty if:
+        // 1) peer failed to provide us the block and got disconnected.
+        // 2) if there are no available peers to request the block from.
+        // And, only when this is empty, 'm_pending' will contain an entry pointing
+        // to this structure. Which can be assigned to a peer by calling 'pop_pending()'.
+        std::vector<NodeId> in_flight;
+
+        explicit BlockRequest() {}
+    };
+
+    Mutex cs_block_tracker;
+    // The blocks we are tracking
+    using BlockTrackMap = std::unordered_map<uint256, BlockRequest, BlockHasher>;
+    BlockTrackMap m_tracked_blocks GUARDED_BY(cs_block_tracker);
+    // Block requests waiting for getdata submission
+    std::list<BlockTrackMap::iterator> m_pending;
+
+    void untrack_internal(const uint256& block_hash) EXCLUSIVE_LOCKS_REQUIRED(cs_block_tracker);
+
+public:
+
+    /**
+     * Add block to the tracking list.
+     * Returns false when block is already tracked or when request is
+     * already in-flight for 'peer_id'.
+     */
+    bool track(const uint256& block_hash, std::optional<NodeId> peer_id) EXCLUSIVE_LOCKS_REQUIRED(!cs_block_tracker);
+
+    /** Stop tracking the block */
+    void untrack(const uint256& block_hash) EXCLUSIVE_LOCKS_REQUIRED(!cs_block_tracker);
+
+    /** Remove request made to peer_id */
+    void untrack_request(NodeId peer_id, const uint256& block_hash) EXCLUSIVE_LOCKS_REQUIRED(!cs_block_tracker);
+
+    /**
+     * Try to pop pending requests and assign them to a certain peer.
+     * The node must send the getdata request after acquiring the pending request.
+     */
+    enum class ForPendingStatus {
+        POP,    // Mark the current pending request as in-flight.
+        SKIP,   // Skip the current pending request.
+        STOP,   // Stop traversing the pending list.
+        CANCEL  // Untrack the request. Remove it from the tracking list.
+    };
+    void for_pending(NodeId peer_id, const std::function<ForPendingStatus(const uint256&)>& check) EXCLUSIVE_LOCKS_REQUIRED(!cs_block_tracker);
+};
+
+#endif // BITCOIN_BLOCKREQUESTTRACKER_H

--- a/src/blockrequesttracker.h
+++ b/src/blockrequesttracker.h
@@ -47,7 +47,7 @@ public:
      * Returns false when block is already tracked or when request is
      * already in-flight for 'peer_id'.
      */
-    bool track(const uint256& block_hash, std::optional<NodeId> peer_id) EXCLUSIVE_LOCKS_REQUIRED(!cs_block_tracker);
+    bool track(const uint256& block_hash, std::optional<NodeId> peer_id=std::nullopt) EXCLUSIVE_LOCKS_REQUIRED(!cs_block_tracker);
 
     /** Stop tracking the block */
     void untrack(const uint256& block_hash) EXCLUSIVE_LOCKS_REQUIRED(!cs_block_tracker);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2050,9 +2050,6 @@ std::optional<std::string> PeerManagerImpl::FetchBlock(NodeId peer_id, const CBl
 
     LOCK(cs_main);
 
-    // Forget about all prior requests
-    RemoveBlockRequest(block_index.GetBlockHash(), std::nullopt);
-
     // Mark block as in-flight
     if (!BlockRequested(peer_id, block_index)) return "Already requested from this peer";
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2045,6 +2045,9 @@ std::optional<std::string> PeerManagerImpl::FetchBlock(NodeId peer_id, const CBl
     // Ignore pre-segwit peers
     if (!CanServeWitnesses(*peer)) return "Pre-SegWit peer";
 
+    // Ignore limited peers
+    if (IsLimitedPeer(*peer) && m_best_height - block_index.nHeight > int{NODE_NETWORK_LIMITED_MIN_BLOCKS}) return "Cannot fetch block from a limited peer";
+
     LOCK(cs_main);
 
     // Forget about all prior requests

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -92,7 +92,7 @@ public:
      * @param[in]  block_index  The blockindex
      * @returns std::nullopt if a request was successfully made, otherwise an error message
      */
-    virtual std::optional<std::string> FetchBlock(std::optional<NodeId> op_peer_id, const CBlockIndex& block_index) = 0;
+    virtual std::optional<std::string> FetchBlock(std::optional<NodeId> op_peer_id, const CBlockIndex& block_index, bool retry) = 0;
 
     /** Begin running background tasks, should only be called once */
     virtual void StartScheduledTasks(CScheduler& scheduler) = 0;

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -88,11 +88,11 @@ public:
     /**
      * Attempt to manually fetch block from a given peer. We must already have the header.
      *
-     * @param[in]  peer_id      The peer id
+     * @param[in]  op_peer_id   The peer id (std::nullopt is equivalent to "any peer")
      * @param[in]  block_index  The blockindex
      * @returns std::nullopt if a request was successfully made, otherwise an error message
      */
-    virtual std::optional<std::string> FetchBlock(NodeId peer_id, const CBlockIndex& block_index) = 0;
+    virtual std::optional<std::string> FetchBlock(std::optional<NodeId> op_peer_id, const CBlockIndex& block_index) = 0;
 
     /** Begin running background tasks, should only be called once */
     virtual void StartScheduledTasks(CScheduler& scheduler) = 0;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -459,7 +459,8 @@ static RPCHelpMan getblockfrompeer()
         "Returns an empty JSON object if the request was successfully scheduled.",
         {
             {"blockhash", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The block hash to try to fetch"},
-            {"peer_id", RPCArg::Type::NUM, RPCArg::Optional::NO, "The peer to fetch it from (see getpeerinfo for peer IDs)"},
+            {"peer_id", RPCArg::Type::NUM, RPCArg::Optional::OMITTED, "The peer to fetch it from (see getpeerinfo for peer IDs). "
+                                                                      "If omitted, the node will fetch the block from any available peer."},
         },
         RPCResult{RPCResult::Type::OBJ, "", /*optional=*/false, "", {}},
         RPCExamples{
@@ -473,7 +474,7 @@ static RPCHelpMan getblockfrompeer()
     PeerManager& peerman = EnsurePeerman(node);
 
     const uint256& block_hash{ParseHashV(request.params[0], "blockhash")};
-    const NodeId peer_id{request.params[1].getInt<int64_t>()};
+    const std::optional<NodeId> peer_id = request.params[1].isNull() ? std::nullopt : std::make_optional(request.params[1].getInt<int64_t>());
 
     const CBlockIndex* const index = WITH_LOCK(cs_main, return chainman.m_blockman.LookupBlockIndex(block_hash););
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -461,6 +461,8 @@ static RPCHelpMan getblockfrompeer()
             {"blockhash", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The block hash to try to fetch"},
             {"peer_id", RPCArg::Type::NUM, RPCArg::Optional::OMITTED, "The peer to fetch it from (see getpeerinfo for peer IDs). "
                                                                       "If omitted, the node will fetch the block from any available peer."},
+            {"retry", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED, "Whether to automatically retry to download the block from different peers if the initial request fails or not. "
+                                                                      "If omitted, the node will continuously attempt to download the block from various peers until it succeeds."},
         },
         RPCResult{RPCResult::Type::OBJ, "", /*optional=*/false, "", {}},
         RPCExamples{
@@ -475,6 +477,8 @@ static RPCHelpMan getblockfrompeer()
 
     const uint256& block_hash{ParseHashV(request.params[0], "blockhash")};
     const std::optional<NodeId> peer_id = request.params[1].isNull() ? std::nullopt : std::make_optional(request.params[1].getInt<int64_t>());
+    const bool retry = !request.params[2].isNull() ? request.params[2].get_bool() : true; // default true
+    if (!retry && !peer_id) throw JSONRPCError(RPC_INVALID_PARAMETER, "Cannot disable the 'retry' process without specifying a peer from which the block will be downloaded ('peer_id')");
 
     const CBlockIndex* const index = WITH_LOCK(cs_main, return chainman.m_blockman.LookupBlockIndex(block_hash););
 
@@ -493,7 +497,7 @@ static RPCHelpMan getblockfrompeer()
         throw JSONRPCError(RPC_MISC_ERROR, "Block already downloaded");
     }
 
-    if (const auto err{peerman.FetchBlock(peer_id, *index)}) {
+    if (const auto err{peerman.FetchBlock(peer_id, *index, retry)}) {
         throw JSONRPCError(RPC_MISC_ERROR, err.value());
     }
     return UniValue::VOBJ;

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -65,6 +65,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "getbalance", 2, "include_watchonly" },
     { "getbalance", 3, "avoid_reuse" },
     { "getblockfrompeer", 1, "peer_id" },
+    { "getblockfrompeer", 2, "retry" },
     { "getblockhash", 0, "height" },
     { "waitforblockheight", 0, "height" },
     { "waitforblockheight", 1, "timeout" },

--- a/test/functional/rpc_getblockfrompeer.py
+++ b/test/functional/rpc_getblockfrompeer.py
@@ -10,6 +10,7 @@ from test_framework.messages import (
     from_hex,
     msg_headers,
     NODE_WITNESS,
+    NODE_NETWORK_LIMITED
 )
 from test_framework.p2p import (
     P2P_SERVICES,
@@ -151,6 +152,19 @@ class GetBlockFromPeerTest(BitcoinTestFramework):
         pruneheight += 250
         assert_equal(pruned_node.pruneblockchain(1000), pruneheight)
         assert_raises_rpc_error(-1, "Block not available (pruned data)", pruned_node.getblock, pruned_block)
+
+        ######################################################
+        # Test reject fetching old block from a limited peer #
+        ######################################################
+
+        self.log.info("Test reject fetching old block from limited peer")
+        pruned_node.add_p2p_connection(P2PInterface(), services=NODE_NETWORK_LIMITED | NODE_WITNESS)
+        limited_peer_id = pruned_node.getpeerinfo()[-1]["id"]  # last connection
+
+        pruned_block_10 = self.nodes[0].getblockhash(10)
+        assert_raises_rpc_error(-1, "Cannot fetch block from a limited peer", pruned_node.getblockfrompeer, pruned_block_10, limited_peer_id)
+
+
 
 
 if __name__ == '__main__':

--- a/test/functional/rpc_getblockfrompeer.py
+++ b/test/functional/rpc_getblockfrompeer.py
@@ -202,6 +202,23 @@ class GetBlockFromPeerTest(BitcoinTestFramework):
         # Now verify that the block was requested and received from another peer after the initial failure
         self.wait_until(lambda: self.check_for_block(node=2, hash=pruned_block_15), timeout=3)
 
+        #######################################
+        # Test fetching block from "any" peer #
+        #######################################
+
+        self.log.info("Fetch block from \"any\" peer")
+        # Disconnect only connection that can provide the block
+        self.disconnect_nodes(0, 2)
+        self.disconnect_nodes(1, 2)
+
+        # Try to fetch the block from "any" peer. When there is no available peer
+        result = pruned_node.getblockfrompeer(pruned_block_10)
+        assert_equal(result, {})
+
+        # Now connect the full node. The node should automatically request the missing block
+        self.connect_nodes(0, 2)
+        self.wait_until(lambda: self.check_for_block(node=2, hash=pruned_block_10), timeout=5)
+
 
 if __name__ == '__main__':
     GetBlockFromPeerTest(__file__).main()


### PR DESCRIPTION
Coming from #27652, part of #29183.

The general idea is to keep track of the user requested blocks so, in
case of a bad behaving peer or a network disconnection, they can be
fetched from another one automatically without any further user interaction.

This was requested by users because the `getblockfrompeer` RPC command
lacks the functionality to notify them about block request failures or peer
disconnections (which is expected due to the asynchronous nature of the block
requests).

Currently, this new functionality is limited to blocks requested by the
user via the 'getblockfrompeer' RPC command.

In the future, this class could expand its scope and be utilized in the
regular chain synchronization process. Or, even could be employed in
special procedures like a prune node rescan that uses BIP158 block filters,
or even into BIP157 itself.