### PR TITLE
refactor: Remove CBlockFileInfo::SetNull

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -42,13 +42,13 @@ static constexpr int64_t MAX_BLOCK_TIME_GAP = 90 * 60;
 class CBlockFileInfo
 {
 public:
-    unsigned int nBlocks;      //!< number of blocks stored in file
-    unsigned int nSize;        //!< number of used bytes of block file
-    unsigned int nUndoSize;    //!< number of used bytes in the undo file
-    unsigned int nHeightFirst; //!< lowest height of block in file
-    unsigned int nHeightLast;  //!< highest height of block in file
-    uint64_t nTimeFirst;       //!< earliest time of block in file
-    uint64_t nTimeLast;        //!< latest time of block in file
+    unsigned int nBlocks{};      //!< number of blocks stored in file
+    unsigned int nSize{};        //!< number of used bytes of block file
+    unsigned int nUndoSize{};    //!< number of used bytes in the undo file
+    unsigned int nHeightFirst{}; //!< lowest height of block in file
+    unsigned int nHeightLast{};  //!< highest height of block in file
+    uint64_t nTimeFirst{};       //!< earliest time of block in file
+    uint64_t nTimeLast{};        //!< latest time of block in file
 
     SERIALIZE_METHODS(CBlockFileInfo, obj)
     {
@@ -61,21 +61,7 @@ public:
         READWRITE(VARINT(obj.nTimeLast));
     }
 
-    void SetNull()
-    {
-        nBlocks = 0;
-        nSize = 0;
-        nUndoSize = 0;
-        nHeightFirst = 0;
-        nHeightLast = 0;
-        nTimeFirst = 0;
-        nTimeLast = 0;
-    }
-
-    CBlockFileInfo()
-    {
-        SetNull();
-    }
+    CBlockFileInfo() {}
 
     std::string ToString() const;
 

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -254,7 +254,7 @@ void BlockManager::PruneOneBlockFile(const int fileNumber)
         }
     }
 
-    m_blockfile_info[fileNumber].SetNull();
+    m_blockfile_info.at(fileNumber) = CBlockFileInfo{};
     m_dirty_fileinfo.insert(fileNumber);
 }
 

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -32,7 +32,6 @@
 class BlockValidationState;
 class CAutoFile;
 class CBlock;
-class CBlockFileInfo;
 class CBlockUndo;
 class CChainParams;
 class Chainstate;


### PR DESCRIPTION
Seems better to use C++11 member initializers and then let the compiler figure out how to construct objects of this class.