### PR TITLE
ci: Run "macOS 11.0 [gui, no tests] [jammy]" job on GitHub Actions

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -320,21 +320,6 @@ task:
     << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
 
 task:
-  name: 'macOS 11.0 [gui, no tests] [jammy]'
-  << : *CONTAINER_DEPENDS_TEMPLATE
-  container:
-    docker_arguments:
-      CI_IMAGE_NAME_TAG: ubuntu:jammy
-      FILE_ENV: "./ci/test/00_setup_env_mac.sh"
-  macos_sdk_cache:
-    folder: "depends/SDKs/$MACOS_SDK"
-    fingerprint_key: "$MACOS_SDK"
-  << : *MAIN_TEMPLATE
-  env:
-    MACOS_SDK: "Xcode-12.2-12B45b-extracted-SDK-with-libcxx-headers"
-    << : *CIRRUS_EPHEMERAL_WORKER_TEMPLATE_ENV
-
-task:
   name: 'macOS 13 native arm64 [gui, sqlite only] [no depends]'
   macos_instance:
     # Use latest image, but hardcode version to avoid silent upgrades (and breaks)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,88 @@
+# Copyright (c) 2023 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+name: CI
+on:
+  # See: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request.
+  pull_request:
+  # See: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#push.
+  push:
+    branches:
+      - '**'
+    tags-ignore:
+      - '**'
+
+env:
+  DANGER_RUN_CI_ON_HOST: 1
+  TEST_RUNNER_TIMEOUT_FACTOR: 40
+
+jobs:
+  macos-cross:
+    name: "macOS 11.0 [gui, no tests] [jammy]"
+    runs-on: ubuntu-latest
+
+    # No need to run on the read-only mirror, unless it is a PR.
+    if: github.repository != 'bitcoin-core/gui' || github.event_name == 'pull_request'
+
+    timeout-minutes: 120
+
+    env:
+      MAKEJOBS: '-j4'
+      CI_IMAGE_NAME_TAG: 'ubuntu:jammy'
+      FILE_ENV: './ci/test/00_setup_env_mac.sh'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          # See: https://github.com/moby/buildkit/issues/3969.
+          driver-opts: |
+            network=host
+
+      - name: Build container
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./ci/test_imagefile
+          build-args: |
+            CI_IMAGE_NAME_TAG
+            FILE_ENV
+          tags: test_image
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=min
+
+      - name: Depends hash
+        id: depends_hash
+        run: |
+          echo "hash=${{ hashFiles('./depends/**') }}" >> "$GITHUB_OUTPUT"
+
+      - name: Depends built cache
+        uses: actions/cache@v3
+        with:
+          path: ./depends/built
+          key: ${{ github.job }}-depends-built-${{ steps.depends_hash.outputs.hash }}
+
+      - name: Set Ccache directory
+        run: echo "CCACHE_DIR=${RUNNER_TEMP}/ccache_dir" >> "$GITHUB_ENV"
+
+      - name: Ccache cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ${{ github.job }}-ccache-cache-${{ github.run_id }}
+          restore-keys: ${{ github.job }}-ccache-cache
+
+      - name: CI script
+        run: >
+          docker run --rm \
+            $(echo '${{ toJSON(env) }}' | jq -r 'keys[] | "--env \(.) "') \
+            --volume ${{ github.workspace }}:${{ github.workspace }} \
+            --volume ${{ env.CCACHE_DIR }}:${{ env.CCACHE_DIR }} \
+            --workdir ${{ github.workspace }} \
+            test_image \
+            bash -c "./ci/test_run_all.sh"


### PR DESCRIPTION
In response to upcoming [limiting free usage of Cirrus CI](https://cirrus-ci.org/blog/2023/07/17/limiting-free-usage-of-cirrus-ci/), suggesting to move the "macOS 11.0 [gui, no tests] [jammy]" task from Cirrus CI to [GitHub Actions](https://docs.github.com/actions) (GHA).

(See slightly related discussion in https://github.com/bitcoin/bitcoin/issues/28098)

Builds in my personal repo:
- unpopulated caches: https://github.com/hebasto/bitcoin/actions/runs/5849385308/attempts/1
![image](https://github.com/bitcoin/bitcoin/assets/32963518/d817b2ff-0491-4251-a58c-96f3e5fc99df)

- populated caches: https://github.com/hebasto/bitcoin/actions/runs/5849385308/attempts/2
![image](https://github.com/bitcoin/bitcoin/assets/32963518/59c92adc-1336-4fe8-8c5f-9da267ac696a)

A list of the used actions for the "Actions permissions" repository settings:
```
actions/cache@*,
actions/checkout@*,
docker/build-push-action@*,
docker/setup-buildx-action@*,
```
