### PR TITLE
rpc: permit any ancestor package through submitpackage

### DIFF
--- a/doc/policy/packages.md
+++ b/doc/policy/packages.md
@@ -5,14 +5,10 @@
 A **package** is an ordered list of transactions, representable by a connected Directed Acyclic
 Graph (a directed edge exists between a transaction that spends the output of another transaction).
 
+An **ancestor package** is a package consisting of 1 transaction and its unconfirmed ancestors.
+
 For every transaction `t` in a **topologically sorted** package, if any of its parents are present
 in the package, they appear somewhere in the list before `t`.
-
-A **child-with-unconfirmed-parents** package is a topologically sorted package that consists of
-exactly one child and all of its unconfirmed parents (no other transactions may be present).
-The last transaction in the package is the child, and its package can be canonically defined based
-on the current state: each of its inputs must be available in the UTXO set as of the current chain
-tip or some preceding transaction in the package.
 
 ## Package Mempool Acceptance Rules
 
@@ -51,8 +47,7 @@ The following rules are enforced for all packages:
 The following rules are only enforced for packages to be submitted to the mempool (not enforced for
 test accepts):
 
-* Packages must be child-with-unconfirmed-parents packages. This also means packages must contain at
-  least 2 transactions. (#22674)
+* Only ancestor packages are permitted. (#26711)
 
    - *Rationale*: This allows for fee-bumping by CPFP. Allowing multiple parents makes it possible
      to fee-bump a batch of transactions. Restricting packages to a defined topology is easier to
@@ -61,8 +56,8 @@ test accepts):
    - Warning: Batched fee-bumping may be unsafe for some use cases. Users and application developers
      should take caution if utilizing multi-parent packages.
 
-* Transactions in the package that have the same txid as another transaction already in the mempool
-  will be removed from the package prior to submission ("deduplication").
+* Transactions in the package that are already in the mempool or have the same txid as another
+  transaction already in the mempool are skipped ("deduplication").
 
    - *Rationale*: Node operators are free to set their mempool policies however they please, nodes
      may receive transactions in different orders, and malicious counterparties may try to take

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -237,6 +237,7 @@ BITCOIN_CORE_H = \
   node/validation_cache_args.h \
   noui.h \
   outputtype.h \
+  policy/ancestor_packages.h \
   policy/feerate.h \
   policy/fees.h \
   policy/fees_args.h \
@@ -438,6 +439,7 @@ libbitcoin_node_a_SOURCES = \
   node/utxo_snapshot.cpp \
   node/validation_cache_args.cpp \
   noui.cpp \
+  policy/ancestor_packages.cpp \
   policy/fees.cpp \
   policy/fees_args.cpp \
   policy/packages.cpp \
@@ -952,7 +954,9 @@ libbitcoinkernel_la_SOURCES = \
   logging.cpp \
   node/blockstorage.cpp \
   node/chainstate.cpp \
+  node/mini_miner.cpp \
   node/utxo_snapshot.cpp \
+  policy/ancestor_packages.cpp \
   policy/feerate.cpp \
   policy/fees.cpp \
   policy/packages.cpp \

--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -13,6 +13,7 @@ GENERATED_BENCH_FILES = $(RAW_BENCH_FILES:.raw=.raw.h)
 bench_bench_bitcoin_SOURCES = \
   $(RAW_BENCH_FILES) \
   bench/addrman.cpp \
+  bench/ancestorpackage.cpp \
   bench/base58.cpp \
   bench/bech32.cpp \
   bench/bench.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -242,6 +242,7 @@ test_fuzz_fuzz_SOURCES = \
  $(FUZZ_WALLET_SRC) \
  test/fuzz/addition_overflow.cpp \
  test/fuzz/addrman.cpp \
+ test/fuzz/ancestorpackage.cpp \
  test/fuzz/asmap.cpp \
  test/fuzz/asmap_direct.cpp \
  test/fuzz/autofile.cpp \

--- a/src/bench/ancestorpackage.cpp
+++ b/src/bench/ancestorpackage.cpp
@@ -1,0 +1,128 @@
+// Copyright (c) 2011-2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <bench/bench.h>
+#include <consensus/validation.h>
+#include <node/mini_miner.h>
+#include <policy/ancestor_packages.h>
+#include <random.h>
+#include <test/util/script.h>
+#include <test/util/setup_common.h>
+
+#include <deque>
+
+static void AncestorPackageRandom(benchmark::Bench& bench)
+{
+    FastRandomContext rand{true};
+    Package txns;
+
+    int cluster_size = 100;
+    if (bench.complexityN() > 1) {
+        cluster_size = static_cast<int>(bench.complexityN());
+    }
+
+    std::deque<COutPoint> available_coins;
+    for (uint32_t i = 0; i < uint32_t{100}; ++i) {
+        available_coins.emplace_back(uint256::ZERO, i);
+    }
+
+    for (uint32_t count = cluster_size - 1; !available_coins.empty() && count; --count)
+    {
+        CMutableTransaction mtx = CMutableTransaction();
+        const size_t num_inputs = rand.randrange(available_coins.size()) + 1;
+        const size_t num_outputs = rand.randrange(50) + 1;
+        for (size_t n{0}; n < num_inputs; ++n) {
+            auto prevout = available_coins.front();
+            mtx.vin.emplace_back(prevout, CScript());
+            available_coins.pop_front();
+        }
+        for (uint32_t n{0}; n < num_outputs; ++n) {
+            mtx.vout.emplace_back(100, P2WSH_OP_TRUE);
+        }
+        CTransactionRef tx = MakeTransactionRef(mtx);
+        txns.emplace_back(tx);
+
+        // At least one output is available for spending by descendant
+        for (uint32_t n{0}; n < num_outputs; ++n) {
+            if (n == 0 || rand.randbool()) {
+                available_coins.emplace_back(tx->GetHash(), n);
+            }
+        }
+    }
+
+    assert(!available_coins.empty());
+
+    // Now spend all available coins to make sure it's an ancestor package
+    size_t num_coins = available_coins.size();
+    CMutableTransaction child_mtx;
+    for (size_t avail = 0; avail < num_coins; avail++) {
+        auto prevout = available_coins[0];
+        child_mtx.vin.emplace_back(prevout, CScript());
+        available_coins.pop_front();
+    }
+    child_mtx.vout.emplace_back(100, P2WSH_OP_TRUE);
+    CTransactionRef child_tx = MakeTransactionRef(child_mtx);
+    txns.emplace_back(child_tx);
+
+    bench.run([&]() NO_THREAD_SAFETY_ANALYSIS {
+        AncestorPackage ancestor_package(txns);
+        assert(ancestor_package.IsAncestorPackage());
+        for (size_t i = 0; i < txns.size(); i++) {
+            ancestor_package.AddFeeAndVsize(txns[i]->GetHash(), rand.randrange(1000000), rand.randrange(1000));
+        }
+        ancestor_package.LinearizeWithFees();
+    });
+}
+
+static void AncestorPackageChain(benchmark::Bench& bench)
+{
+    FastRandomContext det_rand{true};
+
+    // A chain of 25 97-in-1-out transactions, where the nth tx spends the n-1th.  We are trying to
+    // maximize the number of transactions in the package (within MAX_PACKAGE_COUNT) and number of
+    // inputs to look up (while staying within MAX_PACKAGE_WEIGHT) for the "worst case" package.
+    const uint32_t num_txns{25};
+    int32_t total_weight{0};
+    Package txns;
+    txns.reserve(num_txns);
+
+    uint256 starting_txid{det_rand.rand256()};
+    uint256& last_txid = starting_txid;
+    for (uint32_t count{0}; count < num_txns; ++count) {
+        CMutableTransaction mtx = CMutableTransaction();
+        mtx.vin.reserve(97);
+        // First input is the output from the last tx.
+        mtx.vin.emplace_back(last_txid, 0);
+        // The rest are random.
+        for (uint32_t i{1}; i < 97; ++i) {
+            mtx.vin.emplace_back(det_rand.rand256(), count * 100 + i);
+        }
+
+        mtx.vout.emplace_back(1000, P2WSH_OP_TRUE);
+        CTransactionRef tx = MakeTransactionRef(mtx);
+        txns.emplace_back(tx);
+        last_txid = tx->GetHash();
+        total_weight += GetTransactionWeight(*tx);
+    }
+
+    // Just barely below MAX_PACKAGE_WEIGHT.
+    assert(total_weight == 403000);
+
+    // Pass the transactions in backwards for worst-case sorting.
+    Package reversed_txns(txns.rbegin(), txns.rend());
+
+    bench.minEpochIterations(10).run([&]() NO_THREAD_SAFETY_ANALYSIS {
+        AncestorPackage ancestor_package(reversed_txns);
+        assert(ancestor_package.IsAncestorPackage());
+        for (size_t i = 0; i < txns.size(); ++i) {
+            // Decreasing feerate so that "mining" each transaction requires updating all the rest.
+            // Make each transaction 100vB bigger than the previous one.
+            ancestor_package.AddFeeAndVsize(txns.at(i)->GetHash(), 10000000, 100 * (i + 1));
+        }
+        ancestor_package.LinearizeWithFees();
+    });
+}
+
+BENCHMARK(AncestorPackageRandom, benchmark::PriorityLevel::HIGH);
+BENCHMARK(AncestorPackageChain, benchmark::PriorityLevel::HIGH);

--- a/src/consensus/validation.h
+++ b/src/consensus/validation.h
@@ -54,6 +54,8 @@ enum class TxValidationResult {
     TX_CONFLICT,
     TX_MEMPOOL_POLICY,        //!< violated mempool's fee/size/descendant/RBF/etc limits
     TX_NO_MEMPOOL,            //!< this node does not have a mempool so can't validate the transaction
+    TX_RECONSIDERABLE,        //!< fails some policy, but might be acceptable if submitted in a (different) package
+    TX_UNKNOWN,               //!< transaction was not validated because package failed
 };
 
 /** A "reason" why a block was invalid, suitable for determining whether the

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1820,6 +1820,8 @@ bool PeerManagerImpl::MaybePunishNodeForTx(NodeId nodeid, const TxValidationStat
     case TxValidationResult::TX_CONFLICT:
     case TxValidationResult::TX_MEMPOOL_POLICY:
     case TxValidationResult::TX_NO_MEMPOOL:
+    case TxValidationResult::TX_RECONSIDERABLE:
+    case TxValidationResult::TX_UNKNOWN:
         break;
     }
     return false;

--- a/src/policy/ancestor_packages.cpp
+++ b/src/policy/ancestor_packages.cpp
@@ -1,0 +1,267 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#include <policy/ancestor_packages.h>
+
+#include <node/mini_miner.h>
+#include <util/check.h>
+
+#include <algorithm>
+#include <iterator>
+#include <memory>
+#include <numeric>
+
+
+/**Comparator for sorting m_txns which contains reference wrappers.*/
+struct CompareEntry {
+    template<typename T>
+    bool operator()(const std::reference_wrapper<T> a, const std::reference_wrapper<T> b) const
+    {
+        return a.get() < b.get();
+    }
+};
+// Calculates curr_tx's in-package ancestor set. If the tx spends another tx in the package, calls
+// visit() for that transaction first, since any transaction's ancestor set includes its parents'
+// ancestor sets. Transaction dependency cycles are not possible without breaking sha256 and
+// duplicate transactions were checked in the AncestorPackage() ctor, so this won't recurse infinitely.
+// After this function returns, entry is guaranteed to contain a non-empty ancestor_subset.
+void AncestorPackage::visit(const CTransactionRef& curr_tx)
+{
+    const Txid& curr_txid = curr_tx->GetHash();
+    auto& entry = m_txid_to_entry.at(curr_txid);
+    if (!entry.ancestor_subset.empty()) return;
+    std::set<Txid> my_ancestors;
+    my_ancestors.insert(curr_txid);
+    for (const auto& input : curr_tx->vin) {
+        const auto& parent_txid = Txid::FromUint256(input.prevout.hash);
+        if (m_txid_to_entry.count(parent_txid) == 0) continue;
+        auto parent_entry = m_txid_to_entry.at(parent_txid);
+        if (parent_entry.ancestor_subset.empty()) {
+            visit(parent_entry.tx);
+        }
+        auto parent_ancestor_set = m_txid_to_entry.at(parent_txid).ancestor_subset;
+        Assume(!parent_ancestor_set.empty());
+        // This recursive call should not have included ourselves; it should be impossible for this
+        // tx to be both an ancestor and a descendant of us.
+        Assume(m_txid_to_entry.at(curr_txid).ancestor_subset.empty());
+        my_ancestors.insert(parent_ancestor_set.cbegin(), parent_ancestor_set.cend());
+    }
+    entry.ancestor_subset = std::move(my_ancestors);
+}
+
+AncestorPackage::AncestorPackage(const Package& txns_in)
+{
+    if (txns_in.empty()) return;
+    // Duplicate transactions are not allowed, as they will result in infinite visit() recursion.
+    if (!IsConsistentPackage(txns_in)) return;
+
+    // Populate m_txid_to_entry for quick lookup
+    for (const auto& tx : txns_in) {
+        m_txid_to_entry.emplace(tx->GetHash(), PackageEntry{tx});
+        m_txns.emplace_back(std::ref(m_txid_to_entry.at(tx->GetHash())));
+    }
+
+    // Every tx must have a unique txid. We are indexing by Txid to make it easy to look up parents
+    // using prevouts. IsConsistentPackage() should have checked for duplicate transactions.
+    if (!Assume(txns_in.size() == m_txid_to_entry.size())) return;
+
+    // DFS-based algorithm to sort transactions by ancestor count and populate ancestor_subset.
+    // Best case runtime is if the package is already sorted and no recursive calls happen.
+    // An empty PackageEntry::ancestor_subset is equivalent to not yet being processed.
+    for (const auto& tx : txns_in) {
+        if (m_txid_to_entry.at(tx->GetHash()).ancestor_subset.empty()) visit(tx);
+        Assume(!m_txid_to_entry.at(tx->GetHash()).ancestor_subset.empty());
+    }
+    // Sort by the number of in-package ancestors.
+    std::vector<std::reference_wrapper<PackageEntry>> txns_copy(m_txns);
+    std::sort(m_txns.begin(), m_txns.end(), CompareEntry());
+    if (!Assume(m_txns.size() == txns_in.size() && IsTopoSortedPackage(Txns()))) {
+        // If something went wrong with the sorting, just revert to the original order.
+        m_txns = txns_copy;
+    }
+    // This package is ancestor package-shaped if every transaction is an ancestor of the last tx.
+    // We just check if the number of unique txids in ancestor_subset is equal to the number of
+    // transactions in the package.
+    m_ancestor_package_shaped = m_txns.back().get().ancestor_subset.size() == m_txns.size();
+    // Now populate the descendant caches
+    for (const auto& [txid, entry] : m_txid_to_entry) {
+        for (const auto& anc_txid : entry.ancestor_subset) {
+            m_txid_to_entry.at(anc_txid).descendant_subset.insert(txid);
+        }
+    }
+}
+
+Package AncestorPackage::Txns() const
+{
+    Package result;
+    std::transform(m_txns.cbegin(), m_txns.cend(), std::back_inserter(result),
+                   [](const auto refentry){ return refentry.get().tx; });
+    return result;
+}
+
+Package AncestorPackage::FilteredTxns() const
+{
+    Package result;
+    for (const auto entryref : m_txns) {
+        if (entryref.get().m_state == PackageEntry::State::PACKAGE) result.emplace_back(entryref.get().tx);
+    }
+    return result;
+}
+
+std::optional<std::vector<CTransactionRef>> AncestorPackage::FilteredAncestorSet(const CTransactionRef& tx) const
+{
+    const auto& entry_it = m_txid_to_entry.find(tx->GetHash());
+    if (entry_it == m_txid_to_entry.end()) return std::nullopt;
+    const auto& entry = entry_it->second;
+    if (entry.m_state == PackageEntry::State::DANGLING) return std::nullopt;
+
+    std::vector<CTransactionRef> result;
+    result.reserve(entry.ancestor_subset.size());
+    for (const auto entryref : m_txns) {
+        if (entry.ancestor_subset.count(entryref.get().tx->GetHash()) > 0) {
+            // All non-PACKAGE ancestor_subset transactions should have been removed when the
+            // transaction was first skipped.
+            if (Assume(entryref.get().m_state == PackageEntry::State::PACKAGE)) {
+                result.emplace_back(entryref.get().tx);
+            }
+        }
+    }
+    return result;
+}
+
+std::optional<AncestorPackage::SubpackageInfo> AncestorPackage::FilteredSubpackageInfo(const CTransactionRef& tx) const
+{
+    const auto& entry_it = m_txid_to_entry.find(tx->GetHash());
+    if (entry_it == m_txid_to_entry.end()) return std::nullopt;
+    const auto& entry = entry_it->second;
+    if (entry.m_state == PackageEntry::State::DANGLING || !entry.fee.has_value() || !entry.vsize.has_value()) return std::nullopt;
+
+    CAmount total_fee{0};
+    int64_t total_vsize{0};
+    for (const auto& txid : entry.ancestor_subset) {
+        const auto& anc_entry = m_txid_to_entry.at(txid);
+        // All non-PACKAGE ancestor_subset transactions should have been removed when the
+        // transaction was first skipped.
+        if (Assume(anc_entry.m_state == PackageEntry::State::PACKAGE)) {
+            if (anc_entry.fee.has_value() && anc_entry.vsize.has_value()) {
+                total_fee += anc_entry.fee.value();
+                total_vsize += anc_entry.vsize.value();
+            } else {
+                // If any fee or vsize information is missing, we can't return an accurate result.
+                return std::nullopt;
+            }
+        }
+    }
+
+    return SubpackageInfo{
+        .m_self_vsize = entry.vsize.value(),
+        .m_ancestor_vsize = total_vsize,
+        .m_self_fee = entry.fee.value(),
+        .m_ancestor_fee = total_fee
+    };
+}
+
+void AncestorPackage::MarkAsInMempool(const CTransactionRef& transaction)
+{
+    const auto& txid{transaction->GetHash()};
+    if (m_txid_to_entry.count(txid) == 0) return;
+
+    Assume(m_txid_to_entry.at(txid).m_state != PackageEntry::State::DANGLING);
+    m_txid_to_entry.at(txid).m_state = PackageEntry::State::MEMPOOL;
+
+    // Delete this tx from the descendant's ancestor_subset.
+    for (const auto& descendant_txid : m_txid_to_entry.at(transaction->GetHash()).descendant_subset) {
+        m_txid_to_entry.at(descendant_txid).ancestor_subset.erase(txid);
+    }
+}
+void AncestorPackage::IsDanglingWithDescendants(const CTransactionRef& transaction)
+{
+    const auto& txid{transaction->GetHash()};
+    if (m_txid_to_entry.count(txid) == 0) return;
+    m_txid_to_entry.at(txid).m_state = PackageEntry::State::DANGLING;
+
+    // Set all descendants to DANGLING, as they depend on something that is being discarded.
+    // Delete this tx from the descendant's ancestor_subset.
+    for (const auto& descendant_txid : m_txid_to_entry.at(txid).descendant_subset) {
+        Assume(m_txid_to_entry.at(descendant_txid).m_state != PackageEntry::State::MEMPOOL);
+        m_txid_to_entry.at(descendant_txid).m_state = PackageEntry::State::DANGLING;
+        m_txid_to_entry.at(descendant_txid).ancestor_subset.erase(txid);
+    }
+}
+
+void AncestorPackage::AddFeeAndVsize(const Txid& txid, CAmount fee, int64_t vsize)
+{
+    if (auto it = m_txid_to_entry.find(txid); it != m_txid_to_entry.end()) {
+        it->second.fee = fee;
+        it->second.vsize = vsize;
+    }
+}
+
+bool AncestorPackage::LinearizeWithFees()
+{
+    if (!m_ancestor_package_shaped) return false;
+    // All fee and vsize information for PACKAGE txns must be available to do linearization.
+    if (!std::all_of(m_txid_to_entry.cbegin(), m_txid_to_entry.cend(),
+        [](const auto& entry) { return entry.second.m_state != PackageEntry::State::PACKAGE ||
+                                 (entry.second.fee.has_value() && entry.second.vsize.has_value()); })) {
+        return false;
+    }
+    // Clear any previously-calculated mining sequences for all transactions.
+    for (auto& [_, entry] : m_txid_to_entry) entry.mining_sequence = std::nullopt;
+
+    // Construct mempool entries for MiniMiner
+    std::vector<node::MiniMinerMempoolEntry> miniminer_info;
+    std::map<Txid, std::set<Txid>> descendant_caches;
+    for (const auto& [txid, entry] : m_txid_to_entry) {
+        // Skip transactions that are not being considered for submission.
+        if (entry.m_state != PackageEntry::State::PACKAGE) continue;
+
+        auto fee_and_vsize_info = FilteredSubpackageInfo(entry.tx);
+        if (!Assume(fee_and_vsize_info.has_value())) continue;
+        miniminer_info.emplace_back(/*fee_self=*/fee_and_vsize_info->m_self_fee,
+                                    /*fee_ancestor=*/fee_and_vsize_info->m_ancestor_fee,
+                                    /*vsize_self=*/fee_and_vsize_info->m_self_vsize,
+                                    /*vsize_ancestor=*/fee_and_vsize_info->m_ancestor_vsize,
+                                    /*tx_in=*/entry.tx);
+
+        // Provide descendant cache, again skipping transactions that are MEMPOOL or DANGLING.
+        std::set<Txid>& descendant_cache_to_populate = descendant_caches.try_emplace(txid).first->second;
+        for (const auto& txid : entry.descendant_subset) {
+            if (!Assume(m_txid_to_entry.count(txid) > 0)) continue;
+
+            const auto& entry = m_txid_to_entry.at(txid);
+            if (entry.m_state == PackageEntry::State::PACKAGE) {
+                descendant_cache_to_populate.insert(txid);
+            } else {
+                // Descendant shouldn't be MEMPOOL as that would mean submitting a tx without its ancestor.
+                Assume(entry.m_state == PackageEntry::State::DANGLING);
+            }
+        }
+    }
+
+    // Use MiniMiner to calculate the order in which these transactions would be selected for mining.
+    node::MiniMiner miniminer(miniminer_info, descendant_caches);
+    if (!miniminer.IsReadyToCalculate()) return false;
+    for (const auto& [txid, mining_sequence] : miniminer.Linearize()) {
+        m_txid_to_entry.at(txid).mining_sequence = mining_sequence;
+    }
+    // Sort again, this time including mining scores and individual feerates.
+    std::vector<std::reference_wrapper<PackageEntry>> txns_copy(m_txns);
+    std::sort(m_txns.begin(), m_txns.end(), CompareEntry());
+    Assume(std::all_of(m_txid_to_entry.cbegin(), m_txid_to_entry.cend(), [](const auto& entry) {
+        bool should_have_sequence = (entry.second.m_state == PackageEntry::State::PACKAGE);
+        return entry.second.mining_sequence.has_value() == should_have_sequence;
+    }));
+
+    // If something went wrong with the linearization, just revert to the original order and reset
+    // mining_sequences.
+    if (!Assume(IsTopoSortedPackage(Txns()))) {
+        m_txns = txns_copy;
+        for (auto& [txid, entry] : m_txid_to_entry) {
+            entry.mining_sequence = std::nullopt;
+        }
+        Assume(IsTopoSortedPackage(Txns()));
+        return false;
+    }
+    return true;
+}

--- a/src/policy/ancestor_packages.h
+++ b/src/policy/ancestor_packages.h
@@ -1,0 +1,172 @@
+// Copyright (c) 2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_POLICY_ANCESTOR_PACKAGES_H
+#define BITCOIN_POLICY_ANCESTOR_PACKAGES_H
+
+#include <policy/feerate.h>
+#include <policy/packages.h>
+
+#include <vector>
+
+/** A potential ancestor package, i.e. one transaction with its set of unconfirmed ancestors.
+ * This class does not have any knowledge of chainstate, so it cannot determine whether all
+ * unconfirmed ancestors are present. Its constructor accepts any list of transactions that
+ * IsConsistentPackage(), linearizes them topologically, and determines whether it IsAncestorPackage().
+ * If fee and vsizes are given for each transaction, it can also linearize the transactions using
+ * the ancestor score-based mining algorithm via MiniMiner.
+ *
+ * IsIsInMempool() and IsDanglingWithDescendants() can be used to omit transactions.
+ * Txns() and FilteredTxns() return the linearized transactions; FilteredTxns excludes non-PACKAGE ones.
+ * FilteredAncestorSet() can be used to get a transaction's "subpackage," i.e. ancestor set within the
+ * package. Also excludes non-PACKAGE ones.
+ * */
+class AncestorPackage
+{
+    /** Whether m_txns contains a connected package in which all transactions are ancestors of the
+     * last transaction. This object is not aware of chainstate. So if m_txns only includes a
+     * grandparent and not the "connecting" parent, this will (incorrectly) determine that the
+     * grandparent is not an ancestor.
+     * Set in the constructor and then does not change, even if transactions are skipped.
+     * */
+    bool m_ancestor_package_shaped{false};
+
+    struct PackageEntry {
+        enum class State : uint8_t {
+            /** Default value.
+             * If calling LinearizeWithFees(), this tx must have a fee and vsize. */
+            PACKAGE,
+            /** Excluded from FilteredAncestor{Set,FeeAndVsize}.
+             * Should not appear in any transaction's ancestor_subset.
+             * Excluded in LinearizeWithFees().
+             * Set by calling IsIsInMempool() on this tx. */
+            MEMPOOL,
+            /** This and all descendant's FilteredAncestor{Set,FeeAndVsize} will be std::nullopt.
+             * Should not appear in any transaction's ancestor_subset.
+             * Excluded in LinearizeWithFees().
+             * Set by calling IsDanglingWithDescendants() on this tx or its ancestor. */
+            DANGLING,
+        // If a parent is DANGLING, all descendants must also be DANGLING.
+        // If a child is MEMPOOL, all ancestors should also be MEMPOOL.
+        };
+
+        CTransactionRef tx;
+
+        State m_state{State::PACKAGE};
+
+        /** This value starts as std::nullopt when we don't have any fee information yet. It can be
+         * updated by calling LinearizeWithFees() if this entry isn't MEMPOOL or DANGLING. */
+        std::optional<uint32_t> mining_sequence;
+
+        /** Fees of this transaction. Starts as std::nullopt, can be updated using AddFeeAndVsize(). */
+        std::optional<CAmount> fee;
+
+        /** Virtual size of this transaction (depends on policy, calculated externally). Starts as
+         * std::nullopt. Can be updated using AddFeeAndVsize(). */
+        std::optional<int64_t> vsize;
+
+        /** Txids of all PACKAGE ancestors. Populated in AncestorPackage ctor. If an ancestor
+         * becomes MEMPOOL or DANGLING, it is erased from this set. Use FilteredAncestorSet to get
+         * filtered ancestor sets. */
+        std::set<Txid> ancestor_subset;
+
+        /** Txids of all in-package descendant. Populated in AncestorPackage ctor and does not
+         * change within AncestorPackage lifetime. */
+        std::set<Txid> descendant_subset;
+
+        explicit PackageEntry(CTransactionRef tx_in) : tx(tx_in) {}
+
+        // Used to sort the result of Txns, FilteredTxns, and FilteredAncestorSet. Always guarantees
+        // topological sort. If LinearizeWithFees() was called, also uses mining sequence.
+        //
+        // If ancestor score-based linearization sequence exists for both transactions, the
+        // transaction with the lower sequence number comes first.
+        //    If there is a tie, the transaction with fewer in-package ancestors comes first (topological sort).
+        //       If there is still a tie, the transaction with the higher base feerate comes first.
+        // Otherwise, the transaction with fewer in-package ancestors comes first (topological sort).
+        bool operator<(const PackageEntry& rhs) const {
+            if (mining_sequence == std::nullopt || rhs.mining_sequence == std::nullopt) {
+                // If mining sequence is missing for either entry, default to topological order.
+                return ancestor_subset.size() < rhs.ancestor_subset.size();
+            } else {
+                if (mining_sequence.value() == rhs.mining_sequence.value()) {
+                    // Identical mining sequence means they would be included in the same ancestor
+                    // set. The one with fewer ancestors comes first.
+                    if (ancestor_subset.size() == rhs.ancestor_subset.size()) {
+                        // Individual feerate. This is not necessarily fee-optimal, but helps in some situations.
+                        // (a.fee * b.vsize > b.fee * a.vsize) is a shortcut for (a.fee / a.vsize > b.fee / b.vsize)
+                        return *fee * *rhs.vsize  > *rhs.fee * *vsize;
+                    }
+                    return ancestor_subset.size() < rhs.ancestor_subset.size();
+                } else {
+                    return mining_sequence.value() < rhs.mining_sequence.value();
+                }
+            }
+        }
+    };
+    /** Map from each txid to PackageEntry */
+    std::map<Txid, PackageEntry> m_txid_to_entry;
+
+    /** Linearized transactions. Always topologically sorted (IsSorted()). If fee information is
+     * provided through LinearizeWithFees(), using mining_sequence scores. */
+    std::vector<std::reference_wrapper<PackageEntry>> m_txns;
+
+    /** Helper function for recursively constructing ancestor caches in ctor. */
+    void visit(const CTransactionRef&);
+public:
+    /** Constructs ancestor package, sorting the transactions topologically and constructing the
+     * txid_to_tx and ancestor_subsets maps. It is ok if the input txns is not sorted.
+     * Expects:
+     * - No duplicate transactions.
+     * - No conflicts between transactions.
+     */
+    AncestorPackage(const Package& txns_in);
+
+    bool IsAncestorPackage() const { return m_ancestor_package_shaped; }
+
+    /** Returns all of the transactions, linearized. */
+    Package Txns() const;
+
+    /** Returns all of the transactions, without the skipped and dangling ones, linearized. */
+    Package FilteredTxns() const;
+
+    struct SubpackageInfo
+    {
+        std::vector<CTransactionRef> m_subpackage_txns;
+        int64_t m_self_vsize;
+        int64_t m_ancestor_vsize;
+        CAmount m_self_fee;
+        CAmount m_ancestor_fee;
+    };
+
+    /** Get the sorted, filtered ancestor subpackage for a tx. Includes the tx. Does not include
+     * ancestors that are MEMPOOL. If this tx or any ancestors are DANGLING, returns std::nullopt. */
+    std::optional<std::vector<CTransactionRef>> FilteredAncestorSet(const CTransactionRef& tx) const;
+
+    /** Get SubpackageInfo for this tx and its filtered ancestors. Does not include ancestors that
+     * are MEMPOOL. If this tx or any ancestors are DANGLING, returns std::nullopt. This result is
+     * always consistent with FilteredAncestorSet(). */
+    std::optional<SubpackageInfo> FilteredSubpackageInfo(const CTransactionRef& tx) const;
+
+    /** Should be called if a tx or same txid transaction is found in mempool or submitted to it.
+     * From now on, skip this tx from any result in FilteredAncestorSet(). Does not affect Txns(). */
+    void MarkAsInMempool(const CTransactionRef& transaction);
+
+    /** Should be called if a tx will not be considered because it is missing inputs or is
+     * conflicting with another transaction that is already in mempool.
+     * Skip a transaction and all of its descendants. From now on, if this transaction is present
+     * in the ancestor set, FilteredAncestorSet() returns std::nullopt for that tx. Does not affect Txns(). */
+    void IsDanglingWithDescendants(const CTransactionRef& transaction);
+
+    /** Add information about fee and vsize for a transaction. */
+    void AddFeeAndVsize(const Txid& txid, CAmount fee, int64_t vsize);
+
+    /** Re-linearize transactions using the fee and vsize information given. Updates Txns().
+     * Information must have been provided for all non-skipped transactions via AddFeeAndVsize().
+     * @returns true if successful, false if not enough information was provided or an error
+     * occurred - in that case, the transactions are still IsTopoSortedPackage() and it is safe to
+     * still validate them, but we may not have a fee-optimal result. */
+    bool LinearizeWithFees();
+};
+#endif // BITCOIN_POLICY_ANCESTOR_PACKAGES_H

--- a/src/policy/packages.h
+++ b/src/policy/packages.h
@@ -78,14 +78,4 @@ bool IsConsistentPackage(const Package& txns);
  */
 bool IsWellFormedPackage(const Package& txns, PackageValidationState& state, bool require_sorted);
 
-/** Context-free check that a package is exactly one child and its parents; not all parents need to
- * be present, but the package must not contain any transactions that are not the child's parents.
- * It is expected to be sorted, which means the last transaction must be the child.
- */
-bool IsChildWithParents(const Package& package);
-
-/** Context-free check that a package IsChildWithParents() and none of the parents depend on each
- * other (the package is a "tree").
- */
-bool IsChildWithParentsTree(const Package& package);
 #endif // BITCOIN_POLICY_PACKAGES_H

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -820,7 +820,7 @@ static RPCHelpMan submitpackage()
 {
     return RPCHelpMan{"submitpackage",
         "Submit a package of raw transactions (serialized, hex-encoded) to local node.\n"
-        "The package must consist of a child with its parents, and none of the parents may depend on one another.\n"
+        "The package must only consist of a transaction with its unconfirmed ancestors.\n"
         "The package will be validated according to consensus and mempool policy rules. If all transactions pass, they will be accepted to mempool.\n"
         "This RPC is experimental and the interface may be unstable. Refer to doc/policy/packages.md for documentation on package policies.\n"
         "Warning: successful submission does not mean the transactions will propagate throughout the network.\n"
@@ -878,10 +878,6 @@ static RPCHelpMan submitpackage()
                 }
                 txns.emplace_back(MakeTransactionRef(std::move(mtx)));
             }
-            if (!IsChildWithParentsTree(txns)) {
-                throw JSONRPCTransactionError(TransactionError::INVALID_PACKAGE, "package topology disallowed. not child-with-parents or parents depend on each other.");
-            }
-
             NodeContext& node = EnsureAnyNodeContext(request.context);
             CTxMemPool& mempool = EnsureMemPool(node);
             Chainstate& chainstate = EnsureChainman(node).ActiveChainstate();

--- a/src/test/fuzz/ancestorpackage.cpp
+++ b/src/test/fuzz/ancestorpackage.cpp
@@ -1,0 +1,99 @@
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+#include <test/util/script.h>
+#include <test/util/setup_common.h>
+
+#include <policy/ancestor_packages.h>
+
+#include <set>
+#include <vector>
+
+namespace {
+FUZZ_TARGET(ancestorpackage)
+{
+    FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
+    std::vector<CTransactionRef> txns_in;
+    // Avoid repeat coins, as they may cause transactions to conflict
+    std::set<COutPoint> available_coins;
+    for (auto i{0}; i < 100; ++i) {
+        if (auto mtx{ConsumeDeserializable<CMutableTransaction>(fuzzed_data_provider)}) {
+            available_coins.insert(COutPoint{MakeTransactionRef(*mtx)->GetHash(), fuzzed_data_provider.ConsumeIntegralInRange<uint32_t>(0, 10)});
+        }
+    }
+    // Create up to 50 transactions with variable inputs and outputs.
+    LIMITED_WHILE(!available_coins.empty() && fuzzed_data_provider.ConsumeBool(), 50)
+    {
+        // If we're making the "bottom" tx, spend all available coins to make an ancestor package,
+        // and exit this loop afterwards.
+        const bool make_bottom_tx{fuzzed_data_provider.ConsumeBool()};
+
+        CMutableTransaction mtx = CMutableTransaction();
+        const size_t num_inputs = make_bottom_tx ? available_coins.size() :
+            fuzzed_data_provider.ConsumeIntegralInRange<size_t>(1, available_coins.size());
+        const size_t num_outputs = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(1, 50);
+        for (size_t n{0}; n < num_inputs; ++n) {
+            auto prevout = available_coins.begin();
+            mtx.vin.emplace_back(*prevout, CScript());
+            available_coins.erase(prevout);
+        }
+        for (uint32_t n{0}; n < num_outputs; ++n) {
+            mtx.vout.emplace_back(100, P2WSH_OP_TRUE);
+        }
+        CTransactionRef tx = MakeTransactionRef(mtx);
+
+        if (txns_in.empty()) {
+            txns_in.emplace_back(tx);
+        } else {
+            // Place tx in a random spot in the vector, swapping the existing tx at that index to the
+            // back, so the package is not necessarily sorted.
+            const size_t index = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, txns_in.size() - 1);
+            txns_in.emplace_back(txns_in.at(index));
+            txns_in.at(index) = tx;
+        }
+
+        // Make outputs available to spend, unless we want this to be the last tx and have just
+        // swept available_coins.
+        if (!make_bottom_tx) {
+            for (uint32_t n{0}; n < num_outputs; ++n) {
+                COutPoint new_coin{tx->GetHash(), n};
+                // Always add the first output to ensure each tx has an outgoing output we can use
+                // to create an ancestor package.
+                if (n > 0 && fuzzed_data_provider.ConsumeBool()) {
+                    available_coins.insert(new_coin);
+                }
+            }
+        }
+    }
+
+    // AncestorPackage may need to topologically sort txns_in. Find bugs in topological sort and
+    // skipping as a result of MarkAsInMempool() and IsDanglingWithDescendants() functions.
+    AncestorPackage packageified(txns_in);
+    Assert(IsTopoSortedPackage(packageified.Txns()));
+    if (packageified.IsAncestorPackage()) {
+        // Optionally MarkAsInMempool() the first n transactions. These must be at the beginning of the
+        // package as it doesn't make sense for a transaction to be in mempool if its ancestors
+        // aren't as well.  The ith transaction is not necessarily an ancestor of the i+1th
+        // transaction, but just call MarkAsInMempool() for transactions 1...n to keep things simple.
+        // For the rest of the transactions, optionally call IsDanglingWithDescendants().
+        bool skipping = true;
+        for (const auto& tx : packageified.Txns()) {
+            if (skipping) {
+                packageified.MarkAsInMempool(tx);
+                if (fuzzed_data_provider.ConsumeBool()) {
+                    skipping = false;
+                }
+            } else {
+                // Not skipping anymore. Maybe do a IsDanglingWithDescendants().
+                if (fuzzed_data_provider.ConsumeBool()) {
+                    packageified.IsDanglingWithDescendants(tx);
+                }
+            }
+        }
+        Assert(IsTopoSortedPackage(packageified.FilteredTxns()));
+        for (const auto& tx : packageified.FilteredTxns()) {
+            assert(IsTopoSortedPackage(*packageified.FilteredAncestorSet(tx)));
+        }
+    }
+}
+} // namespace

