### PR TITLE
Use shared_ptr for CNode inside CConnman

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1142,7 +1142,6 @@ void CConnman::DisconnectNodes()
                 if (pnode->IsManualOrFullOutboundConn()) --m_network_conn_counts[pnode->addr.GetNetwork()];
 
                 // hold in disconnected pool until all refs are released
-                pnode->Release();
                 m_nodes_disconnected.push_back(pnode);
             }
         }
@@ -1152,7 +1151,7 @@ void CConnman::DisconnectNodes()
         std::vector<CNodeRef> nodes_disconnected_copy = m_nodes_disconnected;
         for (auto& pnode : nodes_disconnected_copy) {
             // Destroy the object only after other threads have stopped using it.
-            if (pnode->GetRefCount() <= 0) {
+            if (pnode.use_count() == 2) {
                 DeleteNode(pnode);
                 m_nodes_disconnected.erase(remove(m_nodes_disconnected.begin(), m_nodes_disconnected.end(), pnode), m_nodes_disconnected.end());
             }

--- a/src/net.h
+++ b/src/net.h
@@ -787,8 +787,7 @@ public:
     using NodeFn = std::function<void(CNodeRef)>;
     void ForEachNode(const NodeFn& func)
     {
-        LOCK(m_nodes_mutex);
-        for (auto&& node : m_nodes) {
+        for (auto& node : NodesSnapshot(*this)) {
             if (NodeFullyConnected(node))
                 func(node);
         }
@@ -796,8 +795,7 @@ public:
 
     void ForEachNode(const NodeFn& func) const
     {
-        LOCK(m_nodes_mutex);
-        for (auto&& node : m_nodes) {
+        for (auto& node : NodesSnapshot(*this)) {
             if (NodeFullyConnected(node))
                 func(node);
         }
@@ -1208,7 +1206,7 @@ private:
     class NodesSnapshot
     {
     public:
-        explicit NodesSnapshot(const CConnman& connman, bool shuffle)
+        explicit NodesSnapshot(const CConnman& connman, bool shuffle = false)
         {
             {
                 LOCK(connman.m_nodes_mutex);
@@ -1219,9 +1217,24 @@ private:
             }
         }
 
+        std::vector<CNodeRef>::const_iterator begin() const
+        {
+            return m_nodes_copy.begin();
+        }
+
+        std::vector<CNodeRef>::const_iterator end() const
+        {
+            return m_nodes_copy.end();
+        }
+
         const std::vector<CNodeRef>& Nodes() const
         {
             return m_nodes_copy;
+        }
+
+        size_t Size() const
+        {
+            return m_nodes_copy.size();
         }
 
     private:

--- a/src/net.h
+++ b/src/net.h
@@ -415,7 +415,6 @@ public:
     // next time DisconnectNodes() runs
     std::atomic_bool fDisconnect{false};
     CSemaphoreGrant grantOutbound;
-    std::atomic<int> nRefCount{0};
 
     const uint64_t nKeyedNetGroup;
     std::atomic_bool fPauseRecv{false};
@@ -581,12 +580,6 @@ public:
         return nLocalHostNonce;
     }
 
-    int GetRefCount() const
-    {
-        assert(nRefCount >= 0);
-        return nRefCount;
-    }
-
     /**
      * Receive bytes from the buffer and deserialize them into messages.
      *
@@ -611,17 +604,6 @@ public:
     CService GetAddrLocal() const EXCLUSIVE_LOCKS_REQUIRED(!m_addr_local_mutex);
     //! May not be called more than once
     void SetAddrLocal(const CService& addrLocalIn) EXCLUSIVE_LOCKS_REQUIRED(!m_addr_local_mutex);
-
-    CNode* AddRef()
-    {
-        nRefCount++;
-        return this;
-    }
-
-    void Release()
-    {
-        nRefCount--;
-    }
 
     void CloseSocketDisconnect() EXCLUSIVE_LOCKS_REQUIRED(!m_sock_mutex);
 
@@ -1231,19 +1213,9 @@ private:
             {
                 LOCK(connman.m_nodes_mutex);
                 m_nodes_copy = connman.m_nodes;
-                for (auto& node : m_nodes_copy) {
-                    node->AddRef();
-                }
             }
             if (shuffle) {
                 Shuffle(m_nodes_copy.begin(), m_nodes_copy.end(), FastRandomContext{});
-            }
-        }
-
-        ~NodesSnapshot()
-        {
-            for (auto& node : m_nodes_copy) {
-                node->Release();
             }
         }
 

--- a/src/net.h
+++ b/src/net.h
@@ -45,6 +45,7 @@
 
 class AddrMan;
 class BanMan;
+class CConnman;
 class CNode;
 class CScheduler;
 struct bilingual_str;
@@ -568,9 +569,11 @@ public:
           const std::string& addrNameIn,
           ConnectionType conn_type_in,
           bool inbound_onion,
+          CConnman* connman = nullptr,
           CNodeOptions&& node_opts = {});
     CNode(const CNode&) = delete;
     CNode& operator=(const CNode&) = delete;
+    ~CNode();
 
     NodeId GetId() const {
         return id;
@@ -647,6 +650,7 @@ private:
      * Otherwise this unique_ptr is empty.
      */
     std::unique_ptr<i2p::sam::Session> m_i2p_sam_session GUARDED_BY(m_sock_mutex);
+    CConnman* m_connman;
 };
 
 using CNodeRef = std::shared_ptr<CNode>;
@@ -1242,6 +1246,7 @@ private:
     };
 
     friend struct ConnmanTestMsg;
+    friend class CNode;
 };
 
 /** Dump binary message to file, with timestamp */

--- a/src/net.h
+++ b/src/net.h
@@ -667,6 +667,8 @@ private:
     std::unique_ptr<i2p::sam::Session> m_i2p_sam_session GUARDED_BY(m_sock_mutex);
 };
 
+using CNodeRef = std::shared_ptr<CNode>;
+
 /**
  * Interface for message handling
  */

--- a/src/net.h
+++ b/src/net.h
@@ -1062,7 +1062,8 @@ private:
     std::vector<std::string> m_added_nodes GUARDED_BY(m_added_nodes_mutex);
     mutable Mutex m_added_nodes_mutex;
     std::vector<CNodeRef> m_nodes GUARDED_BY(m_nodes_mutex);
-    std::vector<CNodeRef> m_nodes_disconnected;
+    mutable GlobalMutex m_nodes_disconnected_mutex;
+    std::vector<CNodeRef> m_nodes_disconnected GUARDED_BY(m_nodes_disconnected_mutex);
     mutable RecursiveMutex m_nodes_mutex;
     std::atomic<NodeId> nLastNodeId{0};
     unsigned int nPrevNodeCount{0};

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -64,7 +64,8 @@ BOOST_AUTO_TEST_CASE(outbound_slow_chain_eviction)
                                                   CAddress(),
                                                   /*addrNameIn=*/"",
                                                   ConnectionType::OUTBOUND_FULL_RELAY,
-                                                  /*inbound_onion=*/false);
+                                                  /*inbound_onion=*/false,
+                                                  /*connman=*/nullptr);
 
     connman.Handshake(
         /*node=*/*dummyNode1,
@@ -128,7 +129,8 @@ static void AddRandomOutboundPeer(NodeId& id, std::vector<CNodeRef>& vNodes, Pee
                                                 CAddress(),
                                                 /*addrNameIn=*/"",
                                                 connType,
-                                                /*inbound_onion=*/false));
+                                                /*inbound_onion=*/false,
+                                                /*connman=*/nullptr));
     auto node = vNodes.back();
     node->SetCommonVersion(PROTOCOL_VERSION);
 
