### PR TITLE
p2p: Fill reconciliation sets (Erlay)

### DIFF
--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -51,6 +51,7 @@ bench_bench_bitcoin_SOURCES = \
   bench/rpc_mempool.cpp \
   bench/streams_findbyte.cpp \
   bench/strencodings.cpp \
+  bench/txreconciliation.cpp \
   bench/util_time.cpp \
   bench/verify_script.cpp \
   bench/xor.cpp

--- a/src/bench/txreconciliation.cpp
+++ b/src/bench/txreconciliation.cpp
@@ -1,0 +1,40 @@
+// Copyright (c) 2020-2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <bench/bench.h>
+
+#include <net.h>
+#include <node/txreconciliation.h>
+
+
+/* Benchmarks */
+
+static void ShouldFanoutTo(benchmark::Bench& bench)
+{
+    FastRandomContext frc{/*fDeterministic=*/true};
+    CSipHasher hasher(frc.rand64(), frc.rand64());
+    TxReconciliationTracker tracker(TXRECONCILIATION_VERSION, hasher);
+    // Register 120 inbound peers
+    int num_peers{120};
+    for (NodeId peer = 0; peer < num_peers; peer++) {
+        tracker.PreRegisterPeer(peer);
+        tracker.RegisterPeer(peer, /*is_peer_inbound=*/true, 1, 1);
+    }
+    FastRandomContext rc{/*fDeterministic=*/true};
+
+    // The target function uses caching, so we want to mimic tx repetitions
+    // of the real-world behavior.
+    std::vector<Wtxid> txs;
+    for (size_t i = 0; i < 1000; i++) {
+        txs.push_back(Wtxid::FromUint256(rc.rand256()));
+    }
+
+    bench.run([&] {
+        for (NodeId peer = 0; peer < num_peers; ++peer) {
+            tracker.ShouldFanoutTo(txs[rand() % txs.size()], peer, /*inbounds_nonrcncl_tx_relay=*/0, /*outbounds_nonrcncl_tx_relay=*/0);
+        }
+    });
+}
+
+BENCHMARK(ShouldFanoutTo, benchmark::PriorityLevel::HIGH);

--- a/src/bench/txreconciliation.cpp
+++ b/src/bench/txreconciliation.cpp
@@ -32,7 +32,7 @@ static void ShouldFanoutTo(benchmark::Bench& bench)
 
     bench.run([&] {
         for (NodeId peer = 0; peer < num_peers; ++peer) {
-            tracker.ShouldFanoutTo(txs[rand() % txs.size()], peer, /*inbounds_nonrcncl_tx_relay=*/0, /*outbounds_nonrcncl_tx_relay=*/0);
+            tracker.ShouldFanoutTo(txs[rand() % txs.size()], peer, /*inbounds_fanout_tx_relay=*/0, /*outbounds_fanout_tx_relay=*/0);
         }
     });
 }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1610,7 +1610,7 @@ void PeerManagerImpl::FinalizeNode(const CNode& node)
     }
     m_orphanage.EraseForPeer(nodeid);
     m_txrequest.DisconnectedPeer(nodeid);
-    if (m_txreconciliation) m_txreconciliation->ForgetPeer(nodeid);
+    if (m_txreconciliation) m_txreconciliation->ForgetPeer(nodeid, node.IsInboundConn());
     m_num_preferred_download_peers -= state->fPreferredDownload;
     m_peers_downloading_from -= (!state->vBlocksInFlight.empty());
     assert(m_peers_downloading_from >= 0);
@@ -3623,7 +3623,7 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
                 // We could have optimistically pre-registered/registered the peer. In that case,
                 // we should forget about the reconciliation state here if this wasn't followed
                 // by WTXIDRELAY (since WTXIDRELAY can't be announced later).
-                m_txreconciliation->ForgetPeer(pfrom.GetId());
+                m_txreconciliation->ForgetPeer(pfrom.GetId(), pfrom.IsInboundConn());
             }
         }
 