--- a/src/test/fuzz/tx_pool.cpp
+++ b/src/test/fuzz/tx_pool.cpp
@@ -154,12 +154,15 @@ void CheckATMPInvariants(const MempoolAcceptResult& res, bool txid_in_mempool, b
         // It may be already in the mempool since in ATMP cases we don't set MEMPOOL_ENTRY or DIFFERENT_WITNESS
         Assert(!res.m_state.IsValid());
         Assert(res.m_state.IsInvalid());
+
+        const bool is_reconsiderable{res.m_state.GetResult() == TxValidationResult::TX_RECONSIDERABLE};
         Assert(!res.m_replaced_transactions);
         Assert(!res.m_vsize);
         Assert(!res.m_base_fees);
-        // Unable or unwilling to calculate fees
-        Assert(!res.m_effective_feerate);
-        Assert(!res.m_wtxids_fee_calculations);
+        // Fee information is provided if the failure is TX_RECONSIDERABLE.
+        // In other cases, validation may be unable or unwilling to calculate the fees.
+        Assert(res.m_effective_feerate.has_value() == is_reconsiderable);
+        Assert(res.m_wtxids_fee_calculations.has_value() == is_reconsiderable);
         Assert(!res.m_other_wtxid);
         break;
     }

--- a/src/test/txpackage_tests.cpp
+++ b/src/test/txpackage_tests.cpp
@@ -753,15 +753,26 @@ BOOST_FIXTURE_TEST_CASE(package_cpfp_tests, TestChain100Setup)
     BOOST_CHECK(m_node.mempool->GetMinFee().GetFee(GetVirtualTransactionSize(*tx_parent_cheap) + GetVirtualTransactionSize(*tx_child_cheap)) > parent_fee + child_fee);
     BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
 
