### PR TITLE
Revert "Remove unused raw-pointer read helper from univalue"

### DIFF
--- a/build_msvc/test_bitcoin/test_bitcoin.vcxproj
+++ b/build_msvc/test_bitcoin/test_bitcoin.vcxproj
@@ -68,7 +68,7 @@
       <RawTestFile Include="..\..\src\test\data\*.raw" />
     </ItemGroup>
     <HeaderFromHexdump RawFilePath="%(RawTestFile.FullPath)" HeaderFilePath="%(RawTestFile.FullPath).h" SourceHeader="static unsigned const char %(RawTestFile.Filename)_raw[] = {" SourceFooter="};" />
-    <HeaderFromHexdump RawFilePath="%(JsonTestFile.FullPath)" HeaderFilePath="%(JsonTestFile.FullPath).h" SourceHeader="#include &lt;string&gt;&#x0D;&#x0A;namespace json_tests{ static const std::string %(JsonTestFile.Filename){" SourceFooter="};}" />
+    <HeaderFromHexdump RawFilePath="%(JsonTestFile.FullPath)" HeaderFilePath="%(JsonTestFile.FullPath).h" SourceHeader="namespace json_tests{ static unsigned const char %(JsonTestFile.Filename)[] = {" SourceFooter="};}" />
   </Target>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -427,9 +427,8 @@ endif
 %.json.h: %.json
 	@$(MKDIR_P) $(@D)
 	$(AM_V_GEN) { \
-	 echo "#include <string>" && \
 	 echo "namespace json_tests{" && \
-	 echo "static const std::string $(*F){" && \
+	 echo "static unsigned const char $(*F)[] = {" && \
 	 $(HEXDUMP) -v -e '8/1 "0x%02x, "' -e '"\n"' $< | $(SED) -e 's/0x  ,//g' && \
 	 echo "};};"; \
 	} > "$@.new" && mv -f "$@.new" "$@"