--- a/src/node/txreconciliation.cpp
+++ b/src/node/txreconciliation.cpp
@@ -36,9 +36,6 @@ class TxReconciliationState
 {
 public:
     /**
-     * TODO: This field is public to ignore -Wunused-private-field. Make private once used in
-     * the following commits.
-     *
      * Reconciliation protocol assumes using one role consistently: either a reconciliation
      * initiator (requesting sketches), or responder (sending sketches). This defines our role,
      * based on the direction of the p2p connection.
@@ -47,9 +44,6 @@ public:
     bool m_we_initiate;
 
     /**
-     * TODO: These fields are public to ignore -Wunused-private-field. Make private once used in
-     * the following commits.
-     *
      * These values are used to salt short IDs, which is necessary for transaction reconciliations.
      */
     uint64_t m_k0, m_k1;

--- a/src/node/txreconciliation.cpp
+++ b/src/node/txreconciliation.cpp
@@ -96,6 +96,12 @@ private:
     std::unordered_map<NodeId, std::variant<uint64_t, TxReconciliationState>> m_states GUARDED_BY(m_txreconciliation_mutex);
 
     /*
+     * Keeps track of how many of the registered peers are inbound. Updated on registering or
+     * forgetting peers.
+     */
+    size_t m_inbounds_count GUARDED_BY(m_txreconciliation_mutex){0};
+
+    /*
      * A least-recently-added cache tracking which peers we should fanout a transaction to.
      *
      * Since the time between cache accesses is on the order of seconds, returning an outdated
@@ -170,6 +176,9 @@ public:
         m_states.erase(recon_state);
         m_states.emplace(peer_id, std::move(new_state));
 
+        if (is_peer_inbound && m_inbounds_count < std::numeric_limits<size_t>::max()) {
+            ++m_inbounds_count;
+        }
         return ReconciliationRegisterResult::SUCCESS;
     }
 
@@ -214,13 +223,20 @@ public:
         return peer_state->m_local_set.erase(wtxid_to_remove) > 0;
     }
 
-    void ForgetPeer(NodeId peer_id) EXCLUSIVE_LOCKS_REQUIRED(!m_txreconciliation_mutex)
+    void ForgetPeer(NodeId peer_id, bool is_peer_inbound) EXCLUSIVE_LOCKS_REQUIRED(!m_txreconciliation_mutex)
     {
         AssertLockNotHeld(m_txreconciliation_mutex);
         LOCK(m_txreconciliation_mutex);
-        if (m_states.erase(peer_id)) {
-            LogPrintLevel(BCLog::TXRECONCILIATION, BCLog::Level::Debug, "Forget txreconciliation state of peer=%d\n", peer_id);
+        const auto peer = m_states.find(peer_id);
+        if (peer == m_states.end()) return;
+        const bool registered = std::holds_alternative<TxReconciliationState>(peer->second);
+        m_states.erase(peer);
+
+        if (registered && is_peer_inbound) {
+            Assert(m_inbounds_count > 0);
+            --m_inbounds_count;
         }
+        LogPrintLevel(BCLog::TXRECONCILIATION, BCLog::Level::Debug, "Forget txreconciliation state of peer=%d\n", peer_id);
     }
 
     /**
@@ -315,16 +331,9 @@ public:
         if (peer_state->m_we_initiate) {
             destinations = OUTBOUND_FANOUT_DESTINATIONS - outbounds_fanout_tx_relay;
         } else {
-            const size_t inbound_rcncl_peers = std::count_if(m_states.begin(), m_states.end(),
-                                                             [](const auto& indexed_state) {
-                                                                 const auto* cur_state = std::get_if<TxReconciliationState>(&indexed_state.second);
-                                                                 if (cur_state) return !cur_state->m_we_initiate;
-                                                                 return false;
-                                                             });
-
             // Since we use the fraction for inbound peers, we first need to compute the total
             // number of inbound targets.
-            const double inbound_targets = (inbounds_fanout_tx_relay + inbound_rcncl_peers) * INBOUND_FANOUT_DESTINATIONS_FRACTION;
+            const double inbound_targets = (inbounds_fanout_tx_relay + m_inbounds_count) * INBOUND_FANOUT_DESTINATIONS_FRACTION;
             destinations = inbound_targets - inbounds_fanout_tx_relay;
         }
 
@@ -363,9 +372,9 @@ bool TxReconciliationTracker::TryRemovingFromSet(NodeId peer_id, const Wtxid& wt
     return m_impl->TryRemovingFromSet(peer_id, wtxid_to_remove);
 }
 
-void TxReconciliationTracker::ForgetPeer(NodeId peer_id)
+void TxReconciliationTracker::ForgetPeer(NodeId peer_id, bool is_peer_inbound)
 {
-    m_impl->ForgetPeer(peer_id);
+    m_impl->ForgetPeer(peer_id, is_peer_inbound);
 }
 
 bool TxReconciliationTracker::IsPeerRegistered(NodeId peer_id) const

--- a/src/node/txreconciliation.h
+++ b/src/node/txreconciliation.h
@@ -55,7 +55,7 @@ private:
     const std::unique_ptr<Impl> m_impl;
 
 public:
-    explicit TxReconciliationTracker(uint32_t recon_version);
+    explicit TxReconciliationTracker(uint32_t recon_version, CSipHasher hasher);
     ~TxReconciliationTracker();
 
     /**
@@ -98,6 +98,12 @@ public:
      * Check if a peer is registered to reconcile transactions with us.
      */
     bool IsPeerRegistered(NodeId peer_id) const;
+
+    /**
+     * Returns whether the peer is chosen as a low-fanout destination for a given tx.
+     */
+    bool ShouldFanoutTo(const Wtxid& wtxid, NodeId peer_id,
+                        size_t inbounds_fanout_tx_relay, size_t outbounds_fanout_tx_relay);
 };
 
 #endif // BITCOIN_NODE_TXRECONCILIATION_H

--- a/src/node/txreconciliation.h
+++ b/src/node/txreconciliation.h
@@ -92,7 +92,7 @@ public:
      * Attempts to forget txreconciliation-related state of the peer (if we previously stored any).
      * After this, we won't be able to reconcile transactions with the peer.
      */
