### PR TITLE
ci: Bump macOS cross task to ubuntu:jammy

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -318,11 +318,11 @@ task:
     << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
 
 task:
-  name: 'macOS 10.15 [gui, no tests] [focal]'
+  name: 'macOS 10.15 [gui, no tests] [jammy]'
   << : *CONTAINER_DEPENDS_TEMPLATE
   container:
     docker_arguments:
-      CI_IMAGE_NAME_TAG: ubuntu:focal
+      CI_IMAGE_NAME_TAG: ubuntu:jammy
       FILE_ENV: "./ci/test/00_setup_env_mac.sh"
   << : *CREDITS_TEMPLATE
   macos_sdk_cache:

--- a/ci/test/00_setup_env_mac.sh
+++ b/ci/test/00_setup_env_mac.sh
@@ -7,7 +7,7 @@
 export LC_ALL=C.UTF-8
 
 export CONTAINER_NAME=ci_macos_cross
-export CI_IMAGE_NAME_TAG=ubuntu:20.04  # Check that Focal can cross-compile to macos
+export CI_IMAGE_NAME_TAG=ubuntu:22.04
 export HOST=x86_64-apple-darwin
 export PACKAGES="cmake libz-dev libtinfo5 python3-setuptools xorriso"
 export XCODE_VERSION=12.2


### PR DESCRIPTION
It shouldn't matter what underlying image is used for the task, because the compiler is fully provided by `./depends/`.

So just use the latest Ubuntu LTS, which is also most likely the OS that is used by people cross-compiling, if there are any at all.