### PR TITLE
guix: update signapple (drop macho & altgraph)

### DIFF
--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -422,7 +422,7 @@ and endian independent.")
     (license license:expat)))
 
 (define-public python-signapple
-  (let ((commit "7a96b4171a360abf0f0f56e499f8f9ed2116280d"))
+  (let ((commit "62155712e7417aba07565c9780a80e452823ae6a"))
     (package
       (name "python-signapple")
       (version (git-version "0.1" "1" commit))
@@ -435,14 +435,13 @@ and endian independent.")
          (file-name (git-file-name name commit))
          (sha256
           (base32
-           "0aa4k180jnpal15yhncnm3g3z9gzmi7qb25q5l0kaj444a1p2pm4"))))
+           "1nm6rm4h4m7kbq729si4cm8rzild62mk4ni8xr5zja7l33fhv3gb"))))
       (build-system python-build-system)
       (propagated-inputs
        `(("python-asn1crypto" ,python-asn1crypto)
          ("python-oscrypto" ,python-oscrypto)
          ("python-certvalidator" ,python-certvalidator)
-         ("python-elfesteem" ,python-elfesteem)
-         ("python-macholib" ,python-macholib)))
+         ("python-elfesteem" ,python-elfesteem)))
       ;; There are no tests, but attempting to run python setup.py test leads to
       ;; problems, just disable the test
       (arguments '(#:tests? #f))

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -19,7 +19,6 @@
              ((gnu packages python) #:select (python-minimal))
              ((gnu packages python-build) #:select (python-tomli))
              ((gnu packages python-crypto) #:select (python-asn1crypto))
-             ((gnu packages python-xyz) #:select (python-altgraph))
              ((gnu packages tls) #:select (openssl))
              ((gnu packages version-control) #:select (git-minimal))
              (guix build-system cmake)
@@ -372,54 +371,6 @@ thus should be able to compile on most platforms where these exist.")
 certificates or paths. Supports various options, including: validation at a
 specific moment in time, whitelisting and revocation checks.")
       (license license:expat))))
-
-(define-public python-macholib
-  (package
-    (name "python-macholib")
-    (version "1.14")
-    (source
-     (origin
-       (method git-fetch)
-       (uri (git-reference
-             (url "https://github.com/ronaldoussoren/macholib")
-             (commit (string-append "v" version))))
-       (file-name (git-file-name name version))
-       (sha256
-        (base32
-         "0aislnnfsza9wl4f0vp45ivzlc0pzhp9d4r08700slrypn5flg42"))))
-    (build-system python-build-system)
-    (propagated-inputs
-     `(("python-altgraph" ,python-altgraph)))
-    (arguments
-     '(#:phases
-       (modify-phases %standard-phases
-         (add-after 'unpack 'disable-broken-tests
-           (lambda _
-             ;; This test is broken as there is no keyboard interrupt.
-             (substitute* "macholib_tests/test_command_line.py"
-               (("^(.*)class TestCmdLine" line indent)
-                (string-append indent
-                               "@unittest.skip(\"Disabled by Guix\")\n"
-                               line)))
-             (substitute* "macholib_tests/test_dyld.py"
-               (("^(.*)def test_\\S+_find" line indent)
-                (string-append indent
-                               "@unittest.skip(\"Disabled by Guix\")\n"
-                               line))
-               (("^(.*)def testBasic" line indent)
-                (string-append indent
-                               "@unittest.skip(\"Disabled by Guix\")\n"
-                               line))
-               )
-             #t)))))
-    (home-page "https://github.com/ronaldoussoren/macholib")
-    (synopsis "Python library for analyzing and editing Mach-O headers")
-    (description "macholib is a Macho-O header analyzer and editor. It's
-typically used as a dependency analysis tool, and also to rewrite dylib
-references in Mach-O headers to be @executable_path relative. Though this tool
-targets a platform specific file format, it is pure python code that is platform
-and endian independent.")
-    (license license:expat)))
 
 (define-public python-signapple
   (let ((commit "62155712e7417aba07565c9780a80e452823ae6a"))


### PR DESCRIPTION
Update to the latest signapple, which includes https://github.com/achow101/signapple/pull/13.
Drop python-macholib and python-altgraph.