### PR TITLE
test: Add UBSan `-fsanitize=integer` suppressions for `src/secp256k1` subtree

### DIFF
--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -15,20 +15,25 @@ unsigned-integer-overflow:*/include/c++/
 unsigned-integer-overflow:FuzzedDataProvider.h
 unsigned-integer-overflow:leveldb/
 unsigned-integer-overflow:minisketch/
+unsigned-integer-overflow:secp256k1/
 unsigned-integer-overflow:test/fuzz/crypto_diff_fuzz_chacha20.cpp
 implicit-integer-sign-change:*/include/boost/
 implicit-integer-sign-change:*/include/c++/
 implicit-integer-sign-change:*/new_allocator.h
 implicit-integer-sign-change:crc32c/
 implicit-integer-sign-change:minisketch/
+implicit-integer-sign-change:secp256k1/
 implicit-signed-integer-truncation:*/include/c++/
 implicit-signed-integer-truncation:leveldb/
+implicit-signed-integer-truncation:secp256k1/
 implicit-unsigned-integer-truncation:*/include/c++/
 implicit-unsigned-integer-truncation:leveldb/
+implicit-unsigned-integer-truncation:secp256k1/
 implicit-unsigned-integer-truncation:test/fuzz/crypto_diff_fuzz_chacha20.cpp
 shift-base:*/include/c++/
 shift-base:leveldb/
 shift-base:minisketch/
+shift-base:secp256k1/
 shift-base:test/fuzz/crypto_diff_fuzz_chacha20.cpp
 # Unsigned integer overflow occurs when the result of an unsigned integer
 # computation cannot be represented in its type. Unlike signed integer overflow,


### PR DESCRIPTION
Required for https://github.com/bitcoin/bitcoin/pull/27991 (see the [comment](https://github.com/bitcoin/bitcoin/pull/27991#issuecomment-1611472816)) and for the upcoming CMake-based build system.