### PR TITLE
RFC: remove clientversion.h usage from kernel

### DIFF
--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -6,7 +6,6 @@
 #define BITCOIN_DBWRAPPER_H
 
 #include <attributes.h>
-#include <clientversion.h>
 #include <serialize.h>
 #include <span.h>
 #include <streams.h>
@@ -167,7 +166,7 @@ public:
 
     template<typename V> bool GetValue(V& value) {
         try {
-            CDataStream ssValue{GetValueImpl(), SER_DISK, CLIENT_VERSION};
+            CDataStream ssValue{GetValueImpl(), SER_DISK, CDataStream::client_version_tag{}};
             ssValue.Xor(dbwrapper_private::GetObfuscateKey(parent));
             ssValue >> value;
         } catch (const std::exception&) {
@@ -229,7 +228,7 @@ public:
             return false;
         }
         try {
-            CDataStream ssValue{MakeByteSpan(*strValue), SER_DISK, CLIENT_VERSION};
+            CDataStream ssValue{MakeByteSpan(*strValue), SER_DISK, CDataStream::client_version_tag{}};
             ssValue.Xor(obfuscate_key);
             ssValue >> value;
         } catch (const std::exception&) {

--- a/src/index/blockfilterindex.cpp
+++ b/src/index/blockfilterindex.cpp
@@ -4,6 +4,7 @@
 
 #include <map>
 
+#include <clientversion.h>
 #include <common/args.h>
 #include <dbwrapper.h>
 #include <hash.h>

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -4,6 +4,7 @@
 
 #include <index/txindex.h>
 
+#include <clientversion.h>
 #include <common/args.h>
 #include <index/disktxpos.h>
 #include <logging.h>

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -19,6 +19,7 @@
 #include <chain.h>
 #include <chainparams.h>
 #include <chainparamsbase.h>
+#include <clientversion.h>
 #include <common/args.h>
 #include <common/system.h>
 #include <consensus/amount.h>

--- a/src/streams.cpp
+++ b/src/streams.cpp
@@ -64,3 +64,12 @@ void AutoFile::write(Span<const std::byte> src)
         }
     }
 }
+
+CDataStream::CDataStream(int nTypeIn, client_version_tag)
+  : nType{nTypeIn}, nVersion{CLIENT_VERSION} {}
+
+CDataStream::CDataStream(Span<const uint8_t> sp, int type, client_version_tag)
+  : CDataStream{AsBytes(sp), type, CLIENT_VERSION} {}
+
+CDataStream::CDataStream(Span<const value_type> sp, int nTypeIn, client_version_tag)
+  : DataStream{sp}, nType{nTypeIn}, nVersion{CLIENT_VERSION}{}

--- a/src/streams.cpp
+++ b/src/streams.cpp
@@ -2,8 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://opensource.org/license/mit/.
 
-#include <span.h>
 #include <streams.h>
+
+#include <clientversion.h>
+#include <span.h>
 
 #include <array>
 

--- a/src/streams.h
+++ b/src/streams.h
@@ -353,6 +353,13 @@ public:
           nType{nTypeIn},
           nVersion{nVersionIn} {}
 
+    struct client_version_tag{};
+
+    // Constructors for using the current client version without knowing it
+    explicit CDataStream(int nTypeIn, client_version_tag);
+    explicit CDataStream(Span<const uint8_t> sp, int type, client_version_tag);
+    explicit CDataStream(Span<const value_type> sp, int nTypeIn, client_version_tag);
+
     int GetType() const          { return nType; }
     void SetVersion(int n)       { nVersion = n; }
     int GetVersion() const       { return nVersion; }

--- a/src/test/blockmanager_tests.cpp
+++ b/src/test/blockmanager_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chainparams.h>
+#include <clientversion.h>
 #include <node/blockstorage.h>
 #include <node/context.h>
 #include <node/kernel_notifications.h>

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -11,6 +11,7 @@
 #include <arith_uint256.h>
 #include <chain.h>
 #include <checkqueue.h>
+#include <clientversion.h>
 #include <consensus/amount.h>
 #include <consensus/consensus.h>
 #include <consensus/merkle.h>


### PR DESCRIPTION
RFC because this is rather hackish and I'd like to know if anyone has a better idea.

I'm working on trimming out headers that libbitcoinkernel should not export. To be clear: the problem is not what headers libbitcoinkernel itself uses, but what headers it requires users to use. Basically.. the headers used directly and indirectly by `bitcoin-chainstate.cpp`.

Topping the list of headers we definitely don't want to require for users are `bitcoin-config.h` and `clientversion.h`. The former is somewhat complicated, but `clientversion.h` only comes from one place: `dbwrapper.h`.

This PR gets rid of that include by creating a new constructor that sets the version in the cpp file, working around the problem.

Another potential solution would be to create a `MakeClientVersionCDataStream()` function which just creates a stream and sets the version, and relies on the caller to do the rest.

Any better ideas? Otherwise I'll undraft and ask for review.