### PR TITLE
test: remove race in the user-agent reception check

### DIFF
--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -633,10 +633,13 @@ class TestNode():
             # in comparison to the upside of making tests less fragile and unexpected intermittent errors less likely.
             p2p_conn.sync_with_ping()
 
-            # Consistency check that the Bitcoin Core has received our user agent string. This checks the
-            # node's newest peer. It could be racy if another Bitcoin Core node has connected since we opened
-            # our connection, but we don't expect that to happen.
-            assert_equal(self.getpeerinfo()[-1]['subver'], P2P_SUBVERSION)
+            # Consistency check that the node received our user agent string.
+            # Find our connection in getpeerinfo by our address:port, as it is unique.
+            sockname = p2p_conn._transport.get_extra_info("socket").getsockname()
+            our_addr_and_port = f"{sockname[0]}:{sockname[1]}"
+            info = [peer for peer in self.getpeerinfo() if peer["addr"] == our_addr_and_port]
+            assert_equal(len(info), 1)
+            assert_equal(info[0]["subver"], P2P_SUBVERSION)
 
         return p2p_conn
 


### PR DESCRIPTION
In `add_p2p_connection()` we connect to `bitcoind` from the Python client and check that it has received our version string.

This check looked up the last/newest entry from `getpeerinfo` RPC, assuming that it must be the connection we have just opened. But this will not be the case if a new inbound or outbound connection is made to/from `bitcoind` in the meantime.

Instead of the last entry in `getpeerinfo`, check all and find the one which corresponds to our connection using our outgoing address:port tuple which is unique.