### PR TITLE
RFC: Remove boost usage from kernel api / headers

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -200,6 +200,7 @@ BITCOIN_CORE_H = \
   logging.h \
   logging/timer.h \
   mapport.h \
+  mempool_set_definitions.h \
   memusage.h \
   merkleblock.h \
   net.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -894,7 +894,7 @@ bitcoin_util_LDADD = \
 
 # bitcoin-chainstate binary #
 bitcoin_chainstate_SOURCES = bitcoin-chainstate.cpp
-bitcoin_chainstate_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(BOOST_CPPFLAGS)
+bitcoin_chainstate_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 bitcoin_chainstate_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 
 bitcoin_chainstate_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(PTHREAD_FLAGS) $(LIBTOOL_APP_LDFLAGS) -static

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -91,6 +91,7 @@
 #include <walletinitinterface.h>
 
 #include <algorithm>
+#include <cmath>
 #include <condition_variable>
 #include <cstdint>
 #include <cstdio>

--- a/src/kernel/mempool_entry.h
+++ b/src/kernel/mempool_entry.h
@@ -127,8 +127,11 @@ public:
           nModFeesWithAncestors{nFee},
           nSigOpCostWithAncestors{sigOpCost} {}
 
+    // Prohibit accidental copies that might invalidate references from parent
+    // and child transactions, or lead to unsafe usage of mapTx.iterator_to.
     CTxMemPoolEntry(ExplicitCopyTag, const CTxMemPoolEntry& entry) : CTxMemPoolEntry(entry) {}
     CTxMemPoolEntry& operator=(const CTxMemPoolEntry&) = delete;
+    // The move constructor is already implicitly deleted, so be explicit about it.
     CTxMemPoolEntry(CTxMemPoolEntry&&) = delete;
     CTxMemPoolEntry& operator=(CTxMemPoolEntry&&) = delete;
 

--- a/src/kernel/mempool_entry.h
+++ b/src/kernel/mempool_entry.h
@@ -22,6 +22,9 @@
 #include <stdint.h>
 
 class CBlockIndex;
