### PR TITLE
wallet: sqlite: don't include sqlite files from our headers

### DIFF
--- a/src/wallet/sqlite.h
+++ b/src/wallet/sqlite.h
@@ -8,9 +8,10 @@
 #include <sync.h>
 #include <wallet/db.h>
 
-#include <sqlite3.h>
-
 struct bilingual_str;
+
+struct sqlite3_stmt;
+struct sqlite3;
 
 namespace wallet {
 class SQLiteDatabase;


### PR DESCRIPTION
Only `#include` upstream sqlite headers from our cpp files.

Like #28039 but simpler :)