### PR TITLE
kernel: Run sanity checks on context construction

### DIFF
--- a/src/bitcoin-chainstate.cpp
+++ b/src/bitcoin-chainstate.cpp
@@ -27,6 +27,7 @@
 #include <script/sigcache.h>
 #include <util/chaintype.h>
 #include <util/fs.h>
+#include <util/signalinterrupt.h>
 #include <util/thread.h>
 #include <validation.h>
 #include <validationinterface.h>
@@ -55,11 +56,11 @@ int main(int argc, char* argv[])
 
 
     // SETUP: Context
-    kernel::Context kernel_context{};
+    auto kernel_context{std::move(kernel::Context::MakeContext().value())};
     // We can't use a goto here, but we can use an assert since none of the
     // things instantiated so far requires running the epilogue to be torn down
     // properly
-    assert(kernel::SanityChecks(kernel_context));
+    assert(kernel::SanityChecks(*kernel_context));
 
     // Necessary for CheckInputScripts (eventually called by ProcessNewBlock),
     // which will try the script cache first and fall back to actually

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -22,6 +22,7 @@
 #include <noui.h>
 #include <util/check.h>
 #include <util/exception.h>
+#include <util/signalinterrupt.h>
 #include <util/strencodings.h>
 #include <util/syserror.h>
 #include <util/threadnames.h>
@@ -183,9 +184,12 @@ static bool AppInit(NodeContext& node)
             return false;
         }
 
-        node.kernel = std::make_unique<kernel::Context>();
-        if (!AppInitSanityChecks(*node.kernel))
-        {
+        if (!InitKernel(node)) {
+            // InitError will have been called with detailed error, which ends up on console
+            return false;
+        }
+
+        if (!AppInitSanityChecks()) {
             // InitError will have been called with detailed error, which ends up on console
             return false;
         }

--- a/src/init.h
+++ b/src/init.h
@@ -19,9 +19,6 @@ class ArgsManager;
 namespace interfaces {
 struct BlockAndHeaderTipInfo;
 }
-namespace kernel {
-struct Context;
-}
 namespace node {
 struct NodeContext;
 } // namespace node
@@ -39,6 +36,8 @@ void InitLogging(const ArgsManager& args);
 //!Parameter interaction: change current parameters depending on various rules
 void InitParameterInteraction(ArgsManager& args);
 
+bool InitKernel(node::NodeContext& node);
+
 /** Initialize bitcoin core: Basic context setup.
  *  @note This can be done before daemonization. Do not call Shutdown() if this function fails.
  *  @pre Parameters should be parsed and config file should be read.
@@ -55,7 +54,7 @@ bool AppInitParameterInteraction(const ArgsManager& args);
  * @note This can be done before daemonization. Do not call Shutdown() if this function fails.
  * @pre Parameters should be parsed and config file should be read, AppInitParameterInteraction should have been called.
  */
-bool AppInitSanityChecks(const kernel::Context& kernel);
+bool AppInitSanityChecks();
 /**
  * Lock bitcoin core data directory.
  * @note This should only be done after daemonization. Do not call Shutdown() if this function fails.

--- a/src/kernel/context.cpp
+++ b/src/kernel/context.cpp
@@ -5,21 +5,31 @@
 #include <kernel/context.h>
 
 #include <crypto/sha256.h>
+#include <kernel/checks.h>
 #include <key.h>
 #include <logging.h>
-#include <pubkey.h>
 #include <random.h>
+#include <util/result.h>
 
+#include <memory>
 #include <string>
-
+#include <utility>
 
 namespace kernel {
-Context::Context()
+
+util::Result<std::unique_ptr<Context>> Context::MakeContext()
 {
+    auto context{std::unique_ptr<Context>(new Context())};
     std::string sha256_algo = SHA256AutoDetect();
     LogPrintf("Using the '%s' SHA256 implementation\n", sha256_algo);
     RandomInit();
     ECC_Start();
+
+    if (auto res{SanityChecks(*context)}; !res) {
+        return util::Error{ErrorString(res)};
+    }
+
+    return {std::move(context)};
 }
 
 Context::~Context()

--- a/src/kernel/context.h
+++ b/src/kernel/context.h
@@ -5,7 +5,7 @@
 #ifndef BITCOIN_KERNEL_CONTEXT_H
 #define BITCOIN_KERNEL_CONTEXT_H
 
-#include <util/signalinterrupt.h>
+#include <util/result.h>
 
 #include <memory>
 
@@ -17,9 +17,15 @@ namespace kernel {
 //!
 //! State stored directly in this struct should be simple. More complex state
 //! should be stored to std::unique_ptr members pointing to opaque types.
+//!
+//! Methods should not be inline, so code instantiating the kernel::Context struct
+//! doesn't need to #include class definitions for all the unique_ptr members.
 struct Context {
-    Context();
+    static util::Result<std::unique_ptr<Context>> MakeContext();
     ~Context();
+
+private:
+    Context() = default;
 };
 } // namespace kernel
 

--- a/src/node/context.h
+++ b/src/node/context.h
@@ -31,6 +31,9 @@ class ChainClient;
 class Init;
 class WalletLoader;
 } // namespace interfaces
+namespace util {
+class SignalInterrupt;
+} // namespace util
 
 namespace node {
 class KernelNotifications;

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -98,9 +98,8 @@ public:
     {
         if (!AppInitBasicSetup(args(), Assert(context())->exit_status)) return false;
         if (!AppInitParameterInteraction(args())) return false;
-
-        m_context->kernel = std::make_unique<kernel::Context>();
-        if (!AppInitSanityChecks(*m_context->kernel)) return false;
+        if (!InitKernel(*m_context)) return false;
+        if (!AppInitSanityChecks()) return false;
 
         if (!AppInitLockDataDirectory()) return false;
         if (!AppInitInterfaces(*m_context)) return false;

--- a/src/node/kernel_notifications.cpp
+++ b/src/node/kernel_notifications.cpp
@@ -16,6 +16,7 @@
 #include <node/abort.h>
 #include <node/interface_ui.h>
 #include <util/check.h>
+#include <util/signalinterrupt.h>
 #include <util/strencodings.h>
 #include <util/string.h>
 #include <util/translation.h>

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -30,6 +30,7 @@
 #include <timedata.h>
 #include <txmempool.h>
 #include <univalue.h>
+#include <util/signalinterrupt.h>
 #include <util/strencodings.h>
 #include <util/string.h>
 #include <util/translation.h>

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -138,7 +138,7 @@ BasicTestingSetup::BasicTestingSetup(const ChainType chainType, const std::vecto
     InitLogging(*m_node.args);
     AppInitParameterInteraction(*m_node.args);
     LogInstance().StartLogging();
-    m_node.kernel = std::make_unique<kernel::Context>();
+    m_node.kernel = std::move(kernel::Context::MakeContext().value());
     SetupEnvironment();
 
     ValidationCacheSizes validation_cache_sizes{};

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -15,6 +15,7 @@
 #include <util/chaintype.h> // IWYU pragma: export
 #include <util/check.h>
 #include <util/fs.h>
+#include <util/signalinterrupt.h>
 #include <util/string.h>
 #include <util/vector.h>
 


### PR DESCRIPTION
Moving the kernel sanity check code to kernel context instantiation time ensures that it is impossible to create an invalid kernel context. This is based on a suggestion made in a [comment](https://github.com/bitcoin/bitcoin/pull/25065#discussion_r882182549) by @theuni in the [original pull request](https://github.com/bitcoin/bitcoin/pull/25065) first introducing the `kernel::Context`.