### PR TITLE
test: Kill `BOOST_ASSERT` and update the linter

### DIFF
--- a/src/wallet/test/db_tests.cpp
+++ b/src/wallet/test/db_tests.cpp
@@ -5,6 +5,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include <test/util/setup_common.h>
+#include <util/check.h>
 #include <util/fs.h>
 #include <util/translation.h>
 #ifdef USE_BDB
@@ -141,12 +142,10 @@ BOOST_AUTO_TEST_CASE(db_cursor_prefix_range_test)
 {
     // Test each supported db
     for (const auto& database : TestDatabases(m_path_root)) {
-        BOOST_ASSERT(database);
-
         std::vector<std::string> prefixes = {"", "FIRST", "SECOND", "P\xfe\xff", "P\xff\x01", "\xff\xff"};
 
         // Write elements to it
-        std::unique_ptr<DatabaseBatch> handler = database->MakeBatch();
+        std::unique_ptr<DatabaseBatch> handler = Assert(database)->MakeBatch();
         for (unsigned int i = 0; i < 10; i++) {
             for (const auto& prefix : prefixes) {
                 BOOST_CHECK(handler->Write(std::make_pair(prefix, i), i));
@@ -162,7 +161,7 @@ BOOST_AUTO_TEST_CASE(db_cursor_prefix_range_test)
             DataStream value;
             for (int i = 0; i < 10; i++) {
                 DatabaseCursor::Status status = cursor->Next(key, value);
-                BOOST_ASSERT(status == DatabaseCursor::Status::MORE);
+                BOOST_CHECK_EQUAL(status, DatabaseCursor::Status::MORE);
 
                 std::string key_back;
                 unsigned int i_back;

--- a/test/lint/lint-assertions.py
+++ b/test/lint/lint-assertions.py
@@ -45,6 +45,16 @@ def main():
         ":(exclude)src/rpc/server.cpp",
     ], "CHECK_NONFATAL(condition) or NONFATAL_UNREACHABLE should be used instead of assert for RPC code.")
 
+    # The `BOOST_ASSERT` macro requires to `#include boost/assert.hpp`,
+    # which is an unnecessary Boost dependency.
+    exit_code |= git_grep([
+        "-E",
+        r"BOOST_ASSERT *\(.*\);",
+        "--",
+        "*.cpp",
+        "*.h",
+    ], "BOOST_ASSERT must be replaced with Assert, BOOST_REQUIRE, or BOOST_CHECK.")
+
     sys.exit(exit_code)
 
 


### PR DESCRIPTION
One of the goals of https://github.com/bitcoin/bitcoin/pull/27783 was to get rid of the `BOOST_ASSERT` macros instead of including the `boost/assert.hpp` headers. See https://github.com/bitcoin/bitcoin/pull/27783#discussion_r1210612717.

It turns out that a couple of those macros sneaked into the codebase in https://github.com/bitcoin/bitcoin/pull/27790.

This PR makes the linter guard against new instances of the `BOOST_ASSERT` macros and replaces the current ones.