### PR TITLE
build: Improve checks for `_FORTIFY_SOURCE`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -966,11 +966,19 @@ if test "$use_hardening" != "no"; then
   dnl However, FORTIFY_SOURCE requires that there is some level of optimization, otherwise it does nothing and just creates a compiler warning.
   dnl Since FORTIFY_SOURCE is a no-op without optimizations, do not enable it when enable_debug is yes.
   if test "$enable_debug" != "yes"; then
-    AX_CHECK_PREPROC_FLAG([-D_FORTIFY_SOURCE=3],[
+    AC_MSG_CHECKING([for __builtin_dynamic_object_size])
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [[
+        (void) __builtin_dynamic_object_size(nullptr, 0);
+      ]])],
+      [ AC_MSG_RESULT([yes]); fortify_source_level=3 ],
+      [ AC_MSG_RESULT([no]); fortify_source_level=2]
+    )
+
+    AX_CHECK_PREPROC_FLAG([-D_FORTIFY_SOURCE=$fortify_source_level],[
       AX_CHECK_PREPROC_FLAG([-U_FORTIFY_SOURCE],[
         HARDENED_CPPFLAGS="$HARDENED_CPPFLAGS -U_FORTIFY_SOURCE"
       ])
-      HARDENED_CPPFLAGS="$HARDENED_CPPFLAGS -D_FORTIFY_SOURCE=3"
+      HARDENED_CPPFLAGS="$HARDENED_CPPFLAGS -D_FORTIFY_SOURCE=$fortify_source_level"
     ])
   fi
 


### PR DESCRIPTION
`_FORTIFY_SOURCE=3` [requires](https://developers.redhat.com/blog/2021/04/16/broadening-compiler-checks-for-buffer-overflows-in-_fortify_source) `__builtin_dynamic_object_size`. If the latter is not supported, the fortification level fallbacks to 2.

However, the user is misled by the `./configure` script:
```
checking whether C++ preprocessor accepts -D_FORTIFY_SOURCE=3... yes
```

This PR avoids misleading the user.

Additionally, it prevents warnings like this:
```
warning: #warning Using _FORTIFY_SOURCE=2 (level 3 requires __builtin_dynamic_object_size support) [-Wcpp]
```