### PR TITLE
test: indexes, fix on error infinite loop

### DIFF
--- a/src/test/util/index.cpp
+++ b/src/test/util/index.cpp
@@ -5,11 +5,18 @@
 #include <test/util/index.h>
 
 #include <index/base.h>
+#include <shutdown.h>
+#include <util/check.h>
 #include <util/time.h>
 
 void IndexWaitSynced(const BaseIndex& index)
 {
     while (!index.BlockUntilSyncedToCurrentChain()) {
+        // Assert shutdown was not requested to abort the test, instead of looping forever, in case
+        // there was an unexpected error in the index that caused it to stop syncing and request a shutdown.
+        Assert(!ShutdownRequested());
+
         UninterruptibleSleep(100ms);
     }
+    assert(index.GetSummary().synced);
 }


### PR DESCRIPTION
Coming from https://github.com/bitcoin/bitcoin/pull/28036#issuecomment-1623813703, I thought that we were going to fix it there but seems that got merged without it for some reason.

As index sync failures trigger a shutdown request without notifying `BaseIndex::BlockUntilSyncedToCurrentChain` in any way, we also need to check whether a shutdown was requested or not inside 'IndexWaitSynced'.

Otherwise, any error inside the index sync process will hang the test forever.