### PR TITLE
build: make sure we can overwrite config.{guess,sub} before doing so

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -16,10 +16,14 @@ command -v autoreconf >/dev/null || \
 autoreconf --install --force --warnings=all
 
 if expr "'$(build-aux/config.guess --timestamp)" \< "'$(depends/config.guess --timestamp)" > /dev/null; then
+  chmod ug+w build-aux/config.guess
+  chmod ug+w src/secp256k1/build-aux/config.guess
   cp depends/config.guess build-aux
   cp depends/config.guess src/secp256k1/build-aux
 fi
 if expr "'$(build-aux/config.sub --timestamp)" \< "'$(depends/config.sub --timestamp)" > /dev/null; then
+  chmod ug+w build-aux/config.sub
+  chmod ug+w src/secp256k1/build-aux/config.sub
   cp depends/config.sub build-aux
   cp depends/config.sub src/secp256k1/build-aux
 fi


### PR DESCRIPTION
Since ea7b8528 (#26422), `autogen.sh` overwrites the `build-aux/config.{guess, sub}` files (installed there by `autoreconf`) with the `depends/config.{guess, sub}` files if these are newer.

The `autoreconf` tool copies them from it's `share/autoconf/build-aux/` directory. Specifically on NixOS, the `share/autoconf/build-aux/` files are located in the nix-store and are read-only. `autoreconf` preserves the read-only permissions when copying. Overwriting them with our `depends/config.{guess, sub}` files subsequently fails.

To make sure we can overwrite the files, set write permissions to the current user and group before overwriting. This fixes the problem on NixOS.

fixes #27873