### PR TITLE
txorphanage: add size accounting, use wtxids, support multiple announcers

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4212,7 +4212,7 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
                     if (!AlreadyHaveTx(gtxid)) AddTxAnnouncement(pfrom, gtxid, current_time);
                 }
 
-                if (m_orphanage.AddTx(ptx, pfrom.GetId())) {
+                if (m_orphanage.AddTx(ptx, pfrom.GetId(), unique_parents)) {
                     AddToCompactExtraTransactions(ptx);
                 }
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2929,6 +2929,7 @@ bool PeerManagerImpl::ProcessOrphanTx(Peer& peer)
                 orphan_wtxid.ToString(),
                 m_mempool.size(), m_mempool.DynamicMemoryUsage() / 1000);
             RelayTransaction(orphanHash, porphanTx->GetWitnessHash());
+            FastRandomContext rng;
             m_orphanage.AddChildrenToWorkSet(*porphanTx);
             m_orphanage.EraseTx(orphan_wtxid);
             for (const CTransactionRef& removedTx : result.m_replaced_transactions.value()) {
@@ -4162,6 +4163,7 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
             m_txrequest.ForgetTxHash(tx.GetHash());
             m_txrequest.ForgetTxHash(tx.GetWitnessHash());
             RelayTransaction(tx.GetHash(), tx.GetWitnessHash());
+            FastRandomContext rng;
             m_orphanage.AddChildrenToWorkSet(tx);
 
             pfrom.m_last_tx_time = GetTime<std::chrono::seconds>();

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2930,7 +2930,7 @@ bool PeerManagerImpl::ProcessOrphanTx(Peer& peer)
                 m_mempool.size(), m_mempool.DynamicMemoryUsage() / 1000);
             RelayTransaction(orphanHash, porphanTx->GetWitnessHash());
             m_orphanage.AddChildrenToWorkSet(*porphanTx);
-            m_orphanage.EraseTx(orphanHash);
+            m_orphanage.EraseTx(orphan_wtxid);
             for (const CTransactionRef& removedTx : result.m_replaced_transactions.value()) {
                 AddToCompactExtraTransactions(removedTx);
             }
@@ -2982,7 +2982,7 @@ bool PeerManagerImpl::ProcessOrphanTx(Peer& peer)
                     m_recent_rejects.insert(porphanTx->GetHash());
                 }
             }
-            m_orphanage.EraseTx(orphanHash);
+            m_orphanage.EraseTx(orphan_wtxid);
             return true;
         }
     }