--- a/src/test/base58_tests.cpp
+++ b/src/test/base58_tests.cpp
@@ -23,7 +23,7 @@ BOOST_FIXTURE_TEST_SUITE(base58_tests, BasicTestingSetup)
 // Goal: test low-level base58 encoding functionality
 BOOST_AUTO_TEST_CASE(base58_EncodeBase58)
 {
-    UniValue tests = read_json(json_tests::base58_encode_decode);
+    UniValue tests = read_json(std::string(json_tests::base58_encode_decode, json_tests::base58_encode_decode + sizeof(json_tests::base58_encode_decode)));
     for (unsigned int idx = 0; idx < tests.size(); idx++) {
         const UniValue& test = tests[idx];
         std::string strTest = test.write();
@@ -43,7 +43,7 @@ BOOST_AUTO_TEST_CASE(base58_EncodeBase58)
 // Goal: test low-level base58 decoding functionality
 BOOST_AUTO_TEST_CASE(base58_DecodeBase58)
 {
-    UniValue tests = read_json(json_tests::base58_encode_decode);
+    UniValue tests = read_json(std::string(json_tests::base58_encode_decode, json_tests::base58_encode_decode + sizeof(json_tests::base58_encode_decode)));
     std::vector<unsigned char> result;
 
     for (unsigned int idx = 0; idx < tests.size(); idx++) {

--- a/src/test/blockfilter_tests.cpp
+++ b/src/test/blockfilter_tests.cpp
@@ -128,7 +128,9 @@ BOOST_AUTO_TEST_CASE(blockfilter_basic_test)
 BOOST_AUTO_TEST_CASE(blockfilters_json_test)
 {
     UniValue json;
-    if (!json.read(json_tests::blockfilters) || !json.isArray()) {
+    std::string json_data(json_tests::blockfilters,
+                          json_tests::blockfilters + sizeof(json_tests::blockfilters));
+    if (!json.read(json_data) || !json.isArray()) {
         BOOST_ERROR("Parse error.");
         return;
     }

--- a/src/test/key_io_tests.cpp
+++ b/src/test/key_io_tests.cpp
@@ -22,7 +22,7 @@ BOOST_FIXTURE_TEST_SUITE(key_io_tests, BasicTestingSetup)
 // Goal: check that parsed keys match test payload
 BOOST_AUTO_TEST_CASE(key_io_valid_parse)
 {
-    UniValue tests = read_json(json_tests::key_io_valid);
+    UniValue tests = read_json(std::string(json_tests::key_io_valid, json_tests::key_io_valid + sizeof(json_tests::key_io_valid)));
     CKey privkey;
     CTxDestination destination;
     SelectParams(ChainType::MAIN);
@@ -83,7 +83,7 @@ BOOST_AUTO_TEST_CASE(key_io_valid_parse)
 // Goal: check that generated keys match test vectors
 BOOST_AUTO_TEST_CASE(key_io_valid_gen)
 {
-    UniValue tests = read_json(json_tests::key_io_valid);
+    UniValue tests = read_json(std::string(json_tests::key_io_valid, json_tests::key_io_valid + sizeof(json_tests::key_io_valid)));
 
     for (unsigned int idx = 0; idx < tests.size(); idx++) {
         const UniValue& test = tests[idx];
@@ -121,7 +121,7 @@ BOOST_AUTO_TEST_CASE(key_io_valid_gen)
 // Goal: check that base58 parsing code is robust against a variety of corrupted data
 BOOST_AUTO_TEST_CASE(key_io_invalid)
 {
-    UniValue tests = read_json(json_tests::key_io_invalid); // Negative testcases
+    UniValue tests = read_json(std::string(json_tests::key_io_invalid, json_tests::key_io_invalid + sizeof(json_tests::key_io_invalid))); // Negative testcases
     CKey privkey;
     CTxDestination destination;
 

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -20,7 +20,7 @@
 static UniValue JSON(std::string_view json)
 {
     UniValue value;
-    BOOST_CHECK(value.read(json));
+    BOOST_CHECK(value.read(json.data(), json.size()));
     return value;
 }
 

--- a/src/test/script_standard_tests.cpp
+++ b/src/test/script_standard_tests.cpp
@@ -394,7 +394,7 @@ BOOST_AUTO_TEST_CASE(bip341_spk_test_vectors)
     using control_set = decltype(TaprootSpendData::scripts)::mapped_type;
 
     UniValue tests;
-    tests.read(json_tests::bip341_wallet_vectors);
+    tests.read((const char*)json_tests::bip341_wallet_vectors, sizeof(json_tests::bip341_wallet_vectors));
 
     const auto& vectors = tests["scriptPubKey"];
 

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -890,7 +890,7 @@ BOOST_AUTO_TEST_CASE(script_build)
     std::set<std::string> tests_set;
 
     {
-        UniValue json_tests = read_json(json_tests::script_tests);
+        UniValue json_tests = read_json(std::string(json_tests::script_tests, json_tests::script_tests + sizeof(json_tests::script_tests)));
 
         for (unsigned int idx = 0; idx < json_tests.size(); idx++) {
             const UniValue& tv = json_tests[idx];
@@ -929,7 +929,7 @@ BOOST_AUTO_TEST_CASE(script_json_test)
     // scripts.
     // If a witness is given, then the last value in the array should be the
     // amount (nValue) to use in the crediting tx
-    UniValue tests = read_json(json_tests::script_tests);
+    UniValue tests = read_json(std::string(json_tests::script_tests, json_tests::script_tests + sizeof(json_tests::script_tests)));
 
     for (unsigned int idx = 0; idx < tests.size(); idx++) {
         const UniValue& test = tests[idx];
@@ -1743,7 +1743,7 @@ BOOST_AUTO_TEST_CASE(script_assets_test)
 BOOST_AUTO_TEST_CASE(bip341_keypath_test_vectors)
 {
     UniValue tests;
-    tests.read(json_tests::bip341_wallet_vectors);
+    tests.read((const char*)json_tests::bip341_wallet_vectors, sizeof(json_tests::bip341_wallet_vectors));
 
     const auto& vectors = tests["keyPathSpending"];
 

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -162,7 +162,7 @@ BOOST_AUTO_TEST_CASE(sighash_test)
 // Goal: check that SignatureHash generates correct hash
 BOOST_AUTO_TEST_CASE(sighash_from_data)
 {
-    UniValue tests = read_json(json_tests::sighash);
+    UniValue tests = read_json(std::string(json_tests::sighash, json_tests::sighash + sizeof(json_tests::sighash)));
 
     for (unsigned int idx = 0; idx < tests.size(); idx++) {
         const UniValue& test = tests[idx];

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -190,7 +190,7 @@ BOOST_AUTO_TEST_CASE(tx_valid)
 {
     BOOST_CHECK_MESSAGE(CheckMapFlagNames(), "mapFlagNames is missing a script verification flag");
     // Read tests from test/data/tx_valid.json
-    UniValue tests = read_json(json_tests::tx_valid);
+    UniValue tests = read_json(std::string(json_tests::tx_valid, json_tests::tx_valid + sizeof(json_tests::tx_valid)));
 
     for (unsigned int idx = 0; idx < tests.size(); idx++) {
         const UniValue& test = tests[idx];
@@ -278,7 +278,7 @@ BOOST_AUTO_TEST_CASE(tx_valid)
 BOOST_AUTO_TEST_CASE(tx_invalid)
 {
     // Read tests from test/data/tx_invalid.json
-    UniValue tests = read_json(json_tests::tx_invalid);
+    UniValue tests = read_json(std::string(json_tests::tx_invalid, json_tests::tx_invalid + sizeof(json_tests::tx_invalid)));
 
     for (unsigned int idx = 0; idx < tests.size(); idx++) {
         const UniValue& test = tests[idx];

--- a/src/univalue/include/univalue.h
+++ b/src/univalue/include/univalue.h
@@ -7,15 +7,13 @@
 #define BITCOIN_UNIVALUE_INCLUDE_UNIVALUE_H
 
 #include <charconv>
-#include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <map>
 #include <stdexcept>
 #include <string>
 #include <string_view>
-#include <system_error>
 #include <type_traits>
-#include <utility>
 #include <vector>
 
 class UniValue {
@@ -96,7 +94,9 @@ public:
     std::string write(unsigned int prettyIndent = 0,
                       unsigned int indentLevel = 0) const;
 
-    bool read(std::string_view raw);
+    bool read(const char *raw, size_t len);
+    bool read(const char *raw) { return read(raw, strlen(raw)); }
+    bool read(std::string_view raw) { return read(raw.data(), raw.size()); }
 
 private:
     UniValue::VType typ;

--- a/src/univalue/lib/univalue_read.cpp
+++ b/src/univalue/lib/univalue_read.cpp
@@ -5,11 +5,10 @@
 #include <univalue.h>
 #include <univalue_utffilter.h>
 
-#include <cstdint>
 #include <cstdio>
+#include <cstdint>
 #include <cstring>
 #include <string>
-#include <string_view>
 #include <vector>
 
 /*
@@ -260,7 +259,7 @@ enum expect_bits : unsigned {
 #define setExpect(bit) (expectMask |= EXP_##bit)
 #define clearExpect(bit) (expectMask &= ~EXP_##bit)
 
-bool UniValue::read(std::string_view str_in)
+bool UniValue::read(const char *raw, size_t size)
 {
     clear();
 
@@ -271,8 +270,7 @@ bool UniValue::read(std::string_view str_in)
     unsigned int consumed;
     enum jtokentype tok = JTOK_NONE;
     enum jtokentype last_tok = JTOK_NONE;
-    const char* raw{str_in.data()};
-    const char* end{raw + str_in.size()};
+    const char* end = raw + size;
     do {
         last_tok = tok;
 

--- a/src/univalue/test/unitester.cpp
+++ b/src/univalue/test/unitester.cpp
@@ -153,7 +153,7 @@ void no_nul_test()
 {
     char buf[] = "___[1,2,3]___";
     UniValue val;
-    assert(val.read({buf + 3, 7}));
+    assert(val.read(buf + 3, 7));
 }
 
 int main (int argc, char *argv[])


### PR DESCRIPTION
This reverts commit fa940f41eaffa4b2a28c465a10a4c12d4b8976b8.

With this commit produce the following compilation error.

```
Making all in src
make[1]: Entering directory '/home/vincent/Github/bitcoin/src'
make[2]: Entering directory '/home/vincent/Github/bitcoin/src'
make[3]: Entering directory '/home/vincent/Github/bitcoin'
make[3]: Leaving directory '/home/vincent/Github/bitcoin'
  GEN      obj/build.h
  CXX      libbitcoin_util_a-clientversion.o
  AR       libbitcoin_util.a
  CXXLD    bitcoind
  CXXLD    bitcoin-cli
  CXXLD    bitcoin-tx
  CXXLD    bitcoin-wallet
  CXXLD    bitcoin-util
  CXX      test/test_bitcoin-base58_tests.o
test/base58_tests.cpp: In member function ‘void base58_tests::base58_EncodeBase58::test_method()’:
test/base58_tests.cpp:26:44: error: invalid initialization of reference of type ‘const std::string&’ {aka ‘const std::__cxx11::basic_string<char>&’} from expression of type ‘const unsigned char [1462]’
   26 |     UniValue tests = read_json(json_tests::base58_encode_decode);
      |                                ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
In file included from test/base58_tests.cpp:8:
./test/util/json.h:12:39: note: in passing argument 1 of ‘UniValue read_json(const std::string&)’
   12 | UniValue read_json(const std::string& jsondata);
      |                    ~~~~~~~~~~~~~~~~~~~^~~~~~~~
test/base58_tests.cpp: In member function ‘void base58_tests::base58_DecodeBase58::test_method()’:
test/base58_tests.cpp:46:44: error: invalid initialization of reference of type ‘const std::string&’ {aka ‘const std::__cxx11::basic_string<char>&’} from expression of type ‘const unsigned char [1462]’
   46 |     UniValue tests = read_json(json_tests::base58_encode_decode);
      |                                ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
./test/util/json.h:12:39: note: in passing argument 1 of ‘UniValue read_json(const std::string&)’
   12 | UniValue read_json(const std::string& jsondata);
      |                    ~~~~~~~~~~~~~~~~~~~^~~~~~~~
make[2]: *** [Makefile:18253: test/test_bitcoin-base58_tests.o] Error 1
make[2]: Leaving directory '/home/vincent/Github/bitcoin/src'
make[1]: *** [Makefile:20006: all-recursive] Error 1
make[1]: Leaving directory '/home/vincent/Github/bitcoin/src'
make: *** [Makefile:815: all-recursive] Error 1
```

The main problem is that we can not auto-convert an unsigned char string to a std::string.

But why the CI did not catch this?

cc: @MarcoFalke, @stickies-v @TheCharlatan

<!--
*** Please remove the following help text before submitting: ***

Pull requests without a rationale and clear improvement may be closed
immediately.

GUI-related pull requests should be opened against
https://github.com/bitcoin-core/gui
first. See CONTRIBUTING.md
-->

<!--
Please provide clear motivation for your patch and explain how it improves
Bitcoin Core user experience or Bitcoin Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Bitcoin Core, if possible.
* Refactoring changes are only accepted if they are required for a feature or
  bug fix or otherwise improve developer experience significantly. For example,
  most "code style" refactoring changes require a thorough explanation why they
  are useful, what downsides they have and why they *significantly* improve
  developer experience or avoid serious programming bugs. Note that code style
  is often a subjective matter. Unless they are explicitly mentioned to be
  preferred in the [developer notes](/doc/developer-notes.md), stylistic code
  changes are usually rejected.
-->

<!--
Bitcoin Core has a thorough review process and even the most trivial change
needs to pass a lot of eyes and requires non-zero or even substantial time
effort to review. There is a huge lack of active reviewers on the project, so
patches often sit for a long time.
-->
