### PR TITLE
script, test: python typing and linter updates

### DIFF
--- a/ci/lint/04_install.sh
+++ b/ci/lint/04_install.sh
@@ -33,11 +33,11 @@ if [ -z "${SKIP_PYTHON_INSTALL}" ]; then
     python3 --version
 fi
 
-${CI_RETRY_EXE} pip3 install codespell==2.2.1
-${CI_RETRY_EXE} pip3 install flake8==5.0.4
-${CI_RETRY_EXE} pip3 install lief==0.13.1
-${CI_RETRY_EXE} pip3 install mypy==0.971
-${CI_RETRY_EXE} pip3 install pyzmq==24.0.1
+${CI_RETRY_EXE} pip3 install codespell==2.2.5
+${CI_RETRY_EXE} pip3 install flake8==6.0.0
+${CI_RETRY_EXE} pip3 install lief==0.13.2
+${CI_RETRY_EXE} pip3 install mypy==1.4.1
+${CI_RETRY_EXE} pip3 install pyzmq==25.1.0
 ${CI_RETRY_EXE} pip3 install vulture==2.6
 
 SHELLCHECK_VERSION=v0.8.0

--- a/contrib/devtools/test-security-check.py
+++ b/contrib/devtools/test-security-check.py
@@ -28,7 +28,7 @@ def clean_files(source, executable):
     os.remove(source)
     os.remove(executable)
 
-def call_security_check(cc, source, executable, options):
+def call_security_check(cc: str, source: str, executable: str, options) -> tuple:
     # This should behave the same as AC_TRY_LINK, so arrange well-known flags
     # in the same order as autoconf would.
     #

--- a/src/addrdb.cpp
+++ b/src/addrdb.cpp
@@ -210,7 +210,7 @@ util::Result<std::unique_ptr<AddrMan>> LoadAddrman(const NetGroupManager& netgro
         return util::Error{strprintf(_("Invalid or corrupt peers.dat (%s). If you believe this is a bug, please report it to %s. As a workaround, you can move the file (%s) out of the way (rename, move, or delete) to have a new one created on the next start."),
                                      e.what(), PACKAGE_BUGREPORT, fs::quoted(fs::PathToString(path_addr)))};
     }
-    return {std::move(addrman)}; // std::move should be unneccessary but is temporarily needed to work around clang bug
+    return {std::move(addrman)}; // std::move should be unnecessary but is temporarily needed to work around clang bug
                                  // (https://github.com/bitcoin/bitcoin/pull/25977#issuecomment-1561270092)
 }
 

--- a/src/test/miniminer_tests.cpp
+++ b/src/test/miniminer_tests.cpp
@@ -463,8 +463,8 @@ BOOST_FIXTURE_TEST_CASE(calculate_cluster, TestChain100Setup)
     }
     const auto vec_iters_zigzag = pool.GetIterVec(zigzag_txids);
     // It doesn't matter which tx we calculate cluster for, everybody is in it.
-    const std::vector<size_t> indeces{0, 22, 72, zigzag_txids.size() - 1};
-    for (const auto index : indeces) {
+    const std::vector<size_t> indices{0, 22, 72, zigzag_txids.size() - 1};
+    for (const auto index : indices) {
         const auto cluster = pool.GatherClusters({zigzag_txids[index]});
         BOOST_CHECK_EQUAL(cluster.size(), zigzag_txids.size());
         CTxMemPool::setEntries clusterset{cluster.begin(), cluster.end()};

--- a/test/functional/interface_rest.py
+++ b/test/functional/interface_rest.py
@@ -26,6 +26,7 @@ from test_framework.wallet import (
     MiniWallet,
     getnewdestination,
 )
+from typing import Optional
 
 
 INVALID_PARAM = "abc"
@@ -64,7 +65,7 @@ class RESTTest (BitcoinTestFramework):
             body: str = '',
             status: int = 200,
             ret_type: RetType = RetType.JSON,
-            query_params: typing.Dict[str, typing.Any] = None,
+            query_params: Optional[typing.Dict[str, typing.Any]] = None,
             ) -> typing.Union[http.client.HTTPResponse, bytes, str, None]:
         rest_uri = '/rest' + uri
         if req_type in ReqType:

--- a/test/functional/p2p_message_capture.py
+++ b/test/functional/p2p_message_capture.py
@@ -19,7 +19,7 @@ TIME_SIZE = 8
 LENGTH_SIZE = 4
 MSGTYPE_SIZE = 12
 
-def mini_parser(dat_file):
+def mini_parser(dat_file: str) -> None:
     """Parse a data file created by CaptureMessageToFile.
 
     From the data file we'll only check the structure.

--- a/test/functional/test_framework/coverage.py
+++ b/test/functional/test_framework/coverage.py
@@ -11,6 +11,7 @@ testing.
 import os
 
 from .authproxy import AuthServiceProxy
+from typing import Optional
 
 REFERENCE_FILENAME = 'rpc_interface.txt'
 
@@ -20,7 +21,7 @@ class AuthServiceProxyWrapper():
     An object that wraps AuthServiceProxy to record specific RPC calls.
 
     """
-    def __init__(self, auth_service_proxy_instance: AuthServiceProxy, rpc_url: str, coverage_logfile: str=None):
+    def __init__(self, auth_service_proxy_instance: AuthServiceProxy, rpc_url: str, coverage_logfile: Optional[str]=None):
         """
         Kwargs:
             auth_service_proxy_instance: the instance being wrapped.

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -92,7 +92,7 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
 
     This class also contains various public and private helper methods."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Sets test framework defaults. Do not override this method. Instead, override the set_test_params() method"""
         self.chain: str = 'regtest'
         self.setup_clean_chain: bool = False

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -309,7 +309,7 @@ class PortSeed:
     n = None
 
 
-def get_rpc_proxy(url: str, node_number: int, *, timeout: int=None, coveragedir: str=None) -> coverage.AuthServiceProxyWrapper:
+def get_rpc_proxy(url: str, node_number: int, *, timeout: Optional[int]=None, coveragedir: Optional[str]=None) -> coverage.AuthServiceProxyWrapper:
     """
     Args:
         url: URL of the RPC server to call

--- a/test/lint/spelling.ignore-words.txt
+++ b/test/lint/spelling.ignore-words.txt
@@ -1,3 +1,4 @@
+afile
 asend
 ba
 blockin
@@ -15,6 +16,7 @@ lief
 mor
 nd
 nin
+requestor
 ser
 siz
 stap


### PR DESCRIPTION
With these updates, `./test/lint/lint-python.py` and `./test/lint/lint-spelling.py` should be green again for developers using relatively recent Python dependencies, in particular mypy 0.991 (released 11/2022) and later. Please see the commit messages for details.
