### PR TITLE
kernel: Prune leveldb headers

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -24,7 +24,7 @@ check_PROGRAMS =
 TESTS =
 BENCHMARKS =
 
-BITCOIN_INCLUDES=-I$(builddir) -I$(srcdir)/$(MINISKETCH_INCLUDE_DIR_INT) -I$(srcdir)/secp256k1/include -I$(srcdir)/$(UNIVALUE_INCLUDE_DIR_INT) $(LEVELDB_CPPFLAGS)
+BITCOIN_INCLUDES=-I$(builddir) -I$(srcdir)/$(MINISKETCH_INCLUDE_DIR_INT) -I$(srcdir)/secp256k1/include -I$(srcdir)/$(UNIVALUE_INCLUDE_DIR_INT)
 
 LIBBITCOIN_NODE=libbitcoin_node.a
 LIBBITCOIN_COMMON=libbitcoin_common.a
@@ -370,7 +370,7 @@ obj/build.h: FORCE
 libbitcoin_util_a-clientversion.$(OBJEXT): obj/build.h
 
 # node #
-libbitcoin_node_a_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(BOOST_CPPFLAGS) $(MINIUPNPC_CPPFLAGS) $(NATPMP_CPPFLAGS) $(EVENT_CFLAGS) $(EVENT_PTHREADS_CFLAGS)
+libbitcoin_node_a_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(LEVELDB_CPPFLAGS) $(BOOST_CPPFLAGS) $(MINIUPNPC_CPPFLAGS) $(NATPMP_CPPFLAGS) $(EVENT_CFLAGS) $(EVENT_PTHREADS_CFLAGS)
 libbitcoin_node_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libbitcoin_node_a_SOURCES = \
   addrdb.cpp \

--- a/src/blockencodings.cpp
+++ b/src/blockencodings.cpp
@@ -9,6 +9,7 @@
 #include <consensus/validation.h>
 #include <crypto/sha256.h>
 #include <crypto/siphash.h>
+#include <logging.h>
 #include <random.h>
 #include <streams.h>
 #include <txmempool.h>

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -306,6 +306,12 @@ bool CDBWrapper::IsEmpty()
     return !(it->Valid());
 }
 
+void CDBIterator::SeekImpl(Span<const std::byte> ssKey)
+{
+    leveldb::Slice slKey(CharCast(ssKey.data()), ssKey.size());
+    piter->Seek(slKey);
+}
+
 CDBIterator::~CDBIterator() { delete piter; }
 bool CDBIterator::Valid() const { return piter->Valid(); }
 void CDBIterator::SeekToFirst() { piter->SeekToFirst(); }

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -27,6 +27,11 @@
 #include <memory>
 #include <optional>
 
+bool DestroyDB(const std::string& path_str)
+{
+    return leveldb::DestroyDB(path_str, {}).ok();
+}
+
 class CBitcoinLevelDBLogger : public leveldb::Logger {
 public:
     // This code is adapted from posix_logger.h, which is why it is using vsprintf.

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -317,6 +317,11 @@ Span<const std::byte> CDBIterator::GetKeyImpl() const
     return MakeByteSpan(piter->key());
 }
 
+Span<const std::byte> CDBIterator::GetValueImpl() const
+{
+    return MakeByteSpan(piter->value());
+}
+
 CDBIterator::~CDBIterator() { delete piter; }
 bool CDBIterator::Valid() const { return piter->Valid(); }
 void CDBIterator::SeekToFirst() { piter->SeekToFirst(); }

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -313,6 +313,21 @@ std::optional<std::string> CDBWrapper::ReadImpl(Span<const std::byte> ssKey) con
     return strValue;
 }
 
+bool CDBWrapper::ExistsImpl(Span<const std::byte> ssKey) const
+{
+    leveldb::Slice slKey(CharCast(ssKey.data()), ssKey.size());
+
+    std::string strValue;
+    leveldb::Status status = pdb->Get(readoptions, slKey, &strValue);
+    if (!status.ok()) {
+        if (status.IsNotFound())
+            return false;
+        LogPrintf("LevelDB read failure: %s\n", status.ToString());
+        dbwrapper_private::HandleError(status);
+    }
+    return true;
+}
+
 bool CDBWrapper::IsEmpty()
 {
     std::unique_ptr<CDBIterator> it(NewIterator());

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -312,6 +312,11 @@ void CDBIterator::SeekImpl(Span<const std::byte> ssKey)
     piter->Seek(slKey);
 }
 
