### PR TITLE
test: Check expected_stderr after stop

### DIFF
--- a/test/functional/feature_abortnode.py
+++ b/test/functional/feature_abortnode.py
@@ -36,7 +36,7 @@ class AbortNodeTest(BitcoinTestFramework):
 
             # Check that node0 aborted
             self.log.info("Waiting for crash")
-            self.nodes[0].wait_until_stopped(timeout=5, expect_error=True)
+            self.nodes[0].wait_until_stopped(timeout=5, expect_error=True, expected_stderr="Error: A fatal internal error occurred, see debug.log for details")
         self.log.info("Node crashed - now verifying restart fails")
         self.nodes[0].assert_start_raises_init_error()
 


### PR DESCRIPTION
This fixes a bug where stderr wasn't checked for the shutdown sequence.

Fix that by waiting for the shutdown to finish and then check stderr.