### PR TITLE
ci: Bump ARM task to debian:bookworm

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -191,14 +191,14 @@ task:
     - python test\functional\test_runner.py --nocleanup --ci --quiet --combinedlogslen=99999999 --jobs=6 --timeout-factor=8 --extended --exclude feature_dbcrash
 
 task:
-  name: 'ARM [unit tests, no functional tests] [bullseye]'
+  name: 'ARM [unit tests, no functional tests] [bookworm]'
   << : *GLOBAL_TASK_TEMPLATE
   arm_container:
     cpu: 2
     memory: 8G
     dockerfile: ci/test_imagefile
     docker_arguments:
-      CI_IMAGE_NAME_TAG: debian:bullseye
+      CI_IMAGE_NAME_TAG: debian:bookworm
       FILE_ENV: "./ci/test/00_setup_env_arm.sh"
   << : *CREDITS_TEMPLATE
   env:

--- a/ci/test/00_setup_env_arm.sh
+++ b/ci/test/00_setup_env_arm.sh
@@ -18,7 +18,7 @@ if [ -n "$QEMU_USER_CMD" ]; then
 fi
 export CONTAINER_NAME=ci_arm_linux
 # Use debian to avoid 404 apt errors when cross compiling
-export CI_IMAGE_NAME_TAG="debian:bullseye"
+export CI_IMAGE_NAME_TAG="debian:bookworm"
 export USE_BUSY_BOX=true
 export RUN_UNIT_TESTS=true
 export RUN_FUNCTIONAL_TESTS=false


### PR DESCRIPTION
The task currently uses Debian 11 Bullseye, which will be EOL in ~2024-07, according to https://wiki.debian.org/DebianReleases#Production_Releases

So it would be good to bump either now or latest in 6 months.

Ideally the ARM CI task uses the version of GCC that guix uses to cross compile, which is currently GCC 10 and Debian Bookworm ships with GCC 12, so I'll leave this in draft for now. See also https://packages.debian.org/bookworm/gcc-arm-linux-gnueabihf