### PR TITLE
valgrind: add suppression for bug 472219

### DIFF
--- a/contrib/valgrind.supp
+++ b/contrib/valgrind.supp
@@ -89,3 +89,9 @@
    ...
    fun:_ZN5BCLog6Logger12StartLoggingEv
 }
+{
+   Suppress https://bugs.kde.org/show_bug.cgi?id=472219 - fixed in Valgrind 3.22.
+   Memcheck:Param
+   ppoll(ufds.events)
+   obj:/lib/ld-musl-aarch64.so.1
+}


### PR DESCRIPTION
Now that https://bugs.kde.org/show_bug.cgi?id=472219 has been fixed upstream in:

https://sourceware.org/git/?p=valgrind.git;a=commit;h=6ce0979884a8f246c80a098333ceef1a7b7f694d

Add a supression to ignore the bug until we are using a fixed version of Valgrind.

Related to #28072.