+Span<const std::byte> CDBIterator::GetKeyImpl() const
+{
+    return MakeByteSpan(piter->key());
+}
+
 CDBIterator::~CDBIterator() { delete piter; }
 bool CDBIterator::Valid() const { return piter->Valid(); }
 void CDBIterator::SeekToFirst() { piter->SeekToFirst(); }

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -33,6 +33,8 @@
 #include <optional>
 #include <utility>
 
+static auto CharCast(const std::byte* data) { return reinterpret_cast<const char*>(data); }
+
 bool DestroyDB(const std::string& path_str)
 {
     return leveldb::DestroyDB(path_str, {}).ok();
@@ -338,6 +340,16 @@ bool CDBWrapper::ExistsImpl(Span<const std::byte> ssKey) const
         HandleError(status);
     }
     return true;
+}
+
+size_t CDBWrapper::EstimateSizeImpl(Span<const std::byte> ssKey1, Span<const std::byte> ssKey2) const
+{
+    leveldb::Slice slKey1(CharCast(ssKey1.data()), ssKey1.size());
+    leveldb::Slice slKey2(CharCast(ssKey2.data()), ssKey2.size());
+    uint64_t size = 0;
+    leveldb::Range range(slKey1, slKey2);
+    pdb->GetApproximateSizes(&range, 1, &size);
+    return size;
 }
 
 bool CDBWrapper::IsEmpty()

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -168,9 +168,9 @@ void CDBBatch::Clear()
     size_estimate = 0;
 }
 
-void CDBBatch::WriteImpl(Span<const std::byte> ssKey, CDataStream& ssValue)
+void CDBBatch::WriteImpl(Span<const std::byte> key, CDataStream& ssValue)
 {
-    leveldb::Slice slKey(CharCast(ssKey.data()), ssKey.size());
+    leveldb::Slice slKey(CharCast(key.data()), key.size());
     ssValue.Xor(dbwrapper_private::GetObfuscateKey(parent));
     leveldb::Slice slValue(CharCast(ssValue.data()), ssValue.size());
     m_impl_batch->batch.Put(slKey, slValue);
@@ -184,9 +184,9 @@ void CDBBatch::WriteImpl(Span<const std::byte> ssKey, CDataStream& ssValue)
     size_estimate += 3 + (slKey.size() > 127) + slKey.size() + (slValue.size() > 127) + slValue.size();
 }
 
-void CDBBatch::EraseImpl(Span<const std::byte> ssKey)
+void CDBBatch::EraseImpl(Span<const std::byte> key)
 {
-    leveldb::Slice slKey(CharCast(ssKey.data()), ssKey.size());
+    leveldb::Slice slKey(CharCast(key.data()), key.size());
     m_impl_batch->batch.Delete(slKey);
     // LevelDB serializes erases as:
     // - byte: header
@@ -336,9 +336,9 @@ std::vector<unsigned char> CDBWrapper::CreateObfuscateKey() const
     return ret;
 }
 
