### PR TITLE
fuzz: Generate with random libFuzzer settings

### DIFF
--- a/test/fuzz/test_runner.py
+++ b/test/fuzz/test_runner.py
@@ -268,6 +268,7 @@ def generate_corpus(*, fuzz_pool, src_dir, build_dir, corpus_dir, targets):
         use_value_profile = int(random.random() < .3)
         command = [
             os.path.join(build_dir, 'src', 'test', 'fuzz', 'fuzz'),
+            "-rss_limit_mb=8000",
             "-max_total_time=6000",
             "-reload=0",
             f"-use_value_profile={use_value_profile}",

--- a/test/fuzz/test_runner.py
+++ b/test/fuzz/test_runner.py
@@ -11,6 +11,7 @@ import argparse
 import configparser
 import logging
 import os
+import random
 import subprocess
 import sys
 
@@ -264,9 +265,12 @@ def generate_corpus(*, fuzz_pool, src_dir, build_dir, corpus_dir, targets):
     for target, t_env in targets:
         target_corpus_dir = corpus_dir / target
         os.makedirs(target_corpus_dir, exist_ok=True)
+        use_value_profile = int(random.random() < .3)
         command = [
             os.path.join(build_dir, 'src', 'test', 'fuzz', 'fuzz'),
-            "-runs=100000",
+            "-max_total_time=6000",
+            "-reload=0",
+            f"-use_value_profile={use_value_profile}",
             target_corpus_dir,
         ]
         futures.append(fuzz_pool.submit(job, command, target, t_env))


### PR DESCRIPTION
Sometimes a libFuzzer setting like `-use_value_profile=1` helps [0], sometimes it hurts [1].

[0] https://github.com/bitcoin/bitcoin/pull/20789#issuecomment-752961937
[1] https://github.com/bitcoin/bitcoin/pull/27888#issuecomment-1645976254

By picking a random value, it is ensured that at least some of the runs will have the beneficial configuration set.

Also, set `-max_total_time` to prevent slow fuzz targets from getting a larger time share, or possibly peg to a single core for a long time and block the python script from exiting for a long time. This can be improved in the future. For example, the python script can exit after some time (https://github.com/bitcoin/bitcoin/pull/20752#discussion_r549248791). Alternatively, it can measure if coverage progress was made and run for less time if no progress has been made recently anyway, so that more time can be spent on targets that are new or still make progress.

