### PR TITLE
refactor: Remove unused includes from wallet.cpp

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -190,6 +190,7 @@ BITCOIN_CORE_H = \
   kernel/mempool_limits.h \
   kernel/mempool_options.h \
   kernel/mempool_persist.h \
+  kernel/mempool_removal_reason.h \
   kernel/notifications_interface.h \
   kernel/validation_cache_sizes.h \
   key.h \
@@ -401,6 +402,7 @@ libbitcoin_node_a_SOURCES = \
   kernel/context.cpp \
   kernel/cs_main.cpp \
   kernel/mempool_persist.cpp \
+  kernel/mempool_removal_reason.cpp \
   mapport.cpp \
   net.cpp \
   net_processing.cpp \
@@ -940,6 +942,7 @@ libbitcoinkernel_la_SOURCES = \
   kernel/context.cpp \
   kernel/cs_main.cpp \
   kernel/mempool_persist.cpp \
+  kernel/mempool_removal_reason.cpp \
   key.cpp \
   logging.cpp \
   node/blockstorage.cpp \

--- a/src/blockfilter.cpp
+++ b/src/blockfilter.cpp
@@ -8,9 +8,11 @@
 #include <blockfilter.h>
 #include <crypto/siphash.h>
 #include <hash.h>
+#include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <script/script.h>
 #include <streams.h>
+#include <undo.h>
 #include <util/golombrice.h>
 #include <util/string.h>
 

--- a/src/blockfilter.h
+++ b/src/blockfilter.h
@@ -5,18 +5,21 @@
 #ifndef BITCOIN_BLOCKFILTER_H
 #define BITCOIN_BLOCKFILTER_H
 
-#include <stdint.h>
-#include <string>
+#include <cstddef>
+#include <cstdint>
+#include <ios>
 #include <set>
+#include <string>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include <attributes.h>
-#include <primitives/block.h>
-#include <serialize.h>
 #include <uint256.h>
-#include <undo.h>
 #include <util/bytevectorhash.h>
+
+class CBlock;
+class CBlockUndo;
 
 /**
  * This implements a Golomb-coded set as defined in BIP 158. It is a

--- a/src/index/blockfilterindex.cpp
+++ b/src/index/blockfilterindex.cpp
@@ -10,6 +10,7 @@
 #include <index/blockfilterindex.h>
 #include <logging.h>
 #include <node/blockstorage.h>
+#include <undo.h>
 #include <util/fs_helpers.h>
 #include <validation.h>
 

--- a/src/index/blockfilterindex.h
+++ b/src/index/blockfilterindex.h
@@ -12,6 +12,8 @@
 #include <index/base.h>
 #include <util/hasher.h>
 
+#include <unordered_map>
+
 static const char* const DEFAULT_BLOCKFILTERINDEX = "0";
 
 /** Interval between compact filter checkpoints. See BIP 157. */

--- a/src/kernel/mempool_removal_reason.cpp
+++ b/src/kernel/mempool_removal_reason.cpp
@@ -1,0 +1,21 @@
+// Copyright (c) 2016-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/license/mit/.
+
+#include <kernel/mempool_removal_reason.h>
+
+#include <cassert>
+#include <string>
+
+std::string RemovalReasonToString(const MemPoolRemovalReason& r) noexcept
+{
+    switch (r) {
+        case MemPoolRemovalReason::EXPIRY: return "expiry";
+        case MemPoolRemovalReason::SIZELIMIT: return "sizelimit";
+        case MemPoolRemovalReason::REORG: return "reorg";
+        case MemPoolRemovalReason::BLOCK: return "block";
+        case MemPoolRemovalReason::CONFLICT: return "conflict";
+        case MemPoolRemovalReason::REPLACED: return "replaced";
+    }
+    assert(false);
+}

--- a/src/kernel/mempool_removal_reason.h
+++ b/src/kernel/mempool_removal_reason.h
@@ -1,0 +1,24 @@
+// Copyright (c) 2016-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/license/mit/.
+
+#ifndef BITCOIN_KERNEL_MEMPOOL_REMOVAL_REASON_H
+#define BITCOIN_KERNEL_MEMPOOL_REMOVAL_REASON_H
+
+#include <string>
+
+/** Reason why a transaction was removed from the mempool,
+ * this is passed to the notification signal.
+ */
+enum class MemPoolRemovalReason {
+    EXPIRY,      //!< Expired from mempool
+    SIZELIMIT,   //!< Removed in size limiting
+    REORG,       //!< Removed for reorganization
+    BLOCK,       //!< Removed for block
+    CONFLICT,    //!< Removed for conflict with in-block transaction
+    REPLACED,    //!< Removed for replacement
+};
+
+std::string RemovalReasonToString(const MemPoolRemovalReason& r) noexcept;
+
+#endif // BITCOIN_KERNEL_MEMPOOL_REMOVAL_REASON_H

--- a/src/node/miner.h
+++ b/src/node/miner.h
@@ -21,10 +21,11 @@
 #include <boost/multi_index_container.hpp>
 
 class ArgsManager;
-class ChainstateManager;
 class CBlockIndex;
 class CChainParams;
 class CScript;
+class Chainstate;
+class ChainstateManager;
 
 namespace Consensus { struct Params; };
 

--- a/src/test/blockfilter_tests.cpp
+++ b/src/test/blockfilter_tests.cpp
@@ -7,8 +7,10 @@
 
 #include <blockfilter.h>
 #include <core_io.h>
+#include <primitives/block.h>
 #include <serialize.h>
 #include <streams.h>
+#include <undo.h>
 #include <univalue.h>
 #include <util/strencodings.h>
 

--- a/src/test/miniminer_tests.cpp
+++ b/src/test/miniminer_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #include <node/mini_miner.h>
+#include <random.h>
 #include <txmempool.h>
 #include <util/time.h>
 

