### PR TITLE
rpc: Add script verification flags to getdeploymentinfo

### DIFF
--- a/src/deploymentinfo.cpp
+++ b/src/deploymentinfo.cpp
@@ -5,6 +5,8 @@
 #include <deploymentinfo.h>
 
 #include <consensus/params.h>
+#include <script/interpreter.h>
+#include <tinyformat.h>
 
 #include <string_view>
 
@@ -51,4 +53,48 @@ std::optional<Consensus::BuriedDeployment> GetBuriedDeployment(const std::string
         return Consensus::BuriedDeployment::DEPLOYMENT_CSV;
     }
     return std::nullopt;
+}
+
+#define FLAG_NAME(flag) {std::string(#flag), SCRIPT_VERIFY_##flag}
+const std::map<std::string, uint32_t> g_verify_flag_names{
+    FLAG_NAME(P2SH),
+    FLAG_NAME(STRICTENC),
+    FLAG_NAME(DERSIG),
+    FLAG_NAME(LOW_S),
+    FLAG_NAME(SIGPUSHONLY),
+    FLAG_NAME(MINIMALDATA),
+    FLAG_NAME(NULLDUMMY),
+    FLAG_NAME(DISCOURAGE_UPGRADABLE_NOPS),
+    FLAG_NAME(CLEANSTACK),
+    FLAG_NAME(MINIMALIF),
+    FLAG_NAME(NULLFAIL),
+    FLAG_NAME(CHECKLOCKTIMEVERIFY),
+    FLAG_NAME(CHECKSEQUENCEVERIFY),
+    FLAG_NAME(WITNESS),
+    FLAG_NAME(DISCOURAGE_UPGRADABLE_WITNESS_PROGRAM),
+    FLAG_NAME(WITNESS_PUBKEYTYPE),
+    FLAG_NAME(CONST_SCRIPTCODE),
+    FLAG_NAME(TAPROOT),
+    FLAG_NAME(DISCOURAGE_UPGRADABLE_PUBKEYTYPE),
+    FLAG_NAME(DISCOURAGE_OP_SUCCESS),
+    FLAG_NAME(DISCOURAGE_UPGRADABLE_TAPROOT_VERSION),
+};
+#undef FLAG_NAME
+
+std::vector<std::string> GetScriptFlagNames(uint32_t flags)
+{
+    std::vector<std::string> res;
+    if (flags == 0) return res;
+
+    uint32_t leftover = flags;
+    for (const auto& [name, flag] : g_verify_flag_names) {
+        if ((flags & flag) != 0) {
+            res.push_back(name);
+            leftover &= ~flag;
+        }
+    }
+    if (leftover != 0) {
+        res.push_back(strprintf("0x%08x", leftover));
+    }
+    return res;
 }

--- a/src/deploymentinfo.h
+++ b/src/deploymentinfo.h
@@ -7,8 +7,12 @@
 
 #include <consensus/params.h>
 
+#include <cassert>
+#include <cstdint>
+#include <map>
 #include <optional>
 #include <string>
+#include <string_view>
 
 struct VBDeploymentInfo {
     /** Deployment name */
@@ -28,5 +32,9 @@ inline std::string DeploymentName(Consensus::DeploymentPos pos)
 }
 
 std::optional<Consensus::BuriedDeployment> GetBuriedDeployment(const std::string_view deployment_name);
