### PR TITLE
assumeutxo, rpc: Add 'start' parameter to loadtxoutset

### DIFF
--- a/contrib/devtools/test_utxo_snapshots.sh
+++ b/contrib/devtools/test_utxo_snapshots.sh
@@ -184,7 +184,7 @@ client_rpc getchainstates
 
 echo
 echo "-- Loading UTXO snapshot into client..."
-client_rpc loadtxoutset "$UTXO_DAT_FILE"
+client_rpc loadtxoutset start "$UTXO_DAT_FILE"
 
 watch -n 0.3 "( tail -n 14 $CLIENT_DATADIR/debug.log ; echo ; ./src/bitcoin-cli -rpcport=$CLIENT_RPC_PORT -datadir=$CLIENT_DATADIR getchainstates) | cat"
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2714,12 +2714,14 @@ static RPCHelpMan loadtxoutset()
         "You can find more information on this process in the `assumeutxo` design "
         "document (<https://github.com/bitcoin/bitcoin/blob/master/doc/design/assumeutxo.md>).",
         {
+            {"action", RPCArg::Type::STR, RPCArg::Optional::NO, "The action to execute\n"
+                "\"start\" for starting to load the file. Currently, this is the only action available.\n"},
             {"path",
                 RPCArg::Type::STR,
                 RPCArg::Optional::NO,
                 "path to the snapshot file. If relative, will be prefixed by datadir."},
         },
-        RPCResult{
+        RPCResult{"when action=='start'; only returns after load completes",
             RPCResult::Type::OBJ, "", "",
                 {
                     {RPCResult::Type::NUM, "coins_loaded", "the number of coins loaded from the snapshot"},
@@ -2729,13 +2731,16 @@ static RPCHelpMan loadtxoutset()
                 }
         },
         RPCExamples{
-            HelpExampleCli("loadtxoutset", "utxo.dat")
+            HelpExampleCli("loadtxoutset", "start utxo.dat")
         },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
+    if (self.Arg<std::string>(0) != "start") {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Invalid action '%s'", self.Arg<std::string>(0)));
+    }
     NodeContext& node = EnsureAnyNodeContext(request.context);
     ChainstateManager& chainman = EnsureChainman(node);
-    fs::path path{AbsPathForConfigVal(EnsureArgsman(node), fs::u8path(request.params[0].get_str()))};
+    fs::path path{AbsPathForConfigVal(EnsureArgsman(node), fs::u8path(self.Arg<std::string>(1)))};
 
     FILE* file{fsbridge::fopen(path, "rb")};
     AutoFile afile{file};

--- a/test/functional/feature_assumeutxo.py
+++ b/test/functional/feature_assumeutxo.py
@@ -75,7 +75,7 @@ class AssumeutxoTest(BitcoinTestFramework):
 
         def expected_error(log_msg="", rpc_details=""):
             with self.nodes[1].assert_debug_log([log_msg]):
-                assert_raises_rpc_error(-32603, f"Unable to load UTXO snapshot{rpc_details}", self.nodes[1].loadtxoutset, bad_snapshot_path)
+                assert_raises_rpc_error(-32603, f"Unable to load UTXO snapshot{rpc_details}", self.nodes[1].loadtxoutset,  "start", bad_snapshot_path)
 
         self.log.info("  - snapshot file referring to a block that is not in the assumeutxo parameters")
         prev_block_hash = self.nodes[0].getblockhash(SNAPSHOT_BASE_HEIGHT - 1)
@@ -195,7 +195,7 @@ class AssumeutxoTest(BitcoinTestFramework):
         self.test_invalid_chainstate_scenarios()
 
         self.log.info(f"Loading snapshot into second node from {dump_output['path']}")
-        loaded = n1.loadtxoutset(dump_output['path'])
+        loaded = n1.loadtxoutset("start",dump_output['path'])
         assert_equal(loaded['coins_loaded'], SNAPSHOT_BASE_HEIGHT)
         assert_equal(loaded['base_height'], SNAPSHOT_BASE_HEIGHT)
 
@@ -285,7 +285,7 @@ class AssumeutxoTest(BitcoinTestFramework):
         assert_equal(n2.getblockcount(), START_HEIGHT)
 
         self.log.info(f"Loading snapshot into third node from {dump_output['path']}")
-        loaded = n2.loadtxoutset(dump_output['path'])
+        loaded = n2.loadtxoutset("start",dump_output['path'])
         assert_equal(loaded['coins_loaded'], SNAPSHOT_BASE_HEIGHT)
         assert_equal(loaded['base_height'], SNAPSHOT_BASE_HEIGHT)
 


### PR DESCRIPTION
Might fix https://github.com/bitcoin/bitcoin/issues/28620 

This PR only modifies the behavior of loadtxoutset to require a mandatory "start" string as a first parameter.

This change will allow to implement "status", "abort" or similar future parameters in follow-ups, without breaking the current RPC protocol with incompatible changes (if this were to be merged in the current release cycle)

Also, it is implemented in a minimalist way, to make it easy to review.
