### PR TITLE
ci: Print full lscpu output

### DIFF
--- a/ci/test/06_script_b.sh
+++ b/ci/test/06_script_b.sh
@@ -14,7 +14,7 @@ if [ "$CI_OS_NAME" == "macos" ]; then
 else
   free -m -h
   echo "Number of CPUs (nproc): $(nproc)"
-  lscpu | grep Endian
+  lscpu
 fi
 echo "Free disk space:"
 df -h


### PR DESCRIPTION
Seems odd to withhold the other output, given that it may be useful to debug issues?