### PR TITLE
wallet: Allow users to create a wallet that encrypts all database records

### DIFF
--- a/build_msvc/libbitcoin_wallet/libbitcoin_wallet.vcxproj.in
+++ b/build_msvc/libbitcoin_wallet/libbitcoin_wallet.vcxproj.in
@@ -9,6 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\wallet\bdb.cpp" />
+    <ClCompile Include="..\..\src\wallet\encrypted_db.cpp" />
     <ClCompile Include="..\..\src\wallet\salvage.cpp" />
     <ClCompile Include="..\..\src\wallet\sqlite.cpp" />
 @SOURCE_FILES@

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -344,6 +344,7 @@ BITCOIN_CORE_H = \
   wallet/crypter.h \
   wallet/db.h \
   wallet/dump.h \
+  wallet/encrypted_db.h \
   wallet/external_signer_scriptpubkeyman.h \
   wallet/feebumper.h \
   wallet/fees.h \
@@ -528,7 +529,7 @@ libbitcoin_wallet_a_SOURCES = \
   $(BITCOIN_CORE_H)
 
 if USE_SQLITE
-libbitcoin_wallet_a_SOURCES += wallet/sqlite.cpp
+libbitcoin_wallet_a_SOURCES += wallet/sqlite.cpp wallet/encrypted_db.cpp
 endif
 if USE_BDB
 libbitcoin_wallet_a_SOURCES += wallet/bdb.cpp wallet/salvage.cpp

