### PR TITLE
memusage: let PoolResource keep track of all allocated/deallocated memory

### DIFF
--- a/src/malloc_usage.h
+++ b/src/malloc_usage.h
@@ -1,0 +1,30 @@
+// Copyright (c) 2023-present The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_MALLOC_USAGE_H
+#define BITCOIN_MALLOC_USAGE_H
+
+#include <cassert>
+#include <cstddef>
+
+namespace memusage {
+
+/** Compute the total memory used by allocating alloc bytes. */
+static inline size_t MallocUsage(size_t alloc)
+{
+    // Measured on libc6 2.19 on Linux.
+    if (alloc == 0) {
+        return 0;
+    } else if (sizeof(void*) == 8) {
+        return ((alloc + 31) >> 4) << 4;
+    } else if (sizeof(void*) == 4) {
+        return ((alloc + 15) >> 3) << 3;
+    } else {
+        assert(0);
+    }
+}
+
+} // namespace memusage
+
+#endif // BITCOIN_MALLOC_USAGE_H

--- a/src/memusage.h
+++ b/src/memusage.h
@@ -175,14 +175,7 @@ static inline size_t DynamicUsage(const std::unordered_map<Key,
                                                                          MAX_BLOCK_SIZE_BYTES,
                                                                          ALIGN_BYTES>>& m)
 {
-    auto* pool_resource = m.get_allocator().resource();
-
-    // The allocated chunks are stored in a std::list. Size per node should
-    // therefore be 3 pointers: next, previous, and a pointer to the chunk.
-    size_t estimated_list_node_size = MallocUsage(sizeof(void*) * 3);
-    size_t usage_resource = estimated_list_node_size * pool_resource->NumAllocatedChunks();
-    size_t usage_chunks = MallocUsage(pool_resource->ChunkSizeBytes()) * pool_resource->NumAllocatedChunks();
-    return usage_resource + usage_chunks + MallocUsage(sizeof(void*) * m.bucket_count());
+    return m.get_allocator().resource()->DynamicMemoryUsage();
 }
 
 } // namespace memusage

--- a/src/memusage.h
+++ b/src/memusage.h
@@ -6,10 +6,10 @@
 #define BITCOIN_MEMUSAGE_H
 
 #include <indirectmap.h>
+#include <malloc_usage.h>
 #include <prevector.h>
 #include <support/allocators/pool.h>
 
-#include <cassert>
 #include <cstdlib>
 #include <list>
 #include <map>
@@ -22,9 +22,6 @@
 
 namespace memusage
 {
-
-/** Compute the total memory used by allocating alloc bytes. */
-static size_t MallocUsage(size_t alloc);
 
 /** Dynamic memory usage for built-in types is zero. */
 static inline size_t DynamicUsage(const int8_t& v) { return 0; }
@@ -47,20 +44,6 @@ template<typename X> static inline size_t DynamicUsage(const X * const &v) { ret
  *  application data structures require more accurate inner accounting, they should
  *  iterate themselves, or use more efficient caching + updating on modification.
  */
-
-static inline size_t MallocUsage(size_t alloc)
-{
-    // Measured on libc6 2.19 on Linux.
-    if (alloc == 0) {
-        return 0;
-    } else if (sizeof(void*) == 8) {
-        return ((alloc + 31) >> 4) << 4;
-    } else if (sizeof(void*) == 4) {
-        return ((alloc + 15) >> 3) << 3;
-    } else {
-        assert(0);
-    }
-}
 
 // STL data structures
 


### PR DESCRIPTION
We recently (in #28906) had OOM problems due to incorrect memory usage estimation. When `PoolResource` is used the estimation can be brittle because when implementing memusage estimation for a container it is not obvious when the pool can be used.

As suggested here https://github.com/bitcoin/bitcoin/issues/28906#issuecomment-1817885270, to prevent these problems in future we can simply let the `PoolResource` do all the accounting. Then the memory usage estimation is always accurate, even when the pool's memory chunks cannot be used.