### PR TITLE
test: wallet_backup.py, fix intermittent failure in "restore using dumped wallet"

### DIFF
--- a/test/functional/wallet_backup.py
+++ b/test/functional/wallet_backup.py
@@ -140,11 +140,6 @@ class WalletBackupTest(BitcoinTestFramework):
         assert_raises_rpc_error(-36, error_message, node.restorewallet, wallet_name, backup_file)
         assert os.path.exists(wallet_file)
 
-    def init_three(self):
-        self.init_wallet(node=0)
-        self.init_wallet(node=1)
-        self.init_wallet(node=2)
-
     def run_test(self):
         self.log.info("Generating initial blockchain")
         self.generate(self.nodes[0], 1)
@@ -230,7 +225,10 @@ class WalletBackupTest(BitcoinTestFramework):
             shutil.rmtree(os.path.join(self.nodes[2].chain_path, 'chainstate'))
 
             self.start_three(["-nowallet"])
-            self.init_three()
+            # Create new wallets for the three nodes.
+            # We will use this empty wallets to test the 'importwallet()' RPC command below.
+            for node_num in range(3):
+                self.nodes[node_num].createwallet(wallet_name=self.default_wallet_name, descriptors=self.options.descriptors, load_on_startup=True)
 
             assert_equal(self.nodes[0].getbalance(), 0)
             assert_equal(self.nodes[1].getbalance(), 0)


### PR DESCRIPTION
Aiming to fix #25652.

The failure arises because the test expects `init_wallet()` (the test framework function) to create a wallet with no keys. However, the function also imports the deterministic private key used to receive the coinbase coins.

This causes a race within the "restore using dumped wallet" case, where we intend to have a new wallet (with no existing keys) to test the 'importwallet()' RPC result.
The reason why this failure is intermittent is that it depends on other peers delivering the chain right after node2 startup and prior to the test 'node2.getbalance()' call and also the synchronization of the validation queue.