@@ -330,7 +332,8 @@ BOOST_AUTO_TEST_CASE(peer_discouragement)
                                        CAddress(),
                                        /*addrNameIn=*/"",
                                        ConnectionType::INBOUND,
-                                       /*inbound_onion=*/false);
+                                       /*inbound_onion=*/false,
+                                       /*connman=*/nullptr);
     nodes[0]->SetCommonVersion(PROTOCOL_VERSION);
     peerLogic->InitializeNode(*nodes[0], NODE_NETWORK);
     nodes[0]->fSuccessfullyConnected = true;
@@ -350,7 +353,8 @@ BOOST_AUTO_TEST_CASE(peer_discouragement)
                                        CAddress(),
                                        /*addrNameIn=*/"",
                                        ConnectionType::INBOUND,
-                                       /*inbound_onion=*/false);
+                                       /*inbound_onion=*/false,
+                                       /*connman=*/nullptr);
     nodes[1]->SetCommonVersion(PROTOCOL_VERSION);
     peerLogic->InitializeNode(*nodes[1], NODE_NETWORK);
     nodes[1]->fSuccessfullyConnected = true;
@@ -381,7 +385,8 @@ BOOST_AUTO_TEST_CASE(peer_discouragement)
                                        CAddress(),
                                        /*addrNameIn=*/"",
                                        ConnectionType::OUTBOUND_FULL_RELAY,
-                                       /*inbound_onion=*/false);
+                                       /*inbound_onion=*/false,
+                                       /*connman=*/nullptr);
     nodes[2]->SetCommonVersion(PROTOCOL_VERSION);
     peerLogic->InitializeNode(*nodes[2], NODE_NETWORK);
     nodes[2]->fSuccessfullyConnected = true;
