### PR TITLE
fuzz: Flatten all FUZZ_TARGET macros into one

### DIFF
--- a/src/test/fuzz/addrman.cpp
+++ b/src/test/fuzz/addrman.cpp
@@ -46,7 +46,7 @@ void initialize_addrman()
     return NetGroupManager(asmap);
 }
 
-FUZZ_TARGET_INIT(data_stream_addr_man, initialize_addrman)
+FUZZ_TARGET(data_stream_addr_man, .init = initialize_addrman)
 {
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
     CDataStream data_stream = ConsumeDataStream(fuzzed_data_provider);
@@ -233,7 +233,7 @@ public:
     }
 };
 
-FUZZ_TARGET_INIT(addrman, initialize_addrman)
+FUZZ_TARGET(addrman, .init = initialize_addrman)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
     SetMockTime(ConsumeTime(fuzzed_data_provider));
@@ -311,7 +311,7 @@ FUZZ_TARGET_INIT(addrman, initialize_addrman)
 }
 
 // Check that serialize followed by unserialize produces the same addrman.
-FUZZ_TARGET_INIT(addrman_serdeser, initialize_addrman)
+FUZZ_TARGET(addrman_serdeser, .init = initialize_addrman)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
     SetMockTime(ConsumeTime(fuzzed_data_provider));

--- a/src/test/fuzz/banman.cpp
+++ b/src/test/fuzz/banman.cpp
@@ -40,7 +40,7 @@ static bool operator==(const CBanEntry& lhs, const CBanEntry& rhs)
            lhs.nBanUntil == rhs.nBanUntil;
 }
 
-FUZZ_TARGET_INIT(banman, initialize_banman)
+FUZZ_TARGET(banman, .init = initialize_banman)
 {
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
     SetMockTime(ConsumeTime(fuzzed_data_provider));

--- a/src/test/fuzz/bitdeque.cpp
+++ b/src/test/fuzz/bitdeque.cpp
@@ -31,7 +31,7 @@ void InitRandData()
 
 } // namespace
 
-FUZZ_TARGET_INIT(bitdeque, InitRandData)
+FUZZ_TARGET(bitdeque, .init = InitRandData)
 {
     FuzzedDataProvider provider(buffer.data(), buffer.size());
     FastRandomContext ctx(true);

--- a/src/test/fuzz/block.cpp
+++ b/src/test/fuzz/block.cpp
@@ -23,7 +23,7 @@ void initialize_block()
     SelectParams(ChainType::REGTEST);
 }
 
-FUZZ_TARGET_INIT(block, initialize_block)
+FUZZ_TARGET(block, .init = initialize_block)
 {
     CDataStream ds(buffer, SER_NETWORK, INIT_PROTO_VERSION);
     CBlock block;

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -41,7 +41,7 @@ void initialize_coins_view()
     g_setup = testing_setup.get();
 }
 
-FUZZ_TARGET_INIT(coins_view, initialize_coins_view)
+FUZZ_TARGET(coins_view, .init = initialize_coins_view)
 {
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
     CCoinsView backend_coins_view;

--- a/src/test/fuzz/connman.cpp
+++ b/src/test/fuzz/connman.cpp
@@ -28,7 +28,7 @@ void initialize_connman()
     g_setup = testing_setup.get();
 }
 
-FUZZ_TARGET_INIT(connman, initialize_connman)
+FUZZ_TARGET(connman, .init = initialize_connman)
 {
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
     SetMockTime(ConsumeTime(fuzzed_data_provider));

--- a/src/test/fuzz/descriptor_parse.cpp
+++ b/src/test/fuzz/descriptor_parse.cpp
@@ -14,7 +14,7 @@ void initialize_descriptor_parse()
     SelectParams(ChainType::MAIN);
 }
 
-FUZZ_TARGET_INIT(descriptor_parse, initialize_descriptor_parse)
+FUZZ_TARGET(descriptor_parse, .init = initialize_descriptor_parse)
 {
     const std::string descriptor(buffer.begin(), buffer.end());
     FlatSigningProvider signing_provider;

--- a/src/test/fuzz/deserialize.cpp
+++ b/src/test/fuzz/deserialize.cpp
@@ -49,7 +49,7 @@ void initialize_deserialize()
 }
 
 #define FUZZ_TARGET_DESERIALIZE(name, code)                \
