### PR TITLE
net: remove unused `CConnmanTest`

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -1219,7 +1219,6 @@ private:
         std::vector<CNode*> m_nodes_copy;
     };
 
-    friend struct CConnmanTest;
     friend struct ConnmanTestMsg;
 };
 


### PR DESCRIPTION
`CConnmanTest` was removed in fa72fce7c948185752a01002000ea511809146ed.