### PR TITLE
ci: Use latest `macos-ventura-xcode:14.3.1` image

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -337,7 +337,7 @@ task:
   name: 'macOS 13 native arm64 [gui, sqlite only] [no depends]'
   macos_instance:
     # Use latest image, but hardcode version to avoid silent upgrades (and breaks)
-    image: ghcr.io/cirruslabs/macos-ventura-xcode:14.1  # https://cirrus-ci.org/guide/macOS
+    image: ghcr.io/cirruslabs/macos-ventura-xcode:14.3.1  # https://cirrus-ci.org/guide/macOS
   << : *BASE_TEMPLATE
   check_clang_script:
     - clang --version


### PR DESCRIPTION
As documented: https://github.com/bitcoin/bitcoin/blob/427853ab49f610e971b73ea4cc1d5366747e52b1/.cirrus.yml#L339

Last time, the image was updated in https://github.com/bitcoin/bitcoin/pull/26388.

The `check_clang` script diff:
```diff
--- master
+++ pr
@@ -1,5 +1,5 @@
 clang --version
-Apple clang version 14.0.0 (clang-1400.0.29.202)
-Target: arm64-apple-darwin22.1.0
+Apple clang version 14.0.3 (clang-1403.0.22.14.1)
+Target: arm64-apple-darwin22.5.0
 Thread model: posix
-InstalledDir: /Applications/Xcode-14.1.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
+InstalledDir: /Applications/Xcode-14.3.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin