### PR TITLE
serialization: Support for multiple parameters

### DIFF
--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -171,7 +171,7 @@ void AddrManImpl::Serialize(Stream& s_) const
      */
 
     // Always serialize in the latest version (FILE_FORMAT).
-    ParamsStream s{CAddress::V2_DISK, s_};
+    ParamsStream s{s_, CAddress::V2_DISK};
 
     s << static_cast<uint8_t>(FILE_FORMAT);
 
@@ -236,7 +236,7 @@ void AddrManImpl::Unserialize(Stream& s_)
     s_ >> Using<CustomUintFormatter<1>>(format);
 
     const auto ser_params = (format >= Format::V3_BIP155 ? CAddress::V2_DISK : CAddress::V1_DISK);
-    ParamsStream s{ser_params, s_};
+    ParamsStream s{s_, ser_params};
 
     uint8_t compat;
     s >> compat;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -199,7 +199,7 @@ static std::vector<CAddress> ConvertSeeds(const std::vector<uint8_t> &vSeedsIn)
     std::vector<CAddress> vSeedsOut;
     FastRandomContext rng;
     DataStream underlying_stream{vSeedsIn};
-    ParamsStream s{CAddress::V2_NETWORK, underlying_stream};
+    ParamsStream s{underlying_stream, CAddress::V2_NETWORK};
     while (!s.eof()) {
         CService endpoint;
         s >> endpoint;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -198,8 +198,7 @@ static std::vector<CAddress> ConvertSeeds(const std::vector<uint8_t> &vSeedsIn)
     const auto one_week{7 * 24h};
     std::vector<CAddress> vSeedsOut;
     FastRandomContext rng;
-    DataStream underlying_stream{vSeedsIn};
-    ParamsStream s{underlying_stream, CAddress::V2_NETWORK};
+    ParamsStream s{DataStream{vSeedsIn}, CAddress::V2_NETWORK};
     while (!s.eof()) {
         CService endpoint;
         s >> endpoint;

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -241,7 +241,7 @@ public:
     template <typename Stream>
     void Serialize(Stream& s) const
     {
-        if (s.GetParams().enc == Encoding::V2) {
+        if (s.template GetParams<SerParams>().enc == Encoding::V2) {
             SerializeV2Stream(s);
         } else {
             SerializeV1Stream(s);
@@ -254,7 +254,7 @@ public:
     template <typename Stream>
     void Unserialize(Stream& s)
     {
-        if (s.GetParams().enc == Encoding::V2) {
+        if (s.template GetParams<SerParams>().enc == Encoding::V2) {
             UnserializeV2Stream(s);
         } else {
             UnserializeV1Stream(s);

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -326,7 +326,7 @@ public:
 
     template <typename Stream>
     inline void Serialize(Stream& s) const {
-        SerializeTransaction(*this, s, s.GetParams());
+        SerializeTransaction(*this, s, s.template GetParams<TransactionSerParams>());
     }
 
     /** This deserializing constructor is provided instead of an Unserialize method.
@@ -386,12 +386,12 @@ struct CMutableTransaction
 
     template <typename Stream>
     inline void Serialize(Stream& s) const {
-        SerializeTransaction(*this, s, s.GetParams());
+        SerializeTransaction(*this, s, s.template GetParams<TransactionSerParams>());
     }
 
     template <typename Stream>
     inline void Unserialize(Stream& s) {
-        UnserializeTransaction(*this, s, s.GetParams());
+        UnserializeTransaction(*this, s, s.template GetParams<TransactionSerParams>());
     }
 
     template <typename Stream>

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -334,7 +334,7 @@ public:
     template <typename Stream>
     CTransaction(deserialize_type, const TransactionSerParams& params, Stream& s) : CTransaction(CMutableTransaction(deserialize, params, s)) {}
     template <typename Stream>
-    CTransaction(deserialize_type, ParamsStream<TransactionSerParams,Stream>& s) : CTransaction(CMutableTransaction(deserialize, s)) {}
+    CTransaction(deserialize_type, Stream& s) : CTransaction(CMutableTransaction(deserialize, s)) {}
 
     bool IsNull() const {
         return vin.empty() && vout.empty();
@@ -400,7 +400,7 @@ struct CMutableTransaction
     }
 
     template <typename Stream>
-    CMutableTransaction(deserialize_type, ParamsStream<TransactionSerParams,Stream>& s) {
+    CMutableTransaction(deserialize_type, Stream& s) {
         Unserialize(s);
     }
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -406,9 +406,10 @@ public:
     static constexpr SerParams V1_DISK{{CNetAddr::Encoding::V1}, Format::Disk};
     static constexpr SerParams V2_DISK{{CNetAddr::Encoding::V2}, Format::Disk};
 
-    SERIALIZE_METHODS_PARAMS(CAddress, obj, SerParams, params)
+    SERIALIZE_METHODS(CAddress, obj)
     {
         bool use_v2;
+        auto& params = SER_PARAMS(SerParams);
         if (params.fmt == Format::Disk) {
             // In the disk serialization format, the encoding (v1 or v2) is determined by a flag version
             // that's part of the serialization itself. ADDRV2_FORMAT in the stream version only determines

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -1104,14 +1104,14 @@ size_t GetSerializeSize(const T& t)
 }
 
 /** Wrapper that overrides the GetParams() function of a stream. */
-template <typename Params, typename SubStream>
+template <typename SubStream, typename Params>
 class ParamsStream
 {
     const Params& m_params;
     SubStream& m_substream;
 
 public:
-    ParamsStream(const Params& params LIFETIMEBOUND, SubStream& substream LIFETIMEBOUND) : m_params{params}, m_substream{substream} {}
+    ParamsStream(SubStream& substream LIFETIMEBOUND, const Params& params LIFETIMEBOUND) : m_params{params}, m_substream{substream} {}
     template <typename U> ParamsStream& operator<<(const U& obj) { ::Serialize(*this, obj); return *this; }
     template <typename U> ParamsStream& operator>>(U&& obj) { ::Unserialize(*this, obj); return *this; }
     void write(Span<const std::byte> src) { m_substream.write(src); }
@@ -1145,13 +1145,13 @@ public:
     template <typename Stream>
     void Serialize(Stream& s) const
     {
-        ParamsStream ss{m_params, s};
+        ParamsStream ss{s, m_params};
         ::Serialize(ss, m_object);
     }
     template <typename Stream>
     void Unserialize(Stream& s)
     {
-        ParamsStream ss{m_params, s};
+        ParamsStream ss{s, m_params};
         ::Unserialize(ss, m_object);
     }
 };

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -1103,12 +1103,12 @@ size_t GetSerializeSize(const T& t)
     return (SizeComputer() << t).size();
 }
 
-/** Wrapper that overrides the GetParams() function of a stream (and hides GetVersion/GetType). */
+/** Wrapper that overrides the GetParams() function of a stream. */
 template <typename Params, typename SubStream>
 class ParamsStream
 {
     const Params& m_params;
-    SubStream& m_substream; // private to avoid leaking version/type into serialization code that shouldn't see it
+    SubStream& m_substream;
 
 public:
     ParamsStream(const Params& params LIFETIMEBOUND, SubStream& substream LIFETIMEBOUND) : m_params{params}, m_substream{substream} {}
@@ -1119,8 +1119,6 @@ public:
     void ignore(size_t num) { m_substream.ignore(num); }
     bool eof() const { return m_substream.eof(); }
     size_t size() const { return m_substream.size(); }
-    int GetVersion() = delete; // Deprecated with Params usage
-    int GetType() = delete;    // Deprecated with Params usage
 
     //! Get reference to stream parameters.
     template <typename P>

--- a/src/test/serialize_tests.cpp
+++ b/src/test/serialize_tests.cpp
@@ -289,7 +289,7 @@ public:
     template <typename Stream>
     void Serialize(Stream& s) const
     {
-        if (s.GetParams().m_base_format == BaseFormat::RAW) {
+        if (s.template GetParams<BaseFormat>().m_base_format == BaseFormat::RAW) {
             s << m_base_data;
         } else {
             s << Span{HexStr(Span{&m_base_data, 1})};
@@ -299,7 +299,7 @@ public:
     template <typename Stream>
     void Unserialize(Stream& s)
     {
-        if (s.GetParams().m_base_format == BaseFormat::RAW) {
+        if (s.template GetParams<BaseFormat>().m_base_format == BaseFormat::RAW) {
             s >> m_base_data;
         } else {
             std::string hex{"aa"};
@@ -327,8 +327,9 @@ class Derived : public Base
 public:
     std::string m_derived_data;
 
-    SERIALIZE_METHODS_PARAMS(Derived, obj, DerivedAndBaseFormat, fmt)
+    SERIALIZE_METHODS(Derived, obj)
     {
+        auto& fmt = SER_PARAMS(DerivedAndBaseFormat);
         READWRITE(fmt.m_base_format(AsBase<Base>(obj)));
 
         if (ser_action.ForRead()) {

--- a/src/test/serialize_tests.cpp
+++ b/src/test/serialize_tests.cpp
@@ -15,6 +15,18 @@
 
 BOOST_FIXTURE_TEST_SUITE(serialize_tests, BasicTestingSetup)
 
+// For testing move-semantics, declare a version of datastream that can be moved
+// but is not copyable.
+class UncopyableStream : public DataStream
+{
+public:
+    using DataStream::DataStream;
+    UncopyableStream(const UncopyableStream&) = delete;
+    UncopyableStream& operator=(const UncopyableStream&) = delete;
+    UncopyableStream(UncopyableStream&&) noexcept = default;
+    UncopyableStream& operator=(UncopyableStream&&) noexcept = default;
+};
+
 class CSerializeMethodsTestSingle
 {
 protected:
@@ -343,6 +355,73 @@ public:
         }
     }
 };
+
+struct OtherParam {
+    uint8_t param;
+    SER_PARAMS_OPFUNC
+};
+
+//! Checker for value of OtherParam. When being serialized, serializes the
+//! param to the stream. When being unserialized, verifies the value in the
+//! stream matches the param.
+class OtherParamChecker
+{
+public:
+    template <typename Stream>
+    void Serialize(Stream& s) const
+    {
+        const uint8_t param = s.template GetParams<OtherParam>().param;
+        s << param;
+    }
+
+    template <typename Stream>
+    void Unserialize(Stream& s) const
+    {
+        const uint8_t param = s.template GetParams<OtherParam>().param;
+        uint8_t value;
+        s >> value;
+        BOOST_CHECK_EQUAL(value, param);
+    }
+};
+
+//! Test creating a stream with multiple parameters and making sure
+//! serialization code requiring different parameters can retrieve them. Also
+//! test that earlier parameters take precedence if the same parameter type is
+//! specified twice. (Choice of whether earlier or later values take precedence
+//! or multiple values of the same type are allowed was arbitrary, and just
+//! decided based on what would require smallest amount of ugly C++ template
+//! code. Intent of the test is to just ensure there is no unexpected behavior.)
+BOOST_AUTO_TEST_CASE(with_params_multi)
+{
+    const OtherParam other_param_used{.param = 0x10};
+    const OtherParam other_param_ignored{.param = 0x11};
+    const OtherParam other_param_override{.param = 0x12};
+    const OtherParamChecker check;
+    DataStream stream;
+    ParamsStream pstream{stream, RAW, other_param_used, other_param_ignored};
+
+    Base base1{0x20};
+    pstream << base1 << check << other_param_override(check);
+    BOOST_CHECK_EQUAL(stream.str(), "\x20\x10\x12");
+
+    Base base2;
+    pstream >> base2 >> check >> other_param_override(check);
+    BOOST_CHECK_EQUAL(base2.m_base_data, 0x20);
+}
+
+//! Test creating a ParamsStream that moves from a stream argument.
+BOOST_AUTO_TEST_CASE(with_params_move)
+{
+    UncopyableStream stream{};
+    ParamsStream pstream{std::move(stream), RAW, HEX, RAW};
+
+    Base base1{0x20};
+    pstream << base1;
+
+    Base base2;
+    pstream >> base2;
+    BOOST_CHECK_EQUAL(base2.m_base_data, 0x20);
+}
 
 BOOST_AUTO_TEST_CASE(with_params_base)
 {

--- a/src/test/serialize_tests.cpp
+++ b/src/test/serialize_tests.cpp
@@ -412,11 +412,14 @@ BOOST_AUTO_TEST_CASE(with_params_multi)
 //! Test creating a ParamsStream that moves from a stream argument.
 BOOST_AUTO_TEST_CASE(with_params_move)
 {
-    UncopyableStream stream{};
+    UncopyableStream stream{MakeByteSpan(std::string_view{"abc"})};
     ParamsStream pstream{std::move(stream), RAW, HEX, RAW};
+    BOOST_CHECK_EQUAL(pstream.GetStream().str(), "abc");
+    pstream.GetStream().clear();
 
     Base base1{0x20};
     pstream << base1;
+    BOOST_CHECK_EQUAL(pstream.GetStream().str(), "\x20");
 
     Base base2;
     pstream >> base2;


### PR DESCRIPTION
Currently it is only possible to attach one serialization parameter to a stream at a time. For example, it is not possible to set a parameter controlling the transaction format and a parameter controlling the address format at the same time because one parameter will override the other.

This limitation is inconvenient for multiprocess code since it is not possible to create just one type of stream and serialize any object to it. Instead it is necessary to create different streams for different object types, which requires extra boilerplate and makes using the new parameter fields a lot more awkward than the older version and type fields.

Fix this problem by allowing an unlimited number of serialization stream parameters to be set, and allowing them to be requested by type. Later parameters will still override earlier parameters, but only if they have the same type.

For an example of different ways multiple parameters can be set, see the new [`with_params_multi`](https://github.com/bitcoin/bitcoin/blob/40f505583f4edeb2859aeb70da20c6374d331a4f/src/test/serialize_tests.cpp#L394-L410) unit test.

This change requires replacing the `stream.GetParams()` method with a `stream.GetParams<T>()` method in order for serialization code to retrieve the desired parameters. The change is more verbose, but probably a good thing for readability because previously it could be difficult to know what type the `GetParams()` method would return, and now it is more obvious.

---

This PR is part of the [process separation project](https://github.com/bitcoin/bitcoin/issues/28722).