### PR TITLE
Adjust Gradle properties to fix `apk` build

### DIFF
--- a/src/qt/android/gradle.properties
+++ b/src/qt/android/gradle.properties
@@ -1,4 +1,4 @@
-androidBuildToolsVersion=28.0.3
-androidCompileSdkVersion=28
+androidBuildToolsVersion=30.0.3
+androidCompileSdkVersion=30
 qt5AndroidDir=new File(".").absolutePath
 org.gradle.jvmargs=-Xmx4608M


### PR DESCRIPTION
On the master branch @ d2b8c5e1234cdaff84bd1f60aea598d219cdac5e, building the `apk` target fails:
```
$ make -C src/qt apk
...
> Task :compileDebugJavaWithJavac FAILED
/home/hebasto/git/gui/src/qt/android/src/org/qtproject/qt5/android/QtActivityDelegate.java:690: error: cannot find symbol
                Display display = (Build.VERSION.SDK_INT < Build.VERSION_CODES.R)
                                                                              ^
  symbol:   variable R
  location: class VERSION_CODES
/home/hebasto/git/gui/src/qt/android/src/org/qtproject/qt5/android/QtActivityDelegate.java:692: error: cannot find symbol
                        : m_activity.getDisplay();
                                    ^
  symbol:   method getDisplay()
  location: variable m_activity of type Activity
/home/hebasto/git/gui/src/qt/android/src/org/qtproject/qt5/android/QtActivityDelegate.java:833: error: cannot find symbol
        float refreshRate = (Build.VERSION.SDK_INT < Build.VERSION_CODES.R)
                                                                        ^
  symbol:   variable R
  location: class VERSION_CODES
/home/hebasto/git/gui/src/qt/android/src/org/qtproject/qt5/android/QtActivityDelegate.java:835: error: cannot find symbol
                : m_activity.getDisplay().getRefreshRate();
                            ^
  symbol:   method getDisplay()
  location: variable m_activity of type Activity
/home/hebasto/git/gui/src/qt/android/src/org/qtproject/qt5/android/QtLayout.java:95: error: cannot find symbol
        Display display = (Build.VERSION.SDK_INT < Build.VERSION_CODES.R)
                                                                      ^
  symbol:   variable R
  location: class VERSION_CODES
/home/hebasto/git/gui/src/qt/android/src/org/qtproject/qt5/android/QtLayout.java:97: error: cannot find symbol
                : ((Activity)getContext()).getDisplay();
                                          ^
  symbol:   method getDisplay()
  location: class Activity
/home/hebasto/git/gui/src/qt/android/src/org/qtproject/qt5/android/ExtractStyle.java:418: error: cannot find symbol
            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q)
                                                           ^
  symbol:   variable Q
  location: class VERSION_CODES
/home/hebasto/git/gui/src/qt/android/src/org/qtproject/qt5/android/ExtractStyle.java:421: error: cannot find symbol
                numStates = stateList.getStateCount();
                                     ^
  symbol:   method getStateCount()
  location: variable stateList of type StateListDrawable
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
8 errors

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':compileDebugJavaWithJavac'.
> Compilation failed; see the compiler error output for details.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.6.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD FAILED in 827ms
...
```

Fixing it by updating the Gradle tool's properties.