### PR TITLE
fuzz: Mock GetRand in process_message(s)

### DIFF
--- a/src/random.cpp
+++ b/src/random.cpp
@@ -21,6 +21,7 @@
 #include <array>
 #include <cmath>
 #include <cstdlib>
+#include <functional>
 #include <thread>
 
 #ifdef WIN32
@@ -564,9 +565,11 @@ void RandAddPeriodic() noexcept { ProcRand(nullptr, 0, RNGLevel::PERIODIC); }
 void RandAddEvent(const uint32_t event_info) noexcept { GetRNGState().AddEvent(event_info); }
 
 bool g_mock_deterministic_tests{false};
-
+std::function<uint64_t(uint64_t)> g_mock_get_rand{nullptr};
 uint64_t GetRandInternal(uint64_t nMax) noexcept
 {
+    if (g_mock_get_rand) return g_mock_get_rand(nMax);
+
     return FastRandomContext(g_mock_deterministic_tests).randrange(nMax);
 }
 

--- a/src/test/fuzz/process_message.cpp
+++ b/src/test/fuzz/process_message.cpp
@@ -18,6 +18,7 @@
 #include <test/fuzz/util/net.h>
 #include <test/util/mining.h>
 #include <test/util/net.h>
+#include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <test/util/validation.h>
 #include <util/chaintype.h>
@@ -61,6 +62,11 @@ void initialize_process_message()
 FUZZ_TARGET(process_message, .init = initialize_process_message)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+
+    g_mock_get_rand = [&](uint64_t max) -> uint64_t {
+        if (fuzzed_data_provider.remaining_bytes() == 0) return 1;
+        return fuzzed_data_provider.ConsumeIntegralInRange<uint64_t>(0, max - 1);
+    };
 
     ConnmanTestMsg& connman = *static_cast<ConnmanTestMsg*>(g_setup->m_node.connman.get());
     auto& chainman = static_cast<TestChainstateManager&>(*g_setup->m_node.chainman);

--- a/src/test/fuzz/process_messages.cpp
+++ b/src/test/fuzz/process_messages.cpp
@@ -12,6 +12,7 @@
 #include <test/fuzz/util/net.h>
 #include <test/util/mining.h>
 #include <test/util/net.h>
+#include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <test/util/validation.h>
 #include <validation.h>
@@ -36,6 +37,11 @@ void initialize_process_messages()
 FUZZ_TARGET(process_messages, .init = initialize_process_messages)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+
+    g_mock_get_rand = [&](uint64_t max) -> uint64_t {
+        if (fuzzed_data_provider.remaining_bytes() == 0) return 1;
+        return fuzzed_data_provider.ConsumeIntegralInRange<uint64_t>(0, max - 1);
+    };
 
     ConnmanTestMsg& connman = *static_cast<ConnmanTestMsg*>(g_setup->m_node.connman.get());
     auto& chainman = static_cast<TestChainstateManager&>(*g_setup->m_node.chainman);

--- a/src/test/util/random.h
+++ b/src/test/util/random.h
@@ -10,6 +10,7 @@
 #include <uint256.h>
 
 #include <cstdint>
+#include <functional>
 
 /**
  * This global and the helpers that use it are not thread-safe.
@@ -24,6 +25,8 @@ extern FastRandomContext g_insecure_rand_ctx;
  * Flag to make GetRand in random.h return the same number
  */
 extern bool g_mock_deterministic_tests;
+/** Function to mock GetRand. */
+extern std::function<uint64_t(uint64_t)> g_mock_get_rand;
 
 enum class SeedRand {
     ZEROS, //!< Seed with a compile time constant of zeros


### PR DESCRIPTION
This PR introduces `g_mock_get_rand` to allow tests to mock `GetRand` and makes `g_mock_get_rand` consume from the fuzzed data in the process_message(s) targets.

Mocking `GetRand` reduces the non-determinism in these targets and results in more stable fuzzing.