### PR TITLE
fuzz: Generate process_message targets individually

### DIFF
--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -12,47 +12,47 @@
 static std::atomic<bool> g_initial_block_download_completed(false);
 
 namespace NetMsgType {
-const char *VERSION="version";
-const char *VERACK="verack";
-const char *ADDR="addr";
-const char *ADDRV2="addrv2";
-const char *SENDADDRV2="sendaddrv2";
-const char *INV="inv";
-const char *GETDATA="getdata";
-const char *MERKLEBLOCK="merkleblock";
-const char *GETBLOCKS="getblocks";
-const char *GETHEADERS="getheaders";
-const char *TX="tx";
-const char *HEADERS="headers";
-const char *BLOCK="block";
-const char *GETADDR="getaddr";
-const char *MEMPOOL="mempool";
-const char *PING="ping";
-const char *PONG="pong";
-const char *NOTFOUND="notfound";
-const char *FILTERLOAD="filterload";
-const char *FILTERADD="filteradd";
-const char *FILTERCLEAR="filterclear";
-const char *SENDHEADERS="sendheaders";
-const char *FEEFILTER="feefilter";
-const char *SENDCMPCT="sendcmpct";
-const char *CMPCTBLOCK="cmpctblock";
-const char *GETBLOCKTXN="getblocktxn";
-const char *BLOCKTXN="blocktxn";
-const char *GETCFILTERS="getcfilters";
-const char *CFILTER="cfilter";
-const char *GETCFHEADERS="getcfheaders";
-const char *CFHEADERS="cfheaders";
-const char *GETCFCHECKPT="getcfcheckpt";
-const char *CFCHECKPT="cfcheckpt";
-const char *WTXIDRELAY="wtxidrelay";
-const char *SENDTXRCNCL="sendtxrcncl";
+const char* VERSION = "version";
+const char* VERACK = "verack";
+const char* ADDR = "addr";
+const char* ADDRV2 = "addrv2";
+const char* SENDADDRV2 = "sendaddrv2";
+const char* INV = "inv";
+const char* GETDATA = "getdata";
+const char* MERKLEBLOCK = "merkleblock";
+const char* GETBLOCKS = "getblocks";
+const char* GETHEADERS = "getheaders";
+const char* TX = "tx";
+const char* HEADERS = "headers";
+const char* BLOCK = "block";
+const char* GETADDR = "getaddr";
+const char* MEMPOOL = "mempool";
+const char* PING = "ping";
+const char* PONG = "pong";
+const char* NOTFOUND = "notfound";
+const char* FILTERLOAD = "filterload";
+const char* FILTERADD = "filteradd";
+const char* FILTERCLEAR = "filterclear";
+const char* SENDHEADERS = "sendheaders";
+const char* FEEFILTER = "feefilter";
+const char* SENDCMPCT = "sendcmpct";
+const char* CMPCTBLOCK = "cmpctblock";
+const char* GETBLOCKTXN = "getblocktxn";
+const char* BLOCKTXN = "blocktxn";
+const char* GETCFILTERS = "getcfilters";
+const char* CFILTER = "cfilter";
+const char* GETCFHEADERS = "getcfheaders";
+const char* CFHEADERS = "cfheaders";
+const char* GETCFCHECKPT = "getcfcheckpt";
+const char* CFCHECKPT = "cfcheckpt";
+const char* WTXIDRELAY = "wtxidrelay";
+const char* SENDTXRCNCL = "sendtxrcncl";
 } // namespace NetMsgType
 
 /** All known message types. Keep this in the same order as the list of
  * messages above and in protocol.h.
  */
-const static std::string allNetMessageTypes[] = {
+const static std::vector<std::string> g_all_net_message_types{
     NetMsgType::VERSION,
     NetMsgType::VERACK,
     NetMsgType::ADDR,
@@ -89,7 +89,6 @@ const static std::string allNetMessageTypes[] = {
     NetMsgType::WTXIDRELAY,
     NetMsgType::SENDTXRCNCL,
 };
-const static std::vector<std::string> allNetMessageTypesVec(std::begin(allNetMessageTypes), std::end(allNetMessageTypes));
 
 CMessageHeader::CMessageHeader(const MessageStartChars& pchMessageStartIn, const char* pszCommand, unsigned int nMessageSizeIn)
 {
@@ -182,7 +181,7 @@ std::string CInv::ToString() const
 
 const std::vector<std::string> &getAllNetMessageTypes()
 {
-    return allNetMessageTypesVec;
+    return g_all_net_message_types;
 }
 
 /**


### PR DESCRIPTION
Now that `LIMIT_TO_MESSAGE_TYPE` is a runtime setting after commit 927b001502a74a7224f04cfe6ffddc9a59409ba1, it shouldn't hurt to also generate each message type individually. Something similar was done for the `rpc` target in commit cf4da5ec29f9e8cd6cc6577e5ecbd87174edba62.