### PR TITLE
Replace "BitCoins" with "Bitcoins" in  ecdsa_secp256k1_sha256_bitcoin…

### DIFF
--- a/src/secp256k1/src/wycheproof/ecdsa_secp256k1_sha256_bitcoin_test.json
+++ b/src/secp256k1/src/wycheproof/ecdsa_secp256k1_sha256_bitcoin_test.json
@@ -95,7 +95,7 @@
     },
     "SignatureMalleabilityBitcoin" : {
       "bugType" : "SIGNATURE_MALLEABILITY",
-      "description" : "\"BitCoins\"-curves are curves where signature malleability can be a serious issue. An implementation should only accept a signature s where s < n/2. If an implementation is not meant for uses cases that require signature malleability then this implemenation should be tested with another set of test vectors.",
+      "description" : "\"Bitcoins\"-curves are curves where signature malleability can be a serious issue. An implementation should only accept a signature s where s < n/2. If an implementation is not meant for uses cases that require signature malleability then this implemenation should be tested with another set of test vectors.",
       "effect" : "In bitcoin exchanges, it may be used to make a double deposits or double withdrawals",
       "links" : [
         "https://en.bitcoin.it/wiki/Transaction_malleability",


### PR DESCRIPTION
…_test.json

This is the only spot in the codebase that uses the capitalization as "BitCoin" so I assume it to be incorrect. Let me know if I am wrong.