### PR TITLE
fuzz: Fix implicit-integer-sign-change in wallet/fees fuzz target

### DIFF
--- a/src/wallet/test/fuzz/fees.cpp
+++ b/src/wallet/test/fuzz/fees.cpp
@@ -56,7 +56,7 @@ FUZZ_TARGET_INIT(wallet_fees, initialize_setup)
         coin_control.m_feerate = CFeeRate{ConsumeMoney(fuzzed_data_provider, /*max=*/COIN)};
     }
     if (fuzzed_data_provider.ConsumeBool()) {
-        coin_control.m_confirm_target = fuzzed_data_provider.ConsumeIntegral<unsigned int>();
+        coin_control.m_confirm_target = fuzzed_data_provider.ConsumeIntegralInRange<unsigned int>(0, 999'000);
     }
 
     FeeCalculation fee_calculation;


### PR DESCRIPTION
This fixes a bug in the fuzz target.

```
echo 'OiAAAPr//wAAAAAAAAA=' | base64  --decode > /tmp/a
UBSAN_OPTIONS="suppressions=$(pwd)/test/sanitizer_suppressions/ubsan:print_stacktrace=1:halt_on_error=1:report_error_type=1" FUZZ=wallet_fees ./src/test/fuzz/fuzz  /tmp/a
```

```
wallet/fees.cpp:58:58: runtime error: implicit conversion from type 'unsigned int' of value 4294574080 (32-bit, unsigned) to type 'int' changed the value to -393216 (32-bit, signed)
    #0 0x5625ef46a094 in wallet::GetMinimumFeeRate(wallet::CWallet const&, wallet::CCoinControl const&, FeeCalculation*) src/wallet/fees.cpp:58:58
    #1 0x5625eedd467f in wallet::(anonymous namespace)::wallet_fees_fuzz_target(Span<unsigned char const>) src/wallet/test/fuzz/fees.cpp:64:11
...

SUMMARY: UndefinedBehaviorSanitizer: implicit-integer-sign-change wallet/fees.cpp:58:58 in 