### PR TITLE
ci: Add missing CI_RETRY_EXE before git clone

### DIFF
--- a/ci/lint/04_install.sh
+++ b/ci/lint/04_install.sh
@@ -18,7 +18,7 @@ ${CI_RETRY_EXE} apt-get install -y curl xz-utils git gpg
 PYTHON_PATH="/python_build"
 if [ ! -d "${PYTHON_PATH}/bin" ]; then
   (
-    git clone https://github.com/pyenv/pyenv.git
+    ${CI_RETRY_EXE} git clone https://github.com/pyenv/pyenv.git
     cd pyenv/plugins/python-build || exit 1
     ./install.sh
   )

--- a/ci/test/01_base_install.sh
+++ b/ci/test/01_base_install.sh
@@ -31,13 +31,8 @@ elif [ "$CI_OS_NAME" != "macos" ]; then
 fi
 
 if [ -n "$PIP_PACKAGES" ]; then
-  if [ "$CI_OS_NAME" == "macos" ]; then
-    # shellcheck disable=SC2086
-    IN_GETOPT_BIN="$(brew --prefix gnu-getopt)/bin/getopt" ${CI_RETRY_EXE} pip3 install --user $PIP_PACKAGES
-  else
-    # shellcheck disable=SC2086
-    ${CI_RETRY_EXE} pip3 install --user $PIP_PACKAGES
-  fi
+  # shellcheck disable=SC2086
+  ${CI_RETRY_EXE} pip3 install --user $PIP_PACKAGES
 fi
 
 if [[ ${USE_MEMORY_SANITIZER} == "true" ]]; then

--- a/ci/test/01_base_install.sh
+++ b/ci/test/01_base_install.sh
@@ -32,7 +32,6 @@ fi
 
 if [ -n "$PIP_PACKAGES" ]; then
   if [ "$CI_OS_NAME" == "macos" ]; then
-    sudo -H pip3 install --upgrade pip
     # shellcheck disable=SC2086
     IN_GETOPT_BIN="$(brew --prefix gnu-getopt)/bin/getopt" ${CI_RETRY_EXE} pip3 install --user $PIP_PACKAGES
   else

--- a/ci/test/02_run_container.sh
+++ b/ci/test/02_run_container.sh
@@ -54,6 +54,11 @@ else
   mkdir -p "${PREVIOUS_RELEASES_DIR}"
 fi
 
+if [ "$CI_OS_NAME" == "macos" ]; then
+  IN_GETOPT_BIN="$(brew --prefix gnu-getopt)/bin/getopt"
+  export IN_GETOPT_BIN
+fi
+
 CI_EXEC () {
   $CI_EXEC_CMD_PREFIX bash -c "export PATH=${BINS_SCRATCH_DIR}:${BASE_ROOT_DIR}/ci/retry:\$PATH && cd \"${BASE_ROOT_DIR}\" && $*"
 }

--- a/ci/test/06_script_b.sh
+++ b/ci/test/06_script_b.sh
@@ -56,7 +56,7 @@ index 65e31724bc..f61b471953 100644
 if [ "$RUN_FUZZ_TESTS" = "true" ]; then
   export DIR_FUZZ_IN=${DIR_QA_ASSETS}/fuzz_seed_corpus/
   if [ ! -d "$DIR_FUZZ_IN" ]; then
-    git clone --depth=1 https://github.com/bitcoin-core/qa-assets "${DIR_QA_ASSETS}"
+    ${CI_RETRY_EXE} git clone --depth=1 https://github.com/bitcoin-core/qa-assets "${DIR_QA_ASSETS}"
   fi
   (
     cd "${DIR_QA_ASSETS}"


### PR DESCRIPTION
This PR is a resurrection of https://github.com/bitcoin/bitcoin/pull/28623:

> This should fix [bitcoin/bitcoin/actions/runs/6457002476/job/17527598426#step:7:240](https://github.com/bitcoin/bitcoin/actions/runs/6457002476/job/17527598426#step:7:240):
> 
> ```
> + git clone --depth=1 https://github.com/bitcoin-core/qa-assets /Users/runner/work/bitcoin/bitcoin/ci/scratch/qa-assets
> Cloning into '/Users/runner/work/bitcoin/bitcoin/ci/scratch/qa-assets'...
> error: RPC failed; curl 18 HTTP/2 stream 5 was reset
> error: 54975 bytes of body are still expected
> fetch-pack: unexpected disconnect while reading sideband packet
> fatal: early EOF
> fatal: fetch-pack: invalid index-pack output
> Error: Process completed with exit code 128.
> ```
