### PR TITLE
rpc: add 'getnetmsgstats' RPC

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -410,6 +410,7 @@ libbitcoin_node_a_SOURCES = \
   kernel/mempool_removal_reason.cpp \
   mapport.cpp \
   net.cpp \
+  netstats.cpp \
   net_processing.cpp \
   netgroup.cpp \
   node/abort.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -209,6 +209,7 @@ BITCOIN_CORE_H = \
   netaddress.h \
   netbase.h \
   netgroup.h \
+  netstats.h \
   netmessagemaker.h \
   node/abort.h \
   node/blockmanager_args.h \

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -103,8 +103,6 @@ enum BindFlags {
 // The sleep time needs to be small to avoid new sockets stalling
 static const uint64_t SELECT_TIMEOUT_MILLISECONDS = 50;
 
-const std::string NET_MESSAGE_TYPE_OTHER = "*other*";
-
 static const uint64_t RANDOMIZER_ID_NETGROUP = 0x6c0edd8036ef4036ULL; // SHA256("netgroup")[0:8]
 static const uint64_t RANDOMIZER_ID_LOCALHOSTNONCE = 0xd93e69e2bbfa5735ULL; // SHA256("localhostnonce")[0:8]
 static const uint64_t RANDOMIZER_ID_ADDRCACHE = 0x1cf2e4ddd306dda9ULL; // SHA256("addrcache")[0:8]

--- a/src/net.h
+++ b/src/net.h
@@ -182,7 +182,6 @@ struct LocalServiceInfo {
 extern GlobalMutex g_maplocalhost_mutex;
 extern std::map<CNetAddr, LocalServiceInfo> mapLocalHost GUARDED_BY(g_maplocalhost_mutex);
 
-extern const std::string NET_MESSAGE_TYPE_OTHER;
 using mapMsgTypeSize = std::map</* message type */ std::string, /* total bytes */ uint64_t>;
 
 class CNodeStats

--- a/src/netstats.cpp
+++ b/src/netstats.cpp
@@ -82,6 +82,19 @@ size_t NetStats::ConnectionTypeToIndex(ConnectionType conn_type)
     assert(false);
 }
 
+
+std::string NetStats::DirectionAsString(Direction direction)
+{
+    switch (direction) {
+    case Direction::SENT:
+        return "sent";
+    case Direction::RECV:
+        return "received";
+    } // no default case, so the compiler can warn about missing cases
+
+    assert(false);
+}
+
 void NetStats::Record(Direction direction,
                       Network net,
                       ConnectionType conn_type,

--- a/src/netstats.cpp
+++ b/src/netstats.cpp
@@ -81,3 +81,19 @@ size_t NetStats::ConnectionTypeToIndex(ConnectionType conn_type)
     }
     assert(false);
 }
+
+void NetStats::Record(Direction direction,
+                      Network net,
+                      ConnectionType conn_type,
+                      const std::string& msg_type,
+                      size_t byte_count)
+{
+    auto& data = m_data
+        .at(DirectionToIndex(direction))
+        .at(NetworkToIndex(net))
+        .at(ConnectionTypeToIndex(conn_type))
+        .at(messageTypeToIndex(msg_type));
+
+    ++data.msg_count;
+    data.byte_count += byte_count;
+}

