### PR TITLE
util/blockstorage: Add `TRACE_RAII`, slightly faster -reindex-chainstate with CBufferedFile

### DIFF
--- a/contrib/tracing/raii_stats.bt
+++ b/contrib/tracing/raii_stats.bt
@@ -1,0 +1,37 @@
+#!/usr/bin/env bpftrace
+
+/*
+
+  USAGE:
+
+  bpftrace contrib/tracing/raii_stats.bt
+
+  Collects runtime & call counts of a code block traced with TRACE_RAII.
+  The collected data (runtime, callcount, histogram) is printed on exit.
+*/
+
+BEGIN
+{
+    @duration_total_ns = (uint64)0;
+}
+
+/* Change the context & event to track a different TRACE_RAII block */
+usdt:./src/bitcoind:block_manager:read_block_from_disk_unserialize
+{
+    $isEntry = arg0;
+    if ($isEntry) {
+        @start_ns = nsecs;
+        @num_calls = count();
+    } else {
+        $duration_ns = nsecs - @start_ns;
+        @duration_total_ns += $duration_ns;
+        @duration_hist_ns = hist($duration_ns);
+    }
+}
+
+END
+{
+    @duration_total_ms = @duration_total_ns/1e6;
+    clear(@start_ns);
+    clear(@duration_total_ns);
+}

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -19,6 +19,7 @@
 #include <util/batchpriority.h>
 #include <util/fs.h>
 #include <util/signalinterrupt.h>
+#include <util/trace.h>
 #include <validation.h>
 
 #include <map>
@@ -774,6 +775,7 @@ bool BlockManager::ReadBlockFromDisk(CBlock& block, const FlatFilePos& pos) cons
 
     // Read block
     try {
+        TRACE_RAII(block_manager, read_block_from_disk_unserialize);
         filein >> block;
     } catch (const std::exception& e) {
         return error("%s: Deserialize or I/O error - %s at %s", __func__, e.what(), pos.ToString());

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -768,7 +768,7 @@ bool BlockManager::ReadBlockFromDisk(CBlock& block, const FlatFilePos& pos) cons
     block.SetNull();
 
     // Open history file to read
-    CAutoFile filein(OpenBlockFile(pos, true), SER_DISK, CLIENT_VERSION);
+    CBufferedFile filein(OpenBlockFile(pos, true), 1024, 0, SER_DISK, CLIENT_VERSION);
     if (filein.IsNull()) {
         return error("ReadBlockFromDisk: OpenBlockFile failed for %s", pos.ToString());
     }

--- a/src/streams.h
+++ b/src/streams.h
@@ -640,6 +640,11 @@ public:
         src = fileIn;
     }
 
