### PR TITLE
p2p: ensure mapBlockSource is removed from in ProcessBlock

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3196,7 +3196,9 @@ void PeerManagerImpl::ProcessBlock(CNode& node, const std::shared_ptr<const CBlo
         // from, we can erase the block request now anyway (as we just stored
         // this block to disk).
         LOCK(cs_main);
-        RemoveBlockRequest(block->GetHash(), std::nullopt);
+        uint256 blockHash{block->GetHash()};
+        RemoveBlockRequest(blockHash, std::nullopt);
+        mapBlockSource.erase(blockHash);
     } else {
         LOCK(cs_main);
         mapBlockSource.erase(block->GetHash());


### PR DESCRIPTION
If we receive a valid block that passes the anti-DoS threshold but doesn't advance the tip, the BlockChecked callback won't be called. This is because ActivateBestChain will return early since pindexMostWork is equal to m_chain.Tip(). Since the BlockChecked callback isn't called, mapBlockSource won't be removed from. Fix that by always removing from mapBlockSource in ProcessBlock.