-    FUZZ_TARGET_INIT(name, initialize_deserialize)         \
+    FUZZ_TARGET(name, .init = initialize_deserialize)         \
     {                                                      \
         try {                                              \
             code                                           \

--- a/src/test/fuzz/fuzz.h
+++ b/src/test/fuzz/fuzz.h
@@ -21,25 +21,28 @@
 using FuzzBufferType = Span<const uint8_t>;
 
 using TypeTestOneInput = std::function<void(FuzzBufferType)>;
-using TypeInitialize = std::function<void()>;
-using TypeHidden = bool;
+struct FuzzTargetOptions {
+    std::function<void()> init{[] {}};
+    bool hidden{false};
+};
 
-void FuzzFrameworkRegisterTarget(std::string_view name, TypeTestOneInput target, TypeInitialize init, TypeHidden hidden);
+void FuzzFrameworkRegisterTarget(std::string_view name, TypeTestOneInput target, FuzzTargetOptions opts);
 
-inline void FuzzFrameworkEmptyInitFun() {}
-
-#define FUZZ_TARGET(name) \
-    FUZZ_TARGET_INIT(name, FuzzFrameworkEmptyInitFun)
+#if defined(__clang__)
+#define FUZZ_TARGET(...) _Pragma("clang diagnostic push") _Pragma("clang diagnostic ignored \"-Wgnu-zero-variadic-macro-arguments\"") DETAIL_FUZZ(__VA_ARGS__) _Pragma("clang diagnostic pop")
+#else
+#define FUZZ_TARGET(...) DETAIL_FUZZ(__VA_ARGS__)
+#endif
 
 #define FUZZ_TARGET_INIT(name, init_fun) \
-    FUZZ_TARGET_INIT_HIDDEN(name, init_fun, false)
+    FUZZ_TARGET(name, .init = init_fun)
 
-#define FUZZ_TARGET_INIT_HIDDEN(name, init_fun, hidden)                               \
+#define DETAIL_FUZZ(name, ...)                                                        \
     void name##_fuzz_target(FuzzBufferType);                                          \
     struct name##_Before_Main {                                                       \
         name##_Before_Main()                                                          \
         {                                                                             \
-            FuzzFrameworkRegisterTarget(#name, name##_fuzz_target, init_fun, hidden); \
+            FuzzFrameworkRegisterTarget(#name, name##_fuzz_target, {__VA_ARGS__});    \
         }                                                                             \
     } const static g_##name##_before_main;                                            \
     void name##_fuzz_target(FuzzBufferType buffer)

--- a/src/test/fuzz/fuzz.h
+++ b/src/test/fuzz/fuzz.h
@@ -34,9 +34,6 @@ void FuzzFrameworkRegisterTarget(std::string_view name, TypeTestOneInput target,
 #define FUZZ_TARGET(...) DETAIL_FUZZ(__VA_ARGS__)
 #endif
 
-#define FUZZ_TARGET_INIT(name, init_fun) \
-    FUZZ_TARGET(name, .init = init_fun)
-
 #define DETAIL_FUZZ(name, ...)                                                        \
     void name##_fuzz_target(FuzzBufferType);                                          \
     struct name##_Before_Main {                                                       \

--- a/src/test/fuzz/headerssync.cpp
+++ b/src/test/fuzz/headerssync.cpp
@@ -46,7 +46,7 @@ public:
     }
 };
 
-FUZZ_TARGET_INIT(headers_sync_state, initialize_headers_sync_state_fuzz)
+FUZZ_TARGET(headers_sync_state, .init = initialize_headers_sync_state_fuzz)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
     auto mock_time{ConsumeTime(fuzzed_data_provider)};

--- a/src/test/fuzz/i2p.cpp
+++ b/src/test/fuzz/i2p.cpp
@@ -18,7 +18,7 @@ void initialize_i2p()
     static const auto testing_setup = MakeNoLogFileContext<>();
 }
 
-FUZZ_TARGET_INIT(i2p, initialize_i2p)
+FUZZ_TARGET(i2p, .init = initialize_i2p)
 {
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
 

--- a/src/test/fuzz/integer.cpp
+++ b/src/test/fuzz/integer.cpp
@@ -46,7 +46,7 @@ void initialize_integer()
     SelectParams(ChainType::REGTEST);
 }
 
-FUZZ_TARGET_INIT(integer, initialize_integer)
+FUZZ_TARGET(integer, .init = initialize_integer)
 {
     if (buffer.size() < sizeof(uint256) + sizeof(uint160)) {
         return;

--- a/src/test/fuzz/key.cpp
+++ b/src/test/fuzz/key.cpp
@@ -35,7 +35,7 @@ void initialize_key()
     SelectParams(ChainType::REGTEST);
 }
 
-FUZZ_TARGET_INIT(key, initialize_key)
+FUZZ_TARGET(key, .init = initialize_key)
 {
     const CKey key = [&] {
         CKey k;
@@ -308,7 +308,7 @@ FUZZ_TARGET_INIT(key, initialize_key)
     }
 }
 
-FUZZ_TARGET_INIT(ellswift_roundtrip, initialize_key)
+FUZZ_TARGET(ellswift_roundtrip, .init = initialize_key)
 {
     FuzzedDataProvider fdp{buffer.data(), buffer.size()};
 
@@ -327,7 +327,7 @@ FUZZ_TARGET_INIT(ellswift_roundtrip, initialize_key)
     assert(key.VerifyPubKey(decoded_pubkey));
 }
 
-FUZZ_TARGET_INIT(bip324_ecdh, initialize_key)
+FUZZ_TARGET(bip324_ecdh, .init = initialize_key)
 {
     FuzzedDataProvider fdp{buffer.data(), buffer.size()};
 

--- a/src/test/fuzz/key_io.cpp
+++ b/src/test/fuzz/key_io.cpp
@@ -18,7 +18,7 @@ void initialize_key_io()
     SelectParams(ChainType::MAIN);
 }
 
-FUZZ_TARGET_INIT(key_io, initialize_key_io)
+FUZZ_TARGET(key_io, .init = initialize_key_io)
 {
     const std::string random_string(buffer.begin(), buffer.end());
 

--- a/src/test/fuzz/load_external_block_file.cpp
+++ b/src/test/fuzz/load_external_block_file.cpp
@@ -23,7 +23,7 @@ void initialize_load_external_block_file()
     g_setup = testing_setup.get();
 }
 
-FUZZ_TARGET_INIT(load_external_block_file, initialize_load_external_block_file)
+FUZZ_TARGET(load_external_block_file, .init = initialize_load_external_block_file)
 {
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
     FuzzedFileProvider fuzzed_file_provider = ConsumeFile(fuzzed_data_provider);

--- a/src/test/fuzz/message.cpp
+++ b/src/test/fuzz/message.cpp
@@ -23,7 +23,7 @@ void initialize_message()
     SelectParams(ChainType::REGTEST);
 }
 
-FUZZ_TARGET_INIT(message, initialize_message)
+FUZZ_TARGET(message, .init = initialize_message)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
     const std::string random_message = fuzzed_data_provider.ConsumeRandomLengthString(1024);

--- a/src/test/fuzz/mini_miner.cpp
+++ b/src/test/fuzz/mini_miner.cpp
@@ -30,7 +30,7 @@ void initialize_miner()
 }
 
 // Test that the MiniMiner can run with various outpoints and feerates.
-FUZZ_TARGET_INIT(mini_miner, initialize_miner)
+FUZZ_TARGET(mini_miner, .init = initialize_miner)
 {
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
     CTxMemPool pool{CTxMemPool::Options{}};
@@ -106,7 +106,7 @@ FUZZ_TARGET_INIT(mini_miner, initialize_miner)
 }
 
 // Test that MiniMiner and BlockAssembler build the same block given the same transactions and constraints.
-FUZZ_TARGET_INIT(mini_miner_selection, initialize_miner)
+FUZZ_TARGET(mini_miner_selection, .init = initialize_miner)
 {
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
     CTxMemPool pool{CTxMemPool::Options{}};

--- a/src/test/fuzz/miniscript.cpp
+++ b/src/test/fuzz/miniscript.cpp
@@ -1058,7 +1058,7 @@ void FuzzInitSmart()
 }
 
 /** Fuzz target that runs TestNode on nodes generated using ConsumeNodeStable. */
-FUZZ_TARGET_INIT(miniscript_stable, FuzzInit)
+FUZZ_TARGET(miniscript_stable, .init = FuzzInit)
 {
     FuzzedDataProvider provider(buffer.data(), buffer.size());
     TestNode(GenNode([&](Type needed_type) {
@@ -1067,7 +1067,7 @@ FUZZ_TARGET_INIT(miniscript_stable, FuzzInit)
 }
 
 /** Fuzz target that runs TestNode on nodes generated using ConsumeNodeSmart. */
-FUZZ_TARGET_INIT(miniscript_smart, FuzzInitSmart)
+FUZZ_TARGET(miniscript_smart, .init = FuzzInitSmart)
 {
     /** The set of types we aim to construct nodes for. Together they cover all. */
     static constexpr std::array<Type, 4> BASE_TYPES{"B"_mst, "V"_mst, "K"_mst, "W"_mst};
@@ -1079,7 +1079,7 @@ FUZZ_TARGET_INIT(miniscript_smart, FuzzInitSmart)
 }
 
 /* Fuzz tests that test parsing from a string, and roundtripping via string. */
-FUZZ_TARGET_INIT(miniscript_string, FuzzInit)
+FUZZ_TARGET(miniscript_string, .init = FuzzInit)
 {
     FuzzedDataProvider provider(buffer.data(), buffer.size());
     auto str = provider.ConsumeRemainingBytesAsString();

--- a/src/test/fuzz/net.cpp
+++ b/src/test/fuzz/net.cpp
@@ -27,7 +27,7 @@ void initialize_net()
     static const auto testing_setup = MakeNoLogFileContext<>(ChainType::MAIN);
 }
 
-FUZZ_TARGET_INIT(net, initialize_net)
+FUZZ_TARGET(net, .init = initialize_net)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
     SetMockTime(ConsumeTime(fuzzed_data_provider));

--- a/src/test/fuzz/p2p_transport_serialization.cpp
+++ b/src/test/fuzz/p2p_transport_serialization.cpp
@@ -22,7 +22,7 @@ void initialize_p2p_transport_serialization()
     SelectParams(ChainType::REGTEST);
 }
 
-FUZZ_TARGET_INIT(p2p_transport_serialization, initialize_p2p_transport_serialization)
+FUZZ_TARGET(p2p_transport_serialization, .init = initialize_p2p_transport_serialization)
 {
     // Construct deserializer, with a dummy NodeId
     V1TransportDeserializer deserializer{Params(), NodeId{0}, SER_NETWORK, INIT_PROTO_VERSION};

--- a/src/test/fuzz/parse_univalue.cpp
+++ b/src/test/fuzz/parse_univalue.cpp
@@ -17,7 +17,7 @@ void initialize_parse_univalue()
     SelectParams(ChainType::REGTEST);
 }
 
-FUZZ_TARGET_INIT(parse_univalue, initialize_parse_univalue)
+FUZZ_TARGET(parse_univalue, .init = initialize_parse_univalue)
 {
     const std::string random_string(buffer.begin(), buffer.end());
     bool valid = true;

--- a/src/test/fuzz/partially_downloaded_block.cpp
+++ b/src/test/fuzz/partially_downloaded_block.cpp
@@ -40,7 +40,7 @@ PartiallyDownloadedBlock::CheckBlockFn FuzzedCheckBlock(std::optional<BlockValid
     };
 }
 
-FUZZ_TARGET_INIT(partially_downloaded_block, initialize_pdb)
+FUZZ_TARGET(partially_downloaded_block, .init = initialize_pdb)
 {
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
 

--- a/src/test/fuzz/policy_estimator.cpp
+++ b/src/test/fuzz/policy_estimator.cpp
@@ -28,7 +28,7 @@ void initialize_policy_estimator()
     g_setup = testing_setup.get();
 }
 
-FUZZ_TARGET_INIT(policy_estimator, initialize_policy_estimator)
+FUZZ_TARGET(policy_estimator, .init = initialize_policy_estimator)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
     CBlockPolicyEstimator block_policy_estimator{FeeestPath(*g_setup->m_node.args), DEFAULT_ACCEPT_STALE_FEE_ESTIMATES};

--- a/src/test/fuzz/policy_estimator_io.cpp
+++ b/src/test/fuzz/policy_estimator_io.cpp
@@ -22,7 +22,7 @@ void initialize_policy_estimator_io()
     g_setup = testing_setup.get();
 }
 
-FUZZ_TARGET_INIT(policy_estimator_io, initialize_policy_estimator_io)
+FUZZ_TARGET(policy_estimator_io, .init = initialize_policy_estimator_io)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
     FuzzedAutoFileProvider fuzzed_auto_file_provider = ConsumeAutoFile(fuzzed_data_provider);

--- a/src/test/fuzz/pow.cpp
+++ b/src/test/fuzz/pow.cpp
@@ -23,7 +23,7 @@ void initialize_pow()
     SelectParams(ChainType::MAIN);
 }
 
-FUZZ_TARGET_INIT(pow, initialize_pow)
+FUZZ_TARGET(pow, .init = initialize_pow)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
     const Consensus::Params& consensus_params = Params().GetConsensus();
@@ -87,7 +87,7 @@ FUZZ_TARGET_INIT(pow, initialize_pow)
 }
 
 
