### PR TITLE
test: assumeutxo func test race fixes

### DIFF
--- a/test/functional/feature_assumeutxo.py
+++ b/test/functional/feature_assumeutxo.py
@@ -142,7 +142,10 @@ class AssumeutxoTest(BitcoinTestFramework):
             f"-stopatheight={PAUSE_HEIGHT}", *self.extra_args[1]])
 
         # Finally connect the nodes and let them sync.
-        self.connect_nodes(0, 1)
+        #
+        # Set `wait_for_connect=False` to avoid a race between performing connection
+        # assertions and the -stopatheight tripping.
+        self.connect_nodes(0, 1, wait_for_connect=False)
 
         n1.wait_until_stopped(timeout=5)
 

--- a/test/functional/feature_assumeutxo.py
+++ b/test/functional/feature_assumeutxo.py
@@ -159,7 +159,15 @@ class AssumeutxoTest(BitcoinTestFramework):
         self.connect_nodes(0, 1)
 
         self.log.info(f"Ensuring snapshot chain syncs to tip. ({FINAL_HEIGHT})")
-        wait_until_helper(lambda: n1.getchainstates()['snapshot']['blocks'] == FINAL_HEIGHT)
+
+        def check_for_final_height():
+            chainstates = n1.getchainstates()
+            # The background validation may have completed before we run our first
+            # check, so accept a final blockheight from either chainstate type.
+            cs = chainstates.get('snapshot') or chainstates.get('normal')
+            return cs['blocks'] == FINAL_HEIGHT
+
+        wait_until_helper(check_for_final_height)
         self.sync_blocks(nodes=(n0, n1))
 
         self.log.info("Ensuring background validation completes")

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -586,7 +586,14 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
     def wait_for_node_exit(self, i, timeout):
         self.nodes[i].process.wait(timeout)
 
-    def connect_nodes(self, a, b, *, peer_advertises_v2=None):
+    def connect_nodes(self, a, b, *, peer_advertises_v2=None, wait_for_connect: bool = True):
+        """
+        Kwargs:
+            wait_for_connect: if True, block until the nodes are verified as connected. You might
+                want to disable this when using -stopatheight with one of the connected nodes,
+                since there will be a race between the actual connection and performing
+                the assertions before one node shuts down.
+        """
         from_connection = self.nodes[a]
         to_connection = self.nodes[b]
         from_num_peers = 1 + len(from_connection.getpeerinfo())
@@ -602,6 +609,9 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
             # skip the optional third argument (default false) for
             # compatibility with older clients
             from_connection.addnode(ip_port, "onetry")
+
+        if not wait_for_connect:
+            return
 
         # poll until version handshake complete to avoid race conditions
         # with transaction relaying


### PR DESCRIPTION
Fixes https://github.com/bitcoin/bitcoin/issues/28585.

Fixes a few races within the assumeutxo tests:
- In general, `-stopatheight` can't be used with `connect_nodes` safely because the latter performs blocking assertions that are racy with the stopatheight triggering.
- Now that the snapshot chainstate is listed as `normal` after background validation, accept the final height from either chainstate.