### PR TITLE
Package Relay 1/3: Introduce TxDownloadManager and improve orphan-handling

### DIFF
--- a/src/node/txdownloadman.h
+++ b/src/node/txdownloadman.h
@@ -92,7 +92,7 @@ struct PackageToValidate {
 struct RejectedTxTodo
 {
     bool m_should_add_extra_compact_tx;
-    std::vector<uint256> m_unique_parents;
+    std::vector<Txid> m_unique_parents;
     std::optional<PackageToValidate> m_package_to_validate;
 };
 

--- a/src/node/txdownloadman.h
+++ b/src/node/txdownloadman.h
@@ -36,6 +36,8 @@ static constexpr auto NONPREF_PEER_TX_DELAY{2s};
 static constexpr auto OVERLOADED_PEER_TX_DELAY{2s};
 /** How long to wait before downloading a transaction from an additional peer */
 static constexpr auto GETDATA_TX_INTERVAL{60s};
+/** How long to wait before requesting orphan parents from an additional peer. */
+static constexpr auto ORPHAN_ANCESTOR_GETDATA_INTERVAL{60s};
 struct TxDownloadOptions {
     /** Read-only reference to mempool. */
     const CTxMemPool& m_mempool;

--- a/src/node/txdownloadman_impl.cpp
+++ b/src/node/txdownloadman_impl.cpp
@@ -308,7 +308,7 @@ node::RejectedTxTodo TxDownloadManagerImpl::MempoolRejectedTx(const CTransaction
     // Whether we should call AddToCompactExtraTransactions at the end
     bool add_extra_compact_tx{first_time_failure};
     // Hashes to pass to AddKnownTx later
-    std::vector<uint256> unique_parents;
+    std::vector<Txid> unique_parents;
     // Populated if failure is reconsiderable and eligible package is found.
     std::optional<node::PackageToValidate> package_to_validate;
 

--- a/src/node/txdownloadman_impl.cpp
+++ b/src/node/txdownloadman_impl.cpp
@@ -97,7 +97,12 @@ void TxDownloadManagerImpl::ActiveTipChange()
 
 void TxDownloadManagerImpl::BlockConnected(const std::shared_ptr<const CBlock>& pblock)
 {
-    m_orphanage.EraseForBlock(*pblock);
+    // Orphanage may include transactions conflicted by this block. There should not be any
+    // transactions in m_orphan_resolution_tracker that aren't in orphanage, so this should include
+    // all of the relevant orphans we were working on.
+    for (const auto& erased_orphan_wtxid : m_orphanage.EraseForBlock(*pblock)) {
+        m_orphan_resolution_tracker.ForgetTxHash(erased_orphan_wtxid);
+    }
 
     for (const auto& ptx : pblock->vtx) {
         RecentConfirmedTransactionsFilter().insert(ptx->GetHash().ToUint256());
@@ -164,6 +169,7 @@ void TxDownloadManagerImpl::DisconnectedPeer(NodeId nodeid)
 {
     m_orphanage.EraseForPeer(nodeid);
     m_txrequest.DisconnectedPeer(nodeid);
+    m_orphan_resolution_tracker.DisconnectedPeer(nodeid);
 
     if (auto it = m_peer_info.find(nodeid); it != m_peer_info.end()) {
         if (it->second.m_connection_info.m_wtxid_relay) m_num_wtxid_peers -= 1;
@@ -174,10 +180,27 @@ void TxDownloadManagerImpl::DisconnectedPeer(NodeId nodeid)
 
 bool TxDownloadManagerImpl::AddTxAnnouncement(NodeId peer, const GenTxid& gtxid, std::chrono::microseconds now, bool p2p_inv)
 {
+    // If this is an inv received from a peer but it's an orphan we are trying to resolve, instead
+    // of adding it to m_txrequest, remember this peer as a potential orphan resolution candidate.
+    if (p2p_inv && m_orphanage.HaveTx(Wtxid::FromUint256(gtxid.GetHash()))) {
+        // m_orphan_resolution_tracker only tracks wtxids
+        if (gtxid.IsWtxid()) {
+            if (auto delay{OrphanResolutionCandidate(peer, Wtxid::FromUint256(gtxid.GetHash()))}) {
+                const auto& info = m_peer_info.at(peer).m_connection_info;
+                m_orphanage.AddAnnouncer(Wtxid::FromUint256(gtxid.GetHash()), peer);
+                m_orphan_resolution_tracker.ReceivedInv(peer, GenTxid::Wtxid(gtxid.GetHash()), info.m_preferred, now + *delay);
+                LogDebug(BCLog::TXPACKAGES, "added peer=%d as a candidate for resolving orphan %s\n", peer, gtxid.GetHash().ToString());
+            }
+        }
+        return true;
+    }
+
+    const bool already_had{AlreadyHaveTx(gtxid, /*include_reconsiderable=*/true)};
+
     // If this is an inv received from a peer and we already have it, we can drop it.
     // If this is a request for the parent of an orphan, we don't drop transactions that we already have. In particular,
     // we *do* want to request parents that are in m_lazy_recent_rejects_reconsiderable, since they can be CPFP'd.
-    if (p2p_inv && AlreadyHaveTx(gtxid, /*include_reconsiderable=*/true)) return true;
+    if (p2p_inv && already_had) return true;
 
     auto it = m_peer_info.find(peer);
     if (it == m_peer_info.end()) return false;
@@ -204,8 +227,83 @@ bool TxDownloadManagerImpl::AddTxAnnouncement(NodeId peer, const GenTxid& gtxid,
     return false;
 }
 
+std::optional<std::chrono::seconds> TxDownloadManagerImpl::OrphanResolutionCandidate(NodeId nodeid, const Wtxid& orphan_wtxid)
+{
+    if (m_peer_info.count(nodeid) == 0) return std::nullopt;
+
+    const auto& peer_entry = m_peer_info.at(nodeid);
+    const auto& info = peer_entry.m_connection_info;
+    // TODO: add delays and limits based on the amount of orphan resolution we are already doing
+    // with this peer, how much they are using the orphanage, etc.
+    if (!info.m_relay_permissions) {
+        // This mirrors the delaying and dropping behavior in AddTxAnnouncement in order to preserve
+        // existing behavior: drop if we are tracking too many invs for this peer already. Each
+        // orphan resolution involves at least 1 transaction request which may or may not be
+        // currently tracked in m_txrequest, so we include that in the count.
+        if (m_txrequest.Count(nodeid) + m_orphan_resolution_tracker.Count(nodeid) >= MAX_PEER_TX_ANNOUNCEMENTS) return std::nullopt;
+    }
+
+    std::chrono::seconds delay{0s};
+    if (!info.m_preferred) delay += NONPREF_PEER_TX_DELAY;
+    // The orphan wtxid is used, but resolution entails requesting the parents by txid. Sometimes
+    // parent and child are announced and thus requested around the same time, and we happen to
+    // receive child sooner. Waiting a few seconds may allow us to cancel the orphan resolution
+    // request if the parent arrives in that time.
+    if (m_num_wtxid_peers > 0) delay += TXID_RELAY_DELAY;
+    const bool overloaded = !info.m_relay_permissions && m_txrequest.CountInFlight(nodeid) >= MAX_PEER_TX_REQUEST_IN_FLIGHT;
+    if (overloaded) delay += OVERLOADED_PEER_TX_DELAY;
+
+    return delay;
+}
+
 std::vector<GenTxid> TxDownloadManagerImpl::GetRequestsToSend(NodeId nodeid, std::chrono::microseconds current_time)
 {
+    // First process orphan resolution so that the tx requests can be sent asap
+    std::vector<std::pair<NodeId, GenTxid>> expired_orphan_resolution;
+    const auto orphans_ready = m_orphan_resolution_tracker.GetRequestable(nodeid, current_time, &expired_orphan_resolution);
+
+    // Expire orphan resolution attempts
+    for (const auto& [nodeid, orphan_gtxid] : expired_orphan_resolution) {
+        LogDebug(BCLog::TXPACKAGES, "timeout of in-flight orphan resolution %s for peer=%d\n", orphan_gtxid.GetHash().ToString(), nodeid);
+        // All txhashes in m_orphan_resolution_tracker are wtxids.
+        Assume(orphan_gtxid.IsWtxid());
+        const auto wtxid = Wtxid::FromUint256(orphan_gtxid.GetHash());
+        m_orphanage.EraseOrphanOfPeer(wtxid, nodeid);
+        Assume(!m_orphanage.HaveTxAndPeer(wtxid, nodeid));
+    }
+
+    // Process orphan resolution attempts that are ready: schedule the parent requests.
+    for (const auto& orphan_gtxid : orphans_ready) {
+        Assume(orphan_gtxid.IsWtxid());
+        const auto wtxid = Wtxid::FromUint256(orphan_gtxid.GetHash());
+        Assume(m_orphanage.HaveTxAndPeer(wtxid, nodeid));
+
+        const auto parent_txids{m_orphanage.GetParentTxids(wtxid)};
+
+        if (parent_txids.has_value()) {
+            if (!Assume(m_peer_info.count(nodeid) > 0)) continue;
+
+            const auto& info = m_peer_info.at(nodeid).m_connection_info;
+            bool requesting{false};
+
+            for (const auto& txid : *parent_txids) {
+                // Schedule with no delay instead of using AddTxAnnouncement. This means it's scheduled
+                // for request immediately unless there is already a request out for the same txhash
+                // (e.g. if there is another orphan that needs this parent).
+                m_txrequest.ReceivedInv(nodeid, GenTxid::Txid(txid), info.m_preferred, current_time);
+                requesting = true;
+                LogDebug(BCLog::TXPACKAGES, "scheduled parent request %s from peer=%d for orphan %s\n",
+                    txid.ToString(), nodeid, orphan_gtxid.GetHash().ToString());
+            }
+
+            if (requesting) m_orphan_resolution_tracker.RequestedTx(nodeid, orphan_gtxid.GetHash(), current_time + ORPHAN_ANCESTOR_GETDATA_INTERVAL);
+        } else {
+            LogDebug(BCLog::TXPACKAGES, "couldn't find parent txids to resolve orphan %s with peer=%d\n", orphan_gtxid.GetHash().ToString(), nodeid);
+            m_orphan_resolution_tracker.ForgetTxHash(orphan_gtxid.GetHash());
+        }
+    }
+
+    // Now process txrequest
     std::vector<GenTxid> requests;
     std::vector<std::pair<NodeId, GenTxid>> expired;
     auto requestable = m_txrequest.GetRequestable(nodeid, current_time, &expired);
@@ -299,6 +397,7 @@ void TxDownloadManagerImpl::MempoolAcceptedTx(const CTransactionRef& tx)
     m_orphanage.AddChildrenToWorkSet(*tx);
     // If it came from the orphanage, remove it. No-op if the tx is not in txorphanage.
     m_orphanage.EraseTx(tx->GetWitnessHash());
+    m_orphan_resolution_tracker.ForgetTxHash(tx->GetWitnessHash());
 }
 
 node::RejectedTxTodo TxDownloadManagerImpl::MempoolRejectedTx(const CTransactionRef& ptx, const TxValidationState& state, NodeId nodeid, bool first_time_failure)
@@ -354,27 +453,43 @@ node::RejectedTxTodo TxDownloadManagerImpl::MempoolRejectedTx(const CTransaction
                 std::erase_if(unique_parents, [&](const auto& txid){
                     return AlreadyHaveTx(GenTxid::Txid(txid), /*include_reconsiderable=*/false);
                 });
-                const auto current_time{GetTime<std::chrono::microseconds>()};
+                const auto now{GetTime<std::chrono::microseconds>()};
+                const auto& wtxid = ptx->GetWitnessHash();
+                // Potentially flip add_extra_compact_tx to false if tx is already in orphanage, which
+                // means it was already added to vExtraTxnForCompact.
+                add_extra_compact_tx &= !m_orphanage.HaveTx(wtxid);
 
-                for (const uint256& parent_txid : unique_parents) {
-                    // Here, we only have the txid (and not wtxid) of the
-                    // inputs, so we only request in txid mode, even for
-                    // wtxidrelay peers.
-                    // Eventually we should replace this with an improved
-                    // protocol for getting all unconfirmed parents.
-                    const auto gtxid{GenTxid::Txid(parent_txid)};
-                    AddTxAnnouncement(nodeid, gtxid, current_time, /*p2p_inv=*/false);
+                auto add_orphan_reso_candidate = [&](const CTransactionRef& orphan_tx, std::vector<Txid> unique_parents, NodeId nodeid, std::chrono::microseconds now) {
+                    const auto& wtxid = orphan_tx->GetWitnessHash();
+                    if (auto delay{OrphanResolutionCandidate(nodeid, wtxid)}) {
+                        const auto& info = m_peer_info.at(nodeid).m_connection_info;
+                        m_orphanage.AddTx(orphan_tx, nodeid, unique_parents);
+                        m_orphan_resolution_tracker.ReceivedInv(nodeid, GenTxid::Wtxid(wtxid), info.m_preferred, now + *delay);
+                        LogDebug(BCLog::TXPACKAGES, "added peer=%d as a candidate for resolving orphan %s\n", nodeid, wtxid.ToString());
+                    }
+                };
+
+                // If there is no candidate for orphan resolution, AddTx will not be called. This means
+                // that if a peer is overloading us with invs and orphans, they will eventually not be
+                // able to add any more transactions to the orphanage.
+                add_orphan_reso_candidate(ptx, unique_parents, nodeid, now);
+                for (const auto& candidate : m_txrequest.GetCandidatePeers(wtxid)) {
+                    add_orphan_reso_candidate(ptx, unique_parents, candidate, now);
                 }
-
-                // Potentially flip add_extra_compact_tx to false if AddTx returns false because the tx was already there
-                add_extra_compact_tx &= m_orphanage.AddTx(ptx, nodeid, unique_parents);
+                for (const auto& candidate : m_txrequest.GetCandidatePeers(ptx->GetHash())) {
+                    add_orphan_reso_candidate(ptx, unique_parents, candidate, now);
+                }
 
                 // Once added to the orphan pool, a tx is considered AlreadyHave, and we shouldn't request it anymore.
                 m_txrequest.ForgetTxHash(tx.GetHash());
                 m_txrequest.ForgetTxHash(tx.GetWitnessHash());
 
                 // DoS prevention: do not allow m_orphanage to grow unbounded (see CVE-2012-3789)
-                m_orphanage.LimitOrphans(m_opts.m_max_orphan_txs, m_opts.m_rng);
+                // Note that, if the orphanage reaches capacity, it's possible that we immediately evict
+                // the transaction we just added.
+                for (const auto& wtxid : m_orphanage.LimitOrphans(m_opts.m_max_orphan_txs, m_opts.m_rng)) {
+                    m_orphan_resolution_tracker.ForgetTxHash(wtxid.ToUint256());
+                }
             } else {
                 unique_parents.clear();
                 LogDebug(BCLog::MEMPOOL, "not keeping orphan with rejected parents %s (wtxid=%s)\n",
@@ -444,6 +559,7 @@ node::RejectedTxTodo TxDownloadManagerImpl::MempoolRejectedTx(const CTransaction
     // If the tx failed in ProcessOrphanTx, it should be removed from the orphanage unless the
     // tx was still missing inputs. If the tx was not in the orphanage, EraseTx does nothing and returns 0.
     if (state.GetResult() != TxValidationResult::TX_MISSING_INPUTS && m_orphanage.EraseTx(ptx->GetWitnessHash()) > 0) {
+        m_orphan_resolution_tracker.ForgetTxHash(ptx->GetWitnessHash());
         LogDebug(BCLog::TXPACKAGES, "   removed orphan tx %s (wtxid=%s)\n", ptx->GetHash().ToString(), ptx->GetWitnessHash().ToString());
     }
 
@@ -524,12 +640,14 @@ CTransactionRef TxDownloadManagerImpl::GetTxToReconsider(NodeId nodeid)
 void TxDownloadManagerImpl::CheckIsEmpty(NodeId nodeid)
 {
     assert(m_txrequest.Count(nodeid) == 0);
+    Assume(m_orphan_resolution_tracker.Count(nodeid) == 0);
 }
 void TxDownloadManagerImpl::CheckIsEmpty()
 {
     assert(m_orphanage.Size() == 0);
     assert(m_txrequest.Size() == 0);
     assert(m_num_wtxid_peers == 0);
+    Assume(m_orphan_resolution_tracker.Size() == 0);
 }
 std::vector<TxOrphanage::OrphanTxBase> TxDownloadManagerImpl::GetOrphanTransactions() const
 {

--- a/src/node/txdownloadman_impl.cpp
+++ b/src/node/txdownloadman_impl.cpp
@@ -341,9 +341,11 @@ std::optional<PackageToValidate> TxDownloadManagerImpl::Find1P1CPackage(const CT
 
     Assume(RecentRejectsReconsiderableFilter().contains(parent_wtxid.ToUint256()));
 
-    // Prefer children from this peer. This helps prevent censorship attempts in which an attacker
+    // Only consider children from this peer. This helps prevent censorship attempts in which an attacker
     // sends lots of fake children for the parent, and we (unluckily) keep selecting the fake
-    // children instead of the real one provided by the honest peer.
+    // children instead of the real one provided by the honest peer. Since we track all announcers
+    // of an orphan, this does not exclude parent + orphan pairs that we happened to request from
+    // different peers.
     const auto cpfp_candidates_same_peer{m_orphanage.GetChildrenFromSamePeer(ptx, nodeid)};
 
     // These children should be sorted from newest to oldest. In the (probably uncommon) case
@@ -354,34 +356,6 @@ std::optional<PackageToValidate> TxDownloadManagerImpl::Find1P1CPackage(const CT
         if (!RecentRejectsReconsiderableFilter().contains(GetPackageHash(maybe_cpfp_package)) &&
             !RecentRejectsFilter().contains(child->GetHash().ToUint256())) {
             return PackageToValidate{ptx, child, nodeid, nodeid};
-        }
-    }
-
-    // If no suitable candidate from the same peer is found, also try children that were provided by
-    // a different peer. This is useful because sometimes multiple peers announce both transactions
-    // to us, and we happen to download them from different peers (we wouldn't have known that these
-    // 2 transactions are related). We still want to find 1p1c packages then.
-    //
-    // If we start tracking all announcers of orphans, we can restrict this logic to parent + child
-    // pairs in which both were provided by the same peer, i.e. delete this step.
-    const auto cpfp_candidates_different_peer{m_orphanage.GetChildrenFromDifferentPeer(ptx, nodeid)};
-
-    // Find the first 1p1c that hasn't already been rejected. We randomize the order to not
-    // create a bias that attackers can use to delay package acceptance.
-    //
-    // Create a random permutation of the indices.
-    std::vector<size_t> tx_indices(cpfp_candidates_different_peer.size());
-    std::iota(tx_indices.begin(), tx_indices.end(), 0);
-    std::shuffle(tx_indices.begin(), tx_indices.end(), m_opts.m_rng);
-
-    for (const auto index : tx_indices) {
-        // If we already tried a package and failed for any reason, the combined hash was
-        // cached in m_lazy_recent_rejects_reconsiderable.
-        const auto [child_tx, child_sender] = cpfp_candidates_different_peer.at(index);
-        Package maybe_cpfp_package{ptx, child_tx};
-        if (!RecentRejectsReconsiderableFilter().contains(GetPackageHash(maybe_cpfp_package)) &&
-            !RecentRejectsFilter().contains(child_tx->GetHash().ToUint256())) {
-            return PackageToValidate{ptx, child_tx, nodeid, child_sender};
         }
     }
     return std::nullopt;

--- a/src/node/txdownloadman_impl.cpp
+++ b/src/node/txdownloadman_impl.cpp
@@ -365,7 +365,7 @@ node::RejectedTxTodo TxDownloadManagerImpl::MempoolRejectedTx(const CTransaction
                 }
 
                 // Potentially flip add_extra_compact_tx to false if AddTx returns false because the tx was already there
-                add_extra_compact_tx &= m_orphanage.AddTx(ptx, nodeid);
+                add_extra_compact_tx &= m_orphanage.AddTx(ptx, nodeid, unique_parents);
 
                 // Once added to the orphan pool, a tx is considered AlreadyHave, and we shouldn't request it anymore.
                 m_txrequest.ForgetTxHash(tx.GetHash());

--- a/src/node/txdownloadman_impl.h
+++ b/src/node/txdownloadman_impl.h
@@ -128,6 +128,11 @@ public:
         return *m_lazy_recent_confirmed_transactions;
     }
 
+    /** Tracks orphans we are trying to resolve. All hashes stored are wtxids, i.e., the wtxid of
+     * the orphan. Used to schedule resolution with peers, which means requesting the missing
+     * parents by txid. */
+    TxRequestTracker m_orphan_resolution_tracker;
+
     TxDownloadManagerImpl(const TxDownloadOptions& options) : m_opts{options}, m_txrequest{options.m_deterministic_txrequest} {}
 
     struct PeerInfo {
@@ -189,6 +194,12 @@ public:
     void CheckIsEmpty(NodeId nodeid);
 
     std::vector<TxOrphanage::OrphanTxBase> GetOrphanTransactions() const;
+protected:
+    /** Determine candidacy (and delay) for potential orphan resolution candidate.
+     * @returns delay for orphan resolution if this peer is a good candidate for orphan resolution,
+     * std::nullopt if this peer cannot be added because it has reached download/orphanage limits.
+     * */
+    std::optional<std::chrono::seconds> OrphanResolutionCandidate(NodeId nodeid, const Wtxid& orphan_wtxid);
 };
 } // namespace node
 #endif // BITCOIN_NODE_TXDOWNLOADMAN_IMPL_H

--- a/src/node/txdownloadman_impl.h
+++ b/src/node/txdownloadman_impl.h
@@ -200,6 +200,9 @@ protected:
      * skipping any combinations that have already been tried. Return the resulting package along with
      * the senders of its respective transactions, or std::nullopt if no package is found. */
     std::optional<PackageToValidate> Find1P1CPackage(const CTransactionRef& ptx, NodeId nodeid);
+
+    /** Internal version of AlreadyHaveTx */
+    bool AlreadyHaveTxInternal(const GenTxid& gtxid, bool include_reconsiderable);
 };
 } // namespace node
 #endif // BITCOIN_NODE_TXDOWNLOADMAN_IMPL_H

--- a/src/node/txdownloadman_impl.h
+++ b/src/node/txdownloadman_impl.h
@@ -176,11 +176,6 @@ public:
     /** Marks a tx as ReceivedResponse in txrequest. */
     void ReceivedNotFound(NodeId nodeid, const std::vector<uint256>& txhashes);
 
-    /** Look for a child of this transaction in the orphanage to form a 1-parent-1-child package,
-     * skipping any combinations that have already been tried. Return the resulting package along with
-     * the senders of its respective transactions, or std::nullopt if no package is found. */
-    std::optional<PackageToValidate> Find1P1CPackage(const CTransactionRef& ptx, NodeId nodeid);
-
     void MempoolAcceptedTx(const CTransactionRef& tx);
     RejectedTxTodo MempoolRejectedTx(const CTransactionRef& ptx, const TxValidationState& state, NodeId nodeid, bool first_time_failure);
     void MempoolRejectedPackage(const Package& package);
@@ -200,6 +195,11 @@ protected:
      * std::nullopt if this peer cannot be added because it has reached download/orphanage limits.
      * */
     std::optional<std::chrono::seconds> OrphanResolutionCandidate(NodeId nodeid, const Wtxid& orphan_wtxid);
+
+    /** Look for a child of this transaction in the orphanage to form a 1-parent-1-child package,
+     * skipping any combinations that have already been tried. Return the resulting package along with
+     * the senders of its respective transactions, or std::nullopt if no package is found. */
+    std::optional<PackageToValidate> Find1P1CPackage(const CTransactionRef& ptx, NodeId nodeid);
 };
 } // namespace node
 #endif // BITCOIN_NODE_TXDOWNLOADMAN_IMPL_H

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -843,7 +843,9 @@ static UniValue OrphanToJSON(const TxOrphanage::OrphanTxBase& orphan)
     o.pushKV("entry", int64_t{TicksSinceEpoch<std::chrono::seconds>(orphan.nTimeExpire - ORPHAN_TX_EXPIRE_TIME)});
     o.pushKV("expiration", int64_t{TicksSinceEpoch<std::chrono::seconds>(orphan.nTimeExpire)});
     UniValue from(UniValue::VARR);
-    from.push_back(orphan.fromPeer); // only one fromPeer for now
+    for (const auto fromPeer: orphan.announcers) {
+        from.push_back(fromPeer);
+    }
     o.pushKV("from", from);
     return o;
 }

--- a/src/test/fuzz/txorphan.cpp
+++ b/src/test/fuzz/txorphan.cpp
@@ -88,12 +88,6 @@ FUZZ_TARGET(txorphan, .init = initialize_orphanage)
                     return input.prevout.hash == ptx_potential_parent->GetHash();
                 }));
             }
-            for (const auto& [child, peer] : orphanage.GetChildrenFromDifferentPeer(ptx_potential_parent, peer_id)) {
-                assert(std::any_of(child->vin.cbegin(), child->vin.cend(), [&](const auto& input) {
-                    return input.prevout.hash == ptx_potential_parent->GetHash();
-                }));
-                assert(peer != peer_id);
-            }
         }
 
         // trigger orphanage functions

--- a/src/test/fuzz/txorphan.cpp
+++ b/src/test/fuzz/txorphan.cpp
@@ -116,13 +116,13 @@ FUZZ_TARGET(txorphan, .init = initialize_orphanage)
                     // AddTx should return false if tx is too big or already have it
                     // tx weight is unknown, we only check when tx is already in orphanage
                     {
-                        bool add_tx = orphanage.AddTx(tx, peer_id);
+                        bool add_tx = orphanage.AddTx(tx, peer_id, {});
                         // have_tx == true -> add_tx == false
                         Assert(!have_tx || !add_tx);
                     }
                     have_tx = orphanage.HaveTx(tx->GetWitnessHash());
                     {
-                        bool add_tx = orphanage.AddTx(tx, peer_id);
+                        bool add_tx = orphanage.AddTx(tx, peer_id, {});
                         // if have_tx is still false, it must be too big
                         Assert(!have_tx == (GetTransactionWeight(*tx) > MAX_STANDARD_TX_WEIGHT));
                         Assert(!have_tx || !add_tx);

--- a/src/test/orphanage_tests.cpp
+++ b/src/test/orphanage_tests.cpp
@@ -390,4 +390,205 @@ BOOST_AUTO_TEST_CASE(too_large_orphan_tx)
     BOOST_CHECK(orphanage.AddTx(MakeTransactionRef(tx), 0, {}));
 }
 
+BOOST_AUTO_TEST_CASE(process_block)
+{
+    FastRandomContext det_rand{true};
+    TxOrphanageTest orphanage{det_rand};
+
+    // Create outpoints that will be spent by transactions in the block
+    std::vector<COutPoint> outpoints;
+    const uint32_t num_outpoints{6};
+    outpoints.reserve(num_outpoints);
+    for (uint32_t i{0}; i < num_outpoints; ++i) {
+        // All the hashes should be different, but change the n just in case.
+        outpoints.emplace_back(Txid::FromUint256(det_rand.rand256()), i);
+    }
+
+    CBlock block;
+    const NodeId node{0};
+
+    auto bo_tx_same_txid = MakeTransactionSpending({outpoints.at(0)}, det_rand);
+    BOOST_CHECK(orphanage.AddTx(bo_tx_same_txid, node, {}));
+    block.vtx.emplace_back(bo_tx_same_txid);
+
+    // 2 transactions with the same txid but different witness
+    auto b_tx_same_txid_diff_witness = MakeTransactionSpending({outpoints.at(1)}, det_rand);
+    block.vtx.emplace_back(b_tx_same_txid_diff_witness);
+
+    auto o_tx_same_txid_diff_witness = MakeMutation(b_tx_same_txid_diff_witness);
+    BOOST_CHECK(orphanage.AddTx(o_tx_same_txid_diff_witness, node, {}));
+
+    // 2 different transactions that spend the same input.
+    auto b_tx_conflict = MakeTransactionSpending({outpoints.at(2)}, det_rand);
+    block.vtx.emplace_back(b_tx_conflict);
+
+    auto o_tx_conflict = MakeTransactionSpending({outpoints.at(2)}, det_rand);
+    BOOST_CHECK(orphanage.AddTx(o_tx_conflict, node, {}));
+
+    // 2 different transactions that have 1 overlapping input.
+    auto b_tx_conflict_partial = MakeTransactionSpending({outpoints.at(3), outpoints.at(4)}, det_rand);
+    block.vtx.emplace_back(b_tx_conflict_partial);
+
+    auto o_tx_conflict_partial_2 = MakeTransactionSpending({outpoints.at(4), outpoints.at(5)}, det_rand);
+    BOOST_CHECK(orphanage.AddTx(o_tx_conflict_partial_2, node, {}));
+
+    const auto removed = orphanage.EraseForBlock(block);
+    for (const auto& expected_removed : {bo_tx_same_txid, o_tx_same_txid_diff_witness, o_tx_conflict, o_tx_conflict_partial_2}) {
+        const auto& expected_removed_wtxid = expected_removed->GetWitnessHash();
+        BOOST_CHECK(std::find_if(removed.begin(), removed.end(), [&](const auto& wtxid) { return wtxid == expected_removed_wtxid; }) != removed.end());
+    }
+    BOOST_CHECK_EQUAL(orphanage.Size(), 0);
+}
+
+BOOST_AUTO_TEST_CASE(multiple_announcers)
+{
+    const NodeId node0{0};
+    const NodeId node1{1};
+    const NodeId node2{2};
+    size_t expected_total_count{0};
+    FastRandomContext det_rand{true};
+    TxOrphanageTest orphanage{det_rand};
+
+    // Check accounting per peer.
+    // Check that EraseForPeer works with multiple announcers.
+    {
+        auto ptx = MakeTransactionSpending({}, det_rand);
+        const auto& wtxid = ptx->GetWitnessHash();
+        BOOST_CHECK(orphanage.AddTx(ptx, node0, {}));
+        BOOST_CHECK(orphanage.HaveTx(wtxid));
+        expected_total_count += 1;
+        BOOST_CHECK_EQUAL(orphanage.Size(), expected_total_count);
+
+        // Adding again should do nothing.
+        BOOST_CHECK(!orphanage.AddTx(ptx, node0, {}));
+        BOOST_CHECK_EQUAL(orphanage.Size(), expected_total_count);
+
+        // We can add another tx with the same txid but different witness.
+        auto ptx_mutated{MakeMutation(ptx)};
+        BOOST_CHECK(orphanage.AddTx(ptx_mutated, node0, {}));
+        BOOST_CHECK(orphanage.HaveTx(ptx_mutated->GetWitnessHash()));
+        expected_total_count += 1;
+
+        // It's too late to add parent_txids through AddTx.
+        BOOST_CHECK(!orphanage.AddTx(ptx, node0, {Txid::FromUint256(ptx->vin.at(0).prevout.hash)}));
+        // Parent txids is empty because the tx exists but no parent_txids were provided.
+        BOOST_CHECK(orphanage.GetParentTxids(wtxid)->empty());
+        BOOST_CHECK(orphanage.GetParentTxids(ptx_mutated->GetWitnessHash())->empty());
+
+        // Adding a new announcer should not change overall accounting.
+        orphanage.AddAnnouncer(ptx->GetWitnessHash(), node2);
+        BOOST_CHECK_EQUAL(orphanage.Size(), expected_total_count);
+
+        // Same with using AddTx for an existing tx, which is equivalent to using AddAnnouncer
+        BOOST_CHECK(!orphanage.AddTx(ptx, node1, {}));
+        BOOST_CHECK_EQUAL(orphanage.Size(), expected_total_count);
+
+        // if EraseForPeer is called for an orphan with multiple announcers, the orphanage should only
+        // erase that peer from the announcers set.
+        orphanage.EraseForPeer(node0);
+        BOOST_CHECK(orphanage.HaveTx(ptx->GetWitnessHash()));
+        // node0 is the only one that announced ptx_mutated
+        expected_total_count -= 1;
+        BOOST_CHECK_EQUAL(orphanage.Size(), expected_total_count);
+
+        // EraseForPeer should delete the orphan if it's the only announcer left.
+        orphanage.EraseForPeer(node1);
+        BOOST_CHECK_EQUAL(orphanage.Size(), expected_total_count);
+        BOOST_CHECK(orphanage.HaveTx(ptx->GetWitnessHash()));
+        orphanage.EraseForPeer(node2);
+        expected_total_count -= 1;
+        BOOST_CHECK_EQUAL(orphanage.Size(), expected_total_count);
+        BOOST_CHECK(!orphanage.HaveTx(ptx->GetWitnessHash()));
+    }
+
+    // EraseOrphanOfPeer only erases the tx for 1 peer
+    {
+        auto ptx = MakeTransactionSpending({}, det_rand);
+        const auto& wtxid = ptx->GetWitnessHash();
+
+        // Add from node0
+        BOOST_CHECK(orphanage.AddTx(ptx, node0, {}));
+        expected_total_count += 1;
+        BOOST_CHECK_EQUAL(orphanage.Size(), expected_total_count);
+        BOOST_CHECK(orphanage.HaveTxAndPeer(wtxid, node0));
+
+        // Add from node1
+        BOOST_CHECK(!orphanage.AddTx(ptx, node1, {}));
+        BOOST_CHECK_EQUAL(orphanage.Size(), expected_total_count);
+        BOOST_CHECK(orphanage.HaveTxAndPeer(wtxid, node1));
+
+        // Erase just for node1
+        orphanage.EraseOrphanOfPeer(wtxid, node1);
+        BOOST_CHECK_EQUAL(orphanage.Size(), expected_total_count);
+        BOOST_CHECK(orphanage.HaveTxAndPeer(wtxid, node0));
+        BOOST_CHECK(!orphanage.HaveTxAndPeer(wtxid, node1));
+
+        // Now erase for node0
+        orphanage.EraseOrphanOfPeer(wtxid, node0);
+        expected_total_count -= 1;
+        BOOST_CHECK_EQUAL(orphanage.Size(), expected_total_count);
+    }
+
+    // Check that erasure for blocks removes for all peers.
+    {
+        CBlock block;
+        auto tx_block = MakeTransactionSpending({}, det_rand);
+        block.vtx.emplace_back(tx_block);
+        orphanage.AddTx(tx_block, node0, {});
+        orphanage.AddTx(tx_block, node1, {});
+
+        expected_total_count += 1;
+
+        BOOST_CHECK_EQUAL(orphanage.Size(), expected_total_count);
+
+        orphanage.EraseForBlock(block);
+
+        expected_total_count -= 1;
+
+        BOOST_CHECK_EQUAL(orphanage.Size(), expected_total_count);
+    }
+}
+BOOST_AUTO_TEST_CASE(peer_worksets)
+{
+    const NodeId node0{0};
+    const NodeId node1{1};
+    const NodeId node2{2};
+    FastRandomContext det_rand{true};
+    TxOrphanageTest orphanage{det_rand};
+    // AddChildrenToWorkSet should pick an announcer randomly
+    {
+        auto tx_missing_parent = MakeTransactionSpending({}, det_rand);
+        auto tx_orphan = MakeTransactionSpending({COutPoint{tx_missing_parent->GetHash(), 0}}, det_rand);
+        const auto& orphan_wtxid = tx_orphan->GetWitnessHash();
+
+        // All 3 peers are announcers.
+        BOOST_CHECK(orphanage.AddTx(tx_orphan, node0, {tx_missing_parent->GetHash()}));
+        BOOST_CHECK(!orphanage.AddTx(tx_orphan, node1, {tx_missing_parent->GetHash()}));
+        orphanage.AddAnnouncer(orphan_wtxid, node2);
+        for (NodeId node = node0; node <= node2; ++node) {
+            BOOST_CHECK(orphanage.HaveTxAndPeer(orphan_wtxid, node));
+        }
+
+        // Parent accepted: add child to all 3 worksets.
+        orphanage.AddChildrenToWorkSet(*tx_missing_parent);
+        BOOST_CHECK_EQUAL(orphanage.GetTxToReconsider(node0), tx_orphan);
+        BOOST_CHECK_EQUAL(orphanage.GetTxToReconsider(node1), tx_orphan);
+        // Don't call GetTxToReconsider(node2) yet because it mutates the workset.
+
+        // EraseOrphanOfPeer also removes that tx from the workset.
+        orphanage.EraseOrphanOfPeer(orphan_wtxid, node0);
+        BOOST_CHECK_EQUAL(orphanage.GetTxToReconsider(node0), nullptr);
+
+        // However, the other peers' worksets are not touched.
+        BOOST_CHECK_EQUAL(orphanage.GetTxToReconsider(node2), tx_orphan);
+
+        // Delete this tx, clearing the orphanage.
+        BOOST_CHECK_EQUAL(orphanage.EraseTx(orphan_wtxid), 1);
+        BOOST_CHECK_EQUAL(orphanage.Size(), 0);
+        for (NodeId node = node0; node <= node2; ++node) {
+            BOOST_CHECK_EQUAL(orphanage.GetTxToReconsider(node), nullptr);
+            BOOST_CHECK(!orphanage.HaveTxAndPeer(orphan_wtxid, node));
+        }
+    }
+}
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/orphanage_tests.cpp
+++ b/src/test/orphanage_tests.cpp
@@ -132,7 +132,7 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
         tx.vin[0].prevout.hash = Txid::FromUint256(m_rng.rand256());
         tx.vin[0].scriptSig << OP_1;
         tx.vout.resize(1);
-        tx.vout[0].nValue = 1*CENT;
+        tx.vout[0].nValue = i*CENT;
         tx.vout[0].scriptPubKey = GetScriptForDestination(PKHash(key.GetPubKey()));
 
         orphanage.AddTx(MakeTransactionRef(tx), i, {});
@@ -148,7 +148,7 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
         tx.vin[0].prevout.n = 0;
         tx.vin[0].prevout.hash = txPrev->GetHash();
         tx.vout.resize(1);
-        tx.vout[0].nValue = 1*CENT;
+        tx.vout[0].nValue = i*CENT;
         tx.vout[0].scriptPubKey = GetScriptForDestination(PKHash(key.GetPubKey()));
         SignatureData empty;
         BOOST_CHECK(SignSignature(keystore, *txPrev, tx, 0, SIGHASH_ALL, empty));

--- a/src/test/orphanage_tests.cpp
+++ b/src/test/orphanage_tests.cpp
@@ -93,15 +93,6 @@ static bool EqualTxns(const std::set<CTransactionRef>& set_txns, const std::vect
     }
     return true;
 }
-static bool EqualTxns(const std::set<CTransactionRef>& set_txns,
-                      const std::vector<std::pair<CTransactionRef, NodeId>>& vec_txns)
-{
-    if (vec_txns.size() != set_txns.size()) return false;
-    for (const auto& [tx, nodeid] : vec_txns) {
-        if (!set_txns.contains(tx)) return false;
-    }
-    return true;
-}
 
 BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
 {
@@ -310,9 +301,6 @@ BOOST_AUTO_TEST_CASE(get_children)
         BOOST_CHECK(EqualTxns(expected_parent1_children, orphanage.GetChildrenFromSamePeer(parent1, node1)));
         BOOST_CHECK(EqualTxns(expected_parent2_children, orphanage.GetChildrenFromSamePeer(parent2, node1)));
 
-        BOOST_CHECK(EqualTxns(expected_parent1_children, orphanage.GetChildrenFromDifferentPeer(parent1, node2)));
-        BOOST_CHECK(EqualTxns(expected_parent2_children, orphanage.GetChildrenFromDifferentPeer(parent2, node2)));
-
         // The peer must match
         BOOST_CHECK(orphanage.GetChildrenFromSamePeer(parent1, node2).empty());
         BOOST_CHECK(orphanage.GetChildrenFromSamePeer(parent2, node2).empty());
@@ -320,8 +308,6 @@ BOOST_AUTO_TEST_CASE(get_children)
         // There shouldn't be any children of this tx in the orphanage
         BOOST_CHECK(orphanage.GetChildrenFromSamePeer(child_p1n0_p2n0, node1).empty());
         BOOST_CHECK(orphanage.GetChildrenFromSamePeer(child_p1n0_p2n0, node2).empty());
-        BOOST_CHECK(orphanage.GetChildrenFromDifferentPeer(child_p1n0_p2n0, node1).empty());
-        BOOST_CHECK(orphanage.GetChildrenFromDifferentPeer(child_p1n0_p2n0, node2).empty());
     }
 
     // Orphans provided by node1 and node2
@@ -344,7 +330,6 @@ BOOST_AUTO_TEST_CASE(get_children)
             std::set<CTransactionRef> expected_parent1_node1{child_p1n0};
 
             BOOST_CHECK(EqualTxns(expected_parent1_node1, orphanage.GetChildrenFromSamePeer(parent1, node1)));
-            BOOST_CHECK(EqualTxns(expected_parent1_node1, orphanage.GetChildrenFromDifferentPeer(parent1, node2)));
         }
 
         // Children of parent2 from node1:
