### PR TITLE
ci: Drop no longer needed "Fix Visual Studio installation" step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,37 +136,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Fix Visual Studio installation
-        # See: https://github.com/actions/runner-images/issues/7832#issuecomment-1617585694.
-        run: |
-          Set-Location "C:\Program Files (x86)\Microsoft Visual Studio\Installer\"
-          $InstallPath = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"
-          $componentsToRemove= @(
-            "Microsoft.VisualStudio.Component.VC.14.35.17.5.ARM"
-            "Microsoft.VisualStudio.Component.VC.14.35.17.5.ARM.Spectre"
-            "Microsoft.VisualStudio.Component.VC.14.35.17.5.ARM64"
-            "Microsoft.VisualStudio.Component.VC.14.35.17.5.ARM64.Spectre"
-            "Microsoft.VisualStudio.Component.VC.14.35.17.5.x86.x64"
-            "Microsoft.VisualStudio.Component.VC.14.35.17.5.x86.x64.Spectre"
-            "Microsoft.VisualStudio.Component.VC.14.35.17.5.ATL"
-            "Microsoft.VisualStudio.Component.VC.14.35.17.5.ATL.Spectre"
-            "Microsoft.VisualStudio.Component.VC.14.35.17.5.ATL.ARM"
-            "Microsoft.VisualStudio.Component.VC.14.35.17.5.ATL.ARM.Spectre"
-            "Microsoft.VisualStudio.Component.VC.14.35.17.5.ATL.ARM64"
-            "Microsoft.VisualStudio.Component.VC.14.35.17.5.ATL.ARM64.Spectre"
-            "Microsoft.VisualStudio.Component.VC.14.35.17.5.MFC"
-            "Microsoft.VisualStudio.Component.VC.14.35.17.5.MFC.Spectre"
-            "Microsoft.VisualStudio.Component.VC.14.35.17.5.MFC.ARM"
-            "Microsoft.VisualStudio.Component.VC.14.35.17.5.MFC.ARM.Spectre"
-            "Microsoft.VisualStudio.Component.VC.14.35.17.5.MFC.ARM64"
-            "Microsoft.VisualStudio.Component.VC.14.35.17.5.MFC.ARM64.Spectre"
-          )
-          [string]$workloadArgs = $componentsToRemove | ForEach-Object {" --remove " +  $_}
-          $Arguments = ('/c', "vs_installer.exe", 'modify', '--installPath', "`"$InstallPath`"",$workloadArgs, '--quiet', '--norestart', '--nocache')
-          # should be run twice
-          $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
-          $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
-
       - name: Configure Developer Command Prompt for Microsoft Visual C++
         # Using microsoft/setup-msbuild is not enough.
         uses: ilammy/msvc-dev-cmd@v1


### PR DESCRIPTION
The underlying issue has been [fixed](https://github.com/actions/runner-images/pull/8686) in the image version 20231029.