### PR TITLE
mempool / rpc: followup to getprioritisedtransactions and delete a mapDeltas entry when delta==0

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -489,7 +489,7 @@ static RPCHelpMan getprioritisedtransactions()
         RPCResult{
             RPCResult::Type::OBJ_DYN, "", "prioritisation keyed by txid",
             {
-                {RPCResult::Type::OBJ, "txid", "", {
+                {RPCResult::Type::OBJ, "<transactionid>", "", {
                     {RPCResult::Type::NUM, "fee_delta", "transaction fee delta in satoshis"},
                     {RPCResult::Type::BOOL, "in_mempool", "whether this transaction is currently in mempool"},
                 }}

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -487,7 +487,7 @@ static RPCHelpMan getprioritisedtransactions()
         "Returns a map of all user-created (see prioritisetransaction) fee deltas by txid, and whether the tx is present in mempool.",
         {},
         RPCResult{
-            RPCResult::Type::OBJ_DYN, "prioritisation-map", "prioritisation keyed by txid",
+            RPCResult::Type::OBJ_DYN, "", "prioritisation keyed by txid",
             {
                 {RPCResult::Type::OBJ, "txid", "", {
                     {RPCResult::Type::NUM, "fee_delta", "transaction fee delta in satoshis"},

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -492,6 +492,7 @@ static RPCHelpMan getprioritisedtransactions()
                 {RPCResult::Type::OBJ, "<transactionid>", "", {
                     {RPCResult::Type::NUM, "fee_delta", "transaction fee delta in satoshis"},
                     {RPCResult::Type::BOOL, "in_mempool", "whether this transaction is currently in mempool"},
+                    {RPCResult::Type::NUM, "modified_fee", /*optional=*/true, "modified fee in satoshis. Only returned if in_mempool=true"},
                 }}
             },
         },
@@ -508,6 +509,9 @@ static RPCHelpMan getprioritisedtransactions()
                 UniValue result_inner{UniValue::VOBJ};
                 result_inner.pushKV("fee_delta", delta_info.delta);
                 result_inner.pushKV("in_mempool", delta_info.in_mempool);
+                if (delta_info.in_mempool) {
+                    result_inner.pushKV("modified_fee", *delta_info.modified_fee);
+                }
                 rpc_result.pushKV(delta_info.txid.GetHex(), result_inner);
             }
             return rpc_result;

--- a/test/functional/mempool_expiry.py
+++ b/test/functional/mempool_expiry.py
@@ -36,13 +36,14 @@ class MempoolExpiryTest(BitcoinTestFramework):
         node = self.nodes[0]
 
         # Send a parent transaction that will expire.
-        parent_txid = self.wallet.send_self_transfer(from_node=node)['txid']
+        parent = self.wallet.send_self_transfer(from_node=node)
+        parent_txid = parent["txid"]
         parent_utxo = self.wallet.get_utxo(txid=parent_txid)
         independent_utxo = self.wallet.get_utxo()
 
         # Add prioritisation to this transaction to check that it persists after the expiry
         node.prioritisetransaction(parent_txid, 0, COIN)
-        assert_equal(node.getprioritisedtransactions()[parent_txid], { "fee_delta" : COIN, "in_mempool" : True})
+        assert_equal(node.getprioritisedtransactions()[parent_txid], { "fee_delta" : COIN, "in_mempool" : True, "modified_fee": COIN + COIN * parent["fee"] })
 
         # Ensure the transactions we send to trigger the mempool check spend utxos that are independent of
         # the transactions being tested for expiration.

--- a/test/functional/mining_prioritisetransaction.py
+++ b/test/functional/mining_prioritisetransaction.py
@@ -263,6 +263,12 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
             if (x != high_fee_tx):
                 assert x not in mempool
 
+
+        self.log.info("Assert that 0 delta is never added to mapDeltas")
+        tx_id_zero_del = self.wallet.create_self_transfer()['txid']
+        self.nodes[0].prioritisetransaction(txid=tx_id_zero_del, fee_delta=0)
+        assert tx_id_zero_del not in self.nodes[0].getprioritisedtransactions()
+
         # Create a free transaction.  Should be rejected.
         tx_res = self.wallet.create_self_transfer(fee_rate=0)
         tx_hex = tx_res['hex']

--- a/test/functional/mining_prioritisetransaction.py
+++ b/test/functional/mining_prioritisetransaction.py
@@ -111,9 +111,7 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
         raw_after = self.nodes[0].getrawmempool(verbose=True)
         assert_equal(raw_before[txid_a], raw_after[txid_a])
         assert_equal(raw_before, raw_after)
-        prioritisation_map_in_mempool = self.nodes[0].getprioritisedtransactions()
-        assert_equal(prioritisation_map_in_mempool[txid_b], {"fee_delta" : fee_delta_b*COIN, "in_mempool" : True})
-        assert_equal(prioritisation_map_in_mempool[txid_c], {"fee_delta" : (fee_delta_c_1 + fee_delta_c_2)*COIN, "in_mempool" : True})
+        assert_equal(self.nodes[0].getprioritisedtransactions(), {txid_b: {"fee_delta" : fee_delta_b*COIN, "in_mempool" : True}, txid_c: {"fee_delta" : (fee_delta_c_1 + fee_delta_c_2)*COIN, "in_mempool" : True}})
         # Clear prioritisation, otherwise the transactions' fee deltas are persisted to mempool.dat and loaded again when the node
         # is restarted at the end of this subtest. Deltas are removed when a transaction is mined, but only at that time. We do
         # not check whether mapDeltas transactions were mined when loading from mempool.dat.
@@ -126,17 +124,13 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
         self.nodes[0].prioritisetransaction(txid=txid_b, fee_delta=int(fee_delta_b * COIN))
         self.nodes[0].prioritisetransaction(txid=txid_c, fee_delta=int(fee_delta_c_1 * COIN))
         self.nodes[0].prioritisetransaction(txid=txid_c, fee_delta=int(fee_delta_c_2 * COIN))
-        prioritisation_map_not_in_mempool = self.nodes[0].getprioritisedtransactions()
-        assert_equal(prioritisation_map_not_in_mempool[txid_b], {"fee_delta" : fee_delta_b*COIN, "in_mempool" : False})
-        assert_equal(prioritisation_map_not_in_mempool[txid_c], {"fee_delta" : (fee_delta_c_1 + fee_delta_c_2)*COIN, "in_mempool" : False})
+        assert_equal(self.nodes[0].getprioritisedtransactions(), {txid_b: {"fee_delta" : fee_delta_b*COIN, "in_mempool" : False}, txid_c: {"fee_delta" : (fee_delta_c_1 + fee_delta_c_2)*COIN, "in_mempool" : False}})
         for t in [tx_o_a["hex"], tx_o_b["hex"], tx_o_c["hex"], tx_o_d["hex"]]:
             self.nodes[0].sendrawtransaction(t)
         raw_after = self.nodes[0].getrawmempool(verbose=True)
         assert_equal(raw_before[txid_a], raw_after[txid_a])
         assert_equal(raw_before, raw_after)
-        prioritisation_map_in_mempool = self.nodes[0].getprioritisedtransactions()
-        assert_equal(prioritisation_map_in_mempool[txid_b], {"fee_delta" : fee_delta_b*COIN, "in_mempool" : True})
-        assert_equal(prioritisation_map_in_mempool[txid_c], {"fee_delta" : (fee_delta_c_1 + fee_delta_c_2)*COIN, "in_mempool" : True})
+        assert_equal(self.nodes[0].getprioritisedtransactions(), {txid_b: {"fee_delta" : fee_delta_b*COIN, "in_mempool" : True}, txid_c: {"fee_delta" : (fee_delta_c_1 + fee_delta_c_2)*COIN, "in_mempool" : True}})
 
         # Clear mempool
         self.generate(self.nodes[0], 1)


### PR DESCRIPTION
In this PR I am addressing some comments in https://github.com/bitcoin/bitcoin/pull/27501 as a followup. 
- changed `prioritisation-map` in the `RPCResult` to `""`
- Directly constructing 2 entry map for getprioritisedtransactions in functional tests
- renamed `txid` to `transactionid` in `RPCResult` to be more consistent with naming elsewhere
- exposed the `modified_fee` field instead of having it be a useless arg
- Created a new test that asserts when `prioritisedtransaction` is called with a fee_delta of 0 it is not added to mempool
