### PR TITLE
Drop CAutoFile

### DIFF
--- a/src/bench/load_external.cpp
+++ b/src/bench/load_external.cpp
@@ -55,7 +55,7 @@ static void LoadExternalBlockFile(benchmark::Bench& bench)
     bench.run([&] {
         // "rb" is "binary, O_RDONLY", positioned to the start of the file.
         // The file will be closed by LoadExternalBlockFile().
-        CAutoFile file{fsbridge::fopen(blkfile, "rb"), CLIENT_VERSION};
+        AutoFile file{fsbridge::fopen(blkfile, "rb")};
         testing_setup->m_node.chainman->LoadExternalBlockFile(file, &pos, &blocks_with_unknown_parent);
     });
     fs::remove(blkfile);

--- a/src/bench/streams_findbyte.cpp
+++ b/src/bench/streams_findbyte.cpp
@@ -14,7 +14,7 @@
 static void FindByte(benchmark::Bench& bench)
 {
     // Setup
-    CAutoFile file{fsbridge::fopen("streams_tmp", "w+b"), 0};
+    AutoFile file{fsbridge::fopen("streams_tmp", "w+b")};
     const size_t file_size = 200;
     uint8_t data[file_size] = {0};
     data[file_size-1] = 1;

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -79,7 +79,7 @@ bool TxIndex::FindTx(const uint256& tx_hash, uint256& block_hash, CTransactionRe
         return false;
     }
 
-    CAutoFile file{m_chainstate->m_blockman.OpenBlockFile(postx, true)};
+    AutoFile file{m_chainstate->m_blockman.OpenBlockFile(postx, true)};
     if (file.IsNull()) {
         return error("%s: OpenBlockFile failed", __func__);
     }

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -8,21 +8,26 @@
 #include <attributes.h>
 #include <chain.h>
 #include <dbwrapper.h>
+#include <flatfile.h>
 #include <kernel/blockmanager_opts.h>
-#include <kernel/chain.h>
 #include <kernel/chainparams.h>
 #include <kernel/cs_main.h>
 #include <kernel/messagestartchars.h>
+#include <primitives/block.h>
+#include <streams.h>
 #include <sync.h>
+#include <uint256.h>
 #include <util/fs.h>
 #include <util/hasher.h>
 
+#include <array>
 #include <atomic>
 #include <cstdint>
 #include <functional>
 #include <limits>
 #include <map>
 #include <memory>
+#include <optional>
 #include <set>
 #include <string>
 #include <unordered_map>
@@ -30,14 +35,9 @@
 #include <vector>
 
 class BlockValidationState;
-class CAutoFile;
-class CBlock;
 class CBlockUndo;
-class CChainParams;
 class Chainstate;
 class ChainstateManager;
-struct CCheckpointData;
-struct FlatFilePos;
 namespace Consensus {
 struct Params;
 }
@@ -162,7 +162,7 @@ private:
     FlatFileSeq BlockFileSeq() const;
     FlatFileSeq UndoFileSeq() const;
 
-    CAutoFile OpenUndoFile(const FlatFilePos& pos, bool fReadOnly = false) const;
+    AutoFile OpenUndoFile(const FlatFilePos& pos, bool fReadOnly = false) const;
 
     bool WriteBlockToDisk(const CBlock& block, FlatFilePos& pos) const;
     bool UndoWriteToDisk(const CBlockUndo& blockundo, FlatFilePos& pos, const uint256& hashBlock) const;
@@ -350,7 +350,7 @@ public:
     void UpdatePruneLock(const std::string& name, const PruneLockInfo& lock_info) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     /** Open a block file (blk?????.dat) */
-    CAutoFile OpenBlockFile(const FlatFilePos& pos, bool fReadOnly = false) const;
+    AutoFile OpenBlockFile(const FlatFilePos& pos, bool fReadOnly = false) const;
 
     /** Translation to a filesystem path */
     fs::path GetBlockPosFilename(const FlatFilePos& pos) const;

--- a/src/streams.h
+++ b/src/streams.h
@@ -529,7 +529,7 @@ public:
     }
 };
 
