### PR TITLE
test: Support riscv64 in get_previous_releases.py

### DIFF
--- a/test/get_previous_releases.py
+++ b/test/get_previous_releases.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2018-2022 The Bitcoin Core developers
+# Copyright (c) 2018-present The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #
@@ -250,6 +250,7 @@ def check_host(args) -> int:
     if args.download_binary:
         platforms = {
             'aarch64-*-linux*': 'aarch64-linux-gnu',
+            'riscv64-*-linux*': 'riscv64-linux-gnu',
             'x86_64-*-linux*': 'x86_64-linux-gnu',
             'x86_64-apple-darwin*': 'x86_64-apple-darwin',
             'aarch64-apple-darwin*': 'arm64-apple-darwin',


### PR DESCRIPTION
To test: `test/get_previous_releases.py -b -t /tmp/prev_releases v0.18.1`

On master: `Not sure which binary to download for riscv64-unknown-linux-gnu`
Here: (pass)