### PR TITLE
refactor: move GetServicesNames from rpc/util.{h,cpp} to rpc/net.cpp

### DIFF
--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -8,6 +8,7 @@
 #include <crypto/hmac_sha256.h>
 #include <httpserver.h>
 #include <logging.h>
+#include <netaddress.h>
 #include <rpc/protocol.h>
 #include <rpc/server.h>
 #include <util/strencodings.h>

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -26,6 +26,7 @@
 #include <txmempool.h>
 #include <util/any.h>
 #include <util/check.h>
+#include <util/strencodings.h>
 #include <validation.h>
 #include <version.h>
 

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -21,6 +21,7 @@
 #include <univalue.h>
 #include <util/fs.h>
 #include <util/moneystr.h>
+#include <util/strencodings.h>
 #include <util/time.h>
 
 #include <utility>

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -15,6 +15,7 @@
 #include <netbase.h>
 #include <node/context.h>
 #include <policy/settings.h>
+#include <protocol.h>
 #include <rpc/blockchain.h>
 #include <rpc/protocol.h>
 #include <rpc/server_util.h>
@@ -89,6 +90,18 @@ static RPCHelpMan ping()
     return UniValue::VNULL;
 },
     };
+}
+
+/** Returns, given services flags, a list of humanly readable (known) network services */
+static UniValue GetServicesNames(ServiceFlags services)
+{
+    UniValue servicesNames(UniValue::VARR);
+
+    for (const auto& flag : serviceFlagsToStr(services)) {
+        servicesNames.push_back(flag);
+    }
+
+    return servicesNames;
 }
 
 static RPCHelpMan getpeerinfo()

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -1302,17 +1302,6 @@ std::vector<CScript> EvalDescriptorStringOrObject(const UniValue& scanobject, Fl
     return ret;
 }
 
-UniValue GetServicesNames(ServiceFlags services)
-{
-    UniValue servicesNames(UniValue::VARR);
-
-    for (const auto& flag : serviceFlagsToStr(services)) {
-        servicesNames.push_back(flag);
-    }
-
-    return servicesNames;
-}
-
 /** Convert a vector of bilingual strings to a UniValue::VARR containing their original untranslated values. */
 [[nodiscard]] static UniValue BilingualStringsToUniValue(const std::vector<bilingual_str>& bilingual_strings)
 {

--- a/src/rpc/util.h
+++ b/src/rpc/util.h
@@ -9,7 +9,6 @@
 #include <consensus/amount.h>
 #include <node/transaction.h>
 #include <outputtype.h>
-#include <protocol.h>
 #include <pubkey.h>
 #include <rpc/protocol.h>
 #include <rpc/request.h>
@@ -59,7 +58,6 @@ extern const std::string UNIX_EPOCH_TIME;
 extern const std::string EXAMPLE_ADDRESS[2];
 
 class FillableSigningProvider;
-class CPubKey;
 class CScript;
 struct Sections;
 

--- a/src/rpc/util.h
+++ b/src/rpc/util.h
@@ -132,9 +132,6 @@ std::pair<int64_t, int64_t> ParseDescriptorRange(const UniValue& value);
 /** Evaluate a descriptor given as a string, or as a {"desc":...,"range":...} object, with default range of 1000. */
 std::vector<CScript> EvalDescriptorStringOrObject(const UniValue& scanobject, FlatSigningProvider& provider, const bool expand_priv = false);
 
-/** Returns, given services flags, a list of humanly readable (known) network services */
-UniValue GetServicesNames(ServiceFlags services);
-
 /**
  * Serializing JSON objects depends on the outer type. Only arrays and
  * dictionaries can be nested in json. The top-level outer type is "NONE".


### PR DESCRIPTION
Move `GetServicesNames()` from `rpc/util` to `rpc/net.cpp`, as it is only called from that compilation unit and there is no reason for other ones to need it.

Remove the `protocol.h` include in `rpc/util.h`, as it was only needed for `GetServicesNames()`, drop an unneeded forward declaration (the other IWYU suggestions would require more extensive changes in other files), and add 3 already-missing include headers in other translation units that are needed to compile without `protocol.h` in `rpc/util.h`, as `protocol.h` includes `netaddress.h`, which in turn includes `util/strencodings.h`.