--- a/src/test/fuzz/txorphan.cpp
+++ b/src/test/fuzz/txorphan.cpp
@@ -117,12 +117,12 @@ FUZZ_TARGET(txorphan, .init = initialize_orphanage)
                     bool have_tx = orphanage.HaveTx(GenTxid::Txid(tx->GetHash())) || orphanage.HaveTx(GenTxid::Wtxid(tx->GetHash()));
                     // EraseTx should return 0 if m_orphans doesn't have the tx
                     {
-                        Assert(have_tx == orphanage.EraseTx(tx->GetHash()));
+                        Assert(have_tx == orphanage.EraseTx(tx->GetWitnessHash()));
                     }
                     have_tx = orphanage.HaveTx(GenTxid::Txid(tx->GetHash())) || orphanage.HaveTx(GenTxid::Wtxid(tx->GetHash()));
                     // have_tx should be false and EraseTx should fail
                     {
-                        Assert(!have_tx && !orphanage.EraseTx(tx->GetHash()));
+                        Assert(!have_tx && !orphanage.EraseTx(tx->GetWitnessHash()));
                     }
                 },
                 [&] {

--- a/src/test/fuzz/txorphan.cpp
+++ b/src/test/fuzz/txorphan.cpp
@@ -102,13 +102,13 @@ FUZZ_TARGET(txorphan, .init = initialize_orphanage)
                     // AddTx should return false if tx is too big or already have it
                     // tx weight is unknown, we only check when tx is already in orphanage
                     {
-                        bool add_tx = orphanage.AddTx(tx, peer_id);
+                        bool add_tx = orphanage.AddTx(tx, peer_id, {});
                         // have_tx == true -> add_tx == false
                         Assert(!have_tx || !add_tx);
                     }
                     have_tx = orphanage.HaveTx(GenTxid::Txid(tx->GetHash())) || orphanage.HaveTx(GenTxid::Wtxid(tx->GetHash()));
                     {
-                        bool add_tx = orphanage.AddTx(tx, peer_id);
+                        bool add_tx = orphanage.AddTx(tx, peer_id, {});
                         // if have_tx is still false, it must be too big
                         Assert(!have_tx == (GetTransactionWeight(*tx) > MAX_STANDARD_TX_WEIGHT));
                         Assert(!have_tx || !add_tx);

--- a/src/test/fuzz/txorphan.cpp
+++ b/src/test/fuzz/txorphan.cpp
@@ -85,6 +85,7 @@ FUZZ_TARGET(txorphan, .init = initialize_orphanage)
             CallOneOf(
                 fuzzed_data_provider,
                 [&] {
+                    FastRandomContext rng{true};
                     orphanage.AddChildrenToWorkSet(*tx);
                 },
                 [&] {

--- a/src/test/orphanage_tests.cpp
+++ b/src/test/orphanage_tests.cpp
@@ -78,7 +78,7 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
         tx.vout[0].scriptPubKey = GetScriptForDestination(PKHash(key.GetPubKey()));
 
         auto ptx{MakeTransactionRef(tx)};
-        if (orphanage.AddTx(ptx, i)) {
+        if (orphanage.AddTx(ptx, i, {})) {
             ++expected_count;
             expected_total_size += ptx->GetTotalSize();
         }
@@ -102,7 +102,7 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
         BOOST_CHECK(SignSignature(keystore, *txPrev, tx, 0, SIGHASH_ALL, empty));
 
         auto ptx{MakeTransactionRef(tx)};
-        if (orphanage.AddTx(ptx, i)) {
+        if (orphanage.AddTx(ptx, i, {})) {
             ++expected_count;
             expected_total_size += ptx->GetTotalSize();
         }
@@ -132,7 +132,7 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
         for (unsigned int j = 1; j < tx.vin.size(); j++)
             tx.vin[j].scriptSig = tx.vin[0].scriptSig;
 
-        BOOST_CHECK(!orphanage.AddTx(MakeTransactionRef(tx), i));
+        BOOST_CHECK(!orphanage.AddTx(MakeTransactionRef(tx), i, {}));
     }
     BOOST_CHECK_EQUAL(orphanage.Size(), expected_count);
     BOOST_CHECK_EQUAL(orphanage.TotalOrphanBytes(), expected_total_size);

--- a/src/test/orphanage_tests.cpp
+++ b/src/test/orphanage_tests.cpp
@@ -38,12 +38,64 @@ public:
     }
 };
 
-static void MakeNewKeyWithFastRandomContext(CKey& key)
+static void MakeNewKeyWithFastRandomContext(CKey& key, FastRandomContext& rand_ctx = g_insecure_rand_ctx)
 {
     std::vector<unsigned char> keydata;
-    keydata = g_insecure_rand_ctx.randbytes(32);
+    keydata = rand_ctx.randbytes(32);
     key.Set(keydata.data(), keydata.data() + keydata.size(), /*fCompressedIn=*/true);
     assert(key.IsValid());
+}
+
+static CTransactionRef MakeLargeOrphan()
+{
+    CKey key;
+    MakeNewKeyWithFastRandomContext(key);
+    CMutableTransaction tx;
+    tx.vout.resize(1);
+    tx.vout[0].nValue = CENT;
+    tx.vout[0].scriptPubKey = GetScriptForDestination(PKHash(key.GetPubKey()));
+    tx.vin.resize(80);
+    for (unsigned int j = 0; j < tx.vin.size(); j++) {
+        tx.vin[j].prevout.n = j;
+        tx.vin[j].prevout.hash = GetRandHash();
+        tx.vin[j].scriptWitness.stack.reserve(100);
+        for (int i = 0; i < 100; ++i) {
+            tx.vin[j].scriptWitness.stack.push_back(std::vector<unsigned char>(j));
+        }
+    }
+    return MakeTransactionRef(tx);
+}
+
+static CTransactionRef MakeTransactionSpending(const std::vector<COutPoint>& outpoints, FastRandomContext& det_rand)
+{
+    CKey key;
+    MakeNewKeyWithFastRandomContext(key, det_rand);
+    CMutableTransaction tx;
+    // If no outpoints are given, create a random one.
+    if (outpoints.empty()) {
+        tx.vin.emplace_back(CTxIn{COutPoint{det_rand.rand256(), 0}});
+    } else {
+        for (const auto& outpoint : outpoints) {
+            tx.vin.emplace_back(CTxIn(outpoint));
+        }
+    }
+    // Ensure txid != wtxid
+    tx.vin[0].scriptWitness.stack.push_back({1});
+    tx.vout.resize(1);
+    tx.vout[0].nValue = CENT;
+    tx.vout[0].scriptPubKey = GetScriptForDestination(PKHash(key.GetPubKey()));
+    return MakeTransactionRef(tx);
+}
+
+// Make another (not necessarily valid) tx with the same txid but different wtxid.
+static CTransactionRef MakeMutation(const CTransactionRef& ptx)
+{
+    CMutableTransaction tx(*ptx);
+    tx.vin[0].scriptWitness.stack.push_back({1});
+    auto mutated_tx = MakeTransactionRef(tx);
+    assert(ptx->GetHash() == mutated_tx->GetHash());
+    assert(ptx->GetWitnessHash() != mutated_tx->GetWitnessHash());
+    return mutated_tx;
 }
 
 BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
@@ -145,7 +197,6 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
         BOOST_CHECK(orphanage.CountOrphans() < sizeBefore);
     }
 
-    // Test LimitOrphanTxSize() function:
     orphanage.LimitOrphans(40);
     BOOST_CHECK(orphanage.CountOrphans() <= 40);
     orphanage.LimitOrphans(10);
@@ -153,10 +204,320 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
     orphanage.LimitOrphans(0);
     BOOST_CHECK(orphanage.CountOrphans() == 0);
 
+    // Limits on total size of orphans
+    const size_t modified_max_count{150};
+    unsigned int size_just_under{0};
+    const unsigned int size_per_tx{MakeLargeOrphan()->GetTotalSize()};
+    // The transaction size needs to be small enough to not be rejected, but big enough so
+    // that we hit the size limit instead of the count limit.
+    BOOST_CHECK(size_per_tx <= MAX_STANDARD_TX_WEIGHT);
+    BOOST_CHECK(size_per_tx * modified_max_count > DEFAULT_MAX_ORPHAN_TOTAL_SIZE);
+
     expected_count = 0;
     expected_total_size = 0;
     BOOST_CHECK_EQUAL(orphanage.CountOrphans(), expected_count);
     BOOST_CHECK_EQUAL(orphanage.TotalOrphanBytes(), expected_total_size);
+
+    while (expected_total_size <= DEFAULT_MAX_ORPHAN_TOTAL_SIZE) {
+        // Create really large orphan tx.
+        auto huge_orphan{MakeLargeOrphan()};
+        BOOST_CHECK_EQUAL(huge_orphan->GetTotalSize(), size_per_tx);
+
+        // Check if this is going to be the orphan that pushes us over DEFAULT_MAX_ORPHAN_TOTAL_SIZE.
+        if (expected_total_size + huge_orphan->GetTotalSize()) size_just_under = expected_total_size;
+
+        // Add tx to orphanage
+        BOOST_CHECK(orphanage.AddTx(huge_orphan, /*peer=*/0, {}));
+        expected_total_size += huge_orphan->GetTotalSize();
+        expected_count += 1;
+        BOOST_CHECK_EQUAL(orphanage.TotalOrphanBytes(), expected_total_size);
+        BOOST_CHECK_EQUAL(orphanage.Size(), expected_count);
+    }
+
+    // LimitOrphans should trim until within the maximum size
+    orphanage.LimitOrphans(modified_max_count);
+    // Both weight and count limits are enforced
+    BOOST_CHECK(orphanage.Size() <= modified_max_count);
+    BOOST_CHECK(orphanage.TotalOrphanBytes() <= DEFAULT_MAX_ORPHAN_TOTAL_SIZE);
+    BOOST_CHECK_EQUAL(orphanage.TotalOrphanBytes(), size_just_under);
+
+    // Now trim to a very small maximum size...
+    orphanage.LimitOrphans(/*max_orphans=*/10, DEFAULT_MAX_ORPHAN_TOTAL_SIZE);
+    BOOST_CHECK_EQUAL(orphanage.TotalOrphanBytes(), 10 * size_per_tx);
+}
+
+BOOST_AUTO_TEST_CASE(process_block)
+{
+    FastRandomContext det_rand{true};
+    TxOrphanageTest orphanage;
+
+    // Create outpoints that will be spent by transactions in the block
+    std::vector<COutPoint> outpoints;
+    const uint32_t num_outpoints{6};
+    outpoints.reserve(num_outpoints);
+    for (uint32_t i{0}; i < num_outpoints; ++i) {
+        // All the hashes should be different, but change the n just in case.
+        outpoints.emplace_back(COutPoint{det_rand.rand256(), i});
+    }
+
+    CBlock block;
+    const NodeId node{0};
+
+    auto bo_tx_same_txid = MakeTransactionSpending({outpoints.at(0)}, det_rand);
+    BOOST_CHECK(orphanage.AddTx(bo_tx_same_txid, node, {}));
+    block.vtx.emplace_back(bo_tx_same_txid);
+
+    // 2 transactions with the same txid but different witness
+    auto b_tx_same_txid_diff_witness = MakeTransactionSpending({outpoints.at(1)}, det_rand);
+    block.vtx.emplace_back(b_tx_same_txid_diff_witness);
+
+    auto o_tx_same_txid_diff_witness = MakeMutation(b_tx_same_txid_diff_witness);
+    BOOST_CHECK(orphanage.AddTx(o_tx_same_txid_diff_witness, node, {}));
+
+    // 2 different transactions that spend the same input.
+    auto b_tx_conflict = MakeTransactionSpending({outpoints.at(2)}, det_rand);
+    block.vtx.emplace_back(b_tx_conflict);
+
+    auto o_tx_conflict = MakeTransactionSpending({outpoints.at(2)}, det_rand);
+    BOOST_CHECK(orphanage.AddTx(o_tx_conflict, node, {}));
+
+    // 2 different transactions that have 1 overlapping input.
+    auto b_tx_conflict_partial = MakeTransactionSpending({outpoints.at(3), outpoints.at(4)}, det_rand);
+    block.vtx.emplace_back(b_tx_conflict_partial);
+
+    auto o_tx_conflict_partial_2 = MakeTransactionSpending({outpoints.at(4), outpoints.at(5)}, det_rand);
+    BOOST_CHECK(orphanage.AddTx(o_tx_conflict_partial_2, node, {}));
+
+    const auto removed = orphanage.EraseForBlock(block);
+    BOOST_CHECK_EQUAL(orphanage.Size(), 0);
+    for (const auto& expected_removed : {bo_tx_same_txid, o_tx_same_txid_diff_witness, o_tx_conflict, o_tx_conflict_partial_2}) {
+        const auto& expected_removed_wtxid = expected_removed->GetWitnessHash();
+        BOOST_CHECK(std::find_if(removed.begin(), removed.end(), [&](const auto& wtxid) { return wtxid == expected_removed_wtxid; }) != removed.end());
+    }
+}
+
+BOOST_AUTO_TEST_CASE(multiple_announcers)
+{
+    const NodeId node0{0};
+    const NodeId node1{1};
+    const NodeId node2{2};
+    size_t expected_total_count{0};
+    size_t expected_total_size{0};
+    size_t expected_node0_size{0};
+    size_t expected_node1_size{0};
+    TxOrphanageTest orphanage;
+    FastRandomContext det_rand{true};
+
+    // Check accounting per peer.
+    // Check that EraseForPeer works with multiple announcers.
+    {
+        auto ptx{MakeLargeOrphan()};
+        const auto& wtxid = ptx->GetWitnessHash();
+        const auto tx_size = ptx->GetTotalSize();
+        BOOST_CHECK(orphanage.AddTx(ptx, node0, {}));
+        BOOST_CHECK(orphanage.HaveTx(GenTxid::Txid(ptx->GetHash())));
+        BOOST_CHECK(orphanage.HaveTx(GenTxid::Wtxid(wtxid)));
+        expected_total_size += tx_size;
+        expected_total_count += 1;
+        expected_node0_size += tx_size;
+        BOOST_CHECK_EQUAL(orphanage.Size(), expected_total_count);
+        BOOST_CHECK_EQUAL(orphanage.TotalOrphanBytes(), expected_total_size);
+        BOOST_CHECK_EQUAL(orphanage.BytesFromPeer(node0), expected_node0_size);
+        BOOST_CHECK_EQUAL(orphanage.BytesFromPeer(node1), expected_node1_size);
+
+        // Adding again should do nothing.
+        BOOST_CHECK(!orphanage.AddTx(ptx, node0, {}));
+        BOOST_CHECK_EQUAL(orphanage.Size(), expected_total_count);
+        BOOST_CHECK_EQUAL(orphanage.TotalOrphanBytes(), expected_total_size);
+        BOOST_CHECK_EQUAL(orphanage.BytesFromPeer(node0), expected_node0_size);
+        BOOST_CHECK_EQUAL(orphanage.BytesFromPeer(node1), expected_node1_size);
+
+        // Adding another tx with the same txid but different witness should not work.
+        auto ptx_mutated{MakeMutation(ptx)};
+        BOOST_CHECK(!orphanage.AddTx(ptx_mutated, node0, {}));
+        BOOST_CHECK(!orphanage.HaveTx(GenTxid::Wtxid(ptx_mutated->GetWitnessHash())));
+
+        // It's too late to add parent_txids through AddTx.
+        BOOST_CHECK(!orphanage.AddTx(ptx, node0, {ptx->vin.at(0).prevout.hash}));
+        // Parent txids is empty because the tx exists but no parent_txids were provided.
+        BOOST_CHECK(orphanage.GetParentTxids(wtxid)->empty());
+        // Parent txids is std::nullopt because the tx doesn't exist.
+        BOOST_CHECK(!orphanage.GetParentTxids(ptx_mutated->GetWitnessHash()).has_value());
+
+        // Adding existing tx for another peer should change that peer's bytes, but not total bytes.
+        BOOST_CHECK(!orphanage.AddTx(ptx, node1, {}));
+        expected_node1_size += tx_size;
+        BOOST_CHECK_EQUAL(orphanage.Size(), expected_total_count);
+        BOOST_CHECK_EQUAL(orphanage.TotalOrphanBytes(), expected_total_size);
+        BOOST_CHECK_EQUAL(orphanage.BytesFromPeer(node0), expected_node0_size);
+        BOOST_CHECK_EQUAL(orphanage.BytesFromPeer(node1), expected_node1_size);
+
+        // Adding new announcer for an existing tx should change that peer's bytes, but not total bytes.
+        orphanage.AddAnnouncer(ptx->GetWitnessHash(), node2);
+        BOOST_CHECK_EQUAL(orphanage.Size(), expected_total_count);
+        BOOST_CHECK_EQUAL(orphanage.TotalOrphanBytes(), expected_total_size);
+        BOOST_CHECK_EQUAL(orphanage.BytesFromPeer(node2), tx_size);
+        orphanage.EraseOrphanOfPeer(ptx->GetWitnessHash(), node2);
+        // AddAnnouncer is by wtxid, not txid.
+        orphanage.AddAnnouncer(ptx->GetHash(), node2);
+        BOOST_CHECK_EQUAL(orphanage.Size(), expected_total_count);
+        BOOST_CHECK_EQUAL(orphanage.TotalOrphanBytes(), expected_total_size);
+        BOOST_CHECK_EQUAL(orphanage.BytesFromPeer(node2), 0);
+
+        // if EraseForPeer is called for an orphan with multiple announcers, the orphanage should only
+        // decrement the number of bytes for that peer.
+        orphanage.EraseForPeer(node0);
+        expected_node0_size -= tx_size;
+        BOOST_CHECK(orphanage.HaveTx(GenTxid::Txid(ptx->GetHash())));
+        BOOST_CHECK_EQUAL(orphanage.Size(), expected_total_count);
+        BOOST_CHECK_EQUAL(orphanage.TotalOrphanBytes(), expected_total_size);
+        BOOST_CHECK_EQUAL(orphanage.BytesFromPeer(node0), expected_node0_size);
+        BOOST_CHECK_EQUAL(orphanage.BytesFromPeer(node1), expected_node1_size);
+
+        // EraseForPeer should delete the orphan if it's the only announcer left.
+        orphanage.EraseForPeer(node1);
+        expected_total_count -= 1;
+        expected_total_size -= tx_size;
+        expected_node1_size -= tx_size;
+        BOOST_CHECK_EQUAL(orphanage.Size(), expected_total_count);
+        BOOST_CHECK_EQUAL(orphanage.TotalOrphanBytes(), expected_total_size);
+        BOOST_CHECK_EQUAL(orphanage.BytesFromPeer(node0), expected_node0_size);
+        BOOST_CHECK_EQUAL(orphanage.BytesFromPeer(node1), expected_node1_size);
+        BOOST_CHECK(!orphanage.HaveTx(GenTxid::Txid(ptx->GetHash())));
+    }
+
+    // EraseOrphanOfPeer only erases the tx for 1 peer
+    {
+        auto ptx = MakeTransactionSpending({}, det_rand);
+        const auto& wtxid = ptx->GetWitnessHash();
+        const auto tx_size = ptx->GetTotalSize();
+
+        // Add from node0
+        BOOST_CHECK(orphanage.AddTx(ptx, node0, {}));
+        expected_total_size += tx_size;
+        expected_total_count += 1;
+        expected_node0_size += tx_size;
+        BOOST_CHECK_EQUAL(orphanage.Size(), expected_total_count);
+        BOOST_CHECK_EQUAL(orphanage.TotalOrphanBytes(), expected_total_size);
+        BOOST_CHECK_EQUAL(orphanage.BytesFromPeer(node0), expected_node0_size);
+        BOOST_CHECK_EQUAL(orphanage.BytesFromPeer(node1), expected_node1_size);
+        BOOST_CHECK(orphanage.HaveTxAndPeer(GenTxid::Wtxid(wtxid), node0));
+
+        // Add from node1
+        BOOST_CHECK(!orphanage.AddTx(ptx, node1, {}));
+        expected_node1_size += tx_size;
+        BOOST_CHECK_EQUAL(orphanage.Size(), expected_total_count);
+        BOOST_CHECK_EQUAL(orphanage.TotalOrphanBytes(), expected_total_size);
+        BOOST_CHECK_EQUAL(orphanage.BytesFromPeer(node0), expected_node0_size);
+        BOOST_CHECK_EQUAL(orphanage.BytesFromPeer(node1), expected_node1_size);
+        BOOST_CHECK(orphanage.HaveTxAndPeer(GenTxid::Wtxid(wtxid), node1));
+
+        // EraseOrphanOfPeer shouldn't work with txid, only with wtxid
+        orphanage.EraseOrphanOfPeer(ptx->GetHash(), node1);
+        BOOST_CHECK_EQUAL(orphanage.Size(), expected_total_count);
+        BOOST_CHECK_EQUAL(orphanage.TotalOrphanBytes(), expected_total_size);
+        BOOST_CHECK_EQUAL(orphanage.BytesFromPeer(node0), expected_node0_size);
+        BOOST_CHECK_EQUAL(orphanage.BytesFromPeer(node1), expected_node1_size);
+
+        // Erase just for node1
+        orphanage.EraseOrphanOfPeer(wtxid, node1);
+        expected_node1_size -= tx_size;
+        BOOST_CHECK_EQUAL(orphanage.Size(), expected_total_count);
+        BOOST_CHECK_EQUAL(orphanage.TotalOrphanBytes(), expected_total_size);
+        BOOST_CHECK_EQUAL(orphanage.BytesFromPeer(node0), expected_node0_size);
+        BOOST_CHECK_EQUAL(orphanage.BytesFromPeer(node1), expected_node1_size);
+        BOOST_CHECK(orphanage.HaveTxAndPeer(GenTxid::Wtxid(wtxid), node0));
+        BOOST_CHECK(!orphanage.HaveTxAndPeer(GenTxid::Wtxid(wtxid), node1));
+
+        // Now erase for node0
+        orphanage.EraseOrphanOfPeer(wtxid, node0);
+        expected_total_count -= 1;
+        expected_total_size -= tx_size;
+        expected_node0_size -= tx_size;
+        BOOST_CHECK_EQUAL(orphanage.Size(), expected_total_count);
+        BOOST_CHECK_EQUAL(orphanage.TotalOrphanBytes(), expected_total_size);
+        BOOST_CHECK_EQUAL(orphanage.BytesFromPeer(node0), expected_node0_size);
+        BOOST_CHECK_EQUAL(orphanage.BytesFromPeer(node1), expected_node1_size);
+    }
+
+    // Check that erasure for blocks removes for all peers.
+    {
+        CBlock block;
+        auto tx_block = MakeTransactionSpending({}, det_rand);
+        const auto tx_block_size = tx_block->GetTotalSize();
+        block.vtx.emplace_back(tx_block);
+        orphanage.AddTx(tx_block, node0, {});
+        orphanage.AddTx(tx_block, node1, {});
+
+        expected_total_count += 1;
+        expected_total_size += tx_block_size;
+        expected_node0_size += tx_block_size;
+        expected_node1_size += tx_block_size;
+
+        BOOST_CHECK_EQUAL(orphanage.Size(), expected_total_count);
+        BOOST_CHECK_EQUAL(orphanage.TotalOrphanBytes(), expected_total_size);
+        BOOST_CHECK_EQUAL(orphanage.BytesFromPeer(node0), expected_node0_size);
+        BOOST_CHECK_EQUAL(orphanage.BytesFromPeer(node1), expected_node1_size);
+
+        const auto removed = orphanage.EraseForBlock(block);
+        BOOST_CHECK_EQUAL(removed.size(), 1);
+        BOOST_CHECK_EQUAL(removed.front(), tx_block->GetWitnessHash());
+
+        expected_total_count -= 1;
+        expected_total_size -= tx_block_size;
+        expected_node0_size -= tx_block_size;
+        expected_node1_size -= tx_block_size;
+
+        BOOST_CHECK_EQUAL(orphanage.Size(), expected_total_count);
+        BOOST_CHECK_EQUAL(orphanage.TotalOrphanBytes(), expected_total_size);
+        BOOST_CHECK_EQUAL(orphanage.BytesFromPeer(node0), expected_node0_size);
+        BOOST_CHECK_EQUAL(orphanage.BytesFromPeer(node1), expected_node1_size);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(peer_worksets)
+{
+    const NodeId node0{0};
+    const NodeId node1{1};
+    const NodeId node2{2};
+    TxOrphanageTest orphanage;
+    FastRandomContext det_rand{true};
+    // AddChildrenToWorkSet should pick an announcer randomly
+    {
+        auto tx_missing_parent = MakeTransactionSpending({}, det_rand);
+        auto tx_orphan = MakeTransactionSpending({COutPoint{tx_missing_parent->GetHash(), 0}}, det_rand);
+        const auto orphan_size = tx_orphan->GetTotalSize();
+
+        // All 3 peers are announcers.
+        BOOST_CHECK(orphanage.AddTx(tx_orphan, node0, {tx_missing_parent->GetHash()}));
+        BOOST_CHECK(!orphanage.AddTx(tx_orphan, node1, {tx_missing_parent->GetHash()}));
+        orphanage.AddAnnouncer(tx_orphan->GetWitnessHash(), node2);
+        for (NodeId node = node0; node <= node2; ++node) {
+            BOOST_CHECK_EQUAL(orphanage.BytesFromPeer(node), orphan_size);
+        }
+
+        // Parent accepted: add child to all 3 worksets.
+        orphanage.AddChildrenToWorkSet(*tx_missing_parent);
+        BOOST_CHECK_EQUAL(orphanage.GetTxToReconsider(node0), tx_orphan);
+        BOOST_CHECK_EQUAL(orphanage.GetTxToReconsider(node1), tx_orphan);
+        // Don't call GetTxToReconsider(node2) yet because it mutates the workset.
+
+        // EraseOrphanOfPeer also removes that tx from the workset.
+        orphanage.EraseOrphanOfPeer(tx_orphan->GetWitnessHash(), node0);
+        BOOST_CHECK_EQUAL(orphanage.GetTxToReconsider(node0), nullptr);
+
+        // However, the other peers' worksets are not touched.
+        BOOST_CHECK_EQUAL(orphanage.GetTxToReconsider(node2), tx_orphan);
+
+        // Delete this tx, clearing the orphanage.
+        BOOST_CHECK_EQUAL(orphanage.EraseTx(tx_orphan->GetWitnessHash()), 1);
+        BOOST_CHECK_EQUAL(orphanage.TotalOrphanBytes(), 0);
+        BOOST_CHECK_EQUAL(orphanage.Size(), 0);
+        for (NodeId node = node0; node <= node2; ++node) {
+            BOOST_CHECK_EQUAL(orphanage.GetTxToReconsider(node), nullptr);
+            BOOST_CHECK_EQUAL(orphanage.BytesFromPeer(node), 0);
+        }
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/txorphanage.cpp
+++ b/src/txorphanage.cpp
@@ -33,7 +33,7 @@ void TxOrphanage::SubtractOrphanBytes(unsigned int size, NodeId peer)
     }
 }
 
-bool TxOrphanage::AddTx(const CTransactionRef& tx, NodeId peer)
+bool TxOrphanage::AddTx(const CTransactionRef& tx, NodeId peer, const std::vector<uint256>& parent_txids)
 {
     LOCK(m_mutex);
 
@@ -62,7 +62,7 @@ bool TxOrphanage::AddTx(const CTransactionRef& tx, NodeId peer)
         return false;
     }
 
-    auto ret = m_orphans.emplace(hash, OrphanTx{tx, GetTime() + ORPHAN_TX_EXPIRE_TIME, m_orphan_list.size(), {peer}});
+    auto ret = m_orphans.emplace(hash, OrphanTx{tx, GetTime() + ORPHAN_TX_EXPIRE_TIME, m_orphan_list.size(), {peer}, parent_txids});
     assert(ret.second);
     m_orphan_list.push_back(ret.first);
     // Allow for lookups in the orphan pool by wtxid, as well as txid
@@ -337,4 +337,13 @@ void TxOrphanage::EraseOrphanOfPeer(const uint256& wtxid, NodeId peer)
             SubtractOrphanBytes(wtxid_it->second->second.tx->GetTotalSize(), peer);
         }
     }
+}
+
+std::optional<std::vector<uint256>> TxOrphanage::GetParentTxids(const uint256& wtxid)
+{
+    AssertLockNotHeld(m_mutex);
+    LOCK(m_mutex);
+    const auto it = m_wtxid_to_orphan_it.find(wtxid);
+    if (it != m_wtxid_to_orphan_it.end()) return it->second->second.parent_txids;
+    return std::nullopt;
 }