-FUZZ_TARGET_INIT(pow_transition, initialize_pow)
+FUZZ_TARGET(pow_transition, .init = initialize_pow)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
     const Consensus::Params& consensus_params{Params().GetConsensus()};

--- a/src/test/fuzz/process_message.cpp
+++ b/src/test/fuzz/process_message.cpp
@@ -58,7 +58,7 @@ void initialize_process_message()
     SyncWithValidationInterfaceQueue();
 }
 
-FUZZ_TARGET_INIT(process_message, initialize_process_message)
+FUZZ_TARGET(process_message, .init = initialize_process_message)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
 

--- a/src/test/fuzz/process_messages.cpp
+++ b/src/test/fuzz/process_messages.cpp
@@ -33,7 +33,7 @@ void initialize_process_messages()
     SyncWithValidationInterfaceQueue();
 }
 
-FUZZ_TARGET_INIT(process_messages, initialize_process_messages)
+FUZZ_TARGET(process_messages, .init = initialize_process_messages)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
 

--- a/src/test/fuzz/rbf.cpp
+++ b/src/test/fuzz/rbf.cpp
@@ -29,7 +29,7 @@ void initialize_rbf()
     g_setup = testing_setup.get();
 }
 
-FUZZ_TARGET_INIT(rbf, initialize_rbf)
+FUZZ_TARGET(rbf, .init = initialize_rbf)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
     SetMockTime(ConsumeTime(fuzzed_data_provider));

