### PR TITLE
msvc: Update vcpkg manifest

### DIFF
--- a/build_msvc/vcpkg.json
+++ b/build_msvc/vcpkg.json
@@ -11,7 +11,7 @@
     "sqlite3",
     "zeromq"
   ],
-  "builtin-baseline": "f14984af3738e69f197bf0e647a8dca12de92996",
+  "builtin-baseline": "9edb1b8e590cc086563301d735cae4b6e732d2d2",
   "overrides": [
     {
       "name": "libevent",

--- a/build_msvc/vcpkg.json
+++ b/build_msvc/vcpkg.json
@@ -3,6 +3,7 @@
   "version-string": "1",
   "dependencies": [
     "berkeleydb",
+    "boost-date-time",
     "boost-multi-index",
     "boost-process",
     "boost-signals2",

--- a/build_msvc/vcpkg.json
+++ b/build_msvc/vcpkg.json
@@ -7,11 +7,8 @@
     "boost-process",
     "boost-signals2",
     "boost-test",
+    "libevent",
     "sqlite3",
-    {
-      "name": "libevent",
-      "features": ["thread"]
-    },
     "zeromq"
   ],
   "builtin-baseline": "f14984af3738e69f197bf0e647a8dca12de92996",


### PR DESCRIPTION
Last time we updated dependency packages used when compiling with MSVC in https://github.com/bitcoin/bitcoin/pull/26891. Then we [switched](https://github.com/bitcoin/bitcoin/pull/27335) to specifying the `builtin-baseline` in the `vcpkg.json` manifest file, which made checking out the entire vcpkg repository to a specific commit or tag unneeded.

This PR updates the manifest baseline from [2023.01.09](https://github.com/microsoft/vcpkg/releases/tag/2023.01.09) to [2023.08.09](https://github.com/microsoft/vcpkg/releases/tag/2023.08.09):
- berkeleydb: 4.8.30#8 --> 4.8.30#9
- boost: 1.81.0 --> 1.82.0#2
- sqlite3: 3.40.0#1 --> 3.42.0#1
- zeromq: 4.3.4#6 --> 2023-06-20#1

The most recent https://github.com/microsoft/vcpkg/releases/tag/2023.11.20 tag is still unavailable in the vcpkg installation in the current GHA Windows image (the head commit is https://github.com/microsoft/vcpkg/commit/2b14b606cea54573eec11080a3ac00737958b6d6 only).

The other https://github.com/microsoft/vcpkg/releases/tag/2023.10.19 tag [introduces](https://github.com/boostorg/process/commit/0c42a58eacab6a96b19196e399307bad8a938a27) a warning C4297 in the Boost.Process 1.83 that is [fixed](https://github.com/boostorg/process/pull/340) in the upcoming version 1.84.