+    [[nodiscard]] bool IsNull() const
+    {
+        return src == nullptr;
+    }
+
     ~CBufferedFile()
     {
         fclose();

--- a/src/util/trace.h
+++ b/src/util/trace.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 The Bitcoin Core developers
+// Copyright (c) 2020-2023 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -6,6 +6,8 @@
 #define BITCOIN_UTIL_TRACE_H
 
 #ifdef ENABLE_TRACING
+
+#include <util/macros.h>
 
 #include <sys/sdt.h>
 
@@ -23,6 +25,40 @@
 #define TRACE11(context, event, a, b, c, d, e, f, g, h, i, j, k) DTRACE_PROBE11(context, event, a, b, c, d, e, f, g, h, i, j, k)
 #define TRACE12(context, event, a, b, c, d, e, f, g, h, i, j, k, l) DTRACE_PROBE12(context, event, a, b, c, d, e, f, g, h, i, j, k, l)
 
+// The RAII object calls the given operation on exit.
+// This is useful to reliably trace at any return point.
+template <typename Op>
+class TraceOnExit
+{
+    Op m_op;
+
+public:
+    TraceOnExit(TraceOnExit&&) = delete;
+    TraceOnExit(TraceOnExit const&) = delete;
+    TraceOnExit& operator=(TraceOnExit&&) = delete;
+    TraceOnExit& operator=(TraceOnExit const&) = delete;
+
+    explicit TraceOnExit(Op op) : m_op(op)
+    {
+    }
+
+    ~TraceOnExit()
+    {
+        m_op();
+    }
+};
+
+// Traces entry & exit point. This can be useful to gather statistics
+// like average runtime of a code block that has multiple exit points.
+//
+// The given trace context is called with a single argument 1 for entry
+// and 0 for the exit.
+#define TRACE_RAII(context, event)                \
+    TRACE1(context, event, 1);                    \
+    auto UNIQUE_NAME(tracer) = ::TraceOnExit([] { \
+        TRACE1(context, event, 0);                \
+    })
+
 #else
 
 #define TRACE(context, event)
@@ -38,6 +74,8 @@
 #define TRACE10(context, event, a, b, c, d, e, f, g, h, i, j)
 #define TRACE11(context, event, a, b, c, d, e, f, g, h, i, j, k)
 #define TRACE12(context, event, a, b, c, d, e, f, g, h, i, j, k, l)
+
+#define TRACE_RAII(context, event)
 
 #endif
 


### PR DESCRIPTION
TLDR: 
* Adds a `TRACE_RAII` macro to easily trace runtime of a code block.
* Switch to `CBufferedFile` in `BlockManager::ReadBlockFromDisk` is slightly faster:
* 9% faster unserialization =>  1.2% faster `-reindex-chainstate`

---
While profiling `-reindex-changestate` I saw lots of `fread()` calls in in `BlockManager::ReadBlockFromDisk`. This replaces the use of `CAutoFile` with `CBufferedFile` with a small buffer, leading to much fewer calls to
`fread()`, which gives a little speedup.

I measured runtime of the synchronization with the `TRACE_RAII` macro. I ran this command which took about 30 minutes on my PC, with and without CBufferedFile:

```sh
sync && sudo /sbin/sysctl vm.drop_caches=3 && ~/git/github.com/martinus/bitcoin/src/bitcoind -dbcache=20000 -reindex-chainstate -printtoconsole=0 -stopatheight=500000
```

The measured time spent in unserializing blocks are:
* 308.227s `CAutoFile`
* 277.827s `CBufferedFile`

It is a bit hard to measure the total effect on `-reindex-chainstate` due to random fluctuations in the benchmark. For somewhat reliable results I've run the benchmark 10 times, using [hyperfine](https://github.com/sharkdp/hyperfine):

```sh
hyperfine \                                                                                                                                                                                                                                                                                         --parameter-list commit 0f3a6a74a2889817df0f52e19c37de19c664daac,ce26cb6025c47bb4b3e51a579689635da7ca1f6b \
--setup 'git checkout {commit} && make -j$(nproc)' \
--prepare 'sync; sudo /sbin/sysctl vm.drop_caches=3' \
'./bitcoind -dbcache=20000 -reindex-chainstate -printtoconsole=0 -stopatheight=500000'
```

The results are:

```
Benchmark 1: ./bitcoind -dbcache=20000 -reindex-chainstate -printtoconsole=0 -stopatheight=500000 (CAutoFile)
  Time (mean ± σ):     1847.622 s ± 13.448 s    [User: 1702.768 s, System: 54.059 s]
  Range (min … max):   1835.319 s … 1877.065 s    10 runs

Benchmark 2: ./bitcoind -dbcache=20000 -reindex-chainstate -printtoconsole=0 -stopatheight=500000 (CBufferedFile)
  Time (mean ± σ):     1824.660 s ± 14.394 s    [User: 1679.417 s, System: 53.965 s]
  Range (min … max):   1798.764 s … 1848.940 s    10 runs
```

So the 9% improvement in unserializing seems to translate to roughly 1.2% total runtime improvement in `-reindex-chainstate` on my machine.