--- a/src/test/fuzz/rpc.cpp
+++ b/src/test/fuzz/rpc.cpp
@@ -348,7 +348,7 @@ void initialize_rpc()
     }
 }
 
-FUZZ_TARGET_INIT(rpc, initialize_rpc)
+FUZZ_TARGET(rpc, .init = initialize_rpc)
 {
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
     SetMockTime(ConsumeTime(fuzzed_data_provider));

--- a/src/test/fuzz/script.cpp
+++ b/src/test/fuzz/script.cpp
@@ -36,7 +36,7 @@ void initialize_script()
     SelectParams(ChainType::REGTEST);
 }
 
-FUZZ_TARGET_INIT(script, initialize_script)
+FUZZ_TARGET(script, .init = initialize_script)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
     const CScript script{ConsumeScript(fuzzed_data_provider)};

--- a/src/test/fuzz/script_assets_test_minimizer.cpp
+++ b/src/test/fuzz/script_assets_test_minimizer.cpp
@@ -186,7 +186,7 @@ void Test(const std::string& str)
 
 void test_init() {}
 
-FUZZ_TARGET_INIT_HIDDEN(script_assets_test_minimizer, test_init, /*hidden=*/true)
+FUZZ_TARGET(script_assets_test_minimizer, .init = test_init, .hidden = true)
 {
     if (buffer.size() < 2 || buffer.back() != '\n' || buffer[buffer.size() - 2] != ',') return;
     const std::string str((const char*)buffer.data(), buffer.size() - 2);

--- a/src/test/fuzz/script_format.cpp
+++ b/src/test/fuzz/script_format.cpp
@@ -18,7 +18,7 @@ void initialize_script_format()
     SelectParams(ChainType::REGTEST);
 }
 
