### PR TITLE
test: previous releases: speed up fetching sources with shallow clone

### DIFF
--- a/test/get_previous_releases.py
+++ b/test/get_previous_releases.py
@@ -207,14 +207,11 @@ def build_release(tag, args) -> int:
             print('Tag {} not found'.format(tag))
             return 1
     ret = subprocess.run([
-        'git', 'clone', githubUrl, tag
+        'git', 'clone', f'--branch={tag}', '--depth=1', githubUrl, tag
     ]).returncode
     if ret:
         return ret
     with pushd(tag):
-        ret = subprocess.run(['git', 'checkout', tag]).returncode
-        if ret:
-            return ret
         host = args.host
         if args.depends:
             with pushd('depends'):


### PR DESCRIPTION
For the sake of building previous releases, fetching the whole history of the repository for each version seems to be overkill as it takes much more time, bandwidth and disk space than necessary. Create a shallow clone instead with history truncated to the one commit of the version tag, which is directly checked out in the same command. This has the nice side-effect that we can remove the extra `git checkout` step after as it's not needed anymore.

Note that it might look confusing to pass a _tag_ to a parameter named `--branch`, but the git-clone manpage explicitly states that this is supported.