### PR TITLE
fuzz: Limit fuzz buffer size in script_flags target

### DIFF
--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -6,21 +6,23 @@
 #ifndef BITCOIN_SCRIPT_INTERPRETER_H
 #define BITCOIN_SCRIPT_INTERPRETER_H
 
+#include <consensus/amount.h>
 #include <hash.h>
-#include <script/script_error.h>
-#include <span.h>
 #include <primitives/transaction.h>
+#include <script/script_error.h> // IWYU pragma: export
+#include <span.h>
+#include <uint256.h>
 
+#include <cstddef>
+#include <cstdint>
 #include <optional>
 #include <vector>
-#include <stdint.h>
 
 class CPubKey;
-class XOnlyPubKey;
 class CScript;
-class CTransaction;
-class CTxOut;
-class uint256;
+class CScriptNum;
+class XOnlyPubKey;
+struct CScriptWitness;
 
 /** Signature hash types/flags */
 enum

--- a/src/test/fuzz/script_flags.cpp
+++ b/src/test/fuzz/script_flags.cpp
@@ -7,21 +7,12 @@
 #include <script/interpreter.h>
 #include <streams.h>
 #include <test/util/script.h>
-#include <version.h>
 
 #include <test/fuzz/fuzz.h>
 
 FUZZ_TARGET(script_flags)
 {
-    CDataStream ds(buffer, SER_NETWORK, INIT_PROTO_VERSION);
-    try {
-        int nVersion;
-        ds >> nVersion;
-        ds.SetVersion(nVersion);
-    } catch (const std::ios_base::failure&) {
-        return;
-    }
-
+    DataStream ds{buffer};
     try {
         const CTransaction tx(deserialize, TX_WITH_WITNESS, ds);
 

--- a/src/test/fuzz/script_flags.cpp
+++ b/src/test/fuzz/script_flags.cpp
@@ -12,6 +12,7 @@
 
 FUZZ_TARGET(script_flags)
 {
+    if (buffer.size() > 100'000) return;
     DataStream ds{buffer};
     try {
         const CTransaction tx(deserialize, TX_WITH_WITNESS, ds);

--- a/src/test/fuzz/script_flags.cpp
+++ b/src/test/fuzz/script_flags.cpp
@@ -3,12 +3,17 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <consensus/amount.h>
-#include <pubkey.h>
+#include <primitives/transaction.h>
 #include <script/interpreter.h>
+#include <serialize.h>
 #include <streams.h>
+#include <test/fuzz/fuzz.h>
 #include <test/util/script.h>
 
-#include <test/fuzz/fuzz.h>
+#include <cassert>
+#include <ios>
+#include <utility>
+#include <vector>
 
 FUZZ_TARGET(script_flags)
 {


### PR DESCRIPTION
Most fuzz targets have an upper limit on the buffer size to avoid excessive runtime. Do the same for `script_flags` to avoid timeouts such as https://github.com/bitcoin/bitcoin/issues/28812#issuecomment-1824696971

Also, fix iwyu. Also, remove legacy `CDataStream`.