### PR TITLE
ci: Disable --coverage temporarily

### DIFF
--- a/ci/test/00_setup_env_native_qt5.sh
+++ b/ci/test/00_setup_env_native_qt5.sh
@@ -11,7 +11,7 @@ export CI_IMAGE_NAME_TAG="ubuntu:20.04"
 # Use minimum supported python3.8 and gcc-9, see doc/dependencies.md
 export PACKAGES="gcc-9 g++-9 python3-zmq qtbase5-dev qttools5-dev-tools libdbus-1-dev libharfbuzz-dev"
 export DEP_OPTS="NO_QT=1 NO_UPNP=1 NO_NATPMP=1 DEBUG=1 ALLOW_HOST_PACKAGES=1 CC=gcc-9 CXX=g++-9"
-export TEST_RUNNER_EXTRA="--previous-releases --coverage --extended --exclude feature_dbcrash"  # Run extended tests so that coverage does not fail, but exclude the very slow dbcrash
+export TEST_RUNNER_EXTRA="--previous-releases --extended --exclude feature_dbcrash"  # Run extended tests so that coverage does not fail, but exclude the very slow dbcrash, --coverage disabled for now to allow fixing outstanding bugs that seem to cause CI failures, see https://github.com/bitcoin/bitcoin/issues/27593
 export RUN_UNIT_TESTS_SEQUENTIAL="true"
 export RUN_UNIT_TESTS="false"
 export GOAL="install"


### PR DESCRIPTION
Looks like this causes all CI builds to be red, and doesn't work anyway, see https://github.com/bitcoin/bitcoin/issues/27593 . Temporarily disable it to allow for more time to rework it from scratch.