### PR TITLE
refactor: Add LIFETIMEBOUND to all (w)txid getters

### DIFF
--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -6,8 +6,8 @@
 #ifndef BITCOIN_PRIMITIVES_TRANSACTION_H
 #define BITCOIN_PRIMITIVES_TRANSACTION_H
 
+#include <attributes.h>
 #include <consensus/amount.h>
-#include <prevector.h>
 #include <script/script.h>
 #include <serialize.h>
 #include <uint256.h>
@@ -335,8 +335,8 @@ public:
         return vin.empty() && vout.empty();
     }
 
-    const Txid& GetHash() const { return hash; }
-    const Wtxid& GetWitnessHash() const { return m_witness_hash; };
+    const Txid& GetHash() const LIFETIMEBOUND { return hash; }
+    const Wtxid& GetWitnessHash() const LIFETIMEBOUND { return m_witness_hash; };
 
     // Return sum of txouts.
     CAmount GetValueOut() const;
@@ -433,7 +433,7 @@ public:
     static GenTxid Txid(const uint256& hash) { return GenTxid{false, hash}; }
     static GenTxid Wtxid(const uint256& hash) { return GenTxid{true, hash}; }
     bool IsWtxid() const { return m_is_wtxid; }
-    const uint256& GetHash() const { return m_hash; }
+    const uint256& GetHash() const LIFETIMEBOUND { return m_hash; }
     friend bool operator==(const GenTxid& a, const GenTxid& b) { return a.m_is_wtxid == b.m_is_wtxid && a.m_hash == b.m_hash; }
     friend bool operator<(const GenTxid& a, const GenTxid& b) { return std::tie(a.m_is_wtxid, a.m_hash) < std::tie(b.m_is_wtxid, b.m_hash); }
 };

--- a/src/test/fuzz/tx_pool.cpp
+++ b/src/test/fuzz/tx_pool.cpp
@@ -343,7 +343,7 @@ FUZZ_TARGET(tx_pool, .init = initialize_tx_pool)
             tx_pool.RollingFeeUpdate();
         }
         if (fuzzed_data_provider.ConsumeBool()) {
-            const auto& txid = fuzzed_data_provider.ConsumeBool() ?
+            const auto txid = fuzzed_data_provider.ConsumeBool() ?
                                    mut_tx.GetHash().ToUint256() :
                                    PickValue(fuzzed_data_provider, txids);
             const auto delta = fuzzed_data_provider.ConsumeIntegralInRange<CAmount>(-50 * COIN, +50 * COIN);

--- a/src/util/transaction_identifier.h
+++ b/src/util/transaction_identifier.h
@@ -1,6 +1,7 @@
 #ifndef BITCOIN_UTIL_TRANSACTION_IDENTIFIER_H
 #define BITCOIN_UTIL_TRANSACTION_IDENTIFIER_H
 
+#include <attributes.h>
 #include <uint256.h>
 #include <util/types.h>
 
@@ -35,7 +36,7 @@ public:
     template <typename Other>
     bool operator<(const Other& other) const { return Compare(other) < 0; }
 
-    uint256 ToUint256() const { return m_wrapped; }
+    const uint256& ToUint256() const LIFETIMEBOUND { return m_wrapped; }
     static transaction_identifier FromUint256(const uint256& id) { return {id}; }
 
     /** Wrapped `uint256` methods. */
@@ -56,7 +57,7 @@ public:
      * TODO: This should be removed once the majority of the code has switched
      * to using the Txid and Wtxid types. Until then it makes for a smoother
      * transition to allow this conversion. */
-    operator uint256() const { return m_wrapped; }
+    operator const uint256&() const LIFETIMEBOUND { return m_wrapped; }
 };
 
 /** Txid commits to all transaction fields except the witness. */

--- a/src/wallet/test/group_outputs_tests.cpp
+++ b/src/wallet/test/group_outputs_tests.cpp
@@ -40,7 +40,7 @@ static void addCoin(CoinsResult& coins,
     tx.vout[0].nValue = nValue;
     tx.vout[0].scriptPubKey = GetScriptForDestination(dest);
 
-    const uint256& txid = tx.GetHash();
+    const auto txid{tx.GetHash().ToUint256()};
     LOCK(wallet.cs_wallet);
     auto ret = wallet.mapWallet.emplace(std::piecewise_construct, std::forward_as_tuple(txid), std::forward_as_tuple(MakeTransactionRef(std::move(tx)), TxStateInactive{}));
     assert(ret.second);

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -963,7 +963,7 @@ BOOST_FIXTURE_TEST_CASE(wallet_sync_tx_invalid_state_test, TestingSetup)
     mtx.vin.clear();
     mtx.vin.emplace_back(tx_id_to_spend, 0);
     wallet.transactionAddedToMempool(MakeTransactionRef(mtx));
-    const uint256& good_tx_id = mtx.GetHash();
+    const auto good_tx_id{mtx.GetHash().ToUint256()};
 
     {
         // Verify balance update for the new tx and the old one

--- a/src/wallet/transaction.h
+++ b/src/wallet/transaction.h
@@ -5,19 +5,20 @@
 #ifndef BITCOIN_WALLET_TRANSACTION_H
 #define BITCOIN_WALLET_TRANSACTION_H
 
-#include <bitset>
-#include <cstdint>
+#include <attributes.h>
 #include <consensus/amount.h>
 #include <primitives/transaction.h>
-#include <serialize.h>
-#include <wallet/types.h>
-#include <threadsafety.h>
 #include <tinyformat.h>
+#include <uint256.h>
 #include <util/overloaded.h>
 #include <util/strencodings.h>
 #include <util/string.h>
+#include <wallet/types.h>
 
-#include <list>
+#include <bitset>
+#include <cstdint>
+#include <map>
+#include <utility>
 #include <variant>
 #include <vector>
 
@@ -330,8 +331,8 @@ public:
     bool isInactive() const { return state<TxStateInactive>(); }
     bool isUnconfirmed() const { return !isAbandoned() && !isConflicted() && !isConfirmed(); }
     bool isConfirmed() const { return state<TxStateConfirmed>(); }
-    const Txid& GetHash() const { return tx->GetHash(); }
-    const Wtxid& GetWitnessHash() const { return tx->GetWitnessHash(); }
+    const Txid& GetHash() const LIFETIMEBOUND { return tx->GetHash(); }
+    const Wtxid& GetWitnessHash() const LIFETIMEBOUND { return tx->GetWitnessHash(); }
     bool IsCoinBase() const { return tx->IsCoinBase(); }
 
 private:


### PR DESCRIPTION
Currently some getters return a reference, some don't. Fix this by returning a reference everywhere. Also, add `LIFETIMEBOUND` to all. Then, use the compiler warnings to create copies only where needed.

Also, fix iwyu includes while touching the includes.