### PR TITLE
build: Patch Qt to handle minimum macOS version properly

### DIFF
--- a/depends/hosts/darwin.mk
+++ b/depends/hosts/darwin.mk
@@ -1,4 +1,4 @@
-OSX_MIN_VERSION=11.0
+OSX_MIN_VERSION=11.0 # This value must be coordinated with depends/patches/qt/fix-minimum-macos.patch.
 OSX_SDK_VERSION=11.0
 XCODE_VERSION=12.2
 XCODE_BUILD_ID=12B45b

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -23,6 +23,7 @@ $(package)_patches += guix_cross_lib_path.patch
 $(package)_patches += fix-macos-linker.patch
 $(package)_patches += memory_resource.patch
 $(package)_patches += windows_lto.patch
+$(package)_patches += fix-minimum-macos.patch
 
 $(package)_qttranslations_file_name=qttranslations-$($(package)_suffix)
 $(package)_qttranslations_sha256_hash=a31785948c640b7c66d9fe2db4993728ca07f64e41c560b3625ad191b276ff20
@@ -242,6 +243,7 @@ endef
 define $(package)_preprocess_cmds
   cp $($(package)_patch_dir)/qt.pro qt.pro && \
   cp $($(package)_patch_dir)/qttools_src.pro qttools/src/src.pro && \
+  patch -p1 -i $($(package)_patch_dir)/fix-minimum-macos.patch && \
   patch -p1 -i $($(package)_patch_dir)/fix-macos-linker.patch && \
   patch -p1 -i $($(package)_patch_dir)/dont_hardcode_pwd.patch && \
   patch -p1 -i $($(package)_patch_dir)/fix_qt_pkgconfig.patch && \

--- a/depends/patches/qt/fix-minimum-macos.patch
+++ b/depends/patches/qt/fix-minimum-macos.patch
@@ -1,0 +1,24 @@
+This patch must be coordinated with the `OSX_MIN_VERSION`
+variable value in depends/hosts/darwin.mk.
+
+
+--- a/qtbase/src/corelib/global/qsystemdetection.h
++++ b/qtbase/src/corelib/global/qsystemdetection.h
+@@ -221,13 +221,13 @@
+ #  include <AvailabilityMacros.h>
+ #
+ #  ifdef Q_OS_MACOS
+-#    if !defined(__MAC_OS_X_VERSION_MIN_REQUIRED) || __MAC_OS_X_VERSION_MIN_REQUIRED < __MAC_10_6
++#    if !defined(__MAC_OS_X_VERSION_MIN_REQUIRED) || __MAC_OS_X_VERSION_MIN_REQUIRED < __MAC_11_0
+ #       undef __MAC_OS_X_VERSION_MIN_REQUIRED
+-#       define __MAC_OS_X_VERSION_MIN_REQUIRED __MAC_10_6
++#       define __MAC_OS_X_VERSION_MIN_REQUIRED __MAC_11_0
+ #    endif
+-#    if !defined(MAC_OS_X_VERSION_MIN_REQUIRED) || MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_6
++#    if !defined(MAC_OS_X_VERSION_MIN_REQUIRED) || MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_11_0
+ #       undef MAC_OS_X_VERSION_MIN_REQUIRED
+-#       define MAC_OS_X_VERSION_MIN_REQUIRED MAC_OS_X_VERSION_10_6
++#       define MAC_OS_X_VERSION_MIN_REQUIRED MAC_OS_X_VERSION_11_0
+ #    endif
+ #  endif
+ #


### PR DESCRIPTION
This PR is:
- required to [switch](https://github.com/bitcoin/bitcoin/pull/28622) to macOS 14 SDK (Xcode 15).
- an alternative to https://github.com/bitcoin/bitcoin/pull/28732.