### PR TITLE
ci: cirrus workaround

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,6 +1,6 @@
 env:  # Global defaults
   CIRRUS_CLONE_DEPTH: 1
-  PACKAGE_MANAGER_INSTALL: "apt-get update && apt-get install -y"
+  PACKAGE_MANAGER_INSTALL: "chmod 1777 /tmp; apt-get update && apt-get install -y"
   MAKEJOBS: "-j10"
   TEST_RUNNER_PORT_MIN: "14000"  # Must be larger than 12321, which is used for the http cache. See https://cirrus-ci.org/guide/writing-tasks/#http-cache
   CI_FAILFAST_TEST_LEAVE_DANGLING: "1"  # Cirrus CI does not care about dangling processes and setting this variable avoids killing the CI script itself on error


### PR DESCRIPTION
For some reason cirrus's /tmp permissions are set to only allow write access by the root user, causing apt-get to fail.