### PR TITLE
ci: Install Homebrew's `pkg-config` package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
         run: clang --version
 
       - name: Install Homebrew packages
-        run: brew install boost libevent qt@5 miniupnpc libnatpmp ccache zeromq qrencode libtool automake gnu-getopt
+        run: brew install automake libtool pkg-config gnu-getopt ccache boost libevent miniupnpc libnatpmp zeromq qt@5 qrencode
 
       - name: Set Ccache directory
         run: echo "CCACHE_DIR=${RUNNER_TEMP}/ccache_dir" >> "$GITHUB_ENV"


### PR DESCRIPTION
Some versions of macOS images lack the `pkg-config` package.

For example, https://github.com/bitcoin/bitcoin/actions/runs/6248032071/job/16961797066:
```
Runner Image
  Image: macos-13
  Version: 20230417.1
```

```
+ ./autogen.sh
configure.ac:16: error: PKG_PROG_PKG_CONFIG macro not found. Please install pkg-config and re-run autogen.sh
```

This PR makes Homebrew install the `pkg-config` package explicitly.

Also please refer to [macOS Build Guide](https://github.com/bitcoin/bitcoin/blob/master/doc/build-osx.md).