### PR TITLE
util: Safer MakeByteSpan with ByteSpanCast

### DIFF
--- a/src/bench/ellswift.cpp
+++ b/src/bench/ellswift.cpp
@@ -17,7 +17,7 @@ static void EllSwiftCreate(benchmark::Bench& bench)
     uint256 entropy = GetRandHash();
 
     bench.batch(1).unit("pubkey").run([&] {
-        auto ret = key.EllSwiftCreate(AsBytes(Span{entropy}));
+        auto ret = key.EllSwiftCreate(MakeByteSpan(entropy));
         /* Use the first 32 bytes of the ellswift encoded public key as next private key. */
         key.Set(UCharCast(ret.data()), UCharCast(ret.data()) + 32, true);
         assert(key.IsValid());

--- a/src/test/fuzz/hex.cpp
+++ b/src/test/fuzz/hex.cpp
@@ -21,7 +21,7 @@ FUZZ_TARGET(hex)
     const std::string random_hex_string(buffer.begin(), buffer.end());
     const std::vector<unsigned char> data = ParseHex(random_hex_string);
     const std::vector<std::byte> bytes{ParseHex<std::byte>(random_hex_string)};
-    assert(AsBytes(Span{data}) == Span{bytes});
+    assert(MakeByteSpan(data) == Span{bytes});
     const std::string hex_data = HexStr(data);
     if (IsHex(random_hex_string)) {
         assert(ToLower(random_hex_string) == hex_data);

--- a/src/test/key_tests.cpp
+++ b/src/test/key_tests.cpp
@@ -351,7 +351,7 @@ BOOST_AUTO_TEST_CASE(key_ellswift)
         BOOST_CHECK(key.IsValid());
 
         uint256 ent32 = InsecureRand256();
-        auto ellswift = key.EllSwiftCreate(AsBytes(Span{ent32}));
+        auto ellswift = key.EllSwiftCreate(MakeByteSpan(ent32));
 
         CPubKey decoded_pubkey = ellswift.Decode();
         if (!key.IsCompressed()) {

--- a/src/wallet/test/db_tests.cpp
+++ b/src/wallet/test/db_tests.cpp
@@ -33,7 +33,7 @@ namespace wallet {
 
 static Span<const std::byte> StringBytes(std::string_view str)
 {
-    return AsBytes<const char>({str.data(), str.size()});
+    return MakeByteSpan(str);
 }
 
 static SerializeData StringData(std::string_view str)


### PR DESCRIPTION
The `AsBytes` helpers (or `std::as_bytes` helpers) are architecture
dependent. For example, the below test case diff [0], applied before
this commit will pass on x86_64, but fail on s390x [1].

Fix this by replacing `AsBytes` with a new `ByteSpanCast` in the `MakeByteSpan` helper.
This will turn the test case diff into a compile failure instead of a runtime error.

[0] test case diff:

```diff
diff --git a/src/test/serialize_tests.cpp b/src/test/serialize_tests.cpp
index 09f77d2b61..4e56ffa351 100644
--- a/src/test/serialize_tests.cpp
+++ b/src/test/serialize_tests.cpp
@@ -241,6 +241,15 @@ BOOST_AUTO_TEST_CASE(class_methods)
     ss2 << intval << boolval << stringval << charstrval << txval;
     ss2 >> methodtest3;
     BOOST_CHECK(methodtest3 == methodtest4);
+
+    {
+        DataStream out;
+        std::vector<uint8_t> in_8{0x00, 0x11, 0x22, 0x33};
+        std::vector<uint16_t> in_16{0xaabb, 0xccdd};
+        out.write(MakeByteSpan(in_8));
+        out.write(MakeByteSpan(in_16));
+        BOOST_CHECK_EQUAL(HexStr(out), "00112233bbaaddcc");
+    }
 }

 BOOST_AUTO_TEST_SUITE_END()
```

[1] test case failure on s390x:
`test/serialize_tests.cpp(251): error: in "serialize_tests/class_methods": check HexStr(out) == "00112233bbaaddcc" has failed [00112233aabbccdd != 00112233bbaaddcc]`