### PR TITLE
[WIP] add a stratum v2 template provider

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -344,6 +344,17 @@ AC_ARG_ENABLE([lto],
     [enable_lto=$enableval],
     [enable_lto=no])
 
+dnl Enable running a StratumV2 Template Provider server.
+AC_ARG_ENABLE([template-provider],
+  [AS_HELP_STRING([--enable-template-provider],
+  [build with a stratumv2 template provider. (default is no)])],
+  [enable_template_provider=$enableval],
+  [enable_template_provider=no])
+
+if test "$enable_template_provider" != "no"; then
+    AC_DEFINE([ENABLE_TEMPLATE_PROVIDER], [1], [Define if the Template Provider is enabled])
+fi
+
 AC_LANG_PUSH([C++])
 
 dnl Check for a flag to turn compiler warnings into errors. This is helpful for checks which may
@@ -2036,6 +2047,7 @@ echo "  debug enabled   = $enable_debug"
 echo "  gprof enabled   = $enable_gprof"
 echo "  werror          = $enable_werror"
 echo "  LTO             = $enable_lto"
+echo "  with stratumv2 template provider = $enable_template_provider"
 echo
 echo "  target os       = $host_os"
 echo "  build os        = $build_os"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -224,6 +224,7 @@ BITCOIN_CORE_H = \
   node/mini_miner.h \
   node/minisketchwrapper.h \
   node/psbt.h \
+  node/sv2_messages.h \
   node/transaction.h \
   node/txreconciliation.h \
   node/utxo_snapshot.h \
@@ -420,6 +421,7 @@ libbitcoin_node_a_SOURCES = \
   node/mini_miner.cpp \
   node/minisketchwrapper.cpp \
   node/psbt.cpp \
+  node/sv2_messages.cpp \
   node/transaction.cpp \
   node/txreconciliation.cpp \
   node/utxo_snapshot.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -273,6 +273,7 @@ BITCOIN_CORE_H = \
   support/cleanse.h \
   support/events.h \
   support/lockedpool.h \
+  sv2_template_provider.h \
   sync.h \
   threadsafety.h \
   timedata.h \
@@ -447,6 +448,7 @@ libbitcoin_node_a_SOURCES = \
   rpc/signmessage.cpp \
   rpc/txoutproof.cpp \
   script/sigcache.cpp \
+  sv2_template_provider.cpp \
   shutdown.cpp \
   signet.cpp \
   timedata.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -147,6 +147,7 @@ BITCOIN_TESTS =\
   test/sync_tests.cpp \
   test/system_tests.cpp \
   test/sv2_messages_tests.cpp \
+  test/sv2_template_provider_tests.cpp \
   test/timedata_tests.cpp \
   test/torcontrol_tests.cpp \
   test/transaction_tests.cpp \
@@ -339,6 +340,7 @@ test_fuzz_fuzz_SOURCES = \
  test/fuzz/strprintf.cpp \
  test/fuzz/system.cpp \
  test/fuzz/sv2_messages.cpp \
+ test/fuzz/sv2_template_provider.cpp \
  test/fuzz/timedata.cpp \
  test/fuzz/torcontrol.cpp \
  test/fuzz/transaction.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -146,6 +146,7 @@ BITCOIN_TESTS =\
   test/streams_tests.cpp \
   test/sync_tests.cpp \
   test/system_tests.cpp \
+  test/sv2_messages_tests.cpp \
   test/timedata_tests.cpp \
   test/torcontrol_tests.cpp \
   test/transaction_tests.cpp \
@@ -337,6 +338,7 @@ test_fuzz_fuzz_SOURCES = \
  test/fuzz/string.cpp \
  test/fuzz/strprintf.cpp \
  test/fuzz/system.cpp \
