### PR TITLE
refactor: Enforce C-str fmt strings in WalletLogPrintf()

### DIFF
--- a/contrib/devtools/bitcoin-tidy/example_logprintf.cpp
+++ b/contrib/devtools/bitcoin-tidy/example_logprintf.cpp
@@ -2,8 +2,9 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-// Warn about any use of LogPrintf that does not end with a newline.
 #include <string>
+
+// Test for bitcoin-unterminated-logprintf
 
 enum LogFlags {
     NONE
@@ -21,8 +22,6 @@ static inline void LogPrintf_(const std::string& logging_function, const std::st
 #define LogPrintLevel_(category, level, ...) LogPrintf_(__func__, __FILE__, __LINE__, category, level, __VA_ARGS__)
 #define LogPrintf(...) LogPrintLevel_(LogFlags::NONE, Level::None, __VA_ARGS__)
 
-// Use a macro instead of a function for conditional logging to prevent
-// evaluating arguments when logging for the category is not enabled.
 #define LogPrint(category, ...) \
     do {                        \
         LogPrintf(__VA_ARGS__); \

--- a/contrib/devtools/bitcoin-tidy/example_logprintf.cpp
+++ b/contrib/devtools/bitcoin-tidy/example_logprintf.cpp
@@ -37,9 +37,9 @@ class CWallet
 
 public:
     template <typename... Params>
-    void WalletLogPrintf(std::string fmt, Params... parameters) const
+    void WalletLogPrintf(const char* fmt, Params... parameters) const
     {
-        LogPrintf(("%s " + fmt).c_str(), GetDisplayName(), parameters...);
+        LogPrintf(("%s " + std::string{fmt}).c_str(), GetDisplayName(), parameters...);
     };
 };
 

--- a/contrib/devtools/bitcoin-tidy/example_logprintf.cpp
+++ b/contrib/devtools/bitcoin-tidy/example_logprintf.cpp
@@ -43,6 +43,20 @@ public:
     };
 };
 
