### PR TITLE
test: Use same timeout for all index sync

### DIFF
--- a/src/Makefile.test_util.include
+++ b/src/Makefile.test_util.include
@@ -11,6 +11,7 @@ TEST_UTIL_H = \
   test/util/blockfilter.h \
   test/util/chainstate.h \
   test/util/coins.h \
+  test/util/index.h \
   test/util/json.h \
   test/util/logging.h \
   test/util/mining.h \
@@ -34,6 +35,7 @@ libtest_util_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libtest_util_a_SOURCES = \
   test/util/blockfilter.cpp \
   test/util/coins.cpp \
+  test/util/index.cpp \
   test/util/json.cpp \
   test/util/logging.cpp \
   test/util/mining.cpp \

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -12,8 +12,8 @@
 #include <pow.h>
 #include <script/standard.h>
 #include <test/util/blockfilter.h>
+#include <test/util/index.h>
 #include <test/util/setup_common.h>
-#include <util/time.h>
 #include <validation.h>
 
 #include <boost/test/unit_test.hpp>
@@ -142,12 +142,7 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
     BOOST_REQUIRE(filter_index.Start());
 
     // Allow filter index to catch up with the block index.
-    constexpr auto timeout{10s};
-    const auto time_start{SteadyClock::now()};
-    while (!filter_index.BlockUntilSyncedToCurrentChain()) {
-        BOOST_REQUIRE(time_start + timeout > SteadyClock::now());
-        UninterruptibleSleep(std::chrono::milliseconds{100});
-    }
+    IndexWaitSynced(filter_index);
 
     // Check that filter index has all blocks that were in the chain before it started.
     {

--- a/src/test/coinstatsindex_tests.cpp
+++ b/src/test/coinstatsindex_tests.cpp
@@ -6,27 +6,14 @@
 #include <index/coinstatsindex.h>
 #include <interfaces/chain.h>
 #include <kernel/coinstats.h>
+#include <test/util/index.h>
 #include <test/util/setup_common.h>
 #include <test/util/validation.h>
-#include <util/time.h>
 #include <validation.h>
 
 #include <boost/test/unit_test.hpp>
 
-#include <chrono>
-
 BOOST_AUTO_TEST_SUITE(coinstatsindex_tests)
-
-static void IndexWaitSynced(BaseIndex& index)
-{
-    // Allow the CoinStatsIndex to catch up with the block index that is syncing
-    // in a background thread.
-    const auto timeout = GetTime<std::chrono::seconds>() + 120s;
-    while (!index.BlockUntilSyncedToCurrentChain()) {
-        BOOST_REQUIRE(timeout > GetTime<std::chrono::milliseconds>());
-        UninterruptibleSleep(100ms);
-    }
-}
 
 BOOST_FIXTURE_TEST_CASE(coinstatsindex_initial_sync, TestChain100Setup)
 {

--- a/src/test/txindex_tests.cpp
+++ b/src/test/txindex_tests.cpp
@@ -6,8 +6,8 @@
 #include <index/txindex.h>
 #include <interfaces/chain.h>
 #include <script/standard.h>
+#include <test/util/index.h>
 #include <test/util/setup_common.h>
-#include <util/time.h>
 #include <validation.h>
 
 #include <boost/test/unit_test.hpp>
@@ -32,12 +32,7 @@ BOOST_FIXTURE_TEST_CASE(txindex_initial_sync, TestChain100Setup)
     BOOST_REQUIRE(txindex.Start());
 
     // Allow tx index to catch up with the block index.
-    constexpr auto timeout{10s};
-    const auto time_start{SteadyClock::now()};
-    while (!txindex.BlockUntilSyncedToCurrentChain()) {
-        BOOST_REQUIRE(time_start + timeout > SteadyClock::now());
-        UninterruptibleSleep(std::chrono::milliseconds{100});
-    }
+    IndexWaitSynced(txindex);
 
     // Check that txindex excludes genesis block transactions.
     const CBlock& genesis_block = Params().GenesisBlock();

--- a/src/test/util/index.cpp
+++ b/src/test/util/index.cpp
@@ -1,0 +1,18 @@
+// Copyright (c) 2020-2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test/util/index.h>
+
+#include <index/base.h>
+#include <util/check.h>
+#include <util/time.h>
+
+void IndexWaitSynced(BaseIndex& index)
+{
+    const auto timeout{SteadyClock::now() + 120s};
+    while (!index.BlockUntilSyncedToCurrentChain()) {
+        Assert(timeout > SteadyClock::now());
+        UninterruptibleSleep(100ms);
+    }
+}

--- a/src/test/util/index.h
+++ b/src/test/util/index.h
@@ -1,0 +1,13 @@
+// Copyright (c) 2020-2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_TEST_UTIL_INDEX_H
+#define BITCOIN_TEST_UTIL_INDEX_H
+
+class BaseIndex;
+
+/** Block until the index is synced to the current chain */
+void IndexWaitSynced(BaseIndex& index);
+
+#endif // BITCOIN_TEST_UTIL_INDEX_H


### PR DESCRIPTION
Seems odd to use different timeouts.

Fix this by using the same timeout for all syncs.

May also fix https://github.com/bitcoin/bitcoin/issues/27355 or at least make it less frequent?