--- a/src/txorphanage.cpp
+++ b/src/txorphanage.cpp
@@ -15,6 +15,23 @@ static constexpr int64_t ORPHAN_TX_EXPIRE_TIME = 20 * 60;
 /** Minimum time between orphan transactions expire time checks in seconds */
 static constexpr int64_t ORPHAN_TX_EXPIRE_INTERVAL = 5 * 60;
 
+void TxOrphanage::AddOrphanBytes(unsigned int size, NodeId peer)
+{
+    AssertLockHeld(m_mutex);
+    m_peer_bytes_used.try_emplace(peer, 0);
+    m_peer_bytes_used.at(peer) += size;
+}
+
+void TxOrphanage::SubtractOrphanBytes(unsigned int size, NodeId peer)
+{
+    AssertLockHeld(m_mutex);
+    if (!Assume(m_peer_bytes_used.count(peer) > 0)) return;
+    if (!Assume(m_peer_bytes_used.at(peer) >= size)) return;
+    m_peer_bytes_used.at(peer) -= size;
+    if (m_peer_bytes_used.at(peer) == 0) {
+        m_peer_bytes_used.erase(peer);
+    }
+}
 
 bool TxOrphanage::AddTx(const CTransactionRef& tx, NodeId peer)
 {
@@ -48,6 +65,8 @@ bool TxOrphanage::AddTx(const CTransactionRef& tx, NodeId peer)
         m_outpoint_to_orphan_it[txin.prevout].insert(ret.first);
     }
 