--- a/src/test/util/blockfilter.cpp
+++ b/src/test/util/blockfilter.cpp
@@ -6,6 +6,8 @@
 
 #include <chainparams.h>
 #include <node/blockstorage.h>
+#include <primitives/block.h>
+#include <undo.h>
 #include <validation.h>
 
 using node::BlockManager;

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1197,19 +1197,6 @@ void CTxMemPool::SetLoadTried(bool load_tried)
     m_load_tried = load_tried;
 }
 
-std::string RemovalReasonToString(const MemPoolRemovalReason& r) noexcept
-{
-    switch (r) {
-        case MemPoolRemovalReason::EXPIRY: return "expiry";
-        case MemPoolRemovalReason::SIZELIMIT: return "sizelimit";
-        case MemPoolRemovalReason::REORG: return "reorg";
-        case MemPoolRemovalReason::BLOCK: return "block";
-        case MemPoolRemovalReason::CONFLICT: return "conflict";
-        case MemPoolRemovalReason::REPLACED: return "replaced";
-    }
-    assert(false);
-}
-
 std::vector<CTxMemPool::txiter> CTxMemPool::GatherClusters(const std::vector<uint256>& txids) const
 {
     AssertLockHeld(cs);

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -6,15 +6,6 @@
 #ifndef BITCOIN_TXMEMPOOL_H
 #define BITCOIN_TXMEMPOOL_H
 
-#include <atomic>
-#include <map>
-#include <optional>
-#include <set>
-#include <string>
-#include <string_view>
-#include <utility>
-#include <vector>
-
 #include <kernel/mempool_limits.h>
 #include <kernel/mempool_options.h>
 
@@ -26,7 +17,6 @@
 #include <policy/feerate.h>
 #include <policy/packages.h>
 #include <primitives/transaction.h>
-#include <random.h>
 #include <sync.h>
 #include <util/epochguard.h>
 #include <util/hasher.h>
@@ -40,9 +30,16 @@
 #include <boost/multi_index/tag.hpp>
 #include <boost/multi_index_container.hpp>
 
-class CBlockIndex;
+#include <atomic>
+#include <map>
+#include <optional>
+#include <set>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
 class CChain;
-class Chainstate;
 
 /** Fake height value used in Coin to signify they are only in the memory pool (since 0.8) */
 static const uint32_t MEMPOOL_HEIGHT = 0x7FFFFFFF;

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -6,14 +6,14 @@
 #ifndef BITCOIN_TXMEMPOOL_H
 #define BITCOIN_TXMEMPOOL_H
 
-#include <kernel/mempool_limits.h>
-#include <kernel/mempool_options.h>
-
 #include <coins.h>
 #include <consensus/amount.h>
 #include <indirectmap.h>
 #include <kernel/cs_main.h>
-#include <kernel/mempool_entry.h>
+#include <kernel/mempool_entry.h>          // IWYU pragma: export
+#include <kernel/mempool_limits.h>         // IWYU pragma: export
+#include <kernel/mempool_options.h>        // IWYU pragma: export
+#include <kernel/mempool_removal_reason.h> // IWYU pragma: export
 #include <policy/feerate.h>
 #include <policy/packages.h>
 #include <primitives/transaction.h>
@@ -224,20 +224,6 @@ struct TxMempoolInfo
     /** The fee delta. */
     int64_t nFeeDelta;
 };
-
-/** Reason why a transaction was removed from the mempool,
- * this is passed to the notification signal.
- */
-enum class MemPoolRemovalReason {
-    EXPIRY,      //!< Expired from mempool
-    SIZELIMIT,   //!< Removed in size limiting
-    REORG,       //!< Removed for reorganization
-    BLOCK,       //!< Removed for block
-    CONFLICT,    //!< Removed for conflict with in-block transaction
-    REPLACED,    //!< Removed for replacement
-};
-
-std::string RemovalReasonToString(const MemPoolRemovalReason& r) noexcept;
 
 /**
  * CTxMemPool stores valid-according-to-the-current-best-chain transactions

--- a/src/wallet/test/util.cpp
+++ b/src/wallet/test/util.cpp
@@ -9,6 +9,7 @@
 #include <key_io.h>
 #include <streams.h>
 #include <test/util/setup_common.h>
+#include <validationinterface.h>
 #include <wallet/context.h>
 #include <wallet/wallet.h>
 #include <wallet/walletdb.h>

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -21,6 +21,7 @@
 #include <test/util/setup_common.h>
 #include <util/translation.h>
 #include <validation.h>
+#include <validationinterface.h>
 #include <wallet/coincontrol.h>
 #include <wallet/context.h>
 #include <wallet/receive.h>

--- a/test/lint/lint-circular-dependencies.py
+++ b/test/lint/lint-circular-dependencies.py
@@ -19,7 +19,6 @@ EXPECTED_CIRCULAR_DEPENDENCIES = (
     "qt/recentrequeststablemodel -> qt/walletmodel -> qt/recentrequeststablemodel",
     "qt/sendcoinsdialog -> qt/walletmodel -> qt/sendcoinsdialog",
     "qt/transactiontablemodel -> qt/walletmodel -> qt/transactiontablemodel",
-    "wallet/fees -> wallet/wallet -> wallet/fees",
     "wallet/wallet -> wallet/walletdb -> wallet/wallet",
     "kernel/coinstats -> validation -> kernel/coinstats",
     "kernel/mempool_persist -> validation -> kernel/mempool_persist",


### PR DESCRIPTION
This makes compilation of wallet.cpp use a few % less memory and time, locally.

Created in the context of https://github.com/bitcoin/bitcoin/issues/28109, but I don't think it is enough to actually fix this problem.