@@ -352,7 +337,6 @@ BOOST_AUTO_TEST_CASE(get_children)
             std::set<CTransactionRef> expected_parent2_node1{child_p2n1};
 
             BOOST_CHECK(EqualTxns(expected_parent2_node1, orphanage.GetChildrenFromSamePeer(parent2, node1)));
-            BOOST_CHECK(EqualTxns(expected_parent2_node1, orphanage.GetChildrenFromDifferentPeer(parent2, node2)));
         }
 
         // Children of parent1 from node2:
@@ -360,7 +344,6 @@ BOOST_AUTO_TEST_CASE(get_children)
             std::set<CTransactionRef> expected_parent1_node2{child_p1n0_p1n1, child_p1n0_p2n0};
 
             BOOST_CHECK(EqualTxns(expected_parent1_node2, orphanage.GetChildrenFromSamePeer(parent1, node2)));
-            BOOST_CHECK(EqualTxns(expected_parent1_node2, orphanage.GetChildrenFromDifferentPeer(parent1, node1)));
         }
 
         // Children of parent2 from node2:
@@ -368,7 +351,6 @@ BOOST_AUTO_TEST_CASE(get_children)
             std::set<CTransactionRef> expected_parent2_node2{child_p1n0_p2n0};
 
             BOOST_CHECK(EqualTxns(expected_parent2_node2, orphanage.GetChildrenFromSamePeer(parent2, node2)));
