### PR TITLE
libconsensus: adapt API header to be compliant to ANSI C

### DIFF
--- a/src/script/bitcoinconsensus.h
+++ b/src/script/bitcoinconsensus.h
@@ -1,7 +1,7 @@
-// Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2009-2021 The Bitcoin Core developers
-// Distributed under the MIT software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+/* Copyright (c) 2009-2010 Satoshi Nakamoto
+ * Copyright (c) 2009-2021 The Bitcoin Core developers
+ * Distributed under the MIT software license, see the accompanying
+ * file COPYING or http://www.opensource.org/licenses/mit-license.php. */
 
 #ifndef BITCOIN_SCRIPT_BITCOINCONSENSUS_H
 #define BITCOIN_SCRIPT_BITCOINCONSENSUS_H
@@ -49,13 +49,13 @@ typedef enum bitcoinconsensus_error_t
 enum
 {
     bitcoinconsensus_SCRIPT_FLAGS_VERIFY_NONE                = 0,
-    bitcoinconsensus_SCRIPT_FLAGS_VERIFY_P2SH                = (1U << 0), // evaluate P2SH (BIP16) subscripts
-    bitcoinconsensus_SCRIPT_FLAGS_VERIFY_DERSIG              = (1U << 2), // enforce strict DER (BIP66) compliance
-    bitcoinconsensus_SCRIPT_FLAGS_VERIFY_NULLDUMMY           = (1U << 4), // enforce NULLDUMMY (BIP147)
-    bitcoinconsensus_SCRIPT_FLAGS_VERIFY_CHECKLOCKTIMEVERIFY = (1U << 9), // enable CHECKLOCKTIMEVERIFY (BIP65)
-    bitcoinconsensus_SCRIPT_FLAGS_VERIFY_CHECKSEQUENCEVERIFY = (1U << 10), // enable CHECKSEQUENCEVERIFY (BIP112)
-    bitcoinconsensus_SCRIPT_FLAGS_VERIFY_WITNESS             = (1U << 11), // enable WITNESS (BIP141)
-    bitcoinconsensus_SCRIPT_FLAGS_VERIFY_TAPROOT             = (1U << 17), // enable TAPROOT (BIPs 341 & 342)
+    bitcoinconsensus_SCRIPT_FLAGS_VERIFY_P2SH                = (1U << 0), /* evaluate P2SH (BIP16) subscripts */
+    bitcoinconsensus_SCRIPT_FLAGS_VERIFY_DERSIG              = (1U << 2), /* enforce strict DER (BIP66) compliance */
+    bitcoinconsensus_SCRIPT_FLAGS_VERIFY_NULLDUMMY           = (1U << 4), /* enforce NULLDUMMY (BIP147) */
+    bitcoinconsensus_SCRIPT_FLAGS_VERIFY_CHECKLOCKTIMEVERIFY = (1U << 9), /* enable CHECKLOCKTIMEVERIFY (BIP65) */
+    bitcoinconsensus_SCRIPT_FLAGS_VERIFY_CHECKSEQUENCEVERIFY = (1U << 10), /* enable CHECKSEQUENCEVERIFY (BIP112) */
+    bitcoinconsensus_SCRIPT_FLAGS_VERIFY_WITNESS             = (1U << 11), /* enable WITNESS (BIP141) */
+    bitcoinconsensus_SCRIPT_FLAGS_VERIFY_TAPROOT             = (1U << 17), /* enable TAPROOT (BIPs 341 & 342) */
     bitcoinconsensus_SCRIPT_FLAGS_VERIFY_ALL                 = bitcoinconsensus_SCRIPT_FLAGS_VERIFY_P2SH | bitcoinconsensus_SCRIPT_FLAGS_VERIFY_DERSIG |
                                                                bitcoinconsensus_SCRIPT_FLAGS_VERIFY_NULLDUMMY | bitcoinconsensus_SCRIPT_FLAGS_VERIFY_CHECKLOCKTIMEVERIFY |
                                                                bitcoinconsensus_SCRIPT_FLAGS_VERIFY_CHECKSEQUENCEVERIFY | bitcoinconsensus_SCRIPT_FLAGS_VERIFY_WITNESS |
@@ -68,10 +68,10 @@ typedef struct {
     int64_t value;
 } UTXO;
 
-/// Returns 1 if the input nIn of the serialized transaction pointed to by
-/// txTo correctly spends the scriptPubKey pointed to by scriptPubKey under
-/// the additional constraints specified by flags.
-/// If not nullptr, err will contain an error/success code for the operation
+/** Returns 1 if the input nIn of the serialized transaction pointed to by
+    txTo correctly spends the scriptPubKey pointed to by scriptPubKey under
+    the additional constraints specified by flags.
+    If not nullptr, err will contain an error/success code for the operation */
 EXPORT_SYMBOL int bitcoinconsensus_verify_script(const unsigned char *scriptPubKey, unsigned int scriptPubKeyLen,
                                                  const unsigned char *txTo        , unsigned int txToLen,
                                                  unsigned int nIn, unsigned int flags, bitcoinconsensus_error* err);
@@ -88,9 +88,9 @@ EXPORT_SYMBOL int bitcoinconsensus_verify_script_with_spent_outputs(const unsign
 EXPORT_SYMBOL unsigned int bitcoinconsensus_version();
 
 #ifdef __cplusplus
-} // extern "C"
+} /* extern "C" */
 #endif
 
 #undef EXPORT_SYMBOL
 
-#endif // BITCOIN_SCRIPT_BITCOINCONSENSUS_H
+#endif /* BITCOIN_SCRIPT_BITCOINCONSENSUS_H */

--- a/test/lint/lint-include-guards.py
+++ b/test/lint/lint-include-guards.py
@@ -25,7 +25,8 @@ EXCLUDE_FILES_WITH_PREFIX = ['contrib/devtools/bitcoin-tidy',
                              'src/minisketch',
                              'src/tinyformat.h',
                              'src/bench/nanobench.h',
-                             'src/test/fuzz/FuzzedDataProvider.h']
+                             'src/test/fuzz/FuzzedDataProvider.h',
+                             'src/script/bitcoinconsensus.h']  # uses C-style comment after #endif
 
 
 def _get_header_file_lst() -> List[str]:


### PR DESCRIPTION
libconsensus currently can't be used in projects that still use the [ANSI C](https://en.wikipedia.org/wiki/ANSI_C) (=ISO C/C89/C90) standard, as the header uses single-line-comments which are only supported since C99:

```
$ echo '#include "./src/script/bitcoinconsensus.h"\nint main() {}' > consensus_test.c
$ gcc -ansi -c consensus_test.c
In file included from consensus_test.c:1:
./src/script/bitcoinconsensus.h:1:1: error: C++ style comments are not allowed in ISO C90
    1 | // Copyright (c) 2009-2010 Satoshi Nakamoto
      | ^
./src/script/bitcoinconsensus.h:1:1: note: (this will be reported only once per input file)
In file included from consensus_test.c:1:
./src/script/bitcoinconsensus.h:96:8: warning: extra tokens at end of #endif directive [-Wendif-labels]
   96 | #endif // BITCOIN_SCRIPT_BITCOINCONSENSUS_H
      |        ^
```

This PR fixed this by changing all single-line comments to /* ... */ comments instead.

I have no knowledge about who current and potential future users of this library are and if this would ever be an issue (apparently it wasn't until now), but it feels to me that the change is trivial enough to be worth it to potentially having to avoid users having to patch the header. As an alternative, we could specify the minimum needed version (i.e. C99) somewhere.