### PR TITLE
test: Avoid intermittent failures in feature_init

### DIFF
--- a/test/functional/feature_init.py
+++ b/test/functional/feature_init.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python3
-# Copyright (c) 2021-2022 The Bitcoin Core developers
+# Copyright (c) 2021-present The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Stress tests related to node initialization."""
 import os
 from pathlib import Path
-from random import randint
 import shutil
 
 from test_framework.test_framework import BitcoinTestFramework, SkipTest
@@ -138,8 +137,8 @@ class InitStressTest(BitcoinTestFramework):
                     # Since the genesis block is not checked by -checkblocks, the
                     # perturbation window must be chosen such that a higher block
                     # in blk*.dat is affected.
-                    tf.seek(randint (150, 15000))
-                    tf.write(b'1' * randint(20, 2000))
+                    tf.seek(150)
+                    tf.write(b"1" * 200)
 
             start_expecting_error(err_fragment)
 


### PR DESCRIPTION
The code not only modifies block dat files, but also leveldb files, which may be of smaller size. Such corruption may not force leveldb to abort, according to the intermittent test failures.

Fix the intermittent test failures by reverting https://github.com/bitcoin/bitcoin/commit/5ab6419f380cc0a8cde78b125f3eeee5fcba43ae .

