### PR TITLE
Libstandardness (edition 2023)

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -234,6 +234,7 @@ BITCOIN_CORE_H = \
   policy/feerate.h \
   policy/fees.h \
   policy/fees_args.h \
+  policy/libstandardness.h \
   policy/packages.h \
   policy/policy.h \
   policy/rbf.h \
@@ -428,6 +429,7 @@ libbitcoin_node_a_SOURCES = \
   noui.cpp \
   policy/fees.cpp \
   policy/fees_args.cpp \
+  policy/libstandardness.cpp \
   policy/packages.cpp \
   policy/rbf.cpp \
   policy/settings.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -137,6 +137,7 @@ BITCOIN_CORE_H = \
   common/bloom.h \
   common/init.h \
   common/run_command.h \
+  common/shared_libs_util.h \
   common/url.h \
   compat/assumptions.h \
   compat/byteswap.h \

--- a/src/common/shared_lib_utils.h
+++ b/src/common/shared_lib_utils.h
@@ -1,0 +1,53 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_SHARED_LIB_UTILS_H
+#define BITCOIN_SHARED_LIB_UTILS_H
+
+#include <primitives/transaction.h>
+
+/** A class that deserializes a single CTransaction one time. */
+class TxInputStream
+{
+public:
+    TxInputStream(int nVersionIn, const unsigned char *txTo, size_t txToLen) :
+    m_version(nVersionIn),
+    m_data(txTo),
+    m_remaining(txToLen)
+    {}
+
+    void read(Span<std::byte> dst)
+    {
+        if (dst.size() > m_remaining) {
+            throw std::ios_base::failure(std::string(__func__) + ": end of data");
+        }
+
+        if (dst.data() == nullptr) {
+            throw std::ios_base::failure(std::string(__func__) + ": bad destination buffer");
+        }
+
+        if (m_data == nullptr) {
+            throw std::ios_base::failure(std::string(__func__) + ": bad source buffer");
+        }
+
+        memcpy(dst.data(), m_data, dst.size());
+        m_remaining -= dst.size();
+        m_data += dst.size();
+    }
+
+    template<typename T>
+    TxInputStream& operator>>(T&& obj)
+    {
+        ::Unserialize(*this, obj);
+        return *this;
+    }
+
+    int GetVersion() const { return m_version; }
+private:
+    const int m_version;
+    const unsigned char* m_data;
+    size_t m_remaining;
+};
+
+#endif // BITCOIN_SHARED_LIB_UTILS_H

