### PR TITLE
p2p: peer connection bug fixes

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -51,6 +51,7 @@
 #include <functional>
 #include <optional>
 #include <unordered_map>
+#include <unordered_set>
 
 #include <math.h>
 
@@ -3465,24 +3466,13 @@ std::vector<CAddress> CConnman::GetAddresses(CNode& requestor, size_t max_addres
 bool CConnman::AddNode(const AddedNodeParams& params)
 {
     LOCK(m_added_nodes_mutex);
-    for (const auto& it : m_added_node_params) {
-        if (params.m_added_node == it.m_added_node) return false;
-    }
-
-    m_added_node_params.push_back(params);
-    return true;
+    return m_added_node_params.insert(params).second;
 }
 
 bool CConnman::RemoveAddedNode(const AddedNodeParams& params)
 {
     LOCK(m_added_nodes_mutex);
-    for (auto it = m_added_node_params.begin(); it != m_added_node_params.end(); ++it) {
-        if (params.m_added_node == it->m_added_node) {
-            m_added_node_params.erase(it);
-            return true;
-        }
-    }
-    return false;
+    return m_added_node_params.erase(params);
 }
 
 size_t CConnman::GetNodeCount(ConnectionDirection flags) const

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2787,7 +2787,7 @@ std::vector<AddedNodeInfo> CConnman::GetAddedNodeInfo() const
     }
 
     for (const auto& addr : lAddresses) {
-        CService service(LookupNumeric(addr.m_added_node, GetDefaultPort(addr.m_added_node)));
+        CService service{MaybeFlipIPv6toCJDNS(LookupNumeric(addr.m_added_node, GetDefaultPort(addr.m_added_node)))};
         AddedNodeInfo addedNode{addr, CService(), false, false};
         if (service.IsValid()) {
             // addr.m_added_node is an addr:port

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1712,7 +1712,9 @@ bool CConnman::AttemptToEvictConnection()
     LOCK(m_nodes_mutex);
     for (CNode* pnode : m_nodes) {
         if (pnode->GetId() == *node_id_to_evict) {
-            LogPrint(BCLog::NET, "selected %s connection for eviction peer=%d; disconnecting\n", pnode->ConnectionTypeAsString(), pnode->GetId());
+            LogPrintLevel(BCLog::NET, BCLog::Level::Debug, "Selected %s connection for eviction, disconnecting: peer=%d net=%s%s\n",
+                          pnode->ConnectionTypeAsString(), pnode->GetId(), GetNetworkName(pnode->ConnectedThroughNetwork()),
+                          fLogIPs ? strprintf(", peeraddr=%s", pnode->addr.ToStringAddrPort()) : "");
             pnode->fDisconnect = true;
             return true;
         }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -435,11 +435,6 @@ CNode* CConnman::ConnectNode(CAddress addrConnect, const char *pszDest, bool fCo
         }
     }
 
-    LogPrintLevel(BCLog::NET, BCLog::Level::Debug, "trying %s connection %s lastseen=%.1fhrs\n",
-        use_v2transport ? "v2" : "v1",
-        pszDest ? pszDest : addrConnect.ToStringAddrPort(),
-        Ticks<HoursDouble>(pszDest ? 0h : Now<NodeSeconds>() - addrConnect.nTime));
-
     // Resolve
     const uint16_t default_port{pszDest != nullptr ? GetDefaultPort(pszDest) :
                                                      m_params.GetDefaultPort()};
@@ -459,6 +454,11 @@ CNode* CConnman::ConnectNode(CAddress addrConnect, const char *pszDest, bool fCo
             }
         }
     }
+
+    LogPrintLevel(BCLog::NET, BCLog::Level::Debug, "Trying v%i %s connection to net=%s%s, lastseen=%.1fh ago\n",
+                  use_v2transport ? 2 : 1, ConnectionTypeAsString(conn_type), GetNetworkName(addrConnect.GetNetwork()),
+                  fLogIPs ? strprintf(", peeraddr=%s", pszDest ? pszDest : addrConnect.ToStringAddrPort()) : "",
+                  Ticks<HoursDouble>(pszDest ? 0h : Now<NodeSeconds>() - addrConnect.nTime));
 
     // Connect
     bool connected = false;
@@ -2766,7 +2766,6 @@ void CConnman::ThreadOpenConnections(const std::vector<std::string> connect)
                 if (!interruptNet.sleep_for(rng.rand_uniform_duration<CThreadInterrupt::Clock>(FEELER_SLEEP_WINDOW))) {
                     return;
                 }
