### PR TITLE
qt: enable` -ltcg` for windows under LTO

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -22,6 +22,7 @@ $(package)_patches += fast_fixed_dtoa_no_optimize.patch
 $(package)_patches += guix_cross_lib_path.patch
 $(package)_patches += fix-macos-linker.patch
 $(package)_patches += memory_resource.patch
+$(package)_patches += windows_lto.patch
 
 $(package)_qttranslations_file_name=qttranslations-$($(package)_suffix)
 $(package)_qttranslations_sha256_hash=38b942bc7e62794dd072945c8a92bb9dfffed24070aea300327a3bb42f855609
@@ -183,6 +184,9 @@ $(package)_config_opts_mingw32 += "QMAKE_LFLAGS = '$($(package)_ldflags)'"
 $(package)_config_opts_mingw32 += "QMAKE_LIB = '$($(package)_ar) rc'"
 $(package)_config_opts_mingw32 += -device-option CROSS_COMPILE="$(host)-"
 $(package)_config_opts_mingw32 += -pch
+ifneq ($(LTO),)
+$(package)_config_opts_mingw32 += -ltcg
+endif
 
 $(package)_config_opts_android = -xplatform android-clang
 $(package)_config_opts_android += -android-sdk $(ANDROID_SDK)
@@ -250,6 +254,7 @@ define $(package)_preprocess_cmds
   patch -p1 -i $($(package)_patch_dir)/duplicate_lcqpafonts.patch && \
   patch -p1 -i $($(package)_patch_dir)/fast_fixed_dtoa_no_optimize.patch && \
   patch -p1 -i $($(package)_patch_dir)/guix_cross_lib_path.patch && \
+  patch -p1 -i $($(package)_patch_dir)/windows_lto.patch && \
   mkdir -p qtbase/mkspecs/macx-clang-linux &&\
   cp -f qtbase/mkspecs/macx-clang/qplatformdefs.h qtbase/mkspecs/macx-clang-linux/ &&\
   cp -f $($(package)_patch_dir)/mac-qmake.conf qtbase/mkspecs/macx-clang-linux/qmake.conf && \

--- a/depends/patches/qt/windows_lto.patch
+++ b/depends/patches/qt/windows_lto.patch
@@ -1,0 +1,31 @@
+Qt (for Windows) fails to build under LTO, due to multiple definition issues, i.e
+
+multiple definition of `QAccessibleLineEdit::~QAccessibleLineEdit()';
+
+Possibly related to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94156.
+
+diff --git a/qtbase/src/widgets/accessible/simplewidgets.cpp b/qtbase/src/widgets/accessible/simplewidgets.cpp
+index 107fd729fe..0e61878f39 100644
+--- a/qtbase/src/widgets/accessible/simplewidgets.cpp
++++ b/qtbase/src/widgets/accessible/simplewidgets.cpp
+@@ -109,6 +109,8 @@ QString qt_accHotKey(const QString &text);
+   \ingroup accessibility
+ */
+ 
++QAccessibleLineEdit::~QAccessibleLineEdit(){};
++
+ /*!
+   Creates a QAccessibleButton object for \a w.
+ */
+diff --git a/qtbase/src/widgets/accessible/simplewidgets_p.h b/qtbase/src/widgets/accessible/simplewidgets_p.h
+index 73572e3059..658da86143 100644
+--- a/qtbase/src/widgets/accessible/simplewidgets_p.h
++++ b/qtbase/src/widgets/accessible/simplewidgets_p.h
+@@ -155,6 +155,7 @@ class QAccessibleLineEdit : public QAccessibleWidget, public QAccessibleTextInte
+ public:
+     explicit QAccessibleLineEdit(QWidget *o, const QString &name = QString());
+ 
++    ~QAccessibleLineEdit();
+     QString text(QAccessible::Text t) const override;
+     void setText(QAccessible::Text t, const QString &text) override;
+     QAccessible::State state() const override;


### PR DESCRIPTION
Patch around multiple definition issues in Qt, and enable `-ltcg` when using `LTO=1`.

Split from #25391.