### PR TITLE
depends: bump libmultiprocess to fix capnproto deprecation warnings

### DIFF
--- a/ci/test/00_setup_env_i686_multiprocess.sh
+++ b/ci/test/00_setup_env_i686_multiprocess.sh
@@ -15,4 +15,3 @@ export GOAL="install"
 export BITCOIN_CONFIG="--enable-debug CC='clang -m32' CXX='clang++ -m32' \
 LDFLAGS='--rtlib=compiler-rt -lgcc_s' CPPFLAGS='-DBOOST_MULTI_INDEX_ENABLE_SAFE_MODE'"
 export TEST_RUNNER_ENV="BITCOIND=bitcoin-node"
-export NO_WERROR=1  # Temporary workaround to avoid -Wdeprecated-declarations from KJ

--- a/depends/packages/native_libmultiprocess.mk
+++ b/depends/packages/native_libmultiprocess.mk
@@ -1,8 +1,8 @@
 package=native_libmultiprocess
-$(package)_version=61d5a0e661f20a4928fbf868ec9c3c6f17883cc7
+$(package)_version=414542f81e0997354b45b8ade13ca144a3e35ff1
 $(package)_download_path=https://github.com/chaincodelabs/libmultiprocess/archive
 $(package)_file_name=$($(package)_version).tar.gz
-$(package)_sha256_hash=5cfda224cc2ce913f2493f843317e0fca3184f6d7c1434c9754b2e7dca440ab5
+$(package)_sha256_hash=8542dbaf8c4fce8fd7af6929f5dc9b34dffa51c43e9ee360e93ee0f34b180bc2
 $(package)_dependencies=native_capnp
 
 define $(package)_config_cmds


### PR DESCRIPTION
This incorporates PR chaincodelabs/libmultiprocess#88 and reverts the NO_WERROR CI workaround added in #28735

Upstream diff: https://github.com/chaincodelabs/libmultiprocess/compare/61d5a0e661f20a4928fbf868ec9c3c6f17883cc7...414542f81e0997354b45b8ade13ca144a3e35ff1

---

This PR is part of the [process separation project](https://github.com/bitcoin/bitcoin/issues/28722).