### PR TITLE
fuzz: Avoid utxo_total_supply timeout (take 2)

### DIFF
--- a/src/test/fuzz/utxo_total_supply.cpp
+++ b/src/test/fuzz/utxo_total_supply.cpp
@@ -94,8 +94,8 @@ FUZZ_TARGET(utxo_total_supply)
     assert(ActiveHeight() == 0);
     // Get at which height we duplicate the coinbase
     // Assuming that the fuzzer will mine relatively short chains (less than 200 blocks), we want the duplicate coinbase to be not too high.
-    // Up to 2000 seems reasonable.
-    int64_t duplicate_coinbase_height = fuzzed_data_provider.ConsumeIntegralInRange(0, 20 * COINBASE_MATURITY);
+    // Up to 300 seems reasonable.
+    int64_t duplicate_coinbase_height = fuzzed_data_provider.ConsumeIntegralInRange(0, 300);
     // Always pad with OP_0 at the end to avoid bad-cb-length error
     const CScript duplicate_coinbase_script = CScript() << duplicate_coinbase_height << OP_0;
     // Mine the first block with this duplicate
@@ -121,7 +121,7 @@ FUZZ_TARGET(utxo_total_supply)
 
     // Limit to avoid timeout, but enough to cover duplicate_coinbase_height
     // and CVE-2018-17144.
-    LIMITED_WHILE(fuzzed_data_provider.remaining_bytes(), 2'000)
+    LIMITED_WHILE(fuzzed_data_provider.remaining_bytes(), 2'00)
     {
         CallOneOf(
             fuzzed_data_provider,


### PR DESCRIPTION
Looks like this still may take a long time to run large fuzz inputs. Thus, reduce it further, but still allow it to catch the regression, if re-introduced:

```diff
diff --git a/src/consensus/tx_check.cpp b/src/consensus/tx_check.cpp
index f949655909..4bdd15c5ee 100644
--- a/src/consensus/tx_check.cpp
+++ b/src/consensus/tx_check.cpp
@@ -40,7 +40,7 @@ bool CheckTransaction(const CTransaction& tx, TxValidationState& state)
     std::set<COutPoint> vInOutPoints;
     for (const auto& txin : tx.vin) {
         if (!vInOutPoints.insert(txin.prevout).second)
-            return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-txns-inputs-duplicate");
+            {}//return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-txns-inputs-duplicate");
     }
 
     if (tx.IsCoinBase())
```

This is the second take, see https://github.com/bitcoin/bitcoin/pull/27780. If in the future it still times out, I think the fuzz test can just be removed.


Example input:

```
JREROy5pcnAgQyw7IC4ODg4ODg4ODg4O0dEODg4ODg4ZDg4ODg4ODg4ODg7RDg4ODg4ODg4O0dEODg4ODg4ODg4ODg7R0Q4ODg4ODg4ODtHRDg4ODtHR0dEODg4O0dEODg7R0Q4ODg4ODg4ODtHRDg4ODg4ODg4ODg4O0dEODg4ODg4ODg7R0Q4ODg7R0Q4O0dEODg4ODg4ODg4ODg7R0Q4ODg4ODtHRDg4ODtHR