### PR TITLE
lint: suppress pip spam

### DIFF
--- a/ci/lint/04_install.sh
+++ b/ci/lint/04_install.sh
@@ -6,6 +6,8 @@
 
 export LC_ALL=C
 
+export PIP_ROOT_USER_ACTION=ignore
+
 ${CI_RETRY_EXE} apt-get update
 # Lint dependencies:
 # - curl/xz-utils (to install shellcheck)


### PR DESCRIPTION
The logs are [currently full of](https://cirrus-ci.com/task/5380096597426176?logs=lint#L240):
```bash
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
WARNING: You are using pip version 22.0.4; however, version 23.1.2 is available.
You should consider upgrading via the '/tmp/python/bin/python3.8 -m pip install --upgrade pip' command.
```

Fix this by upgrading `pip` as part of install. Ignore the irrelevant "root user" output.