### PR TITLE
wallet: Track no-longer-spendable TXOs separately

### DIFF
--- a/src/wallet/receive.cpp
+++ b/src/wallet/receive.cpp
@@ -252,6 +252,8 @@ Balance GetBalance(const CWallet& wallet, const int min_depth, bool avoid_reuse,
         for (const auto& [outpoint, txo] : wallet.GetTXOs()) {
             const bool is_trusted{CachedTxIsTrusted(wallet, txo.GetState(), outpoint.hash, trusted_parents)};
             const int tx_depth{wallet.GetTxStateDepthInMainChain(txo.GetState())};
+            Assert(tx_depth >= 0);
+            Assert(!wallet.IsSpent(outpoint, /*min_depth=*/1));
 
             bool nonmempool_spent = false;
             switch (wallet.HowSpent(outpoint)) {

--- a/src/wallet/receive.cpp
+++ b/src/wallet/receive.cpp
@@ -304,7 +304,7 @@ std::map<CTxDestination, CAmount> GetAddressBalances(const CWallet& wallet)
             if (wallet.IsTXOInImmatureCoinBase(txo)) continue;
 
             int nDepth = wallet.GetTxStateDepthInMainChain(txo.GetState());
-            if (nDepth < (txo.GetWalletTx().m_from_me.value() ? 0 : 1)) continue;
+            if (nDepth < (txo.GetTxFromMe() ? 0 : 1)) continue;
 
             CTxDestination addr;
             Assume(wallet.IsMine(txo.GetTxOut()));

--- a/src/wallet/receive.cpp
+++ b/src/wallet/receive.cpp
@@ -193,14 +193,6 @@ void CachedTxGetAmounts(const CWallet& wallet, const CWalletTx& wtx,
 
 }
 
-bool CachedTxIsFromMe(const CWallet& wallet, const CWalletTx& wtx)
-{
-    if (!wtx.m_cached_from_me.has_value()) {
-        wtx.m_cached_from_me = wallet.IsFromMe(*wtx.GetTx());
-    }
-    return wtx.m_cached_from_me.value();
-}
-
 // NOLINTNEXTLINE(misc-no-recursion)
 bool CachedTxIsTrusted(const CWallet& wallet, const CWalletTx& wtx, std::set<Txid>& trusted_parents)
 {
@@ -212,7 +204,7 @@ bool CachedTxIsTrusted(const CWallet& wallet, const CWalletTx& wtx, std::set<Txi
     if (wtx.isConfirmed()) return true;
     if (wtx.isBlockConflicted()) return false;
     // using wtx's cached debit
-    if (!wallet.m_spend_zero_conf_change || !CachedTxIsFromMe(wallet, wtx)) return false;
+    if (!wallet.m_spend_zero_conf_change || !wtx.m_from_me.value()) return false;
 
     // Don't trust unconfirmed transactions from us unless they are in the mempool.
     if (!wtx.InMempool()) return false;
@@ -308,7 +300,7 @@ std::map<CTxDestination, CAmount> GetAddressBalances(const CWallet& wallet)
             if (wallet.IsTxImmatureCoinBase(wtx)) continue;
 
             int nDepth = wallet.GetTxDepthInMainChain(wtx);
-            if (nDepth < (CachedTxIsFromMe(wallet, wtx) ? 0 : 1)) continue;
+            if (nDepth < (wtx.m_from_me.value() ? 0 : 1)) continue;
 
             CTxDestination addr;
             Assume(wallet.IsMine(txo.GetTxOut()));

--- a/src/wallet/receive.cpp
+++ b/src/wallet/receive.cpp
@@ -194,23 +194,26 @@ void CachedTxGetAmounts(const CWallet& wallet, const CWalletTx& wtx,
 }
 
 // NOLINTNEXTLINE(misc-no-recursion)
-bool CachedTxIsTrusted(const CWallet& wallet, const CWalletTx& wtx, std::set<Txid>& trusted_parents)
+bool CachedTxIsTrusted(const CWallet& wallet, const TxState& state, const Txid& txid, std::set<Txid>& trusted_parents)
 {
     AssertLockHeld(wallet.cs_wallet);
 
     // This wtx is already trusted
-    if (trusted_parents.contains(wtx.GetHash())) return true;
+    if (trusted_parents.contains(txid)) return true;
 
-    if (wtx.isConfirmed()) return true;
-    if (wtx.isBlockConflicted()) return false;
-    // using wtx's cached debit
-    if (!wallet.m_spend_zero_conf_change || !wtx.m_from_me.value()) return false;
+    if (std::holds_alternative<TxStateConfirmed>(state)) return true;
+    if (std::holds_alternative<TxStateBlockConflicted>(state)) return false;
 
     // Don't trust unconfirmed transactions from us unless they are in the mempool.
-    if (!wtx.InMempool()) return false;
+    if (!std::holds_alternative<TxStateInMempool>(state)) return false;
+
+    const CWalletTx* wtx = wallet.GetWalletTx(txid);
+    assert(wtx);
+
+    if (!wallet.m_spend_zero_conf_change || !wtx->m_from_me) return false;
 
     // Trusted if all inputs are from us and are in the mempool:
-    for (const CTxIn& txin : wtx.GetTx()->vin)
+    for (const CTxIn& txin : wtx->GetTx()->vin)
     {
         // Transactions not sent by us: not trusted
         const CWalletTx* parent = wallet.GetWalletTx(txin.prevout.hash);
@@ -221,10 +224,15 @@ bool CachedTxIsTrusted(const CWallet& wallet, const CWalletTx& wtx, std::set<Txi
         // If we've already trusted this parent, continue
         if (trusted_parents.contains(parent->GetHash())) continue;
         // Recurse to check that the parent is also trusted
-        if (!CachedTxIsTrusted(wallet, *parent, trusted_parents)) return false;
+        if (!CachedTxIsTrusted(wallet, parent->GetState(), parent->GetHash(), trusted_parents)) return false;
         trusted_parents.insert(parent->GetHash());
     }
     return true;
+}
+
+bool CachedTxIsTrusted(const CWallet& wallet, const CWalletTx& wtx, std::set<Txid>& trusted_parents)
+{
+    return CachedTxIsTrusted(wallet, wtx.GetState(), wtx.GetHash(), trusted_parents);
 }
 
 bool CachedTxIsTrusted(const CWallet& wallet, const CWalletTx& wtx)
@@ -242,10 +250,8 @@ Balance GetBalance(const CWallet& wallet, const int min_depth, bool avoid_reuse,
         LOCK(wallet.cs_wallet);
         std::set<Txid> trusted_parents;
         for (const auto& [outpoint, txo] : wallet.GetTXOs()) {
-            const CWalletTx& wtx = txo.GetWalletTx();
-
-            const bool is_trusted{CachedTxIsTrusted(wallet, wtx, trusted_parents)};
-            const int tx_depth{wallet.GetTxDepthInMainChain(wtx)};
+            const bool is_trusted{CachedTxIsTrusted(wallet, txo.GetState(), outpoint.hash, trusted_parents)};
+            const int tx_depth{wallet.GetTxStateDepthInMainChain(txo.GetState())};
 
             bool nonmempool_spent = false;
             switch (wallet.HowSpent(outpoint)) {
@@ -261,11 +267,11 @@ Balance GetBalance(const CWallet& wallet, const int min_depth, bool avoid_reuse,
                 CAmount* bucket = nullptr;
 
                 // Set the amounts in the return object
-                if (wallet.IsTxImmatureCoinBase(wtx) && wtx.isConfirmed()) {
+                if (wallet.IsTXOInImmatureCoinBase(txo) && std::holds_alternative<TxStateConfirmed>(txo.GetState())) {
                     bucket = &ret.m_mine_immature;
                 } else if (is_trusted && tx_depth >= min_depth) {
                     bucket = &ret.m_mine_trusted;
-                } else if (!is_trusted && wtx.InMempool()) {
+                } else if (!is_trusted && tx_depth == 0 && std::get_if<TxStateInMempool>(&txo.GetState())) {
                     bucket = &ret.m_mine_untrusted_pending;
                 }
                 if (bucket) {
@@ -294,13 +300,11 @@ std::map<CTxDestination, CAmount> GetAddressBalances(const CWallet& wallet)
         LOCK(wallet.cs_wallet);
         std::set<Txid> trusted_parents;
         for (const auto& [outpoint, txo] : wallet.GetTXOs()) {
-            const CWalletTx& wtx = txo.GetWalletTx();
+            if (!CachedTxIsTrusted(wallet, txo.GetState(), outpoint.hash, trusted_parents)) continue;
+            if (wallet.IsTXOInImmatureCoinBase(txo)) continue;
 
-            if (!CachedTxIsTrusted(wallet, wtx, trusted_parents)) continue;
-            if (wallet.IsTxImmatureCoinBase(wtx)) continue;
-
-            int nDepth = wallet.GetTxDepthInMainChain(wtx);
-            if (nDepth < (wtx.m_from_me.value() ? 0 : 1)) continue;
+            int nDepth = wallet.GetTxStateDepthInMainChain(txo.GetState());
+            if (nDepth < (txo.GetWalletTx().m_from_me.value() ? 0 : 1)) continue;
 
             CTxDestination addr;
             Assume(wallet.IsMine(txo.GetTxOut()));

--- a/src/wallet/receive.h
+++ b/src/wallet/receive.h
@@ -39,7 +39,6 @@ void CachedTxGetAmounts(const CWallet& wallet, const CWalletTx& wtx,
                         std::list<COutputEntry>& listSent,
                         CAmount& nFee,
                         bool include_change);
-bool CachedTxIsFromMe(const CWallet& wallet, const CWalletTx& wtx);
 bool CachedTxIsTrusted(const CWallet& wallet, const CWalletTx& wtx, std::set<Txid>& trusted_parents) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
 bool CachedTxIsTrusted(const CWallet& wallet, const CWalletTx& wtx);
 

--- a/src/wallet/receive.h
+++ b/src/wallet/receive.h
@@ -39,6 +39,7 @@ void CachedTxGetAmounts(const CWallet& wallet, const CWalletTx& wtx,
                         std::list<COutputEntry>& listSent,
                         CAmount& nFee,
                         bool include_change);
+bool CachedTxIsTrusted(const CWallet& wallet, const TxState& state, const Txid& txid, std::set<Txid>& trusted_parents) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
 bool CachedTxIsTrusted(const CWallet& wallet, const CWalletTx& wtx, std::set<Txid>& trusted_parents) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet);
 bool CachedTxIsTrusted(const CWallet& wallet, const CWalletTx& wtx);
 

--- a/src/wallet/rpc/transactions.cpp
+++ b/src/wallet/rpc/transactions.cpp
@@ -765,10 +765,10 @@ RPCMethod gettransaction()
     CAmount nCredit = CachedTxGetCredit(*pwallet, wtx, /*avoid_reuse=*/false);
     CAmount nDebit = CachedTxGetDebit(*pwallet, wtx, /*avoid_reuse=*/false);
     CAmount nNet = nCredit - nDebit;
-    CAmount nFee = (CachedTxIsFromMe(*pwallet, wtx) ? wtx.GetTx()->GetValueOut() - nDebit : 0);
+    CAmount nFee = (*wtx.m_from_me ? wtx.GetTx()->GetValueOut() - nDebit : 0);
 
     entry.pushKV("amount", ValueFromAmount(nNet - nFee));
-    if (CachedTxIsFromMe(*pwallet, wtx))
+    if (*wtx.m_from_me)
         entry.pushKV("fee", ValueFromAmount(nFee));
 
     WalletTxToJSON(*pwallet, wtx, entry);

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -433,6 +433,9 @@ CoinsResult AvailableCoins(const CWallet& wallet,
         if (wallet.IsLockedCoin(outpoint) && params.skip_locked)
             continue;
 
+        Assert(nDepth >= 0);
+        Assert(!wallet.IsSpent(outpoint, /*min_depth=*/1));
+
         if (wallet.IsSpent(outpoint))
             continue;
 

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -441,7 +441,7 @@ CoinsResult AvailableCoins(const CWallet& wallet,
             continue;
         }
 
-        bool tx_from_me = CachedTxIsFromMe(wallet, wtx);
+        bool tx_from_me = *wtx.m_from_me;
 
         std::unique_ptr<SigningProvider> provider = wallet.GetSolvingProvider(output.scriptPubKey);
 

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -336,7 +336,6 @@ CoinsResult AvailableCoins(const CWallet& wallet,
     // Cache for whether each tx passes the tx level checks (first bool), and whether the transaction is "safe" (second bool)
     std::unordered_map<Txid, std::pair<bool, bool>, SaltedTxidHasher> tx_safe_cache;
     for (const auto& [outpoint, txo] : wallet.GetTXOs()) {
-        const CWalletTx& wtx = txo.GetWalletTx();
         const CTxOut& output = txo.GetTxOut();
 
         if (tx_safe_cache.contains(outpoint.hash) && !tx_safe_cache.at(outpoint.hash).first) {
@@ -348,6 +347,7 @@ CoinsResult AvailableCoins(const CWallet& wallet,
         // Perform tx level checks if we haven't already come across outputs from this tx before.
         if (!tx_safe_cache.contains(outpoint.hash)) {
             tx_safe_cache[outpoint.hash] = {false, false};
+            const CWalletTx& wtx = *wallet.GetWalletTx(outpoint.hash);
 
             if (wallet.IsTxImmatureCoinBase(wtx) && !params.include_immature_coinbase)
                 continue;

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -344,7 +344,7 @@ CoinsResult AvailableCoins(const CWallet& wallet,
             continue;
         }
 
-        int nDepth = wallet.GetTxDepthInMainChain(wtx);
+        int nDepth = wallet.GetTxStateDepthInMainChain(txo.GetState());
 
         // Perform tx level checks if we haven't already come across outputs from this tx before.
         if (!tx_safe_cache.contains(outpoint.hash)) {

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -441,7 +441,7 @@ CoinsResult AvailableCoins(const CWallet& wallet,
             continue;
         }
 
-        bool tx_from_me = *wtx.m_from_me;
+        bool tx_from_me = txo.GetTxFromMe();
 
         std::unique_ptr<SigningProvider> provider = wallet.GetSolvingProvider(output.scriptPubKey);
 

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -279,12 +279,11 @@ util::Result<CoinsResult> FetchSelectedInputs(const CWallet& wallet, const CCoin
             if (input_bytes == -1) {
                 input_bytes = CalculateMaximumSignedInputSize(txout, &wallet, &coin_control);
             }
-            const CWalletTx& parent_tx = txo->GetWalletTx();
-            if (wallet.GetTxDepthInMainChain(parent_tx) == 0) {
-                if (parent_tx.GetTx()->version == TRUC_VERSION && coin_control.m_version != TRUC_VERSION) {
+            if (wallet.GetTxStateDepthInMainChain(txo->GetState()) == 0) {
+                if (txo->m_tx_version == TRUC_VERSION && coin_control.m_version != TRUC_VERSION) {
                     return util::Error{strprintf(_("Can't spend unconfirmed version 3 pre-selected input with a version %d tx"), coin_control.m_version)};
-                } else if (coin_control.m_version == TRUC_VERSION && parent_tx.GetTx()->version != TRUC_VERSION) {
-                    return util::Error{strprintf(_("Can't spend unconfirmed version %d pre-selected input with a version 3 tx"), parent_tx.GetTx()->version)};
+                } else if (coin_control.m_version == TRUC_VERSION && txo->m_tx_version != TRUC_VERSION) {
+                    return util::Error{strprintf(_("Can't spend unconfirmed version %d pre-selected input with a version 3 tx"), txo->m_tx_version)};
                 }
             }
         } else {
@@ -468,9 +467,9 @@ CoinsResult AvailableCoins(const CWallet& wallet,
 
         auto available_output_type = GetOutputType(type, is_from_p2sh);
         auto available_output = COutput(outpoint, output, nDepth, input_bytes, solvable, tx_safe, txo.GetTxTime(), tx_from_me, feerate);
-        if (wtx.GetTx()->version == TRUC_VERSION && nDepth == 0 && params.check_version_trucness) {
+        if (txo.m_tx_version == TRUC_VERSION && nDepth == 0 && params.check_version_trucness) {
             unconfirmed_truc_coins.emplace_back(available_output_type, available_output);
-            auto [it, _] = truc_txid_by_value.try_emplace(wtx.GetTx()->GetHash(), 0);
+            auto [it, _] = truc_txid_by_value.try_emplace(outpoint.hash, 0);
             it->second += output.nValue;
         } else {
             result.Add(available_output_type, available_output);

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -467,7 +467,7 @@ CoinsResult AvailableCoins(const CWallet& wallet,
         }
 
         auto available_output_type = GetOutputType(type, is_from_p2sh);
-        auto available_output = COutput(outpoint, output, nDepth, input_bytes, solvable, tx_safe, wtx.GetTxTime(), tx_from_me, feerate);
+        auto available_output = COutput(outpoint, output, nDepth, input_bytes, solvable, tx_safe, txo.GetTxTime(), tx_from_me, feerate);
         if (wtx.GetTx()->version == TRUC_VERSION && nDepth == 0 && params.check_version_trucness) {
             unconfirmed_truc_coins.emplace_back(available_output_type, available_output);
             auto [it, _] = truc_txid_by_value.try_emplace(wtx.GetTx()->GetHash(), 0);

--- a/src/wallet/test/spend_tests.cpp
+++ b/src/wallet/test/spend_tests.cpp
@@ -8,6 +8,7 @@
 #include <script/solver.h>
 #include <validation.h>
 #include <wallet/coincontrol.h>
+#include <wallet/context.h>
 #include <wallet/spend.h>
 #include <wallet/test/util.h>
 #include <wallet/test/wallet_test_fixture.h>
@@ -36,7 +37,10 @@ BOOST_AUTO_TEST_CASE(max_signed_input_size_uses_external_outpoint)
 BOOST_FIXTURE_TEST_CASE(SubtractFee, TestChain100Setup)
 {
     CreateAndProcessBlock({}, GetScriptForRawPubKey(coinbaseKey.GetPubKey()));
-    auto wallet = CreateSyncedWallet(*m_node.chain, WITH_LOCK(Assert(m_node.chainman)->GetMutex(), return m_node.chainman->ActiveChain()), coinbaseKey);
+    WalletContext context;
+    context.chain = m_node.chain.get();
+    context.args = m_node.args;
+    auto wallet = CreateSyncedWallet(context, coinbaseKey);
 
     // Check that a subtract-from-recipient transaction slightly less than the
     // coinbase input amount does not create a change output (because it would
@@ -84,7 +88,10 @@ BOOST_FIXTURE_TEST_CASE(wallet_duplicated_preset_inputs_test, TestChain100Setup)
 
     // Add 4 spendable UTXO, 50 BTC each, to the wallet (total balance 200 BTC)
     for (int i = 0; i < 4; i++) CreateAndProcessBlock({}, GetScriptForRawPubKey(coinbaseKey.GetPubKey()));
-    auto wallet = CreateSyncedWallet(*m_node.chain, WITH_LOCK(Assert(m_node.chainman)->GetMutex(), return m_node.chainman->ActiveChain()), coinbaseKey);
+    WalletContext context;
+    context.chain = m_node.chain.get();
+    context.args = m_node.args;
+    auto wallet = CreateSyncedWallet(context, coinbaseKey);
 
     LOCK(wallet->cs_wallet);
     auto available_coins = AvailableCoins(*wallet);

--- a/src/wallet/test/util.cpp
+++ b/src/wallet/test/util.cpp
@@ -18,18 +18,17 @@
 #include <memory>
 
 namespace wallet {
-std::unique_ptr<CWallet> CreateSyncedWallet(interfaces::Chain& chain, CChain& cchain, const CKey& key)
+std::shared_ptr<CWallet> CreateSyncedWallet(WalletContext& context, const CKey& key)
 {
-    auto wallet = std::make_unique<CWallet>(&chain, "", CreateMockableWalletDatabase());
-    {
-        LOCK2(wallet->cs_wallet, ::cs_main);
-        wallet->SetLastBlockProcessed(cchain.Height(), cchain.Tip()->GetBlockHash());
-    }
+    bilingual_str error;
+    std::vector<bilingual_str> warnings;
+    auto wallet = CWallet::CreateNew(context, "", CreateMockableWalletDatabase(), WALLET_FLAG_DESCRIPTORS, /*born_encrypted=*/false, error, warnings);
+
+    // Allow the fallback fee with its default
+    wallet->m_allow_fallback_fee = true;
+
     {
         LOCK(wallet->cs_wallet);
-        wallet->SetWalletFlag(WALLET_FLAG_DESCRIPTORS);
-        wallet->SetupDescriptorScriptPubKeyMans();
-
         FlatSigningProvider provider;
         std::string error;
         auto descs = Parse("combo(" + EncodeSecret(key) + ")", provider, error, /* require_checksum=*/ false);
@@ -40,11 +39,13 @@ std::unique_ptr<CWallet> CreateSyncedWallet(interfaces::Chain& chain, CChain& cc
     }
     WalletRescanReserver reserver(*wallet);
     reserver.reserve();
-    CWallet::ScanResult result = wallet->ScanForWalletTransactions(cchain.Genesis()->GetBlockHash(), /*start_height=*/0, /*max_height=*/{}, reserver, /*save_progress=*/false);
+    CWallet::ScanResult result = wallet->ScanForWalletTransactions(context.chain->getBlockHash(0), /*start_height=*/0, /*max_height=*/{}, reserver, /*save_progress=*/false);
     assert(result.status == CWallet::ScanResult::SUCCESS);
-    assert(result.last_scanned_block == cchain.Tip()->GetBlockHash());
-    assert(*result.last_scanned_height == cchain.Height());
+    int tip_height = context.chain->getHeight().value();
+    assert(*result.last_scanned_height == tip_height);
+    assert(result.last_scanned_block == context.chain->getBlockHash(tip_height));
     assert(result.last_failed_block.IsNull());
+
     return wallet;
 }
 

--- a/src/wallet/test/util.h
+++ b/src/wallet/test/util.h
@@ -31,7 +31,7 @@ static const DatabaseFormat DATABASE_FORMATS[] = {
 
 const std::string ADDRESS_BCRT1_UNSPENDABLE = "bcrt1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3xueyj";
 
-std::unique_ptr<CWallet> CreateSyncedWallet(interfaces::Chain& chain, CChain& cchain, const CKey& key);
+std::shared_ptr<CWallet> CreateSyncedWallet(WalletContext& chain, const CKey& key);
 
 std::shared_ptr<CWallet> TestCreateWallet(WalletContext& context);
 std::shared_ptr<CWallet> TestCreateWallet(std::unique_ptr<WalletDatabase> database, WalletContext& context, uint64_t create_flags);

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -297,7 +297,7 @@ static int64_t AddTx(ChainstateManager& chainman, CWallet& wallet, uint32_t lock
         // Assign wtx.m_state to simplify test and avoid the need to simulate
         // reorg events. Without this, AddToWallet asserts false when the same
         // transaction is confirmed in different blocks.
-        wtx.SetState(state);
+        wtx.SetState(state, [&wallet](const COutPoint& o, const TxState& s) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet) { wallet.UpdateTXOState(o, s); });
         return true;
     })->nTimeSmart;
 }
@@ -415,7 +415,8 @@ public:
         wallet->SetLastBlockProcessed(wallet->GetLastBlockHeight() + 1, m_node.chainman->ActiveChain().Tip()->GetBlockHash());
         auto it = wallet->mapWallet.find(tx->GetHash());
         BOOST_CHECK(it != wallet->mapWallet.end());
-        it->second.SetState(TxStateConfirmed{m_node.chainman->ActiveChain().Tip()->GetBlockHash(), m_node.chainman->ActiveChain().Height(), /*index=*/1});
+        TxStateConfirmed conf_state{m_node.chainman->ActiveChain().Tip()->GetBlockHash(), m_node.chainman->ActiveChain().Height(), /*index=*/1};
+        it->second.SetState(conf_state, [this](const COutPoint& o, const TxState& s) EXCLUSIVE_LOCKS_REQUIRED(wallet->cs_wallet) { wallet->UpdateTXOState(o, s); });
         return it->second;
     }
 

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -297,7 +297,7 @@ static int64_t AddTx(ChainstateManager& chainman, CWallet& wallet, uint32_t lock
         // Assign wtx.m_state to simplify test and avoid the need to simulate
         // reorg events. Without this, AddToWallet asserts false when the same
         // transaction is confirmed in different blocks.
-        wtx.m_state = state;
+        wtx.SetState(state);
         return true;
     })->nTimeSmart;
 }
@@ -415,7 +415,7 @@ public:
         wallet->SetLastBlockProcessed(wallet->GetLastBlockHeight() + 1, m_node.chainman->ActiveChain().Tip()->GetBlockHash());
         auto it = wallet->mapWallet.find(tx->GetHash());
         BOOST_CHECK(it != wallet->mapWallet.end());
-        it->second.m_state = TxStateConfirmed{m_node.chainman->ActiveChain().Tip()->GetBlockHash(), m_node.chainman->ActiveChain().Height(), /*index=*/1};
+        it->second.SetState(TxStateConfirmed{m_node.chainman->ActiveChain().Tip()->GetBlockHash(), m_node.chainman->ActiveChain().Height(), /*index=*/1});
         return it->second;
     }
 

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -385,7 +385,10 @@ public:
     ListCoinsTestingSetup()
     {
         CreateAndProcessBlock({}, GetScriptForRawPubKey(coinbaseKey.GetPubKey()));
-        wallet = CreateSyncedWallet(*m_node.chain, WITH_LOCK(Assert(m_node.chainman)->GetMutex(), return m_node.chainman->ActiveChain()), coinbaseKey);
+        WalletContext context;
+        context.chain = m_node.chain.get();
+        context.args = m_node.args;
+        wallet = CreateSyncedWallet(context, coinbaseKey);
     }
 
     ~ListCoinsTestingSetup()
@@ -409,18 +412,19 @@ public:
             blocktx = CMutableTransaction(*wallet->mapWallet.at(tx->GetHash()).GetTx());
         }
         CreateAndProcessBlock({CMutableTransaction(blocktx)}, GetScriptForRawPubKey(coinbaseKey.GetPubKey()));
+        m_node.validation_signals->SyncWithValidationInterfaceQueue();
 
         LOCK(wallet->cs_wallet);
         LOCK(Assert(m_node.chainman)->GetMutex());
-        wallet->SetLastBlockProcessed(wallet->GetLastBlockHeight() + 1, m_node.chainman->ActiveChain().Tip()->GetBlockHash());
         auto it = wallet->mapWallet.find(tx->GetHash());
         BOOST_CHECK(it != wallet->mapWallet.end());
         TxStateConfirmed conf_state{m_node.chainman->ActiveChain().Tip()->GetBlockHash(), m_node.chainman->ActiveChain().Height(), /*index=*/1};
         it->second.SetState(conf_state, [this](const COutPoint& o, const TxState& s) EXCLUSIVE_LOCKS_REQUIRED(wallet->cs_wallet) { wallet->UpdateTXOState(o, s); });
+        BOOST_CHECK(it->second.state<TxStateConfirmed>());
         return it->second;
     }
 
-    std::unique_ptr<CWallet> wallet;
+    std::shared_ptr<CWallet> wallet;
 };
 
 BOOST_FIXTURE_TEST_CASE(ListCoinsTest, ListCoinsTestingSetup)
@@ -483,9 +487,10 @@ BOOST_FIXTURE_TEST_CASE(ListCoinsTest, ListCoinsTestingSetup)
 void TestCoinsResult(ListCoinsTest& context, OutputType out_type, CAmount amount,
                      std::map<OutputType, size_t>& expected_coins_sizes)
 {
-    LOCK(context.wallet->cs_wallet);
     util::Result<CTxDestination> dest = Assert(context.wallet->GetNewDestination(out_type, ""));
     CWalletTx& wtx = context.AddTx(CRecipient{*dest, amount, /*fSubtractFeeFromAmount=*/true});
+
+    LOCK(context.wallet->cs_wallet);
     CoinFilterParams filter;
     filter.skip_locked = false;
     CoinsResult available_coins = AvailableCoins(*context.wallet, nullptr, std::nullopt, filter);

--- a/src/wallet/transaction.cpp
+++ b/src/wallet/transaction.cpp
@@ -47,7 +47,9 @@ void CWalletTx::updateState(interfaces::Chain& chain)
         // transaction was reorged out while online and then reconfirmed
         // while offline is covered by the rescan logic.
         if (!chain.findBlock(hash, FoundBlock().inActiveChain(active).height(height)) || !active) {
-            SetState(TxStateInactive{});
+            // Note that it is safe to provide nullptr for update_external_states_fn here as this
+            // function is only called during loading prior to the TXOs being cached.
+            SetState(TxStateInactive{}, nullptr);
         }
     };
     if (auto* conf = state<TxStateConfirmed>()) {
@@ -61,7 +63,7 @@ void CWalletTx::updateState(interfaces::Chain& chain)
     if (!isConfirmed()) RecomputeCanonical();
 }
 
-bool CWalletTx::Update(CTransactionRef new_tx, const TxState& new_state)
+bool CWalletTx::Update(CTransactionRef new_tx, const TxState& new_state, std::function<void(const COutPoint&, const TxState&)> update_external_states_fn)
 {
     Assert(new_tx);
     if (!Assume(GetHash() == new_tx->GetHash())) {
@@ -75,7 +77,7 @@ bool CWalletTx::Update(CTransactionRef new_tx, const TxState& new_state)
     const auto& [wtxid, tx] = *tx_pair;
 
     if (new_state.index() != GetState().index()) {
-        SetState(new_state);
+        SetState(new_state, update_external_states_fn);
         if (state<TxStateConfirmed>()) {
             m_canonical_wtxid = wtxid;
         }
@@ -123,5 +125,15 @@ void CWalletTx::RecomputeCanonical()
         }
     }
     m_canonical_wtxid = best_wtxid;
+}
+
+void CWalletTx::SetState(const TxState& state, std::function<void(const COutPoint&, const TxState&)> update_external_states_fn)
+{
+    m_state = state;
+    if (update_external_states_fn) {
+        for (uint32_t i = 0; i < GetTx()->vout.size(); ++i) {
+            update_external_states_fn(COutPoint{GetHash(), i}, state);
+        }
+    }
 }
 } // namespace wallet

--- a/src/wallet/transaction.cpp
+++ b/src/wallet/transaction.cpp
@@ -39,7 +39,7 @@ int64_t CWalletTx::GetTxTime() const
 void CWalletTx::updateState(interfaces::Chain& chain)
 {
     bool active;
-    auto lookup_block = [&](const uint256& hash, int& height, TxState& state) {
+    auto lookup_block = [&](const uint256& hash, int& height) {
         // If tx block (or conflicting block) was reorged out of chain
         // while the wallet was shutdown, change tx status to UNCONFIRMED
         // and reset block height, hash, and index. ABANDONED tx don't have
@@ -47,13 +47,13 @@ void CWalletTx::updateState(interfaces::Chain& chain)
         // transaction was reorged out while online and then reconfirmed
         // while offline is covered by the rescan logic.
         if (!chain.findBlock(hash, FoundBlock().inActiveChain(active).height(height)) || !active) {
-            state = TxStateInactive{};
+            SetState(TxStateInactive{});
         }
     };
     if (auto* conf = state<TxStateConfirmed>()) {
-        lookup_block(conf->confirmed_block_hash, conf->confirmed_block_height, m_state);
+        lookup_block(conf->confirmed_block_hash, conf->confirmed_block_height);
     } else if (auto* conf = state<TxStateBlockConflicted>()) {
-        lookup_block(conf->conflicting_block_hash, conf->conflicting_block_height, m_state);
+        lookup_block(conf->conflicting_block_hash, conf->conflicting_block_height);
     }
 
     // If the above downgraded a previously-confirmed witness variant back to unconfirmed,
@@ -74,8 +74,8 @@ bool CWalletTx::Update(CTransactionRef new_tx, const TxState& new_state)
     }
     const auto& [wtxid, tx] = *tx_pair;
 
-    if (new_state.index() != m_state.index()) {
-        m_state = new_state;
+    if (new_state.index() != GetState().index()) {
+        SetState(new_state);
         if (state<TxStateConfirmed>()) {
             m_canonical_wtxid = wtxid;
         }

--- a/src/wallet/transaction.h
+++ b/src/wallet/transaction.h
@@ -437,13 +437,15 @@ private:
     const CTxOut& m_output;
     TxState m_tx_state;
     bool m_tx_coinbase;
+    bool m_tx_from_me;
 
 public:
-    WalletTXO(const CWalletTx& wtx, const CTxOut& output, const TxState& state, bool coinbase)
+    WalletTXO(const CWalletTx& wtx, const CTxOut& output, const TxState& state, bool coinbase, bool tx_from_me)
     : m_wtx(wtx),
     m_output(output),
     m_tx_state(state),
-    m_tx_coinbase(coinbase)
+    m_tx_coinbase(coinbase),
+    m_tx_from_me(tx_from_me)
     {
         Assume(std::ranges::find(wtx.GetTx()->vout, output) != wtx.GetTx()->vout.end());
     }
@@ -456,6 +458,9 @@ public:
     void SetState(const TxState& state) { m_tx_state = state; }
 
     bool IsTxCoinBase() const { return m_tx_coinbase; }
+
+    void SetTxFromMe(bool from_me) { m_tx_from_me = from_me; }
+    bool GetTxFromMe() const { return m_tx_from_me; }
 };
 } // namespace wallet
 

--- a/src/wallet/transaction.h
+++ b/src/wallet/transaction.h
@@ -438,14 +438,16 @@ private:
     TxState m_tx_state;
     bool m_tx_coinbase;
     bool m_tx_from_me;
+    int64_t m_tx_time;
 
 public:
-    WalletTXO(const CWalletTx& wtx, const CTxOut& output, const TxState& state, bool coinbase, bool tx_from_me)
+    WalletTXO(const CWalletTx& wtx, const CTxOut& output, const TxState& state, bool coinbase, bool tx_from_me, int64_t tx_time)
     : m_wtx(wtx),
     m_output(output),
     m_tx_state(state),
     m_tx_coinbase(coinbase),
-    m_tx_from_me(tx_from_me)
+    m_tx_from_me(tx_from_me),
+    m_tx_time(tx_time)
     {
         Assume(std::ranges::find(wtx.GetTx()->vout, output) != wtx.GetTx()->vout.end());
     }
@@ -461,6 +463,8 @@ public:
 
     void SetTxFromMe(bool from_me) { m_tx_from_me = from_me; }
     bool GetTxFromMe() const { return m_tx_from_me; }
+
+    int64_t GetTxTime() const { return m_tx_time; }
 };
 } // namespace wallet
 

--- a/src/wallet/transaction.h
+++ b/src/wallet/transaction.h
@@ -366,7 +366,7 @@ public:
     // If the given transaction has a different wtxid, the transaction is stored if it has not been seen before.
     // The canonical wtxid is also updated. The tx that is confirmed becomes canonical. For unconfirmed txs,
     // those with witnesses are preferred, followed by least weight.
-    bool Update(CTransactionRef tx, const TxState& arg_state);
+    bool Update(CTransactionRef tx, const TxState& arg_state, std::function<void(const COutPoint&, const TxState&)> update_external_states_fn);
 
     //! make sure balances are recalculated
     void MarkDirty()
@@ -386,7 +386,7 @@ public:
 
     template<typename T> const T* state() const { return std::get_if<T>(&m_state); }
     template<typename T> T* state() { return std::get_if<T>(&m_state); }
-    void SetState(const TxState& state) { m_state = state; }
+    void SetState(const TxState& state, std::function<void(const COutPoint&, const TxState&)> update_external_states_fn);
     const TxState& GetState() const { return m_state; }
 
     //! Update transaction state when attaching to a chain, filling in heights
@@ -435,11 +435,15 @@ class WalletTXO
 private:
     const CWalletTx& m_wtx;
     const CTxOut& m_output;
+    TxState m_tx_state;
+    bool m_tx_coinbase;
 
 public:
-    WalletTXO(const CWalletTx& wtx, const CTxOut& output)
+    WalletTXO(const CWalletTx& wtx, const CTxOut& output, const TxState& state, bool coinbase)
     : m_wtx(wtx),
-    m_output(output)
+    m_output(output),
+    m_tx_state(state),
+    m_tx_coinbase(coinbase)
     {
         Assume(std::ranges::find(wtx.GetTx()->vout, output) != wtx.GetTx()->vout.end());
     }
@@ -447,6 +451,11 @@ public:
     const CWalletTx& GetWalletTx() const { return m_wtx; }
 
     const CTxOut& GetTxOut() const { return m_output; }
+
+    const TxState& GetState() const { return m_tx_state; }
+    void SetState(const TxState& state) { m_tx_state = state; }
+
+    bool IsTxCoinBase() const { return m_tx_coinbase; }
 };
 } // namespace wallet
 

--- a/src/wallet/transaction.h
+++ b/src/wallet/transaction.h
@@ -260,8 +260,10 @@ public:
         nOrderPos = -1;
     }
 
+private:
     TxState m_state;
 
+public:
     // Set of mempool transactions that conflict
     // directly with the transaction, or that conflict
     // with an ancestor transaction. This set will be
@@ -384,6 +386,8 @@ public:
 
     template<typename T> const T* state() const { return std::get_if<T>(&m_state); }
     template<typename T> T* state() { return std::get_if<T>(&m_state); }
+    void SetState(const TxState& state) { m_state = state; }
+    const TxState& GetState() const { return m_state; }
 
     //! Update transaction state when attaching to a chain, filling in heights
     //! of conflicted and confirmed blocks

--- a/src/wallet/transaction.h
+++ b/src/wallet/transaction.h
@@ -434,7 +434,7 @@ class WalletTXO
 {
 private:
     const CTxOut& m_output;
-    TxState m_tx_state;
+    mutable TxState m_tx_state;
     bool m_tx_coinbase;
     bool m_tx_from_me;
     int64_t m_tx_time;
@@ -454,7 +454,7 @@ public:
     const CTxOut& GetTxOut() const { return m_output; }
 
     const TxState& GetState() const { return m_tx_state; }
-    void SetState(const TxState& state) { m_tx_state = state; }
+    void SetState(const TxState& state) const { m_tx_state = state; }
 
     bool IsTxCoinBase() const { return m_tx_coinbase; }
 

--- a/src/wallet/transaction.h
+++ b/src/wallet/transaction.h
@@ -218,6 +218,8 @@ public:
     unsigned int nTimeSmart;
     // Cached value for whether the transaction spends any inputs known to the wallet
     mutable std::optional<bool> m_cached_from_me{std::nullopt};
+    // Tracks whether the transaction spends any inputs known to the wallet
+    std::optional<bool> m_from_me;
     int64_t nOrderPos; //!< position in ordered transaction list
     std::multimap<int64_t, CWalletTx*>::const_iterator m_it_wtxOrdered;
 
@@ -304,6 +306,7 @@ public:
         uint256 serializedHash = TxStateSerializedBlockHash(m_state);
         int serializedIndex = TxStateSerializedIndex(m_state);
         s << TX_WITH_WITNESS(GetTx()) << serializedHash << dummy_vector1 << serializedIndex << dummy_vector2 << string_values << msgs_reqs << dummy_int << nTimeReceived << dummy_bool << dummy_bool;
+        if (m_from_me) s << *m_from_me;
     }
 
     template<typename Stream>
@@ -323,6 +326,12 @@ public:
         s >> TX_WITH_WITNESS(canonical_tx) >> serialized_block_hash >> dummy_vector1 >> serializedIndex >> dummy_vector2 >> string_values >> msgs_reqs >> dummy_int >> nTimeReceived >> dummy_bool >> dummy_bool;
         m_canonical_wtxid = canonical_tx->GetWitnessHash();
         m_txs.emplace(m_canonical_wtxid, std::move(canonical_tx));
+
+        if (!s.empty()) {
+            bool from_me;
+            s >> from_me;
+            m_from_me = from_me;
+        }
 
         m_state = TxStateInterpretSerialized({serialized_block_hash, serializedIndex});
 

--- a/src/wallet/transaction.h
+++ b/src/wallet/transaction.h
@@ -216,8 +216,6 @@ public:
      * CWallet::ComputeTimeSmart().
      */
     unsigned int nTimeSmart;
-    // Cached value for whether the transaction spends any inputs known to the wallet
-    mutable std::optional<bool> m_cached_from_me{std::nullopt};
     // Tracks whether the transaction spends any inputs known to the wallet
     std::optional<bool> m_from_me;
     int64_t nOrderPos; //!< position in ordered transaction list
@@ -375,7 +373,6 @@ public:
         m_amounts[CREDIT].Reset();
         fChangeCached = false;
         m_is_cache_empty = true;
-        m_cached_from_me = std::nullopt;
     }
 
     /** True if only scriptSigs are different */

--- a/src/wallet/transaction.h
+++ b/src/wallet/transaction.h
@@ -433,7 +433,6 @@ struct WalletTxOrderComparator {
 class WalletTXO
 {
 private:
-    const CWalletTx& m_wtx;
     const CTxOut& m_output;
     TxState m_tx_state;
     bool m_tx_coinbase;
@@ -441,19 +440,14 @@ private:
     int64_t m_tx_time;
 
 public:
-    WalletTXO(const CWalletTx& wtx, const CTxOut& output, const TxState& state, bool coinbase, bool tx_from_me, int64_t tx_time, uint32_t tx_version)
-    : m_wtx(wtx),
-    m_output(output),
+    WalletTXO(const CTxOut& output, const TxState& state, bool coinbase, bool tx_from_me, int64_t tx_time, uint32_t tx_version)
+    : m_output(output),
     m_tx_state(state),
     m_tx_coinbase(coinbase),
     m_tx_from_me(tx_from_me),
     m_tx_time(tx_time),
     m_tx_version(tx_version)
-    {
-        Assume(std::ranges::find(wtx.GetTx()->vout, output) != wtx.GetTx()->vout.end());
-    }
-
-    const CWalletTx& GetWalletTx() const { return m_wtx; }
+    {}
 
     const uint32_t m_tx_version;
 

--- a/src/wallet/transaction.h
+++ b/src/wallet/transaction.h
@@ -441,18 +441,21 @@ private:
     int64_t m_tx_time;
 
 public:
-    WalletTXO(const CWalletTx& wtx, const CTxOut& output, const TxState& state, bool coinbase, bool tx_from_me, int64_t tx_time)
+    WalletTXO(const CWalletTx& wtx, const CTxOut& output, const TxState& state, bool coinbase, bool tx_from_me, int64_t tx_time, uint32_t tx_version)
     : m_wtx(wtx),
     m_output(output),
     m_tx_state(state),
     m_tx_coinbase(coinbase),
     m_tx_from_me(tx_from_me),
-    m_tx_time(tx_time)
+    m_tx_time(tx_time),
+    m_tx_version(tx_version)
     {
         Assume(std::ranges::find(wtx.GetTx()->vout, output) != wtx.GetTx()->vout.end());
     }
 
     const CWalletTx& GetWalletTx() const { return m_wtx; }
+
+    const uint32_t m_tx_version;
 
     const CTxOut& GetTxOut() const { return m_output; }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -774,7 +774,7 @@ void CWallet::SyncMetaData(std::pair<TxSpends::iterator, TxSpends::iterator> ran
  * Outpoint is spent if any non-conflicted transaction
  * spends it:
  */
-bool CWallet::IsSpent(const COutPoint& outpoint) const
+bool CWallet::IsSpent(const COutPoint& outpoint, int min_depth) const
 {
     std::pair<TxSpends::const_iterator, TxSpends::const_iterator> range;
     range = mapTxSpends.equal_range(outpoint);
@@ -784,8 +784,14 @@ bool CWallet::IsSpent(const COutPoint& outpoint) const
         const auto mit = mapWallet.find(txid);
         if (mit != mapWallet.end()) {
             const auto& wtx = mit->second;
-            if (!wtx.isAbandoned() && !wtx.isBlockConflicted() && !wtx.isMempoolConflicted())
-                return true; // Spent
+            int depth = GetTxDepthInMainChain(wtx);
+            if (depth == 0) {
+                if (min_depth == 0 && !wtx.isAbandoned() && !wtx.isMempoolConflicted()) {
+                    return true;
+                }
+            } else if (depth >= min_depth) {
+                return true;
+            }
         }
     }
     return false;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -910,10 +910,9 @@ bool CWallet::EncryptWallet(const SecureString& strWalletPassphrase)
     return true;
 }
 
-DBErrors CWallet::ReorderTransactions()
+bool CWallet::ReorderTransactions(WalletBatch& batch)
 {
-    LOCK(cs_wallet);
-    WalletBatch batch(GetDatabase());
+    AssertLockHeld(cs_wallet);
 
     // Old wallets didn't have any defined order for transactions
     // Probably a bad idea to change the output of this
@@ -940,8 +939,9 @@ DBErrors CWallet::ReorderTransactions()
             nOrderPos = nOrderPosNext++;
             nOrderPosOffsets.push_back(nOrderPos);
 
-            if (!batch.WriteTx(*pwtx))
-                return DBErrors::LOAD_FAIL;
+            if (!batch.WriteTx(*pwtx)) {
+                return false;
+            }
         }
         else
         {
@@ -958,13 +958,14 @@ DBErrors CWallet::ReorderTransactions()
                 continue;
 
             // Since we're changing the order, write it back
-            if (!batch.WriteTx(*pwtx))
-                return DBErrors::LOAD_FAIL;
+            if (!batch.WriteTx(*pwtx)) {
+                return false;
+            }
         }
     }
     batch.WriteOrderPosNext(nOrderPosNext);
 
-    return DBErrors::LOAD_OK;
+    return true;
 }
 
 int64_t CWallet::IncOrderPosNext(WalletBatch* batch)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -150,9 +150,9 @@ static void UpdateWalletSetting(interfaces::Chain& chain,
 static void RefreshMempoolStatus(CWalletTx& tx, interfaces::Chain& chain)
 {
     if (chain.isInMempool(tx.GetHash())) {
-        tx.m_state = TxStateInMempool();
+        tx.SetState(TxStateInMempool());
     } else if (tx.state<TxStateInMempool>()) {
-        tx.m_state = TxStateInactive();
+        tx.SetState(TxStateInactive());
     }
 }
 
@@ -1102,7 +1102,7 @@ CWalletTx* CWallet::AddToWallet(CTransactionRef tx, const TxState& state, const 
         while (!txs.empty()) {
             CWalletTx* desc_tx = txs.back();
             txs.pop_back();
-            desc_tx->m_state = inactive_state;
+            desc_tx->SetState(inactive_state);
             // Break caches since we have changed the state
             desc_tx->MarkDirty();
             batch.WriteTx(*desc_tx);
@@ -1324,7 +1324,7 @@ bool CWallet::AbandonTransaction(CWalletTx& tx)
         assert(!wtx.InMempool());
         // If already conflicted or abandoned, no need to set abandoned
         if (!wtx.isBlockConflicted() && !wtx.isAbandoned()) {
-            wtx.m_state = TxStateInactive{/*abandoned=*/true};
+            wtx.SetState(TxStateInactive{/*abandoned=*/true});
             return TxUpdate::NOTIFY_CHANGED;
         }
         return TxUpdate::UNCHANGED;
@@ -1360,7 +1360,7 @@ void CWallet::MarkConflicted(const uint256& hashBlock, int conflicting_height, c
         if (conflictconfirms < GetTxDepthInMainChain(wtx)) {
             // Block is 'more conflicted' than current confirm; update.
             // Mark transaction as conflicted with this block.
-            wtx.m_state = TxStateBlockConflicted{hashBlock, conflicting_height};
+            wtx.SetState(TxStateBlockConflicted{hashBlock, conflicting_height});
             return TxUpdate::CHANGED;
         }
         return TxUpdate::UNCHANGED;
@@ -1600,7 +1600,7 @@ void CWallet::blockDisconnected(const interfaces::BlockInfo& block)
                 auto try_updating_state = [&](CWalletTx& tx) {
                     if (!tx.isBlockConflicted()) return TxUpdate::UNCHANGED;
                     if (tx.state<TxStateBlockConflicted>()->conflicting_block_height >= disconnect_height) {
-                        tx.m_state = TxStateInactive{};
+                        tx.SetState(TxStateInactive{});
                         return TxUpdate::CHANGED;
                     }
                     return TxUpdate::UNCHANGED;
@@ -2058,7 +2058,7 @@ bool CWallet::SubmitTxMemoryPoolAndRelay(CWalletTx& wtx,
     // If transaction was previously in the mempool, it should be updated when
     // TransactionRemovedFromMempool fires.
     bool ret = chain().broadcastTransaction(wtx.GetTx(), m_default_max_tx_fee, broadcast_method, err_string);
-    if (ret) wtx.m_state = TxStateInMempool{};
+    if (ret) wtx.SetState(TxStateInMempool{});
     return ret;
 }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4655,7 +4655,7 @@ void CWallet::RefreshTXOsFromTx(const CWalletTx& wtx)
             it->second.SetState(wtx.GetState());
             it->second.SetTxFromMe(*wtx.m_from_me);
         } else {
-            m_txos.emplace(outpoint, WalletTXO{wtx, txout, wtx.GetState(), wtx.IsCoinBase(), *wtx.m_from_me, wtx.GetTxTime(), wtx.GetTx()->version});
+            m_txos.emplace(outpoint, WalletTXO{txout, wtx.GetState(), wtx.IsCoinBase(), *wtx.m_from_me, wtx.GetTxTime(), wtx.GetTx()->version});
         }
     }
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4655,7 +4655,7 @@ void CWallet::RefreshTXOsFromTx(const CWalletTx& wtx)
             it->second.SetState(wtx.GetState());
             it->second.SetTxFromMe(*wtx.m_from_me);
         } else {
-            m_txos.emplace(outpoint, WalletTXO{wtx, txout, wtx.GetState(), wtx.IsCoinBase(), *wtx.m_from_me});
+            m_txos.emplace(outpoint, WalletTXO{wtx, txout, wtx.GetState(), wtx.IsCoinBase(), *wtx.m_from_me, wtx.GetTxTime()});
         }
     }
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -147,12 +147,18 @@ static void UpdateWalletSetting(interfaces::Chain& chain,
  * immediately knows the transaction's status: Whether it can be considered
  * trusted and is eligible to be abandoned ...
  */
-static void RefreshMempoolStatus(CWalletTx& tx, interfaces::Chain& chain)
+static void RefreshMempoolStatus(CWallet& wallet, CWalletTx& tx, interfaces::Chain& chain) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
 {
+    AssertLockHeld(wallet.cs_wallet);
+    std::optional<TxState> state;
     if (chain.isInMempool(tx.GetHash())) {
-        tx.SetState(TxStateInMempool());
+        state = TxStateInMempool();
     } else if (tx.state<TxStateInMempool>()) {
-        tx.SetState(TxStateInactive());
+        state = TxStateInactive();
+    }
+    if (state) {
+        tx.SetState(*state, [&wallet](const COutPoint& o, const TxState& s) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet) { wallet.UpdateTXOState(o, s); });
+        wallet.RefreshTXOsFromTx(tx);
     }
 }
 
@@ -999,7 +1005,7 @@ bool CWallet::MarkReplaced(const Txid& originalHash, const Txid& newHash)
     wtx.m_replaced_by_txid = newHash;
 
     // Refresh mempool status without waiting for transactionRemovedFromMempool or transactionAddedToMempool
-    RefreshMempoolStatus(wtx, chain());
+    RefreshMempoolStatus(*this, wtx, chain());
 
     WalletBatch batch(GetDatabase());
 
@@ -1090,7 +1096,7 @@ CWalletTx* CWallet::AddToWallet(CTransactionRef tx, const TxState& state, const 
 
     if (!fInsertedNew)
     {
-        fUpdated |= wtx.Update(tx, state);
+        fUpdated |= wtx.Update(tx, state, [this](const COutPoint& o, const TxState& s) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet) { UpdateTXOState(o, s); });
     }
 
     // Mark inactive coinbase transactions and their descendants as abandoned
@@ -1102,7 +1108,7 @@ CWalletTx* CWallet::AddToWallet(CTransactionRef tx, const TxState& state, const 
         while (!txs.empty()) {
             CWalletTx* desc_tx = txs.back();
             txs.pop_back();
-            desc_tx->SetState(inactive_state);
+            desc_tx->SetState(inactive_state, [this](const COutPoint& o, const TxState& s) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet) { UpdateTXOState(o, s); });
             // Break caches since we have changed the state
             desc_tx->MarkDirty();
             batch.WriteTx(*desc_tx);
@@ -1318,13 +1324,13 @@ bool CWallet::AbandonTransaction(CWalletTx& tx)
         return false;
     }
 
-    auto try_updating_state = [](CWalletTx& wtx) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet) {
+    auto try_updating_state = [this](CWalletTx& wtx) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet) {
         // If the orig tx was not in block/mempool, none of its spends can be.
         assert(!wtx.isConfirmed());
         assert(!wtx.InMempool());
         // If already conflicted or abandoned, no need to set abandoned
         if (!wtx.isBlockConflicted() && !wtx.isAbandoned()) {
-            wtx.SetState(TxStateInactive{/*abandoned=*/true});
+            wtx.SetState(TxStateInactive{/*abandoned=*/true}, [this](const COutPoint& o, const TxState& s) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet) { UpdateTXOState(o, s); });
             return TxUpdate::NOTIFY_CHANGED;
         }
         return TxUpdate::UNCHANGED;
@@ -1360,7 +1366,7 @@ void CWallet::MarkConflicted(const uint256& hashBlock, int conflicting_height, c
         if (conflictconfirms < GetTxDepthInMainChain(wtx)) {
             // Block is 'more conflicted' than current confirm; update.
             // Mark transaction as conflicted with this block.
-            wtx.SetState(TxStateBlockConflicted{hashBlock, conflicting_height});
+            wtx.SetState(TxStateBlockConflicted{hashBlock, conflicting_height}, [this](const COutPoint& o, const TxState& s) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet) { UpdateTXOState(o, s); });
             return TxUpdate::CHANGED;
         }
         return TxUpdate::UNCHANGED;
@@ -1433,7 +1439,7 @@ void CWallet::transactionAddedToMempool(const CTransactionRef& tx) {
 
     auto it = mapWallet.find(tx->GetHash());
     if (it != mapWallet.end()) {
-        RefreshMempoolStatus(it->second, chain());
+        RefreshMempoolStatus(*this, it->second, chain());
     }
 
     const Txid& txid = tx->GetHash();
@@ -1474,7 +1480,7 @@ void CWallet::transactionRemovedFromMempool(const CTransactionRef& tx, MemPoolRe
     LOCK(cs_wallet);
     auto it = mapWallet.find(tx->GetHash());
     if (it != mapWallet.end()) {
-        RefreshMempoolStatus(it->second, chain());
+        RefreshMempoolStatus(*this, it->second, chain());
     }
     // Handle transactions that were removed from the mempool because they
     // conflict with transactions in a newly connected block.
@@ -1600,7 +1606,7 @@ void CWallet::blockDisconnected(const interfaces::BlockInfo& block)
                 auto try_updating_state = [&](CWalletTx& tx) {
                     if (!tx.isBlockConflicted()) return TxUpdate::UNCHANGED;
                     if (tx.state<TxStateBlockConflicted>()->conflicting_block_height >= disconnect_height) {
-                        tx.SetState(TxStateInactive{});
+                        tx.SetState(TxStateInactive{}, [this](const COutPoint& o, const TxState& s) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet) { UpdateTXOState(o, s); });
                         return TxUpdate::CHANGED;
                     }
                     return TxUpdate::UNCHANGED;
@@ -2058,7 +2064,9 @@ bool CWallet::SubmitTxMemoryPoolAndRelay(CWalletTx& wtx,
     // If transaction was previously in the mempool, it should be updated when
     // TransactionRemovedFromMempool fires.
     bool ret = chain().broadcastTransaction(wtx.GetTx(), m_default_max_tx_fee, broadcast_method, err_string);
-    if (ret) wtx.SetState(TxStateInMempool{});
+    if (ret) {
+        wtx.SetState(TxStateInMempool{}, [this](const COutPoint& o, const TxState& s) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet) { UpdateTXOState(o, s); });
+    }
     return ret;
 }
 
@@ -4598,10 +4606,13 @@ void CWallet::RefreshTXOsFromTx(const CWalletTx& wtx)
     for (uint32_t i = 0; i < wtx.GetTx()->vout.size(); ++i) {
         const CTxOut& txout = wtx.GetTx()->vout.at(i);
         if (!IsMine(txout)) continue;
+
         COutPoint outpoint(wtx.GetHash(), i);
-        if (m_txos.contains(outpoint)) {
+        auto it = m_txos.find(outpoint);
+        if (it != m_txos.end()) {
+            it->second.SetState(wtx.GetState());
         } else {
-            m_txos.emplace(outpoint, WalletTXO{wtx, txout});
+            m_txos.emplace(outpoint, WalletTXO{wtx, txout, wtx.GetState(), wtx.IsCoinBase()});
         }
     }
 }
@@ -4643,4 +4654,12 @@ void CWallet::DisconnectChainNotifications()
     }
 }
 
+void CWallet::UpdateTXOState(const COutPoint& outpoint, const TxState& state)
+{
+    AssertLockHeld(cs_wallet);
+    auto it = m_txos.find(outpoint);
+    if (it != m_txos.end()) {
+        it->second.SetState(state);
+    }
+}
 } // namespace wallet

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3375,6 +3375,14 @@ int CWallet::GetTxDepthInMainChain(const CWalletTx& wtx) const
     return GetTxStateDepthInMainChain(wtx.GetState());
 }
 
+int CWallet::GetTxStateBlocksToMaturity(const TxState& state) const
+{
+    AssertLockHeld(cs_wallet);
+    int chain_depth = GetTxStateDepthInMainChain(state);
+    assert(chain_depth >= 0); // coinbase tx should not be conflicted
+    return std::max(0, (COINBASE_MATURITY+1) - chain_depth);
+}
+
 int CWallet::GetTxBlocksToMaturity(const CWalletTx& wtx) const
 {
     AssertLockHeld(cs_wallet);
@@ -3382,9 +3390,7 @@ int CWallet::GetTxBlocksToMaturity(const CWalletTx& wtx) const
     if (!wtx.IsCoinBase()) {
         return 0;
     }
-    int chain_depth = GetTxDepthInMainChain(wtx);
-    assert(chain_depth >= 0); // coinbase tx should not be conflicted
-    return std::max(0, (COINBASE_MATURITY+1) - chain_depth);
+    return GetTxStateBlocksToMaturity(wtx.GetState());
 }
 
 bool CWallet::IsTxImmatureCoinBase(const CWalletTx& wtx) const
@@ -3393,6 +3399,24 @@ bool CWallet::IsTxImmatureCoinBase(const CWalletTx& wtx) const
 
     // note GetBlocksToMaturity is 0 for non-coinbase tx
     return GetTxBlocksToMaturity(wtx) > 0;
+}
+
+int CWallet::GetTXOBlocksToMaturity(const WalletTXO& txo) const
+{
+    AssertLockHeld(cs_wallet);
+
+    if (!txo.IsTxCoinBase()) {
+        return 0;
+    }
+    return GetTxStateBlocksToMaturity(txo.GetState());
+}
+
+bool CWallet::IsTXOInImmatureCoinBase(const WalletTXO& txo) const
+{
+    AssertLockHeld(cs_wallet);
+
+    // note GetBlocksToMaturity is 0 for non-coinbase tx
+    return GetTXOBlocksToMaturity(txo) > 0;
 }
 
 bool CWallet::IsLocked() const

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1080,6 +1080,12 @@ CWalletTx* CWallet::AddToWallet(CTransactionRef tx, const TxState& state, const 
 
         // Update birth time when tx time is older than it.
         MaybeUpdateBirthTime(wtx.GetTxTime());
+
+        wtx.m_from_me = IsFromMe(*wtx.GetTx());
+    } else {
+        bool from_me_before = *wtx.m_from_me;
+        wtx.m_from_me = IsFromMe(*wtx.GetTx());
+        fUpdated = fUpdated || (from_me_before != *wtx.m_from_me);
     }
 
     if (!fInsertedNew)
@@ -3996,7 +4002,7 @@ util::Result<void> CWallet::ApplyMigrationData(WalletBatch& local_wallet_batch, 
 
     // Update m_txos to match the descriptors remaining in this wallet
     m_txos.clear();
-    RefreshAllTXOs();
+    RefreshAllTXOs(&local_wallet_batch);
 
     // Check if the transactions in the wallet are still ours. Either they belong here, or they belong in the watchonly wallet.
     // We need to go through these in the tx insertion order so that lookups to spends works.
@@ -4600,11 +4606,21 @@ void CWallet::RefreshTXOsFromTx(const CWalletTx& wtx)
     }
 }
 
-void CWallet::RefreshAllTXOs()
+void CWallet::RefreshAllTXOs(WalletBatch* batch)
 {
     AssertLockHeld(cs_wallet);
-    for (const auto& [_, wtx] : mapWallet) {
-        RefreshTXOsFromTx(wtx);
+    for (auto& [_, wtx] : wtxOrdered) {
+        bool from_me_before = *wtx->m_from_me;
+        wtx->m_from_me = IsFromMe(*wtx->GetTx());
+        if (from_me_before != *wtx->m_from_me) {
+            if (batch == nullptr) {
+                WalletBatch(GetDatabase()).WriteTx(*wtx);
+            } else {
+                batch->WriteTx(*wtx);
+            }
+        }
+
+        RefreshTXOsFromTx(*wtx);
     }
 }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4655,7 +4655,7 @@ void CWallet::RefreshTXOsFromTx(const CWalletTx& wtx)
             it->second.SetState(wtx.GetState());
             it->second.SetTxFromMe(*wtx.m_from_me);
         } else {
-            m_txos.emplace(outpoint, WalletTXO{wtx, txout, wtx.GetState(), wtx.IsCoinBase(), *wtx.m_from_me, wtx.GetTxTime()});
+            m_txos.emplace(outpoint, WalletTXO{wtx, txout, wtx.GetState(), wtx.IsCoinBase(), *wtx.m_from_me, wtx.GetTxTime(), wtx.GetTx()->version});
         }
     }
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1148,6 +1148,20 @@ CWalletTx* CWallet::AddToWallet(CTransactionRef tx, const TxState& state, const 
     // Break debit/credit balance caches:
     wtx.MarkDirty();
 
+    // Remove or add back the inputs from m_txos to match the state of this tx.
+    if (wtx.isConfirmed())
+    {
+        // When a transaction becomes confirmed, we can remove all of the txos that were spent
+        // in its inputs as they are no longer relevant.
+        for (const CTxIn& txin : wtx.GetTx()->vin) {
+            MarkTXOUnusable(txin.prevout);
+        }
+    } else if (wtx.isInactive()) {
+        // When a transaction becomes inactive, we need to mark its inputs as usable again if they are still unspent
+        for (const CTxIn& txin : wtx.GetTx()->vin) {
+            MaybeMarkTXOUsable(txin.prevout);
+        }
+    }
     // Cache the outputs that belong to the wallet
     RefreshTXOsFromTx(wtx);
 
@@ -1412,11 +1426,19 @@ void CWallet::RecursiveUpdateTxState(WalletBatch* batch, const Txid& tx_hash, co
             if (batch) batch->WriteTx(wtx);
             // Iterate over all its outputs, and update those tx states as well (if applicable)
             for (unsigned int i = 0; i < wtx.GetTx()->vout.size(); ++i) {
-                std::pair<TxSpends::const_iterator, TxSpends::const_iterator> range = mapTxSpends.equal_range(COutPoint(now, i));
+                COutPoint outpoint{now, i};
+                std::pair<TxSpends::const_iterator, TxSpends::const_iterator> range = mapTxSpends.equal_range(outpoint);
                 for (TxSpends::const_iterator iter = range.first; iter != range.second; ++iter) {
                     if (!done.contains(iter->second)) {
                         todo.insert(iter->second);
                     }
+                }
+                if (wtx.state<TxStateBlockConflicted>()) {
+                    // If the state applied is conflicted, the outputs are unusable
+                    MarkTXOUnusable(outpoint);
+                } else {
+                    // Otherwise make the outputs usable
+                    MaybeMarkTXOUsable(outpoint);
                 }
             }
 
@@ -2483,6 +2505,8 @@ util::Result<void> CWallet::RemoveTxs(WalletBatch& batch, std::vector<Txid>& txs
     // Register callback to update the memory state only when the db txn is actually dumped to disk
     batch.RegisterTxnListener({.on_commit=[&, erased_txs]() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet) {
         // Update the in-memory state and notify upper layers about the removals
+        m_txos.clear();
+        m_unusable_txos.clear();
         for (const auto& it : erased_txs) {
             const Txid hash{it->first};
             wtxOrdered.erase(it->second.m_it_wtxOrdered);
@@ -2495,14 +2519,12 @@ util::Result<void> CWallet::RemoveTxs(WalletBatch& batch, std::vector<Txid>& txs
                     }
                 }
             }
-            for (unsigned int i = 0; i < it->second.GetTx()->vout.size(); ++i) {
-                m_txos.erase(COutPoint(hash, i));
-            }
             mapWallet.erase(it);
             NotifyTransactionChanged(hash, CT_DELETED);
         }
 
         MarkDirty();
+        RefreshAllTXOs();
     }, .on_abort={}});
 
     return {};
@@ -3338,6 +3360,10 @@ bool CWallet::AttachChain(const std::shared_ptr<CWallet>& walletInstance, interf
         }
     }
 
+    // Remove TXOs that have already been spent
+    // We do this here as we need to have an attached chain to figure out what has actually been spent.
+    walletInstance->PruneSpentTXOs();
+
     return true;
 }
 
@@ -4050,9 +4076,9 @@ util::Result<void> CWallet::ApplyMigrationData(WalletBatch& local_wallet_batch, 
     CBlockLocator best_block_locator;
     (void)local_wallet_batch.ReadBestBlock(best_block_locator);
 
-    // Update m_txos to match the descriptors remaining in this wallet
+    // Clear m_txos and m_unusable_txos. These will be updated next to match the descriptors remaining in this wallet
     m_txos.clear();
-    RefreshAllTXOs(&local_wallet_batch);
+    m_unusable_txos.clear();
 
     // Check if the transactions in the wallet are still ours. Either they belong here, or they belong in the watchonly wallet.
     // We need to go through these in the tx insertion order so that lookups to spends works.
@@ -4087,6 +4113,7 @@ util::Result<void> CWallet::ApplyMigrationData(WalletBatch& local_wallet_batch, 
         bool is_mine = mine || from_me;
         if (is_mine) {
             wtx->m_from_me = from_me;
+            RefreshTXOsFromTx(*wtx);
             // Rewrite all txs that are "mine" to ensure that any tx upgrades, including the from_me update, is written
             local_wallet_batch.WriteTx(*wtx);
         }
@@ -4663,7 +4690,17 @@ void CWallet::RefreshTXOsFromTx(const CWalletTx& wtx)
             it->second.SetState(wtx.GetState());
             it->second.SetTxFromMe(*wtx.m_from_me);
         } else {
-            m_txos.emplace(outpoint, WalletTXO{txout, wtx.GetState(), wtx.IsCoinBase(), *wtx.m_from_me, wtx.GetTxTime(), wtx.GetTx()->version});
+            it = m_unusable_txos.find(outpoint);
+            if (it != m_unusable_txos.end()) {
+                it->second.SetState(wtx.GetState());
+                it->second.SetTxFromMe(*wtx.m_from_me);
+            } else {
+                WalletTXO txo{txout, wtx.GetState(), wtx.IsCoinBase(), *wtx.m_from_me, wtx.GetTxTime(), wtx.GetTx()->version};
+                bool is_unusable = m_last_block_processed_height >= 0 && IsSpent(outpoint, /*min_depth=*/1);
+                TXOMap& target = is_unusable ? m_unusable_txos : m_txos;
+                auto [txo_it, txos_inserted] = target.emplace(outpoint, std::move(txo));
+                assert(!is_unusable || txos_inserted);
+            }
         }
     }
 }
@@ -4690,10 +4727,62 @@ std::optional<WalletTXO> CWallet::GetTXO(const COutPoint& outpoint) const
 {
     AssertLockHeld(cs_wallet);
     const auto& it = m_txos.find(outpoint);
-    if (it == m_txos.end()) {
-        return std::nullopt;
+    if (it != m_txos.end()) {
+        return it->second;
     }
-    return it->second;
+    const auto& u_it = m_unusable_txos.find(outpoint);
+    if (u_it != m_unusable_txos.end()) {
+        return u_it->second;
+    }
+    return std::nullopt;
+}
+
+void CWallet::PruneSpentTXOs()
+{
+    AssertLockHeld(cs_wallet);
+    auto it = m_txos.begin();
+    while (it != m_txos.end()) {
+        if (std::get_if<TxStateBlockConflicted>(&it->second.GetState()) || IsSpent(it->first, /*min_depth=*/1)) {
+            it = MarkTXOUnusable(it->first).first;
+        } else {
+            it++;
+        }
+    }
+}
+
+std::pair<CWallet::TXOMap::iterator, CWallet::TXOMap::iterator> CWallet::MarkTXOUnusable(const COutPoint& outpoint)
+{
+    AssertLockHeld(cs_wallet);
+    auto txos_it = m_txos.find(outpoint);
+    auto unusable_txos_it = m_unusable_txos.end();
+    if (txos_it != m_txos.end()) {
+        auto next_txo_it = std::next(txos_it);
+        auto nh = m_txos.extract(txos_it);
+        txos_it = next_txo_it;
+        auto [position, inserted, _] = m_unusable_txos.insert(std::move(nh));
+        unusable_txos_it = position;
+        assert(inserted);
+    }
+    return {txos_it, unusable_txos_it};
+}
+
+std::pair<CWallet::TXOMap::iterator, CWallet::TXOMap::iterator> CWallet::MaybeMarkTXOUsable(const COutPoint& outpoint)
+{
+    AssertLockHeld(cs_wallet);
+    if (IsSpent(outpoint)) {
+        return {m_txos.end(), m_unusable_txos.end()};
+    }
+    auto txos_it = m_txos.end();
+    auto unusable_txos_it = m_unusable_txos.find(outpoint);
+    if (unusable_txos_it != m_unusable_txos.end()) {
+        auto next_unusable_txo_it = std::next(unusable_txos_it);
+        auto nh = m_unusable_txos.extract(unusable_txos_it);
+        unusable_txos_it = next_unusable_txo_it;
+        auto [position, inserted, _] = m_txos.insert(std::move(nh));
+        assert(inserted);
+        txos_it = position;
+    }
+    return {unusable_txos_it, txos_it};
 }
 
 void CWallet::DisconnectChainNotifications()
@@ -4711,6 +4800,11 @@ void CWallet::UpdateTXOState(const COutPoint& outpoint, const TxState& state)
     auto it = m_txos.find(outpoint);
     if (it != m_txos.end()) {
         it->second.SetState(state);
+    } else {
+        it = m_unusable_txos.find(outpoint);
+        if (it != m_unusable_txos.end()) {
+            it->second.SetState(state);
+        }
     }
 }
 } // namespace wallet

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1595,11 +1595,13 @@ void CWallet::blockDisconnected(const interfaces::BlockInfo& block)
     // future with a stickier abandoned state or even removing abandontransaction call.
     int disconnect_height = block.height;
 
-    for (size_t index = 0; index < block.data->vtx.size(); index++) {
-        const CTransactionRef& ptx = block.data->vtx[index];
+    Assert(block.data);
+    // Iterate the block backwards so that we can undo the UTXO changes in the correct order
+    for (auto it = block.data->vtx.rbegin(); it != block.data->vtx.rend(); ++it) {
+        const CTransactionRef& ptx = *it;
         // Coinbase transactions are not only inactive but also abandoned,
         // meaning they should never be relayed standalone via the p2p protocol.
-        SyncTransaction(ptx, TxStateInactive{/*abandoned=*/index == 0});
+        SyncTransaction(ptx, TxStateInactive{/*abandoned=*/ptx->IsCoinBase()});
 
         for (const CTxIn& tx_in : ptx->vin) {
             // No other wallet transactions conflicted with this transaction

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1207,7 +1207,10 @@ bool CWallet::LoadToWallet(CWalletTx&& wtx_in)
     MaybeUpdateBirthTime(wtx.GetTxTime());
 
     // Make sure the tx outputs are known by the wallet
-    RefreshTXOsFromTx(wtx);
+    // This cannot be done until m_from_me is upgraded, so skip for any txs that don't have m_from_me set. The caller will handle setting those
+    if (wtx.m_from_me.has_value()) {
+        RefreshTXOsFromTx(wtx);
+    }
     return true;
 }
 
@@ -4071,10 +4074,18 @@ util::Result<void> CWallet::ApplyMigrationData(WalletBatch& local_wallet_batch, 
     for (const auto& [_pos, wtx] : wtxOrdered) {
         // Check it is the watchonly wallet's
         // solvable_wallet doesn't need to be checked because transactions for those scripts weren't being watched for
-        bool is_mine = IsMine(*wtx->GetTx()) || IsFromMe(*wtx->GetTx());
+        bool mine = IsMine(*wtx->GetTx());
+        bool from_me = IsFromMe(*wtx->GetTx());
+        bool is_mine = mine || from_me;
+        if (is_mine) {
+            wtx->m_from_me = from_me;
+            // Rewrite all txs that are "mine" to ensure that any tx upgrades, including the from_me update, is written
+            local_wallet_batch.WriteTx(*wtx);
+        }
         if (data.watchonly_wallet) {
             LOCK(data.watchonly_wallet->cs_wallet);
-            if (data.watchonly_wallet->IsMine(*wtx->GetTx()) || data.watchonly_wallet->IsFromMe(*wtx->GetTx())) {
+            bool watchonly_from_me = data.watchonly_wallet->IsFromMe(*wtx->GetTx());
+            if (data.watchonly_wallet->IsMine(*wtx->GetTx()) || watchonly_from_me) {
                 // Add to watchonly wallet
                 const Txid& hash = wtx->GetHash();
                 DataStream wtx_ser;
@@ -4642,8 +4653,9 @@ void CWallet::RefreshTXOsFromTx(const CWalletTx& wtx)
         auto it = m_txos.find(outpoint);
         if (it != m_txos.end()) {
             it->second.SetState(wtx.GetState());
+            it->second.SetTxFromMe(*wtx.m_from_me);
         } else {
-            m_txos.emplace(outpoint, WalletTXO{wtx, txout, wtx.GetState(), wtx.IsCoinBase()});
+            m_txos.emplace(outpoint, WalletTXO{wtx, txout, wtx.GetState(), wtx.IsCoinBase(), *wtx.m_from_me});
         }
     }
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3355,18 +3355,24 @@ bool CWallet::BackupWallet(const std::string& strDest) const
     return GetDatabase().Backup(strDest);
 }
 
-int CWallet::GetTxDepthInMainChain(const CWalletTx& wtx) const
+int CWallet::GetTxStateDepthInMainChain(const TxState& state) const
 {
     AssertLockHeld(cs_wallet);
-    if (auto* conf = wtx.state<TxStateConfirmed>()) {
+    if (auto* conf = std::get_if<TxStateConfirmed>(&state)) {
         assert(conf->confirmed_block_height >= 0);
         return GetLastBlockHeight() - conf->confirmed_block_height + 1;
-    } else if (auto* conf = wtx.state<TxStateBlockConflicted>()) {
+    } else if (auto* conf = std::get_if<TxStateBlockConflicted>(&state)) {
         assert(conf->conflicting_block_height >= 0);
         return -1 * (GetLastBlockHeight() - conf->conflicting_block_height + 1);
     } else {
         return 0;
     }
+}
+
+int CWallet::GetTxDepthInMainChain(const CWalletTx& wtx) const
+{
+    AssertLockHeld(cs_wallet);
+    return GetTxStateDepthInMainChain(wtx.GetState());
 }
 
 int CWallet::GetTxBlocksToMaturity(const CWalletTx& wtx) const

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2015,7 +2015,7 @@ CWallet::ScanResult CWallet::ScanForWalletTransactions(const uint256& start_bloc
 
 bool CWallet::SubmitTxMemoryPoolAndRelay(CWalletTx& wtx,
                                          std::string& err_string,
-                                         node::TxBroadcast broadcast_method) const
+                                         node::TxBroadcast broadcast_method)
 {
     AssertLockHeld(cs_wallet);
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -543,6 +543,7 @@ public:
      * the height of the last block processed, or the heights of blocks
      * referenced in transaction, and might cause assert failures.
      */
+    int GetTxStateDepthInMainChain(const TxState& state) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     int GetTxDepthInMainChain(const CWalletTx& wtx) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     /**

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -564,7 +564,7 @@ public:
         NONMEMPOOL,
     };
     SpendType HowSpent(const COutPoint& outpoint) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
-    bool IsSpent(const COutPoint& outpoint) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    bool IsSpent(const COutPoint& outpoint, int min_depth = 0) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     // Whether this or any known scriptPubKey with the same single key has been spent.
     bool IsSpentKey(const CScript& scriptPubKey) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -528,7 +528,7 @@ public:
     /** Cache outputs that belong to the wallet from a single transaction */
     void RefreshTXOsFromTx(const CWalletTx& wtx) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     /** Cache outputs that belong to the wallet for all transactions in the wallet */
-    void RefreshAllTXOs() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    void RefreshAllTXOs(WalletBatch* batch = nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     /**
      * Return depth of transaction in blockchain:

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -617,7 +617,7 @@ public:
      * @return next transaction order id
      */
     int64_t IncOrderPosNext(WalletBatch *batch = nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
-    DBErrors ReorderTransactions();
+    bool ReorderTransactions(WalletBatch& batch) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     void MarkDirty();
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -551,8 +551,11 @@ public:
      *  0 : is not a coinbase transaction, or is a mature coinbase transaction
      * >0 : is a coinbase transaction which matures in this many blocks
      */
+    int GetTxStateBlocksToMaturity(const TxState& state) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     int GetTxBlocksToMaturity(const CWalletTx& wtx) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    int GetTXOBlocksToMaturity(const WalletTXO& txo) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     bool IsTxImmatureCoinBase(const CWalletTx& wtx) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    bool IsTXOInImmatureCoinBase(const WalletTXO& txo) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     enum class SpendType {
         UNSPENT,

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -706,7 +706,7 @@ public:
     );
 
     /** Pass this transaction to node for optional mempool insertion and relay to peers. */
-    bool SubmitTxMemoryPoolAndRelay(CWalletTx& wtx, std::string& err_string, node::TxBroadcast broadcast_method) const
+    bool SubmitTxMemoryPoolAndRelay(CWalletTx& wtx, std::string& err_string, node::TxBroadcast broadcast_method)
         EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     /** Updates wallet birth time if 'time' is below it */

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1087,6 +1087,9 @@ public:
 
     //! Disconnect chain notifications and wait for all notifications to be processed
     void DisconnectChainNotifications();
+
+    //! Update the stored tx state for the specified output. Called by every CWalletTx::SetState call.
+    void UpdateTXOState(const COutPoint& outpoint, const TxState& state) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 };
 
 /**

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -434,7 +434,12 @@ private:
     std::unordered_map<CScript, std::vector<ScriptPubKeyMan*>, SaltedSipHasher> m_cached_spks;
 
     //! Set of both spent and unspent transaction outputs owned by this wallet
-    std::unordered_map<COutPoint, WalletTXO, SaltedOutpointHasher> m_txos GUARDED_BY(cs_wallet);
+    using TXOMap = std::unordered_map<COutPoint, WalletTXO, SaltedOutpointHasher>;
+    TXOMap m_txos GUARDED_BY(cs_wallet);
+    //! Set of transaction outputs that are definitely no longer usable
+    //! These outputs may already be spent in a confirmed tx, or are the outputs of a conflicted tx
+    TXOMap m_unusable_txos GUARDED_BY(cs_wallet);
+
 
     /**
      * Catch wallet up to current chain, scanning new blocks, updating the best
@@ -522,13 +527,16 @@ public:
 
     std::set<Txid> GetTxConflicts(const CWalletTx& wtx) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
-    const std::unordered_map<COutPoint, WalletTXO, SaltedOutpointHasher>& GetTXOs() const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet) { AssertLockHeld(cs_wallet); return m_txos; };
+    const TXOMap& GetTXOs() const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet) { AssertLockHeld(cs_wallet); return m_txos; };
     std::optional<WalletTXO> GetTXO(const COutPoint& outpoint) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     /** Cache outputs that belong to the wallet from a single transaction */
     void RefreshTXOsFromTx(const CWalletTx& wtx) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     /** Cache outputs that belong to the wallet for all transactions in the wallet */
     void RefreshAllTXOs(WalletBatch* batch = nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    void PruneSpentTXOs() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    std::pair<TXOMap::iterator, TXOMap::iterator> MarkTXOUnusable(const COutPoint& outpoint) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    std::pair<TXOMap::iterator, TXOMap::iterator> MaybeMarkTXOUsable(const COutPoint& outpoint) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     /**
      * Return depth of transaction in blockchain:

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -1024,13 +1024,27 @@ static std::map<Wtxid, CTransactionRef> ReadWtxVariants(DatabaseBatch& batch, co
     return variants;
 }
 
-static DBErrors LoadTxRecords(CWallet* pwallet, DatabaseBatch& batch, bool& any_unordered, WalletBatch& wallet_batch) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet)
+static DBErrors LoadTxRecords(CWallet* pwallet, DatabaseBatch& batch, WalletBatch& wallet_batch) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet)
 {
     AssertLockHeld(pwallet->cs_wallet);
     DBErrors result = DBErrors::LOAD_OK;
 
+    // Load orderposnext record
+    // Note: There should only be one ORDERPOSNEXT record with nothing trailing the type
+    LoadResult order_pos_res = LoadRecords(pwallet, batch, DBKeys::ORDERPOSNEXT,
+        [] (CWallet* pwallet, DataStream& key, DataStream& value, std::string& err) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet) {
+        try {
+            value >> pwallet->nOrderPosNext;
+        } catch (const std::exception& e) {
+            err = e.what();
+            return DBErrors::NONCRITICAL_ERROR;
+        }
+        return DBErrors::LOAD_OK;
+    });
+    result = std::max(result, order_pos_res.m_result);
+
     // Load tx record
-    any_unordered = false;
+    bool any_unordered = false;
     bool any_missing_from_me = false;
     LoadResult tx_res = LoadRecords(pwallet, batch, DBKeys::TX,
         [&any_unordered, &batch, &any_missing_from_me] (CWallet* pwallet, DataStream& key, DataStream& value, std::string& err) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet) {
@@ -1072,6 +1086,13 @@ static DBErrors LoadTxRecords(CWallet* pwallet, DatabaseBatch& batch, bool& any_
         }
     }
 
+    // Reorder transactions if they are unordered
+    if (any_unordered) {
+        if (!pwallet->ReorderTransactions(wallet_batch)) {
+            result = std::max(result, DBErrors::LOAD_FAIL);
+        }
+    }
+
     // Load locked utxo record
     LoadResult locked_utxo_res = LoadRecords(pwallet, batch, DBKeys::LOCKED_UTXO,
         [] (CWallet* pwallet, DataStream& key, DataStream& value, std::string& err) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet) {
@@ -1083,20 +1104,6 @@ static DBErrors LoadTxRecords(CWallet* pwallet, DatabaseBatch& batch, bool& any_
         return DBErrors::LOAD_OK;
     });
     result = std::max(result, locked_utxo_res.m_result);
-
-    // Load orderposnext record
-    // Note: There should only be one ORDERPOSNEXT record with nothing trailing the type
-    LoadResult order_pos_res = LoadRecords(pwallet, batch, DBKeys::ORDERPOSNEXT,
-        [] (CWallet* pwallet, DataStream& key, DataStream& value, std::string& err) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet) {
-        try {
-            value >> pwallet->nOrderPosNext;
-        } catch (const std::exception& e) {
-            err = e.what();
-            return DBErrors::NONCRITICAL_ERROR;
-        }
-        return DBErrors::LOAD_OK;
-    });
-    result = std::max(result, order_pos_res.m_result);
 
     // After loading all tx records, abandon any coinbase that is no longer in the active chain.
     // This could happen during an external wallet load, or if the user replaced the chain data.
@@ -1156,7 +1163,6 @@ static DBErrors LoadDecryptionKeys(CWallet* pwallet, DatabaseBatch& batch) EXCLU
 DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
 {
     DBErrors result = DBErrors::LOAD_OK;
-    bool any_unordered = false;
 
     LOCK(pwallet->cs_wallet);
 
@@ -1197,7 +1203,7 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
         result = std::max(LoadDecryptionKeys(pwallet, *m_batch), result);
 
         // Load tx records
-        result = std::max(LoadTxRecords(pwallet, *m_batch, any_unordered, *this), result);
+        result = std::max(LoadTxRecords(pwallet, *m_batch, *this), result);
     } catch (std::runtime_error& e) {
         // Exceptions that can be ignored or treated as non-critical are handled by the individual loading functions.
         // Any uncaught exceptions will be caught here and treated as critical.
@@ -1217,9 +1223,6 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
 
     if (!has_last_client || last_client != CLIENT_VERSION) // Update
         this->WriteVersion(CLIENT_VERSION);
-
-    if (any_unordered)
-        result = pwallet->ReorderTransactions();
 
     // Upgrade all of the descriptor caches to cache the last hardened xpub
     // This operation is not atomic, but if it fails, only new entries are added so it is backwards compatible

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -1080,8 +1080,8 @@ static DBErrors LoadTxRecords(CWallet* pwallet, DatabaseBatch& batch, WalletBatc
     // Upgrade each CWalletTx missing m_from_me
     if (any_missing_from_me) {
         for (const auto& [_, wtx] : pwallet->wtxOrdered) {
-            if (wtx->m_from_me) continue;
             wtx->m_from_me = pwallet->IsFromMe(*wtx->GetTx());
+            pwallet->RefreshTXOsFromTx(*wtx);
             wallet_batch.WriteTx(*wtx);
         }
     }

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -1024,15 +1024,16 @@ static std::map<Wtxid, CTransactionRef> ReadWtxVariants(DatabaseBatch& batch, co
     return variants;
 }
 
-static DBErrors LoadTxRecords(CWallet* pwallet, DatabaseBatch& batch, bool& any_unordered) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet)
+static DBErrors LoadTxRecords(CWallet* pwallet, DatabaseBatch& batch, bool& any_unordered, WalletBatch& wallet_batch) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet)
 {
     AssertLockHeld(pwallet->cs_wallet);
     DBErrors result = DBErrors::LOAD_OK;
 
     // Load tx record
     any_unordered = false;
+    bool any_missing_from_me = false;
     LoadResult tx_res = LoadRecords(pwallet, batch, DBKeys::TX,
-        [&any_unordered, &batch] (CWallet* pwallet, DataStream& key, DataStream& value, std::string& err) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet) {
+        [&any_unordered, &batch, &any_missing_from_me] (CWallet* pwallet, DataStream& key, DataStream& value, std::string& err) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet) {
         DBErrors result = DBErrors::LOAD_OK;
         Txid hash;
         key >> hash;
@@ -1046,6 +1047,10 @@ static DBErrors LoadTxRecords(CWallet* pwallet, DatabaseBatch& batch, bool& any_
                 any_unordered = true;
             }
 
+            if (!wtx.m_from_me.has_value()) {
+                any_missing_from_me = true;
+            }
+
             if (!pwallet->LoadToWallet(std::move(wtx))) {
                 err = "Error: Corrupt transaction found. This can be fixed by removing transactions from wallet and rescanning.";
                 return DBErrors::CORRUPT;
@@ -1057,6 +1062,15 @@ static DBErrors LoadTxRecords(CWallet* pwallet, DatabaseBatch& batch, bool& any_
         return result;
     });
     result = std::max(result, tx_res.m_result);
+
+    // Upgrade each CWalletTx missing m_from_me
+    if (any_missing_from_me) {
+        for (const auto& [_, wtx] : pwallet->wtxOrdered) {
+            if (wtx->m_from_me) continue;
+            wtx->m_from_me = pwallet->IsFromMe(*wtx->GetTx());
+            wallet_batch.WriteTx(*wtx);
+        }
+    }
 
     // Load locked utxo record
     LoadResult locked_utxo_res = LoadRecords(pwallet, batch, DBKeys::LOCKED_UTXO,
@@ -1183,7 +1197,7 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
         result = std::max(LoadDecryptionKeys(pwallet, *m_batch), result);
 
         // Load tx records
-        result = std::max(LoadTxRecords(pwallet, *m_batch, any_unordered), result);
+        result = std::max(LoadTxRecords(pwallet, *m_batch, any_unordered, *this), result);
     } catch (std::runtime_error& e) {
         // Exceptions that can be ignored or treated as non-critical are handled by the individual loading functions.
         // Any uncaught exceptions will be caught here and treated as critical.

--- a/test/functional/wallet_backwards_compatibility.py
+++ b/test/functional/wallet_backwards_compatibility.py
@@ -262,10 +262,27 @@ class BackwardsCompatibilityTest(BitcoinTestFramework):
         assert_equal(wallet.gettransaction(txid)["alternate_wtxids"], [script_path_wtxid])
         wallet.unloadwallet()
 
+    def test_txs_out_of_order(self, old_node, master_node):
+        self.log.info("Test m_from_me upgrade")
+        wallet_name = "from_me_upgrade"
+        old_node.createwallet(wallet_name)
+        wallet = old_node.get_wallet_rpc(wallet_name)
+
+        for _ in range(2):
+            self.nodes[0].sendtoaddress(wallet.getnewaddress(), 1)
+            self.generate(self.nodes[0], 1)
+
+        backup_path = os.path.join(self.options.tmpdir, f"{wallet_name}.dat")
+        wallet.backupwallet(backup_path)
+        wallet.unloadwallet()
+
+        # The wallet should load onto master
+        master_node.restorewallet(wallet_name, backup_path)
 
     def run_test(self):
         node_miner = self.nodes[0]
         node_master = self.nodes[1]
+        node_v25 = self.nodes[self.num_nodes - 5]
         node_v21 = self.nodes[self.num_nodes - 2]
         node_v20 = self.nodes[self.num_nodes - 1] # bdb only
 
@@ -504,6 +521,7 @@ class BackwardsCompatibilityTest(BitcoinTestFramework):
             # Legacy wallets are no longer supported. Trying to load these should result in an error
             assert_raises_rpc_error(-18, "The wallet appears to be a Legacy wallet, please use the wallet migration tool (migratewallet RPC or the GUI option)", node_master.restorewallet, wallet_name, backup_path)
 
+        self.test_txs_out_of_order(node_v25, node_master)
         self.test_v22_inactivehdchain_path()
         self.test_ignore_legacy_during_startup(legacy_nodes, node_master)
         node_v25 = self.nodes[2] # note: could be any node prior to v32

--- a/test/functional/wallet_balance.py
+++ b/test/functional/wallet_balance.py
@@ -14,6 +14,8 @@ from test_framework.util import (
     assert_equal,
     assert_is_hash_string,
     assert_raises_rpc_error,
+    find_vout_for_address,
+    wallet_importprivkey,
 )
 from test_framework.wallet_util import get_generate_key
 
@@ -302,6 +304,36 @@ class WalletTest(BitcoinTestFramework):
 
         # Don't rescan to make sure that the import updates the wallet txos
         wallet.importdescriptors([{"desc": descsum_create(f"wpkh({import_key2.privkey})"), "timestamp": "now"}])
+        balances = wallet.getbalances()
+        assert_equal(balances["mine"]["trusted"], amount * 2)
+
+        wallet.unloadwallet()
+
+        self.log.info("Test that the balance is unchanged by an import that makes an already spent output in an existing tx \"mine\"")
+        self.nodes[0].createwallet("importalreadyspent")
+        wallet = self.nodes[0].get_wallet_rpc("importalreadyspent")
+
+        import_change_key = get_generate_key()
+        addr1 = wallet.getnewaddress()
+        addr2 = wallet.getnewaddress()
+
+        wallet_importprivkey(default, privkey=import_change_key.privkey, timestamp="now")
+
+        res = default.send(outputs=[{addr1: amount}], options={"change_address": import_change_key.p2wpkh_addr})
+        inputs = [{"txid":res["txid"], "vout": find_vout_for_address(default, res["txid"], import_change_key.p2wpkh_addr)}]
+        default.send(outputs=[{addr2: amount}], options={"inputs": inputs, "add_inputs": True})
+
+        # Mock the time forward by another day so that "now" will exclude the block we just mined
+        self.nodes[0].setmocktime(int(time.time()) + 86400 * 2)
+        # Mine 11 blocks to move the MTP past the block we just mined
+        self.generate(self.nodes[0], 11, sync_fun=self.no_op)
+
+        balances = wallet.getbalances()
+        assert_equal(balances["mine"]["trusted"], amount * 2)
+
+        # Don't rescan to make sure that the import updates the wallet txos
+        # The balance should not change because the output for this key is already spent
+        wallet_importprivkey(wallet, privkey=import_change_key.privkey, timestamp="now")
         balances = wallet.getbalances()
         assert_equal(balances["mine"]["trusted"], amount * 2)
 

--- a/test/functional/wallet_importprunedfunds.py
+++ b/test/functional/wallet_importprunedfunds.py
@@ -157,6 +157,59 @@ class ImportPrunedFundsTest(BitcoinTestFramework):
         available_utxos = [u["txid"] for u in node.listunspent(minconf=0)]
         assert utxo["txid"] not in available_utxos, "UTXO should still be spent by conflicting tx"
 
+        self.log.info("Test removeprunedfunds preserves inputs spent by another confirmed tx")
+        parent_txid = node.sendtoaddress(node.getnewaddress(), 1)
+        self.generate(node, 1)
+        parent_utxo = next(
+            utxo for utxo in node.listunspent() if utxo["txid"] == parent_txid
+        )
+        parent_outpoint = (parent_txid, parent_utxo["vout"])
+
+        child_txid = node.send(outputs=[{node.getnewaddress(): Decimal("0.5")}], inputs=[parent_utxo])["txid"]
+        child_fee = node.gettransaction(child_txid)["fee"]
+
+        # Replace child_txid with a conflicting tx and confirm it. Removing
+        # child_txid must not make parent_outpoint spendable again.
+        output_value = parent_utxo["amount"] + child_fee - Decimal("0.00001")
+        raw_conflict_tx = node.createrawtransaction(inputs=[parent_utxo], outputs=[{node.getnewaddress(): output_value}])
+        signed_conflict_tx = node.signrawtransactionwithwallet(raw_conflict_tx)
+        conflict_txid = node.sendrawtransaction(signed_conflict_tx["hex"])
+        assert_not_equal(conflict_txid, child_txid)
+        self.generate(node, 1)
+
+        def confirmed_parent_is_unspent():
+            return any(
+                (utxo["txid"], utxo["vout"]) == parent_outpoint
+                for utxo in node.listunspent(minconf=0)
+            )
+
+        assert_equal(confirmed_parent_is_unspent(), False)
+        node.removeprunedfunds(child_txid)
+        assert_equal(confirmed_parent_is_unspent(), False)
+
+        self.log.info("Test removeprunedfunds restores inputs of removed confirmed spend")
+        parent_txid = node.sendtoaddress(node.getnewaddress(), 1)
+        self.generate(node, 1)
+        parent_utxo = next(
+            utxo for utxo in node.listunspent() if utxo["txid"] == parent_txid
+        )
+        parent_outpoint = (parent_txid, parent_utxo["vout"])
+
+        child_txid = node.sendall(
+            recipients=[w1.getnewaddress()], inputs=[parent_utxo]
+        )["txid"]
+        self.generate(node, 1)
+
+        def parent_is_unspent():
+            return any(
+                (utxo["txid"], utxo["vout"]) == parent_outpoint
+                for utxo in node.listunspent(minconf=0)
+            )
+
+        assert_equal(parent_is_unspent(), False)
+        node.removeprunedfunds(child_txid)
+        assert_equal(parent_is_unspent(), True)
+
 
 if __name__ == '__main__':
     ImportPrunedFundsTest(__file__).main()

--- a/test/functional/wallet_send.py
+++ b/test/functional/wallet_send.py
@@ -528,6 +528,8 @@ class WalletSendTest(BitcoinTestFramework):
         # Check tx creation size limits
         self.test_weight_limits()
 
+        self.test_send_commit_inactive()
+
     def test_weight_limits(self):
         self.log.info("Test weight limits")
 
@@ -558,6 +560,25 @@ class WalletSendTest(BitcoinTestFramework):
 
         self.nodes[1].unloadwallet("test_weight_limits")
 
+    def test_send_commit_inactive(self):
+        self.log.info("Test that send always adds signed transactions to the wallet as inactive")
+        self.nodes[0].createwallet("commit")
+        wallet = self.nodes[0].get_wallet_rpc("commit")
+        def_wallet = self.nodes[0].get_wallet_rpc(self.default_wallet_name)
+
+        def_wallet.sendtoaddress(wallet.getnewaddress(), 1)
+        self.generate(self.nodes[0], 1)
+
+        utxos = wallet.listunspent()
+        wallet.sendtoaddress(def_wallet.getnewaddress(), 0.5)
+        self.generate(self.nodes[0], 1)
+        bals = wallet.getbalances()
+
+        res = wallet.send(outputs=[{def_wallet.getnewaddress(): 0.25}], inputs=utxos, add_to_wallet=True)
+        assert_equal(res["complete"], True)
+        txinfo = wallet.gettransaction(res["txid"])
+        assert_equal(txinfo["confirmations"], 0)
+        assert_equal(bals, wallet.getbalances())
 
 if __name__ == '__main__':
     WalletSendTest(__file__).main()


### PR DESCRIPTION
In #27286, the wallet keeps track of all of its transaction outputs, even if they are already spent or are otherwise unspendable. This TXO set is iterated for balance checking and coin selection preparation, which can still be slow for wallets that have had a lot of activity. This PR aims to improve the performance of such wallets by moving UTXOs that are definitely no longer spendable to a different map in the wallet so that far fewer TXOs need to be iterated for the aforementioned functions.

Unspendable TXOs (not to be confused with Unspent TXOs) are those which have a spending transaction that has been confirmed, or are no longer valid due to reorgs. TXOs that are spent in unconfirmed transactions remain in the primary TXO set, and are filtered out of balance and coin selection as before.