--- a/src/wallet/crypter.cpp
+++ b/src/wallet/crypter.cpp
@@ -86,7 +86,7 @@ bool CCrypter::SetIV(const std::vector<unsigned char>& chNewIV)
 
 bool CCrypter::Encrypt(const CKeyingMaterial& vchPlaintext, std::vector<unsigned char> &vchCiphertext) const
 {
-    if (!fKeySet)
+    if (!fKeySet && !m_iv_set)
         return false;
 
     // max ciphertext len for a n bytes of plaintext is
@@ -104,7 +104,7 @@ bool CCrypter::Encrypt(const CKeyingMaterial& vchPlaintext, std::vector<unsigned
 
 bool CCrypter::Decrypt(const std::vector<unsigned char>& vchCiphertext, CKeyingMaterial& vchPlaintext) const
 {
-    if (!fKeySet)
+    if (!fKeySet && !m_iv_set)
         return false;
 
     // plaintext will always be equal to or lesser than length of ciphertext

--- a/src/wallet/crypter.cpp
+++ b/src/wallet/crypter.cpp
@@ -59,13 +59,28 @@ bool CCrypter::SetKeyFromPassphrase(const SecureString& strKeyData, const std::v
 
 bool CCrypter::SetKey(const CKeyingMaterial& chNewKey, const std::vector<unsigned char>& chNewIV)
 {
-    if (chNewKey.size() != WALLET_CRYPTO_KEY_SIZE || chNewIV.size() != WALLET_CRYPTO_IV_SIZE)
+    return SetKey(chNewKey) && SetIV(chNewIV);
+}
+
+bool CCrypter::SetKey(const CKeyingMaterial& chNewKey)
+{
+    if (chNewKey.size() != WALLET_CRYPTO_KEY_SIZE)
         return false;
 
     memcpy(vchKey.data(), chNewKey.data(), chNewKey.size());
-    memcpy(vchIV.data(), chNewIV.data(), chNewIV.size());
 
     fKeySet = true;
+    return true;
+}
+
+bool CCrypter::SetIV(const std::vector<unsigned char>& chNewIV)
+{
+    if (chNewIV.size() != WALLET_CRYPTO_IV_SIZE)
+        return false;
+
+    memcpy(vchIV.data(), chNewIV.data(), chNewIV.size());
+
+    m_iv_set = true;
     return true;
 }
 

--- a/src/wallet/crypter.h
+++ b/src/wallet/crypter.h
@@ -74,6 +74,7 @@ private:
     std::vector<unsigned char, secure_allocator<unsigned char>> vchKey;
     std::vector<unsigned char, secure_allocator<unsigned char>> vchIV;
     bool fKeySet;
+    bool m_iv_set;
 
     int BytesToKeySHA512AES(const std::vector<unsigned char>& chSalt, const SecureString& strKeyData, int count, unsigned char *key,unsigned char *iv) const;
 
@@ -82,6 +83,8 @@ public:
     bool Encrypt(const CKeyingMaterial& vchPlaintext, std::vector<unsigned char> &vchCiphertext) const;
     bool Decrypt(const std::vector<unsigned char>& vchCiphertext, CKeyingMaterial& vchPlaintext) const;
     bool SetKey(const CKeyingMaterial& chNewKey, const std::vector<unsigned char>& chNewIV);
+    bool SetKey(const CKeyingMaterial& key);
+    bool SetIV(const std::vector<unsigned char>& chNewIV);
 
     void CleanKey()
     {

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -16,6 +16,9 @@
 #include <vector>
 
 namespace wallet {
+bool operator<(BytePrefix a, Span<const std::byte> b) { return a.prefix < b.subspan(0, std::min(a.prefix.size(), b.size())); }
+bool operator<(Span<const std::byte> a, BytePrefix b) { return a.subspan(0, std::min(a.size(), b.prefix.size())) < b.prefix; }
+
 std::vector<fs::path> ListDatabases(const fs::path& wallet_dir)
 {
     std::vector<fs::path> paths;

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -196,6 +196,7 @@ public:
 enum class DatabaseFormat {
     BERKELEY,
     SQLITE,
+    ENCRYPTED_SQLITE,
 };
 
 struct DatabaseOptions {

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -20,6 +20,11 @@ class ArgsManager;
 struct bilingual_str;
 
 namespace wallet {
+// BytePrefix compares equality with other byte spans that begin with the same prefix.
+struct BytePrefix { Span<const std::byte> prefix; };
+bool operator<(BytePrefix a, Span<const std::byte> b);
+bool operator<(Span<const std::byte> a, BytePrefix b);
+
 void SplitWalletPath(const fs::path& wallet_path, fs::path& env_directory, std::string& database_filename);
 
 class DatabaseCursor
@@ -195,7 +200,8 @@ struct DatabaseOptions {
     bool require_create = false;
     std::optional<DatabaseFormat> require_format;
     uint64_t create_flags = 0;
-    SecureString create_passphrase;
+    SecureString create_passphrase; //!< The passphrase for wallet-level encryption
+    SecureString db_passphrase;     //!< The passphrase for database-level encryption
 
     // Specialized options. Not every option is supported by every backend.
     bool verify = true;             //!< Check data integrity on load.

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -77,6 +77,16 @@ public:
         }
     }
 
+    template <typename K>
+    bool Read(const K& key, DataStream& value)
+    {
+        DataStream s_key{};
+        s_key.reserve(1000);
+        s_key << key;
+
+        return ReadKey(std::move(s_key), value);
+    }
+
     template <typename K, typename T>
     bool Write(const K& key, const T& value, bool fOverwrite = true)
     {

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -11,6 +11,7 @@
 #include <support/allocators/secure.h>
 #include <util/fs.h>
 
+#include <array>
 #include <atomic>
 #include <memory>
 #include <optional>
@@ -26,6 +27,8 @@ bool operator<(BytePrefix a, Span<const std::byte> b);
 bool operator<(Span<const std::byte> a, BytePrefix b);
 
 void SplitWalletPath(const fs::path& wallet_path, fs::path& env_directory, std::string& database_filename);
+
+const std::array<const std::byte, 4> ENCRYPTED_DB_XOR{std::byte{0x36}, std::byte{0x93}, std::byte{0x2d}, std::byte{0x47}};
 
 class DatabaseCursor
 {
@@ -234,6 +237,7 @@ fs::path BDBDataFile(const fs::path& path);
 fs::path SQLiteDataFile(const fs::path& path);
 bool IsBDBFile(const fs::path& path);
 bool IsSQLiteFile(const fs::path& path);
+bool IsEncryptedSQLiteFile(const fs::path& path);
 } // namespace wallet
 
 #endif // BITCOIN_WALLET_DB_H

--- a/src/wallet/encrypted_db.cpp
+++ b/src/wallet/encrypted_db.cpp
@@ -1,0 +1,366 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+#include <random.h>
+#include <util/check.h>
+#include <util/result.h>
+#include <util/time.h>
+#include <wallet/crypter.h>
+#include <wallet/db.h>
+#include <wallet/encrypted_db.h>
+#include <wallet/sqlite.h>
+
+namespace wallet {
+EncryptedDatabase::EncryptedDatabase(std::unique_ptr<WalletDatabase> database, const SecureString& passphrase, bool create)
+    : m_database(std::move(database))
+{
+    std::unique_ptr<DatabaseBatch> batch = m_database->MakeBatch();
+
+    if (create) {
+        // Doesn't exist, set it up
+        // Generate the encryption secret
+        CKeyingMaterial enc_secret;
+        enc_secret.resize(WALLET_CRYPTO_KEY_SIZE);
+        GetStrongRandBytes(enc_secret);
+
+        // Encrypt the secret with the passphrase
+        CMasterKey enc_key;
+        enc_key.vchSalt.resize(WALLET_CRYPTO_SALT_SIZE);
+        GetStrongRandBytes(enc_key.vchSalt);
+
+        CCrypter crypter;
+        constexpr MillisecondsDouble target{100};
+        auto start{SteadyClock::now()};
+        crypter.SetKeyFromPassphrase(passphrase, enc_key.vchSalt, 25000, enc_key.nDerivationMethod);
+        enc_key.nDeriveIterations = static_cast<unsigned int>(25000 * target / (SteadyClock::now() - start));
+
+        start = SteadyClock::now();
+        crypter.SetKeyFromPassphrase(passphrase, enc_key.vchSalt, enc_key.nDeriveIterations, enc_key.nDerivationMethod);
+        enc_key.nDeriveIterations = (enc_key.nDeriveIterations + static_cast<unsigned int>(enc_key.nDeriveIterations * target / (SteadyClock::now() - start))) / 2;
+
+        if (enc_key.nDeriveIterations < 25000)
+            enc_key.nDeriveIterations = 25000;
+
+        if (!crypter.SetKeyFromPassphrase(passphrase, enc_key.vchSalt, enc_key.nDeriveIterations, enc_key.nDerivationMethod)) {
+            throw std::runtime_error("Unable to set encryption key from passphrase");
+        }
+        if (!crypter.Encrypt(enc_secret, enc_key.vchCryptedKey)) {
+            throw std::runtime_error("Unable to encrypt key with passphrase");
+        }
+
+        // Write that to disk
+        if (!batch->Write(ENCRYPTION_RECORD, enc_key)) {
+            throw std::runtime_error("Unable to write the encryption key data");
+        }
+    }
+
+    // Read the encrypted encryption key
+    CMasterKey enc_key;
+    if (!batch->Read(ENCRYPTION_RECORD, enc_key)) {
+        throw std::runtime_error("Unable to read the encryption key data");
+    }
+    batch.reset();
+
+    // Decrypt the key with passphrase
+    CCrypter crypter;
+    if (!crypter.SetKeyFromPassphrase(passphrase, enc_key.vchSalt, enc_key.nDeriveIterations, enc_key.nDerivationMethod)) {
+        throw std::runtime_error("Unable to get decryption key from passphrase");
+    }
+    CKeyingMaterial enc_secret;
+    if (!crypter.Decrypt(enc_key.vchCryptedKey, enc_secret)) {
+        throw std::runtime_error("Unable to decrypt database, are you sure the passphrase is correct?");
+    }
+    m_enc_secret = std::move(enc_secret);
+
+    // Make sure our crypter has the correct secret
+    m_crypter.SetKey(m_enc_secret);
+
+    Open();
+}
+
+util::Result<SerializeData> EncryptedDatabase::DecryptRecordData(Span<const std::byte> data)
+{
+    DataStream s_data(data);
+    std::vector<unsigned char> iv;
+    std::vector<unsigned char> ciphertext;
+    s_data >> iv;
+    s_data >> ciphertext;
+
+    CKeyingMaterial plaintext;
+    if (!m_crypter.SetIV(iv)) return util::Error{Untranslated("IV is not valid")};
+    if (!m_crypter.Decrypt(ciphertext, plaintext)) return util::Error{Untranslated("Could not decrypt data")};
+
+    SerializeData out{reinterpret_cast<std::byte*>(plaintext.data()), reinterpret_cast<std::byte*>(plaintext.data() + plaintext.size())};
+    return out;
+}
+
+util::Result<SerializeData> EncryptedDatabase::EncryptRecordData(Span<const std::byte> data)
+{
+    DataStream s_out;
+
+    HashWriter hasher;
+    hasher << data;
+    uint256 hash = hasher.GetHash();
+    std::vector<unsigned char> iv(hash.begin(), hash.begin() + WALLET_CRYPTO_IV_SIZE);
+    if (!m_crypter.SetIV(iv)) return util::Error{Untranslated("Unable to set IV")};
+    s_out << iv;
+
+    CKeyingMaterial plaintext(UCharCast(data.begin()), UCharCast(data.end()));
+    std::vector<unsigned char> enc;
+    if (!m_crypter.Encrypt(plaintext, enc)) return util::Error{Untranslated("Could not encrypt data")};
+    s_out << enc;
+    SerializeData out{s_out.begin(), s_out.end()};
+    return out;
+}
+
+void EncryptedDatabase::Open()
+{
+    // Read all records into memory and decrypt them
+    std::unique_ptr<DatabaseBatch> batch = m_database->MakeBatch();
+    if (!batch) {
+        throw std::runtime_error("Error getting database batch");
+    }
+    std::unique_ptr<DatabaseCursor> cursor = batch->GetNewCursor();
+    if (!cursor) {
+        throw std::runtime_error("Error getting database cursor");
+    }
+    DataStream key, value;
+    while (true) {
+        DatabaseCursor::Status status = cursor->Next(key, value);
+        if (status == DatabaseCursor::Status::DONE) {
+            break;
+        } else if (status == DatabaseCursor::Status::FAIL) {
+            throw std::runtime_error("Error reading next record in database");
+        }
+
+        // If this record is the encrypted key record, ignore it
+        if (key == ENCRYPTION_RECORD) {
+            continue;
+        }
+
+        // Every key-value record is serialized in the same way: both keys and values are an
+        // IV followed by the ciphertext as a vector of bytes
+        // The decrypted ciphertext is the data that the application stored.
+        util::Result<SerializeData> key_data = DecryptRecordData(key);
+        if (!key_data) {
+            throw std::runtime_error(util::ErrorString(key_data).original);
+        }
+        SerializeData enc_key_data{key.begin(), key.end()};
+        m_record_keys.emplace(*key_data, enc_key_data);
+    }
+}
+
+bool EncryptedDBBatch::ReadKey(DataStream&& key, DataStream& value)
+{
+    // Lookup the encrypted key data from our map
+    SerializeData key_data{key.begin(), key.end()};
+    const auto& it = m_database.m_record_keys.find(key_data);
+    if (it == m_database.m_record_keys.end()) {
+        return false;
+    }
+    return ReadEncryptedKey(it->second, value);
+}
+
+bool EncryptedDBBatch::ReadEncryptedKey(SerializeData enc_key, DataStream& value)
+{
+    DataStream crypt_value;
+    if (!m_batch->Read(MakeByteSpan(enc_key), crypt_value)) {
+        return false;
+    }
+    util::Result<SerializeData> value_data = m_database.DecryptRecordData(crypt_value);
+    if (!value_data) {
+        return false;
+    }
+    value.write(*value_data);
+    return true;
+}
+
+bool EncryptedDBBatch::WriteKey(DataStream&& key, DataStream&& value, bool overwrite)
+{
+    util::Result<SerializeData> enc_value = m_database.EncryptRecordData(value);
+    if (!enc_value) {
+        return false;
+    }
+
+    // Lookup the encrypted key data from our map
+    SerializeData key_data{key.begin(), key.end()};
+    SerializeData enc_key;
+    const auto& it = m_database.m_record_keys.find(key_data);
+    if (it != m_database.m_record_keys.end()) {
+        enc_key = it->second;
+    } else {
+        util::Result<SerializeData> enc_key_res = m_database.EncryptRecordData(key);
+        if (!enc_key_res) {
+            return false;
+        }
+        enc_key = *enc_key_res;
+    }
+
+    if (!m_batch->Write(MakeByteSpan(enc_key), MakeByteSpan(*enc_value), overwrite)) {
+        return false;
+    }
+    if (m_txn_started) {
+        m_txn_writes.emplace_back(key_data, enc_key);
+    } else {
+        m_database.m_record_keys.emplace(key_data, enc_key);
+    }
+    return true;
+}
+
+bool EncryptedDBBatch::EraseKey(DataStream&& key)
+{
+    // Lookup the encrypted key data from our map
+    SerializeData key_data{key.begin(), key.end()};
+    const auto& it = m_database.m_record_keys.find(key_data);
+    if (it == m_database.m_record_keys.end()) {
+        return false;
+    }
+    if (!m_batch->Erase(MakeByteSpan(it->second))) {
+        return false;
+    }
+    if (m_txn_started) {
+        m_txn_erases.emplace_back(key_data);
+    } else {
+        m_database.m_record_keys.erase(it);
+    }
+    return true;
+}
+bool EncryptedDBBatch::HasKey(DataStream&& key)
+{
+    // Lookup the encrypted key data from our map
+    SerializeData key_data{key.begin(), key.end()};
+    const auto& it = m_database.m_record_keys.find(key_data);
+    if (it == m_database.m_record_keys.end()) {
+        return false;
+    }
+    Assume(m_batch->Exists(MakeByteSpan(it->second)));
+    return true;
+}
+
+void EncryptedDBBatch::Close()
+{
+    if (m_txn_started) {
+        TxnAbort();
+    }
+    m_batch->Close();
+}
+
+bool EncryptedDBBatch::ErasePrefix(Span<const std::byte> prefix)
+{
+    auto it = m_database.m_record_keys.begin();
+    while (it != m_database.m_record_keys.end()) {
+        auto& key = it->first;
+        if (key.size() < prefix.size() || std::search(key.begin(), key.end(), prefix.begin(), prefix.end()) != key.begin()) {
+            it++;
+            continue;
+        }
+        m_batch->Erase(MakeByteSpan(it->second));
+        if (m_txn_started) {
+            m_txn_erases.emplace_back(key);
+            it++;
+        } else {
+            it = m_database.m_record_keys.erase(it);
+        }
+    }
+    return true;
+}
+
+bool EncryptedDBBatch::TxnBegin()
+{
+    if (m_txn_started) {
+        return false;
+    }
+    if (!m_batch->TxnBegin()) {
+        return false;
+    }
+    m_txn_writes.clear();
+    m_txn_erases.clear();
+    m_txn_started = true;
+    return true;
+}
+
+bool EncryptedDBBatch::TxnCommit()
+{
+    if (!m_txn_started) {
+        return false;
+    }
+    if (!m_batch->TxnCommit()) {
+        return false;
+    }
+
+    for (const auto& [key_data, enc_key] : m_txn_writes) {
+        m_database.m_record_keys.emplace(key_data, enc_key);
+    }
+    for (const auto& key_data : m_txn_erases) {
+        m_database.m_record_keys.erase(key_data);
+    }
+
+    m_txn_started = false;
+    m_txn_writes.clear();
+    m_txn_erases.clear();
+    return true;
+}
+
+bool EncryptedDBBatch::TxnAbort()
+{
+    if (!m_txn_started) {
+        return false;
+    }
+    if (!m_batch->TxnAbort()) {
+        return false;
+    }
+    m_txn_started = false;
+    m_txn_writes.clear();
+    m_txn_erases.clear();
+    return true;
+}
+
+std::unique_ptr<DatabaseCursor> EncryptedDBBatch::GetNewCursor()
+{
+    return std::make_unique<EncryptedDBCursor>(m_database.m_record_keys, *this);
+}
+
+std::unique_ptr<DatabaseCursor> EncryptedDBBatch::GetNewPrefixCursor(Span<const std::byte> prefix)
+{
+    return std::make_unique<EncryptedDBCursor>(m_database.m_record_keys, *this, prefix);
+}
+
+EncryptedDBCursor::EncryptedDBCursor(const DecryptedRecordKeys& records, EncryptedDBBatch& batch, Span<const std::byte> prefix) : m_batch(batch)
+{
+    std::tie(m_cursor, m_cursor_end) = records.equal_range(BytePrefix{prefix});
+}
+
+DatabaseCursor::Status EncryptedDBCursor::Next(DataStream& key, DataStream& value)
+{
+    if (m_cursor == m_cursor_end) {
+        return DatabaseCursor::Status::DONE;
+    }
+    key.clear();
+    value.clear();
+
+    const auto& [key_data, enc_key] = *m_cursor;
+    key.write(key_data);
+
+    if (!m_batch.ReadEncryptedKey(enc_key, value)) {
+        return DatabaseCursor::Status::FAIL;
+    }
+    m_cursor++;
+    return DatabaseCursor::Status::MORE;
+}
+
+std::unique_ptr<EncryptedDatabase> MakeEncryptedSQLiteDatabase(const fs::path& path, const DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error)
+{
+    std::unique_ptr<SQLiteDatabase> backing_db = MakeSQLiteDatabase(path, options, status, error);
+    try {
+        auto db = std::make_unique<EncryptedDatabase>(std::move(backing_db), options.db_passphrase, options.require_create);
+        status = DatabaseStatus::SUCCESS;
+        return db;
+    } catch (const std::runtime_error& e) {
+        status = DatabaseStatus::FAILED_LOAD;
+        error = Untranslated(e.what());
+        return nullptr;
+    }
+}
+
+} // namespace wallet

--- a/src/wallet/encrypted_db.cpp
+++ b/src/wallet/encrypted_db.cpp
@@ -351,7 +351,7 @@ DatabaseCursor::Status EncryptedDBCursor::Next(DataStream& key, DataStream& valu
 
 std::unique_ptr<EncryptedDatabase> MakeEncryptedSQLiteDatabase(const fs::path& path, const DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error)
 {
-    std::unique_ptr<SQLiteDatabase> backing_db = MakeSQLiteDatabase(path, options, status, error);
+    std::unique_ptr<SQLiteDatabase> backing_db = MakeSQLiteDatabase(path, options, status, error, ENCRYPTED_DB_XOR);
     try {
         auto db = std::make_unique<EncryptedDatabase>(std::move(backing_db), options.db_passphrase, options.require_create);
         status = DatabaseStatus::SUCCESS;

--- a/src/wallet/encrypted_db.h
+++ b/src/wallet/encrypted_db.h
@@ -1,0 +1,127 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_WALLET_ENCRYPTED_DB_H
+#define BITCOIN_WALLET_ENCRYPTED_DB_H
+
+#include <streams.h>
+#include <util/result.h>
+#include <wallet/crypter.h>
+#include <wallet/db.h>
+
+namespace wallet {
+// Map of decrypted record key data to the encrypted record key data
+// This allows us to get the actual db key data in order to lookups against the underlying db.
+using DecryptedRecordKeys = std::map<SerializeData, SerializeData, std::less<>>;
+
+class EncryptedDatabase;
+class EncryptedDBBatch;
+
+class EncryptedDBCursor : public DatabaseCursor
+{
+public:
+    DecryptedRecordKeys::const_iterator m_cursor;
+    DecryptedRecordKeys::const_iterator m_cursor_end;
+    EncryptedDBBatch& m_batch;
+
+    explicit EncryptedDBCursor(const DecryptedRecordKeys& records, EncryptedDBBatch& batch) : m_cursor(records.begin()), m_cursor_end(records.end()), m_batch(batch) {}
+    EncryptedDBCursor(const DecryptedRecordKeys& records, EncryptedDBBatch& batch, Span<const std::byte> prefix);
+    ~EncryptedDBCursor() {}
+
+    Status Next(DataStream& key, DataStream& value) override;
+};
+
+/** RAII class that provides access to a WalletDatabase */
+class EncryptedDBBatch : public DatabaseBatch
+{
+private:
+    //! A DatabaseBatch for the db underlying the EncryptedDatabase
+    std::unique_ptr<DatabaseBatch> m_batch;
+    EncryptedDatabase& m_database;
+
+    bool m_txn_started{false};
+    std::vector<std::pair<SerializeData, SerializeData>> m_txn_writes;
+    std::vector<SerializeData> m_txn_erases;
+
+    bool ReadKey(DataStream&& key, DataStream& value) override;
+    bool WriteKey(DataStream&& key, DataStream&& value, bool overwrite = true) override;
+    bool EraseKey(DataStream&& key) override;
+    bool HasKey(DataStream&& key) override;
+
+public:
+    explicit EncryptedDBBatch(std::unique_ptr<DatabaseBatch> batch, EncryptedDatabase& database) : m_batch(std::move(batch)), m_database(database) {}
+    ~EncryptedDBBatch() {}
+
+    void Flush() override { m_batch->Flush(); }
+    void Close() override;
+
+    bool ErasePrefix(Span<const std::byte> prefix) override;
+
+    std::unique_ptr<DatabaseCursor> GetNewCursor() override;
+    std::unique_ptr<DatabaseCursor> GetNewPrefixCursor(Span<const std::byte> prefix) override;
+    bool TxnBegin() override;
+    bool TxnCommit() override;
+    bool TxnAbort() override;
+
+    bool ReadEncryptedKey(SerializeData enc_key, DataStream& value);
+};
+
+/**
+ * EncryptedDatabase encrypts and decrypts records as they are read and written from an underlying
+ * database. Most functions are simply passed through.
+ * An unencrypted copy of every record key is held in memory. This allows to lookup records by
+ * unencrypted record key. The value will be read from the underlying db and decrypted.
+ **/
+class EncryptedDatabase : public WalletDatabase
+{
+private:
+    /** The underlying database */
+    std::unique_ptr<WalletDatabase> m_database;
+
+    /** CCrypter which encrypts and decrypts the data */
+    CCrypter m_crypter;
+    /** The key used to encrypt the records */
+    CKeyingMaterial m_enc_secret;
+
+public:
+    /** The unencrypted record keys, using a data type with secure allocation */
+    DecryptedRecordKeys m_record_keys;
+
+    EncryptedDatabase() = delete;
+
+    EncryptedDatabase(std::unique_ptr<WalletDatabase> database, const SecureString& passphrase, bool create);
+
+    ~EncryptedDatabase() {};
+
+    inline static const Span<const std::byte> ENCRYPTION_RECORD = MakeByteSpan("encrypted_db_key");
+
+    util::Result<SerializeData> DecryptRecordData(Span<const std::byte> data);
+    util::Result<SerializeData> EncryptRecordData(Span<const std::byte> data);
+
+    /** Open the database if it is not already opened. */
+    void Open() override;
+
+    std::string Format() override { return "encrypted_" + m_database->Format(); }
+
+    /** Passthrough */
+    void Close() override { m_database->Close(); }
+    void AddRef() override { m_database->AddRef() ;}
+    void RemoveRef() override { m_database->RemoveRef(); }
+    bool Rewrite(const char* pszSkip=nullptr) override { return m_database->Rewrite(pszSkip); }
+    bool Backup(const std::string& strDest) const override { return m_database->Backup(strDest); }
+    void Flush() override { m_database->Flush(); }
+    bool PeriodicFlush() override { return m_database->PeriodicFlush(); }
+    void IncrementUpdateCounter() override { m_database->IncrementUpdateCounter(); }
+    void ReloadDbEnv() override { m_database->ReloadDbEnv(); }
+    std::string Filename() override { return m_database->Filename(); }
+
+    /** Make a DatabaseBatch connected to this database */
+    std::unique_ptr<DatabaseBatch> MakeBatch(bool flush_on_close = true) override { return std::make_unique<EncryptedDBBatch>(m_database->MakeBatch(flush_on_close), *this); }
+};
+
+std::unique_ptr<EncryptedDatabase> MakeEncryptedSQLiteDatabase(const fs::path& path, const DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error);
+
+} // namespace wallet
+
+#endif // BITCOIN_WALLET_ENCRYPTED_DB_H

--- a/src/wallet/load.cpp
+++ b/src/wallet/load.cpp
@@ -92,6 +92,8 @@ bool VerifyWallets(WalletContext& context)
         if (!MakeWalletDatabase(wallet_file, options, status, error_string)) {
             if (status == DatabaseStatus::FAILED_NOT_FOUND) {
                 chain.initWarning(Untranslated(strprintf("Skipping -wallet path that doesn't exist. %s", error_string.original)));
+            } else if (status == DatabaseStatus::FAILED_ENCRYPT) {
+                chain.initWarning(Untranslated(strprintf("Skipping -wallet path to encrypted wallet, use loadwallet to load it. %s", error_string.original)));
             } else {
                 chain.initError(error_string);
                 return false;
@@ -120,7 +122,7 @@ bool LoadWallets(WalletContext& context)
             bilingual_str error;
             std::vector<bilingual_str> warnings;
             std::unique_ptr<WalletDatabase> database = MakeWalletDatabase(name, options, status, error);
-            if (!database && status == DatabaseStatus::FAILED_NOT_FOUND) {
+            if (!database && (status == DatabaseStatus::FAILED_NOT_FOUND || status == DatabaseStatus::FAILED_ENCRYPT)) {
                 continue;
             }
             chain.initMessage(_("Loading wallet…").translated);

--- a/src/wallet/sqlite.h
+++ b/src/wallet/sqlite.h
@@ -8,6 +8,8 @@
 #include <sync.h>
 #include <wallet/db.h>
 
+#include <array>
+
 struct bilingual_str;
 
 struct sqlite3_stmt;
@@ -84,6 +86,8 @@ private:
 
     const std::string m_file_path;
 
+    std::array<const std::byte, 4> m_app_id;
+
     /**
      * This mutex protects SQLite initialization and shutdown.
      * sqlite3_config() and sqlite3_shutdown() are not thread-safe (sqlite3_initialize() is).
@@ -99,7 +103,7 @@ public:
     SQLiteDatabase() = delete;
 
     /** Create DB handle to real database */
-    SQLiteDatabase(const fs::path& dir_path, const fs::path& file_path, const DatabaseOptions& options, bool mock = false);
+    SQLiteDatabase(const fs::path& dir_path, const fs::path& file_path, const DatabaseOptions& options, bool mock = false, std::array<const std::byte, 4> app_id_xor = {std::byte{0}, std::byte{0}, std::byte{0}, std::byte{0}});
 
     ~SQLiteDatabase();
 
@@ -146,7 +150,7 @@ public:
     bool m_use_unsafe_sync;
 };
 
-std::unique_ptr<SQLiteDatabase> MakeSQLiteDatabase(const fs::path& path, const DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error);
+std::unique_ptr<SQLiteDatabase> MakeSQLiteDatabase(const fs::path& path, const DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error, std::array<const std::byte, 4> app_id_xor = {std::byte{0}, std::byte{0}, std::byte{0}, std::byte{0}});
 
 std::string SQLiteDatabaseVersion();
 } // namespace wallet

--- a/src/wallet/test/db_tests.cpp
+++ b/src/wallet/test/db_tests.cpp
@@ -13,6 +13,7 @@
 #endif
 #ifdef USE_SQLITE
 #include <wallet/sqlite.h>
+#include <wallet/encrypted_db.h>
 #endif
 #include <wallet/test/util.h>
 #include <wallet/walletutil.h> // for WALLET_FLAG_DESCRIPTORS
@@ -126,6 +127,7 @@ static std::vector<std::unique_ptr<WalletDatabase>> TestDatabases(const fs::path
 {
     std::vector<std::unique_ptr<WalletDatabase>> dbs;
     DatabaseOptions options;
+    options.require_create = true;
     DatabaseStatus status;
     bilingual_str error;
 #ifdef USE_BDB
@@ -133,6 +135,8 @@ static std::vector<std::unique_ptr<WalletDatabase>> TestDatabases(const fs::path
 #endif
 #ifdef USE_SQLITE
     dbs.emplace_back(MakeSQLiteDatabase(path_root / "sqlite", options, status, error));
+    options.db_passphrase = "pass";
+    dbs.emplace_back(MakeEncryptedSQLiteDatabase(path_root / "enc_sqlite", options, status, error));
 #endif
     dbs.emplace_back(CreateMockableWalletDatabase());
     return dbs;

--- a/src/wallet/test/util.cpp
+++ b/src/wallet/test/util.cpp
@@ -93,11 +93,6 @@ CTxDestination getNewDestination(CWallet& w, OutputType output_type)
     return *Assert(w.GetNewDestination(output_type, ""));
 }
 
-// BytePrefix compares equality with other byte spans that begin with the same prefix.
-struct BytePrefix { Span<const std::byte> prefix; };
-bool operator<(BytePrefix a, Span<const std::byte> b) { return a.prefix < b.subspan(0, std::min(a.prefix.size(), b.size())); }
-bool operator<(Span<const std::byte> a, BytePrefix b) { return a.subspan(0, std::min(a.size(), b.prefix.size())) < b.prefix; }
-
 MockableCursor::MockableCursor(const MockableData& records, bool pass, Span<const std::byte> prefix)
 {
     m_pass = pass;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -375,7 +375,17 @@ std::shared_ptr<CWallet> CreateWallet(WalletContext& context, const std::string&
     uint64_t wallet_creation_flags = options.create_flags;
     const SecureString& passphrase = options.create_passphrase;
 
-    if (wallet_creation_flags & WALLET_FLAG_DESCRIPTORS) options.require_format = DatabaseFormat::SQLITE;
+    if (wallet_creation_flags & WALLET_FLAG_DESCRIPTORS) {
+        if (!options.db_passphrase.empty()) {
+            options.require_format = DatabaseFormat::ENCRYPTED_SQLITE;
+        } else {
+            options.require_format = DatabaseFormat::SQLITE;
+        }
+    } else if (!options.db_passphrase.empty()) {
+        error = Untranslated("Database encryption is only supported for descriptor wallets");
+        status = DatabaseStatus::FAILED_CREATE;
+        return nullptr;
+    }
 
     // Indicate that the wallet is actually supposed to be blank and not just blank to make it encrypted
     bool create_blank = (wallet_creation_flags & WALLET_FLAG_BLANK_WALLET);

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -846,10 +846,10 @@ class RPCOverloadWrapper():
     def createwallet_passthrough(self, *args, **kwargs):
         return self.__getattr__("createwallet")(*args, **kwargs)
 
-    def createwallet(self, wallet_name, disable_private_keys=None, blank=None, passphrase='', avoid_reuse=None, descriptors=None, load_on_startup=None, external_signer=None):
+    def createwallet(self, wallet_name, disable_private_keys=None, blank=None, passphrase='', avoid_reuse=None, descriptors=None, load_on_startup=None, external_signer=None, db_passphrase=''):
         if descriptors is None:
             descriptors = self.descriptors
-        return self.__getattr__('createwallet')(wallet_name, disable_private_keys, blank, passphrase, avoid_reuse, descriptors, load_on_startup, external_signer)
+        return self.__getattr__('createwallet')(wallet_name, disable_private_keys, blank, passphrase, avoid_reuse, descriptors, load_on_startup, external_signer, db_passphrase)
 
     def importprivkey(self, privkey, label=None, rescan=None):
         wallet_info = self.getwalletinfo()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -312,6 +312,7 @@ BASE_SCRIPTS = [
     'p2p_leak.py',
     'wallet_encryption.py --legacy-wallet',
     'wallet_encryption.py --descriptors',
+    'wallet_db_encryption.py --descriptors',
     'feature_dersig.py',
     'feature_cltv.py',
     'rpc_uptime.py',

--- a/test/functional/wallet_createwallet.py
+++ b/test/functional/wallet_createwallet.py
@@ -16,6 +16,8 @@ from test_framework.wallet_util import generate_keypair, WalletUnlock
 
 
 EMPTY_PASSPHRASE_MSG = "Empty string given as passphrase, wallet will not be encrypted."
+EMPTY_DB_PASSPHRASE_MSG = "Empty string given as database passphrase, wallet database will not be encrypted."
+EMPTY_PASSPHRASE_MSGS = [EMPTY_PASSPHRASE_MSG, EMPTY_DB_PASSPHRASE_MSG]
 LEGACY_WALLET_MSG = "Wallet created successfully. The legacy wallet type is being deprecated and support for creating and opening legacy wallets will be removed in the future."
 
 
@@ -161,7 +163,7 @@ class CreateWalletTest(BitcoinTestFramework):
             assert_equal(walletinfo['keypoolsize_hd_internal'], keys)
         # Allow empty passphrase, but there should be a warning
         resp = self.nodes[0].createwallet(wallet_name='w7', disable_private_keys=False, blank=False, passphrase='')
-        assert_equal(resp["warnings"], [EMPTY_PASSPHRASE_MSG] if self.options.descriptors else [EMPTY_PASSPHRASE_MSG, LEGACY_WALLET_MSG])
+        assert_equal(resp["warnings"], EMPTY_PASSPHRASE_MSGS if self.options.descriptors else EMPTY_PASSPHRASE_MSGS + [LEGACY_WALLET_MSG])
 
         w7 = node.get_wallet_rpc('w7')
         assert_raises_rpc_error(-15, 'Error: running with an unencrypted wallet, but walletpassphrase was called.', w7.walletpassphrase, '', 60)
@@ -180,12 +182,12 @@ class CreateWalletTest(BitcoinTestFramework):
             result = self.nodes[0].createwallet(wallet_name="legacy_w0", descriptors=False, passphrase=None)
             assert_equal(result, {
                 "name": "legacy_w0",
-                "warnings": [LEGACY_WALLET_MSG],
+                "warnings": [EMPTY_DB_PASSPHRASE_MSG, LEGACY_WALLET_MSG],
             })
             result = self.nodes[0].createwallet(wallet_name="legacy_w1", descriptors=False, passphrase="")
             assert_equal(result, {
                 "name": "legacy_w1",
-                "warnings": [EMPTY_PASSPHRASE_MSG, LEGACY_WALLET_MSG],
+                "warnings": EMPTY_PASSPHRASE_MSGS + [LEGACY_WALLET_MSG],
             })
 
 

--- a/test/functional/wallet_db_encryption.py
+++ b/test/functional/wallet_db_encryption.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+# Copyright (c) 2023 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://www.opensource.org/licenses/mit-license.php.
+"""Test Wallets with encrypted database"""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_raises_rpc_error,
+    assert_equal,
+    assert_greater_than,
+)
+
+
+class WalletDBEncryptionTest(BitcoinTestFramework):
+    PASSPHRASE = "WalletPassphrase"
+    PASSPHRASE2 = "SecondWalletPassphrase"
+    WRONG_PASSPHRASE = "NotTheRightPassphrase"
+    PASSPHRASE_WITH_NULLS = "Passphrase\0With\0Nulls"
+
+    def add_options(self, parser):
+        self.add_wallet_options(parser, descriptors=True)
+
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def test_no_legacy(self):
+        if not self.is_bdb_compiled():
+            return
+        self.log.info("Test that legacy wallets do not support encrypted databases")
+        assert_raises_rpc_error(-4, "Database encryption is only supported for descriptor wallets", self.nodes[0].createwallet, wallet_name="legacy_encdb", db_passphrase=self.PASSPHRASE, descriptors=False)
+
+    def test_create_and_load(self):
+        self.log.info("Testing that a wallet with encrypted database can be created")
+        self.nodes[0].createwallet(wallet_name="basic_encrypted_db", db_passphrase=self.PASSPHRASE)
+        wallet = self.nodes[0].get_wallet_rpc("basic_encrypted_db")
+        info = wallet.getwalletinfo()
+        assert_equal("encrypted_sqlite", info["format"])
+
+        # Add some data to the wallet that we should see persisted
+        addr = wallet.getnewaddress()
+        txid_in = self.default_wallet.sendtoaddress(addr, 10)
+        self.generate(self.nodes[0], 1)
+        txid_out = wallet.sendtoaddress(self.default_wallet.getnewaddress(), 5)
+        self.generate(self.nodes[0], 1)
+
+        wallet.unloadwallet()
+
+        self.log.info("Testing loading of a wallet with encrypted database")
+        assert_raises_rpc_error(-4, "Database is encrypted but passphrase was not provided", self.nodes[0].loadwallet, filename="basic_encrypted_db")
+        assert_raises_rpc_error(-4, "Unable to decrypt database, are you sure the passphrase is correct?", self.nodes[0].loadwallet, filename="basic_encrypted_db", db_passphrase=self.WRONG_PASSPHRASE)
+        self.nodes[0].loadwallet(filename="basic_encrypted_db", db_passphrase=self.PASSPHRASE)
+        info = wallet.getwalletinfo()
+        assert_equal("encrypted_sqlite", info["format"])
+
+        # Make sure that our persisted data is still here
+        addr_info = wallet.getaddressinfo(addr)
+        assert_equal(addr_info["ismine"], True)
+        tx_in = wallet.gettransaction(txid_in)
+        assert_equal(tx_in["amount"], 10)
+        tx_out = wallet.gettransaction(txid_out)
+        assert_equal(tx_out["amount"], -5)
+        wallet.sendtoaddress(self.default_wallet.getnewaddress(), 2)
+
+        wallet.unloadwallet()
+
+        self.log.info("Test that listwalletdir lists wallets with encrypted dbs")
+        wallets = [w["name"] for w in self.nodes[0].listwalletdir()["wallets"]]
+        assert "basic_encrypted_db" in wallets
+
+    def test_passphrases_with_nulls(self):
+        self.log.info("Testing passphrases with nulls for wallets with encrypted databases")
+        self.nodes[0].createwallet(wallet_name="encdb_with_nulls", db_passphrase=self.PASSPHRASE_WITH_NULLS)
+        wallet = self.nodes[0].get_wallet_rpc("encdb_with_nulls")
+        info = wallet.getwalletinfo()
+        assert_equal("encrypted_sqlite", info["format"])
+        wallet.unloadwallet()
+
+        assert_raises_rpc_error(-4, "Unable to decrypt database, are you sure the passphrase is correct?", self.nodes[0].loadwallet, filename="encdb_with_nulls", db_passphrase=self.PASSPHRASE_WITH_NULLS.partition("\0")[0])
+        self.nodes[0].loadwallet(filename="encdb_with_nulls", db_passphrase=self.PASSPHRASE_WITH_NULLS)
+
+    def test_on_start(self):
+        self.log.info("Test that wallets with encrypted db are ignored on startup")
+        self.nodes[0].createwallet(wallet_name="startup_encdb", db_passphrase=self.PASSPHRASE)
+        with self.nodes[0].assert_debug_log(expected_msgs=["Warning: Skipping -wallet path to encrypted wallet, use loadwallet to load it."]):
+            self.stop_node(0)
+            self.start_node(0, extra_args=["-wallet=startup_encdb"])
+            # Need to clear stderr file so that test shutdown works
+            self.nodes[0].stderr.seek(0)
+            self.nodes[0].stderr.truncate(0)
+        assert_equal(self.nodes[0].listwallets(), [self.default_wallet_name])
+        self.nodes[0].loadwallet(filename="startup_encdb", db_passphrase=self.PASSPHRASE)
+
+    def test_double_encrypted(self):
+        self.log.info("Test that wallet encryption is not db encryption")
+        self.nodes[0].createwallet(wallet_name="enc_wallet_not_db", passphrase=self.PASSPHRASE)
+        wallet = self.nodes[0].get_wallet_rpc("enc_wallet_not_db")
+        info = wallet.getwalletinfo()
+        assert_equal(info["format"], "sqlite")
+        assert_equal(info["unlocked_until"], 0)
+
+        self.nodes[0].createwallet(wallet_name="enc_wallet_not_db2")
+        wallet = self.nodes[0].get_wallet_rpc("enc_wallet_not_db2")
+        wallet.encryptwallet(self.PASSPHRASE)
+        info = wallet.getwalletinfo()
+        assert_equal(info["format"], "sqlite")
+        assert_equal(info["unlocked_until"], 0)
+
+        self.log.info("Test that wallets with encrypted db can also be encrypted normally")
+        self.nodes[0].createwallet(wallet_name="double_enc", db_passphrase=self.PASSPHRASE, passphrase=self.PASSPHRASE2)
+        wallet = self.nodes[0].get_wallet_rpc("double_enc")
+        info = wallet.getwalletinfo()
+        assert_equal(info["format"], "encrypted_sqlite")
+        assert_equal(info["unlocked_until"], 0)
+        wallet.walletpassphrase(self.PASSPHRASE2, 10)
+        assert_greater_than(wallet.getwalletinfo()["unlocked_until"], 0)
+        wallet.walletlock()
+
+        self.nodes[0].createwallet(wallet_name="double_enc2", db_passphrase=self.PASSPHRASE)
+        wallet = self.nodes[0].get_wallet_rpc("double_enc2")
+        wallet.encryptwallet(self.PASSPHRASE2)
+        info = wallet.getwalletinfo()
+        assert_equal(info["format"], "encrypted_sqlite")
+        assert_equal(info["unlocked_until"], 0)
+        wallet.walletpassphrase(self.PASSPHRASE2, 10)
+        assert_greater_than(wallet.getwalletinfo()["unlocked_until"], 0)
+        wallet.walletlock()
+
+        self.log.info("Test that changing wallet passphrase does not affect database passphrase")
+        wallet.walletpassphrase(self.PASSPHRASE2, 10)
+        wallet.walletpassphrasechange(self.PASSPHRASE2, self.PASSPHRASE_WITH_NULLS)
+        wallet.walletlock()
+        assert_raises_rpc_error(-14, "Error: The wallet passphrase entered was incorrect.", wallet.walletpassphrase, self.PASSPHRASE, 10)
+        assert_raises_rpc_error(-14, "Error: The wallet passphrase entered was incorrect.", wallet.walletpassphrase, self.PASSPHRASE2, 10)
+        wallet.walletpassphrase(self.PASSPHRASE_WITH_NULLS, 10)
+        wallet.unloadwallet()
+
+        assert_raises_rpc_error(-4, "Wallet file verification failed. Unable to decrypt database, are you sure the passphrase is correct?", self.nodes[0].loadwallet, filename="double_enc2", db_passphrase=self.PASSPHRASE_WITH_NULLS)
+        assert_raises_rpc_error(-4, "Wallet file verification failed. Unable to decrypt database, are you sure the passphrase is correct?", self.nodes[0].loadwallet, filename="double_enc2", db_passphrase=self.PASSPHRASE2)
+        self.nodes[0].loadwallet(filename="double_enc2", db_passphrase=self.PASSPHRASE)
+
+    def run_test(self):
+        self.default_wallet = self.nodes[0].get_wallet_rpc(self.default_wallet_name)
+        self.generate(self.nodes[0], 101)
+
+        self.test_no_legacy()
+        self.test_create_and_load()
+        self.test_passphrases_with_nulls()
+        self.test_on_start()
+        self.test_double_encrypted()
+
+if __name__ == '__main__':
+    WalletDBEncryptionTest().main()


### PR DESCRIPTION
A couple of users have requested that we support wallets that encrypt everything, even if the wallet is watch-only, in order to have better privacy if the wallet is stolen. This PR introduces an `EncryptedDatabase` backend for the wallet which encrypts/decrypts each key-value record individually before reading from or writing to the database.

`EncryptedDatabase` is only supported for SQLite databases and descriptor wallets. This was done in order to have an easier way to get downgrade protection that also does not involve writing an existing record in plaintext (e.g. `minversion` or `flags`). SQLite has a fixed field "application id" that we already use for cross-network protection. This is reused to detect if a sqlite database is an encrypted wallet, and thus it prevents older software from attempting to open such wallets.

In order to read records from the database, `EncryptedDatabase` will cache the decrypted key in memory so that it can lookup the encrypted key in the database. Values will always be decrypted when read.

The encryption scheme is the same one that we use for encrypting private keys. It's not that great, but I didn't feel like re-implementing it, and it seems good enough. The encryption key itself is encrypted with the passphrase and stored in a new record.

Wallets with encrypted databases cannot be loaded on start. They can only be loaded by explicit user action through `loadwallet` which now has a `db_passphrase` parameter to allow the decryption of these wallets. `createwallet` also has a `db_passphrase` to create these wallets. For now, there is no way to encrypt the database after it has been created, nor is there a way to change the passphrase.