-FUZZ_TARGET_INIT(script_format, initialize_script_format)
+FUZZ_TARGET(script_format, .init = initialize_script_format)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
     const CScript script{ConsumeScript(fuzzed_data_provider)};

--- a/src/test/fuzz/script_sigcache.cpp
+++ b/src/test/fuzz/script_sigcache.cpp
@@ -26,7 +26,7 @@ void initialize_script_sigcache()
     g_setup = testing_setup.get();
 }
 
-FUZZ_TARGET_INIT(script_sigcache, initialize_script_sigcache)
+FUZZ_TARGET(script_sigcache, .init = initialize_script_sigcache)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
 

--- a/src/test/fuzz/script_sign.cpp
+++ b/src/test/fuzz/script_sign.cpp
@@ -30,7 +30,7 @@ void initialize_script_sign()
     SelectParams(ChainType::REGTEST);
 }
 
-FUZZ_TARGET_INIT(script_sign, initialize_script_sign)
+FUZZ_TARGET(script_sign, .init = initialize_script_sign)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
     const std::vector<uint8_t> key = ConsumeRandomLengthByteVector(fuzzed_data_provider, 128);

--- a/src/test/fuzz/signet.cpp
+++ b/src/test/fuzz/signet.cpp
@@ -22,7 +22,7 @@ void initialize_signet()
     static const auto testing_setup = MakeNoLogFileContext<>(ChainType::SIGNET);
 }
 