-std::optional<std::string> CDBWrapper::ReadImpl(Span<const std::byte> ssKey) const
+std::optional<std::string> CDBWrapper::ReadImpl(Span<const std::byte> key) const
 {
-    leveldb::Slice slKey(CharCast(ssKey.data()), ssKey.size());
+    leveldb::Slice slKey(CharCast(key.data()), key.size());
     std::string strValue;
     leveldb::Status status = DBContext().pdb->Get(DBContext().readoptions, slKey, &strValue);
     if (!status.ok()) {
@@ -350,9 +350,9 @@ std::optional<std::string> CDBWrapper::ReadImpl(Span<const std::byte> ssKey) con
     return strValue;
 }
 
-bool CDBWrapper::ExistsImpl(Span<const std::byte> ssKey) const
+bool CDBWrapper::ExistsImpl(Span<const std::byte> key) const
 {
-    leveldb::Slice slKey(CharCast(ssKey.data()), ssKey.size());
+    leveldb::Slice slKey(CharCast(key.data()), key.size());
 
     std::string strValue;
     leveldb::Status status = DBContext().pdb->Get(DBContext().readoptions, slKey, &strValue);
@@ -365,10 +365,10 @@ bool CDBWrapper::ExistsImpl(Span<const std::byte> ssKey) const
     return true;
 }
 
-size_t CDBWrapper::EstimateSizeImpl(Span<const std::byte> ssKey1, Span<const std::byte> ssKey2) const
+size_t CDBWrapper::EstimateSizeImpl(Span<const std::byte> key1, Span<const std::byte> key2) const
 {
-    leveldb::Slice slKey1(CharCast(ssKey1.data()), ssKey1.size());
-    leveldb::Slice slKey2(CharCast(ssKey2.data()), ssKey2.size());
+    leveldb::Slice slKey1(CharCast(key1.data()), key1.size());
+    leveldb::Slice slKey2(CharCast(key2.data()), key2.size());
     uint64_t size = 0;
     leveldb::Range range(slKey1, slKey2);
     DBContext().pdb->GetApproximateSizes(&range, 1, &size);
@@ -396,9 +396,9 @@ CDBIterator* CDBWrapper::NewIterator()
     return new CDBIterator{*this, std::make_unique<CDBIterator::IteratorImpl>(DBContext().pdb->NewIterator(DBContext().iteroptions))};
 }
 
-void CDBIterator::SeekImpl(Span<const std::byte> ssKey)
+void CDBIterator::SeekImpl(Span<const std::byte> key)
 {
-    leveldb::Slice slKey(CharCast(ssKey.data()), ssKey.size());
+    leveldb::Slice slKey(CharCast(key.data()), key.size());
     m_impl_iter->iter->Seek(slKey);
 }
 

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -20,7 +20,7 @@
 #include <leveldb/options.h>
 #include <leveldb/slice.h>
 #include <leveldb/status.h>
-#include <leveldb/write_batch.h>
+#include <memory>
 #include <optional>
 #include <stdexcept>
 #include <string>
@@ -90,7 +90,9 @@ class CDBBatch
 
 private:
     const CDBWrapper &parent;
-    leveldb::WriteBatch batch;
+
+    struct WriteBatchImpl;
+    const std::unique_ptr<WriteBatchImpl> m_impl_batch;
 
     DataStream ssKey{};
     CDataStream ssValue;
@@ -104,13 +106,9 @@ public:
     /**
      * @param[in] _parent   CDBWrapper that this batch is to be submitted to
      */
-    explicit CDBBatch(const CDBWrapper& _parent) : parent(_parent), ssValue(SER_DISK, CLIENT_VERSION){};
-
-    void Clear()
-    {
-        batch.Clear();
-        size_estimate = 0;
-    }
+    explicit CDBBatch(const CDBWrapper& _parent);
+    ~CDBBatch();
+    void Clear();
 
     template <typename K, typename V>
     void Write(const K& key, const V& value)

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -140,6 +140,8 @@ private:
     const CDBWrapper &parent;
     leveldb::Iterator *piter;
 
+    void SeekImpl(Span<const std::byte> ssKey);
+
 public:
 
     /**
@@ -158,8 +160,7 @@ public:
         DataStream ssKey{};
         ssKey.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
         ssKey << key;
-        leveldb::Slice slKey(CharCast(ssKey.data()), ssKey.size());
-        piter->Seek(slKey);
+        SeekImpl(ssKey);
     }
 
     void Next();

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -26,7 +26,6 @@
 #include <vector>
 namespace leveldb {
 class Env;
-class Iterator;
 }
 
 static const size_t DBWRAPPER_PREALLOC_KEY_SIZE = 64;
@@ -136,9 +135,12 @@ public:
 
 class CDBIterator
 {
+public:
+    struct IteratorImpl;
+
 private:
     const CDBWrapper &parent;
-    leveldb::Iterator *piter;
+    const std::unique_ptr<IteratorImpl> m_impl_iter;
 
     void SeekImpl(Span<const std::byte> ssKey);
     Span<const std::byte> GetKeyImpl() const;
@@ -150,8 +152,7 @@ public:
      * @param[in] _parent          Parent CDBWrapper instance.
      * @param[in] _piter           The original leveldb iterator.
      */
-    CDBIterator(const CDBWrapper &_parent, leveldb::Iterator *_piter) :
-        parent(_parent), piter(_piter) { };
+    CDBIterator(const CDBWrapper& _parent, std::unique_ptr<IteratorImpl> _piter);
     ~CDBIterator();
 
     bool Valid() const;
@@ -315,10 +316,7 @@ public:
     // Get an estimate of LevelDB memory usage (in bytes).
     size_t DynamicMemoryUsage() const;
 
-    CDBIterator *NewIterator()
-    {
-        return new CDBIterator(*this, pdb->NewIterator(iteroptions));
-    }
+    CDBIterator* NewIterator();
 
     /**
      * Return true if the database managed by this class contains no entries.

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -98,6 +98,7 @@ private:
     size_t size_estimate{0};
 
     void WriteImpl(Span<const std::byte> ssKey, CDataStream& ssValue);
+    void EraseImpl(Span<const std::byte> ssKey);
 
 public:
     /**
@@ -128,15 +129,7 @@ public:
     {
         ssKey.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
         ssKey << key;
-        leveldb::Slice slKey(CharCast(ssKey.data()), ssKey.size());
-
-        batch.Delete(slKey);
-        // LevelDB serializes erases as:
-        // - byte: header
-        // - varint: key length
-        // - byte[]: key
-        // The formula below assumes the key is less than 16kB.
-        size_estimate += 2 + (slKey.size() > 127) + slKey.size();
+        EraseImpl(ssKey);
         ssKey.clear();
     }
 

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -21,6 +21,7 @@
 #include <leveldb/slice.h>
 #include <leveldb/status.h>
 #include <leveldb/write_batch.h>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -64,10 +65,6 @@ public:
 
 class CDBWrapper;
 
-namespace dbwrapper {
-    using leveldb::DestroyDB;
-}
-
 /** These should be considered an implementation detail of the specific database.
  */
 namespace dbwrapper_private {
@@ -82,7 +79,9 @@ void HandleError(const leveldb::Status& status);
  */
 const std::vector<unsigned char>& GetObfuscateKey(const CDBWrapper &w);
 
-};
+}; // namespace dbwrapper_private
+
+bool DestroyDB(const std::string& path_str);
 
 /** Batch of changes queued to be written to a CDBWrapper */
 class CDBBatch

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -16,7 +16,6 @@
 #include <cstdint>
 #include <exception>
 #include <leveldb/db.h>
