### PR TITLE
ci: Set DEBUG=1 for valgrind fuzz task

### DIFF
--- a/ci/test/00_setup_env_native_fuzz_with_valgrind.sh
+++ b/ci/test/00_setup_env_native_fuzz_with_valgrind.sh
@@ -8,13 +8,12 @@ export LC_ALL=C.UTF-8
 
 export CI_IMAGE_NAME_TAG="debian:bookworm"
 export CONTAINER_NAME=ci_native_fuzz_valgrind
-export PACKAGES="clang llvm libclang-rt-dev libevent-dev libboost-dev libsqlite3-dev valgrind"
-export NO_DEPENDS=1
+export PACKAGES="clang llvm libclang-rt-dev valgrind"
+export DEP_OPTS="DEBUG=1 CC='clang -gdwarf-4' CXX='clang++ -gdwarf-4'"  # Temporarily pin dwarf 4, until using Valgrind 3.20 or later
 export RUN_UNIT_TESTS=false
 export RUN_FUNCTIONAL_TESTS=false
 export RUN_FUZZ_TESTS=true
 export FUZZ_TESTS_CONFIG="--valgrind"
 export GOAL="install"
-# Temporarily pin dwarf 4, until using Valgrind 3.20 or later
-export BITCOIN_CONFIG="--enable-fuzz --with-sanitizers=fuzzer CC='clang -gdwarf-4' CXX='clang++ -gdwarf-4'"
+export BITCOIN_CONFIG="--enable-fuzz --with-sanitizers=fuzzer CPPFLAGS='-DBOOST_MULTI_INDEX_ENABLE_SAFE_MODE'"
 export CCACHE_SIZE=200M


### PR DESCRIPTION
Currently this is only done by OSS-Fuzz. As a fallback add it to the valgrind fuzz task as well.