### PR TITLE
util: Don't derive secure_allocator from std::allocator

### DIFF
--- a/src/support/allocators/secure.h
+++ b/src/support/allocators/secure.h
@@ -17,27 +17,14 @@
 // out of memory and clears its contents before deletion.
 //
 template <typename T>
-struct secure_allocator : public std::allocator<T> {
-    using base = std::allocator<T>;
-    using traits = std::allocator_traits<base>;
-    using size_type = typename traits::size_type;
-    using difference_type = typename traits::difference_type;
-    using pointer = typename traits::pointer;
-    using const_pointer = typename traits::const_pointer;
-    using value_type = typename traits::value_type;
-    secure_allocator() noexcept {}
-    secure_allocator(const secure_allocator& a) noexcept : base(a) {}
-    template <typename U>
-    secure_allocator(const secure_allocator<U>& a) noexcept : base(a)
-    {
-    }
-    ~secure_allocator() noexcept {}
-    template <typename Other>
-    struct rebind {
-        typedef secure_allocator<Other> other;
-    };
+struct secure_allocator {
+    using value_type = T;
 
-    T* allocate(std::size_t n, const void* hint = nullptr)
+    secure_allocator() = default;
+    template <typename U>
+    secure_allocator(const secure_allocator<U>&) noexcept {}
+
+    T* allocate(std::size_t n)
     {
         T* allocation = static_cast<T*>(LockedPoolManager::Instance().alloc(sizeof(T) * n));
         if (!allocation) {
@@ -52,6 +39,17 @@ struct secure_allocator : public std::allocator<T> {
             memory_cleanse(p, sizeof(T) * n);
         }
         LockedPoolManager::Instance().free(p);
+    }
+
+    template <typename U>
+    friend bool operator==(const secure_allocator&, const secure_allocator<U>&) noexcept
+    {
+        return true;
+    }
+    template <typename U>
+    friend bool operator!=(const secure_allocator&, const secure_allocator<U>&) noexcept
+    {
+        return false;
     }
 };
 


### PR DESCRIPTION
Giving the C++ Standard Committee control of the public interface of your type means they will break it. C++23 adds a new `allocate_at_least` member to `std::allocator`. Very bad things happen when, say, `std::vector` uses `allocate_at_least` from `secure_allocator`'s base to allocate memory which it then tries to free with `secure_allocator::deallocate`.

(Discovered by microsoft/STL#3712, which will be reverted by microsoft/STL#3819 before it ships.)