### PR TITLE
depends: remove `PYTHONPATH` from config.site

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -14,8 +14,6 @@ endif
 .PHONY: deploy FORCE
 .INTERMEDIATE: $(COVERAGE_INFO)
 
-export PYTHONPATH
-
 if BUILD_BITCOIN_LIBS
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = libbitcoinconsensus.pc

--- a/configure.ac
+++ b/configure.ac
@@ -139,8 +139,6 @@ AC_PATH_TOOL([OBJCOPY], [objcopy])
 AC_PATH_PROG([DOXYGEN], [doxygen])
 AM_CONDITIONAL([HAVE_DOXYGEN], [test -n "$DOXYGEN"])
 
-AC_ARG_VAR([PYTHONPATH], [Augments the default search path for python module files])
-
 AC_ARG_ENABLE([wallet],
   [AS_HELP_STRING([--disable-wallet],
   [disable wallet (enabled by default)])],

--- a/depends/config.site.in
+++ b/depends/config.site.in
@@ -102,7 +102,6 @@ fi
 if test -n "@CXX@" -a -z "${CXX}"; then
   CXX="@CXX@"
 fi
-PYTHONPATH="${depends_prefix}/native/lib/python3/dist-packages${PYTHONPATH:+${PATH_SEPARATOR}}${PYTHONPATH}"
 
 if test -n "@AR@"; then
   AR="@AR@"


### PR DESCRIPTION
We no-longer need this, as we no-longer build python packages.