### PR TITLE
contrib: use a raw string for a regular expression literal that contains backslashes in signet/miner

### DIFF
--- a/contrib/signet/miner
+++ b/contrib/signet/miner
@@ -30,7 +30,7 @@ logging.basicConfig(
 
 SIGNET_HEADER = b"\xec\xc7\xda\xa2"
 PSBT_SIGNET_BLOCK = b"\xfc\x06signetb"    # proprietary PSBT global field holding the block being signed
-RE_MULTIMINER = re.compile("^(\d+)(-(\d+))?/(\d+)$")
+RE_MULTIMINER = re.compile(r"^(\d+)(-(\d+))?/(\d+)$")
 
 def create_coinbase(height, value, spk):
     cb = CTransaction()


### PR DESCRIPTION
Running `contrib/signet/miner` under python >= 3.12 causes a `SyntaxWarning`. The problem was already present in previous versions, but it only triggered a `DeprecationWarning`, which was not shown by default.

The change is useful for future-proofing the code base, since future python versions will start to exit with a runtime exception (see the reference given later).

Command to see the warning at runtime under python3.11 (`DeprecationWarning`, needs "-Walways"):
```
$ python3.11 -Walways ./contrib/signet/miner
<BASE>/contrib/signet/miner:33: DeprecationWarning: invalid escape sequence '\d'
  RE_MULTIMINER = re.compile("^(\d+)(-(\d+))?/(\d+)$")
2023-11-15 16:02:49 ERROR Must specify command
```

Command to see the warning at runtime under python3.12 (`SyntaxWarning`, no modifiers needed):
```
$ python3.12 ./contrib/signet/miner
<BASE>/contrib/signet/miner:33: SyntaxWarning: invalid escape sequence '\d'
  RE_MULTIMINER = re.compile("^(\d+)(-(\d+))?/(\d+)$")
2023-11-15 16:03:00 ERROR Must specify command
```

Reference (https://docs.python.org/3.8/library/re.html):
> Regular expressions use the backslash character ('\') [...]. This collides with Python’s usage of the same character for the same purpose in string literals; [...]
>
> Also, please note that any invalid escape sequences in Python’s usage of the backslash in string literals now generate a DeprecationWarning and in the future this will become a SyntaxError.
>
> The solution is to use Python’s raw string notation for regular expression patterns;
