### PR TITLE
test: clean up is node stopped

### DIFF
--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -365,7 +365,7 @@ class TestNode():
         if wait_until_stopped:
             self.wait_until_stopped()
 
-    def is_node_stopped(self, expected_ret_code=None):
+    def is_node_stopped(self, expected_ret_code=0):
         """Checks whether the node has stopped.
 
         Returns True if the node has stopped. False otherwise.
@@ -377,13 +377,8 @@ class TestNode():
             return False
 
         # process has stopped. Assert that it didn't return an error code.
-        # unless 'expected_ret_code' is provided.
-        if expected_ret_code is not None:
-            assert return_code == expected_ret_code, self._node_msg(
-                "Node returned unexpected exit code (%d) vs (%d) when stopping" % (return_code, expected_ret_code))
-        else:
-            assert return_code == 0, self._node_msg(
-                "Node returned non-zero exit code (%d) when stopping" % return_code)
+        assert return_code == expected_ret_code, self._node_msg(
+            f"Node returned unexpected exit code ({return_code}) vs ({expected_ret_code}) when stopping")
         self.running = False
         self.process = None
         self.rpc_connected = False
@@ -392,7 +387,7 @@ class TestNode():
         return True
 
     def wait_until_stopped(self, timeout=BITCOIND_PROC_WAIT_TIMEOUT, expect_error=False):
-        expected_ret_code = 1 if expect_error else None  # Whether node shutdown return EXIT_FAILURE or EXIT_SUCCESS
+        expected_ret_code = 1 if expect_error else 0  # Whether node shutdown return EXIT_FAILURE or EXIT_SUCCESS
         wait_until_helper(lambda: self.is_node_stopped(expected_ret_code=expected_ret_code), timeout=timeout, timeout_factor=self.timeout_factor)
 
     def replace_in_config(self, replacements):


### PR DESCRIPTION
Fixes #27893

Use f'strings for the message when asserting `expected_ret_code` and `return_code`. Change the `expected_ret_code` from an optional to have a default value of `0`.

cc MarcoFalke