### PR TITLE
ci: Use podman stop over podman kill

### DIFF
--- a/ci/test/04_install.sh
+++ b/ci/test/04_install.sh
@@ -42,7 +42,7 @@ if [ -z "$DANGER_RUN_CI_ON_HOST" ]; then
 
   if [ -n "${RESTART_CI_DOCKER_BEFORE_RUN}" ] ; then
     echo "Restart docker before run to stop and clear all containers started with --rm"
-    podman container kill --all  # Similar to "systemctl restart docker"
+    podman container stop --all  # Similar to "systemctl restart docker"
     echo "Prune all dangling images"
     docker image prune --force
   fi


### PR DESCRIPTION
This should avoid a race where the kill is not done when spinning up the new container. podman stop waits 10 seconds by default.

Fixes https://github.com/bitcoin/bitcoin/pull/27777#discussion_r1217942753