### PR TITLE
build: Move `message.{h,cpp}` from `libbitcoin_util` to `libbitcoin_common`

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -138,6 +138,7 @@ BITCOIN_CORE_H = \
   common/args.h \
   common/bloom.h \
   common/init.h \
+  common/message.h \
   common/run_command.h \
   common/url.h \
   compat/assumptions.h \
@@ -309,7 +310,6 @@ BITCOIN_CORE_H = \
   util/hasher.h \
   util/insert.h \
   util/macros.h \
-  util/message.h \
   util/moneystr.h \
   util/overflow.h \
   util/overloaded.h \
@@ -674,6 +674,7 @@ libbitcoin_common_a_SOURCES = \
   common/config.cpp \
   common/init.cpp \
   common/interfaces.cpp \
+  common/message.cpp \
   common/run_command.cpp \
   common/settings.cpp \
   common/system.cpp \
@@ -743,7 +744,6 @@ libbitcoin_util_a_SOURCES = \
   util/hasher.cpp \
   util/sock.cpp \
   util/syserror.cpp \
-  util/message.cpp \
   util/moneystr.cpp \
   util/rbf.cpp \
   util/readwritefile.cpp \

--- a/src/common/message.cpp
+++ b/src/common/message.cpp
@@ -3,12 +3,13 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <common/message.h>
+
 #include <hash.h>
 #include <key.h>
 #include <key_io.h>
 #include <pubkey.h>
 #include <uint256.h>
-#include <util/message.h>
 #include <util/strencodings.h>
 
 #include <cassert>

--- a/src/common/message.h
+++ b/src/common/message.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_UTIL_MESSAGE_H
-#define BITCOIN_UTIL_MESSAGE_H
+#ifndef BITCOIN_COMMON_MESSAGE_H
+#define BITCOIN_COMMON_MESSAGE_H
 
 #include <uint256.h>
 
@@ -74,4 +74,4 @@ uint256 MessageHash(const std::string& message);
 
 std::string SigningResultString(const SigningResult res);
 
-#endif // BITCOIN_UTIL_MESSAGE_H
+#endif // BITCOIN_COMMON_MESSAGE_H

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -6,13 +6,13 @@
 #define BITCOIN_INTERFACES_WALLET_H
 
 #include <addresstype.h>
+#include <common/message.h>
 #include <consensus/amount.h>
 #include <interfaces/chain.h>
 #include <pubkey.h>
 #include <script/script.h>
 #include <support/allocators/secure.h>
 #include <util/fs.h>
-#include <util/message.h>
 #include <util/result.h>
 #include <util/ui_change_type.h>
 

--- a/src/qt/signverifymessagedialog.cpp
+++ b/src/qt/signverifymessagedialog.cpp
@@ -10,8 +10,8 @@
 #include <qt/platformstyle.h>
 #include <qt/walletmodel.h>
 
+#include <common/message.h>
 #include <key_io.h>
-#include <util/message.h> // For MessageSign(), MessageVerify()
 #include <wallet/wallet.h>
 
 #include <vector>

--- a/src/rpc/signmessage.cpp
+++ b/src/rpc/signmessage.cpp
@@ -3,6 +3,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <common/message.h>
 #include <key.h>
 #include <key_io.h>
 #include <rpc/protocol.h>
@@ -10,7 +11,6 @@
 #include <rpc/server.h>
 #include <rpc/util.h>
 #include <univalue.h>
-#include <util/message.h>
 
 #include <string>
 

--- a/src/test/fuzz/message.cpp
+++ b/src/test/fuzz/message.cpp
@@ -3,12 +3,12 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chainparams.h>
+#include <common/message.h>
 #include <key_io.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <util/chaintype.h>
-#include <util/message.h>
 #include <util/strencodings.h>
 
 #include <cassert>

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <clientversion.h>
+#include <common/message.h>
 #include <hash.h> // For Hash()
 #include <key.h>  // For CKey
 #include <sync.h>
@@ -13,7 +14,6 @@
 #include <util/fs.h>
 #include <util/fs_helpers.h>
 #include <util/getuniquepath.h>
-#include <util/message.h> // For MessageSign(), MessageVerify(), MESSAGE_MAGIC
 #include <util/moneystr.h>
 #include <util/overflow.h>
 #include <util/readwritefile.h>

--- a/src/wallet/rpc/signmessage.cpp
+++ b/src/wallet/rpc/signmessage.cpp
@@ -2,9 +2,9 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <common/message.h>
 #include <key_io.h>
 #include <rpc/util.h>
-#include <util/message.h>
 #include <wallet/rpc/util.h>
 #include <wallet/wallet.h>
 

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -6,13 +6,13 @@
 #define BITCOIN_WALLET_SCRIPTPUBKEYMAN_H
 
 #include <addresstype.h>
+#include <common/message.h>
 #include <logging.h>
 #include <psbt.h>
 #include <script/descriptor.h>
 #include <script/script.h>
 #include <script/signingprovider.h>
 #include <util/error.h>
-#include <util/message.h>
 #include <util/result.h>
 #include <util/time.h>
 #include <wallet/crypter.h>

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -13,6 +13,7 @@
 #include <chain.h>
 #include <coins.h>
 #include <common/args.h>
+#include <common/message.h>
 #include <common/settings.h>
 #include <common/system.h>
 #include <consensus/amount.h>
@@ -53,7 +54,6 @@
 #include <util/error.h>
 #include <util/fs.h>
 #include <util/fs_helpers.h>
-#include <util/message.h>
 #include <util/moneystr.h>
 #include <util/result.h>
 #include <util/string.h>


### PR DESCRIPTION
This PR breaks the `libbitcoin_util` library's dependency on the `libbitcoin_consensus` library due to the `CPubKey::RecoverCompact` symbol, which is not in alignment with our library design goals.

The `libbitcoin_util` library, unlike `libbitcoin_common`, is a dependency of the kernel library, so we are trying to move unnecessary things out of it, to make the kernel library smaller.

For more details please refer to https://github.com/bitcoin/bitcoin/issues/28548.