### PR TITLE
doc: remove mingw-w64 install for "older" systems

### DIFF
--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -48,16 +48,9 @@ Acquire the source in the usual way:
 ## Building for 64-bit Windows
 
 The first step is to install the mingw-w64 cross-compilation tool chain:
-  - on modern systems (Ubuntu 21.04 Hirsute Hippo or newer, Debian 11 Bullseye or newer):
 
 ```sh
 sudo apt install g++-mingw-w64-x86-64-posix
-```
-
-  - on older systems:
-
-```sh
-sudo apt install g++-mingw-w64-x86-64
 ```
 
 Once the toolchain is installed the build steps are common:


### PR DESCRIPTION
Now that we require GCC 10.1+, the posix variant is available on supported systems.

i.e:
https://packages.debian.org/bullseye/g++-mingw-w64-x86-64-posix
https://packages.ubuntu.com/jammy/g++-mingw-w64-x86-64-posix