### PR TITLE
fuzz: BIP324: damage ciphertext/aad in full byte range

### DIFF
--- a/src/test/fuzz/bip324.cpp
+++ b/src/test/fuzz/bip324.cpp
@@ -98,7 +98,7 @@ FUZZ_TARGET(bip324_cipher_roundtrip, .init=Initialize)
             unsigned damage_bit = provider.ConsumeIntegralInRange<unsigned>(0,
                 (ciphertext.size() + aad.size()) * 8U - 1U);
             unsigned damage_pos = damage_bit >> 3;
-            std::byte damage_val{(uint8_t)(1U << (damage_bit & 3))};
+            std::byte damage_val{(uint8_t)(1U << (damage_bit & 7))};
             if (damage_pos >= ciphertext.size()) {
                 aad[damage_pos - ciphertext.size()] ^= damage_val;
             } else {


### PR DESCRIPTION
This PR is a tiny improvement for the `bip324_cipher_roundtrip` fuzz target: currently the damaging of input data for decryption (either ciphertext or aad) only ever happens in the lower nibble within the byte at the damage position, as the bit position for the `damage_val` byte was calculated with `damage_bit & 3` (corresponding to `% 4`) rather than `damage_bit & 7` (corresponding to the expected `% 8`).

Noticed while reviewing #28263 which uses similar constructs.