### PR TITLE
[WIP] BIP300 (Drivechains) consensus-level logic

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -271,6 +271,7 @@ BITCOIN_CORE_H = \
   script/signingprovider.h \
   script/solver.h \
   shutdown.h \
+  sidechain.h \
   signet.h \
   streams.h \
   support/allocators/pool.h \
@@ -457,6 +458,7 @@ libbitcoin_node_a_SOURCES = \
   rpc/txoutproof.cpp \
   script/sigcache.cpp \
   shutdown.cpp \
+  sidechain.cpp \
   signet.cpp \
   timedata.cpp \
   torcontrol.cpp \
@@ -968,6 +970,7 @@ libbitcoinkernel_la_SOURCES = \
   script/script_error.cpp \
   script/sigcache.cpp \
   script/solver.cpp \
+  sidechain.cpp \
   signet.cpp \
   streams.cpp \
   support/cleanse.cpp \

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -69,7 +69,7 @@ bool CCoinsViewCache::GetCoinRaw(const COutPoint &outpoint, Coin &coin) const {
 
 void CCoinsViewCache::AddCoin(const COutPoint &outpoint, Coin&& coin, bool possible_overwrite) {
     assert(!coin.IsSpent());
-    if (coin.out.scriptPubKey.IsUnspendable()) return;
+    if (coin.out.scriptPubKey.IsUnspendable() && outpoint.n <= COutPoint::MAX_INDEX) return;
     CCoinsMap::iterator it;
     bool inserted;
     std::tie(it, inserted) = cacheCoins.emplace(std::piecewise_construct, std::forward_as_tuple(outpoint), std::tuple<>());

--- a/src/coins.h
+++ b/src/coins.h
@@ -177,10 +177,22 @@ public:
      *  Returns true only when an unspent coin was found, which is returned in coin.
      *  When false is returned, coin's value is unspecified.
      */
-    virtual bool GetCoin(const COutPoint &outpoint, Coin &coin) const;
+    bool GetCoin(const COutPoint &outpoint, Coin &coin) const {
+        if (outpoint.n > COutPoint::MAX_INDEX) {
+            return false;
+        }
+        return GetCoinRaw(outpoint, coin);
+    }
+    virtual bool GetCoinRaw(const COutPoint &outpoint, Coin &coin) const;
 
     //! Just check whether a given outpoint is unspent.
-    virtual bool HaveCoin(const COutPoint &outpoint) const;
+    bool HaveCoin(const COutPoint &outpoint) const {
+        if (outpoint.n > COutPoint::MAX_INDEX) {
+            return false;
+        }
+        return HaveCoinRaw(outpoint);
+    }
+    virtual bool HaveCoinRaw(const COutPoint &outpoint) const;
 
     //! Retrieve the block hash whose state this CCoinsView currently represents
     virtual uint256 GetBestBlock() const;
@@ -214,8 +226,8 @@ protected:
 
 public:
     CCoinsViewBacked(CCoinsView *viewIn);
-    bool GetCoin(const COutPoint &outpoint, Coin &coin) const override;
-    bool HaveCoin(const COutPoint &outpoint) const override;
+    bool GetCoinRaw(const COutPoint &outpoint, Coin &coin) const override;
+    bool HaveCoinRaw(const COutPoint &outpoint) const override;
     uint256 GetBestBlock() const override;
     std::vector<uint256> GetHeadBlocks() const override;
     void SetBackend(CCoinsView &viewIn);
@@ -252,8 +264,8 @@ public:
     CCoinsViewCache(const CCoinsViewCache &) = delete;
 
     // Standard CCoinsView methods
-    bool GetCoin(const COutPoint &outpoint, Coin &coin) const override;
-    bool HaveCoin(const COutPoint &outpoint) const override;
+    bool GetCoinRaw(const COutPoint &outpoint, Coin &coin) const override;
+    bool HaveCoinRaw(const COutPoint &outpoint) const override;
     uint256 GetBestBlock() const override;
     void SetBestBlock(const uint256 &hashBlock);
     bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock, bool erase = true) override;
@@ -382,8 +394,8 @@ public:
         m_err_callbacks.emplace_back(std::move(f));
     }
 
-    bool GetCoin(const COutPoint &outpoint, Coin &coin) const override;
-    bool HaveCoin(const COutPoint &outpoint) const override;
+    bool GetCoinRaw(const COutPoint &outpoint, Coin &coin) const override;
+    bool HaveCoinRaw(const COutPoint &outpoint) const override;
 
 private:
     /** A list of callbacks to execute upon leveldb read error. */

--- a/src/consensus/validation.h
+++ b/src/consensus/validation.h
@@ -147,16 +147,16 @@ class BlockValidationState : public ValidationState<BlockValidationResult> {};
 // weight = (stripped_size * 3) + total_size.
 static inline int32_t GetTransactionWeight(const CTransaction& tx)
 {
-    return ::GetSerializeSize(tx, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS) * (WITNESS_SCALE_FACTOR - 1) + ::GetSerializeSize(tx, PROTOCOL_VERSION);
+    return ::GetSerializeSize(tx, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS | SERIALIZE_TRANSACTION_FOR_WEIGHT) * (WITNESS_SCALE_FACTOR - 1) + ::GetSerializeSize(tx, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_FOR_WEIGHT);
 }
 static inline int64_t GetBlockWeight(const CBlock& block)
 {
-    return ::GetSerializeSize(block, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS) * (WITNESS_SCALE_FACTOR - 1) + ::GetSerializeSize(block, PROTOCOL_VERSION);
+    return ::GetSerializeSize(block, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS | SERIALIZE_TRANSACTION_FOR_WEIGHT) * (WITNESS_SCALE_FACTOR - 1) + ::GetSerializeSize(block, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_FOR_WEIGHT);
 }
 static inline int64_t GetTransactionInputWeight(const CTxIn& txin)
 {
     // scriptWitness size is added here because witnesses and txins are split up in segwit serialization.
-    return ::GetSerializeSize(txin, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS) * (WITNESS_SCALE_FACTOR - 1) + ::GetSerializeSize(txin, PROTOCOL_VERSION) + ::GetSerializeSize(txin.scriptWitness.stack, PROTOCOL_VERSION);
+    return ::GetSerializeSize(txin, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS | SERIALIZE_TRANSACTION_FOR_WEIGHT) * (WITNESS_SCALE_FACTOR - 1) + ::GetSerializeSize(txin, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_FOR_WEIGHT) + ::GetSerializeSize(txin.scriptWitness.stack, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_FOR_WEIGHT);
 }
 
 /** Compute at which vout of the block's coinbase transaction the witness commitment occurs, or -1 if not found */

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -411,6 +411,11 @@ Span<const std::byte> CDBIterator::GetValueImpl() const
     return MakeByteSpan(m_impl_iter->iter->value());
 }
 
