### PR TITLE
policy: make unstructured annex standard

### DIFF
--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -208,10 +208,40 @@ bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
     return true;
 }
 
+bool IsAnnexStandard(const std::vector<unsigned char>& annex)
+{
+    // Get the size of the annex excluding the tag byte.
+    size_t annex_size = annex.size() - 1;
+
+    // Allow an empty annex. This allows inputs to opt-in to annex
+    // usage with the minimal number of bytes.
+    if (annex_size == 0) {
+        return true;
+    }
+
+    // Annexes are nonstandard as long as they don't start with a
+    // 0x00 byte which signals unstructured data.
+    if (annex[1] != 0) {
+        return false;
+    }
+
+    // Unstructured annexes are nonstandard if they are larger than 256 bytes
+    // excluding the 0x00 tag. This limits the potential of annex inflation
+    // attacks.
+    if (annex_size > MAX_PER_INPUT_ANNEX_SIZE) {
+        return false;
+    }
+
+    return true;
+}
+
 bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
 {
     if (tx.IsCoinBase())
         return true; // Coinbases are skipped
+
+    // Track the number of inputs that commit to an annex.
+    unsigned int annex_input_count = 0;
 
     for (unsigned int i = 0; i < tx.vin.size(); i++)
     {
@@ -266,8 +296,17 @@ bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
             // Taproot spend (non-P2SH-wrapped, version 1, witness program size 32; see BIP 341)
             Span stack{tx.vin[i].scriptWitness.stack};
             if (stack.size() >= 2 && !stack.back().empty() && stack.back()[0] == ANNEX_TAG) {
-                // Annexes are nonstandard as long as no semantics are defined for them.
-                return false;
+                // An annex is present. Remove it from the stack and save it for
+                // standardness checks.
+                const auto& annex = SpanPopBack(stack);
+
+                // Check that the annex is standard.
+                if (!IsAnnexStandard(annex)) {
+                    return false;
+                }
+
+                // Increment the number of inputs that commit to an annex.
+                annex_input_count++;
             }
             if (stack.size() >= 2) {
                 // Script path spend (2 or more stack elements after removing optional annex)
@@ -289,6 +328,12 @@ bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
             }
         }
     }
+
+    // If any inputs commit to an annex, all inputs must commit to an annex.
+    if (annex_input_count > 0 && annex_input_count != tx.vin.size()) {
+        return false;
+    }
+
     return true;
 }
 

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -69,6 +69,8 @@ static constexpr unsigned int DEFAULT_DESCENDANT_SIZE_LIMIT_KVB{101};
  * configurable as it doesn't materially change DoS parameters.
  */
 static constexpr unsigned int EXTRA_DESCENDANT_TX_SIZE_LIMIT{10000};
+/** The maximum size of the annex of an input */
+static constexpr unsigned int MAX_PER_INPUT_ANNEX_SIZE{257};
 /**
  * Standard script verification flags that standard transactions will comply
  * with. However scripts violating these flags may still be present in valid


### PR DESCRIPTION
This PR opens up the annex in a limited way:

* If any one of the inputs commits to an annex, all inputs must. This is a mechanism to opt-in to annex use, preventing participants in a multi-party transaction from adding an unexpected annex which would increase the tx weight and lower the fee rate. See https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2023-June/021736.html

* Allow empty annexes, to let users opt-in to annex usage with the minimum number of bytes.

* Additionally, only allow annexes that start with `0x00`. This keeps open the possibility to support structured annexes such as for example the tlv format proposed in https://github.com/bitcoin/bips/pull/1381. A potential future structured format would start with a non-zero byte.

* Limit the maximum size of unstructured annex data to 256 bytes. Including the annex tag 0x50 and the unstructured data tag 0x00, this makes for a maximum total witness element size of 258 bytes. This upper limit somewhat protects participants in a multi-party transaction that uses the annex against annex inflation.

  The constant 256 is chosen so that it provides enough space to accommodate several schnorr signatures. This is useful for implementing annex covenants with multiple presigned transactions. For a PoC of a single transaction annex covenant, see https://github.com/joostjager/annex-covenants

Todo:
* [ ] fix/add tests

Related:
* Max 126 byte unstructured annex without opt-in: https://github.com/bitcoin-inquisition/bitcoin/pull/22