### PR TITLE
doc: remove mention of missing bdb being a configure error

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -175,7 +175,6 @@ There are many ways to configure Bitcoin Core, here are a few common examples:
 ##### Wallet (BDB + SQlite) Support, No GUI:
 
 If `berkeley-db@4` is installed, then legacy wallet support will be built.
-If `berkeley-db@4` is not installed, then this will throw an error.
 If `sqlite` is installed, then descriptor wallet support will also be built.
 Additionally, this explicitly disables the GUI.
 


### PR DESCRIPTION
This is no-longer the case, unless you're passing additional flags, which is not the case in this example.