-            BOOST_CHECK(EqualTxns(expected_parent2_node2, orphanage.GetChildrenFromDifferentPeer(parent2, node1)));
         }
     }
 }

--- a/src/test/orphanage_tests.cpp
+++ b/src/test/orphanage_tests.cpp
@@ -135,7 +135,7 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
         tx.vout[0].nValue = 1*CENT;
         tx.vout[0].scriptPubKey = GetScriptForDestination(PKHash(key.GetPubKey()));
 
-        orphanage.AddTx(MakeTransactionRef(tx), i);
+        orphanage.AddTx(MakeTransactionRef(tx), i, {});
     }
 
     // ... and 50 that depend on other orphans:
@@ -153,7 +153,7 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
         SignatureData empty;
         BOOST_CHECK(SignSignature(keystore, *txPrev, tx, 0, SIGHASH_ALL, empty));
 
-        orphanage.AddTx(MakeTransactionRef(tx), i);
+        orphanage.AddTx(MakeTransactionRef(tx), i, {});
     }
 
     // This really-big orphan should be ignored:
@@ -178,7 +178,7 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
         for (unsigned int j = 1; j < tx.vin.size(); j++)
             tx.vin[j].scriptSig = tx.vin[0].scriptSig;
 
-        BOOST_CHECK(!orphanage.AddTx(MakeTransactionRef(tx), i));
+        BOOST_CHECK(!orphanage.AddTx(MakeTransactionRef(tx), i, {}));
     }
 
     size_t expected_num_orphans = orphanage.CountOrphans();
