### PR TITLE
doc: Remove confusing assert linter

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -739,12 +739,6 @@ Common misconceptions are clarified in those sections:
 - Passing (non-)fundamental types in the [C++ Core
   Guideline](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rf-conventional).
 
-- Assertions should not have side-effects.
-
-  - *Rationale*: Even though the source code is set to refuse to compile
-    with assertions disabled, having side-effects in assertions is unexpected and
-    makes the code harder to understand.
-
 - If you use the `.h`, you must link the `.cpp`.
 
   - *Rationale*: Include files define the interface for the code in implementation files. Including one but

--- a/test/lint/lint-assertions.py
+++ b/test/lint/lint-assertions.py
@@ -23,20 +23,10 @@ def git_grep(params: [], error_msg: ""):
 
 
 def main():
-    # PRE31-C (SEI CERT C Coding Standard):
-    # "Assertions should not contain assignments, increment, or decrement operators."
-    exit_code = git_grep([
-        "-E",
-        r"[^_]assert\(.*(\+\+|\-\-|[^=!<>]=[^=!<>]).*\);",
-        "--",
-        "*.cpp",
-        "*.h",
-    ], "Assertions should not have side effects:")
-
     # Aborting the whole process is undesirable for RPC code. So nonfatal
     # checks should be used over assert. See: src/util/check.h
     # src/rpc/server.cpp is excluded from this check since it's mostly meta-code.
-    exit_code |= git_grep([
+    exit_code = git_grep([
         "-nE",
         r"\<(A|a)ss(ume|ert) *\(.*\);",
         "--",


### PR DESCRIPTION
The `assert()` documentation and linter are redundant and confusing:

* The source code already refuses to compile with `assert()` disabled.
* They violate the assumptions about `Assert()`, which *requires* side effects.
* The existing linter doesn't enforce the guideline, only checking for `++` and `--` side effects.

Fix all issues by removing the docs and the linter. See also https://github.com/bitcoin/bitcoin/pull/26684#discussion_r1287370102

Going forward everyone is free to use whatever code in this regard they think is the easiest to read. Also, everyone is still free to share style-nits, if they think it is a good use of their time and of the pull request author. Finally, the author is still free to dismiss or ignore this style-nit, or any other style-nit.