### PR TITLE
refactor: Miniminer package linearization followups

### DIFF
--- a/src/node/mini_miner.cpp
+++ b/src/node/mini_miner.cpp
@@ -154,7 +154,7 @@ MiniMiner::MiniMiner(const std::vector<MiniMinerMempoolEntry>& manual_entries,
             m_ready_to_calculate = false;
             return;
         }
-        std::vector<MockEntryMap::iterator> cached_descendants;
+        std::vector<MockEntryMap::iterator> descendants;
         for (const auto& desc_txid : desc_txids) {
             auto desc_it{m_entries_by_txid.find(desc_txid)};
             // Descendants should only include transactions with corresponding entries.
@@ -162,10 +162,10 @@ MiniMiner::MiniMiner(const std::vector<MiniMinerMempoolEntry>& manual_entries,
                 m_ready_to_calculate = false;
                 return;
             } else {
-                cached_descendants.emplace_back(desc_it);
+                descendants.emplace_back(desc_it);
             }
         }
-        m_descendant_set_by_txid.emplace(txid, cached_descendants);
+        m_descendant_set_by_txid.emplace(txid, descendants);
     }
     Assume(m_to_be_replaced.empty());
     Assume(m_requested_outpoints_by_txid.empty());

--- a/src/node/mini_miner.cpp
+++ b/src/node/mini_miner.cpp
@@ -78,11 +78,11 @@ MiniMiner::MiniMiner(const CTxMemPool& mempool, const std::vector<COutPoint>& ou
     for (const auto& txiter : cluster) {
         if (!m_to_be_replaced.count(txiter->GetTx().GetHash())) {
             auto [mapiter, success] = m_entries_by_txid.emplace(txiter->GetTx().GetHash(),
-                MiniMinerMempoolEntry{/*fee_self=*/txiter->GetModifiedFee(),
-                                      /*fee_ancestor=*/txiter->GetModFeesWithAncestors(),
+                MiniMinerMempoolEntry{/*tx_in=*/txiter->GetSharedTx(),
                                       /*vsize_self=*/txiter->GetTxSize(),
                                       /*vsize_ancestor=*/txiter->GetSizeWithAncestors(),
-                                      /*tx_in=*/txiter->GetSharedTx()});
+                                      /*fee_self=*/txiter->GetModifiedFee(),
+                                      /*fee_ancestor=*/txiter->GetModFeesWithAncestors()});
             m_entries.push_back(mapiter);
         } else {
             auto outpoints_it = m_requested_outpoints_by_txid.find(txiter->GetTx().GetHash());

--- a/src/node/mini_miner.h
+++ b/src/node/mini_miner.h
@@ -137,10 +137,10 @@ public:
     */
     MiniMiner(const CTxMemPool& mempool, const std::vector<COutPoint>& outpoints);
 
-    /** Constructor in which the MiniMinerMempoolEntry entries have been constructed manually,
-     * presumably because these transactions are not in the mempool (yet). It is assumed that all
-     * entries are unique and their values are correct, otherwise results computed by MiniMiner may
-     * be incorrect. Callers should check IsReadyToCalculate() after construction.
+    /** Constructor in which the MiniMinerMempoolEntry entries have been constructed manually.
+     * It is assumed that all entries are unique and their values are correct, otherwise results
+     * computed by MiniMiner may be incorrect. Callers should check IsReadyToCalculate() after
+     * construction.
      * @param[in] descendant_caches A map from each transaction to the set of txids of this
      *                              transaction's descendant set, including itself. Each tx in
      *                              manual_entries must have a corresponding entry in this map, and

--- a/src/node/mini_miner.h
+++ b/src/node/mini_miner.h
@@ -34,11 +34,11 @@ class MiniMinerMempoolEntry
 // methods can be called without holding that lock.
 
 public:
-    explicit MiniMinerMempoolEntry(CAmount fee_self,
-                                   CAmount fee_ancestor,
+    explicit MiniMinerMempoolEntry(const CTransactionRef& tx_in,
                                    int64_t vsize_self,
                                    int64_t vsize_ancestor,
-                                   const CTransactionRef& tx_in):
+                                   CAmount fee_self,
+                                   CAmount fee_ancestor):
         tx{tx_in},
         vsize_individual{vsize_self},
         vsize_with_ancestors{vsize_ancestor},

--- a/src/test/miniminer_tests.cpp
+++ b/src/test/miniminer_tests.cpp
@@ -646,7 +646,7 @@ BOOST_FIXTURE_TEST_CASE(manual_ctor, TestChain100Setup)
     CTxMemPool& pool = *Assert(m_node.mempool);
     LOCK2(cs_main, pool.cs);
     {
-        // 3 pairs of fee-bumping grandparent + parent, plus 1 low-feerate child.
+        // 3 pairs of grandparent + fee-bumping parent, plus 1 low-feerate child.
         // 0 fee + high fee
         auto grandparent_zero_fee = make_tx({{m_coinbase_txns.at(0)->GetHash(), 0}}, 1);
         auto parent_high_feerate = make_tx({{grandparent_zero_fee->GetHash(), 0}}, 1);
@@ -692,7 +692,7 @@ BOOST_FIXTURE_TEST_CASE(manual_ctor, TestChain100Setup)
         BOOST_CHECK_EQUAL(sequences.at(grandparent_double_low_feerate->GetHash()), 1);
         BOOST_CHECK_EQUAL(sequences.at(parent_med_feerate->GetHash()), 1);
 
-        // CPFP low + med
+        // CPFP low + double low
         BOOST_CHECK_EQUAL(sequences.at(grandparent_low_feerate->GetHash()), 2);
         BOOST_CHECK_EQUAL(sequences.at(parent_double_low_feerate->GetHash()), 2);
 

--- a/src/test/miniminer_tests.cpp
+++ b/src/test/miniminer_tests.cpp
@@ -325,14 +325,14 @@ BOOST_FIXTURE_TEST_CASE(miniminer_1p1c, TestChain100Setup)
         const int32_t tx6_vsize{tx_dims.at(tx6->GetHash()).vsize};
         const int32_t tx7_vsize{tx_dims.at(tx7->GetHash()).vsize};
 
-        miniminer_info.emplace_back(/*fee_self=*/med_fee,/*fee_ancestor=*/med_fee,/*vsize_self=*/tx0_vsize,/*vsize_ancestor=*/tx0_vsize, tx0);
-        miniminer_info.emplace_back(             med_fee,               2*med_fee,               tx1_vsize,       tx0_vsize + tx1_vsize, tx1);
-        miniminer_info.emplace_back(             low_fee,                 low_fee,               tx2_vsize,                   tx2_vsize, tx2);
-        miniminer_info.emplace_back(            high_fee,      low_fee + high_fee,               tx3_vsize,       tx2_vsize + tx3_vsize, tx3);
-        miniminer_info.emplace_back(             low_fee,                 low_fee,               tx4_vsize,                   tx4_vsize, tx4);
-        miniminer_info.emplace_back(         tx5_mod_fee,   low_fee + tx5_mod_fee,               tx5_vsize,       tx4_vsize + tx5_vsize, tx5);
-        miniminer_info.emplace_back(            high_fee,                high_fee,               tx6_vsize,                   tx6_vsize, tx6);
-        miniminer_info.emplace_back(             low_fee,      high_fee + low_fee,               tx7_vsize,       tx6_vsize + tx7_vsize, tx7);
+        miniminer_info.emplace_back(tx0,/*vsize_self=*/tx0_vsize,/*vsize_ancestor=*/tx0_vsize,/*fee_self=*/med_fee,/*fee_ancestor=*/med_fee);
+        miniminer_info.emplace_back(tx1,               tx1_vsize,       tx0_vsize + tx1_vsize,             med_fee,               2*med_fee);
+        miniminer_info.emplace_back(tx2,               tx2_vsize,                   tx2_vsize,             low_fee,                 low_fee);
+        miniminer_info.emplace_back(tx3,               tx3_vsize,       tx2_vsize + tx3_vsize,            high_fee,      low_fee + high_fee);
+        miniminer_info.emplace_back(tx4,               tx4_vsize,                   tx4_vsize,             low_fee,                 low_fee);
+        miniminer_info.emplace_back(tx5,               tx5_vsize,       tx4_vsize + tx5_vsize,         tx5_mod_fee,   low_fee + tx5_mod_fee);
+        miniminer_info.emplace_back(tx6,               tx6_vsize,                   tx6_vsize,            high_fee,                high_fee);
+        miniminer_info.emplace_back(tx7,               tx7_vsize,       tx6_vsize + tx7_vsize,             low_fee,      high_fee + low_fee);
     }
     std::map<Txid, std::set<Txid>> descendant_caches;
     descendant_caches.emplace(tx0->GetHash(), std::set<Txid>{tx0->GetHash(), tx1->GetHash()});
