### PR TITLE
Make provably unsignable standard P2PK and P2MS outpoints unspendable.

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -115,6 +115,7 @@ BITCOIN_TESTS =\
   test/net_tests.cpp \
   test/netbase_tests.cpp \
   test/orphanage_tests.cpp \
+  test/p2pk_detect_unspendable.cpp \
   test/pmt_tests.cpp \
   test/policy_fee_tests.cpp \
   test/policyestimator_tests.cpp \

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -532,6 +532,8 @@ public:
      */
     unsigned int GetSigOpCount(const CScript& scriptSig) const;
 
+    bool IsPayToPublicKey() const;
+    bool IsPayToMultisig() const;
     bool IsPayToScriptHash() const;
     bool IsPayToWitnessScriptHash() const;
     bool IsWitnessProgram(int& version, std::vector<unsigned char>& program) const;
@@ -548,10 +550,7 @@ public:
      * regardless of the initial stack. This allows outputs to be pruned
      * instantly when entering the UTXO set.
      */
-    bool IsUnspendable() const
-    {
-        return (size() > 0 && *begin() == OP_RETURN) || (size() > MAX_SCRIPT_SIZE);
-    }
+    bool IsUnspendable() const;
 
     void clear()
     {
@@ -588,6 +587,9 @@ public:
 
 /** Test for OP_SUCCESSx opcodes as defined by BIP342. */
 bool IsOpSuccess(const opcodetype& opcode);
+
+bool IsOpN(const unsigned char op_code);
+bool IsOpN(const unsigned char op_code, unsigned char& value);
 
 bool CheckMinimalPush(const std::vector<unsigned char>& data, opcodetype opcode);
 

--- a/src/test/p2pk_detect_unspendable.cpp
+++ b/src/test/p2pk_detect_unspendable.cpp
@@ -1,0 +1,40 @@
+#include <script/script.h>
+#include <script/solver.h>
+#include <test/util/str.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <string>
+
+BOOST_AUTO_TEST_SUITE(p2pk_detect)
+
+BOOST_AUTO_TEST_CASE(p2pk_testvectors_valid)
+{
+    // Generate valid vectors from OP_0 to OP_PUSHBYTES_75
+    for (int op = OP_0; op < OP_PUSHDATA1; ++op) {
+        CScript p2pk;
+        if(op != OP_0) {
+            std::vector<unsigned char> bytes(op, 0x00);
+            p2pk << bytes << OP_CHECKSIG;
+            BOOST_CHECK(p2pk.IsPayToPublicKey() == true);
+        } else {
+            p2pk << op << OP_CHECKSIG;
+            BOOST_CHECK(p2pk.IsPayToPublicKey() == false);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(p2pk_dual_ops_invalid)
+{
+    // Test double OP_CHECKSIG scripts
+    for (int op = OP_0; op < OP_PUSHDATA1; ++op) {
+        CScript p2pk;
+        unsigned char n_op = OP_PUSHDATA1 - 4 - op;
+        std::vector<unsigned char> bytes(op,0x00);
+        std::vector<unsigned char> n_bytes(n_op,0xFF);
+        p2pk << bytes << OP_CHECKSIG << n_bytes << OP_CHECKSIG;
+        BOOST_CHECK(p2pk.IsPayToPublicKey() == false);
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -944,7 +944,7 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     CheckIsNotStandard(t, "dust");
 
     // Check uncompressed P2PK outputs dust threshold (must have leading 04/06/07)
-    t.vout[0].scriptPubKey = CScript() << std::vector<unsigned char>(65, 0x04) << OP_CHECKSIG;
+    t.vout[0].scriptPubKey = CScript() << ParseHex("044f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa385b6b1b8ead809ca67454d9683fcf2ba03456d6fe2c4abe2b07f0fbdbb2f1c1") << OP_CHECKSIG;
     t.vout[0].nValue = 672;
     CheckIsStandard(t);
     t.vout[0].nValue = 671;


### PR DESCRIPTION
### Overview
This pr introduces additional conditionals into ```IsUnspendable()``` to remove provably unspendable P2PK and P2MS tx outpoints from the UTXO set. This is done by using ```IsFullyValid()``` to check that the public key(s) for the outpoints script are valid. This trims nearly 20K outpoints from the UTXO set at height 805618. https://gist.github.com/russeree/85fb9519e0a1fc166177a6d5e0e15be2  

A side effect of this PR is it removes the use case for uncompressed public keys through standard tx types to store arbitrary data in the UTXO set.

### P2PK
P2PK outpoints with a single pubkey that is invalid can by flagged as unspendable becuase the public key does not exist on the SECP256K1 curve and thus no private key exists to make OP_CHECKSIG evaluate to true. 

Script must be in the format of ```OP_PUSHBBYTES PUBKEY OP_CHECKSIG(VERIFY)```

### P2MS
P2MS outpoints that do not have enough valid public keys to meet the threshold. where (n-k < m) where k is the number of invalid public keys. 

Script must be in the format of ```OP_(N) PUBKEY1 .... OP_(N) OP_CHECKMULTISIG(VERIFY)```