### PR TITLE
test: p2p: check that `getaddr` msgs are only responded once per connection

### DIFF
--- a/test/functional/p2p_addr_relay.py
+++ b/test/functional/p2p_addr_relay.py
@@ -299,6 +299,16 @@ class AddrTest(BitcoinTestFramework):
         assert_equal(block_relay_peer.num_ipv4_received, 0)
         assert inbound_peer.num_ipv4_received > 100
 
+        self.log.info('Check that we answer getaddr messages only once per connection')
+        received_addrs_before = inbound_peer.num_ipv4_received
+        with self.nodes[0].assert_debug_log(['Ignoring repeated "getaddr".']):
+            inbound_peer.send_and_ping(msg_getaddr())
+        self.mocktime += 10 * 60
+        self.nodes[0].setmocktime(self.mocktime)
+        inbound_peer.sync_with_ping()
+        received_addrs_after = inbound_peer.num_ipv4_received
+        assert_equal(received_addrs_before, received_addrs_after)
+
         self.nodes[0].disconnect_p2ps()
 
     def blocksonly_mode_tests(self):


### PR DESCRIPTION
This simple PR adds missing test coverage for ignoring repeated `getaddr` requests (introduced in #7856, commit 66b07247a7a9e48e082502338176cc06edf61474):
https://github.com/bitcoin/bitcoin/blob/6f03c45f6bb5a6edaa3051968b6a1ca4f84d2ccb/src/net_processing.cpp#L4642-L4648