### PR TITLE
gui: make '-min' minimize wallet loading dialog

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -407,18 +407,21 @@ void BitcoinApplication::initializeResult(bool success, interfaces::BlockAndHead
         qInfo() << "Platform customization:" << platformStyle->getName();
         clientModel = new ClientModel(node(), optionsModel);
         window->setClientModel(clientModel, &tip_info);
+
+        // If '-min' option passed, start window minimized (iconified) or minimized to tray
+        bool start_minimized = gArgs.GetBoolArg("-min", false);
 #ifdef ENABLE_WALLET
         if (WalletModel::isWalletEnabled()) {
             m_wallet_controller = new WalletController(*clientModel, platformStyle, this);
-            window->setWalletController(m_wallet_controller);
+            window->setWalletController(m_wallet_controller, /*show_loading_minimized=*/start_minimized);
             if (paymentServer) {
                 paymentServer->setOptionsModel(optionsModel);
             }
         }
 #endif // ENABLE_WALLET
 
-        // If -min option passed, start window minimized (iconified) or minimized to tray
-        if (!gArgs.GetBoolArg("-min", false)) {
+        // Show or minimize window
+        if (!start_minimized) {
             window->show();
         } else if (clientModel->getOptionsModel()->getMinimizeToTray() && window->hasTrayIcon()) {
             // do nothing as the window is managed by the tray icon

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -679,7 +679,7 @@ void BitcoinGUI::enableHistoryAction(bool privacy)
     if (historyAction->isChecked()) gotoOverviewPage();
 }
 
-void BitcoinGUI::setWalletController(WalletController* wallet_controller)
+void BitcoinGUI::setWalletController(WalletController* wallet_controller, bool show_loading_minimized)
 {
     assert(!m_wallet_controller);
     assert(wallet_controller);
@@ -699,7 +699,7 @@ void BitcoinGUI::setWalletController(WalletController* wallet_controller)
     });
 
     auto activity = new LoadWalletsActivity(m_wallet_controller, this);
-    activity->load();
+    activity->load(show_loading_minimized);
 }
 
 WalletController* BitcoinGUI::getWalletController()

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -81,7 +81,7 @@ public:
     */
     void setClientModel(ClientModel *clientModel = nullptr, interfaces::BlockAndHeaderTipInfo* tip_info = nullptr);
 #ifdef ENABLE_WALLET
-    void setWalletController(WalletController* wallet_controller);
+    void setWalletController(WalletController* wallet_controller, bool show_loading_minimized);
     WalletController* getWalletController();
 #endif
 

--- a/src/qt/walletcontroller.cpp
+++ b/src/qt/walletcontroller.cpp
@@ -191,7 +191,7 @@ WalletControllerActivity::WalletControllerActivity(WalletController* wallet_cont
     connect(this, &WalletControllerActivity::finished, this, &QObject::deleteLater);
 }
 
-void WalletControllerActivity::showProgressDialog(const QString& title_text, const QString& label_text)
+void WalletControllerActivity::showProgressDialog(const QString& title_text, const QString& label_text, bool show_minimized)
 {
     auto progress_dialog = new QProgressDialog(m_parent_widget);
     progress_dialog->setAttribute(Qt::WA_DeleteOnClose);
@@ -206,6 +206,8 @@ void WalletControllerActivity::showProgressDialog(const QString& title_text, con
     // The setValue call forces QProgressDialog to start the internal duration estimation.
     // See details in https://bugreports.qt.io/browse/QTBUG-47042.
     progress_dialog->setValue(0);
+    // When requested, launch dialog minimized
+    if (show_minimized) progress_dialog->showMinimized();
 }
 
 CreateWalletActivity::CreateWalletActivity(WalletController* wallet_controller, QWidget* parent_widget)
@@ -368,14 +370,15 @@ LoadWalletsActivity::LoadWalletsActivity(WalletController* wallet_controller, QW
 {
 }
 
-void LoadWalletsActivity::load()
+void LoadWalletsActivity::load(bool show_loading_minimized)
 {
     showProgressDialog(
         //: Title of progress window which is displayed when wallets are being loaded.
         tr("Load Wallets"),
         /*: Descriptive text of the load wallets progress window which indicates to
             the user that wallets are currently being loaded.*/
-        tr("Loading wallets…"));
+        tr("Loading wallets…"),
+        /*show_minimized=*/show_loading_minimized);
 
     QTimer::singleShot(0, worker(), [this] {
         for (auto& wallet : node().walletLoader().getWallets()) {

--- a/src/qt/walletcontroller.h
+++ b/src/qt/walletcontroller.h
@@ -100,7 +100,7 @@ protected:
     interfaces::Node& node() const { return m_wallet_controller->m_node; }
     QObject* worker() const { return m_wallet_controller->m_activity_worker; }
 
-    void showProgressDialog(const QString& title_text, const QString& label_text);
+    void showProgressDialog(const QString& title_text, const QString& label_text, bool show_minimized=false);
 
     WalletController* const m_wallet_controller;
     QWidget* const m_parent_widget;
@@ -156,7 +156,7 @@ class LoadWalletsActivity : public WalletControllerActivity
 public:
     LoadWalletsActivity(WalletController* wallet_controller, QWidget* parent_widget);
 
-    void load();
+    void load(bool show_loading_minimized);
 };
 
 class RestoreWalletActivity : public WalletControllerActivity


### PR DESCRIPTION
Simple fix for #748.

When '-min' is enabled, no loading dialog should
be presented on screen during startup.