### PR TITLE
Bugfix: Package relay / bytespersigop checks

### DIFF
--- a/src/bench/mempool_eviction.cpp
+++ b/src/bench/mempool_eviction.cpp
@@ -130,7 +130,7 @@ static void MempoolEviction(benchmark::Bench& bench)
         AddTx(tx6_r, 1100LL, pool);
         AddTx(tx7_r, 9000LL, pool);
         pool.TrimToSize(pool.DynamicMemoryUsage() * 3 / 4);
-        pool.TrimToSize(GetVirtualTransactionSize(*tx1_r));
+        pool.TrimToSize(GetVirtualTransactionSize(*tx1_r, 0, 0));
     });
 }
 

--- a/src/bench/mempool_stress.cpp
+++ b/src/bench/mempool_stress.cpp
@@ -99,7 +99,7 @@ static void ComplexMemPool(benchmark::Bench& bench)
             AddTx(tx, pool);
         }
         pool.TrimToSize(pool.DynamicMemoryUsage() * 3 / 4);
-        pool.TrimToSize(GetVirtualTransactionSize(*ordered_coins.front()));
+        pool.TrimToSize(GetVirtualTransactionSize(*ordered_coins.front(), 0, 0));
     });
 }
 

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -259,6 +259,7 @@ public:
     virtual void getPackageLimits(unsigned int& limit_ancestor_count, unsigned int& limit_descendant_count) = 0;
 
     //! Check if transaction will pass the mempool's chain limits.
+    //! WARNING: Does not consider non-weight vsize, so only safe for wallet transactions.
     virtual bool checkChainLimits(const CTransactionRef& tx) = 0;
 
     //! Estimate smart fee.

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -20,6 +20,7 @@
 #include <stdint.h>
 #include <string>
 #include <tuple>
+#include <variant>
 #include <vector>
 
 class BanMan;
@@ -208,7 +209,7 @@ public:
     virtual bool getUnspentOutput(const COutPoint& output, Coin& coin) = 0;
 
     //! Broadcast transaction.
-    virtual TransactionError broadcastTransaction(CTransactionRef tx, CAmount max_tx_fee, std::string& err_string) = 0;
+    virtual TransactionError broadcastTransaction(CTransactionRef tx, const std::variant<CAmount, CFeeRate>& max_tx_fee, std::string& err_string) = 0;
 
     //! Get wallet loader.
     virtual WalletLoader& walletLoader() = 0;

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -333,7 +333,7 @@ public:
         LOCK(::cs_main);
         return chainman().ActiveChainstate().CoinsTip().GetCoin(output, coin);
     }
-    TransactionError broadcastTransaction(CTransactionRef tx, CAmount max_tx_fee, std::string& err_string) override
+    TransactionError broadcastTransaction(CTransactionRef tx, const std::variant<CAmount, CFeeRate>& max_tx_fee, std::string& err_string) override
     {
         return BroadcastTransaction(*m_context, std::move(tx), err_string, max_tx_fee, /*relay=*/ true, /*wait_callback=*/ false);
     }

--- a/src/node/transaction.cpp
+++ b/src/node/transaction.cpp
@@ -30,7 +30,7 @@ static TransactionError HandleATMPError(const TxValidationState& state, std::str
     }
 }
 
