### PR TITLE
build, macos: Fix `qt` package build with new Xcode 15 linker

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -22,6 +22,7 @@ $(package)_patches += rcc_hardcode_timestamp.patch
 $(package)_patches += duplicate_lcqpafonts.patch
 $(package)_patches += fast_fixed_dtoa_no_optimize.patch
 $(package)_patches += guix_cross_lib_path.patch
+$(package)_patches += fix-macos-linker.patch
 
 $(package)_qttranslations_file_name=qttranslations-$($(package)_suffix)
 $(package)_qttranslations_sha256_hash=c92af4171397a0ed272330b4fa0669790fcac8d050b07c8b8cc565ebeba6735e
@@ -238,6 +239,7 @@ endef
 define $(package)_preprocess_cmds
   cp $($(package)_patch_dir)/qt.pro qt.pro && \
   cp $($(package)_patch_dir)/qttools_src.pro qttools/src/src.pro && \
+  patch -p1 -i $($(package)_patch_dir)/fix-macos-linker.patch && \
   patch -p1 -i $($(package)_patch_dir)/dont_hardcode_pwd.patch && \
   patch -p1 -i $($(package)_patch_dir)/fix_qt_pkgconfig.patch && \
   patch -p1 -i $($(package)_patch_dir)/fix_android_jni_static.patch && \

--- a/depends/patches/qt/fix-macos-linker.patch
+++ b/depends/patches/qt/fix-macos-linker.patch
@@ -1,0 +1,55 @@
+qmake: Don't error out if QMAKE_DEFAULT_LIBDIRS is empty on macOS
+
+The new linker in Xcode 15 doesn't provide any default linker or
+framework paths when requested via -v, but still seems to use the
+default paths documented in the ld man page.
+
+We trust that linker will do the right thing, even if we don't
+know of its default linker paths.
+
+We also need to opt out of the default fallback logic to
+set the libdirs to /lib and /usr/lib.
+
+This may result in UnixMakefileGenerator::findLibraries finding
+different libraries than expected, if additional paths are
+passed with -L, which will then take precedence for qmake,
+even if the linker itself will use the library from the
+SDK's default paths. This should hopefully not be an issue
+in practice, as we don't turn -lFoo into absolute paths in
+qmake, so the only risk is that we're picking up the wrong
+prl files and adding additional dependencies that the lib
+in the SDK doesn't have.
+
+Upstream commits:
+ - Qt 5.15.16: Not yet publicly available.
+ - Qt dev: cdf64b0e47115cc473e1afd1472b4b09e130b2a5
+
+For other Qt branches see
+https://codereview.qt-project.org/q/I2347b26e2df0828471373b0e15b8c9089274c65d
+
+--- old/qtbase/mkspecs/features/toolchain.prf
++++ new/qtbase/mkspecs/features/toolchain.prf
+@@ -283,9 +283,12 @@ isEmpty($${target_prefix}.INCDIRS) {
+                 }
+             }
+         }
+-        isEmpty(QMAKE_DEFAULT_LIBDIRS)|isEmpty(QMAKE_DEFAULT_INCDIRS): \
++        isEmpty(QMAKE_DEFAULT_INCDIRS): \
+             !integrity: \
+-                error("failed to parse default search paths from compiler output")
++                error("failed to parse default include paths from compiler output")
++        isEmpty(QMAKE_DEFAULT_LIBDIRS): \
++            !integrity:!darwin: \
++                error("failed to parse default library paths from compiler output")
+         QMAKE_DEFAULT_LIBDIRS = $$unique(QMAKE_DEFAULT_LIBDIRS)
+     } else: ghs {
+         cmd = $$QMAKE_CXX $$QMAKE_CXXFLAGS -$${LITERAL_HASH} -o /tmp/fake_output /tmp/fake_input.cpp
+@@ -407,7 +410,7 @@ isEmpty($${target_prefix}.INCDIRS) {
+         QMAKE_DEFAULT_INCDIRS = $$split(INCLUDE, $$QMAKE_DIRLIST_SEP)
+     }
+ 
+-    unix:if(!cross_compile|host_build) {
++    unix:!darwin:if(!cross_compile|host_build) {
+         isEmpty(QMAKE_DEFAULT_INCDIRS): QMAKE_DEFAULT_INCDIRS = /usr/include /usr/local/include
+         isEmpty(QMAKE_DEFAULT_LIBDIRS): QMAKE_DEFAULT_LIBDIRS = /lib /usr/lib
+     }


### PR DESCRIPTION
Fixes https://github.com/bitcoin/bitcoin/issues/28541 by backporting an upstream [patch](https://github.com/qt/qtbase/commit/cdf64b0e47115cc473e1afd1472b4b09e130b2a5).

Guix build:
```
x86_64
b37713bc8a526662eac3d9535924f4a4d2893c58f9c12d3c7599e761e6ff677c  guix-build-79ef528511f0/output/arm64-apple-darwin/SHA256SUMS.part
0befb524181aa10e1635a2616a8bed53f51beafa4f0d495d3bf52a64cbd2d977  guix-build-79ef528511f0/output/arm64-apple-darwin/bitcoin-79ef528511f0-arm64-apple-darwin-unsigned.tar.gz
9cba170f2ffe542c33fdd1ac52b7684dd6301e91d32aa45af7b4ce8769d88d4a  guix-build-79ef528511f0/output/arm64-apple-darwin/bitcoin-79ef528511f0-arm64-apple-darwin-unsigned.zip
04556309266c791ae4d7409359222c88cd7aeb569566f7ef4d29816148a5b7e4  guix-build-79ef528511f0/output/arm64-apple-darwin/bitcoin-79ef528511f0-arm64-apple-darwin.tar.gz
51229df8e104a2ffcd5c5b3f81f7585e1258ef10461d136948ea2a2d690a920d  guix-build-79ef528511f0/output/dist-archive/bitcoin-79ef528511f0.tar.gz
3fe216a05561f2fe7229ddf186ff495b29a5cc31b6f35f407187573d072c5743  guix-build-79ef528511f0/output/x86_64-apple-darwin/SHA256SUMS.part
961d71104e61a2baf727576eb2da630697bb4f109f66e73be5c96add25378d12  guix-build-79ef528511f0/output/x86_64-apple-darwin/bitcoin-79ef528511f0-x86_64-apple-darwin-unsigned.tar.gz
5598f514d065756ac376e2f3c4f8e758bfba53a43ddef778f106456de1536073  guix-build-79ef528511f0/output/x86_64-apple-darwin/bitcoin-79ef528511f0-x86_64-apple-darwin-unsigned.zip
5360ae1f1b7d96a44a33b2c87708b466e4a7bf3f9de0fc58bccbbcdb21ee254e  guix-build-79ef528511f0/output/x86_64-apple-darwin/bitcoin-79ef528511f0-x86_64-apple-darwin.tar.gz
```