-FUZZ_TARGET_INIT(signet, initialize_signet)
+FUZZ_TARGET(signet, .init = initialize_signet)
 {
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
     const std::optional<CBlock> block = ConsumeDeserializable<CBlock>(fuzzed_data_provider);

--- a/src/test/fuzz/socks5.cpp
+++ b/src/test/fuzz/socks5.cpp
@@ -26,7 +26,7 @@ void initialize_socks5()
     default_socks5_recv_timeout = g_socks5_recv_timeout;
 }
 
-FUZZ_TARGET_INIT(socks5, initialize_socks5)
+FUZZ_TARGET(socks5, .init = initialize_socks5)
 {
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
     ProxyCredentials proxy_credentials;

--- a/src/test/fuzz/system.cpp
+++ b/src/test/fuzz/system.cpp
@@ -27,7 +27,7 @@ std::string GetArgumentName(const std::string& name)
     return name.substr(0, idx);
 }
 
-FUZZ_TARGET_INIT(system, initialize_system)
+FUZZ_TARGET(system, .init = initialize_system)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
     ArgsManager args_manager{};

--- a/src/test/fuzz/torcontrol.cpp
+++ b/src/test/fuzz/torcontrol.cpp
@@ -39,7 +39,7 @@ void initialize_torcontrol()
     static const auto testing_setup = MakeNoLogFileContext<>();
 }
 
-FUZZ_TARGET_INIT(torcontrol, initialize_torcontrol)
+FUZZ_TARGET(torcontrol, .init = initialize_torcontrol)
 {
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
 

--- a/src/test/fuzz/transaction.cpp
+++ b/src/test/fuzz/transaction.cpp
@@ -27,7 +27,7 @@ void initialize_transaction()
     SelectParams(ChainType::REGTEST);
 }
 
-FUZZ_TARGET_INIT(transaction, initialize_transaction)
+FUZZ_TARGET(transaction, .init = initialize_transaction)
 {
     CDataStream ds(buffer, SER_NETWORK, INIT_PROTO_VERSION);
     try {

--- a/src/test/fuzz/tx_pool.cpp
+++ b/src/test/fuzz/tx_pool.cpp
@@ -131,7 +131,7 @@ CTxMemPool MakeMempool(FuzzedDataProvider& fuzzed_data_provider, const NodeConte
     return CTxMemPool{mempool_opts};
 }
 
-FUZZ_TARGET_INIT(tx_pool_standard, initialize_tx_pool)
+FUZZ_TARGET(tx_pool_standard, .init = initialize_tx_pool)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
     const auto& node = g_setup->m_node;
@@ -307,7 +307,7 @@ FUZZ_TARGET_INIT(tx_pool_standard, initialize_tx_pool)
     Finish(fuzzed_data_provider, tx_pool, chainstate);
 }
 
-FUZZ_TARGET_INIT(tx_pool, initialize_tx_pool)
+FUZZ_TARGET(tx_pool, .init = initialize_tx_pool)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
     const auto& node = g_setup->m_node;

--- a/src/test/fuzz/txorphan.cpp
+++ b/src/test/fuzz/txorphan.cpp
@@ -30,7 +30,7 @@ void initialize_orphanage()
     static const auto testing_setup = MakeNoLogFileContext();
 }
 
