### PR TITLE
ci: Use concurrency for pull requests only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.event_name != 'pull_request' && github.run_id || github.ref }}
+  cancel-in-progress: true
 
 env:
   DANGER_RUN_CI_ON_HOST: 1


### PR DESCRIPTION
This PR is an amendment for https://github.com/bitcoin/bitcoin/pull/28282.

It avoids skipping builds when some pushes were done consequentially:

![image](https://github.com/bitcoin/bitcoin/assets/32963518/977e9ead-1856-4020-82eb-d16dbead5753)

From GitHub Actions [docs](https://docs.github.com/en/actions/using-jobs/using-concurrency):

> When a concurrent ... workflow is queued, if another ... workflow using the same concurrency group in the repository is in progress, the queued ... workflow will be pending. **Any previously pending ... workflow in the concurrency group will be canceled.**

No behavior change for pull requests:

![image](https://github.com/bitcoin/bitcoin/assets/32963518/4865ae04-fc42-4028-b91e-500c0b36bce6)