@@ -423,7 +428,8 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
                                                  CAddress(),
                                                  /*addrNameIn=*/"",
                                                  ConnectionType::INBOUND,
-                                                 /*inbound_onion=*/false);
+                                                 /*inbound_onion=*/false,
+                                                 /*connman=*/nullptr);
     dummyNode->SetCommonVersion(PROTOCOL_VERSION);
     peerLogic->InitializeNode(*dummyNode, NODE_NETWORK);
     dummyNode->fSuccessfullyConnected = true;

--- a/src/test/fuzz/connman.cpp
+++ b/src/test/fuzz/connman.cpp
@@ -38,12 +38,12 @@ FUZZ_TARGET(connman, .init = initialize_connman)
                      *g_setup->m_node.netgroupman,
                      fuzzed_data_provider.ConsumeBool()};
     CNetAddr random_netaddr;
-    CNode random_node = ConsumeNode(fuzzed_data_provider);
+    CNodeRef random_node = ConsumeNode(fuzzed_data_provider);
     CSubNet random_subnet;
     std::string random_string;
 
     LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 100) {
-        CNode& p2p_node{*ConsumeNodeAsUniquePtr(fuzzed_data_provider).release()};
+        CNodeRef p2p_node{ConsumeNodeAsUniquePtr(fuzzed_data_provider)};
         connman.AddTestNode(p2p_node);
     }
 
@@ -91,7 +91,7 @@ FUZZ_TARGET(connman, .init = initialize_connman)
             },
             [&] {
                 (void)connman.GetAddresses(
-                    /*requestor=*/random_node,
+                    /*requestor=*/*random_node,
                     /*max_addresses=*/fuzzed_data_provider.ConsumeIntegral<size_t>(),
                     /*max_pct=*/fuzzed_data_provider.ConsumeIntegral<size_t>());
             },
@@ -108,7 +108,7 @@ FUZZ_TARGET(connman, .init = initialize_connman)
                 CSerializedNetMsg serialized_net_msg;
                 serialized_net_msg.m_type = fuzzed_data_provider.ConsumeRandomLengthString(CMessageHeader::COMMAND_SIZE);
                 serialized_net_msg.data = ConsumeRandomLengthByteVector(fuzzed_data_provider);
-                connman.PushMessage(&random_node, std::move(serialized_net_msg));
+                connman.PushMessage(random_node.get(), std::move(serialized_net_msg));
             },
             [&] {
                 connman.RemoveAddedNode(random_string);

--- a/src/test/fuzz/net.cpp
+++ b/src/test/fuzz/net.cpp
@@ -60,7 +60,7 @@ FUZZ_TARGET(net, .init = initialize_net)
     (void)node->GetAddrLocal();
     (void)node->GetId();
     (void)node->GetLocalNonce();
-    const int ref_count = node->GetRefCount();
+    const int ref_count = node.use_count();
     assert(ref_count >= 0);
     (void)node->GetCommonVersion();
 

--- a/src/test/fuzz/process_message.cpp
+++ b/src/test/fuzz/process_message.cpp
@@ -73,10 +73,10 @@ FUZZ_TARGET(process_message, .init = initialize_process_message)
     if (!LIMIT_TO_MESSAGE_TYPE.empty() && random_message_type != LIMIT_TO_MESSAGE_TYPE) {
         return;
     }
-    CNode& p2p_node = *ConsumeNodeAsUniquePtr(fuzzed_data_provider).release();
+    CNodeRef p2p_node = ConsumeNodeAsUniquePtr(fuzzed_data_provider);
 
     connman.AddTestNode(p2p_node);
-    FillNode(fuzzed_data_provider, connman, p2p_node);
+    FillNode(fuzzed_data_provider, connman, *p2p_node);
 
     const auto mock_time = ConsumeTime(fuzzed_data_provider);
     SetMockTime(mock_time);
@@ -84,11 +84,11 @@ FUZZ_TARGET(process_message, .init = initialize_process_message)
     // fuzzed_data_provider is fully consumed after this call, don't use it
     CDataStream random_bytes_data_stream{fuzzed_data_provider.ConsumeRemainingBytes<unsigned char>(), SER_NETWORK, PROTOCOL_VERSION};
     try {
-        g_setup->m_node.peerman->ProcessMessage(p2p_node, random_message_type, random_bytes_data_stream,
+        g_setup->m_node.peerman->ProcessMessage(*p2p_node, random_message_type, random_bytes_data_stream,
                                                 GetTime<std::chrono::microseconds>(), std::atomic<bool>{false});
     } catch (const std::ios_base::failure&) {
     }
-    g_setup->m_node.peerman->SendMessages(&p2p_node);
+    g_setup->m_node.peerman->SendMessages(p2p_node.get());
     SyncWithValidationInterfaceQueue();
     g_setup->m_node.connman->StopNodes();
 }

--- a/src/test/fuzz/process_messages.cpp
+++ b/src/test/fuzz/process_messages.cpp
@@ -44,13 +44,13 @@ FUZZ_TARGET(process_messages, .init = initialize_process_messages)
 
     LOCK(NetEventsInterface::g_msgproc_mutex);
 
-    std::vector<CNode*> peers;
+    std::vector<CNodeRef> peers;
     const auto num_peers_to_add = fuzzed_data_provider.ConsumeIntegralInRange(1, 3);
     for (int i = 0; i < num_peers_to_add; ++i) {
-        peers.push_back(ConsumeNodeAsUniquePtr(fuzzed_data_provider, i).release());
-        CNode& p2p_node = *peers.back();
+        peers.push_back(ConsumeNodeAsUniquePtr(fuzzed_data_provider, i));
+        CNodeRef p2p_node = peers.back();
 
-        FillNode(fuzzed_data_provider, connman, p2p_node);
+        FillNode(fuzzed_data_provider, connman, *p2p_node);
 
         connman.AddTestNode(p2p_node);
     }

--- a/src/test/fuzz/util/net.h
+++ b/src/test/fuzz/util/net.h
@@ -122,16 +122,16 @@ auto ConsumeNode(FuzzedDataProvider& fuzzed_data_provider, const std::optional<N
                                        inbound_onion,
                                        CNodeOptions{ .permission_flags = permission_flags });
     } else {
-        return CNode{node_id,
-                     sock,
-                     address,
-                     keyed_net_group,
-                     local_host_nonce,
-                     addr_bind,
-                     addr_name,
-                     conn_type,
-                     inbound_onion,
-                     CNodeOptions{ .permission_flags = permission_flags }};
+        return std::make_shared<CNode>(node_id,
+                                       sock,
+                                       address,
+                                       keyed_net_group,
+                                       local_host_nonce,
+                                       addr_bind,
+                                       addr_name,
+                                       conn_type,
+                                       inbound_onion,
+                                       CNodeOptions{.permission_flags = permission_flags});
     }
 }
 inline std::unique_ptr<CNode> ConsumeNodeAsUniquePtr(FuzzedDataProvider& fdp, const std::optional<NodeId>& node_id_in = std::nullopt) { return ConsumeNode<true>(fdp, node_id_in); }

