### PR TITLE
fuzz: Add missing PROVIDE_FUZZ_MAIN_FUNCTION guard to __AFL_FUZZ_INIT

### DIFF
--- a/src/test/fuzz/fuzz.cpp
+++ b/src/test/fuzz/fuzz.cpp
@@ -29,7 +29,7 @@
 #include <utility>
 #include <vector>
 
-#ifdef __AFL_FUZZ_INIT
+#if defined(PROVIDE_FUZZ_MAIN_FUNCTION) && defined(__AFL_FUZZ_INIT)
 __AFL_FUZZ_INIT();
 #endif
 


### PR DESCRIPTION
Should fix https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=62455