### PR TITLE
test: Minor fix in test - locale in terminal

### DIFF
--- a/src/test/system_tests.cpp
+++ b/src/test/system_tests.cpp
@@ -79,6 +79,7 @@ BOOST_AUTO_TEST_CASE(run_command)
         const std::string command{"cmd.exe /c dir nosuchfile"};
         const std::string expected{wine_runtime ? "File not found." : "File Not Found"};
 #else
+        setenv("LC_ALL", "C", 1); // explicitly set locale env to get error message in English
         const std::string command{"ls nosuchfile"};
         const std::string expected{"No such file or directory"};
 #endif


### PR DESCRIPTION
Running tests with non-English locale set in Linux terminal makes system tests (`system_tests/run_command`) fail. Setting the locale in failing test explicitly to 'C' fixes the failure.

_How to reproduce test failure:_
Setting LC_ALL=cs_CZ.UTF-8 (`export LC_ALL=cs_CZ.UTF-8`) in terminal and then running `make check` should be enough.

_Fix:_
My terminal is by default set to non-English locale and the test failed because it checks for English error message, but the terminal produces error message in the language set by locale. Then I manually set `export LC_ALL=C` in my terminal and all tests passed. So I explicitly set env variable 'LC_ALL' to 'C' in the code of failing test.