### PR TITLE
test: Disable known broken USDT test

### DIFF
--- a/test/functional/interface_usdt_mempool.py
+++ b/test/functional/interface_usdt_mempool.py
@@ -307,7 +307,10 @@ class MempoolTracepointTest(BitcoinTestFramework):
         self.log.info("Ensuring mempool:rejected event was handled successfully...")
         assert_equal(EXPECTED_REJECTED_EVENTS, handled_rejected_events)
         assert_equal(bytes(event.hash)[::-1].hex(), tx["tx"].hash)
-        assert_equal(event.reason.decode("UTF-8"), "min relay fee not met")
+        # The next test is already known to fail, so disable it to avoid
+        # wasting CPU time and developer time. See
+        # https://github.com/bitcoin/bitcoin/issues/27380
+        #assert_equal(event.reason.decode("UTF-8"), "min relay fee not met")
 
         bpf.cleanup()
         self.generate(self.wallet, 1)


### PR DESCRIPTION
The failure is known and running into more failures doesn't help anyone. Not disabling the test would be a waste of CPU and developer time.

https://github.com/bitcoin/bitcoin/issues/27380