### PR TITLE
refactor: Remove unused boost signals2 from torcontrol

### DIFF
--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -22,18 +22,18 @@
 #include <ws2tcpip.h>
 #include <cstdint>
 #else
-#include <fcntl.h>// IWYU pragma: export
-#include <sys/mman.h>// IWYU pragma: export
-#include <sys/select.h>// IWYU pragma: export
-#include <sys/socket.h>// IWYU pragma: export
-#include <sys/types.h>// IWYU pragma: export
-#include <net/if.h>// IWYU pragma: export
-#include <netinet/in.h>// IWYU pragma: export
-#include <netinet/tcp.h>// IWYU pragma: export
-#include <arpa/inet.h>// IWYU pragma: export
-#include <ifaddrs.h>// IWYU pragma: export
-#include <netdb.h>// IWYU pragma: export
-#include <unistd.h>// IWYU pragma: export
+#include <arpa/inet.h>   // IWYU pragma: export
+#include <fcntl.h>       // IWYU pragma: export
+#include <ifaddrs.h>     // IWYU pragma: export
+#include <net/if.h>      // IWYU pragma: export
+#include <netdb.h>       // IWYU pragma: export
+#include <netinet/in.h>  // IWYU pragma: export
+#include <netinet/tcp.h> // IWYU pragma: export
+#include <sys/mman.h>    // IWYU pragma: export
+#include <sys/select.h>  // IWYU pragma: export
+#include <sys/socket.h>  // IWYU pragma: export
+#include <sys/types.h>   // IWYU pragma: export
+#include <unistd.h>      // IWYU pragma: export
 #endif
 
 // We map Linux / BSD error functions and codes, to the equivalent

--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -22,19 +22,19 @@
 #include <ws2tcpip.h>
 #include <cstdint>
 #else
-#include <fcntl.h>
-#include <sys/mman.h>
-#include <sys/select.h>
-#include <sys/socket.h>
-#include <sys/types.h>
-#include <net/if.h>
-#include <netinet/in.h>
-#include <netinet/tcp.h>
-#include <arpa/inet.h>
-#include <ifaddrs.h>
+#include <fcntl.h>// IWYU pragma: export
+#include <sys/mman.h>// IWYU pragma: export
+#include <sys/select.h>// IWYU pragma: export
+#include <sys/socket.h>// IWYU pragma: export
+#include <sys/types.h>// IWYU pragma: export
+#include <net/if.h>// IWYU pragma: export
+#include <netinet/in.h>// IWYU pragma: export
+#include <netinet/tcp.h>// IWYU pragma: export
+#include <arpa/inet.h>// IWYU pragma: export
+#include <ifaddrs.h>// IWYU pragma: export
 #include <limits.h>
-#include <netdb.h>
-#include <unistd.h>
+#include <netdb.h>// IWYU pragma: export
+#include <unistd.h>// IWYU pragma: export
 #endif
 
 // We map Linux / BSD error functions and codes, to the equivalent

--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -32,7 +32,6 @@
 #include <netinet/tcp.h>// IWYU pragma: export
 #include <arpa/inet.h>// IWYU pragma: export
 #include <ifaddrs.h>// IWYU pragma: export
-#include <limits.h>
 #include <netdb.h>// IWYU pragma: export
 #include <unistd.h>// IWYU pragma: export
 #endif

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -91,7 +91,7 @@ void TorControlConnection::readcb(struct bufferevent *bev, void *ctx)
         if (s.size() < 4) // Short line
             continue;
         // <status>(-|+| )<data><CRLF>
-        self->message.code = LocaleIndependentAtoi<int>(s.substr(0,3));
+        self->message.code = ToIntegral<int>(s.substr(0, 3)).value_or(0);
         self->message.lines.push_back(s.substr(4));
         char ch = s[3]; // '-','+' or ' '
         if (ch == ' ') {

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -85,9 +85,9 @@ void TorControlConnection::readcb(struct bufferevent *bev, void *ctx)
         if (ch == ' ') {
             // Final line, dispatch reply and clean up
             if (self->message.code >= 600) {
+                // (currently unused)
                 // Dispatch async notifications to async handler
                 // Synchronous and asynchronous messages are never interleaved
-                self->async_handler(*self, self->message);
             } else {
                 if (!self->reply_handlers.empty()) {
                     // Invoke reply handler with message

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -14,14 +14,26 @@
 #include <net.h>
 #include <netaddress.h>
 #include <netbase.h>
+#include <random.h>
+#include <tinyformat.h>
+#include <util/check.h>
+#include <util/fs.h>
 #include <util/readwritefile.h>
 #include <util/strencodings.h>
+#include <util/string.h>
 #include <util/thread.h>
 #include <util/time.h>
 
+#include <algorithm>
+#include <cassert>
+#include <cstdlib>
 #include <deque>
 #include <functional>
+#include <map>
+#include <optional>
 #include <set>
+#include <thread>
+#include <utility>
 #include <vector>
 
 #include <event2/buffer.h>

--- a/src/torcontrol.h
+++ b/src/torcontrol.h
@@ -11,7 +11,6 @@
 #include <netaddress.h>
 #include <util/fs.h>
 
-#include <boost/signals2/signal.hpp>
 
 #include <event2/bufferevent.h>
 #include <event2/event.h>
@@ -83,8 +82,6 @@ public:
      */
     bool Command(const std::string &cmd, const ReplyHandlerCB& reply_handler);
 
-    /** Response handlers for async replies */
-    boost::signals2::signal<void(TorControlConnection &,const TorControlReply &)> async_handler;
 private:
     /** Callback when ready for use */
     std::function<void(TorControlConnection&)> connected;

--- a/src/torcontrol.h
+++ b/src/torcontrol.h
@@ -11,17 +11,13 @@
 #include <netaddress.h>
 #include <util/fs.h>
 
+#include <event2/util.h>
 
-#include <event2/bufferevent.h>
-#include <event2/event.h>
-
-#include <cstdlib>
+#include <cstdint>
 #include <deque>
 #include <functional>
 #include <string>
 #include <vector>
-
-class CService;
 
 extern const std::string DEFAULT_TOR_CONTROL;
 static const bool DEFAULT_LISTEN_ONION = true;


### PR DESCRIPTION
Remove unused boost, and other includes, and other legacy functions from torcontrol.