### PR TITLE
RPC: `descriptorprocesspsbt` returns hex encoded tx if complete

### DIFF
--- a/doc/release-notes-28414.md
+++ b/doc/release-notes-28414.md
@@ -1,5 +1,6 @@
 RPC Wallet
 ----------
 
-- RPC `walletprocesspsbt` return object now includes field `hex` (if the transaction
-is complete) containing the serialized transaction suitable for RPC `sendrawtransaction`. (#28414)
+- RPC `walletprocesspsbt`, and `descriptorprocesspsbt` return object now includes field `hex` (if the transaction
+is complete) containing the serialized transaction suitable for RPC `sendrawtransaction`.
+

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1949,6 +1949,7 @@ RPCHelpMan descriptorprocesspsbt()
                     {
                         {RPCResult::Type::STR, "psbt", "The base64-encoded partially signed transaction"},
                         {RPCResult::Type::BOOL, "complete", "If the transaction has a complete set of signatures"},
+                        {RPCResult::Type::STR_HEX, "hex", /*optional=*/true, "The hex-encoded network transaction if complete"},
                     }
                 },
                 RPCExamples{
@@ -1989,7 +1990,14 @@ RPCHelpMan descriptorprocesspsbt()
 
     result.pushKV("psbt", EncodeBase64(ssTx));
     result.pushKV("complete", complete);
-
+    if (complete) {
+        CMutableTransaction mtx;
+        PartiallySignedTransaction psbtx_copy = psbtx;
+        CHECK_NONFATAL(FinalizeAndExtractPSBT(psbtx_copy, mtx));
+        CDataStream ssTx_final(SER_NETWORK, PROTOCOL_VERSION);
+        ssTx_final << mtx;
+        result.pushKV("hex", HexStr(ssTx_final));
+    }
     return result;
 },
     };


### PR DESCRIPTION
Coming from [#28414 comment](https://github.com/bitcoin/bitcoin/pull/28414#pullrequestreview-1618684391) Same thing also for `descriptorprocesspsbt`.

Before this PR `descriptorprocesspsbt` returns a boolean `complete` which indicates that the psbt is final, users then have to call `finalizepsbt` to get the hex encoded network transaction.

In this PR if the psbt is complete the return object also has the hex encoded network transaction ready for broadcast with `sendrawtransaction`.

This save users calling `finalizepsbt` with the descriptor, if it is already complete.