### PR TITLE
test doc: tests `acceptstalefeeestimates` option is only supported on regtest chain

### DIFF
--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -548,14 +548,12 @@ CBlockPolicyEstimator::CBlockPolicyEstimator(const fs::path& estimation_filepath
 
     AutoFile est_file{fsbridge::fopen(m_estimation_filepath, "rb")};
 
-    // Whenever the fee estimation file is not present return early
     if (est_file.IsNull()) {
         LogPrintf("%s is not found. Continue anyway.\n", fs::PathToString(m_estimation_filepath));
         return;
     }
 
     std::chrono::hours file_age = GetFeeEstimatorFileAge();
-    // fee estimate file must not be too old to avoid wrong fee estimates.
     if (file_age > MAX_FILE_AGE && !read_stale_estimates) {
         LogPrintf("Fee estimation file %s too old (age=%lld > %lld hours) and will not be used to avoid serving stale estimates.\n", fs::PathToString(m_estimation_filepath), Ticks<std::chrono::hours>(file_age), Ticks<std::chrono::hours>(MAX_FILE_AGE));
         return;

--- a/src/policy/fees.h
+++ b/src/policy/fees.h
@@ -25,8 +25,9 @@
 // How often to flush fee estimates to fee_estimates.dat.
 static constexpr std::chrono::hours FEE_FLUSH_INTERVAL{1};
 
-/** fee_estimates.dat that are more than 60 hours (2.5 days) will not be read,
- * as the estimates in the file are stale.
+/** fee_estimates.dat that are more than 60 hours (2.5 days) old will not be read,
+ * as fee estimates are based on historical data and may be inaccurate if
+ * network activity has changed.
  */
 static constexpr std::chrono::hours MAX_FILE_AGE{60};
 

--- a/test/functional/feature_config_args.py
+++ b/test/functional/feature_config_args.py
@@ -371,6 +371,14 @@ class ConfArgsTest(BitcoinTestFramework):
             f'is being used instead.') + r"[\s\S]*", env=env, match=ErrorMatch.FULL_REGEX)
         node.args = node_args
 
+    def test_acceptstalefeeestimates_arg_support(self):
+        self.log.info("Test -acceptstalefeeestimates option support")
+        conf_file = self.nodes[0].datadir_path / "bitcoin.conf"
+        for chain, chain_name in {("main", ""), ("test", "testnet3"), ("signet", "signet")}:
+            util.write_config(conf_file, n=0, chain=chain_name, extra_config='acceptstalefeeestimates=1\n')
+            self.nodes[0].assert_start_raises_init_error(expected_msg=f'Error: acceptstalefeeestimates is not supported on {chain} chain.')
+        util.write_config(conf_file, n=0, chain="regtest")  # Reset to regtest
+
     def run_test(self):
         self.test_log_buffer()
         self.test_args_log()
@@ -383,6 +391,7 @@ class ConfArgsTest(BitcoinTestFramework):
         self.test_invalid_command_line_options()
         self.test_ignored_conf()
         self.test_ignored_default_conf()
+        self.test_acceptstalefeeestimates_arg_support()
 
         # Remove the -datadir argument so it doesn't override the config file
         self.nodes[0].args = [arg for arg in self.nodes[0].args if not arg.startswith("-datadir")]


### PR DESCRIPTION
This PR Follow up comments from [#27622](https://github.com/bitcoin/bitcoin/pull/27622) 

It test that the new `regtest-only` option `acceptstalefeeestimates` is not supported on [main, signet and test chains](https://github.com/bitcoin/bitcoin/pull/27622/files#r1235218268), removes an unnecessary [comment](https://github.com/bitcoin/bitcoin/pull/27622/files#r1235204323), and update fee estimator  `MAXFILEAGE` [description comment](https://github.com/bitcoin/bitcoin/pull/27622/files#r1233887314).