--- a/src/test/fuzz/util/net.h
+++ b/src/test/fuzz/util/net.h
@@ -120,7 +120,8 @@ auto ConsumeNode(FuzzedDataProvider& fuzzed_data_provider, const std::optional<N
                                        addr_name,
                                        conn_type,
                                        inbound_onion,
-                                       CNodeOptions{ .permission_flags = permission_flags });
+                                       nullptr,
+                                       CNodeOptions{.permission_flags = permission_flags});
     } else {
         return std::make_shared<CNode>(node_id,
                                        sock,
@@ -131,6 +132,7 @@ auto ConsumeNode(FuzzedDataProvider& fuzzed_data_provider, const std::optional<N
                                        addr_name,
                                        conn_type,
                                        inbound_onion,
+                                       nullptr,
                                        CNodeOptions{.permission_flags = permission_flags});
     }
 }

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -25,20 +25,17 @@ struct ConnmanTestMsg : public CConnman {
         m_peer_connect_timeout = timeout;
     }
 
-    void AddTestNode(CNode& node)
+    void AddTestNode(const CNodeRef& node)
     {
         LOCK(m_nodes_mutex);
-        m_nodes.push_back(&node);
 
-        if (node.IsManualOrFullOutboundConn()) ++m_network_conn_counts[node.addr.GetNetwork()];
+        if (node->IsManualOrFullOutboundConn()) ++m_network_conn_counts[node->addr.GetNetwork()];
+        m_nodes.push_back(node);
     }
 
     void ClearTestNodes()
     {
         LOCK(m_nodes_mutex);
-        for (CNode* node : m_nodes) {
-            delete node;
-        }
         m_nodes.clear();
     }
 


### PR DESCRIPTION
Switch to using smart pointers to `CNode`s inside of `CConnman`.

Currently we are manually refcounting CNodes which is potentially error-prone and makes operations such as deleting them from multiple threads difficult without introducing new locks or other synchronisation operations (see https://github.com/bitcoin/bitcoin/pull/27912).

Switch to using `std::shared_ptr` references to `CNode`s inside of `m_nodes` and `m_nodes_disconnected` to give us better memory safety today, and in the future allow `AttemptToEvictConnection` (and optionally other sites) to safely synchronously disconnect nodes when needed.

Opening as draft for now as I want to both gauge feedback on the approach, and see which PRs this may conflict with (#27213?) before moving it forwards.

CC @vasild 