### PR TITLE
Bech32 LocateErrors "Bech32 string too short" case

### DIFF
--- a/src/test/bech32_tests.cpp
+++ b/src/test/bech32_tests.cpp
@@ -83,7 +83,7 @@ BOOST_AUTO_TEST_CASE(bech32_testvectors_invalid)
         {"Invalid separator position", {2}},
         {"Invalid character or mixed case", {8}},
         {"Invalid checksum", {}}, // The checksum is calculated using the uppercase form so the entire string is invalid, not just a few characters
-        {"Invalid separator position", {0}},
+        {"Bech32 string too short", {0, 1, 2, 3, 4, 5, 6}},
         {"Invalid separator position", {0}},
         {"Invalid character or mixed case", {3, 4, 5, 7}},
         {"Invalid character or mixed case", {3}},
@@ -137,7 +137,7 @@ BOOST_AUTO_TEST_CASE(bech32m_testvectors_invalid)
         {"Invalid Base 32 character", {8}},
         {"Invalid Base 32 character", {7}},
         {"Invalid checksum", {}},
-        {"Invalid separator position", {0}},
+        {"Bech32 string too short", {0, 1, 2, 3, 4, 5, 6}},
         {"Invalid separator position", {0}},
         {"Invalid Bech32m checksum", {21}},
         {"Invalid Bech32m checksum", {13, 32}},


### PR DESCRIPTION
### Summary 

Add a "Bech32 string too short" case to Bech32.cpp LocateErrors to reduce ambiguity and collisions with "Invalid separator position" case.

### Problem

Error representation when calling LocateErrors within ```src/test/bech32_tests.cpp``` is ambiguous and incorrect in some cases because of a missing bech32 string to short case. Not having a too short case causes a fall though into the conditions of ```"Invalid separator position" || "Missing separator"```

### Solution

Simply add a check for a minimum Bech32 string size after or during the check for the maximum size which is already implemented.

Cascading effects of this would be seen in DecodeDestination if https://github.com/bitcoin/bitcoin/blob/32c15237b656209b932c5d6d2e20736c0e3d5a34/src/key_io.cpp#L85-L86 was patched to not consider bech32 invalid then attempt to Base58Decode it becuase of the incorrect HRP for the current chain.

Referenced in 
https://github.com/bitcoin/bitcoin/issues/26290

PR 
https://github.com/bitcoin/bitcoin/pull/27260

### Alternatives

You could case this into other logic on a case by case basis in code. Example make a speical case inside DecodeDestination to display the correct error message to the user by if LocateErrors returns 'Invalid ```"separator position" || "Missing separator"``` then you check to see if the string is to short.

### Additional Context

As an aside there is already a check for string length greater than 90 (MAX LEN)

in src/test/bech32_tests.cpp both ["10a06t8","1qzzfhee"] produce ```{"Invalid separator position", {0}}``` The former is non conformant to BIP173 due not even having enough chars to represent a BASE32 string and the second genuinely has a wrong separator position. 

Adding this case would make DecodeDestination more accurate for anyone who wants to to implement bech32.{cpp,h}


### A comparison of this PRs error vs the current 25.99 error for Bech32 string that does not meet the minimum length requirement.

![image](https://github.com/bitcoin/bitcoin/assets/3104223/2b975904-3a65-46b9-bee2-99c64eae59b9)