--- a/src/netstats.cpp
+++ b/src/netstats.cpp
@@ -1,0 +1,83 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <netstats.h>
+
+NetStats::Direction NetStats::DirectionFromIndex(size_t index)
+{
+    switch (index) {
+    case 0: return Direction::SENT;
+    case 1: return Direction::RECV;
+    }
+
+    assert(false);
+}
+
+size_t NetStats::DirectionToIndex(Direction direction)
+{
+    switch (direction) {
+    case Direction::SENT: return 0;
+    case Direction::RECV: return 1;
+    }
+
+    assert(false);
+}
+
+Network NetStats::NetworkFromIndex(size_t index)
+{
+    switch (index) {
+    case 0: return Network::NET_UNROUTABLE;
+    case 1: return Network::NET_IPV4;
+    case 2: return Network::NET_IPV6;
+    case 3: return Network::NET_ONION;
+    case 4: return Network::NET_I2P;
+    case 5: return Network::NET_CJDNS;
+    case 6: return Network::NET_INTERNAL;
+    }
+
+    assert(false);
+}
+
+size_t NetStats::NetworkToIndex(Network net)
+{
+    switch (net) {
+    case Network::NET_UNROUTABLE: return 0;
+    case Network::NET_IPV4: return 1;
+    case Network::NET_IPV6: return 2;
+    case Network::NET_ONION: return 3;
+    case Network::NET_I2P: return 4;
+    case Network::NET_CJDNS: return 5;
+    case Network::NET_INTERNAL: return 6;
+    case Network::NET_MAX: assert(false);
+    }
+    assert(false);
+}
+
+ConnectionType NetStats::ConnectionTypeFromIndex(size_t index)
+{
+    switch (index) {
+    case 0: return ConnectionType::INBOUND;
+    case 1: return ConnectionType::OUTBOUND_FULL_RELAY;
+    case 2: return ConnectionType::MANUAL;
+    case 3: return ConnectionType::FEELER;
+    case 4: return ConnectionType::BLOCK_RELAY;
+    case 5: return ConnectionType::ADDR_FETCH;
+    }
+
+    assert(false);
+}
+
+size_t NetStats::ConnectionTypeToIndex(ConnectionType conn_type)
+{
+    switch (conn_type) {
+    case ConnectionType::INBOUND: return 0;
+    case ConnectionType::OUTBOUND_FULL_RELAY: return 1;
+    case ConnectionType::MANUAL: return 2;
+    case ConnectionType::FEELER: return 3;
+    case ConnectionType::BLOCK_RELAY: return 4;
+    case ConnectionType::ADDR_FETCH: return 5;
+    }
+    assert(false);
+}

--- a/src/netstats.h
+++ b/src/netstats.h
@@ -50,6 +50,21 @@ public:
     using MultiDimensionalStats = std::array<NetMaxArray, NUM_DIRECTIONS>;
 
     MultiDimensionalStats m_data;
+
+    // The ...FromIndex() and ...ToIndex() methods below convert from/to
+    // indexes of `m_data[]` to the actual values they represent. For example,
+    // assuming MessageTypeToIndex("ping") == 15, then everything stored in
+    // m_data[x][y][z][15] is traffic from "ping" messages (for any x, y or z).
+
+    [[nodiscard]] static Direction DirectionFromIndex(size_t index);
+    [[nodiscard]] static Network NetworkFromIndex(size_t index);
+    [[nodiscard]] static ConnectionType ConnectionTypeFromIndex(size_t index);
+
+private:
+    // Helper methods to make sure the indexes associated with enums are reliable
+    [[nodiscard]] static size_t DirectionToIndex(Direction direction);
+    [[nodiscard]] static size_t NetworkToIndex(Network net);
+    [[nodiscard]] static size_t ConnectionTypeToIndex(ConnectionType conn_type);
 };
 
 #endif // BITCOIN_NETSTATS_H

--- a/src/netstats.h
+++ b/src/netstats.h
@@ -1,0 +1,55 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2023 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_NETSTATS_H
+#define BITCOIN_NETSTATS_H
+
+#include <node/connection_types.h>
+#include <protocol.h>
+
+#include <array>
+#include <atomic>
+#include <cstddef>
+
+/**
+ * Placeholder for total network traffic. Split by direction, network, connection
+ * type and message type (byte and message counts).
+ */
+class NetStats
+{
+public:
+    struct MsgStat {
+        std::atomic_uint64_t byte_count; //!< Number of bytes transferred.
+        std::atomic_uint64_t msg_count;  //!< Number of messages transferred.
+
+        MsgStat() = default;
+
+        MsgStat(const MsgStat& x) : byte_count{x.byte_count.load()}, msg_count{x.msg_count.load()} {}
+
+        MsgStat(std::atomic_uint64_t x, std::atomic_uint64_t y) : byte_count{x.load()}, msg_count{y.load()} {}
+    };
+
+    enum class Direction { SENT,
+                           RECV };
+
+    /// Number of elements in `Direction`.
+    static constexpr size_t NUM_DIRECTIONS{2};
+
+    // Innermost array
+    using MsgStatArray = std::array<MsgStat, NUM_NET_MESSAGE_TYPES + 1>; // Add 1 for "Other" message type
+
+    // Second innermost array
+    using ConnectionTypeArray = std::array<MsgStatArray, NUM_CONNECTION_TYPES>;
+
+    // Third innermost array
+    using NetMaxArray = std::array<ConnectionTypeArray, NET_MAX>;
+
+    // Outer array
+    using MultiDimensionalStats = std::array<NetMaxArray, NUM_DIRECTIONS>;
+
+    MultiDimensionalStats m_data;
+};
+
+#endif // BITCOIN_NETSTATS_H

