### PR TITLE
lint: replace deprecated pkg_resources with importlib.metadata

### DIFF
--- a/test/lint/lint-python.py
+++ b/test/lint/lint-python.py
@@ -9,9 +9,11 @@ Check for specified flake8 and mypy warnings in python files.
 """
 
 import os
-import pkg_resources
 import subprocess
 import sys
+
+from importlib.metadata import metadata, PackageNotFoundError
+
 
 DEPS = ['flake8', 'lief', 'mypy', 'pyzmq']
 MYPY_CACHE_DIR = f"{os.getenv('BASE_ROOT_DIR', '')}/test/.mypy_cache"
@@ -99,10 +101,10 @@ ENABLED = (
 
 
 def check_dependencies():
-    working_set = {pkg.key for pkg in pkg_resources.working_set}
-
     for dep in DEPS:
-        if dep not in working_set:
+        try:
+            metadata(dep)
+        except PackageNotFoundError:
             print(f"Skipping Python linting since {dep} is not installed.")
             exit(0)
 


### PR DESCRIPTION
Running our python linter with a recent python and the latest release of setuptools [v68.1.2](https://setuptools.pypa.io/en/stable/history.html):

```
$ python3 --version
Python 3.11.5
$ ./test/lint/lint-python.py:12: DeprecationWarning: pkg_resources is deprecated as an API.
  See https://setuptools.pypa.io/en/latest/pkg_resources.html
  import pkg_resources
```

Using `pkg_resources` was [deprecated](https://github.com/pypa/setuptools/pull/3843) earlier in [v67.5.0](https://setuptools.pypa.io/en/stable/history.html#id55): "Although pkg_resources has been discouraged for use, some projects still consider pkg_resources viable for usage. This change makes it clear that pkg_resources should not be used, emitting a DeprecationWarning when imported."

The `importlib.metadata` library requires Python 3.8, which is currently our minimum-supported Python version.

For more details about `importlib.metadata` and the two methods imported and used here, see: 

- https://docs.python.org/3/library/importlib.metadata.html
- https://importlib-metadata.readthedocs.io/en/latest/api.html#importlib_metadata.metadata
- https://importlib-metadata.readthedocs.io/en/latest/api.html#importlib_metadata.PackageNotFoundError