### PR TITLE
refactor: consistently use ApplyArgsManOptions for PeerManager::Options

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1168,7 +1168,9 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 
     fListen = args.GetBoolArg("-listen", DEFAULT_LISTEN);
     fDiscover = args.GetBoolArg("-discover", true);
-    const bool ignores_incoming_txs{args.GetBoolArg("-blocksonly", DEFAULT_BLOCKSONLY)};
+
+    PeerManager::Options peerman_opts{};
+    ApplyArgsManOptions(args, peerman_opts);
 
     {
 
@@ -1216,7 +1218,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     assert(!node.fee_estimator);
     // Don't initialize fee estimation with old data if we don't relay transactions,
     // as they would never get updated.
-    if (!ignores_incoming_txs) {
+    if (!peerman_opts.ignore_incoming_txs) {
         bool read_stale_estimates = args.GetBoolArg("-acceptstalefeeestimates", DEFAULT_ACCEPT_STALE_FEE_ESTIMATES);
         if (read_stale_estimates && (chainparams.GetChainType() != ChainType::REGTEST)) {
             return InitError(strprintf(_("acceptstalefeeestimates is not supported on %s chain."), chainparams.GetChainTypeString()));
@@ -1538,10 +1540,6 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     }
 
     ChainstateManager& chainman = *Assert(node.chainman);
-
-
-    PeerManager::Options peerman_opts{};
-    ApplyArgsManOptions(args, peerman_opts);
 
     assert(!node.peerman);
     node.peerman = PeerManager::make(*node.connman, *node.addrman,

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1540,9 +1540,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     ChainstateManager& chainman = *Assert(node.chainman);
 
 
-    PeerManager::Options peerman_opts{
-        .ignore_incoming_txs = ignores_incoming_txs,
-    };
+    PeerManager::Options peerman_opts{};
     ApplyArgsManOptions(args, peerman_opts);
 
     assert(!node.peerman);

--- a/src/node/peerman_args.cpp
+++ b/src/node/peerman_args.cpp
@@ -18,6 +18,8 @@ void ApplyArgsManOptions(const ArgsManager& argsman, PeerManager::Options& optio
     }
 
     if (auto value{argsman.GetBoolArg("-capturemessages")}) options.capture_messages = *value;
+
+    if (auto value{argsman.GetBoolArg("-blocksonly")}) options.ignore_incoming_txs = *value;
 }
 
 } // namespace node


### PR DESCRIPTION
Consistently use `ApplyArgsManOptions` for `PeerManager::Options`, and initialize `PeerManager::Options` early to avoid reading `"-blocksonly"` twice. Suggested in https://github.com/bitcoin/bitcoin/pull/27499#discussion_r1268400386 and also requested in https://github.com/bitcoin/bitcoin/pull/27499#discussion_r1273346189.

No behaviour change, but the [`TestingSetup`](https://github.com/bitcoin/bitcoin/blob/e35fb7bc48d360585b80d0c7f89ac5087c1d405e/src/test/util/setup_common.cpp#L255-L256) is now also able to access `"-blocksonly"`.