### PR TITLE
depends: drop -O1 workaround from arm64 apple Qt build

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -134,9 +134,6 @@ $(package)_config_opts_darwin += -no-feature-corewlan
 $(package)_config_opts_darwin += -no-freetype
 $(package)_config_opts_darwin += QMAKE_MACOSX_DEPLOYMENT_TARGET=$(OSX_MIN_VERSION)
 
-# Optimizing using > -O1 causes non-determinism when building across arches.
-$(package)_config_opts_aarch64_darwin += "QMAKE_CFLAGS_OPTIMIZE_FULL = -O1"
-
 ifneq ($(build_os),darwin)
 $(package)_config_opts_darwin += -xplatform macx-clang-linux
 $(package)_config_opts_darwin += -device-option MAC_SDK_PATH=$(OSX_SDK)


### PR DESCRIPTION
Drop the workaround of setting optimization flags to -O1 for the `arm64-apple-darwin` builds. I no-longer see reproducibility issues when building across `x86_64` and `aarch64`:
```bash
real	7m21.192s
user	67m41.047s
sys	5m8.596s
fedora-32gb-hel1-1 bitcoin]# find guix-build-$(git rev-parse --short=12 HEAD)/output/ -type f -print0 | env LC_ALL=C sort -z | xargs -r0 sha256sum
62373549d2884e8ef8f46a77b9a93f64ebfc88603569e9d33b68fc67beaf2226  guix-build-664c87354f9e/output/arm64-apple-darwin/SHA256SUMS.part
597889f1908fdb67a6419177a98935b7119c637a962f03f47270893c5ba3fd6f  guix-build-664c87354f9e/output/arm64-apple-darwin/bitcoin-664c87354f9e-arm64-apple-darwin-unsigned.tar.gz
289340354532a54a42b7235c831d13fdb28751c643f0fa0fc417ab195e9b5d90  guix-build-664c87354f9e/output/arm64-apple-darwin/bitcoin-664c87354f9e-arm64-apple-darwin-unsigned.zip
74f4ab3819a186d6c34ca0a4b9dda7c38fcb36bd9b22075a5d91df9bdd5df98a  guix-build-664c87354f9e/output/arm64-apple-darwin/bitcoin-664c87354f9e-arm64-apple-darwin.tar.gz
f0d0dad63057c7dddf6d6ccee244e7916ac0ee26b3bef8dd35f8430280043b38  guix-build-664c87354f9e/output/dist-archive/bitcoin-664c87354f9e.tar.gz
fedora-32gb-hel1-1 bitcoin]# uname -m
aarch64
```

```bash
real	18m10.759s
user	108m21.656s
sys	6m12.930s
ubuntu-32gb-hel1-1:~/bitcoin# find guix-build-$(git rev-parse --short=12 HEAD)/output/ -type f -print0 | env LC_ALL=C sort -z | xargs -r0 sha256sum
62373549d2884e8ef8f46a77b9a93f64ebfc88603569e9d33b68fc67beaf2226  guix-build-664c87354f9e/output/arm64-apple-darwin/SHA256SUMS.part
597889f1908fdb67a6419177a98935b7119c637a962f03f47270893c5ba3fd6f  guix-build-664c87354f9e/output/arm64-apple-darwin/bitcoin-664c87354f9e-arm64-apple-darwin-unsigned.tar.gz
289340354532a54a42b7235c831d13fdb28751c643f0fa0fc417ab195e9b5d90  guix-build-664c87354f9e/output/arm64-apple-darwin/bitcoin-664c87354f9e-arm64-apple-darwin-unsigned.zip
74f4ab3819a186d6c34ca0a4b9dda7c38fcb36bd9b22075a5d91df9bdd5df98a  guix-build-664c87354f9e/output/arm64-apple-darwin/bitcoin-664c87354f9e-arm64-apple-darwin.tar.gz
f0d0dad63057c7dddf6d6ccee244e7916ac0ee26b3bef8dd35f8430280043b38  guix-build-664c87354f9e/output/dist-archive/bitcoin-664c87354f9e.tar.gz
ubuntu-32gb-hel1-1:~/bitcoin# uname -m
x86_64
```