--- a/src/netstats.h
+++ b/src/netstats.h
@@ -90,6 +90,8 @@ public:
     [[nodiscard]] static Network NetworkFromIndex(size_t index);
     [[nodiscard]] static ConnectionType ConnectionTypeFromIndex(size_t index);
 
+    static std::string DirectionAsString(Direction direction);
+
 private:
     // Helper methods to make sure the indexes associated with enums are reliable
     [[nodiscard]] static size_t DirectionToIndex(Direction direction);

--- a/src/netstats.h
+++ b/src/netstats.h
@@ -51,6 +51,36 @@ public:
 
     MultiDimensionalStats m_data;
 
+    void Init()
+    {
+        for (std::size_t direction_index = 0; direction_index < NUM_DIRECTIONS; direction_index++) {
+            for (int network_index = 0; network_index < NET_MAX; network_index++) {
+                for (std::size_t connection_index = 0; connection_index < NUM_CONNECTION_TYPES; connection_index++) {
+                    for (std::size_t message_index = 0; message_index < NUM_NET_MESSAGE_TYPES + 1; message_index++) {
+                        // +1 for the "other" message type
+                        auto& stat = m_data
+                            .at(direction_index)
+                            .at(network_index)
+                            .at(connection_index)
+                            .at(message_index);
+
+                        stat.msg_count = 0;
+                        stat.byte_count = 0;
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Increment the amount of bytes transferred by `bytes` and the amount of messages by 1.
+     */
+    void Record(Direction direction,
+                Network net,
+                ConnectionType conn_type,
+                const std::string& msg_type,
+                size_t byte_count);
+
     // The ...FromIndex() and ...ToIndex() methods below convert from/to
     // indexes of `m_data[]` to the actual values they represent. For example,
     // assuming MessageTypeToIndex("ping") == 15, then everything stored in

--- a/src/node/connection_types.h
+++ b/src/node/connection_types.h
@@ -14,7 +14,8 @@
  *
  * If adding or removing types, please update CONNECTION_TYPE_DOC in
  * src/rpc/net.cpp and src/qt/rpcconsole.cpp, as well as the descriptions in
- * src/qt/guiutil.cpp and src/bitcoin-cli.cpp::NetinfoRequestHandler. */
+ * src/qt/guiutil.cpp and src/bitcoin-cli.cpp::NetinfoRequestHandler and
+ * NUM_CONNECTION_TYPES below. */
 enum class ConnectionType {
     /**
      * Inbound connections are those initiated by a peer. This is the only
@@ -76,6 +77,9 @@ enum class ConnectionType {
      */
     ADDR_FETCH,
 };
+
+/** Number of entries in ConnectionType. */
+static constexpr size_t NUM_CONNECTION_TYPES{6};
 
 /** Convert ConnectionType enum to a string value */
 std::string ConnectionTypeAsString(ConnectionType conn_type);

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -49,6 +49,8 @@ const char* WTXIDRELAY = "wtxidrelay";
 const char* SENDTXRCNCL = "sendtxrcncl";
 } // namespace NetMsgType
 
+const std::string NET_MESSAGE_TYPE_OTHER{"*other*"};
+
 /** All known message types. Keep this in the same order as the list of
  * messages above and in protocol.h.
  */

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -189,6 +189,29 @@ const std::vector<std::string> &getAllNetMessageTypes()
     return allNetMessageTypesVec;
 }
 
+int messageTypeToIndex(const std::string& msg_type)
+{
+    const std::vector<std::string>& message_types = getAllNetMessageTypes();
+    auto msg_type_itr = std::find(message_types.begin(), message_types.end(), msg_type);
+
+    if (msg_type_itr != message_types.end()) {
+        int index = msg_type_itr - message_types.begin();
+        return index;
+    } else {
+        // assign the last index to be a catch all for NET_MESSAGE_TYPE_OTHER
+        return NUM_NET_MESSAGE_TYPES;
+    }
+}
+
+const std::string& messageTypeFromIndex(size_t index)
+{
+    if (index >= NUM_NET_MESSAGE_TYPES) {
+        return NET_MESSAGE_TYPE_OTHER;
+    }
+
+    return getAllNetMessageTypes().at(index);
+}
+
 /**
  * Convert a service flag (NODE_*) to a human readable string.
  * It supports unknown service flags which will be returned as "UNKNOWN[...]".

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -54,7 +54,7 @@ const std::string NET_MESSAGE_TYPE_OTHER{"*other*"};
 /** All known message types. Keep this in the same order as the list of
  * messages above and in protocol.h.
  */
-const static std::vector<std::string> g_all_net_message_types{
+const static std::string allNetMessageTypes[] = {
     NetMsgType::VERSION,
     NetMsgType::VERACK,
     NetMsgType::ADDR,
@@ -91,6 +91,10 @@ const static std::vector<std::string> g_all_net_message_types{
     NetMsgType::WTXIDRELAY,
     NetMsgType::SENDTXRCNCL,
 };
+
+static_assert(NUM_NET_MESSAGE_TYPES == sizeof(allNetMessageTypes) / sizeof(allNetMessageTypes[0]), "Please update NUM_NET_MESSAGE_TYPES");
+
+const static std::vector<std::string> allNetMessageTypesVec(std::begin(allNetMessageTypes), std::end(allNetMessageTypes));
 
 CMessageHeader::CMessageHeader(const MessageStartChars& pchMessageStartIn, const char* pszCommand, unsigned int nMessageSizeIn)
     : pchMessageStart{pchMessageStartIn}
@@ -182,7 +186,7 @@ std::string CInv::ToString() const
 
 const std::vector<std::string> &getAllNetMessageTypes()
 {
-    return g_all_net_message_types;
+    return allNetMessageTypesVec;
 }
 
 /**

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -269,6 +269,9 @@ extern const char* SENDTXRCNCL;
 
 extern const std::string NET_MESSAGE_TYPE_OTHER;
 
+/* Number of entries in allNetMessageTypes in protocol.cpp */
+static constexpr size_t NUM_NET_MESSAGE_TYPES{35};
+
 /* Get a vector of all valid message types (see above) */
 const std::vector<std::string>& getAllNetMessageTypes();
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -275,6 +275,12 @@ static constexpr size_t NUM_NET_MESSAGE_TYPES{35};
 /* Get a vector of all valid message types (see above) */
 const std::vector<std::string>& getAllNetMessageTypes();
 
+/* Get the index of a message type from the vector of all message types */
+int messageTypeToIndex(const std::string& msg_type);
+
+/* Get the string value of a message type from an index */
+const std::string& messageTypeFromIndex(size_t index);
+
 /** nServices flags */
 enum ServiceFlags : uint64_t {
     // NOTE: When adding here, be sure to update serviceFlagToStr too

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -267,6 +267,8 @@ extern const char* WTXIDRELAY;
 extern const char* SENDTXRCNCL;
 }; // namespace NetMsgType
 
+extern const std::string NET_MESSAGE_TYPE_OTHER;
+
 /* Get a vector of all valid message types (see above) */
 const std::vector<std::string>& getAllNetMessageTypes();
 

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -242,6 +242,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "verifychain", 1, "nblocks" },
     { "getblockstats", 0, "hash_or_height" },
     { "getblockstats", 1, "stats" },
+    { "getnetmsgstats", 0, "group_by"},
     { "pruneblockchain", 0, "height" },
     { "keypoolrefill", 0, "newsize" },
     { "getrawmempool", 0, "verbose" },

--- a/src/test/fuzz/rpc.cpp
+++ b/src/test/fuzz/rpc.cpp
@@ -136,6 +136,7 @@ const std::vector<std::string> RPC_COMMANDS_SAFE_FOR_FUZZING{
     "getmempoolentry",
     "getmempoolinfo",
     "getmininginfo",
+    "getnetmsgstats",
     "getnettotals",
     "getnetworkhashps",
     "getnetworkinfo",

--- a/src/test/util/net.cpp
+++ b/src/test/util/net.cpp
@@ -72,7 +72,8 @@ void ConnmanTestMsg::NodeReceiveMsgBytes(CNode& node, Span<const uint8_t> msg_by
 {
     assert(node.ReceiveMsgBytes(msg_bytes, complete));
     if (complete) {
-        node.MarkReceivedMsgsForProcessing();
+        NetStats net_stats = NetStats(m_net_stats);
+        node.MarkReceivedMsgsForProcessing(net_stats);
     }
 }
 

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -14,14 +14,17 @@ import time
 import test_framework.messages
 from test_framework.netutil import ADDRMAN_NEW_BUCKET_COUNT, ADDRMAN_TRIED_BUCKET_COUNT, ADDRMAN_BUCKET_SIZE
 from test_framework.p2p import (
+    P2PDataStore,
     P2PInterface,
     P2P_SERVICES,
 )
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_approx,
+    assert_array_result,
     assert_equal,
     assert_greater_than,
+    assert_greater_than_or_equal,
     assert_raises_rpc_error,
     p2p_port,
 )
@@ -61,6 +64,7 @@ class NetTest(BitcoinTestFramework):
         self.test_connection_count()
         self.test_getpeerinfo()
         self.test_getnettotals()
+        self.test_getnetmsgstats()
         self.test_getnetworkinfo()
         self.test_addnode_getaddednodeinfo()
         self.test_service_flags()
@@ -174,12 +178,111 @@ class NetTest(BitcoinTestFramework):
             self.wait_until(lambda: peer_after()['bytesrecv_per_msg'].get('pong', 0) >= peer_before['bytesrecv_per_msg'].get('pong', 0) + 32, timeout=1)
             self.wait_until(lambda: peer_after()['bytessent_per_msg'].get('ping', 0) >= peer_before['bytessent_per_msg'].get('ping', 0) + 32, timeout=1)
 
+    def test_getnetmsgstats(self):
+        self.log.info("Test getnetmsgstats")
+
+        # Remove all P2P connections to avoid random/unpredictable packets (e.g. ping)
+        # messing with the tests below.
+        self.disconnect_nodes(0, 1)
+        node0 = self.nodes[0]
+        assert_equal(len(node0.getpeerinfo()), 0)
+
+        # Compare byte count with what getnettotals returns
+        getnettotals_response = self.nodes[0].getnettotals()
+        getnetmsgstats_response = self.nodes[0].getnetmsgstats()
+
+        assert_equal(getnettotals_response['totalbytessent'] + getnettotals_response['totalbytesrecv'],
+                     getnetmsgstats_response['totals']['byte_count'])
+
+        # Test aggregation of results by trying out a few different combinations
+        getnetmsgstats_msgtype = self.nodes[0].getnetmsgstats(group_by=["direction", "message_type"])
+        assert_array_result([getnetmsgstats_msgtype['sent']['ping']], {'message_count': 4}, {'byte_count': 128})
+        assert_array_result([getnetmsgstats_msgtype['received']['pong']], {'message_count': 4}, {'byte_count': 128})
+
+        getnetmsgstats_conntype_msgtype = self.nodes[0].getnetmsgstats(group_by=["direction", "connection_type", "message_type"])
+        assert_array_result([getnetmsgstats_conntype_msgtype['received']['manual']['pong']], {'message_count': 2}, {'byte_count': 64})
+
+        getnetmsgstats_conntype_msgtype_network = self.nodes[0].getnetmsgstats(group_by=["direction", "connection_type",
+                                                                                             "message_type", "network"])
+        manualconn_sendaddrv2_stats = [{'message_count': 1}, {'byte_count': 24}]
+        assert_array_result([getnetmsgstats_conntype_msgtype_network['sent']['manual']['sendaddrv2']['not_publicly_routable']],
+            manualconn_sendaddrv2_stats[0], manualconn_sendaddrv2_stats[1])
+
+        # stats should be the same as the previous test, even with the dimension types reordered
+        getnetmsgstats_network_conntype_msgtype = self.nodes[0].getnetmsgstats(group_by=["direction", "network",
+                                                                                             "connection_type", "message_type"])
+        assert_array_result([getnetmsgstats_network_conntype_msgtype['sent']['not_publicly_routable']['manual']['sendaddrv2']],
+            manualconn_sendaddrv2_stats[0], manualconn_sendaddrv2_stats[1])
+
+        # check that the breakdown of sent ping messages matches the results that only show message type
+        getnetmsgstats_msgtype_conntype = self.nodes[0].getnetmsgstats(group_by=["direction", "message_type", "connection_type"])
+        sent_ping_inbound = getnetmsgstats_msgtype_conntype['sent']['ping']['inbound']
+        sent_ping_manual = getnetmsgstats_msgtype_conntype['sent']['ping']['manual']
+        assert_equal(sent_ping_inbound['message_count'] + sent_ping_manual['message_count'],
+            getnetmsgstats_msgtype['sent']['ping']['message_count'])
+        assert_equal(sent_ping_inbound['byte_count'] + sent_ping_manual['byte_count'],
+            getnetmsgstats_msgtype['sent']['ping']['byte_count'])
+
+        # Test that message and byte counts increment when a ping message is sent
+        total_sent_ping_stats = getnetmsgstats_msgtype['sent']['ping']
+        total_received_pong_stats = getnetmsgstats_msgtype['received']['pong']
+
+        # Reconnect to peers 0 and 1
+        self.connect_nodes(0, 1)
+        self.connect_nodes(1, 0)
+        assert_equal(len(node0.getpeerinfo()), 2)
+
+        # ping() sends a ping to all other nodes, so message count increases by at least two pings.
+        # One for peer0 and one for peer1
+        self.nodes[0].ping()
+        self.wait_until(lambda: (self.nodes[0].getnetmsgstats(group_by=["direction", "message_type"])
+                                 ['sent']['ping']['message_count'] >= total_sent_ping_stats['message_count'] + 1), timeout=1)
+        self.wait_until(lambda: (self.nodes[0].getnetmsgstats(group_by=["direction", "message_type"])
+                                 ['received']['pong']['message_count'] >= total_received_pong_stats['message_count'] + 1), timeout=1)
+
+        getnetmsgstats_sent_ping = self.nodes[0].getnetmsgstats(group_by=["direction", "message_type"])['sent']['ping']
+        assert_greater_than_or_equal(getnetmsgstats_sent_ping['byte_count'], total_sent_ping_stats['byte_count'] + 2 * 32)
+
+        getnetmsgstats_received_pong = self.nodes[0].getnetmsgstats(group_by=["direction", "message_type"])['received']['pong']
+        assert_greater_than_or_equal(getnetmsgstats_received_pong['byte_count'], total_received_pong_stats['byte_count'] + 2 * 32)
+
+        # Test that when a message is broken in two, the stats only update once the full message has been received
+        # Create valid message for another node to send to me
+        conn = self.nodes[0].add_p2p_connection(P2PDataStore())
+        ping_msg = conn.build_message(test_framework.messages.msg_ping(nonce=12345))
+        cut_pos = 12  # Chosen at an arbitrary position within the header
+        # Send message in two pieces
+        getnettotals_before_partial_ping = self.nodes[0].getnettotals()['totalbytesrecv']
+        netmsgstats_before_partial_ping = self.nodes[0].getnetmsgstats(group_by=["direction", "message_type"])['received']['ping']
+
+        conn.send_raw_message(ping_msg[:cut_pos])
+        # getnettotals gets updated even for partial messages
+        self.wait_until(lambda: self.nodes[0].getnettotals()['totalbytesrecv'] > getnettotals_before_partial_ping)
+        getnettotals_partial_ping = self.nodes[0].getnettotals()['totalbytesrecv']
+        # If this assert fails, we've hit an unlikely race
+        # where the test framework sent a message in between the two halves
+        assert_equal(getnettotals_partial_ping, getnettotals_before_partial_ping + cut_pos)
+
+        # check that getnetmsgstats did not update
+        getnetmsgstats_after_partial_ping = self.nodes[0].getnetmsgstats(group_by=["direction", "message_type"])['received']['ping']
+        assert_equal(getnetmsgstats_after_partial_ping['message_count'], netmsgstats_before_partial_ping['message_count'])
+        assert_equal(getnetmsgstats_after_partial_ping['byte_count'], netmsgstats_before_partial_ping['byte_count'])
+
+        # send the rest of the ping
+        conn.send_raw_message(ping_msg[cut_pos:])
+        self.wait_until(lambda: self.nodes[0].getnettotals()['totalbytesrecv'] > getnettotals_partial_ping)
+        getnetmsgstats_finished_ping = self.nodes[0].getnetmsgstats(group_by=["direction", "message_type"])['received']['ping']
+        assert_equal(getnetmsgstats_finished_ping['message_count'], netmsgstats_before_partial_ping['message_count'] + 1)
+        assert_equal(getnetmsgstats_finished_ping['byte_count'], netmsgstats_before_partial_ping['byte_count'] + 32)
+
+        conn.sync_with_ping(timeout=1)
+
     def test_getnetworkinfo(self):
         self.log.info("Test getnetworkinfo")
         info = self.nodes[0].getnetworkinfo()
         assert_equal(info['networkactive'], True)
-        assert_equal(info['connections'], 2)
-        assert_equal(info['connections_in'], 1)
+        assert_equal(info['connections'], 3)
+        assert_equal(info['connections_in'], 2)
         assert_equal(info['connections_out'], 1)
 
         with self.nodes[0].assert_debug_log(expected_msgs=['SetNetworkActive: false\n']):


### PR DESCRIPTION
This picks up #27534 with a rebase and a few fixups, now squashed. See #27534 for more background information.

Considerations from the previous draft:

> Should we allow dimensions to be rearraged?
> 
> When it comes time to gather up the RPC results, @vasild has provided an [alternate implementation](https://github.com/vasild/bitcoin/commits/getnetmsgstats) that uses an array instead of the MultiMap structure. This results in two changes:
> 
>> using the stack over the heap (yay!)
>> enforcing a strict ordering of dimensions (direction, network, connection type, message type)
> 
> Aside from being good for memory, the reasoning here is allowing users to rearrange dimensions may be too confusing. I personally really like the ability to rearrange dimensions, which is why I have not integrated that solution into this PR, but am open to whatever the larger community prefers :) [Link](https://github.com/bitcoin/bitcoin/pull/27534#issue-1685662150)

^ I have looked at the alternative implementation (thanks @vasild!), but prefer the current version myself so long as the performance is not an issue. I've left this as-is for now. If folks here think that it might be an issue then I can investigate the alternative further. See the next consideration for additional reasoning on sticking with the current approach.

> Now that an effort has been made to remove the friendship between CConnman and CNode (see this PR: https://github.com/bitcoin/bitcoin/pull/27257) I'm unsure if this (recording network stats on a CConnman object) belongs here. [Link](https://github.com/bitcoin/bitcoin/pull/27534#discussion_r1179508199)

^ These changes make @valid's alternative approach a bit harder to rebase and AB test with the current approach, as it relied on access to the `CNode` msg queue, and #27257 included the change: "CNode's message processing queue is made private in the process and its mutex is turned into a non-recursive mutex." It can be worked around, but I'm not convinced it will be worth it.

> this function should handle if index > NUM_NET_MESSAGE_TYPES [Link](https://github.com/bitcoin/bitcoin/pull/27534#discussion_r1191793368)

^ I took this suggestion as part in 800ec2ac762cb48ac667cdf04de263634404569e

> https://github.com/bitcoin/bitcoin/pull/27534#discussion_r1191798171

^ I refactored this array in c909dc5704465aa96ce4496ed14452719e0b7860 to make it more comprehensible in the source code.

Additional considerations from OP:

* The code organisation was mainly taken care of by @satsie, with _src/netstats.{h\|cpp}_ now code from the netstats namespace instead of being contained within _net.cpp_
