### PR TITLE
ci: Temporarily disable test-each-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,23 +23,6 @@ env:
   MAKEJOBS: '-j10'
 
 jobs:
-  test-each-commit:
-    name: 'test each commit'
-    runs-on: ubuntu-22.04
-    if: github.event_name == 'pull_request'
-    timeout-minutes: 360  # Use maximum time, see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes. Assuming a worst case time of 1 hour per commit, this leads to a --max-count=6 below.
-    env:
-      MAX_COUNT: '--max-count=6'
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: '8'  # Two more than $MAX_COUNT
-      - run: git checkout HEAD~  # Skip the top commit, because it is already checked by the other tasks.
-      - run: sudo apt install clang ccache build-essential libtool autotools-dev automake pkg-config bsdmainutils python3-zmq libevent-dev libboost-dev libsqlite3-dev libdb++-dev systemtap-sdt-dev libminiupnpc-dev libnatpmp-dev libqt5gui5 libqt5core5a libqt5dbus5 qttools5-dev qttools5-dev-tools qtwayland5 libqrencode-dev -y
-      # Use clang++, because it is a bit faster and uses less memory than g++
-      - run: git rebase --exec "echo Running test-one-commit on \$( git log -1 ) && ./autogen.sh && CC=clang CXX=clang++ ./configure && make clean && make -j $(nproc) check && ./test/functional/test_runner.py -j $(( $(nproc) * 2 ))" "$( git log '^'$( git log --merges -1 --format='%H' ) HEAD --format='%H' ${MAX_COUNT} | tail -1 )~1"
-
   macos-native-x86_64:
     name: 'macOS 13 native, x86_64, no depends, sqlite only, gui'
     # Use latest image, but hardcode version to avoid silent upgrades (and breaks).


### PR DESCRIPTION
This should unbreak the GHA CI for now, and allow someone to fix the task in a follow-up. The issue is https://github.com/bitcoin/bitcoin/pull/28279#issuecomment-1719324530 .

If no one fixes it, it can be replaced by a Cirrus CI self-hosted runner.