### PR TITLE
build: Include `config/bitcoin-config.h` explicitly in `util/trace.h`

### DIFF
--- a/src/util/trace.h
+++ b/src/util/trace.h
@@ -5,6 +5,10 @@
 #ifndef BITCOIN_UTIL_TRACE_H
 #define BITCOIN_UTIL_TRACE_H
 
+#if defined(HAVE_CONFIG_H)
+#include <config/bitcoin-config.h>
+#endif
+
 #ifdef ENABLE_TRACING
 
 #include <sys/sdt.h>


### PR DESCRIPTION
The `ENABLE_TRACING` macro is expected to be defined in the `config/bitcoin-config.h` header.

Therefore, the current code is error-prone as it depends on whether the `config/bitcoin-config.h` header was included before or not.

This bug was noticed while working on CMake [stuff](https://github.com/hebasto/bitcoin/pull/37).