@@ -543,15 +543,14 @@ BOOST_FIXTURE_TEST_CASE(miniminer_overlap, TestChain100Setup)
     }
     // Check linearization order
     std::vector<node::MiniMinerMempoolEntry> miniminer_info;
-    miniminer_info.emplace_back(/*fee_self=*/low_fee,   /*fee_ancestor=*/low_fee,/*vsize_self=*/tx_vsizes[0],                     /*vsize_ancestor=*/tx_vsizes[0], tx0);
-    miniminer_info.emplace_back(             med_fee,                    med_fee,               tx_vsizes[1],                                        tx_vsizes[1], tx1);
-    miniminer_info.emplace_back(            high_fee,                   high_fee,               tx_vsizes[2],                                        tx_vsizes[2], tx2);
-    miniminer_info.emplace_back(            high_fee, low_fee+med_fee+2*high_fee,               tx_vsizes[3], tx_vsizes[0]+tx_vsizes[1]+tx_vsizes[2]+tx_vsizes[3], tx3);
-
-    miniminer_info.emplace_back(            high_fee,                   high_fee,               tx_vsizes[4],                                        tx_vsizes[4], tx4);
-    miniminer_info.emplace_back(             low_fee,         low_fee + high_fee,               tx_vsizes[5],                           tx_vsizes[4]+tx_vsizes[5], tx5);
-    miniminer_info.emplace_back(             med_fee,   high_fee+low_fee+med_fee,               tx_vsizes[6],              tx_vsizes[4]+tx_vsizes[5]+tx_vsizes[6], tx6);
-    miniminer_info.emplace_back(            high_fee,  high_fee+low_fee+high_fee,               tx_vsizes[7],              tx_vsizes[4]+tx_vsizes[5]+tx_vsizes[7], tx7);
+    miniminer_info.emplace_back(tx0,/*vsize_self=*/tx_vsizes[0],                     /*vsize_ancestor=*/tx_vsizes[0], /*fee_self=*/low_fee,   /*fee_ancestor=*/low_fee);
+    miniminer_info.emplace_back(tx1,               tx_vsizes[1],                                        tx_vsizes[1],              med_fee,                    med_fee);
+    miniminer_info.emplace_back(tx2,               tx_vsizes[2],                                        tx_vsizes[2],             high_fee,                   high_fee);
+    miniminer_info.emplace_back(tx3,               tx_vsizes[3], tx_vsizes[0]+tx_vsizes[1]+tx_vsizes[2]+tx_vsizes[3],             high_fee, low_fee+med_fee+2*high_fee);
+    miniminer_info.emplace_back(tx4,               tx_vsizes[4],                                        tx_vsizes[4],             high_fee,                   high_fee);
+    miniminer_info.emplace_back(tx5,               tx_vsizes[5],                           tx_vsizes[4]+tx_vsizes[5],              low_fee,         low_fee + high_fee);
+    miniminer_info.emplace_back(tx6,               tx_vsizes[6],              tx_vsizes[4]+tx_vsizes[5]+tx_vsizes[6],              med_fee,   high_fee+low_fee+med_fee);
+    miniminer_info.emplace_back(tx7,               tx_vsizes[7],              tx_vsizes[4]+tx_vsizes[5]+tx_vsizes[7],             high_fee,  high_fee+low_fee+high_fee);
 
     std::map<Txid, std::set<Txid>> descendant_caches;
     descendant_caches.emplace(tx0->GetHash(), std::set<Txid>{tx0->GetHash(), tx3->GetHash()});
