### PR TITLE
ci: build Valgrind (3.21) from source

### DIFF
--- a/ci/test/00_setup_env_native_fuzz_with_valgrind.sh
+++ b/ci/test/00_setup_env_native_fuzz_with_valgrind.sh
@@ -8,13 +8,13 @@ export LC_ALL=C.UTF-8
 
 export CI_IMAGE_NAME_TAG="debian:bookworm"
 export CONTAINER_NAME=ci_native_fuzz_valgrind
-export PACKAGES="clang llvm libclang-rt-dev libevent-dev libboost-dev libsqlite3-dev valgrind"
+export PACKAGES="libc6-dbg clang llvm libclang-rt-dev libevent-dev libboost-dev libsqlite3-dev"
+export BUILD_VALGRIND="true"
 export NO_DEPENDS=1
 export RUN_UNIT_TESTS=false
 export RUN_FUNCTIONAL_TESTS=false
 export RUN_FUZZ_TESTS=true
 export FUZZ_TESTS_CONFIG="--valgrind"
 export GOAL="install"
-# Temporarily pin dwarf 4, until using Valgrind 3.20 or later
-export BITCOIN_CONFIG="--enable-fuzz --with-sanitizers=fuzzer CC=clang CXX=clang++ CFLAGS='-gdwarf-4' CXXFLAGS='-gdwarf-4'"
+export BITCOIN_CONFIG="--enable-fuzz --with-sanitizers=fuzzer CC=clang CXX=clang++"
 export CCACHE_SIZE=200M

--- a/ci/test/00_setup_env_native_valgrind.sh
+++ b/ci/test/00_setup_env_native_valgrind.sh
@@ -8,10 +8,10 @@ export LC_ALL=C.UTF-8
 
 export CI_IMAGE_NAME_TAG="debian:bookworm"
 export CONTAINER_NAME=ci_native_valgrind
-export PACKAGES="valgrind clang llvm libclang-rt-dev python3-zmq libevent-dev libboost-dev libdb5.3++-dev libminiupnpc-dev libnatpmp-dev libzmq3-dev libsqlite3-dev"
+export PACKAGES="libc6-dbg clang llvm libclang-rt-dev python3-zmq libevent-dev libboost-dev libdb5.3++-dev libminiupnpc-dev libnatpmp-dev libzmq3-dev libsqlite3-dev"
+export BUILD_VALGRIND="true"
 export USE_VALGRIND=1
 export NO_DEPENDS=1
 export TEST_RUNNER_EXTRA="--exclude feature_init,rpc_bind,feature_bind_extra"  # Excluded for now, see https://github.com/bitcoin/bitcoin/issues/17765#issuecomment-602068547
 export GOAL="install"
-# Temporarily pin dwarf 4, until using Valgrind 3.20 or later
-export BITCOIN_CONFIG="--enable-zmq --with-incompatible-bdb --with-gui=no CC=clang CXX=clang++ CFLAGS='-gdwarf-4' CXXFLAGS='-gdwarf-4'"  # TODO enable GUI
+export BITCOIN_CONFIG="--enable-zmq --with-incompatible-bdb --with-gui=no CC=clang CXX=clang++"  # TODO enable GUI

--- a/ci/test/01_base_install.sh
+++ b/ci/test/01_base_install.sh
@@ -41,6 +41,11 @@ if [ -n "$PIP_PACKAGES" ]; then
   fi
 fi
 
+if [[ ${BUILD_VALGRIND} == "true" ]]; then
+  git clone --depth=1 https://sourceware.org/git/valgrind.git -b VALGRIND_3_21_0 "${BASE_SCRATCH_DIR}"/valgrind
+  cd "${BASE_SCRATCH_DIR}"/valgrind/ && ./autogen.sh && ./configure --prefix=/usr && make install "$MAKEJOBS"
+fi
+
 if [[ ${USE_MEMORY_SANITIZER} == "true" ]]; then
   git clone --depth=1 https://github.com/llvm/llvm-project -b llvmorg-16.0.6 "${BASE_SCRATCH_DIR}"/msan/llvm-project
 


### PR DESCRIPTION
I've been using this branch for some time, for working Valgrind CI jobs on aarch64. Benefits include:
* Valgrind CI jobs work across x86_64 & aarch64.
* Can use latest (hopefully less buggy) Valgrind, rather than whatever the distro happens to package.
* No need to "bless" a specific compiler, (current discussion includes switching from Clang to GCC as a workaround).
* Valgrind from source runs significantly faster compared to the system package. i.e, when fuzzing under valgrind:

