### PR TITLE
ci: Refactor: Remove CI_USE_APT_INSTALL

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,7 +3,7 @@ env:  # Global defaults
   PACKAGE_MANAGER_INSTALL: "apt-get update && apt-get install -y"
   MAKEJOBS: "-j10"
   TEST_RUNNER_PORT_MIN: "14000"  # Must be larger than 12321, which is used for the http cache. See https://cirrus-ci.org/guide/writing-tasks/#http-cache
-  CI_FAILFAST_TEST_LEAVE_DANGLING: "1"  # Cirrus CI does not care about dangling process and setting this variable avoids killing the CI script itself on error
+  CI_FAILFAST_TEST_LEAVE_DANGLING: "1"  # Cirrus CI does not care about dangling processes and setting this variable avoids killing the CI script itself on error
   CCACHE_MAXSIZE: "200M"
   CCACHE_DIR: "/tmp/ccache_dir"
   CCACHE_NOHASHDIR: "1"  # Debug info might contain a stale path if the build dir changes, but this is fine

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,14 +15,15 @@ on:
 
 env:
   DANGER_RUN_CI_ON_HOST: 1
-  TEST_RUNNER_TIMEOUT_FACTOR: 40
+  CI_FAILFAST_TEST_LEAVE_DANGLING: 1  # GHA does not care about dangling processes and setting this variable avoids killing the CI script itself on error
+  MAKEJOBS: '-j10'
 
 jobs:
   macos-native-x86_64:
     name: macOS 13 native, x86_64 [no depends, sqlite only, gui]
     # Use latest image, but hardcode version to avoid silent upgrades (and breaks).
     # See: https://github.com/actions/runner-images#available-images.
-    runs-on: macos-13
+    runs-on: macos-13  # Use M1 once available https://github.com/github/roadmap/issues/528
 
     # No need to run on the read-only mirror, unless it is a PR.
     if: github.repository != 'bitcoin-core/gui' || github.event_name == 'pull_request'
@@ -30,9 +31,6 @@ jobs:
     timeout-minutes: 120
 
     env:
-      MAKEJOBS: '-j4'
-      CI_USE_APT_INSTALL: 'no'
-      PACKAGE_MANAGER_INSTALL: 'echo'  # Nothing to do
       FILE_ENV: './ci/test/00_setup_env_mac_native.sh'
       BASE_ROOT_DIR: ${{ github.workspace }}
 

--- a/ci/test/01_base_install.sh
+++ b/ci/test/01_base_install.sh
@@ -22,7 +22,7 @@ fi
 if [[ $CI_IMAGE_NAME_TAG == *centos* ]]; then
   bash -c "dnf -y install epel-release"
   bash -c "dnf -y --allowerasing install $CI_BASE_PACKAGES $PACKAGES"
-elif [ "$CI_USE_APT_INSTALL" != "no" ]; then
+elif [ "$CI_OS_NAME" != "macos" ]; then
   if [[ -n "${APPEND_APT_SOURCES_LIST}" ]]; then
     echo "${APPEND_APT_SOURCES_LIST}" >> /etc/apt/sources.list
   fi


### PR DESCRIPTION
Seems odd to use `CI_USE_APT_INSTALL == no` as an alias for `CI_OS_NAME == macos`. Fix this by removing the alias.

Also, for github CI:
* restore MAKEJOBS to the same value as in cirrus.yml.
* remove cirrus-only PACKAGE_MANAGER_INSTALL.
* remove redundant TEST_RUNNER_TIMEOUT_FACTOR
* Add M1 link