### PR TITLE
assumeutxo, rpc: Improve EOF error when reading snapshot metadata in loadtxoutset

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2778,7 +2778,15 @@ static RPCHelpMan loadtxoutset()
     }
 
     SnapshotMetadata metadata;
-    afile >> metadata;
+    try {
+        // Read data from the file
+        afile >> metadata;
+    } catch (const std::exception&) {
+        // Handle any exception, which includes reaching the end of the file e.g. file size < sizeOf(metadata)
+        throw JSONRPCError(RPC_DESERIALIZATION_ERROR, strprintf("Unable to load UTXO snapshot, "
+            "couldn't read snapshot metadata from file %s.\nThe file may be corrupted "
+            "or it was crafted in an incompatible format.", path.utf8string()));
+    }
 
     uint256 base_blockhash = metadata.m_base_blockhash;
     if (!chainman.GetParams().AssumeutxoForBlockhash(base_blockhash).has_value()) {


### PR DESCRIPTION
Improve error messaging in `loadtxoutset` to provide a more user-friendly error message when the utxo snapshot file size is insufficient to contain the necessary metadata structure (40 bytes).

- Error message output before the change (current master):
```
./src/bitcoin-cli -datadir=${AU_DATADIR} loadtxoutset ${AU_DATADIR}/utxo-111.dat
error code: -1
error message:
AutoFile::read: end of file: iostream error
```

- Error message output after the change:
```
./src/bitcoin-cli -datadir=${AU_DATADIR} loadtxoutset ${AU_DATADIR}/utxo-111.dat
error code: -32603
error message:
Unable to load UTXO snapshot, couldn't read snapshot metadata from file /tmp/.test_utxo_3/utxo-111.dat.
The file may be corrupted or it was crafted in an incompatible format.
```


Original strategy was to check the size of the file before de-serialisation and the current strategy was presented at that time as an alternative which has been preferred by reviewers and it looks simpler since `streams` source code files are no longer touched.

This PR needs to be backported to 26.x