### PR TITLE
Small refactoring of iterator type declaration

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -330,7 +330,7 @@ static bool HTTPBindAddresses(struct evhttp* http)
     }
 
     // Bind addresses
-    for (std::vector<std::pair<std::string, uint16_t> >::iterator i = endpoints.begin(); i != endpoints.end(); ++i) {
+    for (auto i = endpoints.begin(); i != endpoints.end(); ++i) {
         LogPrintf("Binding RPC on address %s port %i\n", i->first, i->second);
         evhttp_bound_socket *bind_handle = evhttp_bind_socket_with_handle(http, i->first.empty() ? nullptr : i->first.c_str(), i->second);
         if (bind_handle) {
@@ -703,14 +703,14 @@ void RegisterHTTPHandler(const std::string &prefix, bool exactMatch, const HTTPR
 void UnregisterHTTPHandler(const std::string &prefix, bool exactMatch)
 {
     LOCK(g_httppathhandlers_mutex);
-    std::vector<HTTPPathHandler>::iterator i = pathHandlers.begin();
-    std::vector<HTTPPathHandler>::iterator iend = pathHandlers.end();
-    for (; i != iend; ++i)
+
+    for (auto i = pathHandlers.begin(); i != pathHandlers.end(); ++i)
         if (i->prefix == prefix && i->exactMatch == exactMatch)
             break;
-    if (i != iend)
-    {
-        LogPrint(BCLog::HTTP, "Unregistering HTTP handler for %s (exactmatch %d)\n", prefix, exactMatch);
-        pathHandlers.erase(i);
-    }
+    
+    if (i == iend)
+        return;
+    
+    LogPrint(BCLog::HTTP, "Unregistering HTTP handler for %s (exactmatch %d)\n", prefix, exactMatch);
+    pathHandlers.erase(i);
 }

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -704,7 +704,9 @@ void UnregisterHTTPHandler(const std::string &prefix, bool exactMatch)
 {
     LOCK(g_httppathhandlers_mutex);
 
-    for (auto i = pathHandlers.begin(); i != pathHandlers.end(); ++i)
+    auto i = pathHandlers.begin();
+    auto iend = pathHandlers.end();
+    for (; i != iend; ++i)
         if (i->prefix == prefix && i->exactMatch == exactMatch)
             break;
     


### PR DESCRIPTION
There are a few functions in `httpserver.cpp` (`HTTPBindAddresses` and `UnregisterHTTPHandler`) that are declaring `std::vector::iterator` explicitly, which is really verbose and visually noisy. My guess is that they were written pre-C++11 and they would be written differently today, so I modified them a little and used `auto` instead.

Also, I inverted the logic of an `if` block in `UnregisterHTTPHandler` in order to remove a nesting level.