### PR TITLE
rpc: getaddrmaninfo followups

### DIFF
--- a/doc/release-notes/release-notes-27511.md
+++ b/doc/release-notes/release-notes-27511.md
@@ -1,0 +1,6 @@
+New RPCs
+--------
+
+- A new RPC `getaddrmaninfo` has been added to view the distribution of addresses in the new and tried table of the
+  node's address manager across different networks(ipv4, ipv6, onion, i2p, cjdns). The RPC returns count of addresses
+  in new and tried table as well as their sum for all networks. (#27511)

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -1033,50 +1033,43 @@ static RPCHelpMan sendmsgtopeer()
 
 static RPCHelpMan getaddrmaninfo()
 {
-    return RPCHelpMan{"getaddrmaninfo",
-                      "\nProvides information about the node's address manager by returning the number of "
-                      "addresses in the `new` and `tried` tables and their sum for all networks.\n"
-                      "This RPC is for testing only.\n",
-                      {},
-                      RPCResult{
-                              RPCResult::Type::OBJ_DYN, "", "json object with network type as keys",
-                              {
-                                      {RPCResult::Type::OBJ, "network", "the network (" + Join(GetNetworkNames(), ", ") + ")",
-                                       {
-                                               {RPCResult::Type::NUM, "new", "number of addresses in the new table, which represent potential peers the node has discovered but hasn't yet successfully connected to."},
-                                               {RPCResult::Type::NUM, "tried", "number of addresses in the tried table, which represent peers the node has successfully connected to in the past."},
-                                               {RPCResult::Type::NUM, "total", "total number of addresses in both new/tried tables"},
-                                       }},
-                              }
-                      },
-                      RPCExamples{
-                              HelpExampleCli("getaddrmaninfo", "")
-                              + HelpExampleRpc("getaddrmaninfo", "")
-                      },
-                      [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
-                      {
-                          NodeContext& node = EnsureAnyNodeContext(request.context);
-                          if (!node.addrman) {
-                              throw JSONRPCError(RPC_CLIENT_P2P_DISABLED, "Error: Address manager functionality missing or disabled");
-                          }
+    return RPCHelpMan{
+        "getaddrmaninfo",
+        "\nProvides information about the node's address manager by returning the number of "
+        "addresses in the `new` and `tried` tables and their sum for all networks.\n",
+        {},
+        RPCResult{
+            RPCResult::Type::OBJ_DYN, "", "json object with network type as keys", {
+                {RPCResult::Type::OBJ, "network", "the network (" + Join(GetNetworkNames(), ", ") + ", all_networks)", {
+                {RPCResult::Type::NUM, "new", "number of addresses in the new table, which represent potential peers the node has discovered but hasn't yet successfully connected to."},
+                {RPCResult::Type::NUM, "tried", "number of addresses in the tried table, which represent peers the node has successfully connected to in the past."},
+                {RPCResult::Type::NUM, "total", "total number of addresses in both new/tried tables"},
+            }},
+        }},
+        RPCExamples{HelpExampleCli("getaddrmaninfo", "") + HelpExampleRpc("getaddrmaninfo", "")},
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue {
+            NodeContext& node = EnsureAnyNodeContext(request.context);
+            if (!node.addrman) {
+                throw JSONRPCError(RPC_CLIENT_P2P_DISABLED, "Error: Address manager functionality missing or disabled");
+            }
 
-                          UniValue ret(UniValue::VOBJ);
-                          for (int n = 0; n < NET_MAX; ++n) {
-                              enum Network network = static_cast<enum Network>(n);
-                              if (network == NET_UNROUTABLE || network == NET_INTERNAL) continue;
-                              UniValue obj(UniValue::VOBJ);
-                              obj.pushKV("new", node.addrman->Size(network, true));
-                              obj.pushKV("tried", node.addrman->Size(network, false));
-                              obj.pushKV("total", node.addrman->Size(network));
-                              ret.pushKV(GetNetworkName(network), obj);
-                          }
-                          UniValue obj(UniValue::VOBJ);
-                          obj.pushKV("new", node.addrman->Size(std::nullopt, true));
-                          obj.pushKV("tried", node.addrman->Size(std::nullopt, false));
-                          obj.pushKV("total", node.addrman->Size());
-                          ret.pushKV("all_networks", obj);
-                          return ret;
-                      },
+            UniValue ret(UniValue::VOBJ);
+            for (int n = 0; n < NET_MAX; ++n) {
+                enum Network network = static_cast<enum Network>(n);
+                if (network == NET_UNROUTABLE || network == NET_INTERNAL) continue;
+                UniValue obj(UniValue::VOBJ);
+                obj.pushKV("new", node.addrman->Size(network, true));
+                obj.pushKV("tried", node.addrman->Size(network, false));
+                obj.pushKV("total", node.addrman->Size(network));
+                ret.pushKV(GetNetworkName(network), obj);
+            }
+            UniValue obj(UniValue::VOBJ);
+            obj.pushKV("new", node.addrman->Size(std::nullopt, true));
+            obj.pushKV("tried", node.addrman->Size(std::nullopt, false));
+            obj.pushKV("total", node.addrman->Size());
+            ret.pushKV("all_networks", obj);
+            return ret;
+        },
     };
 }
 
@@ -1164,10 +1157,10 @@ void RegisterNetRPCCommands(CRPCTable& t)
         {"network", &clearbanned},
         {"network", &setnetworkactive},
         {"network", &getnodeaddresses},
+        {"network", &getaddrmaninfo},
         {"hidden", &addconnection},
         {"hidden", &addpeeraddress},
         {"hidden", &sendmsgtopeer},
-        {"hidden", &getaddrmaninfo},
         {"hidden", &getrawaddrman},
     };
     for (const auto& c : commands) {

--- a/src/rpc/server_util.cpp
+++ b/src/rpc/server_util.cpp
@@ -108,3 +108,16 @@ PeerManager& EnsurePeerman(const NodeContext& node)
     }
     return *node.peerman;
 }
+
+AddrMan& EnsureAddrman(const NodeContext& node)
+{
+    if (!node.addrman) {
+        throw JSONRPCError(RPC_CLIENT_P2P_DISABLED, "Error: Address manager functionality missing or disabled");
+    }
+    return *node.addrman;
+}
+
+AddrMan& EnsureAnyAddrman(const std::any& context)
+{
+    return EnsureAddrman(EnsureAnyNodeContext(context));
+}

--- a/src/rpc/server_util.h
+++ b/src/rpc/server_util.h
@@ -7,6 +7,7 @@
 
 #include <any>
 
+class AddrMan;
 class ArgsManager;
 class CBlockPolicyEstimator;
 class CConnman;
@@ -31,5 +32,7 @@ CBlockPolicyEstimator& EnsureFeeEstimator(const node::NodeContext& node);
 CBlockPolicyEstimator& EnsureAnyFeeEstimator(const std::any& context);
 CConnman& EnsureConnman(const node::NodeContext& node);
 PeerManager& EnsurePeerman(const node::NodeContext& node);
+AddrMan& EnsureAddrman(const node::NodeContext& node);
+AddrMan& EnsureAnyAddrman(const std::any& context);
 
 #endif // BITCOIN_RPC_SERVER_UTIL_H

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -371,11 +371,6 @@ class NetTest(BitcoinTestFramework):
         self.log.info("Test getaddrmaninfo")
         node = self.nodes[1]
 
-        self.log.debug("Test that getaddrmaninfo is a hidden RPC")
-        # It is hidden from general help, but its detailed help may be called directly.
-        assert "getaddrmaninfo" not in node.help()
-        assert "getaddrmaninfo" in node.help("getaddrmaninfo")
-
         # current count of ipv4 addresses in addrman is {'new':1, 'tried':1}
         self.log.info("Test that count of addresses in addrman match expected values")
         res = node.getaddrmaninfo()


### PR DESCRIPTION
- make `getaddrmaninfo` RPC public since it's not for development purposes only and regular users might find it useful. [#26988 (comment)](https://github.com/bitcoin/bitcoin/pull/26988#issuecomment-1738371584)
- add missing `all_networks` key to RPC help. [#27511 (comment)](https://github.com/bitcoin/bitcoin/pull/27511#discussion_r1335084087)
- fix clang format spacing
- add and use `EnsureAddrman` in RPC code. [#27511 (comment)](https://github.com/bitcoin/bitcoin/pull/27511#discussion_r1331501491)
