### PR TITLE
doc: use llvm-config for bitcoin-tidy example

### DIFF
--- a/contrib/devtools/bitcoin-tidy/README
+++ b/contrib/devtools/bitcoin-tidy/README
@@ -3,6 +3,9 @@
 Example Usage:
 
 ```bash
-cmake -S . -B build -DLLVM_DIR=/path/to/lib/cmake/llvm -DCMAKE_BUILD_TYPE=Release
-make -C build -j$(nproc)
+cmake -S . -B build -DLLVM_DIR=$(llvm-config --cmakedir) -DCMAKE_BUILD_TYPE=Release
+
+cmake --build build -j$(nproc)
+
+cmake --build build --target bitcoin-tidy-tests -j$(nproc)
 ```


### PR DESCRIPTION
An LLVM installation will have `llvm-config` available to query for info. Ask it for the `--cmakedir`, and use that in our bitcoin-tidy example, rather than listing multiple different (potential) paths per distro/OS etc.