### PR TITLE
ci: win64 task does use boost:process

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -111,7 +111,7 @@ task:
     FILE_ENV: "./ci/test/00_setup_env_arm.sh"
 
 task:
-  name: 'Win64, unit tests, no gui tests, no boost::process, no functional tests'
+  name: 'Win64, unit tests, no gui tests, no functional tests'
   << : *GLOBAL_TASK_TEMPLATE
   persistent_worker:
     labels:


### PR DESCRIPTION
It passes `--enable-external-signer`.