### PR TITLE
depends: Allow PATH with spaces in directory names.

### DIFF
--- a/depends/config.guess
+++ b/depends/config.guess
@@ -141,7 +141,7 @@ set_cc_for_build() {
 # This is needed to find uname on a Pyramid OSx when run in the BSD universe.
 # (ghazi@noc.rutgers.edu 1994-08-24)
 if test -f /.attbin/uname ; then
-	PATH=$PATH:/.attbin ; export PATH
+	PATH="$PATH:/.attbin" ; export PATH
 fi
 
 UNAME_MACHINE=`(uname -m) 2>/dev/null` || UNAME_MACHINE=unknown

--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -139,9 +139,9 @@ $(1)_config_env+=PKG_CONFIG_LIBDIR=$($($(1)_type)_prefix)/lib/pkgconfig
 $(1)_config_env+=PKG_CONFIG_PATH=$($($(1)_type)_prefix)/share/pkgconfig
 $(1)_config_env+=PKG_CONFIG_SYSROOT_DIR=/
 $(1)_config_env+=CMAKE_MODULE_PATH=$($($(1)_type)_prefix)/lib/cmake
-$(1)_config_env+=PATH=$(build_prefix)/bin:$(PATH)
-$(1)_build_env+=PATH=$(build_prefix)/bin:$(PATH)
-$(1)_stage_env+=PATH=$(build_prefix)/bin:$(PATH)
+$(1)_config_env+=PATH="$(build_prefix)/bin:$(PATH)"
+$(1)_build_env+=PATH="$(build_prefix)/bin:$(PATH)"
+$(1)_stage_env+=PATH="$(build_prefix)/bin:$(PATH)"
 
 # Setting a --build type that differs from --host will explicitly enable
 # cross-compilation mode. Note that --build defaults to the output of


### PR DESCRIPTION
Title pretty much says it all. On one of my systems there is a component of the PATH which has a space in it, so expanding `$PATH` will be tokenized by the shell. This PR just adds a few key quotes to make sure that expansions of `$PATH` are handled correctly.