### PR TITLE
Mempool: persist mempoolminfee accross restarts

### DIFF
--- a/src/kernel/mempool_options.h
+++ b/src/kernel/mempool_options.h
@@ -57,6 +57,7 @@ struct MemPoolOptions {
     bool require_standard{true};
     bool full_rbf{DEFAULT_MEMPOOL_FULL_RBF};
     MemPoolLimits limits{};
+    bool is_min_relay_feerate_set{false};
 };
 } // namespace kernel
 

--- a/src/node/mempool_args.cpp
+++ b/src/node/mempool_args.cpp
@@ -59,6 +59,7 @@ util::Result<void> ApplyArgsManOptions(const ArgsManager& argsman, const CChainP
         if (std::optional<CAmount> min_relay_feerate = ParseMoney(argsman.GetArg("-minrelaytxfee", ""))) {
             // High fee check is done afterward in CWallet::Create()
             mempool_opts.min_relay_feerate = CFeeRate{min_relay_feerate.value()};
+            mempool_opts.is_min_relay_feerate_set = true;
         } else {
             return util::Error{AmountErrMsg("minrelaytxfee", argsman.GetArg("-minrelaytxfee", ""))};
         }

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -734,6 +734,13 @@ public:
         return m_sequence_number;
     }
 
+    /** Flush fee estimates and mempool minimum fee to file */
+    void FlushFeeEstimatesAndMempoolMinFee() const EXCLUSIVE_LOCKS_REQUIRED(!cs);
+
+    void SetMempoolMinFee() const EXCLUSIVE_LOCKS_REQUIRED(!cs);
+
+    CAmount GetMempoolMinFee() const EXCLUSIVE_LOCKS_REQUIRED(!cs);
+
 private:
     /** UpdateForDescendants is used by UpdateTransactionsFromBlock to update
      *  the descendants for a single transaction that has been added to the

--- a/test/functional/feature_fee_estimation.py
+++ b/test/functional/feature_fee_estimation.py
@@ -232,7 +232,7 @@ class EstimateFeeTest(BitcoinTestFramework):
         high_val = 3 * self.nodes[1].estimatesmartfee(1)["feerate"]
         self.restart_node(1, extra_args=[f"-minrelaytxfee={high_val}"])
         check_estimates(self.nodes[1], self.fees_per_kb)
-        self.restart_node(1)
+        self.restart_node(1, extra_args=["-minrelaytxfee=0.00001000"])
 
     def sanity_check_rbf_estimates(self, utxos):
         """During 5 blocks, broadcast low fee transactions. Only 10% of them get

--- a/test/functional/feature_mempool_min_fee_persist.py
+++ b/test/functional/feature_mempool_min_fee_persist.py
@@ -1,0 +1,161 @@
+# !/usr/bin/env python3
+# Copyright (c) 2014-2023 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test mempool minimum fee persistence.
+
+bitcoind will dump mempool minimum fee periodically and on shutdown.
+On start, it will reload the maximum of persisted mempool minimum fee and
+default minimum fee as the mempool minimum fee in the absence of
+user-configured minrelaytxfee.
+"""
+
+from decimal import Decimal
+import os
+import time
+
+from feature_fee_estimation import SECONDS_PER_HOUR
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+from test_framework.wallet import MiniWallet
+
+DEFAULT_MEMPOOL_MINIMUM_FEE = 0.00001000
+DUMP_VERSION = 1
+LOW_MEMPOOL_MINIMUM_FEE = 0.00000100
+HIGH_MEMPOOL_MINIMUM_FEE = 0.00025000
+MAX_MEMPOOL_MIN_FEE_AGE = 1
+
+class MempoolMinFeePersistTest(BitcoinTestFramework):
+    def add_options(self, parser):
+        self.add_wallet_options(parser, legacy=False, descriptors=True)
+
+    def set_test_params(self):
+        self.num_nodes = 2
+        self.extra_args = [[f"-minrelaytxfee={HIGH_MEMPOOL_MINIMUM_FEE}"], []]
+
+    def setup_network(self):
+        self.add_nodes(2, extra_args=self.extra_args)
+        self.start_nodes(extra_args=self.extra_args)
+        self.node0 = self.nodes[0]
+        self.wallet0 = MiniWallet(self.node0)
+        self.node1 = self.nodes[1]
+
+    def test_persistence_of_mempool_min_fee(self):
+        # Test that the mempool_min fee is set initially
+        assert_equal(float(self.node0.getmempoolinfo()["mempoolminfee"]), HIGH_MEMPOOL_MINIMUM_FEE)
+        assert_equal(float(self.node1.getmempoolinfo()["mempoolminfee"]), DEFAULT_MEMPOOL_MINIMUM_FEE)
+
+        # Test transactions with fee rate >= mempool minimum fee will be accepted into the Mempool
+        high_fee_tx_hex = self.wallet0.create_self_transfer(fee_rate=Decimal(HIGH_MEMPOOL_MINIMUM_FEE * 2))["tx"].serialize().hex()
+        res = self.node0.testmempoolaccept([high_fee_tx_hex])[0]
+        assert_equal(res['allowed'], True)
+        res = self.node1.testmempoolaccept([high_fee_tx_hex])[0]
+        assert_equal(res['allowed'], True)
+
+        # Test transactions with a fee rate < memPool minimum fee will not be accepted into node0 the Mempool
+        default_fee_tx_hex = self.wallet0.create_self_transfer(fee_rate=Decimal(DEFAULT_MEMPOOL_MINIMUM_FEE))["tx"].serialize().hex()
+        res = self.node0.testmempoolaccept([default_fee_tx_hex])[0]
+        assert_equal(res['allowed'], False)
+
+        # Since node1 has a low mempool minimum fee it will accept the low fee transaction into it's Mempool
+        res = self.node1.testmempoolaccept([default_fee_tx_hex])[0]
+        assert_equal(res['allowed'], True)
+
+        # Stop the nodes and test that the Mempool minimum fee will be flushed
+        self.stop_nodes()
+
+        # Verify that the string "Mempool minimum fee flushed to fee_estimates.dat." is present in both
+        # nodes debug.log. If present, then the Mempool minimum fee was flushed.
+        self.node0.assert_debug_log(expected_msgs=["Mempool minimum fee flushed to fee_estimates.dat."])
+        self.node1.assert_debug_log(expected_msgs=["Mempool minimum fee flushed to fee_estimates.dat."])
+
+        # Start the nodes without the minrelaytxfee option on node0 and verify that the persisted will be read
+        self.start_nodes(extra_args=[[], []])
+        self.node0.assert_debug_log(expected_msgs=["Mempool minimum fee read from fee_estimates.dat."])
+        self.node1.assert_debug_log(expected_msgs=["Mempool minimum fee read from fee_estimates.dat."])
+
+        assert_equal(float(self.node0.getmempoolinfo()["mempoolminfee"]), HIGH_MEMPOOL_MINIMUM_FEE)
+        assert_equal(float(self.node1.getmempoolinfo()["mempoolminfee"]), DEFAULT_MEMPOOL_MINIMUM_FEE)
+
+        self.log.info("Test after restart, transactions with fee rate lower than Mempool min fee will not be accepted into the Mempool")
+        # Test transactions with enough fee rate
+        res = self.node0.testmempoolaccept([high_fee_tx_hex])[0]
+        assert_equal(res['allowed'], True)
+        res = self.node1.testmempoolaccept([high_fee_tx_hex])[0]
+        assert_equal(res['allowed'], True)
+
+        # Test with a low fee rate lower than node0's mempool minimum fee
+        res = self.node0.testmempoolaccept([default_fee_tx_hex])[0]
+        assert_equal(res['allowed'], False)
+
+        # Test with a low fee rate higher than node1's mempool minimum fee
+        res = self.node1.testmempoolaccept([default_fee_tx_hex])[0]
+        assert_equal(res['allowed'], True)
+
+    def test_not_reading_lower_mempool_min_fee(self):
+        # Restart node0 with a low mempool minimum fee
+        self.restart_node(0, extra_args=[f"-minrelaytxfee={LOW_MEMPOOL_MINIMUM_FEE:.8f}"])
+        # Restart node1 with the persisted Mempool minimum fee
+        self.restart_node(1)
+        assert_equal(float(self.node0.getmempoolinfo()["mempoolminfee"]), LOW_MEMPOOL_MINIMUM_FEE)
+        assert_equal(float(self.node1.getmempoolinfo()["mempoolminfee"]), DEFAULT_MEMPOOL_MINIMUM_FEE)
+
+        # Create a low fee transaction and test that it will be accepted into node0's Mempool
+        low_fee_tx_hex = self.wallet0.create_self_transfer(fee_rate=Decimal(LOW_MEMPOOL_MINIMUM_FEE))["tx"].serialize().hex()
+        res = self.node0.testmempoolaccept([low_fee_tx_hex])[0]
+        assert_equal(res['allowed'], True)
+
+        # Test that the low fee transaction will not be accepted into node1
+        res = self.node1.testmempoolaccept([low_fee_tx_hex])[0]
+        assert_equal(res['allowed'], False)
+
+        # Restart the nodes with the persisted mempool minimum fee
+        self.restart_node(0, extra_args=[])
+        self.restart_node(1, extra_args=[])
+
+        # Test that the fee rate for node0 is back to default
+        assert_equal(float(self.node0.getmempoolinfo()["mempoolminfee"]), DEFAULT_MEMPOOL_MINIMUM_FEE)
+        assert_equal(float(self.node1.getmempoolinfo()["mempoolminfee"]), DEFAULT_MEMPOOL_MINIMUM_FEE)
+
+    def test_mempool_min_fee_is_flushed_periodically(self):
+        with self.nodes[0].assert_debug_log(expected_msgs=["Mempool minimum fee flushed to fee_estimates.dat."]):
+            # Mock the scheduler for an hour, the mempool minimum fee will be flushed to fee_estimates.dat.
+            self.nodes[0].mockscheduler(SECONDS_PER_HOUR)
+
+    def test_reading_stale_mempool_min_fee(self):
+        # Get the mempool minimum fee rate while node is running
+        mempoolminfee = self.nodes[0].getmempoolinfo()["mempoolminfee"]
+
+        # Restart node to ensure mempool minimum fee is read
+        self.restart_node(0)
+        assert_equal(self.nodes[0].getmempoolinfo()["mempoolminfee"], mempoolminfee)
+
+        fee_dat = self.nodes[0].chain_path / "fee_estimates.dat"
+
+        # Stop the node and backdate the fee_estimates.dat file more than MAX_MEMPOOL_MIN_FEE_AGE with a second
+        self.stop_node(0)
+        last_modified_time = time.time() - (((MAX_MEMPOOL_MIN_FEE_AGE) * SECONDS_PER_HOUR)  + 1 )
+        os.utime(fee_dat, (last_modified_time, last_modified_time))
+
+        # Start node and ensure the mempool minimum fee file was not read and is back to default
+        self.start_node(0)
+        assert_equal(float(self.node1.getmempoolinfo()["mempoolminfee"]), DEFAULT_MEMPOOL_MINIMUM_FEE)
+
+    def run_test(self):
+        self.log.info("Test that the mempool minimum fee will be persisted to fee_estimates.dat.")
+        self.test_persistence_of_mempool_min_fee()
+
+        self.log.info("Test that the persisted mempool minimum fee lower than default mempool minimum fee will not be read.")
+        self.test_not_reading_lower_mempool_min_fee()
+
+        self.log.info("Test that the mempool minimum fee will be flushed to disk periodically.")
+        self.test_mempool_min_fee_is_flushed_periodically()
+
+        self.log.info("Test stale mempool minimum fee will not be read")
+        self.restart_node(0, extra_args=[f"-minrelaytxfee={HIGH_MEMPOOL_MINIMUM_FEE:.8f}"])
+        self.test_reading_stale_mempool_min_fee()
+
+
+
+if __name__ == "__main__":
+    MempoolMinFeePersistTest().main()

--- a/test/functional/mempool_limit.py
+++ b/test/functional/mempool_limit.py
@@ -132,9 +132,9 @@ class MempoolLimitTest(BitcoinTestFramework):
         node = self.nodes[0]
         self.log.info("Check a package where each parent passes the current mempoolminfee but would cause eviction before package submission terminates")
 
-        self.restart_node(0, extra_args=self.extra_args[0])
+        # Reset mempool minimum feerate
+        self.restart_node(0, ["-minrelaytxfee=0.00001000"] + self.extra_args[0])
 
-        # Restarting the node resets mempool minimum feerate
         assert_equal(node.getmempoolinfo()['minrelaytxfee'], Decimal('0.00001000'))
         assert_equal(node.getmempoolinfo()['mempoolminfee'], Decimal('0.00001000'))
 

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -309,6 +309,7 @@ BASE_SCRIPTS = [
     'wallet_encryption.py --descriptors',
     'feature_dersig.py',
     'feature_cltv.py',
+    'feature_mempool_min_fee_persist.py --descriptors',
     'rpc_uptime.py',
     'feature_discover.py',
     'wallet_resendwallettransactions.py --legacy-wallet',

--- a/test/functional/wallet_bumpfee.py
+++ b/test/functional/wallet_bumpfee.py
@@ -459,7 +459,7 @@ def test_bumpfee_with_abandoned_descendant_succeeds(self, rbf_node, rbf_node_add
     assert bumped_result['txid'] in rbf_node.getrawmempool()
     assert parent_id not in rbf_node.getrawmempool()
     # Cleanup
-    self.restart_node(1, self.extra_args[1])
+    self.restart_node(1, ["-minrelaytxfee=0.00001000"] + self.extra_args[1])
     rbf_node.walletpassphrase(WALLET_PASSPHRASE, WALLET_PASSPHRASE_TIMEOUT)
     self.connect_nodes(1, 0)
     self.clear_mempool()

--- a/test/functional/wallet_fundrawtransaction.py
+++ b/test/functional/wallet_fundrawtransaction.py
@@ -1380,7 +1380,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         do_fund_send(lower_bound)
         do_fund_send(upper_bound)
 
-        self.restart_node(0)
+        self.restart_node(0, ["-minrelaytxfee=0.00001000"])
         self.connect_nodes(0, 1)
         self.connect_nodes(0, 2)
         self.connect_nodes(0, 3)


### PR DESCRIPTION
Follow-up [#27622](https://github.com/bitcoin/bitcoin/pull/27622)
See –> [Comment](https://github.com/bitcoin/bitcoin/issues/27555#issuecomment-1538504504) 
Currently, there is no persistence of mempoolminfee
As mentioned in the comment

> persist `mempoolminfee` across restarts to at least tell user a plausible value to stay in the mempool for a bit

The suggestions outlined in the comment are implemented in this pull request. The `mempoolminfee` will now be persisted on shutdown and periodically in the event of an unclean shutdown.
Upon restart, the previous `mempoolminfee` value will be remembered, and any transactions with fees below the persisted mempoolminfee will be rejected from entering the mempool.

If a user passes the `-minrelaytxfee`, it will be utilized as the `mempoolminfee`, just as it was prior to this pull request. 
When reading the persisted mempoolminfee, we take the max of the persisted value and the default minimum fee of 1000 satoshis, ensuring that the remembered `mempoolminfee` value will not be less than 1000 satoshis.