+struct ScriptPubKeyMan
+{
+    std::string GetDisplayName() const
+    {
+        return "default wallet";
+    }
+
+    template <typename... Params>
+    void WalletLogPrintf(const char* fmt, Params... parameters) const
+    {
+        LogPrintf(("%s " + std::string{fmt}).c_str(), GetDisplayName(), parameters...);
+    };
+};
+
 void good_func()
 {
     LogPrintf("hello world!\n");
@@ -51,6 +65,8 @@ void good_func2()
 {
     CWallet wallet;
     wallet.WalletLogPrintf("hi\n");
+    ScriptPubKeyMan spkm;
+    spkm.WalletLogPrintf("hi\n");
 
     const CWallet& walletref = wallet;
     walletref.WalletLogPrintf("hi\n");
@@ -80,6 +96,8 @@ void bad_func5()
 {
     CWallet wallet;
     wallet.WalletLogPrintf("hi");
+    ScriptPubKeyMan spkm;
+    spkm.WalletLogPrintf("hi");
 
     const CWallet& walletref = wallet;
     walletref.WalletLogPrintf("hi");

--- a/contrib/devtools/bitcoin-tidy/logprintf.cpp
+++ b/contrib/devtools/bitcoin-tidy/logprintf.cpp
@@ -36,14 +36,12 @@ void LogPrintfCheck::registerMatchers(clang::ast_matchers::MatchFinder* finder)
         this);
 
     /*
-      CWallet wallet;
       auto walletptr = &wallet;
       wallet.WalletLogPrintf("foo");
       wallet->WalletLogPrintf("foo");
     */
     finder->addMatcher(
         cxxMemberCallExpr(
-            thisPointerType(qualType(hasDeclaration(cxxRecordDecl(hasName("CWallet"))))),
             callee(cxxMethodDecl(hasName("WalletLogPrintf"))),
             hasArgument(0, stringLiteral(unterminated()).bind("logstring"))),
         this);

--- a/contrib/devtools/bitcoin-tidy/logprintf.h
+++ b/contrib/devtools/bitcoin-tidy/logprintf.h
@@ -9,6 +9,7 @@
 
 namespace bitcoin {
 
+// Warn about any use of LogPrintf that does not end with a newline.
 class LogPrintfCheck final : public clang::tidy::ClangTidyCheck
 {
 public:

--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -1,6 +1,6 @@
 Checks: '
 -*,
-bitcoin-unterminated-logprintf,
+bitcoin-*,
 bugprone-argument-comment,
 bugprone-use-after-move,
 misc-unused-using-decls,

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -249,9 +249,10 @@ public:
     virtual std::unordered_set<CScript, SaltedSipHasher> GetScriptPubKeys() const { return {}; };
 
     /** Prepends the wallet name in logging output to ease debugging in multi-wallet use cases */
-    template<typename... Params>
-    void WalletLogPrintf(std::string fmt, Params... parameters) const {
-        LogPrintf(("%s " + fmt).c_str(), m_storage.GetDisplayName(), parameters...);
+    template <typename... Params>
+    void WalletLogPrintf(const char* fmt, Params... parameters) const
+    {
+        LogPrintf(("%s " + std::string{fmt}).c_str(), m_storage.GetDisplayName(), parameters...);
     };
 
     /** Watch-only address added */

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2319,7 +2319,7 @@ OutputType CWallet::TransactionChangeType(const std::optional<OutputType>& chang
 void CWallet::CommitTransaction(CTransactionRef tx, mapValue_t mapValue, std::vector<std::pair<std::string, std::string>> orderForm)
 {
     LOCK(cs_wallet);
-    WalletLogPrintf("CommitTransaction:\n%s", tx->ToString());
+    WalletLogPrintf("CommitTransaction:\n%s", tx->ToString()); // NOLINT(bitcoin-unterminated-logprintf)
 
     // Add tx to wallet, because if it has change it's also ours,
     // otherwise just for transaction history.

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -890,9 +890,10 @@ public:
     };
 
     /** Prepends the wallet name in logging output to ease debugging in multi-wallet use cases */
-    template<typename... Params>
-    void WalletLogPrintf(std::string fmt, Params... parameters) const {
-        LogPrintf(("%s " + fmt).c_str(), GetDisplayName(), parameters...);
+    template <typename... Params>
+    void WalletLogPrintf(const char* fmt, Params... parameters) const
+    {
+        LogPrintf(("%s " + std::string{fmt}).c_str(), GetDisplayName(), parameters...);
     };
 
     /** Upgrade the wallet */

--- a/test/lint/run-lint-format-strings.py
+++ b/test/lint/run-lint-format-strings.py
@@ -20,10 +20,10 @@ FALSE_POSITIVES = [
     ("src/clientversion.cpp", "strprintf(_(COPYRIGHT_HOLDERS).translated, COPYRIGHT_HOLDERS_SUBSTITUTION)"),
     ("src/test/translation_tests.cpp", "strprintf(format, arg)"),
     ("src/validationinterface.cpp", "LogPrint(BCLog::VALIDATION, fmt \"\\n\", __VA_ARGS__)"),
-    ("src/wallet/wallet.h",  "WalletLogPrintf(std::string fmt, Params... parameters)"),
-    ("src/wallet/wallet.h", "LogPrintf((\"%s \" + fmt).c_str(), GetDisplayName(), parameters...)"),
-    ("src/wallet/scriptpubkeyman.h",  "WalletLogPrintf(std::string fmt, Params... parameters)"),
-    ("src/wallet/scriptpubkeyman.h", "LogPrintf((\"%s \" + fmt).c_str(), m_storage.GetDisplayName(), parameters...)"),
+    ("src/wallet/wallet.h", "WalletLogPrintf(const char* fmt, Params... parameters)"),
+    ("src/wallet/wallet.h", "LogPrintf((\"%s \" + std::string{fmt}).c_str(), GetDisplayName(), parameters...)"),
+    ("src/wallet/scriptpubkeyman.h", "WalletLogPrintf(const char* fmt, Params... parameters)"),
+    ("src/wallet/scriptpubkeyman.h", "LogPrintf((\"%s \" + std::string{fmt}).c_str(), m_storage.GetDisplayName(), parameters...)"),
 ]
 
 


### PR DESCRIPTION
All fmt functions only accept a raw C-string as argument.

There should never be a need to pass a format string that is not a compile-time string literal, so disallow it in `WalletLogPrintf()` to avoid accidentally introducing it.

Apart from consistency, this also fixes the clang-tidy plugin bug https://github.com/bitcoin/bitcoin/pull/26296#discussion_r1286821141.