### PR TITLE
refactor: Make more transaction size variables signed

### DIFF
--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -442,7 +442,7 @@ private:
      *
      * @return all in-mempool ancestors, or an error if any ancestor or descendant limits were hit
      */
-    util::Result<setEntries> CalculateAncestorsAndCheckLimits(size_t entry_size,
+    util::Result<setEntries> CalculateAncestorsAndCheckLimits(int64_t entry_size,
                                                               size_t entry_count,
                                                               CTxMemPoolEntry::Parents &staged_ancestors,
                                                               const Limits& limits


### PR DESCRIPTION
This PR is a continuation of https://github.com/bitcoin/bitcoin/pull/23962 and it:
- gets rid of two static casts,
- addresses https://github.com/bitcoin/bitcoin/pull/23962#issuecomment-1593289706,
- is useful for https://github.com/bitcoin/bitcoin/pull/25972, see the failed ARM and multiprocess CI jobs.
