### PR TITLE
doc: Use GitHub's "Alert" markdown syntax

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,7 +127,8 @@ If a particular commit references another issue, please add the reference. For
 example: `refs #1234` or `fixes #4321`. Using the `fixes` or `closes` keywords
 will cause the corresponding issue to be closed when the pull request is merged.
 
-Commit messages should never contain any `@` mentions (usernames prefixed with "@").
+> [!NOTE]
+> Commit messages should never contain any `@` mentions (usernames prefixed with "@").
 
 Please refer to the [Git manual](https://git-scm.com/doc) for more information
 about Git.
@@ -277,13 +278,14 @@ behaviour of code within the pull request (bugs must be preserved as is).
 Project maintainers aim for a quick turnaround on refactoring pull requests, so
 where possible keep them short, uncomplex and easy to verify.
 
-Pull requests that refactor the code should not be made by new contributors. It
-requires a certain level of experience to know where the code belongs to and to
-understand the full ramification (including rebase effort of open pull requests).
-
-Trivial pull requests or pull requests that refactor the code with no clear
-benefits may be immediately closed by the maintainers to reduce unnecessary
-workload on reviewing.
+> [!NOTE]
+> Pull requests that refactor the code should not be made by new contributors. It
+> requires a certain level of experience to know where the code belongs to and to
+> understand the full ramification (including rebase effort of open pull requests).
+>
+> Trivial pull requests or pull requests that refactor the code with no clear
+> benefits may be immediately closed by the maintainers to reduce unnecessary
+> workload on reviewing.
 
 
 "Decision Making" Process

--- a/README.md
+++ b/README.md
@@ -24,9 +24,13 @@ information or see https://opensource.org/licenses/MIT.
 Development Process
 -------------------
 
-The `master` branch is regularly built (see `doc/build-*.md` for instructions) and tested, but it is not guaranteed to be
-completely stable. [Tags](https://github.com/bitcoin/bitcoin/tags) are created
-regularly from release branches to indicate new official, stable release versions of Bitcoin Core.
+The `master` branch is regularly built (see `doc/build-*.md` for instructions)
+and tested. [Tags](https://github.com/bitcoin/bitcoin/tags) are created
+regularly from release branches to indicate new official, stable release
+versions of Bitcoin Core.
+
+> [!WARNING]
+> The `master` branch is not guaranteed to be completely stable.
 
 The https://github.com/bitcoin-core/gui repository is used exclusively for the
 development of the GUI. Its master branch is identical in all monotree
@@ -74,5 +78,6 @@ Changes to translations as well as new translations can be submitted to
 Translations are periodically pulled from Transifex and merged into the git repository. See the
 [translation process](doc/translation_process.md) for details on how this works.
 
-**Important**: We do not accept translation changes as GitHub pull requests because the next
-pull from Transifex would automatically overwrite them again.
+> [!NOTE]
+> We do not accept translation changes as GitHub pull requests because the next
+> pull from Transifex would automatically overwrite them again.

--- a/doc/JSON-RPC-interface.md
+++ b/doc/JSON-RPC-interface.md
@@ -76,12 +76,14 @@ were deprecated and how to re-enable them temporarily.
 
 ## Security
 
-The RPC interface allows other programs to control Bitcoin Core,
-including the ability to spend funds from your wallets, affect consensus
-verification, read private data, and otherwise perform operations that
-can cause loss of money, data, or privacy.  This section suggests how
-you should use and configure Bitcoin Core to reduce the risk that its
-RPC interface will be abused.
+> [!WARNING]
+> The RPC interface allows other programs to control Bitcoin Core,
+> including the ability to spend funds from your wallets, affect consensus
+> verification, read private data, and otherwise perform operations that
+> can cause loss of money, data, or privacy.
+
+This section suggests how you should use and configure Bitcoin Core to reduce
+the risk that its RPC interface will be abused.
 
 - **Securing the executable:** Anyone with physical or remote access to
   the computer, container, or virtual machine running Bitcoin Core can
@@ -188,11 +190,14 @@ this RPC may not yet be reflected as such in this RPC response.
 
 ## Limitations
 
-There is a known issue in the JSON-RPC interface that can cause a node to crash if
-too many http connections are being opened at the same time because the system runs
-out of available file descriptors. To prevent this from happening you might
-want to increase the number of maximum allowed file descriptors in your system
-and try to prevent opening too many connections to your JSON-RPC interface at the
-same time if this is under your control. It is hard to give general advice
-since this depends on your system but if you make several hundred requests at
-once you are definitely at risk of encountering this issue.
+> [!IMPORTANT]
+> There is a known issue in the JSON-RPC interface that can cause a node to
+> crash if too many http connections are being opened at the same time because
+> the system runs out of available file descriptors.
+
+To prevent this from happening you might want to increase the number of maximum
+allowed file descriptors in your system and try to prevent opening too many
+connections to your JSON-RPC interface at the same time if this is under your
+control. It is hard to give general advice since this depends on your system
+but if you make several hundred requests at once you are definitely at risk of
+encountering this issue.

--- a/doc/REST-interface.md
+++ b/doc/REST-interface.md
@@ -15,14 +15,17 @@ apply.
 Limitations
 -----------
 
-There is a known issue in the REST interface that can cause a node to crash if
-too many http connections are being opened at the same time because the system runs
-out of available file descriptors. To prevent this from happening you might
-want to increase the number of maximum allowed file descriptors in your system
-and try to prevent opening too many connections to your rest interface at the
-same time if this is under your control. It is hard to give general advice
-since this depends on your system but if you make several hundred requests at
-once you are definitely at risk of encountering this issue.
+> [!WARNING]
+> There is a known issue in the REST interface that can cause a node to crash
+> if too many http connections are being opened at the same time because the
+> system runs out of available file descriptors.
+
+To prevent this from happening you might want to increase the number of maximum
+allowed file descriptors in your system and try to prevent opening too many
+connections to your rest interface at the same time if this is under your
+control. It is hard to give general advice since this depends on your system
+but if you make several hundred requests at once you are definitely at risk of
+encountering this issue.
 
 Supported API
 -------------
@@ -146,4 +149,9 @@ Refer to the `getrawmempool` RPC help for details. Defaults to setting
 
 Risks
 -------------
-Running a web browser on the same node with a REST enabled bitcoind can be a risk. Accessing prepared XSS websites could read out tx/block data of your node by placing links like `<script src="http://127.0.0.1:8332/rest/tx/1234567890.json">` which might break the nodes privacy.
+
+> [!WARNING]
+> Running a web browser on the same node with a REST enabled bitcoind can be a risk.
+> Accessing prepared XSS websites could read out tx/block data of your node by placing
+> links like `<script src="http://127.0.0.1:8332/rest/tx/1234567890.json">` which
+> might break the nodes privacy.

--- a/doc/bitcoin-conf.md
+++ b/doc/bitcoin-conf.md
@@ -6,7 +6,8 @@ All command-line options (except for `-?`, `-help`, `-version` and `-conf`) may 
 
 Changes to the configuration file while `bitcoind` or `bitcoin-qt` is running only take effect after restarting.
 
-Users should never make any configuration changes which they do not understand. Furthermore, users should always be wary of accepting any configuration changes provided to them by another source (even if they believe that they do understand them).
+> [!WARNING]
+> Users should never make any configuration changes which they do not understand. Furthermore, users should always be wary of accepting any configuration changes provided to them by another source (even if they believe that they do understand them).
 
 ## Configuration File Format
 

--- a/doc/build-freebsd.md
+++ b/doc/build-freebsd.md
@@ -36,10 +36,14 @@ pkg install sqlite3
 ```
 
 ###### Legacy Wallet Support
-BerkeleyDB is only required if legacy wallet support is required.
 
-It is required to use Berkeley DB 4.8. You **cannot** use the BerkeleyDB library
-from ports. However, you can build DB 4.8 yourself [using depends](/depends).
+> [!NOTE]
+> BerkeleyDB is only required if legacy wallet support is required.
+
+> [!IMPORTANT]
+> It is required to use Berkeley DB 4.8. You **cannot** use the BerkeleyDB
+> library from ports. However, you can build DB 4.8 yourself [using
+> depends](/depends).
 
 ```
 gmake -C depends NO_BOOST=1 NO_LIBEVENT=1 NO_QT=1 NO_SQLITE=1 NO_NATPMP=1 NO_UPNP=1 NO_ZMQ=1 NO_USDT=1
@@ -124,7 +128,9 @@ This enables support for both wallet types and disables the GUI, assuming
 ```
 
 ### 2. Compile
-**Important**: Use `gmake` (the non-GNU `make` will exit with an error).
+
+> [!NOTE]
+> Use `gmake` (the non-GNU `make` will exit with an error).
 
 ```bash
 gmake # use "-j N" for N parallel jobs

--- a/doc/build-netbsd.md
+++ b/doc/build-netbsd.md
@@ -89,7 +89,8 @@ pkgin install python37
 
 ### Building Bitcoin Core
 
-**Note**: Use `gmake` (the non-GNU `make` will exit with an error).
+> [!Note]
+> Use `gmake` (the non-GNU `make` will exit with an error).
 
 
 ### 1. Configuration

--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -38,10 +38,14 @@ pkg_add sqlite3
 ```
 
 ###### Legacy Wallet Support
-BerkeleyDB is only required to support legacy wallets.
 
-It is recommended to use Berkeley DB 4.8. You cannot use the BerkeleyDB library
-from ports. However you can build it yourself, [using depends](/depends).
+> [!NOTE]
+> BerkeleyDB is only required if legacy wallet support is required.
+
+> [!IMPORTANT]
+> It is recommended to use Berkeley DB 4.8. You cannot use the BerkeleyDB
+> library from ports. However you can build it yourself, [using
+> depends](/depends).
 
 ```bash
 gmake -C depends NO_BOOST=1 NO_LIBEVENT=1 NO_QT=1 NO_SQLITE=1 NO_NATPMP=1 NO_UPNP=1 NO_ZMQ=1 NO_USDT=1
@@ -66,7 +70,8 @@ pkg_add qt5
 
 ## Building Bitcoin Core
 
-**Important**: Use `gmake` (the non-GNU `make` will exit with an error).
+> [!NOTE]
+> Use `gmake` (the non-GNU `make` will exit with an error).
 
 Preparation:
 ```bash

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -54,10 +54,12 @@ SQLite is required for the descriptor wallet:
 
     sudo apt install libsqlite3-dev
 
-Berkeley DB is only required for the legacy wallet. Ubuntu and Debian have their own `libdb-dev` and `libdb++-dev` packages,
-but these will install Berkeley DB 5.3 or later. This will break binary wallet compatibility with the distributed
-executables, which are based on BerkeleyDB 4.8. If you do not care about wallet compatibility, pass
-`--with-incompatible-bdb` to configure. Otherwise, you can build Berkeley DB [yourself](#berkeley-db).
+> [!NOTE] Berkeley DB is only required for the legacy wallet. Ubuntu and Debian
+> have their own `libdb-dev` and `libdb++-dev` packages, but these will install
+> Berkeley DB 5.3 or later. This will break binary wallet compatibility with
+> the distributed executables, which are based on BerkeleyDB 4.8. If you do not
+> care about wallet compatibility, pass `--with-incompatible-bdb` to configure.
+> Otherwise, you can build Berkeley DB [yourself](#berkeley-db).
 
 To build Bitcoin Core without wallet, see [*Disable-wallet mode*](#disable-wallet-mode)
 
@@ -111,10 +113,12 @@ SQLite is required for the descriptor wallet:
 
     sudo dnf install sqlite-devel
 
-Berkeley DB is only required for the legacy wallet. Fedora releases have only `libdb-devel` and `libdb-cxx-devel` packages, but these will install
-Berkeley DB 5.3 or later. This will break binary wallet compatibility with the distributed executables, which
-are based on Berkeley DB 4.8. If you do not care about wallet compatibility,
-pass `--with-incompatible-bdb` to configure. Otherwise, you can build Berkeley DB [yourself](#berkeley-db).
+> [!NOTE] Berkeley DB is only required for the legacy wallet. Fedora releases
+> have only `libdb-devel` and `libdb-cxx-devel` packages, but these will
+> install Berkeley DB 5.3 or later. This will break binary wallet compatibility
+> with the distributed executables, which are based on Berkeley DB 4.8. If you
+> do not care about wallet compatibility, pass `--with-incompatible-bdb` to
+> configure. Otherwise, you can build Berkeley DB [yourself](#berkeley-db).
 
 To build Bitcoin Core without wallet, see [*Disable-wallet mode*](#disable-wallet-mode)
 

--- a/doc/external-signer.md
+++ b/doc/external-signer.md
@@ -4,7 +4,10 @@ Bitcoin Core can be launched with `-signer=<cmd>` where `<cmd>` is an external t
 
 ## Example usage
 
-The following example is based on the [HWI](https://github.com/bitcoin-core/HWI) tool. Version 2.0 or newer is required. Although this tool is hosted under the Bitcoin Core GitHub organization and maintained by Bitcoin Core developers, it should be used with caution. It is considered experimental and has far less review than Bitcoin Core itself. Be particularly careful when running tools such as these on a computer with private keys on it.
+The following example is based on the [HWI](https://github.com/bitcoin-core/HWI) tool. Version 2.0 or newer is required.
+
+> [!IMPORTANT]
+> Although this tool is hosted under the Bitcoin Core GitHub organization and maintained by Bitcoin Core developers, it should be used with caution. It is considered experimental and has far less review than Bitcoin Core itself. Be particularly careful when running tools such as these on a computer with private keys on it.
 
 When using a hardware wallet, consult the manufacturer website for (alternative) software they recommend. As long as their software conforms to the standard below, it should be able to work with Bitcoin Core.
 

--- a/doc/init.md
+++ b/doc/init.md
@@ -66,21 +66,23 @@ configuration file and data directory only readable by the bitcoin user and
 group. Access to bitcoin-cli and other bitcoind rpc clients can then be
 controlled by group membership.
 
-NOTE: When using the systemd .service file, the creation of the aforementioned
-directories and the setting of their permissions is automatically handled by
-systemd. Directories are given a permission of 710, giving the bitcoin group
-access to files under it _if_ the files themselves give permission to the
-bitcoin group to do so. This does not allow
-for the listing of files under the directory.
+> [!NOTE]
+> When using the systemd .service file, the creation of the aforementioned
+> directories and the setting of their permissions is automatically handled by
+> systemd. Directories are given a permission of 710, giving the bitcoin group
+> access to files under it _if_ the files themselves give permission to the
+> bitcoin group to do so. This does not allow for the listing of files under
+> the directory.
 
-NOTE: It is not currently possible to override `datadir` in
-`/etc/bitcoin/bitcoin.conf` with the current systemd, OpenRC, and Upstart init
-files out-of-the-box. This is because the command line options specified in the
-init files take precedence over the configurations in
-`/etc/bitcoin/bitcoin.conf`. However, some init systems have their own
-configuration mechanisms that would allow for overriding the command line
-options specified in the init files (e.g. setting `BITCOIND_DATADIR` for
-OpenRC).
+> [!NOTE]
+> It is not currently possible to override `datadir` in
+> `/etc/bitcoin/bitcoin.conf` with the current systemd, OpenRC, and Upstart
+> init files out-of-the-box. This is because the command line options specified
+> in the init files take precedence over the configurations in
+> `/etc/bitcoin/bitcoin.conf`. However, some init systems have their own
+> configuration mechanisms that would allow for overriding the command line
+> options specified in the init files (e.g. setting `BITCOIND_DATADIR` for
+> OpenRC).
 
 ### macOS
 
@@ -101,7 +103,8 @@ Installing this .service file consists of just copying it to
 To test, run `systemctl start bitcoind` and to enable for system startup run
 `systemctl enable bitcoind`
 
-NOTE: When installing for systemd in Debian/Ubuntu the .service file needs to be copied to the /lib/systemd/system directory instead.
+> [!NOTE]
+> When installing for systemd in Debian/Ubuntu the .service file needs to be copied to the /lib/systemd/system directory instead.
 
 ### OpenRC
 
@@ -117,8 +120,9 @@ Upstart is the default init system for Debian/Ubuntu versions older than 15.04. 
 Drop bitcoind.conf in /etc/init.  Test by running `service bitcoind start`
 it will automatically start on reboot.
 
-NOTE: This script is incompatible with CentOS 5 and Amazon Linux 2014 as they
-use old versions of Upstart and do not supply the start-stop-daemon utility.
+> [!NOTE]
+> This script is incompatible with CentOS 5 and Amazon Linux 2014 as they use
+> old versions of Upstart and do not supply the start-stop-daemon utility.
 
 ### CentOS
 
@@ -135,9 +139,10 @@ running `launchctl load ~/Library/LaunchAgents/org.bitcoin.bitcoind.plist`.
 
 This Launch Agent will cause bitcoind to start whenever the user logs in.
 
-NOTE: This approach is intended for those wanting to run bitcoind as the current user.
-You will need to modify org.bitcoin.bitcoind.plist if you intend to use it as a
-Launch Daemon with a dedicated bitcoin user.
+> [!NOTE]
+> This approach is intended for those wanting to run bitcoind as the current
+> user. You will need to modify org.bitcoin.bitcoind.plist if you intend to use
+> it as a Launch Daemon with a dedicated bitcoin user.
 
 Auto-respawn
 -----------------------------------

--- a/doc/managing-wallets.md
+++ b/doc/managing-wallets.md
@@ -27,11 +27,13 @@ By default, wallets are created in the `wallets` folder of the data directory, w
 
 The `wallet.dat` file is not encrypted by default and is, therefore, vulnerable if an attacker gains access to the device where the wallet or the backups are stored.
 
-Wallet encryption may prevent unauthorized access. However, this significantly increases the risk of losing coins due to forgotten passphrases. There is no way to recover a passphrase. This tradeoff should be well thought out by the user.
+> [!NOTE]
+> Wallet encryption may prevent unauthorized access. However, this significantly increases the risk of losing coins due to forgotten passphrases. There is no way to recover a passphrase. This tradeoff should be well thought out by the user.
 
 Wallet encryption may also not protect against more sophisticated attacks. An attacker can, for example, obtain the password by installing a keylogger on the user's machine.
 
-After encrypting the wallet or changing the passphrase, a new backup needs to be created immediately. The reason is that the keypool is flushed and a new HD seed is generated after encryption. Any bitcoins received by the new seed cannot be recovered from the previous backups.
+> [!WARNING]
+> After encrypting the wallet or changing the passphrase, a new backup needs to be created immediately. The reason is that the keypool is flushed and a new HD seed is generated after encryption. Any bitcoins received by the new seed cannot be recovered from the previous backups.
 
 The wallet's private key may be encrypted with the following command:
 
@@ -80,7 +82,8 @@ In the GUI, there is no specific menu item to unlock the wallet. When the user s
 
 ### 1.4 Backing Up the Wallet
 
-To backup the wallet, the `backupwallet` RPC or the `Backup Wallet` GUI menu item must be used to ensure the file is in a safe state when the copy is made.
+> [!IMPORTANT]
+> To backup the wallet, the `backupwallet` RPC or the `Backup Wallet` GUI menu item must be used to ensure the file is in a safe state when the copy is made.
 
 In the RPC, the destination parameter must include the name of the file. Otherwise, the command will return an error message like "Error: Wallet backup failed!" for descriptor wallets. If it is a legacy wallet, it will be copied and a file will be created with the default file name `wallet.dat`.
 
@@ -104,7 +107,8 @@ Bitcoin Core [version 0.13](https://github.com/bitcoin/bitcoin/blob/master/doc/r
 
 This means that a single backup is enough to recover the coins at any time. It is still recommended to make regular backups (once a week) or after a significant number of new transactions to maintain the metadata, such as labels. Metadata cannot be retrieved from a blockchain rescan, so if the backup is too old, the metadata will be lost forever.
 
-Wallets created before version 0.13 are not HD and must be backed up every 100 keys used since the previous backup, or even more often to maintain the metadata.
+> [!IMPORTANT]
+> Wallets created before version 0.13 are not HD and must be backed up every 100 keys used since the previous backup, or even more often to maintain the metadata.
 
 ### 1.6 Restoring the Wallet From a Backup
 
@@ -137,12 +141,16 @@ Migrated wallets will also generate new addresses differently. While the same BI
 used, the BIP 44, 49, 84, and 86 standard derivation paths will be used. After migrating, a new
 backup of the wallet(s) will need to be created.
 
-Given that there is an extremely large number of possible configurations for the scripts that
-Legacy wallets can know about, be watching for, and be able to sign for, `migratewallet` only
-makes a best effort attempt to capture all of these things into Descriptor wallets. There may be
-unforeseen configurations which result in some scripts being excluded. If a migration fails
-unexpectedly or otherwise misses any scripts, please create an issue on GitHub. A backup of the
-original wallet can be found in the wallet directory with the name `<name>-<timestamp>.legacy.bak`.
+> [!IMPORTANT]
+> Given that there is an extremely large number of possible configurations for
+> the scripts that Legacy wallets can know about, be watching for, and be able
+> to sign for, `migratewallet` only makes a best effort attempt to capture all
+> of these things into Descriptor wallets. There may be unforeseen
+> configurations which result in some scripts being excluded.
+
+If a migration fails unexpectedly or otherwise misses any scripts, please
+create an issue on GitHub. A backup of the original wallet can be found in the
+wallet directory with the name `<name>-<timestamp>.legacy.bak`.
 
 The backup can be restored using the methods discussed in the
 [Restoring the Wallet From a Backup](#16-restoring-the-wallet-from-a-backup) section.

--- a/doc/productivity.md
+++ b/doc/productivity.md
@@ -42,9 +42,11 @@ max_size = 50.0G  # or whatever cache size you prefer; default is 5G; 0 means un
 base_dir = /home/yourname  # or wherever you keep your source files
 ```
 
-Note: base_dir is required for ccache to share cached compiles of the same file across different repositories / paths; it will only do this for paths under base_dir. So this option is required for effective use of ccache with git worktrees (described below).
+> [!NOTE]
+> base_dir is required for ccache to share cached compiles of the same file across different repositories / paths; it will only do this for paths under base_dir. So this option is required for effective use of ccache with git worktrees (described below).
 
-You _must not_ set base_dir to "/", or anywhere that contains system headers (according to the ccache docs).
+> [!NOTE]
+> You _must not_ set base_dir to "/", or anywhere that contains system headers (according to the ccache docs).
 
 ### Disable features with `./configure`
 


### PR DESCRIPTION
GH has introduced new "Alert" syntax for md files (a.k.a "Admonitions" in other languages).

Whilst being wary of changing documentation just for the sake of "shiny" new features, in my opinion this is worthwhile in this case as we can use it to draw user attention to particularly important sections of docs.

The format is relatively backwards-compatible (i.e outside of GH), as the syntax is effectively a multi-block quotation, where the first line includes the alert type. This means the text still renders fine outside of GH, but is improved on GH. Samples below:

GitHub render:
![image](https://github.com/bitcoin/bitcoin/assets/6606587/34282644-bf21-42d8-bbe6-6f18069a3081)

Hackmd render:
![image](https://github.com/bitcoin/bitcoin/assets/6606587/d88a98a8-e9c0-4dce-abf1-58f59de9c6a5)

See e.g. https://github.com/willcl-ark/bitcoin/blob/2023-08-gh-alerts/doc/managing-wallets.md for a doc containing a few alerts.

Opening as draft for now to see if others would consider such a change worthwhile, not interested in bike-shedding over which alert level is used where, for now :) But for reference GH provides [documentation](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts) with _their_ recommended usage of alert levels, which I did try to roughly use in this draft. 