+    AddOrphanBytes(tx->GetTotalSize(), peer);
+    m_total_orphan_bytes += tx->GetTotalSize();
     LogPrint(BCLog::TXPACKAGES, "stored orphan tx %s (wtxid=%s) (mapsz %u outsz %u)\n", hash.ToString(), wtxid.ToString(),
              m_orphans.size(), m_outpoint_to_orphan_it.size());
     return true;
@@ -72,6 +91,8 @@ int TxOrphanage::EraseTxNoLock(const uint256& wtxid)
     const auto wtxid_it = m_wtxid_to_orphan_it.find(wtxid);
     if (wtxid_it == m_wtxid_to_orphan_it.end()) return 0;
     std::map<uint256, OrphanTx>::iterator it = wtxid_it->second;
+    m_total_orphan_bytes -= it->second.tx->GetTotalSize();
+    SubtractOrphanBytes(it->second.tx->GetTotalSize(), it->second.fromPeer);
     for (const CTxIn& txin : it->second.tx->vin)
     {
         auto itPrev = m_outpoint_to_orphan_it.find(txin.prevout);
@@ -118,6 +139,9 @@ void TxOrphanage::EraseForPeer(NodeId peer)
         }
     }
     if (nErased > 0) LogPrint(BCLog::TXPACKAGES, "Erased %d orphan tx from peer=%d\n", nErased, peer);
