### PR TITLE
contrib: verify-binaries accept full arch-platform specifier

### DIFF
--- a/contrib/verify-binaries/README.md
+++ b/contrib/verify-binaries/README.md
@@ -42,14 +42,14 @@ See the `Config` object for various options.
 
 Validate releases with default settings:
 ```sh
-./contrib/verify-binaries/verify.py pub 22.0
-./contrib/verify-binaries/verify.py pub 22.0-rc3
+./contrib/verify-binaries/verify.py pub 26.0
+./contrib/verify-binaries/verify.py pub 25.1-rc1
 ```
 
 Get JSON output and don't prompt for user input (no auto key import):
 
 ```sh
-./contrib/verify-binaries/verify.py --json pub 22.0-x86
+./contrib/verify-binaries/verify.py --json pub 26.0-x86_64
 ```
 
 Rely only on local GPG state and manually specified keys, while requiring a
@@ -57,20 +57,21 @@ threshold of at least 10 trusted signatures:
 ```sh
 ./contrib/verify-binaries/verify.py \
     --trusted-keys 74E2DEF5D77260B98BC19438099BAD163C70FBFA,9D3CC86A72F8494342EA5FD10A41BDC3F4FAFF1C \
-    --min-good-sigs 10 pub 22.0-x86
+    --min-good-sigs 10 pub 22.1-x86_64
 ```
 
-If you only want to download the binaries for a certain platform, add the corresponding suffix, e.g.:
+If you only want to download the binaries for a certain architecture and/or platform, add the corresponding suffix, e.g.:
 
 ```sh
-./contrib/verify-binaries/verify.py pub 24.0.1-darwin
-./contrib/verify-binaries/verify.py pub 23.1-rc1-win64
+./contrib/verify-binaries/verify.py pub 24.2-rc1-win64
+./contrib/verify-binaries/verify.py pub 25.1-linux-gnu
+./contrib/verify-binaries/verify.py pub 26.0-x86_64-linux-gnu
 ```
 
-If you do not want to keep the downloaded binaries, specify the cleanup option.
+If you do not want to keep the downloaded binaries, specify the `cleanup` option.
 
 ```sh
-./contrib/verify-binaries/verify.py pub --cleanup 22.0
+./contrib/verify-binaries/verify.py pub --cleanup 22.1
 ```
 
 Use the bin subcommand to verify all files listed in a local checksum file
@@ -83,6 +84,6 @@ Verify only a subset of the files listed in a local checksum file
 
 ```sh
 ./contrib/verify-binaries/verify.py bin ~/Downloads/SHA256SUMS \
-    ~/Downloads/bitcoin-24.0.1-x86_64-linux-gnu.tar.gz \
-    ~/Downloads/bitcoin-24.0.1-arm-linux-gnueabihf.tar.gz
+    ~/Downloads/bitcoin-24.1-x86_64-linux-gnu.tar.gz \
+    ~/Downloads/bitcoin-24.1-arm-linux-gnueabihf.tar.gz
 ```


### PR DESCRIPTION
Currently the verify-binaries script will accept "wildcards" such as "linux" or "darwin" as binary specifiers.

Builders however usually only want to verify for their specific architecture-platform that they want to use, or verify everything. Update the script to accept single full architecture-platform specifiers as used by the binary repositories.

Previously if you tried to use a complete specifier, e.g. 25.0-x86_64-linux-gnu it would download all `linux-gnu` platform binaries as this is parsed into 4 parts, and so `version_rc` and `version_os` are [unspecified](https://github.com/bitcoin/bitcoin/blob/9d3b216e009a53ffcecd57e7f10df15cccd5fd6d/contrib/verify-binaries/verify.py#L107-L114).

With the new parser it's still possible to specify "25.0-linux" or "25.0-x86_64" to verify multiple builds if so desired.