### PR TITLE
net_processing: re-allow fetching of genesis block via `getblockfrompeer`

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4646,7 +4646,8 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
 
             // Check work on this block against our anti-dos thresholds.
             const CBlockIndex* prev_block = m_chainman.m_blockman.LookupBlockIndex(pblock->hashPrevBlock);
-            if (prev_block && prev_block->nChainWork + CalculateHeadersWork({pblock->GetBlockHeader()}) >= GetAntiDoSWorkThreshold()) {
+            if (hash == m_chainparams.GetConsensus().hashGenesisBlock ||
+                (prev_block && prev_block->nChainWork + CalculateHeadersWork({pblock->GetBlockHeader()}) >= GetAntiDoSWorkThreshold())) {
                 min_pow_checked = true;
             }
         }

--- a/test/functional/rpc_getblockfrompeer.py
+++ b/test/functional/rpc_getblockfrompeer.py
@@ -152,6 +152,13 @@ class GetBlockFromPeerTest(BitcoinTestFramework):
         assert_equal(pruned_node.pruneblockchain(1000), pruneheight)
         assert_raises_rpc_error(-1, "Block not available (pruned data)", pruned_node.getblock, pruned_block)
 
+        self.log.info("Fetch genesis block")
+        genesis_block_hash = self.nodes[0].getblockhash(0)
+        assert_raises_rpc_error(-1, "Block not available (pruned data)", pruned_node.getblock, genesis_block_hash)
+        result = pruned_node.getblockfrompeer(genesis_block_hash, pruned_node_peer_0_id)
+        self.wait_until(lambda: self.check_for_block(node=2, hash=genesis_block_hash), timeout=1)
+        assert_equal(result, {})
+
 
 if __name__ == '__main__':
     GetBlockFromPeerTest().main()


### PR DESCRIPTION
Since commit ed6cddd98e32263fc116a4380af6d66da20da990 (PR #25717) incoming BLOCK messages have to pass an anti-DoS check in order to be accepted. Passing this check is currently only possible if there's a previous block available, which is obviously not the case for the genesis block, so it is denied:

`ERROR: ProcessNewBlock: AcceptBlock FAILED (too-little-chainwork)`
    
Fix that by adding the special case for the genesis block, so fetching it via `getblockfrompeer` on pruned nodes (which was possible pre v24.0) is working again. Inspiration for looking into this was the following twitter post: https://twitter.com/colemaktypo/status/1686423428155297796 as I vaguely remembered that this was possible in the past. The practical relevance of all this is of course debatable; on the long-term it might make more sense to put an exception on the `getblock` RPC to return the genesis block directly as embedded in the code, rather than trying to read it from disk, so fetching it from other peers is not needed in the first place (if we care about having it available on pruned nodes at all).