### PR TITLE
Remove needless `GetTransactionOutputWeight` helper

### DIFF
--- a/src/consensus/validation.h
+++ b/src/consensus/validation.h
@@ -158,10 +158,6 @@ static inline int64_t GetTransactionInputWeight(const CTxIn& txin)
     // scriptWitness size is added here because witnesses and txins are split up in segwit serialization.
     return ::GetSerializeSize(txin, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS) * (WITNESS_SCALE_FACTOR - 1) + ::GetSerializeSize(txin, PROTOCOL_VERSION) + ::GetSerializeSize(txin.scriptWitness.stack, PROTOCOL_VERSION);
 }
-static inline int64_t GetTransactionOutputWeight(const CTxOut& txout)
-{
-    return ::GetSerializeSize(txout, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS) * (WITNESS_SCALE_FACTOR - 1) + ::GetSerializeSize(txout, PROTOCOL_VERSION);
-}
 
 /** Compute at which vout of the block's coinbase transaction the witness commitment occurs, or -1 if not found */
 inline int GetWitnessCommitmentIndex(const CBlock& block)

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -144,7 +144,7 @@ TxSize CalculateMaximumSignedTxSize(const CTransaction &tx, const CWallet *walle
     if (is_segwit) weight += 2;
 
     // Add the size of the transaction outputs.
-    for (const auto& txo : tx.vout) weight += GetTransactionOutputWeight(txo);
+    for (const auto& txo : tx.vout) weight += GetSerializeSize(txo) * WITNESS_SCALE_FACTOR;
 
     // Add the size of the transaction inputs as if they were signed.
     for (uint32_t i = 0; i < txouts.size(); i++) {


### PR DESCRIPTION
Introduced in #26567. My bad. Thanks AJ for noticing.