### PR TITLE
refactor: Open file in FileCommit

### DIFF
--- a/src/addrdb.cpp
+++ b/src/addrdb.cpp
@@ -55,6 +55,7 @@ bool SerializeFileDB(const std::string& prefix, const fs::path& path, const Data
 
     // open temp output file, and associate with CAutoFile
     fs::path pathTmp = gArgs.GetDataDirNet() / fs::u8path(tmpfn);
+    {
     CAutoFile fileout{fsbridge::fopen(pathTmp, "wb"), SER_DISK, version};
     if (fileout.IsNull()) {
         fileout.fclose();
@@ -68,12 +69,11 @@ bool SerializeFileDB(const std::string& prefix, const fs::path& path, const Data
         remove(pathTmp);
         return false;
     }
-    if (!FileCommit(fileout.Get())) {
-        fileout.fclose();
+    } // fileout
+    if (!FileCommit(pathTmp)) {
         remove(pathTmp);
         return error("%s: Failed to flush file %s", __func__, fs::PathToString(pathTmp));
     }
-    fileout.fclose();
 
     // replace existing file, if any, with new file
     if (!RenameOver(pathTmp, path)) {

--- a/src/addrdb.cpp
+++ b/src/addrdb.cpp
@@ -55,8 +55,7 @@ bool SerializeFileDB(const std::string& prefix, const fs::path& path, const Data
 
     // open temp output file, and associate with CAutoFile
     fs::path pathTmp = gArgs.GetDataDirNet() / fs::u8path(tmpfn);
-    FILE *file = fsbridge::fopen(pathTmp, "wb");
-    CAutoFile fileout(file, SER_DISK, version);
+    CAutoFile fileout{fsbridge::fopen(pathTmp, "wb"), SER_DISK, version};
     if (fileout.IsNull()) {
         fileout.fclose();
         remove(pathTmp);

--- a/src/flatfile.cpp
+++ b/src/flatfile.cpp
@@ -84,7 +84,7 @@ bool FlatFileSeq::Flush(const FlatFilePos& pos, bool finalize)
     if (!file) {
         return error("%s: failed to open file %d", __func__, pos.nFile);
     }
-    if (finalize && !TruncateFile(file, pos.nPos)) {
+    if (finalize && !ResizeFile(FileName(pos), pos.nPos)) {
         fclose(file);
         return error("%s: failed to truncate file %d", __func__, pos.nFile);
     }

--- a/src/index/blockfilterindex.cpp
+++ b/src/index/blockfilterindex.cpp
@@ -181,7 +181,7 @@ size_t BlockFilterIndex::WriteFilterToDisk(FlatFilePos& pos, const BlockFilter& 
             LogPrintf("%s: Failed to open filter file %d\n", __func__, pos.nFile);
             return 0;
         }
-        if (!TruncateFile(last_file.Get(), pos.nPos)) {
+        if (!ResizeFile(m_filter_fileseq->FileName(pos), pos.nPos)) {
             LogPrintf("%s: Failed to truncate filter file %d\n", __func__, pos.nFile);
             return 0;
         }

--- a/src/kernel/mempool_persist.cpp
+++ b/src/kernel/mempool_persist.cpp
@@ -145,12 +145,10 @@ bool DumpMempool(const CTxMemPool& pool, const fs::path& dump_path, FopenFn mock
     auto mid = SteadyClock::now();
 
     try {
-        FILE* filestr{mockable_fopen_function(dump_path + ".new", "wb")};
-        if (!filestr) {
+        CAutoFile file{mockable_fopen_function(dump_path + ".new", "wb"), SER_DISK, CLIENT_VERSION};
+        if (file.IsNull()) {
             return false;
         }
-
-        CAutoFile file(filestr, SER_DISK, CLIENT_VERSION);
 
         uint64_t version = MEMPOOL_DUMP_VERSION;
         file << version;

--- a/src/kernel/mempool_persist.cpp
+++ b/src/kernel/mempool_persist.cpp
@@ -145,6 +145,7 @@ bool DumpMempool(const CTxMemPool& pool, const fs::path& dump_path, FopenFn mock
     auto mid = SteadyClock::now();
 
     try {
+        {
         CAutoFile file{mockable_fopen_function(dump_path + ".new", "wb"), SER_DISK, CLIENT_VERSION};
         if (file.IsNull()) {
             return false;
@@ -165,10 +166,11 @@ bool DumpMempool(const CTxMemPool& pool, const fs::path& dump_path, FopenFn mock
 
         LogPrintf("Writing %d unbroadcast transactions to disk.\n", unbroadcast_txids.size());
         file << unbroadcast_txids;
+        } // file
 
-        if (!skip_file_commit && !FileCommit(file.Get()))
+        if (!skip_file_commit && !FileCommit(dump_path + ".new")) {
             throw std::runtime_error("FileCommit failed");
-        file.fclose();
+        }
         if (!RenameOver(dump_path + ".new", dump_path)) {
             throw std::runtime_error("Rename failed");
         }

--- a/src/util/fs_helpers.cpp
+++ b/src/util/fs_helpers.cpp
@@ -11,13 +11,11 @@
 
 #include <logging.h>
 #include <sync.h>
-#include <tinyformat.h>
 #include <util/fs.h>
 #include <util/getuniquepath.h>
 #include <util/syserror.h>
 
 #include <cerrno>
-#include <filesystem>
 #include <fstream>
 #include <map>
 #include <memory>
@@ -41,7 +39,7 @@
 #include <sys/resource.h>
 #include <unistd.h>
 #else
-#include <io.h> /* For _get_osfhandle, _chsize */
+#include <io.h>     /* For _get_osfhandle */
 #include <shlobj.h> /* For SHGetSpecialFolderPathW */
 #endif // WIN32
 
@@ -160,13 +158,11 @@ void DirectoryCommit(const fs::path& dirname)
 #endif
 }
 
-bool TruncateFile(FILE* file, unsigned int length)
+bool ResizeFile(const fs::path& file, unsigned int length)
 {
-#if defined(WIN32)
-    return _chsize(_fileno(file), length) == 0;
-#else
-    return ftruncate(fileno(file), length) == 0;
-#endif
+    std::error_code ec;
+    fs::resize_file(file, length, ec);
+    return !ec;
 }
 
 /**

--- a/src/util/fs_helpers.h
+++ b/src/util/fs_helpers.h
@@ -25,7 +25,7 @@ bool FileCommit(FILE* file);
  */
 void DirectoryCommit(const fs::path& dirname);
 
-bool TruncateFile(FILE* file, unsigned int length);
+bool ResizeFile(const fs::path& file, unsigned int length);
 int RaiseFileDescriptorLimit(int nMinFD);
 void AllocateFileRange(FILE* file, unsigned int offset, unsigned int length);
 

--- a/src/util/fs_helpers.h
+++ b/src/util/fs_helpers.h
@@ -16,8 +16,9 @@
 /**
  * Ensure file contents are fully committed to disk, using a platform-specific
  * feature analogous to fsync().
+ * The call site is resposible to flush prior, for example by closing the file.
  */
-bool FileCommit(FILE* file);
+bool FileCommit(const fs::path& file_path);
 
 /**
  * Sync directory contents. This is required on some environments to ensure that


### PR DESCRIPTION
This improves `FileCommit`: The patch removes the requirement from the call site to open or obtain a raw C-style FILE pointer. Now the call site can use any style of file IO.

There are many other smaller improvements, which are explained in each commit.