-    // Cheap package should fail with package-fee-too-low.
+    // Cheap package should fail for being too low fee.
     {
         const auto submit_package_too_low = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
                                                    package_still_too_low, /*test_accept=*/false);
-        BOOST_CHECK_EQUAL(submit_package_too_low.m_state.GetResult(), PackageValidationResult::PCKG_POLICY);
-        BOOST_CHECK_EQUAL(submit_package_too_low.m_state.GetRejectReason(), "package-fee-too-low");
         if (auto err_package_too_low{CheckPackageMempoolAcceptResult(package_still_too_low, submit_package_too_low, /*expect_valid=*/false, m_node.mempool.get())}) {
             BOOST_ERROR(err_package_too_low.value());
+        } else {
+            // Individual feerate of parent is too low.
+            BOOST_CHECK_EQUAL(submit_package_too_low.m_tx_results.at(tx_parent_cheap->GetWitnessHash()).m_state.GetResult(),
+                              TxValidationResult::TX_RECONSIDERABLE);
+            BOOST_CHECK(submit_package_too_low.m_tx_results.at(tx_parent_cheap->GetWitnessHash()).m_effective_feerate.value() ==
+                        CFeeRate(parent_fee, GetVirtualTransactionSize(*tx_parent_cheap)));
+            // Package feerate of parent + child is too low.
+            BOOST_CHECK_EQUAL(submit_package_too_low.m_tx_results.at(tx_child_cheap->GetWitnessHash()).m_state.GetResult(),
+                              TxValidationResult::TX_RECONSIDERABLE);
+            BOOST_CHECK(submit_package_too_low.m_tx_results.at(tx_child_cheap->GetWitnessHash()).m_effective_feerate.value() ==
+                        CFeeRate(parent_fee + child_fee, GetVirtualTransactionSize(*tx_parent_cheap) + GetVirtualTransactionSize(*tx_child_cheap)));
         }
