### PR TITLE
test: Restore unlimited timeout in IndexWaitSynced

### DIFF
--- a/src/test/util/index.cpp
+++ b/src/test/util/index.cpp
@@ -5,14 +5,11 @@
 #include <test/util/index.h>
 
 #include <index/base.h>
-#include <util/check.h>
 #include <util/time.h>
 
-void IndexWaitSynced(BaseIndex& index)
+void IndexWaitSynced(const BaseIndex& index)
 {
-    const auto timeout{SteadyClock::now() + 120s};
     while (!index.BlockUntilSyncedToCurrentChain()) {
-        Assert(timeout > SteadyClock::now());
         UninterruptibleSleep(100ms);
     }
 }

--- a/src/test/util/index.h
+++ b/src/test/util/index.h
@@ -8,6 +8,6 @@
 class BaseIndex;
 
 /** Block until the index is synced to the current chain */
-void IndexWaitSynced(BaseIndex& index);
+void IndexWaitSynced(const BaseIndex& index);
 
 #endif // BITCOIN_TEST_UTIL_INDEX_H


### PR DESCRIPTION
The timeout was unlimited before, so just restore that value for now: https://github.com/bitcoin/bitcoin/pull/27988#issuecomment-1619218007 .

(Strictly speaking, this is a behavior change for the blockfilterindex and txindex tests, because it only restores the coinstatsindex behavior.)