### PR TITLE
feerate: For GetFeePerK() return nSatoshisPerK instead of round trip through GetFee

### DIFF
--- a/src/policy/feerate.h
+++ b/src/policy/feerate.h
@@ -62,7 +62,7 @@ public:
     /**
      * Return the fee in satoshis for a vsize of 1000 vbytes
      */
-    CAmount GetFeePerK() const { return GetFee(1000); }
+    CAmount GetFeePerK() const { return nSatoshisPerK; }
     friend bool operator<(const CFeeRate& a, const CFeeRate& b) { return a.nSatoshisPerK < b.nSatoshisPerK; }
     friend bool operator>(const CFeeRate& a, const CFeeRate& b) { return a.nSatoshisPerK > b.nSatoshisPerK; }
     friend bool operator==(const CFeeRate& a, const CFeeRate& b) { return a.nSatoshisPerK == b.nSatoshisPerK; }


### PR DESCRIPTION
Returning the sats/kvb does not need to round trip through GetFee(1000) since the feerate is already stored as sats/kvb.

Fixes #27913, although this does bring up a larger question of how we should handle such large feerates in fuzzing.