+        BOOST_CHECK_EQUAL(submit_package_too_low.m_state.GetResult(), PackageValidationResult::PCKG_TX);
+        BOOST_CHECK_EQUAL(submit_package_too_low.m_state.GetRejectReason(), "transaction failed");
         BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
     }
 

--- a/src/test/txpackage_tests.cpp
+++ b/src/test/txpackage_tests.cpp
@@ -668,7 +668,7 @@ BOOST_FIXTURE_TEST_CASE(package_witness_swap_tests, TestChain100Setup)
         const CFeeRate expected_feerate(1 * COIN, GetVirtualTransactionSize(*ptx_parent3) + GetVirtualTransactionSize(*ptx_mixed_child));
         BOOST_CHECK(it_parent3->second.m_effective_feerate.value() == expected_feerate);
         BOOST_CHECK(it_child->second.m_effective_feerate.value() == expected_feerate);
-        std::vector<uint256> expected_wtxids({ptx_parent3->GetWitnessHash(), ptx_mixed_child->GetWitnessHash()});
+        std::vector<Wtxid> expected_wtxids({ptx_parent3->GetWitnessHash(), ptx_mixed_child->GetWitnessHash()});
         BOOST_CHECK(it_parent3->second.m_wtxids_fee_calculations.value() == expected_wtxids);
         BOOST_CHECK(it_child->second.m_wtxids_fee_calculations.value() == expected_wtxids);
     }
@@ -756,7 +756,7 @@ BOOST_FIXTURE_TEST_CASE(package_cpfp_tests, TestChain100Setup)
                                         GetVirtualTransactionSize(*tx_parent) + GetVirtualTransactionSize(*tx_child));
         BOOST_CHECK(it_parent->second.m_effective_feerate.value() == expected_feerate);
         BOOST_CHECK(it_child->second.m_effective_feerate.value() == expected_feerate);
-        std::vector<uint256> expected_wtxids({tx_parent->GetWitnessHash(), tx_child->GetWitnessHash()});
+        std::vector<Wtxid> expected_wtxids({tx_parent->GetWitnessHash(), tx_child->GetWitnessHash()});
         BOOST_CHECK(it_parent->second.m_wtxids_fee_calculations.value() == expected_wtxids);
         BOOST_CHECK(it_child->second.m_wtxids_fee_calculations.value() == expected_wtxids);
         BOOST_CHECK(expected_feerate.GetFeePerK() > 1000);
@@ -820,7 +820,7 @@ BOOST_FIXTURE_TEST_CASE(package_cpfp_tests, TestChain100Setup)
         BOOST_CHECK(it_child->second.m_result_type == MempoolAcceptResult::ResultType::VALID);
         BOOST_CHECK(it_child->second.m_base_fees.value() == child_fee);
         BOOST_CHECK(it_child->second.m_effective_feerate.value() == expected_feerate);
-        std::vector<uint256> expected_wtxids({tx_parent_cheap->GetWitnessHash(), tx_child_cheap->GetWitnessHash()});
+        std::vector<Wtxid> expected_wtxids({tx_parent_cheap->GetWitnessHash(), tx_child_cheap->GetWitnessHash()});
         BOOST_CHECK(it_parent->second.m_wtxids_fee_calculations.value() == expected_wtxids);
         BOOST_CHECK(it_child->second.m_wtxids_fee_calculations.value() == expected_wtxids);
     }

--- a/src/test/txpackage_tests.cpp
+++ b/src/test/txpackage_tests.cpp
@@ -11,6 +11,7 @@
 #include <test/util/random.h>
 #include <test/util/script.h>
 #include <test/util/setup_common.h>
+#include <test/util/txmempool.h>
 #include <validation.h>
 
 #include <boost/test/unit_test.hpp>
@@ -132,36 +133,35 @@ BOOST_FIXTURE_TEST_CASE(package_validation_tests, TestChain100Setup)
                                                    /*output_destination=*/child_locking_script,
                                                    /*output_amount=*/CAmount(48 * COIN), /*submit=*/false);
     CTransactionRef tx_child = MakeTransactionRef(mtx_child);
-    const auto result_parent_child = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, {tx_parent, tx_child}, /*test_accept=*/true);
-    BOOST_CHECK_MESSAGE(result_parent_child.m_state.IsValid(),
-                        "Package validation unexpectedly failed: " << result_parent_child.m_state.GetRejectReason());
-    BOOST_CHECK(result_parent_child.m_tx_results.size() == 2);
-    auto it_parent = result_parent_child.m_tx_results.find(tx_parent->GetWitnessHash());
-    auto it_child = result_parent_child.m_tx_results.find(tx_child->GetWitnessHash());
-    BOOST_CHECK(it_parent != result_parent_child.m_tx_results.end());
-    BOOST_CHECK_MESSAGE(it_parent->second.m_state.IsValid(),
-                        "Package validation unexpectedly failed: " << it_parent->second.m_state.GetRejectReason());
-    BOOST_CHECK(it_parent->second.m_effective_feerate.value().GetFee(GetVirtualTransactionSize(*tx_parent)) == COIN);
-    BOOST_CHECK_EQUAL(it_parent->second.m_wtxids_fee_calculations.value().size(), 1);
-    BOOST_CHECK_EQUAL(it_parent->second.m_wtxids_fee_calculations.value().front(), tx_parent->GetWitnessHash());
-    BOOST_CHECK(it_child != result_parent_child.m_tx_results.end());
-    BOOST_CHECK_MESSAGE(it_child->second.m_state.IsValid(),
-                        "Package validation unexpectedly failed: " << it_child->second.m_state.GetRejectReason());
-    BOOST_CHECK(it_child->second.m_effective_feerate.value().GetFee(GetVirtualTransactionSize(*tx_child)) == COIN);
-    BOOST_CHECK_EQUAL(it_child->second.m_wtxids_fee_calculations.value().size(), 1);
-    BOOST_CHECK_EQUAL(it_child->second.m_wtxids_fee_calculations.value().front(), tx_child->GetWitnessHash());
+    Package package_parent_child{tx_parent, tx_child};
+    const auto result_parent_child = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package_parent_child, /*test_accept=*/true);
+    if (auto err_parent_child{CheckPackageMempoolAcceptResult(package_parent_child, result_parent_child, /*expect_valid=*/true, nullptr)}) {
+        BOOST_ERROR(err_parent_child.value());
+    } else {
+        auto it_parent = result_parent_child.m_tx_results.find(tx_parent->GetWitnessHash());
+        auto it_child = result_parent_child.m_tx_results.find(tx_child->GetWitnessHash());
 
+        BOOST_CHECK(it_parent->second.m_effective_feerate.value().GetFee(GetVirtualTransactionSize(*tx_parent)) == COIN);
+        BOOST_CHECK_EQUAL(it_parent->second.m_wtxids_fee_calculations.value().size(), 1);
+        BOOST_CHECK_EQUAL(it_parent->second.m_wtxids_fee_calculations.value().front(), tx_parent->GetWitnessHash());
+
+        BOOST_CHECK(it_child->second.m_effective_feerate.value().GetFee(GetVirtualTransactionSize(*tx_child)) == COIN);
+        BOOST_CHECK_EQUAL(it_child->second.m_wtxids_fee_calculations.value().size(), 1);
+        BOOST_CHECK_EQUAL(it_child->second.m_wtxids_fee_calculations.value().front(), tx_child->GetWitnessHash());
+    }
     // A single, giant transaction submitted through ProcessNewPackage fails on single tx policy.
     CTransactionRef giant_ptx = create_placeholder_tx(999, 999);
     BOOST_CHECK(GetVirtualTransactionSize(*giant_ptx) > DEFAULT_ANCESTOR_SIZE_LIMIT_KVB * 1000);
-    auto result_single_large = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, {giant_ptx}, /*test_accept=*/true);
-    BOOST_CHECK(result_single_large.m_state.IsInvalid());
-    BOOST_CHECK_EQUAL(result_single_large.m_state.GetResult(), PackageValidationResult::PCKG_TX);
-    BOOST_CHECK_EQUAL(result_single_large.m_state.GetRejectReason(), "transaction failed");
-    BOOST_CHECK(result_single_large.m_tx_results.size() == 1);
-    auto it_giant_tx = result_single_large.m_tx_results.find(giant_ptx->GetWitnessHash());
-    BOOST_CHECK(it_giant_tx != result_single_large.m_tx_results.end());
-    BOOST_CHECK_EQUAL(it_giant_tx->second.m_state.GetRejectReason(), "tx-size");
+    Package package_single_giant{giant_ptx};
+    auto result_single_large = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package_single_giant, /*test_accept=*/true);
+    if (auto err_single_large{CheckPackageMempoolAcceptResult(package_single_giant, result_single_large, /*expect_valid=*/false, nullptr)}) {
+        BOOST_ERROR(err_single_large.value());
+    } else {
+        BOOST_CHECK_EQUAL(result_single_large.m_state.GetResult(), PackageValidationResult::PCKG_TX);
+        BOOST_CHECK_EQUAL(result_single_large.m_state.GetRejectReason(), "transaction failed");
+        auto it_giant_tx = result_single_large.m_tx_results.find(giant_ptx->GetWitnessHash());
+        BOOST_CHECK_EQUAL(it_giant_tx->second.m_state.GetRejectReason(), "tx-size");
+    }
 
     // Check that mempool size hasn't changed.
     BOOST_CHECK_EQUAL(m_node.mempool->size(), initialPoolSize);
@@ -281,6 +281,7 @@ BOOST_FIXTURE_TEST_CASE(package_submission_tests, TestChain100Setup)
     }
     auto result_unrelated_submit = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
                                                      package_unrelated, /*test_accept=*/false);
+    // We don't expect m_tx_results for each transaction when basic sanity checks haven't passed.
     BOOST_CHECK(result_unrelated_submit.m_state.IsInvalid());
     BOOST_CHECK_EQUAL(result_unrelated_submit.m_state.GetResult(), PackageValidationResult::PCKG_POLICY);
     BOOST_CHECK_EQUAL(result_unrelated_submit.m_state.GetRejectReason(), "package-not-child-with-parents");
@@ -336,20 +337,20 @@ BOOST_FIXTURE_TEST_CASE(package_submission_tests, TestChain100Setup)
         CMutableTransaction mtx_parent_invalid{mtx_parent};
         mtx_parent_invalid.vin[0].scriptWitness = bad_witness;
         CTransactionRef tx_parent_invalid = MakeTransactionRef(mtx_parent_invalid);
+        Package package_invalid_parent{tx_parent_invalid, tx_child};
         auto result_quit_early = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                   {tx_parent_invalid, tx_child}, /*test_accept=*/ false);
-        BOOST_CHECK(result_quit_early.m_state.IsInvalid());
+                                                   package_invalid_parent, /*test_accept=*/ false);
+        if (auto err_parent_invalid{CheckPackageMempoolAcceptResult(package_invalid_parent, result_quit_early, /*expect_valid=*/false, m_node.mempool.get())}) {
+            BOOST_ERROR(err_parent_invalid.value());
+        } else {
+            auto it_parent = result_quit_early.m_tx_results.find(tx_parent_invalid->GetWitnessHash());
+            auto it_child = result_quit_early.m_tx_results.find(tx_child->GetWitnessHash());
+            BOOST_CHECK_EQUAL(it_parent->second.m_state.GetResult(), TxValidationResult::TX_WITNESS_MUTATED);
+            BOOST_CHECK_EQUAL(it_parent->second.m_state.GetRejectReason(), "bad-witness-nonstandard");
+            BOOST_CHECK_EQUAL(it_child->second.m_state.GetResult(), TxValidationResult::TX_MISSING_INPUTS);
+            BOOST_CHECK_EQUAL(it_child->second.m_state.GetRejectReason(), "bad-txns-inputs-missingorspent");
+        }
         BOOST_CHECK_EQUAL(result_quit_early.m_state.GetResult(), PackageValidationResult::PCKG_TX);
-        BOOST_CHECK(!result_quit_early.m_tx_results.empty());
-        BOOST_CHECK_EQUAL(result_quit_early.m_tx_results.size(), 2);
-        auto it_parent = result_quit_early.m_tx_results.find(tx_parent_invalid->GetWitnessHash());
-        auto it_child = result_quit_early.m_tx_results.find(tx_child->GetWitnessHash());
-        BOOST_CHECK(it_parent != result_quit_early.m_tx_results.end());
-        BOOST_CHECK(it_child != result_quit_early.m_tx_results.end());
-        BOOST_CHECK_EQUAL(it_parent->second.m_state.GetResult(), TxValidationResult::TX_WITNESS_MUTATED);
-        BOOST_CHECK_EQUAL(it_parent->second.m_state.GetRejectReason(), "bad-witness-nonstandard");
-        BOOST_CHECK_EQUAL(it_child->second.m_state.GetResult(), TxValidationResult::TX_MISSING_INPUTS);
-        BOOST_CHECK_EQUAL(it_child->second.m_state.GetRejectReason(), "bad-txns-inputs-missingorspent");
     }
 
     // Child with missing parent.
