### PR TITLE
test: Add implicit-signed-integer-truncation:*/include/c++/ suppression

### DIFF
--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -23,6 +23,7 @@ implicit-integer-sign-change:crc32c/
 # implicit-integer-sign-change in FuzzedDataProvider's ConsumeIntegralInRange
 implicit-integer-sign-change:FuzzedDataProvider.h
 implicit-integer-sign-change:minisketch/
+implicit-signed-integer-truncation:*/include/c++/
 implicit-signed-integer-truncation:leveldb/
 implicit-unsigned-integer-truncation:*/include/c++/
 implicit-unsigned-integer-truncation:leveldb/


### PR DESCRIPTION
Needed for aarch64. Steps to test on aarch64:

```
lscpu | grep Arch
FILE_ENV="./ci/test/00_setup_env_native_fuzz.sh" ./ci/test_run_all.sh
```

