### PR TITLE
fuzz: Minor improvements to tx_package_eval target

### DIFF
--- a/src/test/fuzz/package_eval.cpp
+++ b/src/test/fuzz/package_eval.cpp
@@ -40,7 +40,7 @@ void initialize_tx_pool()
     g_setup = testing_setup.get();
 
     for (int i = 0; i < 2 * COINBASE_MATURITY; ++i) {
-        COutPoint prevout{MineBlock(g_setup->m_node, P2WSH_OP_TRUE)};
+        COutPoint prevout{MineBlock(g_setup->m_node, P2WSH_EMPTY)};
         if (i < COINBASE_MATURITY) {
             // Remember the txids to avoid expensive disk access later on
             g_outpoints_coinbase_init_mature.push_back(prevout);
@@ -195,7 +195,8 @@ FUZZ_TARGET(tx_package_eval, .init = initialize_tx_pool)
                     // Create input
                     const auto sequence = ConsumeSequence(fuzzed_data_provider);
                     const auto script_sig = CScript{};
-                    const auto script_wit_stack = std::vector<std::vector<uint8_t>>{WITNESS_STACK_ELEM_OP_TRUE};
+                    const auto script_wit_stack = fuzzed_data_provider.ConsumeBool() ? P2WSH_EMPTY_TRUE_STACK : P2WSH_EMPTY_TWO_STACK;
+
                     CTxIn in;
                     in.prevout = outpoint;
                     in.nSequence = sequence;
@@ -207,7 +208,7 @@ FUZZ_TARGET(tx_package_eval, .init = initialize_tx_pool)
                 const auto amount_fee = fuzzed_data_provider.ConsumeIntegralInRange<CAmount>(0, amount_in);
                 const auto amount_out = (amount_in - amount_fee) / num_out;
                 for (int i = 0; i < num_out; ++i) {
-                    tx_mut.vout.emplace_back(amount_out, P2WSH_OP_TRUE);
+                    tx_mut.vout.emplace_back(amount_out, P2WSH_EMPTY);
                 }
                 // TODO vary transaction sizes to catch size-related issues
                 auto tx = MakeTransactionRef(tx_mut);

--- a/src/test/util/script.h
+++ b/src/test/util/script.h
@@ -18,6 +18,18 @@ static const CScript P2WSH_OP_TRUE{
            return hash;
        }())};
 
+static const std::vector<uint8_t> EMPTY{};
+static const CScript P2WSH_EMPTY{
+    CScript{}
+    << OP_0
+    << ToByteVector([] {
+           uint256 hash;
+           CSHA256().Write(EMPTY.data(), EMPTY.size()).Finalize(hash.begin());
+           return hash;
+       }())};
+static const std::vector<std::vector<uint8_t>> P2WSH_EMPTY_TRUE_STACK{{static_cast<uint8_t>(OP_TRUE)}, {}};
+static const std::vector<std::vector<uint8_t>> P2WSH_EMPTY_TWO_STACK{{static_cast<uint8_t>(OP_2)}, {}};
+
 /** Flags that are not forbidden by an assert in script validation */
 bool IsValidFlagCombination(unsigned flags);
 


### PR DESCRIPTION
Exercises `DIFFERENT_WITNESS` by using "blank" WSH() and allowing witness to determine wtxid, and attempts to make invalid/duplicate inputs.