+class CTxMemPoolEntry;
+
+using CTxMemPoolEntryRef = std::reference_wrapper<const CTxMemPoolEntry>;
 
 struct LockPoints {
     // Will be set to the blockchain height and median time past
@@ -65,7 +68,6 @@ struct CompareIteratorByHash {
 class CTxMemPoolEntry
 {
 public:
-    typedef std::reference_wrapper<const CTxMemPoolEntry> CTxMemPoolEntryRef;
     // two aliases, should the types ever diverge
     typedef std::set<CTxMemPoolEntryRef, CompareIteratorByHash> Parents;
     typedef std::set<CTxMemPoolEntryRef, CompareIteratorByHash> Children;
@@ -190,7 +192,5 @@ public:
     mutable size_t idx_randomized; //!< Index in mempool's txns_randomized
     mutable Epoch::Marker m_epoch_marker; //!< epoch when last touched, useful for graph algorithms
 };
-
-using CTxMemPoolEntryRef = CTxMemPoolEntry::CTxMemPoolEntryRef;
 
 #endif // BITCOIN_KERNEL_MEMPOOL_ENTRY_H

--- a/src/mempool_set_definitions.h
+++ b/src/mempool_set_definitions.h
@@ -1,0 +1,215 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_MEMPOOL_SET_DEFINITIONS_H
+#define BITCOIN_MEMPOOL_SET_DEFINITIONS_H
+
+#include <kernel/mempool_entry.h>
+#include <uint256.h>
+#include <util/hasher.h>
+
+#include <boost/multi_index/hashed_index.hpp>
+#include <boost/multi_index/identity.hpp>
+#include <boost/multi_index/indexed_by.hpp>
+#include <boost/multi_index/ordered_index.hpp>
+#include <boost/multi_index/sequenced_index.hpp>
+#include <boost/multi_index/tag.hpp>
+#include <boost/multi_index_container.hpp>
+
+/* This file should only be included in implementation (.cpp) files. */
+
+namespace MemPoolMultiIndex {
+
+// extracts a transaction hash from CTxMemPoolEntry or CTransactionRef
+struct mempoolentry_txid
+{
+    typedef uint256 result_type;
+    result_type operator() (const CTxMemPoolEntry &entry) const
+    {
+        return entry.GetTx().GetHash();
+    }
+
+    result_type operator() (const CTransactionRef& tx) const
+    {
+        return tx->GetHash();
+    }
+};
+
+// extracts a transaction witness-hash from CTxMemPoolEntry or CTransactionRef
+struct mempoolentry_wtxid
+{
+    typedef uint256 result_type;
+    result_type operator() (const CTxMemPoolEntry &entry) const
+    {
+        return entry.GetTx().GetWitnessHash();
+    }
+
+    result_type operator() (const CTransactionRef& tx) const
+    {
+        return tx->GetWitnessHash();
+    }
+};
+
+
+/** \class CompareTxMemPoolEntryByDescendantScore
+ *
+ *  Sort an entry by max(score/size of entry's tx, score/size with all descendants).
+ */
+class CompareTxMemPoolEntryByDescendantScore
+{
+public:
+    bool operator()(const CTxMemPoolEntry& a, const CTxMemPoolEntry& b) const
+    {
+        double a_mod_fee, a_size, b_mod_fee, b_size;
+
+        GetModFeeAndSize(a, a_mod_fee, a_size);
+        GetModFeeAndSize(b, b_mod_fee, b_size);
+
+        // Avoid division by rewriting (a/b > c/d) as (a*d > c*b).
+        double f1 = a_mod_fee * b_size;
+        double f2 = a_size * b_mod_fee;
+
+        if (f1 == f2) {
+            return a.GetTime() >= b.GetTime();
+        }
+        return f1 < f2;
+    }
+
+    // Return the fee/size we're using for sorting this entry.
+    void GetModFeeAndSize(const CTxMemPoolEntry &a, double &mod_fee, double &size) const
+    {
+        // Compare feerate with descendants to feerate of the transaction, and
+        // return the fee/size for the max.
+        double f1 = (double)a.GetModifiedFee() * a.GetSizeWithDescendants();
+        double f2 = (double)a.GetModFeesWithDescendants() * a.GetTxSize();
+
+        if (f2 > f1) {
+            mod_fee = a.GetModFeesWithDescendants();
+            size = a.GetSizeWithDescendants();
+        } else {
+            mod_fee = a.GetModifiedFee();
+            size = a.GetTxSize();
+        }
+    }
+};
+
+/** \class CompareTxMemPoolEntryByScore
+ *
+ *  Sort by feerate of entry (fee/size) in descending order
+ *  This is only used for transaction relay, so we use GetFee()
+ *  instead of GetModifiedFee() to avoid leaking prioritization
+ *  information via the sort order.
+ */
+class CompareTxMemPoolEntryByScore
+{
+public:
+    bool operator()(const CTxMemPoolEntry& a, const CTxMemPoolEntry& b) const
+    {
+        double f1 = (double)a.GetFee() * b.GetTxSize();
+        double f2 = (double)b.GetFee() * a.GetTxSize();
+        if (f1 == f2) {
+            return b.GetTx().GetHash() < a.GetTx().GetHash();
+        }
+        return f1 > f2;
+    }
+};
+
+class CompareTxMemPoolEntryByEntryTime
+{
+public:
+    bool operator()(const CTxMemPoolEntry& a, const CTxMemPoolEntry& b) const
+    {
+        return a.GetTime() < b.GetTime();
+    }
+};
+
+/** \class CompareTxMemPoolEntryByAncestorScore
+ *
+ *  Sort an entry by min(score/size of entry's tx, score/size with all ancestors).
+ */
+class CompareTxMemPoolEntryByAncestorFee
+{
+public:
+    template<typename T>
+    bool operator()(const T& a, const T& b) const
+    {
+        double a_mod_fee, a_size, b_mod_fee, b_size;
+
+        GetModFeeAndSize(a, a_mod_fee, a_size);
+        GetModFeeAndSize(b, b_mod_fee, b_size);
+
+        // Avoid division by rewriting (a/b > c/d) as (a*d > c*b).
+        double f1 = a_mod_fee * b_size;
+        double f2 = a_size * b_mod_fee;
+
+        if (f1 == f2) {
+            return a.GetTx().GetHash() < b.GetTx().GetHash();
+        }
+        return f1 > f2;
+    }
+
+    // Return the fee/size we're using for sorting this entry.
+    template <typename T>
+    void GetModFeeAndSize(const T &a, double &mod_fee, double &size) const
+    {
+        // Compare feerate with ancestors to feerate of the transaction, and
+        // return the fee/size for the min.
+        double f1 = (double)a.GetModifiedFee() * a.GetSizeWithAncestors();
+        double f2 = (double)a.GetModFeesWithAncestors() * a.GetTxSize();
+
+        if (f1 > f2) {
+            mod_fee = a.GetModFeesWithAncestors();
+            size = a.GetSizeWithAncestors();
+        } else {
+            mod_fee = a.GetModifiedFee();
+            size = a.GetTxSize();
+        }
+    }
+};
+
+// Multi_index tag names
+struct descendant_score {};
+struct entry_time {};
+struct ancestor_score {};
+struct index_by_wtxid {};
+
+typedef boost::multi_index_container<
+    CTxMemPoolEntry,
+    boost::multi_index::indexed_by<
+        // sorted by txid
+        boost::multi_index::hashed_unique<mempoolentry_txid, SaltedTxidHasher>,
+        // sorted by wtxid
+        boost::multi_index::hashed_unique<
+            boost::multi_index::tag<index_by_wtxid>,
+            mempoolentry_wtxid,
+            SaltedTxidHasher
+        >,
+        // sorted by fee rate
+        boost::multi_index::ordered_non_unique<
+            boost::multi_index::tag<descendant_score>,
+            boost::multi_index::identity<CTxMemPoolEntry>,
+            CompareTxMemPoolEntryByDescendantScore
+        >,
+        // sorted by entry time
+        boost::multi_index::ordered_non_unique<
+            boost::multi_index::tag<entry_time>,
+            boost::multi_index::identity<CTxMemPoolEntry>,
+            CompareTxMemPoolEntryByEntryTime
+        >,
+        // sorted by fee rate with ancestors
+        boost::multi_index::ordered_non_unique<
+            boost::multi_index::tag<ancestor_score>,
+            boost::multi_index::identity<CTxMemPoolEntry>,
+            CompareTxMemPoolEntryByAncestorFee
+        >
+    >
+> indexed_transaction_set;
+
+typedef indexed_transaction_set::nth_index<0>::type::const_iterator txiter;
+
+typedef indexed_transaction_set::const_iterator const_txiter;
+
+} // namespace MemPoolMultiIndex
+
+#endif // BITCOIN_MEMPOOL_SET_DEFINITIONS_H

--- a/src/mempool_set_definitions.h
+++ b/src/mempool_set_definitions.h
@@ -221,8 +221,6 @@ struct txiter {
         : impl(inner_impl) {}
 };
 
-typedef std::set<raw_txiter, CompareIteratorByHash> setEntries;
-
 typedef indexed_transaction_set::const_iterator const_txiter;
 
 } // namespace MemPoolMultiIndex

--- a/src/mempool_set_definitions.h
+++ b/src/mempool_set_definitions.h
@@ -208,6 +208,10 @@ typedef boost::multi_index_container<
     >
 > indexed_transaction_set;
 
+struct MapTxImpl {
+    indexed_transaction_set impl;
+};
+
 typedef indexed_transaction_set::nth_index<0>::type::const_iterator raw_txiter;
 
 struct txiter {

--- a/src/mempool_set_definitions.h
+++ b/src/mempool_set_definitions.h
@@ -9,6 +9,8 @@
 #include <uint256.h>
 #include <util/hasher.h>
 
+#include <set>
+
 #include <boost/multi_index/hashed_index.hpp>
 #include <boost/multi_index/identity.hpp>
 #include <boost/multi_index/indexed_by.hpp>
@@ -206,7 +208,16 @@ typedef boost::multi_index_container<
     >
 > indexed_transaction_set;
 
-typedef indexed_transaction_set::nth_index<0>::type::const_iterator txiter;
+typedef indexed_transaction_set::nth_index<0>::type::const_iterator raw_txiter;
+
+struct txiter {
+    raw_txiter impl;
+
+    txiter(const raw_txiter& inner_impl)
+        : impl(inner_impl) {}
+};
+
+typedef std::set<raw_txiter, CompareIteratorByHash> setEntries;
 
 typedef indexed_transaction_set::const_iterator const_txiter;
 

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -35,11 +35,12 @@
 
 using MemPoolMultiIndex::ancestor_score;
 using MemPoolMultiIndex::CompareTxMemPoolEntryByAncestorFee;
+using MemPoolMultiIndex::raw_txiter;
 
 // Container for tracking updates to ancestor feerate as we include (parent)
 // transactions in a block
 struct CTxMemPoolModifiedEntry {
-    explicit CTxMemPoolModifiedEntry(CTxMemPool::txiter entry)
+    explicit CTxMemPoolModifiedEntry(raw_txiter entry)
     {
         iter = entry;
         nSizeWithAncestors = entry->GetSizeWithAncestors();
@@ -53,26 +54,26 @@ struct CTxMemPoolModifiedEntry {
     size_t GetTxSize() const { return iter->GetTxSize(); }
     const CTransaction& GetTx() const { return iter->GetTx(); }
 
-    CTxMemPool::txiter iter;
+    raw_txiter iter;
     uint64_t nSizeWithAncestors;
     CAmount nModFeesWithAncestors;
     int64_t nSigOpCostWithAncestors;
 };
 
-/** Comparator for CTxMemPool::txiter objects.
+/** Comparator for MemPoolMultiIndex::txiter objects.
  *  It simply compares the internal memory address of the CTxMemPoolEntry object
  *  pointed to. This means it has no meaning, and is only useful for using them
  *  as key in other indexes.
  */
 struct CompareCTxMemPoolIter {
-    bool operator()(const CTxMemPool::txiter& a, const CTxMemPool::txiter& b) const
+    bool operator()(const raw_txiter& a, const raw_txiter& b) const
     {
         return &(*a) < &(*b);
     }
 };
 
 struct modifiedentry_iter {
-    typedef CTxMemPool::txiter result_type;
+    typedef raw_txiter result_type;
     result_type operator() (const CTxMemPoolModifiedEntry &entry) const
     {
         return entry.iter;
@@ -83,7 +84,7 @@ struct modifiedentry_iter {
 // This is sufficient to sort an ancestor package in an order that is valid
 // to appear in a block.
 struct CompareTxIterByAncestorCount {
-    bool operator()(const CTxMemPool::txiter& a, const CTxMemPool::txiter& b) const
+    bool operator()(const raw_txiter& a, const raw_txiter& b) const
     {
         if (a->GetCountWithAncestors() != b->GetCountWithAncestors()) {
             return a->GetCountWithAncestors() < b->GetCountWithAncestors();
@@ -107,7 +108,7 @@ struct CompareMemPoolEntryByAncestorCount {
 
 struct update_for_parent_inclusion
 {
-    explicit update_for_parent_inclusion(CTxMemPool::txiter it) : iter(it) {}
+    explicit update_for_parent_inclusion(raw_txiter it) : iter(it) {}
 
     void operator() (CTxMemPoolModifiedEntry &e)
     {
@@ -116,7 +117,7 @@ struct update_for_parent_inclusion
         e.nSigOpCostWithAncestors -= iter->GetSigOpCost();
     }
 
-    CTxMemPool::txiter iter;
+    raw_txiter iter;
 };
 
 typedef boost::multi_index_container<
@@ -414,7 +415,7 @@ void BlockAssembler::addPackageTxs(const CTxMemPool& mempool, int& nPackagesSele
     std::set<Txid> failedTx;
 
     CTxMemPool::indexed_transaction_set::index<ancestor_score>::type::iterator mi = mempool.mapTx.get<ancestor_score>().begin();
-    CTxMemPool::txiter iter;
+    raw_txiter iter;
 
     // Limit the number of attempts to add transactions to the block when it is
     // close to full; this is just a simple heuristic to finish quickly if the

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -27,6 +27,9 @@
 #include <algorithm>
 #include <utility>
 
+using MemPoolMultiIndex::ancestor_score;
+using MemPoolMultiIndex::CompareTxMemPoolEntryByAncestorFee;
+
 namespace node {
 int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev)
 {

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -16,6 +16,7 @@
 #include <consensus/validation.h>
 #include <deploymentstatus.h>
 #include <logging.h>
+#include <mempool_set_definitions.h>
 #include <policy/feerate.h>
 #include <policy/policy.h>
 #include <pow.h>
@@ -35,6 +36,7 @@
 
 using MemPoolMultiIndex::ancestor_score;
 using MemPoolMultiIndex::CompareTxMemPoolEntryByAncestorFee;
+using MemPoolMultiIndex::indexed_transaction_set;
 using MemPoolMultiIndex::raw_txiter;
 
 // Container for tracking updates to ancestor feerate as we include (parent)
@@ -414,7 +416,7 @@ void BlockAssembler::addPackageTxs(const CTxMemPool& mempool, int& nPackagesSele
     // Keep track of entries that failed inclusion, to avoid duplicate work
     std::set<Txid> failedTx;
 
-    CTxMemPool::indexed_transaction_set::index<ancestor_score>::type::iterator mi = mempool.mapTx->impl.get<ancestor_score>().begin();
+    indexed_transaction_set::index<ancestor_score>::type::iterator mi = mempool.mapTx->impl.get<ancestor_score>().begin();
     raw_txiter iter;
 
     // Limit the number of attempts to add transactions to the block when it is

--- a/src/node/miner.h
+++ b/src/node/miner.h
@@ -106,15 +106,15 @@ typedef boost::multi_index_container<
         // sorted by modified ancestor fee rate
         boost::multi_index::ordered_non_unique<
             // Reuse same tag from CTxMemPool's similar index
-            boost::multi_index::tag<ancestor_score>,
+            boost::multi_index::tag<MemPoolMultiIndex::ancestor_score>,
             boost::multi_index::identity<CTxMemPoolModifiedEntry>,
-            CompareTxMemPoolEntryByAncestorFee
+            MemPoolMultiIndex::CompareTxMemPoolEntryByAncestorFee
         >
     >
 > indexed_modified_transaction_set;
 
 typedef indexed_modified_transaction_set::nth_index<0>::type::iterator modtxiter;
-typedef indexed_modified_transaction_set::index<ancestor_score>::type::iterator modtxscoreiter;
+typedef indexed_modified_transaction_set::index<MemPoolMultiIndex::ancestor_score>::type::iterator modtxscoreiter;
 
 struct update_for_parent_inclusion
 {

--- a/src/node/miner.h
+++ b/src/node/miner.h
@@ -14,12 +14,6 @@
 #include <optional>
 #include <stdint.h>
 
-#include <boost/multi_index/identity.hpp>
-#include <boost/multi_index/indexed_by.hpp>
-#include <boost/multi_index/ordered_index.hpp>
-#include <boost/multi_index/tag.hpp>
-#include <boost/multi_index_container.hpp>
-
 class ArgsManager;
 class CBlockIndex;
 class CChainParams;
@@ -38,96 +32,6 @@ struct CBlockTemplate
     std::vector<CAmount> vTxFees;
     std::vector<int64_t> vTxSigOpsCost;
     std::vector<unsigned char> vchCoinbaseCommitment;
-};
-
-// Container for tracking updates to ancestor feerate as we include (parent)
-// transactions in a block
-struct CTxMemPoolModifiedEntry {
-    explicit CTxMemPoolModifiedEntry(CTxMemPool::txiter entry)
-    {
-        iter = entry;
-        nSizeWithAncestors = entry->GetSizeWithAncestors();
-        nModFeesWithAncestors = entry->GetModFeesWithAncestors();
-        nSigOpCostWithAncestors = entry->GetSigOpCostWithAncestors();
-    }
-
-    CAmount GetModifiedFee() const { return iter->GetModifiedFee(); }
-    uint64_t GetSizeWithAncestors() const { return nSizeWithAncestors; }
-    CAmount GetModFeesWithAncestors() const { return nModFeesWithAncestors; }
-    size_t GetTxSize() const { return iter->GetTxSize(); }
-    const CTransaction& GetTx() const { return iter->GetTx(); }
-
-    CTxMemPool::txiter iter;
-    uint64_t nSizeWithAncestors;
-    CAmount nModFeesWithAncestors;
-    int64_t nSigOpCostWithAncestors;
-};
-
-/** Comparator for CTxMemPool::txiter objects.
- *  It simply compares the internal memory address of the CTxMemPoolEntry object
- *  pointed to. This means it has no meaning, and is only useful for using them
- *  as key in other indexes.
- */
-struct CompareCTxMemPoolIter {
-    bool operator()(const CTxMemPool::txiter& a, const CTxMemPool::txiter& b) const
-    {
-        return &(*a) < &(*b);
-    }
-};
-
-struct modifiedentry_iter {
-    typedef CTxMemPool::txiter result_type;
-    result_type operator() (const CTxMemPoolModifiedEntry &entry) const
-    {
-        return entry.iter;
-    }
-};
-
-// A comparator that sorts transactions based on number of ancestors.
-// This is sufficient to sort an ancestor package in an order that is valid
-// to appear in a block.
-struct CompareMemPoolEntryByAncestorCount {
-    bool operator()(const CTxMemPoolEntry& a, const CTxMemPoolEntry& b) const
-    {
-        if (a.GetCountWithAncestors() != b.GetCountWithAncestors()) {
-            return a.GetCountWithAncestors() < b.GetCountWithAncestors();
-        }
-        return a.GetTx().GetHash() < b.GetTx().GetHash();
-    }
-};
-
-typedef boost::multi_index_container<
-    CTxMemPoolModifiedEntry,
-    boost::multi_index::indexed_by<
-        boost::multi_index::ordered_unique<
-            modifiedentry_iter,
-            CompareCTxMemPoolIter
-        >,
-        // sorted by modified ancestor fee rate
-        boost::multi_index::ordered_non_unique<
-            // Reuse same tag from CTxMemPool's similar index
-            boost::multi_index::tag<MemPoolMultiIndex::ancestor_score>,
-            boost::multi_index::identity<CTxMemPoolModifiedEntry>,
-            MemPoolMultiIndex::CompareTxMemPoolEntryByAncestorFee
-        >
-    >
-> indexed_modified_transaction_set;
-
-typedef indexed_modified_transaction_set::nth_index<0>::type::iterator modtxiter;
-typedef indexed_modified_transaction_set::index<MemPoolMultiIndex::ancestor_score>::type::iterator modtxscoreiter;
-
-struct update_for_parent_inclusion
-{
-    explicit update_for_parent_inclusion(CTxMemPool::txiter it) : iter(it) {}
-
-    void operator() (CTxMemPoolModifiedEntry &e)
-    {
-        e.nModFeesWithAncestors -= iter->GetModifiedFee();
-        e.nSizeWithAncestors -= iter->GetTxSize();
-        e.nSigOpCostWithAncestors -= iter->GetSigOpCost();
-    }
-
-    CTxMemPool::txiter iter;
 };
 
 /** Generate a new block, without valid proof-of-work */

--- a/src/node/miner.h
+++ b/src/node/miner.h
@@ -86,13 +86,13 @@ struct modifiedentry_iter {
 // A comparator that sorts transactions based on number of ancestors.
 // This is sufficient to sort an ancestor package in an order that is valid
 // to appear in a block.
-struct CompareTxIterByAncestorCount {
-    bool operator()(const CTxMemPool::txiter& a, const CTxMemPool::txiter& b) const
+struct CompareMemPoolEntryByAncestorCount {
+    bool operator()(const CTxMemPoolEntry& a, const CTxMemPoolEntry& b) const
     {
-        if (a->GetCountWithAncestors() != b->GetCountWithAncestors()) {
-            return a->GetCountWithAncestors() < b->GetCountWithAncestors();
+        if (a.GetCountWithAncestors() != b.GetCountWithAncestors()) {
+            return a.GetCountWithAncestors() < b.GetCountWithAncestors();
         }
-        return CompareIteratorByHash()(a, b);
+        return a.GetTx().GetHash() < b.GetTx().GetHash();
     }
 };
 
@@ -177,7 +177,7 @@ private:
     /** Clear the block's state and prepare for assembling a new block */
     void resetBlock();
     /** Add a tx to the block */
-    void AddToBlock(CTxMemPool::txiter iter);
+    void AddToBlock(const CTxMemPoolEntry& entry);
 
     // Methods for how to add transactions to a block.
     /** Add transactions based on feerate including unconfirmed ancestors
@@ -187,16 +187,16 @@ private:
 
     // helper functions for addPackageTxs()
     /** Remove confirmed (inBlock) entries from given set */
-    void onlyUnconfirmed(CTxMemPool::setEntries& testSet);
+    void onlyUnconfirmed(CTxMemPool::setEntryRefs& testSet);
     /** Test if a new package would "fit" in the block */
     bool TestPackage(uint64_t packageSize, int64_t packageSigOpsCost) const;
     /** Perform checks on each transaction in a package:
       * locktime, premature-witness, serialized size (if necessary)
       * These checks should always succeed, and they're here
       * only as an extra check in case of suboptimal node configuration */
-    bool TestPackageTransactions(const CTxMemPool::setEntries& package) const;
+    bool TestPackageTransactions(const CTxMemPool::setEntryRefs& package) const;
     /** Sort the package in an order that is valid to appear in a block */
-    void SortForBlock(const CTxMemPool::setEntries& package, std::vector<CTxMemPool::txiter>& sortedEntries);
+    void SortForBlock(const CTxMemPool::setEntryRefs& package, std::vector<CTxMemPoolEntryRef>& sortedEntries);
 };
 
 int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev);

--- a/src/policy/rbf.h
+++ b/src/policy/rbf.h
@@ -47,27 +47,27 @@ enum class RBFTransactionState {
 RBFTransactionState IsRBFOptIn(const CTransaction& tx, const CTxMemPool& pool) EXCLUSIVE_LOCKS_REQUIRED(pool.cs);
 RBFTransactionState IsRBFOptInEmptyMempool(const CTransaction& tx);
 
-/** Get all descendants of iters_conflicting. Checks that there are no more than
+/** Get all descendants of entries_conflicting. Checks that there are no more than
  * MAX_REPLACEMENT_CANDIDATES potential entries. May overestimate if the entries in
- * iters_conflicting have overlapping descendants.
- * @param[in]   iters_conflicting   The set of iterators to mempool entries.
+ * entries_conflicting have overlapping descendants.
+ * @param[in]   entries_conflicting   The set of iterators to mempool entries.
  * @param[out]  all_conflicts       Populated with all the mempool entries that would be replaced,
- *                                  which includes iters_conflicting and all entries' descendants.
+ *                                  which includes entries_conflicting and all entries' descendants.
  *                                  Not cleared at the start; any existing mempool entries will
  *                                  remain in the set.
  * @returns an error message if MAX_REPLACEMENT_CANDIDATES may be exceeded, otherwise a std::nullopt.
  */
 std::optional<std::string> GetEntriesForConflicts(const CTransaction& tx, CTxMemPool& pool,
-                                                  const CTxMemPool::setEntries& iters_conflicting,
-                                                  CTxMemPool::setEntries& all_conflicts)
+                                                  const CTxMemPool::setEntryRefs& entries_conflicting,
+                                                  CTxMemPool::setEntryRefs& all_conflicts)
     EXCLUSIVE_LOCKS_REQUIRED(pool.cs);
 
 /** The replacement transaction may only include an unconfirmed input if that input was included in
  * one of the original transactions.
- * @returns error message if tx spends unconfirmed inputs not also spent by iters_conflicting,
+ * @returns error message if tx spends unconfirmed inputs not also spent by entries_conflicting,
  * otherwise std::nullopt. */
 std::optional<std::string> HasNoNewUnconfirmed(const CTransaction& tx, const CTxMemPool& pool,
-                                               const CTxMemPool::setEntries& iters_conflicting)
+                                               const CTxMemPool::setEntryRefs& entries_conflicting)
     EXCLUSIVE_LOCKS_REQUIRED(pool.cs);
 
 /** Check the intersection between two sets of transactions (a set of mempool entries and a set of
@@ -79,16 +79,16 @@ std::optional<std::string> HasNoNewUnconfirmed(const CTransaction& tx, const CTx
  * @param[in]   txid                Transaction ID, included in the error message if violation occurs.
  * @returns error message if the sets intersect, std::nullopt if they are disjoint.
  */
-std::optional<std::string> EntriesAndTxidsDisjoint(const CTxMemPool::setEntries& ancestors,
+std::optional<std::string> EntriesAndTxidsDisjoint(const CTxMemPool::setEntryRefs& ancestors,
                                                    const std::set<uint256>& direct_conflicts,
                                                    const uint256& txid);
 
 /** Check that the feerate of the replacement transaction(s) is higher than the feerate of each
- * of the transactions in iters_conflicting.
- * @param[in]   iters_conflicting  The set of mempool entries.
+ * of the transactions in entries_conflicting.
+ * @param[in]   entries_conflicting  The set of mempool entries.
  * @returns error message if fees insufficient, otherwise std::nullopt.
  */
-std::optional<std::string> PaysMoreThanConflicts(const CTxMemPool::setEntries& iters_conflicting,
+std::optional<std::string> PaysMoreThanConflicts(const CTxMemPool::setEntryRefs& entries_conflicting,
                                                  CFeeRate replacement_feerate, const uint256& txid);
 
 /** The replacement transaction must pay more fees than the original transactions. The additional

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <common/system.h>
+#include <mempool_set_definitions.h>
 #include <policy/policy.h>
 #include <test/util/txmempool.h>
 #include <txmempool.h>
@@ -15,6 +16,7 @@
 
 using MemPoolMultiIndex::ancestor_score;
 using MemPoolMultiIndex::descendant_score;
+using MemPoolMultiIndex::indexed_transaction_set;
 
 BOOST_FIXTURE_TEST_SUITE(mempool_tests, TestingSetup)
 
@@ -122,7 +124,7 @@ template <typename name>
 static void CheckSort(CTxMemPool& pool, std::vector<std::string>& sortedOrder) EXCLUSIVE_LOCKS_REQUIRED(pool.cs)
 {
     BOOST_CHECK_EQUAL(pool.size(), sortedOrder.size());
-    typename CTxMemPool::indexed_transaction_set::index<name>::type::iterator it = pool.mapTx->impl.get<name>().begin();
+    typename indexed_transaction_set::index<name>::type::iterator it = pool.mapTx->impl.get<name>().begin();
     int count = 0;
     for (; it != pool.mapTx->impl.get<name>().end(); ++it, ++count) {
         BOOST_CHECK_EQUAL(it->GetTx().GetHash().ToString(), sortedOrder[count]);

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -122,9 +122,9 @@ template <typename name>
 static void CheckSort(CTxMemPool& pool, std::vector<std::string>& sortedOrder) EXCLUSIVE_LOCKS_REQUIRED(pool.cs)
 {
     BOOST_CHECK_EQUAL(pool.size(), sortedOrder.size());
-    typename CTxMemPool::indexed_transaction_set::index<name>::type::iterator it = pool.mapTx.get<name>().begin();
+    typename CTxMemPool::indexed_transaction_set::index<name>::type::iterator it = pool.mapTx->impl.get<name>().begin();
     int count = 0;
-    for (; it != pool.mapTx.get<name>().end(); ++it, ++count) {
+    for (; it != pool.mapTx->impl.get<name>().end(); ++it, ++count) {
         BOOST_CHECK_EQUAL(it->GetTx().GetHash().ToString(), sortedOrder[count]);
     }
 }

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -13,6 +13,9 @@
 #include <boost/test/unit_test.hpp>
 #include <vector>
 
+using MemPoolMultiIndex::ancestor_score;
+using MemPoolMultiIndex::descendant_score;
+
 BOOST_FIXTURE_TEST_SUITE(mempool_tests, TestingSetup)
 
 static constexpr auto REMOVAL_REASON_DUMMY = MemPoolRemovalReason::REPLACED;

--- a/src/test/miniminer_tests.cpp
+++ b/src/test/miniminer_tests.cpp
@@ -609,9 +609,9 @@ BOOST_FIXTURE_TEST_CASE(calculate_cluster, TestChain100Setup)
         lasttx = tx;
     }
     const auto cluster_500tx = pool.GatherClusters({lasttx->GetHash()});
-    CTxMemPool::setEntries cluster_500tx_set{cluster_500tx.begin(), cluster_500tx.end()};
+    CTxMemPool::setEntryRefs cluster_500tx_set{cluster_500tx.begin(), cluster_500tx.end()};
     BOOST_CHECK_EQUAL(cluster_500tx.size(), cluster_500tx_set.size());
-    const auto vec_iters_500 = pool.GetIterVec(convert_to_uint256_vec(chain_txids));
+    const auto vec_iters_500 = pool.GetEntryVec(convert_to_uint256_vec(chain_txids));
     for (const auto& iter : vec_iters_500) BOOST_CHECK(cluster_500tx_set.count(iter));
 
     // GatherClusters stops at 500 transactions.
@@ -637,13 +637,13 @@ BOOST_FIXTURE_TEST_CASE(calculate_cluster, TestChain100Setup)
         pool.addUnchecked(entry.Fee(CENT).FromTx(txc));
         zigzag_txids.push_back(txc->GetHash());
     }
-    const auto vec_iters_zigzag = pool.GetIterVec(convert_to_uint256_vec(zigzag_txids));
+    const auto vec_iters_zigzag = pool.GetEntryVec(convert_to_uint256_vec(zigzag_txids));
     // It doesn't matter which tx we calculate cluster for, everybody is in it.
     const std::vector<size_t> indices{0, 22, 72, zigzag_txids.size() - 1};
     for (const auto index : indices) {
         const auto cluster = pool.GatherClusters({zigzag_txids[index]});
         BOOST_CHECK_EQUAL(cluster.size(), zigzag_txids.size());
-        CTxMemPool::setEntries clusterset{cluster.begin(), cluster.end()};
+        CTxMemPool::setEntryRefs clusterset{cluster.begin(), cluster.end()};
         BOOST_CHECK_EQUAL(cluster.size(), clusterset.size());
         for (const auto& iter : vec_iters_zigzag) BOOST_CHECK(clusterset.count(iter));
     }

--- a/src/test/miniminer_tests.cpp
+++ b/src/test/miniminer_tests.cpp
@@ -617,7 +617,7 @@ BOOST_FIXTURE_TEST_CASE(calculate_cluster, TestChain100Setup)
     // GatherClusters stops at 500 transactions.
     const auto tx_501 = make_tx({COutPoint{lasttx->GetHash(), 0}}, /*num_outputs=*/1);
     pool.addUnchecked(entry.Fee(CENT).FromTx(tx_501));
-    const auto cluster_501 = pool.GatherClusters({tx_501->GetHash()});
+    const auto cluster_501{pool.GatherClusters({tx_501->GetHash()})};
     BOOST_CHECK_EQUAL(cluster_501.size(), 0);
 
     /* Zig Zag cluster:

--- a/src/test/util/txmempool.h
+++ b/src/test/util/txmempool.h
@@ -38,6 +38,14 @@ struct TestMemPoolEntryHelper {
     TestMemPoolEntryHelper& SigOpsCost(unsigned int _sigopsCost) { sigOpCost = _sigopsCost; return *this; }
 };
 
+// Comparator for allowing direct comparison of CTxMemPoolEntryRef
+struct CompareEntryByHash {
+    bool operator()(const CTxMemPoolEntryRef& a, const CTxMemPoolEntryRef& b) const
+    {
+        return a.get().GetTx().GetHash() == b.get().GetTx().GetHash();
+    }
+};
+
 /** Check expected properties for every PackageMempoolAcceptResult, regardless of value. Returns
  * a string if an error occurs with error populated, nullopt otherwise. If mempool is provided,
  * checks that the expected transactions are in mempool (this should be set to nullptr for a test_accept).

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -60,12 +60,12 @@ void CTxMemPool::UpdateForDescendants(txiter updateIt, cacheMap& cachedDescendan
         stageEntries.erase(descendant);
         const CTxMemPoolEntry::Children& children = descendant.GetMemPoolChildrenConst();
         for (const CTxMemPoolEntry& childEntry : children) {
-            cacheMap::iterator cacheIt = cachedDescendants.find(mapTx.iterator_to(childEntry));
+            cacheMap::iterator cacheIt = cachedDescendants.find(childEntry);
             if (cacheIt != cachedDescendants.end()) {
                 // We've already calculated this one, just add the entries for this set
                 // but don't traverse again.
-                for (txiter cacheEntry : cacheIt->second) {
-                    descendants.insert(*cacheEntry);
+                for (const CTxMemPoolEntry& cacheEntry : cacheIt->second) {
+                    descendants.insert(cacheEntry);
                 }
             } else if (!descendants.count(childEntry)) {
                 // Schedule for later processing
@@ -83,7 +83,7 @@ void CTxMemPool::UpdateForDescendants(txiter updateIt, cacheMap& cachedDescendan
             modifySize += descendant.GetTxSize();
             modifyFee += descendant.GetModifiedFee();
             modifyCount++;
-            cachedDescendants[updateIt].insert(mapTx.iterator_to(descendant));
+            cachedDescendants[*updateIt].insert(descendant);
             // Update ancestor state for each descendant
             mapTx.modify(mapTx.iterator_to(descendant), [=](CTxMemPoolEntry& e) {
               e.UpdateAncestorState(updateIt->GetTxSize(), updateIt->GetModifiedFee(), 1, updateIt->GetSigOpCost());
@@ -136,9 +136,9 @@ void CTxMemPool::UpdateTransactionsFromBlock(const std::vector<uint256>& vHashes
                 assert(childIter != mapTx.end());
                 // We can skip updating entries we've encountered before or that
                 // are in the block (which are already accounted for).
-                if (!visited(childIter) && !setAlreadyIncluded.count(childHash)) {
-                    UpdateChild(it, childIter, true);
-                    UpdateParent(childIter, it, true);
+                if (!visited(*childIter) && !setAlreadyIncluded.count(childHash)) {
+                    UpdateChild(*it, *childIter, true);
+                    UpdateParent(*childIter, *it, true);
                 }
             }
         } // release epoch guard for UpdateForDescendants
@@ -154,37 +154,34 @@ void CTxMemPool::UpdateTransactionsFromBlock(const std::vector<uint256>& vHashes
     }
 }
 
-util::Result<CTxMemPool::setEntries> CTxMemPool::CalculateAncestorsAndCheckLimits(
+util::Result<CTxMemPool::setEntryRefs> CTxMemPool::CalculateAncestorsAndCheckLimits(
     int64_t entry_size,
     size_t entry_count,
     CTxMemPoolEntry::Parents& staged_ancestors,
     const Limits& limits) const
 {
     int64_t totalSizeWithAncestors = entry_size;
-    setEntries ancestors;
+    setEntryRefs ancestors;
 
     while (!staged_ancestors.empty()) {
         const CTxMemPoolEntry& stage = staged_ancestors.begin()->get();
-        txiter stageit = mapTx.iterator_to(stage);
 
-        ancestors.insert(stageit);
+        ancestors.insert(stage);
         staged_ancestors.erase(stage);
-        totalSizeWithAncestors += stageit->GetTxSize();
+        totalSizeWithAncestors += stage.GetTxSize();
 
-        if (stageit->GetSizeWithDescendants() + entry_size > limits.descendant_size_vbytes) {
-            return util::Error{Untranslated(strprintf("exceeds descendant size limit for tx %s [limit: %u]", stageit->GetTx().GetHash().ToString(), limits.descendant_size_vbytes))};
-        } else if (stageit->GetCountWithDescendants() + entry_count > static_cast<uint64_t>(limits.descendant_count)) {
-            return util::Error{Untranslated(strprintf("too many descendants for tx %s [limit: %u]", stageit->GetTx().GetHash().ToString(), limits.descendant_count))};
+        if (stage.GetSizeWithDescendants() + entry_size > limits.descendant_size_vbytes) {
+            return util::Error{Untranslated(strprintf("exceeds descendant size limit for tx %s [limit: %u]", stage.GetTx().GetHash().ToString(), limits.descendant_size_vbytes))};
+        } else if (stage.GetCountWithDescendants() + entry_count > static_cast<uint64_t>(limits.descendant_count)) {
+            return util::Error{Untranslated(strprintf("too many descendants for tx %s [limit: %u]", stage.GetTx().GetHash().ToString(), limits.descendant_count))};
         } else if (totalSizeWithAncestors > limits.ancestor_size_vbytes) {
             return util::Error{Untranslated(strprintf("exceeds ancestor size limit [limit: %u]", limits.ancestor_size_vbytes))};
         }
 
-        const CTxMemPoolEntry::Parents& parents = stageit->GetMemPoolParentsConst();
+        const CTxMemPoolEntry::Parents& parents = stage.GetMemPoolParentsConst();
         for (const CTxMemPoolEntry& parent : parents) {
-            txiter parent_it = mapTx.iterator_to(parent);
-
             // If this is a new ancestor, add it.
-            if (ancestors.count(parent_it) == 0) {
+            if (ancestors.count(parent) == 0) {
                 staged_ancestors.insert(parent);
             }
             if (staged_ancestors.size() + ancestors.size() + entry_count > static_cast<uint64_t>(limits.ancestor_count)) {
@@ -240,8 +237,8 @@ bool CTxMemPool::CheckPackageLimits(const Package& package,
     return ancestors.has_value();
 }
 
-util::Result<CTxMemPool::setEntries> CTxMemPool::CalculateMemPoolAncestors(
-    const CTxMemPoolEntry &entry,
+util::Result<CTxMemPool::setEntryRefs> CTxMemPool::CalculateMemPoolAncestors(
+    const CTxMemPoolEntry& entry,
     const Limits& limits,
     bool fSearchForParents /* = true */) const
 {
@@ -264,17 +261,16 @@ util::Result<CTxMemPool::setEntries> CTxMemPool::CalculateMemPoolAncestors(
     } else {
         // If we're not searching for parents, we require this to already be an
         // entry in the mempool and use the entry's cached parents.
-        txiter it = mapTx.iterator_to(entry);
-        staged_ancestors = it->GetMemPoolParentsConst();
+        staged_ancestors = entry.GetMemPoolParentsConst();
     }
 
     return CalculateAncestorsAndCheckLimits(entry.GetTxSize(), /*entry_count=*/1, staged_ancestors,
                                             limits);
 }
 
-CTxMemPool::setEntries CTxMemPool::AssumeCalculateMemPoolAncestors(
+CTxMemPool::setEntryRefs CTxMemPool::AssumeCalculateMemPoolAncestors(
     std::string_view calling_fn_name,
-    const CTxMemPoolEntry &entry,
+    const CTxMemPoolEntry& entry,
     const Limits& limits,
     bool fSearchForParents /* = true */) const
 {
@@ -283,47 +279,47 @@ CTxMemPool::setEntries CTxMemPool::AssumeCalculateMemPoolAncestors(
         LogPrintLevel(BCLog::MEMPOOL, BCLog::Level::Error, "%s: CalculateMemPoolAncestors failed unexpectedly, continuing with empty ancestor set (%s)\n",
                       calling_fn_name, util::ErrorString(result).original);
     }
-    return std::move(result).value_or(CTxMemPool::setEntries{});
+    return std::move(result).value_or(CTxMemPool::setEntryRefs{});
 }
 
-void CTxMemPool::UpdateAncestorsOf(bool add, txiter it, setEntries &setAncestors)
+void CTxMemPool::UpdateAncestorsOf(bool add, const CTxMemPoolEntry& entry, setEntryRefs& setAncestors)
 {
-    const CTxMemPoolEntry::Parents& parents = it->GetMemPoolParentsConst();
+    const CTxMemPoolEntry::Parents& parents = entry.GetMemPoolParentsConst();
     // add or remove this tx as a child of each parent
     for (const CTxMemPoolEntry& parent : parents) {
-        UpdateChild(mapTx.iterator_to(parent), it, add);
+        UpdateChild(parent, entry, add);
     }
     const int32_t updateCount = (add ? 1 : -1);
-    const int32_t updateSize{updateCount * it->GetTxSize()};
-    const CAmount updateFee = updateCount * it->GetModifiedFee();
-    for (txiter ancestorIt : setAncestors) {
-        mapTx.modify(ancestorIt, [=](CTxMemPoolEntry& e) { e.UpdateDescendantState(updateSize, updateFee, updateCount); });
+    const int32_t updateSize{updateCount * entry.GetTxSize()};
+    const CAmount updateFee = updateCount * entry.GetModifiedFee();
+    for (const CTxMemPoolEntry& ancestor : setAncestors) {
+        mapTx.modify(mapTx.iterator_to(ancestor), [=](CTxMemPoolEntry& e) { e.UpdateDescendantState(updateSize, updateFee, updateCount); });
     }
 }
 
-void CTxMemPool::UpdateEntryForAncestors(txiter it, const setEntries &setAncestors)
+void CTxMemPool::UpdateEntryForAncestors(txiter it, const setEntryRefs& setAncestors)
 {
     int64_t updateCount = setAncestors.size();
     int64_t updateSize = 0;
     CAmount updateFee = 0;
     int64_t updateSigOpsCost = 0;
-    for (txiter ancestorIt : setAncestors) {
-        updateSize += ancestorIt->GetTxSize();
-        updateFee += ancestorIt->GetModifiedFee();
-        updateSigOpsCost += ancestorIt->GetSigOpCost();
+    for (const CTxMemPoolEntry& ancestor : setAncestors) {
+        updateSize += ancestor.GetTxSize();
+        updateFee += ancestor.GetModifiedFee();
+        updateSigOpsCost += ancestor.GetSigOpCost();
     }
     mapTx.modify(it, [=](CTxMemPoolEntry& e){ e.UpdateAncestorState(updateSize, updateFee, updateCount, updateSigOpsCost); });
 }
 
-void CTxMemPool::UpdateChildrenForRemoval(txiter it)
+void CTxMemPool::UpdateChildrenForRemoval(const CTxMemPoolEntry& entry)
 {
-    const CTxMemPoolEntry::Children& children = it->GetMemPoolChildrenConst();
+    const CTxMemPoolEntry::Children& children = entry.GetMemPoolChildrenConst();
     for (const CTxMemPoolEntry& updateIt : children) {
-        UpdateParent(mapTx.iterator_to(updateIt), it, false);
+        UpdateParent(updateIt, entry, false);
     }
 }
 
-void CTxMemPool::UpdateForRemoveFromMempool(const setEntries &entriesToRemove, bool updateDescendants)
+void CTxMemPool::UpdateForRemoveFromMempool(const setEntryRefs& entriesToRemove, bool updateDescendants)
 {
     // For each entry, walk back all ancestors and decrement size associated with this
     // transaction
@@ -334,20 +330,19 @@ void CTxMemPool::UpdateForRemoveFromMempool(const setEntries &entriesToRemove, b
         // Here we only update statistics and not data in CTxMemPool::Parents
         // and CTxMemPoolEntry::Children (which we need to preserve until we're
         // finished with all operations that need to traverse the mempool).
-        for (txiter removeIt : entriesToRemove) {
-            setEntries setDescendants;
-            CalculateDescendants(removeIt, setDescendants);
-            setDescendants.erase(removeIt); // don't update state for self
-            int32_t modifySize = -removeIt->GetTxSize();
-            CAmount modifyFee = -removeIt->GetModifiedFee();
-            int modifySigOps = -removeIt->GetSigOpCost();
-            for (txiter dit : setDescendants) {
-                mapTx.modify(dit, [=](CTxMemPoolEntry& e){ e.UpdateAncestorState(modifySize, modifyFee, -1, modifySigOps); });
+        for (const CTxMemPoolEntry& remove : entriesToRemove) {
+            setEntryRefs setDescendants;
+            CalculateDescendants(remove, setDescendants);
+            setDescendants.erase(remove); // don't update state for self
+            int32_t modifySize = -remove.GetTxSize();
+            CAmount modifyFee = -remove.GetModifiedFee();
+            int modifySigOps = -remove.GetSigOpCost();
+            for (const CTxMemPoolEntry& descendant : setDescendants) {
+                mapTx.modify(mapTx.iterator_to(descendant), [=](CTxMemPoolEntry& e) { e.UpdateAncestorState(modifySize, modifyFee, -1, modifySigOps); });
             }
         }
     }
-    for (txiter removeIt : entriesToRemove) {
-        const CTxMemPoolEntry &entry = *removeIt;
+    for (const CTxMemPoolEntry& entry : entriesToRemove) {
         // Since this is a tx that is already in the mempool, we can call CMPA
         // with fSearchForParents = false.  If the mempool is in a consistent
         // state, then using true or false should both be correct, though false
@@ -370,13 +365,13 @@ void CTxMemPool::UpdateForRemoveFromMempool(const setEntries &entriesToRemove, b
         auto ancestors{AssumeCalculateMemPoolAncestors(__func__, entry, Limits::NoLimits(), /*fSearchForParents=*/false)};
         // Note that UpdateAncestorsOf severs the child links that point to
         // removeIt in the entries for the parents of removeIt.
-        UpdateAncestorsOf(false, removeIt, ancestors);
+        UpdateAncestorsOf(false, entry, ancestors);
     }
     // After updating all the ancestor sizes, we can now sever the link between each
     // transaction being removed and any mempool children (ie, update CTxMemPoolEntry::m_parents
     // for each direct child of a transaction being removed).
-    for (txiter removeIt : entriesToRemove) {
-        UpdateChildrenForRemoval(removeIt);
+    for (const auto& remove : entriesToRemove) {
+        UpdateChildrenForRemoval(remove);
     }
 }
 
@@ -433,7 +428,7 @@ void CTxMemPool::AddTransactionsUpdated(unsigned int n)
     nTransactionsUpdated += n;
 }
 
-void CTxMemPool::addUnchecked(const CTxMemPoolEntry &entry, setEntries &setAncestors, bool validFeeEstimate)
+void CTxMemPool::addUnchecked(const CTxMemPoolEntry& entry, setEntryRefs& setAncestors, bool validFeeEstimate)
 {
     // Add to memory pool without checking anything.
     // Used by AcceptToMemoryPool(), which DOES do
@@ -468,10 +463,10 @@ void CTxMemPool::addUnchecked(const CTxMemPoolEntry &entry, setEntries &setAnces
     // to clean up the mess we're leaving here.
 
     // Update ancestors with information about this tx
-    for (const auto& pit : GetIterSet(setParentTransactions)) {
-            UpdateParent(newit, pit, true);
+    for (const CTxMemPoolEntry& pentry : GetEntrySet(setParentTransactions)) {
+        UpdateParent(*newit, pentry, true);
     }
-    UpdateAncestorsOf(true, newit, setAncestors);
+    UpdateAncestorsOf(true, *newit, setAncestors);
     UpdateEntryForAncestors(newit, setAncestors);
 
     nTransactionsUpdated++;
@@ -544,25 +539,24 @@ void CTxMemPool::removeUnchecked(txiter it, MemPoolRemovalReason reason)
 // Also assumes that if an entry is in setDescendants already, then all
 // in-mempool descendants of it are already in setDescendants as well, so that we
 // can save time by not iterating over those entries.
-void CTxMemPool::CalculateDescendants(txiter entryit, setEntries& setDescendants) const
+void CTxMemPool::CalculateDescendants(const CTxMemPoolEntry& entry, setEntryRefs& setDescendants) const
 {
-    setEntries stage;
-    if (setDescendants.count(entryit) == 0) {
-        stage.insert(entryit);
+    setEntryRefs stage;
+    if (setDescendants.count(entry) == 0) {
+        stage.insert(entry);
     }
     // Traverse down the children of entry, only adding children that are not
     // accounted for in setDescendants already (because those children have either
     // already been walked, or will be walked in this iteration).
     while (!stage.empty()) {
-        txiter it = *stage.begin();
+        auto it = *stage.begin();
         setDescendants.insert(it);
         stage.erase(it);
 
-        const CTxMemPoolEntry::Children& children = it->GetMemPoolChildrenConst();
+        const CTxMemPoolEntry::Children& children = it.get().GetMemPoolChildrenConst();
         for (const CTxMemPoolEntry& child : children) {
-            txiter childiter = mapTx.iterator_to(child);
-            if (!setDescendants.count(childiter)) {
-                stage.insert(childiter);
+            if (!setDescendants.count(child)) {
+                stage.insert(child);
             }
         }
     }
@@ -590,15 +584,15 @@ void CTxMemPool::removeRecursive(const CTransaction &origTx, MemPoolRemovalReaso
                 txToRemove.insert(nextit);
             }
         }
-        setEntries setAllRemoves;
+        setEntryRefs setAllRemoves;
         for (txiter it : txToRemove) {
-            CalculateDescendants(it, setAllRemoves);
+            CalculateDescendants(*it, setAllRemoves);
         }
 
         RemoveStaged(setAllRemoves, false, reason);
 }
 
-void CTxMemPool::removeForReorg(CChain& chain, std::function<bool(txiter)> check_final_and_mature)
+void CTxMemPool::removeForReorg(CChain& chain, std::function<bool(const CTxMemPoolEntry&)> check_final_and_mature)
 {
     // Remove transactions spending a coinbase which are now immature and no-longer-final transactions
     AssertLockHeld(cs);
@@ -606,11 +600,11 @@ void CTxMemPool::removeForReorg(CChain& chain, std::function<bool(txiter)> check
 
     setEntries txToRemove;
     for (indexed_transaction_set::const_iterator it = mapTx.begin(); it != mapTx.end(); it++) {
-        if (check_final_and_mature(it)) txToRemove.insert(it);
+        if (check_final_and_mature(*it)) txToRemove.insert(it);
     }
-    setEntries setAllRemoves;
+    setEntryRefs setAllRemoves;
     for (txiter it : txToRemove) {
-        CalculateDescendants(it, setAllRemoves);
+        CalculateDescendants(*it, setAllRemoves);
     }
     RemoveStaged(setAllRemoves, false, MemPoolRemovalReason::REORG);
     for (indexed_transaction_set::const_iterator it = mapTx.begin(); it != mapTx.end(); it++) {
@@ -656,8 +650,8 @@ void CTxMemPool::removeForBlock(const std::vector<CTransactionRef>& vtx, unsigne
     {
         txiter it = mapTx.find(tx->GetHash());
         if (it != mapTx.end()) {
-            setEntries stage;
-            stage.insert(it);
+            setEntryRefs stage;
+            stage.insert(*it);
             RemoveStaged(stage, true, MemPoolRemovalReason::BLOCK);
         }
         removeConflicts(*tx);
@@ -721,10 +715,10 @@ void CTxMemPool::check(const CCoinsViewCache& active_coins_tip, int64_t spendhei
         CAmount nFeesCheck = it->GetModifiedFee();
         int64_t nSigOpCheck = it->GetSigOpCost();
 
-        for (txiter ancestorIt : ancestors) {
-            nSizeCheck += ancestorIt->GetTxSize();
-            nFeesCheck += ancestorIt->GetModifiedFee();
-            nSigOpCheck += ancestorIt->GetSigOpCost();
+        for (const CTxMemPoolEntry& ancestor : ancestors) {
+            nSizeCheck += ancestor.GetTxSize();
+            nFeesCheck += ancestor.GetModifiedFee();
+            nSigOpCheck += ancestor.GetSigOpCost();
         }
 
         assert(it->GetCountWithAncestors() == nCountCheck);
@@ -912,15 +906,15 @@ void CTxMemPool::PrioritiseTransaction(const uint256& hash, const CAmount& nFeeD
             mapTx.modify(it, [&nFeeDelta](CTxMemPoolEntry& e) { e.UpdateModifiedFee(nFeeDelta); });
             // Now update all ancestors' modified fees with descendants
             auto ancestors{AssumeCalculateMemPoolAncestors(__func__, *it, Limits::NoLimits(), /*fSearchForParents=*/false)};
-            for (txiter ancestorIt : ancestors) {
-                mapTx.modify(ancestorIt, [=](CTxMemPoolEntry& e){ e.UpdateDescendantState(0, nFeeDelta, 0);});
+            for (const CTxMemPoolEntry& ancestor : ancestors) {
+                mapTx.modify(mapTx.iterator_to(ancestor), [=](CTxMemPoolEntry& e) { e.UpdateDescendantState(0, nFeeDelta, 0); });
             }
             // Now update all descendants' modified fees with ancestors
-            setEntries setDescendants;
-            CalculateDescendants(it, setDescendants);
-            setDescendants.erase(it);
-            for (txiter descendantIt : setDescendants) {
-                mapTx.modify(descendantIt, [=](CTxMemPoolEntry& e){ e.UpdateAncestorState(0, nFeeDelta, 0, 0); });
+            setEntryRefs setDescendants;
+            CalculateDescendants(*it, setDescendants);
+            setDescendants.erase(*it);
+            for (const auto& descendantIt : setDescendants) {
+                mapTx.modify(mapTx.iterator_to(descendantIt), [=](CTxMemPoolEntry& e) { e.UpdateAncestorState(0, nFeeDelta, 0, 0); });
             }
             ++nTransactionsUpdated;
         }
@@ -988,6 +982,30 @@ CTxMemPool::setEntries CTxMemPool::GetIterSet(const std::set<uint256>& hashes) c
     for (const auto& h : hashes) {
         const auto mi = GetIter(h);
         if (mi) ret.insert(*mi);
+    }
+    return ret;
+}
+
+CTxMemPool::setEntryRefs CTxMemPool::GetEntrySet(const std::set<uint256>& hashes) const
+{
+    AssertLockHeld(cs);
+    CTxMemPool::setEntryRefs ret;
+    for (const auto& h : hashes) {
+        const auto e{GetEntry(Txid::FromUint256(h))};
+        if (e) ret.insert(*e);
+    }
+    return ret;
+}
+
+std::vector<CTxMemPoolEntryRef> CTxMemPool::GetEntryVec(const std::vector<uint256>& txids) const
+{
+    AssertLockHeld(cs);
+    std::vector<CTxMemPoolEntryRef> ret;
+    ret.reserve(txids.size());
+    for (const auto& txid : txids) {
+        const auto e{GetEntry(Txid::FromUint256(txid))};
+        if (!e) return {};
+        ret.emplace_back(*e);
     }
     return ret;
 }
@@ -1067,11 +1085,11 @@ void CTxMemPool::RemoveUnbroadcastTx(const uint256& txid, const bool unchecked) 
     }
 }
 
-void CTxMemPool::RemoveStaged(setEntries &stage, bool updateDescendants, MemPoolRemovalReason reason) {
+void CTxMemPool::RemoveStaged(setEntryRefs& stage, bool updateDescendants, MemPoolRemovalReason reason) {
     AssertLockHeld(cs);
     UpdateForRemoveFromMempool(stage, updateDescendants);
-    for (txiter it : stage) {
-        removeUnchecked(it, reason);
+    for (const auto& entry : stage) {
+        removeUnchecked(mapTx.iterator_to(entry), reason);
     }
 }
 
@@ -1084,9 +1102,9 @@ int CTxMemPool::Expire(std::chrono::seconds time)
         toremove.insert(mapTx.project<0>(it));
         it++;
     }
-    setEntries stage;
+    setEntryRefs stage;
     for (txiter removeit : toremove) {
-        CalculateDescendants(removeit, stage);
+        CalculateDescendants(*removeit, stage);
     }
     RemoveStaged(stage, false, MemPoolRemovalReason::EXPIRY);
     return stage.size();
@@ -1098,24 +1116,24 @@ void CTxMemPool::addUnchecked(const CTxMemPoolEntry &entry, bool validFeeEstimat
     return addUnchecked(entry, ancestors, validFeeEstimate);
 }
 
-void CTxMemPool::UpdateChild(txiter entry, txiter child, bool add)
+void CTxMemPool::UpdateChild(const CTxMemPoolEntry& entry, const CTxMemPoolEntry& child, bool add)
 {
     AssertLockHeld(cs);
     CTxMemPoolEntry::Children s;
-    if (add && entry->GetMemPoolChildren().insert(*child).second) {
+    if (add && entry.GetMemPoolChildren().insert(child).second) {
         cachedInnerUsage += memusage::IncrementalDynamicUsage(s);
-    } else if (!add && entry->GetMemPoolChildren().erase(*child)) {
+    } else if (!add && entry.GetMemPoolChildren().erase(child)) {
         cachedInnerUsage -= memusage::IncrementalDynamicUsage(s);
     }
 }
 
-void CTxMemPool::UpdateParent(txiter entry, txiter parent, bool add)
+void CTxMemPool::UpdateParent(const CTxMemPoolEntry& entry, const CTxMemPoolEntry& parent, bool add)
 {
     AssertLockHeld(cs);
     CTxMemPoolEntry::Parents s;
-    if (add && entry->GetMemPoolParents().insert(*parent).second) {
+    if (add && entry.GetMemPoolParents().insert(parent).second) {
         cachedInnerUsage += memusage::IncrementalDynamicUsage(s);
-    } else if (!add && entry->GetMemPoolParents().erase(*parent)) {
+    } else if (!add && entry.GetMemPoolParents().erase(parent)) {
         cachedInnerUsage -= memusage::IncrementalDynamicUsage(s);
     }
 }
@@ -1169,15 +1187,15 @@ void CTxMemPool::TrimToSize(size_t sizelimit, std::vector<COutPoint>* pvNoSpends
         trackPackageRemoved(removed);
         maxFeeRateRemoved = std::max(maxFeeRateRemoved, removed);
 
-        setEntries stage;
-        CalculateDescendants(mapTx.project<0>(it), stage);
+        setEntryRefs stage;
+        CalculateDescendants(*mapTx.project<0>(it), stage);
         nTxnRemoved += stage.size();
 
         std::vector<CTransaction> txn;
         if (pvNoSpendsRemaining) {
             txn.reserve(stage.size());
-            for (txiter iter : stage)
-                txn.push_back(iter->GetTx());
+            for (const CTxMemPoolEntry& entry : stage)
+                txn.push_back(entry.GetTx());
         }
         RemoveStaged(stage, false, MemPoolRemovalReason::SIZELIMIT);
         if (pvNoSpendsRemaining) {
@@ -1195,22 +1213,22 @@ void CTxMemPool::TrimToSize(size_t sizelimit, std::vector<COutPoint>* pvNoSpends
     }
 }
 
-uint64_t CTxMemPool::CalculateDescendantMaximum(txiter entry) const {
+uint64_t CTxMemPool::CalculateDescendantMaximum(const CTxMemPoolEntry& entry) const {
     // find parent with highest descendant count
-    std::vector<txiter> candidates;
-    setEntries counted;
-    candidates.push_back(entry);
+    std::vector<CTxMemPoolEntryRef> candidates;
+    setEntryRefs counted;
+    candidates.emplace_back(entry);
     uint64_t maximum = 0;
     while (candidates.size()) {
-        txiter candidate = candidates.back();
+        const CTxMemPoolEntry& candidate = candidates.back();
         candidates.pop_back();
         if (!counted.insert(candidate).second) continue;
-        const CTxMemPoolEntry::Parents& parents = candidate->GetMemPoolParentsConst();
+        const CTxMemPoolEntry::Parents& parents = candidate.GetMemPoolParentsConst();
         if (parents.size() == 0) {
-            maximum = std::max(maximum, candidate->GetCountWithDescendants());
+            maximum = std::max(maximum, candidate.GetCountWithDescendants());
         } else {
-            for (const CTxMemPoolEntry& i : parents) {
-                candidates.push_back(mapTx.iterator_to(i));
+            for (const CTxMemPoolEntry& e : parents) {
+                candidates.emplace_back(e);
             }
         }
     }
@@ -1225,7 +1243,7 @@ void CTxMemPool::GetTransactionAncestry(const uint256& txid, size_t& ancestors, 
         ancestors = it->GetCountWithAncestors();
         if (ancestorsize) *ancestorsize = it->GetSizeWithAncestors();
         if (ancestorfees) *ancestorfees = it->GetModFeesWithAncestors();
-        descendants = CalculateDescendantMaximum(it);
+        descendants = CalculateDescendantMaximum(*it);
     }
 }
 
@@ -1241,10 +1259,10 @@ void CTxMemPool::SetLoadTried(bool load_tried)
     m_load_tried = load_tried;
 }
 
-std::vector<CTxMemPool::txiter> CTxMemPool::GatherClusters(const std::vector<uint256>& txids) const
+std::vector<CTxMemPoolEntryRef> CTxMemPool::GatherClusters(const std::vector<uint256>& txids) const
 {
     AssertLockHeld(cs);
-    std::vector<txiter> clustered_txs{GetIterVec(txids)};
+    std::vector<CTxMemPoolEntryRef> clustered_txs{GetEntryVec(txids)};
     // Use epoch: visiting an entry means we have added it to the clustered_txs vector. It does not
     // necessarily mean the entry has been processed.
     WITH_FRESH_EPOCH(m_epoch);
@@ -1255,12 +1273,11 @@ std::vector<CTxMemPool::txiter> CTxMemPool::GatherClusters(const std::vector<uin
     for (size_t i{0}; i < clustered_txs.size(); ++i) {
         // DoS protection: if there are 500 or more entries to process, just quit.
         if (clustered_txs.size() > 500) return {};
-        const txiter& tx_iter = clustered_txs.at(i);
-        for (const auto& entries : {tx_iter->GetMemPoolParentsConst(), tx_iter->GetMemPoolChildrenConst()}) {
+        const CTxMemPoolEntry& tx = clustered_txs.at(i);
+        for (const auto& entries : {tx.GetMemPoolParentsConst(), tx.GetMemPoolChildrenConst()}) {
             for (const CTxMemPoolEntry& entry : entries) {
-                const auto entry_it = mapTx.iterator_to(entry);
-                if (!visited(entry_it)) {
-                    clustered_txs.push_back(entry_it);
+                if (!visited(entry)) {
+                    clustered_txs.emplace_back(entry);
                 }
             }
         }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1283,6 +1283,27 @@ void CTxMemPool::SetLoadTried(bool load_tried)
     m_load_tried = load_tried;
 }
 
+unsigned long CTxMemPool::size() const
+{
+    LOCK(cs);
+    return mapTx->impl.size();
+}
+
+bool CTxMemPool::exists(const GenTxid& gtxid) const
+{
+    LOCK(cs);
+    if (gtxid.IsWtxid()) {
+        return (mapTx->impl.get<MemPoolMultiIndex::index_by_wtxid>().count(gtxid.GetHash()) != 0);
+    }
+    return (mapTx->impl.count(gtxid.GetHash()) != 0);
+}
+
+std::unique_ptr<txiter> CTxMemPool::get_iter_from_wtxid(const uint256& wtxid) const EXCLUSIVE_LOCKS_REQUIRED(cs)
+{
+    AssertLockHeld(cs);
+    return std::make_unique<txiter>(mapTx->impl.project<0>(mapTx->impl.get<MemPoolMultiIndex::index_by_wtxid>().find(wtxid)));
+}
+
 std::vector<CTxMemPoolEntryRef> CTxMemPool::GatherClusters(const std::vector<uint256>& txids) const
 {
     AssertLockHeld(cs);

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -976,16 +976,6 @@ std::optional<CTxMemPool::txiter> CTxMemPool::GetIter(const uint256& txid) const
     return std::nullopt;
 }
 
-CTxMemPool::setEntries CTxMemPool::GetIterSet(const std::set<uint256>& hashes) const
-{
-    CTxMemPool::setEntries ret;
-    for (const auto& h : hashes) {
-        const auto mi = GetIter(h);
-        if (mi) ret.insert(*mi);
-    }
-    return ret;
-}
-
 CTxMemPool::setEntryRefs CTxMemPool::GetEntrySet(const std::set<uint256>& hashes) const
 {
     AssertLockHeld(cs);
@@ -1006,19 +996,6 @@ std::vector<CTxMemPoolEntryRef> CTxMemPool::GetEntryVec(const std::vector<uint25
         const auto e{GetEntry(Txid::FromUint256(txid))};
         if (!e) return {};
         ret.emplace_back(*e);
-    }
-    return ret;
-}
-
-std::vector<CTxMemPool::txiter> CTxMemPool::GetIterVec(const std::vector<uint256>& txids) const
-{
-    AssertLockHeld(cs);
-    std::vector<txiter> ret;
-    ret.reserve(txids.size());
-    for (const auto& txid : txids) {
-        const auto it{GetIter(txid)};
-        if (!it) return {};
-        ret.push_back(*it);
     }
     return ret;
 }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -31,6 +31,8 @@
 #include <string_view>
 #include <utility>
 
+using setEntries = std::set<CTxMemPool::txiter, CompareIteratorByHash>;
+
 bool TestLockPointValidity(CChain& active_chain, const LockPoints& lp)
 {
     AssertLockHeld(cs_main);

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -12,6 +12,7 @@
 #include <consensus/tx_verify.h>
 #include <consensus/validation.h>
 #include <logging.h>
+#include <mempool_set_definitions.h>
 #include <policy/fees.h>
 #include <policy/policy.h>
 #include <policy/settings.h>
@@ -35,6 +36,7 @@ using setEntries = std::set<MemPoolMultiIndex::raw_txiter, CompareIteratorByHash
 using MemPoolMultiIndex::CompareTxMemPoolEntryByScore;
 using MemPoolMultiIndex::descendant_score;
 using MemPoolMultiIndex::entry_time;
+using MemPoolMultiIndex::indexed_transaction_set;
 using MemPoolMultiIndex::MapTxImpl;
 using MemPoolMultiIndex::raw_txiter;
 using MemPoolMultiIndex::txiter;
@@ -91,7 +93,7 @@ static void UpdateForDescendants(
     CTxMemPool::cacheMap& cachedDescendants,
     const std::set<uint256>& setExclude,
     std::set<uint256>& descendants_to_remove,
-    CTxMemPool::indexed_transaction_set& mapTx,
+    indexed_transaction_set& mapTx,
     const CTxMemPool::Limits& limits)
 {
     CTxMemPoolEntry::Children stageEntries, descendants;
@@ -456,6 +458,8 @@ CTxMemPool::CTxMemPool(const Options& opts)
 {
 }
 
+CTxMemPool::~CTxMemPool() = default;
+
 bool CTxMemPool::isSpent(const COutPoint& outpoint) const
 {
     LOCK(cs);
@@ -711,7 +715,7 @@ namespace {
 class DepthAndScoreComparator
 {
 public:
-    bool operator()(const CTxMemPool::indexed_transaction_set::const_iterator& a, const CTxMemPool::indexed_transaction_set::const_iterator& b)
+    bool operator()(const indexed_transaction_set::const_iterator& a, const indexed_transaction_set::const_iterator& b)
     {
         uint64_t counta = a->GetCountWithAncestors();
         uint64_t countb = b->GetCountWithAncestors();
@@ -723,15 +727,15 @@ public:
 };
 } // namespace
 
-static std::vector<MemPoolMultiIndex::indexed_transaction_set::const_iterator> GetSortedDepthAndScore(
-    const std::unique_ptr<MemPoolMultiIndex::MapTxImpl>& mapTx, RecursiveMutex& cs) EXCLUSIVE_LOCKS_REQUIRED(cs)
+static std::vector<indexed_transaction_set::const_iterator> GetSortedDepthAndScore(
+    const std::unique_ptr<MapTxImpl>& mapTx, RecursiveMutex& cs) EXCLUSIVE_LOCKS_REQUIRED(cs)
 {
-    std::vector<MemPoolMultiIndex::indexed_transaction_set::const_iterator> iters;
+    std::vector<indexed_transaction_set::const_iterator> iters;
     AssertLockHeld(cs);
 
     iters.reserve(mapTx->impl.size());
 
-    for (MemPoolMultiIndex::indexed_transaction_set::iterator mi = mapTx->impl.begin(); mi != mapTx->impl.end(); ++mi) {
+    for (indexed_transaction_set::iterator mi = mapTx->impl.begin(); mi != mapTx->impl.end(); ++mi) {
         iters.push_back(mi);
     }
     std::sort(iters.begin(), iters.end(), DepthAndScoreComparator());
@@ -876,7 +880,8 @@ void CTxMemPool::queryHashes(std::vector<uint256>& vtxid) const
     }
 }
 
-static TxMempoolInfo GetInfo(CTxMemPool::indexed_transaction_set::const_iterator it) {
+static TxMempoolInfo GetInfo(indexed_transaction_set::const_iterator it)
+{
     return TxMempoolInfo{it->GetSharedTx(), it->GetTime(), it->GetFee(), it->GetTxSize(), it->GetModifiedFee() - it->GetFee()};
 }
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -32,6 +32,9 @@
 #include <utility>
 
 using setEntries = std::set<CTxMemPool::txiter, CompareIteratorByHash>;
+using MemPoolMultiIndex::CompareTxMemPoolEntryByScore;
+using MemPoolMultiIndex::descendant_score;
+using MemPoolMultiIndex::entry_time;
 
 bool TestLockPointValidity(CChain& active_chain, const LockPoints& lp)
 {

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -218,8 +218,6 @@ private:
     void UpdateParent(const CTxMemPoolEntry& entry, const CTxMemPoolEntry& parent, bool add) EXCLUSIVE_LOCKS_REQUIRED(cs);
     void UpdateChild(const CTxMemPoolEntry& entry, const CTxMemPoolEntry& child, bool add) EXCLUSIVE_LOCKS_REQUIRED(cs);
 
-    std::vector<MemPoolMultiIndex::const_txiter> GetSortedDepthAndScore() const EXCLUSIVE_LOCKS_REQUIRED(cs);
-
     /**
      * Track locally submitted transactions to periodically retry initial broadcast.
      */

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -14,6 +14,7 @@
 #include <kernel/mempool_limits.h>         // IWYU pragma: export
 #include <kernel/mempool_options.h>        // IWYU pragma: export
 #include <kernel/mempool_removal_reason.h> // IWYU pragma: export
+#include <mempool_set_definitions.h>
 #include <policy/feerate.h>
 #include <policy/packages.h>
 #include <primitives/transaction.h>
@@ -21,14 +22,6 @@
 #include <util/epochguard.h>
 #include <util/hasher.h>
 #include <util/result.h>
-
-#include <boost/multi_index/hashed_index.hpp>
-#include <boost/multi_index/identity.hpp>
-#include <boost/multi_index/indexed_by.hpp>
-#include <boost/multi_index/ordered_index.hpp>
-#include <boost/multi_index/sequenced_index.hpp>
-#include <boost/multi_index/tag.hpp>
-#include <boost/multi_index_container.hpp>
 
 #include <atomic>
 #include <map>
@@ -48,159 +41,6 @@ static const uint32_t MEMPOOL_HEIGHT = 0x7FFFFFFF;
  * Test whether the LockPoints height and time are still valid on the current chain
  */
 bool TestLockPointValidity(CChain& active_chain, const LockPoints& lp) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
-
-// extracts a transaction hash from CTxMemPoolEntry or CTransactionRef
-struct mempoolentry_txid
-{
-    typedef uint256 result_type;
-    result_type operator() (const CTxMemPoolEntry &entry) const
-    {
-        return entry.GetTx().GetHash();
-    }
-
-    result_type operator() (const CTransactionRef& tx) const
-    {
-        return tx->GetHash();
-    }
-};
-
-// extracts a transaction witness-hash from CTxMemPoolEntry or CTransactionRef
-struct mempoolentry_wtxid
-{
-    typedef uint256 result_type;
-    result_type operator() (const CTxMemPoolEntry &entry) const
-    {
-        return entry.GetTx().GetWitnessHash();
-    }
-
-    result_type operator() (const CTransactionRef& tx) const
-    {
-        return tx->GetWitnessHash();
-    }
-};
-
-
-/** \class CompareTxMemPoolEntryByDescendantScore
- *
- *  Sort an entry by max(score/size of entry's tx, score/size with all descendants).
- */
-class CompareTxMemPoolEntryByDescendantScore
-{
-public:
-    bool operator()(const CTxMemPoolEntry& a, const CTxMemPoolEntry& b) const
-    {
-        double a_mod_fee, a_size, b_mod_fee, b_size;
-
-        GetModFeeAndSize(a, a_mod_fee, a_size);
-        GetModFeeAndSize(b, b_mod_fee, b_size);
-
-        // Avoid division by rewriting (a/b > c/d) as (a*d > c*b).
-        double f1 = a_mod_fee * b_size;
-        double f2 = a_size * b_mod_fee;
-
-        if (f1 == f2) {
-            return a.GetTime() >= b.GetTime();
-        }
-        return f1 < f2;
-    }
-
-    // Return the fee/size we're using for sorting this entry.
-    void GetModFeeAndSize(const CTxMemPoolEntry &a, double &mod_fee, double &size) const
-    {
-        // Compare feerate with descendants to feerate of the transaction, and
-        // return the fee/size for the max.
-        double f1 = (double)a.GetModifiedFee() * a.GetSizeWithDescendants();
-        double f2 = (double)a.GetModFeesWithDescendants() * a.GetTxSize();
-
-        if (f2 > f1) {
-            mod_fee = a.GetModFeesWithDescendants();
-            size = a.GetSizeWithDescendants();
-        } else {
-            mod_fee = a.GetModifiedFee();
-            size = a.GetTxSize();
-        }
-    }
-};
-
-/** \class CompareTxMemPoolEntryByScore
- *
- *  Sort by feerate of entry (fee/size) in descending order
- *  This is only used for transaction relay, so we use GetFee()
- *  instead of GetModifiedFee() to avoid leaking prioritization
- *  information via the sort order.
- */
-class CompareTxMemPoolEntryByScore
-{
-public:
-    bool operator()(const CTxMemPoolEntry& a, const CTxMemPoolEntry& b) const
-    {
-        double f1 = (double)a.GetFee() * b.GetTxSize();
-        double f2 = (double)b.GetFee() * a.GetTxSize();
-        if (f1 == f2) {
-            return b.GetTx().GetHash() < a.GetTx().GetHash();
-        }
-        return f1 > f2;
-    }
-};
-
-class CompareTxMemPoolEntryByEntryTime
-{
-public:
-    bool operator()(const CTxMemPoolEntry& a, const CTxMemPoolEntry& b) const
-    {
-        return a.GetTime() < b.GetTime();
-    }
-};
-
-/** \class CompareTxMemPoolEntryByAncestorScore
- *
- *  Sort an entry by min(score/size of entry's tx, score/size with all ancestors).
- */
-class CompareTxMemPoolEntryByAncestorFee
-{
-public:
-    template<typename T>
-    bool operator()(const T& a, const T& b) const
-    {
-        double a_mod_fee, a_size, b_mod_fee, b_size;
-
-        GetModFeeAndSize(a, a_mod_fee, a_size);
-        GetModFeeAndSize(b, b_mod_fee, b_size);
-
-        // Avoid division by rewriting (a/b > c/d) as (a*d > c*b).
-        double f1 = a_mod_fee * b_size;
-        double f2 = a_size * b_mod_fee;
-
-        if (f1 == f2) {
-            return a.GetTx().GetHash() < b.GetTx().GetHash();
-        }
-        return f1 > f2;
-    }
-
-    // Return the fee/size we're using for sorting this entry.
-    template <typename T>
-    void GetModFeeAndSize(const T &a, double &mod_fee, double &size) const
-    {
-        // Compare feerate with ancestors to feerate of the transaction, and
-        // return the fee/size for the min.
-        double f1 = (double)a.GetModifiedFee() * a.GetSizeWithAncestors();
-        double f2 = (double)a.GetModFeesWithAncestors() * a.GetTxSize();
-
-        if (f1 > f2) {
-            mod_fee = a.GetModFeesWithAncestors();
-            size = a.GetSizeWithAncestors();
-        } else {
-            mod_fee = a.GetModifiedFee();
-            size = a.GetTxSize();
-        }
-    }
-};
-
-// Multi_index tag names
-struct descendant_score {};
-struct entry_time {};
-struct ancestor_score {};
-struct index_by_wtxid {};
 
 class CBlockPolicyEstimator;
 
@@ -329,38 +169,6 @@ public:
 
     static const int ROLLING_FEE_HALFLIFE = 60 * 60 * 12; // public only for testing
 
-    typedef boost::multi_index_container<
-        CTxMemPoolEntry,
-        boost::multi_index::indexed_by<
-            // sorted by txid
-            boost::multi_index::hashed_unique<mempoolentry_txid, SaltedTxidHasher>,
-            // sorted by wtxid
-            boost::multi_index::hashed_unique<
-                boost::multi_index::tag<index_by_wtxid>,
-                mempoolentry_wtxid,
-                SaltedTxidHasher
-            >,
-            // sorted by fee rate
-            boost::multi_index::ordered_non_unique<
-                boost::multi_index::tag<descendant_score>,
-                boost::multi_index::identity<CTxMemPoolEntry>,
-                CompareTxMemPoolEntryByDescendantScore
-            >,
-            // sorted by entry time
-            boost::multi_index::ordered_non_unique<
-                boost::multi_index::tag<entry_time>,
-                boost::multi_index::identity<CTxMemPoolEntry>,
-                CompareTxMemPoolEntryByEntryTime
-            >,
-            // sorted by fee rate with ancestors
-            boost::multi_index::ordered_non_unique<
-                boost::multi_index::tag<ancestor_score>,
-                boost::multi_index::identity<CTxMemPoolEntry>,
-                CompareTxMemPoolEntryByAncestorFee
-            >
-        >
-    > indexed_transaction_set;
-
     /**
      * This mutex needs to be locked when accessing `mapTx` or other members
      * that are guarded by it.
@@ -388,10 +196,13 @@ public:
      * changing the chain tip. It's necessary to keep both mutexes locked until
      * the mempool is consistent with the new chain tip and fully populated.
      */
+
+    using indexed_transaction_set = MemPoolMultiIndex::indexed_transaction_set;
+
     mutable RecursiveMutex cs;
     indexed_transaction_set mapTx GUARDED_BY(cs);
 
-    using txiter = indexed_transaction_set::nth_index<0>::type::const_iterator;
+    using txiter = MemPoolMultiIndex::txiter;
     std::vector<CTransactionRef> txns_randomized GUARDED_BY(cs); //!< All transactions in mapTx, in random order
 
     typedef std::set<CTxMemPoolEntryRef, CompareIteratorByHash> setEntryRefs;
@@ -407,7 +218,7 @@ private:
     void UpdateParent(const CTxMemPoolEntry& entry, const CTxMemPoolEntry& parent, bool add) EXCLUSIVE_LOCKS_REQUIRED(cs);
     void UpdateChild(const CTxMemPoolEntry& entry, const CTxMemPoolEntry& child, bool add) EXCLUSIVE_LOCKS_REQUIRED(cs);
 
-    std::vector<indexed_transaction_set::const_iterator> GetSortedDepthAndScore() const EXCLUSIVE_LOCKS_REQUIRED(cs);
+    std::vector<MemPoolMultiIndex::const_txiter> GetSortedDepthAndScore() const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /**
      * Track locally submitted transactions to periodically retry initial broadcast.
@@ -678,7 +489,7 @@ public:
     {
         LOCK(cs);
         if (gtxid.IsWtxid()) {
-            return (mapTx.get<index_by_wtxid>().count(gtxid.GetHash()) != 0);
+            return (mapTx.get<MemPoolMultiIndex::index_by_wtxid>().count(gtxid.GetHash()) != 0);
         }
         return (mapTx.count(gtxid.GetHash()) != 0);
     }
@@ -786,7 +597,7 @@ private:
     txiter get_iter_from_wtxid(const uint256& wtxid) const EXCLUSIVE_LOCKS_REQUIRED(cs)
     {
         AssertLockHeld(cs);
-        return mapTx.project<0>(mapTx.get<index_by_wtxid>().find(wtxid));
+        return mapTx.project<0>(mapTx.get<MemPoolMultiIndex::index_by_wtxid>().find(wtxid));
     }
 
     /** visited marks a CTxMemPoolEntry as having been traversed

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -467,11 +467,7 @@ public:
      */
     void SetLoadTried(bool load_tried);
 
-    unsigned long size() const
-    {
-        LOCK(cs);
-        return mapTx->impl.size();
-    }
+    unsigned long size() const;
 
     uint64_t GetTotalTxSize() const EXCLUSIVE_LOCKS_REQUIRED(cs)
     {
@@ -485,14 +481,7 @@ public:
         return m_total_fee;
     }
 
-    bool exists(const GenTxid& gtxid) const
-    {
-        LOCK(cs);
-        if (gtxid.IsWtxid()) {
-            return (mapTx->impl.get<MemPoolMultiIndex::index_by_wtxid>().count(gtxid.GetHash()) != 0);
-        }
-        return (mapTx->impl.count(gtxid.GetHash()) != 0);
-    }
+    bool exists(const GenTxid& gtxid) const;
 
     const CTxMemPoolEntry* GetEntry(const Txid& txid) const LIFETIMEBOUND EXCLUSIVE_LOCKS_REQUIRED(cs);
 
@@ -564,11 +553,7 @@ private:
      */
     void removeUnchecked(txiter& entry, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(cs);
 
-    std::unique_ptr<txiter> get_iter_from_wtxid(const uint256& wtxid) const EXCLUSIVE_LOCKS_REQUIRED(cs)
-    {
-        AssertLockHeld(cs);
-        return std::make_unique<txiter>(mapTx->impl.project<0>(mapTx->impl.get<MemPoolMultiIndex::index_by_wtxid>().find(wtxid)));
-    }
+    std::unique_ptr<txiter> get_iter_from_wtxid(const uint256& wtxid) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /** visited marks a CTxMemPoolEntry as having been traversed
      * during the lifetime of the most recently created Epoch::Guard

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -14,7 +14,6 @@
 #include <kernel/mempool_limits.h>         // IWYU pragma: export
 #include <kernel/mempool_options.h>        // IWYU pragma: export
 #include <kernel/mempool_removal_reason.h> // IWYU pragma: export
-#include <mempool_set_definitions.h>
 #include <policy/feerate.h>
 #include <policy/packages.h>
 #include <primitives/transaction.h>
@@ -33,6 +32,11 @@
 #include <vector>
 
 class CChain;
+
+namespace MemPoolMultiIndex {
+struct txiter;
+struct MapTxImpl;
+} // namespace MemPoolMultiIndex
 
 /** Fake height value used in Coin to signify they are only in the memory pool (since 0.8) */
 static const uint32_t MEMPOOL_HEIGHT = 0x7FFFFFFF;
@@ -197,7 +201,6 @@ public:
      * the mempool is consistent with the new chain tip and fully populated.
      */
 
-    using indexed_transaction_set = MemPoolMultiIndex::indexed_transaction_set;
     using MapTxImpl = MemPoolMultiIndex::MapTxImpl;
 
     mutable RecursiveMutex cs;
@@ -269,6 +272,8 @@ public:
      * in the pool.
      */
     explicit CTxMemPool(const Options& opts);
+
+    ~CTxMemPool();
 
     /**
      * If sanity-checking is turned on, check makes sure the pool is

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -209,12 +209,11 @@ public:
 
     using Limits = kernel::MemPoolLimits;
 
+    typedef std::map<CTxMemPoolEntryRef, setEntryRefs, CompareIteratorByHash> cacheMap;
+
     uint64_t CalculateDescendantMaximum(const CTxMemPoolEntry& entry) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
 private:
-    typedef std::map<CTxMemPoolEntryRef, setEntryRefs, CompareIteratorByHash> cacheMap;
-
-
     void UpdateParent(const CTxMemPoolEntry& entry, const CTxMemPoolEntry& parent, bool add) EXCLUSIVE_LOCKS_REQUIRED(cs);
     void UpdateChild(const CTxMemPoolEntry& entry, const CTxMemPoolEntry& child, bool add) EXCLUSIVE_LOCKS_REQUIRED(cs);
 
@@ -543,36 +542,6 @@ public:
     }
 
 private:
-    /** UpdateForDescendants is used by UpdateTransactionsFromBlock to update
-     *  the descendants for a single transaction that has been added to the
-     *  mempool but may have child transactions in the mempool, eg during a
-     *  chain reorg.
-     *
-     * @pre CTxMemPoolEntry::m_children is correct for the given tx and all
-     *      descendants.
-     * @pre cachedDescendants is an accurate cache where each entry has all
-     *      descendants of the corresponding key, including those that should
-     *      be removed for violation of ancestor limits.
-     * @post if updateIt has any non-excluded descendants, cachedDescendants has
-     *       a new cache line for updateIt.
-     * @post descendants_to_remove has a new entry for any descendant which exceeded
-     *       ancestor limits relative to updateIt.
-     *
-     * @param[in] updateIt the entry to update for its descendants
-     * @param[in,out] cachedDescendants a cache where each line corresponds to all
-     *     descendants. It will be updated with the descendants of the transaction
-     *     being updated, so that future invocations don't need to walk the same
-     *     transaction again, if encountered in another transaction chain.
-     * @param[in] setExclude the set of descendant transactions in the mempool
-     *     that must not be accounted for (because any descendants in setExclude
-     *     were added to the mempool after the transaction being updated and hence
-     *     their state is already reflected in the parent state).
-     * @param[out] descendants_to_remove Populated with the txids of entries that
-     *     exceed ancestor limits. It's the responsibility of the caller to
-     *     removeRecursive them.
-     */
-    void UpdateForDescendants(txiter updateIt, cacheMap& cachedDescendants,
-                              const std::set<uint256>& setExclude, std::set<uint256>& descendants_to_remove) EXCLUSIVE_LOCKS_REQUIRED(cs);
     /** Update ancestors of hash to add/remove it as a descendant transaction. */
     void UpdateAncestorsOf(bool add, const CTxMemPoolEntry& hash, setEntryRefs& setAncestors) EXCLUSIVE_LOCKS_REQUIRED(cs);
     /** Set ancestor state for an entry */

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -525,17 +525,10 @@ public:
     /** Returns an iterator to the given hash, if found */
     std::optional<txiter> GetIter(const uint256& txid) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
-    /** Translate a set of hashes into a set of pool iterators to avoid repeated lookups.
+    /** Translate a set of hashes into a set of pool entries to avoid repeated lookups.
      * Does not require that all of the hashes correspond to actual transactions in the mempool,
      * only returns the ones that exist. */
-    setEntries GetIterSet(const std::set<uint256>& hashes) const EXCLUSIVE_LOCKS_REQUIRED(cs);
-
     setEntryRefs GetEntrySet(const std::set<uint256>& hashes) const EXCLUSIVE_LOCKS_REQUIRED(cs);
-
-    /** Translate a list of hashes into a list of mempool iterators to avoid repeated lookups.
-     * The nth element in txids becomes the nth element in the returned vector. If any of the txids
-     * don't actually exist in the mempool, returns an empty vector. */
-    std::vector<txiter> GetIterVec(const std::vector<uint256>& txids) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     std::vector<CTxMemPoolEntryRef> GetEntryVec(const std::vector<uint256>& txids) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
@@ -797,12 +790,6 @@ private:
      */
     void removeUnchecked(txiter entry, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(cs);
 
-    bool visited(const CTxMemPoolEntry& entry) const EXCLUSIVE_LOCKS_REQUIRED(cs, m_epoch)
-    {
-        return m_epoch.visited(entry.m_epoch_marker);
-    }
-
-public:
     /** visited marks a CTxMemPoolEntry as having been traversed
      * during the lifetime of the most recently created Epoch::Guard
      * and returns false if we are the first visitor, true otherwise.
@@ -811,15 +798,9 @@ public:
      * triggered.
      *
      */
-    bool visited(const txiter it) const EXCLUSIVE_LOCKS_REQUIRED(cs, m_epoch)
+    bool visited(const CTxMemPoolEntry& entry) const EXCLUSIVE_LOCKS_REQUIRED(cs, m_epoch)
     {
-        return m_epoch.visited(it->m_epoch_marker);
-    }
-
-    bool visited(std::optional<txiter> it) const EXCLUSIVE_LOCKS_REQUIRED(cs, m_epoch)
-    {
-        assert(m_epoch.guarded()); // verify guard even when it==nullopt
-        return !it || visited(*it);
+        return m_epoch.visited(entry.m_epoch_marker);
     }
 };
 

--- a/src/util/epochguard.h
+++ b/src/util/epochguard.h
@@ -14,7 +14,7 @@
 /** Epoch: RAII-style guard for using epoch-based graph traversal algorithms.
  *     When walking ancestors or descendants, we generally want to avoid
  * visiting the same transactions twice. Some traversal algorithms use
- * std::set (or setEntries) to deduplicate the transaction we visit.
+ * std::set (or setEntryRefs) to deduplicate the transaction we visit.
  * However, use of std::set is algorithmically undesirable because it both
  * adds an asymptotic factor of O(log n) to traversals cost and triggers O(n)
  * more dynamic memory allocations.


### PR DESCRIPTION
Similarly to #28327 I wanted to open this PR to receive some opinions and better approaches.

The kernel library is currently at the stage where unwanted headers are removed from its set of headers. In practice, this means we are reducing the number of includes that are required for compiling the experimental `bitcoin-chainstate` binary. This is described in stage 1 step 3 of the [project tracking issue](https://github.com/bitcoin/bitcoin/issues/27587).

Currently the mempool is part of the kernel library. The mempool headers include the boost multi index headers. Thus any application wanting to use the kernel library and its headers will have to include the boost headers too. This is not only undesirable because of the sheer size of these headers, but also might lead to conflicts if the including application uses a different boost version.

In the approach laid out by this PR, mempool member variables and methods are declared in the header without having to include boost by either wrapping them in a struct and [pimpling](https://en.cppreference.com/w/cpp/language/pimpl) them, or making methods static implementation functions. The boost definitions are gathered into separate header (`mempool_set_definitions.h`) that is only included by implementation files that require definitions of the boost types. This allows us to retain the current architecture with roughly the same interfaces. 

The approach laid out by this PR also has some, albeit small, compilation speed and size benefits. Averaged over a few of compilation runs I consistently observe faster compilation by a couple of seconds and some smaller pre-processed and compiled object sizes. The main detractor of this method is obviously the number of lines touched. However it also has the benefit of inventorizing all the files that require direct access to the mempool data structures as well getting rid of boost multi index includes in non-kernel implementation files that include the mempool, but don't directly manipulate its data structures (e.g. wallet.cpp).

A much simpler alternative approach, at least on the surface, would be removing all `txmempool.h` includes from kernel library headers (see [this branch](https://github.com/TheCharlatan/bitcoin/tree/mempoolBoostSimple)). Currently this is only `validation.h`.  Due to the mutex member of `CTxMemPool` and the correspondingly defined lock decorators on the chainstate methods this becomes a bit more complicated though and I am not sure how this might be possible with the current architecture.

A discussion of how and if to remove the mempool from the kernel library has so far been intentionally punted to the next stage of the kernel library development. Pimpling the mempool itself precludes this discussion, since the library could never be shipped with the `CTxMemPool` headers. Pimpling the mempool members (like done in this PR) might also make a future splitting of block and mempool validation logic into separate compilation units easier.