### PR TITLE
policy: Enable full-rbf by default

### DIFF
--- a/doc/release-notes-28132.md
+++ b/doc/release-notes-28132.md
@@ -1,0 +1,5 @@
+Full Replace-By-Fee
+===================
+
+`mempoolfullrbf=1` is now set by default, which matches the policies of the
+supermajority of hash power.

--- a/src/kernel/mempool_options.h
+++ b/src/kernel/mempool_options.h
@@ -22,7 +22,7 @@ static constexpr unsigned int DEFAULT_BLOCKSONLY_MAX_MEMPOOL_SIZE_MB{5};
 /** Default for -mempoolexpiry, expiration time for mempool transactions in hours */
 static constexpr unsigned int DEFAULT_MEMPOOL_EXPIRY_HOURS{336};
 /** Default for -mempoolfullrbf, if the transaction replaceability signaling is ignored */
-static constexpr bool DEFAULT_MEMPOOL_FULL_RBF{false};
+static constexpr bool DEFAULT_MEMPOOL_FULL_RBF{true};
 /** Whether to fall back to legacy V1 serialization when writing mempool.dat */
 static constexpr bool DEFAULT_PERSIST_V1_DAT{false};
 /** Default for -acceptnonstdtxn */

--- a/test/functional/feature_rbf.py
+++ b/test/functional/feature_rbf.py
@@ -26,8 +26,10 @@ class ReplaceByFeeTest(BitcoinTestFramework):
 
     def set_test_params(self):
         self.num_nodes = 2
+        # both nodes disable full-rbf to test BIP125 signaling
         self.extra_args = [
             [
+                "-mempoolfullrbf=0",
                 "-limitancestorcount=50",
                 "-limitancestorsize=101",
                 "-limitdescendantcount=200",
@@ -35,6 +37,7 @@ class ReplaceByFeeTest(BitcoinTestFramework):
             ],
             # second node has default mempool parameters
             [
+                "-mempoolfullrbf=0",
             ],
         ]
         self.supports_cli = False

--- a/test/functional/mempool_accept.py
+++ b/test/functional/mempool_accept.py
@@ -54,6 +54,7 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
         self.num_nodes = 1
         self.extra_args = [[
             '-txindex','-permitbaremultisig=0',
+            '-mempoolfullrbf=0',
         ]] * self.num_nodes
         self.supports_cli = False
 

--- a/test/functional/mempool_truc.py
+++ b/test/functional/mempool_truc.py
@@ -162,7 +162,7 @@ class MempoolTRUC(BitcoinTestFramework):
         self.check_mempool([tx_v3_bip125_rbf_v2["txid"], tx_v3_parent["txid"], tx_v3_child["txid"]])
 
 
-    @cleanup(extra_args=None)
+    @cleanup(extra_args=["-mempoolfullrbf=0"])
     def test_truc_bip125(self):
         node = self.nodes[0]
         self.log.info("Test TRUC transactions that don't signal BIP125 are replaceable")

--- a/test/functional/p2p_permissions.py
+++ b/test/functional/p2p_permissions.py
@@ -30,7 +30,7 @@ class P2PPermissionsTests(BitcoinTestFramework):
         self.check_tx_relay()
 
         self.checkpermission(
-            # default permissions (no specific permissions)
+            # default permissions (no specific permissions), with full-rbf disabled
             ["-whitelist=127.0.0.1"],
             # Make sure the default values in the command line documentation match the ones here
             ["relay", "noban", "mempool", "download"])
@@ -101,7 +101,7 @@ class P2PPermissionsTests(BitcoinTestFramework):
         # A test framework p2p connection is needed to send the raw transaction directly. If a full node was used, it could only
         # rebroadcast via the inv-getdata mechanism. However, even for forcerelay connections, a full node would
         # currently not request a txid that is already in the mempool.
-        self.restart_node(1, extra_args=["-whitelist=forcerelay@127.0.0.1"])
+        self.restart_node(1, extra_args=["-whitelist=forcerelay@127.0.0.1", "-mempoolfullrbf=0"])
         p2p_rebroadcast_wallet = self.nodes[1].add_p2p_connection(P2PDataStore())
 
         self.log.debug("Send a tx from the wallet initially")


### PR DESCRIPTION
The following pools are have enabled full-rbf:

- [Foundry USA, 30%](https://mempool.space/tx/ca2ed3ea924131d4051569c9c59dc62191020674ba9b89606c3a725eefbc955b)
- [Antpool, 28%](https://mempool.space/tx/53cec64b52989c531550ac4606bedf1ff83d5bfd90efdc4006f122ac6b1b7643)
- [ViaBTC, 14%](https://mempool.space/tx/4381156979261d6d46af74e0bc0553d24787bad9b3f2301fa9c9ba7c56e27bd3)
- [F2Pool, 10%](https://mempool.space/tx/e1213b60f1ac93b412a992deb0a79eebbde0032179c545350cc2136d0a3754fb)
- [Binance Pool, 4.4%](https://mempool.space/tx/64a26f750c7c58812bd475d054a9aa05248b6a8a2d53c0db38c0624197a4c68a)
- [Luxor, 2.1%](https://mempool.space/tx/5517832dfb36322b285ef4cd17e06d79c84ba58085a99fc8666482c074623e4d)
- [BTC.com, 1.9%](https://mempool.space/tx/ef68f5a79c555f4381769fb8bfcacf8868b035e42f10e458e7d5632e09ab04ff)
- [SECPOOL, 1.8%](https://mempool.space/tx/59bc0dcfc27acc249b3de131322e2a0ec95da86a59a560d4b51650ed89291534)
- [Braaiins Pool, 1.8%](https://x.com/peterktodd/status/1748845926607638555)
- [Poolin, 0.9%](https://mempool.space/tx/d14956420077974d8d28c2fcd005cd9f4aa65b2501b469f3f324f83f57d51c79)
- [Ocean](https://ocean.xyz/docs/nodepolicy), 0.2%

...and others. The above list is **90%+ of total hash power**.

Frankly, I can't think of another time in Bitcoin's history where a *supermajority* of hash power had chosen to change Bitcoin Core's default mempool policy in the same way.

Enabling full-RBF by default is well overdue. Miners have chosen to mine it on a large scale, it simplifies mempool logic, and it [makes certain types of DoS attacks on multiparty protocols significantly more expensive](https://petertodd.org/2023/fullrbf-multiparty-protocols) so there's no reason to continue to try to prevent full-RBF replacements from getting to miners.