### PR TITLE
test:  Use pathlib over os path

### DIFF
--- a/test/functional/feature_anchors.py
+++ b/test/functional/feature_anchors.py
@@ -4,8 +4,6 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test block-relay-only anchors functionality"""
 
-import os
-
 from test_framework.p2p import P2PInterface, P2P_SERVICES
 from test_framework.socks5 import Socks5Configuration, Socks5Server
 from test_framework.messages import CAddress, hash256
@@ -26,7 +24,7 @@ class AnchorsTest(BitcoinTestFramework):
         node_anchors_path = self.nodes[0].chain_path / "anchors.dat"
 
         self.log.info("When node starts, check if anchors.dat doesn't exist")
-        assert not os.path.exists(node_anchors_path)
+        assert not node_anchors_path.exists()
 
         self.log.info(f"Add {BLOCK_RELAY_CONNECTIONS} block-relay-only connections to node")
         for i in range(BLOCK_RELAY_CONNECTIONS):
@@ -85,7 +83,7 @@ class AnchorsTest(BitcoinTestFramework):
             self.start_node(0)
 
         self.log.info("When node starts, check if anchors.dat doesn't exist anymore")
-        assert not os.path.exists(node_anchors_path)
+        assert not node_anchors_path.exists()
 
         self.log.info("Ensure addrv2 support")
         # Use proxies to catch outbound connections to networks with 256-bit addresses

--- a/test/functional/feature_asmap.py
+++ b/test/functional/feature_asmap.py
@@ -23,7 +23,7 @@ Verify node behaviour and debug log when launching bitcoind in these cases:
 The tests are order-independent.
 
 """
-import os
+from pathlib import Path
 import shutil
 
 from test_framework.test_framework import BitcoinTestFramework
@@ -55,21 +55,21 @@ class AsmapTest(BitcoinTestFramework):
     def test_asmap_with_absolute_path(self):
         self.log.info('Test bitcoind -asmap=<absolute path>')
         self.stop_node(0)
-        filename = os.path.join(self.datadir, 'my-map-file.map')
+        filename = self.datadir / 'my-map-file.map'
         shutil.copyfile(self.asmap_raw, filename)
         with self.node.assert_debug_log(expected_messages(filename)):
             self.start_node(0, [f'-asmap={filename}'])
-        os.remove(filename)
+        filename.unlink()
 
     def test_asmap_with_relative_path(self):
         self.log.info('Test bitcoind -asmap=<relative path>')
         self.stop_node(0)
         name = 'ASN_map'
-        filename = os.path.join(self.datadir, name)
+        filename = self.datadir / name
         shutil.copyfile(self.asmap_raw, filename)
         with self.node.assert_debug_log(expected_messages(filename)):
             self.start_node(0, [f'-asmap={name}'])
-        os.remove(filename)
+        filename.unlink()
 
     def test_default_asmap(self):
         shutil.copyfile(self.asmap_raw, self.default_asmap)
@@ -78,7 +78,7 @@ class AsmapTest(BitcoinTestFramework):
             self.stop_node(0)
             with self.node.assert_debug_log(expected_messages(self.default_asmap)):
                 self.start_node(0, [arg])
-        os.remove(self.default_asmap)
+        self.default_asmap.unlink()
 
     def test_asmap_interaction_with_addrman_containing_entries(self):
         self.log.info("Test bitcoind -asmap restart with addrman containing new and tried entries")
@@ -94,7 +94,7 @@ class AsmapTest(BitcoinTestFramework):
             ]
         ):
             self.node.getnodeaddresses()  # getnodeaddresses re-runs the addrman checks
-        os.remove(self.default_asmap)
+        self.default_asmap.unlink()
 
     def test_default_asmap_with_missing_file(self):
         self.log.info('Test bitcoind -asmap with missing default map file')
@@ -105,17 +105,17 @@ class AsmapTest(BitcoinTestFramework):
     def test_empty_asmap(self):
         self.log.info('Test bitcoind -asmap with empty map file')
         self.stop_node(0)
-        with open(self.default_asmap, "w", encoding="utf-8") as f:
+        with self.default_asmap.open(mode="w", encoding="utf-8") as f:
             f.write("")
         msg = f"Error: Could not parse asmap file \"{self.default_asmap}\""
         self.node.assert_start_raises_init_error(extra_args=['-asmap'], expected_msg=msg)
-        os.remove(self.default_asmap)
+        self.default_asmap.unlink()
 
     def run_test(self):
         self.node = self.nodes[0]
         self.datadir = self.node.chain_path
-        self.default_asmap = os.path.join(self.datadir, DEFAULT_ASMAP_FILENAME)
-        self.asmap_raw = os.path.join(os.path.dirname(os.path.realpath(__file__)), ASMAP)
+        self.default_asmap = self.datadir / DEFAULT_ASMAP_FILENAME
+        self.asmap_raw = Path(__file__).parent / ASMAP
 
         self.test_without_asmap_arg()
         self.test_asmap_with_absolute_path()

--- a/test/functional/feature_blocksdir.py
+++ b/test/functional/feature_blocksdir.py
@@ -5,8 +5,8 @@
 """Test the blocksdir option.
 """
 
-import os
 import shutil
+from pathlib import Path
 
 from test_framework.test_framework import BitcoinTestFramework, initialize_datadir
 
@@ -18,20 +18,20 @@ class BlocksdirTest(BitcoinTestFramework):
 
     def run_test(self):
         self.stop_node(0)
-        assert os.path.isdir(os.path.join(self.nodes[0].chain_path, "blocks"))
-        assert not os.path.isdir(os.path.join(self.nodes[0].datadir, "blocks"))
-        shutil.rmtree(self.nodes[0].datadir)
+        assert (self.nodes[0].chain_path / "blocks").is_dir()
+        assert not (self.nodes[0].datadir_path / "blocks").is_dir()
+        shutil.rmtree(self.nodes[0].datadir_path)
         initialize_datadir(self.options.tmpdir, 0, self.chain)
         self.log.info("Starting with nonexistent blocksdir ...")
-        blocksdir_path = os.path.join(self.options.tmpdir, 'blocksdir')
+        blocksdir_path = Path(self.options.tmpdir) / 'blocksdir'
         self.nodes[0].assert_start_raises_init_error([f"-blocksdir={blocksdir_path}"], f'Error: Specified blocks directory "{blocksdir_path}" does not exist.')
-        os.mkdir(blocksdir_path)
+        blocksdir_path.mkdir()
         self.log.info("Starting with existing blocksdir ...")
         self.start_node(0, [f"-blocksdir={blocksdir_path}"])
         self.log.info("mining blocks..")
         self.generatetoaddress(self.nodes[0], 10, self.nodes[0].get_deterministic_priv_key().address)
-        assert os.path.isfile(os.path.join(blocksdir_path, self.chain, "blocks", "blk00000.dat"))
-        assert os.path.isdir(os.path.join(self.nodes[0].chain_path, "blocks", "index"))
+        assert (blocksdir_path / self.chain / "blocks" / "blk00000.dat").is_file()
+        assert (self.nodes[0].chain_path / "blocks" / "index").is_dir()
 
 
 if __name__ == '__main__':

--- a/test/functional/feature_fee_estimation.py
+++ b/test/functional/feature_fee_estimation.py
@@ -315,10 +315,10 @@ class EstimateFeeTest(BitcoinTestFramework):
 
     def test_estimate_dat_is_flushed_periodically(self):
         fee_dat = self.nodes[0].chain_path / "fee_estimates.dat"
-        os.remove(fee_dat) if os.path.exists(fee_dat) else None
-
+        fee_dat.unlink() if fee_dat.exists() else None
+        
         # Verify that fee_estimates.dat does not exist
-        assert_equal(os.path.isfile(fee_dat), False)
+        assert_equal(fee_dat.is_file(), False)
 
         # Verify if the string "Flushed fee estimates to fee_estimates.dat." is present in the debug log file.
         # If present, it indicates that fee estimates have been successfully flushed to disk.
@@ -327,7 +327,7 @@ class EstimateFeeTest(BitcoinTestFramework):
             self.nodes[0].mockscheduler(SECONDS_PER_HOUR)
 
         # Verify that fee estimates were flushed and fee_estimates.dat file is created
-        assert_equal(os.path.isfile(fee_dat), True)
+        assert_equal(fee_dat.is_file(), True)
 
         # Verify that the estimates remain the same if there are no blocks in the flush interval
         block_hash_before = self.nodes[0].getbestblockhash()
@@ -421,8 +421,8 @@ class EstimateFeeTest(BitcoinTestFramework):
 
         self.log.info("Restarting node with fresh estimation")
         self.stop_node(0)
-        fee_dat = os.path.join(self.nodes[0].chain_path, "fee_estimates.dat")
-        os.remove(fee_dat)
+        fee_dat = self.nodes[0].chain_path / "fee_estimates.dat"
+        fee_dat.unlink()
         self.start_node(0)
         self.connect_nodes(0, 1)
         self.connect_nodes(0, 2)

--- a/test/functional/feature_filelock.py
+++ b/test/functional/feature_filelock.py
@@ -28,7 +28,7 @@ class FilelockTest(BitcoinTestFramework):
 
         self.log.info("Check that we can't start a second bitcoind instance using the same datadir")
         expected_msg = f"Error: Cannot obtain a lock on data directory {datadir}. {self.config['environment']['PACKAGE_NAME']} is probably already running."
-        self.nodes[1].assert_start_raises_init_error(extra_args=[f'-datadir={self.nodes[0].datadir}', '-noserver'], expected_msg=expected_msg)
+        self.nodes[1].assert_start_raises_init_error(extra_args=[f'-datadir={self.nodes[0].datadir_path}', '-noserver'], expected_msg=expected_msg)
 
         if self.is_wallet_compiled():
             def check_wallet_filelock(descriptors):

--- a/test/functional/feature_loadblock.py
+++ b/test/functional/feature_loadblock.py
@@ -10,7 +10,7 @@ To generate that file this test uses the helper scripts available
 in contrib/linearize.
 """
 
-import os
+from pathlib import Path
 import subprocess
 import sys
 import tempfile
@@ -32,10 +32,10 @@ class LoadblockTest(BitcoinTestFramework):
         self.generate(self.nodes[0], COINBASE_MATURITY, sync_fun=self.no_op)
 
         # Parsing the url of our node to get settings for config file
-        data_dir = self.nodes[0].datadir
+        data_dir = self.nodes[0].datadir_path
         node_url = urllib.parse.urlparse(self.nodes[0].url)
-        cfg_file = os.path.join(data_dir, "linearize.cfg")
-        bootstrap_file = os.path.join(self.options.tmpdir, "bootstrap.dat")
+        cfg_file = data_dir / "linearize.cfg"
+        bootstrap_file = Path(self.options.tmpdir) / "bootstrap.dat"
         genesis_block = self.nodes[0].getblockhash(0)
         blocks_dir = self.nodes[0].blocks_path
         hash_list = tempfile.NamedTemporaryFile(dir=data_dir,
@@ -58,16 +58,16 @@ class LoadblockTest(BitcoinTestFramework):
             cfg.write(f"hashlist={hash_list.name}\n")
 
         base_dir = self.config["environment"]["SRCDIR"]
-        linearize_dir = os.path.join(base_dir, "contrib", "linearize")
+        linearize_dir = Path(base_dir) / "contrib" / "linearize"
 
         self.log.info("Run linearization of block hashes")
-        linearize_hashes_file = os.path.join(linearize_dir, "linearize-hashes.py")
+        linearize_hashes_file = linearize_dir / "linearize-hashes.py"
         subprocess.run([sys.executable, linearize_hashes_file, cfg_file],
                        stdout=hash_list,
                        check=True)
 
         self.log.info("Run linearization of block data")
-        linearize_data_file = os.path.join(linearize_dir, "linearize-data.py")
+        linearize_data_file = linearize_dir / "linearize-data.py"
         subprocess.run([sys.executable, linearize_data_file, cfg_file],
                        check=True)
 

--- a/test/functional/feature_logging.py
+++ b/test/functional/feature_logging.py
@@ -4,7 +4,8 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test debug logging."""
 