@@ -213,7 +213,7 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
 
     // Add one more orphan, check timeout logic
     auto timeout_tx = MakeTransactionSpending(/*outpoints=*/{}, rng);
-    orphanage.AddTx(timeout_tx, 0);
+    orphanage.AddTx(timeout_tx, 0, {});
     orphanage.LimitOrphans(1, rng);
     BOOST_CHECK_EQUAL(orphanage.CountOrphans(), 1);
 
@@ -246,14 +246,14 @@ BOOST_AUTO_TEST_CASE(same_txid_diff_witness)
     const auto& mutated_wtxid = child_mutated->GetWitnessHash();
     BOOST_CHECK(normal_wtxid != mutated_wtxid);
 
-    BOOST_CHECK(orphanage.AddTx(child_normal, peer));
+    BOOST_CHECK(orphanage.AddTx(child_normal, peer, {parent->GetHash()}));
     // EraseTx fails as transaction by this wtxid doesn't exist.
     BOOST_CHECK_EQUAL(orphanage.EraseTx(mutated_wtxid), 0);
     BOOST_CHECK(orphanage.HaveTx(normal_wtxid));
     BOOST_CHECK(!orphanage.HaveTx(mutated_wtxid));
 
     // Must succeed. Both transactions should be present in orphanage.