@@ -381,36 +382,27 @@ BOOST_FIXTURE_TEST_CASE(package_submission_tests, TestChain100Setup)
         BOOST_CHECK(it_parent->second.m_effective_feerate == CFeeRate(1 * COIN, GetVirtualTransactionSize(*tx_parent)));
         BOOST_CHECK_EQUAL(it_parent->second.m_wtxids_fee_calculations.value().size(), 1);
         BOOST_CHECK_EQUAL(it_parent->second.m_wtxids_fee_calculations.value().front(), tx_parent->GetWitnessHash());
-        BOOST_CHECK(it_child != submit_parent_child.m_tx_results.end());
-        BOOST_CHECK(it_child->second.m_state.IsValid());
         BOOST_CHECK(it_child->second.m_effective_feerate == CFeeRate(1 * COIN, GetVirtualTransactionSize(*tx_child)));
         BOOST_CHECK_EQUAL(it_child->second.m_wtxids_fee_calculations.value().size(), 1);
         BOOST_CHECK_EQUAL(it_child->second.m_wtxids_fee_calculations.value().front(), tx_child->GetWitnessHash());
 
         BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
-        BOOST_CHECK(m_node.mempool->exists(GenTxid::Txid(tx_parent->GetHash())));
-        BOOST_CHECK(m_node.mempool->exists(GenTxid::Txid(tx_child->GetHash())));
     }
 
     // Already-in-mempool transactions should be detected and de-duplicated.
     {
         const auto submit_deduped = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
                                                       package_parent_child, /*test_accept=*/false);
-        BOOST_CHECK_MESSAGE(submit_deduped.m_state.IsValid(),
-                            "Package validation unexpectedly failed: " << submit_deduped.m_state.GetRejectReason());
-        BOOST_CHECK_EQUAL(submit_deduped.m_tx_results.size(), package_parent_child.size());
-        auto it_parent_deduped = submit_deduped.m_tx_results.find(tx_parent->GetWitnessHash());
-        auto it_child_deduped = submit_deduped.m_tx_results.find(tx_child->GetWitnessHash());
-        BOOST_CHECK(it_parent_deduped != submit_deduped.m_tx_results.end());
-        BOOST_CHECK(it_parent_deduped->second.m_state.IsValid());
-        BOOST_CHECK(it_parent_deduped->second.m_result_type == MempoolAcceptResult::ResultType::MEMPOOL_ENTRY);
-        BOOST_CHECK(it_child_deduped != submit_deduped.m_tx_results.end());
-        BOOST_CHECK(it_child_deduped->second.m_state.IsValid());
-        BOOST_CHECK(it_child_deduped->second.m_result_type == MempoolAcceptResult::ResultType::MEMPOOL_ENTRY);
+        if (auto err_deduped{CheckPackageMempoolAcceptResult(package_parent_child, submit_deduped, /*expect_valid=*/true, m_node.mempool.get())}) {
+            BOOST_ERROR(err_deduped.value());
+        } else {
+            auto it_parent_deduped = submit_deduped.m_tx_results.find(tx_parent->GetWitnessHash());
+            auto it_child_deduped = submit_deduped.m_tx_results.find(tx_child->GetWitnessHash());
+            BOOST_CHECK(it_parent_deduped->second.m_result_type == MempoolAcceptResult::ResultType::MEMPOOL_ENTRY);
+            BOOST_CHECK(it_child_deduped->second.m_result_type == MempoolAcceptResult::ResultType::MEMPOOL_ENTRY);
+        }
 
         BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
-        BOOST_CHECK(m_node.mempool->exists(GenTxid::Txid(tx_parent->GetHash())));
-        BOOST_CHECK(m_node.mempool->exists(GenTxid::Txid(tx_child->GetHash())));
     }
 }
 
@@ -470,51 +462,39 @@ BOOST_FIXTURE_TEST_CASE(package_witness_swap_tests, TestChain100Setup)
     // Try submitting Package1{parent, child1} and Package2{parent, child2} where the children are
     // same-txid-different-witness.
     {
+        Package package_parent_child1{ptx_parent, ptx_child1};
         const auto submit_witness1 = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                       {ptx_parent, ptx_child1}, /*test_accept=*/false);
-        BOOST_CHECK_MESSAGE(submit_witness1.m_state.IsValid(),
-                            "Package validation unexpectedly failed: " << submit_witness1.m_state.GetRejectReason());
-        BOOST_CHECK_EQUAL(submit_witness1.m_tx_results.size(), 2);
-        auto it_parent1 = submit_witness1.m_tx_results.find(ptx_parent->GetWitnessHash());
-        auto it_child1 = submit_witness1.m_tx_results.find(ptx_child1->GetWitnessHash());
-        BOOST_CHECK(it_parent1 != submit_witness1.m_tx_results.end());
-        BOOST_CHECK_MESSAGE(it_parent1->second.m_state.IsValid(),
-                            "Transaction unexpectedly failed: " << it_parent1->second.m_state.GetRejectReason());
-        BOOST_CHECK(it_child1 != submit_witness1.m_tx_results.end());
-        BOOST_CHECK_MESSAGE(it_child1->second.m_state.IsValid(),
-                            "Transaction unexpectedly failed: " << it_child1->second.m_state.GetRejectReason());
-
-        BOOST_CHECK(m_node.mempool->exists(GenTxid::Txid(ptx_parent->GetHash())));
-        BOOST_CHECK(m_node.mempool->exists(GenTxid::Txid(ptx_child1->GetHash())));
+                                                       package_parent_child1, /*test_accept=*/false);
+        if (auto err_witness1{CheckPackageMempoolAcceptResult(package_parent_child1, submit_witness1, /*expect_valid=*/true, m_node.mempool.get())}) {
+            BOOST_ERROR(err_witness1.value());
+        }
 
         // Child2 would have been validated individually.
+        Package package_parent_child2{ptx_parent, ptx_child2};
         const auto submit_witness2 = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                       {ptx_parent, ptx_child2}, /*test_accept=*/false);
-        BOOST_CHECK_MESSAGE(submit_witness2.m_state.IsValid(),
-                            "Package validation unexpectedly failed: " << submit_witness2.m_state.GetRejectReason());
-        BOOST_CHECK_EQUAL(submit_witness2.m_tx_results.size(), 2);
-        auto it_parent2_deduped = submit_witness2.m_tx_results.find(ptx_parent->GetWitnessHash());
-        auto it_child2 = submit_witness2.m_tx_results.find(ptx_child2->GetWitnessHash());
-        BOOST_CHECK(it_parent2_deduped != submit_witness2.m_tx_results.end());
-        BOOST_CHECK(it_parent2_deduped->second.m_result_type == MempoolAcceptResult::ResultType::MEMPOOL_ENTRY);
-        BOOST_CHECK(it_child2 != submit_witness2.m_tx_results.end());
-        BOOST_CHECK(it_child2->second.m_result_type == MempoolAcceptResult::ResultType::DIFFERENT_WITNESS);
-        BOOST_CHECK_EQUAL(ptx_child1->GetWitnessHash(), it_child2->second.m_other_wtxid.value());
-
-        BOOST_CHECK(m_node.mempool->exists(GenTxid::Txid(ptx_child2->GetHash())));
-        BOOST_CHECK(!m_node.mempool->exists(GenTxid::Wtxid(ptx_child2->GetWitnessHash())));
+                                                       package_parent_child2, /*test_accept=*/false);
+        if (auto err_witness2{CheckPackageMempoolAcceptResult(package_parent_child2, submit_witness2, /*expect_valid=*/true, m_node.mempool.get())}) {
+            BOOST_ERROR(err_witness2.value());
+        } else {
+            auto it_parent2_deduped = submit_witness2.m_tx_results.find(ptx_parent->GetWitnessHash());
+            auto it_child2 = submit_witness2.m_tx_results.find(ptx_child2->GetWitnessHash());
+            BOOST_CHECK(it_parent2_deduped->second.m_result_type == MempoolAcceptResult::ResultType::MEMPOOL_ENTRY);
+            BOOST_CHECK(it_child2->second.m_result_type == MempoolAcceptResult::ResultType::DIFFERENT_WITNESS);
+            BOOST_CHECK_EQUAL(ptx_child1->GetWitnessHash(), it_child2->second.m_other_wtxid.value());
+        }
 
         // Deduplication should work when wtxid != txid. Submit package with the already-in-mempool
         // transactions again, which should not fail.
         const auto submit_segwit_dedup = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                           {ptx_parent, ptx_child1}, /*test_accept=*/false);
-        BOOST_CHECK_MESSAGE(submit_segwit_dedup.m_state.IsValid(),
-                            "Package validation unexpectedly failed: " << submit_segwit_dedup.m_state.GetRejectReason());
-        BOOST_CHECK_EQUAL(submit_segwit_dedup.m_tx_results.size(), 2);
-        auto it_parent_dup = submit_segwit_dedup.m_tx_results.find(ptx_parent->GetWitnessHash());
-        auto it_child_dup = submit_segwit_dedup.m_tx_results.find(ptx_child1->GetWitnessHash());
-        BOOST_CHECK(it_parent_dup->second.m_result_type == MempoolAcceptResult::ResultType::MEMPOOL_ENTRY);
-        BOOST_CHECK(it_child_dup->second.m_result_type == MempoolAcceptResult::ResultType::MEMPOOL_ENTRY);
+                                                           package_parent_child1, /*test_accept=*/false);
+        if (auto err_segwit_dedup{CheckPackageMempoolAcceptResult(package_parent_child1, submit_segwit_dedup, /*expect_valid=*/true, m_node.mempool.get())}) {
+            BOOST_ERROR(err_segwit_dedup.value());
+        } else {
+            auto it_parent_dup = submit_segwit_dedup.m_tx_results.find(ptx_parent->GetWitnessHash());
+            auto it_child_dup = submit_segwit_dedup.m_tx_results.find(ptx_child1->GetWitnessHash());
+            BOOST_CHECK(it_parent_dup->second.m_result_type == MempoolAcceptResult::ResultType::MEMPOOL_ENTRY);
+            BOOST_CHECK(it_child_dup->second.m_result_type == MempoolAcceptResult::ResultType::MEMPOOL_ENTRY);
+        }
     }
 
     // Try submitting Package1{child2, grandchild} where child2 is same-txid-different-witness as
@@ -535,21 +515,17 @@ BOOST_FIXTURE_TEST_CASE(package_witness_swap_tests, TestChain100Setup)
 
     // We already submitted child1 above.
     {
+        Package package_child2_grandchild{ptx_child2, ptx_grandchild};
         const auto submit_spend_ignored = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                            {ptx_child2, ptx_grandchild}, /*test_accept=*/false);
-        BOOST_CHECK_MESSAGE(submit_spend_ignored.m_state.IsValid(),
-                            "Package validation unexpectedly failed: " << submit_spend_ignored.m_state.GetRejectReason());
-        BOOST_CHECK_EQUAL(submit_spend_ignored.m_tx_results.size(), 2);
-        auto it_child2_ignored = submit_spend_ignored.m_tx_results.find(ptx_child2->GetWitnessHash());
-        auto it_grandchild = submit_spend_ignored.m_tx_results.find(ptx_grandchild->GetWitnessHash());
-        BOOST_CHECK(it_child2_ignored != submit_spend_ignored.m_tx_results.end());
-        BOOST_CHECK(it_child2_ignored->second.m_result_type == MempoolAcceptResult::ResultType::DIFFERENT_WITNESS);
-        BOOST_CHECK(it_grandchild != submit_spend_ignored.m_tx_results.end());
-        BOOST_CHECK(it_grandchild->second.m_result_type == MempoolAcceptResult::ResultType::VALID);
-
-        BOOST_CHECK(m_node.mempool->exists(GenTxid::Txid(ptx_child2->GetHash())));
-        BOOST_CHECK(!m_node.mempool->exists(GenTxid::Wtxid(ptx_child2->GetWitnessHash())));
-        BOOST_CHECK(m_node.mempool->exists(GenTxid::Wtxid(ptx_grandchild->GetWitnessHash())));
+                                                            package_child2_grandchild, /*test_accept=*/false);
+        if (auto err_spend_ignored{CheckPackageMempoolAcceptResult(package_child2_grandchild, submit_spend_ignored, /*expect_valid=*/true, m_node.mempool.get())}) {
+            BOOST_ERROR(err_spend_ignored.value());
+        } else {
+            auto it_child2_ignored = submit_spend_ignored.m_tx_results.find(ptx_child2->GetWitnessHash());
+            auto it_grandchild = submit_spend_ignored.m_tx_results.find(ptx_grandchild->GetWitnessHash());
+            BOOST_CHECK(it_child2_ignored->second.m_result_type == MempoolAcceptResult::ResultType::DIFFERENT_WITNESS);
+            BOOST_CHECK(it_grandchild->second.m_result_type == MempoolAcceptResult::ResultType::VALID);
+        }
     }
 
     // A package Package{parent1, parent2, parent3, child} where the parents are a mixture of
@@ -641,36 +617,28 @@ BOOST_FIXTURE_TEST_CASE(package_witness_swap_tests, TestChain100Setup)
     // child should be accepted
     {
         const auto mixed_result = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool, package_mixed, false);