-#include <leveldb/iterator.h>
 #include <leveldb/options.h>
 #include <leveldb/slice.h>
 #include <leveldb/status.h>
@@ -27,6 +26,7 @@
 #include <vector>
 namespace leveldb {
 class Env;
+class Iterator;
 }
 
 static const size_t DBWRAPPER_PREALLOC_KEY_SIZE = 64;
@@ -142,6 +142,7 @@ private:
 
     void SeekImpl(Span<const std::byte> ssKey);
     Span<const std::byte> GetKeyImpl() const;
+    Span<const std::byte> GetValueImpl() const;
 
 public:
 
@@ -177,9 +178,8 @@ public:
     }
 
     template<typename V> bool GetValue(V& value) {
-        leveldb::Slice slValue = piter->value();
         try {
-            CDataStream ssValue{MakeByteSpan(slValue), SER_DISK, CLIENT_VERSION};
+            CDataStream ssValue{GetValueImpl(), SER_DISK, CLIENT_VERSION};
             ssValue.Xor(dbwrapper_private::GetObfuscateKey(parent));
             ssValue >> value;
         } catch (const std::exception&) {

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -85,8 +85,8 @@ private:
 
     size_t size_estimate{0};
 
-    void WriteImpl(Span<const std::byte> ssKey, CDataStream& ssValue);
-    void EraseImpl(Span<const std::byte> ssKey);
+    void WriteImpl(Span<const std::byte> key, CDataStream& ssValue);
+    void EraseImpl(Span<const std::byte> key);
 
 public:
     /**
@@ -129,7 +129,7 @@ private:
     const CDBWrapper &parent;
     const std::unique_ptr<IteratorImpl> m_impl_iter;
 
-    void SeekImpl(Span<const std::byte> ssKey);
+    void SeekImpl(Span<const std::byte> key);
     Span<const std::byte> GetKeyImpl() const;
     Span<const std::byte> GetValueImpl() const;
 
@@ -206,9 +206,9 @@ private:
     //! whether or not the database resides in memory
     bool m_is_memory;
 
-    std::optional<std::string> ReadImpl(Span<const std::byte> ssKey) const;
-    bool ExistsImpl(Span<const std::byte> ssKey) const;
-    size_t EstimateSizeImpl(Span<const std::byte> ssKey1, Span<const std::byte> ssKey2) const;
+    std::optional<std::string> ReadImpl(Span<const std::byte> key) const;
+    bool ExistsImpl(Span<const std::byte> key) const;
+    size_t EstimateSizeImpl(Span<const std::byte> key1, Span<const std::byte> key2) const;
     auto& DBContext() const LIFETIMEBOUND { return *Assert(m_db_context); }
 
 public:

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -97,6 +97,8 @@ private:
 
     size_t size_estimate{0};
 
+    void WriteImpl(Span<const std::byte> ssKey, CDataStream& ssValue);
+
 public:
     /**
      * @param[in] _parent   CDBWrapper that this batch is to be submitted to
@@ -113,23 +115,10 @@ public:
     void Write(const K& key, const V& value)
     {
         ssKey.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
-        ssKey << key;
-        leveldb::Slice slKey(CharCast(ssKey.data()), ssKey.size());
-
         ssValue.reserve(DBWRAPPER_PREALLOC_VALUE_SIZE);
+        ssKey << key;
         ssValue << value;
-        ssValue.Xor(dbwrapper_private::GetObfuscateKey(parent));
-        leveldb::Slice slValue(CharCast(ssValue.data()), ssValue.size());
-
-        batch.Put(slKey, slValue);
-        // LevelDB serializes writes as:
-        // - byte: header
-        // - varint: key length (1 byte up to 127B, 2 bytes up to 16383B, ...)
-        // - byte[]: key
-        // - varint: value length
-        // - byte[]: value
-        // The formula below assumes the key and value are both less than 16k.
-        size_estimate += 3 + (slKey.size() > 127) + slKey.size() + (slValue.size() > 127) + slValue.size();
+        WriteImpl(ssKey, ssValue);
         ssKey.clear();
         ssValue.clear();
     }

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -141,6 +141,7 @@ private:
     leveldb::Iterator *piter;
 
     void SeekImpl(Span<const std::byte> ssKey);
+    Span<const std::byte> GetKeyImpl() const;
 
 public:
 
@@ -166,9 +167,8 @@ public:
     void Next();
 
     template<typename K> bool GetKey(K& key) {
-        leveldb::Slice slKey = piter->key();
         try {
-            DataStream ssKey{MakeByteSpan(slKey)};
+            DataStream ssKey{GetKeyImpl()};
             ssKey >> key;
         } catch (const std::exception&) {
             return false;

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -24,7 +24,6 @@
 #include <vector>
 namespace leveldb {
 class Env;
-class Status;
 }
 
 static const size_t DBWRAPPER_PREALLOC_KEY_SIZE = 64;
@@ -66,10 +65,6 @@ class CDBWrapper;
 /** These should be considered an implementation detail of the specific database.
  */
 namespace dbwrapper_private {
-
-/** Handle database error by throwing dbwrapper_error exception.
- */
-void HandleError(const leveldb::Status& status);
 
 /** Work around circular dependency, as well as for testing in dbwrapper_tests.
  * Database obfuscation should be considered an implementation detail of the

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -6,7 +6,6 @@
 #define BITCOIN_DBWRAPPER_H
 
 #include <clientversion.h>
-#include <logging.h>
 #include <serialize.h>
 #include <span.h>
 #include <streams.h>
@@ -18,7 +17,6 @@
 #include <leveldb/db.h>
 #include <leveldb/options.h>
 #include <leveldb/slice.h>
-#include <leveldb/status.h>
 #include <memory>
 #include <optional>
 #include <stdexcept>
@@ -26,6 +24,7 @@
 #include <vector>
 namespace leveldb {
 class Env;
+class Status;
 }
 
 static const size_t DBWRAPPER_PREALLOC_KEY_SIZE = 64;
@@ -236,6 +235,7 @@ private:
     bool m_is_memory;
 
     std::optional<std::string> ReadImpl(Span<const std::byte> ssKey) const;
+    bool ExistsImpl(Span<const std::byte> ssKey) const;
 
 public:
     CDBWrapper(const DBParams& params);
@@ -286,17 +286,7 @@ public:
         DataStream ssKey{};
         ssKey.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
         ssKey << key;
-        leveldb::Slice slKey(CharCast(ssKey.data()), ssKey.size());
-
-        std::string strValue;
-        leveldb::Status status = pdb->Get(readoptions, slKey, &strValue);
-        if (!status.ok()) {
-            if (status.IsNotFound())
-                return false;
-            LogPrintf("LevelDB read failure: %s\n", status.ToString());
-            dbwrapper_private::HandleError(status);
-        }
-        return true;
+        return ExistsImpl(ssKey);
     }
 
     template <typename K>

--- a/src/index/blockfilterindex.cpp
+++ b/src/index/blockfilterindex.cpp
@@ -8,6 +8,7 @@
 #include <dbwrapper.h>
 #include <hash.h>
 #include <index/blockfilterindex.h>
+#include <logging.h>
 #include <node/blockstorage.h>
 #include <util/fs_helpers.h>
 #include <validation.h>

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -33,6 +33,7 @@
 #include <interfaces/chain.h>
 #include <interfaces/init.h>
 #include <interfaces/node.h>
+#include <logging.h>
 #include <mapport.h>
 #include <net.h>
 #include <net_permissions.h>

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -17,6 +17,7 @@
 #include <headerssync.h>
 #include <index/blockfilterindex.h>
 #include <kernel/mempool_entry.h>
+#include <logging.h>
 #include <merkleblock.h>
 #include <netbase.h>
 #include <netmessagemaker.h>

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -18,6 +18,7 @@
 #include <interfaces/wallet.h>
 #include <kernel/chain.h>
 #include <kernel/mempool_entry.h>
+#include <logging.h>
 #include <mapport.h>
 #include <net.h>
 #include <net_processing.h>

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -15,6 +15,7 @@
 #include <consensus/tx_verify.h>
 #include <consensus/validation.h>
 #include <deploymentstatus.h>
+#include <logging.h>
 #include <policy/feerate.h>
 #include <policy/policy.h>
 #include <pow.h>

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -9,7 +9,6 @@
 #include <qt/bitcoin.h>
 
 #include <chainparams.h>
-#include <node/context.h>
 #include <common/args.h>
 #include <common/init.h>
 #include <common/system.h>
@@ -17,6 +16,8 @@
 #include <interfaces/handler.h>
 #include <interfaces/init.h>
 #include <interfaces/node.h>
+#include <logging.h>
+#include <node/context.h>
 #include <node/interface_ui.h>
 #include <noui.h>
 #include <qt/bitcoingui.h>

--- a/src/qt/test/apptests.cpp
+++ b/src/qt/test/apptests.cpp
@@ -6,6 +6,7 @@
 
 #include <chainparams.h>
 #include <key.h>
+#include <logging.h>
 #include <qt/bitcoin.h>
 #include <qt/bitcoingui.h>
 #include <qt/networkstyle.h>

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -18,6 +18,7 @@
 #include <interfaces/node.h>
 #include <interfaces/wallet.h>
 #include <key_io.h>
+#include <logging.h>
 #include <policy/policy.h>
 #include <validation.h>
 #include <wallet/types.h>

--- a/src/rpc/node.cpp
+++ b/src/rpc/node.cpp
@@ -13,6 +13,7 @@
 #include <interfaces/init.h>
 #include <interfaces/ipc.h>
 #include <kernel/cs_main.h>
+#include <logging.h>
 #include <node/context.h>
 #include <rpc/server.h>
 #include <rpc/server_util.h>

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -19,6 +19,7 @@
 #include <init/common.h>
 #include <interfaces/chain.h>
 #include <kernel/mempool_entry.h>
+#include <logging.h>
 #include <net.h>
 #include <net_processing.h>
 #include <node/blockstorage.h>

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5027,7 +5027,7 @@ static bool DeleteCoinsDBFromDisk(const fs::path db_path, bool is_snapshot)
 
     // We have to destruct before this call leveldb::DB in order to release the db
     // lock, otherwise `DestroyDB` will fail. See `leveldb::~DBImpl()`.
-    const bool destroyed = dbwrapper::DestroyDB(path_str, {}).ok();
+    const bool destroyed = DestroyDB(path_str);
 
     if (!destroyed) {
         LogPrintf("error: leveldb DestroyDB call failed on %s\n", path_str);


### PR DESCRIPTION
Leveldb headers are currently included in the `dbwrapper.h` file and thus available to many of Bitcoin Core's source files. However, leveldb-specific functionality should be abstracted by the `dbwrapper` and does not need to be available to the rest of the code. Having leveldb included in a widely-used header such as `dbwrapper.h` bloats the entire project's header tree.

The `dbwrapper` is a key component of the libbitcoinkernel library. Future users of this library would not want to contend with  having the leveldb headers exposed and potentially polluting their project's namespace.

For these reasons, the leveldb headers are removed from the `dbwrapper` by moving leveldb-specific code to the implementation file and creating a [pimpl](https://en.cppreference.com/w/cpp/language/pimpl) where leveldb member variables are indispensable. As a final step, the leveldb include flags are removed from the `BITCOIN_INCLUDES` and moved to places where the dbwrapper is compiled.

---

This pull request is part of the [libbitcoinkernel project](https://github.com/bitcoin/bitcoin/issues/27587), and more specifically its stage 1 step 3 "Decouple most non-consensus headers from libbitcoinkernel".