+unsigned int CDBIterator::GetValueSize() const
+{
+    return m_impl_iter->iter->value().size();
+}
+
 CDBIterator::~CDBIterator() = default;
 bool CDBIterator::Valid() const { return m_impl_iter->iter->Valid(); }
 void CDBIterator::SeekToFirst() { m_impl_iter->iter->SeekToFirst(); }

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -174,6 +174,9 @@ public:
         }
         return true;
     }
+
+    unsigned int GetValueSize() const;
+
 };
 
 struct LevelDBContext;

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -57,7 +57,7 @@ public:
     bool ReadLastBlockFile(int& nFile);
     bool WriteReindexing(bool fReindexing);
     void ReadReindexing(bool& fReindexing);
-    bool WriteFlag(const std::string& name, bool fValue);
+    bool WriteFlag(const std::string& name, bool fValue, bool allow_ignore = true);
     bool ReadFlag(const std::string& name, bool& fValue);
     bool LoadBlockIndexGuts(const Consensus::Params& consensusParams, std::function<CBlockIndex*(const uint256&)> insertBlockIndex, const util::SignalInterrupt& interrupt)
         EXCLUSIVE_LOCKS_REQUIRED(::cs_main);

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -30,6 +30,7 @@
  * or with `ADDRV2_FORMAT`.
  */
 static const int SERIALIZE_TRANSACTION_NO_WITNESS = 0x40000000;
+static const int SERIALIZE_TRANSACTION_FOR_WEIGHT = 0x20000000;
 
 /** An outpoint - a combination of a transaction hash and an index n into its vout */
 class COutPoint

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -137,6 +137,14 @@ public:
 
     SERIALIZE_METHODS(CTxIn, obj) { READWRITE(obj.prevout, obj.scriptSig, obj.nSequence); }
 