+    // Belt-and-suspenders if our accounting is off. We shouldn't keep an entry for a disconnected
+    // peer as we will have no other opportunity to delete it.
+    if (!Assume(m_peer_bytes_used.count(peer) == 0)) m_peer_bytes_used.erase(peer);
 }
 
 void TxOrphanage::LimitOrphans(unsigned int max_orphans)

--- a/src/txorphanage.cpp
+++ b/src/txorphanage.cpp
@@ -348,3 +348,14 @@ std::optional<std::vector<uint256>> TxOrphanage::GetParentTxids(const uint256& w
     if (it != m_wtxid_to_orphan_it.end()) return it->second->second.parent_txids;
     return std::nullopt;
 }
+
+std::vector<uint256> TxOrphanage::GetAllWtxids() const
+{
+    AssertLockNotHeld(m_mutex);
+    LOCK(m_mutex);
+    std::vector<uint256> wtxids;
+    wtxids.reserve(m_wtxid_to_orphan_it.size());
+    std::transform(m_wtxid_to_orphan_it.cbegin(), m_wtxid_to_orphan_it.cend(), std::back_inserter(wtxids),
+            [](const auto& kv) { return kv.first; });
+    return wtxids;
+}

--- a/src/txorphanage.cpp
+++ b/src/txorphanage.cpp
@@ -39,8 +39,14 @@ bool TxOrphanage::AddTx(const CTransactionRef& tx, NodeId peer)
 
     const uint256& hash = tx->GetHash();
     const uint256& wtxid = tx->GetWitnessHash();
