### PR TITLE
Don't empty dbcache on prune flushes: >30% faster IBD

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -85,6 +85,7 @@ BITCOIN_TESTS =\
   test/checkqueue_tests.cpp \
   test/cluster_linearize_tests.cpp \
   test/coins_tests.cpp \
+  test/coinscachepair_tests.cpp \
   test/coinstatsindex_tests.cpp \
   test/common_url_tests.cpp \
   test/compilerbug_tests.cpp \

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -12,7 +12,7 @@
 bool CCoinsView::GetCoin(const COutPoint &outpoint, Coin &coin) const { return false; }
 uint256 CCoinsView::GetBestBlock() const { return uint256(); }
 std::vector<uint256> CCoinsView::GetHeadBlocks() const { return std::vector<uint256>(); }
-bool CCoinsView::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock, bool erase) { return false; }
+bool CCoinsView::BatchWrite(CoinsViewCacheCursor& cursor, const uint256 &hashBlock) { return false; }
 std::unique_ptr<CCoinsViewCursor> CCoinsView::Cursor() const { return nullptr; }
 
 bool CCoinsView::HaveCoin(const COutPoint &outpoint) const
@@ -27,7 +27,7 @@ bool CCoinsViewBacked::HaveCoin(const COutPoint &outpoint) const { return base->
 uint256 CCoinsViewBacked::GetBestBlock() const { return base->GetBestBlock(); }
 std::vector<uint256> CCoinsViewBacked::GetHeadBlocks() const { return base->GetHeadBlocks(); }
 void CCoinsViewBacked::SetBackend(CCoinsView &viewIn) { base = &viewIn; }
-bool CCoinsViewBacked::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock, bool erase) { return base->BatchWrite(mapCoins, hashBlock, erase); }
+bool CCoinsViewBacked::BatchWrite(CoinsViewCacheCursor& cursor, const uint256 &hashBlock) { return base->BatchWrite(cursor, hashBlock); }
 std::unique_ptr<CCoinsViewCursor> CCoinsViewBacked::Cursor() const { return base->Cursor(); }
 size_t CCoinsViewBacked::EstimateSize() const { return base->EstimateSize(); }
 
@@ -183,10 +183,8 @@ void CCoinsViewCache::SetBestBlock(const uint256 &hashBlockIn) {
     hashBlock = hashBlockIn;
 }
 
