### PR TITLE
fuzz: Fix nullptr deref in scriptpubkeyman

### DIFF
--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -5,14 +5,14 @@
 #ifndef BITCOIN_TEST_UTIL_SETUP_COMMON_H
 #define BITCOIN_TEST_UTIL_SETUP_COMMON_H
 
-#include <common/args.h>
+#include <common/args.h> // IWYU pragma: export
 #include <key.h>
 #include <node/caches.h>
 #include <node/context.h> // IWYU pragma: export
 #include <primitives/transaction.h>
 #include <pubkey.h>
 #include <stdexcept>
-#include <util/chaintype.h>
+#include <util/chaintype.h> // IWYU pragma: export
 #include <util/check.h>
 #include <util/fs.h>
 #include <util/string.h>


### PR DESCRIPTION
This should fix the UB that was found by review (https://github.com/bitcoin/bitcoin/pull/28578#discussion_r1404246109) and by fuzzing (https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=64487)