### PR TITLE
Show transactions as not fully confirmed during background validation

### DIFF
--- a/doc/release-notes-28616.md
+++ b/doc/release-notes-28616.md
@@ -1,0 +1,6 @@
+GUI changes
+------
+
+- Transactions that are confirmed while assume utxo background sync is in progress,
+  will have a clock icon and a tooltip explaining that historical blocks are still
+  being verified. (#28616)

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -426,6 +426,8 @@ struct WalletTxStatus
     bool is_abandoned;
     bool is_coinbase;
     bool is_in_main_chain;
+    // The block containing this transaction is assumed valid
+    bool is_assumed;
 };
 
 //! Wallet transaction output.

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -175,42 +175,31 @@ void TransactionRecord::updateStatus(const interfaces::WalletTxStatus& wtx, cons
 
     // For generated transactions, determine maturity
     if (type == TransactionRecord::Generated) {
-        if (wtx.blocks_to_maturity > 0)
-        {
+        if (wtx.blocks_to_maturity > 0) {
             status.status = TransactionStatus::Immature;
 
-            if (wtx.is_in_main_chain)
-            {
+            if (wtx.is_in_main_chain) {
                 status.matures_in = wtx.blocks_to_maturity;
-            }
-            else
-            {
+            } else {
                 status.status = TransactionStatus::NotAccepted;
             }
-        }
-        else
-        {
+        } else {
             status.status = TransactionStatus::Confirmed;
         }
-    }
-    else
-    {
-        if (status.depth < 0)
-        {
+    } else {
+        if (status.depth < 0) {
             status.status = TransactionStatus::Conflicted;
         }
-        else if (status.depth == 0)
-        {
+        else if (status.depth == 0) {
             status.status = TransactionStatus::Unconfirmed;
-            if (wtx.is_abandoned)
+            if (wtx.is_abandoned) {
                 status.status = TransactionStatus::Abandoned;
-        }
-        else if (status.depth < RecommendedNumConfirmations)
-        {
+            }
+        } else if (wtx.is_assumed) {
+            status.status = TransactionStatus::AssumedConfirmed;
+        } else if (status.depth < RecommendedNumConfirmations) {
             status.status = TransactionStatus::Confirming;
-        }
-        else
-        {
+        } else {
             status.status = TransactionStatus::Confirmed;
         }
     }

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -25,6 +25,7 @@ struct TransactionStatus {
         Confirmed,          /**< Have 6 or more confirmations (normal tx) or fully mature (mined tx) **/
         /// Normal (sent/received) transactions
         Unconfirmed,        /**< Not yet mined into a block **/
+        AssumedConfirmed,   /**< Confirmed, but background validation hasn't finished  */
         Confirming,         /**< Confirmed, but waiting for the recommended number of confirmations **/
         Conflicted,         /**< Conflicts with other transaction or mempool **/
         Abandoned,          /**< Abandoned from the wallet **/

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -320,6 +320,9 @@ QString TransactionTableModel::formatTxStatus(const TransactionRecord *wtx) cons
     case TransactionStatus::Abandoned:
         status = tr("Abandoned");
         break;
+    case TransactionStatus::AssumedConfirmed:
+        status = tr("%1 confirmations, pending verification of historical blocks").arg(wtx->status.depth);
+        break;
     case TransactionStatus::Confirming:
         status = tr("Confirming (%1 of %2 recommended confirmations)").arg(wtx->status.depth).arg(TransactionRecord::RecommendedNumConfirmations);
         break;
@@ -465,6 +468,8 @@ QVariant TransactionTableModel::txStatusDecoration(const TransactionRecord *wtx)
         return QIcon(":/icons/transaction_0");
     case TransactionStatus::Abandoned:
         return QIcon(":/icons/transaction_abandoned");
+    case TransactionStatus::AssumedConfirmed:
+        return QIcon(":/icons/transaction_1");
     case TransactionStatus::Confirming:
         switch(wtx->status.depth)
         {
@@ -639,7 +644,14 @@ QVariant TransactionTableModel::data(const QModelIndex &index, int role) const
             return details;
         }
     case ConfirmedRole:
-        return rec->status.status == TransactionStatus::Status::Confirming || rec->status.status == TransactionStatus::Status::Confirmed;
+        switch (rec->status.status) {
+            case TransactionStatus::Status::AssumedConfirmed:
+            case TransactionStatus::Status::Confirming:
+            case TransactionStatus::Status::Confirmed:
+                return true;
+            default:
+                return false;
+        }
     case FormattedAmountRole:
         // Used for copy/export, so don't include separators
         return formatTxAmount(rec, false, BitcoinUnits::SeparatorStyle::NEVER);

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -104,6 +104,7 @@ WalletTxStatus MakeWalletTxStatus(const CWallet& wallet, const CWalletTx& wtx)
     result.is_abandoned = wtx.isAbandoned();
     result.is_coinbase = wtx.IsCoinBase();
     result.is_in_main_chain = wtx.isConfirmed();
+    result.is_assumed = wallet.IsTxAssumed(wtx);
     return result;
 }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1505,11 +1505,22 @@ void CWallet::transactionRemovedFromMempool(const CTransactionRef& tx, MemPoolRe
 
 void CWallet::blockConnected(ChainstateRole role, const interfaces::BlockInfo& block)
 {
-    if (role == ChainstateRole::BACKGROUND) {
-        return;
-    }
     assert(block.data);
     LOCK(cs_wallet);
+
+    switch (role) {
+        case ChainstateRole::BACKGROUND:
+            m_background_validation_height = block.height;
+            return;
+        case ChainstateRole::ASSUMEDVALID:
+            if (m_background_validation_height == -1) {
+                m_background_validation_height = 0;
+            }
+            break;
+        case ChainstateRole::NORMAL:
+            m_background_validation_height = -1;
+            break;
+    } // no default case, so the compiler can warn about missing cases
 
     m_last_block_processed_height = block.height;
     m_last_block_processed = block.hash;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3481,6 +3481,18 @@ bool CWallet::IsTxImmatureCoinBase(const CWalletTx& wtx) const
     return GetTxBlocksToMaturity(wtx) > 0;
 }
 
+bool CWallet::IsTxAssumed(const CWalletTx& wtx) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet)
+{
+    AssertLockHeld(cs_wallet);
+    if (GetBackgroundValidationHeight() == -1) return false;
+    if (auto* conf = wtx.state<TxStateConfirmed>()) {
+        int height{conf->confirmed_block_height};
+        return height > GetBackgroundValidationHeight();
+    }
+    return false;
+}
+
+
 bool CWallet::IsCrypted() const
 {
     return HasEncryptionKeys();

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -525,6 +525,7 @@ public:
      * referenced in transaction, and might cause assert failures.
      */
     int GetTxDepthInMainChain(const CWalletTx& wtx) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    bool IsTxAssumed(const CWalletTx& wtx) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     /**
      * @return number of blocks to maturity for this transaction:

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -408,6 +408,13 @@ private:
      */
     int m_last_block_processed_height GUARDED_BY(cs_wallet) = -1;
 
+    /**
+     * The following is used to track whether a confirmed transaction is in
+     * a block that background validation hasn't checked yet, or above the
+     * assume utxo snapshot height when background validation hasn't completed.
+     */
+    int m_background_validation_height GUARDED_BY(cs_wallet) = -1;
+
     std::map<OutputType, ScriptPubKeyMan*> m_external_spk_managers;
     std::map<OutputType, ScriptPubKeyMan*> m_internal_spk_managers;
 
@@ -989,6 +996,12 @@ public:
         AssertLockHeld(cs_wallet);
         m_last_block_processed_height = block_height;
         m_last_block_processed = block_hash;
+    };
+    /** Height of background validation. Returns -1 if there is no background validation. */
+    int GetBackgroundValidationHeight() const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet)
+    {
+        AssertLockHeld(cs_wallet);
+        return m_background_validation_height;
     };
 
     //! Connect the signals from ScriptPubKeyMans to the signals in CWallet


### PR DESCRIPTION
Fixes #28598: currently if assumeutxo were to be used, transactions might get shown as confirmed even while the entire chainstate is unconfirmed.

This also adds an `assumed` value to `listtransactions` etc, shown only for confirmed transactions when a snapshot is loaded.

The UI experience for assume utxo still needs work. This PR makes the wallet UI safer by not rendering transactions as fully confirmed until the background validation is done.

Instead it shows the same icon as when a transaction has 1 confirmation. This is quite conservative. The cost of tricking someone into accepting a fake coin, by giving them a invalid snapshot`*` and then mining a block on top of it, is higher than a regular doublespend by mining.

![pending](https://github.com/bitcoin/bitcoin/assets/10217/a2a95190-a1a7-402e-822b-b0829d5bdf45)

`* =` in the current implementation this involves giving someone a malicious binary or getting them to recompile

Caveat: because transaction state is updated after `blockConnected`, if you restart the node during background sync, then the transaction will show as fully confirmed (`"assumed": false`) briefly - until the next block is connected.