-    if (m_orphans.count(hash))
+    if (m_orphans.count(hash)) {
+        Assume(m_orphans.at(hash).announcers.size() > 0);
+        const auto ret = m_orphans.at(hash).announcers.insert(peer);
+        if (ret.second) {
+            AddOrphanBytes(tx->GetTotalSize(), peer);
+        }
         return false;
+    }
 
     // Ignore big transactions, to avoid a
     // send-big-orphans memory exhaustion attack. If a peer has a legitimate
@@ -56,7 +62,7 @@ bool TxOrphanage::AddTx(const CTransactionRef& tx, NodeId peer)
         return false;
     }
 
-    auto ret = m_orphans.emplace(hash, OrphanTx{tx, peer, GetTime() + ORPHAN_TX_EXPIRE_TIME, m_orphan_list.size()});
+    auto ret = m_orphans.emplace(hash, OrphanTx{tx, GetTime() + ORPHAN_TX_EXPIRE_TIME, m_orphan_list.size(), {peer}});
     assert(ret.second);
     m_orphan_list.push_back(ret.first);
     // Allow for lookups in the orphan pool by wtxid, as well as txid
@@ -70,6 +76,19 @@ bool TxOrphanage::AddTx(const CTransactionRef& tx, NodeId peer)
     LogPrint(BCLog::TXPACKAGES, "stored orphan tx %s (wtxid=%s) (mapsz %u outsz %u)\n", hash.ToString(), wtxid.ToString(),
              m_orphans.size(), m_outpoint_to_orphan_it.size());
     return true;
+}
+void TxOrphanage::AddAnnouncer(const uint256& wtxid, NodeId peer)
+{
+    LOCK(m_mutex);
+    const auto it = m_wtxid_to_orphan_it.find(wtxid);
+    if (it != m_wtxid_to_orphan_it.end()) {
+        Assume(!it->second->second.announcers.empty());
+        const auto ret = it->second->second.announcers.insert(peer);
+        if (ret.second) {
+            LogPrint(BCLog::TXPACKAGES, "added peer=%d as announcer of orphan tx %s\n", peer, wtxid.ToString());
+            AddOrphanBytes(it->second->second.tx->GetTotalSize(), peer);
+        }
+    }
 }
 
 CTransactionRef TxOrphanage::GetTx(const uint256& wtxid)
@@ -92,7 +111,9 @@ int TxOrphanage::EraseTxNoLock(const uint256& wtxid)
     if (wtxid_it == m_wtxid_to_orphan_it.end()) return 0;
     std::map<uint256, OrphanTx>::iterator it = wtxid_it->second;
     m_total_orphan_bytes -= it->second.tx->GetTotalSize();
-    SubtractOrphanBytes(it->second.tx->GetTotalSize(), it->second.fromPeer);
+    for (const auto peer : it->second.announcers) {
+        SubtractOrphanBytes(it->second.tx->GetTotalSize(), peer);
+    }
     for (const CTxIn& txin : it->second.tx->vin)
     {
         auto itPrev = m_outpoint_to_orphan_it.find(txin.prevout);
@@ -133,9 +154,14 @@ void TxOrphanage::EraseForPeer(NodeId peer)
     while (iter != m_orphans.end())
     {
         std::map<uint256, OrphanTx>::iterator maybeErase = iter++; // increment to avoid iterator becoming invalid
-        if (maybeErase->second.fromPeer == peer)
-        {
-            nErased += EraseTxNoLock(maybeErase->second.tx->GetWitnessHash());
+        if (maybeErase->second.announcers.count(peer) > 0) {
+            if (maybeErase->second.announcers.size() == 1) {
+                nErased += EraseTxNoLock(maybeErase->second.tx->GetWitnessHash());
+            } else {
+                // Don't erase this orphan. Another peer has also announced it, so it may still be useful.
+                maybeErase->second.announcers.erase(peer);
+                SubtractOrphanBytes(maybeErase->second.tx->GetTotalSize(), peer);
+            }
         }
     }
     if (nErased > 0) LogPrint(BCLog::TXPACKAGES, "Erased %d orphan tx from peer=%d\n", nErased, peer);
@@ -184,18 +210,21 @@ void TxOrphanage::AddChildrenToWorkSet(const CTransaction& tx)
 {
     LOCK(m_mutex);
 
-
     for (unsigned int i = 0; i < tx.vout.size(); i++) {
         const auto it_by_prev = m_outpoint_to_orphan_it.find(COutPoint(tx.GetHash(), i));
         if (it_by_prev != m_outpoint_to_orphan_it.end()) {
             for (const auto& elem : it_by_prev->second) {
-                // Get this source peer's work set, emplacing an empty set if it didn't exist
-                // (note: if this peer wasn't still connected, we would have removed the orphan tx already)
-                std::set<uint256>& orphan_work_set = m_peer_work_set.try_emplace(elem->second.fromPeer).first->second;
-                // Add this tx to the work set
-                orphan_work_set.insert(elem->first);
-                LogPrint(BCLog::TXPACKAGES, "added %s (wtxid=%s) to peer %d workset\n",
-                         tx.GetHash().ToString(), tx.GetWitnessHash().ToString(), elem->second.fromPeer);
+                // Belt and suspenders, each orphan should always have at least 1 announcer.
+                if (!Assume(!elem->second.announcers.empty())) break;
+                for (const auto announcer: elem->second.announcers) {
+                    // Get this source peer's work set, emplacing an empty set if it didn't exist
+                    // (note: if this peer wasn't still connected, we would have removed the orphan tx already)
+                    std::set<uint256>& orphan_work_set = m_peer_work_set.try_emplace(announcer).first->second;
+                    // Add this tx to the work set
+                    orphan_work_set.insert(elem->first);
+                    LogPrint(BCLog::TXPACKAGES, "added %s (wtxid=%s) to peer %d workset\n",
+                             tx.GetHash().ToString(), tx.GetWitnessHash().ToString(), announcer);
+                }
             }
         }
     }
@@ -209,6 +238,17 @@ bool TxOrphanage::HaveTx(const GenTxid& gtxid) const
     } else {
         return m_orphans.count(gtxid.GetHash());
     }
+}
+
+bool TxOrphanage::HaveTxAndPeer(const GenTxid& gtxid, NodeId peer) const
+{
+    LOCK(m_mutex);
+    if (gtxid.IsWtxid()) {
+        auto it = m_wtxid_to_orphan_it.find(gtxid.GetHash());
+        return (it != m_wtxid_to_orphan_it.end() && it->second->second.announcers.count(peer) > 0);
+    }
+    auto it = m_orphans.find(gtxid.GetHash());
+    return (it != m_orphans.end() && it->second.announcers.count(peer) > 0);
 }
 
 CTransactionRef TxOrphanage::GetTxToReconsider(NodeId peer)
@@ -271,5 +311,30 @@ void TxOrphanage::EraseForBlock(const CBlock& block)
             nErased += EraseTxNoLock(orphan_wtxid);
         }
         LogPrint(BCLog::TXPACKAGES, "Erased %d orphan tx included or conflicted by block\n", nErased);