--- a/src/policy/libstandardness.cpp
+++ b/src/policy/libstandardness.cpp
@@ -1,0 +1,83 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <policy/libstandardness.h>
+
+#include <chainparams.h>
+#include <common/args.h>
+#include <common/shared_lib_utils.h>
+#include <node/blockstorage.h>
+#include <node/kernel_notifications.h>
+#include <policy/fees.h>
+#include <policy/fees_args.h>
+#include <timedata.h>
+#include <validation.h>
+
+namespace {
+
+inline int set_result(libstandardness_result* ret, libstandardness_result sret)
+{
+    if (ret)
+        *ret = sret;
+    return 0;
+}
+
+} // namespace
+
+int libstandard_verify_transaction(const unsigned char *txTo, unsigned int txToLen, libstandardness_result* result)
+{
+    try {
+        TxInputStream stream(PROTOCOL_VERSION, txTo, txToLen);
+        CTransaction tx(deserialize, stream);
+
+        const auto args = ArgsManager{};
+        //TODO: pass the chain type as a library argument
+        const auto chainParams = CreateChainParams(args, ChainType::MAIN);
+
+        // We initialize block manager options for the dummy chainstate.
+        node::BlockManager::Options blockman_opts {
+            .chainparams = *chainParams,
+            .blocks_dir = args.GetBlocksDirPath(),
+        };
+
+        // We initialize mempool options and mempool for the dummy chainstate.
+        const auto fee_estimator = std::make_unique<CBlockPolicyEstimator>(FeeestPath(args));
+        //TODO: give an adequate value for internal mempool consistency check
+        CTxMemPool::Options mempool_opts {
+            .estimator = fee_estimator.get(),
+            .check_ratio = 0,
+        };
+
+        const auto dummy_mempool = std::make_unique<CTxMemPool>(mempool_opts);
+
+        node::KernelNotifications notifications{};
+        ChainstateManager::Options chainman_opts{
+            .chainparams = *chainParams,
+            .datadir = args.GetDataDirNet(), 
+            .adjusted_time_callback = GetAdjustedTime,
+            .notifications = notifications,
+        };
+        const auto chainman = std::make_unique<ChainstateManager>(chainman_opts, blockman_opts);
+
+        const auto dummy_chainstate = std::make_unique<Chainstate>(dummy_mempool.get(), chainman->m_blockman, *chainman);
+        //TODO: initialize dummy_chainstate with chain tip as seen by the caller and spent_UTXO
+
+        const auto tx_ref = MakeTransactionRef(tx);
+        LOCK(::cs_main);
+        // The accept_time is only used for CTxMemPoolEntry construction in PreChecks.
+        const auto mempool_result = AcceptToMemoryPool(*dummy_chainstate, tx_ref, /*dummy_timestamp*/ 0, /*bypass_limits=*/false, /*test_accept=*/false);
+        if (mempool_result.m_result_type == MempoolAcceptResult::ResultType::VALID) {
+            return set_result(result, libstandardness_RESULT_OK);
+        }
+        return set_result(result, libstandardness_RESULT_INVALID);
+    } catch (const std::exception&) {
+        return set_result(result, libstandardness_RESULT_INVALID);
+    }
+}
+
+unsigned int libstandardness_version()
+{
+    // Just use the API version for now
+    return LIBSTANDARD_API_VER;
+}

--- a/src/policy/libstandardness.h
+++ b/src/policy/libstandardness.h
@@ -1,0 +1,35 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_POLICY_LIBSTANDARD_H
+#define BITCOIN_POLICY_LIBSTANDARD_H
+
+#ifndef EXPORT_SYMBOL
+  #define EXPORT_SYMBOL
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define LIBSTANDARD_API_VER 1
+
+typedef enum libstandardness_result_t
+{
+    libstandardness_RESULT_OK = 0,
+    libstandardness_RESULT_INVALID,
+
+} libstandardness_result;
+
+EXPORT_SYMBOL int libstandard_verify_transaction(const unsigned char *txTo, unsigned int txToLen, libstandardness_result* result);
+
+EXPORT_SYMBOL unsigned int bitcoinconsensus_version();
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#undef EXPORT_SYMBOL
+
+#endif // BITCOIN_POLICY_LIBSTANDARD_H

--- a/src/script/bitcoinconsensus.cpp
+++ b/src/script/bitcoinconsensus.cpp
@@ -5,55 +5,13 @@
 
 #include <script/bitcoinconsensus.h>
 