-import os
+from os import devnull
+from pathlib import Path
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.test_node import ErrorMatch
@@ -16,58 +17,58 @@ class LoggingTest(BitcoinTestFramework):
         self.setup_clean_chain = True
 
     def relative_log_path(self, name):
-        return os.path.join(self.nodes[0].chain_path, name)
+        return self.nodes[0].chain_path / name
 
     def run_test(self):
         # test default log file name
         default_log_path = self.relative_log_path("debug.log")
-        assert os.path.isfile(default_log_path)
+        assert default_log_path.is_file()
 
         # test alternative log file name in datadir
         self.restart_node(0, ["-debuglogfile=foo.log"])
-        assert os.path.isfile(self.relative_log_path("foo.log"))
+        assert self.relative_log_path("foo.log").is_file()
 
         # test alternative log file name outside datadir
-        tempname = os.path.join(self.options.tmpdir, "foo.log")
+        tempname = Path(self.options.tmpdir) / "foo.log"
         self.restart_node(0, [f"-debuglogfile={tempname}"])
-        assert os.path.isfile(tempname)
+        assert tempname.is_file()
 
         # check that invalid log (relative) will cause error
         invdir = self.relative_log_path("foo")
-        invalidname = os.path.join("foo", "foo.log")
+        invfile = invdir / "foo.log"
         self.stop_node(0)
         exp_stderr = r"Error: Could not open debug log file \S+$"
-        self.nodes[0].assert_start_raises_init_error([f"-debuglogfile={invalidname}"], exp_stderr, match=ErrorMatch.FULL_REGEX)
-        assert not os.path.isfile(os.path.join(invdir, "foo.log"))
+        self.nodes[0].assert_start_raises_init_error([f"-debuglogfile={invfile}"], exp_stderr, match=ErrorMatch.FULL_REGEX)
+        assert not invfile.is_file()
 
         # check that invalid log (relative) works after path exists
         self.stop_node(0)
-        os.mkdir(invdir)
-        self.start_node(0, [f"-debuglogfile={invalidname}"])
-        assert os.path.isfile(os.path.join(invdir, "foo.log"))
+        invdir.mkdir()
+        self.start_node(0, [f"-debuglogfile={invfile}"])
+        assert invfile.is_file()
 
         # check that invalid log (absolute) will cause error
         self.stop_node(0)
-        invdir = os.path.join(self.options.tmpdir, "foo")
-        invalidname = os.path.join(invdir, "foo.log")
-        self.nodes[0].assert_start_raises_init_error([f"-debuglogfile={invalidname}"], exp_stderr, match=ErrorMatch.FULL_REGEX)
-        assert not os.path.isfile(os.path.join(invdir, "foo.log"))
+        invdir = Path(self.options.tmpdir) / "foo"
+        invfile = invdir / "foo.log"
+        self.nodes[0].assert_start_raises_init_error([f"-debuglogfile={invfile}"], exp_stderr, match=ErrorMatch.FULL_REGEX)
+        assert not invfile.is_file()
 
         # check that invalid log (absolute) works after path exists
         self.stop_node(0)
-        os.mkdir(invdir)
-        self.start_node(0, [f"-debuglogfile={invalidname}"])
-        assert os.path.isfile(os.path.join(invdir, "foo.log"))
+        invdir.mkdir()
+        self.start_node(0, [f"-debuglogfile={invfile}"])
+        assert invfile.is_file()
 
         # check that -nodebuglogfile disables logging
         self.stop_node(0)
-        os.unlink(default_log_path)
-        assert not os.path.isfile(default_log_path)
+        default_log_path.unlink()
+        assert not default_log_path.is_file()
         self.start_node(0, ["-nodebuglogfile"])
-        assert not os.path.isfile(default_log_path)
+        assert not default_log_path.is_file()
 
         # just sanity check no crash here
-        self.restart_node(0, [f"-debuglogfile={os.devnull}"])
+        self.restart_node(0, [f"-debuglogfile={devnull}"])
 
         self.log.info("Test -debug and -debugexclude raise when invalid values are passed")
         self.stop_node(0)

--- a/test/functional/feature_notifications.py
+++ b/test/functional/feature_notifications.py
@@ -3,7 +3,8 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test the -alertnotify, -blocknotify and -walletnotify options."""
-import os
+from os import name as os_name
+from pathlib import Path
 
 from test_framework.address import ADDRESS_BCRT1_UNSPENDABLE
 from test_framework.descriptors import descsum_create
@@ -14,13 +15,13 @@ from test_framework.util import (
 
 # Linux allow all characters other than \x00
 # Windows disallow control characters (0-31) and /\?%:|"<>
-FILE_CHAR_START = 32 if os.name == 'nt' else 1
+FILE_CHAR_START = 32 if os_name == 'nt' else 1
 FILE_CHAR_END = 128
-FILE_CHARS_DISALLOWED = '/\\?%*:|"<>' if os.name == 'nt' else '/'
+FILE_CHARS_DISALLOWED = '/\\?%*:|"<>' if os_name == 'nt' else '/'
 UNCONFIRMED_HASH_STRING = 'unconfirmed'
 
 def notify_outputname(walletname, txid):
-    return txid if os.name == 'nt' else f'{walletname}_{txid}'
+    return txid if os_name == 'nt' else f'{walletname}_{txid}'
 
 
 class NotificationsTest(BitcoinTestFramework):
@@ -33,23 +34,23 @@ class NotificationsTest(BitcoinTestFramework):
 
     def setup_network(self):
         self.wallet = ''.join(chr(i) for i in range(FILE_CHAR_START, FILE_CHAR_END) if chr(i) not in FILE_CHARS_DISALLOWED)
-        self.alertnotify_dir = os.path.join(self.options.tmpdir, "alertnotify")
-        self.blocknotify_dir = os.path.join(self.options.tmpdir, "blocknotify")
-        self.walletnotify_dir = os.path.join(self.options.tmpdir, "walletnotify")
-        self.shutdownnotify_dir = os.path.join(self.options.tmpdir, "shutdownnotify")
-        self.shutdownnotify_file = os.path.join(self.shutdownnotify_dir, "shutdownnotify.txt")
-        os.mkdir(self.alertnotify_dir)
-        os.mkdir(self.blocknotify_dir)
-        os.mkdir(self.walletnotify_dir)
-        os.mkdir(self.shutdownnotify_dir)
+        self.alertnotify_dir = Path(self.options.tmpdir) / "alertnotify"
+        self.blocknotify_dir = Path(self.options.tmpdir) / "blocknotify"
+        self.walletnotify_dir = Path(self.options.tmpdir) / "walletnotify"
+        self.shutdownnotify_dir = Path(self.options.tmpdir) / "shutdownnotify"
+        self.shutdownnotify_file = Path(self.shutdownnotify_dir) / "shutdownnotify.txt"
+        self.alertnotify_dir.mkdir()
+        self.blocknotify_dir.mkdir()
+        self.walletnotify_dir.mkdir()
+        self.shutdownnotify_dir.mkdir()
 
         # -alertnotify and -blocknotify on node0, walletnotify on node1
         self.extra_args = [[
-            f"-alertnotify=echo > {os.path.join(self.alertnotify_dir, '%s')}",
-            f"-blocknotify=echo > {os.path.join(self.blocknotify_dir, '%s')}",
+            f"-alertnotify=echo > {self.alertnotify_dir / '%s'}",
+            f"-blocknotify=echo > {self.blocknotify_dir / '%s'}",
             f"-shutdownnotify=echo > {self.shutdownnotify_file}",
         ], [
-            f"-walletnotify=echo %h_%b > {os.path.join(self.walletnotify_dir, notify_outputname('%w', '%s'))}",
+            f"-walletnotify=echo %h_%b > {self.walletnotify_dir / notify_outputname('%w', '%s')}",
         ]]
         self.wallet_names = [self.default_wallet_name, self.wallet]
         super().setup_network()
@@ -85,15 +86,15 @@ class NotificationsTest(BitcoinTestFramework):
         blocks = self.generatetoaddress(self.nodes[1], block_count, self.nodes[1].getnewaddress() if self.is_wallet_compiled() else ADDRESS_BCRT1_UNSPENDABLE)
 
         # wait at most 10 seconds for expected number of files before reading the content
-        self.wait_until(lambda: len(os.listdir(self.blocknotify_dir)) == block_count, timeout=10)
+        self.wait_until(lambda: len(list(self.blocknotify_dir.iterdir())) == block_count, timeout=10)
 
         # directory content should equal the generated blocks hashes
-        assert_equal(sorted(blocks), sorted(os.listdir(self.blocknotify_dir)))
+        assert_equal(sorted(blocks), sorted([f.name for f in self.blocknotify_dir.iterdir()]))
 
         if self.is_wallet_compiled():
             self.log.info("test -walletnotify")
             # wait at most 10 seconds for expected number of files before reading the content
-            self.wait_until(lambda: len(os.listdir(self.walletnotify_dir)) == block_count, timeout=10)
+            self.wait_until(lambda: len(list(self.walletnotify_dir.iterdir())) == block_count, timeout=10)
 
             # directory content should equal the generated transaction hashes
             tx_details = list(map(lambda t: (t['txid'], t['blockheight'], t['blockhash']), self.nodes[1].listtransactions("*", block_count)))
@@ -102,7 +103,7 @@ class NotificationsTest(BitcoinTestFramework):
             self.log.info("test -walletnotify after rescan")
             # rescan to force wallet notifications
             self.nodes[1].rescanblockchain()
-            self.wait_until(lambda: len(os.listdir(self.walletnotify_dir)) == block_count, timeout=10)
+            self.wait_until(lambda: len(list(self.walletnotify_dir.iterdir())) == block_count, timeout=10)
 
             self.connect_nodes(0, 1)
 
@@ -165,31 +166,32 @@ class NotificationsTest(BitcoinTestFramework):
 
         self.log.info("test -shutdownnotify")
         self.stop_nodes()
-        self.wait_until(lambda: os.path.isfile(self.shutdownnotify_file), timeout=10)
+        self.wait_until(lambda: self.shutdownnotify_file.is_file(), timeout=10)
 
     def expect_wallet_notify(self, tx_details):
-        self.wait_until(lambda: len(os.listdir(self.walletnotify_dir)) >= len(tx_details), timeout=10)
+        self.wait_until(lambda: len(list(self.walletnotify_dir.iterdir())) >= len(tx_details), timeout=10)
         # Should have no more and no less files than expected
-        assert_equal(sorted(notify_outputname(self.wallet, tx_id) for tx_id, _, _ in tx_details), sorted(os.listdir(self.walletnotify_dir)))
+        assert_equal(sorted(notify_outputname(self.wallet, tx_id) for tx_id, _, _ in tx_details), 
+                     sorted([f.name for f in self.walletnotify_dir.iterdir()]))
         # Should now verify contents of each file
         for tx_id, blockheight, blockhash in tx_details:
-            fname = os.path.join(self.walletnotify_dir, notify_outputname(self.wallet, tx_id))
+            fname = self.walletnotify_dir / notify_outputname(self.wallet, tx_id)
             # Wait for the cached writes to hit storage
-            self.wait_until(lambda: os.path.getsize(fname) > 0, timeout=10)
+            self.wait_until(lambda: fname.stat().st_size > 0, timeout=10)
             with open(fname, 'rt', encoding='utf-8') as f:
                 text = f.read()
                 # Universal newline ensures '\n' on 'nt'
                 assert_equal(text[-1], '\n')
                 text = text[:-1]
-                if os.name == 'nt':
+                if os_name == 'nt':
                     # On Windows, echo as above will append a whitespace
                     assert_equal(text[-1], ' ')
                     text = text[:-1]
                 expected = str(blockheight) + '_' + blockhash
                 assert_equal(text, expected)
 
-        for tx_file in os.listdir(self.walletnotify_dir):
-            os.remove(os.path.join(self.walletnotify_dir, tx_file))
+        for tx_file in self.walletnotify_dir.iterdir():
+            (self.walletnotify_dir / tx_file).unlink()
 
 
 if __name__ == '__main__':

--- a/test/functional/feature_remove_pruned_files_on_startup.py
+++ b/test/functional/feature_remove_pruned_files_on_startup.py
@@ -33,22 +33,22 @@ class FeatureRemovePrunedFilesOnStartupTest(BitcoinTestFramework):
 
         # Windows systems will not remove files with an open fd
         if os.name != 'nt':
-            assert not os.path.exists(blk0)
-            assert not os.path.exists(rev0)
-            assert not os.path.exists(blk1)
-            assert not os.path.exists(rev1)
+            assert not blk0.exists()
+            assert not rev0.exists()
+            assert not blk1.exists()
+            assert not rev1.exists()
         else:
-            assert os.path.exists(blk0)
-            assert not os.path.exists(rev0)
-            assert not os.path.exists(blk1)
-            assert os.path.exists(rev1)
+            assert blk0.exists()
+            assert not rev0.exists()
+            assert not blk1.exists()
+            assert rev1.exists()
 
         # Check that the files are removed on restart once the fds are closed
         fd1.close()
         fd2.close()
         self.restart_node(0)
-        assert not os.path.exists(blk0)
-        assert not os.path.exists(rev1)
+        assert not blk0.exists()
+        assert not rev1.exists()
 
 if __name__ == '__main__':
     FeatureRemovePrunedFilesOnStartupTest().main()

--- a/test/functional/feature_settings.py
+++ b/test/functional/feature_settings.py
@@ -22,7 +22,7 @@ class SettingsTest(BitcoinTestFramework):
     def run_test(self):
         node, = self.nodes
         settings = Path(node.chain_path, "settings.json")
-        conf = Path(node.datadir, "bitcoin.conf")
+        conf = Path(node.datadir_path, "bitcoin.conf")
 
         # Assert empty settings file was created
         self.stop_node(0)
@@ -79,7 +79,7 @@ class SettingsTest(BitcoinTestFramework):
             self.stop_node(0)
 
         # Test alternate settings path
-        altsettings = Path(node.datadir, "altsettings.json")
+        altsettings = Path(node.datadir_path, "altsettings.json")
         with altsettings.open("w") as fp:
             fp.write('{"key": "value"}')
         with node.assert_debug_log(expected_msgs=['Setting file arg: key = "value"']):

--- a/test/functional/feature_versionbits_warning.py
+++ b/test/functional/feature_versionbits_warning.py
@@ -7,7 +7,7 @@
 Generate chains with block versions that appear to be signalling unknown
 soft-forks, and test that warning alerts are generated.
 """
