### PR TITLE
refactor: deduplicate AmountFromValue() functions

### DIFF
--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -28,7 +28,6 @@
 #include <util/rbf.h>
 #include <util/strencodings.h>
 #include <util/string.h>
-#include <util/translation.h>
 
 #include <cstdio>
 #include <functional>
@@ -550,18 +549,6 @@ static bool findSighashFlags(int& flags, const std::string& flagStr)
     return false;
 }
 
-static CAmount AmountFromValue(const UniValue& value)
-{
-    if (!value.isNum() && !value.isStr())
-        throw std::runtime_error("Amount is not a number or string");
-    CAmount amount;
-    if (!ParseFixedPoint(value.getValStr(), 8, &amount))
-        throw std::runtime_error("Invalid amount");
-    if (!MoneyRange(amount))
-        throw std::runtime_error("Amount out of range");
-    return amount;
-}
-
 static std::vector<unsigned char> ParseHexUV(const UniValue& v, const std::string& strName)
 {
     std::string strHex;
@@ -645,7 +632,7 @@ static void MutateTxSign(CMutableTransaction& tx, const std::string& flagStr)
                 newcoin.out.scriptPubKey = scriptPubKey;
                 newcoin.out.nValue = MAX_MONEY;
                 if (prevOut.exists("amount")) {
-                    newcoin.out.nValue = AmountFromValue(prevOut["amount"]);
+                    newcoin.out.nValue = AmountFromValue(prevOut["amount"], /*decimals=*/8, /*rpc=*/false);
                 }
                 newcoin.nHeight = 1;
                 view.AddCoin(out, std::move(newcoin), true);

--- a/src/core_io.h
+++ b/src/core_io.h
@@ -50,6 +50,15 @@ bool ParseHashStr(const std::string& strHex, uint256& result);
 
 // core_write.cpp
 UniValue ValueFromAmount(const CAmount amount);
+/**
+ * Validate and return a CAmount from a UniValue number or string.
+ *
+ * @param[in] value     UniValue number or string to parse.
+ * @param[in] decimals  Number of significant digits (default: 8).
+ * @param[in] rpc       Whether caller is an RPC for error handling (default: true).
+ * @returns a CAmount if the various checks pass.
+ */
+CAmount AmountFromValue(const UniValue& value, int decimals = 8, bool rpc = true);
 std::string FormatScript(const CScript& script);
 std::string EncodeHexTx(const CTransaction& tx, const int serializeFlags = 0);
 std::string SighashToStr(unsigned char sighash_type);

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -26,7 +26,6 @@
 #include <rpc/rawtransaction_util.h>
 #include <rpc/server.h>
 #include <rpc/server_util.h>
-#include <rpc/util.h>
 #include <script/script.h>
 #include <script/sign.h>
 #include <script/signingprovider.h>

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -5,7 +5,6 @@
 #include <clientversion.h>
 #include <core_io.h>
 #include <common/args.h>
-#include <consensus/amount.h>
 #include <script/interpreter.h>
 #include <key_io.h>
 #include <outputtype.h>
@@ -60,18 +59,6 @@ void RPCTypeCheckObj(const UniValue& o,
             }
         }
     }
-}
-
-CAmount AmountFromValue(const UniValue& value, int decimals)
-{
-    if (!value.isNum() && !value.isStr())
-        throw JSONRPCError(RPC_TYPE_ERROR, "Amount is not a number or string");
-    CAmount amount;
-    if (!ParseFixedPoint(value.getValStr(), decimals, &amount))
-        throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount");
-    if (!MoneyRange(amount))
-        throw JSONRPCError(RPC_TYPE_ERROR, "Amount out of range");
-    return amount;
 }
 
 uint256 ParseHashV(const UniValue& v, std::string strName)

--- a/src/rpc/util.h
+++ b/src/rpc/util.h
@@ -6,7 +6,6 @@
 #define BITCOIN_RPC_UTIL_H
 
 #include <addresstype.h>
-#include <consensus/amount.h>
 #include <node/transaction.h>
 #include <outputtype.h>
 #include <protocol.h>
@@ -95,15 +94,6 @@ uint256 ParseHashV(const UniValue& v, std::string strName);
 uint256 ParseHashO(const UniValue& o, std::string strKey);
 std::vector<unsigned char> ParseHexV(const UniValue& v, std::string strName);
 std::vector<unsigned char> ParseHexO(const UniValue& o, std::string strKey);
-
-/**
- * Validate and return a CAmount from a UniValue number or string.
- *
- * @param[in] value     UniValue number or string to parse.
- * @param[in] decimals  Number of significant digits (default: 8).
- * @returns a CAmount if the various checks pass.
- */
-CAmount AmountFromValue(const UniValue& value, int decimals = 8);
 
 using RPCArgList = std::vector<std::pair<std::string, UniValue>>;
 std::string HelpExampleCli(const std::string& methodname, const std::string& args);

--- a/src/test/fuzz/parse_univalue.cpp
+++ b/src/test/fuzz/parse_univalue.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chainparams.h>
+#include <core_io.h>
 #include <rpc/client.h>
 #include <rpc/util.h>
 #include <test/fuzz/fuzz.h>

--- a/src/test/fuzz/rpc.cpp
+++ b/src/test/fuzz/rpc.cpp
@@ -3,7 +3,6 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <base58.h>
-#include <core_io.h>
 #include <key.h>
 #include <key_io.h>
 #include <node/context.h>
@@ -14,7 +13,6 @@
 #include <rpc/client.h>
 #include <rpc/request.h>
 #include <rpc/server.h>
-#include <rpc/util.h>
 #include <span.h>
 #include <streams.h>
 #include <test/fuzz/FuzzedDataProvider.h>

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -8,7 +8,6 @@
 #include <common/system.h>
 #include <core_io.h>
 #include <key.h>
-#include <rpc/util.h>
 #include <script/script.h>
 #include <script/script_error.h>
 #include <script/sigcache.h>

--- a/src/wallet/rpc/util.cpp
+++ b/src/wallet/rpc/util.cpp
@@ -5,7 +5,6 @@
 #include <wallet/rpc/util.h>
 
 #include <common/url.h>
-#include <rpc/util.h>
 #include <util/any.h>
 #include <util/translation.h>
 #include <wallet/context.h>


### PR DESCRIPTION
It makes sense to deduplicate this logic and merge it to a single point of truth.

Reviewers mentioned this in the thread at https://github.com/bitcoin/bitcoin/pull/19092#discussion_r436443371, where I wanted to use `AmountFromValue()` in `bitcoin-cli.cpp`, making yet another (third) copy of that same function.