### PR TITLE
depends: fix libmultiprocess build on aarch64

### DIFF
--- a/depends/packages/capnp.mk
+++ b/depends/packages/capnp.mk
@@ -5,10 +5,15 @@ $(package)_download_file=$(native_$(package)_download_file)
 $(package)_file_name=$(native_$(package)_file_name)
 $(package)_sha256_hash=$(native_$(package)_sha256_hash)
 
+# Hardcode library install path to "lib" to match the PKG_CONFIG_PATH
+# setting in depends/config.site.in, which also hardcodes "lib".
+# Without this setting, cmake by default would use the OS library
+# directory, which might be "lib64" or something else, not "lib", on multiarch systems.
 define $(package)_set_vars :=
-$(package)_config_opts := -DBUILD_TESTING=OFF
-$(package)_config_opts += -DWITH_OPENSSL=OFF
-$(package)_config_opts += -DWITH_ZLIB=OFF
+  $(package)_config_opts := -DBUILD_TESTING=OFF
+  $(package)_config_opts += -DWITH_OPENSSL=OFF
+  $(package)_config_opts += -DWITH_ZLIB=OFF
+  $(package)_config_opts += -DCMAKE_INSTALL_LIBDIR=lib/
 endef
 
 define $(package)_config_cmds

--- a/depends/packages/libmultiprocess.mk
+++ b/depends/packages/libmultiprocess.mk
@@ -14,6 +14,7 @@ endif
 # directory, which might be "lib64" or something else, not "lib", on multiarch systems.
 define $(package)_set_vars :=
 $(package)_config_opts += -DCMAKE_INSTALL_LIBDIR=lib/
+$(package)_config_opts += -DCMAKE_POSITION_INDEPENDENT_CODE=ON
 ifneq ($(host),$(build))
 $(package)_config_opts := -DCAPNP_EXECUTABLE="$$(native_capnp_prefixbin)/capnp"
 $(package)_config_opts += -DCAPNPC_CXX_EXECUTABLE="$$(native_capnp_prefixbin)/capnpc-c++"

--- a/depends/packages/libmultiprocess.mk
+++ b/depends/packages/libmultiprocess.mk
@@ -8,7 +8,12 @@ ifneq ($(host),$(build))
 $(package)_dependencies += native_capnp
 endif
 
+# Hardcode library install path to "lib" to match the PKG_CONFIG_PATH
+# setting in depends/config.site.in, which also hardcodes "lib".
+# Without this setting, cmake by default would use the OS library
+# directory, which might be "lib64" or something else, not "lib", on multiarch systems.
 define $(package)_set_vars :=
+$(package)_config_opts += -DCMAKE_INSTALL_LIBDIR=lib/
 ifneq ($(host),$(build))
 $(package)_config_opts := -DCAPNP_EXECUTABLE="$$(native_capnp_prefixbin)/capnp"
 $(package)_config_opts += -DCAPNPC_CXX_EXECUTABLE="$$(native_capnp_prefixbin)/capnpc-c++"


### PR DESCRIPTION
Change to always install libmultiprocess into `lib/`. On some systems (my Fedora aarch64 box), libmultiprocess was being installed into `lib64/`, and then configure would fail to pick it up, because we only add `lib/` to pkgconfig/ldflags out of depends. Rather than adding lib64 to those, I opted for installing libmultiprocess into lib, with every other dependency we build.

This was broken in our build after https://github.com/chaincodelabs/libmultiprocess/pull/79 upstream.