@@ -665,13 +664,13 @@ BOOST_FIXTURE_TEST_CASE(manual_ctor, TestChain100Setup)
         const int64_t child_vsize{1000};
 
         std::vector<node::MiniMinerMempoolEntry> miniminer_info;
-        miniminer_info.emplace_back(/*fee_self=*/0,         /*fee_ancestor=*/0,/*vsize_self=*/tx_vsize,/*vsize_ancestor=*/tx_vsize, grandparent_zero_fee);
-        miniminer_info.emplace_back(      high_fee,                   high_fee,               tx_vsize,                 2*tx_vsize, parent_high_feerate);
-        miniminer_info.emplace_back(     2*low_fee,                  2*low_fee,               tx_vsize,                   tx_vsize, grandparent_double_low_feerate);
-        miniminer_info.emplace_back(       med_fee,          2*low_fee+med_fee,               tx_vsize,                 2*tx_vsize, parent_med_feerate);
-        miniminer_info.emplace_back(       low_fee,                    low_fee,               tx_vsize,                   tx_vsize, grandparent_low_feerate);
-        miniminer_info.emplace_back(     2*low_fee,                  3*low_fee,               tx_vsize,                 2*tx_vsize, parent_double_low_feerate);
-        miniminer_info.emplace_back(       low_fee, high_fee+med_fee+6*low_fee,            child_vsize,     6*tx_vsize+child_vsize, child);
+        miniminer_info.emplace_back(grandparent_zero_fee,          /*vsize_self=*/tx_vsize,/*vsize_ancestor=*/tx_vsize, /*fee_self=*/0,/*fee_ancestor=*/0);
+        miniminer_info.emplace_back(parent_high_feerate,                          tx_vsize,                 2*tx_vsize, high_fee,      high_fee);
+        miniminer_info.emplace_back(grandparent_double_low_feerate,               tx_vsize,                   tx_vsize, 2*low_fee,     2*low_fee);
+        miniminer_info.emplace_back(parent_med_feerate,                           tx_vsize,                 2*tx_vsize, med_fee,       2*low_fee+med_fee);
+        miniminer_info.emplace_back(grandparent_low_feerate,                      tx_vsize,                   tx_vsize, low_fee,       low_fee);
+        miniminer_info.emplace_back(parent_double_low_feerate,                    tx_vsize,                 2*tx_vsize, 2*low_fee,     3*low_fee);
+        miniminer_info.emplace_back(child,                                     child_vsize,     6*tx_vsize+child_vsize, low_fee,       high_fee+med_fee+6*low_fee);
         std::map<Txid, std::set<Txid>> descendant_caches;
         descendant_caches.emplace(grandparent_zero_fee->GetHash(), std::set<Txid>{grandparent_zero_fee->GetHash(), parent_high_feerate->GetHash(), child->GetHash()});
         descendant_caches.emplace(grandparent_low_feerate->GetHash(), std::set<Txid>{grandparent_low_feerate->GetHash(), parent_double_low_feerate->GetHash(), child->GetHash()});