-    void ForgetPeer(NodeId peer_id);
+    void ForgetPeer(NodeId peer_id, bool is_peer_inbound);
 
     /**
      * Check if a peer is registered to reconcile transactions with us.

--- a/src/node/txreconciliation.h
+++ b/src/node/txreconciliation.h
@@ -75,6 +75,20 @@ public:
                                               uint32_t peer_recon_version, uint64_t remote_salt);
 
     /**
+     * Step 1. Add a new transaction we want to announce to the peer to the local reconciliation set
+     * of the peer, so that it will be reconciled later, unless the set limit is reached.
+     * Returns whether the transaction appears in the set.
+     */
+    bool AddToSet(NodeId peer_id, const Wtxid& wtxid);
+
+    /**
+     * Before Step 2, we might want to remove a wtxid from the reconciliation set, for example if
+     * the peer just announced the transaction to us.
+     * Returns whether the wtxid was removed.
+     */
+    bool TryRemovingFromSet(NodeId peer_id, const Wtxid& wtxid_to_remove);
+
+    /**
      * Attempts to forget txreconciliation-related state of the peer (if we previously stored any).
      * After this, we won't be able to reconcile transactions with the peer.
      */

--- a/src/test/txreconciliation_tests.cpp
+++ b/src/test/txreconciliation_tests.cpp
@@ -53,9 +53,13 @@ BOOST_AUTO_TEST_CASE(ForgetPeerTest)
     TxReconciliationTracker tracker(TXRECONCILIATION_VERSION, hasher);
     NodeId peer_id0 = 0;
 
+    // Removing peer which is not there works.
+    tracker.ForgetPeer(peer_id0, true);
+    tracker.ForgetPeer(peer_id0, false);
+
     // Removing peer after pre-registring works and does not let to register the peer.
     tracker.PreRegisterPeer(peer_id0);
-    tracker.ForgetPeer(peer_id0);
+    tracker.ForgetPeer(peer_id0, true);
     BOOST_CHECK_EQUAL(tracker.RegisterPeer(peer_id0, true, 1, 1), ReconciliationRegisterResult::NOT_FOUND);
 
     // Removing peer after it is registered works.
@@ -63,7 +67,7 @@ BOOST_AUTO_TEST_CASE(ForgetPeerTest)
     BOOST_REQUIRE(!tracker.IsPeerRegistered(peer_id0));
     BOOST_REQUIRE_EQUAL(tracker.RegisterPeer(peer_id0, true, 1, 1), ReconciliationRegisterResult::SUCCESS);
     BOOST_CHECK(tracker.IsPeerRegistered(peer_id0));
-    tracker.ForgetPeer(peer_id0);
+    tracker.ForgetPeer(peer_id0, true);
     BOOST_CHECK(!tracker.IsPeerRegistered(peer_id0));
 }
 
@@ -80,7 +84,7 @@ BOOST_AUTO_TEST_CASE(IsPeerRegisteredTest)
     BOOST_REQUIRE_EQUAL(tracker.RegisterPeer(peer_id0, true, 1, 1), ReconciliationRegisterResult::SUCCESS);
     BOOST_CHECK(tracker.IsPeerRegistered(peer_id0));
 
-    tracker.ForgetPeer(peer_id0);
+    tracker.ForgetPeer(peer_id0, true);
     BOOST_CHECK(!tracker.IsPeerRegistered(peer_id0));
 }
 
@@ -102,7 +106,7 @@ BOOST_AUTO_TEST_CASE(AddToSetTest)
 
     BOOST_REQUIRE(tracker.AddToSet(peer_id0, wtxid));
 
-    tracker.ForgetPeer(peer_id0);
+    tracker.ForgetPeer(peer_id0, true);
     Wtxid wtxid2{Wtxid::FromUint256(frc.rand256())};
     BOOST_REQUIRE(!tracker.AddToSet(peer_id0, wtxid2));
 
@@ -138,7 +142,7 @@ BOOST_AUTO_TEST_CASE(TryRemovingFromSetTest)
     BOOST_REQUIRE(!tracker.TryRemovingFromSet(peer_id0, wtxid));
 
     BOOST_REQUIRE(tracker.AddToSet(peer_id0, wtxid));
-    tracker.ForgetPeer(peer_id0);
+    tracker.ForgetPeer(peer_id0, true);
     BOOST_REQUIRE(!tracker.TryRemovingFromSet(peer_id0, wtxid));
 }
 
@@ -178,7 +182,7 @@ BOOST_AUTO_TEST_CASE(ShouldFanoutToTest)
                                             /*inbounds_fanout_tx_relay=*/0, /*outbounds_fanout_tx_relay=*/1));
     }
 
-    tracker.ForgetPeer(peer_id0);
+    tracker.ForgetPeer(peer_id0, false);
     // A forgotten (reconciliation-wise) peer should be always selected for fanout again.
     for (int i = 0; i < 100; ++i) {
         BOOST_CHECK(tracker.ShouldFanoutTo(Wtxid::FromUint256(frc.rand256()), peer_id0,


### PR DESCRIPTION
Keep track of per-peer reconciliation sets containing transactions to be exchanged efficiently. The remaining transactions are announced via usual flooding.

Erlay Project Tracking: #28646