### PR TITLE
test: Fuzz merge with -use_value_profile=0 for now

### DIFF
--- a/test/fuzz/test_runner.py
+++ b/test/fuzz/test_runner.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2019-2021 The Bitcoin Core developers
+# Copyright (c) 2019-present The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Run fuzz test targets.
@@ -279,7 +279,11 @@ def merge_inputs(*, fuzz_pool, corpus, test_list, src_dir, build_dir, merge_dir)
             '-merge=1',
             '-shuffle=0',
             '-prefer_small=1',
-            '-use_value_profile=1',  # Also done by oss-fuzz https://github.com/google/oss-fuzz/issues/1406#issuecomment-387790487
+            '-use_value_profile=0',
+            # use_value_profile is enabled by oss-fuzz [0], but disabled for
+            # now to avoid bloating the qa-assets git repository [1].
+            # [0] https://github.com/google/oss-fuzz/issues/1406#issuecomment-387790487
+            # [1] https://github.com/bitcoin-core/qa-assets/issues/130#issuecomment-1749075891
             os.path.join(corpus, t),
             os.path.join(merge_dir, t),
         ]


### PR DESCRIPTION
Seems odd that this has to be done, but for now there are (unknown) size limits on the qa-assets repo. Also, a larger size means that cloning and iterating over the files takes a longer time.

Not sure how to measure the net impact of this, but with some backups reverting this commit, it can be limited on the downside?