### PR TITLE
test: make assumeUTXO test capture the expected fatal error

### DIFF
--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -10,6 +10,7 @@
 #include <rpc/blockchain.h>
 #include <sync.h>
 #include <test/util/chainstate.h>
+#include <test/util/logging.h>
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <timedata.h>
@@ -659,8 +660,11 @@ BOOST_FIXTURE_TEST_CASE(chainstatemanager_snapshot_completion_hash_mismatch, Sna
     fs::path snapshot_chainstate_dir = gArgs.GetDataDirNet() / "chainstate_snapshot";
     BOOST_CHECK(fs::exists(snapshot_chainstate_dir));
 
-    res = WITH_LOCK(::cs_main, return chainman.MaybeCompleteSnapshotValidation());
-    BOOST_CHECK_EQUAL(res, SnapshotCompletionResult::HASH_MISMATCH);
+    {
+        ASSERT_DEBUG_LOG("failed to validate the -assumeutxo snapshot state");
+        res = WITH_LOCK(::cs_main, return chainman.MaybeCompleteSnapshotValidation());
+        BOOST_CHECK_EQUAL(res, SnapshotCompletionResult::HASH_MISMATCH);
+    }
 
     auto all_chainstates = chainman.GetAll();
     BOOST_CHECK_EQUAL(all_chainstates.size(), 1);


### PR DESCRIPTION
The test is exercising the error, so it can capture it before the
test framework displays it on the console as an unforeseen
fatal error.

It is odd to observe a fatal error after executing the complete
test suite and seeing it pass successfully.

Reproduction Steps:
Run the unit test suite. A long AssumeUTXO fatal error will be
printed even when all tests pass successfully.