### PR TITLE
ParseHDKeypath: support h as hardened marker

### DIFF
--- a/src/util/bip32.h
+++ b/src/util/bip32.h
@@ -9,8 +9,13 @@
 #include <string>
 #include <vector>
 
-/** Parse an HD keypaths like "m/7/0'/2000". */
-[[nodiscard]] bool ParseHDKeypath(const std::string& keypath_str, std::vector<uint32_t>& keypath);
+/** Parse an HD keypath
+    *
+    * @param[in] keypath_str the path, e.g. "m/7'/0/2000" or "m/0h/0h"
+    * @param[out] keypath the parsed path values
+    * @param[in] check_hardened_marker Check that hardened deriviation markers h and ' are not mixed.
+    */
+[[nodiscard]] bool ParseHDKeypath(const std::string& keypath_str, std::vector<uint32_t>& keypath, bool check_hardened_marker = false);
 
 /** Write HD keypaths as strings */
 std::string WriteHDKeypath(const std::vector<uint32_t>& keypath, bool apostrophe = false);

--- a/src/wallet/test/psbt_wallet_tests.cpp
+++ b/src/wallet/test/psbt_wallet_tests.cpp
@@ -128,6 +128,14 @@ BOOST_AUTO_TEST_CASE(parse_hd_keypath)
     BOOST_CHECK(ParseHDKeypath("m/0'/0'", keypath));
     BOOST_CHECK(!ParseHDKeypath("m/'0/0'", keypath));
 
+    // Use h as derivation marker:
+    BOOST_CHECK(ParseHDKeypath("m/0h/0h", keypath));
+    BOOST_CHECK(!ParseHDKeypath("m/h0/0h", keypath));
+
+    // Hardened derivation marker consistency is not checked by default:
+    BOOST_CHECK(ParseHDKeypath("m/0'/0h", keypath));
+    BOOST_CHECK(!ParseHDKeypath("m/0'/0h", keypath, /*check_hardened_marker=*/true));
+
     BOOST_CHECK(ParseHDKeypath("m/0/0", keypath));
     BOOST_CHECK(!ParseHDKeypath("n/0/0", keypath));
 


### PR DESCRIPTION
BIP32 allows both `'` and `h` as hardened derivation marker. Our legacy wallet uses `'`. Since #26076 our descriptor wallets use `h` by default.

`ParseHDKeypath` only supports `'`. It's currently only used in the legacy wallet context, so this doesn't cause any problems. But it will once #22341 uses it (to parse the RPC `path` argument for `getxpub`). Might as well fix it now.

I added a restriction for not combining `h` and `'`. Afaik this currently isn't enforced anywhere else in the codebase, including for descriptors, but it seems sane. I've occasionally messed that up in the past.