### PR TITLE
tests: Increase wallet_miniscript.py rpc timeout to 90 seconds

### DIFF
--- a/test/functional/wallet_miniscript.py
+++ b/test/functional/wallet_miniscript.py
@@ -208,6 +208,7 @@ class WalletMiniscriptTest(BitcoinTestFramework):
 
     def set_test_params(self):
         self.num_nodes = 1
+        self.rpc_timeout = 180
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()


### PR DESCRIPTION
The signing test for the large miniscript can sometimes take longer than the 30 second timeout, depending on the load on my system. Increasing it to 90 seconds seems to be good enough.