-import os
+from pathlib import Path
 import re
 
 from test_framework.blocktools import create_block, create_coinbase
@@ -30,7 +30,7 @@ class VersionBitsWarningTest(BitcoinTestFramework):
         self.num_nodes = 1
 
     def setup_network(self):
-        self.alert_filename = os.path.join(self.options.tmpdir, "alert.txt")
+        self.alert_filename = Path(self.options.tmpdir) / "alert.txt"
         # Open and close to create zero-length file
         with open(self.alert_filename, 'w', encoding='utf8'):
             pass

--- a/test/functional/interface_bitcoin_cli.py
+++ b/test/functional/interface_bitcoin_cli.py
@@ -94,7 +94,7 @@ class TestBitcoinCli(BitcoinTestFramework):
         assert_equal(self.nodes[0].cli("-named", "echo", "arg0=0", "arg1=1", "arg2=2", "arg1=3").send_cli(), ['0', '3', '2'])
         assert_raises_rpc_error(-8, "Parameter args specified multiple times", self.nodes[0].cli("-named", "echo", "args=[0,1,2,3]", "4", "5", "6", ).send_cli)
 
-        user, password = get_auth_cookie(self.nodes[0].datadir, self.chain)
+        user, password = get_auth_cookie(self.nodes[0].datadir_path, self.chain)
 
         self.log.info("Test -stdinrpcpass option")
         assert_equal(BLOCKS, self.nodes[0].cli(f'-rpcuser={user}', '-stdinrpcpass', input=password).getblockcount())

--- a/test/functional/interface_rpc.py
+++ b/test/functional/interface_rpc.py
@@ -4,7 +4,6 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Tests some generic aspects of the RPC interface."""
 
-import os
 from test_framework.authproxy import JSONRPCException
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, assert_greater_than_or_equal
@@ -46,7 +45,7 @@ class RPCInterfaceTest(BitcoinTestFramework):
         command = info['active_commands'][0]
         assert_equal(command['method'], 'getrpcinfo')
         assert_greater_than_or_equal(command['duration'], 0)
-        assert_equal(info['logpath'], os.path.join(self.nodes[0].chain_path, 'debug.log'))
+        assert_equal(info['logpath'], str(self.nodes[0].chain_path / 'debug.log'))
 
     def test_batch_request(self):
         self.log.info("Testing basic JSON-RPC batch request...")

--- a/test/functional/mocks/invalid_signer.py
+++ b/test/functional/mocks/invalid_signer.py
@@ -3,14 +3,14 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-import os
 import sys
 import argparse
 import json
+from pathlib import Path
 
 def perform_pre_checks():
-    mock_result_path = os.path.join(os.getcwd(), "mock_result")
-    if os.path.isfile(mock_result_path):
+    mock_result_path = Path.cwd() / "mock_result"
+    if mock_result_path.is_file():
         with open(mock_result_path, "r", encoding="utf8") as f:
             mock_result = f.read()
         if mock_result[0]:

--- a/test/functional/mocks/signer.py
+++ b/test/functional/mocks/signer.py
@@ -3,14 +3,14 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-import os
 import sys
 import argparse
 import json
+from pathlib import Path
 
 def perform_pre_checks():
-    mock_result_path = os.path.join(os.getcwd(), "mock_result")
-    if os.path.isfile(mock_result_path):
+    mock_result_path = Path.cwd() / "mock_result"
+    if mock_result_path.is_file():
         with open(mock_result_path, "r", encoding="utf8") as f:
             mock_result = f.read()
         if mock_result[0]:
@@ -59,7 +59,7 @@ def signtx(args):
     if args.fingerprint != "00000001":
         return sys.stdout.write(json.dumps({"error": "Unexpected fingerprint", "fingerprint": args.fingerprint}))
 
-    with open(os.path.join(os.getcwd(), "mock_psbt"), "r", encoding="utf8") as f:
+    with (Path.cwd() / "mock_psbt").open(mode="r", encoding="utf8") as f:
         mock_psbt = f.read()
 
     if args.fingerprint == "00000001" :

--- a/test/functional/p2p_dos_header_tree.py
+++ b/test/functional/p2p_dos_header_tree.py
@@ -14,7 +14,7 @@ from test_framework.p2p import (
 )
 from test_framework.test_framework import BitcoinTestFramework
 
-import os
+from pathlib import Path
 
 
 class RejectLowDifficultyHeadersTest(BitcoinTestFramework):
@@ -33,7 +33,7 @@ class RejectLowDifficultyHeadersTest(BitcoinTestFramework):
 
     def run_test(self):
         self.log.info("Read headers data")
-        self.headers_file_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), self.options.datafile)
+        self.headers_file_path = Path(__file__).parent / self.options.datafile
         with open(self.headers_file_path, encoding='utf-8') as headers_data:
             h_lines = [l.strip() for l in headers_data.readlines()]
 

--- a/test/functional/p2p_message_capture.py
+++ b/test/functional/p2p_message_capture.py
@@ -62,9 +62,9 @@ class MessageCaptureTest(BitcoinTestFramework):
         # Connect a node so that the handshake occurs
         self.nodes[0].add_p2p_connection(P2PDataStore())
         self.nodes[0].disconnect_p2ps()
-        recv_file = glob.glob(os.path.join(capturedir, "*/msgs_recv.dat"))[0]
+        recv_file = glob.glob(str(capturedir / "*/msgs_recv.dat"))[0]
         mini_parser(recv_file)
-        sent_file = glob.glob(os.path.join(capturedir, "*/msgs_sent.dat"))[0]
+        sent_file = glob.glob(str(capturedir / "*/msgs_sent.dat"))[0]
         mini_parser(sent_file)
 
 

--- a/test/functional/rpc_bind.py
+++ b/test/functional/rpc_bind.py
@@ -56,7 +56,7 @@ class RPCBindTest(BitcoinTestFramework):
         self.nodes[0].rpchost = None
         self.start_nodes([node_args])
         # connect to node through non-loopback interface
-        node = get_rpc_proxy(rpc_url(self.nodes[0].datadir, 0, self.chain, "%s:%d" % (rpchost, rpcport)), 0, coveragedir=self.options.coveragedir)
+        node = get_rpc_proxy(rpc_url(self.nodes[0].datadir_path, 0, self.chain, "%s:%d" % (rpchost, rpcport)), 0, coveragedir=self.options.coveragedir)
         node.getnetworkinfo()
         self.stop_nodes()
 

--- a/test/functional/rpc_createmultisig.py
+++ b/test/functional/rpc_createmultisig.py
@@ -6,7 +6,7 @@
 import decimal
 import itertools
 import json
-import os
+from pathlib import Path
 
 from test_framework.address import address_to_scriptpubkey
 from test_framework.blocktools import COINBASE_MATURITY
@@ -104,7 +104,7 @@ class RpcCreateMultiSigTest(BitcoinTestFramework):
                     assert_equal(result['warnings'], err_msg)
 
         self.log.info('Testing sortedmulti descriptors with BIP 67 test vectors')
-        with open(os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data/rpc_bip67.json'), encoding='utf-8') as f:
+        with (Path(__file__).parent / 'data' / 'rpc_bip67.json').open(encoding='utf-8') as f:
             vectors = json.load(f)
 
         for t in vectors:

--- a/test/functional/rpc_decodescript.py
+++ b/test/functional/rpc_decodescript.py
@@ -5,7 +5,7 @@
 """Test decoding scripts via decodescript RPC command."""
 
 import json
-import os
+from pathlib import Path
 
 from test_framework.messages import (
     sha256,
@@ -256,7 +256,7 @@ class DecodeScriptTest(BitcoinTestFramework):
         assert_equal('OP_RETURN 3011020701010101010101020601010101010101', rpc_result['vin'][0]['scriptSig']['asm'])
 
     def decodescript_datadriven_tests(self):
-        with open(os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data/rpc_decodescript.json'), encoding='utf-8') as f:
+        with (Path(__file__).parent / 'data' / 'rpc_decodescript.json').open(encoding='utf-8') as f:
             dd_tests = json.load(f)
 
         for script, result in dd_tests:

--- a/test/functional/rpc_dumptxoutset.py
+++ b/test/functional/rpc_dumptxoutset.py
@@ -29,7 +29,7 @@ class DumptxoutsetTest(BitcoinTestFramework):
 
         FILENAME = 'txoutset.dat'
         out = node.dumptxoutset(FILENAME)
-        expected_path = Path(node.datadir) / self.chain / FILENAME
+        expected_path = Path(node.datadir_path) / self.chain / FILENAME
 
         assert expected_path.is_file()
 

--- a/test/functional/rpc_getblockstats.py
+++ b/test/functional/rpc_getblockstats.py
@@ -14,9 +14,9 @@ from test_framework.util import (
     assert_raises_rpc_error,
 )
 import json
-import os
+from pathlib import Path
 
-TESTSDIR = os.path.dirname(os.path.realpath(__file__))
+TESTSDIR = Path(__file__).parent
 
 class GetblockstatsTest(BitcoinTestFramework):
 
@@ -97,7 +97,7 @@ class GetblockstatsTest(BitcoinTestFramework):
 
 
     def run_test(self):
-        test_data = os.path.join(TESTSDIR, self.options.test_data)
+        test_data = str(TESTSDIR / self.options.test_data)
         if self.options.gen_test_data:
             self.generate_test_data(test_data)
         else:

--- a/test/functional/rpc_help.py
+++ b/test/functional/rpc_help.py
@@ -8,7 +8,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, assert_raises_rpc_error
 
 from collections import defaultdict
-import os
+from pathlib import Path
 import re
 
 
@@ -18,11 +18,11 @@ def parse_string(s):
     return s[1:-1]
 
 
-def process_mapping(fname):
+def process_mapping(file):
     """Find and parse conversion table in implementation file `fname`."""
     cmds = []
     in_rpcs = False
-    with open(fname, "r", encoding="utf8") as f:
+    with file.open(mode="r", encoding="utf8") as f:
         for line in f:
             line = line.rstrip()
             if not in_rpcs:
@@ -58,7 +58,7 @@ class HelpRpcTest(BitcoinTestFramework):
             self.wallet_help()
 
     def test_client_conversion_table(self):
-        file_conversion_table = os.path.join(self.config["environment"]["SRCDIR"], 'src', 'rpc', 'client.cpp')
+        file_conversion_table = Path(self.config["environment"]["SRCDIR"]) / 'src' / 'rpc' / 'client.cpp'
         mapping_client = process_mapping(file_conversion_table)
         # Ignore echojson in client table
         mapping_client = [m for m in mapping_client if m[0] != 'echojson']
@@ -117,11 +117,11 @@ class HelpRpcTest(BitcoinTestFramework):
         assert_equal(titles, sorted(components))
 
     def dump_help(self):
-        dump_dir = os.path.join(self.options.tmpdir, 'rpc_help_dump')
-        os.mkdir(dump_dir)
+        dump_dir = Path(self.options.tmpdir) / 'rpc_help_dump'
+        dump_dir.mkdir()
         calls = [line.split(' ', 1)[0] for line in self.nodes[0].help().splitlines() if line and not line.startswith('==')]
         for call in calls:
-            with open(os.path.join(dump_dir, call), 'w', encoding='utf-8') as f:
+            with (dump_dir / call).open(mode='w', encoding='utf-8') as f:
                 # Make sure the node can generate the help at runtime without crashing
                 f.write(self.nodes[0].help(call))
 

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -48,7 +48,7 @@ from test_framework.wallet_util import (
 )
 
 import json
-import os
+from pathlib import Path
 
 
 class PSBTTest(BitcoinTestFramework):
@@ -524,7 +524,7 @@ class PSBTTest(BitcoinTestFramework):
         assert_equal(unknown_psbt, unknown_out)
 
         # Open the data file
-        with open(os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data/rpc_psbt.json'), encoding='utf-8') as f:
+        with (Path(__file__).parent / 'data' / 'rpc_psbt.json').open(encoding='utf-8') as f:
             d = json.load(f)
             invalids = d['invalid']
             invalid_with_msgs = d["invalid_with_msg"]

--- a/test/functional/rpc_signer.py
+++ b/test/functional/rpc_signer.py
@@ -7,7 +7,7 @@
 Verify that a bitcoind node can use an external signer command.
 See also wallet_signer.py for tests that require wallet context.
 """
