### PR TITLE
DRAFT: Checking for multi/single-value types in UniValue.

### DIFF
--- a/src/univalue/include/univalue.h
+++ b/src/univalue/include/univalue.h
@@ -62,10 +62,10 @@ public:
     void setObject();
 
     enum VType getType() const { return typ; }
-    const std::string& getValStr() const { return val; }
-    bool empty() const { return (values.size() == 0); }
+    const std::string& getValStr() const { checkTypeSingleValue(); return val; }
+    bool empty() const { return size() == 0; }
 
-    size_t size() const { return values.size(); }
+    size_t size() const { checkTypeMultiValue(); return values.size(); }
 
     void getObjMap(std::map<std::string,UniValue>& kv) const;
     bool checkObject(const std::map<std::string,UniValue::VType>& memberTypes) const;
@@ -105,6 +105,8 @@ private:
     std::vector<UniValue> values;
 
     void checkType(const VType& expected) const;
+    void checkTypeMultiValue() const;
+    void checkTypeSingleValue() const;
     bool findKey(const std::string& key, size_t& retIdx) const;
     void writeArray(unsigned int prettyIndent, unsigned int indentLevel, std::string& s) const;
     void writeObject(unsigned int prettyIndent, unsigned int indentLevel, std::string& s) const;

--- a/src/univalue/lib/univalue.cpp
+++ b/src/univalue/lib/univalue.cpp
@@ -215,6 +215,25 @@ void UniValue::checkType(const VType& expected) const
     }
 }
 
+void UniValue::checkTypeMultiValue() const
+{
+    if (typ != UniValue::VARR
+        && typ != UniValue::VOBJ
+        && typ != UniValue::VNULL) {
+        throw type_error{"JSON value of type " + std::string{uvTypeName(typ)} + " is not a multi value type."};
+    }
+}
+
+void UniValue::checkTypeSingleValue() const
+{
+    if (typ != UniValue::VBOOL
+        && typ != UniValue::VSTR
+        && typ != UniValue::VNUM
+        && typ != UniValue::VNULL) {
+        throw type_error{"JSON value of type " + std::string{uvTypeName(typ)} + " is not a single value type."};
+    }
+}
+
 const char *uvTypeName(UniValue::VType t)
 {
     switch (t) {


### PR DESCRIPTION
Previously it was possible to call getValStr() on a VOBJ and VARR, which silently resulted in the return of an empty string. However, such a call would be most likely a bug. We are now throwing in case of such types.

Similarly, calling empty() and size() didn't make sense for none VOBJ/VARR UniValues.

**Please note:** This is a draft and not meant to be merged just yet. I created the pull request already because I wanted to see what the CI-Pipeline tells me about this. I also want to give this change another code read pass to convince myself that these changes are actually okay in every case they are currently used.