### PR TITLE
ci: Remove deprecated container.greedy

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -45,7 +45,6 @@ container_depends_template: &CONTAINER_DEPENDS_TEMPLATE
     # https://cirrus-ci.org/faq/#are-there-any-limits
     # Each project has 16 CPU in total, assign 2 to each container, so that 8 tasks run in parallel
     cpu: 2
-    greedy: true
     memory: 8G  # Set to 8GB to avoid OOM. https://cirrus-ci.org/guide/linux/#linux-containers
     dockerfile: ci/test_imagefile  # https://cirrus-ci.org/guide/docker-builder-vm/#dockerfile-as-a-ci-environment
   depends_built_cache:
@@ -84,13 +83,11 @@ task:
   name: 'tidy [lunar]'
   << : *GLOBAL_TASK_TEMPLATE
   container:
-    cpu: 2
+    cpu: 4
     memory: 5G
     docker_arguments:
       CI_IMAGE_NAME_TAG: ubuntu:lunar
       FILE_ENV: "./ci/test/00_setup_env_native_tidy.sh"
-  # For faster CI feedback, immediately schedule the linters
-  << : *CREDITS_TEMPLATE
   env:
     << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
 
@@ -244,7 +241,6 @@ task:
     docker_arguments:
       CI_IMAGE_NAME_TAG: ubuntu:lunar
       FILE_ENV: "./ci/test/00_setup_env_native_tsan.sh"
-  << : *CREDITS_TEMPLATE
   env:
     << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
 
@@ -320,7 +316,6 @@ task:
     docker_arguments:
       CI_IMAGE_NAME_TAG: ubuntu:jammy
       FILE_ENV: "./ci/test/00_setup_env_mac.sh"
-  << : *CREDITS_TEMPLATE
   macos_sdk_cache:
     folder: "depends/SDKs/$MACOS_SDK"
     fingerprint_key: "$MACOS_SDK"


### PR DESCRIPTION
The option is to be phased out, so remove it to avoid relying on it. Update container.cpu where needed.