### PR TITLE
refactor: Remove confusing static_cast in address types

### DIFF
--- a/src/addresstype.cpp
+++ b/src/addresstype.cpp
@@ -3,13 +3,16 @@
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
 #include <addresstype.h>
-#include <script/script.h>
-#include <script/solver.h>
+
+#include <crypto/sha256.h>
 #include <hash.h>
 #include <pubkey.h>
+#include <script/script.h>
+#include <script/solver.h>
 #include <uint256.h>
 #include <util/hash_type.h>
 
+#include <cassert>
 #include <vector>
 
 typedef std::vector<unsigned char> valtype;

--- a/src/addresstype.cpp
+++ b/src/addresstype.cpp
@@ -18,27 +18,27 @@
 typedef std::vector<unsigned char> valtype;
 
 ScriptHash::ScriptHash(const CScript& in) : BaseHash(Hash160(in)) {}
-ScriptHash::ScriptHash(const CScriptID& in) : BaseHash(static_cast<uint160>(in)) {}
+ScriptHash::ScriptHash(const CScriptID& in) : BaseHash{in} {}
 
 PKHash::PKHash(const CPubKey& pubkey) : BaseHash(pubkey.GetID()) {}
 PKHash::PKHash(const CKeyID& pubkey_id) : BaseHash(pubkey_id) {}
 
 WitnessV0KeyHash::WitnessV0KeyHash(const CPubKey& pubkey) : BaseHash(pubkey.GetID()) {}
-WitnessV0KeyHash::WitnessV0KeyHash(const PKHash& pubkey_hash) : BaseHash(static_cast<uint160>(pubkey_hash)) {}
+WitnessV0KeyHash::WitnessV0KeyHash(const PKHash& pubkey_hash) : BaseHash{pubkey_hash} {}
 
 CKeyID ToKeyID(const PKHash& key_hash)
 {
-    return CKeyID{static_cast<uint160>(key_hash)};
+    return CKeyID{uint160{key_hash}};
 }
 
 CKeyID ToKeyID(const WitnessV0KeyHash& key_hash)
 {
-    return CKeyID{static_cast<uint160>(key_hash)};
+    return CKeyID{uint160{key_hash}};
 }
 
 CScriptID ToScriptID(const ScriptHash& script_hash)
 {
-    return CScriptID{static_cast<uint160>(script_hash)};
+    return CScriptID{uint160{script_hash}};
 }
 
 WitnessV0ScriptHash::WitnessV0ScriptHash(const CScript& in)

--- a/src/script/solver.cpp
+++ b/src/script/solver.cpp
@@ -3,14 +3,15 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <script/solver.h>
 #include <pubkey.h>
 #include <script/interpreter.h>
 #include <script/script.h>
+#include <script/solver.h>
 #include <span.h>
 
-#include <string>
 #include <algorithm>
+#include <cassert>
+#include <string>
 
 typedef std::vector<unsigned char> valtype;
 


### PR DESCRIPTION
It seems confusing to use `static_cast<uint160>(bla)` to call the constructor of `uint160`. The normal and common way to call a constructor is by simply calling it. (`uint160{bla}`).

Do this, and also drop the constructor completely where the existing `const&` reference is enough.

Also, add missing includes while touching the file.