### PR TITLE
doc: Fix bugprone-lambda-function-name errors

### DIFF
--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -3,6 +3,7 @@ Checks: '
 bitcoin-*,
 bugprone-argument-comment,
 bugprone-use-after-move,
+bugprone-lambda-function-name,
 misc-unused-using-decls,
 modernize-use-default-member-init,
 modernize-use-emplace,

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -465,7 +465,7 @@ static RPCHelpMan getmempoolancestors()
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Transaction not in mempool");
     }
 
-    auto ancestors{mempool.AssumeCalculateMemPoolAncestors(__func__, *it, CTxMemPool::Limits::NoLimits(), /*fSearchForParents=*/false)};
+    auto ancestors{mempool.AssumeCalculateMemPoolAncestors(self.m_name, *it, CTxMemPool::Limits::NoLimits(), /*fSearchForParents=*/false)};
 
     if (!fVerbose) {
         UniValue o(UniValue::VARR);

--- a/src/util/check.h
+++ b/src/util/check.h
@@ -20,8 +20,6 @@ public:
     NonFatalCheckError(std::string_view msg, std::string_view file, int line, std::string_view func);
 };
 
-#define STR_INTERNAL_BUG(msg) StrFormatInternalBug((msg), __FILE__, __LINE__, __func__)
-
 /** Helper for CHECK_NONFATAL() */
 template <typename T>
 T&& inline_check_non_fatal(LIFETIMEBOUND T&& val, const char* file, int line, const char* func, const char* assertion)
@@ -31,20 +29,6 @@ T&& inline_check_non_fatal(LIFETIMEBOUND T&& val, const char* file, int line, co
     }
     return std::forward<T>(val);
 }
-
-/**
- * Identity function. Throw a NonFatalCheckError when the condition evaluates to false
- *
- * This should only be used
- * - where the condition is assumed to be true, not for error handling or validating user input
- * - where a failure to fulfill the condition is recoverable and does not abort the program
- *
- * For example in RPC code, where it is undesirable to crash the whole program, this can be generally used to replace
- * asserts or recoverable logic errors. A NonFatalCheckError in RPC code is caught and passed as a string to the RPC
- * caller, which can then report the issue to the developers.
- */
-#define CHECK_NONFATAL(condition) \
-    inline_check_non_fatal(condition, __FILE__, __LINE__, __func__, #condition)
 
 #if defined(NDEBUG)
 #error "Cannot compile without assertions!"
@@ -69,6 +53,25 @@ T&& inline_assertion_check(LIFETIMEBOUND T&& val, [[maybe_unused]] const char* f
     return std::forward<T>(val);
 }
 
+// All macros may use __func__ inside a lambda, so put them under nolint.
+// NOLINTBEGIN(bugprone-lambda-function-name)
+
+#define STR_INTERNAL_BUG(msg) StrFormatInternalBug((msg), __FILE__, __LINE__, __func__)
+
+/**
+ * Identity function. Throw a NonFatalCheckError when the condition evaluates to false
+ *
+ * This should only be used
+ * - where the condition is assumed to be true, not for error handling or validating user input
+ * - where a failure to fulfill the condition is recoverable and does not abort the program
+ *
+ * For example in RPC code, where it is undesirable to crash the whole program, this can be generally used to replace
+ * asserts or recoverable logic errors. A NonFatalCheckError in RPC code is caught and passed as a string to the RPC
+ * caller, which can then report the issue to the developers.
+ */
+#define CHECK_NONFATAL(condition) \
+    inline_check_non_fatal(condition, __FILE__, __LINE__, __func__, #condition)
+
 /** Identity function. Abort if the value compares equal to zero */
 #define Assert(val) inline_assertion_check<true>(val, __FILE__, __LINE__, __func__, #val)
 
@@ -90,5 +93,7 @@ T&& inline_assertion_check(LIFETIMEBOUND T&& val, [[maybe_unused]] const char* f
 #define NONFATAL_UNREACHABLE()                                        \
     throw NonFatalCheckError(                                         \
         "Unreachable code reached (non-fatal)", __FILE__, __LINE__, __func__)
+
+// NOLINTEND(bugprone-lambda-function-name)
 
 #endif // BITCOIN_UTIL_CHECK_H

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5953,8 +5953,8 @@ bool ChainstateManager::ValidatedSnapshotCleanup()
                                    fs::path p_old,
                                    fs::path p_new,
                                    const fs::filesystem_error& err) {
-        LogPrintf("%s: error renaming file (%s): %s\n",
-                __func__, fs::PathToString(p_old), err.what());
+        LogPrintf("Error renaming path (%s) -> (%s): %s\n",
+                  fs::PathToString(p_old), fs::PathToString(p_new), err.what());
         GetNotifications().fatalError(strprintf(
             "Rename of '%s' -> '%s' failed. "
             "Cannot clean up the background chainstate leveldb directory.",


### PR DESCRIPTION
Inside a lambda, `__func__` will evaluate to something like `"operator()"`. Fix this by either removing it, or by using the real name.

https://clang.llvm.org/extra/clang-tidy/checks/bugprone/lambda-function-name.html