-    BOOST_CHECK(orphanage.AddTx(child_mutated, peer));
+    BOOST_CHECK(orphanage.AddTx(child_mutated, peer, {parent->GetHash()}));
     BOOST_CHECK(orphanage.HaveTx(normal_wtxid));
     BOOST_CHECK(orphanage.HaveTx(mutated_wtxid));
 
@@ -299,10 +299,10 @@ BOOST_AUTO_TEST_CASE(get_children)
     // All orphans provided by node1
     {
         TxOrphanage orphanage;
-        BOOST_CHECK(orphanage.AddTx(child_p1n0, node1));
-        BOOST_CHECK(orphanage.AddTx(child_p2n1, node1));
-        BOOST_CHECK(orphanage.AddTx(child_p1n0_p1n1, node1));
-        BOOST_CHECK(orphanage.AddTx(child_p1n0_p2n0, node1));
+        BOOST_CHECK(orphanage.AddTx(child_p1n0, node1, {parent1->GetHash()}));
+        BOOST_CHECK(orphanage.AddTx(child_p2n1, node1, {parent2->GetHash()}));
+        BOOST_CHECK(orphanage.AddTx(child_p1n0_p1n1, node1, {parent1->GetHash()}));
+        BOOST_CHECK(orphanage.AddTx(child_p1n0_p2n0, node1, {parent1->GetHash(), parent2->GetHash()}));
 
         std::set<CTransactionRef> expected_parent1_children{child_p1n0, child_p1n0_p2n0, child_p1n0_p1n1};
         std::set<CTransactionRef> expected_parent2_children{child_p2n1, child_p1n0_p2n0};
@@ -327,10 +327,10 @@ BOOST_AUTO_TEST_CASE(get_children)
     // Orphans provided by node1 and node2
     {
         TxOrphanage orphanage;
-        BOOST_CHECK(orphanage.AddTx(child_p1n0, node1));
-        BOOST_CHECK(orphanage.AddTx(child_p2n1, node1));
-        BOOST_CHECK(orphanage.AddTx(child_p1n0_p1n1, node2));
-        BOOST_CHECK(orphanage.AddTx(child_p1n0_p2n0, node2));
+        BOOST_CHECK(orphanage.AddTx(child_p1n0, node1, {parent1->GetHash()}));
+        BOOST_CHECK(orphanage.AddTx(child_p2n1, node1, {parent2->GetHash()}));
+        BOOST_CHECK(orphanage.AddTx(child_p1n0_p1n1, node2, {parent1->GetHash()}));
+        BOOST_CHECK(orphanage.AddTx(child_p1n0_p2n0, node2, {parent1->GetHash(), parent2->GetHash()}));
 
         // +----------------+---------------+----------------------------------+
         // |                | sender=node1  |           sender=node2           |
@@ -382,12 +382,12 @@ BOOST_AUTO_TEST_CASE(too_large_orphan_tx)
     // check that txs larger than MAX_STANDARD_TX_WEIGHT are not added to the orphanage
     BulkTransaction(tx, MAX_STANDARD_TX_WEIGHT + 4);
     BOOST_CHECK_EQUAL(GetTransactionWeight(CTransaction(tx)), MAX_STANDARD_TX_WEIGHT + 4);
-    BOOST_CHECK(!orphanage.AddTx(MakeTransactionRef(tx), 0));
+    BOOST_CHECK(!orphanage.AddTx(MakeTransactionRef(tx), 0, {}));
 
     tx.vout.clear();
     BulkTransaction(tx, MAX_STANDARD_TX_WEIGHT);
     BOOST_CHECK_EQUAL(GetTransactionWeight(CTransaction(tx)), MAX_STANDARD_TX_WEIGHT);
-    BOOST_CHECK(orphanage.AddTx(MakeTransactionRef(tx), 0));
+    BOOST_CHECK(orphanage.AddTx(MakeTransactionRef(tx), 0, {}));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/txdownload_tests.cpp
+++ b/src/test/txdownload_tests.cpp
@@ -231,10 +231,14 @@ BOOST_FIXTURE_TEST_CASE(handle_missing_inputs, TestChain100Setup)
         // it's in RecentRejectsFilter. Specifically, the parent is allowed to be in
         // RecentRejectsReconsiderableFilter, but it cannot be in RecentRejectsFilter.
         const bool expect_keep_orphan = !parent_recent_rej;
+        const unsigned int expected_parents = parent_recent_rej || parent_recent_conf || parent_in_mempool ? 0 : 1;
+        // If we don't expect to keep the orphan then expected_parents is 0.
+        // !expect_keep_orphan => (expected_parents == 0)
+        BOOST_CHECK(expect_keep_orphan || expected_parents == 0);
         const auto ret_1p1c = txdownload_impl.MempoolRejectedTx(orphan, state_orphan, nodeid, /*first_time_failure=*/true);
         std::string err_msg;
         const bool ok = CheckOrphanBehavior(txdownload_impl, orphan, ret_1p1c, err_msg,
-                                            /*expect_orphan=*/expect_keep_orphan, /*expect_keep=*/true, /*expected_parents=*/expect_keep_orphan ? 1 : 0);
+                                            /*expect_orphan=*/expect_keep_orphan, /*expect_keep=*/true, /*expected_parents=*/expected_parents);
         BOOST_CHECK_MESSAGE(ok, err_msg);
     }
 
