### PR TITLE
depends: xcb-proto 1.15.2

### DIFF
--- a/depends/packages/xcb_proto.mk
+++ b/depends/packages/xcb_proto.mk
@@ -1,8 +1,8 @@
 package=xcb_proto
-$(package)_version=1.14.1
+$(package)_version=1.15.2
 $(package)_download_path=https://xorg.freedesktop.org/archive/individual/proto
 $(package)_file_name=xcb-proto-$($(package)_version).tar.xz
-$(package)_sha256_hash=f04add9a972ac334ea11d9d7eb4fc7f8883835da3e4859c9afa971efdf57fcc3
+$(package)_sha256_hash=7072beb1f680a2fe3f9e535b797c146d22528990c72f63ddb49d2f350a3653ed
 
 define $(package)_config_cmds
   $($(package)_autoconf)


### PR DESCRIPTION
Resolves build failures with Python 3.12, i.e building on rawhide:
```bash
make -C depends -j9
...
make[3]: Nothing to be done for 'install-exec-am'.
 /usr/bin/mkdir -p '/bitcoin/depends/work/staging/aarch64-unknown-linux-gnu/xcb_proto/1.14.1-4a91ac9dc41/bitcoin/depends/aarch64-unknown-linux-gnu/lib/python3.12/site-packages/xcbgen'
 /usr/bin/install -c -m 644 __init__.py error.py expr.py align.py matcher.py state.py xtypes.py '/bitcoin/depends/work/staging/aarch64-unknown-linux-gnu/xcb_proto/1.14.1-4a91ac9dc41/bitcoin/depends/aarch64-unknown-linux-gnu/lib/python3.12/site-packages/xcbgen'
Traceback (most recent call last):
  File "<string>", line 2, in <module>
ModuleNotFoundError: No module named 'imp'
make[3]: *** [Makefile:271: install-pkgpythonPYTHON] Error 1
```

`imp` was removed in 3.12: https://docs.python.org/3/library/imp.html.