-bool CCoinsViewCache::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlockIn, bool erase) {
-    for (CCoinsMap::iterator it = mapCoins.begin();
-            it != mapCoins.end();
-            it = erase ? mapCoins.erase(it) : std::next(it)) {
+bool CCoinsViewCache::BatchWrite(CoinsViewCacheCursor& cursor, const uint256 &hashBlockIn) {
+    for (auto it{cursor.Begin()}; it != cursor.End(); it = cursor.NextAndMaybeErase(*it)) {
         // Ignore non-dirty entries (optimization).
         if (!it->second.IsDirty()) {
             continue;
@@ -200,10 +198,9 @@ bool CCoinsViewCache::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlockIn
                 // and mark it as dirty.
                 itUs = cacheCoins.try_emplace(it->first).first;
                 CCoinsCacheEntry& entry{itUs->second};
-                if (erase) {
-                    // The `move` call here is purely an optimization; we rely on the
-                    // `mapCoins.erase` call in the `for` expression to actually remove
-                    // the entry from the child map.
+                if (cursor.WillErase(*it)) {
+                    // Since this entry will be erased,
+                    // we can move the coin into us instead of copying it
                     entry.coin = std::move(it->second.coin);
                 } else {
                     entry.coin = it->second.coin;
@@ -235,10 +232,9 @@ bool CCoinsViewCache::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlockIn
             } else {
                 // A normal modification.
                 cachedCoinsUsage -= itUs->second.coin.DynamicMemoryUsage();
-                if (erase) {
-                    // The `move` call here is purely an optimization; we rely on the
-                    // `mapCoins.erase` call in the `for` expression to actually remove
-                    // the entry from the child map.
+                if (cursor.WillErase(*it)) {
+                    // Since this entry will be erased,
+                    // we can move the coin into us instead of copying it
                     itUs->second.coin = std::move(it->second.coin);
                 } else {
                     itUs->second.coin = it->second.coin;
@@ -257,12 +253,10 @@ bool CCoinsViewCache::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlockIn
 }
 
 bool CCoinsViewCache::Flush() {
-    bool fOk = base->BatchWrite(cacheCoins, hashBlock, /*erase=*/true);
+    auto cursor{CoinsViewCacheCursor(cachedCoinsUsage, m_sentinel, cacheCoins, /*will_erase=*/true)};
+    bool fOk = base->BatchWrite(cursor, hashBlock);
     if (fOk) {
-        if (!cacheCoins.empty()) {
-            /* BatchWrite must erase all cacheCoins elements when erase=true. */
-            throw std::logic_error("Not all cached coins were erased");
-        }
+        cacheCoins.clear();
         ReallocateCache();
     }
     cachedCoinsUsage = 0;
@@ -271,7 +265,8 @@ bool CCoinsViewCache::Flush() {
 
 bool CCoinsViewCache::Sync()
 {
-    bool fOk = base->BatchWrite(cacheCoins, hashBlock, /*erase=*/false);
+    auto cursor{CoinsViewCacheCursor(cachedCoinsUsage, m_sentinel, cacheCoins, /*will_erase=*/false)};
+    bool fOk = base->BatchWrite(cursor, hashBlock);
     // Instead of clearing `cacheCoins` as we would in Flush(), just clear the
     // FRESH/DIRTY flags of any coin that isn't spent.
     for (auto it = cacheCoins.begin(); it != cacheCoins.end(); ) {

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -34,7 +34,9 @@ size_t CCoinsViewBacked::EstimateSize() const { return base->EstimateSize(); }
 CCoinsViewCache::CCoinsViewCache(CCoinsView* baseIn, bool deterministic) :
     CCoinsViewBacked(baseIn), m_deterministic(deterministic),
     cacheCoins(0, SaltedOutpointHasher(/*deterministic=*/deterministic), CCoinsMap::key_equal{}, &m_cache_coins_memory_resource)
-{}
+{
+    m_sentinel.second.SelfRef(m_sentinel);
+}
 
 size_t CCoinsViewCache::DynamicMemoryUsage() const {
     return memusage::DynamicUsage(cacheCoins) + cachedCoinsUsage;
@@ -51,7 +53,7 @@ CCoinsMap::iterator CCoinsViewCache::FetchCoin(const COutPoint &outpoint) const 
     if (ret->second.coin.IsSpent()) {
         // The parent only has an empty entry for this outpoint; we can consider our
         // version as fresh.
-        ret->second.AddFlags(CCoinsCacheEntry::FRESH);
+        ret->second.AddFlags(CCoinsCacheEntry::FRESH, *ret, m_sentinel);
     }
     cachedCoinsUsage += ret->second.coin.DynamicMemoryUsage();
     return ret;
@@ -96,7 +98,7 @@ void CCoinsViewCache::AddCoin(const COutPoint &outpoint, Coin&& coin, bool possi
         fresh = !it->second.IsDirty();
     }
     it->second.coin = std::move(coin);
-    it->second.AddFlags(CCoinsCacheEntry::DIRTY | (fresh ? CCoinsCacheEntry::FRESH : 0));
+    it->second.AddFlags(CCoinsCacheEntry::DIRTY | (fresh ? CCoinsCacheEntry::FRESH : 0), *it, m_sentinel);
     cachedCoinsUsage += it->second.coin.DynamicMemoryUsage();
     TRACE5(utxocache, add,
            outpoint.hash.data(),
@@ -113,7 +115,7 @@ void CCoinsViewCache::EmplaceCoinInternalDANGER(COutPoint&& outpoint, Coin&& coi
         std::forward_as_tuple(std::move(outpoint)),
         std::forward_as_tuple(std::move(coin)));
     if (inserted) {
-        it->second.AddFlags(CCoinsCacheEntry::DIRTY);
+        it->second.AddFlags(CCoinsCacheEntry::DIRTY, *it, m_sentinel);
     }
 }
 
@@ -144,7 +146,7 @@ bool CCoinsViewCache::SpendCoin(const COutPoint &outpoint, Coin* moveout) {
     if (it->second.IsFresh()) {
         cacheCoins.erase(it);
     } else {
-        it->second.AddFlags(CCoinsCacheEntry::DIRTY);
+        it->second.AddFlags(CCoinsCacheEntry::DIRTY, *it, m_sentinel);
         it->second.coin.Clear();
     }
     return true;
@@ -196,7 +198,8 @@ bool CCoinsViewCache::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlockIn
             if (!(it->second.IsFresh() && it->second.coin.IsSpent())) {
                 // Create the coin in the parent cache, move the data up
                 // and mark it as dirty.
-                CCoinsCacheEntry& entry = cacheCoins[it->first];
+                itUs = cacheCoins.try_emplace(it->first).first;
+                CCoinsCacheEntry& entry{itUs->second};
                 if (erase) {
                     // The `move` call here is purely an optimization; we rely on the
                     // `mapCoins.erase` call in the `for` expression to actually remove
@@ -206,12 +209,12 @@ bool CCoinsViewCache::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlockIn
                     entry.coin = it->second.coin;
                 }
                 cachedCoinsUsage += entry.coin.DynamicMemoryUsage();
-                entry.AddFlags(CCoinsCacheEntry::DIRTY);
+                entry.AddFlags(CCoinsCacheEntry::DIRTY, *itUs, m_sentinel);
                 // We can mark it FRESH in the parent if it was FRESH in the child
                 // Otherwise it might have just been flushed from the parent's cache
                 // and already exist in the grandparent
                 if (it->second.IsFresh()) {
-                    entry.AddFlags(CCoinsCacheEntry::FRESH);
+                    entry.AddFlags(CCoinsCacheEntry::FRESH, *itUs, m_sentinel);
                 }
             }
         } else {
@@ -241,7 +244,7 @@ bool CCoinsViewCache::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlockIn
                     itUs->second.coin = it->second.coin;
                 }
                 cachedCoinsUsage += itUs->second.coin.DynamicMemoryUsage();
-                itUs->second.AddFlags(CCoinsCacheEntry::DIRTY);
+                itUs->second.AddFlags(CCoinsCacheEntry::DIRTY, *itUs, m_sentinel);
                 // NOTE: It isn't safe to mark the coin as FRESH in the parent
                 // cache. If it already existed and was spent in the parent
                 // cache then marking it FRESH would prevent that spentness

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -108,10 +108,13 @@ void CCoinsViewCache::AddCoin(const COutPoint &outpoint, Coin&& coin, bool possi
 
 void CCoinsViewCache::EmplaceCoinInternalDANGER(COutPoint&& outpoint, Coin&& coin) {
     cachedCoinsUsage += coin.DynamicMemoryUsage();
-    cacheCoins.emplace(
+    auto [it, inserted] = cacheCoins.emplace(
         std::piecewise_construct,
         std::forward_as_tuple(std::move(outpoint)),
-        std::forward_as_tuple(std::move(coin), CCoinsCacheEntry::DIRTY));
+        std::forward_as_tuple(std::move(coin)));
+    if (inserted) {
+        it->second.AddFlags(CCoinsCacheEntry::DIRTY);
+    }
 }
 
 void AddCoins(CCoinsViewCache& cache, const CTransaction &tx, int nHeight, bool check_for_overwrite) {

--- a/src/coins.h
+++ b/src/coins.h
@@ -245,9 +245,26 @@ private:
 
 /**
  * Cursor for iterating over the linked list of flagged entries in CCoinsViewCache.
+ *
+ * This is a helper struct to encapsulate the diverging logic between a non-erasing
+ * CCoinsViewCache::Sync and an erasing CCoinsViewCache::Flush. This allows the receiver
+ * of CCoinsView::BatchWrite to iterate through the flagged entries without knowing
+ * the caller's intent.
+ *
+ * However, the receiver can still call CoinsViewCacheCursor::WillErase to see if the
+ * caller will erase the entry after BatchWrite returns. If so, the receiver can
+ * perform optimizations such as moving the coin out of the CCoinsCachEntry instead
+ * of copying it.
  */
 struct CoinsViewCacheCursor
 {
+    //! If will_erase is not set, iterating through the cursor will erase spent coins from the map,
+    //! and other coins will be unflagged (removing them from the linked list).
+    //! If will_erase is set, the underlying map and linked list will not be modified,
+    //! as the caller is expected to wipe the entire map anyway.
+    //! This is an optimization compared to erasing all entries as the cursor iterates them when will_erase is set.
+    //! Calling CCoinsMap::clear() afterwards is faster because a CoinsCachePair cannot be coerced back into a
+    //! CCoinsMap::iterator to be erased, and must therefore be looked up again by key in the CCoinsMap before being erased.
     CoinsViewCacheCursor(size_t& usage LIFETIMEBOUND,
                         CoinsCachePair& sentinel LIFETIMEBOUND,
                         CCoinsMap& map LIFETIMEBOUND,
@@ -257,9 +274,24 @@ struct CoinsViewCacheCursor
     inline CoinsCachePair* Begin() const noexcept { return m_sentinel.second.Next(); }
     inline CoinsCachePair* End() const noexcept { return &m_sentinel; }
 
-    inline CoinsCachePair* NextAndMaybeErase(CoinsCachePair& current) noexcept { return current.second.Next(); }
+    //! Return the next entry after current, possibly erasing current
+    inline CoinsCachePair* NextAndMaybeErase(CoinsCachePair& current) noexcept
+    {
+        const auto next_entry{current.second.Next()};
+        // If we are not going to erase the cache, we must still erase spent entries.
+        // Otherwise clear the flags on the entry.
+        if (!m_will_erase) {
+            if (current.second.coin.IsSpent()) {
+                m_usage -= current.second.coin.DynamicMemoryUsage();
+                m_map.erase(current.first);
+            } else {
+                current.second.ClearFlags();
+            }
+        }
+        return next_entry;
+    }
 
-    inline bool WillErase(CoinsCachePair& current) const noexcept { return m_will_erase; }
+    inline bool WillErase(CoinsCachePair& current) const noexcept { return m_will_erase || current.second.coin.IsSpent(); }
 private:
     size_t& m_usage;
     CoinsCachePair& m_sentinel;

--- a/src/coins.h
+++ b/src/coins.h
@@ -136,6 +136,10 @@ public:
 
     CCoinsCacheEntry() noexcept = default;
     explicit CCoinsCacheEntry(Coin&& coin_) noexcept : coin(std::move(coin_)) {}
+    ~CCoinsCacheEntry()
+    {
+        ClearFlags();
+    }
 
     //! Adding a flag also requires a self reference to the pair that contains
     //! this entry in the CCoinsCache map and a reference to the sentinel of the

--- a/src/coins.h
+++ b/src/coins.h
@@ -131,6 +131,11 @@ struct CCoinsCacheEntry
     explicit CCoinsCacheEntry(Coin&& coin_) : coin(std::move(coin_)), flags(0) {}
     CCoinsCacheEntry(Coin&& coin_, unsigned char flag) : coin(std::move(coin_)), flags(flag) {}
 
+    inline void AddFlags(unsigned char flags) noexcept { this->flags |= flags; }
+    inline void ClearFlags() noexcept
+    {
+        flags = 0;
+    }
     inline unsigned char GetFlags() const noexcept { return flags; }
     inline bool IsDirty() const noexcept { return flags & DIRTY; }
     inline bool IsFresh() const noexcept { return flags & FRESH; }

--- a/src/coins.h
+++ b/src/coins.h
@@ -130,6 +130,9 @@ struct CCoinsCacheEntry
     CCoinsCacheEntry() : flags(0) {}
     explicit CCoinsCacheEntry(Coin&& coin_) : coin(std::move(coin_)), flags(0) {}
     CCoinsCacheEntry(Coin&& coin_, unsigned char flag) : coin(std::move(coin_)), flags(flag) {}
+
+    inline bool IsDirty() const noexcept { return flags & DIRTY; }
+    inline bool IsFresh() const noexcept { return flags & FRESH; }
 };
 
 /**

--- a/src/coins.h
+++ b/src/coins.h
@@ -103,8 +103,11 @@ public:
  */
 struct CCoinsCacheEntry
 {
+private:
+    uint8_t m_flags{0};
+
+public:
     Coin coin; // The actual cached data.
-    unsigned char flags{0};
 
     enum Flags {
         /**
@@ -130,14 +133,14 @@ struct CCoinsCacheEntry
     CCoinsCacheEntry() noexcept = default;
     explicit CCoinsCacheEntry(Coin&& coin_) noexcept : coin(std::move(coin_)) {}
 
-    inline void AddFlags(unsigned char flags) noexcept { this->flags |= flags; }
+    inline void AddFlags(uint8_t flags) noexcept { m_flags |= flags; }
     inline void ClearFlags() noexcept
     {
-        flags = 0;
+        m_flags = 0;
     }
-    inline unsigned char GetFlags() const noexcept { return flags; }
-    inline bool IsDirty() const noexcept { return flags & DIRTY; }
-    inline bool IsFresh() const noexcept { return flags & FRESH; }
+    inline uint8_t GetFlags() const noexcept { return m_flags; }
+    inline bool IsDirty() const noexcept { return m_flags & DIRTY; }
+    inline bool IsFresh() const noexcept { return m_flags & FRESH; }
 };
 
 /**

--- a/src/coins.h
+++ b/src/coins.h
@@ -86,6 +86,9 @@ public:
     }
 };
 
+struct CCoinsCacheEntry;
+using CoinsCachePair = std::pair<const COutPoint, CCoinsCacheEntry>;
+
 /**
  * A Coin in one level of the coins database caching hierarchy.
  *
@@ -155,8 +158,8 @@ using CCoinsMap = std::unordered_map<COutPoint,
                                      CCoinsCacheEntry,
                                      SaltedOutpointHasher,
                                      std::equal_to<COutPoint>,
-                                     PoolAllocator<std::pair<const COutPoint, CCoinsCacheEntry>,
-                                                   sizeof(std::pair<const COutPoint, CCoinsCacheEntry>) + sizeof(void*) * 4>>;
+                                     PoolAllocator<CoinsCachePair,
+                                                   sizeof(CoinsCachePair) + sizeof(void*) * 4>>;
 
 using CCoinsMapMemoryResource = CCoinsMap::allocator_type::ResourceType;
 

--- a/src/coins.h
+++ b/src/coins.h
@@ -104,7 +104,7 @@ public:
 struct CCoinsCacheEntry
 {
     Coin coin; // The actual cached data.
-    unsigned char flags;
+    unsigned char flags{0};
 
     enum Flags {
         /**
@@ -127,9 +127,8 @@ struct CCoinsCacheEntry
         FRESH = (1 << 1),
     };
 
-    CCoinsCacheEntry() : flags(0) {}
-    explicit CCoinsCacheEntry(Coin&& coin_) : coin(std::move(coin_)), flags(0) {}
-    CCoinsCacheEntry(Coin&& coin_, unsigned char flag) : coin(std::move(coin_)), flags(flag) {}
+    CCoinsCacheEntry() noexcept = default;
+    explicit CCoinsCacheEntry(Coin&& coin_) noexcept : coin(std::move(coin_)) {}
 
     inline void AddFlags(unsigned char flags) noexcept { this->flags |= flags; }
     inline void ClearFlags() noexcept

--- a/src/coins.h
+++ b/src/coins.h
@@ -131,6 +131,7 @@ struct CCoinsCacheEntry
     explicit CCoinsCacheEntry(Coin&& coin_) : coin(std::move(coin_)), flags(0) {}
     CCoinsCacheEntry(Coin&& coin_, unsigned char flag) : coin(std::move(coin_)), flags(flag) {}
 
+    inline unsigned char GetFlags() const noexcept { return flags; }
     inline bool IsDirty() const noexcept { return flags & DIRTY; }
     inline bool IsFresh() const noexcept { return flags & FRESH; }
 };

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -58,7 +58,7 @@ public:
     bool BatchWrite(CCoinsMap& mapCoins, const uint256& hashBlock, bool erase = true) override
     {
         for (CCoinsMap::iterator it = mapCoins.begin(); it != mapCoins.end(); it = erase ? mapCoins.erase(it) : std::next(it)) {
-            if (it->second.flags & CCoinsCacheEntry::DIRTY) {
+            if (it->second.IsDirty()) {
                 // Same optimization used in CCoinsViewDB is to only write dirty entries.
                 map_[it->first] = it->second.coin;
                 if (it->second.coin.IsSpent() && InsecureRandRange(3) == 0) {

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -584,7 +584,7 @@ static size_t InsertCoinsMapEntry(CCoinsMap& map, CAmount value, char flags)
     }
     assert(flags != NO_ENTRY);
     CCoinsCacheEntry entry;
-    entry.flags = flags;
+    entry.AddFlags(flags);
     SetCoinsValue(value, entry.coin);
     auto inserted = map.emplace(OUTPOINT, std::move(entry));
     assert(inserted.second);

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -603,7 +603,7 @@ void GetCoinsMapEntry(const CCoinsMap& map, CAmount& value, char& flags, const C
         } else {
             value = it->second.coin.out.nValue;
         }
-        flags = it->second.flags;
+        flags = it->second.GetFlags();
         assert(flags != NO_ENTRY);
     }
 }

--- a/src/test/coinscachepair_tests.cpp
+++ b/src/test/coinscachepair_tests.cpp
@@ -1,0 +1,219 @@
+// Copyright (c) 2024-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <coins.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <list>
+
+BOOST_AUTO_TEST_SUITE(coinscachepair_tests)
+
+static constexpr auto NUM_NODES{4};
+
+std::list<CoinsCachePair> CreatePairs(CoinsCachePair& sentinel)
+{
+    std::list<CoinsCachePair> nodes;
+    for (auto i{0}; i < NUM_NODES; ++i) {
+        nodes.emplace_back();
+
+        auto node{std::prev(nodes.end())};
+        node->second.AddFlags(CCoinsCacheEntry::DIRTY, *node, sentinel);
+
+        BOOST_CHECK_EQUAL(node->second.GetFlags(), CCoinsCacheEntry::DIRTY);
+        BOOST_CHECK_EQUAL(node->second.Next(), &sentinel);
+        BOOST_CHECK_EQUAL(sentinel.second.Prev(), &(*node));
+
+        if (i > 0) {
+            BOOST_CHECK_EQUAL(std::prev(node)->second.Next(), &(*node));
+            BOOST_CHECK_EQUAL(node->second.Prev(), &(*std::prev(node)));
+        }
+    }
+    return nodes;
+}
+
+BOOST_AUTO_TEST_CASE(linked_list_iteration)
+{
+    CoinsCachePair sentinel;
+    sentinel.second.SelfRef(sentinel);
+    auto nodes{CreatePairs(sentinel)};
+
+    // Check iterating through pairs is identical to iterating through a list
+    auto node{sentinel.second.Next()};
+    for (const auto& expected : nodes) {
+        BOOST_CHECK_EQUAL(&expected, node);
+        node = node->second.Next();
+    }
+    BOOST_CHECK_EQUAL(node, &sentinel);
+
+    // Check iterating through pairs is identical to iterating through a list
+    // Clear the flags during iteration
+    node = sentinel.second.Next();
+    for (const auto& expected : nodes) {
+        BOOST_CHECK_EQUAL(&expected, node);
+        auto next = node->second.Next();
+        node->second.ClearFlags();
+        node = next;
+    }
+    BOOST_CHECK_EQUAL(node, &sentinel);
+    // Check that sentinel's next and prev are itself
+    BOOST_CHECK_EQUAL(sentinel.second.Next(), &sentinel);
+    BOOST_CHECK_EQUAL(sentinel.second.Prev(), &sentinel);
+
+    // Delete the nodes from the list to make sure there are no dangling pointers
+    for (auto it{nodes.begin()}; it != nodes.end(); it = nodes.erase(it)) {
+        BOOST_CHECK_EQUAL(it->second.GetFlags(), 0);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(linked_list_iterate_erase)
+{
+    CoinsCachePair sentinel;
+    sentinel.second.SelfRef(sentinel);
+    auto nodes{CreatePairs(sentinel)};
+
+    // Check iterating through pairs is identical to iterating through a list
+    // Erase the nodes as we iterate through, but don't clear flags
+    // The flags will be cleared by the CCoinsCacheEntry's destructor
+    auto node{sentinel.second.Next()};
+    for (auto expected{nodes.begin()}; expected != nodes.end(); expected = nodes.erase(expected)) {
+        BOOST_CHECK_EQUAL(&(*expected), node);
+        node = node->second.Next();
+    }
+    BOOST_CHECK_EQUAL(node, &sentinel);
+
+    // Check that sentinel's next and prev are itself
+    BOOST_CHECK_EQUAL(sentinel.second.Next(), &sentinel);
+    BOOST_CHECK_EQUAL(sentinel.second.Prev(), &sentinel);
+}
+
+BOOST_AUTO_TEST_CASE(linked_list_random_deletion)
+{
+    CoinsCachePair sentinel;
+    sentinel.second.SelfRef(sentinel);
+    auto nodes{CreatePairs(sentinel)};
+
+    // Create linked list sentinel->n1->n2->n3->n4->sentinel
+    auto n1{nodes.begin()};
+    auto n2{std::next(n1)};
+    auto n3{std::next(n2)};
+    auto n4{std::next(n3)};
+
+    // Delete n2
+    // sentinel->n1->n3->n4->sentinel
+    nodes.erase(n2);
+    // Check that n1 now points to n3, and n3 still points to n4
+    // Also check that flags were not altered
+    BOOST_CHECK_EQUAL(n1->second.GetFlags(), CCoinsCacheEntry::DIRTY);
+    BOOST_CHECK_EQUAL(n1->second.Next(), &(*n3));
+    BOOST_CHECK_EQUAL(n3->second.GetFlags(), CCoinsCacheEntry::DIRTY);
+    BOOST_CHECK_EQUAL(n3->second.Next(), &(*n4));
+    BOOST_CHECK_EQUAL(n3->second.Prev(), &(*n1));
+
+    // Delete n1
+    // sentinel->n3->n4->sentinel
+    nodes.erase(n1);
+    // Check that sentinel now points to n3, and n3 still points to n4
+    // Also check that flags were not altered
+    BOOST_CHECK_EQUAL(n3->second.GetFlags(), CCoinsCacheEntry::DIRTY);
+    BOOST_CHECK_EQUAL(sentinel.second.Next(), &(*n3));
+    BOOST_CHECK_EQUAL(n3->second.Next(), &(*n4));
+    BOOST_CHECK_EQUAL(n3->second.Prev(), &sentinel);
+
+    // Delete n4
+    // sentinel->n3->sentinel
+    nodes.erase(n4);
+    // Check that sentinel still points to n3, and n3 points to sentinel
+    // Also check that flags were not altered
+    BOOST_CHECK_EQUAL(n3->second.GetFlags(), CCoinsCacheEntry::DIRTY);
+    BOOST_CHECK_EQUAL(sentinel.second.Next(), &(*n3));
+    BOOST_CHECK_EQUAL(n3->second.Next(), &sentinel);
+    BOOST_CHECK_EQUAL(sentinel.second.Prev(), &(*n3));
+
+    // Delete n3
+    // sentinel->sentinel
+    nodes.erase(n3);
+    // Check that sentinel's next and prev are itself
+    BOOST_CHECK_EQUAL(sentinel.second.Next(), &sentinel);
+    BOOST_CHECK_EQUAL(sentinel.second.Prev(), &sentinel);
+}
+
+BOOST_AUTO_TEST_CASE(linked_list_add_flags)
+{
+    CoinsCachePair sentinel;
+    sentinel.second.SelfRef(sentinel);
+    CoinsCachePair n1;
+    CoinsCachePair n2;
+
+    // Check that adding 0 flag has no effect
+    n1.second.AddFlags(0, n1, sentinel);
+    BOOST_CHECK_EQUAL(n1.second.GetFlags(), 0);
+    BOOST_CHECK_EQUAL(sentinel.second.Next(), &sentinel);
+    BOOST_CHECK_EQUAL(sentinel.second.Prev(), &sentinel);
+
+    // Check that adding DIRTY flag inserts it into linked list and sets flags
+    n1.second.AddFlags(CCoinsCacheEntry::DIRTY, n1, sentinel);
+    BOOST_CHECK_EQUAL(n1.second.GetFlags(), CCoinsCacheEntry::DIRTY);
+    BOOST_CHECK_EQUAL(n1.second.Next(), &sentinel);
+    BOOST_CHECK_EQUAL(n1.second.Prev(), &sentinel);
+    BOOST_CHECK_EQUAL(sentinel.second.Next(), &n1);
+    BOOST_CHECK_EQUAL(sentinel.second.Prev(), &n1);
+
+    // Check that adding FRESH flag on new node inserts it after n1
+    n2.second.AddFlags(CCoinsCacheEntry::FRESH, n2, sentinel);
+    BOOST_CHECK_EQUAL(n2.second.GetFlags(), CCoinsCacheEntry::FRESH);
+    BOOST_CHECK_EQUAL(n2.second.Next(), &sentinel);
+    BOOST_CHECK_EQUAL(n2.second.Prev(), &n1);
+    BOOST_CHECK_EQUAL(n1.second.Next(), &n2);
+    BOOST_CHECK_EQUAL(sentinel.second.Prev(), &n2);
+
+    // Check that adding 0 flag has no effect, and doesn't change position
+    n1.second.AddFlags(0, n1, sentinel);
+    BOOST_CHECK_EQUAL(n1.second.GetFlags(), CCoinsCacheEntry::DIRTY);
+    BOOST_CHECK_EQUAL(n1.second.Next(), &n2);
+    BOOST_CHECK_EQUAL(n1.second.Prev(), &sentinel);
+    BOOST_CHECK_EQUAL(sentinel.second.Next(), &n1);
+    BOOST_CHECK_EQUAL(n2.second.Prev(), &n1);
+
+    // Check that we can add extra flags, but they don't change our position
+    n1.second.AddFlags(CCoinsCacheEntry::FRESH, n1, sentinel);
+    BOOST_CHECK_EQUAL(n1.second.GetFlags(), CCoinsCacheEntry::DIRTY | CCoinsCacheEntry::FRESH);
+    BOOST_CHECK_EQUAL(n1.second.Next(), &n2);
+    BOOST_CHECK_EQUAL(n1.second.Prev(), &sentinel);
+    BOOST_CHECK_EQUAL(sentinel.second.Next(), &n1);
+    BOOST_CHECK_EQUAL(n2.second.Prev(), &n1);
+
+    // Check that we can clear flags then re-add them
+    n1.second.ClearFlags();
+    BOOST_CHECK_EQUAL(n1.second.GetFlags(), 0);
+    BOOST_CHECK_EQUAL(sentinel.second.Next(), &n2);
+    BOOST_CHECK_EQUAL(sentinel.second.Prev(), &n2);
+    BOOST_CHECK_EQUAL(n2.second.Next(), &sentinel);
+    BOOST_CHECK_EQUAL(n2.second.Prev(), &sentinel);
+
+    // Check that calling `ClearFlags` with 0 flags has no effect
+    n1.second.ClearFlags();
+    BOOST_CHECK_EQUAL(n1.second.GetFlags(), 0);
+    BOOST_CHECK_EQUAL(sentinel.second.Next(), &n2);
+    BOOST_CHECK_EQUAL(sentinel.second.Prev(), &n2);
+    BOOST_CHECK_EQUAL(n2.second.Next(), &sentinel);
+    BOOST_CHECK_EQUAL(n2.second.Prev(), &sentinel);
+
+    // Adding 0 still has no effect
+    n1.second.AddFlags(0, n1, sentinel);
+    BOOST_CHECK_EQUAL(sentinel.second.Next(), &n2);
+    BOOST_CHECK_EQUAL(sentinel.second.Prev(), &n2);
+    BOOST_CHECK_EQUAL(n2.second.Next(), &sentinel);
+    BOOST_CHECK_EQUAL(n2.second.Prev(), &sentinel);
+
+    // But adding DIRTY re-inserts it after n2
+    n1.second.AddFlags(CCoinsCacheEntry::DIRTY, n1, sentinel);
+    BOOST_CHECK_EQUAL(n1.second.GetFlags(), CCoinsCacheEntry::DIRTY);
+    BOOST_CHECK_EQUAL(n2.second.Next(), &n1);
+    BOOST_CHECK_EQUAL(n1.second.Prev(), &n2);
+    BOOST_CHECK_EQUAL(n1.second.Next(), &sentinel);
+    BOOST_CHECK_EQUAL(sentinel.second.Prev(), &n1);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -125,7 +125,7 @@ FUZZ_TARGET(coins_view, .init = initialize_coins_view)
                 LIMITED_WHILE(good_data && fuzzed_data_provider.ConsumeBool(), 10'000)
                 {
                     CCoinsCacheEntry coins_cache_entry;
-                    coins_cache_entry.flags = fuzzed_data_provider.ConsumeIntegral<unsigned char>();
+                    coins_cache_entry.AddFlags(fuzzed_data_provider.ConsumeIntegral<unsigned char>());
                     if (fuzzed_data_provider.ConsumeBool()) {
                         coins_cache_entry.coin = random_coin;
                     } else {

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -125,7 +125,7 @@ FUZZ_TARGET(coins_view, .init = initialize_coins_view)
                 LIMITED_WHILE(good_data && fuzzed_data_provider.ConsumeBool(), 10'000)
                 {
                     CCoinsCacheEntry coins_cache_entry;
-                    coins_cache_entry.AddFlags(fuzzed_data_provider.ConsumeIntegral<unsigned char>());
+                    coins_cache_entry.AddFlags(fuzzed_data_provider.ConsumeIntegral<uint8_t>());
                     if (fuzzed_data_provider.ConsumeBool()) {
                         coins_cache_entry.coin = random_coin;
                     } else {

--- a/src/test/fuzz/coinscache_sim.cpp
+++ b/src/test/fuzz/coinscache_sim.cpp
@@ -172,13 +172,13 @@ public:
     std::unique_ptr<CCoinsViewCursor> Cursor() const final { return {}; }
     size_t EstimateSize() const final { return m_data.size(); }
 
-    bool BatchWrite(CCoinsMap& data, const uint256&, bool erase) final
+    bool BatchWrite(CoinsViewCacheCursor& cursor, const uint256&) final
     {
-        for (auto it = data.begin(); it != data.end(); it = erase ? data.erase(it) : std::next(it)) {
+        for (auto it{cursor.Begin()}; it != cursor.End(); it = cursor.NextAndMaybeErase(*it)) {
             if (it->second.IsDirty()) {
                 if (it->second.coin.IsSpent() && (it->first.n % 5) != 4) {
                     m_data.erase(it->first);
-                } else if (erase) {
+                } else if (cursor.WillErase(*it)) {
                     m_data[it->first] = std::move(it->second.coin);
                 } else {
                     m_data[it->first] = it->second.coin;

--- a/src/test/fuzz/coinscache_sim.cpp
+++ b/src/test/fuzz/coinscache_sim.cpp
@@ -175,7 +175,7 @@ public:
     bool BatchWrite(CCoinsMap& data, const uint256&, bool erase) final
     {
         for (auto it = data.begin(); it != data.end(); it = erase ? data.erase(it) : std::next(it)) {
-            if (it->second.flags & CCoinsCacheEntry::DIRTY) {
+            if (it->second.IsDirty()) {
                 if (it->second.coin.IsSpent() && (it->first.n % 5) != 4) {
                     m_data.erase(it->first);
                 } else if (erase) {

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -115,7 +115,7 @@ bool CCoinsViewDB::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock, boo
     batch.Write(DB_HEAD_BLOCKS, Vector(hashBlock, old_tip));
 
     for (CCoinsMap::iterator it = mapCoins.begin(); it != mapCoins.end();) {
-        if (it->second.flags & CCoinsCacheEntry::DIRTY) {
+        if (it->second.IsDirty()) {
             CoinEntry entry(&it->first);
             if (it->second.coin.IsSpent())
                 batch.Erase(entry);

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -88,7 +88,7 @@ std::vector<uint256> CCoinsViewDB::GetHeadBlocks() const {
     return vhashHeadBlocks;
 }
 
-bool CCoinsViewDB::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock, bool erase) {
+bool CCoinsViewDB::BatchWrite(CoinsViewCacheCursor& cursor, const uint256 &hashBlock) {
     CDBBatch batch(*m_db);
     size_t count = 0;
     size_t changed = 0;
@@ -114,7 +114,7 @@ bool CCoinsViewDB::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock, boo
     batch.Erase(DB_BEST_BLOCK);
     batch.Write(DB_HEAD_BLOCKS, Vector(hashBlock, old_tip));
 
-    for (CCoinsMap::iterator it = mapCoins.begin(); it != mapCoins.end();) {
+    for (auto it{cursor.Begin()}; it != cursor.End();) {
         if (it->second.IsDirty()) {
             CoinEntry entry(&it->first);
             if (it->second.coin.IsSpent())
@@ -124,7 +124,7 @@ bool CCoinsViewDB::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock, boo
             changed++;
         }
         count++;
-        it = erase ? mapCoins.erase(it) : std::next(it);
+        it = cursor.NextAndMaybeErase(*it);
         if (batch.SizeEstimate() > m_options.batch_write_bytes) {
             LogPrint(BCLog::COINDB, "Writing partial batch of %.2f MiB\n", batch.SizeEstimate() * (1.0 / 1048576.0));
             m_db->WriteBatch(batch);

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -63,7 +63,7 @@ public:
     bool HaveCoin(const COutPoint &outpoint) const override;
     uint256 GetBestBlock() const override;
     std::vector<uint256> GetHeadBlocks() const override;
-    bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock, bool erase = true) override;
+    bool BatchWrite(CoinsViewCacheCursor& cursor, const uint256 &hashBlock) override;
     std::unique_ptr<CCoinsViewCursor> Cursor() const override;
 
     //! Whether an unsupported database format is used.

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2902,7 +2902,7 @@ bool Chainstate::FlushStateToDisk(
                 return FatalError(m_chainman.GetNotifications(), state, _("Disk space is too low!"));
             }
             // Flush the chainstate (which may refer to block index entries).
-            const auto empty_cache{(mode == FlushStateMode::ALWAYS) || fCacheLarge || fCacheCritical || fFlushForPrune};
+            const auto empty_cache{(mode == FlushStateMode::ALWAYS) || fCacheLarge || fCacheCritical};
             if (empty_cache ? !CoinsTip().Flush() : !CoinsTip().Sync()) {
                 return FatalError(m_chainman.GetNotifications(), state, _("Failed to write to coin database."));
             }


### PR DESCRIPTION
Since https://github.com/bitcoin/bitcoin/pull/17487 we no longer need to clear the coins cache when syncing to disk. A warm coins cache significantly speeds up block connection, and only needs to be fully flushed when nearing the `dbcache` limit.

For frequent pruning flushes there's no need to empty the cache and kill connect block speed. However, simply using `Sync` in place of `Flush` actually slows down a pruned full IBD with a high `dbcache` value. This is because as the cache grows, sync takes longer since every coin in the cache is scanned to check if it's dirty. For frequent prune flushes and a large cache this constant scanning starts to really slow IBD down, and just emptying the cache on every prune becomes faster.

To fix this, we can add two pointers to each cache entry and construct a doubly linked list of dirty entries. We can then only iterate through all dirty entries on each `Sync`, and simply clear the pointers after.

With this approach a full IBD with `dbcache=16384` and `prune=550` was 32% faster than master. For default `dbcache=450` speedup was ~9%. All benchmarks were run with `stopatheight=800000`.

|  | prune | dbcache | time | max RSS | speedup |
|-----------:|----------:|------------:|--------:|-------------:|--------------:|
| master | 550 | 16384 | 8:52:57 | 2,417,464k | - |
| branch | 550 | 16384 | 6:01:00 | 16,216,736k | 32% |
| branch | 550 | 450 | 8:05:08 | 2,818,072k | 8.8% |
| master | 10000 | 5000 | 8:19:59 | 2,962,752k | - |
| branch | 10000 | 5000| 5:56:39 | 6,179,764k | 28.8% |
| master | 0 | 16384 | 4:51:53 | 14,726,408k | - |
| branch | 0 | 16384 | 4:43:11 | 16,526,348k | 2.7% |
| master | 0 | 450 | 7:08:07 | 3,005,892k | - |
| branch | 0 | 450 | 6:57:24 | 3,013,556k |2.6%|

While the 2 pointers add memory to each cache entry, it did not slow down IBD. For non-pruned IBD results were similar for this branch and master. When I performed the initial IBD, the full UTXO set could be held in memory when using the max `dbcache` value. For non-pruned IBD with max `dbcache` to tip ended up using 12% more memory, but it was also 2.7% faster somehow. For smaller `dbcache` values the `dbcache` limit is respected so does not consume more memory, and the potentially more frequent flushes were not significant enough to cause any slowdown.

For reviewers, the commits in order do the following:
First 4 commits encapsulate all accesses to `flags` on cache entries, and then the 5th makes `flags` private.
Commits `refactor: add CoinsCachePair alias` to `coins: call ClearFlags in CCoinsCacheEntry destructor` create the linked list head nodes and cache entry self references and pass them into `AddFlags`.
Commit `coins: track flagged cache entries in linked list` actually adds the entries into a linked list when they are flagged DIRTY or FRESH and removes them from the linked list when they are destroyed or the flags are cleared manually. However, the linked list is not yet used anywhere.
Commit `test: add cache entry linked list tests` adds unit tests for the linked list.
Commit `coins: pass linked list of flagged entries to BatchWrite` uses the linked list to iterate through DIRTY entries instead of using the entire coins cache.
Commit `validation: don't erase coins cache on prune flushes` uses `Sync` instead of `Flush` for pruning flushes, so the cache is no longer cleared. 

Inspired by [this comment](https://github.com/bitcoin/bitcoin/pull/15265#issuecomment-457720636).

Fixes https://github.com/bitcoin/bitcoin/issues/11315.