+ test/fuzz/sv2_messages.cpp \
  test/fuzz/timedata.cpp \
  test/fuzz/torcontrol.cpp \
  test/fuzz/transaction.cpp \

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -630,6 +630,10 @@ void SetupServerArgs(ArgsManager& argsman)
 #if defined(USE_SYSCALL_SANDBOX)
     argsman.AddArg("-sandbox=<mode>", "Use the experimental syscall sandbox in the specified mode (-sandbox=log-and-abort or -sandbox=abort). Allow only expected syscalls to be used by bitcoind. Note that this is an experimental new feature that may cause bitcoind to exit or crash unexpectedly: use with caution. In the \"log-and-abort\" mode the invocation of an unexpected syscall results in a debug handler being invoked which will log the incident and terminate the program (without executing the unexpected syscall). In the \"abort\" mode the invocation of an unexpected syscall results in the entire process being killed immediately by the kernel without executing the unexpected syscall.", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
 #endif // USE_SYSCALL_SANDBOX
+       //
+#if ENABLE_TEMPLATE_PROVIDER
+    argsman.AddArg("-stratumv2=<port>", "Listen for stratumv2 connections on <port>. Bitcoind will act as a Template Provider. (default: 8442)", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+#endif
 
     // Add the hidden options
     argsman.AddHiddenArgs(hidden_args);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1888,8 +1888,13 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 
     node.sv2_template_provider = std::make_unique<Sv2TemplateProvider>(*node.chainman, *node.mempool);
 
-    auto sv2_port{static_cast<uint16_t>(gArgs.GetIntArg("-stratumv2", 8442))};
-    node.sv2_template_provider->Start(Sv2TemplateProviderOptions { .port = sv2_port });
+    try {
+        auto sv2_port{static_cast<uint16_t>(gArgs.GetIntArg("-stratumv2", 8442))};
+        node.sv2_template_provider->Start(Sv2TemplateProviderOptions { .port = sv2_port });
+    } catch (const std::runtime_error& e) {
+        LogPrintf("sv2: %s\n", e.what());
+        return false;
+    }
 #endif
 
     // ********************************************************* Step 13: finished

--- a/src/node/context.cpp
+++ b/src/node/context.cpp
@@ -14,6 +14,7 @@
 #include <node/kernel_notifications.h>
 #include <policy/fees.h>
 #include <scheduler.h>
+#include <sv2_template_provider.h>
 #include <txmempool.h>
 #include <validation.h>
 

--- a/src/node/context.h
+++ b/src/node/context.h
@@ -22,6 +22,7 @@ class CTxMemPool;
 class ChainstateManager;
 class NetGroupManager;
 class PeerManager;
+class Sv2TemplateProvider;
 namespace interfaces {
 class Chain;
 class ChainClient;
@@ -55,6 +56,7 @@ struct NodeContext {
     std::unique_ptr<PeerManager> peerman;
     std::unique_ptr<ChainstateManager> chainman;
     std::unique_ptr<BanMan> banman;
+    std::unique_ptr<Sv2TemplateProvider> sv2_template_provider;
     ArgsManager* args{nullptr}; // Currently a raw pointer because the memory is not managed by this struct
     std::unique_ptr<interfaces::Chain> chain;
     //! List of all chain clients (wallet processes or other client) connected to node.

--- a/src/node/sv2_messages.cpp
+++ b/src/node/sv2_messages.cpp
@@ -1,0 +1,44 @@
+#include <arith_uint256.h>
+#include <consensus/validation.h>
+#include <node/sv2_messages.h>
+#include <primitives/block.h>
+#include <primitives/transaction.h>
+
+node::Sv2NewTemplateMsg::Sv2NewTemplateMsg(const CBlock& block, uint64_t template_id, bool future_template)
+    : m_template_id{template_id}, m_future_template{future_template}
+{
+    m_version = block.GetBlockHeader().nVersion;
+
+    const CTransactionRef coinbase_tx = block.vtx[0];
+    m_coinbase_tx_version = coinbase_tx->CURRENT_VERSION;
+    m_coinbase_prefix = coinbase_tx->vin[0].scriptSig;
+    m_coinbase_tx_input_sequence = coinbase_tx->vin[0].nSequence;
+
+    // The coinbase nValue already contains the nFee + the Block Subsidy when built using CreateBlock().
+    m_coinbase_tx_value_remaining = static_cast<uint64_t>(block.vtx[0]->vout[0].nValue);
+
+    m_coinbase_tx_outputs_count = 0;
+    int commitpos = GetWitnessCommitmentIndex(block);
+    if (commitpos != NO_WITNESS_COMMITMENT) {
+        m_coinbase_tx_outputs_count = 1;
+
+        std::vector<CTxOut> coinbase_tx_outputs{block.vtx[0]->vout[commitpos]};
+        m_coinbase_tx_outputs = coinbase_tx_outputs;
+    }
+
+    m_coinbase_tx_locktime = coinbase_tx->nLockTime;
+
+    // Skip the coinbase_tx hash from the merkle path since the downstream client
+    // will build their own coinbase tx.
+    for (auto it = block.vtx.begin() + 1; it != block.vtx.end(); ++it) {
+        m_merkle_path.push_back((*it)->GetHash());
+    }
+}
+
+node::Sv2SetNewPrevHashMsg::Sv2SetNewPrevHashMsg(const CBlock& block, uint64_t template_id) : m_template_id{template_id}
+{
+    m_prev_hash = block.hashPrevBlock;
+    m_header_timestamp = block.nTime;
+    m_nBits = block.nBits;
+    m_target = ArithToUint256(arith_uint256().SetCompact(block.nBits));
+}

--- a/src/node/sv2_messages.h
+++ b/src/node/sv2_messages.h
@@ -1,0 +1,510 @@
+#ifndef BITCOIN_NODE_SV2_MESSAGES_H
+#define BITCOIN_NODE_SV2_MESSAGES_H
+
+#include <consensus/validation.h>
+#include <cstdint>
+#include <script/script.h>
+#include <streams.h>
+#include <string>
+#include <vector>
+#include <uint256.h>
+
+class CBlock;
+struct CMutableTransaction;
+class CTxOut;
+class ArithToUint256;
+
+namespace node {
+/**
+ * All the stratum v2 message types handled by the template provider.
+ */
+enum class Sv2MsgType {
+    SETUP_CONNECTION = 0x00,
+    SETUP_CONNECTION_SUCCESS = 0x01,
+    SETUP_CONNECTION_ERROR = 0x02,
+    NEW_TEMPLATE = 0x71,
+    SET_NEW_PREV_HASH = 0x72,
+    SUBMIT_SOLUTION = 0x76,
+    COINBASE_OUTPUT_DATA_SIZE = 0x70,
+};
+
+struct Sv2SetupConnectionMsg
+{
+    /**
+     * The default message type value for this Stratum V2 message.
+     */
+    static const auto m_msg_type = Sv2MsgType::SETUP_CONNECTION;
+
+    /**
+     * Specifies the subprotocol for the new connection. It will always be TemplateDistribution
+     * (0x02).
+     */
+    uint8_t m_protocol;
+
+    /**
+     * The minimum protocol version the client supports (currently must be 2).
+     */
+    uint16_t m_min_version;
+
+    /**
+     * The maximum protocol version the client supports (currently must be 2).
+     */
+    uint16_t m_max_version;
+
+    /**
+     * Flags indicating optional protocol features the client supports. Each protocol
+     * from protocol field has its own values/flags.
+     */
+    uint32_t m_flags;
+
+    /**
+     * ASCII text indicating the hostname or IP address.
+     */
+    std::string m_endpoint_host;
+
+    /**
+     * Connecting port value.
+     */
+    uint16_t m_endpoint_port;
+
+    /**
+     * Vendor name of the connecting device.
+     */
+    std::string m_vendor;
+
+    /**
+     * Hardware version of the connecting device.
+     */
+    std::string m_hardware_version;
+
+    /**
+     * Firmware of the connecting device.
+     */
+    std::string m_firmware;
+
+    /**
+     * Unique identifier of the device as defined by the vendor.
+     */
+    std::string m_device_id;
+
+    template <typename Stream>
+    void Unserialize(Stream& s)
+    {
+        s >> m_protocol
+          >> m_min_version
+          >> m_max_version
+          >> m_flags
+          >> m_endpoint_host
+          >> m_endpoint_port
+          >> m_vendor
+          >> m_hardware_version
+          >> m_firmware
+          >> m_device_id;
+    }
+};
+
+/**
+ * Set the coinbase outputs data len for the outputs that the client wants to add to the coinbase.
+ * The Template Provider MUST NOT provide NewWork messages which would represent consensus-invalid blocks once this
+ * additional size — along with a maximally-sized (100 byte) coinbase field — is added.
+ */
+struct Sv2CoinbaseOutputDataSizeMsg
+{
+    /**
+     * The default message type value for this Stratum V2 message.
+     */
+    static const auto m_msg_type = Sv2MsgType::COINBASE_OUTPUT_DATA_SIZE;
+
+    /**
+     * The maximum additional serialized bytes which the pool will add in coinbase transaction outputs.
+     */
+    uint32_t m_coinbase_output_max_additional_size;
+
+
+    template <typename Stream>
+    void Unserialize(Stream& s)
+    {
+        s >> m_coinbase_output_max_additional_size;
+    }
+};
+
+/**
+ * Response to the SetupConnection message if the server accepts the connection.
+ * The client is required to verify the set of feature flags that the server
+ * supports and act accordingly.
+ */
+struct Sv2SetupConnectionSuccessMsg
+{
+    /**
+     * The default message type value for this Stratum V2 message.
+     */
+    static const auto m_msg_type = Sv2MsgType::SETUP_CONNECTION_SUCCESS;
+
+    /**
+     * Selected version proposed by the connecting node that the upstream node supports.
+     * This version will be used on the connection for the rest of its life.
+     */
+    uint16_t m_used_version;
+
+    /**
+     * Flags indicating optional protocol features the server supports. Each protocol
+     * from protocol field has its own values/flags.
+     */
+    uint32_t m_flags;
+
+    explicit Sv2SetupConnectionSuccessMsg(uint16_t used_version, uint32_t flags) : m_used_version{used_version}, m_flags{flags} {};
+
+    template <typename Stream>
+    void Serialize(Stream& s) const
+    {
+        s << m_used_version
+          << m_flags;
+    }
+};
+
+/**
+ * Response to the SetupConnection message if the server rejects the connection.
+ */
+struct Sv2SetupConnectionErrorMsg
+{
+    static const auto m_msg_type = Sv2MsgType::SETUP_CONNECTION_ERROR;
+
+    /**
+     * Flags indicating optional protocol features the server supports. Each protocol
+     * from protocol field has its own values/flags.
+     */
+    uint32_t m_flags;
+
+    /**
+     * Human-readable error codes.
+     */
+    std::string m_error_code;
+
+    explicit Sv2SetupConnectionErrorMsg(uint32_t flags, std::string&& error_code) : m_flags{flags}, m_error_code{std::move(error_code)} {};
+
+    template <typename Stream>
+    void Serialize(Stream& s) const
+    {
+        s << m_flags
+          << m_error_code;
+    }
+};
+
+/**
+ * The work template for downstream devices. Can be used for future work or immediate work.
+ * The NewTemplate will be matched to a cached block using the template id.
+ */
+struct Sv2NewTemplateMsg
+{
+    /**
+     * The default message type value for this Stratum V2 message.
+     */
+    static const auto m_msg_type = Sv2MsgType::NEW_TEMPLATE;
+
+    /**
+     * Server’s identification of the template. Strictly increasing, the current UNIX
+     * time may be used in place of an ID.
+     */
+    uint64_t m_template_id;
+
+    /**
+     * True if the template is intended for future SetNewPrevHash message sent on the channel.
+     * If False, the job relates to the last sent SetNewPrevHash message on the channel
+     * and the miner should start to work on the job immediately.
+     */
+    bool m_future_template;
+
+    /**
+     * Valid header version field that reflects the current network consensus.
+     * The general purpose bits (as specified in BIP320) can be freely manipulated
+     * by the downstream node. The downstream node MUST NOT rely on the upstream
+     * node to set the BIP320 bits to any particular value.
+     */
+    uint32_t m_version;
+
+    /**
+     * The coinbase transaction nVersion field.
+     */
+    uint32_t m_coinbase_tx_version;
+
+    /**
+     * Up to 8 bytes (not including the length byte) which are to be placed at
+     * the beginning of the coinbase field in the coinbase transaction.
+     */
+    CScript m_coinbase_prefix;
+
+    /**
+     * The coinbase transaction input’s nSequence field.
+     */
+    uint32_t m_coinbase_tx_input_sequence;
+
+    /**
+     * The value, in satoshis, available for spending in coinbase outputs added
+     * by the client. Includes both transaction fees and block subsidy.
+     */
+    uint64_t m_coinbase_tx_value_remaining;
+
+    /**
+     * The number of transaction outputs included in coinbase_tx_outputs.
+     */
+    uint32_t m_coinbase_tx_outputs_count;
+
+    /**
+     * Bitcoin transaction outputs to be included as the last outputs in the coinbase transaction.
+     */
+    std::vector<CTxOut> m_coinbase_tx_outputs;
+
+    /**
+     * The locktime field in the coinbase transaction.
+     */
+    uint32_t m_coinbase_tx_locktime;
+
+    /**
+     * Merkle path hashes ordered from deepest.
+     */
+    std::vector<uint256> m_merkle_path;
+
+    Sv2NewTemplateMsg() = default;
+    explicit Sv2NewTemplateMsg(const CBlock& block, uint64_t template_id, bool future_template);
+
+    template <typename Stream>
+    void Serialize(Stream& s) const
+    {
+        s << m_template_id
+          << m_future_template
+          << m_version
+          << m_coinbase_tx_version
+          << m_coinbase_prefix
+          << m_coinbase_tx_input_sequence
+          << m_coinbase_tx_value_remaining
+          << m_coinbase_tx_outputs_count;
+
+        // If there are more than 0 coinbase tx outputs, then we need to serialize them
+        // as [B0_64K](https://github.com/stratum-mining/sv2-spec/blob/main/03-Protocol-Overview.md#31-data-types-mapping)
+        if (m_coinbase_tx_outputs_count > 0) {
+            std::vector<uint8_t> outputs_bytes;
+            CVectorWriter{SER_NETWORK, PROTOCOL_VERSION, outputs_bytes, 0, m_coinbase_tx_outputs.at(0)};
+
+            s << static_cast<uint16_t>(outputs_bytes.size());
+            s.write(MakeByteSpan(outputs_bytes));
+        } else {
+            // We will still need to send 2 bytes indicating an empty coinbase-tx_outputs array as a B0_64K.
+            s << static_cast<uint16_t>(0);
+        }
+
+        s << m_coinbase_tx_locktime
+          << m_merkle_path;
+    }
+};
+
+/**
+ * When the template provider creates a new valid best block, the Template Provider
+ * MUST immediately send the SetNewPrevHash message. This message can also be used
+ * for a future template, indicating the client can begin work on a previously
+ * received and cached NewTemplate which contains the same template id.
+ */
+struct Sv2SetNewPrevHashMsg
+{
+    /**
+     * The default message type value for this Stratum V2 message.
+     */
+    static const auto m_msg_type = Sv2MsgType::SET_NEW_PREV_HASH;
+
+    /**
+     * The id referenced in a previous NewTemplate message.
+     */
+    uint64_t m_template_id;
+
+    /**
+     * Previous block’s hash, as it must appear in the next block’s header.
+     */
+    uint256 m_prev_hash;
+
+    /**
+     * The nTime field in the block header at which the client should start (usually current time).
+     * This is NOT the minimum valid nTime value.
+     */
+    uint32_t m_header_timestamp;
+
+    /**
+     * Block header field.
+     */
+    uint32_t m_nBits;
+
+    /**
+     * The maximum double-SHA256 hash value which would represent a valid block.
+     * Note that this may be lower than the target implied by nBits in several cases,
+     * including weak-block based block propagation.
+     */
+    uint256 m_target;
+
+    Sv2SetNewPrevHashMsg() = default;
+    explicit Sv2SetNewPrevHashMsg(const CBlock& block, uint64_t template_id);
+
+    template <typename Stream>
+    void Serialize(Stream& s) const
+    {
+        s << m_template_id
+          << m_prev_hash
+          << m_header_timestamp
+          << m_nBits
+          << m_target;
+    }
+};
+
+/**
+ * The client sends a SubmitSolution after finding a coinbase transaction/nonce
+ * pair which double-SHA256 hashes at or below SetNewPrevHash::target. The Template Provider
+ * finds the cached block according to the template id and reconstructs the block with the
+ * values from SubmitSolution. The Template Provider must then propagate the block to the
+ * Bitcoin Network.
+ */
+struct Sv2SubmitSolutionMsg
+{
+    /**
+     * The default message type value for this Stratum V2 message.
+     */
+    static const auto m_msg_type = Sv2MsgType::SUBMIT_SOLUTION;
+
+    /**
+     * The id referenced in a NewTemplate.
+     */
+    uint64_t m_template_id;
+
+    /**
+     * The version field in the block header. Bits not defined by BIP320 as additional
+     * nonce MUST be the same as they appear in the NewWork message, other bits may
+     * be set to any value.
+     */
+    uint32_t m_version;
+
+    /**
+     * The nTime field in the block header. This MUST be greater than or equal to
+     * the header_timestamp field in the latest SetNewPrevHash message and lower
+     * than or equal to that value plus the number of seconds since the receipt
+     * of that message.
+     */
+    uint32_t m_header_timestamp;
+
+    /**
+     * The nonce field in the header.
+     */
+    uint32_t m_header_nonce;
+
+    /**
+     * The full serialized coinbase transaction, meeting all the requirements of the NewWork message, above.
+     */
+    CMutableTransaction m_coinbase_tx;
+
+    Sv2SubmitSolutionMsg() = default;
+
+    template <typename Stream>
+    void Unserialize(Stream& s)
+    {
+        s >> m_template_id >> m_version >> m_header_timestamp >> m_header_nonce;
+
+        // Ignore the 2 byte length as the rest of the stream is assumed to be
+        // the m_coinbase_tx.
+        s.ignore(2);
+        s >> m_coinbase_tx;
+    }
+};
+
+/**
+ * Header for all stratum v2 messages. Each header must contain the message type,
+ * the length of the serialized message and a 2 byte extension field currently
+ * not utilised by the template provider.
+ */
+class Sv2NetHeader
+{
+private:
+    /**
+     * A type used as the message length field in stratum v2 messages.
+     */
+    using u24_t = uint8_t[3];
+
+public:
+    /**
+     * Unique identifier of the message.
+     */
+    Sv2MsgType m_msg_type;
+
+    /**
+     * Serialized length of the message.
+     */
+    uint32_t m_msg_len;
+
+    Sv2NetHeader() = default;
+    explicit Sv2NetHeader(Sv2MsgType msg_type, uint32_t msg_len) : m_msg_type{msg_type}, m_msg_len{msg_len} {};
+
+    template <typename Stream>
+    void Serialize(Stream& s) const
+    {
+        // The Template Provider currently does not use the extension_type field,
+        // but the field is still required for all headers.
+        uint16_t extension_type = 0;
+
+        u24_t msg_len;
+        msg_len[2] = (m_msg_len >> 16) & 0xff;
+        msg_len[1] = (m_msg_len >> 8) & 0xff;
+        msg_len[0] = m_msg_len & 0xff;
+
+        s << extension_type
+          << static_cast<uint8_t>(m_msg_type)
+          << msg_len;
+    };
+
+    template <typename Stream>
+    void Unserialize(Stream& s)
+    {
+        // Ignore the first 2 bytes (extension type) as the Template Provider currently doesn't
+        // interpret this field.
+        s.ignore(2);
+
+        uint8_t msg_type;
+        s >> msg_type;
+        m_msg_type = static_cast<Sv2MsgType>(msg_type);
+
+        u24_t msg_len_bytes;
+        for (unsigned int i = 0; i < sizeof(u24_t); ++i) {
+            s >> msg_len_bytes[i];
+        }
+
+        m_msg_len = msg_len_bytes[2];
+        m_msg_len = m_msg_len << 8 | msg_len_bytes[1];
+        m_msg_len = m_msg_len << 8 | msg_len_bytes[0];
+    }
+};
+
+/**
+ * The networked form for all stratum v2 messages, contains a header and a serialized
+ * payload from a referenced stratum v2 message.
+ */
+template <typename M>
+class Sv2NetMsg
+{
+private:
+    Sv2NetHeader m_sv2_header;
+    std::vector<uint8_t> m_msg;
+
+public:
+    /**
+     * Serializes the message M and sets an Sv2 network header.
+     * @throws std::ios_base or std::out_of_range errors.
+     */
+    explicit Sv2NetMsg(const M& msg)
+    {
+        CVectorWriter{SER_NETWORK, PROTOCOL_VERSION, m_msg, 0, msg};
+        m_sv2_header = Sv2NetHeader{msg.m_msg_type, static_cast<uint32_t>(m_msg.size())};
+    }
+
+    template <typename Stream>
+    void Serialize(Stream& s) const
+    {
+        s << m_sv2_header;
+        s.write(MakeByteSpan(m_msg));
+    }
+};
+}
+
+#endif // BITCOIN_NODE_SV2_MESSAGES_H

--- a/src/node/sv2_messages.h
+++ b/src/node/sv2_messages.h
@@ -18,7 +18,7 @@ namespace node {
 /**
  * All the stratum v2 message types handled by the template provider.
  */
-enum class Sv2MsgType {
+enum class Sv2MsgType : uint8_t {
     SETUP_CONNECTION = 0x00,
     SETUP_CONNECTION_SUCCESS = 0x01,
     SETUP_CONNECTION_ERROR = 0x02,
@@ -33,7 +33,7 @@ struct Sv2SetupConnectionMsg
     /**
      * The default message type value for this Stratum V2 message.
      */
-    static const auto m_msg_type = Sv2MsgType::SETUP_CONNECTION;
+    static constexpr auto m_msg_type = Sv2MsgType::SETUP_CONNECTION;
 
     /**
      * Specifies the subprotocol for the new connection. It will always be TemplateDistribution
@@ -53,7 +53,7 @@ struct Sv2SetupConnectionMsg
 
     /**
      * Flags indicating optional protocol features the client supports. Each protocol
-     * from protocol field has its own values/flags.
+     * from the protocol field has its own values/flags.
      */
     uint32_t m_flags;
 
@@ -105,7 +105,7 @@ struct Sv2SetupConnectionMsg
 
 /**
  * Set the coinbase outputs data len for the outputs that the client wants to add to the coinbase.
- * The Template Provider MUST NOT provide NewWork messages which would represent consensus-invalid blocks once this
+ * The template provider MUST NOT provide NewWork messages which would represent consensus-invalid blocks once this
  * additional size — along with a maximally-sized (100 byte) coinbase field — is added.
  */
 struct Sv2CoinbaseOutputDataSizeMsg
@@ -113,7 +113,7 @@ struct Sv2CoinbaseOutputDataSizeMsg
     /**
      * The default message type value for this Stratum V2 message.
      */
-    static const auto m_msg_type = Sv2MsgType::COINBASE_OUTPUT_DATA_SIZE;
+    static constexpr auto m_msg_type = Sv2MsgType::COINBASE_OUTPUT_DATA_SIZE;
 
     /**
      * The maximum additional serialized bytes which the pool will add in coinbase transaction outputs.
@@ -138,7 +138,7 @@ struct Sv2SetupConnectionSuccessMsg
     /**
      * The default message type value for this Stratum V2 message.
      */
-    static const auto m_msg_type = Sv2MsgType::SETUP_CONNECTION_SUCCESS;
+    static constexpr auto m_msg_type = Sv2MsgType::SETUP_CONNECTION_SUCCESS;
 
     /**
      * Selected version proposed by the connecting node that the upstream node supports.
@@ -167,7 +167,7 @@ struct Sv2SetupConnectionSuccessMsg
  */
 struct Sv2SetupConnectionErrorMsg
 {
-    static const auto m_msg_type = Sv2MsgType::SETUP_CONNECTION_ERROR;
+    static constexpr auto m_msg_type = Sv2MsgType::SETUP_CONNECTION_ERROR;
 
     /**
      * Flags indicating optional protocol features the server supports. Each protocol
@@ -199,7 +199,7 @@ struct Sv2NewTemplateMsg
     /**
      * The default message type value for this Stratum V2 message.
      */
-    static const auto m_msg_type = Sv2MsgType::NEW_TEMPLATE;
+    static constexpr auto m_msg_type = Sv2MsgType::NEW_TEMPLATE;
 
     /**
      * Server’s identification of the template. Strictly increasing, the current UNIX
@@ -298,7 +298,7 @@ struct Sv2NewTemplateMsg
 };
 
 /**
- * When the template provider creates a new valid best block, the Template Provider
+ * When the template provider creates a new valid best block, the template provider
  * MUST immediately send the SetNewPrevHash message. This message can also be used
  * for a future template, indicating the client can begin work on a previously
  * received and cached NewTemplate which contains the same template id.
@@ -308,7 +308,7 @@ struct Sv2SetNewPrevHashMsg
     /**
      * The default message type value for this Stratum V2 message.
      */
-    static const auto m_msg_type = Sv2MsgType::SET_NEW_PREV_HASH;
+    static constexpr auto m_msg_type = Sv2MsgType::SET_NEW_PREV_HASH;
 
     /**
      * The id referenced in a previous NewTemplate message.
@@ -354,9 +354,9 @@ struct Sv2SetNewPrevHashMsg
 
 /**
  * The client sends a SubmitSolution after finding a coinbase transaction/nonce
- * pair which double-SHA256 hashes at or below SetNewPrevHash::target. The Template Provider
+ * pair which double-SHA256 hashes at or below SetNewPrevHash::target. The template provider
  * finds the cached block according to the template id and reconstructs the block with the
- * values from SubmitSolution. The Template Provider must then propagate the block to the
+ * values from SubmitSolution. The template provider must then propagate the block to the
  * Bitcoin Network.
  */
 struct Sv2SubmitSolutionMsg
@@ -364,7 +364,7 @@ struct Sv2SubmitSolutionMsg
     /**
      * The default message type value for this Stratum V2 message.
      */
-    static const auto m_msg_type = Sv2MsgType::SUBMIT_SOLUTION;
+    static constexpr auto m_msg_type = Sv2MsgType::SUBMIT_SOLUTION;
 
     /**
      * The id referenced in a NewTemplate.
@@ -440,7 +440,7 @@ public:
     template <typename Stream>
     void Serialize(Stream& s) const
     {
-        // The Template Provider currently does not use the extension_type field,
+        // The template provider currently does not use the extension_type field,
         // but the field is still required for all headers.
         uint16_t extension_type = 0;
 
@@ -457,7 +457,7 @@ public:
     template <typename Stream>
     void Unserialize(Stream& s)
     {
-        // Ignore the first 2 bytes (extension type) as the Template Provider currently doesn't
+        // Ignore the first 2 bytes (extension type) as the template provider currently doesn't
         // interpret this field.
         s.ignore(2);
 
@@ -494,7 +494,10 @@ public:
      */
     explicit Sv2NetMsg(const M& msg)
     {
+        // Serialize the sv2 message.
         CVectorWriter{SER_NETWORK, PROTOCOL_VERSION, m_msg, 0, msg};
+
+        // Create the header for the message.
         m_sv2_header = Sv2NetHeader{msg.m_msg_type, static_cast<uint32_t>(m_msg.size())};
     }
 

--- a/src/sv2_template_provider.cpp
+++ b/src/sv2_template_provider.cpp
@@ -1,0 +1,389 @@
+#include <consensus/merkle.h>
+#include <logging.h>
+#include <netbase.h>
+#include <netaddress.h>
+#include <node/miner.h>
+#include <node/sv2_messages.h>
+#include <sv2_template_provider.h>
+#include <txmempool.h>
+#include <util/thread.h>
+#include <validation.h>
+
+void Sv2TemplateProvider::Start(const Sv2TemplateProviderOptions& options)
+{
+    Init(options);
+
+    // Intentionally no error handling for BindListenPort() since if an sv2 port cannot be opened,
+    // the process should exit.
+    auto sock = BindListenPort(options.port);
+    m_listening_socket = std::move(sock);
+    LogPrintf("Sv2 Template Provider listening on port: %d\n", options.port);
+
+    m_thread_sv2_handler = std::thread(&util::TraceThread, "sv2", [this] { ThreadSv2Handler(); });
+}
+
+void Sv2TemplateProvider::Init(const Sv2TemplateProviderOptions& options)
+{
+    m_protocol_version = options.protocol_version;
+    m_optional_features = options.optional_features;
+    m_default_coinbase_tx_additional_output_size = options.default_coinbase_tx_additional_output_size;
+    m_default_future_templates = options.default_future_templates;
+}
+
+void Sv2TemplateProvider::Interrupt()
+{
+    m_flag_interrupt_sv2 = true;
+}
+
+void Sv2TemplateProvider::StopThreads()
+{
+    if (m_thread_sv2_handler.joinable()) {
+        m_thread_sv2_handler.join();
+    }
+}
+
+std::shared_ptr<Sock> Sv2TemplateProvider::BindListenPort(uint16_t port) const
+{
+    const CService addr_bind = LookupNumeric("0.0.0.0", port);
+
+    auto sock = CreateSock(addr_bind);
+    if (!sock) {
+        throw std::runtime_error("Sv2 Template Provider cannot create socket");
+    }
+
+    struct sockaddr_storage sockaddr;
+    socklen_t len = sizeof(sockaddr);
+
+    if (!addr_bind.GetSockAddr(reinterpret_cast<struct sockaddr*>(&sockaddr), &len)) {
+        throw std::runtime_error("Sv2 Template Provider failed to get socket address");
+    }
+
+    if (sock->Bind(reinterpret_cast<struct sockaddr*>(&sockaddr), len) == SOCKET_ERROR) {
+        const int nErr = WSAGetLastError();
+        if (nErr == WSAEADDRINUSE) {
+            throw std::runtime_error(strprintf("Unable to bind to %d on this computer. %s is probably already running.\n", port, PACKAGE_NAME));
+        }
+
+        throw std::runtime_error(strprintf("Unable to bind to %d on this computer (bind returned error %s )\n", port, NetworkErrorString(nErr)));
+    }
+
+    constexpr int max_pending_conns{4096};
+    if (sock->Listen(max_pending_conns) == SOCKET_ERROR) {
+        throw std::runtime_error("Sv2 Template Provider listening socket has an error listening");
+    }
+
+    return sock;
+}
+
+void Sv2TemplateProvider::ThreadSv2Handler()
+{
+    while (!m_flag_interrupt_sv2) {
+        if (m_chainman.ActiveChainstate().IsInitialBlockDownload()) {
+            m_interrupt_sv2.sleep_for(std::chrono::milliseconds(100));
+            continue;
+        }
+
+        // Remove clients that are flagged for disconnection.
+        m_sv2_clients.erase(
+            std::remove_if(m_sv2_clients.begin(), m_sv2_clients.end(), [](const auto &client) {
+                return client->m_disconnect_flag;
+        }), m_sv2_clients.end());
+
+        {
+            // Required locking order for g_best_block_mutex.
+            LOCK2(cs_main, m_mempool.cs);
+
+            {
+                WAIT_LOCK(g_best_block_mutex, lock);
+                auto checktime = std::chrono::steady_clock::now() + std::chrono::milliseconds(50);
+                if (g_best_block_cv.wait_until(lock, checktime) == std::cv_status::timeout) {
+                    if (m_best_prev_hash.m_prev_hash != g_best_block) {
+                        // Clear the block cache when the best known block changes since all
+                        // previous work is now invalid.
+                        BlockCache block_cache;
+                        m_block_cache.swap(block_cache);
+
+                        // Build a new best template, best prev hash and update the block cache.
+                        ++m_template_id;
+                        auto new_work_set = BuildNewWorkSet(m_default_future_templates, m_default_coinbase_tx_additional_output_size, m_template_id);
+                        m_best_new_template = std::move(new_work_set.new_template);
+                        m_best_prev_hash = std::move(new_work_set.prev_hash);
+                        m_block_cache.insert({m_template_id, std::move(new_work_set.block_template)});
+
+                        // Update all clients with the new template and prev hash.
+                        for (const auto& client : m_sv2_clients) {
+                            if (!SendWork(*client.get(), m_best_new_template, m_best_prev_hash, m_block_cache, m_template_id))
+                                continue;
+                        }
+                    }
+                }
+            }
+        }
+
+        // Poll/Select the sockets that need handling.
+        Sock::EventsPerSock events_per_sock = GenerateWaitSockets(m_listening_socket, m_sv2_clients);
+
+        constexpr auto timeout = std::chrono::milliseconds(50);
+        if (!events_per_sock.begin()->first->WaitMany(timeout, events_per_sock)) {
+            continue;
+        }
+
+        // Accept any new connections for sv2 clients.
+        const auto listening_sock = events_per_sock.find(m_listening_socket);
+        if (listening_sock != events_per_sock.end() && listening_sock->second.occurred & Sock::RECV) {
+            struct sockaddr_storage sockaddr;
+            socklen_t sockaddr_len = sizeof(sockaddr);
+
+            auto sock = m_listening_socket->Accept(reinterpret_cast<struct sockaddr*>(&sockaddr), &sockaddr_len);
+            if (sock) {
+                m_sv2_clients.emplace_back(std::make_unique<Sv2Client>(Sv2Client{std::move(sock)}));
+            }
+        }
+
+        // Process messages from connected sv2_clients.
+        for (auto& client : m_sv2_clients) {
+            bool has_received_data = false;
+            bool has_error_occurred = false;
+
+            const auto it = events_per_sock.find(client->m_sock);
+            if (it != events_per_sock.end()) {
+                has_received_data = it->second.occurred & Sock::RECV;
+                has_error_occurred = it->second.occurred & Sock::ERR;
+            }
+
+            if (has_error_occurred) {
+                client->m_disconnect_flag = true;
+            }
+
+            if (has_received_data) {
+                uint8_t bytes_received_buf[0x10000];
+                const auto num_bytes_received = client->m_sock->Recv(bytes_received_buf, sizeof(bytes_received_buf), MSG_DONTWAIT);
+
+                if (num_bytes_received <= 0) {
+                    client->m_disconnect_flag = true;
+                    continue;
+                }
+
+                CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+                ss << Span<uint8_t>(bytes_received_buf, num_bytes_received);
+
+                node::Sv2NetHeader sv2_header;
+                try {
+                    ss >> sv2_header;
+                } catch (const std::exception& e) {
+                    LogPrintf("Received an invalid sv2 header: %s\n", e.what());
+                    client->m_disconnect_flag = true;
+                    continue;
+                }
+
+                ProcessSv2Message(sv2_header, ss, *client.get(), m_best_new_template, m_best_prev_hash, m_block_cache, m_template_id);
+            }
+        }
+    }
+}
+
+Sv2TemplateProvider::NewWorkSet Sv2TemplateProvider::BuildNewWorkSet(bool future_template, unsigned int coinbase_output_max_additional_size, uint64_t template_id)
+{
+    node::BlockAssembler::Options options;
+
+    // Reducing the size of nBlockMaxWeight by the coinbase output additional size allows the miner extra weighted bytes in their coinbase space.
+    options.nBlockMaxWeight = MAX_BLOCK_WEIGHT - coinbase_output_max_additional_size;
+    options.blockMinFeeRate = CFeeRate(DEFAULT_BLOCK_MIN_TX_FEE);
+
+    auto blocktemplate = node::BlockAssembler(m_chainman.ActiveChainstate(), &m_mempool, options).CreateNewBlock(CScript());
+    node::Sv2NewTemplateMsg new_template{blocktemplate->block, template_id, future_template};
+    node::Sv2SetNewPrevHashMsg set_new_prev_hash{blocktemplate->block, template_id};
+
+    return NewWorkSet { new_template, std::move(blocktemplate), set_new_prev_hash};
+}
+
+bool Sv2TemplateProvider::SendWork(const Sv2Client& client, const node::Sv2NewTemplateMsg& best_template, const node::Sv2SetNewPrevHashMsg& best_prev_hash, BlockCache& block_cache, uint64_t& template_id)
+{
+    if (client.m_coinbase_tx_outputs_size > 0) {
+        ++template_id;
+        auto new_work_set = BuildNewWorkSet(m_default_future_templates, client.m_coinbase_tx_outputs_size, template_id);
+        block_cache.insert({template_id, std::move(new_work_set.block_template)});
+
+        try {
+            if (!Send(client, node::Sv2NetMsg{new_work_set.new_template})) {
+                LogPrintf("Error sending Sv2NewTemplate message\n");
+                return false;
+            }
+        } catch (const std::exception& e) {
+            LogPrintf("Failed to serialize new template: %s\n", e.what());
+        }
+
+        try {
+            if (!Send(client, node::Sv2NetMsg{new_work_set.prev_hash})) {
+                LogPrintf("Error sending Sv2SetNewPrevHash message\n");
+                return false;
+            }
+        } catch (const std::exception& e) {
+            LogPrintf("Failed to serialize new prev hash: %s\n", e.what());
+        }
+    } else {
+        try {
+            if (!Send(client, node::Sv2NetMsg{best_template})) {
+                LogPrintf("Error sending best Sv2NewTemplate message\n");
+                return false;
+            }
+        } catch (const std::exception& e) {
+            LogPrintf("Failed to serialize best new template: %s\n", e.what());
+        }
+
+        try {
+            if (!Send(client, node::Sv2NetMsg{best_prev_hash})) {
+                LogPrintf("Error sending best Sv2SetNewPrevHash message\n");
+                return false;
+            }
+        } catch (const std::exception& e) {
+            LogPrintf("Failed to serialize best new prev hash: %s\n", e.what());
+        }
+    }
+
+    return true;
+}
+
+Sock::EventsPerSock Sv2TemplateProvider::GenerateWaitSockets(const std::shared_ptr<Sock>& listen_socket, const Clients& sv2_clients) const
+{
+    Sock::EventsPerSock events_per_sock;
+    events_per_sock.emplace(listen_socket, Sock::Events(Sock::RECV));
+
+    for (const auto& client : sv2_clients) {
+        if (!client->m_disconnect_flag && client->m_sock) {
+            events_per_sock.emplace(client->m_sock, Sock::Events{Sock::RECV | Sock::ERR});
+        }
+    }
+
+    return events_per_sock;
+}
+
+void Sv2TemplateProvider::ProcessSv2Message(const node::Sv2NetHeader& sv2_header, CDataStream& ss, Sv2Client& client, const node::Sv2NewTemplateMsg& best_new_template, const node::Sv2SetNewPrevHashMsg& best_prev_hash, BlockCache& block_cache, uint64_t& template_id)
+{
+    switch (sv2_header.m_msg_type) {
+    case node::Sv2MsgType::SETUP_CONNECTION: {
+        if (client.m_setup_connection_confirmed) {
+            return;
+        }
+
+        node::Sv2SetupConnectionMsg setup_conn;
+        try {
+            ss >> setup_conn;
+        } catch (const std::exception& e) {
+            LogPrintf("Received invalid SetupConnection message: %s\n", e.what());
+            client.m_disconnect_flag = true;
+            return;
+        }
+
+        // Disconnect a client that connects on the wrong subprotocol.
+        if (setup_conn.m_protocol != TP_SUBPROTOCOL) {
+          node::Sv2SetupConnectionErrorMsg setup_conn_err{setup_conn.m_flags, std::string{"unsupported-protocol"}};
+
+          try {
+            if (!Send(client, node::Sv2NetMsg{setup_conn_err})) {
+              LogPrintf("Failed to send Sv2SetupConnectionError message\n");
+            }
+          } catch (const std::exception& e) {
+            LogPrintf("Failed to serialize best new prev hash: %s\n", e.what());
+          }
+
+            client.m_disconnect_flag = true;
+            return;
+        }
+
+        // Disconnect a client if they are not running a compatible protocol version.
+        if ((m_protocol_version < setup_conn.m_min_version) || (m_protocol_version > setup_conn.m_max_version)) {
+            node::Sv2SetupConnectionErrorMsg setup_conn_err{setup_conn.m_flags, std::string{"protocol-version-mismatch"}};
+
+            try {
+                if (!Send(client, node::Sv2NetMsg{setup_conn_err})) {
+                    LogPrintf("Failed to send Sv2SetupConnectionError message\n");
+                }
+            } catch (const std::exception& e) {
+                LogPrintf("Failed to serialize best new prev hash: %s\n", e.what());
+            }
+
+            LogPrintf("Received a connection with incompatible protocol_versions: min_version: %d, max_version: %d\n", setup_conn.m_min_version, setup_conn.m_max_version);
+            client.m_disconnect_flag = true;
+            return;
+        }
+
+        node::Sv2SetupConnectionSuccessMsg setup_success{m_protocol_version, m_optional_features};
+        try {
+            if (!Send(client, node::Sv2NetMsg{setup_success})) {
+                LogPrintf("Failed to send Sv2SetupSuccess message\n");
+                client.m_disconnect_flag = true;
+                return;
+            }
+        } catch (const std::exception& e) {
+            LogPrintf("Failed to serialize setup success message: %s\n", e.what());
+            client.m_disconnect_flag = true;
+            return;
+        }
+
+        client.m_setup_connection_confirmed = true;
+
+        break;
+    }
+    case node::Sv2MsgType::COINBASE_OUTPUT_DATA_SIZE: {
+        if (!client.m_setup_connection_confirmed) {
+            client.m_disconnect_flag = true;
+            return;
+        }
+
+        node::Sv2CoinbaseOutputDataSizeMsg coinbase_output_data_size;
+        try {
+            ss >> coinbase_output_data_size;
+            client.m_coinbase_output_data_size_recv = true;
+        } catch (const std::exception& e) {
+            LogPrintf("Received invalid CoinbaseOutputDataSize message: %s\n", e.what());
+            client.m_disconnect_flag = true;
+            return;
+        }
+
+        client.m_coinbase_tx_outputs_size = coinbase_output_data_size.m_coinbase_output_max_additional_size;
+
+        if (!SendWork(client, best_new_template, best_prev_hash, block_cache, template_id)) {
+            return;
+        }
+
+        break;
+    }
+    case node::Sv2MsgType::SUBMIT_SOLUTION: {
+        if (!client.m_setup_connection_confirmed && !client.m_coinbase_output_data_size_recv) {
+            client.m_disconnect_flag = true;
+            return;
+        }
+
+        node::Sv2SubmitSolutionMsg submit_solution;
+        try {
+            ss >> submit_solution;
+        } catch (const std::exception& e) {
+            LogPrintf("Received invalid SubmitSolution message: %e\n", e.what());
+            return;
+        }
+
+        auto cached_block = block_cache.find(submit_solution.m_template_id);
+        if (cached_block != block_cache.end()) {
+            CBlock& block = (*cached_block->second).block;
+
+            auto coinbase_tx = CTransaction(std::move(submit_solution.m_coinbase_tx));
+            block.vtx[0] = std::make_shared<CTransaction>(std::move(coinbase_tx));
+
+            block.nVersion = submit_solution.m_version;
+            block.nTime = submit_solution.m_header_timestamp;
+            block.nNonce = submit_solution.m_header_nonce;
+            block.hashMerkleRoot = BlockMerkleRoot(block);
+
+            auto blockptr = std::make_shared<CBlock>(std::move(block));
+            bool new_block{true};
+
+            m_chainman.ProcessNewBlock(blockptr, true /* force_processing */, true /* min_pow_checked */, &new_block);
+        }
+        break;
+    }
+    default: {
+        break;
+    }
+    }
+}

--- a/src/sv2_template_provider.h
+++ b/src/sv2_template_provider.h
@@ -155,6 +155,11 @@ private:
      */
     bool m_default_future_templates;
 
+    /**
+     * The configured port to listen for new connections.
+     */
+    uint16_t m_port;
+
 public:
     explicit Sv2TemplateProvider(ChainstateManager& chainman, CTxMemPool& mempool) : m_chainman{chainman}, m_mempool{mempool}
     {

--- a/src/sv2_template_provider.h
+++ b/src/sv2_template_provider.h
@@ -1,0 +1,253 @@
+#ifndef BITCOIN_SV2_TEMPLATE_PROVIDER_H
+#define BITCOIN_SV2_TEMPLATE_PROVIDER_H
+
+#include <logging.h>
+#include <node/sv2_messages.h>
+#include <node/miner.h>
+#include <streams.h>
+#include <util/sock.h>
+
+class ChainstateManager;
+class CTxMemPool;
+
+struct Sv2Client
+{
+    /**
+     * Receiving and sending socket for the connected client
+     */
+    std::shared_ptr<Sock> m_sock;
+
+    /**
+     * Whether the client has confirmed the connection with a successful SetupConnection.
+     */
+    bool m_setup_connection_confirmed;
+
+    /**
+     * Whether the client is a candidate for disconnection.
+     */
+    bool m_disconnect_flag;
+
+    /**
+     * Whether the client has received CoinbaseOutputDataSize message.
+     */
+    bool m_coinbase_output_data_size_recv;
+
+    /**
+     * Specific additional coinbase tx output size required for the client.
+     */
+    unsigned int m_coinbase_tx_outputs_size;
+
+    explicit Sv2Client(std::shared_ptr<Sock> sock) : m_sock{sock} {};
+};
+
+struct Sv2TemplateProviderOptions
+{
+    /**
+     * The default listening port for the server.
+     */
+    uint16_t port = 8442;
+
+    /**
+     * The current protocol version of stratum v2 supported by the server. Not to be confused
+     * with byte value of identitying the stratum v2 subprotocol.
+     */
+    uint16_t protocol_version = 2;
+
+    /**
+     * Optional protocol features provided by the server.
+     */
+    uint16_t optional_features = 0;
+
+    /**
+     * The default option for the additional space required for coinbase output.
+     */
+    unsigned int default_coinbase_tx_additional_output_size = 0;
+
+    /**
+     * The default flag for all new work.
+     */
+    bool default_future_templates = true;
+};
+
+/**
+ * The main class that runs the template provider server.
+ */
+class Sv2TemplateProvider
+{
+
+private:
+    /**
+     * The template provider subprotocol used in setup connection messages. The stratum v2
+     * template provider only recognizes its own subprotocol.
+     */
+    static constexpr uint8_t TP_SUBPROTOCOL{0x02};
+
+    /**
+     * The main listening socket for new stratum v2 connections.
+     */
+    std::shared_ptr<Sock> m_listening_socket;
+
+    /**
+     * The main thread for the template provider.
+     */
+    std::thread m_thread_sv2_handler;
+
+    /**
+     * Signal for handling interrupts and stopping the template provider event loop.
+     */
+    std::atomic<bool> m_flag_interrupt_sv2{false};
+    CThreadInterrupt m_interrupt_sv2;
+
+    /**
+     * ChainstateManager and CTxMemPool are both used to build new valid blocks,
+     * getting the best known block hash and checking whether the node is still
+     * in IBD.
+     */
+    ChainstateManager& m_chainman;
+    CTxMemPool& m_mempool;
+
+
+    /**
+     * A list of all connected stratum v2 clients.
+     */
+    using Clients = std::vector<std::unique_ptr<Sv2Client>>;
+    Clients m_sv2_clients;
+
+    /**
+     * The current best known new template id. This is incremented on each new template.
+     */
+    uint64_t m_template_id;
+
+    /**
+     * The best known template to send to all sv2 clients.
+     */
+    node::Sv2NewTemplateMsg m_best_new_template;
+
+    /**
+     * The current best known SetNewPrevHash that references the current best known
+     * block hash in the network.
+     */
+    node::Sv2SetNewPrevHashMsg m_best_prev_hash;
+
+    /**
+     * A cache that maps ids used in NewTemplate messages and its associated block.
+     */
+    using BlockCache = std::map<uint64_t, std::unique_ptr<node::CBlockTemplate>>;
+    BlockCache m_block_cache;
+
+    /**
+     * The currently supported protocol version.
+     */
+    uint16_t m_protocol_version;
+
+    /**
+     * The currently supported optional features.
+     */
+    uint16_t m_optional_features;
+
+    /**
+     * The default additional size output required for NewTemplates.
+     */
+    unsigned int m_default_coinbase_tx_additional_output_size;
+
+    /**
+     * The default setting for sending future templates.
+     */
+    bool m_default_future_templates;
+
+public:
+    explicit Sv2TemplateProvider(ChainstateManager& chainman, CTxMemPool& mempool) : m_chainman{chainman}, m_mempool{mempool}
+    {
+        Init({});
+    }
+
+    /**
+     * Starts the template provider server and thread.
+     * @throws std::runtime_error if port is unable to bind.
+     */
+    void Start(const Sv2TemplateProviderOptions& options);
+
+    /**
+     * Triggered on interrupt signals to stop the main event loop in ThreadSv2Handler().
+     */
+    void Interrupt();
+
+    /**
+     * Tear down of the template provider thread and any other necessary tear down.
+     */
+    void StopThreads();
+
+    /**
+     * Main handler for all received stratum v2 messages.
+     */
+    void ProcessSv2Message(const node::Sv2NetHeader& sv2_header, CDataStream& ss, Sv2Client& client, const node::Sv2NewTemplateMsg& best_new_template, const node::Sv2SetNewPrevHashMsg& best_prev_hash, BlockCache& block_cache, uint64_t& template_id);
+
+private:
+    void Init(const Sv2TemplateProviderOptions& options);
+
+    /**
+     * Creates a socket and binds the port for new stratum v2 connections.
+     * @throws std::runtime_error if port is unable to bind.
+     */
+    [[nodiscard]] std::shared_ptr<Sock> BindListenPort(uint16_t port) const;
+
+    /**
+     * The main thread for the template provider, contains an event loop handling
+     * all tasks for the template provider.
+     */
+    void ThreadSv2Handler();
+
+    /**
+     * NewWorkSet contains the messages matching block for valid stratum v2 work.
+     */
+    struct NewWorkSet
+    {
+        node::Sv2NewTemplateMsg new_template;
+        std::unique_ptr<node::CBlockTemplate> block_template;
+        node::Sv2SetNewPrevHashMsg prev_hash;
+    };
+
+    /**
+     * Builds a NewWorkSet that contains the Sv2NewTemplateMsg, a new full block and a Sv2SetNewPrevHashMsg that are all linked to the same work.
+     */
+    [[nodiscard]] NewWorkSet BuildNewWorkSet(bool future_template, unsigned int coinbase_output_max_additional_size, uint64_t template_id);
+
+    /**
+     * Sends the best NewTemplate and SetNewPrevHash to a client.
+     */
+    [[nodiscard]] bool SendWork(const Sv2Client& client, const node::Sv2NewTemplateMsg& new_template, const node::Sv2SetNewPrevHashMsg& prev_hash, BlockCache& block_cache, uint64_t& template_id);
+
+    /**
+     * Generates the socket events for each Sv2Client socket and the main listening socket.
+     */
+    [[nodiscard]] Sock::EventsPerSock GenerateWaitSockets(const std::shared_ptr<Sock>& listen_socket, const Clients& sv2_clients) const;
+
+    /**
+     * A helper method that will serialize and send a Sv2NetMsg to an Sv2Client.
+     */
+    template <typename T>
+    [[nodiscard]] bool Send(const Sv2Client& client, const node::Sv2NetMsg<T>& sv2_msg) {
+        CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+
+        try {
+            ss << sv2_msg;
+        } catch (const std::exception& e) {
+            LogPrintf("Error serializing Sv2NetMsg: %s\n", e.what());
+            return false;
+        }
+
+        try {
+            ssize_t sent = client.m_sock->Send(ss.data(), ss.size(), MSG_NOSIGNAL | MSG_DONTWAIT);
+            if (sent != static_cast<ssize_t>(ss.size())) {
+                return false;
+            }
+        } catch (const std::exception& e) {
+            LogPrintf("Error sending Sv2NetMsg: %s\n", e.what());
+            return false;
+        }
+
+        return true;
+    }
+};
+
+#endif // BITCOIN_SV2_TEMPLATE_PROVIDER_H

--- a/src/test/fuzz/sv2_messages.cpp
+++ b/src/test/fuzz/sv2_messages.cpp
@@ -1,0 +1,46 @@
+// Copyright (c) 2019-2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <node/sv2_messages.h>
+#include <test/fuzz/fuzz.h>
+#include <streams.h>
+
+FUZZ_TARGET(sv2_msgs)
+{
+    CDataStream ss_setup_conn(buffer, SER_NETWORK, INIT_PROTO_VERSION);
+    node::Sv2SetupConnectionMsg setup_conn;
+
+    try {
+        ss_setup_conn >> setup_conn;
+    } catch (const std::exception &e) {
+        return;
+    }
+
+    CDataStream ss_submit_solution(buffer, SER_NETWORK, INIT_PROTO_VERSION);
+    node::Sv2SubmitSolutionMsg submit_solution;
+
+    try {
+        ss_submit_solution >> submit_solution;
+    } catch (const std::exception &e) {
+        return;
+    }
+
+    CDataStream ss_coinbase_output_data(buffer, SER_NETWORK, INIT_PROTO_VERSION);
+    node::Sv2CoinbaseOutputDataSizeMsg coinbase_output_data;
+
+    try {
+        ss_coinbase_output_data >> coinbase_output_data;
+    } catch (const std::exception &e) {
+        return;
+    }
+
+    CDataStream ss_sv2_header(buffer, SER_NETWORK, INIT_PROTO_VERSION);
+    node::Sv2NetHeader sv2_header;
+
+    try {
+        ss_sv2_header >> sv2_header;
+    } catch (const std::exception &e) {
+        return;
+    }
+}

--- a/src/test/fuzz/sv2_template_provider.cpp
+++ b/src/test/fuzz/sv2_template_provider.cpp
@@ -1,0 +1,55 @@
+// Copyright (c) 2019-2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <node/sv2_messages.h>
+#include <sv2_template_provider.h>
+#include <test/fuzz/fuzz.h>
+#include <streams.h>
+#include <test/util/net.h>
+#include <test/util/setup_common.h>
+
+FUZZ_TARGET(sv2_template_provider)
+{
+    const auto testing_setup = MakeNoLogFileContext<const TestingSetup>();
+    const TestingSetup* setup = testing_setup.get();
+
+    CDataStream random_bytes(buffer, SER_NETWORK, INIT_PROTO_VERSION);
+
+    Sv2TemplateProvider template_provider{*setup->m_node.chainman, *setup->m_node.mempool};
+
+    node::Sv2NewTemplateMsg best_new_template;
+    node::Sv2SetNewPrevHashMsg best_prev_hash;
+    std::map<uint64_t, std::unique_ptr<node::CBlockTemplate>> block_cache;
+    uint64_t template_id;
+
+    auto sock = std::make_shared<StaticContentsSock>(std::string(1, 'a'));
+    Sv2Client client{sock};
+
+    client.m_setup_connection_confirmed = false;
+    template_provider.ProcessSv2Message(node::Sv2NetHeader{node::Sv2MsgType::SETUP_CONNECTION, static_cast<uint32_t>(buffer.size())},
+                                        random_bytes,
+                                        client,
+                                        best_new_template,
+                                        best_prev_hash,
+                                        block_cache,
+                                        template_id);
+
+    client.m_setup_connection_confirmed = true;
+    template_provider.ProcessSv2Message(node::Sv2NetHeader{node::Sv2MsgType::COINBASE_OUTPUT_DATA_SIZE, static_cast<uint32_t>(buffer.size())},
+                                        random_bytes,
+                                        client,
+                                        best_new_template,
+                                        best_prev_hash,
+                                        block_cache,
+                                        template_id);
+
+    client.m_coinbase_output_data_size_recv = true;
+    template_provider.ProcessSv2Message(node::Sv2NetHeader{node::Sv2MsgType::SUBMIT_SOLUTION, static_cast<uint32_t>(buffer.size())},
+                                        random_bytes,
+                                        client,
+                                        best_new_template,
+                                        best_prev_hash,
+                                        block_cache,
+                                        template_id);
+};

--- a/src/test/sv2_messages_tests.cpp
+++ b/src/test/sv2_messages_tests.cpp
@@ -1,0 +1,238 @@
+#include <boost/test/unit_test.hpp>
+#include <node/sv2_messages.h>
+#include <util/strencodings.h>
+
+BOOST_AUTO_TEST_SUITE(sv2_messages_tests)
+
+BOOST_AUTO_TEST_CASE(Sv2SetupConnection_test)
+{
+    uint8_t input[]{
+        0x02,                                                 // protocol
+        0x02, 0x00,                                           // min_version
+        0x02, 0x00,                                           // max_version
+        0x01, 0x00, 0x00, 0x00,                               // flags
+        0x07, 0x30, 0x2e, 0x30, 0x2e, 0x30, 0x2e, 0x30,       // endpoint_host
+        0x61, 0x21,                                           // endpoint_port
+        0x07, 0x42, 0x69, 0x74, 0x6d, 0x61, 0x69, 0x6e,       // vendor
+        0x08, 0x53, 0x39, 0x69, 0x20, 0x31, 0x33, 0x2e, 0x35, // hardware_version
+        0x1c, 0x62, 0x72, 0x61, 0x69, 0x69, 0x6e, 0x73, 0x2d, 0x6f, 0x73, 0x2d, 0x32, 0x30,
+        0x31, 0x38, 0x2d, 0x30, 0x39, 0x2d, 0x32, 0x32, 0x2d, 0x31, 0x2d, 0x68, 0x61, 0x73,
+        0x68, // firmware
+        0x10, 0x73, 0x6f, 0x6d, 0x65, 0x2d, 0x64, 0x65, 0x76, 0x69, 0x63, 0x65, 0x2d, 0x75,
+        0x75, 0x69, 0x64, // device_id
+    };
+    BOOST_CHECK_EQUAL(sizeof(input), 82);
+
+    CDataStream ss(input, SER_NETWORK, PROTOCOL_VERSION);
+    BOOST_CHECK_EQUAL(ss.size(), sizeof(input));
+
+    node::Sv2SetupConnectionMsg setup_conn;
+    ss >> setup_conn;
+
+    BOOST_CHECK_EQUAL(setup_conn.m_protocol, 2);
+    BOOST_CHECK_EQUAL(setup_conn.m_min_version, 2);
+    BOOST_CHECK_EQUAL(setup_conn.m_max_version, 2);
+    BOOST_CHECK_EQUAL(setup_conn.m_flags, 1);
+    BOOST_CHECK_EQUAL(setup_conn.m_endpoint_host, "0.0.0.0");
+    BOOST_CHECK_EQUAL(setup_conn.m_endpoint_port, 8545);
+    BOOST_CHECK_EQUAL(setup_conn.m_vendor, "Bitmain");
+    BOOST_CHECK_EQUAL(setup_conn.m_hardware_version, "S9i 13.5");
+    BOOST_CHECK_EQUAL(setup_conn.m_firmware, "braiins-os-2018-09-22-1-hash");
+    BOOST_CHECK_EQUAL(setup_conn.m_device_id, "some-device-uuid");
+}
+
+BOOST_AUTO_TEST_CASE(Sv2NetHeader_SetupConnection_test)
+{
+    uint8_t input[]{
+        0x00, 0x00,       // extension type
+        0x00,             // msg type (SetupConnection)
+        0x52, 0x00, 0x00, // msg length
+    };
+
+    CDataStream ss(input, SER_NETWORK, PROTOCOL_VERSION);
+    node::Sv2NetHeader sv2_header;
+    ss >> sv2_header;
+
+    BOOST_CHECK(sv2_header.m_msg_type == node::Sv2MsgType::SETUP_CONNECTION);
+    BOOST_CHECK_EQUAL(sv2_header.m_msg_len, 82);
+}
+
+BOOST_AUTO_TEST_CASE(Sv2SetupConnectionSuccess_test)
+{
+    // 0200 - used_version
+    // 03000000 - flags
+    std::string expected{"020003000000"};
+    node::Sv2SetupConnectionSuccessMsg setup_conn_success{2, 3};
+
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << setup_conn_success;
+
+    BOOST_CHECK_EQUAL(HexStr(ss), expected);
+}
+
+BOOST_AUTO_TEST_CASE(Sv2NetMsg_SetupConnectionSuccess_test)
+{
+    // 0000     - extension type
+    // 01       - msg type (SetupConnectionSuccess)
+    // 060000   - msg length
+    // 0200     - used_version
+    // 03000000 - flags
+    std::string expected{"000001060000020003000000"};
+    node::Sv2NetMsg sv2_net_msg{node::Sv2SetupConnectionSuccessMsg{2, 3}};
+
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << sv2_net_msg;
+
+    BOOST_CHECK_EQUAL(HexStr(ss), expected);
+}
+
+BOOST_AUTO_TEST_CASE(Sv2SetupConnectionError_test)
+{
+    // 00 00 00 00     - flags
+    // 19 - error_code length
+    // 70726f746f636f6c2d76657273696f6e2d6d69736d61746368 - error_code
+    std::string expected{"000000001970726f746f636f6c2d76657273696f6e2d6d69736d61746368"};
+    node::Sv2SetupConnectionErrorMsg setup_conn_err{0, std::string{"protocol-version-mismatch"}};
+
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << setup_conn_err;
+
+    BOOST_CHECK_EQUAL(HexStr(ss), expected);
+}
+
+
+BOOST_AUTO_TEST_CASE(Sv2NewTemplate_test)
+{
+    // 0100000000000000 - template_id
+    // 00 - future_template
+    // 00000030 - version
+    // 02000000 - coinbase tx version
+    // 04 - coinbase_prefix len
+    // 03012100 - coinbase prefix
+    // ffffffff - coinbase tx input sequence
+    // 0000000000000000 - coinbase tx value remaining
+    // 00000000 - coinbase tx outputs count
+    // 0000 - coinbase t outputs
+    // 01 - merkle path length
+    // 1a6240823de4c8d6aaf826851bdf2b0e8d5acf7c31e8578cff4c394b5a32bd4e - merkle path
+    std::string expected{"01000000000000000000000030020000000403012100ffffffff000000000000000000000000000000000000011a6240823de4c8d6aaf826851bdf2b0e8d5acf7c31e8578cff4c394b5a32bd4e"};
+
+    node::Sv2NewTemplateMsg new_template;
+    new_template.m_template_id = 1;
+    new_template.m_future_template = false;
+    new_template.m_version = 805306368;
+    new_template.m_coinbase_tx_version = 2;
+
+    std::vector<uint8_t> coinbase_prefix{0x03, 0x01, 0x21, 0x00};
+    CScript prefix(coinbase_prefix.begin(), coinbase_prefix.end());
+    new_template.m_coinbase_prefix = prefix;
+
+    new_template.m_coinbase_tx_input_sequence = 4294967295;
+    new_template.m_coinbase_tx_value_remaining = 0;
+    new_template.m_coinbase_tx_outputs_count = 0;
+
+    std::vector<CTxOut> coinbase_tx_ouputs;
+    new_template.m_coinbase_tx_outputs = coinbase_tx_ouputs;
+
+    new_template.m_coinbase_tx_locktime = 0;
+
+    std::vector<uint256> merkle_path;
+    CMutableTransaction mtx_tx;
+    CTransaction tx{mtx_tx};
+    merkle_path.push_back(tx.GetHash());
+    new_template.m_merkle_path = merkle_path;
+
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << new_template;
+
+    BOOST_CHECK_EQUAL(HexStr(ss), expected);
+}
+
+BOOST_AUTO_TEST_CASE(Sv2NetHeader_NewTemplate_test)
+{
+    // 0000 - extension type
+    // 71 - msg type (NewTemplate)
+    // 000000 - msg length
+    std::string expected{"000071000000"};
+    node::Sv2NetHeader sv2_header{node::Sv2MsgType::NEW_TEMPLATE, 0};
+
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << sv2_header;
+
+    BOOST_CHECK_EQUAL(HexStr(ss), expected);
+}
+
+
+BOOST_AUTO_TEST_CASE(Sv2SetNewPrevHash_test)
+{
+    // 0200000000000000 - template_id
+    // e59a2ef8d4826b89fe637f3b 5322c0f167fd2d3dc88ec568a7c2c8ffd8eb8873 - prev hash
+    // 973c0e63 - header timestamp
+    // ffff7f03 - nbits
+    // ffff7f0000000000000000000000000000000000000000000000000000000000 - target
+    std::string expected{"0200000000000000e59a2ef8d4826b89fe637f3b5322c0f167fd2d3dc88ec568a7c2c8ffd8eb8873973c0e63ffff7f03ffff7f0000000000000000000000000000000000000000000000000000000000"};
+
+    std::vector<uint8_t> prev_hash_input{
+        0xe5, 0x9a, 0x2e, 0xf8, 0xd4, 0x82, 0x6b, 0x89, 0xfe, 0x63, 0x7f, 0x3b,
+        0x53, 0x22, 0xc0, 0xf1, 0x67, 0xfd, 0x2d, 0x3d, 0xc8, 0x8e, 0xc5, 0x68,
+        0xa7, 0xc2, 0xc8, 0xff, 0xd8, 0xeb, 0x88, 0x73};
+    uint256 prev_hash = uint256(prev_hash_input);
+
+    CBlock block;
+    block.hashPrevBlock = prev_hash;
+    block.nTime = 1661877399;
+    block.nBits = 58720255;
+
+    node::Sv2SetNewPrevHashMsg new_prev_hash{block, 2};
+
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << new_prev_hash;
+
+    BOOST_CHECK_EQUAL(HexStr(ss), expected);
+}
+
+BOOST_AUTO_TEST_CASE(Sv2NetHeader_SetNewPrevHash_test)
+{
+    // 0000 - extension type
+    // 72 - msg type (SetNewPrevHash)
+    // 000000 - msg length
+    std::string expected{"000072000000"};
+    node::Sv2NetHeader sv2_header{node::Sv2MsgType::SET_NEW_PREV_HASH, 0};
+
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << sv2_header;
+
+    BOOST_CHECK_EQUAL(HexStr(ss), expected);
+}
+
+BOOST_AUTO_TEST_CASE(Sv2SubmitSolution_test)
+{
+    uint8_t input[]{
+        0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,   // template_id
+        0x02, 0x00, 0x00, 0x00,                           // version
+        0x97, 0x3c, 0x0e, 0x63,                           // header_timestamp
+        0xff, 0xff, 0x7f, 0x03,                           // header_nonce
+        0x5d, 0x00,                                       // 2 byte length of coinbase_tx
+        0x2, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, // coinbase_tx
+        0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+        0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+        0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0xff, 0xff,
+        0xff, 0x22, 0x1, 0x18, 0x0, 0x0, 0x3, 0x0, 0x0, 0x0,
+        0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+        0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+        0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0xff,
+        0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x16,
+        0x0, 0x14, 0x53, 0x12, 0x60, 0xaa, 0x2a, 0x19, 0x9e,
+        0x22, 0x8c, 0x53, 0x7d, 0xfa, 0x42, 0xc8, 0x2b, 0xea,
+        0x2c, 0x7c, 0x1f, 0x4d, 0x0, 0x0, 0x0, 0x0};
+    CDataStream ss(input, SER_NETWORK, PROTOCOL_VERSION);
+
+    node::Sv2SubmitSolutionMsg submit_solution;
+    ss >> submit_solution;
+
+    BOOST_CHECK_EQUAL(submit_solution.m_template_id, 2);
+    BOOST_CHECK_EQUAL(submit_solution.m_version, 2);
+    BOOST_CHECK_EQUAL(submit_solution.m_header_timestamp, 1661877399);
+    BOOST_CHECK_EQUAL(submit_solution.m_header_nonce, 58720255);
+}
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/sv2_template_provider_tests.cpp
+++ b/src/test/sv2_template_provider_tests.cpp
@@ -1,0 +1,141 @@
+#include <boost/test/unit_test.hpp>
+#include <node/sv2_messages.h>
+#include <sv2_template_provider.h>
+#include <util/strencodings.h>
+#include <util/sock.h>
+#include <test/util/setup_common.h>
+#include <test/util/net.h>
+
+BOOST_FIXTURE_TEST_SUITE(sv2_template_provider_tests, TestChain100Setup)
+
+BOOST_AUTO_TEST_CASE(Sv2TemplateProvider_ProcessSv2Message_test)
+{
+    Sv2TemplateProvider template_provider{*m_node.chainman, *m_node.mempool};
+
+    auto sock = std::make_shared<StaticContentsSock>(std::string(1, 'a'));
+    Sv2Client client{sock};
+    client.m_disconnect_flag = false;
+    client.m_setup_connection_confirmed = false;
+    BOOST_CHECK(!client.m_disconnect_flag);
+    BOOST_CHECK(!client.m_setup_connection_confirmed);
+
+    std::map<uint64_t, std::unique_ptr<node::CBlockTemplate>> block_cache;
+    uint64_t template_id{0};
+
+    node::Sv2NewTemplateMsg best_new_template;
+    node::Sv2SetNewPrevHashMsg best_prev_hash;
+
+    // Check that failure to deserialize the body of the message into a SetupConnection
+    // results in a disconnection for the client.
+    node::Sv2NetHeader sv2_net_header{node::Sv2MsgType::SETUP_CONNECTION, 0};
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+
+    template_provider.ProcessSv2Message(sv2_net_header,
+                                        ss,
+                                        client,
+                                        best_new_template,
+                                        best_prev_hash,
+                                        block_cache,
+                                        template_id);
+    BOOST_CHECK(client.m_disconnect_flag);
+
+    // Check that if a client is already connected and sends a SetupConnection message twice,
+    // they do not get marked for disconnection.
+    client.m_setup_connection_confirmed = true;
+    client.m_disconnect_flag = false;
+
+    template_provider.ProcessSv2Message(sv2_net_header,
+                                        ss,
+                                        client,
+                                        best_new_template,
+                                        best_prev_hash,
+                                        block_cache,
+                                        template_id);
+    BOOST_CHECK(!client.m_disconnect_flag);
+
+    // Check that sending a valid setup connection message can be handled successfully.
+    uint8_t setup_conn_bytes[]{
+        0x02,                                                 // protocol
+        0x02, 0x00,                                           // min_version
+        0x02, 0x00,                                           // max_version
+        0x01, 0x00, 0x00, 0x00,                               // flags
+        0x07, 0x30, 0x2e, 0x30, 0x2e, 0x30, 0x2e, 0x30,       // endpoint_host
+        0x61, 0x21,                                           // endpoint_port
+        0x07, 0x42, 0x69, 0x74, 0x6d, 0x61, 0x69, 0x6e,       // vendor
+        0x08, 0x53, 0x39, 0x69, 0x20, 0x31, 0x33, 0x2e, 0x35, // hardware_version
+        0x1c, 0x62, 0x72, 0x61, 0x69, 0x69, 0x6e, 0x73, 0x2d, 0x6f, 0x73, 0x2d, 0x32, 0x30,
+        0x31, 0x38, 0x2d, 0x30, 0x39, 0x2d, 0x32, 0x32, 0x2d, 0x31, 0x2d, 0x68, 0x61, 0x73,
+        0x68, // firmware
+        0x10, 0x73, 0x6f, 0x6d, 0x65, 0x2d, 0x64, 0x65, 0x76, 0x69, 0x63, 0x65, 0x2d, 0x75,
+        0x75, 0x69, 0x64, // device_id
+    };
+    CDataStream ss_setup_conn(setup_conn_bytes, SER_NETWORK, PROTOCOL_VERSION);
+
+    template_provider.ProcessSv2Message(node::Sv2NetHeader{node::Sv2MsgType::SETUP_CONNECTION, sizeof(setup_conn_bytes)},
+                                        ss_setup_conn,
+                                        client,
+                                        best_new_template,
+                                        best_prev_hash,
+                                        block_cache,
+                                        template_id);
+
+    BOOST_CHECK(client.m_setup_connection_confirmed);
+    BOOST_CHECK(!client.m_disconnect_flag);
+
+    // Check that sending an invalid sub protocol results in the client
+    // being set for disconnection.
+    client.m_setup_connection_confirmed = false;
+    setup_conn_bytes[0] = 0x03;
+    ss_setup_conn.clear();
+    ss_setup_conn = CDataStream(setup_conn_bytes, SER_NETWORK, PROTOCOL_VERSION);
+
+    template_provider.ProcessSv2Message(node::Sv2NetHeader{node::Sv2MsgType::SETUP_CONNECTION, sizeof(setup_conn_bytes)},
+                                        ss_setup_conn,
+                                        client,
+                                        best_new_template,
+                                        best_prev_hash,
+                                        block_cache,
+                                        template_id);
+
+    BOOST_CHECK(!client.m_setup_connection_confirmed);
+    BOOST_CHECK(client.m_disconnect_flag);
+
+    // Check that incompatible versions of the current sv2 protocol means the client is
+    // set for disconnection.
+    client.m_disconnect_flag = false;
+    BOOST_CHECK(!client.m_disconnect_flag);
+    setup_conn_bytes[1] = 0x05;
+    setup_conn_bytes[3] = 0x1a;
+    ss_setup_conn.clear();
+    ss_setup_conn = CDataStream(setup_conn_bytes, SER_NETWORK, PROTOCOL_VERSION);
+
+    template_provider.ProcessSv2Message(node::Sv2NetHeader{node::Sv2MsgType::SETUP_CONNECTION, sizeof(setup_conn_bytes)},
+                                        ss_setup_conn,
+                                        client,
+                                        best_new_template,
+                                        best_prev_hash,
+                                        block_cache,
+                                        template_id);
+
+    BOOST_CHECK(!client.m_setup_connection_confirmed);
+    BOOST_CHECK(client.m_disconnect_flag);
+
+    // Check that receiving a valid coinbase_output_max_additional_size_bytes results
+    // in a new block in the block cache matched with an incremented template id.
+    client.m_setup_connection_confirmed = true;
+    uint8_t coinbase_output_max_additional_size_bytes[]{
+        0x01, 0x00, 0x00, 0x00, // additional coinbase output size
+    };
+    CDataStream ss_coinbase_output_max_additional_size(coinbase_output_max_additional_size_bytes, SER_NETWORK, PROTOCOL_VERSION);
+
+    template_provider.ProcessSv2Message(node::Sv2NetHeader{node::Sv2MsgType::COINBASE_OUTPUT_DATA_SIZE, sizeof(coinbase_output_max_additional_size_bytes)},
+                                        ss_coinbase_output_max_additional_size,
+                                        client,
+                                        best_new_template,
+                                        best_prev_hash,
+                                        block_cache,
+                                        template_id);
+    BOOST_CHECK_EQUAL(template_id, 1);
+    BOOST_CHECK(block_cache.count(template_id));
+}
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -348,6 +348,8 @@ def p2p_port(n):
 def rpc_port(n):
     return PORT_MIN + PORT_RANGE + n + (MAX_NODES * PortSeed.n) % (PORT_RANGE - 1 - MAX_NODES)
 
+def sv2_port(n):
+    return rpc_port(n) * 2
 
 def rpc_url(datadir, i, chain, rpchost):
     rpc_u, rpc_p = get_auth_cookie(datadir, chain)
@@ -391,6 +393,7 @@ def write_config(config_path, *, n, chain, extra_config="", disable_autoconnect=
             f.write("[{}]\n".format(chain_name_conf_section))
         f.write("port=" + str(p2p_port(n)) + "\n")
         f.write("rpcport=" + str(rpc_port(n)) + "\n")
+        f.write("stratumv2=" + str(sv2_port(n)) + "\n")
         # Disable server-side timeouts to avoid intermittent issues
         f.write("rpcservertimeout=99000\n")
         f.write("rpcdoccheck=1\n")


### PR DESCRIPTION
## Description
                                                                                                                                                                                                                                               
This is a WIP/draft pull request seeking concept/approach ACK. The goal is to initiate discussion and gather feedback on the proposed changes to see if there is sufficient support for an ACK before finalizing an implementation.

This PR initially proposes the addition of a new thread and server to enable Bitcoin Core to run as a Sv2 TP (Stratum V2 Template Provider). This approach is the most direct and naive approach in regards to integrating into the Bitcoin architecture. It builds on https://github.com/bitcoin/bitcoin/pull/23049 but no longer uses the Rust library and implements the server and message de/serialization in C++.

This PR branch has been used for testing with the [SRI (Stratum V2 Reference Implementation)](https://github.com/stratum-mining/stratum), but it has been limited to regtest and some tests on testnet. This branch is considered far from complete.

## Context

Stratum V2 is a proposed evolution of the stratum mining protocol, it has several benefits over its predecessor:

- By default, it uses secure communication, which can protect against man-in-the-middle-attacks, e.g. [hashrate hijacking](https://braiins.com/blog/hashrate-robbery-stratum-v2-fixes-this-and-more)                                                           

- It uses a binary protocol instead of JSON, optimizing data transfer between all parties

- It allows miners/downstream connections to propose their own transaction sets to mining pools                                                                                                                                    

- It can reduce occurrence of empty mined blocks

Links below for further reference:

- Stratum V2 specification: https://github.com/stratum-mining/sv2-spec
- SRI (Stratum V2 Reference Implementation): https://github.com/stratum-mining/stratum
- Stratum V2 overview: https://stratumprotocol.org/

## Motivation
                                                                                                                                                                                                                  
The motivation for this PR and potential future work is to allow Bitcoin Core to run as a Sv2 TP. This will enable downstream Sv2 connections to be able to connect and receive/submit valid work over the Sv2 protocol.

Below is an outline of a few pros/cons regarding the Sv2 TP  in Bitcoin Core.

Pros:

- Running Bitcoin Core with a config flag to enable the Sv2 TP could be arguably easier for adoption. A user would only need to be able to compile and run Bitcoin Core and its dependencies to be able to extract valid work and broadcast legitimate work over the Sv2 protocol

- The Sv2 TP being as close as possible to the mempool and p2p network benefits downstream connections so that they can start new work quickly. The time between a node learning of a  new best block and then sending new work downstream should be as minimal as possible

- Implementing the Sv2 TP in C++ means it should be (hopefully) easier for a wider range of contributors/reviewers to be able to maintain and build. The Sv2 TP only uses a small subset of messages from the entire Sv2 Rust library. Therefore, we realized that re-implementing a subset of the messages in C++ and implementing a server carries less external dependency risk and less architectural complexity

- No additional external dependencies are required

Cons:

- The Sv2 TP in core will need to be kept up to date with changes in the SRI, coordination would be required to prevent any potential versioning issues

- Adds  another thread/sub-module that will need to access the mempool to build candidate blocks, so there would be another area of the code attempting to acquire `cs_main` via `BlockAssembler`

- Another architectural approach other than a new thread and server for the Sv2 TP might be preferred such as the current work in the [multiprocess project](https://github.com/bitcoin-core/bitcoin-devwiki/wiki/Process-Separation)


## Build

To run the Sv2 TP on this branch, Bitcoin needs to be configured with `./configure --enable-template-provider`.

## Future work

If there is sufficient approach/concept ACK or support in general. Then the below points are outstanding future work and existing nits.

Future work:

- A noise implementation from the noise protocol framework needs to be introduced for secure communication between the Sv2 TP and downstream connections. The [noise spec for Sv2 has been reworked](https://github.com/stratum-mining/sv2-spec/blob/main/04-Protocol-Security.md#43-choice-of-cryptographic-primitives) to accommodate resources currently available in core e.g. `secp256k1` and `BIP 340 schnorrsig`

- There are current working changes proposed to the Sv2 TP spec, to allow downstream connections to send shorttxid  sets, allowing miners/downstream connections to present their own tx sets 

- Perhaps the Sv2 TP should be adapted to current work in the Bitcoin Core architecture. The new thread has been helpful for testing against the current SRI stack, it seems like the server implementation can adapt easily to different architectural needs

Existing/known nits:

- The server implementation has no limit on the number of downstream connections, it needs to be added

- There could be potential conflict with functional tests. The Sv2 TP responds to the best new block change by reaching into the mempool and building a new block for downstream. My guess is that it would be acceptable to disable the Sv2 TP when running functional tests that asserts mempool state and then enable the Sv2 TP when it needs to specifically run its functional tests

- Getting the full merkle path is required in the [NewTemplate](https://github.com/stratum-mining/sv2-spec/blob/main/07-Template-Distribution-Protocol.md#72-newtemplate-server---client) message. I noticed that this was previously possible with the old implementation that was moved to [merkle_test.cpp](https://github.com/bitcoin/bitcoin/blob/2026301405f83c925ca68db6a3cd5134ed619ca7/src/test/merkle_tests.cpp#L114) , the current implementation does an in-place calculation to just return the root.  I was wondering if anyone has any suggestions or insight to a preferred solution? e.g. Move back  the old functions from merkle_tests or write a new implementation?
 
Thank you to all who helped contribute to the process of building this branch including working on the SRI, using this branch for testing and refining the Sv2 specs.

Any feedback or reviews from nits to overall approach would be very much appreciated.