Guix Build:
```bash
6d1725c9346bdf04e1eeec2deffda90957bd081700ba896834a143756410fb0e  guix-build-7cb88c8b4672/output/aarch64-linux-gnu/SHA256SUMS.part
34486c39daea8a3ce8d92e9c1501f26e5f5e300d9612a25bd56c48ab56353329  guix-build-7cb88c8b4672/output/aarch64-linux-gnu/bitcoin-7cb88c8b4672-aarch64-linux-gnu-debug.tar.gz
cb0080d75d0fc4fc5c7fc022b5771470c60609c35836e7b66c4f479a2edcd098  guix-build-7cb88c8b4672/output/aarch64-linux-gnu/bitcoin-7cb88c8b4672-aarch64-linux-gnu.tar.gz
395c332f83206125819aabf9a5dad5c906bdcd78ec13269fdfb4215bb5cc3247  guix-build-7cb88c8b4672/output/arm-linux-gnueabihf/SHA256SUMS.part
f9e72693dd59f1b4dce6b6efa7bf325b2b589075a904c57b430dbe5c39add4ff  guix-build-7cb88c8b4672/output/arm-linux-gnueabihf/bitcoin-7cb88c8b4672-arm-linux-gnueabihf-debug.tar.gz
14cfcebcd557d30d5a07837ab38ca217346f9b97e238a96376d6467d0db39e1a  guix-build-7cb88c8b4672/output/arm-linux-gnueabihf/bitcoin-7cb88c8b4672-arm-linux-gnueabihf.tar.gz
1aaa7c04156a78628060a2ec47077589fb5dfb7a2e558fe604aaaa916b8a7f51  guix-build-7cb88c8b4672/output/arm64-apple-darwin/SHA256SUMS.part
94585898babc8fdce7660c3160fe7b26c6f6749ac53a177f91a8b4226856ab7b  guix-build-7cb88c8b4672/output/arm64-apple-darwin/bitcoin-7cb88c8b4672-arm64-apple-darwin-unsigned.dmg
9bcc693e5fad668e6c7beb8280c9c3e6988318569e0efa7d24f8cd990a3c1dd4  guix-build-7cb88c8b4672/output/arm64-apple-darwin/bitcoin-7cb88c8b4672-arm64-apple-darwin-unsigned.tar.gz
3e427a7c2530cc3bb2f87125997bafa94234c21ebb7004cc36dc8408c0b0c9ff  guix-build-7cb88c8b4672/output/arm64-apple-darwin/bitcoin-7cb88c8b4672-arm64-apple-darwin.tar.gz
988909c91077cb83b8d5ee77933192525d1fa1fd0bba0874138433314cb64927  guix-build-7cb88c8b4672/output/dist-archive/bitcoin-7cb88c8b4672.tar.gz
b13c8b1f4f75505d2356f9e702db384dbb58ee3f7f0af3b110df4b7bc4c80f52  guix-build-7cb88c8b4672/output/powerpc64-linux-gnu/SHA256SUMS.part
6f2f204401c36ee59564c8d56f9adf4f2587471ea0705e0f6a89ade4a8decf55  guix-build-7cb88c8b4672/output/powerpc64-linux-gnu/bitcoin-7cb88c8b4672-powerpc64-linux-gnu-debug.tar.gz
c1af63ec54fcbfd267a047d2dca41bdfcace1ae6a5746df11bd710217b17b205  guix-build-7cb88c8b4672/output/powerpc64-linux-gnu/bitcoin-7cb88c8b4672-powerpc64-linux-gnu.tar.gz
2407bc6d0beaa12dd7601ff14ef2c077346752a7b57fdf27df0a512f2af825bd  guix-build-7cb88c8b4672/output/powerpc64le-linux-gnu/SHA256SUMS.part
ff033b4b2a3c2816555ee3a443e4087cba47d4eb05b00e092603892ff91acc30  guix-build-7cb88c8b4672/output/powerpc64le-linux-gnu/bitcoin-7cb88c8b4672-powerpc64le-linux-gnu-debug.tar.gz
ebd9c3ab462290e2c3264dd4184a1d132b90cc93d8359ae28bc23a120b918716  guix-build-7cb88c8b4672/output/powerpc64le-linux-gnu/bitcoin-7cb88c8b4672-powerpc64le-linux-gnu.tar.gz
57afcfe859903b960ef792447d34a17d556e44c98c021f5a35bfbd963f9e7be5  guix-build-7cb88c8b4672/output/riscv64-linux-gnu/SHA256SUMS.part
105e6ef4fbac91e1bbbea3e98c80915654894d247cbfe0e4d2ff89b633ace10e  guix-build-7cb88c8b4672/output/riscv64-linux-gnu/bitcoin-7cb88c8b4672-riscv64-linux-gnu-debug.tar.gz
e893e321ddd966c29fa949c3d7866fd0dca6ea87f9185e702a17c62896acf90b  guix-build-7cb88c8b4672/output/riscv64-linux-gnu/bitcoin-7cb88c8b4672-riscv64-linux-gnu.tar.gz
80e7610cdb2ea9f1a503fa7c9ac7e29600e98fdac020951a76525494822416d9  guix-build-7cb88c8b4672/output/x86_64-apple-darwin/SHA256SUMS.part
8fe050ca40af1d2830f7efe928f8ea8e30800dfa286f5d22549255d7ed893a30  guix-build-7cb88c8b4672/output/x86_64-apple-darwin/bitcoin-7cb88c8b4672-x86_64-apple-darwin-unsigned.dmg
51a06c78edb9b29008deab11f5e98acac04de64080804d22b5a4f30c4b195ee5  guix-build-7cb88c8b4672/output/x86_64-apple-darwin/bitcoin-7cb88c8b4672-x86_64-apple-darwin-unsigned.tar.gz
5cb44b69b2315fd2bb4122fa252158a9460269f24121226d88f6146e52aafc5b  guix-build-7cb88c8b4672/output/x86_64-apple-darwin/bitcoin-7cb88c8b4672-x86_64-apple-darwin.tar.gz
d57f8ad1041a8112b012472ff00593a214f55215a29c5e5c3bc724d5eb645b1e  guix-build-7cb88c8b4672/output/x86_64-linux-gnu/SHA256SUMS.part
76f1865d49cedf4b03f9ac5c4cb968968e54f8b19e96391340d82669a9395e93  guix-build-7cb88c8b4672/output/x86_64-linux-gnu/bitcoin-7cb88c8b4672-x86_64-linux-gnu-debug.tar.gz
63cca6f0cbfd74148b20093bc2494b9abf50594cfb7055c5b5d702583d6c37a4  guix-build-7cb88c8b4672/output/x86_64-linux-gnu/bitcoin-7cb88c8b4672-x86_64-linux-gnu.tar.gz
8d2afd4156525bc4684271092b5017e12f01fcc3dad29608886d10c0ef01b09d  guix-build-7cb88c8b4672/output/x86_64-w64-mingw32/SHA256SUMS.part
6ebb038dc1f589bf92bcf3766dfcb0310f7df9ff4f75c943c2eb6fcced1a2580  guix-build-7cb88c8b4672/output/x86_64-w64-mingw32/bitcoin-7cb88c8b4672-win64-debug.zip
d73aad8495174a49dad172278fbe590b86104bca9fcec8301a548a9fc8b1118f  guix-build-7cb88c8b4672/output/x86_64-w64-mingw32/bitcoin-7cb88c8b4672-win64-setup-unsigned.exe
7697fffdb9b2c2f0c6042f56daf9940c561ed4c950692a2adbb039ecd885e047  guix-build-7cb88c8b4672/output/x86_64-w64-mingw32/bitcoin-7cb88c8b4672-win64-unsigned.tar.gz
4483876d0e5709b25bd2e238958a820f7996eaebe21c1c3f3a8c3f490a0c8562  guix-build-7cb88c8b4672/output/x86_64-w64-mingw32/bitcoin-7cb88c8b4672-win64.zip
```