### PR TITLE
bench: bugfix, disable birth time block skip for wallet_create_tx.cpp

### DIFF
--- a/src/bench/wallet_create_tx.cpp
+++ b/src/bench/wallet_create_tx.cpp
@@ -83,6 +83,8 @@ static void WalletCreateTx(benchmark::Bench& bench, const OutputType output_type
 {
     const auto test_setup = MakeNoLogFileContext<const TestingSetup>();
 
+    // Set clock to genesis block, so the descriptors/keys creation time don't interfere with the blocks scanning process.
+    SetMockTime(test_setup->m_node.chainman->GetParams().GenesisBlock().nTime);
     CWallet wallet{test_setup->m_node.chain.get(), "", CreateMockableWalletDatabase()};
     {
         LOCK(wallet.cs_wallet);
@@ -136,6 +138,8 @@ static void WalletCreateTx(benchmark::Bench& bench, const OutputType output_type
 static void AvailableCoins(benchmark::Bench& bench, const std::vector<OutputType>& output_type)
 {
     const auto test_setup = MakeNoLogFileContext<const TestingSetup>();
+    // Set clock to genesis block, so the descriptors/keys creation time don't interfere with the blocks scanning process.
+    SetMockTime(test_setup->m_node.chainman->GetParams().GenesisBlock().nTime);
     CWallet wallet{test_setup->m_node.chain.get(), "", CreateMockableWalletDatabase()};
     {
         LOCK(wallet.cs_wallet);


### PR DESCRIPTION
As the  benchmarks inside `wallet_create_tx.cpp` assert the wallet
balance at the end, they require all blocks to be scanned by the wallet.
So, we need to ensure that no blocks are skipped by the recently added
wallet birth time functionality.

This just means setting the wallet birth time to the genesis block time.
So the wallet is always older than any new block.