### PR TITLE
doc: Be vague instead of wrong about MALLOC_ARENA_MAX

### DIFF
--- a/doc/reduce-memory.md
+++ b/doc/reduce-memory.md
@@ -43,7 +43,7 @@ threads take up 8MiB for the thread stack on a 64-bit system, and 4MiB in a
 
 ## Linux specific
 
-By default, glibc will create up to two heap arenas per core. This is known to cause excessive memory usage in some scenarios. To avoid this make a script that sets `MALLOC_ARENA_MAX` before starting bitcoind:
+By default, glibc's implementation of `malloc` may use more than one arena. This is known to cause excessive memory usage in some scenarios. To avoid this, make a script that sets `MALLOC_ARENA_MAX` before starting bitcoind:
 
 ```bash
 #!/usr/bin/env bash


### PR DESCRIPTION
Before this commit, we claim that glibc's malloc implementation uses 2 arenas by default. But that's true only on 32-bit systems, and even there, it uses *up* to 2 arenas.

This commit fixes the wrong statement. The new statement is intentionally vague to reduce our maintenance burden.

For details, see:
https://www.gnu.org/software/libc/manual/html_node/Memory-Allocation-Tunables.html#index-glibc_002emalloc_002earena_005fmax

Noticed in:
https://github.com/bitcoin/bitcoin/pull/27642#issuecomment-1728103427