-        BOOST_CHECK_MESSAGE(mixed_result.m_state.IsValid(), mixed_result.m_state.GetRejectReason());
-        BOOST_CHECK_EQUAL(mixed_result.m_tx_results.size(), package_mixed.size());
-        auto it_parent1 = mixed_result.m_tx_results.find(ptx_parent1->GetWitnessHash());
-        auto it_parent2 = mixed_result.m_tx_results.find(ptx_parent2_v1->GetWitnessHash());
-        auto it_parent3 = mixed_result.m_tx_results.find(ptx_parent3->GetWitnessHash());
-        auto it_child = mixed_result.m_tx_results.find(ptx_mixed_child->GetWitnessHash());
-        BOOST_CHECK(it_parent1 != mixed_result.m_tx_results.end());
-        BOOST_CHECK(it_parent2 != mixed_result.m_tx_results.end());
-        BOOST_CHECK(it_parent3 != mixed_result.m_tx_results.end());
-        BOOST_CHECK(it_child != mixed_result.m_tx_results.end());
+        if (auto err_mixed{CheckPackageMempoolAcceptResult(package_mixed, mixed_result, /*expect_valid=*/true, m_node.mempool.get())}) {
+            BOOST_ERROR(err_mixed.value());
+        } else {
+            auto it_parent1 = mixed_result.m_tx_results.find(ptx_parent1->GetWitnessHash());
+            auto it_parent2 = mixed_result.m_tx_results.find(ptx_parent2_v1->GetWitnessHash());
+            auto it_parent3 = mixed_result.m_tx_results.find(ptx_parent3->GetWitnessHash());
+            auto it_child = mixed_result.m_tx_results.find(ptx_mixed_child->GetWitnessHash());
 
-        BOOST_CHECK(it_parent1->second.m_result_type == MempoolAcceptResult::ResultType::MEMPOOL_ENTRY);
-        BOOST_CHECK(it_parent2->second.m_result_type == MempoolAcceptResult::ResultType::DIFFERENT_WITNESS);
-        BOOST_CHECK(it_parent3->second.m_result_type == MempoolAcceptResult::ResultType::VALID);
-        BOOST_CHECK(it_child->second.m_result_type == MempoolAcceptResult::ResultType::VALID);
-        BOOST_CHECK_EQUAL(ptx_parent2_v2->GetWitnessHash(), it_parent2->second.m_other_wtxid.value());
+            BOOST_CHECK(it_parent1->second.m_result_type == MempoolAcceptResult::ResultType::MEMPOOL_ENTRY);
+            BOOST_CHECK(it_parent2->second.m_result_type == MempoolAcceptResult::ResultType::DIFFERENT_WITNESS);
+            BOOST_CHECK(it_parent3->second.m_result_type == MempoolAcceptResult::ResultType::VALID);
+            BOOST_CHECK(it_child->second.m_result_type == MempoolAcceptResult::ResultType::VALID);
+            BOOST_CHECK_EQUAL(ptx_parent2_v2->GetWitnessHash(), it_parent2->second.m_other_wtxid.value());
 
-        BOOST_CHECK(m_node.mempool->exists(GenTxid::Txid(ptx_parent1->GetHash())));
-        BOOST_CHECK(m_node.mempool->exists(GenTxid::Txid(ptx_parent2_v1->GetHash())));
-        BOOST_CHECK(!m_node.mempool->exists(GenTxid::Wtxid(ptx_parent2_v1->GetWitnessHash())));
-        BOOST_CHECK(m_node.mempool->exists(GenTxid::Txid(ptx_parent3->GetHash())));
-        BOOST_CHECK(m_node.mempool->exists(GenTxid::Txid(ptx_mixed_child->GetHash())));
-
-        // package feerate should include parent3 and child. It should not include parent1 or parent2_v1.
-        const CFeeRate expected_feerate(1 * COIN, GetVirtualTransactionSize(*ptx_parent3) + GetVirtualTransactionSize(*ptx_mixed_child));
-        BOOST_CHECK(it_parent3->second.m_effective_feerate.value() == expected_feerate);
-        BOOST_CHECK(it_child->second.m_effective_feerate.value() == expected_feerate);
-        std::vector<Wtxid> expected_wtxids({ptx_parent3->GetWitnessHash(), ptx_mixed_child->GetWitnessHash()});
-        BOOST_CHECK(it_parent3->second.m_wtxids_fee_calculations.value() == expected_wtxids);
-        BOOST_CHECK(it_child->second.m_wtxids_fee_calculations.value() == expected_wtxids);
+            // package feerate should include parent3 and child. It should not include parent1 or parent2_v1.
+            const CFeeRate expected_feerate(1 * COIN, GetVirtualTransactionSize(*ptx_parent3) + GetVirtualTransactionSize(*ptx_mixed_child));
+            BOOST_CHECK(it_parent3->second.m_effective_feerate.value() == expected_feerate);
+            BOOST_CHECK(it_child->second.m_effective_feerate.value() == expected_feerate);
+            std::vector<Wtxid> expected_wtxids({ptx_parent3->GetWitnessHash(), ptx_mixed_child->GetWitnessHash()});
+            BOOST_CHECK(it_parent3->second.m_wtxids_fee_calculations.value() == expected_wtxids);
+            BOOST_CHECK(it_child->second.m_wtxids_fee_calculations.value() == expected_wtxids);
+        }
     }
 }
 
@@ -715,15 +683,17 @@ BOOST_FIXTURE_TEST_CASE(package_cpfp_tests, TestChain100Setup)
         BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
         const auto submit_cpfp_deprio = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
                                                    package_cpfp, /*test_accept=*/ false);
-        BOOST_CHECK_EQUAL(submit_cpfp_deprio.m_state.GetResult(), PackageValidationResult::PCKG_TX);
-        BOOST_CHECK(submit_cpfp_deprio.m_state.IsInvalid());
-        BOOST_CHECK_EQUAL(submit_cpfp_deprio.m_tx_results.find(tx_parent->GetWitnessHash())->second.m_state.GetResult(),
-                          TxValidationResult::TX_MEMPOOL_POLICY);
-        BOOST_CHECK_EQUAL(submit_cpfp_deprio.m_tx_results.find(tx_child->GetWitnessHash())->second.m_state.GetResult(),
-                          TxValidationResult::TX_MISSING_INPUTS);
-        BOOST_CHECK(submit_cpfp_deprio.m_tx_results.find(tx_parent->GetWitnessHash())->second.m_state.GetRejectReason() == "min relay fee not met");
-        BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
-        const CFeeRate expected_feerate(0, GetVirtualTransactionSize(*tx_parent) + GetVirtualTransactionSize(*tx_child));
+        if (auto err_cpfp_deprio{CheckPackageMempoolAcceptResult(package_cpfp, submit_cpfp_deprio, /*expect_valid=*/false, m_node.mempool.get())}) {
+            BOOST_ERROR(err_cpfp_deprio.value());
+        } else {
+            BOOST_CHECK_EQUAL(submit_cpfp_deprio.m_state.GetResult(), PackageValidationResult::PCKG_TX);
+            BOOST_CHECK_EQUAL(submit_cpfp_deprio.m_tx_results.find(tx_parent->GetWitnessHash())->second.m_state.GetResult(),
+                              TxValidationResult::TX_MEMPOOL_POLICY);
+            BOOST_CHECK_EQUAL(submit_cpfp_deprio.m_tx_results.find(tx_child->GetWitnessHash())->second.m_state.GetResult(),
+                              TxValidationResult::TX_MISSING_INPUTS);
+            BOOST_CHECK(submit_cpfp_deprio.m_tx_results.find(tx_parent->GetWitnessHash())->second.m_state.GetRejectReason() == "min relay fee not met");
+            BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
+        }
     }
 
     // Clear the prioritisation of the parent transaction.
@@ -735,31 +705,27 @@ BOOST_FIXTURE_TEST_CASE(package_cpfp_tests, TestChain100Setup)
         BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
         const auto submit_cpfp = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
                                                    package_cpfp, /*test_accept=*/ false);
+        if (auto err_cpfp{CheckPackageMempoolAcceptResult(package_cpfp, submit_cpfp, /*expect_valid=*/true, m_node.mempool.get())}) {
+            BOOST_ERROR(err_cpfp.value());
+        } else {
+            auto it_parent = submit_cpfp.m_tx_results.find(tx_parent->GetWitnessHash());
+            auto it_child = submit_cpfp.m_tx_results.find(tx_child->GetWitnessHash());
+            BOOST_CHECK(it_parent->second.m_result_type == MempoolAcceptResult::ResultType::VALID);
+            BOOST_CHECK(it_parent->second.m_base_fees.value() == coinbase_value - parent_value);
+            BOOST_CHECK(it_child->second.m_result_type == MempoolAcceptResult::ResultType::VALID);
+            BOOST_CHECK(it_child->second.m_base_fees.value() == COIN);
+
+            const CFeeRate expected_feerate(coinbase_value - child_value,
+                                            GetVirtualTransactionSize(*tx_parent) + GetVirtualTransactionSize(*tx_child));
+            BOOST_CHECK(it_parent->second.m_effective_feerate.value() == expected_feerate);
+            BOOST_CHECK(it_child->second.m_effective_feerate.value() == expected_feerate);
+            std::vector<Wtxid> expected_wtxids({tx_parent->GetWitnessHash(), tx_child->GetWitnessHash()});
+            BOOST_CHECK(it_parent->second.m_wtxids_fee_calculations.value() == expected_wtxids);
+            BOOST_CHECK(it_child->second.m_wtxids_fee_calculations.value() == expected_wtxids);
+            BOOST_CHECK(expected_feerate.GetFeePerK() > 1000);
+        }
         expected_pool_size += 2;
-        BOOST_CHECK_MESSAGE(submit_cpfp.m_state.IsValid(),
-                            "Package validation unexpectedly failed: " << submit_cpfp.m_state.GetRejectReason());
-        BOOST_CHECK_EQUAL(submit_cpfp.m_tx_results.size(), package_cpfp.size());
-        auto it_parent = submit_cpfp.m_tx_results.find(tx_parent->GetWitnessHash());
-        auto it_child = submit_cpfp.m_tx_results.find(tx_child->GetWitnessHash());
-        BOOST_CHECK(it_parent != submit_cpfp.m_tx_results.end());
-        BOOST_CHECK(it_parent->second.m_result_type == MempoolAcceptResult::ResultType::VALID);
-        BOOST_CHECK(it_parent->second.m_base_fees.value() == coinbase_value - parent_value);
-        BOOST_CHECK(it_child != submit_cpfp.m_tx_results.end());
-        BOOST_CHECK(it_child->second.m_result_type == MempoolAcceptResult::ResultType::VALID);
-        BOOST_CHECK(it_child->second.m_base_fees.value() == COIN);
-
         BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
-        BOOST_CHECK(m_node.mempool->exists(GenTxid::Txid(tx_parent->GetHash())));
-        BOOST_CHECK(m_node.mempool->exists(GenTxid::Txid(tx_child->GetHash())));
-
-        const CFeeRate expected_feerate(coinbase_value - child_value,
-                                        GetVirtualTransactionSize(*tx_parent) + GetVirtualTransactionSize(*tx_child));
-        BOOST_CHECK(it_parent->second.m_effective_feerate.value() == expected_feerate);
-        BOOST_CHECK(it_child->second.m_effective_feerate.value() == expected_feerate);
-        std::vector<Wtxid> expected_wtxids({tx_parent->GetWitnessHash(), tx_child->GetWitnessHash()});
-        BOOST_CHECK(it_parent->second.m_wtxids_fee_calculations.value() == expected_wtxids);
-        BOOST_CHECK(it_child->second.m_wtxids_fee_calculations.value() == expected_wtxids);
-        BOOST_CHECK(expected_feerate.GetFeePerK() > 1000);
     }
 
     // Just because we allow low-fee parents doesn't mean we allow low-feerate packages.
@@ -785,15 +751,17 @@ BOOST_FIXTURE_TEST_CASE(package_cpfp_tests, TestChain100Setup)
     package_still_too_low.push_back(tx_child_cheap);
     BOOST_CHECK(m_node.mempool->GetMinFee().GetFee(GetVirtualTransactionSize(*tx_child_cheap)) <= child_fee);
     BOOST_CHECK(m_node.mempool->GetMinFee().GetFee(GetVirtualTransactionSize(*tx_parent_cheap) + GetVirtualTransactionSize(*tx_child_cheap)) > parent_fee + child_fee);
+    BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
 
     // Cheap package should fail with package-fee-too-low.
     {
-        BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
         const auto submit_package_too_low = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
                                                    package_still_too_low, /*test_accept=*/false);
-        BOOST_CHECK_MESSAGE(submit_package_too_low.m_state.IsInvalid(), "Package validation unexpectedly succeeded");
         BOOST_CHECK_EQUAL(submit_package_too_low.m_state.GetResult(), PackageValidationResult::PCKG_POLICY);
         BOOST_CHECK_EQUAL(submit_package_too_low.m_state.GetRejectReason(), "package-fee-too-low");
+        if (auto err_package_too_low{CheckPackageMempoolAcceptResult(package_still_too_low, submit_package_too_low, /*expect_valid=*/false, m_node.mempool.get())}) {
+            BOOST_ERROR(err_package_too_low.value());
+        }
         BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
     }
 
@@ -804,25 +772,26 @@ BOOST_FIXTURE_TEST_CASE(package_cpfp_tests, TestChain100Setup)
     {
         const auto submit_prioritised_package = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
                                                                   package_still_too_low, /*test_accept=*/false);
+        if (auto err_prioritised{CheckPackageMempoolAcceptResult(package_still_too_low, submit_prioritised_package, /*expect_valid=*/true, m_node.mempool.get())}) {
+            BOOST_ERROR(err_prioritised.value());
+        } else {
+            const CFeeRate expected_feerate(1 * COIN + parent_fee + child_fee,
+                GetVirtualTransactionSize(*tx_parent_cheap) + GetVirtualTransactionSize(*tx_child_cheap));
+            BOOST_CHECK_EQUAL(submit_prioritised_package.m_tx_results.size(), package_still_too_low.size());
+            auto it_parent = submit_prioritised_package.m_tx_results.find(tx_parent_cheap->GetWitnessHash());
+            auto it_child = submit_prioritised_package.m_tx_results.find(tx_child_cheap->GetWitnessHash());
+            BOOST_CHECK(it_parent->second.m_result_type == MempoolAcceptResult::ResultType::VALID);
+            BOOST_CHECK(it_parent->second.m_base_fees.value() == parent_fee);
+            BOOST_CHECK(it_parent->second.m_effective_feerate.value() == expected_feerate);
+            BOOST_CHECK(it_child->second.m_result_type == MempoolAcceptResult::ResultType::VALID);
+            BOOST_CHECK(it_child->second.m_base_fees.value() == child_fee);
+            BOOST_CHECK(it_child->second.m_effective_feerate.value() == expected_feerate);
+            std::vector<Wtxid> expected_wtxids({tx_parent_cheap->GetWitnessHash(), tx_child_cheap->GetWitnessHash()});
+            BOOST_CHECK(it_parent->second.m_wtxids_fee_calculations.value() == expected_wtxids);
+            BOOST_CHECK(it_child->second.m_wtxids_fee_calculations.value() == expected_wtxids);
+        }
         expected_pool_size += 2;
