### PR TITLE
Wallet: Functions to enable adding used balance to GUI overview page

### DIFF
--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -280,6 +280,9 @@ public:
     //! Return whether is a legacy wallet
     virtual bool isLegacy() = 0;
 
+    //Return whether wallet has 'avoid_reuse' flag set
+    virtual bool isAvoidReuseEnabled() = 0;
+
     //! Register handler for unload message.
     using UnloadFn = std::function<void()>;
     virtual std::unique_ptr<Handler> handleUnload(UnloadFn fn) = 0;
@@ -377,13 +380,14 @@ struct WalletBalances
     CAmount watch_only_balance = 0;
     CAmount unconfirmed_watch_only_balance = 0;
     CAmount immature_watch_only_balance = 0;
+    CAmount used = 0;
 
     bool balanceChanged(const WalletBalances& prev) const
     {
         return balance != prev.balance || unconfirmed_balance != prev.unconfirmed_balance ||
                immature_balance != prev.immature_balance || watch_only_balance != prev.watch_only_balance ||
                unconfirmed_watch_only_balance != prev.unconfirmed_watch_only_balance ||
-               immature_watch_only_balance != prev.immature_watch_only_balance;
+               immature_watch_only_balance != prev.immature_watch_only_balance || used != prev.used;;
     }
 };
 

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -410,6 +410,11 @@ public:
             result.unconfirmed_watch_only_balance = bal.m_watchonly_untrusted_pending;
             result.immature_watch_only_balance = bal.m_watchonly_immature;
         }
+        if (m_wallet->IsWalletFlagSet(WALLET_FLAG_AVOID_REUSE)) {
+            const auto full_bal = GetBalance(*m_wallet, 0, false);
+            result.used = full_bal.m_mine_trusted + full_bal.m_mine_untrusted_pending - bal.m_mine_trusted - bal.m_mine_untrusted_pending;
+        }
+
         return result;
     }
     bool tryGetBalances(WalletBalances& balances, uint256& block_hash) override
@@ -524,6 +529,7 @@ public:
         RemoveWallet(m_context, m_wallet, /*load_on_start=*/false);
     }
     bool isLegacy() override { return m_wallet->IsLegacy(); }
+    bool isAvoidReuseEnabled() override { return m_wallet->IsWalletFlagSet(WALLET_FLAG_AVOID_REUSE); }
     std::unique_ptr<Handler> handleUnload(UnloadFn fn) override
     {
         return MakeSignalHandler(m_wallet->NotifyUnload.connect(fn));


### PR DESCRIPTION
**First Part:** Fixes https://github.com/bitcoin-core/gui/issues/769

Functions to enable adding used balance to the overview page for wallets with the avoid_reuse flag

### Dependency

- **Part two**: https://github.com/bitcoin-core/gui/pull/775

![Screenshot from 2023-11-02 18-10-06](https://github.com/bitcoin/bitcoin/assets/15610188/99864db1-2b44-495d-a782-50b64f77094d)
