### PR TITLE
docs: Add reference to total.coverage report

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -488,7 +488,9 @@ To enable LCOV report generation during test runs:
 make
 make cov
 
-# A coverage report will now be accessible at `./test_bitcoin.coverage/index.html`.
+# A coverage report will now be accessible at `./test_bitcoin.coverage/index.html`,
+# which covers unit tests, and `./total.coverage/index.html`, which covers
+# unit and functional tests.
 ```
 
 ### Performance profiling with perf


### PR DESCRIPTION
I couldn't get fuzz coverage to work, so couldn't verify what it would look like if made.