-        BOOST_CHECK_MESSAGE(submit_prioritised_package.m_state.IsValid(),
-                "Package validation unexpectedly failed" << submit_prioritised_package.m_state.GetRejectReason());
-        const CFeeRate expected_feerate(1 * COIN + parent_fee + child_fee,
-            GetVirtualTransactionSize(*tx_parent_cheap) + GetVirtualTransactionSize(*tx_child_cheap));
-        BOOST_CHECK_EQUAL(submit_prioritised_package.m_tx_results.size(), package_still_too_low.size());
-        auto it_parent = submit_prioritised_package.m_tx_results.find(tx_parent_cheap->GetWitnessHash());
-        auto it_child = submit_prioritised_package.m_tx_results.find(tx_child_cheap->GetWitnessHash());
-        BOOST_CHECK(it_parent != submit_prioritised_package.m_tx_results.end());
-        BOOST_CHECK(it_parent->second.m_result_type == MempoolAcceptResult::ResultType::VALID);
-        BOOST_CHECK(it_parent->second.m_base_fees.value() == parent_fee);
-        BOOST_CHECK(it_parent->second.m_effective_feerate.value() == expected_feerate);
-        BOOST_CHECK(it_child != submit_prioritised_package.m_tx_results.end());
-        BOOST_CHECK(it_child->second.m_result_type == MempoolAcceptResult::ResultType::VALID);
-        BOOST_CHECK(it_child->second.m_base_fees.value() == child_fee);
-        BOOST_CHECK(it_child->second.m_effective_feerate.value() == expected_feerate);
-        std::vector<Wtxid> expected_wtxids({tx_parent_cheap->GetWitnessHash(), tx_child_cheap->GetWitnessHash()});
-        BOOST_CHECK(it_parent->second.m_wtxids_fee_calculations.value() == expected_wtxids);
-        BOOST_CHECK(it_child->second.m_wtxids_fee_calculations.value() == expected_wtxids);
+        BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
     }
 
     // Package feerate is calculated without topology in mind; it's just aggregating fees and sizes.
@@ -851,31 +820,27 @@ BOOST_FIXTURE_TEST_CASE(package_cpfp_tests, TestChain100Setup)
         BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
         const auto submit_rich_parent = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
                                                           package_rich_parent, /*test_accept=*/false);
+        if (auto err_rich_parent{CheckPackageMempoolAcceptResult(package_rich_parent, submit_rich_parent, /*expect_valid=*/false, m_node.mempool.get())}) {
+            BOOST_ERROR(err_rich_parent.value());
+        } else {
+            // The child would have been validated on its own and failed.
+            BOOST_CHECK_EQUAL(submit_rich_parent.m_state.GetResult(), PackageValidationResult::PCKG_TX);
+            BOOST_CHECK_EQUAL(submit_rich_parent.m_state.GetRejectReason(), "transaction failed");
+
+            auto it_parent = submit_rich_parent.m_tx_results.find(tx_parent_rich->GetWitnessHash());
+            auto it_child = submit_rich_parent.m_tx_results.find(tx_child_poor->GetWitnessHash());
+            BOOST_CHECK(it_parent->second.m_result_type == MempoolAcceptResult::ResultType::VALID);
+            BOOST_CHECK(it_child->second.m_result_type == MempoolAcceptResult::ResultType::INVALID);
+            BOOST_CHECK(it_parent->second.m_state.GetRejectReason() == "");
+            BOOST_CHECK_MESSAGE(it_parent->second.m_base_fees.value() == high_parent_fee,
+                    strprintf("rich parent: expected fee %s, got %s", high_parent_fee, it_parent->second.m_base_fees.value()));
+            BOOST_CHECK(it_parent->second.m_effective_feerate == CFeeRate(high_parent_fee, GetVirtualTransactionSize(*tx_parent_rich)));
+            BOOST_CHECK_EQUAL(it_child->second.m_result_type, MempoolAcceptResult::ResultType::INVALID);
+            BOOST_CHECK_EQUAL(it_child->second.m_state.GetResult(), TxValidationResult::TX_MEMPOOL_POLICY);
+            BOOST_CHECK(it_child->second.m_state.GetRejectReason() == "min relay fee not met");
+        }
         expected_pool_size += 1;
-        BOOST_CHECK_MESSAGE(submit_rich_parent.m_state.IsInvalid(), "Package validation unexpectedly succeeded");
-
-        // The child would have been validated on its own and failed.
-        BOOST_CHECK_EQUAL(submit_rich_parent.m_state.GetResult(), PackageValidationResult::PCKG_TX);
-        BOOST_CHECK_EQUAL(submit_rich_parent.m_state.GetRejectReason(), "transaction failed");
-
-        auto it_parent = submit_rich_parent.m_tx_results.find(tx_parent_rich->GetWitnessHash());
-        auto it_child = submit_rich_parent.m_tx_results.find(tx_child_poor->GetWitnessHash());
-        BOOST_CHECK(it_parent != submit_rich_parent.m_tx_results.end());
-        BOOST_CHECK(it_child != submit_rich_parent.m_tx_results.end());
-        BOOST_CHECK(it_parent->second.m_result_type == MempoolAcceptResult::ResultType::VALID);
-        BOOST_CHECK(it_child->second.m_result_type == MempoolAcceptResult::ResultType::INVALID);
-        BOOST_CHECK(it_parent->second.m_state.GetRejectReason() == "");
-        BOOST_CHECK_MESSAGE(it_parent->second.m_base_fees.value() == high_parent_fee,
-                strprintf("rich parent: expected fee %s, got %s", high_parent_fee, it_parent->second.m_base_fees.value()));
-        BOOST_CHECK(it_parent->second.m_effective_feerate == CFeeRate(high_parent_fee, GetVirtualTransactionSize(*tx_parent_rich)));
-        BOOST_CHECK(it_child != submit_rich_parent.m_tx_results.end());
-        BOOST_CHECK_EQUAL(it_child->second.m_result_type, MempoolAcceptResult::ResultType::INVALID);
-        BOOST_CHECK_EQUAL(it_child->second.m_state.GetResult(), TxValidationResult::TX_MEMPOOL_POLICY);
-        BOOST_CHECK(it_child->second.m_state.GetRejectReason() == "min relay fee not met");
-
         BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
-        BOOST_CHECK(m_node.mempool->exists(GenTxid::Txid(tx_parent_rich->GetHash())));
-        BOOST_CHECK(!m_node.mempool->exists(GenTxid::Txid(tx_child_poor->GetHash())));
     }
 }
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/util/txmempool.cpp
+++ b/src/test/util/txmempool.cpp
@@ -89,11 +89,14 @@ std::optional<std::string> CheckPackageMempoolAcceptResult(const Package& txns,
         }
 
         // m_effective_feerate and m_wtxids_fee_calculations should exist iff the result was valid
-        if (atmp_result.m_effective_feerate.has_value() != valid) {
+        // or if the failure was TX_RECONSIDERABLE
+        const bool valid_or_reconsiderable{atmp_result.m_result_type == MempoolAcceptResult::ResultType::VALID ||
+                    atmp_result.m_state.GetResult() == TxValidationResult::TX_RECONSIDERABLE};
+        if (atmp_result.m_effective_feerate.has_value() != valid_or_reconsiderable) {
             return strprintf("tx %s result should %shave m_effective_feerate",
                                     wtxid.ToString(), valid ? "" : "not ");
         }
-        if (atmp_result.m_wtxids_fee_calculations.has_value() != valid) {
+        if (atmp_result.m_wtxids_fee_calculations.has_value() != valid_or_reconsiderable) {
             return strprintf("tx %s result should %shave m_effective_feerate",
                                     wtxid.ToString(), valid ? "" : "not ");
         }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -670,11 +670,11 @@ private:
         AssertLockHeld(m_pool.cs);
         CAmount mempoolRejectFee = m_pool.GetMinFee().GetFee(package_size);
         if (mempoolRejectFee > 0 && package_fee < mempoolRejectFee) {
-            return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "mempool min fee not met", strprintf("%d < %d", package_fee, mempoolRejectFee));
+            return state.Invalid(TxValidationResult::TX_RECONSIDERABLE, "mempool min fee not met", strprintf("%d < %d", package_fee, mempoolRejectFee));
         }
 
         if (package_fee < m_pool.m_min_relay_feerate.GetFee(package_size)) {
-            return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "min relay fee not met",
+            return state.Invalid(TxValidationResult::TX_RECONSIDERABLE, "min relay fee not met",
                                  strprintf("%d < %d", package_fee, m_pool.m_min_relay_feerate.GetFee(package_size)));
         }
         return true;
@@ -867,6 +867,8 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
     // method of ensuring the tx remains bumped. For example, the fee-bumping child could disappear
     // due to a replacement.
     if (!bypass_limits && ws.m_modified_fees < m_pool.m_min_relay_feerate.GetFee(ws.m_vsize)) {
+        // Even though this is a fee-related failure, this result is TX_MEMPOOL_POLICY, not
+        // TX_RECONSIDERABLE, because it cannot be bypassed using package validation.
         return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "min relay fee not met",
                              strprintf("%d < %d", ws.m_modified_fees, m_pool.m_min_relay_feerate.GetFee(ws.m_vsize)));
     }
@@ -981,6 +983,9 @@ bool MemPoolAccept::ReplacementChecks(Workspace& ws)
     //   descendant transaction of a direct conflict to pay a higher feerate than the transaction that
     //   might replace them, under these rules.
     if (const auto err_string{PaysMoreThanConflicts(ws.m_iters_conflicting, newFeeRate, hash)}) {
+        // Even though this is a fee-related failure, this result is TX_MEMPOOL_POLICY, not
+        // TX_RECONSIDERABLE, because it cannot be bypassed using package validation.
+        // This must be changed if package RBF is enabled.
         return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "insufficient fee", *err_string);
     }
 
@@ -1002,6 +1007,9 @@ bool MemPoolAccept::ReplacementChecks(Workspace& ws)
     }
     if (const auto err_string{PaysForRBF(ws.m_conflicting_fees, ws.m_modified_fees, ws.m_vsize,
                                          m_pool.m_incremental_relay_feerate, hash)}) {
+        // Even though this is a fee-related failure, this result is TX_MEMPOOL_POLICY, not
+        // TX_RECONSIDERABLE, because it cannot be bypassed using package validation.
+        // This must be changed if package RBF is enabled.
         return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "insufficient fee", *err_string);
     }
     return true;
@@ -1139,7 +1147,8 @@ bool MemPoolAccept::Finalize(const ATMPArgs& args, Workspace& ws)
     if (!args.m_package_submission && !bypass_limits) {
         LimitMempoolSize(m_pool, m_active_chainstate.CoinsTip());
         if (!m_pool.exists(GenTxid::Txid(hash)))
-            return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "mempool full");
+            // The tx no longer meets our (new) mempool minimum feerate but could be reconsidered in a package.
+            return state.Invalid(TxValidationResult::TX_RECONSIDERABLE, "mempool full");
     }
     return true;
 }
