### PR TITLE
ci: Unbreak Asan CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -43,7 +43,7 @@ env:  # Global defaults
 # The following specific types should exist, with the following requirements:
 # - small: For an x86_64 machine, recommended to have 2 CPUs and 8 GB of memory.
 # - medium: For an x86_64 machine, recommended to have 4 CPUs and 16 GB of memory.
-# - lunar: For a machine running the Linux kernel shipped with Ubuntu Lunar 23.04. The machine is recommended to have 4 CPUs and 16 GB of memory.
+# - lunar: For a machine running the Linux kernel shipped with exactly Ubuntu Mantic 23.10. The machine is recommended to have 4 CPUs and 16 GB of memory.
 # - arm64: For an aarch64 machine, recommended to have 2 CPUs and 8 GB of memory.
 
 # https://cirrus-ci.org/guide/tips-and-tricks/#sharing-configuration-between-tasks

--- a/ci/test/00_setup_env_native_asan.sh
+++ b/ci/test/00_setup_env_native_asan.sh
@@ -17,7 +17,7 @@ fi
 
 export CONTAINER_NAME=ci_native_asan
 export PACKAGES="systemtap-sdt-dev clang-16 llvm-16 libclang-rt-16-dev python3-zmq qtbase5-dev qttools5-dev-tools libevent-dev libboost-dev libdb5.3++-dev libminiupnpc-dev libnatpmp-dev libzmq3-dev libqrencode-dev libsqlite3-dev ${BPFCC_PACKAGE}"
-export CI_IMAGE_NAME_TAG="docker.io/ubuntu:23.04"  # Version 23.04 will reach EOL in Jan 2024, and can be replaced by "ubuntu:24.04" (or anything else that ships the wanted clang version).
+export CI_IMAGE_NAME_TAG="docker.io/ubuntu:23.10"  # Version 23.10 will reach EOL in Jul 2024, and can be replaced by "ubuntu:24.04" (or anything else that ships the wanted clang version).
 export NO_DEPENDS=1
 export GOAL="install"
 export BITCOIN_CONFIG="--enable-c++20 --enable-usdt --enable-zmq --with-incompatible-bdb --with-gui=qt5 \


### PR DESCRIPTION
Someone upgraded the `lunar` type persistent workers to Ubuntu Mantic. This broke CI https://cirrus-ci.com/task/4900424734474240?logs=ci#L322 :

```
Get:17 http://archive.ubuntu.com/ubuntu lunar-backports/universe amd64 Packages [4208 B]
Fetched 25.1 MB in 3s (9362 kB/s)
Reading package lists...
+ retry -- bash -c 'apt-get install --no-install-recommends --no-upgrade -y systemtap-sdt-dev clang-16 llvm-16 libclang-rt-16-dev python3-zmq qtbase5-dev qttools5-dev-tools libevent-dev libboost-dev libdb5.3++-dev libminiupnpc-dev libnatpmp-dev libzmq3-dev libqrencode-dev libsqlite3-dev bpfcc-tools linux-headers-6.3.0-7-generic build-essential libtool autotools-dev automake pkg-config bsdmainutils curl ca-certificates ccache python3 rsync git procps bison'
Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package linux-headers-6.3.0-7-generic
E: Couldn't find any package by glob 'linux-headers-6.3.0-7-generic'
E: Couldn't find any package by regex 'linux-headers-6.3.0-7-generic'
Before retry #1: sleeping 0.3 seconds
```

Fix it by also upgrading the CI config.