### PR TITLE
refactor: Revert additional univalue check in ParseSighashString

### DIFF
--- a/doc/release-notes-28113.md
+++ b/doc/release-notes-28113.md
@@ -2,6 +2,6 @@ RPC Wallet
 ----------
 
 - The `signrawtransactionwithkey`, `signrawtransactionwithwallet`,
-  `walletprocesspsbt` and `descriptorprocesspsbt` calls now return more
-  specific RPC_INVALID_PARAMETER instead of RPC_PARSE_ERROR if their
-  sighashtype argument is malformed or not a string.
+  `walletprocesspsbt` and `descriptorprocesspsbt` calls now return the more
+  specific RPC_INVALID_PARAMETER error instead of RPC_MISC_ERROR if their
+  sighashtype argument is malformed.

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -313,13 +313,15 @@ UniValue DescribeAddress(const CTxDestination& dest)
     return std::visit(DescribeAddressVisitor(), dest);
 }
 
+/**
+ * Returns a sighash value corresponding to the passed in argument.
+ *
+ * @pre The sighash argument should be string or null.
+*/
 int ParseSighashString(const UniValue& sighash)
 {
     if (sighash.isNull()) {
         return SIGHASH_DEFAULT;
-    }
-    if (!sighash.isStr()) {
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "sighash needs to be null or string");
     }
     const auto result{SighashFromStr(sighash.get_str())};
     if (!result) {

--- a/src/test/fuzz/parse_univalue.cpp
+++ b/src/test/fuzz/parse_univalue.cpp
@@ -67,7 +67,7 @@ FUZZ_TARGET(parse_univalue, .init = initialize_parse_univalue)
     } catch (const std::runtime_error&) {
     }
     try {
-        (void)ParseSighashString(univalue);
+        if (univalue.isNull() || univalue.isStr()) (void)ParseSighashString(univalue);
     } catch (const UniValue&) {
     }
     try {


### PR DESCRIPTION
This is a follow up for #28113.

The string type check is already done by the rpc parser / RPCHelpMan. Re-doing it is adding dead code. Instead, throwing an exception when the assumption does not hold is the already correct behavior. Pointed out in this [comment](https://github.com/bitcoin/bitcoin/pull/28113/files#r1274568557).

Also correct the release note for the correct sighashtype exception change. There is no change in the handling of non-string sighashtype arugments. Pointed out in this [comment](https://github.com/bitcoin/bitcoin/pull/28113/files#r1274567555).