### PR TITLE
validation: add missing insert to m_dirty_blockindex

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2914,6 +2914,7 @@ CBlockIndex* Chainstate::FindMostWorkChain()
                 while (pindexTest != pindexFailed) {
                     if (fFailedChain) {
                         pindexFailed->nStatus |= BLOCK_FAILED_CHILD;
+                        m_blockman.m_dirty_blockindex.insert(pindexFailed);
                     } else if (fMissingData) {
                         // If we're missing data, then add back to m_blocks_unlinked,
                         // so that if the block arrives in the future we can try adding


### PR DESCRIPTION
When the status of a block index is changed, we must add it to `m_dirty_blockindex` or the change might not get persisted to disk.
This is missing from one spot in `FindMostWorkChain()`, where `BLOCK_FAILED_CHILD` is set.
Since we have [code](https://github.com/bitcoin/bitcoin/blob/f0758d8a6696657269d9c057e7aa079ffa9e1c16/src/node/blockstorage.cpp#L284-L287) that later sets missing `BLOCK_FAILED_CHILD` during the next startup, I don't think that this can lead to bad block indexes in practice, but I still think it's worth fixing.