### PR TITLE
util: Allow FastRandomContext::randbytes for std::byte, Allow std::byte serialization

### DIFF
--- a/src/random.cpp
+++ b/src/random.cpp
@@ -589,15 +589,18 @@ uint256 FastRandomContext::rand256() noexcept
     return ret;
 }
 
-std::vector<unsigned char> FastRandomContext::randbytes(size_t len)
+template <typename B>
+std::vector<B> FastRandomContext::randbytes(size_t len)
 {
     if (requires_seed) RandomSeed();
-    std::vector<unsigned char> ret(len);
+    std::vector<B> ret(len);
     if (len > 0) {
-        rng.Keystream(ret.data(), len);
+        rng.Keystream(UCharCast(ret.data()), len);
     }
     return ret;
 }
+template std::vector<unsigned char> FastRandomContext::randbytes(size_t);
+template std::vector<std::byte> FastRandomContext::randbytes(size_t);
 
 void FastRandomContext::fillrand(Span<std::byte> output)
 {

--- a/src/random.h
+++ b/src/random.h
@@ -211,7 +211,8 @@ public:
     }
 
     /** Generate random bytes. */
-    std::vector<unsigned char> randbytes(size_t len);
+    template <typename B = unsigned char>
+    std::vector<B> randbytes(size_t len);
 
     /** Fill a byte Span with random bytes. */
     void fillrand(Span<std::byte> output);

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -192,6 +192,7 @@ template<typename X> const X& ReadWriteAsHelper(const X& x) { return x; }
 #ifndef CHAR_EQUALS_INT8
 template <typename Stream> void Serialize(Stream&, char) = delete; // char serialization forbidden. Use uint8_t or int8_t
 #endif
+template <typename Stream> void Serialize(Stream& s, std::byte a) { ser_writedata8(s, uint8_t(a)); }
 template<typename Stream> inline void Serialize(Stream& s, int8_t a  ) { ser_writedata8(s, a); }
 template<typename Stream> inline void Serialize(Stream& s, uint8_t a ) { ser_writedata8(s, a); }
 template<typename Stream> inline void Serialize(Stream& s, int16_t a ) { ser_writedata16(s, a); }
@@ -207,6 +208,7 @@ template <typename Stream, typename B> void Serialize(Stream& s, Span<B> span) {
 #ifndef CHAR_EQUALS_INT8
 template <typename Stream> void Unserialize(Stream&, char) = delete; // char serialization forbidden. Use uint8_t or int8_t
 #endif
+template <typename Stream> void Unserialize(Stream& s, std::byte& a) { a = std::byte{ser_readdata8(s)}; }
 template<typename Stream> inline void Unserialize(Stream& s, int8_t& a  ) { a = ser_readdata8(s); }
 template<typename Stream> inline void Unserialize(Stream& s, uint8_t& a ) { a = ser_readdata8(s); }
 template<typename Stream> inline void Unserialize(Stream& s, int16_t& a ) { a = ser_readdata16(s); }

--- a/src/test/serialize_tests.cpp
+++ b/src/test/serialize_tests.cpp
@@ -244,11 +244,13 @@ BOOST_AUTO_TEST_CASE(class_methods)
     {
         DataStream ds;
         const std::string in{"ab"};
-        ds << Span{in};
+        ds << Span{in} << std::byte{'c'};
         std::array<std::byte, 2> out;
-        ds >> Span{out};
+        std::byte out_3;
+        ds >> Span{out} >> out_3;
         BOOST_CHECK_EQUAL(out.at(0), std::byte{'a'});
         BOOST_CHECK_EQUAL(out.at(1), std::byte{'b'});
+        BOOST_CHECK_EQUAL(out_3, std::byte{'c'});
     }
 }
 


### PR DESCRIPTION
I need this for some stuff, but it should also be useful by itself for other developers that need it.