@@ -278,11 +282,12 @@ BOOST_FIXTURE_TEST_CASE(handle_missing_inputs, TestChain100Setup)
             for (int32_t i = 1; i < num_parents; ++i) {
                 txdownload_impl.RecentConfirmedTransactionsFilter().insert(parents[i]->GetHash().ToUint256());
             }
+            const unsigned int expected_parents = 1;
 
             const auto ret_1recon_conf = txdownload_impl.MempoolRejectedTx(orphan, state_orphan, nodeid, /*first_time_failure=*/true);
             std::string err_msg;
             const bool ok = CheckOrphanBehavior(txdownload_impl, orphan, ret_1recon_conf, err_msg,
-                                                /*expect_orphan=*/true, /*expect_keep=*/true, /*expected_parents=*/num_parents);
+                                                /*expect_orphan=*/true, /*expect_keep=*/true, /*expected_parents=*/expected_parents);
             BOOST_CHECK_MESSAGE(ok, err_msg);
         }
 

--- a/src/txorphanage.cpp
+++ b/src/txorphanage.cpp
@@ -217,7 +217,7 @@ bool TxOrphanage::HaveTxToReconsider(NodeId peer)
     return false;
 }
 
-void TxOrphanage::EraseForBlock(const CBlock& block)
+std::vector<Wtxid> TxOrphanage::EraseForBlock(const CBlock& block)
 {
     std::vector<Wtxid> vOrphanErase;
 
@@ -243,6 +243,8 @@ void TxOrphanage::EraseForBlock(const CBlock& block)
         }
         LogDebug(BCLog::TXPACKAGES, "Erased %d orphan transaction(s) included or conflicted by block\n", nErased);
     }
+
+    return vOrphanErase;
 }
 
 std::vector<CTransactionRef> TxOrphanage::GetChildrenFromSamePeer(const CTransactionRef& parent, NodeId nodeid) const

--- a/src/txorphanage.cpp
+++ b/src/txorphanage.cpp
@@ -292,38 +292,6 @@ std::vector<CTransactionRef> TxOrphanage::GetChildrenFromSamePeer(const CTransac
     return children_found;
 }
 
