### PR TITLE
test: enable reindex readonly test on *BSD

### DIFF
--- a/test/functional/feature_reindex_readonly.py
+++ b/test/functional/feature_reindex_readonly.py
@@ -7,7 +7,6 @@
 """
 
 import os
-import platform
 import stat
 import subprocess
 from test_framework.test_framework import BitcoinTestFramework
@@ -34,11 +33,13 @@ class BlockstoreReindexTest(BitcoinTestFramework):
         filename = self.nodes[0].chain_path / "blocks" / "blk00000.dat"
         filename.chmod(stat.S_IREAD)
 
-        used_chattr = False
-        if platform.system() == "Linux":
+        undo_immutable = lambda: None
+        # Linux
+        try:
+            subprocess.run(['chattr'], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
             try:
                 subprocess.run(['chattr', '+i', filename], capture_output=True, check=True)
-                used_chattr = True
+                undo_immutable = lambda: subprocess.check_call(['chattr', '-i', filename])
                 self.log.info("Made file immutable with chattr")
             except subprocess.CalledProcessError as e:
                 self.log.warning(str(e))
@@ -50,15 +51,33 @@ class BlockstoreReindexTest(BitcoinTestFramework):
                     self.log.warning("Return early on Linux under root, because chattr failed.")
                     self.log.warning("This should only happen due to missing capabilities in a container.")
                     self.log.warning("Make sure to --cap-add LINUX_IMMUTABLE if you want to run this test.")
-                    return
+                    undo_immutable = False
+        except Exception:
+            # macOS, and *BSD
+            try:
+                subprocess.run(['chflags'], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                try:
+                    subprocess.run(['chflags', 'uchg', filename], capture_output=True, check=True)
+                    undo_immutable = lambda: subprocess.check_call(['chflags', 'nouchg', filename])
+                    self.log.info("Made file immutable with chflags")
+                except subprocess.CalledProcessError as e:
+                    self.log.warning(str(e))
+                    if e.stdout:
+                        self.log.warning(f"stdout: {e.stdout}")
+                    if e.stderr:
+                        self.log.warning(f"stderr: {e.stderr}")
+                    if os.getuid() == 0:
+                        self.log.warning("Return early on BSD under root, because chflags failed.")
+                        undo_immutable = False
+            except Exception:
+                pass
 
-        self.log.debug("Attempt to restart and reindex the node with the unwritable block file")
-        with self.nodes[0].assert_debug_log(expected_msgs=['FlushStateToDisk', 'failed to open file'], unexpected_msgs=[]):
-            self.nodes[0].assert_start_raises_init_error(extra_args=['-reindex', '-fastprune'],
-                expected_msg="Error: A fatal internal error occurred, see debug.log for details")
-
-        if used_chattr:
-            subprocess.check_call(['chattr', '-i', filename])
+        if undo_immutable:
+            self.log.info("Attempt to restart and reindex the node with the unwritable block file")
+            with self.nodes[0].assert_debug_log(expected_msgs=['FlushStateToDisk', 'failed to open file'], unexpected_msgs=[]):
+                self.nodes[0].assert_start_raises_init_error(extra_args=['-reindex', '-fastprune'],
+                    expected_msg="Error: A fatal internal error occurred, see debug.log for details")
+            undo_immutable()
 
         filename.chmod(0o777)
 


### PR DESCRIPTION
see https://github.com/bitcoin/bitcoin/pull/27850#discussion_r1349505585

OpenBSD and FreeBSD don't have `chattr` but they do have `chflags`, use that method to make the block file immutable for the reindex_readonly test.

Written and tested on a VPS running FreeBSD:
```
FreeBSD freebsd-13-1 13.2-RELEASE-p4 FreeBSD 13.2-RELEASE-p4 GENERIC amd64
```