### PR TITLE
lint: Report all lint errors instead of early exit

### DIFF
--- a/ci/lint/06_script.sh
+++ b/ci/lint/06_script.sh
@@ -23,16 +23,7 @@ else
 fi
 export COMMIT_RANGE
 
-# This only checks that the trees are pure subtrees, it is not doing a full
-# check with -r to not have to fetch all the remotes.
-test/lint/git-subtree-check.sh src/crypto/ctaes
-test/lint/git-subtree-check.sh src/secp256k1
-test/lint/git-subtree-check.sh src/minisketch
-test/lint/git-subtree-check.sh src/leveldb
-test/lint/git-subtree-check.sh src/crc32c
 RUST_BACKTRACE=1 "${LINT_RUNNER_PATH}/test_runner"
-test/lint/check-doc.py
-test/lint/all-lint.py
 
 if [ "$CIRRUS_REPO_FULL_NAME" = "bitcoin/bitcoin" ] && [ "$CIRRUS_PR" = "" ] ; then
     # Sanity check only the last few commits to get notified of missing sigs,

--- a/ci/lint_imagefile
+++ b/ci/lint_imagefile
@@ -12,6 +12,7 @@ ENV LC_ALL=C.UTF-8
 COPY ./.python-version /.python-version
 COPY ./ci/lint/container-entrypoint.sh /entrypoint.sh
 COPY ./ci/lint/04_install.sh /install.sh
+COPY ./test/lint/test_runner /test/lint/test_runner
 
 RUN /install.sh && \
   echo 'alias lint="./ci/lint/06_script.sh"' >> ~/.bashrc && \


### PR DESCRIPTION
`all-lint.py` currently collects all failures. However, the `06_script.sh` does not, since July this year (https://github.com/bitcoin/bitcoin/pull/28103#discussion_r1268115806).

Fix this by printing all failures before exiting.

Can be tested by modifying (for example) two subtrees in the same commit and then running the linters.