+    }
+}
+void TxOrphanage::EraseOrphanOfPeer(const uint256& wtxid, NodeId peer)
+{
+    AssertLockNotHeld(m_mutex);
+    LOCK(m_mutex);
+    // Nothing to do if this tx doesn't exist.
+    const auto wtxid_it = m_wtxid_to_orphan_it.find(wtxid);
+    if (wtxid_it == m_wtxid_to_orphan_it.end()) return;
+    const auto& txid = wtxid_it->second->second.tx->GetHash();
+
+    // If this tx is in the peer's workset, delete it.
+    auto work_set_it = m_peer_work_set.find(peer);
+    if (work_set_it != m_peer_work_set.end()) {
+        work_set_it->second.erase(txid);
+    }
+
+    if (wtxid_it->second->second.announcers.count(peer) > 0) {
+        if (wtxid_it->second->second.announcers.size() == 1) {
+            EraseTxNoLock(wtxid);
+        } else {
+            // Don't erase this orphan. Another peer has also announced it, so it may still be useful.
+            wtxid_it->second->second.announcers.erase(peer);
+            SubtractOrphanBytes(wtxid_it->second->second.tx->GetTotalSize(), peer);
+        }
     }
 }

--- a/src/txorphanage.cpp
+++ b/src/txorphanage.cpp
@@ -170,7 +170,7 @@ void TxOrphanage::EraseForPeer(NodeId peer)
     if (!Assume(m_peer_bytes_used.count(peer) == 0)) m_peer_bytes_used.erase(peer);
 }
 
-void TxOrphanage::LimitOrphans(unsigned int max_orphans)
+void TxOrphanage::LimitOrphans(unsigned int max_orphans, unsigned int max_total_size)
 {
     LOCK(m_mutex);
 
@@ -196,7 +196,7 @@ void TxOrphanage::LimitOrphans(unsigned int max_orphans)
         if (nErased > 0) LogPrint(BCLog::TXPACKAGES, "Erased %d orphan tx due to expiration\n", nErased);
     }
     FastRandomContext rng;
-    while (m_orphans.size() > max_orphans)
+    while (m_orphans.size() > max_orphans || m_total_orphan_bytes > max_total_size)
     {
         // Evict a random orphan:
         size_t randompos = rng.randrange(m_orphan_list.size());

--- a/src/txorphanage.cpp
+++ b/src/txorphanage.cpp
@@ -283,7 +283,7 @@ bool TxOrphanage::HaveTxToReconsider(NodeId peer)
     return false;
 }
 
-void TxOrphanage::EraseForBlock(const CBlock& block)
+std::vector<uint256> TxOrphanage::EraseForBlock(const CBlock& block)
 {
     LOCK(m_mutex);
 
@@ -312,6 +312,7 @@ void TxOrphanage::EraseForBlock(const CBlock& block)
         }
         LogPrint(BCLog::TXPACKAGES, "Erased %d orphan tx included or conflicted by block\n", nErased);
     }
+    return vOrphanErase;
 }
 void TxOrphanage::EraseOrphanOfPeer(const uint256& wtxid, NodeId peer)
 {

--- a/src/txorphanage.h
+++ b/src/txorphanage.h
@@ -23,6 +23,9 @@ public:
     /** Add a new orphan transaction */
     bool AddTx(const CTransactionRef& tx, NodeId peer) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
+    /** Get orphan transaction by wtxid. Returns nullptr if we don't have it anymore. */
+    CTransactionRef GetTx(const uint256& wtxid) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
     /** Check if we already have an orphan transaction (by txid or wtxid) */
     bool HaveTx(const GenTxid& gtxid) const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
@@ -33,8 +36,8 @@ public:
      */
     CTransactionRef GetTxToReconsider(NodeId peer) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
-    /** Erase an orphan by txid */
-    int EraseTx(const uint256& txid) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+    /** Erase an orphan by wtxid */
+    int EraseTx(const uint256& wtxid) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /** Erase all orphans announced by a peer (eg, after that peer disconnects) */
     void EraseForPeer(NodeId peer) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
@@ -98,8 +101,8 @@ protected:
      *  transactions using their witness ids. */
     std::map<uint256, OrphanMap::iterator> m_wtxid_to_orphan_it GUARDED_BY(m_mutex);
 
-    /** Erase an orphan by txid */
-    int EraseTxNoLock(const uint256& txid) EXCLUSIVE_LOCKS_REQUIRED(m_mutex);
+    /** Erase an orphan by wtxid */
+    int EraseTxNoLock(const uint256& wtxid) EXCLUSIVE_LOCKS_REQUIRED(m_mutex);
 };
 
 #endif // BITCOIN_TXORPHANAGE_H

--- a/src/txorphanage.h
+++ b/src/txorphanage.h
@@ -98,6 +98,9 @@ public:
     /** Get an orphan's parent_txids, or std::nullopt if the orphan is not present. */
     std::optional<std::vector<uint256>> GetParentTxids(const uint256& wtxid) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
+    /** Get wtxids of all orphan transactions. */
+    std::vector<uint256> GetAllWtxids() const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
 protected:
     /** Total bytes of all transactions. */
     unsigned int m_total_orphan_bytes{0};

--- a/src/txorphanage.h
+++ b/src/txorphanage.h
@@ -51,8 +51,8 @@ public:
      * has been announced by another peer, don't erase, just remove this peer from the list of announcers. */
     void EraseForPeer(NodeId peer) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
-    /** Erase all orphans included in or invalidated by a new block */
-    void EraseForBlock(const CBlock& block) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+    /** Erase all orphans included in or invalidated by a new block. Returns wtxids of erased txns. */
+    std::vector<uint256> EraseForBlock(const CBlock& block) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /** Limit the orphanage to the given maximum. Returns all expired entries. */
     void LimitOrphans(unsigned int max_orphans) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);

