### PR TITLE
lint: fix custom mypy cache dir setting

### DIFF
--- a/test/lint/lint-python.py
+++ b/test/lint/lint-python.py
@@ -9,14 +9,17 @@ Check for specified flake8 and mypy warnings in python files.
 """
 
 import os
+from pathlib import Path
 import subprocess
 import sys
 
 from importlib.metadata import metadata, PackageNotFoundError
 
+# Customize mypy cache dir via environment variable
+cache_dir = Path(__file__).parent.parent / ".mypy_cache"
+os.environ["MYPY_CACHE_DIR"] = str(cache_dir)
 
 DEPS = ['flake8', 'lief', 'mypy', 'pyzmq']
-MYPY_CACHE_DIR = f"{os.getenv('BASE_ROOT_DIR', '')}/test/.mypy_cache"
 
 # All .py files, except those in src/ (to exclude subtrees there)
 FLAKE_FILES_ARGS = ['git', 'ls-files', '*.py', ':!:src/*.py']


### PR DESCRIPTION
fixes #28183

The custom cache dir for `mypy` can only be set via an environment variable, setting the `MYPY_CACHE_DIR` variable in the program is not sufficient. This error was introduced while translating the shell script to python.

See also the mypy documentation: https://mypy.readthedocs.io/en/stable/config_file.html#confval-cache_dir