### PR TITLE
build: add `-mbranch-protection=bti` (aarch64) to hardening flags

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -964,6 +964,11 @@ if test "$use_hardening" != "no"; then
       ;;
   esac
 
+  case $host in
+    *aarch64*)
+      AX_CHECK_COMPILE_FLAG([-mbranch-protection=bti], [HARDENED_CXXFLAGS="$HARDENED_CXXFLAGS -mbranch-protection=bti"])
+    ;;
+  esac
 
   dnl When enable_debug is yes, all optimizations are disabled.
   dnl However, FORTIFY_SOURCE requires that there is some level of optimization, otherwise it does nothing and just creates a compiler warning.


### PR DESCRIPTION
This is a simpler (less hardening) version of https://github.com/bitcoin/bitcoin/pull/24123.

You can inspect binaries using `readelf -n`, and look for BTI in a `.note.gnu.property`. i.e
```bash
readelf -n src/bitcoin-cli

Displaying notes found in: .note.gnu.property
  Owner                Data size 	Description
  GNU                  0x00000010	NT_GNU_PROPERTY_TYPE_0
      Properties: AArch64 feature: BTI
```

Related to https://github.com/bitcoin/bitcoin/issues/19075.