### PR TITLE
fuzz: call lookup functions before calling `Ban`

### DIFF
--- a/ci/test/00_setup_env_mac_native.sh
+++ b/ci/test/00_setup_env_mac_native.sh
@@ -15,4 +15,3 @@ export NO_DEPENDS=1
 export OSX_SDK=""
 export CCACHE_MAXSIZE=400M
 export RUN_FUZZ_TESTS=true
-export FUZZ_TESTS_CONFIG="--exclude banman"  # https://github.com/bitcoin/bitcoin/issues/27924


### PR DESCRIPTION
Fixes #27924 

To not have any discrepancy, it's required to call lookup functions before calling `Ban`. If we don't do it, the assertion `assert(banmap == banmap_read);` may fail because `BanMapFromJson` will call `LookupSubNet` and cause the discrepancy between the banned and the loaded one. It happens especially in MacOS (#27924). 

Also, calling lookup functions before banning is what RPC `setban` does.