### PR TITLE
rfc: Nuke getblocks message

### DIFF
--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -20,7 +20,6 @@ const char *SENDADDRV2="sendaddrv2";
 const char *INV="inv";
 const char *GETDATA="getdata";
 const char *MERKLEBLOCK="merkleblock";
-const char *GETBLOCKS="getblocks";
 const char *GETHEADERS="getheaders";
 const char *TX="tx";
 const char *HEADERS="headers";
@@ -61,7 +60,6 @@ const static std::string allNetMessageTypes[] = {
     NetMsgType::INV,
     NetMsgType::GETDATA,
     NetMsgType::MERKLEBLOCK,
-    NetMsgType::GETBLOCKS,
     NetMsgType::GETHEADERS,
     NetMsgType::TX,
     NetMsgType::HEADERS,

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -102,11 +102,6 @@ extern const char* GETDATA;
  */
 extern const char* MERKLEBLOCK;
 /**
- * The getblocks message requests an inv message that provides block header
- * hashes starting from a particular point in the block chain.
- */
-extern const char* GETBLOCKS;
-/**
  * The getheaders message requests a headers message that provides block
  * headers starting from a particular point in the block chain.
  * @since protocol version 31800.


### PR DESCRIPTION
Is this message still needed, given that we have had headers first sync for a **very** long time (https://github.com/bitcoin/bitcoin/pull/4468)?