### PR TITLE
contrib: add macOS test for fixup_chains usage

### DIFF
--- a/contrib/devtools/security-check.py
+++ b/contrib/devtools/security-check.py
@@ -158,6 +158,12 @@ def check_MACHO_NOUNDEFS(binary) -> bool:
     '''
     return binary.header.has(lief.MachO.HEADER_FLAGS.NOUNDEFS)
 
+def check_MACHO_FIXUP_CHAINS(binary) -> bool:
+    '''
+    Check for use of chained fixups.
+    '''
+    return binary.has_dyld_chained_fixups
+
 def check_MACHO_Canary(binary) -> bool:
     '''
     Check for use of stack canary
@@ -208,6 +214,7 @@ BASE_PE = [
 BASE_MACHO = [
     ('NOUNDEFS', check_MACHO_NOUNDEFS),
     ('Canary', check_MACHO_Canary),
+    ('FIXUP_CHAINS', check_MACHO_FIXUP_CHAINS),
 ]
 
 CHECKS = {

--- a/contrib/devtools/test-security-check.py
+++ b/contrib/devtools/test-security-check.py
@@ -119,27 +119,31 @@ class TestSecurityChecks(unittest.TestCase):
         arch = get_arch(cc, source, executable)
 
         if arch == lief.ARCHITECTURES.X86:
-            self.assertEqual(call_security_check(cc, source, executable, ['-Wl,-no_pie','-Wl,-flat_namespace','-Wl,-allow_stack_execute','-fno-stack-protector']),
+            self.assertEqual(call_security_check(cc, source, executable, ['-Wl,-no_pie','-Wl,-flat_namespace','-Wl,-allow_stack_execute','-fno-stack-protector', '-Wl,-no_fixup_chains']),
+                (1, executable+': failed NOUNDEFS Canary FIXUP_CHAINS PIE NX CONTROL_FLOW'))
+            self.assertEqual(call_security_check(cc, source, executable, ['-Wl,-no_pie','-Wl,-flat_namespace','-Wl,-allow_stack_execute','-fno-stack-protector', '-Wl,-fixup_chains']),
                 (1, executable+': failed NOUNDEFS Canary PIE NX CONTROL_FLOW'))
-            self.assertEqual(call_security_check(cc, source, executable, ['-Wl,-no_pie','-Wl,-flat_namespace','-Wl,-allow_stack_execute','-fstack-protector-all']),
+            self.assertEqual(call_security_check(cc, source, executable, ['-Wl,-no_pie','-Wl,-flat_namespace','-Wl,-allow_stack_execute','-fstack-protector-all', '-Wl,-fixup_chains']),
                 (1, executable+': failed NOUNDEFS PIE NX CONTROL_FLOW'))
-            self.assertEqual(call_security_check(cc, source, executable, ['-Wl,-no_pie','-Wl,-flat_namespace','-fstack-protector-all']),
+            self.assertEqual(call_security_check(cc, source, executable, ['-Wl,-no_pie','-Wl,-flat_namespace','-fstack-protector-all', '-Wl,-fixup_chains']),
                 (1, executable+': failed NOUNDEFS PIE CONTROL_FLOW'))
-            self.assertEqual(call_security_check(cc, source, executable, ['-Wl,-no_pie','-fstack-protector-all']),
+            self.assertEqual(call_security_check(cc, source, executable, ['-Wl,-no_pie','-fstack-protector-all', '-Wl,-fixup_chains']),
                 (1, executable+': failed PIE CONTROL_FLOW'))
-            self.assertEqual(call_security_check(cc, source, executable, ['-Wl,-no_pie','-Wl,-bind_at_load','-fstack-protector-all']),
+            self.assertEqual(call_security_check(cc, source, executable, ['-Wl,-no_pie','-Wl,-bind_at_load','-fstack-protector-all', '-Wl,-fixup_chains']),
                 (1, executable+': failed PIE CONTROL_FLOW'))
-            self.assertEqual(call_security_check(cc, source, executable, ['-Wl,-no_pie','-Wl,-bind_at_load','-fstack-protector-all', '-fcf-protection=full']),
+            self.assertEqual(call_security_check(cc, source, executable, ['-Wl,-no_pie','-Wl,-bind_at_load','-fstack-protector-all', '-fcf-protection=full', '-Wl,-fixup_chains']),
                 (1, executable+': failed PIE'))
-            self.assertEqual(call_security_check(cc, source, executable, ['-Wl,-pie','-Wl,-bind_at_load','-fstack-protector-all', '-fcf-protection=full']),
+            self.assertEqual(call_security_check(cc, source, executable, ['-Wl,-pie','-Wl,-bind_at_load','-fstack-protector-all', '-fcf-protection=full', '-Wl,-fixup_chains']),
                 (0, ''))
         else:
             # arm64 darwin doesn't support non-PIE binaries, control flow or executable stacks
-            self.assertEqual(call_security_check(cc, source, executable, ['-Wl,-flat_namespace','-fno-stack-protector']),
+            self.assertEqual(call_security_check(cc, source, executable, ['-Wl,-flat_namespace','-fno-stack-protector', '-Wl,-no_fixup_chains']),
+                (1, executable+': failed NOUNDEFS Canary FIXUP_CHAINS'))
+            self.assertEqual(call_security_check(cc, source, executable, ['-Wl,-flat_namespace','-fno-stack-protector', '-Wl,-fixup_chains']),
                 (1, executable+': failed NOUNDEFS Canary'))
-            self.assertEqual(call_security_check(cc, source, executable, ['-Wl,-flat_namespace','-fstack-protector-all']),
+            self.assertEqual(call_security_check(cc, source, executable, ['-Wl,-flat_namespace','-fstack-protector-all', '-Wl,-fixup_chains']),
                 (1, executable+': failed NOUNDEFS'))
-            self.assertEqual(call_security_check(cc, source, executable, ['-Wl,-bind_at_load','-fstack-protector-all']),
+            self.assertEqual(call_security_check(cc, source, executable, ['-Wl,-bind_at_load','-fstack-protector-all', '-Wl,-fixup_chains']),
                 (0, ''))
 
 

--- a/depends/packages/native_cctools.mk
+++ b/depends/packages/native_cctools.mk
@@ -5,6 +5,7 @@ $(package)_file_name=$($(package)_version).tar.gz
 $(package)_sha256_hash=6b73269efdf5c58a070e7357b66ee760501388549d6a12b423723f45888b074b
 $(package)_build_subdir=cctools
 $(package)_dependencies=native_libtapi
+$(package)_patches=no_fixup_chains.patch
 
 define $(package)_set_vars
   $(package)_config_opts=--target=$(host) --enable-lto-support
@@ -18,11 +19,13 @@ ifneq ($(strip $(FORCE_USE_SYSTEM_CLANG)),)
 define $(package)_preprocess_cmds
   mkdir -p $($(package)_staging_prefix_dir)/lib && \
   cp $(llvm_lib_dir)/libLTO.so $($(package)_staging_prefix_dir)/lib/ && \
-  cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub cctools
+  cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub cctools && \
+  patch -p1 < $($(package)_patch_dir)/no_fixup_chains.patch
 endef
 else
 define $(package)_preprocess_cmds
-  cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub cctools
+  cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub cctools && \
+  patch -p1 < $($(package)_patch_dir)/no_fixup_chains.patch
 endef
 endif
 

--- a/depends/patches/native_cctools/no_fixup_chains.patch
+++ b/depends/patches/native_cctools/no_fixup_chains.patch
@@ -1,0 +1,23 @@
+commit 5860b35ff6c7241d1c35a1b3197b45e5c9ff86cf
+Author: fanquake <fanquake@gmail.com>
+Date:   Thu Jun 29 11:52:43 2023 +0100
+
+    ld64: add support for -no_fixup_chains
+    
+    This is added in later versions, and is required if we want to be able
+    to disable fixup_chains, for use in security tests.
+
+diff --git a/cctools/ld64/src/ld/Options.cpp b/cctools/ld64/src/ld/Options.cpp
+index 15e8e88..b6580af 100644
+--- a/cctools/ld64/src/ld/Options.cpp
++++ b/cctools/ld64/src/ld/Options.cpp
+@@ -4128,6 +4128,9 @@ void Options::parse(int argc, const char* argv[])
+ 			else if ( strcmp(arg, "-fixup_chains") == 0 ) {
+ 				fMakeChainedFixups = true;
+ 			}
++			else if ( strcmp(arg, "-no_fixup_chains") == 0 ) {
++				fMakeChainedFixups = false;
++			}
+ 			else if (strcmp(arg, "-debug_variant") == 0) {
+ 			    fDebugVariant = true;
+             }


### PR DESCRIPTION
Followup to #27676, adding the check for chained fixups.

Somewhat annoyingly, we have to patch support for `-no_fixup_chains` into ld64. As it doesn't seem to have been added [until a later version](https://github.com/apple-oss-distributions/ld64/blob/59a99ab60399c5e6c49e6945a9e1049c42b71135/src/ld/Options.cpp#L4172).

Guix Build:
```bash
0e17d462808f86aa7157e27a957da88fd1adeb491ad6c01138aca93e5ad1d018  guix-build-7f96638723a0/output/arm64-apple-darwin/SHA256SUMS.part
ceb208e6374f5d7367b73128e90ca6eaeea15d50c69e49c8cf75b47212525ad7  guix-build-7f96638723a0/output/arm64-apple-darwin/bitcoin-7f96638723a0-arm64-apple-darwin-unsigned.dmg
e31663554cfde8a37a9f3438c9c895dde94b90ff87e28f12f78be71ef6421d93  guix-build-7f96638723a0/output/arm64-apple-darwin/bitcoin-7f96638723a0-arm64-apple-darwin-unsigned.tar.gz
68a7bbc42418641eab391a85725b5c2f3c46d38a7acc07e7a8cef98909be07ec  guix-build-7f96638723a0/output/arm64-apple-darwin/bitcoin-7f96638723a0-arm64-apple-darwin.tar.gz
38d966ad93e7384f4f1ce16faded003a675ecce7be1987e6c4eee8e4b82c0432  guix-build-7f96638723a0/output/dist-archive/bitcoin-7f96638723a0.tar.gz
9d314f595d897a715a321a9fba0d552220fbd4bf69aff84eb8c0001cdb48234f  guix-build-7f96638723a0/output/x86_64-apple-darwin/SHA256SUMS.part
c218ebfd0e96348c4912e6d522492b621bb043ef45b75105ff1fde979d1004d0  guix-build-7f96638723a0/output/x86_64-apple-darwin/bitcoin-7f96638723a0-x86_64-apple-darwin-unsigned.dmg
1c5ff7fa82f5c76d7d8b9582ad5202f4a82a917102ecafdc3c1fb7b783f6bc3e  guix-build-7f96638723a0/output/x86_64-apple-darwin/bitcoin-7f96638723a0-x86_64-apple-darwin-unsigned.tar.gz
15fb01e5afcc842db6a3e793b42c70c05ce07bec79e0d2d605e241901ff9f639  guix-build-7f96638723a0/output/x86_64-apple-darwin/bitcoin-7f96638723a0-x86_64-apple-darwin.tar.gz
```