+    void SetNull()
+    {
+        prevout.SetNull();
+        scriptSig.clear();
+        nSequence = SEQUENCE_FINAL;
+        scriptWitness.SetNull();
+    }
+
     friend bool operator==(const CTxIn& a, const CTxIn& b)
     {
         return (a.prevout   == b.prevout &&

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -38,6 +38,7 @@ public:
     uint256 hash;
     uint32_t n;
 
+    static constexpr uint32_t MAX_INDEX = 0x00ffffff;
     static constexpr uint32_t NULL_INDEX = std::numeric_limits<uint32_t>::max();
 
     COutPoint(): n(NULL_INDEX) { }

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2005,6 +2005,7 @@ bool FindScriptPubKey(std::atomic<int>& scan_progress, const std::atomic<bool>& 
         COutPoint key;
         Coin coin;
         if (!cursor->GetKey(key) || !cursor->GetValue(coin)) return false;
+        if (key.n > COutPoint::MAX_INDEX) continue;
         if (++count % 8192 == 0) {
             interruption_point();
             if (should_abort) {

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -591,6 +591,8 @@ bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& 
                     break;
                 }
 
+                // NOTE: OP_DRIVECHAIN (OP_NOP5) is enforced in VerifyDrivechainSpend
+
                 case OP_NOP1: case OP_NOP4: case OP_NOP5:
                 case OP_NOP6: case OP_NOP7: case OP_NOP8: case OP_NOP9: case OP_NOP10:
                 {

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -245,6 +245,66 @@ bool CScript::IsDrivechain() const
             (*this)[3] == OP_TRUE);
 }
 
+bool CScript::IsDrivechainWithdrawProposal() const
+{
+    if (this->size() < 5)
+        return false;
+
+    if ((*this)[0] != OP_RETURN ||
+            (*this)[1] != 0xD4 ||
+            (*this)[2] != 0x5A ||
+            (*this)[3] != 0xA9 ||
+            (*this)[4] != 0x43)
+        return false;
+
+    return true;
+}
+
+bool CScript::IsDrivechainProposal() const
+{
+    if (this->size() < 5)
+        return false;
+
+    if ((*this)[0] != OP_RETURN ||
+            (*this)[1] != 0xD5 ||
+            (*this)[2] != 0xE0 ||
+            (*this)[3] != 0xC4 ||
+            (*this)[4] != 0xAF)
+        return false;
+
+    return true;
+}
+
+bool CScript::IsDrivechainProposalACK() const
+{
+    if (this->size() < 5)
+        return false;
+
+    if ((*this)[0] != OP_RETURN ||
+            (*this)[1] != 0xD6 ||
+            (*this)[2] != 0xE1 ||
+            (*this)[3] != 0xC5 ||
+            (*this)[4] != 0xBF)
+        return false;
+
+    return true;
+}
+
+bool CScript::IsDrivechainWithdrawProposalACK() const
+{
+    if (this->size() < 5)
+        return false;
+
+    if ((*this)[0] != OP_RETURN ||
+            (*this)[1] != 0xD7 ||
+            (*this)[2] != 0x7D ||
+            (*this)[3] != 0x17 ||
+            (*this)[4] != 0x76)
+        return false;
+
+    return true;
+}
+
 bool CScript::IsPushOnly(const_iterator pc) const
 {
     while (pc < end())

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -136,7 +136,7 @@ std::string GetOpName(opcodetype opcode)
     case OP_CHECKLOCKTIMEVERIFY    : return "OP_CHECKLOCKTIMEVERIFY";
     case OP_CHECKSEQUENCEVERIFY    : return "OP_CHECKSEQUENCEVERIFY";
     case OP_NOP4                   : return "OP_NOP4";
-    case OP_NOP5                   : return "OP_NOP5";
+    case OP_NOP5                   : return "OP_DRIVECHAIN";
     case OP_NOP6                   : return "OP_NOP6";
     case OP_NOP7                   : return "OP_NOP7";
     case OP_NOP8                   : return "OP_NOP8";
@@ -234,6 +234,14 @@ bool CScript::IsWitnessProgram(int& version, std::vector<unsigned char>& program
         return true;
     }
     return false;
+}
+
+bool CScript::IsDrivechain() const
+{
+    // Extra-fast test for drivechain CScripts:
+    return (this->size() == 1 &&
+            (*this)[0] == OP_DRIVECHAIN);
+    // TODO: Consider adding sidechain # and/or OP_TRUE
 }
 
 bool CScript::IsPushOnly(const_iterator pc) const

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -239,9 +239,10 @@ bool CScript::IsWitnessProgram(int& version, std::vector<unsigned char>& program
 bool CScript::IsDrivechain() const
 {
     // Extra-fast test for drivechain CScripts:
-    return (this->size() == 1 &&
-            (*this)[0] == OP_DRIVECHAIN);
-    // TODO: Consider adding sidechain # and/or OP_TRUE
+    return (this->size() == 4 &&
+            (*this)[0] == OP_DRIVECHAIN &&
+            (*this)[1] == 1 &&
+            (*this)[3] == OP_TRUE);
 }
 
 bool CScript::IsPushOnly(const_iterator pc) const

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -197,7 +197,8 @@ enum opcodetype
     OP_CHECKSEQUENCEVERIFY = 0xb2,
     OP_NOP3 = OP_CHECKSEQUENCEVERIFY,
     OP_NOP4 = 0xb3,
-    OP_NOP5 = 0xb4,
+    OP_DRIVECHAIN = 0xb4,
+    OP_NOP5 = OP_DRIVECHAIN,
     OP_NOP6 = 0xb5,
     OP_NOP7 = 0xb6,
     OP_NOP8 = 0xb7,
@@ -535,6 +536,7 @@ public:
     bool IsPayToScriptHash() const;
     bool IsPayToWitnessScriptHash() const;
     bool IsWitnessProgram(int& version, std::vector<unsigned char>& program) const;
+    bool IsDrivechain() const;
 
     /** Called by IsStandardTx and P2SH/BIP62 VerifyScript (which makes it consensus-critical). */
     bool IsPushOnly(const_iterator pc) const;

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -538,6 +538,11 @@ public:
     bool IsWitnessProgram(int& version, std::vector<unsigned char>& program) const;
     bool IsDrivechain() const;
 
+    bool IsDrivechainProposal() const;
+    bool IsDrivechainProposalACK() const;
+    bool IsDrivechainWithdrawProposal() const;
+    bool IsDrivechainWithdrawProposalACK() const;
+
     /** Called by IsStandardTx and P2SH/BIP62 VerifyScript (which makes it consensus-critical). */
     bool IsPushOnly(const_iterator pc) const;
     bool IsPushOnly() const;

--- a/src/sidechain.cpp
+++ b/src/sidechain.cpp
@@ -1,0 +1,174 @@
+// Copyright (c) 2017-2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <sidechain.h>
+
+#include <arith_uint256.h>
+#include <coins.h>
+#include <hash.h>
+#include <primitives/transaction.h>
+#include <streams.h>
+#include <undo.h>
+#include <util/check.h>
+
+#include <algorithm>
+#include <cstdint>
+
+void CreateDBUndoData(CTxUndo &txundo, const uint8_t type, const COutPoint& record_id, const Coin& encoded_data) {
+    Assert(record_id.n <= COutPoint::MAX_INDEX);
+    Coin& undo = txundo.vprevout.emplace_back();
+    undo = encoded_data;
+    CDataStream s(SER_NETWORK, PROTOCOL_VERSION);
+    s << record_id;
+    Assert(s.size() == 0x24);
+    auto& undo_data = undo.out.scriptPubKey;
+    undo_data.insert(undo_data.begin(), 1 + s.size(), type);
+    memcpy(&undo_data[1], &s[0], s.size());  // TODO: figure out how to jump through C++'s hoops to do this right
+}
+
+void CreateDBEntry(CCoinsViewCache& cache, CTxUndo &txundo, const int block_height, const COutPoint& record_id, const Span<const std::byte>& record_data) {
+    CScript scriptPubKey(UCharCast(record_data.begin()), UCharCast(record_data.end()));
+    cache.AddCoin(record_id, Coin(CTxOut{0, scriptPubKey}, block_height, /*fCoinbase=*/false), /*overwrite=*/false);
+
+    // Create undo data to tell DisconnectBlock to delete it
+    Coin undo;
+    CreateDBUndoData(txundo, 1, record_id, undo);
+}
+
+void DeleteDBEntry(CCoinsViewCache& inputs, CTxUndo &txundo, const COutPoint& record_id) {
+    Coin undo;
+    bool is_spent = inputs.SpendCoin(record_id, &undo);
+    assert(is_spent);
+    CreateDBUndoData(txundo, 0, record_id, undo);
+}
+
+CDataStream GetDBEntry(CCoinsViewCache& inputs, const COutPoint& record_id) {
+    const Coin& coin = inputs.AccessCoin(record_id);
+    assert(!coin.IsSpent());
+    return CDataStream(MakeByteSpan(coin.out.scriptPubKey), SER_NETWORK, PROTOCOL_VERSION);
+}
+
+void ModifyDBEntry(CCoinsViewCache& view, CTxUndo &txundo, const int block_height, const COutPoint& record_id, const std::function<void(CDataStream&)>& modify_func) {
+    CDataStream s = GetDBEntry(view, record_id);
+    modify_func(s);
+    DeleteDBEntry(view, txundo, record_id);
+    CreateDBEntry(view, txundo, block_height, record_id, s);
+}
+
+void IncrementDBEntry(CCoinsViewCache& view, CTxUndo &txundo, const int block_height, const COutPoint& record_id, const int change) {
+    ModifyDBEntry(view, txundo, block_height, record_id, [change](CDataStream& s){
+        uint16_t counter;
+        s >> counter;
+        if (change < 0 && !counter) return;  // may be surprising if change is <-1
+        counter += change;
+        s.clear();
+        s << counter;
+    });
+}
+
+void UpdateDrivechains(const CTransaction& tx, CCoinsViewCache& view, CTxUndo &txundo, int block_height)
+{
+    Assert(tx.IsCoinBase());
+
+    std::vector<unsigned char> sidechain_proposal_list, withdraw_proposal_list;
+
+    for (auto& out : tx.vout) {
+        if (out.scriptPubKey.size() < 5) continue;
+        if (out.scriptPubKey[0] != OP_RETURN) continue;
+        // FIXME: The rest should probably be serialised, but neither BIP300 nor its reference implementation does that
+        static constexpr uint8_t BIP300_HEADER_SIDECHAIN_PROPOSE[] = {0xd5, 0xe0, 0xc4, 0xaf};  // n.b. 20 sigops
+        static constexpr uint8_t BIP300_HEADER_SIDECHAIN_ACK[]     = {0xd6, 0xe1, 0xc5, 0xbf};
+        static constexpr uint8_t BIP300_HEADER_WITHDRAW_PROPOSE[]  = {0xd4, 0x5a, 0xa9, 0x43};  // n.b. 67 byte push followed by only 32 bytes
+        static constexpr uint8_t BIP300_HEADER_WITHDRAW_ACK[]      = {0xd7, 0x7d, 0x17, 0x76};  // n.b. 23-byte push followed by variable bytes
+        if (std::equal(&out.scriptPubKey[1], &out.scriptPubKey[5], BIP300_HEADER_WITHDRAW_ACK)) {
+            const uint8_t data_format = out.scriptPubKey[6];
+            // TODO: Implement formats 3+? Or at least validate
+            // TODO: How is vote vector actually encoded?
+            // TODO: Block is invalid if there are no bundles proposed at all
+            for (int sidechain_id = 0; sidechain_id < 0x100; ++sidechain_id) {
+                // FIXME: bounds checking
+                uint16_t vote = out.scriptPubKey[6 + (sidechain_id * data_format)];
+                if (data_format == 2) {
+                    vote |= uint16_t{out.scriptPubKey[6 + (sidechain_id * data_format) + 1]} << 8;
+                } else if (vote >= 0xfe) {
+                    vote |= 0xff00;
+                }
+
+                if (vote == 0xffff) continue;  // abstain
+
+                COutPoint record_id{uint256{sidechain_id}, DBIDX_SIDECHAIN_WITHDRAW_PROPOSAL_LIST};
+                // FIXME: what if it's missing?
+                CDataStream withdraw_proposals = GetDBEntry(view, record_id);
+                uint256 bundle_hash;
+                bool found_bundle{false};
+                for (uint16_t bundle_hash_num = 0; !withdraw_proposals.eof(); ++bundle_hash_num) {
+                    withdraw_proposals >> bundle_hash;
+                    record_id.hash = bundle_hash;
+                    record_id.n = DBIDX_SIDECHAIN_WITHDRAW_PROPOSAL_ACKS;
+                    if (bundle_hash_num == vote) found_bundle = true;
+                    IncrementDBEntry(view, txundo, block_height, record_id, (bundle_hash_num == vote) ? 1 : -1);
+                }
+                // TODO: invalid if ((!found_bundle) && vote != 0xfffe)
+            }
+        } else if (std::equal(&out.scriptPubKey[1], &out.scriptPubKey[5], BIP300_HEADER_WITHDRAW_PROPOSE)) {
+            // FIXME; size check; [at least] 38 bytes
+            CDataStream s(MakeByteSpan(out.scriptPubKey).subspan(5), SER_NETWORK, PROTOCOL_VERSION);
+            uint256 bundle_hash;
+            uint8_t sidechain_id;
+            s >> bundle_hash;
+            s >> sidechain_id;
+
+            // FIXME: make sure sidechain_id hasn't been encountered here in this block before
+            // FIXME: make sure this proposal isn't already listed (check for ACKS existing?)
+            // FIXME: allow the same bundle for multiple sidechain_id to prevent DoS attacks?
+
+            COutPoint record_id{uint256{sidechain_id}, DBIDX_SIDECHAIN_WITHDRAW_PROPOSAL_LIST};
+            ModifyDBEntry(view, txundo, block_height, record_id, [&bundle_hash](CDataStream& withdraw_proposals){
+                withdraw_proposals << bundle_hash;
+            });
+
+            record_id.hash = bundle_hash;
+            record_id.n = DBIDX_SIDECHAIN_WITHDRAW_PROPOSAL_ACKS;
+            s.clear();
+            s << uint16_t{0};
+            CreateDBEntry(view, txundo, block_height, record_id, s);
+
+            withdraw_proposal_list.resize(withdraw_proposal_list.size() + record_id.hash.size());
+            memcpy(&withdraw_proposal_list.data()[withdraw_proposal_list.size() - record_id.hash.size()], record_id.hash.data(), record_id.hash.size());  // FIXME: C++ify
+        } else if (std::equal(&out.scriptPubKey[1], &out.scriptPubKey[5], BIP300_HEADER_SIDECHAIN_ACK)) {
+            // FIXME: check size is [at least?] 37 bytes
+            COutPoint record_id;
+            memcpy(record_id.hash.data(), &out.scriptPubKey[5], 0x20);
+            record_id.n = DBIDX_SIDECHAIN_PROPOSAL_ACKS;
+
+            IncrementDBEntry(view, txundo, block_height, record_id, 1);
+        } else if (std::equal(&out.scriptPubKey[1], &out.scriptPubKey[5], BIP300_HEADER_SIDECHAIN_PROPOSE)) {
+            CDataStream s(MakeByteSpan(out.scriptPubKey).subspan(5), SER_NETWORK, PROTOCOL_VERSION);
+            Sidechain proposed;
+            // FIXME: What happens if parsing fails?
+            s >> proposed;
+
+            COutPoint record_id;
+            CSHA256().Write(out.scriptPubKey.data() + 5, out.scriptPubKey.size() - 5).Finalize(record_id.hash.data());
+            record_id.n = DBIDX_SIDECHAIN_PROPOSAL;
+            CreateDBEntry(view, txundo, block_height, record_id, s);
+
+            s.clear();
+            s << uint16_t{0};
+            record_id.n = DBIDX_SIDECHAIN_PROPOSAL_ACKS;
+            CreateDBEntry(view, txundo, block_height, record_id, s);
+
+            sidechain_proposal_list.resize(sidechain_proposal_list.size() + record_id.hash.size());
+            memcpy(&sidechain_proposal_list.data()[sidechain_proposal_list.size() - record_id.hash.size()], record_id.hash.data(), record_id.hash.size());  // FIXME: C++ify
+        }
+    }
+
+    if (sidechain_proposal_list.empty() && withdraw_proposal_list.empty()) return;
+
+    CScript proposal_list;
+    proposal_list << sidechain_proposal_list;
+    proposal_list << withdraw_proposal_list;
+    COutPoint record_id{ArithToUint256(arith_uint256{uint64_t{block_height}}), DBIDX_SIDECHAIN_PROPOSAL_LIST};
+    CreateDBEntry(view, txundo, block_height, record_id, MakeByteSpan(proposal_list));
+}

--- a/src/sidechain.cpp
+++ b/src/sidechain.cpp
@@ -113,7 +113,7 @@ void UpdateDrivechains(const CTransaction& tx, CCoinsViewCache& view, CTxUndo &t
                 if (vote == 0xffff) continue;  // abstain
 
                 // FIXME: what if it's missing?
-                CDataStream withdraw_proposals = GetDBEntry(view, {uint256{sidechain_id}, DBIDX_SIDECHAIN_WITHDRAW_PROPOSAL_LIST});
+                CDataStream withdraw_proposals = GetDBEntry(view, {uint256{(uint8_t)sidechain_id}, DBIDX_SIDECHAIN_WITHDRAW_PROPOSAL_LIST});
                 uint256 bundle_hash;
                 bool found_bundle{false};
                 for (uint16_t bundle_hash_num = 0; !withdraw_proposals.eof(); ++bundle_hash_num) {
@@ -175,12 +175,12 @@ void UpdateDrivechains(const CTransaction& tx, CCoinsViewCache& view, CTxUndo &t
         CDataStream proposal_list(SER_NETWORK, PROTOCOL_VERSION);
         proposal_list << sidechain_proposal_list;
         proposal_list << withdraw_proposal_list;
-        CreateDBEntry(view, txundo, block_height, {ArithToUint256(arith_uint256{uint64_t{block_height}}), DBIDX_SIDECHAIN_PROPOSAL_LIST}, proposal_list);
+        CreateDBEntry(view, txundo, block_height, {ArithToUint256(arith_uint256{(uint64_t)block_height}), DBIDX_SIDECHAIN_PROPOSAL_LIST}, proposal_list);
     }
 
     // Perform sidechain overwriting/expiry and withdraw expiry
     int completed_block_height = block_height - (SIDECHAIN_WITHDRAW_PERIOD - 1);
-    COutPoint record_id{ArithToUint256(arith_uint256{uint64_t{completed_block_height}}), DBIDX_SIDECHAIN_PROPOSAL_LIST};
+    COutPoint record_id{ArithToUint256(arith_uint256{(uint64_t)completed_block_height}), DBIDX_SIDECHAIN_PROPOSAL_LIST};
     CDataStream completed_proposal_list = GetDBEntry(view, record_id);
     if (!completed_proposal_list.empty()) {
         DeleteDBEntry(view, txundo, record_id);
@@ -222,7 +222,7 @@ void UpdateDrivechains(const CTransaction& tx, CCoinsViewCache& view, CTxUndo &t
 
     // New sidechain activation
     completed_block_height = block_height - (SIDECHAIN_ACTIVATION_PERIOD - 1);
-    completed_proposal_list = GetDBEntry(view, {ArithToUint256(arith_uint256{uint64_t{completed_block_height}}), DBIDX_SIDECHAIN_PROPOSAL_LIST});
+    completed_proposal_list = GetDBEntry(view, {ArithToUint256(arith_uint256{(uint64_t)completed_block_height}), DBIDX_SIDECHAIN_PROPOSAL_LIST});
     if (!completed_proposal_list.empty()) {
         completed_proposal_list >> sidechain_proposal_list;
         completed_proposal_list >> withdraw_proposal_list;
@@ -284,7 +284,7 @@ void UpdateDrivechains(const CTransaction& tx, CCoinsViewCache& view, CTxUndo &t
 
         if (sidechain_proposal_list.size() != sidechain_proposal_list_new.size()) {
             Assume(!new_sidechains_activated.empty());
-            COutPoint record_id{ArithToUint256(arith_uint256{uint64_t{completed_block_height}}), DBIDX_SIDECHAIN_PROPOSAL_LIST};
+            COutPoint record_id{ArithToUint256(arith_uint256{(uint64_t)completed_block_height}), DBIDX_SIDECHAIN_PROPOSAL_LIST};
             DeleteDBEntry(view, txundo, record_id);
 
             if (!(sidechain_proposal_list_new.empty() && withdraw_proposal_list.empty())) {

--- a/src/sidechain.cpp
+++ b/src/sidechain.cpp
@@ -202,7 +202,11 @@ bool UpdateDrivechains(const CTransaction& tx, CCoinsViewCache& view, CTxUndo &t
             }
             proposed_a_sidechain = true;
 
-            CDataStream s(MakeByteSpan(out.scriptPubKey).subspan(5), SER_NETWORK, PROTOCOL_VERSION);
+            // Sidechain proposal serialization bytes from script
+            Span<const std::byte> bytes = MakeByteSpan(out.scriptPubKey).subspan(5);
+
+            // Test deserializing sidechain proposal
+            CDataStream s(bytes, SER_NETWORK, PROTOCOL_VERSION);
             Sidechain proposed;
             try {
                 s >> proposed;
@@ -214,7 +218,7 @@ bool UpdateDrivechains(const CTransaction& tx, CCoinsViewCache& view, CTxUndo &t
 
             uint256 sidechain_proposal_hash;
             CSHA256().Write(out.scriptPubKey.data() + 5, out.scriptPubKey.size() - 5).Finalize(sidechain_proposal_hash.data());
-            CreateDBEntry(view, txundo, block_height, {sidechain_proposal_hash, DBIDX_SIDECHAIN_PROPOSAL}, s);
+            CreateDBEntry(view, txundo, block_height, {sidechain_proposal_hash, DBIDX_SIDECHAIN_PROPOSAL}, CDataStream(bytes, SER_NETWORK, PROTOCOL_VERSION));
 
             s.clear();
             s << uint16_t{0};

--- a/src/sidechain.cpp
+++ b/src/sidechain.cpp
@@ -281,7 +281,9 @@ bool UpdateDrivechains(const CTransaction& tx, CCoinsViewCache& view, CTxUndo &t
                     continue;
                 }
 
-                // TODO: assign
+                CDataStream ctip_info(SER_NETWORK, PROTOCOL_VERSION);
+                ctip_info << sidechain_id;
+                CreateDBEntry(view, txundo, block_height, {tx.GetHash(), DBIDX_SIDECHAIN_CTIP_INFO}, ctip_info);
             }
             if (!new_sidechains_activated.empty()) {
                 return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-drivechain-activated-without-ctip");

--- a/src/sidechain.cpp
+++ b/src/sidechain.cpp
@@ -17,7 +17,7 @@
 #include <cstdint>
 
 void CreateDBUndoData(CTxUndo &txundo, const uint8_t type, const COutPoint& record_id, const Coin& encoded_data) {
-    Assert(record_id.n <= COutPoint::MAX_INDEX);
+    Assert(record_id.n > COutPoint::MAX_INDEX);
     Coin& undo = txundo.vprevout.emplace_back();
     undo = encoded_data;
     CDataStream s(SER_NETWORK, PROTOCOL_VERSION);

--- a/src/sidechain.h
+++ b/src/sidechain.h
@@ -12,6 +12,7 @@
 #include <string>
 #include <vector>
 
+class BlockValidationState;
 class CBlock;
 class CCoinsViewCache;
 class CTransaction;
@@ -55,7 +56,7 @@ struct Sidechain {
     }
 };
 
-void UpdateDrivechains(const CTransaction& tx, CCoinsViewCache& inputs, CTxUndo &txundo, int nHeight);
+bool UpdateDrivechains(const CTransaction& tx, CCoinsViewCache& inputs, CTxUndo &txundo, int nHeight, BlockValidationState& state);
 bool VerifyDrivechainSpend(const CTransaction& tx, unsigned int sidechain_input_n, const std::vector<CTxOut>& spent_outputs, const CCoinsViewCache& view, TxValidationState& state);
 
 #endif // BITCOIN_SIDECHAIN_H

--- a/src/sidechain.h
+++ b/src/sidechain.h
@@ -10,10 +10,13 @@
 
 #include <cstdint>
 #include <string>
+#include <vector>
 
-class CTransaction;
 class CCoinsViewCache;
+class CTransaction;
+class CTxOut;
 class CTxUndo;
+class TxValidationState;
 
 //! The current sidechain version
 static constexpr int SIDECHAIN_VERSION_CURRENT{0};
@@ -28,6 +31,8 @@ static constexpr uint32_t DBIDX_SIDECHAIN_PROPOSAL_ACKS{0xff010002};
 static constexpr uint32_t DBIDX_SIDECHAIN_WITHDRAW_PROPOSAL_LIST{0xff010003};
 // Key is a blinded withdrawl hash; Data is a uint16_t with ACK count
 static constexpr uint32_t DBIDX_SIDECHAIN_WITHDRAW_PROPOSAL_ACKS{0xff010004};
+// Key is a CTIP; data is uint8 sidechain id it's for and uint32 output index
+static constexpr uint32_t DBIDX_SIDECHAIN_CTIP_INFO{0xff010005};
 
 struct Sidechain {
     uint8_t idnum{0};
@@ -43,5 +48,6 @@ struct Sidechain {
 };
 
 void UpdateDrivechains(const CTransaction& tx, CCoinsViewCache& inputs, CTxUndo &txundo, int nHeight);
+bool VerifyDrivechainSpend(const CTransaction& tx, unsigned int sidechain_input_n, const std::vector<CTxOut>& spent_outputs, const CCoinsViewCache& view, TxValidationState& state);
 
 #endif // BITCOIN_SIDECHAIN_H

--- a/src/sidechain.h
+++ b/src/sidechain.h
@@ -1,0 +1,47 @@
+// Copyright (c) 2017-2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_SIDECHAIN_H
+#define BITCOIN_SIDECHAIN_H
+
+#include <serialize.h>
+#include <uint256.h>
+
+#include <cstdint>
+#include <string>
+
+class CTransaction;
+class CCoinsViewCache;
+class CTxUndo;
+
+//! The current sidechain version
+static constexpr int SIDECHAIN_VERSION_CURRENT{0};
+
+// Key is the proposal hash; Data is the proposal itself
+static constexpr uint32_t DBIDX_SIDECHAIN_PROPOSAL{0xff010000};
+// Key is the block height; Data is a serialised list of hashes of sidechain proposals in the block, then a serialised list of withdraw proposals in the block
+static constexpr uint32_t DBIDX_SIDECHAIN_PROPOSAL_LIST{0xff010001};
+// Key is the proposal hash; Data is a uint16_t with ACK count
+static constexpr uint32_t DBIDX_SIDECHAIN_PROPOSAL_ACKS{0xff010002};
+// Key is the sidechain number; Data is a raw list of blinded-hashes of withdraw proposals
+static constexpr uint32_t DBIDX_SIDECHAIN_WITHDRAW_PROPOSAL_LIST{0xff010003};
+// Key is a blinded withdrawl hash; Data is a uint16_t with ACK count
+static constexpr uint32_t DBIDX_SIDECHAIN_WITHDRAW_PROPOSAL_ACKS{0xff010004};
+
+struct Sidechain {
+    uint8_t idnum{0};
+    int32_t version{SIDECHAIN_VERSION_CURRENT};
+    std::string title;
+    std::string description;
+    uint256 hashID1;
+    uint160 hashID2;
+
+    SERIALIZE_METHODS(Sidechain, obj) {
+        READWRITE(obj.idnum, obj.version, obj.title, obj.description, obj.hashID1, obj.hashID2);
+    }
+};
+
+void UpdateDrivechains(const CTransaction& tx, CCoinsViewCache& inputs, CTxUndo &txundo, int nHeight);
+
+#endif // BITCOIN_SIDECHAIN_H

--- a/src/sidechain.h
+++ b/src/sidechain.h
@@ -12,6 +12,7 @@
 #include <string>
 #include <vector>
 
+class CBlock;
 class CCoinsViewCache;
 class CTransaction;
 class CTxOut;
@@ -21,6 +22,15 @@ class TxValidationState;
 //! The current sidechain version
 static constexpr int SIDECHAIN_VERSION_CURRENT{0};
 
+// Number of blocks for a new sidechain
+static constexpr int SIDECHAIN_ACTIVATION_PERIOD = 2016;
+static constexpr int SIDECHAIN_ACTIVATION_THRESHOLD = SIDECHAIN_ACTIVATION_PERIOD - 200;
+// Number of blocks a sidechain withdraw (or overwrite) can be valid (after acquiring enough ACKs)
+static constexpr int SIDECHAIN_WITHDRAW_PERIOD = 26300;
+static constexpr int SIDECHAIN_WITHDRAW_THRESHOLD = SIDECHAIN_WITHDRAW_PERIOD / 2;
+
+// Key is the sidechain number; Data is the Sidechain itself
+static constexpr uint32_t DBIDX_SIDECHAIN_DATA{0xff010006};
 // Key is the proposal hash; Data is the proposal itself
 static constexpr uint32_t DBIDX_SIDECHAIN_PROPOSAL{0xff010000};
 // Key is the block height; Data is a serialised list of hashes of sidechain proposals in the block, then a serialised list of withdraw proposals in the block
@@ -39,11 +49,9 @@ struct Sidechain {
     int32_t version{SIDECHAIN_VERSION_CURRENT};
     std::string title;
     std::string description;
-    uint256 hashID1;
-    uint160 hashID2;
 
     SERIALIZE_METHODS(Sidechain, obj) {
-        READWRITE(obj.idnum, obj.version, obj.title, obj.description, obj.hashID1, obj.hashID2);
+        READWRITE(obj.idnum, obj.version, obj.title, obj.description);
     }
 };
 

--- a/src/sidechain.h
+++ b/src/sidechain.h
@@ -45,6 +45,9 @@ static constexpr uint32_t DBIDX_SIDECHAIN_WITHDRAW_PROPOSAL_ACKS{0xff010004};
 // Key is a CTIP; data is uint8 sidechain id it's for and uint32 output index
 static constexpr uint32_t DBIDX_SIDECHAIN_CTIP_INFO{0xff010005};
 
+// Offset into an OP_DRIVECHAIN script, where we find the raw sidechain id
+static constexpr int DRIVECHAIN_SCRIPT_SIDECHAIN_ID_OFFSET = 2;
+
 struct Sidechain {
     uint8_t idnum{0};
     int32_t version{SIDECHAIN_VERSION_CURRENT};

--- a/src/sidechain.h
+++ b/src/sidechain.h
@@ -39,7 +39,7 @@ static constexpr uint32_t DBIDX_SIDECHAIN_PROPOSAL_LIST{0xff010001};
 static constexpr uint32_t DBIDX_SIDECHAIN_PROPOSAL_ACKS{0xff010002};
 // Key is the sidechain number; Data is a raw list of blinded-hashes of withdraw proposals
 static constexpr uint32_t DBIDX_SIDECHAIN_WITHDRAW_PROPOSAL_LIST{0xff010003};
-// Key is a blinded withdrawl hash; Data is a uint16_t with ACK count
+// Key is SHA256(blinded withdraw hash | sidechain id); Data is a uint16_t with ACK count
 static constexpr uint32_t DBIDX_SIDECHAIN_WITHDRAW_PROPOSAL_ACKS{0xff010004};
 // Key is a CTIP; data is uint8 sidechain id it's for and uint32 output index
 static constexpr uint32_t DBIDX_SIDECHAIN_CTIP_INFO{0xff010005};

--- a/src/test/fuzz/coins_view.cpp
+++ b/src/test/fuzz/coins_view.cpp
@@ -146,22 +146,28 @@ FUZZ_TARGET(coins_view, .init = initialize_coins_view)
     {
         const Coin& coin_using_access_coin = coins_view_cache.AccessCoin(random_out_point);
         const bool exists_using_access_coin = !(coin_using_access_coin == EMPTY_COIN);
-        const bool exists_using_have_coin = coins_view_cache.HaveCoin(random_out_point);
+        const bool exists_using_have_coin = coins_view_cache.HaveCoinRaw(random_out_point);
         const bool exists_using_have_coin_in_cache = coins_view_cache.HaveCoinInCache(random_out_point);
         Coin coin_using_get_coin;
-        const bool exists_using_get_coin = coins_view_cache.GetCoin(random_out_point, coin_using_get_coin);
+        const bool exists_using_get_coin = coins_view_cache.GetCoinRaw(random_out_point, coin_using_get_coin);
         if (exists_using_get_coin) {
             assert(coin_using_get_coin == coin_using_access_coin);
         }
         assert((exists_using_access_coin && exists_using_have_coin_in_cache && exists_using_have_coin && exists_using_get_coin) ||
                (!exists_using_access_coin && !exists_using_have_coin_in_cache && !exists_using_have_coin && !exists_using_get_coin));
+        if (exists_using_have_coin && random_out_point.n > 0x00ffffff) {
+            assert(!coins_view_cache.HaveCoin(random_out_point));
+        }
         // If HaveCoin on the backend is true, it must also be on the cache if the coin wasn't spent.
-        const bool exists_using_have_coin_in_backend = backend_coins_view.HaveCoin(random_out_point);
+        const bool exists_using_have_coin_in_backend = backend_coins_view.HaveCoinRaw(random_out_point);
         if (!coin_using_access_coin.IsSpent() && exists_using_have_coin_in_backend) {
             assert(exists_using_have_coin);
+            if (random_out_point.n > 0x00ffffff) {
+                assert(!backend_coins_view.HaveCoin(random_out_point));
+            }
         }
         Coin coin_using_backend_get_coin;
-        if (backend_coins_view.GetCoin(random_out_point, coin_using_backend_get_coin)) {
+        if (backend_coins_view.GetCoinRaw(random_out_point, coin_using_backend_get_coin)) {
             assert(exists_using_have_coin_in_backend);
             // Note we can't assert that `coin_using_get_coin == coin_using_backend_get_coin` because the coin in
             // the cache may have been modified but not yet flushed.

--- a/src/test/fuzz/coinscache_sim.cpp
+++ b/src/test/fuzz/coinscache_sim.cpp
@@ -145,7 +145,7 @@ class CoinsViewBottom final : public CCoinsView
     std::map<COutPoint, Coin> m_data;
 
 public:
-    bool GetCoin(const COutPoint& outpoint, Coin& coin) const final
+    bool GetCoinRaw(const COutPoint& outpoint, Coin& coin) const final
     {
         auto it = m_data.find(outpoint);
         if (it == m_data.end()) {
@@ -160,7 +160,7 @@ public:
         }
     }
 
-    bool HaveCoin(const COutPoint& outpoint) const final
+    bool HaveCoinRaw(const COutPoint& outpoint) const final
     {
         return m_data.count(outpoint);
     }
@@ -269,7 +269,7 @@ FUZZ_TARGET(coinscache_sim)
                 auto sim = lookup(outpointidx);
                 // Look up in real caches.
                 Coin realcoin;
-                auto real = caches.back()->GetCoin(data.outpoints[outpointidx], realcoin);
+                auto real = caches.back()->GetCoinRaw(data.outpoints[outpointidx], realcoin);
                 // Compare results.
                 if (!sim.has_value()) {
                     assert(!real || realcoin.IsSpent());
@@ -287,7 +287,7 @@ FUZZ_TARGET(coinscache_sim)
                 // Look up in simulation data.
                 auto sim = lookup(outpointidx);
                 // Look up in real caches.
-                auto real = caches.back()->HaveCoin(data.outpoints[outpointidx]);
+                auto real = caches.back()->HaveCoinRaw(data.outpoints[outpointidx]);
                 // Compare results.
                 assert(sim.has_value() == real);
             },
@@ -464,7 +464,7 @@ FUZZ_TARGET(coinscache_sim)
     // Compare the bottom coinsview (not a CCoinsViewCache) with sim_cache[0].
     for (uint32_t outpointidx = 0; outpointidx < NUM_OUTPOINTS; ++outpointidx) {
         Coin realcoin;
-        bool real = bottom.GetCoin(data.outpoints[outpointidx], realcoin);
+        bool real = bottom.GetCoinRaw(data.outpoints[outpointidx], realcoin);
         auto sim = lookup(outpointidx, 0);
         if (!sim.has_value()) {
             assert(!real || realcoin.IsSpent());

--- a/src/test/fuzz/tx_pool.cpp
+++ b/src/test/fuzz/tx_pool.cpp
@@ -161,7 +161,7 @@ FUZZ_TARGET(tx_pool_standard, .init = initialize_tx_pool)
     const CCoinsViewMemPool amount_view{WITH_LOCK(::cs_main, return &chainstate.CoinsTip()), tx_pool};
     const auto GetAmount = [&](const COutPoint& outpoint) {
         Coin c;
-        Assert(amount_view.GetCoin(outpoint, c));
+        Assert(amount_view.GetCoinRaw(outpoint, c));
         return c.out.nValue;
     };
 

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -74,11 +74,11 @@ void CCoinsViewDB::ResizeCache(size_t new_cache_size)
     }
 }
 
-bool CCoinsViewDB::GetCoin(const COutPoint &outpoint, Coin &coin) const {
+bool CCoinsViewDB::GetCoinRaw(const COutPoint &outpoint, Coin &coin) const {
     return m_db->Read(CoinEntry(&outpoint), coin);
 }
 
-bool CCoinsViewDB::HaveCoin(const COutPoint &outpoint) const {
+bool CCoinsViewDB::HaveCoinRaw(const COutPoint &outpoint) const {
     return m_db->Exists(CoinEntry(&outpoint));
 }
 

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -59,8 +59,8 @@ protected:
 public:
     explicit CCoinsViewDB(DBParams db_params, CoinsViewOptions options);
 
-    bool GetCoin(const COutPoint &outpoint, Coin &coin) const override;
-    bool HaveCoin(const COutPoint &outpoint) const override;
+    bool GetCoinRaw(const COutPoint &outpoint, Coin &coin) const override;
+    bool HaveCoinRaw(const COutPoint &outpoint) const override;
     uint256 GetBestBlock() const override;
     std::vector<uint256> GetHeadBlocks() const override;
     bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock, bool erase = true) override;

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -993,7 +993,7 @@ bool CTxMemPool::HasNoInputsOf(const CTransaction &tx) const
 
 CCoinsViewMemPool::CCoinsViewMemPool(CCoinsView* baseIn, const CTxMemPool& mempoolIn) : CCoinsViewBacked(baseIn), mempool(mempoolIn) { }
 
-bool CCoinsViewMemPool::GetCoin(const COutPoint &outpoint, Coin &coin) const {
+bool CCoinsViewMemPool::GetCoinRaw(const COutPoint &outpoint, Coin &coin) const {
     // Check to see if the inputs are made available by another tx in the package.
     // These Coins would not be available in the underlying CoinsView.
     if (auto it = m_temp_added.find(outpoint); it != m_temp_added.end()) {
@@ -1014,7 +1014,7 @@ bool CCoinsViewMemPool::GetCoin(const COutPoint &outpoint, Coin &coin) const {
             return false;
         }
     }
-    return base->GetCoin(outpoint, coin);
+    return base->GetCoinRaw(outpoint, coin);
 }
 
 void CCoinsViewMemPool::PackageAddTransaction(const CTransactionRef& tx)

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -839,7 +839,7 @@ public:
     CCoinsViewMemPool(CCoinsView* baseIn, const CTxMemPool& mempoolIn);
     /** GetCoin, returning whether it exists and is not spent. Also updates m_non_base_coins if the
      * coin is not fetched from base. */
-    bool GetCoin(const COutPoint &outpoint, Coin &coin) const override;
+    bool GetCoinRaw(const COutPoint &outpoint, Coin &coin) const override;
     /** Add the coins created by this transaction. These coins are only temporarily stored in
      * m_temp_added and cannot be flushed to the back end. Only used for package validation. */
     void PackageAddTransaction(const CTransactionRef& tx);

--- a/src/undo.h
+++ b/src/undo.h
@@ -63,7 +63,7 @@ public:
 class CBlockUndo
 {
 public:
-    std::vector<CTxUndo> vtxundo; // for all but the coinbase
+    std::vector<CTxUndo> vtxundo; // for all but the coinbase, plus an extra on the end for drivechains
 
     SERIALIZE_METHODS(CBlockUndo, obj) { READWRITE(obj.vtxundo); }
 };

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1956,7 +1956,7 @@ int ApplyTxInUndo(Coin&& undo, CCoinsViewCache& view, const COutPoint& out)
 {
     bool fClean = true;
 
-    if (view.HaveCoin(out)) fClean = false; // overwriting transaction output
+    if (view.HaveCoinRaw(out)) fClean = false; // overwriting transaction output
 
     if (undo.nHeight == 0) {
         // Missing undo metadata (height and coinbase). Older versions included this

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2456,7 +2456,10 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
 
     // BIP300 logic
     blockundo.vtxundo.push_back(CTxUndo());
-    UpdateDrivechains(*block.vtx[0], view, blockundo.vtxundo.back(), pindex->nHeight);
+    if (!UpdateDrivechains(*block.vtx[0], view, blockundo.vtxundo.back(), pindex->nHeight, state)) {
+        // state.Invalid already called inside UpdateDrivechains
+        return false;
+    }
 
     const auto time_3{SteadyClock::now()};
     time_connect += time_3 - time_2;


### PR DESCRIPTION
This is a (rough draft) clean rewrite of BIP300 (Drivechain) consensus-level code.

Instead of a separate sidechain database (which may be prone to hard-to-review/test consistency issues), instead the unusable 8 MSB of the UTXO index are reserved for non-UTXO database entries, and the existing UTXO db and caching layer is shared. This can be refactored in the future, but I think it is the cleanest and most reviewable approach initially - open to other ideas, though. There's also some ugliness in the undo data to handle restoring the new data, but it's abstracted and shouldn't be too hard to reason about.

Using these new primitives, Drivechains can be reimplemented with a UTXO-like model. Note that there is zero activation logic in the current PR: the protocol changes are *always* active. Therefore, this will *not* work (at least not safely) on Bitcoin today, and cannot be deployed without significant additional changes to handle an activation.

A new `SERIALIZE_TRANSACTION_FOR_WEIGHT` serialization flag is also added, that is meant only for weight counting. This allows for adjusting weight (upward) to fit additional resource requirements by new functionality. In this case, several Drivechain "messages" are expected to have a larger burden than their `OP_RETURN` encoding would otherwise weigh. However, the specific adjustments are not implemented in this draft.

As a consensus change, this can only be implemented with community support. Many people seem to have opinions, but please keep them to other forums. Despite providing and continuing this implementation, I myself do not thereby endorse or otherwise comment on the proposal itself.

Therefore, not looking for concept ACKs/NACKs (ie, about Drivechains), just *Approach* ACKs / constructive criticism (ie, about *how* I'm implementing it).