### PR TITLE
fix: unnecessary continuation after finding mutation

### DIFF
--- a/src/consensus/merkle.cpp
+++ b/src/consensus/merkle.cpp
@@ -47,7 +47,10 @@ uint256 ComputeMerkleRoot(std::vector<uint256> hashes, bool* mutated) {
     while (hashes.size() > 1) {
         if (mutated) {
             for (size_t pos = 0; pos + 1 < hashes.size(); pos += 2) {
-                if (hashes[pos] == hashes[pos + 1]) mutation = true;
+                if (hashes[pos] == hashes[pos + 1]) {
+                    mutation = true;
+                    break;
+                }
             }
         }
         if (hashes.size() & 1) {


### PR DESCRIPTION
A simple increment so that when the mutation is successfully found, the break already exits the for to avoid an unnecessary continuation.

The concept is simple, this change should improve the performance of this function, providing a faster completion when meeting the given objective.