### PR TITLE
rpc: remove one more quote from non-string oneline description

### DIFF
--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -744,7 +744,7 @@ static RPCHelpMan importmempool()
                   "Whether to apply the unbroadcast set metadata from the mempool file.\n"
                   "Warning: Importing untrusted metadata may lead to unexpected issues and undesirable behavior."},
              },
-             RPCArgOptions{.oneline_description = "\"options\""}},
+             RPCArgOptions{.oneline_description = "options"}},
         },
         RPCResult{RPCResult::Type::OBJ, "", "", std::vector<RPCResult>{}},
         RPCExamples{HelpExampleCli("importmempool", "/path/to/mempool.dat") + HelpExampleRpc("importmempool", "/path/to/mempool.dat")},


### PR DESCRIPTION
This fixes a silent conflict between https://github.com/bitcoin/bitcoin/pull/28123 (which removed all `\"options\"`) and https://github.com/bitcoin/bitcoin/pull/27460 (which added a new one). 

It should fix the current CI failures.