### PR TITLE
ci: Fix macOS-cross SDK rsync

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -64,8 +64,8 @@ container_depends_template: &CONTAINER_DEPENDS_TEMPLATE
     cpu: 2
     memory: 8G  # Set to 8GB to avoid OOM. https://cirrus-ci.org/guide/linux/#linux-containers
     dockerfile: ci/test_imagefile  # https://cirrus-ci.org/guide/docker-builder-vm/#dockerfile-as-a-ci-environment
-  depends_built_cache:
-    folder: "depends/built"
+  base_depends_built_cache:
+    folder: "/ci_container_base/depends/built"
     fingerprint_script: echo $CIRRUS_TASK_NAME $(git rev-parse HEAD:depends)
 
 global_task_template: &GLOBAL_TASK_TEMPLATE

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
       CI_USE_APT_INSTALL: 'no'
       PACKAGE_MANAGER_INSTALL: 'echo'  # Nothing to do
       FILE_ENV: './ci/test/00_setup_env_mac_native.sh'
+      BASE_ROOT_DIR: ${{ github.workspace }}
 
     steps:
       - name: Checkout

--- a/ci/test/00_setup_env.sh
+++ b/ci/test/00_setup_env.sh
@@ -13,13 +13,9 @@ set -ex
 BASE_READ_ONLY_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../../ >/dev/null 2>&1 && pwd )
 export BASE_READ_ONLY_DIR
 # The destination root dir inside the container.
-if [ -z "${DANGER_RUN_CI_ON_HOST}" ] ; then
-  # This folder only exists on the ci guest and will be a copy of BASE_READ_ONLY_DIR
-  export BASE_ROOT_DIR="/ci_container_base"
-else
-  # This folder is equal to BASE_READ_ONLY_DIR and is read-write
-  export BASE_ROOT_DIR="${BASE_READ_ONLY_DIR}"
-fi
+# This folder will also hold any SDKs.
+# This folder only exists on the ci guest and will be a copy of BASE_READ_ONLY_DIR
+export BASE_ROOT_DIR="/ci_container_base"
 # The depends dir.
 # This folder exists only on the ci guest, and on the ci host as a volume.
 export DEPENDS_DIR=${DEPENDS_DIR:-$BASE_ROOT_DIR/depends}

--- a/ci/test/00_setup_env.sh
+++ b/ci/test/00_setup_env.sh
@@ -15,7 +15,7 @@ export BASE_READ_ONLY_DIR
 # The destination root dir inside the container.
 # This folder will also hold any SDKs.
 # This folder only exists on the ci guest and will be a copy of BASE_READ_ONLY_DIR
-export BASE_ROOT_DIR="/ci_container_base"
+export BASE_ROOT_DIR="${BASE_ROOT_DIR:-/ci_container_base}"
 # The depends dir.
 # This folder exists only on the ci guest, and on the ci host as a volume.
 export DEPENDS_DIR=${DEPENDS_DIR:-$BASE_ROOT_DIR/depends}

--- a/ci/test/04_install.sh
+++ b/ci/test/04_install.sh
@@ -58,7 +58,8 @@ CI_EXEC () {
 }
 export -f CI_EXEC
 
-CI_EXEC rsync --archive --stats --human-readable /ci_base_install/ "${BASE_ROOT_DIR}" || echo "/ci_base_install/ missing"
+# Normalize all folders to BASE_ROOT_DIR
+CI_EXEC rsync --archive --stats --human-readable "${BASE_READ_ONLY_DIR}/" "${BASE_ROOT_DIR}" || echo "Nothing to copy from ${BASE_READ_ONLY_DIR}/"
 CI_EXEC "${BASE_ROOT_DIR}/ci/test/01_base_install.sh"
 CI_EXEC rsync --archive --stats --human-readable /ro_base/ "${BASE_ROOT_DIR}" || echo "Nothing to copy from ro_base"
 # Fixes permission issues when there is a container UID/GID mismatch with the owner

--- a/ci/test_imagefile
+++ b/ci/test_imagefile
@@ -11,6 +11,6 @@ ARG FILE_ENV
 ENV FILE_ENV=${FILE_ENV}
 
 COPY ./ci/retry/retry /usr/bin/retry
-COPY ./ci/test/00_setup_env.sh ./${FILE_ENV} ./ci/test/01_base_install.sh /ci_base_install/ci/test/
+COPY ./ci/test/00_setup_env.sh ./${FILE_ENV} ./ci/test/01_base_install.sh /ci_container_base/ci/test/
 
-RUN ["bash", "-c", "cd /ci_base_install/ && set -o errexit && source ./ci/test/00_setup_env.sh && ./ci/test/01_base_install.sh"]
+RUN ["bash", "-c", "cd /ci_container_base/ && set -o errexit && source ./ci/test/00_setup_env.sh && ./ci/test/01_base_install.sh"]


### PR DESCRIPTION
This should fix the macOS-cross build on Cirrus CI containers.

Locally this was already working, because the SDK was cached in
`/ci_container_base/` in the image, which is also the folder used for a
later CI run.

However, on Cirrus CI, when using an image *and* a custom `BASE_ROOT_DIR`,
the SDK will not be found in `/ci_base_install/`, nor in `BASE_ROOT_DIR`.

Fix this by normalizing *all* folders to `/ci_container_base/`.