### PR TITLE
qa: Fix intermittent "Unable to connect to bitcoind" errors on Windows

### DIFF
--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -469,6 +469,13 @@ def delete_cookie_file(datadir, chain):
         os.remove(os.path.join(datadir, chain, ".cookie"))
 
 
+# If a PID file exists in the given datadir, delete it.
+def delete_pid_file(datadir, chain):
+    if os.path.isfile(os.path.join(datadir, chain, "bitcoind.pid")):
+        logger.debug("Deleting leftover PID file")
+        os.remove(os.path.join(datadir, chain, "bitcoind.pid"))
+
+
 def softfork_active(node, key):
     """Return whether a softfork is active."""
     return node.getdeploymentinfo()['deployments'][key]['active']


### PR DESCRIPTION
During my [investigation](https://github.com/bitcoin/bitcoin/issues/28411#issuecomment-1724233900) of https://github.com/bitcoin/bitcoin/issues/28411 and other similar functional test failures on Windows in CI, I found out that https://github.com/bitcoin/bitcoin/blob/abe4fedab735c145881e85dc2b02cf819a241635/test/functional/test_framework/test_node.py#L223 sometimes fails for unknown to me reasons. By "fails", I mean that a child process does not make any progress.

This PR ensures a child process's progress by checking a created PID file shortly. If the check fails, another two attempts are following.

Although this PR fixes tests on Windows, the new logic is platform-agnostic and increases test robustness.

In several dozens of runs in my personal repo GHA, the only intermittent failure still happens -- https://github.com/bitcoin/bitcoin/issues/28491.

Closes https://github.com/bitcoin/bitcoin/issues/28411.