-import os
+from pathlib import Path
 import platform
 
 from test_framework.test_framework import BitcoinTestFramework
@@ -19,9 +19,9 @@ from test_framework.util import (
 
 class RPCSignerTest(BitcoinTestFramework):
     def mock_signer_path(self):
-        path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'mocks', 'signer.py')
+        path = Path(__file__).parent / 'mocks' /'signer.py'
         if platform.system() == "Windows":
-            return "py -3 " + path
+            return f"py -3 {path}" 
         else:
             return path
 
@@ -39,11 +39,11 @@ class RPCSignerTest(BitcoinTestFramework):
         self.skip_if_no_external_signer()
 
     def set_mock_result(self, node, res):
-        with open(os.path.join(node.cwd, "mock_result"), "w", encoding="utf8") as f:
+        with (Path(node.cwd) / "mock_result").open(mode="w", encoding="utf8") as f:
             f.write(res)
 
     def clear_mock_result(self, node):
-        os.remove(os.path.join(node.cwd, "mock_result"))
+        (Path(node.cwd) / "mock_result").unlink()
 
     def run_test(self):
         self.log.debug(f"-signer={self.mock_signer_path()}")

--- a/test/functional/test_framework/coverage.py
+++ b/test/functional/test_framework/coverage.py
@@ -8,7 +8,8 @@ Provides a way to track which RPC commands are exercised during
 testing.
 """
 
-import os
+from os import getpid
+from pathlib import Path
 
 from .authproxy import AuthServiceProxy
 from typing import Optional
@@ -73,9 +74,7 @@ def get_filename(dirname, n_node):
 
     This file will contain a list of RPC commands covered.
     """
-    pid = str(os.getpid())
-    return os.path.join(
-        dirname, "coverage.pid%s.node%s.txt" % (pid, str(n_node)))
+    return str(Path(dirname) / f'coverage.pid{getpid()}.node{n_node}.txt')
 
 
 def write_all_rpc_commands(dirname: str, node: AuthServiceProxy) -> bool:
@@ -92,9 +91,9 @@ def write_all_rpc_commands(dirname: str, node: AuthServiceProxy) -> bool:
         if the RPC interface file was written.
 
     """
-    filename = os.path.join(dirname, REFERENCE_FILENAME)
+    filename = Path(dirname) / REFERENCE_FILENAME
 
-    if os.path.isfile(filename):
+    if filename.is_file():
         return False
 
     help_output = node.help().split('\n')
@@ -107,7 +106,7 @@ def write_all_rpc_commands(dirname: str, node: AuthServiceProxy) -> bool:
         if line and not line.startswith('='):
             commands.add("%s\n" % line.split()[0])
 
-    with open(filename, 'w', encoding='utf8') as f:
+    with filename.open(mode='w', encoding='utf8') as f:
         f.writelines(list(commands))
 
     return True

--- a/test/functional/test_framework/ellswift.py
+++ b/test/functional/test_framework/ellswift.py
@@ -8,9 +8,9 @@ WARNING: This code is slow and uses bad randomness.
 Do not use for anything but tests."""
 
 import csv
-import os
 import random
 import unittest
+from pathlib import Path
 
 from test_framework.secp256k1 import FE, G, GE
 
@@ -133,7 +133,7 @@ class TestFrameworkEllSwift(unittest.TestCase):
 
     def test_elligator_encode_testvectors(self):
         """Implement the BIP324 test vectors for ellswift encoding (read from xswiftec_inv_test_vectors.csv)."""
-        vectors_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'xswiftec_inv_test_vectors.csv')
+        vectors_file = Path(__file__).parent / 'xswiftec_inv_test_vectors.csv'
         with open(vectors_file, newline='', encoding='utf8') as csvfile:
             reader = csv.DictReader(csvfile)
             for row in reader:
@@ -149,7 +149,7 @@ class TestFrameworkEllSwift(unittest.TestCase):
 
     def test_elligator_decode_testvectors(self):
         """Implement the BIP324 test vectors for ellswift decoding (read from ellswift_decode_test_vectors.csv)."""
-        vectors_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'ellswift_decode_test_vectors.csv')
+        vectors_file = Path(__file__).parent / 'ellswift_decode_test_vectors.csv'
         with open(vectors_file, newline='', encoding='utf8') as csvfile:
             reader = csv.DictReader(csvfile)
             for row in reader:

--- a/test/functional/test_framework/key.py
+++ b/test/functional/test_framework/key.py
@@ -9,9 +9,9 @@ anything but tests."""
 import csv
 import hashlib
 import hmac
-import os
 import random
 import unittest
+from pathlib import Path
 
 from test_framework import secp256k1
 
@@ -312,7 +312,7 @@ class TestFrameworkKey(unittest.TestCase):
     def test_schnorr_testvectors(self):
         """Implement the BIP340 test vectors (read from bip340_test_vectors.csv)."""
         num_tests = 0
-        vectors_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'bip340_test_vectors.csv')
+        vectors_file = Path(__file__).parent / 'bip340_test_vectors.csv'
         with open(vectors_file, newline='', encoding='utf8') as csvfile:
             reader = csv.reader(csvfile)
             next(reader)

--- a/test/functional/test_framework/netutil.py
+++ b/test/functional/test_framework/netutil.py
@@ -11,7 +11,7 @@ import sys
 import socket
 import struct
 import array
-import os
+from pathlib import Path
 
 # STATE_ESTABLISHED = '01'
 # STATE_SYN_SENT  = '02'
@@ -29,10 +29,10 @@ def get_socket_inodes(pid):
     '''
     Get list of socket inodes for process pid.
     '''
-    base = '/proc/%i/fd' % pid
+    base = Path(f'/proc/{pid}/fd')
     inodes = []
-    for item in os.listdir(base):
-        target = os.readlink(os.path.join(base, item))
+    for item in base.iterdir():
+        target = str((base / item).readlink())
         if target.startswith('socket:'):
             inodes.append(int(target[8:-1]))
     return inodes

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -67,7 +67,7 @@ class TestNode():
     To make things easier for the test writer, any unrecognised messages will
     be dispatched to the RPC connection."""
 
