### PR TITLE
guix: use GCC 12.3.0 to build releases

### DIFF
--- a/ci/test/00_setup_env_arm.sh
+++ b/ci/test/00_setup_env_arm.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2019-2021 The Bitcoin Core developers
+# Copyright (c) 2019-present The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -10,7 +10,7 @@ export HOST=arm-linux-gnueabihf
 export DPKG_ADD_ARCH="armhf"
 export PACKAGES="python3-zmq g++-arm-linux-gnueabihf busybox libc6:armhf libstdc++6:armhf libfontconfig1:armhf libxcb1:armhf"
 export CONTAINER_NAME=ci_arm_linux
-export CI_IMAGE_NAME_TAG="docker.io/arm64v8/debian:bookworm"
+export CI_IMAGE_NAME_TAG="docker.io/arm64v8/debian:bookworm"  # Check that https://packages.debian.org/bookworm/g++-arm-linux-gnueabihf (version 12.2, similar to guix) can cross-compile
 export USE_BUSY_BOX=true
 export RUN_UNIT_TESTS=true
 export RUN_FUNCTIONAL_TESTS=false

--- a/ci/test/00_setup_env_win64.sh
+++ b/ci/test/00_setup_env_win64.sh
@@ -7,7 +7,7 @@
 export LC_ALL=C.UTF-8
 
 export CONTAINER_NAME=ci_win64
-export CI_IMAGE_NAME_TAG="docker.io/amd64/ubuntu:22.04"  # Check that Jammy can cross-compile to win64
+export CI_IMAGE_NAME_TAG="docker.io/amd64/debian:bookworm"  # Check that https://packages.debian.org/bookworm/g++-mingw-w64-x86-64-posix (version 12.2, similar to guix) can cross-compile
 export HOST=x86_64-w64-mingw32
 export DPKG_ADD_ARCH="i386"
 export PACKAGES="nsis g++-mingw-w64-x86-64-posix wine-binfmt wine64 wine32 file"

--- a/contrib/guix/guix-build
+++ b/contrib/guix/guix-build
@@ -74,7 +74,8 @@ mkdir -p "$VERSION_BASE"
 ################
 
 # Default to building for all supported HOSTs (overridable by environment)
-export HOSTS="${HOSTS:-x86_64-linux-gnu arm-linux-gnueabihf aarch64-linux-gnu riscv64-linux-gnu powerpc64-linux-gnu powerpc64le-linux-gnu
+# powerpc64le-linux-gnu currently disabled due non-determinism issues across build arches.
+export HOSTS="${HOSTS:-x86_64-linux-gnu arm-linux-gnueabihf aarch64-linux-gnu riscv64-linux-gnu powerpc64-linux-gnu
                        x86_64-w64-mingw32
                        x86_64-apple-darwin arm64-apple-darwin}"
 

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -91,7 +91,7 @@ chain for " target " development."))
       (home-page (package-home-page xgcc))
       (license (package-license xgcc)))))
 