-FUZZ_TARGET_INIT(txorphan, initialize_orphanage)
+FUZZ_TARGET(txorphan, .init = initialize_orphanage)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
     SetMockTime(ConsumeTime(fuzzed_data_provider));

--- a/src/test/fuzz/utxo_snapshot.cpp
+++ b/src/test/fuzz/utxo_snapshot.cpp
@@ -28,7 +28,7 @@ void initialize_chain()
     g_chain = &chain;
 }
 
-FUZZ_TARGET_INIT(utxo_snapshot, initialize_chain)
+FUZZ_TARGET(utxo_snapshot, .init = initialize_chain)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
     std::unique_ptr<const TestingSetup> setup{MakeNoLogFileContext<const TestingSetup>()};

--- a/src/test/fuzz/validation_load_mempool.cpp
+++ b/src/test/fuzz/validation_load_mempool.cpp
@@ -33,7 +33,7 @@ void initialize_validation_load_mempool()
     g_setup = testing_setup.get();
 }
 
-FUZZ_TARGET_INIT(validation_load_mempool, initialize_validation_load_mempool)
+FUZZ_TARGET(validation_load_mempool, .init = initialize_validation_load_mempool)
 {
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
     SetMockTime(ConsumeTime(fuzzed_data_provider));

--- a/src/test/fuzz/versionbits.cpp
+++ b/src/test/fuzz/versionbits.cpp
@@ -111,7 +111,7 @@ void initialize()
 
 constexpr uint32_t MAX_START_TIME = 4102444800; // 2100-01-01
 
-FUZZ_TARGET_INIT(versionbits, initialize)
+FUZZ_TARGET(versionbits, .init = initialize)
 {
     const CChainParams& params = *g_params;
     const int64_t interval = params.GetConsensus().nPowTargetSpacing;

--- a/src/wallet/test/fuzz/coincontrol.cpp
+++ b/src/wallet/test/fuzz/coincontrol.cpp
@@ -20,7 +20,7 @@ void initialize_coincontrol()
     g_setup = testing_setup.get();
 }
 
-FUZZ_TARGET_INIT(coincontrol, initialize_coincontrol)
+FUZZ_TARGET(coincontrol, .init = initialize_coincontrol)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
     const auto& node = g_setup->m_node;

--- a/src/wallet/test/fuzz/fees.cpp
+++ b/src/wallet/test/fuzz/fees.cpp
@@ -25,7 +25,7 @@ void initialize_setup()
     g_wallet_ptr = std::make_unique<CWallet>(node.chain.get(), "", CreateMockableWalletDatabase());
 }
 
-FUZZ_TARGET_INIT(wallet_fees, initialize_setup)
+FUZZ_TARGET(wallet_fees, .init = initialize_setup)
 {
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
     const auto& node{g_setup->m_node};

--- a/src/wallet/test/fuzz/notifications.cpp
+++ b/src/wallet/test/fuzz/notifications.cpp
@@ -79,7 +79,7 @@ struct FuzzedWallet {
     }
 };
 
-FUZZ_TARGET_INIT(wallet_notifications, initialize_setup)
+FUZZ_TARGET(wallet_notifications, .init = initialize_setup)
 {
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
     // The total amount, to be distributed to the wallets a and b in txs


### PR DESCRIPTION
The `FUZZ_TARGET` macros have many issues:
* The developer will have to pick the right macro to pass the wanted option.
* Adding a new option requires doubling the number of existing macros in the worst case.

Fix all issues by using only a single macro.

This refactor does not change behavior.