### PR TITLE
test: Avoid intermittent issues due to async events in validationinterface_tests

### DIFF
--- a/src/test/validationinterface_tests.cpp
+++ b/src/test/validationinterface_tests.cpp
@@ -12,7 +12,7 @@
 
 #include <atomic>
 
-BOOST_FIXTURE_TEST_SUITE(validationinterface_tests, TestingSetup)
+BOOST_FIXTURE_TEST_SUITE(validationinterface_tests, ChainTestingSetup)
 
 struct TestSubscriberNoop final : public CValidationInterface {
     void BlockChecked(const CBlock&, const BlockValidationState&) override {}


### PR DESCRIPTION
Currently the tests have many issues:

* They setup the genesis block, even though it is not needed
* They queue an async `UpdatedBlockTip` even, which causes intermittent issues: https://github.com/bitcoin/bitcoin/issues/28146#issuecomment-1650064645

Fix all issues by trimming down the setup to just `ChainTestingSetup`.