### PR TITLE
contrib: drop GCC MAX_VERSION to 4.3.0 in symbol-check

### DIFF
--- a/contrib/devtools/symbol-check.py
+++ b/contrib/devtools/symbol-check.py
@@ -32,7 +32,7 @@ import lief
 # See https://gcc.gnu.org/onlinedocs/libstdc++/manual/abi.html for more info.
 
 MAX_VERSIONS = {
-'GCC':       (4,8,0),
+'GCC':       (4,3,0),
 'GLIBC': {
     lief.ELF.ARCH.x86_64: (2,27),
     lief.ELF.ARCH.ARM:    (2,27),


### PR DESCRIPTION
Reflect the actual symbols used, i.e:

```bash
bitcoind: symbol __bswapsi2 from unsupported version GCC_4.3.0(7)
```