### PR TITLE
contrib: docs fix --import-keys flag on verify.py

### DIFF
--- a/contrib/verify-binaries/README.md
+++ b/contrib/verify-binaries/README.md
@@ -17,7 +17,7 @@ must obtain that key for your local GPG installation.
 You can obtain these keys by
   - through a browser using a key server (e.g. keyserver.ubuntu.com),
   - manually using the `gpg --keyserver <url> --recv-keys <key>` command, or
-  - you can run the packaged `verify.py ... --import-keys` script to
+  - you can run the packaged `verify.py --import-keys ...` script to
     have it automatically retrieve unrecognized keys.
 
 #### Usage


### PR DESCRIPTION
When trying to run `./contrib/verify-binaries/verify.py` with the --import-keys flag, I figured that there was a little mistake in the docs. It stated that the `--import-keys` flag has to be provided after the arguments, instead of before. It was stated correctly in the rest of the README, but not in this particular case.

I tested this on macOS 13.4 as well as on Debian 10.