### PR TITLE
wallet: default -fallbackfee to same as -mintxfee on test chains

### DIFF
--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -56,7 +56,7 @@ void WalletInit::AddWalletOptions(ArgsManager& argsman) const
                                                                 "Note: An output is discarded if it is dust at this rate, but we will always discard up to the dust relay fee and a discard fee above that is limited by the fee estimate for the longest target",
                                                               CURRENCY_UNIT, FormatMoney(DEFAULT_DISCARD_FEE)), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
 
-    argsman.AddArg("-fallbackfee=<amt>", strprintf("A fee rate (in %s/kvB) that will be used when fee estimation has insufficient data. 0 to entirely disable the fallbackfee feature. (default: %s)",
+    argsman.AddArg("-fallbackfee=<amt>", strprintf("A fee rate (in %s/kvB) that will be used when fee estimation has insufficient data. 0 to entirely disable the fallbackfee feature. (default: %s; or -mintxfee value on test chains)",
                                                                CURRENCY_UNIT, FormatMoney(DEFAULT_FALLBACK_FEE)), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
     argsman.AddArg("-keypool=<n>", strprintf("Set key pool size to <n> (default: %u). Warning: Smaller sizes may increase the risk of losing funds when restoring from an old backup, if none of the addresses in the original keypool have been used.", DEFAULT_KEYPOOL_SIZE), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
     argsman.AddArg("-maxapsfee=<n>", strprintf("Spend up to this amount in additional (absolute) fees (in %s) if it allows the use of partial spend avoidance (default: %s)", CURRENCY_UNIT, FormatMoney(DEFAULT_MAX_AVOIDPARTIALSPEND_FEE)), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3074,6 +3074,8 @@ std::shared_ptr<CWallet> CWallet::Create(WalletContext& context, const std::stri
                                _("This is the transaction fee you may pay when fee estimates are not available."));
         }
         walletInstance->m_fallback_fee = CFeeRate{fallback_fee.value()};
+    } else if (Params().IsTestChain()) {
+        walletInstance->m_fallback_fee = walletInstance->m_min_fee;
     }
 
     // Disable fallback fee in case value was set to 0, enable if non-null value


### PR DESCRIPTION
On mainnet, the error message:

```
Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.
```

is helpful, because if you aren't able to set a fee based on an external source or the internal fee estimation code, then you're likely to either waste money when the default is too high, or have a tx that won't confirm if the default is too low. On regtest and friends it's not help, and the advice may well be wrong: particularly on regtest, mining additional empty blocks won't help at all.

But for test net's there is an easy default available that is quite reliable: just use the minimum tx fee.