### PR TITLE
doc: Add release note for coinstatsindex in pruned mode

### DIFF
--- a/doc/release-notes/release-notes-24.0.1.md
+++ b/doc/release-notes/release-notes-24.0.1.md
@@ -199,6 +199,11 @@ New settings
   accept transaction replacement without enforcing BIP125 replaceability
   signaling. (#25353)
 
+Updated settings
+----------------
+
+- The `-coinstatsindex` option can now also be used in pruned mode. (#21726)
+
 Wallet
 ------
 


### PR DESCRIPTION
#21726 enabled using `coinstatsindex` in pruned mode. I recently had to update one of my nodes from 23.0 because of this and noticed that this isn't mentioned in the release notes for 24.0.1.