### PR TITLE
wallet: fix BnB selection upper bound

### DIFF
--- a/src/wallet/coinselection.h
+++ b/src/wallet/coinselection.h
@@ -409,7 +409,7 @@ public:
     int GetWeight() const { return m_weight; }
 };
 
-util::Result<SelectionResult> SelectCoinsBnB(std::vector<OutputGroup>& utxo_pool, const CAmount& selection_target, const CAmount& cost_of_change,
+util::Result<SelectionResult> SelectCoinsBnB(std::vector<OutputGroup>& utxo_pool, const CAmount& selection_target, const CAmount& min_viable_change,
                                              int max_weight);
 
 /** Select coins by Single Random Draw. OutputGroups are selected randomly from the eligible

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -572,7 +572,7 @@ util::Result<SelectionResult> ChooseSelectionResult(const CAmount& nTargetValue,
     // Maximum allowed weight
     int max_inputs_weight = MAX_STANDARD_TX_WEIGHT - (coin_selection_params.tx_noinputs_size * WITNESS_SCALE_FACTOR);
 
-    if (auto bnb_result{SelectCoinsBnB(groups.positive_group, nTargetValue, coin_selection_params.m_cost_of_change, max_inputs_weight)}) {
+    if (auto bnb_result{SelectCoinsBnB(groups.positive_group, nTargetValue, coin_selection_params.min_viable_change, max_inputs_weight)}) {
         results.push_back(*bnb_result);
     } else append_error(bnb_result);
 

--- a/src/wallet/test/coinselector_tests.cpp
+++ b/src/wallet/test/coinselector_tests.cpp
@@ -431,7 +431,7 @@ BOOST_AUTO_TEST_CASE(bnb_search_test)
 
         CAmount selection_target = 16 * CENT;
         const auto& no_res = SelectCoinsBnB(GroupCoins(available_coins.All(), /*subtract_fee_outputs*/true),
-                                            selection_target, /*cost_of_change=*/0, MAX_STANDARD_TX_WEIGHT);
+                                            selection_target, /*min_viable_change=*/0, MAX_STANDARD_TX_WEIGHT);
         BOOST_REQUIRE(!no_res);
         BOOST_CHECK(util::ErrorString(no_res).original.find("The inputs size exceeds the maximum weight") != std::string::npos);
 

--- a/src/wallet/test/fuzz/coinselection.cpp
+++ b/src/wallet/test/fuzz/coinselection.cpp
@@ -116,9 +116,9 @@ FUZZ_TARGET(coinselection)
     }
 
     // Run coinselection algorithms
-    auto result_bnb = SelectCoinsBnB(group_pos, target, coin_params.m_cost_of_change, MAX_STANDARD_TX_WEIGHT);
+    auto result_bnb = SelectCoinsBnB(group_pos, target, coin_params.min_viable_change, MAX_STANDARD_TX_WEIGHT);
     if (result_bnb) {
-        assert(result_bnb->GetChange(coin_params.m_cost_of_change, CAmount{0}) == 0);
+        assert(result_bnb->GetChange(coin_params.min_viable_change, CAmount{0}) == 0);
         assert(result_bnb->GetSelectedValue() >= target);
         (void)result_bnb->GetShuffledInputVector();
         (void)result_bnb->GetInputSet();


### PR DESCRIPTION
As BnB is an algorithm specialized in seeking changeless solutions, the
final selection amount (the sum of all the selected UTXOs amount) can be
as high as one unit below the amount where the transaction creation
process starts creating a change output. Which is: target + min_viable_change - 1.

In other words, the range of the possible solutions is:
target <= solution_amount < target + min_viable_change - 1.

Code level description:
We have a discrepancy on the threshold at which we create, or not, "change" between the BnB
algorithm and the, higher level, transaction creation process.

BnB selection upper bound uses `cost_of_change`, while the transaction creation process uses
the `min_viable_change` variable to obtain the resulting change amount from the coin selection
solution ([here](https://github.com/bitcoin/bitcoin/blob/6f03c45f6bb5a6edaa3051968b6a1ca4f84d2ccb/src/wallet/spend.cpp#L987)).

Essentially, this means that under certain circumstances; when the BnB solution excess is
in-between `min_viable_change` and `cost_of_change`, the BnB algorithm returns a
successful solution which, under the transaction creation process perspective, requires to create
change output. This, isn't an expected behavior as BnB is specialized to only return a changeless
solution.

This can happen when min_viable_change <= BnB_solution_amount - target < cost_of_change.

Note:
This should solve the issue presented in #28372.

Testing Note:
I have decoupled the test in a standalone commit so it can be easily cherry-picked on top of master to
verify the test failure vs the test passing here after the changes.