### PR TITLE
test: python E721 and flake8 updates

### DIFF
--- a/ci/lint/04_install.sh
+++ b/ci/lint/04_install.sh
@@ -35,7 +35,7 @@ python3 --version
 
 ${CI_RETRY_EXE} pip3 install \
   codespell==2.2.5 \
-  flake8==6.0.0 \
+  flake8==6.1.0 \
   lief==0.13.2 \
   mypy==1.4.1 \
   pyzmq==25.1.0 \

--- a/src/test/fuzz/descriptor_parse.cpp
+++ b/src/test/fuzz/descriptor_parse.cpp
@@ -85,7 +85,7 @@ public:
         std::string desc;
         desc.reserve(mocked_desc.size());
 
-        // Replace all occurences of '%' followed by two hex characters with the corresponding key.
+        // Replace all occurrences of '%' followed by two hex characters with the corresponding key.
         for (size_t i = 0; i < mocked_desc.size();) {
             if (mocked_desc[i] == '%') {
                 if (i + 3 >= mocked_desc.size()) return {};

--- a/test/functional/p2p_invalid_locator.py
+++ b/test/functional/p2p_invalid_locator.py
@@ -32,7 +32,7 @@ class InvalidLocatorTest(BitcoinTestFramework):
             within_max_peer = node.add_p2p_connection(P2PInterface())
             msg.locator.vHave = [int(node.getblockhash(i - 1), 16) for i in range(block_count, block_count - (MAX_LOCATOR_SZ), -1)]
             within_max_peer.send_message(msg)
-            if type(msg) == msg_getheaders:
+            if type(msg) is msg_getheaders:
                 within_max_peer.wait_for_header(node.getbestblockhash())
             else:
                 within_max_peer.wait_for_block(int(node.getbestblockhash(), 16))

--- a/test/functional/test_framework/siphash.py
+++ b/test/functional/test_framework/siphash.py
@@ -31,7 +31,7 @@ def siphash_round(v0, v1, v2, v3):
 
 
 def siphash(k0, k1, data):
-    assert type(data) == bytes
+    assert type(data) is bytes
     v0 = 0x736f6d6570736575 ^ k0
     v1 = 0x646f72616e646f6d ^ k1
     v2 = 0x6c7967656e657261 ^ k0
@@ -61,5 +61,5 @@ def siphash(k0, k1, data):
 
 
 def siphash256(k0, k1, num):
-    assert type(num) == int
+    assert type(num) is int
     return siphash(k0, k1, num.to_bytes(32, 'little'))


### PR DESCRIPTION
Update our functional tests per [E721](https://www.flake8rules.com/rules/E721.html) enforced by [flake8 6.1.0](https://flake8.pycqa.org/en/latest/release-notes/6.1.0.html), and update our CI lint task to use that release.  This makes the following linter output on current master with flake8 6.1.0 green.

```
$ ./test/lint/lint-python.py ; ./test/lint/lint-spelling.py 
test/functional/p2p_invalid_locator.py:35:16: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
test/functional/test_framework/siphash.py:34:12: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
test/functional/test_framework/siphash.py:64:12: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
src/test/fuzz/descriptor_parse.cpp:88: occurences ==> occurrences
^ Warning: codespell identified likely spelling errors. Any false positives? Add them to the list of ignored words in test/lint/spelling.ignore-words.txt
```
