### PR TITLE
net: Sanity check private keys received from SAM proxy

### DIFF
--- a/src/i2p.cpp
+++ b/src/i2p.cpp
@@ -351,10 +351,25 @@ Binary Session::MyDestination() const
     static constexpr size_t CERT_LEN_POS = 385;
 
     uint16_t cert_len;
+
+    if (m_private_key.size() < CERT_LEN_POS + sizeof(cert_len)) {
+        throw std::runtime_error(strprintf("The private key is too short (%d < %d)",
+                                           m_private_key.size(),
+                                           CERT_LEN_POS + sizeof(cert_len)));
+    }
+
     memcpy(&cert_len, &m_private_key.at(CERT_LEN_POS), sizeof(cert_len));
     cert_len = be16toh(cert_len);
 
     const size_t dest_len = DEST_LEN_BASE + cert_len;
+
+    if (dest_len > m_private_key.size()) {
+        throw std::runtime_error(strprintf("Certificate length (%d) designates that the private key should "
+                                           "be %d bytes, but it is only %d bytes",
+                                           cert_len,
+                                           dest_len,
+                                           m_private_key.size()));
+    }
 
     return Binary{m_private_key.begin(), m_private_key.begin() + dest_len};
 }

--- a/src/test/i2p_tests.cpp
+++ b/src/test/i2p_tests.cpp
@@ -9,6 +9,7 @@
 #include <test/util/logging.h>
 #include <test/util/net.h>
 #include <test/util/setup_common.h>
+#include <util/readwritefile.h>
 #include <util/threadinterrupt.h>
 
 #include <boost/test/unit_test.hpp>
@@ -43,6 +44,49 @@ BOOST_AUTO_TEST_CASE(unlimited_recv)
 
     CreateSock = CreateSockOrig;
     LogInstance().SetLogLevel(prev_log_level);
+}
+
+BOOST_AUTO_TEST_CASE(damaged_private_key)
+{
+    const auto CreateSockOrig = CreateSock;
+
+    CreateSock = [](const CService&) {
+        return std::make_unique<StaticContentsSock>("HELLO REPLY RESULT=OK VERSION=3.1\n"
+                                                    "SESSION STATUS RESULT=OK DESTINATION=\n");
+    };
+
+    const auto i2p_private_key_file = m_args.GetDataDirNet() / "test_i2p_private_key_damaged";
+
+    for (const auto& [file_contents, expected_error] : std::vector<std::tuple<std::string, std::string>>{
+             {"", "The private key is too short (0 < 387)"},
+
+             {"abcd", "The private key is too short (4 < 387)"},
+
+             {std::string(386, '\0'), "The private key is too short (386 < 387)"},
+
+             {std::string(385, '\0') + '\0' + '\1',
+              "Certificate length (1) designates that the private key should be 388 bytes, but it is only "
+              "387 bytes"},
+
+             {std::string(385, '\0') + '\0' + '\5' + "abcd",
+              "Certificate length (5) designates that the private key should be 392 bytes, but it is only "
+              "391 bytes"}}) {
+        BOOST_REQUIRE(WriteBinaryFile(i2p_private_key_file, file_contents));
+
+        CThreadInterrupt interrupt;
+        i2p::sam::Session session(i2p_private_key_file, CService{}, &interrupt);
+
+        {
+            ASSERT_DEBUG_LOG("Creating persistent SAM session");
+            ASSERT_DEBUG_LOG(expected_error);
+
+            i2p::Connection conn;
+            bool proxy_error;
+            BOOST_CHECK(!session.Connect(CService{}, conn, proxy_error));
+        }
+    }
+
+    CreateSock = CreateSockOrig;
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Not sanity checking can lead to crashes or worse:

```
==1715589==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x6140000055c2 at pc 0x5622ed66e7ad bp 0x7ffee547a2c0 sp 0x7ffee547a2b8
READ of size 2 at 0x6140000055c2 thread T0 (b-test)
    #0 0x5622ed66e7ac in memcpy include/bits/string_fortified.h:29:10
    #1 0x5622ed66e7ac in i2p::sam::Session::MyDestination() const src/i2p.cpp:362:5
    #2 0x5622ed662e46 in i2p::sam::Session::CreateIfNotCreatedAlready() src/i2p.cpp:414:40
    #3 0x5622ed6619f2 in i2p::sam::Session::Listen(i2p::Connection&) src/i2p.cpp:143:9
```