### PR TITLE
build: Bump `native_clang` up to 17.0.2

### DIFF
--- a/depends/packages/native_clang.mk
+++ b/depends/packages/native_clang.mk
@@ -1,16 +1,17 @@
 package=native_clang
-$(package)_version=15.0.6
+$(package)_version=17.0.2
+$(package)_major_version=$(firstword $(subst ., ,$($(package)_version)))
 $(package)_download_path=https://github.com/llvm/llvm-project/releases/download/llvmorg-$($(package)_version)
 ifneq (,$(findstring aarch64,$(BUILD)))
 $(package)_file_name=clang+llvm-$($(package)_version)-aarch64-linux-gnu.tar.xz
-$(package)_sha256_hash=8ca4d68cf103da8331ca3f35fe23d940c1b78fb7f0d4763c1c059e352f5d1bec
+$(package)_sha256_hash=b08480f2a77167556907869065b0e0e30f4d6cb64ecc625d523b61c22ff0200f
 else
-$(package)_file_name=clang+llvm-$($(package)_version)-x86_64-linux-gnu-ubuntu-18.04.tar.xz
-$(package)_sha256_hash=38bc7f5563642e73e69ac5626724e206d6d539fbef653541b34cae0ba9c3f036
+$(package)_file_name=clang+llvm-$($(package)_version)-x86_64-linux-gnu-ubuntu-22.04.tar.xz
+$(package)_sha256_hash=df297df804766f8fb18f10a188af78e55d82bb8881751408c2fa694ca19163a8
 endif
 
 define $(package)_stage_cmds
-  mkdir -p $($(package)_staging_prefix_dir)/lib/clang/$($(package)_version)/include && \
+  mkdir -p $($(package)_staging_prefix_dir)/lib/clang/$($(package)_major_version)/include && \
   mkdir -p $($(package)_staging_prefix_dir)/bin && \
   mkdir -p $($(package)_staging_prefix_dir)/include/llvm-c && \
   cp bin/clang $($(package)_staging_prefix_dir)/bin/ && \
@@ -20,5 +21,5 @@ define $(package)_stage_cmds
   cp include/llvm-c/ExternC.h $($(package)_staging_prefix_dir)/include/llvm-c && \
   cp include/llvm-c/lto.h $($(package)_staging_prefix_dir)/include/llvm-c && \
   cp lib/libLTO.so $($(package)_staging_prefix_dir)/lib/ && \
-  cp -r lib/clang/$($(package)_version)/include/* $($(package)_staging_prefix_dir)/lib/clang/$($(package)_version)/include/
+  cp -r lib/clang/$($(package)_major_version)/include/* $($(package)_staging_prefix_dir)/lib/clang/$($(package)_major_version)/include/
 endef


### PR DESCRIPTION
This PR makes it possible to build the `qt` package with macOS 14 SDK (Xcode 15.0).

For more details, please refer to https://github.com/bitcoin/bitcoin/pull/28622.