### PR TITLE
doc: remove x86_64 build assumption from depends doc

### DIFF
--- a/depends/description.md
+++ b/depends/description.md
@@ -6,8 +6,7 @@ There are several features that make it different from most similar systems:
 In theory, binaries for any target OS/architecture can be created, from a
 builder running any OS/architecture. In practice, build-side tools must be
 specified when the defaults don't fit, and packages must be amended to work
-on new hosts. For now, a build architecture of x86_64 is assumed, either on
-Linux or macOS.
+on new hosts.
 
 ### No reliance on timestamps
 


### PR DESCRIPTION
This dates from the introduction of depends, and has not been the case for some time now.