-    def __init__(self, i, datadir, *, chain, rpchost, timewait, timeout_factor, bitcoind, bitcoin_cli, coverage_dir, cwd, extra_conf=None, extra_args=None, use_cli=False, start_perf=False, use_valgrind=False, version=None, descriptors=False):
+    def __init__(self, i, datadir_path, *, chain, rpchost, timewait, timeout_factor, bitcoind, bitcoin_cli, coverage_dir, cwd, extra_conf=None, extra_args=None, use_cli=False, start_perf=False, use_valgrind=False, version=None, descriptors=False):
         """
         Kwargs:
             start_perf (bool): If True, begin profiling the node with `perf` as soon as
@@ -76,10 +76,10 @@ class TestNode():
 
         self.index = i
         self.p2p_conn_index = 1
-        self.datadir = datadir
-        self.bitcoinconf = os.path.join(self.datadir, "bitcoin.conf")
-        self.stdout_dir = os.path.join(self.datadir, "stdout")
-        self.stderr_dir = os.path.join(self.datadir, "stderr")
+        self.datadir_path = datadir_path
+        self.bitcoinconf = self.datadir_path / "bitcoin.conf"
+        self.stdout_dir = self.datadir_path / "stdout"
+        self.stderr_dir = self.datadir_path / "stderr"
         self.chain = chain
         self.rpchost = rpchost
         self.rpc_timeout = timewait
@@ -88,7 +88,7 @@ class TestNode():
         self.cwd = cwd
         self.descriptors = descriptors
         if extra_conf is not None:
-            append_config(datadir, extra_conf)
+            append_config(self.datadir_path, extra_conf)
         # Most callers will just need to add extra args to the standard list below.
         # For those callers that need more flexibility, they can just set the args property directly.
         # Note that common args are set in the config file (see initialize_datadir)
@@ -99,7 +99,7 @@ class TestNode():
         # spam debug.log.
         self.args = [
             self.binary,
-            "-datadir=" + self.datadir,
+            "-datadir=" + str(self.datadir_path),
             "-logtimemicros",
             "-debug",
             "-debugexclude=libevent",
@@ -111,9 +111,7 @@ class TestNode():
             self.args.append("-disablewallet")
 
         if use_valgrind:
-            default_suppressions_file = os.path.join(
-                os.path.dirname(os.path.realpath(__file__)),
-                "..", "..", "..", "contrib", "valgrind.supp")
+            default_suppressions_file = Path(__file__).parents[3] / "contrib" / "valgrind.supp"
             suppressions_file = os.getenv("VALGRIND_SUPPRESSIONS_FILE",
                                           default_suppressions_file)
             self.args = ["valgrind", "--suppressions={}".format(suppressions_file),
@@ -127,7 +125,7 @@ class TestNode():
         if self.version_is_at_least(239000):
             self.args.append("-loglevel=trace")
 
-        self.cli = TestNodeCLI(bitcoin_cli, self.datadir)
+        self.cli = TestNodeCLI(bitcoin_cli, str(self.datadir_path))
         self.use_cli = use_cli
         self.start_perf = start_perf
 
@@ -213,7 +211,7 @@ class TestNode():
         # Delete any existing cookie file -- if such a file exists (eg due to
         # unclean shutdown), it will get overwritten anyway by bitcoind, and
         # potentially interfere with our attempt to authenticate
-        delete_cookie_file(self.datadir, self.chain)
+        delete_cookie_file(self.datadir_path, self.chain)
 
         # add environment variable LIBC_FATAL_STDERR_=1 so that libc errors are written to stderr and not the terminal
         subp_env = dict(os.environ, LIBC_FATAL_STDERR_="1")
@@ -238,7 +236,7 @@ class TestNode():
                     'bitcoind exited with status {} during initialization'.format(self.process.returncode)))
             try:
                 rpc = get_rpc_proxy(
-                    rpc_url(self.datadir, self.index, self.chain, self.rpchost),
+                    rpc_url(self.datadir_path, self.index, self.chain, self.rpchost),
                     self.index,
                     timeout=self.rpc_timeout // 2,  # Shorter timeout to allow for one retry in case of ETIMEDOUT
                     coveragedir=self.coverage_dir,
@@ -302,7 +300,7 @@ class TestNode():
         poll_per_s = 4
         for _ in range(poll_per_s * self.rpc_timeout):
             try:
-                get_auth_cookie(self.datadir, self.chain)
+                get_auth_cookie(self.datadir_path, self.chain)
                 self.log.debug("Cookie credentials successfully retrieved")
                 return
             except ValueError:  # cookie file not found and no rpcuser or rpcpassword; bitcoind is still starting
@@ -418,10 +416,6 @@ class TestNode():
             conf_data = conf_data.replace(old, new)
         with open(self.bitcoinconf, 'w', encoding='utf8') as conf:
             conf.write(conf_data)
-
-    @property
-    def datadir_path(self) -> Path:
-        return Path(self.datadir)
 
     @property
     def chain_path(self) -> Path:
@@ -551,7 +545,7 @@ class TestNode():
                 "perf output won't be very useful without debug symbols compiled into bitcoind")
 
         output_path = tempfile.NamedTemporaryFile(
-            dir=self.datadir,
+            dir=self.datadir_path,
             prefix="{}.perf.data.".format(profile_name or 'test'),
             delete=False,
         ).name

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -11,8 +11,8 @@ import hashlib
 import inspect
 import json
 import logging
-import os
-import pathlib
+from os import getenv
+from pathlib import Path
 import random
 import re
 import sys
@@ -299,7 +299,7 @@ def random_bytes(n):
 # The maximum number of nodes a single test can spawn
 MAX_NODES = 12
 # Don't assign rpc or p2p ports lower than this
-PORT_MIN = int(os.getenv('TEST_RUNNER_PORT_MIN', default=11000))
+PORT_MIN = int(getenv('TEST_RUNNER_PORT_MIN', default=11000))
 # The number of ports to "reserve" for p2p and rpc, each
 PORT_RANGE = 5000
 
@@ -343,8 +343,8 @@ def rpc_port(n):
     return PORT_MIN + PORT_RANGE + n + (MAX_NODES * PortSeed.n) % (PORT_RANGE - 1 - MAX_NODES)
 
 
-def rpc_url(datadir, i, chain, rpchost):
-    rpc_u, rpc_p = get_auth_cookie(datadir, chain)
+def rpc_url(datadir_path, i, chain, rpchost):
+    rpc_u, rpc_p = get_auth_cookie(datadir_path, chain)
     host = '127.0.0.1'
     port = rpc_port(i)
     if rpchost:
@@ -362,11 +362,11 @@ def rpc_url(datadir, i, chain, rpchost):
 
 def initialize_datadir(dirname, n, chain, disable_autoconnect=True):
     datadir = get_datadir_path(dirname, n)
-    if not os.path.isdir(datadir):
-        os.makedirs(datadir)
-    write_config(os.path.join(datadir, "bitcoin.conf"), n=n, chain=chain, disable_autoconnect=disable_autoconnect)
-    os.makedirs(os.path.join(datadir, 'stderr'), exist_ok=True)
-    os.makedirs(os.path.join(datadir, 'stdout'), exist_ok=True)
+    if not datadir.is_dir():
+        datadir.mkdir(parents=True)
+    write_config(datadir / "bitcoin.conf", n=n, chain=chain, disable_autoconnect=disable_autoconnect)
+    (datadir / 'stderr').mkdir(parents=True, exist_ok=True)
+    (datadir / 'stdout').mkdir(parents=True, exist_ok=True)
     return datadir
 
 
@@ -378,7 +378,7 @@ def write_config(config_path, *, n, chain, extra_config="", disable_autoconnect=
     else:
         chain_name_conf_arg = chain
         chain_name_conf_section = chain
-    with open(config_path, 'w', encoding='utf8') as f:
+    with config_path.open(mode='w', encoding='utf8') as f:
         if chain_name_conf_arg:
             f.write("{}=1\n".format(chain_name_conf_arg))
         if chain_name_conf_section:
@@ -412,10 +412,10 @@ def write_config(config_path, *, n, chain, extra_config="", disable_autoconnect=
 
 
 def get_datadir_path(dirname, n):
-    return os.path.join(dirname, "node" + str(n))
+    return Path(dirname) / f"node{n}"
 
 
-def get_temp_default_datadir(temp_dir: pathlib.Path) -> Tuple[dict, pathlib.Path]:
+def get_temp_default_datadir(temp_dir: Path) -> Tuple[dict, Path]:
     """Return os-specific environment variables that can be set to make the
     GetDefaultDataDir() function return a datadir path under the provided
     temp_dir, as well as the complete path it would return."""
@@ -432,16 +432,16 @@ def get_temp_default_datadir(temp_dir: pathlib.Path) -> Tuple[dict, pathlib.Path
 
 
 def append_config(datadir, options):
-    with open(os.path.join(datadir, "bitcoin.conf"), 'a', encoding='utf8') as f:
+    with (datadir / "bitcoin.conf").open(mode='a', encoding='utf8') as f:
         for option in options:
             f.write(option + "\n")
 
 
-def get_auth_cookie(datadir, chain):
+def get_auth_cookie(datadir_path, chain):
     user = None
     password = None
-    if os.path.isfile(os.path.join(datadir, "bitcoin.conf")):
-        with open(os.path.join(datadir, "bitcoin.conf"), 'r', encoding='utf8') as f:
+    if (datadir_path / "bitcoin.conf").is_file():
+        with (datadir_path / "bitcoin.conf").open(mode='r', encoding='utf8') as f:
             for line in f:
                 if line.startswith("rpcuser="):
                     assert user is None  # Ensure that there is only one rpcuser line
@@ -450,7 +450,7 @@ def get_auth_cookie(datadir, chain):
                     assert password is None  # Ensure that there is only one rpcpassword line
                     password = line.split("=")[1].strip("\n")
     try:
-        with open(os.path.join(datadir, chain, ".cookie"), 'r', encoding="ascii") as f:
+        with (datadir_path / chain / '.cookie').open(mode='r', encoding="ascii") as f:
             userpass = f.read()
             split_userpass = userpass.split(':')
             user = split_userpass[0]
@@ -463,10 +463,11 @@ def get_auth_cookie(datadir, chain):
 
 
 # If a cookie file exists in the given datadir, delete it.
-def delete_cookie_file(datadir, chain):
-    if os.path.isfile(os.path.join(datadir, chain, ".cookie")):
+def delete_cookie_file(datadir_path, chain):
+    filepath = datadir_path / f'{chain}.cookie'
+    if filepath.is_file():
         logger.debug("Deleting leftover cookie file")
-        os.remove(os.path.join(datadir, chain, ".cookie"))
+        filepath.unlink()
 
 
 def softfork_active(node, key):

--- a/test/functional/tool_signet_miner.py
+++ b/test/functional/tool_signet_miner.py
@@ -4,7 +4,7 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test signet miner tool"""
 
-import os.path
+from pathlib import Path
 import subprocess
 import sys
 import time
@@ -47,7 +47,7 @@ class SignetMinerTest(BitcoinTestFramework):
 
         # generate block with signet miner tool
         base_dir = self.config["environment"]["SRCDIR"]
