### PR TITLE
guix: update time-machine

### DIFF
--- a/contrib/guix/libexec/prelude.bash
+++ b/contrib/guix/libexec/prelude.bash
@@ -51,7 +51,7 @@ fi
 time-machine() {
     # shellcheck disable=SC2086
     guix time-machine --url=https://git.savannah.gnu.org/git/guix.git \
-                      --commit=160f78a4d92205df986ed9efcce7d3aac188cb24 \
+                      --commit=77386bdbfe6b0c649c05ab37f08051d1ab3e5074 \
                       --cores="$JOBS" \
                       --keep-failed \
                       --fallback \

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -19,6 +19,7 @@
              ((gnu packages python) #:select (python-minimal))
              ((gnu packages python-build) #:select (python-tomli))
              ((gnu packages python-crypto) #:select (python-asn1crypto))
+             ((gnu packages python-xyz) #:select (python-altgraph))
              ((gnu packages tls) #:select (openssl))
              ((gnu packages version-control) #:select (git-minimal))
              (guix build-system cmake)
@@ -371,29 +372,6 @@ thus should be able to compile on most platforms where these exist.")
 certificates or paths. Supports various options, including: validation at a
 specific moment in time, whitelisting and revocation checks.")
       (license license:expat))))
-
-(define-public python-altgraph
-  (package
-    (name "python-altgraph")
-    (version "0.17")
-    (source
-     (origin
-       (method git-fetch)
-       (uri (git-reference
-             (url "https://github.com/ronaldoussoren/altgraph")
-             (commit (string-append "v" version))))
-       (file-name (git-file-name name version))
-       (sha256
-        (base32
-         "09sm4srvvkw458pn48ga9q7ykr4xlz7q8gh1h9w7nxpf001qgpwb"))))
-    (build-system python-build-system)
-    (home-page "https://github.com/ronaldoussoren/altgraph")
-    (synopsis "Python graph (network) package")
-    (description "altgraph is a fork of graphlib: a graph (network) package for
-constructing graphs, BFS and DFS traversals, topological sort, shortest paths,
-etc. with graphviz output.")
-    (license license:expat)))
-
 
 (define-public python-macholib
   (package


### PR DESCRIPTION
python-altgraph (0.17.4) has been upstreamed, see: https://git.savannah.gnu.org/cgit/guix.git/commit/?id=0c6198319a61d85cd8925af418466dcdccf3daff, so we can use it, and drop our package definition.

Also includes:
* GCC 10.4.0 -> 10.5.0: https://git.savannah.gnu.org/cgit/guix.git/commit/?id=2fbb5398a39bf18e41235891a0740fa0bc4d7a4d.
* Linux Kernel Headers 6.1 -> 6.1.61
* LLVM 16 & LLVM 17 become available.