### PR TITLE
Autogen 25.x

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -3,14 +3,64 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-export LC_ALL=C
+# Set error handling
 set -e
-srcdir="$(dirname "$0")"
-cd "$srcdir"
-if [ -z "${LIBTOOLIZE}" ] && GLIBTOOLIZE="$(command -v glibtoolize)"; then
-  LIBTOOLIZE="${GLIBTOOLIZE}"
-  export LIBTOOLIZE
-fi
-command -v autoreconf >/dev/null || \
-  (echo "configuration failed, please install autoconf first" && exit 1)
-autoreconf --install --force --warnings=all
+
+# If verbose is non-zero, print messages
+verbose=1
+
+# Sets environment variables and navigates to the source directory
+set_environment_variables() {
+  export LC_ALL=C
+  srcdir="$(dirname "$0")"
+  cd "$srcdir"
+}
+
+# Check for libtoolize and set LIBTOOLIZE variable
+check_libtoolize() {
+  if [ -z "${LIBTOOLIZE}" ] && LIBTOOLIZE="$(command -v libtoolize)"; then
+    LIBTOOLIZE="${LIBTOOLIZE}"
+    export LIBTOOLIZE
+  fi
+}
+
+# Run autoreconf
+run_autoreconf() {
+  command -V autoreconf >/dev/null || { echo "Error: autoreconf not found."; exit 1; }
+  autoreconf --install --force --warnings=all || { echo "Error: autoreconf failed"; exit 1; }
+}
+
+# Copy file if newer
+copy_if_newer() {
+  local src=$1 dst=$2
+
+  if [ ! -f "$src" ]; then
+    echo "Source file $src does not exist. Skipping copy operation."
+    return
+  fi
+
+  if [ "$verbose" -ne 0 ]; then
+    echo "Checking if $src is newer than $dst..."
+  fi
+  
+  if [ "$src" -nt "$dst" ]; then
+    cp "$src" "$dst" || { echo "Error: Failed to copy $src to $dst."; exit 1; }
+    if [ "$verbose" -ne 0 ]; then
+      echo "Copied $src to $dst"
+    fi
+  else
+    if [ "$verbose" -ne 0 ]; then
+      echo "$src is not newer than $dst. Skipping copy operation."
+    fi
+  fi
+}
+
+# Call functions
+set_environment_variables
+check_libtoolize
+run_autoreconf
+
+copy_if_newer 'depends/config.guess' 'build-aux/config.guess'
+copy_if_newer 'depends/config.guess' 'src/secp256k1/build-aux/config.guess'
+copy_if_newer 'depends/config.sub' 'build-aux/config.sub'
+copy_if_newer 'depends/config.sub' 'src/secp256k1/build-aux/config.sub'

--- a/autogen.sh
+++ b/autogen.sh
@@ -18,10 +18,8 @@ set_environment_variables() {
 
 # Check for libtoolize and set LIBTOOLIZE variable
 check_libtoolize() {
-  if [ -z "${LIBTOOLIZE}" ] && LIBTOOLIZE="$(command -v libtoolize)"; then
-    LIBTOOLIZE="${LIBTOOLIZE}"
-    export LIBTOOLIZE
-  fi
+  LIBTOOLIZE="${LIBTOOLIZE:=$(command -v libtoolize)}"
+  export LIBTOOLIZE
 }
 
 # Run autoreconf

--- a/autogen.sh
+++ b/autogen.sh
@@ -4,7 +4,7 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 # Set error handling
-set -e
+set -euo pipefail
 
 # If verbose is non-zero, print messages
 verbose=1

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright (c) 2013-2019 The Bitcoin Core developers
+# Copyright (c) 2013-2023 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -26,7 +26,7 @@ check_libtoolize() {
 
 # Run autoreconf
 run_autoreconf() {
-  command -V autoreconf >/dev/null || { echo "Error: autoreconf not found."; exit 1; }
+  [ -x "$(command -v autoreconf)" ] >/dev/null || { echo "Error: autoreconf not found or not executable."; exit 1; }
   autoreconf --install --force --warnings=all || { echo "Error: autoreconf failed"; exit 1; }
 }
 

--- a/autogen.sh
+++ b/autogen.sh
@@ -25,7 +25,7 @@ check_libtoolize() {
 # Run autoreconf
 run_autoreconf() {
   [ -x "$(command -v autoreconf)" ] >/dev/null || { echo "Error: autoreconf not found or not executable."; exit 1; }
-  autoreconf --install --force --warnings=all || { echo "Error: autoreconf failed"; exit 1; }
+  autoreconf --install --force --warnings=all || { echo "Error: autoreconf failed to execute. Please ensure autoreconf is installed and available in your PATH."; exit 1; }
 }
 
 # Copy file if newer


### PR DESCRIPTION
Refactoring the script by encapsulating related operations into functions for readability and maintainability

Replace ``set -e`` with ``set -euo pipefail`` at the beginning of the script. This will cause the script to exit if any variable is unset (due to the -u option) and also if any command in a pipeline fails (due to the ``-o pipefail``option). This may make the script more robust and easier to debug

In the ``run_autoreconf`` function, I've added an error message to be displayed if the ``autoreconf`` command fails.

``check_libtoolize`` function using parameter substitution

check if ``autoreconf`` is executable

Also using the ``copy_if_newer`` function which is being called 4 times.</br>

- The first time, it's checking if ``'depends/config.guess'`` is newer than ``'build-aux/config.guess'``. If it is, it copies the former over the latter.

- The second time, it's doing the same check and potential copy, but this time between ``'depends/config.guess'`` and ``'src/secp256k1/build-aux/config.guess'``.

- The third and fourth calls are doing similar checks and potential copies, but with ``'depends/config.sub'`` and the destination files.

The ``'config.guess'`` and ``'config.sub'`` scripts are used by GNU Autotools, and they help determine the type of system your software is building on. The ``'config.guess'`` script guesses the build type for your system, and ``'config.sub'`` validates and canonicalizes that guess.

The ``copy_if_newer`` calls ensure that the most recent versions of ``'config.guess'`` and ``'config.sub'`` are used in the directories where they are needed. Could be useful ie, when the scripts in those directories are not updated as frequently or need to be isolated from changes in other parts of someone's system.


Currently ``#!/bin/sh`` is used, which is the system's default shell. I'm not sure if that will be ever problematic.
If we know that this script should run in bash, maybe it's better to specify ``#!/usr/bin/env bash`` ?

