### PR TITLE
ci, windows: Do not run extended functional tests for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,5 +262,7 @@ jobs:
         run: py -3 test\util\rpcauth-test.py
 
       - name: Run functional tests
+        env:
+          TEST_RUNNER_EXTRA: ${{ github.event_name != 'pull_request' && '--extended' || '' }}
         shell: cmd
-        run: py -3 test\functional\test_runner.py --ci --quiet --tmpdirprefix=%RUNNER_TEMP% --combinedlogslen=99999999 --timeout-factor=%TEST_RUNNER_TIMEOUT_FACTOR% --extended --exclude feature_dbcrash
+        run: py -3 test\functional\test_runner.py --ci --quiet --tmpdirprefix=%RUNNER_TEMP% --combinedlogslen=99999999 --timeout-factor=%TEST_RUNNER_TIMEOUT_FACTOR% %TEST_RUNNER_EXTRA%


### PR DESCRIPTION
This PR is intended to speed up the CI feedback for pull requests:

- a [PR](https://github.com/bitcoin/bitcoin/actions/runs/6019964104?pr=28196) opened against the current master branch:
![image](https://github.com/bitcoin/bitcoin/assets/32963518/481a70eb-13f3-40c9-8f6a-ca2f06350158)

- this PR:
![image](https://github.com/bitcoin/bitcoin/assets/32963518/2582307f-7b72-4816-b5be-e84d5e4a3016)


Suggested in https://github.com/bitcoin/bitcoin/pull/28173#discussion_r1302929493:

> An alternative would be to run them on non-pr pushes only. Failures should be rare enough to deal with them post-merge.