### PR TITLE
refactor: Remove redundant checks in compat/assumptions.h

### DIFF
--- a/src/common/system.cpp
+++ b/src/common/system.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2009-2022 The Bitcoin Core developers
+// Copyright (c) 2009-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -12,6 +12,7 @@
 #ifndef WIN32
 #include <sys/stat.h>
 #else
+#include <compat/compat.h>
 #include <codecvt>
 #endif
 

--- a/src/common/system.h
+++ b/src/common/system.h
@@ -1,5 +1,5 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2009-2022 The Bitcoin Core developers
+// Copyright (c) 2009-present The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -10,10 +10,7 @@
 #include <config/bitcoin-config.h>
 #endif
 
-#include <compat/compat.h>
-
-#include <set>
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 
 // Application startup time (used for uptime calculation)

--- a/src/common/system.h
+++ b/src/common/system.h
@@ -10,7 +10,6 @@
 #include <config/bitcoin-config.h>
 #endif
 
-#include <compat/assumptions.h>
 #include <compat/compat.h>
 
 #include <set>

--- a/src/compat/assumptions.h
+++ b/src/compat/assumptions.h
@@ -11,13 +11,6 @@
 #include <cstddef>
 #include <limits>
 
-// Assumption: We assume that the macro NDEBUG is not defined.
-// Example(s): We use assert(...) extensively with the assumption of it never
-//             being a noop at runtime.
-#if defined(NDEBUG)
-# error "Bitcoin cannot be compiled without assertions."
-#endif
-
 // Assumption: We assume a C++17 (ISO/IEC 14882:2017) compiler (minimum requirement).
 // Example(s): We assume the presence of C++17 features everywhere :-)
 // ISO Standard C++17 [cpp.predefined]p1:

--- a/src/compat/assumptions.h
+++ b/src/compat/assumptions.h
@@ -11,13 +11,6 @@
 #include <cstddef>
 #include <limits>
 
-// Assumption: We assume a C++17 (ISO/IEC 14882:2017) compiler (minimum requirement).
-// Example(s): We assume the presence of C++17 features everywhere :-)
-// ISO Standard C++17 [cpp.predefined]p1:
-// "The name __cplusplus is defined to the value 201703L when compiling a C++
-//  translation unit."
-static_assert(__cplusplus >= 201703L, "C++17 standard assumed");
-
 // Assumption: We assume the floating-point types to fulfill the requirements of
 //             IEC 559 (IEEE 754) standard.
 // Example(s): Floating-point division by zero in ConnectBlock, CreateTransaction

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -16,9 +16,9 @@
 #include <hash.h>
 #include <headerssync.h>
 #include <index/blockfilterindex.h>
+#include <kernel/chain.h>
 #include <kernel/mempool_entry.h>
 #include <logging.h>
-#include <kernel/chain.h>
 #include <merkleblock.h>
 #include <netbase.h>
 #include <netmessagemaker.h>
@@ -39,7 +39,7 @@
 #include <txmempool.h>
 #include <txorphanage.h>
 #include <txrequest.h>
-#include <util/check.h> // For NDEBUG compile time check
+#include <util/check.h>
 #include <util/strencodings.h>
 #include <util/trace.h>
 #include <validation.h>

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -7,7 +7,10 @@
 #define BITCOIN_SERIALIZE_H
 
 #include <attributes.h>
+#include <compat/assumptions.h> // IWYU pragma: keep
 #include <compat/endian.h>
+#include <prevector.h>
+#include <span.h>
 
 #include <algorithm>
 #include <cstdint>
@@ -18,12 +21,8 @@
 #include <memory>
 #include <set>
 #include <string>
-#include <string.h>
 #include <utility>
 #include <vector>
-
-#include <prevector.h>
-#include <span.h>
 
 /**
  * The maximum size of a serialized object in bytes or number of elements

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -47,7 +47,7 @@
 #include <txmempool.h>
 #include <uint256.h>
 #include <undo.h>
-#include <util/check.h> // For NDEBUG compile time check
+#include <util/check.h>
 #include <util/fs.h>
 #include <util/fs_helpers.h>
 #include <util/hasher.h>


### PR DESCRIPTION
Generally, compile-time checks should be close to the code that use them. Especially, since `compat/assumptions.h` is only included in one place, where iwyu suggests to remove it.

Fix all issues:
* The `NDEBUG` check is used in `util/check`, so it is redundant in `compat/assumptions.h`.
* The `__cplusplus` check is redundant with `doc/dependencies.md` (see commit message).
* Add missing `// IWYU pragma: keep` to avoid removing the include by accident.