### PR TITLE
ci: Switch to `amd64` container in "ARM" task

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -193,17 +193,13 @@ task:
 task:
   name: 'ARM [unit tests, no functional tests] [bullseye]'
   << : *GLOBAL_TASK_TEMPLATE
-  arm_container:
-    cpu: 2
-    memory: 8G
-    dockerfile: ci/test_imagefile
+  container:
     docker_arguments:
       CI_IMAGE_NAME_TAG: debian:bullseye
       FILE_ENV: "./ci/test/00_setup_env_arm.sh"
   << : *CREDITS_TEMPLATE
   env:
     << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
-    QEMU_USER_CMD: ""  # Disable qemu and run the test natively
 
 task:
   name: 'Win64 [unit tests, no gui tests, no boost::process, no functional tests] [jammy]'


### PR DESCRIPTION
The `arm_container` does not support 32-bit mode anymore.

Fixes https://github.com/bitcoin/bitcoin/issues/27879.

Also, the `arm_container` could be used for testing `aarch64` binaries, which are the part of our releases. Leaving that for another PR.