### PR TITLE
kernel: remove `script/solver.{h,cpp}` from kernel headers

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -268,6 +268,7 @@ BITCOIN_CORE_H = \
   script/sign.h \
   script/signingprovider.h \
   script/solver.h \
+  script/txouttype.h \
   shutdown.h \
   signet.h \
   streams.h \
@@ -704,6 +705,7 @@ libbitcoin_common_a_SOURCES = \
   script/sign.cpp \
   script/signingprovider.cpp \
   script/solver.cpp \
+  script/txouttype.cpp \
   warnings.cpp \
   $(BITCOIN_CORE_H)
 
@@ -966,6 +968,7 @@ libbitcoinkernel_la_SOURCES = \
   script/script_error.cpp \
   script/sigcache.cpp \
   script/solver.cpp \
+  script/txouttype.cpp \
   signet.cpp \
   streams.cpp \
   support/cleanse.cpp \

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -21,6 +21,7 @@
 #include <script/script.h>
 #include <script/sign.h>
 #include <script/signingprovider.h>
+#include <script/solver.h>
 #include <univalue.h>
 #include <util/exception.h>
 #include <util/fs.h>

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -10,7 +10,7 @@
 #include <consensus/consensus.h>
 #include <primitives/transaction.h>
 #include <script/interpreter.h>
-#include <script/solver.h>
+#include <script/txouttype.h>
 
 #include <cstdint>
 #include <string>

--- a/src/script/miniscript.cpp
+++ b/src/script/miniscript.cpp
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 #include <script/script.h>
+#include <script/solver.h>
 #include <script/miniscript.h>
 
 #include <assert.h>

--- a/src/script/solver.cpp
+++ b/src/script/solver.cpp
@@ -11,26 +11,8 @@
 
 #include <algorithm>
 #include <cassert>
-#include <string>
 
 typedef std::vector<unsigned char> valtype;
-
-std::string GetTxnOutputType(TxoutType t)
-{
-    switch (t) {
-    case TxoutType::NONSTANDARD: return "nonstandard";
-    case TxoutType::PUBKEY: return "pubkey";
-    case TxoutType::PUBKEYHASH: return "pubkeyhash";
-    case TxoutType::SCRIPTHASH: return "scripthash";
-    case TxoutType::MULTISIG: return "multisig";
-    case TxoutType::NULL_DATA: return "nulldata";
-    case TxoutType::WITNESS_V0_KEYHASH: return "witness_v0_keyhash";
-    case TxoutType::WITNESS_V0_SCRIPTHASH: return "witness_v0_scripthash";
-    case TxoutType::WITNESS_V1_TAPROOT: return "witness_v1_taproot";
-    case TxoutType::WITNESS_UNKNOWN: return "witness_unknown";
-    } // no default case, so the compiler can warn about missing cases
-    assert(false);
-}
 
 static bool MatchPayToPubkey(const CScript& script, valtype& pubkey)
 {

--- a/src/script/solver.h
+++ b/src/script/solver.h
@@ -10,31 +10,14 @@
 
 #include <attributes.h>
 #include <script/script.h>
+#include <script/txouttype.h>
 
-#include <string>
 #include <optional>
 #include <utility>
 #include <vector>
 
 class CPubKey;
 template <typename C> class Span;
-
-enum class TxoutType {
-    NONSTANDARD,
-    // 'standard' transaction types:
-    PUBKEY,
-    PUBKEYHASH,
-    SCRIPTHASH,
-    MULTISIG,
-    NULL_DATA, //!< unspendable OP_RETURN script that carries data
-    WITNESS_V0_SCRIPTHASH,
-    WITNESS_V0_KEYHASH,
-    WITNESS_V1_TAPROOT,
-    WITNESS_UNKNOWN, //!< Only for Witness versions not already defined above
-};
-
-/** Get the name of a TxoutType as a string */
-std::string GetTxnOutputType(TxoutType t);
 
 constexpr bool IsPushdataOp(opcodetype opcode)
 {

--- a/src/script/txouttype.cpp
+++ b/src/script/txouttype.cpp
@@ -1,0 +1,26 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <script/txouttype.h>
+
+#include <cassert>
+#include <string>
+
+std::string GetTxnOutputType(TxoutType t)
+{
+    switch (t) {
+    case TxoutType::NONSTANDARD: return "nonstandard";
+    case TxoutType::PUBKEY: return "pubkey";
+    case TxoutType::PUBKEYHASH: return "pubkeyhash";
+    case TxoutType::SCRIPTHASH: return "scripthash";
+    case TxoutType::MULTISIG: return "multisig";
+    case TxoutType::NULL_DATA: return "nulldata";
+    case TxoutType::WITNESS_V0_KEYHASH: return "witness_v0_keyhash";
+    case TxoutType::WITNESS_V0_SCRIPTHASH: return "witness_v0_scripthash";
+    case TxoutType::WITNESS_V1_TAPROOT: return "witness_v1_taproot";
+    case TxoutType::WITNESS_UNKNOWN: return "witness_unknown";
+    } // no default case, so the compiler can warn about missing cases
+    assert(false);
+}

--- a/src/script/txouttype.h
+++ b/src/script/txouttype.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_SCRIPT_TXOUTTYPE_H
+#define BITCOIN_SCRIPT_TXOUTTYPE_H
+
+#include <string>
+
+enum class TxoutType {
+    NONSTANDARD,
+    // 'standard' transaction types:
+    PUBKEY,
+    PUBKEYHASH,
+    SCRIPTHASH,
+    MULTISIG,
+    NULL_DATA, //!< unspendable OP_RETURN script that carries data
+    WITNESS_V0_SCRIPTHASH,
+    WITNESS_V0_KEYHASH,
+    WITNESS_V1_TAPROOT,
+    WITNESS_UNKNOWN, //!< Only for Witness versions not already defined above
+};
+
+/** Get the name of a TxoutType as a string */
+std::string GetTxnOutputType(TxoutType t);
+
+#endif // BITCOIN_SCRIPT_TXOUTTYPE_H

--- a/src/test/script_p2sh_tests.cpp
+++ b/src/test/script_p2sh_tests.cpp
@@ -10,6 +10,7 @@
 #include <script/script_error.h>
 #include <script/sign.h>
 #include <script/signingprovider.h>
+#include <script/solver.h>
 #include <test/util/setup_common.h>
 #include <validation.h>
 


### PR DESCRIPTION
This removes the non consensus-critical `solver.h` header from the kernel headers by stripping out the `TxoutType` enum (needed by `policy.h`) into its own header.

It's only a small gain but it's also pretty straightforward. Figured i'd PR it directly to gather whether people think that's worth it.