### PR TITLE
improve MallocUsage() accuracy

### DIFF
--- a/src/memusage.h
+++ b/src/memusage.h
@@ -184,25 +184,33 @@ template<typename X>
 struct unordered_node : private X
 {
 private:
-    void* ptr;
-    void* ptr2;
+    void* next;
+    void* prev;
 };
 
-// The memory used by an unordered_set or unordered map is the sum of the
+// The memory used by an unordered_set or unordered_map is the sum of the
 // sizes of the individual nodes (which are separately allocated) plus
 // the size of the bucket array (which is a single allocation).
 // Empirically, each element of the bucket array consists of two pointers
 // on some platforms (Windows and macOS), so be conservative.
+struct unordered_bucket_element
+{
+    void* next;
+    void* prev;
+};
+
 template<typename X, typename Y>
 static inline size_t DynamicUsage(const std::unordered_set<X, Y>& s)
 {
-    return MallocUsage(sizeof(unordered_node<X>)) * s.size() + MallocUsage(2 * sizeof(void*) * s.bucket_count());
+    return MallocUsage(sizeof(unordered_node<X>)) * s.size() +
+           MallocUsage(sizeof(unordered_bucket_element) * s.bucket_count());
 }
 
 template<typename X, typename Y, typename Z>
 static inline size_t DynamicUsage(const std::unordered_map<X, Y, Z>& m)
 {
-    return MallocUsage(sizeof(unordered_node<std::pair<const X, Y> >)) * m.size() + MallocUsage(2 * sizeof(void*) * m.bucket_count());
+    return MallocUsage(sizeof(unordered_node<std::pair<const X, Y> >)) * m.size() +
+           MallocUsage(sizeof(unordered_bucket_element) * m.bucket_count());
 }
 
 template <class Key, class T, class Hash, class Pred, std::size_t MAX_BLOCK_SIZE_BYTES, std::size_t ALIGN_BYTES>

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -113,6 +113,7 @@ add_executable(test_bitcoin
   txvalidation_tests.cpp
   txvalidationcache_tests.cpp
   uint256_tests.cpp
+  util_malloc_usage_tests.cpp
   util_string_tests.cpp
   util_tests.cpp
   util_threadnames_tests.cpp

--- a/src/test/util_malloc_usage_tests.cpp
+++ b/src/test/util_malloc_usage_tests.cpp
@@ -1,0 +1,105 @@
+// Copyright (c) 2025 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <memusage.h>
+#include <tinyformat.h>
+
+#include <unordered_map>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_SUITE(util_malloc_usage_tests)
+
+// Allocate memory of various sizes and keep track of the most common address
+// difference between consecutive allocations of the same size. This reliably
+// indicates the amount of actual memory consumed by that allocation size.
+BOOST_AUTO_TEST_CASE(malloc_usage)
+{
+    std::vector<void*> allocations;
+    for (size_t s{1}; s < 120; ++s) {
+        // histogram to track address difference frequencies
+        std::vector<int> hist;
+        hist.resize(200);
+
+        uintptr_t prev{0};
+        for (int i{1}; i < 1000; ++i) {
+            void *a{malloc(s)};
+            allocations.push_back(a);
+            uintptr_t next{uintptr_t(a)};
+            // Some memory allocators go from higher to lower addresses.
+            uintptr_t d{(next > prev) ? next - prev : prev - next};
+            prev = next;
+            if (d < hist.size()) hist[d]++;
+        }
+        // Find the most common (most frequently occurring) address difference.
+        int max_frequency{0};
+        size_t most_common_diff{0};
+        for (size_t c{1}; c < hist.size(); ++c) {
+            if (max_frequency < hist[c]) {
+                max_frequency = hist[c];
+                most_common_diff = c;
+            }
+        }
+        // We assume most_common_diff is the actual allocation amount.
+
+        // this stuff is temporary (just to get info from CI)
+        if (most_common_diff != memusage::MallocUsage(s)) {
+            BOOST_TEST_MESSAGE(strprintf("%i %i %i", s, most_common_diff, memusage::MallocUsage(s)));
+        }
+
+        BOOST_CHECK_EQUAL(most_common_diff, memusage::MallocUsage(s));
+    }
+    for (void* a : allocations) free(a);
+}
+
+// Add nodes to an unordered map, and keep track of the address differences
+// between consecutive nodes. The difference that is most common reliably
+// indicates the amount of actual memory allocated to each node. Note that
+// each node needs to include at least a pointer to the next element in the
+// per-bucket list.
+BOOST_AUTO_TEST_CASE(unordered_map)
+{
+    std::string display{"map: "};
+    // Make the data size strange so some alignment rounding is likely needed.
+    using map_data = std::unordered_map<size_t, std::array<uint8_t, 50>>;
+    std::unordered_map<size_t, map_data> m;
+    // Try to prevent bucket reallocations, which interfere with node allocations.
+    m.reserve(20'000);
+
+    // histogram to track address difference frequencies
+    std::vector<int> hist;
+    hist.resize(200);
+
+    uintptr_t prev{0};
+    for (size_t i{0}; i < 10'000; ++i) {
+        m[i] = map_data{};
+        auto x{&m[i]};
+        uintptr_t next{uintptr_t(x)};
+        // Some memory allocators go from higher to lower addresses.
+        uintptr_t d{(next > prev) ? next - prev : prev - next};
+        prev = next;
+        if (d < hist.size()) hist[d]++;
+    }
+    // Find the most common (most frequently occurring) address difference.
+    int max_frequency{0};
+    size_t most_common_diff{0};
+    for (size_t c{1}; c < hist.size(); ++c) {
+        if (max_frequency < hist[c]) {
+            max_frequency = hist[c];
+            most_common_diff = c;
+        }
+    }
+    // We assume most_common_diff is the actual allocation amount.
+    using node_type = std::pair<size_t, map_data>;
+    size_t node_malloc_usage{memusage::MallocUsage(sizeof(node_type) + sizeof(void*))};
+    BOOST_REQUIRE_EQUAL(most_common_diff, node_malloc_usage);
+
+    // this stuff is temporary (just to get info from CI)
+    BOOST_TEST_MESSAGE(node_malloc_usage);
+    BOOST_TEST_MESSAGE(m.bucket_count());
+    BOOST_TEST_MESSAGE(memusage::DynamicUsage(m));
+    BOOST_CHECK(false);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/validation_flush_tests.cpp
+++ b/src/test/validation_flush_tests.cpp
@@ -21,115 +21,113 @@ BOOST_AUTO_TEST_CASE(getcoinscachesizestate)
 {
     Chainstate& chainstate{m_node.chainman->ActiveChainstate()};
 
-    constexpr bool is_64_bit = sizeof(void*) == 8;
-
     LOCK(::cs_main);
     auto& view = chainstate.CoinsTip();
 
-    // The number of bytes consumed by coin's heap data, i.e. CScript
-    // (prevector<28, unsigned char>) when assigned 56 bytes of data per above.
-    //
-    // See also: Coin::DynamicMemoryUsage().
-    constexpr unsigned int COIN_SIZE = is_64_bit ? 80 : 64;
+    // An empty coins cache still allocates one PoolResource 'chunk', which is 256 KiB, and there
+    // is some overhead. As a sanity check, an empty coins cache should be only slightly larger.
+    BOOST_CHECK_LT(view.DynamicMemoryUsage(), 256 * 1024 * 100 / 98);
 
-    auto print_view_mem_usage = [](CCoinsViewCache& view) {
-        BOOST_TEST_MESSAGE("CCoinsViewCache memory usage: " << view.DynamicMemoryUsage());
-    };
+    // PoolResource defaults to 256 KiB that will be allocated, so we need to test with a size
+    // significantly larger that size so that fragmentation effects are minimal.
+    // But this size can still be much smaller than the default coins cache size, 450 MB.
+    constexpr size_t MAX_COINS_CACHE_BYTES{8'000'000};
 
-    // PoolResource defaults to 256 KiB that will be allocated, so we'll take that and make it a bit larger.
-    constexpr size_t MAX_COINS_CACHE_BYTES = 262144 + 512;
+    // The coins cache can also use the mempool.
+    constexpr size_t MAX_MEMPOOL_CACHE_BYTES{4'000'000};
+
+    // Check GetCoinsCacheSizeState() with an empty coins cache.
+    const CoinsCacheSizeState empty_cache{chainstate.GetCoinsCacheSizeState(MAX_COINS_CACHE_BYTES, /*max_mempool_size_bytes=*/0)};
 
     // Without any coins in the cache, we shouldn't need to flush.
-    BOOST_TEST(
-        chainstate.GetCoinsCacheSizeState(MAX_COINS_CACHE_BYTES, /*max_mempool_size_bytes=*/ 0) != CoinsCacheSizeState::CRITICAL);
+    BOOST_CHECK_NE(empty_cache, CoinsCacheSizeState::CRITICAL);
 
-    // If the initial memory allocations of cacheCoins don't match these common
-    // cases, we can't really continue to make assertions about memory usage.
-    // End the test early.
-    if (view.DynamicMemoryUsage() != 32 && view.DynamicMemoryUsage() != 16) {
-        // Add a bunch of coins to see that we at least flip over to CRITICAL.
+    // And we shouldn't be within 10% of full.
+    BOOST_CHECK_NE(empty_cache, CoinsCacheSizeState::LARGE);
 
-        for (int i{0}; i < 1000; ++i) {
-            const COutPoint res = AddTestCoin(m_rng, view);
-            BOOST_CHECK_EQUAL(view.AccessCoin(res).DynamicMemoryUsage(), COIN_SIZE);
-        }
+    // There should be plenty of space.
+    BOOST_CHECK_EQUAL(empty_cache, CoinsCacheSizeState::OK);
 
-        BOOST_CHECK_EQUAL(
-            chainstate.GetCoinsCacheSizeState(MAX_COINS_CACHE_BYTES, /*max_mempool_size_bytes=*/0),
-            CoinsCacheSizeState::CRITICAL);
-
-        BOOST_TEST_MESSAGE("Exiting cache flush tests early due to unsupported arch");
-        return;
-    }
-
-    print_view_mem_usage(view);
-    BOOST_CHECK_EQUAL(view.DynamicMemoryUsage(), is_64_bit ? 32U : 16U);
-
-    // We should be able to add COINS_UNTIL_CRITICAL coins to the cache before going CRITICAL.
-    // This is contingent not only on the dynamic memory usage of the Coins
-    // that we're adding (COIN_SIZE bytes per), but also on how much memory the
-    // cacheCoins (unordered_map) preallocates.
-    constexpr int COINS_UNTIL_CRITICAL{3};
-
-    // no coin added, so we have plenty of space left.
-    BOOST_CHECK_EQUAL(
-        chainstate.GetCoinsCacheSizeState(MAX_COINS_CACHE_BYTES, /*max_mempool_size_bytes*/ 0),
-        CoinsCacheSizeState::OK);
-
-    for (int i{0}; i < COINS_UNTIL_CRITICAL; ++i) {
-        const COutPoint res = AddTestCoin(m_rng, view);
-        print_view_mem_usage(view);
-        BOOST_CHECK_EQUAL(view.AccessCoin(res).DynamicMemoryUsage(), COIN_SIZE);
-
-        // adding first coin causes the MemoryResource to allocate one 256 KiB chunk of memory,
-        // pushing us immediately over to LARGE
-        BOOST_CHECK_EQUAL(
-            chainstate.GetCoinsCacheSizeState(MAX_COINS_CACHE_BYTES, /*max_mempool_size_bytes=*/ 0),
-            CoinsCacheSizeState::LARGE);
-    }
-
-    // Adding some additional coins will push us over the edge to CRITICAL.
-    for (int i{0}; i < 4; ++i) {
+    // Add coins until the cache is just under 90% full; the returned state should
+    // be OK until 90%. The loop counter prevents a runaway test.
+    size_t i;
+    for (i = 0; i < 80'000; ++i) {
         AddTestCoin(m_rng, view);
-        print_view_mem_usage(view);
-        if (chainstate.GetCoinsCacheSizeState(MAX_COINS_CACHE_BYTES, /*max_mempool_size_bytes=*/0) ==
-            CoinsCacheSizeState::CRITICAL) {
-            break;
-        }
-    }
 
+        // Fill to about 89% (below 90%) of the cache size limit.
+        if (view.DynamicMemoryUsage() >= MAX_COINS_CACHE_BYTES * 89 / 100) break;
+
+        BOOST_REQUIRE_EQUAL(
+            chainstate.GetCoinsCacheSizeState(MAX_COINS_CACHE_BYTES, /*max_mempool_size_bytes=*/0),
+            CoinsCacheSizeState::OK);
+    }
+    BOOST_CHECK_LT(i, 80'000);
+
+    // This loop transitions the cache state from OK (< 90%) to LARGE (between 90% and 100%).
+    for (i = 0; i < 80'000; ++i) {
+        AddTestCoin(m_rng, view);
+
+        // Fill to about 95% of the cache size limit.
+        if (view.DynamicMemoryUsage() >= MAX_COINS_CACHE_BYTES * 95 / 100) break;
+    }
+    BOOST_CHECK_LT(i, 80'000);
+    BOOST_CHECK_EQUAL(
+        chainstate.GetCoinsCacheSizeState(MAX_COINS_CACHE_BYTES, /*max_mempool_size_bytes=*/0),
+        CoinsCacheSizeState::LARGE);
+
+    // This loop moves the cache state from LARGE (90% to 100%) to CRITICAL (over 100%).
+    for (i = 0; i < 80'000; ++i) {
+        AddTestCoin(m_rng, view);
+
+        // Fill to just beyojnd the cache size limit.
+        if (view.DynamicMemoryUsage() > MAX_COINS_CACHE_BYTES) break;
+    }
+    BOOST_CHECK_LT(i, 80'000);
     BOOST_CHECK_EQUAL(
         chainstate.GetCoinsCacheSizeState(MAX_COINS_CACHE_BYTES, /*max_mempool_size_bytes=*/0),
         CoinsCacheSizeState::CRITICAL);
 
-    // Passing non-zero max mempool usage (512 KiB) should allow us more headroom.
+    // Repeat (continuing with the existing cache) but with a non-zero max mempool;
+    // this allows more headroom.
     BOOST_CHECK_EQUAL(
-        chainstate.GetCoinsCacheSizeState(MAX_COINS_CACHE_BYTES, /*max_mempool_size_bytes=*/ 1 << 19),
+        chainstate.GetCoinsCacheSizeState(MAX_COINS_CACHE_BYTES, /*max_mempool_size_bytes=*/MAX_MEMPOOL_CACHE_BYTES),
         CoinsCacheSizeState::OK);
 
-    for (int i{0}; i < 3; ++i) {
+    for (i = 0; i < 80'000; ++i) {
         AddTestCoin(m_rng, view);
-        print_view_mem_usage(view);
-        BOOST_CHECK_EQUAL(
-            chainstate.GetCoinsCacheSizeState(MAX_COINS_CACHE_BYTES, /*max_mempool_size_bytes=*/ 1 << 19),
+        // Fill to about 89% (below 90%) of the cache size limit.
+        if (view.DynamicMemoryUsage() >= (MAX_COINS_CACHE_BYTES + MAX_MEMPOOL_CACHE_BYTES) * 89 / 100) break;
+
+        BOOST_REQUIRE_EQUAL(
+            chainstate.GetCoinsCacheSizeState(MAX_COINS_CACHE_BYTES, /*max_mempool_size_bytes=*/MAX_MEMPOOL_CACHE_BYTES),
             CoinsCacheSizeState::OK);
     }
+    BOOST_CHECK_LT(i, 80'000);
 
-    // Adding another coin with the additional mempool room will put us >90%
-    // but not yet critical.
-    AddTestCoin(m_rng, view);
-    print_view_mem_usage(view);
+    // This loop transitions the cache state from OK (< 90%) to LARGE (between 90% and 100%).
+    for (i = 0; i < 80'000; ++i) {
+        AddTestCoin(m_rng, view);
 
-    // Only perform these checks on 64 bit hosts; I haven't done the math for 32.
-    if (is_64_bit) {
-        float usage_percentage = (float)view.DynamicMemoryUsage() / (MAX_COINS_CACHE_BYTES + (1 << 10));
-        BOOST_TEST_MESSAGE("CoinsTip usage percentage: " << usage_percentage);
-        BOOST_CHECK(usage_percentage >= 0.9);
-        BOOST_CHECK(usage_percentage < 1);
-        BOOST_CHECK_EQUAL(
-            chainstate.GetCoinsCacheSizeState(MAX_COINS_CACHE_BYTES, /*max_mempool_size_bytes*/ 1 << 10), // 1024
-            CoinsCacheSizeState::LARGE);
+        // Fill to about 95% of the cache size limit..
+        if (view.DynamicMemoryUsage() >= (MAX_COINS_CACHE_BYTES + MAX_MEMPOOL_CACHE_BYTES) * 95 / 100) break;
     }
+    BOOST_CHECK_LT(i, 80'000);
+    BOOST_CHECK_EQUAL(
+        chainstate.GetCoinsCacheSizeState(MAX_COINS_CACHE_BYTES, /*max_mempool_size_bytes=*/MAX_MEMPOOL_CACHE_BYTES),
+        CoinsCacheSizeState::LARGE);
+
+    // This loop moves the cache state from LARGE (90% to 100%) to CRITICAL (over 100%).
+    for (i = 0; i < 80'000; ++i) {
+        AddTestCoin(m_rng, view);
+
+        // Fill to just beyojnd the cache size limit.
+        if (view.DynamicMemoryUsage() > MAX_COINS_CACHE_BYTES + MAX_MEMPOOL_CACHE_BYTES) break;
+    }
+    BOOST_CHECK_LT(i, 80'000);
+    BOOST_CHECK_EQUAL(
+        chainstate.GetCoinsCacheSizeState(MAX_COINS_CACHE_BYTES, /*max_mempool_size_bytes=*/MAX_MEMPOOL_CACHE_BYTES),
+        CoinsCacheSizeState::CRITICAL);
+
 
     // Using the default max_* values permits way more coins to be added.
     for (int i{0}; i < 1000; ++i) {
@@ -140,14 +138,12 @@ BOOST_AUTO_TEST_CASE(getcoinscachesizestate)
     }
 
     // Flushing the view does take us back to OK because ReallocateCache() is called
-
     BOOST_CHECK_EQUAL(
         chainstate.GetCoinsCacheSizeState(MAX_COINS_CACHE_BYTES, 0),
         CoinsCacheSizeState::CRITICAL);
 
     view.SetBestBlock(m_rng.rand256());
     BOOST_CHECK(view.Flush());
-    print_view_mem_usage(view);
 
     BOOST_CHECK_EQUAL(
         chainstate.GetCoinsCacheSizeState(MAX_COINS_CACHE_BYTES, 0),


### PR DESCRIPTION
The `MallocUsage()` function takes an allocation size as an argument and returns the amount of physical memory consumed, which is greater due to memory allocator overhead and alignment. It was first added in 2015 (first commit of #6102), but its accuracy has degraded as memory allocation libraries have evolved. It's used when it's important that large data structures, such as the coins cache and mempool, should use a predictable, configurable (limited) amount of physical memory (see the `-dbcache` and `-maxmempool` configuration options), as well as a few other places.

sipa figured out a concise, efficient [expression](https://github.com/bitcoin/bitcoin/pull/27748#discussion_r1215541260) that this function can use, and that's what's implemented here.

Also add a unit test, which is more helpful than usual in this case since platforms, operating systems, and libraries vary significantly in this area.