### PR TITLE
rpc: Drop migratewallet experimental warning

### DIFF
--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -744,7 +744,8 @@ static RPCHelpMan migratewallet()
         "\nThe migration process will create a backup of the wallet before migrating. This backup\n"
         "file will be named <wallet name>-<timestamp>.legacy.bak and can be found in the directory\n"
         "for this wallet. In the event of an incorrect migration, the backup can be restored using restorewallet."
-        "\nEncrypted wallets must have the passphrase provided as an argument to this call.",
+        "\nEncrypted wallets must have the passphrase provided as an argument to this call.\n"
+        "\nThis RPC may take a long time to complete. Increasing the RPC client timeout is recommended.",
         {
             {"wallet_name", RPCArg::Type::STR, RPCArg::DefaultHint{"the wallet name from the RPC endpoint"}, "The name of the wallet to migrate. If provided both here and in the RPC endpoint, the two must be identical."},
             {"passphrase", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "The wallet passphrase"},

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -739,7 +739,6 @@ RPCHelpMan simulaterawtransaction()
 static RPCHelpMan migratewallet()
 {
     return RPCHelpMan{"migratewallet",
-        "EXPERIMENTAL warning: This call may not work as expected and may be changed in future releases\n"
         "\nMigrate the wallet to a descriptor wallet.\n"
         "A new wallet backup will need to be made.\n"
         "\nThe migration process will create a backup of the wallet before migrating. This backup\n"


### PR DESCRIPTION
The migration process itself hasn't fundamentally changed since it was added, so I think it's reasonable to say that it is no longer experimental.