--- a/src/txorphanage.h
+++ b/src/txorphanage.h
@@ -20,14 +20,21 @@
  */
 class TxOrphanage {
 public:
-    /** Add a new orphan transaction */
+    /** Add a new orphan transaction. If the tx already exists, add this peer to its list of announcers.
+      @returns true if the transaction was added as a new orphan. */
     bool AddTx(const CTransactionRef& tx, NodeId peer) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
+    /** Add an additional announcer to an orphan if it exists. Otherwise, do nothing. */
+    void AddAnnouncer(const uint256& wtxid, NodeId peer) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /** Get orphan transaction by wtxid. Returns nullptr if we don't have it anymore. */
     CTransactionRef GetTx(const uint256& wtxid) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /** Check if we already have an orphan transaction (by txid or wtxid) */
     bool HaveTx(const GenTxid& gtxid) const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
+    /** Check if a {tx, peer} exists in the orphanage (by txid or wtxid).*/
+    bool HaveTxAndPeer(const GenTxid& gtxid, NodeId peer) const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /** Extract a transaction from a peer's work set
      *  Returns nullptr if there are no transactions to work on.
@@ -39,7 +46,8 @@ public:
     /** Erase an orphan by wtxid */
     int EraseTx(const uint256& wtxid) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
-    /** Erase all orphans announced by a peer (eg, after that peer disconnects) */
+    /** Maybe erase all orphans announced by a peer (eg, after that peer disconnects). If an orphan
+     * has been announced by another peer, don't erase, just remove this peer from the list of announcers. */
     void EraseForPeer(NodeId peer) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /** Erase all orphans included in or invalidated by a new block */
@@ -53,6 +61,9 @@ public:
 
     /** Does this peer have any work to do? */
     bool HaveTxToReconsider(NodeId peer) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);;
+
+    /** Erase this peer as an announcer of this orphan. If there are no more announcers, delete the orphan. */
+    void EraseOrphanOfPeer(const uint256& wtxid, NodeId peer) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /** Return how many entries exist in the orphange */
     size_t Size() EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
@@ -68,7 +79,9 @@ public:
         LOCK(m_mutex);
         return m_total_orphan_bytes;
     }
-    /** Return total amount of orphans stored by this peer, in bytes. */
+    /** Return total amount of orphans stored by this peer, in bytes.  Since an orphan can have
+     * multiple announcers, the aggregate BytesFromPeer() for all peers may exceed
+     * TotalOrphanBytes(). */
     unsigned int BytesFromPeer(NodeId peer) const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
     {
         LOCK(m_mutex);
@@ -85,9 +98,9 @@ protected:
 
     struct OrphanTx {
         CTransactionRef tx;
-        NodeId fromPeer;
         int64_t nTimeExpire;
         size_t list_pos;
+        std::set<NodeId> announcers;
     };
 
     /** Map from txid to orphan transaction record. Limited by

--- a/src/txorphanage.h
+++ b/src/txorphanage.h
@@ -21,8 +21,9 @@
 class TxOrphanage {
 public:
     /** Add a new orphan transaction. If the tx already exists, add this peer to its list of announcers.
+     * parent_txids should contain a (de-duplicated) list of txids of this transaction's missing parents.
       @returns true if the transaction was added as a new orphan. */
-    bool AddTx(const CTransactionRef& tx, NodeId peer) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+    bool AddTx(const CTransactionRef& tx, NodeId peer, const std::vector<uint256>& parent_txids) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /** Add an additional announcer to an orphan if it exists. Otherwise, do nothing. */
     void AddAnnouncer(const uint256& wtxid, NodeId peer) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
@@ -53,7 +54,7 @@ public:
     /** Erase all orphans included in or invalidated by a new block */
     void EraseForBlock(const CBlock& block) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
-    /** Limit the orphanage to the given maximum */
+    /** Limit the orphanage to the given maximum. Returns all expired entries. */
     void LimitOrphans(unsigned int max_orphans) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /** Add any orphans that list a particular tx as a parent into the from peer's work set */
@@ -89,6 +90,9 @@ public:
         return peer_bytes_it == m_peer_bytes_used.end() ? 0 : peer_bytes_it->second;
     }
 
+    /** Get an orphan's parent_txids, or std::nullopt if the orphan is not present. */
+    std::optional<std::vector<uint256>> GetParentTxids(const uint256& wtxid) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
 protected:
     /** Total bytes of all transactions. */
     unsigned int m_total_orphan_bytes{0};
@@ -101,6 +105,8 @@ protected:
         int64_t nTimeExpire;
         size_t list_pos;
         std::set<NodeId> announcers;
+        /** Txids of the missing parents to request. Determined by peerman. */
+        std::vector<uint256> parent_txids;
     };
 
     /** Map from txid to orphan transaction record. Limited by

--- a/src/txorphanage.h
+++ b/src/txorphanage.h
@@ -6,12 +6,16 @@
 #define BITCOIN_TXORPHANAGE_H
 
 #include <net.h>
+#include <policy/policy.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <sync.h>
 
 #include <map>
 #include <set>
+
+/** Maximum total size of orphan transactions stored, in bytes. */
+static constexpr unsigned int DEFAULT_MAX_ORPHAN_TOTAL_SIZE{100 * MAX_STANDARD_TX_WEIGHT};
 
 /** A class to track orphan transactions (failed on TX_MISSING_INPUTS)
  * Since we cannot distinguish orphans from bad transactions with
@@ -55,7 +59,8 @@ public:
     std::vector<uint256> EraseForBlock(const CBlock& block) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /** Limit the orphanage to the given maximum. Returns all expired entries. */
-    void LimitOrphans(unsigned int max_orphans) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+    void LimitOrphans(unsigned int max_orphans, unsigned int max_total_size = DEFAULT_MAX_ORPHAN_TOTAL_SIZE)
+        EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /** Add any orphans that list a particular tx as a parent into the from peer's work set */
     void AddChildrenToWorkSet(const CTransaction& tx) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);;


### PR DESCRIPTION
This PR contains changes to `TxOrphanage` needed for package relay stuff. See #27463 for project tracking and #28031 for how this code is used.

Separating this PR was suggested in https://github.com/bitcoin/bitcoin/pull/28031#discussion_r1261414179.

Changes here:
- Change params to wtxid instead of txid.
- Track total size (`CTransaction::GetTotalSize()` of orphans stored, as well as the size per peer.
- Support having multiple announcers for the same tx. This helps us retry resolving the same orphan with multiple peers if it fails the first time.
- Store the deduplicated missing parent txids in `OrphanTx` so that we don't need to calculate them again later on.
- Return the erased wtxids from `EraseForBlock` which includes orphans that conflicted with the block. This helps us delete those orphan resolution attempts from our tracker.
- Enable limiting the total size of orphans instead of just the total count. No new limits are introduced, the default is maximum count * maximum tx size.
- Unit tests + fuzzer.