### PR TITLE
guix: Remove librt usage from release binaries

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -919,8 +919,6 @@ if test "$ac_cv_sys_large_files" != "" &&
   CORE_CPPFLAGS="$CORE_CPPFLAGS -D_LARGE_FILES=$ac_cv_sys_large_files"
 fi
 
-AC_SEARCH_LIBS([clock_gettime],[rt])
-
 if test "$enable_gprof" = "yes"; then
     dnl -pg is incompatible with -pie. Since hardening and profiling together doesn't make sense,
     dnl we simply make them mutually exclusive here. Additionally, hardened toolchains may force

--- a/contrib/devtools/symbol-check.py
+++ b/contrib/devtools/symbol-check.py
@@ -98,7 +98,6 @@ ELF_ALLOWED_LIBRARIES = {
 'libc.so.6', # C library
 'libpthread.so.0', # threading
 'libm.so.6', # math library
-'librt.so.1', # real-time (clock)
 'libatomic.so.1',
 'ld-linux-x86-64.so.2', # 64-bit dynamic linker
 'ld-linux.so.2', # 32-bit dynamic linker

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -558,7 +558,8 @@ inspecting signatures in Mach-O binaries.")
                 "0azpb9cvnbv25zg8019rqz48h8i2257ngyjg566dlnp74ivrs9vq"))
               (patches (search-our-patches "glibc-2.27-riscv64-Use-__has_include-to-include-asm-syscalls.h.patch"
                                            "glibc-2.27-fcommon.patch"
-                                           "glibc-2.27-guix-prefix.patch"))))))
+                                           "glibc-2.27-guix-prefix.patch"
+                                           "glibc-2.27-no-librt.patch"))))))
 
 (packages->manifest
  (append

--- a/contrib/guix/patches/glibc-2.27-no-librt.patch
+++ b/contrib/guix/patches/glibc-2.27-no-librt.patch
@@ -1,0 +1,53 @@
+This patch can be dropped when we are building with glibc 2.30+.
+
+commit 6e41ef56c9baab719a02f1377b1e7ce7bff61e73
+Author: Florian Weimer <fweimer@redhat.com>
+Date:   Fri Feb 8 10:21:56 2019 +0100
+
+    rt: Turn forwards from librt to libc into compat symbols [BZ #24194]
+    
+    As the  result of commit 6e6249d0b461b952d0f544792372663feb6d792a
+    ("BZ#14743: Move clock_* symbols from librt to libc."), in glibc 2.17,
+    clock_gettime, clock_getres, clock_settime, clock_getcpuclockid,
+    clock_nanosleep were added to libc, and the file rt/clock-compat.c
+    was added with forwarders to the actual implementations in libc.
+    These forwarders were wrapped in
+
+    #if SHLIB_COMPAT (librt, GLIBC_2_2, GLIBC_2_17)
+    
+    so that they are not present for newer architectures (such as
+    powerpc64le) with a 2.17 or later ABI baseline.  But the forwarders
+    were not marked as compatibility symbols.  As a result, on older
+    architectures, historic configure checks such as
+    
+    AC_CHECK_LIB(rt, clock_gettime)
+    
+    still cause linking against librt, even though this is completely
+    unnecessary.  It also creates a needless porting hazard because
+    architectures behave differently when it comes to symbol availability.
+    
+    Reviewed-by: Carlos O'Donell <carlos@redhat.com>
+
+diff --git a/rt/clock-compat.c b/rt/clock-compat.c
+index f816973c05..11e71aa890 100644
+--- a/rt/clock-compat.c
++++ b/rt/clock-compat.c
+@@ -30,14 +30,16 @@
+ #if HAVE_IFUNC
+ # undef INIT_ARCH
+ # define INIT_ARCH()
+-# define COMPAT_REDIRECT(name, proto, arglist) libc_ifunc (name, &__##name)
++# define COMPAT_REDIRECT(name, proto, arglist) libc_ifunc (name, &__##name) \
++    compat_symbol (librt, name, name, GLIBC_2_2);
+ #else
+ # define COMPAT_REDIRECT(name, proto, arglist)				      \
+   int									      \
+   name proto								      \
+   {									      \
+     return __##name arglist;						      \
+-  }
++  }									      \
++  compat_symbol (librt, name, name, GLIBC_2_2);
+ #endif
+ 
+ COMPAT_REDIRECT (clock_getres,


### PR DESCRIPTION
Our release binaries currently have a runtime dependency on `librt`. However this is redundant, and only the case due to  a bug in glibc. The `clock_*` suit of funcs were absorbed into libc long ago, however an issue with compatibility code meant that librt would still be linked against / used redundantly:
> But the forwarders were not marked as compatibility symbols.
> As a result, on older architectures, historic configure checks such as
> AC_CHECK_LIB(rt, clock_gettime)
> still cause linking against librt, even though this is completely
> unnecessary.  It also creates a needless porting hazard because
> architectures behave differently when it comes to symbol availability.

This PR drops our configure check for librt (which is redundant, and could be PR'd standalone), and backports [the relevant patch](https://sourceware.org/git/?p=glibc.git;a=commit;h=f289e656ec8221756519a601042bc9fbe1b310fb) into our glibc, so we can drop librt from our runtime dependencies.

Guix Build:
```bash
67078bddd5dc32801b8c916c3bc12f1404da572312f0158a89b9603c1f753969  guix-build-8f6f0d81ee3a/output/aarch64-linux-gnu/SHA256SUMS.part
794dd00009860fd67d7e51463ee1c5ea9677dfff1c739dd0b91cf73136deb655  guix-build-8f6f0d81ee3a/output/aarch64-linux-gnu/bitcoin-8f6f0d81ee3a-aarch64-linux-gnu-debug.tar.gz
eb9cf3f472ffbc37446fe4d80fe81dc62cf1c28c4d57dd8a7b7176e65487aeeb  guix-build-8f6f0d81ee3a/output/aarch64-linux-gnu/bitcoin-8f6f0d81ee3a-aarch64-linux-gnu.tar.gz
e775a9e9b23be44b5c7e7121e88124746836d5bdeda1cd9ba693080d9f3a52a8  guix-build-8f6f0d81ee3a/output/arm-linux-gnueabihf/SHA256SUMS.part
8289f0770333d800e414747026c0fb105d95f389f6c8d901c1041cc65272fb02  guix-build-8f6f0d81ee3a/output/arm-linux-gnueabihf/bitcoin-8f6f0d81ee3a-arm-linux-gnueabihf-debug.tar.gz
e40256c5fb1b9a137845a50fc051f92c3e4cc013b0875a71c62af32f7024af9d  guix-build-8f6f0d81ee3a/output/arm-linux-gnueabihf/bitcoin-8f6f0d81ee3a-arm-linux-gnueabihf.tar.gz
c8db222e54e78b27a8a5d3a373a9bbafa51ed29a1fda5c19e8b0eac819b002f2  guix-build-8f6f0d81ee3a/output/arm64-apple-darwin/SHA256SUMS.part
52d4063af628467605fcf533205705b38237a0cc60cafbec224ca8cf4a644738  guix-build-8f6f0d81ee3a/output/arm64-apple-darwin/bitcoin-8f6f0d81ee3a-arm64-apple-darwin-unsigned.dmg
103d80180a9f38e7c903d0b6581e4bb5130c640fac1fd5019eee7fa90e303c1d  guix-build-8f6f0d81ee3a/output/arm64-apple-darwin/bitcoin-8f6f0d81ee3a-arm64-apple-darwin-unsigned.tar.gz
a8f0a89c4d4b1d05e6ea968dde3b13368999dfc1c3ea765e81fd3c4db46197b3  guix-build-8f6f0d81ee3a/output/arm64-apple-darwin/bitcoin-8f6f0d81ee3a-arm64-apple-darwin.tar.gz
726d2671bbed2355c083b8516faa5d8e0422fab6cb38a135f68ee011f9e09af5  guix-build-8f6f0d81ee3a/output/dist-archive/bitcoin-8f6f0d81ee3a.tar.gz
955fff1c9998bb04bcf1afe9b467590960206e9c512b3446ecdd701e251bb419  guix-build-8f6f0d81ee3a/output/powerpc64-linux-gnu/SHA256SUMS.part
e95cdeda727d641c002755c4a3e3b69049a35f1bff4867ac14320585d65595c4  guix-build-8f6f0d81ee3a/output/powerpc64-linux-gnu/bitcoin-8f6f0d81ee3a-powerpc64-linux-gnu-debug.tar.gz
21bda341cd8af44bc731cf7e3637322a92032e7a956acdde25ea6e59989c67b9  guix-build-8f6f0d81ee3a/output/powerpc64-linux-gnu/bitcoin-8f6f0d81ee3a-powerpc64-linux-gnu.tar.gz
6f90c38998696f61c373c3546bcc03e6b5ecfbe3b9fec9a7c75d601b3175b698  guix-build-8f6f0d81ee3a/output/powerpc64le-linux-gnu/SHA256SUMS.part
7166c2354b8777464bf8c5c3d7e4a171d00b5e0617635fa8b12c4d47ad619e84  guix-build-8f6f0d81ee3a/output/powerpc64le-linux-gnu/bitcoin-8f6f0d81ee3a-powerpc64le-linux-gnu-debug.tar.gz
8c879a3ae9fefc1071d0b6ea3b0cf858295386860b10079b472b526abfdcd2b5  guix-build-8f6f0d81ee3a/output/powerpc64le-linux-gnu/bitcoin-8f6f0d81ee3a-powerpc64le-linux-gnu.tar.gz
7dc7153d3c180308d873cb20320e8a6221cec81d8018da85683870168380eef7  guix-build-8f6f0d81ee3a/output/riscv64-linux-gnu/SHA256SUMS.part
c37b79e33b9a318d3acee9114cdf057ee518abaa09736bd63e015d924d2c3ffb  guix-build-8f6f0d81ee3a/output/riscv64-linux-gnu/bitcoin-8f6f0d81ee3a-riscv64-linux-gnu-debug.tar.gz
d25abfb09d12e74bffd7f42e95eba211317acefa4718dbea27055d905f5b6999  guix-build-8f6f0d81ee3a/output/riscv64-linux-gnu/bitcoin-8f6f0d81ee3a-riscv64-linux-gnu.tar.gz
5ffc5c97012d8ae85cb56e635760029b774ea4f57a64e41cd4bdade4ed93e619  guix-build-8f6f0d81ee3a/output/x86_64-apple-darwin/SHA256SUMS.part
ecf96275016e82af2c1a4842578feac286de9db8b7f5e4266cf877cb29da1da8  guix-build-8f6f0d81ee3a/output/x86_64-apple-darwin/bitcoin-8f6f0d81ee3a-x86_64-apple-darwin-unsigned.dmg
50bee378ed88471dc326730564ca24cea2625ce1477b82881cda572f0a8913cc  guix-build-8f6f0d81ee3a/output/x86_64-apple-darwin/bitcoin-8f6f0d81ee3a-x86_64-apple-darwin-unsigned.tar.gz
f4215a018f18e3639c50f10909af3ceff6982abf8b292fd88fa5d690b06d704a  guix-build-8f6f0d81ee3a/output/x86_64-apple-darwin/bitcoin-8f6f0d81ee3a-x86_64-apple-darwin.tar.gz
ee5278c8afc7ead80853aff69c1bbd624ef078428076f0e92b0ad35931036b3f  guix-build-8f6f0d81ee3a/output/x86_64-linux-gnu/SHA256SUMS.part
daed3889107ffe8b3ec2c59abff93d4b92a4dff382457485d29489a0e9421965  guix-build-8f6f0d81ee3a/output/x86_64-linux-gnu/bitcoin-8f6f0d81ee3a-x86_64-linux-gnu-debug.tar.gz
f1acd6b1d296f2de5ff838fe3fb82035f2774485b06678ecdd461e631ebbe092  guix-build-8f6f0d81ee3a/output/x86_64-linux-gnu/bitcoin-8f6f0d81ee3a-x86_64-linux-gnu.tar.gz
3e9f9f92e4de995c9029f17962c33e317f7000df9c1afa2a447b65ac98c27f4b  guix-build-8f6f0d81ee3a/output/x86_64-w64-mingw32/SHA256SUMS.part
4b50a73917450770c793bfc787a6785c7389ce02bd25368db9a1445da07bb7b1  guix-build-8f6f0d81ee3a/output/x86_64-w64-mingw32/bitcoin-8f6f0d81ee3a-win64-debug.zip
832ddec19b8c5698cc3497f93fc59f0f72b0d7a3f313d46c2c1c52b5badf19fd  guix-build-8f6f0d81ee3a/output/x86_64-w64-mingw32/bitcoin-8f6f0d81ee3a-win64-setup-unsigned.exe
d9bc2dabd0cff8e9ee6ccb309bee34a6faa1298771c0cc9bff8f948d34ec047e  guix-build-8f6f0d81ee3a/output/x86_64-w64-mingw32/bitcoin-8f6f0d81ee3a-win64-unsigned.tar.gz
55cc5607d3fdf113fde463d87c5dd895c305ba0313e56bba1b0875a8a78c65a7  guix-build-8f6f0d81ee3a/output/x86_64-w64-mingw32/bitcoin-8f6f0d81ee3a-win64.zip
```