-(define base-gcc gcc-10)
+(define base-gcc gcc-12)
 (define base-linux-kernel-headers linux-libre-headers-6.1)
 
 (define* (make-bitcoin-cross-toolchain target
@@ -505,9 +505,6 @@ inspecting signatures in Mach-O binaries.")
         automake
         pkg-config
         bison
-        ;; Native GCC 10 toolchain
-        gcc-toolchain-10
-        (list gcc-toolchain-10 "static")
         ;; Scripting
         python-minimal ;; (3.10)
         ;; Git
@@ -516,14 +513,26 @@ inspecting signatures in Mach-O binaries.")
         python-lief)
   (let ((target (getenv "HOST")))
     (cond ((string-suffix? "-mingw32" target)
-           ;; Windows
-           (list zip
+           (list ;; Native GCC 12 toolchain
+                 gcc-toolchain-12
+                 (list gcc-toolchain-12 "static")
+                 zip
                  (make-mingw-pthreads-cross-toolchain "x86_64-w64-mingw32")
                  nsis-x86_64
                  nss-certs
                  osslsigncode))
           ((string-contains target "-linux-")
-           (list (make-bitcoin-cross-toolchain target)))
+           (list ;; Native GCC 12 toolchain
+                 gcc-toolchain-12
+                 (list gcc-toolchain-12 "static")
+                 (make-bitcoin-cross-toolchain target)))
           ((string-contains target "darwin")
-           (list clang-toolchain-17 binutils cmake-minimal python-signapple zip))
+           (list ;; Native GCC 10 toolchain
+                 gcc-toolchain-10
+                 (list gcc-toolchain-10 "static")
+                 binutils
+                 clang-toolchain-17
+                 cmake-minimal
+                 python-signapple
+                 zip))
           (else '())))))

--- a/contrib/guix/patches/vmov-alignment.patch
+++ b/contrib/guix/patches/vmov-alignment.patch
@@ -168,14 +168,19 @@ Based on a patch originally by Claude Heiland-Allen <claude@mathr.co.uk>
  	default:
  	  gcc_unreachable ();
  	}
---- a/gcc/config/i386/i386.c
-+++ b/gcc/config/i386/i386.c
-@@ -4981,13 +4981,13 @@
-       switch (type)
+--- a/gcc/config/i386/i386.cc
++++ b/gcc/config/i386/i386.cc
+@@ -5418,17 +5418,15 @@ ix86_get_ssemov (rtx *operands, unsigned size,
  	{
  	case opcode_int:
--	  opcode = misaligned_p ? "vmovdqu32" : "vmovdqa32";
-+	  opcode = "vmovdqu32";
+ 	  if (scalar_mode == E_HFmode)
+-	    opcode = (misaligned_p
+-		      ? (TARGET_AVX512BW ? "vmovdqu16" : "vmovdqu64")
+-		      : "vmovdqa64");
++	    opcode = TARGET_AVX512BW ? "vmovdqu16" : "vmovdqu64";
+ 	  else
+-	    opcode = misaligned_p ? "vmovdqu32" : "vmovdqa32";
++	    opcode = "vmovdqu32";
  	  break;
  	case opcode_float:
 -	  opcode = misaligned_p ? "vmovups" : "vmovaps";
@@ -187,9 +192,24 @@ Based on a patch originally by Claude Heiland-Allen <claude@mathr.co.uk>
  	  break;
  	}
      }
-@@ -4996,16 +4996,16 @@
-       switch (scalar_mode)
+@@ -5438,29 +5436,21 @@ ix86_get_ssemov (rtx *operands, unsigned size,
  	{
+ 	case E_HFmode:
+ 	  if (evex_reg_p)
+-	    opcode = (misaligned_p
+-		      ? (TARGET_AVX512BW
+-			 ? "vmovdqu16"
+-			 : "vmovdqu64")
+-		      : "vmovdqa64");
++	    opcode = TARGET_AVX512BW ? "vmovdqu16" : "vmovdqu64";
+ 	  else
+-	    opcode = (misaligned_p
+-		      ? (TARGET_AVX512BW
+-			 ? "vmovdqu16"
+-			 : "%vmovdqu")
+-		      : "%vmovdqa");
++	    opcode = TARGET_AVX512BW ? "vmovdqu16" : "%vmovdqu";
+ 	  break;
  	case E_SFmode:
 -	  opcode = misaligned_p ? "%vmovups" : "%vmovaps";
 +	  opcode = "%vmovups";
@@ -208,7 +228,7 @@ Based on a patch originally by Claude Heiland-Allen <claude@mathr.co.uk>
  	  break;
  	default:
  	  gcc_unreachable ();
-@@ -5017,48 +5017,32 @@
+@@ -5472,48 +5462,32 @@ ix86_get_ssemov (rtx *operands, unsigned size,
  	{
  	case E_QImode:
  	  if (evex_reg_p)


### PR DESCRIPTION
Switch to using [GCC `12.3.0`](https://gcc.gnu.org/gcc-12/) to build release binaries.

Temporarily disables the `powerpc64le-linux-gnu` target due to non-determinism issues when building across `aarch64` and `x86_64`. Trying to fix the non-determinism was going to require trying to selectively disable optimization flags, which is already not ideal (and didn't fix all issues), and the migration to GCC 12 as our release compiler is now the blocker for multiple other (c++20 and similar) changes, so leaving this blocked on the `powerpc64le` binaries does not seem like a good tradeoff.