### PR TITLE
doc: i2p documentation updates

### DIFF
--- a/doc/i2p.md
+++ b/doc/i2p.md
@@ -10,7 +10,7 @@ started with I2P terminology.
 ## Run Bitcoin Core with an I2P router (proxy)
 
 A running I2P router (proxy) is required with the [SAM](https://geti2p.net/en/docs/api/samv3)
-application bridge enabled. Options include:
+application bridge enabled. The following routers are recommended for use with Bitcoin Core:
 
 - [i2prouter (I2P Router)](https://geti2p.net), the official implementation in
   Java. The SAM bridge is not enabled by default; it must be started manually,
@@ -19,8 +19,6 @@ application bridge enabled. Options include:
 - [i2pd (I2P Daemon)](https://github.com/PurpleI2P/i2pd)
   ([documentation](https://i2pd.readthedocs.io/en/latest)), a lighter
   alternative in C++. It enables the SAM bridge by default.
-- [i2p-zero](https://github.com/i2p-zero/i2p-zero)
-- [other alternatives](https://en.wikipedia.org/wiki/I2P#Routers)
 
 Note the IP address and port the SAM proxy is listening to; usually, it is
 `127.0.0.1:7656`.

--- a/doc/i2p.md
+++ b/doc/i2p.md
@@ -9,14 +9,16 @@ started with I2P terminology.
 
 ## Run Bitcoin Core with an I2P router (proxy)
 
-A running I2P router (proxy) with [SAM](https://geti2p.net/en/docs/api/samv3)
-enabled is required. Options include:
+A running I2P router (proxy) is required with the [SAM](https://geti2p.net/en/docs/api/samv3)
+application bridge enabled. Options include:
 
 - [i2prouter (I2P Router)](https://geti2p.net), the official implementation in
-  Java
+  Java. The SAM bridge is not enabled by default; it must be started manually,
+  or configured to start automatically, in the Clients page in the
+  router console (`http://127.0.0.1:7657/configclients`) or in the `clients.config` file.
 - [i2pd (I2P Daemon)](https://github.com/PurpleI2P/i2pd)
   ([documentation](https://i2pd.readthedocs.io/en/latest)), a lighter
-  alternative in C++
+  alternative in C++. It enables the SAM bridge by default.
 - [i2p-zero](https://github.com/i2p-zero/i2p-zero)
 - [other alternatives](https://en.wikipedia.org/wiki/I2P#Routers)
 
@@ -118,8 +120,7 @@ to connect to the I2P network. Any I2P router that supports it can be used.
 
 ## Ports in I2P and Bitcoin Core
 
-Bitcoin Core uses the [SAM v3.1](https://geti2p.net/en/docs/api/samv3)
-protocol. One particularity of SAM v3.1 is that it does not support ports,
+One particularity of SAM v3.1 is that it does not support ports,
 unlike newer versions of SAM (v3.2 and up) that do support them and default the
 port numbers to 0. From the point of view of peers that use newer versions of
 SAM or other protocols that support ports, a SAM v3.1 peer is connecting to them


### PR DESCRIPTION
1. Clarify when and how to launch the SAM application bridge to address user questions and https://github.com/bitcoin/bitcoin/issues/22759#issuecomment-1599449753. The bridge is not enabled by default in the Java I2P Router, and the relevant info is somewhat difficult to find in its documentation.

2. Remove a duplicate sentence and link (the preceding paragraph begins with the same sentence and link).

3. Simplify the router options:

    - the Java I2P router and i2pd are the two routers have been heavily tested with Bitcoin Core and are what node operators and node software packages are using

    - [i2p-zero](https://github.com/i2p-zero/i2p-zero) hasn't been updated since July 2021 and its last release was in December 2020

    - the other routers in the wikipedia page are niche and I haven't heard anyone report using them