### PR TITLE
ci: Bump `actions/checkout` version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Clang version
         run: clang --version
@@ -90,7 +90,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Fix Visual Studio installation
         # See: https://github.com/actions/runner-images/issues/7832#issuecomment-1617585694.


### PR DESCRIPTION
See: https://github.com/actions/checkout/releases/tag/v4.0.0.