### PR TITLE
ci: filter all subtrees from tidy output

### DIFF
--- a/ci/test/06_script_b.sh
+++ b/ci/test/06_script_b.sh
@@ -155,8 +155,7 @@ if [ "${RUN_TIDY}" = "true" ]; then
   # accepted in src/.bear-tidy-config
   # Filter out:
   # * qt qrc and moc generated files
-  # * secp256k1
-  jq 'map(select(.file | test("src/qt/qrc_.*\\.cpp$|/moc_.*\\.cpp$|src/secp256k1/src/") | not))' ../compile_commands.json > tmp.json
+  jq 'map(select(.file | test("src/qt/qrc_.*\\.cpp$|/moc_.*\\.cpp$") | not))' ../compile_commands.json > tmp.json
   mv tmp.json ../compile_commands.json
   cd "${BASE_BUILD_DIR}/bitcoin-$HOST/"
   python3 "${DIR_IWYU}/include-what-you-use/iwyu_tool.py" \

--- a/src/.bear-tidy-config
+++ b/src/.bear-tidy-config
@@ -4,7 +4,11 @@
       "include_only_existing_source": true,
       "paths_to_include": [],
       "paths_to_exclude": [
-        "src/leveldb"
+        "src/crc32c",
+        "src/crypto/ctaes",
+        "src/leveldb",
+        "src/minisketch",
+        "src/secp256k1"
       ]
     },
     "format": {


### PR DESCRIPTION
We are currently dumping output for some. i.e:
```bash
diff --git a/src/minisketch/src/fields/clmul_1byte.cpp b/src/minisketch/src/fields/clmul_1byte.cpp
index 8826af9..7fd6f2a 100644
--- a/src/minisketch/src/fields/clmul_1byte.cpp
+++ b/src/minisketch/src/fields/clmul_1byte.cpp
@@ -4,21 +4,16 @@
  * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/

-/* This file was substantially auto-generated by doc/gen_params.sage. */
-#include "../fielddefines.h"
-
+class Sketch;
 #if defined(ENABLE_FIELD_BYTES_INT_1)
```