### PR TITLE
net: disconnect inside AttemptToEvictConnection

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1098,6 +1098,37 @@ bool CConnman::AddConnection(const std::string& address, ConnectionType conn_typ
     return true;
 }
 
+void CConnman::DeleteDisconnectedNode(CNode* pnode)
+{
+    // Destroy the object only after other threads have stopped using it.
+    // Prevent double free by setting nRefCount to -1 before delete.
+    int expectedRefCount = 0;
+    if (pnode->nRefCount.compare_exchange_strong(expectedRefCount, -1)) {
+        WITH_LOCK(m_nodes_disconnected_mutex, m_nodes_disconnected.remove(pnode));
+        DeleteNode(pnode);
+    }
+}
+
+void CConnman::DisconnectAndReleaseNode(CNode* pnode)
+{
+    LOCK(m_nodes_mutex);
+    if (std::find(m_nodes.begin(), m_nodes.end(), pnode) != m_nodes.end()) {
+
+        // remove from m_nodes
+        m_nodes.erase(remove(m_nodes.begin(), m_nodes.end(), pnode), m_nodes.end());
+
+        // release outbound grant (if any)
+        pnode->grantOutbound.Release();
+
+        // close socket and cleanup
+        pnode->CloseSocketDisconnect();
+
+        // hold in disconnected pool until all refs are released
+        pnode->Release();
+        WITH_LOCK(m_nodes_disconnected_mutex, m_nodes_disconnected.push_back(pnode));
+    }
+}
+
 void CConnman::DisconnectNodes()
 {
     {

--- a/src/net.h
+++ b/src/net.h
@@ -936,6 +936,8 @@ private:
                                       const CAddress& addr_bind,
                                       const CAddress& addr);
 
+    void DeleteDisconnectedNode(CNode* pnode);
+    void DisconnectAndReleaseNode(CNode* pnode);
     void DisconnectNodes();
     void NotifyNumConnectionsChanged();
     /** Return true if the peer is inactive and should be disconnected. */

--- a/src/net.h
+++ b/src/net.h
@@ -1043,7 +1043,8 @@ private:
     std::vector<std::string> m_added_nodes GUARDED_BY(m_added_nodes_mutex);
     mutable Mutex m_added_nodes_mutex;
     std::vector<CNode*> m_nodes GUARDED_BY(m_nodes_mutex);
-    std::list<CNode*> m_nodes_disconnected;
+    GlobalMutex m_nodes_disconnected_mutex;
+    std::list<CNode*> m_nodes_disconnected GUARDED_BY(m_nodes_disconnected_mutex);
     mutable RecursiveMutex m_nodes_mutex;
     std::atomic<NodeId> nLastNodeId{0};
     unsigned int nPrevNodeCount{0};


### PR DESCRIPTION
Fixes #27843

To avoid overflowing `-maxconnections` disconnect nodes marked for eviction directly inside of `AttemptToEvictConnection()`. This has the end result that new connections will only be accepted _after_ an existing connection is dropped, otherwise the new connection is dropped.

Previously the number of connected nodes could overflow `nMaxInbound` as (multiple) new connections could be accepted from `ThreadI2PAccept` -- each marking an existing connection to drop (in the future) -- before `ThreadSocketHandler` looped through to `DisconnectNodes()` and took care of the disconnections.

Node disconnection and deletion are broken out into individual functions which handle a single node so they can be called both from `DisconnectNodes()` and `AttemptToEvictConnection`. This will result in more un/locking operations to perform mass disconnections, but as this only really happens when the network becomes inactive it should not be a problem.