### PR TITLE
doc: Simplify guix install doc, after 1.4 release

### DIFF
--- a/contrib/guix/INSTALL.md
+++ b/contrib/guix/INSTALL.md
@@ -389,10 +389,7 @@ git clone https://git.savannah.gnu.org/git/guix.git
 cd guix
 ```
 
-You will likely want to build the latest release, however, if the latest release
-when you're reading this is still 1.3.0 then you may want to use 998eda30 instead
-to avoid the issues described in [#25099](
-https://github.com/bitcoin/bitcoin/pull/25099).
+You will likely want to build the latest release.
 
 ```
 git branch -a -l 'origin/version-*'  # check for the latest release


### PR DESCRIPTION
Now that 1.4 is out (for a while), remove the recommendation to build a random commit.