-std::vector<std::pair<CTransactionRef, NodeId>> TxOrphanage::GetChildrenFromDifferentPeer(const CTransactionRef& parent, NodeId nodeid) const
-{
-    // First construct vector of iterators to ensure we do not return duplicates of the same tx.
-    std::vector<OrphanMap::iterator> iters;
-
-    // For each output, get all entries spending this prevout, filtering for ones not from the specified peer.
-    for (unsigned int i = 0; i < parent->vout.size(); i++) {
-        const auto it_by_prev = m_outpoint_to_orphan_it.find(COutPoint(parent->GetHash(), i));
-        if (it_by_prev != m_outpoint_to_orphan_it.end()) {
-            for (const auto& elem : it_by_prev->second) {
-                if (!elem->second.announcers.contains(nodeid)) {
-                    iters.emplace_back(elem);
-                }
-            }
-        }
-    }
-
-    // Erase duplicates
-    std::sort(iters.begin(), iters.end(), IteratorComparator());
-    iters.erase(std::unique(iters.begin(), iters.end()), iters.end());
-
-    // Convert iterators to pair<CTransactionRef, NodeId>
-    std::vector<std::pair<CTransactionRef, NodeId>> children_found;
-    children_found.reserve(iters.size());
-    for (const auto& child_iter : iters) {
-        // Use first peer in announcers list
-        auto peer = *(child_iter->second.announcers.begin());
-        children_found.emplace_back(child_iter->second.tx, peer);
-    }
-    return children_found;
-}
-
 std::vector<TxOrphanage::OrphanTxBase> TxOrphanage::GetOrphanTransactions() const
 {
     std::vector<OrphanTxBase> ret;

--- a/src/txorphanage.cpp
+++ b/src/txorphanage.cpp
@@ -16,8 +16,16 @@ bool TxOrphanage::AddTx(const CTransactionRef& tx, NodeId peer, const std::vecto
 {
     const Txid& hash = tx->GetHash();
     const Wtxid& wtxid = tx->GetWitnessHash();
-    if (m_orphans.count(wtxid))
+    auto it = m_orphans.find(wtxid);
+    if (it != m_orphans.end()) {
+        Assume(!it->second.announcers.empty());
+        const auto ret = it->second.announcers.insert(peer);
+        if (ret.second) {
+            LogDebug(BCLog::TXPACKAGES, "added peer=%d as announcer of orphan tx %s\n", peer, wtxid.ToString());
+        }
+        // Even if an announcer was added, no new orphan entry was created.
         return false;
+    }
 
     // Ignore big transactions, to avoid a
     // send-big-orphans memory exhaustion attack. If a peer has a legitimate
@@ -33,7 +41,7 @@ bool TxOrphanage::AddTx(const CTransactionRef& tx, NodeId peer, const std::vecto
         return false;
     }
 
-    auto ret = m_orphans.emplace(wtxid, OrphanTx{{tx, peer, Now<NodeSeconds>() + ORPHAN_TX_EXPIRE_TIME}, m_orphan_list.size(), parent_txids});
+    auto ret = m_orphans.emplace(wtxid, OrphanTx{{tx, {peer}, Now<NodeSeconds>() + ORPHAN_TX_EXPIRE_TIME}, m_orphan_list.size(), parent_txids});
     assert(ret.second);
     m_orphan_list.push_back(ret.first);
     for (const CTxIn& txin : tx->vin) {
@@ -43,6 +51,20 @@ bool TxOrphanage::AddTx(const CTransactionRef& tx, NodeId peer, const std::vecto
     LogDebug(BCLog::TXPACKAGES, "stored orphan tx %s (wtxid=%s), weight: %u (mapsz %u outsz %u)\n", hash.ToString(), wtxid.ToString(), sz,
              m_orphans.size(), m_outpoint_to_orphan_it.size());
     return true;
+}
+
+bool TxOrphanage::AddAnnouncer(const Wtxid& wtxid, NodeId peer)
+{
+    const auto it = m_orphans.find(wtxid);
+    if (it != m_orphans.end()) {
+        Assume(!it->second.announcers.empty());
+        const auto ret = it->second.announcers.insert(peer);
+        if (ret.second) {
+            LogDebug(BCLog::TXPACKAGES, "added peer=%d as announcer of orphan tx %s\n", peer, wtxid.ToString());
+            return true;
+        }
+    }
+    return false;
 }
 
 int TxOrphanage::EraseTx(const Wtxid& wtxid)
@@ -89,9 +111,14 @@ void TxOrphanage::EraseForPeer(NodeId peer)
     while (iter != m_orphans.end())
     {
         // increment to avoid iterator becoming invalid after erasure
-        const auto& [wtxid, orphan] = *iter++;
-        if (orphan.fromPeer == peer) {
-            nErased += EraseTx(wtxid);
+        auto& [wtxid, orphan] = *iter++;
+        if (orphan.announcers.contains(peer)) {
+            if (orphan.announcers.size() == 1) {
+                nErased += EraseTx(orphan.tx->GetWitnessHash());
+            } else {
+                // Don't erase this orphan. Another peer has also announced it, so it may still be useful.
+                orphan.announcers.erase(peer);
+            }
         }
     }
     if (nErased > 0) LogDebug(BCLog::TXPACKAGES, "Erased %d orphan transaction(s) from peer=%d\n", nErased, peer);
@@ -135,13 +162,17 @@ void TxOrphanage::AddChildrenToWorkSet(const CTransaction& tx)
         const auto it_by_prev = m_outpoint_to_orphan_it.find(COutPoint(tx.GetHash(), i));
         if (it_by_prev != m_outpoint_to_orphan_it.end()) {
             for (const auto& elem : it_by_prev->second) {
-                // Get this source peer's work set, emplacing an empty set if it didn't exist
-                // (note: if this peer wasn't still connected, we would have removed the orphan tx already)
-                std::set<Wtxid>& orphan_work_set = m_peer_work_set.try_emplace(elem->second.fromPeer).first->second;
-                // Add this tx to the work set
-                orphan_work_set.insert(elem->first);
-                LogDebug(BCLog::TXPACKAGES, "added %s (wtxid=%s) to peer %d workset\n",
-                         tx.GetHash().ToString(), tx.GetWitnessHash().ToString(), elem->second.fromPeer);
+                // Belt and suspenders, each orphan should always have at least 1 announcer.
+                if (!Assume(!elem->second.announcers.empty())) break;
+                for (const auto announcer: elem->second.announcers) {
+                    // Get this source peer's work set, emplacing an empty set if it didn't exist
+                    // (note: if this peer wasn't still connected, we would have removed the orphan tx already)
+                    std::set<Wtxid>& orphan_work_set = m_peer_work_set.try_emplace(announcer).first->second;
+                    // Add this tx to the work set
+                    orphan_work_set.insert(elem->first);
+                    LogDebug(BCLog::TXPACKAGES, "added %s (wtxid=%s) to peer %d workset\n",
+                             tx.GetHash().ToString(), tx.GetWitnessHash().ToString(), announcer);
+                }
             }
         }
     }
@@ -150,6 +181,12 @@ void TxOrphanage::AddChildrenToWorkSet(const CTransaction& tx)
 bool TxOrphanage::HaveTx(const Wtxid& wtxid) const
 {
     return m_orphans.count(wtxid);
+}
+
+bool TxOrphanage::HaveTxAndPeer(const Wtxid& wtxid, NodeId peer) const
+{
+    auto it = m_orphans.find(wtxid);
+    return (it != m_orphans.end() && it->second.announcers.count(peer) > 0);
 }
 
 CTransactionRef TxOrphanage::GetTxToReconsider(NodeId peer)
@@ -219,7 +256,7 @@ std::vector<CTransactionRef> TxOrphanage::GetChildrenFromSamePeer(const CTransac
         const auto it_by_prev = m_outpoint_to_orphan_it.find(COutPoint(parent->GetHash(), i));
         if (it_by_prev != m_outpoint_to_orphan_it.end()) {
             for (const auto& elem : it_by_prev->second) {
-                if (elem->second.fromPeer == nodeid) {
+                if (elem->second.announcers.contains(nodeid)) {
                     iters.emplace_back(elem);
                 }
             }
@@ -258,7 +295,7 @@ std::vector<std::pair<CTransactionRef, NodeId>> TxOrphanage::GetChildrenFromDiff
         const auto it_by_prev = m_outpoint_to_orphan_it.find(COutPoint(parent->GetHash(), i));
         if (it_by_prev != m_outpoint_to_orphan_it.end()) {
             for (const auto& elem : it_by_prev->second) {
-                if (elem->second.fromPeer != nodeid) {
+                if (!elem->second.announcers.contains(nodeid)) {
                     iters.emplace_back(elem);
                 }
             }
@@ -273,7 +310,9 @@ std::vector<std::pair<CTransactionRef, NodeId>> TxOrphanage::GetChildrenFromDiff
     std::vector<std::pair<CTransactionRef, NodeId>> children_found;
     children_found.reserve(iters.size());
     for (const auto& child_iter : iters) {
-        children_found.emplace_back(child_iter->second.tx, child_iter->second.fromPeer);
+        // Use first peer in announcers list
+        auto peer = *(child_iter->second.announcers.begin());
+        children_found.emplace_back(child_iter->second.tx, peer);
     }
     return children_found;
 }
@@ -283,7 +322,7 @@ std::vector<TxOrphanage::OrphanTxBase> TxOrphanage::GetOrphanTransactions() cons
     std::vector<OrphanTxBase> ret;
     ret.reserve(m_orphans.size());
     for (auto const& o : m_orphans) {
-        ret.push_back({o.second.tx, o.second.fromPeer, o.second.nTimeExpire});
+        ret.push_back({o.second.tx, o.second.announcers, o.second.nTimeExpire});
     }
     return ret;
 }
@@ -293,4 +332,28 @@ std::optional<std::vector<Txid>> TxOrphanage::GetParentTxids(const Wtxid& wtxid)
     const auto it = m_orphans.find(wtxid);
     if (it != m_orphans.end()) return it->second.parent_txids;
     return std::nullopt;
+}
+
+void TxOrphanage::EraseOrphanOfPeer(const Wtxid& wtxid, NodeId peer)
+{
+    // Nothing to do if this tx doesn't exist.
+    const auto it = m_orphans.find(wtxid);
+    if (it == m_orphans.end()) return;
+
+    // It wouldn't make sense for the orphan to show up in GetTxToReconsider after we gave up on
+    // this orphan with this peer. If this tx is in the peer's workset, delete it, because the
+    // transaction may persist in the orphanage with a different peer.
+    auto work_set_it = m_peer_work_set.find(peer);
+    if (work_set_it != m_peer_work_set.end()) {
+        work_set_it->second.erase(wtxid);
+    }
+
+    if (it->second.announcers.count(peer) > 0) {
+        if (it->second.announcers.size() == 1) {
+            EraseTx(wtxid);
+        } else {
+            // Don't erase this orphan. Another peer has also announced it, so it may still be useful.
+            it->second.announcers.erase(peer);
+        }
+    }
 }

--- a/src/txorphanage.h
+++ b/src/txorphanage.h
@@ -59,7 +59,7 @@ public:
     std::vector<Wtxid> EraseForBlock(const CBlock& block);
 
     /** Limit the orphanage to the given maximum */
-    void LimitOrphans(unsigned int max_orphans, FastRandomContext& rng);
+    std::vector<Wtxid> LimitOrphans(unsigned int max_orphans, FastRandomContext& rng);
 
     /** Add any orphans that list a particular tx as a parent into the from peer's work set */
     void AddChildrenToWorkSet(const CTransaction& tx);

--- a/src/txorphanage.h
+++ b/src/txorphanage.h
@@ -56,7 +56,7 @@ public:
     void EraseForPeer(NodeId peer);
 
     /** Erase all orphans included in or invalidated by a new block */
-    void EraseForBlock(const CBlock& block);
+    std::vector<Wtxid> EraseForBlock(const CBlock& block);
 
     /** Limit the orphanage to the given maximum */
     void LimitOrphans(unsigned int max_orphans, FastRandomContext& rng);

--- a/src/txorphanage.h
+++ b/src/txorphanage.h
@@ -71,10 +71,6 @@ public:
      * recent to least recent. */
     std::vector<CTransactionRef> GetChildrenFromSamePeer(const CTransactionRef& parent, NodeId nodeid) const;
 
-    /** Get all children that spend from this tx but were not received from nodeid. Also return
-     * which peer provided each tx. */
-    std::vector<std::pair<CTransactionRef, NodeId>> GetChildrenFromDifferentPeer(const CTransactionRef& parent, NodeId nodeid) const;
-
     /** Get an orphan's parent_txids, or std::nullopt if the orphan is not present. */
     std::optional<std::vector<Txid>> GetParentTxids(const Wtxid& wtxid);
 

--- a/src/txrequest.h
+++ b/src/txrequest.h
@@ -173,6 +173,12 @@ public:
      */
     void RequestedTx(NodeId peer, const uint256& txhash, std::chrono::microseconds expiry);
 
+    /** For some already REQUESTED announcement, reset the expiry.
+     *
+     * If no REQUESTED announcement for the provided peer and txhash exists, this call has no effect.
+     */
+    void ResetRequestTimeout(NodeId peer, const uint256& txhash, std::chrono::microseconds new_expiry);
+
     /** Converts a CANDIDATE or REQUESTED announcement to a COMPLETED one. If no such announcement exists for the
      *  provided peer and txhash, nothing happens.
      *
@@ -194,6 +200,9 @@ public:
 
     /** Count how many announcements are being tracked in total across all peers and transaction hashes. */
     size_t Size() const;
+
+    /** For some tx hash (either txid or wtxid), return all peers with non-COMPLETED announcements. */
+    std::vector<NodeId> GetCandidatePeers(const uint256& txhash) const;
 
     /** Access to the internal priority computation (testing only) */
     uint64_t ComputePriority(const uint256& txhash, NodeId peer, bool preferred) const;

--- a/test/functional/p2p_1p1c_network.py
+++ b/test/functional/p2p_1p1c_network.py
@@ -143,12 +143,6 @@ class PackageRelayTest(BitcoinTestFramework):
         for (i, peer) in enumerate(self.peers):
             for tx in transactions_to_presend[i]:
                 peer.send_and_ping(msg_tx(tx))
-            # This disconnect removes any sent orphans from the orphanage (EraseForPeer) and times
-            # out the in-flight requests.  It is currently required for the test to pass right now,
-            # because the node will not reconsider an orphan tx and will not (re)try requesting
-            # orphan parents from multiple peers if the first one didn't respond.
-            # TODO: remove this in the future if the node tries orphan resolution with multiple peers.
-            peer.peer_disconnect()
 
         self.log.info("Submit full packages to node0")
         for package_hex in packages_to_submit:
@@ -156,7 +150,7 @@ class PackageRelayTest(BitcoinTestFramework):
             assert_equal(submitpackage_result["package_msg"], "success")
 
         self.log.info("Wait for mempools to sync")
-        self.sync_mempools(timeout=20)
+        self.sync_mempools(timeout=62)
 
 
 if __name__ == '__main__':

--- a/test/functional/p2p_opportunistic_1p1c.py
+++ b/test/functional/p2p_opportunistic_1p1c.py
@@ -215,7 +215,7 @@ class PackageRelayTest(BitcoinTestFramework):
 
     @cleanup
     def test_orphan_consensus_failure(self):
-        self.log.info("Check opportunistic 1p1c logic with consensus-invalid orphan causes disconnect of the correct peer")
+        self.log.info("Check opportunistic 1p1c logic requires parent and child to be from the same peer")
         node = self.nodes[0]
         low_fee_parent = self.create_tx_below_mempoolminfee(self.wallet)
         coin = low_fee_parent["new_utxo"]
@@ -239,19 +239,14 @@ class PackageRelayTest(BitcoinTestFramework):
         parent_txid_int = int(low_fee_parent["txid"], 16)
         bad_orphan_sender.wait_for_getdata([parent_txid_int])
 
-        # 3. A different peer relays the parent. Parent+Child are evaluated as a package and rejected.
-        parent_sender.send_message(msg_tx(low_fee_parent["tx"]))
+        # 3. A different peer relays the parent. Packages is not evaluated because the transactions
+        # were not sent from the same peer.
+        parent_sender.send_and_ping(msg_tx(low_fee_parent["tx"]))
 
         # 4. Transactions should not be in mempool.
         node_mempool = node.getrawmempool()
         assert low_fee_parent["txid"] not in node_mempool
         assert tx_orphan_bad_wit.rehash() not in node_mempool
-
-        # 5. Peer that sent a consensus-invalid transaction should be disconnected.
-        bad_orphan_sender.wait_for_disconnect()
-
-        # The peer that didn't provide the orphan should not be disconnected.
-        parent_sender.sync_with_ping()
 
     @cleanup
     def test_parent_consensus_failure(self):
@@ -279,20 +274,17 @@ class PackageRelayTest(BitcoinTestFramework):
         package_sender.wait_for_getdata([parent_txid_int])
 
         # 3. A different node relays the parent. The parent is first evaluated by itself and
-        # rejected for being too low feerate. Then it is evaluated as a package and, after passing
-        # feerate checks, rejected for having a bad signature (consensus error).
-        fake_parent_sender.send_message(msg_tx(tx_parent_bad_wit))
+        # rejected for being too low feerate. It is not evaluated as a package because the child was
+        # sent from a different peer, so we don't find out that the child is consensus-invalid.
+        fake_parent_sender.send_and_ping(msg_tx(tx_parent_bad_wit))
 
         # 4. Transactions should not be in mempool.
         node_mempool = node.getrawmempool()
         assert tx_parent_bad_wit.rehash() not in node_mempool
         assert high_fee_child["txid"] not in node_mempool
 
-        # 5. Peer sent a consensus-invalid transaction.
-        fake_parent_sender.wait_for_disconnect()
-
         self.log.info("Check that fake parent does not cause orphan to be deleted and real package can still be submitted")
-        # 6. Child-sending should not have been punished and the orphan should remain in orphanage.
+        # 5. Child-sending should not have been punished and the orphan should remain in orphanage.
         # It can send the "real" parent transaction, and the package is accepted.
         parent_wtxid_int = int(low_fee_parent["tx"].getwtxid(), 16)
         package_sender.send_and_ping(msg_inv([CInv(t=MSG_WTX, h=parent_wtxid_int)]))

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -2052,6 +2052,9 @@ class SegWitTest(BitcoinTestFramework):
             self.wtx_node.last_message.pop("getdata", None)
         test_transaction_acceptance(self.nodes[0], self.wtx_node, tx2, with_witness=True, accepted=False)
 
+        # Disconnect tx_node to avoid the possibility of it being selected for orphan resolution.
+        self.tx_node.peer_disconnect()
+
         # Expect a request for parent (tx) by txid despite use of WTX peer
         self.wtx_node.wait_for_getdata([tx.sha256], timeout=60)
         with p2p_lock:

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -108,6 +108,8 @@ TXID_RELAY_DELAY = 2
 OVERLOADED_PEER_TX_DELAY = 2
 # How long to wait before downloading a transaction from an additional peer
 GETDATA_TX_INTERVAL = 60
+# How long to wait before requesting orphan ancpkginfo/parents from an additional peer
+ORPHAN_ANCESTOR_GETDATA_INTERVAL = 60
 
 MESSAGEMAP = {
     b"addr": msg_addr,


### PR DESCRIPTION
See #27463 for full project tracking.
Please see #27742 for how this PR fits into the big picture. This PR is based on a more recent commit than that one.

This branch includes:
(1) (now merged, see #30110) Introduces `TxDownloadManager`, which handles all transaction downloading. Adds tests for `TxDownloadManager`.
(2) (now merged, see #31397) Adds an "orphan resolution module". It adds all announcers of an orphan as potential resolution candidates, in a tracker implemented as a `TxRequestTracker`. In this PR, "orphan resolution" means requesting missing parents by `getdata(MSG_TX | MSG_WITNESS_FLAG, missing_txid)`. In a future PR, we'll add another resolution method, requesting ancestor wtxids using `getdata(MSG_ANCPKGINFO, orphan_wtxid)`.
(3) Makes `TxDownloadManager` internally thread-safe