### PR TITLE
refactor: Remove C-style const-violating cast, Use reinterpret_cast

### DIFF
--- a/src/crypto/common.h
+++ b/src/crypto/common.h
@@ -17,73 +17,73 @@
 uint16_t static inline ReadLE16(const unsigned char* ptr)
 {
     uint16_t x;
-    memcpy((char*)&x, ptr, 2);
+    memcpy(&x, ptr, 2);
     return le16toh(x);
 }
 
 uint32_t static inline ReadLE32(const unsigned char* ptr)
 {
     uint32_t x;
-    memcpy((char*)&x, ptr, 4);
+    memcpy(&x, ptr, 4);
     return le32toh(x);
 }
 
 uint64_t static inline ReadLE64(const unsigned char* ptr)
 {
     uint64_t x;
-    memcpy((char*)&x, ptr, 8);
+    memcpy(&x, ptr, 8);
     return le64toh(x);
 }
 
 void static inline WriteLE16(unsigned char* ptr, uint16_t x)
 {
     uint16_t v = htole16(x);
-    memcpy(ptr, (char*)&v, 2);
+    memcpy(ptr, &v, 2);
 }
 
 void static inline WriteLE32(unsigned char* ptr, uint32_t x)
 {
     uint32_t v = htole32(x);
-    memcpy(ptr, (char*)&v, 4);
+    memcpy(ptr, &v, 4);
 }
 
 void static inline WriteLE64(unsigned char* ptr, uint64_t x)
 {
     uint64_t v = htole64(x);
-    memcpy(ptr, (char*)&v, 8);
+    memcpy(ptr, &v, 8);
 }
 
 uint16_t static inline ReadBE16(const unsigned char* ptr)
 {
     uint16_t x;
-    memcpy((char*)&x, ptr, 2);
+    memcpy(&x, ptr, 2);
     return be16toh(x);
 }
 
 uint32_t static inline ReadBE32(const unsigned char* ptr)
 {
     uint32_t x;
-    memcpy((char*)&x, ptr, 4);
+    memcpy(&x, ptr, 4);
     return be32toh(x);
 }
 
 uint64_t static inline ReadBE64(const unsigned char* ptr)
 {
     uint64_t x;
-    memcpy((char*)&x, ptr, 8);
+    memcpy(&x, ptr, 8);
     return be64toh(x);
 }
 
 void static inline WriteBE32(unsigned char* ptr, uint32_t x)
 {
     uint32_t v = htobe32(x);
-    memcpy(ptr, (char*)&v, 4);
+    memcpy(ptr, &v, 4);
 }
 
 void static inline WriteBE64(unsigned char* ptr, uint64_t x)
 {
     uint64_t v = htobe64(x);
-    memcpy(ptr, (char*)&v, 8);
+    memcpy(ptr, &v, 8);
 }
 
 /** Return the smallest number n such that (x >> n) == 0 (or 64 if the highest bit in x is set. */

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -54,6 +54,8 @@ struct DBParams {
     DBOptions options{};
 };
 