-TransactionError BroadcastTransaction(NodeContext& node, const CTransactionRef tx, std::string& err_string, const CAmount& max_tx_fee, bool relay, bool wait_callback)
+TransactionError BroadcastTransaction(NodeContext& node, const CTransactionRef tx, std::string& err_string, const std::variant<CAmount, CFeeRate>& max_tx_fee, bool relay, bool wait_callback)
 {
     // BroadcastTransaction can be called by either sendrawtransaction RPC or the wallet.
     // chainman, mempool and peerman are initialized before the RPC server and wallet are started
@@ -68,14 +68,23 @@ TransactionError BroadcastTransaction(NodeContext& node, const CTransactionRef t
             wtxid = mempool_tx->GetWitnessHash();
         } else {
             // Transaction is not already in the mempool.
-            if (max_tx_fee > 0) {
+            const bool max_tx_fee_set{(std::holds_alternative<CAmount>(max_tx_fee) ? std::get<CAmount>(max_tx_fee) : std::get<CFeeRate>(max_tx_fee).GetFeePerK()) > 0};
+            if (max_tx_fee_set) {
                 // First, call ATMP with test_accept and check the fee. If ATMP
                 // fails here, return error immediately.
                 const MempoolAcceptResult result = node.chainman->ProcessTransaction(tx, /*test_accept=*/ true);
                 if (result.m_result_type != MempoolAcceptResult::ResultType::VALID) {
                     return HandleATMPError(result.m_state, err_string);
-                } else if (result.m_base_fees.value() > max_tx_fee) {
-                    return TransactionError::MAX_FEE_EXCEEDED;
+                } else {
+                    CAmount max_tx_fee_abs;
+                    if (std::holds_alternative<CFeeRate>(max_tx_fee)) {
+                        max_tx_fee_abs = std::get<CFeeRate>(max_tx_fee).GetFee(*Assert(result.m_vsize));
+                    } else {
+                        max_tx_fee_abs = std::get<CAmount>(max_tx_fee);
+                    }
+                    if (result.m_base_fees.value() > max_tx_fee_abs) {
+                        return TransactionError::MAX_FEE_EXCEEDED;
+                    }
                 }
             }
             // Try to submit the transaction to the mempool.

--- a/src/node/transaction.h
+++ b/src/node/transaction.h
@@ -9,6 +9,8 @@
 #include <primitives/transaction.h>
 #include <util/error.h>
 
+#include <variant>
+
 class CBlockIndex;
 class CTxMemPool;
 namespace Consensus {
@@ -43,7 +45,7 @@ static const CFeeRate DEFAULT_MAX_RAW_TX_FEE_RATE{COIN / 10};
  * @param[in]  wait_callback wait until callbacks have been processed to avoid stale result due to a sequentially RPC.
  * return error
  */
-[[nodiscard]] TransactionError BroadcastTransaction(NodeContext& node, CTransactionRef tx, std::string& err_string, const CAmount& max_tx_fee, bool relay, bool wait_callback);
+[[nodiscard]] TransactionError BroadcastTransaction(NodeContext& node, CTransactionRef tx, std::string& err_string, const std::variant<CAmount, CFeeRate>& max_tx_fee, bool relay, bool wait_callback);
 
 /**
  * Return transaction with a given hash.

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -158,11 +158,6 @@ int64_t GetVirtualTransactionSize(int64_t nWeight, int64_t nSigOpCost, unsigned 
 int64_t GetVirtualTransactionSize(const CTransaction& tx, int64_t nSigOpCost, unsigned int bytes_per_sigop);
 int64_t GetVirtualTransactionInputSize(const CTxIn& tx, int64_t nSigOpCost, unsigned int bytes_per_sigop);
 
-static inline int64_t GetVirtualTransactionSize(const CTransaction& tx)
-{
-    return GetVirtualTransactionSize(tx, 0, 0);
-}
-
 static inline int64_t GetVirtualTransactionInputSize(const CTxIn& tx)
 {
     return GetVirtualTransactionInputSize(tx, 0, 0);

--- a/src/qt/psbtoperationsdialog.cpp
+++ b/src/qt/psbtoperationsdialog.cpp
@@ -116,7 +116,7 @@ void PSBTOperationsDialog::broadcastTransaction()
     CTransactionRef tx = MakeTransactionRef(mtx);
     std::string err_string;
     TransactionError error =
-        m_client_model->node().broadcastTransaction(tx, DEFAULT_MAX_RAW_TX_FEE_RATE.GetFeePerK(), err_string);
+        m_client_model->node().broadcastTransaction(tx, DEFAULT_MAX_RAW_TX_FEE_RATE, err_string);
 
     if (error == TransactionError::OK) {
         showStatus(tr("Transaction broadcast successfully! Transaction ID: %1")

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -306,7 +306,8 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
 
     strHTML += "<b>" + tr("Transaction ID") + ":</b> " + rec->getTxHash() + "<br>";
     strHTML += "<b>" + tr("Transaction total size") + ":</b> " + QString::number(wtx.tx->GetTotalSize()) + " bytes<br>";
-    strHTML += "<b>" + tr("Transaction virtual size") + ":</b> " + QString::number(GetVirtualTransactionSize(*wtx.tx)) + " bytes<br>";
+    // BUG: The virtual size displayed currently fails to consider non-weight vsize, which could potentially be abused to fool the user into thinking the feerate is reasonable when it actually isn't.
+    strHTML += "<b>" + tr("Transaction virtual size") + ":</b> " + QString::number(GetVirtualTransactionSize(*wtx.tx, 0, 0 /* BUG */)) + " bytes<br>";
     strHTML += "<b>" + tr("Output index") + ":</b> " + QString::number(rec->getOutputIndex()) + "<br>";
 
     // Message from normal bitcoin:URI (bitcoin:123...?message=example)

--- a/src/qt/walletmodeltransaction.cpp
+++ b/src/qt/walletmodeltransaction.cpp
@@ -32,7 +32,7 @@ void WalletModelTransaction::setWtx(const CTransactionRef& newTx)
 
 unsigned int WalletModelTransaction::getTransactionSize()
 {
-    return wtx ? GetVirtualTransactionSize(*wtx) : 0;
+    return wtx ? GetVirtualTransactionSize(*wtx, 0, 0) : 0;
 }
 
 CAmount WalletModelTransaction::getTransactionFee() const

--- a/src/qt/walletmodeltransaction.h
+++ b/src/qt/walletmodeltransaction.h
@@ -29,6 +29,7 @@ public:
     CTransactionRef& getWtx();
     void setWtx(const CTransactionRef&);
 
+    //! WARNING: Currently only safe for self-generated transactions due to bypassing non-weight logic of GetVirtualTransactionSize
     unsigned int getTransactionSize();
 
     void setTransactionFee(const CAmount& newFee);

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -84,14 +84,10 @@ static RPCHelpMan sendrawtransaction()
                                                      DEFAULT_MAX_RAW_TX_FEE_RATE :
                                                      CFeeRate(AmountFromValue(request.params[1]));
 
-            // BUG: The virtual size here currently fails to consider sigops, which could potentially result in an incorrectly-low max_raw_tx_fee
-            int64_t virtual_size = GetVirtualTransactionSize(*tx, 0, 0 /* BUG */);
-            CAmount max_raw_tx_fee = max_raw_tx_fee_rate.GetFee(virtual_size);
-
             std::string err_string;
             AssertLockNotHeld(cs_main);
             NodeContext& node = EnsureAnyNodeContext(request.context);
-            const TransactionError err = BroadcastTransaction(node, tx, err_string, max_raw_tx_fee, /*relay=*/true, /*wait_callback=*/true);
+            const TransactionError err = BroadcastTransaction(node, tx, err_string, max_raw_tx_fee_rate, /*relay=*/true, /*wait_callback=*/true);
             if (TransactionError::OK != err) {
                 throw JSONRPCTransactionError(err, err_string);
             }

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -84,7 +84,8 @@ static RPCHelpMan sendrawtransaction()
                                                      DEFAULT_MAX_RAW_TX_FEE_RATE :
                                                      CFeeRate(AmountFromValue(request.params[1]));
 
-            int64_t virtual_size = GetVirtualTransactionSize(*tx);
+            // BUG: The virtual size here currently fails to consider sigops, which could potentially result in an incorrectly-low max_raw_tx_fee
+            int64_t virtual_size = GetVirtualTransactionSize(*tx, 0, 0 /* BUG */);
             CAmount max_raw_tx_fee = max_raw_tx_fee_rate.GetFee(virtual_size);
 
             std::string err_string;

--- a/src/test/fuzz/mini_miner.cpp
+++ b/src/test/fuzz/mini_miner.cpp
@@ -4,6 +4,7 @@
 #include <test/fuzz/util/mempool.h>
 #include <test/util/script.h>
 #include <test/util/setup_common.h>
+#include <test/util/transaction_utils.h>
 #include <test/util/txmempool.h>
 #include <test/util/mining.h>
 

--- a/src/test/fuzz/transaction.cpp
+++ b/src/test/fuzz/transaction.cpp
@@ -14,6 +14,7 @@
 #include <primitives/transaction.h>
 #include <streams.h>
 #include <test/fuzz/fuzz.h>
+#include <test/util/transaction_utils.h>
 #include <univalue.h>
 #include <util/chaintype.h>
 #include <util/rbf.h>

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -4,6 +4,7 @@
 
 #include <common/system.h>
 #include <policy/policy.h>
+#include <test/util/transaction_utils.h>
 #include <test/util/txmempool.h>
 #include <txmempool.h>
 #include <util/time.h>

--- a/src/test/miniminer_tests.cpp
+++ b/src/test/miniminer_tests.cpp
@@ -7,6 +7,7 @@
 #include <util/time.h>
 
 #include <test/util/setup_common.h>
+#include <test/util/transaction_utils.h>
 #include <test/util/txmempool.h>
 
 #include <boost/test/unit_test.hpp>

--- a/src/test/policyestimator_tests.cpp
+++ b/src/test/policyestimator_tests.cpp
@@ -4,6 +4,7 @@
 
 #include <policy/fees.h>
 #include <policy/policy.h>
+#include <test/util/transaction_utils.h>
 #include <test/util/txmempool.h>
 #include <txmempool.h>
 #include <uint256.h>

--- a/src/test/txpackage_tests.cpp
+++ b/src/test/txpackage_tests.cpp
@@ -10,6 +10,7 @@
 #include <script/script.h>
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
+#include <test/util/transaction_utils.h>
 #include <validation.h>
 
 #include <boost/test/unit_test.hpp>

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -44,6 +44,7 @@
 #include <streams.h>
 #include <test/util/net.h>
 #include <test/util/random.h>
+#include <test/util/transaction_utils.h>
 #include <test/util/txmempool.h>
 #include <timedata.h>
 #include <txdb.h>

--- a/src/test/util/transaction_utils.h
+++ b/src/test/util/transaction_utils.h
@@ -5,6 +5,7 @@
 #ifndef BITCOIN_TEST_UTIL_TRANSACTION_UTILS_H
 #define BITCOIN_TEST_UTIL_TRANSACTION_UTILS_H
 
+#include <policy/policy.h>
 #include <primitives/transaction.h>
 
 #include <array>
@@ -25,5 +26,11 @@ CMutableTransaction BuildSpendingTransaction(const CScript& scriptSig, const CSc
 // The first has nValues[0] and nValues[1] outputs paid to a TxoutType::PUBKEY,
 // the second nValues[2] and nValues[3] outputs paid to a TxoutType::PUBKEYHASH.
 std::vector<CMutableTransaction> SetupDummyInputs(FillableSigningProvider& keystoreRet, CCoinsViewCache& coinsRet, const std::array<CAmount,4>& nValues);
+
+// Calculates the BIP 141 virtual size, without consideration for other vsize factors.
+static inline int64_t GetVirtualTransactionSize(const CTransaction& tx)
+{
+    return GetVirtualTransactionSize(tx, 0, 0);
+}
 
 #endif // BITCOIN_TEST_UTIL_TRANSACTION_UTILS_H

--- a/src/wallet/feebumper.cpp
+++ b/src/wallet/feebumper.cpp
@@ -126,7 +126,8 @@ static CFeeRate EstimateFeeRate(const CWallet& wallet, const CWalletTx& wtx, con
     // Get the fee rate of the original transaction. This is calculated from
     // the tx fee/vsize, so it may have been rounded down. Add 1 satoshi to the
     // result.
-    int64_t txSize = GetVirtualTransactionSize(*(wtx.tx));
+    // NOTE: Ignoring non-weight vsize is safe because it should only be our own normal tx anyway
+    int64_t txSize = GetVirtualTransactionSize(*(wtx.tx), 0, 0);
     CFeeRate feerate(old_fee, txSize);
     feerate += CFeeRate(1);
 

--- a/src/wallet/spend.h
+++ b/src/wallet/spend.h
@@ -20,6 +20,7 @@ namespace wallet {
 int CalculateMaximumSignedInputSize(const CTxOut& txout, const CWallet* pwallet, const CCoinControl* coin_control);
 int CalculateMaximumSignedInputSize(const CTxOut& txout, const COutPoint outpoint, const SigningProvider* pwallet, bool can_grind_r, const CCoinControl* coin_control);
 struct TxSize {
+    // WARNING: vsize assumes a normal input and does not account for non-weight factors
     int64_t vsize{-1};
     int64_t weight{-1};
 };


### PR DESCRIPTION
`GetVirtualTransactionSize(CTransaction&)` passes by default 0 sigops and 0 `-bytespersigop`, which is incorrect. In many cases (ie, wallet), this is harmless since we have control over the transactions and don't do anything absurd in normal usage. But in other cases (including wallet *received* transactions), this isn't safe. To avoid invisible bugs like this, I delete (or rather, move to `bitcoin_test`) the function signature that allows for omitting sigop inputs.

This also then fixes the new package relay code to use the correct virtual sizes for its checks, and documents calling locations where the behaviour is broken or safe.

In particular, note that the `sendrawtransaction` RPC and GUI transaction details remain buggy and not fixed in this PR.