### PR TITLE
p2p: stop announcing txs with ancestors below fee filter

### DIFF
--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -675,6 +675,10 @@ public:
         return m_total_fee;
     }
 
+    /** If the transaction is in mempool, returns the minimum base feerate of this transaction and
+     * all of its in-mempool ancestors. Otherwise, returns std::nullopt. */
+    std::optional<CFeeRate> GetMinimumAncestorFeerate(const GenTxid& gtxid) const EXCLUSIVE_LOCKS_REQUIRED(cs);
+
     bool exists(const GenTxid& gtxid) const
     {
         LOCK(cs);
@@ -691,6 +695,10 @@ public:
         return mapTx.project<0>(mapTx.get<index_by_wtxid>().find(wtxid));
     }
     TxMempoolInfo info(const GenTxid& gtxid) const;
+
+    /** Returns TxMempoolInfo and MinimumAncestorFeerate of a tx if it is present in the mempool. If
+     * not, returns std::nullopt. */
+    std::optional<std::pair<TxMempoolInfo, CFeeRate>> info_for_announcement(const GenTxid& gtxid) const;
 
     /** Returns info for a transaction if its entry_sequence < last_sequence */
     TxMempoolInfo info_for_relay(const GenTxid& gtxid, uint64_t last_sequence) const;

--- a/test/functional/p2p_feefilter.py
+++ b/test/functional/p2p_feefilter.py
@@ -178,8 +178,8 @@ class FeeFilterTest(BitcoinTestFramework):
         assert_greater_than(parent_low_prioritised["tx"].get_vsize() * peer_minfee_sat_vb, parent_low_prioritised["fee"] * COIN)
 
         # Check what was announced to peer_minfee_sat_vb
-        unexpected_invs = [int(tx["tx"].getwtxid(), 16) for tx in [parent_low, parent_low_prioritised]]
-        expected_invs = [int(tx["tx"].getwtxid(), 16) for tx in [parent_high, child_high]]
+        unexpected_invs = [int(tx["tx"].getwtxid(), 16) for tx in [parent_low, parent_low_prioritised, child_high]]
+        expected_invs = [int(tx["tx"].getwtxid(), 16) for tx in [parent_high]]
         for wtxid in unexpected_invs:
             assert wtxid not in peer_diff_policy.get_invs()
         for wtxid in expected_invs:


### PR DESCRIPTION
Our mempool may receive a CPFP of a transaction that is below our peer's mempool minimum feerate. There are many possible reasons, but the most common is when our peer's mempool has a smaller capacity and so their mempool minimum feerate is higher than ours. In the future, another likely reason is that we accept packages but they don't (this change was originally part of package relay but seems beneficial today).

Today, we broadcast this CPFP transaction to our peers (assuming its individual feerate is above the fee filter). Assuming they're running Bitcoin Core, this happens:
- Peer requests the child
- We send the child
- The peer sees this child as an orphan, stores it in orphanage, and requests the parent
- We send the parent
- The parent is rejected for being too low feerate

This is a waste of bandwidth and computation. It also wastes the peer's orphanage slots - instagibbs has been monitoring orphanage usage recently and noted that this is happening pretty frequently.

When announcing a transaction, if it contains a mempool ancestor below the peer's fee filter, drop it.