### PR TITLE
ci: Drop no longer needed `NOLINTNEXTLINE`

### DIFF
--- a/src/test/fuzz/miniscript.cpp
+++ b/src/test/fuzz/miniscript.cpp
@@ -20,8 +20,6 @@ using NodeRef = miniscript::NodeRef<CPubKey>;
 using Node = miniscript::Node<CPubKey>;
 using Type = miniscript::Type;
 using MsCtx = miniscript::MiniscriptContext;
-// https://github.com/llvm/llvm-project/issues/53444
-// NOLINTNEXTLINE(misc-unused-using-decls)
 using miniscript::operator"" _mst;
 
 //! Some pre-computed data for more efficient string roundtrips and to simulate challenges.


### PR DESCRIPTION
After recent tool updates in the "tidy" CI task, the one instance of `NOLINTNEXTLINE` is not required anymore.