Master:
```bash
asmap_direct with args
Done 646 runs in 155 second(s)
....
addrman_deserialize with args
Done 2944 runs in 2875 second(s)
```

vs running this branch:
```bash
asmap_direct with args
Done 646 runs in 23 second(s)
...
addrman_deserialize with args
Done 2944 runs in 413 second(s)
```

This is also being seen in the qa-assets repo: https://github.com/bitcoin-core/qa-assets/pull/136#issuecomment-1611072317.

For example, the `tx_pool_standard` target under Valgrind [currently takes > 10 hours](https://cirrus-ci.com/task/5211294249254912?logs=ci#L5334) to complete:
```bash
Run tx_pool_standard with args ['valgrind', '--quiet', '--error-exitcode=1', '/tmp/cirrus-build/bitcoin-core/ci/scratch/build/bitcoin-x86_64-pc-linux-gnu/src/test/fuzz/fuzz', '-runs=1', PosixPath('/tmp/cirrus-build/bitcoin-core/ci/scratch/qa-assets/fuzz_seed_corpus/tx_pool_standard')]INFO: Running with entropic power schedule (0xFF, 100).
INFO: Seed: 242510469
INFO: Loaded 1 modules   (248538 inline 8-bit counters): 248538 [0x27fd278, 0x2839d52), 
INFO: Loaded 1 PC tables (248538 PCs): 248538 [0x2839d58,0x2c04af8), 
INFO:     3775 files found in /tmp/cirrus-build/bitcoin-core/ci/scratch/qa-assets/fuzz_seed_corpus/tx_pool_standard
INFO: -max_len is not provided; libFuzzer will not generate inputs larger than 1048576 bytes
INFO: seed corpus: files: 3775 min: 1b max: 2090089b total: 88593805b rss: 321Mb
#16	pulse  cov: 4536 ft: 4537 corp: 1/1b exec/s: 5 rss: 323Mb
#32	pulse  cov: 4538 ft: 4544 corp: 4/10b exec/s: 6 rss: 323Mb
#64	pulse  cov: 4540 ft: 4553 corp: 8/34b exec/s: 6 rss: 323Mb
#128	pulse  cov: 6319 ft: 9483 corp: 21/196b exec/s: 4 rss: 327Mb
#256	pulse  cov: 6339 ft: 13188 corp: 104/1621b exec/s: 2 rss: 327Mb
#512	pulse  cov: 8952 ft: 24180 corp: 262/6023b exec/s: 2 rss: 335Mb
#1024	pulse  cov: 9924 ft: 36577 corp: 575/23Kb exec/s: 1 rss: 343Mb
<snip>
#2048	pulse  cov: 10161 ft: 56438 corp: 1218/244Kb exec/s: 0 rss: 371Mb
<snip>
#3776	INITED cov: 10988 ft: 65398 corp: 1933/10331Kb exec/s: 0 rss: 430Mb
#3776	DONE   cov: 10988 ft: 65398 corp: 1933/10331Kb lim: 1048576 exec/s: 0 rss: 430Mb
Done 3776 runs in 37778 second(s)
```

however [with this branch, it takes](https://cirrus-ci.com/task/4623075795271680?) 1.5 hours:

```bash
Run tx_pool_standard with args ['valgrind', '--quiet', '--error-exitcode=1', '/tmp/cirrus-build-1174734651/bitcoin-core/ci/scratch/build/bitcoin-x86_64-pc-linux-gnu/src/test/fuzz/fuzz', '-runs=1', PosixPath('/tmp/cirrus-build-1174734651/bitcoin-core/ci/scratch/qa-assets/fuzz_seed_corpus/tx_pool_standard')]INFO: Running with entropic power schedule (0xFF, 100).
INFO: Seed: 350811728
INFO: Loaded 1 modules   (366489 inline 8-bit counters): 366489 [0x1c106d0, 0x1c69e69), 
INFO: Loaded 1 PC tables (366489 PCs): 366489 [0x1c69e70,0x2201800), 
INFO:     3775 files found in /tmp/cirrus-build-1174734651/bitcoin-core/ci/scratch/qa-assets/fuzz_seed_corpus/tx_pool_standard
INFO: -max_len is not provided; libFuzzer will not generate inputs larger than 1048576 bytes
INFO: seed corpus: files: 3775 min: 1b max: 2090089b total: 88593805b rss: 302Mb
#64	pulse  cov: 1172 ft: 1186 corp: 11/47b exec/s: 32 rss: 304Mb
#128	pulse  cov: 1793 ft: 2253 corp: 32/285b exec/s: 32 rss: 304Mb
#256	pulse  cov: 1862 ft: 3792 corp: 99/1399b exec/s: 19 rss: 305Mb
#512	pulse  cov: 3074 ft: 7764 corp: 221/4862b exec/s: 15 rss: 308Mb
#1024	pulse  cov: 3767 ft: 12721 corp: 498/20Kb exec/s: 10 rss: 314Mb
#2048	pulse  cov: 4141 ft: 22302 corp: 1101/224Kb exec/s: 5 rss: 341Mb
<snip>
#3776	INITED cov: 4573 ft: 26452 corp: 1737/6505Kb exec/s: 0 rss: 400Mb
#3776	DONE   cov: 4573 ft: 26452 corp: 1737/6505Kb lim: 698384 exec/s: 0 rss: 400Mb
Done 3776 runs in 5163 second(s)
```

Running the native_valgrind CI (master, aarch64):
```bash
test/sighash_tests.cpp(120): Entering test case "sighash_test"
==21957== Source and destination overlap in memcpy(0x871e4b0, 0x871e4b0, 36)
==21957==    at 0x488CFA0: __GI_memcpy (in /usr/libexec/valgrind/vgpreload_memcheck-arm64-linux.so)
==21957==    by 0x8F7F63: CTxIn::operator=(CTxIn const&) (transaction.h:74)
==21957==    by 0x93F96B: SignatureHashOld(CScript, CTransaction const&, unsigned int, int) (sighash_tests.cpp:76)
==21957==    by 0x93EF1F: sighash_tests::sighash_test::test_method() (sighash_tests.cpp:138)
==21957==    by 0x93EB73: sighash_tests::sighash_test_invoker() (sighash_tests.cpp:120)
==21957==    by 0x36CF47: boost::detail::function::void_function_invoker0<void (*)(), void>::invoke(boost::detail::function::function_buffer&) (function_template.hpp:117)
==21957==    by 0x25B367: boost::function0<void>::operator()() const (function_template.hpp:763)
==21957==    by 0x2D6647: boost::detail::forward::operator()() (execution_monitor.ipp:1388)
==21957==    by 0x2D627F: boost::detail::function::function_obj_invoker0<boost::detail::forward, int>::invoke(boost::detail::function::function_buffer&) (function_template.hpp:137)
==21957==    by 0x2D0393: boost::function0<int>::operator()() const (function_template.hpp:763)
==21957==    by 0x234A6B: int boost::detail::do_invoke<boost::shared_ptr<boost::detail::translator_holder_base>, boost::function<int ()> >(boost::shared_ptr<boost::detail::translator_holder_base> const&, boost::function<int ()> const&) (execution_monitor.ipp:301)
==21957==    by 0x1F7277: boost::execution_monitor::catch_signals(boost::function<int ()> const&) (execution_monitor.ipp:903)
==21957==
{
   <insert_a_suppression_name_here>
   Memcheck:Overlap
   fun:__GI_memcpy
   fun:_ZN5CTxInaSERKS_
   fun:_ZL16SignatureHashOld7CScriptRK12CTransactionji
   fun:_ZN13sighash_tests12sighash_test11test_methodEv
   fun:_ZN13sighash_testsL20sighash_test_invokerEv
   fun:_ZN5boost6detail8function22void_function_invoker0IPFvvEvE6invokeERNS1_15function_bufferE
   fun:_ZNK5boost9function0IvEclEv
   fun:_ZN5boost6detail7forwardclEv
   fun:_ZN5boost6detail8function21function_obj_invoker0INS0_7forwardEiE6invokeERNS1_15function_bufferE
   fun:_ZNK5boost9function0IiEclEv
   fun:_ZN5boost6detail9do_invokeINS_10shared_ptrINS0_22translator_holder_baseEEENS_8functionIFivEEEEEiRKT_RKT0_
   fun:_ZN5boost17execution_monitor13catch_signalsERKNS_8functionIFivEEE
}
```

vs running this branch:
```bash
real	118m55.057s
```

Disadvantages includes:
* Becoming slightly more of a package manager in the CI.

Related to the discussion in https://github.com/bitcoin/bitcoin/pull/27444. See also https://github.com/bitcoin-core/qa-assets/pull/136.