### PR TITLE
ci: Add missing --external to podman image prune

### DIFF
--- a/ci/test/02_run_container.sh
+++ b/ci/test/02_run_container.sh
@@ -35,10 +35,13 @@ if [ -z "$DANGER_RUN_CI_ON_HOST" ]; then
 
     # Still prune everything in case the filtered pruning doesn't work, or if labels were not set
     # on a previous run. Belt and suspenders approach, should be fine to remove in the future.
+    # Prune images used by --external containers (e.g. build containers) when
+    # using podman.
     echo "Prune all dangling images"
-    docker image prune --force
+    podman image prune --force --external
   fi
   echo "Prune all dangling $CI_IMAGE_LABEL images"
+  # When detecting podman-docker, `--external` should be added.
   docker image prune --force --filter "label=$CI_IMAGE_LABEL"
 
   # shellcheck disable=SC2086


### PR DESCRIPTION
This should fix the out-of-space issues seen in CI. For example:

https://cirrus-ci.com/task/6208410429947904?logs=ci#L8613


```
Error: committing container for step {Env:[FILE_ENV=./ci/test/00_setup_env_native_msan.sh PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin] Command:run Args:[bash -c cd /ci_container_base/ && set -o errexit && source ./ci/test/00_setup_env.sh && ./ci/test/01_base_install.sh] Flags:[] Attrs:map[json:true] Message:RUN bash -c cd /ci_container_base/ && set -o errexit && source ./ci/test/00_setup_env.sh && ./ci/test/01_base_install.sh Original:RUN ["bash", "-c", "cd /ci_container_base/ && set -o errexit && source ./ci/test/00_setup_env.sh && ./ci/test/01_base_install.sh"]}: copying layers and metadata for container "8d882455cc157be6a85d9779b45cacf4dd92a37cfb16fad38213f758a830827d": writing blob: adding layer with blob "sha256:371f657e226fef20f4af6fb88a288dd6248c82c2088daca2d53aaacb51b4303a": processing tar file(write /usr/lib/x86_64-linux-gnu/perl/5.34.0/auto/Unicode/Collate/Collate.so: no space left on device): exit status 1