-/** Wrapper around a CAutoFile& that implements a ring buffer to
+/** Wrapper around an AutoFile& that implements a ring buffer to
  *  deserialize from. It guarantees the ability to rewind a given number of bytes.
  *
  *  Will automatically close the file when it goes out of scope if not null.
@@ -538,7 +538,7 @@ public:
 class BufferedFile
 {
 private:
-    CAutoFile& m_src;
+    AutoFile& m_src;
     uint64_t nSrcPos{0};  //!< how many bytes have been read from source
     uint64_t m_read_pos{0}; //!< how many bytes have been read from this
     uint64_t nReadLimit;  //!< up to which position we're allowed to read
@@ -585,14 +585,12 @@ private:
     }
 
 public:
-    BufferedFile(CAutoFile& file, uint64_t nBufSize, uint64_t nRewindIn)
+    BufferedFile(AutoFile& file, uint64_t nBufSize, uint64_t nRewindIn)
         : m_src{file}, nReadLimit{std::numeric_limits<uint64_t>::max()}, nRewind{nRewindIn}, vchBuf(nBufSize, std::byte{0})
     {
         if (nRewindIn >= nBufSize)
             throw std::ios_base::failure("Rewind limit must be less than buffer size");
     }
-
-    int GetVersion() const { return m_src.GetVersion(); }
 
     //! check whether we're at the end of the source file
     bool eof() const {

--- a/src/streams.h
+++ b/src/streams.h
@@ -505,26 +505,6 @@ public:
     }
 };
 
-class CAutoFile : public AutoFile
-{
-public:
-    explicit CAutoFile(std::FILE* file, int /*unused*/, std::vector<std::byte> data_xor = {}) : AutoFile{file, std::move(data_xor)} {}
-
-    template<typename T>
-    CAutoFile& operator<<(const T& obj)
-    {
-        ::Serialize(*this, obj);
-        return (*this);
-    }
-
-    template<typename T>
-    CAutoFile& operator>>(T&& obj)
-    {
-        ::Unserialize(*this, obj);
-        return (*this);
-    }
-};
-
 /** Wrapper around an AutoFile& that implements a ring buffer to
  *  deserialize from. It guarantees the ability to rewind a given number of bytes.
  *

--- a/src/streams.h
+++ b/src/streams.h
@@ -507,12 +507,8 @@ public:
 
 class CAutoFile : public AutoFile
 {
-private:
-    const int nVersion;
-
 public:
-    explicit CAutoFile(std::FILE* file, int version, std::vector<std::byte> data_xor = {}) : AutoFile{file, std::move(data_xor)}, nVersion{version} {}
-    int GetVersion() const       { return nVersion; }
+    explicit CAutoFile(std::FILE* file, int /*unused*/, std::vector<std::byte> data_xor = {}) : AutoFile{file, std::move(data_xor)} {}
 
     template<typename T>
     CAutoFile& operator<<(const T& obj)

--- a/src/test/fuzz/buffered_file.cpp
+++ b/src/test/fuzz/buffered_file.cpp
@@ -20,9 +20,8 @@ FUZZ_TARGET(buffered_file)
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
     FuzzedFileProvider fuzzed_file_provider{fuzzed_data_provider};
     std::optional<BufferedFile> opt_buffered_file;
-    CAutoFile fuzzed_file{
+    AutoFile fuzzed_file{
         fuzzed_file_provider.open(),
-        0,
         ConsumeRandomLengthByteVector<std::byte>(fuzzed_data_provider),
     };
     try {
@@ -65,6 +64,5 @@ FUZZ_TARGET(buffered_file)
                 });
         }
         opt_buffered_file->GetPos();
-        opt_buffered_file->GetVersion();
     }
 }