+#include <common/shared_lib_utils.h>
 #include <primitives/transaction.h>
 #include <pubkey.h>
 #include <script/interpreter.h>
 #include <version.h>
 
 namespace {
-
-/** A class that deserializes a single CTransaction one time. */
-class TxInputStream
-{
-public:
-    TxInputStream(int nVersionIn, const unsigned char *txTo, size_t txToLen) :
-    m_version(nVersionIn),
-    m_data(txTo),
-    m_remaining(txToLen)
-    {}
-
-    void read(Span<std::byte> dst)
-    {
-        if (dst.size() > m_remaining) {
-            throw std::ios_base::failure(std::string(__func__) + ": end of data");
-        }
-
-        if (dst.data() == nullptr) {
-            throw std::ios_base::failure(std::string(__func__) + ": bad destination buffer");
-        }
-
-        if (m_data == nullptr) {
-            throw std::ios_base::failure(std::string(__func__) + ": bad source buffer");
-        }
-
-        memcpy(dst.data(), m_data, dst.size());
-        m_remaining -= dst.size();
-        m_data += dst.size();
-    }
-
-    template<typename T>
-    TxInputStream& operator>>(T&& obj)
-    {
-        ::Unserialize(*this, obj);
-        return *this;
-    }
-
-    int GetVersion() const { return m_version; }
-private:
-    const int m_version;
-    const unsigned char* m_data;
-    size_t m_remaining;
-};
 
 inline int set_error(bitcoinconsensus_error* ret, bitcoinconsensus_error serror)
 {


### PR DESCRIPTION
This PR proposes to introduce a new interface to allow applications and second layers protocols to verify that their unconfirmed and non-propagated transactions are valid under Bitcoin Core transaction relay policy.

This new `libstandardness` interface is designed at the image of the `bitcoinconsensus` library, which already exposes some of the script verification internals to other applications. A new method is introduced `libstandard_verify_transaction` which indicate to the caller if the transaction is valid, i.e can propagate at current chain tip. For now, the policy rules as considered as a "black box", there is no detail (i.e `TxValidationState::m_reject_reason`) on thepolicy rule violated.

This interface allows second layers like contracting protocols relying on pre-signed transactions and efficient propagation over the network mempools for the security of user funds. E.g for the Lightning Network, counterparties are exchanging signatures for the commitment transaction and second-stage HTLCs during the BOLT2's `commitment_signed` message dance. A policy invalid commitment transaction with pending HTLC outputs not propagating on the network can be source of failure, a serious vulnerability for a Lightning implementation as [CVE-2020-26895](https://lists.linuxfoundation.org/pipermail/lightning-dev/2020-October/002858.html) showed it. Beyond being source of loss of funds, a policy rule violation can be a source of [liquidity griefing](https://lists.linuxfoundation.org/pipermail/lightning-dev/2023-May/003920.html) for a Lightning node participating in a collaborative transaction flow (dual-funding / splicing), where inputs/outputs are freely added by the counterparties.

For some contracting protocols, where the pre-signed txn are malleable by the counterparty it doesn't seem computationally plausible to `testmempoolaccept` all the combinationd valid under the protocol template and this would still assume some changes in our current transaction validation interface to bypass some stateful checks such as timelocks and mempool min fee.

As of today, there is no straightforward software tooling for applications and second-layers to verify the validity of the policy rules of their transactions, and most of implementations to the best of my knwoledge are re-implementing the policy rules in their backend, or delegate this verification to their bitcoin libraries. Such re-implementation is sometimes imperfect, must be updated at each Bitcoin Core policy rules changes (e.g packages policy rules) and be adapted for each protocol transaction templates (e.g for Lightning, commitment tx, second-stage tx, closing_tx, collaborative tx, legacy/anchor/taproot).

The proposed interface is introduced as a shared library rather than a RPC interface, as ideally policy rules could be enforced on embedded / resource constrained platforms such as L2 signers enforcing security rule validation of the second layer state machine (and from where one should be able to extract propagating pre-signed transactions in case of emergency recovery) and generally allow for more flexibility for applications and second layers, e.g on mobile phone where a full-node is not assumed (all caveats reserved on the lower security model in that latter case).

This interface has been proposed in the past, see previous PRs
- https://github.com/bitcoin/bitcoin/pull/18797
- https://github.com/bitcoin/bitcoin/pull/21413
- https://github.com/bitcoin/bitcoin/pull/25434

Opening the PR for now to collect conceptual and implementation-approach feedbacks. If the new interface is judged as relevant and useful, I'll add bindings in rust-bitcoin to test the interface end-to-end with adequate Lightning software.

TODO:
- write documentation for language bindings write in `doc/shared-libraries.md` and maybe in `doc/policy/`
- integrate as a config flag only feature in build system (e.g `BUILD_BITCOIN_LIBSTANDARDNESS` in `src/Makefile.am` and `configure.ac`)
- initialize the chainstate and its associated mempool with the spent utxos
- some other things