-        signet_miner_path = os.path.join(base_dir, "contrib", "signet", "miner")
+        signet_miner_path = Path(base_dir) / "contrib" / "signet" / "miner"
         subprocess.run([
                 sys.executable,
                 signet_miner_path,

--- a/test/functional/wallet_backup.py
+++ b/test/functional/wallet_backup.py
@@ -31,7 +31,6 @@ Shutdown again, restore using importwallet,
 and confirm again balances are correct.
 """
 from decimal import Decimal
-import os
 from random import randint
 import shutil
 
@@ -109,36 +108,35 @@ class WalletBackupTest(BitcoinTestFramework):
         self.stop_node(2)
 
     def erase_three(self):
-        os.remove(os.path.join(self.nodes[0].wallets_path, self.default_wallet_name, self.wallet_data_filename))
-        os.remove(os.path.join(self.nodes[1].wallets_path, self.default_wallet_name, self.wallet_data_filename))
-        os.remove(os.path.join(self.nodes[2].wallets_path, self.default_wallet_name, self.wallet_data_filename))
+        for node_num in range(3):
+            (self.nodes[node_num].wallets_path / self.default_wallet_name / self.wallet_data_filename).unlink()
 
     def restore_invalid_wallet(self):
         node = self.nodes[3]
-        invalid_wallet_file = os.path.join(self.nodes[0].datadir, 'invalid_wallet_file.bak')
+        invalid_wallet_file = self.nodes[0].datadir_path / 'invalid_wallet_file.bak'
         open(invalid_wallet_file, 'a', encoding="utf8").write('invald wallet')
         wallet_name = "res0"
-        not_created_wallet_file = os.path.join(node.wallets_path, wallet_name)
+        not_created_wallet_file = node.wallets_path / wallet_name
         error_message = "Wallet file verification failed. Failed to load database path '{}'. Data is not in recognized format.".format(not_created_wallet_file)
         assert_raises_rpc_error(-18, error_message, node.restorewallet, wallet_name, invalid_wallet_file)
-        assert not os.path.exists(not_created_wallet_file)
+        assert not not_created_wallet_file.exists()
 
     def restore_nonexistent_wallet(self):
         node = self.nodes[3]
-        nonexistent_wallet_file = os.path.join(self.nodes[0].datadir, 'nonexistent_wallet.bak')
+        nonexistent_wallet_file = self.nodes[0].datadir_path / 'nonexistent_wallet.bak'
         wallet_name = "res0"
         assert_raises_rpc_error(-8, "Backup file does not exist", node.restorewallet, wallet_name, nonexistent_wallet_file)
-        not_created_wallet_file = os.path.join(node.wallets_path, wallet_name)
-        assert not os.path.exists(not_created_wallet_file)
+        not_created_wallet_file = node.wallets_path / wallet_name
+        assert not not_created_wallet_file.exists()
 
     def restore_wallet_existent_name(self):
         node = self.nodes[3]
-        backup_file = os.path.join(self.nodes[0].datadir, 'wallet.bak')
+        backup_file = self.nodes[0].datadir_path / 'wallet.bak'
         wallet_name = "res0"
-        wallet_file = os.path.join(node.wallets_path, wallet_name)
+        wallet_file = node.wallets_path / wallet_name
         error_message = "Failed to create database path '{}'. Database already exists.".format(wallet_file)
         assert_raises_rpc_error(-36, error_message, node.restorewallet, wallet_name, backup_file)
-        assert os.path.exists(wallet_file)
+        assert wallet_file.exists()
 
     def run_test(self):
         self.log.info("Generating initial blockchain")
@@ -159,14 +157,12 @@ class WalletBackupTest(BitcoinTestFramework):
 
         self.log.info("Backing up")
 
-        self.nodes[0].backupwallet(os.path.join(self.nodes[0].datadir, 'wallet.bak'))
-        self.nodes[1].backupwallet(os.path.join(self.nodes[1].datadir, 'wallet.bak'))
-        self.nodes[2].backupwallet(os.path.join(self.nodes[2].datadir, 'wallet.bak'))
+        for node_num in range(3):
+            self.nodes[node_num].backupwallet(self.nodes[node_num].datadir_path / 'wallet.bak')    
 
         if not self.options.descriptors:
-            self.nodes[0].dumpwallet(os.path.join(self.nodes[0].datadir, 'wallet.dump'))
-            self.nodes[1].dumpwallet(os.path.join(self.nodes[1].datadir, 'wallet.dump'))
-            self.nodes[2].dumpwallet(os.path.join(self.nodes[2].datadir, 'wallet.dump'))
+            for node_num in range(3):
+                self.nodes[node_num].dumpwallet(self.nodes[node_num].datadir_path / 'wallet.dump')
 
         self.log.info("More transactions")
         for _ in range(5):
@@ -193,17 +189,13 @@ class WalletBackupTest(BitcoinTestFramework):
         self.restore_invalid_wallet()
         self.restore_nonexistent_wallet()
 
-        backup_file_0 = os.path.join(self.nodes[0].datadir, 'wallet.bak')
-        backup_file_1 = os.path.join(self.nodes[1].datadir, 'wallet.bak')
-        backup_file_2 = os.path.join(self.nodes[2].datadir, 'wallet.bak')
+        backup_files = []
+        for node_num in range(3):
+            backup_files.append(self.nodes[node_num].datadir_path / 'wallet.bak')
 
-        self.nodes[3].restorewallet("res0", backup_file_0)
-        self.nodes[3].restorewallet("res1", backup_file_1)
-        self.nodes[3].restorewallet("res2", backup_file_2)
-
-        assert os.path.exists(os.path.join(self.nodes[3].wallets_path, "res0"))
-        assert os.path.exists(os.path.join(self.nodes[3].wallets_path, "res1"))
-        assert os.path.exists(os.path.join(self.nodes[3].wallets_path, "res2"))
+        for idx, backup_file in enumerate(backup_files):
+            self.nodes[3].restorewallet(f'res{idx}', backup_file)
+            assert (self.nodes[3].wallets_path / f'res{idx}').exists()
 
         res0_rpc = self.nodes[3].get_wallet_rpc("res0")
         res1_rpc = self.nodes[3].get_wallet_rpc("res1")
@@ -221,22 +213,16 @@ class WalletBackupTest(BitcoinTestFramework):
             self.erase_three()
 
             #start node2 with no chain
-            shutil.rmtree(os.path.join(self.nodes[2].chain_path, 'blocks'))
-            shutil.rmtree(os.path.join(self.nodes[2].chain_path, 'chainstate'))
+            shutil.rmtree(self.nodes[2].chain_path / 'blocks')
+            shutil.rmtree(self.nodes[2].chain_path / 'chainstate')
 
             self.start_three(["-nowallet"])
             # Create new wallets for the three nodes.
             # We will use this empty wallets to test the 'importwallet()' RPC command below.
             for node_num in range(3):
                 self.nodes[node_num].createwallet(wallet_name=self.default_wallet_name, descriptors=self.options.descriptors, load_on_startup=True)
-
-            assert_equal(self.nodes[0].getbalance(), 0)
-            assert_equal(self.nodes[1].getbalance(), 0)
-            assert_equal(self.nodes[2].getbalance(), 0)
-
-            self.nodes[0].importwallet(os.path.join(self.nodes[0].datadir, 'wallet.dump'))
-            self.nodes[1].importwallet(os.path.join(self.nodes[1].datadir, 'wallet.dump'))
-            self.nodes[2].importwallet(os.path.join(self.nodes[2].datadir, 'wallet.dump'))
+                assert_equal(self.nodes[node_num].getbalance(), 0)
+                self.nodes[node_num].importwallet(self.nodes[node_num].datadir_path / 'wallet.dump')
 
             self.sync_blocks()
 
@@ -246,13 +232,13 @@ class WalletBackupTest(BitcoinTestFramework):
 
         # Backup to source wallet file must fail
         sourcePaths = [
-            os.path.join(self.nodes[0].wallets_path, self.default_wallet_name, self.wallet_data_filename),
-            os.path.join(self.nodes[0].wallets_path, '.', self.default_wallet_name, self.wallet_data_filename),
-            os.path.join(self.nodes[0].wallets_path, self.default_wallet_name),
-            os.path.join(self.nodes[0].wallets_path)]
+            self.nodes[0].wallets_path / self.default_wallet_name / self.wallet_data_filename,
+            self.nodes[0].wallets_path / 'x' / self.default_wallet_name / self.wallet_data_filename,
+            self.nodes[0].wallets_path / self.default_wallet_name,
+            self.nodes[0].wallets_path]
 
         for sourcePath in sourcePaths:
-            assert_raises_rpc_error(-4, "backup failed", self.nodes[0].backupwallet, sourcePath)
+            assert_raises_rpc_error(-4, "backup failed", self.nodes[0].backupwallet, str(sourcePath))
 
 
 if __name__ == '__main__':

--- a/test/functional/wallet_backwards_compatibility.py
+++ b/test/functional/wallet_backwards_compatibility.py
@@ -14,7 +14,6 @@ Use only the latest patch version of each release, unless a test specifically
 needs an older patch version.
 """
 
-import os
 import shutil
 
 from test_framework.blocktools import COINBASE_MATURITY
@@ -167,10 +166,10 @@ class BackwardsCompatibilityTest(BitcoinTestFramework):
 
         for node in legacy_nodes:
             # Copy wallets to previous version
-            for wallet in os.listdir(node_master_wallets_dir):
+            for wallet in node_master_wallets_dir.iterdir():
                 shutil.copytree(
-                    os.path.join(node_master_wallets_dir, wallet),
-                    os.path.join(self.nodes_wallet_dir(node), wallet)
+                    node_master_wallets_dir / wallet,
+                    self.nodes_wallet_dir(node)/ wallet
                 )
 
         if not self.options.descriptors:
@@ -260,8 +259,8 @@ class BackwardsCompatibilityTest(BitcoinTestFramework):
             # Old wallets are BDB and will only work if BDB is compiled
             # Copy the 0.16 wallet to the last Bitcoin Core version and open it:
             shutil.copyfile(
-                os.path.join(node_v16_wallets_dir, "wallets/u1_v16"),
-                os.path.join(node_master_wallets_dir, "u1_v16")
+                node_v16_wallets_dir / "wallets/u1_v16",
+                node_master_wallets_dir / "u1_v16"
             )
             load_res = node_master.loadwallet("u1_v16")
             # Make sure this wallet opens with only the migration warning. See https://github.com/bitcoin/bitcoin/pull/19054
@@ -279,10 +278,10 @@ class BackwardsCompatibilityTest(BitcoinTestFramework):
 
             # Now copy that same wallet back to 0.16 to make sure no automatic upgrade breaks it
             node_master.unloadwallet("u1_v16")
-            os.remove(os.path.join(node_v16_wallets_dir, "wallets/u1_v16"))
+            (node_v16_wallets_dir / "wallets/u1_v16").unlink()
             shutil.copyfile(
-                os.path.join(node_master_wallets_dir, "u1_v16"),
-                os.path.join(node_v16_wallets_dir, "wallets/u1_v16")
+                node_master_wallets_dir / "u1_v16",
+                node_v16_wallets_dir / "wallets/u1_v16"
             )
             self.start_node(node_v16.index, extra_args=["-wallet=u1_v16"])
             wallet = node_v16.get_wallet_rpc("u1_v16")
@@ -292,8 +291,8 @@ class BackwardsCompatibilityTest(BitcoinTestFramework):
             # Copy the 0.17 wallet to the last Bitcoin Core version and open it:
             node_v17.unloadwallet("u1_v17")
             shutil.copytree(
-                os.path.join(node_v17_wallets_dir, "u1_v17"),
-                os.path.join(node_master_wallets_dir, "u1_v17")
+                node_v17_wallets_dir / "u1_v17",
+                node_master_wallets_dir / "u1_v17"
             )
             node_master.loadwallet("u1_v17")
             wallet = node_master.get_wallet_rpc("u1_v17")
@@ -303,10 +302,10 @@ class BackwardsCompatibilityTest(BitcoinTestFramework):
 
             # Now copy that same wallet back to 0.17 to make sure no automatic upgrade breaks it
             node_master.unloadwallet("u1_v17")
-            shutil.rmtree(os.path.join(node_v17_wallets_dir, "u1_v17"))
+            shutil.rmtree(node_v17_wallets_dir / "u1_v17")
             shutil.copytree(
-                os.path.join(node_master_wallets_dir, "u1_v17"),
-                os.path.join(node_v17_wallets_dir, "u1_v17")
+                node_master_wallets_dir / "u1_v17",
+                node_v17_wallets_dir / "u1_v17"
             )
             node_v17.loadwallet("u1_v17")
             wallet = node_v17.get_wallet_rpc("u1_v17")
@@ -315,8 +314,8 @@ class BackwardsCompatibilityTest(BitcoinTestFramework):
 
             # Copy the 0.19 wallet to the last Bitcoin Core version and open it:
             shutil.copytree(
-                os.path.join(node_v19_wallets_dir, "w1_v19"),
-                os.path.join(node_master_wallets_dir, "w1_v19")
+                node_v19_wallets_dir / "w1_v19",
+                node_master_wallets_dir / "w1_v19"
             )
             node_master.loadwallet("w1_v19")
             wallet = node_master.get_wallet_rpc("w1_v19")
@@ -324,10 +323,10 @@ class BackwardsCompatibilityTest(BitcoinTestFramework):
 
             # Now copy that same wallet back to 0.19 to make sure no automatic upgrade breaks it
             node_master.unloadwallet("w1_v19")
-            shutil.rmtree(os.path.join(node_v19_wallets_dir, "w1_v19"))
+            shutil.rmtree(node_v19_wallets_dir / "w1_v19")
             shutil.copytree(
-                os.path.join(node_master_wallets_dir, "w1_v19"),
-                os.path.join(node_v19_wallets_dir, "w1_v19")
+                node_master_wallets_dir / "w1_v19",
+                node_v19_wallets_dir / "w1_v19"
             )
             node_v19.loadwallet("w1_v19")
             wallet = node_v19.get_wallet_rpc("w1_v19")

--- a/test/functional/wallet_blank.py
+++ b/test/functional/wallet_blank.py
@@ -3,7 +3,6 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
-import os
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.address import (
@@ -110,7 +109,7 @@ class WalletBlankTest(BitcoinTestFramework):
         assert_equal(info["descriptors"], False)
         assert_equal(info["blank"], True)
 
-        wallet_dump_path = os.path.join(self.nodes[0].datadir, "wallet.dump")
+        wallet_dump_path = self.nodes[0].datadir_path / "wallet.dump"
         def_wallet.dumpwallet(wallet_dump_path)
 
         wallet.importwallet(wallet_dump_path)

--- a/test/functional/wallet_crosschain.py
+++ b/test/functional/wallet_crosschain.py
@@ -3,8 +3,6 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-import os
-
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_raises_rpc_error
 
@@ -31,13 +29,13 @@ class WalletCrossChain(BitcoinTestFramework):
     def run_test(self):
         self.log.info("Creating wallets")
 
-        node0_wallet = os.path.join(self.nodes[0].datadir, 'node0_wallet')
-        node0_wallet_backup = os.path.join(self.nodes[0].datadir, 'node0_wallet.bak')
+        node0_wallet = self.nodes[0].datadir_path / 'node0_wallet'
+        node0_wallet_backup = self.nodes[0].datadir_path / 'node0_wallet.bak'
         self.nodes[0].createwallet(node0_wallet)
         self.nodes[0].backupwallet(node0_wallet_backup)
         self.nodes[0].unloadwallet(node0_wallet)
-        node1_wallet = os.path.join(self.nodes[1].datadir, 'node1_wallet')
-        node1_wallet_backup = os.path.join(self.nodes[0].datadir, 'node1_wallet.bak')
+        node1_wallet = self.nodes[1].datadir_path / 'node1_wallet'
+        node1_wallet_backup = self.nodes[0].datadir_path / 'node1_wallet.bak'
         self.nodes[1].createwallet(node1_wallet)
         self.nodes[1].backupwallet(node1_wallet_backup)
         self.nodes[1].unloadwallet(node1_wallet)

--- a/test/functional/wallet_descriptor.py
+++ b/test/functional/wallet_descriptor.py
@@ -3,7 +3,6 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test descriptor wallet function."""
-import os
 
 try:
     import sqlite3
@@ -234,7 +233,7 @@ class WalletDescriptorTest(BitcoinTestFramework):
         self.log.info("Test that loading descriptor wallet containing legacy key types throws error")
         self.nodes[0].createwallet(wallet_name="crashme", descriptors=True)
         self.nodes[0].unloadwallet("crashme")
-        wallet_db = os.path.join(self.nodes[0].wallets_path, "crashme", self.wallet_data_filename)
+        wallet_db = self.nodes[0].wallets_path / "crashme" / self.wallet_data_filename
         conn = sqlite3.connect(wallet_db)
         with conn:
             # add "cscript" entry: key type is uint160 (20 bytes), value type is CScript (zero-length here)

--- a/test/functional/wallet_dump.py
+++ b/test/functional/wallet_dump.py
@@ -111,8 +111,8 @@ class WalletDumpTest(BitcoinTestFramework):
     def run_test(self):
         self.nodes[0].createwallet("dump")
 
-        wallet_unenc_dump = os.path.join(self.nodes[0].datadir, "wallet.unencrypted.dump")
-        wallet_enc_dump = os.path.join(self.nodes[0].datadir, "wallet.encrypted.dump")
+        wallet_unenc_dump = self.nodes[0].datadir_path / "wallet.unencrypted.dump"
+        wallet_enc_dump = self.nodes[0].datadir_path / "wallet.encrypted.dump"
 
         # generate 30 addresses to compare against the dump
         # - 10 legacy P2PKH
@@ -156,7 +156,7 @@ class WalletDumpTest(BitcoinTestFramework):
 
         self.log.info('Dump unencrypted wallet')
         result = self.nodes[0].dumpwallet(wallet_unenc_dump)
-        assert_equal(result['filename'], wallet_unenc_dump)
+        assert_equal(result['filename'], str(wallet_unenc_dump))
 
         found_comments, found_legacy_addr, found_p2sh_segwit_addr, found_bech32_addr, found_script_addr, found_addr_chg, found_addr_rsv, hd_master_addr_unenc = \
             read_dump(wallet_unenc_dump, addrs, [multisig_addr], None)
@@ -220,7 +220,7 @@ class WalletDumpTest(BitcoinTestFramework):
         w3.sendtoaddress(w3.getnewaddress(), 10)
         w3.unloadwallet()
         self.nodes[0].loadwallet("w3")
-        w3.dumpwallet(os.path.join(self.nodes[0].datadir, "w3.dump"))
+        w3.dumpwallet(self.nodes[0].datadir_path / "w3.dump")
 
 if __name__ == '__main__':
     WalletDumpTest().main()

--- a/test/functional/wallet_fast_rescan.py
+++ b/test/functional/wallet_fast_rescan.py
@@ -43,7 +43,7 @@ class WalletFastRescanTest(BitcoinTestFramework):
         wallet = MiniWallet(node)
 
         self.log.info("Create descriptor wallet with backup")
-        WALLET_BACKUP_FILENAME = os.path.join(node.datadir, 'wallet.bak')
+        WALLET_BACKUP_FILENAME = node.datadir_path / 'wallet.bak'
         node.createwallet(wallet_name='topup_test', descriptors=True)
         w = node.get_wallet_rpc('topup_test')
         fixed_key = get_generate_key()

--- a/test/functional/wallet_hd.py
+++ b/test/functional/wallet_hd.py
@@ -4,7 +4,6 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test Hierarchical Deterministic wallet function."""
 
-import os
 import shutil
 
 from test_framework.blocktools import COINBASE_MATURITY
@@ -51,8 +50,8 @@ class WalletHDTest(BitcoinTestFramework):
         self.nodes[1].importprivkey(non_hd_key)
 
         # This should be enough to keep the master key and the non-HD key
-        self.nodes[1].backupwallet(os.path.join(self.nodes[1].datadir, "hd.bak"))
-        #self.nodes[1].dumpwallet(os.path.join(self.nodes[1].datadir, "hd.dump"))
+        self.nodes[1].backupwallet(self.nodes[1].datadir_path / "hd.bak")
+        #self.nodes[1].dumpwallet(self.nodes[1].datadir_path / "hd.dump")
 
         # Derive some HD addresses and remember the last
         # Also send funds to each add
@@ -87,11 +86,11 @@ class WalletHDTest(BitcoinTestFramework):
         self.stop_node(1)
         # we need to delete the complete chain directory
         # otherwise node1 would auto-recover all funds in flag the keypool keys as used
-        shutil.rmtree(os.path.join(self.nodes[1].chain_path, "blocks"))
-        shutil.rmtree(os.path.join(self.nodes[1].chain_path, "chainstate"))
+        shutil.rmtree(self.nodes[1].chain_path / "blocks")
+        shutil.rmtree(self.nodes[1].chain_path / "chainstate")
         shutil.copyfile(
-            os.path.join(self.nodes[1].datadir, "hd.bak"),
-            os.path.join(self.nodes[1].wallets_path, self.default_wallet_name, self.wallet_data_filename),
+            self.nodes[1].datadir_path / "hd.bak",
+            self.nodes[1].wallets_path / self.default_wallet_name / self.wallet_data_filename
         )
         self.start_node(1)
 
@@ -115,11 +114,11 @@ class WalletHDTest(BitcoinTestFramework):
 
         # Try a RPC based rescan
         self.stop_node(1)
-        shutil.rmtree(os.path.join(self.nodes[1].chain_path, "blocks"))
-        shutil.rmtree(os.path.join(self.nodes[1].chain_path, "chainstate"))
+        shutil.rmtree(self.nodes[1].chain_path / "blocks")
+        shutil.rmtree(self.nodes[1].chain_path / "chainstate")
         shutil.copyfile(
-            os.path.join(self.nodes[1].datadir, "hd.bak"),
-            os.path.join(self.nodes[1].wallets_path, self.default_wallet_name, self.wallet_data_filename),
+            self.nodes[1].datadir_path / "hd.bak",
+            self.nodes[1].wallets_path / self.default_wallet_name / self.wallet_data_filename
         )
         self.start_node(1, extra_args=self.extra_args[1])
         self.connect_nodes(0, 1)

--- a/test/functional/wallet_keypool_topup.py
+++ b/test/functional/wallet_keypool_topup.py
@@ -10,7 +10,6 @@ Two nodes. Node1 is under test. Node0 is providing transactions and generating b
 - Generate 110 keys (enough to drain the keypool). Store key 90 (in the initial keypool) and key 110 (beyond the initial keypool). Send funds to key 90 and key 110.
 - Stop node1, clear the datadir, move wallet file back into the datadir and restart node1.
 - connect node1 to node0. Verify that they sync and node1 receives its funds."""
-import os
 import shutil
 
 from test_framework.blocktools import COINBASE_MATURITY
@@ -33,8 +32,8 @@ class KeypoolRestoreTest(BitcoinTestFramework):
         self.skip_if_no_wallet()
 
     def run_test(self):
-        wallet_path = os.path.join(self.nodes[1].wallets_path, self.default_wallet_name, self.wallet_data_filename)
-        wallet_backup_path = os.path.join(self.nodes[1].datadir, "wallet.bak")
+        wallet_path = self.nodes[1].wallets_path / self.default_wallet_name / self.wallet_data_filename
+        wallet_backup_path = self.nodes[1].datadir_path / "wallet.bak"
         self.generate(self.nodes[0], COINBASE_MATURITY + 1)
 
         self.log.info("Make backup of wallet")

--- a/test/functional/wallet_listtransactions.py
+++ b/test/functional/wallet_listtransactions.py
@@ -5,7 +5,6 @@
 """Test the listtransactions API."""
 
 from decimal import Decimal
-import os
 import shutil
 
 from test_framework.messages import (
@@ -234,8 +233,8 @@ class ListTransactionsTest(BitcoinTestFramework):
         # refill keypool otherwise the second node wouldn't recognize addresses generated on the first nodes
         self.nodes[0].keypoolrefill(1000)
         self.stop_nodes()
-        wallet0 = os.path.join(self.nodes[0].chain_path, self.default_wallet_name, "wallet.dat")
-        wallet2 = os.path.join(self.nodes[2].chain_path, self.default_wallet_name, "wallet.dat")
+        wallet0 = self.nodes[0].chain_path / self.default_wallet_name / "wallet.dat"
+        wallet2 = self.nodes[2].chain_path / self.default_wallet_name / "wallet.dat"
         shutil.copyfile(wallet0, wallet2)
         self.start_nodes()
         # reconnect nodes

--- a/test/functional/wallet_pruning.py
+++ b/test/functional/wallet_pruning.py
@@ -4,7 +4,6 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 """Test wallet import on pruned node."""
-import os
 
 from test_framework.util import assert_equal, assert_raises_rpc_error
 from test_framework.blocktools import (
@@ -74,7 +73,7 @@ class WalletPruningTest(BitcoinTestFramework):
 
         # Import wallet into pruned node
         self.nodes[1].createwallet(wallet_name="wallet_pruned", descriptors=False, load_on_startup=True)
-        self.nodes[1].importwallet(os.path.join(self.nodes[0].datadir, wallet_file))
+        self.nodes[1].importwallet(self.nodes[0].datadir_path / wallet_file)
 
         # Make sure that prune node's wallet correctly accounts for balances
         assert_equal(self.nodes[1].getbalance(), self.nodes[0].getbalance())
@@ -93,12 +92,12 @@ class WalletPruningTest(BitcoinTestFramework):
         # Make sure wallet cannot be imported because of missing blocks
         # This will try to rescan blocks `TIMESTAMP_WINDOW` (2h) before the wallet birthheight.
         # There are 6 blocks an hour, so 11 blocks (excluding birthheight).
-        assert_raises_rpc_error(-4, f"Pruned blocks from height {wallet_birthheight - 11} required to import keys. Use RPC call getblockchaininfo to determine your pruned height.", self.nodes[1].importwallet, os.path.join(self.nodes[0].datadir, wallet_file))
+        assert_raises_rpc_error(-4, f"Pruned blocks from height {wallet_birthheight - 11} required to import keys. Use RPC call getblockchaininfo to determine your pruned height.", self.nodes[1].importwallet, self.nodes[0].datadir_path / wallet_file)
         self.log.info("- Done")
 
     def get_birthheight(self, wallet_file):
         """Gets birthheight of a wallet on node0"""
-        with open(os.path.join(self.nodes[0].datadir, wallet_file), 'r', encoding="utf8") as f:
+        with (self.nodes[0].datadir_path / wallet_file).open(mode='r', encoding="utf8") as f:
             for line in f:
                 if line.startswith('# * Best block at time of backup'):
                     wallet_birthheight = int(line.split(' ')[9])
@@ -106,12 +105,12 @@ class WalletPruningTest(BitcoinTestFramework):
 
     def has_block(self, block_index):
         """Checks if the pruned node has the specific blk0000*.dat file"""
-        return os.path.isfile(os.path.join(self.nodes[1].chain_path, "blocks", f"blk{block_index:05}.dat"))
+        return (self.nodes[1].chain_path / "blocks" / f"blk{block_index:05}.dat").is_file()
 
     def create_wallet(self, wallet_name, *, unload=False):
         """Creates and dumps a wallet on the non-pruned node0 to be later import by the pruned node"""
         self.nodes[0].createwallet(wallet_name=wallet_name, descriptors=False, load_on_startup=True)
-        self.nodes[0].dumpwallet(os.path.join(self.nodes[0].datadir, wallet_name + ".dat"))
+        self.nodes[0].dumpwallet(self.nodes[0].datadir_path / f"{wallet_name}.dat")
         if (unload):
             self.nodes[0].unloadwallet(wallet_name)
 

--- a/test/functional/wallet_reorgsrestore.py
+++ b/test/functional/wallet_reorgsrestore.py
@@ -14,7 +14,6 @@ disconnected.
 """
 
 from decimal import Decimal
-import os
 import shutil
 
 from test_framework.test_framework import BitcoinTestFramework
@@ -88,8 +87,8 @@ class ReorgsRestoreTest(BitcoinTestFramework):
 
         # Node0 wallet file is loaded on longest sync'ed node1
         self.stop_node(1)
-        self.nodes[0].backupwallet(os.path.join(self.nodes[0].datadir, 'wallet.bak'))
-        shutil.copyfile(os.path.join(self.nodes[0].datadir, 'wallet.bak'), os.path.join(self.nodes[1].chain_path, self.default_wallet_name, self.wallet_data_filename))
+        self.nodes[0].backupwallet(self.nodes[0].datadir_path / 'wallet.bak')
+        shutil.copyfile(self.nodes[0].datadir_path / 'wallet.bak', self.nodes[1].chain_path / self.default_wallet_name / self.wallet_data_filename)
         self.start_node(1)
         tx_after_reorg = self.nodes[1].gettransaction(txid)
         # Check that normal confirmed tx is confirmed again but with different blockhash

--- a/test/functional/wallet_signer.py
+++ b/test/functional/wallet_signer.py
@@ -7,8 +7,8 @@
 Verify that a bitcoind node can use an external signer command
 See also rpc_signer.py for tests without wallet context.
 """
-import os
 import platform
+from pathlib import Path
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
@@ -23,23 +23,23 @@ class WalletSignerTest(BitcoinTestFramework):
         self.add_wallet_options(parser, legacy=False)
 
     def mock_signer_path(self):
-        path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'mocks', 'signer.py')
+        path = Path(__file__).parent / 'mocks' / 'signer.py'
         if platform.system() == "Windows":
-            return "py -3 " + path
+            return f"py -3 {path}"
         else:
             return path
 
     def mock_invalid_signer_path(self):
-        path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'mocks', 'invalid_signer.py')
+        path = Path(__file__).parent / 'mocks' / 'invalid_signer.py'
         if platform.system() == "Windows":
-            return "py -3 " + path
+            return f"py -3 {path}"
         else:
             return path
 
     def mock_multi_signers_path(self):
-        path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'mocks', 'multi_signers.py')
+        path = Path(__file__).parent / 'mocks' / 'multi_signers.py'
         if platform.system() == "Windows":
-            return "py -3 " + path
+            return f"py -3 {path}"
         else:
             return path
 
@@ -56,11 +56,11 @@ class WalletSignerTest(BitcoinTestFramework):
         self.skip_if_no_wallet()
 
     def set_mock_result(self, node, res):
-        with open(os.path.join(node.cwd, "mock_result"), "w", encoding="utf8") as f:
+        with (Path(node.cwd) / "mock_result").open(mode="w", encoding="utf8") as f:
             f.write(res)
 
     def clear_mock_result(self, node):
-        os.remove(os.path.join(node.cwd, "mock_result"))
+        (Path(node.cwd) / "mock_result").unlink()
 
     def run_test(self):
         self.test_valid_signer()
@@ -202,7 +202,7 @@ class WalletSignerTest(BitcoinTestFramework):
 
         assert hww.testmempoolaccept([mock_tx])[0]["allowed"]
 
-        with open(os.path.join(self.nodes[1].cwd, "mock_psbt"), "w", encoding="utf8") as f:
+        with (Path(self.nodes[1].cwd) / "mock_psbt").open(mode="w", encoding="utf8") as f:
             f.write(mock_psbt_signed["psbt"])
 
         self.log.info('Test send using hww1')
@@ -227,7 +227,7 @@ class WalletSignerTest(BitcoinTestFramework):
         mock_psbt_bumped = mock_wallet.psbtbumpfee(orig_tx_id)["psbt"]
         mock_psbt_bumped_signed = mock_wallet.walletprocesspsbt(psbt=mock_psbt_bumped, sign=True, sighashtype="ALL", bip32derivs=True)
 
-        with open(os.path.join(self.nodes[1].cwd, "mock_psbt"), "w", encoding="utf8") as f:
+        with (Path(self.nodes[1].cwd) / "mock_psbt").open(mode="w", encoding="utf8") as f:
             f.write(mock_psbt_bumped_signed["psbt"])
 
         self.log.info('Test bumpfee using hww1')

--- a/test/functional/wallet_upgradewallet.py
+++ b/test/functional/wallet_upgradewallet.py
@@ -178,7 +178,7 @@ class UpgradeWalletTest(BitcoinTestFramework):
             os.mkdir(node_master_wallet_dir)
             shutil.copy(
                 split_hd_wallet,
-                os.path.join(node_master_wallet_dir, 'wallet.dat')
+                (node_master_wallet_dir /'wallet.dat')
             )
             node_master.loadwallet(self.default_wallet_name)
 

--- a/test/util/rpcauth-test.py
+++ b/test/util/rpcauth-test.py
@@ -8,19 +8,17 @@ import re
 import configparser
 import hmac
 import importlib
-import os
+from pathlib import Path
 import sys
 import unittest
 
 class TestRPCAuth(unittest.TestCase):
     def setUp(self):
         config = configparser.ConfigParser()
-        config_path = os.path.abspath(
-            os.path.join(os.sep, os.path.abspath(os.path.dirname(__file__)),
-            "../config.ini"))
-        with open(config_path, encoding="utf8") as config_file:
+        config_path = Path(__file__).parents[1] / 'config.ini'        
+        with config_path.open(encoding="utf8") as config_file:
             config.read_file(config_file)
-        sys.path.insert(0, os.path.dirname(config['environment']['RPCAUTH']))
+        sys.path.insert(0, str(Path(config['environment']['RPCAUTH']).parent))
         self.rpcauth = importlib.import_module('rpcauth')
 
     def test_generate_salt(self):


### PR DESCRIPTION
In reference to issue #28362 refactoring of functional tests to use pathlib over os.path to reduce verbosity and increase the intuitiveness of managing file access.