### PR TITLE
test: Support powerpc64le in get_previous_releases.py

### DIFF
--- a/test/get_previous_releases.py
+++ b/test/get_previous_releases.py
@@ -247,6 +247,7 @@ def check_host(args) -> int:
     if args.download_binary:
         platforms = {
             'aarch64-*-linux*': 'aarch64-linux-gnu',
+            'powerpc64le-*-linux-*': 'powerpc64le-linux-gnu',
             'riscv64-*-linux*': 'riscv64-linux-gnu',
             'x86_64-*-linux*': 'x86_64-linux-gnu',
             'x86_64-apple-darwin*': 'x86_64-apple-darwin',


### PR DESCRIPTION
To test: `test/get_previous_releases.py -b -t /tmp/prev_releases v22.0`

On master: `Not sure which binary to download for powerpc64le-unknown-linux-gnu`
Here: (pass)