### PR TITLE
guix: Zip needs to include all files and set time to SOURCE_DATE_EPOCH

### DIFF
--- a/contrib/guix/libexec/codesign.sh
+++ b/contrib/guix/libexec/codesign.sh
@@ -86,7 +86,11 @@ mkdir -p "$DISTSRC"
             signapple apply dist/Bitcoin-Qt.app codesignatures/osx/dist
 
             # Make a .zip from dist/
-            zip "${OUTDIR}/${DISTNAME}-${HOST}.zip" dist/*
+            cd dist/
+            find . -print0 \
+                | xargs -0r touch --no-dereference --date="@${SOURCE_DATE_EPOCH}"
+            find . | sort \
+                | zip -X@ "${OUTDIR}/${DISTNAME}-${HOST}.zip"
             ;;
         *)
             exit 1


### PR DESCRIPTION
The zip for codesigned MacOS distribution needs to have all files included and have their timestamps set to the same value (`SOURCE_DATE_EPOCH`). 

This uses the same pattern for zip as is done for the other zip files produced by guix.