-                LogPrint(BCLog::NET, "Making feeler connection to %s\n", addrConnect.ToStringAddrPort());
             }
 
             if (preferred_net != std::nullopt) LogPrint(BCLog::NET, "Making network specific connection to %s on %s.\n", addrConnect.ToStringAddrPort(), GetNetworkName(preferred_net.value()));

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -328,33 +328,33 @@ bool IsLocal(const CService& addr)
     return mapLocalHost.count(addr) > 0;
 }
 
-CNode* CConnman::FindNode(const CNetAddr& ip)
+CNode* CConnman::FindNode(const CNetAddr& addr, std::optional<bool> inbound)
 {
     AssertLockHeld(m_nodes_mutex);
     for (CNode* pnode : m_nodes) {
-      if (static_cast<CNetAddr>(pnode->addr) == ip) {
+        if (static_cast<CNetAddr>(pnode->addr) == addr && (!inbound.has_value() || pnode->IsInboundConn() == inbound.value())) {
             return pnode;
         }
     }
     return nullptr;
 }
 
-CNode* CConnman::FindNode(const std::string& addrName)
+CNode* CConnman::FindNode(const std::string& addr, std::optional<bool> inbound)
 {
     AssertLockHeld(m_nodes_mutex);
     for (CNode* pnode : m_nodes) {
-        if (pnode->m_addr_name == addrName) {
+        if (pnode->m_addr_name == addr && (!inbound.has_value() || pnode->IsInboundConn() == inbound.value())) {
             return pnode;
         }
     }
     return nullptr;
 }
 
-CNode* CConnman::FindNode(const CService& addr)
+CNode* CConnman::FindNode(const CService& addr, std::optional<bool> inbound)
 {
     AssertLockHeld(m_nodes_mutex);
     for (CNode* pnode : m_nodes) {
-        if (static_cast<CService>(pnode->addr) == addr) {
+        if (static_cast<CService>(pnode->addr) == addr && (!inbound.has_value() || pnode->IsInboundConn() == inbound.value())) {
             return pnode;
         }
     }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1823,6 +1823,13 @@ void CConnman::CreateNodeFromAcceptedSocket(std::unique_ptr<Sock>&& sock,
     }
 
     const bool inbound_onion = std::find(m_onion_binds.begin(), m_onion_binds.end(), addr_bind) != m_onion_binds.end();
+
+    // Do not accept inbound connections from I2P peers already connected to us,
+    // as creating new tunnels is expensive.
+    if (addr.IsI2P() && AlreadyConnectedToAddress(addr, ConnectionType::INBOUND)) {
+        return;
+    }
+
     // The V2Transport transparently falls back to V1 behavior when an incoming V1 connection is
     // detected, so use it whenever we signal NODE_P2P_V2.
     const bool use_v2transport(nodeServices & NODE_P2P_V2);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -363,7 +363,8 @@ CNode* CConnman::FindNode(const CService& addr)
 
 bool CConnman::AlreadyConnectedToAddress(const CAddress& addr)
 {
-    return FindNode(static_cast<CNetAddr>(addr)) || FindNode(addr.ToStringAddrPort());
+    const CService service{MaybeFlipIPv6toCJDNS(addr)};
+    return FindNode(static_cast<CNetAddr>(service)) || FindNode(service.ToStringAddrPort());
 }
 
 bool CConnman::CheckIncomingNonce(uint64_t nonce)

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3462,22 +3462,22 @@ std::vector<CAddress> CConnman::GetAddresses(CNode& requestor, size_t max_addres
     return cache_entry.m_addrs_response_cache;
 }
 
-bool CConnman::AddNode(const AddedNodeParams& add)
+bool CConnman::AddNode(const AddedNodeParams& params)
 {
     LOCK(m_added_nodes_mutex);
     for (const auto& it : m_added_node_params) {
-        if (add.m_added_node == it.m_added_node) return false;
+        if (params.m_added_node == it.m_added_node) return false;
     }
 
-    m_added_node_params.push_back(add);
+    m_added_node_params.push_back(params);
     return true;
 }
 
-bool CConnman::RemoveAddedNode(const std::string& strNode)
+bool CConnman::RemoveAddedNode(const AddedNodeParams& params)
 {
     LOCK(m_added_nodes_mutex);
     for (auto it = m_added_node_params.begin(); it != m_added_node_params.end(); ++it) {
-        if (strNode == it->m_added_node) {
+        if (params.m_added_node == it->m_added_node) {
             m_added_node_params.erase(it);
             return true;
         }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -429,10 +429,7 @@ CNode* CConnman::ConnectNode(CAddress addrConnect, const char *pszDest, bool fCo
             return nullptr;
 
         // Look for an existing connection
-        CNode* pnode = WITH_LOCK(m_nodes_mutex, return FindNode(static_cast<CService>(addrConnect)));
-        if (pnode)
-        {
-            LogPrintf("Failed to open new connection, already connected\n");
+        if (AlreadyConnectedToAddress(addrConnect, conn_type)) {
             return nullptr;
         }
     }
@@ -456,10 +453,7 @@ CNode* CConnman::ConnectNode(CAddress addrConnect, const char *pszDest, bool fCo
             }
             // It is possible that we already have a connection to the IP/port pszDest resolved to.
             // In that case, drop the connection that was just created.
-            LOCK(m_nodes_mutex);
-            CNode* pnode = FindNode(static_cast<CService>(addrConnect));
-            if (pnode) {
-                LogPrintf("Failed to open new connection, already connected\n");
+            if (AlreadyConnectedToAddress(addrConnect, conn_type)) {
                 return nullptr;
             }
         }

--- a/src/net.h
+++ b/src/net.h
@@ -1341,8 +1341,12 @@ private:
     /**
      * Determine whether we're already connected to a given address, in order to
      * avoid initiating duplicate connections.
+     *
+     * @param[in] addr  Address to search for.
+     * @param[in] conn_type  Intended connection type of the address.
+     * @param[in] log  Whether to log if already connected to the address.
      */
-    bool AlreadyConnectedToAddress(const CAddress& addr);
+    bool AlreadyConnectedToAddress(const CAddress& addr, ConnectionType conn_type, bool log = true);
 
     bool AttemptToEvictConnection();
     CNode* ConnectNode(CAddress addrConnect, const char *pszDest, bool fCountFailure, ConnectionType conn_type, bool use_v2transport) EXCLUSIVE_LOCKS_REQUIRED(!m_unused_i2p_sessions_mutex);

--- a/src/net.h
+++ b/src/net.h
@@ -1328,9 +1328,15 @@ private:
 
     uint64_t CalculateKeyedNetGroup(const CAddress& ad) const;
 
-    CNode* FindNode(const CNetAddr& ip) EXCLUSIVE_LOCKS_REQUIRED(m_nodes_mutex);
-    CNode* FindNode(const std::string& addrName) EXCLUSIVE_LOCKS_REQUIRED(m_nodes_mutex);
-    CNode* FindNode(const CService& addr) EXCLUSIVE_LOCKS_REQUIRED(m_nodes_mutex);
+    /**
+     * Search for a peer by address from among the peers we're connected to.
+     * @param[in] addr  Address to search for.
+     * @param[in] inbound (optional)  Whether to also filter by inbound status true/false.
+     * @returns a pointer to the peer if one is found, otherwise nullptr.
+     */
+    CNode* FindNode(const CNetAddr& addr, std::optional<bool> inbound = std::nullopt) EXCLUSIVE_LOCKS_REQUIRED(m_nodes_mutex);
+    CNode* FindNode(const std::string& addr, std::optional<bool> inbound = std::nullopt) EXCLUSIVE_LOCKS_REQUIRED(m_nodes_mutex);
+    CNode* FindNode(const CService& addr, std::optional<bool> inbound = std::nullopt) EXCLUSIVE_LOCKS_REQUIRED(m_nodes_mutex);
 
     /**
      * Determine whether we're already connected to a given address, in order to

--- a/src/net.h
+++ b/src/net.h
@@ -1187,8 +1187,8 @@ public:
     // Count the number of block-relay-only peers we have over our limit.
     int GetExtraBlockRelayCount() const;
 
-    bool AddNode(const AddedNodeParams& add) EXCLUSIVE_LOCKS_REQUIRED(!m_added_nodes_mutex);
-    bool RemoveAddedNode(const std::string& node) EXCLUSIVE_LOCKS_REQUIRED(!m_added_nodes_mutex);
+    bool AddNode(const AddedNodeParams& params) EXCLUSIVE_LOCKS_REQUIRED(!m_added_nodes_mutex);
+    bool RemoveAddedNode(const AddedNodeParams& params) EXCLUSIVE_LOCKS_REQUIRED(!m_added_nodes_mutex);
     std::vector<AddedNodeInfo> GetAddedNodeInfo() const EXCLUSIVE_LOCKS_REQUIRED(!m_added_nodes_mutex);
 
     /**

--- a/src/net.h
+++ b/src/net.h
@@ -1393,12 +1393,8 @@ private:
      * currently don't have any OUTBOUND_FULL_RELAY or MANUAL connections.
      * There needs to be at least one address in AddrMan for a preferred
      * network to be picked.
-     *
-     * @param[out]    network        Preferred network, if found.
-     *
-     * @return           bool        Whether a preferred network was found.
      */
-    bool MaybePickPreferredNetwork(std::optional<Network>& network);
+    std::optional<Network> MaybePickPreferredNetwork() const EXCLUSIVE_LOCKS_REQUIRED(!m_nodes_mutex);
 
     // Whether the node should be passed out in ForEach* callbacks
     static bool NodeFullyConnected(const CNode* pnode);

--- a/src/net.h
+++ b/src/net.h
@@ -1200,6 +1200,7 @@ public:
 
     bool AddNode(const AddedNodeParams& params) EXCLUSIVE_LOCKS_REQUIRED(!m_added_nodes_mutex);
     bool RemoveAddedNode(const AddedNodeParams& params) EXCLUSIVE_LOCKS_REQUIRED(!m_added_nodes_mutex);
+    bool AddedNodesContain(const CAddress& addr) const EXCLUSIVE_LOCKS_REQUIRED(!m_added_nodes_mutex);
     std::vector<AddedNodeInfo> GetAddedNodeInfo() const EXCLUSIVE_LOCKS_REQUIRED(!m_added_nodes_mutex);
 
     /**

--- a/src/net.h
+++ b/src/net.h
@@ -1328,9 +1328,9 @@ private:
 
     uint64_t CalculateKeyedNetGroup(const CAddress& ad) const;
 
-    CNode* FindNode(const CNetAddr& ip);
-    CNode* FindNode(const std::string& addrName);
-    CNode* FindNode(const CService& addr);
+    CNode* FindNode(const CNetAddr& ip) EXCLUSIVE_LOCKS_REQUIRED(m_nodes_mutex);
+    CNode* FindNode(const std::string& addrName) EXCLUSIVE_LOCKS_REQUIRED(m_nodes_mutex);
+    CNode* FindNode(const CService& addr) EXCLUSIVE_LOCKS_REQUIRED(m_nodes_mutex);
 
     /**
      * Determine whether we're already connected to a given address, in order to

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3598,12 +3598,14 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
         // can be triggered by an attacker at high rate.
         if (!pfrom.IsInboundConn() || LogAcceptCategory(BCLog::NET, BCLog::Level::Debug)) {
             const auto mapped_as{m_connman.GetMappedAS(pfrom.addr)};
-            LogPrintf("New %s %s peer connected: version: %d, blocks=%d, peer=%d%s%s\n",
+            LogPrintf("New %s %s peer connected: version=%d, blocks=%d, peer=%d, net=%s%s%s, subver=%s\n",
                       pfrom.ConnectionTypeAsString(),
                       TransportTypeAsString(pfrom.m_transport->GetInfo().transport_type),
                       pfrom.nVersion.load(), peer->m_starting_height,
-                      pfrom.GetId(), (fLogIPs ? strprintf(", peeraddr=%s", pfrom.addr.ToStringAddrPort()) : ""),
-                      (mapped_as ? strprintf(", mapped_as=%d", mapped_as) : ""));
+                      pfrom.GetId(), GetNetworkName(pfrom.addr.GetNetwork()),
+                      fLogIPs ? strprintf(", peeraddr=%s", pfrom.addr.ToStringAddrPort()) : "",
+                      mapped_as ? strprintf(", mapped_as=%d", mapped_as) : "",
+                      WITH_LOCK(pfrom.m_subver_mutex, return pfrom.cleanSubVer));
         }
 
         if (pfrom.GetCommonVersion() >= SHORT_IDS_BLOCKS_VERSION) {

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -261,6 +261,7 @@ public:
         }
     }
 
+    friend class CNetAddrHash;
     friend class CSubNet;
 
 private:
@@ -477,6 +478,30 @@ private:
         // will not be gossiped, but continue reading next addresses from the stream.
         m_net = NET_IPV6;
         m_addr.assign(ADDR_IPV6_SIZE, 0x0);
+    }
+};
+
+class CNetAddrHash
+{
+private:
+    const uint64_t m_salt_k0;
+    const uint64_t m_salt_k1;
+
+public:
+    CNetAddrHash()
+        : m_salt_k0{GetRand<uint64_t>()},
+          m_salt_k1{GetRand<uint64_t>()}
+    {
+    }
+
+    CNetAddrHash(uint64_t salt_k0, uint64_t salt_k1) : m_salt_k0{salt_k0}, m_salt_k1{salt_k1} {}
+
+    size_t operator()(const CNetAddr& a) const noexcept
+    {
+        CSipHasher hasher(m_salt_k0, m_salt_k1);
+        hasher.Write(a.m_net);
+        hasher.Write(a.m_addr);
+        return static_cast<size_t>(hasher.Finalize());
     }
 };
 

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -340,7 +340,7 @@ static RPCHelpMan addnode()
     }
     else if (command == "remove")
     {
-        if (!connman.RemoveAddedNode(node_arg)) {
+        if (!connman.RemoveAddedNode({node_arg, use_v2transport})) {
             throw JSONRPCError(RPC_CLIENT_NODE_NOT_ADDED, "Error: Node could not be removed. It has not been added previously.");
         }
     }

--- a/src/test/fuzz/connman.cpp
+++ b/src/test/fuzz/connman.cpp
@@ -112,7 +112,7 @@ FUZZ_TARGET(connman, .init = initialize_connman)
                 connman.PushMessage(&random_node, std::move(serialized_net_msg));
             },
             [&] {
-                connman.RemoveAddedNode(random_string);
+                connman.RemoveAddedNode({random_string, fuzzed_data_provider.ConsumeBool()});
             },
             [&] {
                 connman.SetNetworkActive(fuzzed_data_provider.ConsumeBool());

--- a/test/functional/feature_anchors.py
+++ b/test/functional/feature_anchors.py
@@ -136,8 +136,8 @@ class AnchorsTest(BitcoinTestFramework):
             file_handler.write(new_data + new_data_hash)
 
         self.log.info("Restarting node attempts to reconnect to anchors")
-        with self.nodes[0].assert_debug_log([f"Trying to make an anchor connection to {ONION_ADDR}"]):
-            self.start_node(0, extra_args=[f"-onion={onion_conf.addr[0]}:{onion_conf.addr[1]}"])
+        with self.nodes[0].assert_debug_log([f"Trying block-relay-only anchor connection to net=onion, peeraddr={ONION_ADDR}"]):
+            self.start_node(0, extra_args=[f"-onion={onion_conf.addr[0]}:{onion_conf.addr[1]}", "-logips"])
 
 
 if __name__ == "__main__":

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -216,9 +216,10 @@ class NetTest(BitcoinTestFramework):
         ip_port = "127.0.0.1:{}".format(p2p_port(2))
         self.nodes[0].addnode(node=ip_port, command='add')
         # check that the node has indeed been added
-        added_nodes = self.nodes[0].getaddednodeinfo(ip_port)
-        assert_equal(len(added_nodes), 1)
-        assert_equal(added_nodes[0]['addednode'], ip_port)
+        assert_equal(
+            self.nodes[0].getaddednodeinfo(ip_port),
+            [{"addednode": ip_port, "addresses": [{"address": ip_port, "connected": "inbound"}], "connected": True}]
+        )
         # check that node cannot be added again
         assert_raises_rpc_error(-23, "Node already added", self.nodes[0].addnode, node=ip_port, command='add')
         # check that node can be removed


### PR DESCRIPTION
This pull fixes several peer connection bugs in our p2p code, along with the logging that uncovered them:

1. Fix detection of inbound peer connections in `GetAddedNodeInfo`.

2. Fix addnode CJDNS peers not detected in `GetAddedNodeInfo`, causing `ThreadOpenAddedConnections` to continually retry to connect to them and RPC `getaddednodeinfo` incorrectly showing them as not connected.

3. Fix `ThreadOpenConnections` not detecting inbound CJDNS connections and making automatic outbound connections to them.

4. Fix detection of already connected peers in `AlreadyConnectedToAddress()`.

5. Fix detection of already connected peers when making outbound connections in `ConnectNode`.

6. Do not accept inbound connections in `CreateNodeFromAcceptedSocket` from I2P peers we're already connected to, as building I2P tunnels is expensive.

7. Fix making automatic outbound connections in `ThreadOpenConnections` to addnode peers, in order not to allocate our limited outbound slots to them and to ensure addnode connections benefit from their intended protections. Our addnode logic usually connects the addnode peers before the automatic outbound logic does, but not always, as a connection race can occur (see the commit message for further details and mainnet examples). When an addnode peer is connected as an automatic outbound peer and is the only connection we have to a network, it can be protected by our new outbound network-specific eviction logic and persist in the "wrong role". Fix these issues by checking if the selected address is an addnode peer in our automatic outbound connection logic.

Update the p2p logging with the improvements that allowed seeing/understanding/debugging the current behavior. Please see the commit messages for details.

Simplify `MaybePickPreferredNetwork` to return `std::optional`, make it a const class method, and add Clang thread-safety analysis annotation and related assertions.
