### PR TITLE
exclude ipc scheme from port check

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1261,7 +1261,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         for (const std::string& socket_addr : args.GetArgs(port_option)) {
             std::string host_out;
             uint16_t port_out{0};
-            if (!SplitHostPort(socket_addr, port_out, host_out)) {
+            if (socket_addr.rfind("ipc:", 0) != 0 && !SplitHostPort(socket_addr, port_out, host_out)) {
                 return InitError(InvalidPortErrMsg(port_option, socket_addr));
             }
         }


### PR DESCRIPTION
Previous PR https://github.com/bitcoin/bitcoin/pull/22087 cause new error, makes it impossible to use ipc protocol using zmq, this patch will exclude port checking on ipc urls.