### PR TITLE
ci: Ensure that only a single workflow processes `github.ref` at a time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ on:
     tags-ignore:
       - '**'
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   DANGER_RUN_CI_ON_HOST: 1
   TEST_RUNNER_TIMEOUT_FACTOR: 40


### PR DESCRIPTION
This PR ensures that only a single workflow processes any push or pull request at a time.

A new push will be queued (including the master branch).

For a new pull request update, the previous in-progress one will be cancelled.

Address https://github.com/bitcoin/bitcoin/pull/28187#discussion_r1295144563.