### PR TITLE
refactor: Move sock from util to common

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -137,6 +137,7 @@ BITCOIN_CORE_H = \
   common/bloom.h \
   common/init.h \
   common/run_command.h \
+  common/sock.h \
   common/url.h \
   compat/assumptions.h \
   compat/byteswap.h \
@@ -310,7 +311,6 @@ BITCOIN_CORE_H = \
   util/readwritefile.h \
   util/result.h \
   util/serfloat.h \
-  util/sock.h \
   util/spanparsing.h \
   util/string.h \
   util/syserror.h \
@@ -663,6 +663,7 @@ libbitcoin_common_a_SOURCES = \
   common/interfaces.cpp \
   common/run_command.cpp \
   common/settings.cpp \
+  common/sock.cpp \
   common/system.cpp \
   compressor.cpp \
   core_read.cpp \
@@ -727,7 +728,6 @@ libbitcoin_util_a_SOURCES = \
   util/fs_helpers.cpp \
   util/getuniquepath.cpp \
   util/hasher.cpp \
-  util/sock.cpp \
   util/syserror.cpp \
   util/message.cpp \
   util/moneystr.cpp \

--- a/src/common/sock.cpp
+++ b/src/common/sock.cpp
@@ -2,11 +2,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <common/sock.h>
+
 #include <common/system.h>
 #include <compat/compat.h>
 #include <logging.h>
 #include <tinyformat.h>
-#include <util/sock.h>
 #include <util/syserror.h>
 #include <util/threadinterrupt.h>
 #include <util/time.h>

--- a/src/common/sock.h
+++ b/src/common/sock.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_UTIL_SOCK_H
-#define BITCOIN_UTIL_SOCK_H
+#ifndef BITCOIN_COMMON_SOCK_H
+#define BITCOIN_COMMON_SOCK_H
 
 #include <compat/compat.h>
 #include <util/threadinterrupt.h>
@@ -282,4 +282,4 @@ private:
 /** Return readable error string for a network error code */
 std::string NetworkErrorString(int err);
 
-#endif // BITCOIN_UTIL_SOCK_H
+#endif // BITCOIN_COMMON_SOCK_H

--- a/src/i2p.cpp
+++ b/src/i2p.cpp
@@ -4,6 +4,7 @@
 
 #include <chainparams.h>
 #include <common/args.h>
+#include <common/sock.h>
 #include <compat/compat.h>
 #include <compat/endian.h>
 #include <crypto/sha256.h>
@@ -15,7 +16,6 @@
 #include <tinyformat.h>
 #include <util/fs.h>
 #include <util/readwritefile.h>
-#include <util/sock.h>
 #include <util/spanparsing.h>
 #include <util/strencodings.h>
 #include <util/threadinterrupt.h>

--- a/src/i2p.h
+++ b/src/i2p.h
@@ -5,11 +5,11 @@
 #ifndef BITCOIN_I2P_H
 #define BITCOIN_I2P_H
 
+#include <common/sock.h>
 #include <compat/compat.h>
 #include <netaddress.h>
 #include <sync.h>
 #include <util/fs.h>
-#include <util/sock.h>
 #include <util/threadinterrupt.h>
 
 #include <memory>

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -14,6 +14,7 @@
 #include <banman.h>
 #include <clientversion.h>
 #include <common/args.h>
+#include <common/sock.h>
 #include <compat/compat.h>
 #include <consensus/consensus.h>
 #include <crypto/sha256.h>
@@ -28,7 +29,6 @@
 #include <random.h>
 #include <scheduler.h>
 #include <util/fs.h>
-#include <util/sock.h>
 #include <util/strencodings.h>
 #include <util/thread.h>
 #include <util/threadinterrupt.h>

--- a/src/net.h
+++ b/src/net.h
@@ -8,8 +8,8 @@
 
 #include <chainparams.h>
 #include <common/bloom.h>
+#include <common/sock.h>
 #include <compat/compat.h>
-#include <node/connection_types.h>
 #include <consensus/amount.h>
 #include <crypto/siphash.h>
 #include <hash.h>
@@ -18,6 +18,7 @@
 #include <netaddress.h>
 #include <netbase.h>
 #include <netgroup.h>
+#include <node/connection_types.h>
 #include <policy/feerate.h>
 #include <protocol.h>
 #include <random.h>
@@ -26,7 +27,6 @@
 #include <sync.h>
 #include <uint256.h>
 #include <util/check.h>
-#include <util/sock.h>
 #include <util/threadinterrupt.h>
 
 #include <atomic>

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -5,11 +5,11 @@
 
 #include <netbase.h>
 
+#include <common/sock.h>
 #include <compat/compat.h>
 #include <logging.h>
 #include <sync.h>
 #include <tinyformat.h>
-#include <util/sock.h>
 #include <util/strencodings.h>
 #include <util/string.h>
 #include <util/time.h>

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -9,10 +9,10 @@
 #include <config/bitcoin-config.h>
 #endif
 
+#include <common/sock.h>
 #include <compat/compat.h>
 #include <netaddress.h>
 #include <serialize.h>
-#include <util/sock.h>
 
 #include <functional>
 #include <memory>

--- a/src/test/fuzz/fuzz.cpp
+++ b/src/test/fuzz/fuzz.cpp
@@ -4,12 +4,12 @@
 
 #include <test/fuzz/fuzz.h>
 
+#include <common/sock.h>
 #include <netaddress.h>
 #include <netbase.h>
 #include <test/util/setup_common.h>
 #include <util/check.h>
 #include <util/fs.h>
-#include <util/sock.h>
 #include <util/time.h>
 
 #include <csignal>

--- a/src/test/fuzz/util/net.cpp
+++ b/src/test/fuzz/util/net.cpp
@@ -4,13 +4,13 @@
 
 #include <test/fuzz/util/net.h>
 
+#include <common/sock.h>
 #include <compat/compat.h>
 #include <netaddress.h>
 #include <protocol.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/util.h>
 #include <test/util/net.h>
-#include <util/sock.h>
 #include <util/time.h>
 #include <version.h>
 

--- a/src/test/fuzz/util/net.h
+++ b/src/test/fuzz/util/net.h
@@ -5,6 +5,7 @@
 #ifndef BITCOIN_TEST_FUZZ_UTIL_NET_H
 #define BITCOIN_TEST_FUZZ_UTIL_NET_H
 
+#include <common/sock.h>
 #include <net.h>
 #include <net_permissions.h>
 #include <netaddress.h>
@@ -15,7 +16,6 @@
 #include <test/fuzz/util.h>
 #include <test/util/net.h>
 #include <threadsafety.h>
-#include <util/sock.h>
 
 #include <chrono>
 #include <cstdint>

--- a/src/test/sock_tests.cpp
+++ b/src/test/sock_tests.cpp
@@ -2,10 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <common/sock.h>
 #include <common/system.h>
 #include <compat/compat.h>
 #include <test/util/setup_common.h>
-#include <util/sock.h>
 #include <util/threadinterrupt.h>
 
 #include <boost/test/unit_test.hpp>

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -5,11 +5,11 @@
 #ifndef BITCOIN_TEST_UTIL_NET_H
 #define BITCOIN_TEST_UTIL_NET_H
 
+#include <common/sock.h>
 #include <compat/compat.h>
-#include <node/eviction.h>
-#include <netaddress.h>
 #include <net.h>
-#include <util/sock.h>
+#include <netaddress.h>
+#include <node/eviction.h>
 
 #include <array>
 #include <cassert>


### PR DESCRIPTION
Networking code should not be required by the kernel.