### PR TITLE
fuzz: Test headers pre-sync through p2p interface

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -302,6 +302,7 @@ test_fuzz_fuzz_SOURCES = \
  test/fuzz/netaddress.cpp \
  test/fuzz/netbase_dns_lookup.cpp \
  test/fuzz/node_eviction.cpp \
+ test/fuzz/p2p_headers_sync.cpp \
  test/fuzz/p2p_transport_serialization.cpp \
  test/fuzz/package_eval.cpp \
  test/fuzz/parse_hd_keypath.cpp \

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -110,9 +110,6 @@ static const int MAX_BLOCKS_IN_TRANSIT_PER_PEER = 16;
 static constexpr auto BLOCK_STALLING_TIMEOUT_DEFAULT{2s};
 /** Maximum timeout for stalling block download. */
 static constexpr auto BLOCK_STALLING_TIMEOUT_MAX{64s};
-/** Number of headers sent in one getheaders result. We rely on the assumption that if a peer sends
- *  less than this number, we reached its tip. Changing this value is a protocol upgrade. */
-static const unsigned int MAX_HEADERS_RESULTS = 2000;
 /** Maximum depth of blocks we're willing to serve as compact blocks to peers
  *  when requested. For older blocks, a regular BLOCK response will be sent. */
 static const int MAX_CMPCTBLOCK_DEPTH = 5;