+
+extern const std::map<std::string, uint32_t> g_verify_flag_names;
+
+std::vector<std::string> GetScriptFlagNames(uint32_t flags);
 
 #endif // BITCOIN_DEPLOYMENTINFO_H

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1330,6 +1330,9 @@ RPCHelpMan getdeploymentinfo()
             RPCResult::Type::OBJ, "", "", {
                 {RPCResult::Type::STR, "hash", "requested block hash (or tip)"},
                 {RPCResult::Type::NUM, "height", "requested block height (or tip)"},
+                {RPCResult::Type::ARR, "script_flags", "script verify flags for the block", {
+                    {RPCResult::Type::STR, "flag", "a script verify flag"},
+                }},
                 {RPCResult::Type::OBJ_DYN, "deployments", "", {
                     {RPCResult::Type::OBJ, "xxxx", "name of the deployment", RPCHelpForDeployment}
                 }},
@@ -1356,6 +1359,12 @@ RPCHelpMan getdeploymentinfo()
             UniValue deploymentinfo(UniValue::VOBJ);
             deploymentinfo.pushKV("hash", blockindex->GetBlockHash().ToString());
             deploymentinfo.pushKV("height", blockindex->nHeight);
+            {
+                const auto flagnames = GetScriptFlagNames(GetBlockScriptFlags(*blockindex, chainman));
+                UniValue uv_flagnames(UniValue::VARR);
+                uv_flagnames.push_backV(flagnames.begin(), flagnames.end());
+                deploymentinfo.pushKV("script_flags", uv_flagnames);
+            }
             deploymentinfo.pushKV("deployments", DeploymentInfo(blockindex, chainman));
             return deploymentinfo;
         },

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -7,6 +7,7 @@
 
 #include <common/system.h>
 #include <core_io.h>
+#include <deploymentinfo.h>
 #include <key.h>
 #include <rpc/util.h>
 #include <script/script.h>
@@ -22,6 +23,7 @@
 #include <test/util/transaction_utils.h>
 #include <util/fs.h>
 #include <util/strencodings.h>
+#include <util/string.h>
 
 #if defined(HAVE_CONSENSUS_LIB)
 #include <script/bitcoinconsensus.h>
@@ -42,7 +44,6 @@
 static const unsigned int gFlags = SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_STRICTENC;
 
 unsigned int ParseScriptFlags(std::string strFlags);
