### PR TITLE
wallet: allowing walletpassphrase timeout to be MAX_SLEEP_TIME if set to -1

### DIFF
--- a/doc/release-notes-28454.md
+++ b/doc/release-notes-28454.md
@@ -1,0 +1,5 @@
+RPC Wallet
+----------
+
+- The `walletpassphrase` call will now uses the value of 100,000,000 seconds (~3 years)
+  if the user passes a `timeout` value of `-1`. (#28454)

--- a/src/wallet/rpc/encrypt.cpp
+++ b/src/wallet/rpc/encrypt.cpp
@@ -18,7 +18,7 @@ RPCHelpMan walletpassphrase()
             "time that overrides the old one.\n",
                 {
                     {"passphrase", RPCArg::Type::STR, RPCArg::Optional::NO, "The wallet passphrase"},
-                    {"timeout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The time to keep the decryption key in seconds; capped at 100000000 (~3 years)."},
+                    {"timeout", RPCArg::Type::NUM, RPCArg::Optional::NO, "The time to keep the decryption key in seconds; capped at 100000000 (~3 years), will use cap if -1 specified."},
                 },
                 RPCResult{RPCResult::Type::NONE, "", ""},
                 RPCExamples{
@@ -54,12 +54,13 @@ RPCHelpMan walletpassphrase()
         // Get the timeout
         nSleepTime = request.params[1].getInt<int64_t>();
         // Timeout cannot be negative, otherwise it will relock immediately
-        if (nSleepTime < 0) {
+        if (nSleepTime < 0 && nSleepTime != -1) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Timeout cannot be negative.");
         }
         // Clamp timeout
         constexpr int64_t MAX_SLEEP_TIME = 100000000; // larger values trigger a macos/libevent bug?
-        if (nSleepTime > MAX_SLEEP_TIME) {
+
+        if (nSleepTime > MAX_SLEEP_TIME || nSleepTime == -1) {
             nSleepTime = MAX_SLEEP_TIME;
         }
 

--- a/test/functional/test_framework/wallet_util.py
+++ b/test/functional/test_framework/wallet_util.py
@@ -128,9 +128,7 @@ class WalletUnlock():
     A context manager for unlocking a wallet with a passphrase and automatically locking it afterward.
     """
 
-    MAXIMUM_TIMEOUT = 999000
-
-    def __init__(self, wallet, passphrase, timeout=MAXIMUM_TIMEOUT):
+    def __init__(self, wallet, passphrase, timeout=-1):
         self.wallet = wallet
         self.passphrase = passphrase
         self.timeout = timeout


### PR DESCRIPTION
In this change we allow the timeout for walletpassphrase to be
set to MAX_SLEEP_TIME,
if set as -1 then we then use the MAX_SLEEP_TIME amount

context from PR 28403

added release notes for RPC Wallet

Also tests were modified to use the max timeout amount using timeout = -1

<!--
*** Please remove the following help text before submitting: ***

Pull requests without a rationale and clear improvement may be closed
immediately.

GUI-related pull requests should be opened against
https://github.com/bitcoin-core/gui
first. See CONTRIBUTING.md
-->

<!--
Please provide clear motivation for your patch and explain how it improves
Bitcoin Core user experience or Bitcoin Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Bitcoin Core, if possible.
* Refactoring changes are only accepted if they are required for a feature or
  bug fix or otherwise improve developer experience significantly. For example,
  most "code style" refactoring changes require a thorough explanation why they
  are useful, what downsides they have and why they *significantly* improve
  developer experience or avoid serious programming bugs. Note that code style
  is often a subjective matter. Unless they are explicitly mentioned to be
  preferred in the [developer notes](/doc/developer-notes.md), stylistic code
  changes are usually rejected.
-->

<!--
Bitcoin Core has a thorough review process and even the most trivial change
needs to pass a lot of eyes and requires non-zero or even substantial time
effort to review. There is a huge lack of active reviewers on the project, so
patches often sit for a long time.
-->