+inline auto CharCast(const std::byte* data) { return reinterpret_cast<const char*>(data); }
+
 class dbwrapper_error : public std::runtime_error
 {
 public:
@@ -113,12 +115,12 @@ public:
     {
         ssKey.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
         ssKey << key;
-        leveldb::Slice slKey((const char*)ssKey.data(), ssKey.size());
+        leveldb::Slice slKey(CharCast(ssKey.data()), ssKey.size());
 
         ssValue.reserve(DBWRAPPER_PREALLOC_VALUE_SIZE);
         ssValue << value;
         ssValue.Xor(dbwrapper_private::GetObfuscateKey(parent));
-        leveldb::Slice slValue((const char*)ssValue.data(), ssValue.size());
+        leveldb::Slice slValue(CharCast(ssValue.data()), ssValue.size());
 
         batch.Put(slKey, slValue);
         // LevelDB serializes writes as:
@@ -138,7 +140,7 @@ public:
     {
         ssKey.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
         ssKey << key;
-        leveldb::Slice slKey((const char*)ssKey.data(), ssKey.size());
+        leveldb::Slice slKey(CharCast(ssKey.data()), ssKey.size());
 
         batch.Delete(slKey);
         // LevelDB serializes erases as:
@@ -177,7 +179,7 @@ public:
         DataStream ssKey{};
         ssKey.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
         ssKey << key;
-        leveldb::Slice slKey((const char*)ssKey.data(), ssKey.size());
+        leveldb::Slice slKey(CharCast(ssKey.data()), ssKey.size());
         piter->Seek(slKey);
     }
 
@@ -265,7 +267,7 @@ public:
         DataStream ssKey{};
         ssKey.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
         ssKey << key;
-        leveldb::Slice slKey((const char*)ssKey.data(), ssKey.size());
+        leveldb::Slice slKey(CharCast(ssKey.data()), ssKey.size());
 
         std::string strValue;
         leveldb::Status status = pdb->Get(readoptions, slKey, &strValue);
@@ -307,7 +309,7 @@ public:
         DataStream ssKey{};
         ssKey.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
         ssKey << key;
-        leveldb::Slice slKey((const char*)ssKey.data(), ssKey.size());
+        leveldb::Slice slKey(CharCast(ssKey.data()), ssKey.size());
 
         std::string strValue;
         leveldb::Status status = pdb->Get(readoptions, slKey, &strValue);
@@ -351,8 +353,8 @@ public:
         ssKey2.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
         ssKey1 << key_begin;
         ssKey2 << key_end;
-        leveldb::Slice slKey1((const char*)ssKey1.data(), ssKey1.size());
-        leveldb::Slice slKey2((const char*)ssKey2.data(), ssKey2.size());
+        leveldb::Slice slKey1(CharCast(ssKey1.data()), ssKey1.size());
+        leveldb::Slice slKey2(CharCast(ssKey2.data()), ssKey2.size());
         uint64_t size = 0;
         leveldb::Range range(slKey1, slKey2);
         pdb->GetApproximateSizes(&range, 1, &size);

--- a/src/span.h
+++ b/src/span.h
@@ -5,10 +5,10 @@
 #ifndef BITCOIN_SPAN_H
 #define BITCOIN_SPAN_H
 
-#include <type_traits>
-#include <cstddef>
 #include <algorithm>
-#include <assert.h>
+#include <cassert>
+#include <cstddef>
+#include <type_traits>
 
 #ifdef DEBUG
 #define CONSTEXPR_IF_NOT_DEBUG
@@ -267,9 +267,9 @@ Span<std::byte> MakeWritableByteSpan(V&& v) noexcept
 }
 
 // Helper functions to safely cast to unsigned char pointers.
-inline unsigned char* UCharCast(char* c) { return (unsigned char*)c; }
+inline unsigned char* UCharCast(char* c) { return reinterpret_cast<unsigned char*>(c); }
 inline unsigned char* UCharCast(unsigned char* c) { return c; }
-inline unsigned char* UCharCast(std::byte* c) { return (unsigned char*)c; }
+inline unsigned char* UCharCast(std::byte* c) { return reinterpret_cast<unsigned char*>(c); }
 inline const unsigned char* UCharCast(const char* c) { return reinterpret_cast<const unsigned char*>(c); }
 inline const unsigned char* UCharCast(const unsigned char* c) { return c; }
 inline const unsigned char* UCharCast(const std::byte* c) { return reinterpret_cast<const unsigned char*>(c); }

--- a/src/span.h
+++ b/src/span.h
@@ -270,7 +270,7 @@ Span<std::byte> MakeWritableByteSpan(V&& v) noexcept
 inline unsigned char* UCharCast(char* c) { return (unsigned char*)c; }
 inline unsigned char* UCharCast(unsigned char* c) { return c; }
 inline unsigned char* UCharCast(std::byte* c) { return (unsigned char*)c; }
-inline const unsigned char* UCharCast(const char* c) { return (unsigned char*)c; }
+inline const unsigned char* UCharCast(const char* c) { return reinterpret_cast<const unsigned char*>(c); }
 inline const unsigned char* UCharCast(const unsigned char* c) { return c; }
 inline const unsigned char* UCharCast(const std::byte* c) { return reinterpret_cast<const unsigned char*>(c); }
 

--- a/src/wallet/crypter.cpp
+++ b/src/wallet/crypter.cpp
@@ -112,7 +112,7 @@ bool EncryptSecret(const CKeyingMaterial& vMasterKey, const CKeyingMaterial &vch
     memcpy(chIV.data(), &nIV, WALLET_CRYPTO_IV_SIZE);
     if(!cKeyCrypter.SetKey(vMasterKey, chIV))
         return false;
-    return cKeyCrypter.Encrypt(*((const CKeyingMaterial*)&vchPlaintext), vchCiphertext);
+    return cKeyCrypter.Encrypt(vchPlaintext, vchCiphertext);
 }
 
 bool DecryptSecret(const CKeyingMaterial& vMasterKey, const std::vector<unsigned char>& vchCiphertext, const uint256& nIV, CKeyingMaterial& vchPlaintext)


### PR DESCRIPTION
Using a C-style cast to convert pointer types to a byte-like pointer type has many issues:

* It may accidentally and silently throw away `const`.
* It forces reviewers to check that it doesn't accidentally throw away `const`.

For example, on current master a `const char*` is cast to `unsigned char*` (without `const`), see https://github.com/bitcoin/bitcoin/blob/d23fda05842ba4539b225bbab01b94df0060f697/src/span.h#L273 . This can lead to UB, and the only reason why it didn't lead to UB is because the return type added back the `const`. (Obviously this would break if the return type was deduced via `auto`)

Fix all issues by adding back the `const` and using `reinterpret_cast` where appropriate.