### PR TITLE
refactor: Fix bugprone-string-constructor warning

### DIFF
--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -2,6 +2,7 @@ Checks: '
 -*,
 bitcoin-*,
 bugprone-argument-comment,
+bugprone-string-constructor,
 bugprone-use-after-move,
 bugprone-lambda-function-name,
 misc-unused-using-decls,

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -129,9 +129,9 @@ bool IsSQLiteFile(const fs::path& path)
 
     file.close();
 
-    // Check the magic, see https://sqlite.org/fileformat2.html
+    // Check the magic, see https://sqlite.org/fileformat.html
     std::string magic_str(magic, 16);
-    if (magic_str != std::string("SQLite format 3", 16)) {
+    if (magic_str != std::string{"SQLite format 3\000", 16}) {
         return false;
     }
 


### PR DESCRIPTION
String literals in C++ have a trailing null character, so the current code is fine to rely on that implicitly. However,
* the sqlite documentation explicitly mentions the null character
* code readers may wonder if the code is intentional
* clang-tidy warns about the code via `bugprone-string-constructor`

Address the points by putting the null character into the code and enable the clang-tidy `bugprone-string-constructor` check.