### PR TITLE
lint: Include test_utxo_snapshots in lint_shell, fix linter errors

### DIFF
--- a/test/lint/lint-shell.py
+++ b/test/lint/lint-shell.py
@@ -70,7 +70,7 @@ def main():
     reg = re.compile(r'src/[leveldb,secp256k1,minisketch]')
 
     def should_exclude(fname: str) -> bool:
-        return bool(reg.match(fname)) or 'test_utxo_snapshots.sh' in fname
+        return bool(reg.match(fname))
 
     # remove everything that doesn't match this regex
     files[:] = [file for file in files if not should_exclude(file)]


### PR DESCRIPTION
jamesob excluded `test_utxo_snapshots.sh` from the shell linter with this explanation: "Add the script to the shellcheck exception list since the quoted variables rule needs to be violated in order to get bitcoind to pick up on $EARLY_IBD_FLAGS." However, macrofake pointed out that single lines can be excluded from linting.

This fixes one fixable rule violation, excludes the rest of the offending lines from the linter and then removes the exclusion of the `test_utxo_snapshots.sh` file. Also adds documentation.