### PR DESCRIPTION
### Motivation
In https://github.com/bitcoin/bitcoin/pull/28762 there were some post merge comments which are being addressed in this PR with the following commits

### [8d4c46f](https://github.com/kevkevinpal/bitcoin/pull/5/commits/8d4c46f54d10fb67d20d7a9a6afa37ecfd2bdc18) Reorganizing `MiniMinerMempoolEntry` to match the order we have elsewhere
* https://github.com/bitcoin/bitcoin/pull/28762#discussion_r1381775670

### [7505ec2](https://github.com/kevkevinpal/bitcoin/pull/5/commits/7505ec2054e5918068e1f18f290c8d5e9e4c2590) Renaming `cached_descendants` to `descendants` for simpler variable naming
* https://github.com/bitcoin/bitcoin/pull/28762#discussion_r1381819567

### [b21f2f2](https://github.com/kevkevinpal/bitcoin/pull/5/commits/b21f2f2f5567dc16953df13d4423a315c2a040e1) Code comment modifications to be more accurate to what is actually happening 
* https://github.com/bitcoin/bitcoin/pull/28762#discussion_r1381902909 and
* https://github.com/bitcoin/bitcoin/pull/28762#discussion_r1382002278 and
* https://github.com/bitcoin/bitcoin/pull/28762#discussion_r1383041819 