--- a/src/test/fuzz/load_external_block_file.cpp
+++ b/src/test/fuzz/load_external_block_file.cpp
@@ -28,7 +28,7 @@ FUZZ_TARGET(load_external_block_file, .init = initialize_load_external_block_fil
 {
     FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
     FuzzedFileProvider fuzzed_file_provider{fuzzed_data_provider};
-    CAutoFile fuzzed_block_file{fuzzed_file_provider.open(), CLIENT_VERSION};
+    AutoFile fuzzed_block_file{fuzzed_file_provider.open()};
     if (fuzzed_block_file.IsNull()) {
         return;
     }

--- a/src/test/streams_tests.cpp
+++ b/src/test/streams_tests.cpp
@@ -271,9 +271,6 @@ BOOST_AUTO_TEST_CASE(streams_buffered_file)
     BufferedFile bf{file, 25, 10};
     BOOST_CHECK(!bf.eof());
 
-    // This member has no functional effect.
-    BOOST_CHECK_EQUAL(bf.GetVersion(), 333);
-
     uint8_t i;
     bf >> i;
     BOOST_CHECK_EQUAL(i, 0);

--- a/src/test/streams_tests.cpp
+++ b/src/test/streams_tests.cpp
@@ -249,7 +249,7 @@ BOOST_AUTO_TEST_CASE(streams_serializedata_xor)
 BOOST_AUTO_TEST_CASE(streams_buffered_file)
 {
     fs::path streams_test_filename = m_args.GetDataDirBase() / "streams_test_tmp";
-    CAutoFile file{fsbridge::fopen(streams_test_filename, "w+b"), 333};
+    AutoFile file{fsbridge::fopen(streams_test_filename, "w+b")};
 
     // The value at each offset is the offset.
     for (uint8_t j = 0; j < 40; ++j) {
@@ -380,7 +380,7 @@ BOOST_AUTO_TEST_CASE(streams_buffered_file)
 BOOST_AUTO_TEST_CASE(streams_buffered_file_skip)
 {
     fs::path streams_test_filename = m_args.GetDataDirBase() / "streams_test_tmp";
-    CAutoFile file{fsbridge::fopen(streams_test_filename, "w+b"), 333};
+    AutoFile file{fsbridge::fopen(streams_test_filename, "w+b")};
     // The value at each offset is the byte offset (e.g. byte 1 in the file has the value 0x01).
     for (uint8_t j = 0; j < 40; ++j) {
         file << j;
@@ -433,7 +433,7 @@ BOOST_AUTO_TEST_CASE(streams_buffered_file_rand)
 
     fs::path streams_test_filename = m_args.GetDataDirBase() / "streams_test_tmp";
     for (int rep = 0; rep < 50; ++rep) {
-        CAutoFile file{fsbridge::fopen(streams_test_filename, "w+b"), 333};
+        AutoFile file{fsbridge::fopen(streams_test_filename, "w+b")};
         size_t fileSize = InsecureRandRange(256);
         for (uint8_t i = 0; i < fileSize; ++i) {
             file << i;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4649,7 +4649,7 @@ bool Chainstate::LoadGenesisBlock()
 }
 
 void ChainstateManager::LoadExternalBlockFile(
-    CAutoFile& file_in,
+    AutoFile& file_in,
     FlatFilePos* dbp,
     std::multimap<uint256, FlatFilePos>* blocks_with_unknown_parent)
 {

--- a/src/validation.h
+++ b/src/validation.h
@@ -1137,7 +1137,7 @@ public:
      *                                              (only used for reindex)
      * */
     void LoadExternalBlockFile(
-        CAutoFile& file_in,
+        AutoFile& file_in,
         FlatFilePos* dbp = nullptr,
         std::multimap<uint256, FlatFilePos>* blocks_with_unknown_parent = nullptr);
 


### PR DESCRIPTION
Continuing the move away from `GetVersion()`, replace uses of `CAutoFile` with `AutoFile`.