### PR TITLE
p2p: attempt to fill full outbound connection slots with peers that support tx relay

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2347,12 +2347,13 @@ void CConnman::StartExtraBlockRelayPeers()
 }
 
 // Return the number of peers we have over our outbound connection limit
+// Returns 0 if we are at the limit, and a negative number if below.
 // Exclude peers that are marked for disconnect, or are going to be
 // disconnected soon (eg ADDR_FETCH and FEELER)
 // Also exclude peers that haven't finished initial connection handshake yet
 // (so that we don't decide we're over our desired connection limit, and then
 // evict some peer that has finished the handshake)
-int CConnman::GetExtraFullOutboundCount() const
+int CConnman::GetFullOutboundDelta() const
 {
     int full_outbound_peers = 0;
     {
@@ -2363,7 +2364,7 @@ int CConnman::GetExtraFullOutboundCount() const
             }
         }
     }
-    return std::max(full_outbound_peers - m_max_outbound_full_relay, 0);
+    return full_outbound_peers - m_max_outbound_full_relay;
 }
 
 int CConnman::GetExtraBlockRelayCount() const

--- a/src/net.h
+++ b/src/net.h
@@ -1124,7 +1124,7 @@ public:
     void PushMessage(CNode* pnode, CSerializedNetMsg&& msg) EXCLUSIVE_LOCKS_REQUIRED(!m_total_bytes_sent_mutex);
 
     using NodeFn = std::function<void(CNode*)>;
-    void ForEachNode(const NodeFn& func)
+    void ForEachFullyConnectedNode(const NodeFn& func)
     {
         LOCK(m_nodes_mutex);
         for (auto&& node : m_nodes) {
@@ -1133,7 +1133,7 @@ public:
         }
     };
 
-    void ForEachNode(const NodeFn& func) const
+    void ForEachFullyConnectedNode(const NodeFn& func) const
     {
         LOCK(m_nodes_mutex);
         for (auto&& node : m_nodes) {

--- a/src/net.h
+++ b/src/net.h
@@ -1173,7 +1173,8 @@ public:
     // return a value less than (num_outbound_connections - num_outbound_slots)
     // in cases where some outbound connections are not yet fully connected, or
     // not yet fully disconnected.
-    int GetExtraFullOutboundCount() const;
+    // Returns 0 if we are at the target, and a negative number if below.
+    int GetFullOutboundDelta() const;
     // Count the number of block-relay-only peers we have over our limit.
     int GetExtraBlockRelayCount() const;
 

--- a/src/test/fuzz/connman.cpp
+++ b/src/test/fuzz/connman.cpp
@@ -123,7 +123,7 @@ FUZZ_TARGET(connman, .init = initialize_connman)
             });
     }
     (void)connman.GetAddedNodeInfo(fuzzed_data_provider.ConsumeBool());
-    (void)connman.GetExtraFullOutboundCount();
+    (void)connman.GetFullOutboundDelta();
     (void)connman.GetLocalServices();
     (void)connman.GetMaxOutboundTarget();
     (void)connman.GetMaxOutboundTimeframe();

--- a/src/test/fuzz/connman.cpp
+++ b/src/test/fuzz/connman.cpp
@@ -79,7 +79,7 @@ FUZZ_TARGET(connman, .init = initialize_connman)
                 connman.DisconnectNode(random_subnet);
             },
             [&] {
-                connman.ForEachNode([](auto) {});
+                connman.ForEachFullyConnectedNode([](auto) {});
             },
             [&] {
                 (void)connman.ForNode(fuzzed_data_provider.ConsumeIntegral<NodeId>(), [&](auto) { return fuzzed_data_provider.ConsumeBool(); });

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -351,12 +351,12 @@ class P2PInterface(P2PConnection):
         # If the peer supports wtxid-relay
         self.wtxidrelay = wtxidrelay
 
-    def peer_connect_send_version(self, services):
+    def peer_connect_send_version(self, services, txrelay):
         # Send a version msg
         vt = msg_version()
         vt.nVersion = P2P_VERSION
         vt.strSubVer = P2P_SUBVERSION
-        vt.relay = P2P_VERSION_RELAY
+        vt.relay = P2P_VERSION_RELAY if txrelay else 0
         vt.nServices = services
         vt.addrTo.ip = self.dstaddr
         vt.addrTo.port = self.dstport
@@ -368,13 +368,14 @@ class P2PInterface(P2PConnection):
         create_conn = super().peer_connect(**kwargs)
 
         if send_version:
-            self.peer_connect_send_version(services)
+            self.peer_connect_send_version(services, txrelay=True)
 
         return create_conn
 
     def peer_accept_connection(self, *args, services=P2P_SERVICES, **kwargs):
+        txrelay = kwargs.pop('txrelay', True)
         create_conn = super().peer_accept_connection(*args, **kwargs)
-        self.peer_connect_send_version(services)
+        self.peer_connect_send_version(services, txrelay)
 
         return create_conn
 


### PR DESCRIPTION
As described in the issues #16418 and #28371, it's a possibility that we could end up having an insufficient number of outbound peers relaying our transactions. Having fewer outbound peers support tx-relay could also have implications on [privacy](https://github.com/bitcoin/bitcoin/issues/16418#issuecomment-514328042) and fee estimation.

While #28488 is suggesting meaures based on comparing fee filters / mempool sizes, there is also the simpler issue of peers that tell us they don't want transactions, which is determined by the `fRelay` field in the `version` msg. If such a peer runs bitcoin core, that usually means that it's running in `-blocksonly` mode and accepting inbound connections. The status quo is that we will not avoid these peers and just not send them any transactions.

This PR proposes not to waste any of our 8 full-relay outbound slots on these peers (unless we are in `-blocksonly` mode ourselves). Using them as outbound peers for block-relay-only connections is fine though and not impacted.

As was suggested by ajtowns below, we don't disconnect during version processing, but later during the regularly scheduled `EvictExtraOutboundPeers()` task, and only if we are at the maximum of full-outbound peers.

If reviewers think that this proposal is too aggressive, an alternative solution (with a little more complexity) would be to restrict the maximum number of outbound connections to `-blocksonly` peers to 1 or 2. Although I currently think that it's ok to be selective with outbound connections, so I didn't implement that right away.