@@ -1510,7 +1519,7 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptPackage(const Package& package, 
                 // in package validation, because its fees should only be "used" once.
                 assert(m_pool.exists(GenTxid::Wtxid(wtxid)));
                 results_final.emplace(wtxid, single_res);
-            } else if (single_res.m_state.GetResult() != TxValidationResult::TX_MEMPOOL_POLICY &&
+            } else if (single_res.m_state.GetResult() != TxValidationResult::TX_RECONSIDERABLE &&
                        single_res.m_state.GetResult() != TxValidationResult::TX_MISSING_INPUTS) {
                 // Package validation policy only differs from individual policy in its evaluation
                 // of feerate. For example, if a transaction fails here due to violation of a

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1237,7 +1237,13 @@ MempoolAcceptResult MemPoolAccept::AcceptSingleTransaction(const CTransactionRef
     Workspace ws(ptx);
     const std::vector<Wtxid> single_wtxid{ws.m_ptx->GetWitnessHash()};
 
-    if (!PreChecks(args, ws)) return MempoolAcceptResult::Failure(ws.m_state);
+    if (!PreChecks(args, ws)) {
+        if (ws.m_state.GetResult() == TxValidationResult::TX_RECONSIDERABLE) {
+            // Failed for fee reasons. Provide the effective feerate and which tx was included.
+            return MempoolAcceptResult::FeeFailure(ws.m_state, CFeeRate(ws.m_modified_fees, ws.m_vsize), single_wtxid);
+        }
+        return MempoolAcceptResult::Failure(ws.m_state);
+    }
 
     if (m_rbf && !ReplacementChecks(ws)) return MempoolAcceptResult::Failure(ws.m_state);
 
@@ -1254,7 +1260,12 @@ MempoolAcceptResult MemPoolAccept::AcceptSingleTransaction(const CTransactionRef
                                             ws.m_base_fees, effective_feerate, single_wtxid);
     }
 
-    if (!Finalize(args, ws)) return MempoolAcceptResult::Failure(ws.m_state);
+    if (!Finalize(args, ws)) {
+        // The only possible failure reason is fee-related (mempool full).
+        // Failed for fee reasons. Provide the effective feerate and which txns were included.
+        Assume(ws.m_state.GetResult() == TxValidationResult::TX_RECONSIDERABLE);
+        return MempoolAcceptResult::FeeFailure(ws.m_state, CFeeRate(ws.m_modified_fees, ws.m_vsize), {ws.m_ptx->GetWitnessHash()});
+    }
 
     GetMainSignals().TransactionAddedToMempool(ptx, m_pool.GetAndIncrementSequence());
 
@@ -1308,11 +1319,16 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptMultipleTransactions(const std::
     const auto m_total_modified_fees = std::accumulate(workspaces.cbegin(), workspaces.cend(), CAmount{0},
         [](CAmount sum, auto& ws) { return sum + ws.m_modified_fees; });
     const CFeeRate package_feerate(m_total_modified_fees, m_total_vsize);
+    std::vector<Wtxid> all_package_wtxids;
+    all_package_wtxids.reserve(workspaces.size());
+    std::transform(workspaces.cbegin(), workspaces.cend(), std::back_inserter(all_package_wtxids),
+                   [](const auto& ws) { return ws.m_ptx->GetWitnessHash(); });
     TxValidationState placeholder_state;
     if (args.m_package_feerates &&
         !CheckFeeRate(m_total_vsize, m_total_modified_fees, placeholder_state)) {
-        package_state.Invalid(PackageValidationResult::PCKG_POLICY, "package-fee-too-low");
-        return PackageMempoolAcceptResult(package_state, {});
+        package_state.Invalid(PackageValidationResult::PCKG_TX, "transaction failed");
+        return PackageMempoolAcceptResult(package_state, {{workspaces.back().m_ptx->GetWitnessHash(),
+            MempoolAcceptResult::FeeFailure(placeholder_state, CFeeRate(m_total_modified_fees, m_total_vsize), all_package_wtxids)}});
     }
 
     // Apply package mempool ancestor/descendant limits. Skip if there is only one transaction,
@@ -1323,10 +1339,6 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptMultipleTransactions(const std::
         return PackageMempoolAcceptResult(package_state, std::move(results));
     }
 
-    std::vector<Wtxid> all_package_wtxids;
-    all_package_wtxids.reserve(workspaces.size());
-    std::transform(workspaces.cbegin(), workspaces.cend(), std::back_inserter(all_package_wtxids),
-                   [](const auto& ws) { return ws.m_ptx->GetWitnessHash(); });
     for (Workspace& ws : workspaces) {
         ws.m_package_feerate = package_feerate;
         if (!PolicyScriptChecks(args, ws)) {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -497,8 +497,8 @@ public:
             };
         }
 
-        /** Parameters for child-with-unconfirmed-parents package validation. */
-        static ATMPArgs PackageChildWithParents(const CChainParams& chainparams, int64_t accept_time,
+        /** Parameters for package validation of a tx with ancestors. */
+        static ATMPArgs AncestorPackageAccept(const CChainParams& chainparams, int64_t accept_time,
                                                 std::vector<COutPoint>& coins_to_uncache) {
             return ATMPArgs{/* m_chainparams */ chainparams,
                             /* m_accept_time */ accept_time,
@@ -1446,55 +1446,17 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptPackage(const Package& package, 
 
     // Check that the package is well-formed. If it isn't, we won't try to validate any of the
     // transactions and thus won't return any MempoolAcceptResults, just a package-wide error.
-
     // Context-free package checks.
-    if (!IsWellFormedPackage(package, package_state_quit_early, /*require_sorted=*/true)) {
-        return PackageMempoolAcceptResult(package_state_quit_early, {});
-    }
-
-    // All transactions in the package must be a parent of the last transaction. This is just an
-    // opportunity for us to fail fast on a context-free check without taking the mempool lock.
-    if (!IsChildWithParents(package)) {
-        package_state_quit_early.Invalid(PackageValidationResult::PCKG_POLICY, "package-not-child-with-parents");
+    if (!package.empty() && !IsWellFormedPackage(package, package_state_quit_early, /*require_sorted=*/false)) {
         return PackageMempoolAcceptResult(package_state_quit_early, {});
     }
     AncestorPackage linearized_package{package};
 
-    // IsChildWithParents() guarantees the package is > 1 transactions.
-    assert(package.size() > 1);
-    // The package must be 1 child with all of its unconfirmed parents. The package is expected to
-    // be sorted, so the last transaction is the child.
-    const auto& child = package.back();
-    std::unordered_set<uint256, SaltedTxidHasher> unconfirmed_parent_txids;
-    std::transform(package.cbegin(), package.cend() - 1,
-                   std::inserter(unconfirmed_parent_txids, unconfirmed_parent_txids.end()),
-                   [](const auto& tx) { return tx->GetHash(); });
-
-    // All child inputs must refer to a preceding package transaction or a confirmed UTXO. The only
-    // way to verify this is to look up the child's inputs in our current coins view (not including
-    // mempool), and enforce that all parents not present in the package be available at chain tip.
-    // Since this check can bring new coins into the coins cache, keep track of these coins and
-    // uncache them if we don't end up submitting this package to the mempool.
-    const CCoinsViewCache& coins_tip_cache = m_active_chainstate.CoinsTip();
-    for (const auto& input : child->vin) {
-        if (!coins_tip_cache.HaveCoinInCache(input.prevout)) {
-            args.m_coins_to_uncache.push_back(input.prevout);
-        }
-    }
-    // Using the MemPoolAccept m_view cache allows us to look up these same coins faster later.
-    // This should be connecting directly to CoinsTip, not to m_viewmempool, because we specifically
-    // require inputs to be confirmed if they aren't in the package.
-    m_view.SetBackend(m_active_chainstate.CoinsTip());
-    const auto package_or_confirmed = [this, &unconfirmed_parent_txids](const auto& input) {
-         return unconfirmed_parent_txids.count(input.prevout.hash) > 0 || m_view.HaveCoin(input.prevout);
-    };
-    if (!std::all_of(child->vin.cbegin(), child->vin.cend(), package_or_confirmed)) {
-        package_state_quit_early.Invalid(PackageValidationResult::PCKG_POLICY, "package-not-child-with-unconfirmed-parents");
+    if (!linearized_package.IsAncestorPackage()) {
+        package_state_quit_early.Invalid(PackageValidationResult::PCKG_POLICY, "not-ancestor-package");
         return PackageMempoolAcceptResult(package_state_quit_early, {});
     }
-    // Protect against bugs where we pull more inputs from disk that miss being added to
-    // coins_to_uncache. The backend will be connected again when needed in PreChecks.
-    m_view.SetBackend(m_dummy);
+    Assume(IsWellFormedPackage(linearized_package.Txns(), package_state_quit_early, /*require_sorted=*/true));
 
     LOCK(m_pool.cs);
     // Stores results from which we will create the returned PackageMempoolAcceptResult.
@@ -1820,7 +1782,7 @@ PackageMempoolAcceptResult ProcessNewPackage(Chainstate& active_chainstate, CTxM
             auto args = MemPoolAccept::ATMPArgs::PackageTestAccept(chainparams, GetTime(), coins_to_uncache);
             return MemPoolAccept(pool, active_chainstate).AcceptMultipleTransactions(package, args);
         } else {
-            auto args = MemPoolAccept::ATMPArgs::PackageChildWithParents(chainparams, GetTime(), coins_to_uncache);
+            auto args = MemPoolAccept::ATMPArgs::AncestorPackageAccept(chainparams, GetTime(), coins_to_uncache);
             return MemPoolAccept(pool, active_chainstate).AcceptPackage(package, args);
         }
     }();

--- a/src/validation.h
+++ b/src/validation.h
@@ -149,7 +149,7 @@ struct MempoolAcceptResult {
      * package. This is not necessarily equivalent to the list of transactions passed to
      * ProcessNewPackage().
      * Only present when m_result_type = ResultType::VALID. */
-    const std::optional<std::vector<uint256>> m_wtxids_fee_calculations;
+    const std::optional<std::vector<Wtxid>> m_wtxids_fee_calculations;
 
     // The following field is only present when m_result_type = ResultType::DIFFERENT_WITNESS
     /** The wtxid of the transaction in the mempool which has the same txid but different witness. */
@@ -163,7 +163,7 @@ struct MempoolAcceptResult {
                                        int64_t vsize,
                                        CAmount fees,
                                        CFeeRate effective_feerate,
-                                       const std::vector<uint256>& wtxids_fee_calculations) {
+                                       const std::vector<Wtxid>& wtxids_fee_calculations) {
         return MempoolAcceptResult(std::move(replaced_txns), vsize, fees,
                                    effective_feerate, wtxids_fee_calculations);
     }
@@ -189,7 +189,7 @@ private:
                                  int64_t vsize,
                                  CAmount fees,
                                  CFeeRate effective_feerate,
-                                 const std::vector<uint256>& wtxids_fee_calculations)
+                                 const std::vector<Wtxid>& wtxids_fee_calculations)
         : m_result_type(ResultType::VALID),
         m_replaced_transactions(std::move(replaced_txns)),
         m_vsize{vsize},

--- a/src/validation.h
+++ b/src/validation.h
@@ -114,7 +114,27 @@ double GuessVerificationProgress(const ChainTxData& data, const CBlockIndex* pin
 void PruneBlockFilesManual(Chainstate& active_chainstate, int nManualPruneHeight);
 
 /**
-* Validation result for a single transaction mempool acceptance.
+* Validation result for a transaction evaluated by MemPoolAccept (single or package).
+* Here are the expected fields and properties of a result depending on its ResultType, applicable to
+* results returned from package evaluation:
+*+---------------------------+----------------+-------------------+------------------+----------------+-------------------+
+*| Field or property         |    VALID       |                 INVALID              |  MEMPOOL_ENTRY | DIFFERENT_WITNESS |
+*|                           |                |--------------------------------------|                |                   |
+*|                           |                | TX_RECONSIDERABLE |     Other        |                |                   |
+*+---------------------------+----------------+-------------------+------------------+----------------+-------------------+
+*| txid in mempool?          | yes            | no                | no*              | yes            | yes               |
+*| wtxid in mempool?         | yes            | no                | no*              | yes            | no                |
+*| m_state                   | yes, IsValid() | yes, IsInvalid()  | yes, IsInvalid() | yes, IsValid() | yes, IsValid()    |
+*| m_replaced_transactions   | yes            | no                | no               | no             | no                |
+*| m_vsize                   | yes            | no                | no               | yes            | no                |
+*| m_base_fees               | yes            | no                | no               | yes            | no                |
+*| m_effective_feerate       | yes            | yes               | no               | no             | no                |
+*| m_wtxids_fee_calculations | yes            | yes               | no               | no             | no                |
+*| m_other_wtxid             | no             | no                | no               | no             | yes               |
+*+---------------------------+----------------+-------------------+------------------+----------------+-------------------+
+* (*) Individual transaction acceptance doesn't return MEMPOOL_ENTRY and DIFFERENT_WITNESS. It returns
+* INVALID, with the errors txn-already-in-mempool and txn-same-nonwitness-data-in-mempool
+* respectively. In those cases, the txid or wtxid may be in the mempool for a TX_CONFLICT.
 */
 struct MempoolAcceptResult {
     /** Used to indicate the results of mempool validation. */
@@ -130,7 +150,6 @@ struct MempoolAcceptResult {
     /** Contains information about why the transaction failed. */
     const TxValidationState m_state;
 
-    // The following fields are only present when m_result_type = ResultType::VALID or MEMPOOL_ENTRY
     /** Mempool transactions replaced by the tx. */
     const std::optional<std::list<CTransactionRef>> m_replaced_transactions;
     /** Virtual size as used by the mempool, calculated using serialized size and sigops. */
@@ -141,7 +160,6 @@ struct MempoolAcceptResult {
      * using prioritisetransaction (i.e. modified fees). If this transaction was submitted as a
      * package, this is the package feerate, which may also include its descendants and/or
      * ancestors (see m_wtxids_fee_calculations below).
-     * Only present when m_result_type = ResultType::VALID.
      */
     const std::optional<CFeeRate> m_effective_feerate;
     /** Contains the wtxids of the transactions used for fee-related checks. Includes this
@@ -151,12 +169,17 @@ struct MempoolAcceptResult {
      * Only present when m_result_type = ResultType::VALID. */
     const std::optional<std::vector<Wtxid>> m_wtxids_fee_calculations;
 
-    // The following field is only present when m_result_type = ResultType::DIFFERENT_WITNESS
     /** The wtxid of the transaction in the mempool which has the same txid but different witness. */
     const std::optional<uint256> m_other_wtxid;
 
     static MempoolAcceptResult Failure(TxValidationState state) {
         return MempoolAcceptResult(state);
+    }
+
+    static MempoolAcceptResult FeeFailure(TxValidationState state,
+                                          CFeeRate effective_feerate,
+                                          const std::vector<Wtxid>& wtxids_fee_calculations) {
+        return MempoolAcceptResult(state, effective_feerate, wtxids_fee_calculations);
     }
 
     static MempoolAcceptResult Success(std::list<CTransactionRef>&& replaced_txns,
@@ -194,6 +217,15 @@ private:
         m_replaced_transactions(std::move(replaced_txns)),
         m_vsize{vsize},
         m_base_fees(fees),
+        m_effective_feerate(effective_feerate),
+        m_wtxids_fee_calculations(wtxids_fee_calculations) {}
+
+    /** Constructor for fee-related failure case */
+    explicit MempoolAcceptResult(TxValidationState state,
+                                 CFeeRate effective_feerate,
+                                 const std::vector<Wtxid>& wtxids_fee_calculations)
+        : m_result_type(ResultType::INVALID),
+        m_state(state),
         m_effective_feerate(effective_feerate),
         m_wtxids_fee_calculations(wtxids_fee_calculations) {}
 


### PR DESCRIPTION
After #26711, validation should be able to handle any ancestor package properly. We can remove the child-with-unconfirmed-parents restriction and the `IsTree` restriction.

In draft while #26711 is still open.