### PR TITLE
[23.x] depends: xcb-proto 1.15.2

### DIFF
--- a/depends/packages/xcb_proto.mk
+++ b/depends/packages/xcb_proto.mk
@@ -1,8 +1,8 @@
 package=xcb_proto
-$(package)_version=1.14.1
+$(package)_version=1.15.2
 $(package)_download_path=https://xorg.freedesktop.org/archive/individual/proto
 $(package)_file_name=xcb-proto-$($(package)_version).tar.xz
-$(package)_sha256_hash=f04add9a972ac334ea11d9d7eb4fc7f8883835da3e4859c9afa971efdf57fcc3
+$(package)_sha256_hash=7072beb1f680a2fe3f9e535b797c146d22528990c72f63ddb49d2f350a3653ed
 
 define $(package)_config_cmds
   $($(package)_autoconf)

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -1,9 +1,9 @@
-23.2 Release Notes
+23.3rc1 Release Notes
 ==================
 
-Bitcoin Core version 23.2 is now available from:
+Bitcoin Core version 23.3rc1 is now available from:
 
-  <https://bitcoincore.org/bin/bitcoin-core-23.2/>
+  <https://bitcoincore.org/bin/bitcoin-core-23.3/test.rc1>
 
 This release includes various bug fixes and performance
 improvements, as well as updated translations.
@@ -37,36 +37,21 @@ Core should also work on most other Unix-like systems but is not as
 frequently tested on them.  It is not recommended to use Bitcoin Core on
 unsupported systems.
 
-### P2P
+### RPC
 
-- #26909 net: prevent peers.dat corruptions by only serializing once
-- #27608 p2p: Avoid prematurely clearing download state for other peers
-- #27610 Improve performance of p2p inv to send queues
+- #27727 rpc: Fix invalid bech32 address handling
 
 ### Build system
 
-- #25436 build: suppress array-bounds errors in libxkbcommon
-- #25763 bdb: disable Werror for format-security
-- #26944 depends: fix systemtap download URL
-- #27462 depends: fix compiling bdb with clang-16 on aarch64
-
-### Miscellaneous
-
-- #25444 ci: macOS task imrovements
-- #26388 ci: Use macos-ventura-xcode:14.1 image for "macOS native" task
-- #26924 refactor: Add missing includes to fix gcc-13 compile error
+- #28097 depends: xcb-proto 1.15.2
 
 Credits
 =======
 
 Thanks to everyone who directly contributed to this release:
 
-- Anthony Towns
-- Hennadii Stepanov
 - MacroFake
-- Martin Zumsande
 - Michael Ford
-- Suhas Daftuar
 
 As well as to everyone that helped with translations on
 [Transifex](https://www.transifex.com/bitcoin/bitcoin/).

--- a/doc/release-notes/release-notes-23.2.md
+++ b/doc/release-notes/release-notes-23.2.md
@@ -1,0 +1,72 @@
+23.2 Release Notes
+==================
+
+Bitcoin Core version 23.2 is now available from:
+
+  <https://bitcoincore.org/bin/bitcoin-core-23.2/>
+
+This release includes various bug fixes and performance
+improvements, as well as updated translations.
+
+Please report bugs using the issue tracker at GitHub:
+
+  <https://github.com/bitcoin/bitcoin/issues>
+
+To receive security and update notifications, please subscribe to:
+
+  <https://bitcoincore.org/en/list/announcements/join/>
+
+How to Upgrade
+==============
+
+If you are running an older version, shut it down. Wait until it has completely
+shut down (which might take a few minutes in some cases), then run the
+installer (on Windows) or just copy over `/Applications/Bitcoin-Qt` (on macOS)
+or `bitcoind`/`bitcoin-qt` (on Linux).
+
+Upgrading directly from a version of Bitcoin Core that has reached its EOL is
+possible, but it might take some time if the data directory needs to be migrated. Old
+wallet versions of Bitcoin Core are generally supported.
+
+Compatibility
+==============
+
+Bitcoin Core is supported and extensively tested on operating systems
+using the Linux kernel, macOS 10.15+, and Windows 7 and newer.  Bitcoin
+Core should also work on most other Unix-like systems but is not as
+frequently tested on them.  It is not recommended to use Bitcoin Core on
+unsupported systems.
+
+### P2P
+
+- #26909 net: prevent peers.dat corruptions by only serializing once
+- #27608 p2p: Avoid prematurely clearing download state for other peers
+- #27610 Improve performance of p2p inv to send queues
+
+### Build system
+
+- #25436 build: suppress array-bounds errors in libxkbcommon
+- #25763 bdb: disable Werror for format-security
+- #26944 depends: fix systemtap download URL
+- #27462 depends: fix compiling bdb with clang-16 on aarch64
+
+### Miscellaneous
+
+- #25444 ci: macOS task imrovements
+- #26388 ci: Use macos-ventura-xcode:14.1 image for "macOS native" task
+- #26924 refactor: Add missing includes to fix gcc-13 compile error
+
+Credits
+=======
+
+Thanks to everyone who directly contributed to this release:
+
+- Anthony Towns
+- Hennadii Stepanov
+- MacroFake
+- Martin Zumsande
+- Michael Ford
+- Suhas Daftuar
+
+As well as to everyone that helped with translations on
+[Transifex](https://www.transifex.com/bitcoin/bitcoin/).


### PR DESCRIPTION
Resolves build failures under Python 3.12:
```bash
make[3]: Nothing to be done for 'install-exec-am'.
 /usr/bin/mkdir -p '/bitcoin/depends/work/staging/aarch64-unknown-linux-gnu/xcb_proto/1.14.1-4a91ac9dc41/bitcoin/depends/aarch64-unknown-linux-gnu/lib/python3.12/site-packages/xcbgen'
 /usr/bin/install -c -m 644 __init__.py error.py expr.py align.py matcher.py state.py xtypes.py '/bitcoin/depends/work/staging/aarch64-unknown-linux-gnu/xcb_proto/1.14.1-4a91ac9dc41/bitcoin/depends/aarch64-unknown-linux-gnu/lib/python3.12/site-packages/xcbgen'
Traceback (most recent call last):
  File "<string>", line 2, in <module>
ModuleNotFoundError: No module named 'imp'
make[3]: *** [Makefile:271: install-pkgpythonPYTHON] Error 1
```

`imp` was removed in 3.12: https://docs.python.org/3/library/imp.html.

Also backported for 25.x & 24.x.

Also:
* Add historical release-notes for 23.2.
* Update release notes for currently backported changes.

It's not clear if a 23.3 will be released, as 23.x goes [EOL 01-12-2023](https://bitcoincore.org/en/lifecycle/#schedule).