@@ -2568,7 +2565,7 @@ bool PeerManagerImpl::CheckHeadersAreContinuous(const std::vector<CBlockHeader>&
 bool PeerManagerImpl::IsContinuationOfLowWorkHeadersSync(Peer& peer, CNode& pfrom, std::vector<CBlockHeader>& headers)
 {
     if (peer.m_headers_sync) {
-        auto result = peer.m_headers_sync->ProcessNextHeaders(headers, headers.size() == MAX_HEADERS_RESULTS);
+        auto result = peer.m_headers_sync->ProcessNextHeaders(headers, headers.size() == m_opts.max_headers_result);
         if (result.request_more) {
             auto locator = peer.m_headers_sync->NextHeadersRequestLocator();
             // If we were instructed to ask for a locator, it should not be empty.
@@ -2666,7 +2663,7 @@ bool PeerManagerImpl::TryLowWorkHeadersSync(Peer& peer, CNode& pfrom, const CBlo
         // Only try to sync with this peer if their headers message was full;
         // otherwise they don't have more headers after this so no point in
         // trying to sync their too-little-work chain.
-        if (headers.size() == MAX_HEADERS_RESULTS) {
+        if (headers.size() == m_opts.max_headers_result) {
             // Note: we could advance to the last header in this set that is
             // known to us, rather than starting at the first header (which we
             // may already have); however this is unlikely to matter much since
@@ -2979,7 +2976,7 @@ void PeerManagerImpl::ProcessHeadersMessage(CNode& pfrom, Peer& peer,
     assert(pindexLast);
 
     // Consider fetching more headers if we are not using our headers-sync mechanism.
-    if (nCount == MAX_HEADERS_RESULTS && !have_headers_sync) {
+    if (nCount == m_opts.max_headers_result && !have_headers_sync) {
         // Headers message had its maximum size; the peer may have more headers.
         if (MaybeSendGetHeaders(pfrom, GetLocator(pindexLast), peer)) {
             LogPrint(BCLog::NET, "more getheaders (%d) to end to peer=%d (startheight:%d)\n",
@@ -2987,7 +2984,7 @@ void PeerManagerImpl::ProcessHeadersMessage(CNode& pfrom, Peer& peer,
         }
     }
 
-    UpdatePeerStateForReceivedHeaders(pfrom, peer, *pindexLast, received_new_header, nCount == MAX_HEADERS_RESULTS);
+    UpdatePeerStateForReceivedHeaders(pfrom, peer, *pindexLast, received_new_header, nCount == m_opts.max_headers_result);
 
     // Consider immediately downloading blocks.
     HeadersDirectFetchBlocks(pfrom, peer, *pindexLast);
@@ -4139,7 +4136,7 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
 
         // we must use CBlocks, as CBlockHeaders won't include the 0x00 nTx count at the end
         std::vector<CBlock> vHeaders;
-        int nLimit = MAX_HEADERS_RESULTS;
+        int nLimit = m_opts.max_headers_result;
         LogPrint(BCLog::NET, "getheaders %d to %s from peer=%d\n", (pindex ? pindex->nHeight : -1), hashStop.IsNull() ? "end" : hashStop.ToString(), pfrom.GetId());
         for (; pindex; pindex = m_chainman.ActiveChain().Next(pindex))
         {
@@ -4640,7 +4637,7 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
 
         // Bypass the normal CBlock deserialization, as we don't want to risk deserializing 2000 full blocks.
         unsigned int nCount = ReadCompactSize(vRecv);
-        if (nCount > MAX_HEADERS_RESULTS) {
+        if (nCount > m_opts.max_headers_result) {
             Misbehaving(*peer, 20, strprintf("headers message size = %u", nCount));
             return;
         }

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -27,6 +27,9 @@ static const bool DEFAULT_PEERBLOCKFILTERS = false;
 static const int DISCOURAGEMENT_THRESHOLD{100};
 /** Maximum number of outstanding CMPCTBLOCK requests for the same block. */
 static const unsigned int MAX_CMPCTBLOCKS_INFLIGHT_PER_BLOCK = 3;
+/** Number of headers sent in one getheaders result. We rely on the assumption that if a peer sends
+ *  less than this number, we reached its tip. Changing this value is a protocol upgrade. */
+static const unsigned int MAX_HEADERS_RESULTS = 2000;
 
 struct CNodeStateStats {
     int nSyncHeight = -1;
@@ -61,6 +64,7 @@ public:
         //! Whether or not the internal RNG behaves deterministically (this is
         //! a test-only option).
         bool deterministic_rng{false};
+        uint32_t max_headers_result{MAX_HEADERS_RESULTS};
     };
 
     static std::unique_ptr<PeerManager> make(CConnman& connman, AddrMan& addrman,

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -122,8 +122,14 @@ bool PermittedDifficultyTransition(const Consensus::Params& params, int64_t heig
     return true;
 }
 
+std::function<bool(uint256, unsigned int, const Consensus::Params&)> g_check_pow_mock = nullptr;
+
 bool CheckProofOfWork(uint256 hash, unsigned int nBits, const Consensus::Params& params)
 {
+    if (g_check_pow_mock) {
+        return g_check_pow_mock(hash, nBits, params);
+    }
+
     bool fNegative;
     bool fOverflow;
     arith_uint256 bnTarget;

--- a/src/pow.h
+++ b/src/pow.h
@@ -8,6 +8,7 @@
 
 #include <consensus/params.h>
 
+#include <functional>
 #include <stdint.h>
 
 class CBlockHeader;
@@ -18,6 +19,7 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
 unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nFirstBlockTime, const Consensus::Params&);
 
 /** Check whether a block hash satisfies the proof-of-work requirement specified by nBits */
+extern std::function<bool(uint256, unsigned int, const Consensus::Params&)> g_check_pow_mock;
 bool CheckProofOfWork(uint256 hash, unsigned int nBits, const Consensus::Params&);
 
 /**

--- a/src/test/fuzz/p2p_headers_sync.cpp
+++ b/src/test/fuzz/p2p_headers_sync.cpp
@@ -1,0 +1,196 @@
+#include <blockencodings.h>
+#include <net.h>
+#include <net_processing.h>
+#include <netmessagemaker.h>
+#include <node/peerman_args.h>
+#include <pow.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+#include <test/util/net.h>
+#include <test/util/script.h>
+#include <test/util/setup_common.h>
+#include <validation.h>
+
+namespace {
+constexpr uint32_t FUZZ_MAX_HEADERS_RESULTS{16};
+
+class HeadersSyncSetup : public TestingSetup
+{
+    std::vector<CNode*> m_connections;
+
+public:
+    HeadersSyncSetup(const ChainType chain_type = ChainType::MAIN,
+                     const std::vector<const char*>& extra_args = {})
+        : TestingSetup(chain_type, extra_args)
+    {
+        PeerManager::Options peerman_opts;
+        node::ApplyArgsManOptions(*m_node.args, peerman_opts);
+        peerman_opts.max_headers_result = FUZZ_MAX_HEADERS_RESULTS;
+        m_node.peerman = PeerManager::make(*m_node.connman, *m_node.addrman,
+                                           m_node.banman.get(), *m_node.chainman,
+                                           *m_node.mempool, peerman_opts);
+
+        CConnman::Options options;
+        options.m_msgproc = m_node.peerman.get();
+        m_node.connman->Init(options);
+    }
+
+    void ResetAndInitialize() EXCLUSIVE_LOCKS_REQUIRED(NetEventsInterface::g_msgproc_mutex);
+    void SendMessage(FuzzedDataProvider& fuzzed_data_provider, CSerializedNetMsg&& msg)
+        EXCLUSIVE_LOCKS_REQUIRED(NetEventsInterface::g_msgproc_mutex);
+};
+
+void HeadersSyncSetup::ResetAndInitialize()
+{
+    m_connections.clear();
+    auto& connman = static_cast<ConnmanTestMsg&>(*m_node.connman);
+    connman.StopNodes();
+
+    NodeId id{0};
+    std::vector<ConnectionType> conn_types = {};
+    conn_types.resize(1, ConnectionType::OUTBOUND_FULL_RELAY);
+    conn_types.resize(conn_types.size() + 1, ConnectionType::BLOCK_RELAY);
+    conn_types.resize(conn_types.size() + 1, ConnectionType::INBOUND);
+
+    for (auto conn_type : conn_types) {
+        CAddress addr{};
+        m_connections.push_back(new CNode(id++, nullptr, addr, 0, 0, addr, "", conn_type, false));
+        CNode& p2p_node = *m_connections.back();
+
+        connman.Handshake(
+            /*node=*/p2p_node,
+            /*successfully_connected=*/true,
+            /*remote_services=*/ServiceFlags(NODE_NETWORK | NODE_WITNESS),
+            /*local_services=*/ServiceFlags(NODE_NETWORK | NODE_WITNESS),
+            /*version=*/PROTOCOL_VERSION,
+            /*relay_txs=*/true);
+
+        connman.AddTestNode(p2p_node);
+    }
+}
+
+void HeadersSyncSetup::SendMessage(FuzzedDataProvider& fuzzed_data_provider, CSerializedNetMsg&& msg)
+{
+    auto& connman = static_cast<ConnmanTestMsg&>(*m_node.connman);
+    CNode& connection = *PickValue(fuzzed_data_provider, m_connections);
+
+    connman.FlushSendBuffer(connection);
+    (void)connman.ReceiveMsgFrom(connection, std::move(msg));
+    connection.fPauseSend = false;
+    try {
+        connman.ProcessMessagesOnce(connection);
+    } catch (const std::ios_base::failure&) {
+    }
+    m_node.peerman->SendMessages(&connection);
+}
+
+CBlockHeader ConsumeHeader(FuzzedDataProvider& fuzzed_data_provider, const uint256& prev_hash, uint32_t prev_nbits)
+{
+    CBlockHeader header;
+    header.nNonce = 0;
+    // Either use the previous difficulty or let the fuzzer choose
+    header.nBits = fuzzed_data_provider.ConsumeBool() ?
+                       prev_nbits :
+                       fuzzed_data_provider.ConsumeIntegralInRange<uint32_t>(0x17058EBE, 0x1D00FFFF);
+    header.nTime = fuzzed_data_provider.ConsumeIntegral<uint32_t>();
+    header.hashPrevBlock = prev_hash;
+    return header;
+}
+
+CBlock ConsumeBlock(FuzzedDataProvider& fuzzed_data_provider, const uint256& prev_hash, uint32_t prev_nbits)
+{
+    auto header = ConsumeHeader(fuzzed_data_provider, prev_hash, prev_nbits);
+    // Doesn't need to be a valid block but it needs to have one transaction
+    // for compact block construction.
+    CBlock block{header};
+    block.vtx.push_back(MakeTransactionRef(CMutableTransaction{}));
+    return block;
+}
+
+void FinalizeHeader(CBlockHeader& header)
+{
+    while (!CheckProofOfWork(header.GetHash(), header.nBits, Params().GetConsensus())) {
+        ++(header.nNonce);
+    }
+}
+
+// Global setup works for this test as state modification (specifically in the
+// block index) would indicate a bug.
+HeadersSyncSetup* g_testing_setup;
+
+void initialize()
+{
+    // Reduce proof-of-work check to one bit.
+    g_check_pow_mock = [](uint256 hash, unsigned int, const Consensus::Params&) {
+        return (hash.data()[31] & 0x80) == 0;
+    };
+
+    static auto setup = MakeNoLogFileContext<HeadersSyncSetup>(ChainType::MAIN, {"-checkpoints=0"});
+    g_testing_setup = setup.get();
+}
+} // namespace
+
+FUZZ_TARGET(p2p_headers_sync, .init = initialize)
+{
+    ChainstateManager& chainman = *g_testing_setup->m_node.chainman;
+
+    LOCK(NetEventsInterface::g_msgproc_mutex);
+
+    g_testing_setup->ResetAndInitialize();
+
+    FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
+
+    CBlockHeader base{Params().GenesisBlock()};
+    SetMockTime(Params().GenesisBlock().nTime);
+
+    size_t original_index_size{WITH_LOCK(cs_main, return chainman.m_blockman.m_block_index.size())};
+
+    LIMITED_WHILE(fuzzed_data_provider.remaining_bytes(), 100)
+    {
+        auto finalized_block = [&]() {
+            auto prev = WITH_LOCK(cs_main,
+                                  return PickValue(fuzzed_data_provider, chainman.m_blockman.m_block_index))
+                            .second.GetBlockHeader();
+            CBlock block = ConsumeBlock(fuzzed_data_provider, prev.GetHash(), prev.nBits);
+            FinalizeHeader(block);
+            return block;
+        };
+
+        CallOneOf(
+            fuzzed_data_provider,
+            [&]() NO_THREAD_SAFETY_ANALYSIS {
+                // Send FUZZ_MAX_HEADERS_RESULTS headers
+                std::vector<CBlock> headers;
+                headers.resize(FUZZ_MAX_HEADERS_RESULTS);
+                for (CBlock& header : headers) {
+                    header = ConsumeHeader(fuzzed_data_provider, base.GetHash(), base.nBits);
+                    FinalizeHeader(header);
+                    base = header;
+                }
+
+                auto headers_msg = NetMsg::Make(NetMsgType::HEADERS, TX_WITH_WITNESS(headers));
+                g_testing_setup->SendMessage(fuzzed_data_provider, std::move(headers_msg));
+            },
+            [&]() NO_THREAD_SAFETY_ANALYSIS {
+                // Send a compact block
+                auto block = finalized_block();
+                CBlockHeaderAndShortTxIDs cmpct_block{block};
+
+                auto headers_msg = NetMsg::Make(NetMsgType::CMPCTBLOCK, TX_WITH_WITNESS(cmpct_block));
+                g_testing_setup->SendMessage(fuzzed_data_provider, std::move(headers_msg));
+            },
+            [&]() NO_THREAD_SAFETY_ANALYSIS {
+                // Send a block
+                auto block = finalized_block();
+
+                auto headers_msg = NetMsg::Make(NetMsgType::BLOCK, TX_WITH_WITNESS(block));
+                g_testing_setup->SendMessage(fuzzed_data_provider, std::move(headers_msg));
+            });
+    }
+
+    // If the block index grew in size, then we found a bug in the headers pre-sync logic.
+    assert(WITH_LOCK(cs_main, return chainman.m_blockman.m_block_index.size()) == original_index_size);
+
+    SyncWithValidationInterfaceQueue();
+}


### PR DESCRIPTION
This PR adds a regression fuzz test for #26355 and [some of the bugs](https://github.com/bitcoin/bitcoin/pull/25717/commits/ed6cddd98e32263fc116a4380af6d66da20da990) found during review of #25717.

Should give us more confidence in doing #25725.