-std::string FormatScriptFlags(unsigned int flags);
 
 struct ScriptErrorDesc
 {
@@ -95,6 +96,11 @@ static ScriptErrorDesc script_errors[]={
     {SCRIPT_ERR_OP_CODESEPARATOR, "OP_CODESEPARATOR"},
     {SCRIPT_ERR_SIG_FINDANDDELETE, "SIG_FINDANDDELETE"},
 };
+
+std::string FormatScriptFlags(uint32_t flags)
+{
+    return Join(GetScriptFlagNames(flags), ",");
+}
 
 static std::string FormatScriptError(ScriptError_t err)
 {
@@ -1893,6 +1899,15 @@ BOOST_AUTO_TEST_CASE(compute_tapleaf)
 
     BOOST_CHECK_EQUAL(ComputeTapleafHash(0xc0, Span(script)), tlc0);
     BOOST_CHECK_EQUAL(ComputeTapleafHash(0xc2, Span(script)), tlc2);
+}
+
+BOOST_AUTO_TEST_CASE(formatscriptflags)
+{
+    // quick check that FormatScriptFlags reports any unknown/unexpected bits
+    BOOST_CHECK_EQUAL(FormatScriptFlags(SCRIPT_VERIFY_P2SH), "P2SH");
+    BOOST_CHECK_EQUAL(FormatScriptFlags(SCRIPT_VERIFY_P2SH | (1u<<31)), "P2SH,0x80000000");
+    BOOST_CHECK_EQUAL(FormatScriptFlags(SCRIPT_VERIFY_TAPROOT | (1u<<27)), "TAPROOT,0x08000000");
+    BOOST_CHECK_EQUAL(FormatScriptFlags(1u<<26), "0x04000000");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -12,6 +12,7 @@
 #include <consensus/tx_check.h>
 #include <consensus/validation.h>
 #include <core_io.h>
+#include <deploymentinfo.h>
 #include <key.h>
 #include <policy/policy.h>
 #include <policy/settings.h>
@@ -43,29 +44,7 @@ typedef std::vector<unsigned char> valtype;
 static CFeeRate g_dust{DUST_RELAY_TX_FEE};
 static bool g_bare_multi{DEFAULT_PERMIT_BAREMULTISIG};
 
-static std::map<std::string, unsigned int> mapFlagNames = {
-    {std::string("P2SH"), (unsigned int)SCRIPT_VERIFY_P2SH},
-    {std::string("STRICTENC"), (unsigned int)SCRIPT_VERIFY_STRICTENC},
-    {std::string("DERSIG"), (unsigned int)SCRIPT_VERIFY_DERSIG},
-    {std::string("LOW_S"), (unsigned int)SCRIPT_VERIFY_LOW_S},
-    {std::string("SIGPUSHONLY"), (unsigned int)SCRIPT_VERIFY_SIGPUSHONLY},
-    {std::string("MINIMALDATA"), (unsigned int)SCRIPT_VERIFY_MINIMALDATA},
-    {std::string("NULLDUMMY"), (unsigned int)SCRIPT_VERIFY_NULLDUMMY},
-    {std::string("DISCOURAGE_UPGRADABLE_NOPS"), (unsigned int)SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_NOPS},
-    {std::string("CLEANSTACK"), (unsigned int)SCRIPT_VERIFY_CLEANSTACK},
-    {std::string("MINIMALIF"), (unsigned int)SCRIPT_VERIFY_MINIMALIF},
-    {std::string("NULLFAIL"), (unsigned int)SCRIPT_VERIFY_NULLFAIL},
-    {std::string("CHECKLOCKTIMEVERIFY"), (unsigned int)SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY},
-    {std::string("CHECKSEQUENCEVERIFY"), (unsigned int)SCRIPT_VERIFY_CHECKSEQUENCEVERIFY},
-    {std::string("WITNESS"), (unsigned int)SCRIPT_VERIFY_WITNESS},
-    {std::string("DISCOURAGE_UPGRADABLE_WITNESS_PROGRAM"), (unsigned int)SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_WITNESS_PROGRAM},
-    {std::string("WITNESS_PUBKEYTYPE"), (unsigned int)SCRIPT_VERIFY_WITNESS_PUBKEYTYPE},
-    {std::string("CONST_SCRIPTCODE"), (unsigned int)SCRIPT_VERIFY_CONST_SCRIPTCODE},
-    {std::string("TAPROOT"), (unsigned int)SCRIPT_VERIFY_TAPROOT},
-    {std::string("DISCOURAGE_UPGRADABLE_PUBKEYTYPE"), (unsigned int)SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_PUBKEYTYPE},
-    {std::string("DISCOURAGE_OP_SUCCESS"), (unsigned int)SCRIPT_VERIFY_DISCOURAGE_OP_SUCCESS},
-    {std::string("DISCOURAGE_UPGRADABLE_TAPROOT_VERSION"), (unsigned int)SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_TAPROOT_VERSION},
-};
+static const std::map<std::string, unsigned int>& mapFlagNames = g_verify_flag_names;
 
 unsigned int ParseScriptFlags(std::string strFlags)
 {
@@ -75,9 +54,11 @@ unsigned int ParseScriptFlags(std::string strFlags)
 
     for (const std::string& word : words)
     {
-        if (!mapFlagNames.count(word))
+        if (!mapFlagNames.count(word)) {
             BOOST_ERROR("Bad test: unknown verification flag '" << word << "'");
-        flags |= mapFlagNames[word];
+            continue;
+        }
+        flags |= mapFlagNames.at(word);
     }
 
     return flags;
@@ -91,22 +72,6 @@ bool CheckMapFlagNames()
         standard_flags_missing &= ~(pair.second);
     }
     return standard_flags_missing == 0;
-}
-
-std::string FormatScriptFlags(unsigned int flags)
-{
-    if (flags == 0) {
-        return "";
-    }
-    std::string ret;
-    std::map<std::string, unsigned int>::const_iterator it = mapFlagNames.begin();
-    while (it != mapFlagNames.end()) {
-        if (flags & it->second) {
-            ret += it->first + ",";
-        }
-        it++;
-    }
-    return ret.substr(0, ret.size() - 1);
 }
 
 /*

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -255,9 +255,6 @@ bool CheckSequenceLocksAtTip(CBlockIndex* tip,
     return EvaluateSequenceLocks(index, {lock_points.height, lock_points.time});
 }
 
-// Returns the script flags which should be checked for a given block
-static unsigned int GetBlockScriptFlags(const CBlockIndex& block_index, const ChainstateManager& chainman);
-
 static void LimitMempoolSize(CTxMemPool& pool, CCoinsViewCache& coins_cache)
     EXCLUSIVE_LOCKS_REQUIRED(::cs_main, pool.cs)
 {
@@ -2109,7 +2106,7 @@ public:
     }
 };
 
-static unsigned int GetBlockScriptFlags(const CBlockIndex& block_index, const ChainstateManager& chainman)
+unsigned int GetBlockScriptFlags(const CBlockIndex& block_index, const ChainstateManager& chainman)
 {
     const Consensus::Params& consensusparams = chainman.GetConsensus();
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -1300,4 +1300,7 @@ bool IsBIP30Repeat(const CBlockIndex& block_index);
 /** Identifies blocks which coinbase output was subsequently overwritten in the UTXO set (see BIP30) */
 bool IsBIP30Unspendable(const CBlockIndex& block_index);
 
+// Returns the script flags which should be checked for a given block
+unsigned int GetBlockScriptFlags(const CBlockIndex& block_index, const ChainstateManager& chainman);
+
 #endif // BITCOIN_VALIDATION_H

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -197,6 +197,7 @@ class BlockchainTest(BitcoinTestFramework):
         assert_equal(gdi_result, {
           "hash": blockhash,
           "height": height,
+          "script_flags": ["CHECKLOCKTIMEVERIFY","CHECKSEQUENCEVERIFY","DERSIG","NULLDUMMY","P2SH","TAPROOT","WITNESS"],
           "deployments": {
             'bip34': {'type': 'buried', 'active': True, 'height': 2},
             'bip66': {'type': 'buried', 'active': True, 'height': 3},


### PR DESCRIPTION
Adds a `script_flags` field to the output of the `getdeploymentinfo` RPC that lists the flags selected by `GetBlockScriptFlags()`. This can be useful for seeing the detailed consequences of soft-fork activation behaviour, eg:

```sh
$ bitcoin-cli getdeploymentinfo | jq -j '.deployments | to_entries | .[] | (.value.height, " ", .key, "\n")'
227931 bip34
363725 bip66
388381 bip65
419328 csv
481824 segwit
709632 taproot
$ for a in 1 170060 227931 363725 388381 419328 481824 692261 709632; do echo -n "$a: "; bitcoin-cli getdeploymentinfo $(bitcoin-cli getblockhash $a) | jq -r .script_flags; done
1: P2SH,TAPROOT,WITNESS
170060: 
227931: P2SH,TAPROOT,WITNESS
363725: DERSIG,P2SH,TAPROOT,WITNESS
388381: CHECKLOCKTIMEVERIFY,DERSIG,P2SH,TAPROOT,WITNESS
419328: CHECKLOCKTIMEVERIFY,CHECKSEQUENCEVERIFY,DERSIG,P2SH,TAPROOT,WITNESS
481824: CHECKLOCKTIMEVERIFY,CHECKSEQUENCEVERIFY,DERSIG,NULLDUMMY,P2SH,TAPROOT,WITNESS
692261: CHECKLOCKTIMEVERIFY,CHECKSEQUENCEVERIFY,DERSIG,NULLDUMMY,P2SH,WITNESS
709632: CHECKLOCKTIMEVERIFY,CHECKSEQUENCEVERIFY,DERSIG,NULLDUMMY,P2SH,TAPROOT,WITNESS
```

This allows you to see that P2SH, WITNESS and TAPROOT are enforced since genesis; that the p2sh exception block (170060) has none of these extra rules enforced, that the taproot exception block (692261) is exempted from taproot enforcement, and exactly which rules were activated by each soft fork (eg, NULLDUMMY as part of the segwit soft fork).